### PR TITLE
improve parallelism in openshift-resource

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -65,9 +65,13 @@ def openshift_rolebinding(ctx):
 
 
 @integration.command()
+@click.option('--thread-pool-size',
+              help='number of threads to run in parallel',
+              default=10)
 @click.pass_context
-def openshift_resources(ctx):
-    run_integration(reconcile.openshift_resources.run, ctx.obj['dry_run'])
+def openshift_resources(ctx, thread_pool_size):
+    run_integration(reconcile.openshift_resources.run,
+                    ctx.obj['dry_run'], thread_pool_size)
 
 
 @integration.command()

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -253,7 +253,7 @@ def fetch_openshift_resource(resource):
     return openshift_resource
 
 
-def fetch_current_state(ri, oc, cluster, namespace, resource_type):
+def fetch_current_state(oc, ri, cluster, namespace, resource_type):
     for item in oc.get_items(resource_type, namespace=namespace):
         openshift_resource = OR(item)
         ri.add_current(
@@ -318,7 +318,7 @@ def fetch_desired_state(ri, cluster, namespace, resource):
 
 def fetch_states(spec, ri):
     if spec.oc is not None:
-        fetch_current_state(ri, spec.oc, spec.cluster,
+        fetch_current_state(spec.oc, ri, spec.cluster,
                             spec.namespace, spec.resource)
     else:
         fetch_desired_state(ri, spec.cluster, spec.namespace, spec.resource)

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -14,6 +14,8 @@ from utils.openshift_resource import (OpenshiftResource,
                                       ResourceInventory,
                                       ResourceKeyExistsError)
 from multiprocessing.dummy import Pool as ThreadPool
+from functools import partial
+from threading import Lock
 
 """
 +-----------------------+--------------------+-------------+
@@ -69,6 +71,8 @@ QONTRACT_INTEGRATION = 'openshift_resources'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 2, 0)
 QONTRACT_BASE64_SUFFIX = '_qb64'
 
+_log_lock = Lock()
+
 
 class FetchResourceError(Exception):
     def __init__(self, msg):
@@ -96,6 +100,21 @@ class OR(OpenshiftResource):
         super(OR, self).__init__(
             body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION
         )
+
+
+class CurrentStateSpec(object):
+    def __init__(self, oc, cluster, namespace, resource_type):
+        self.oc = oc
+        self.cluster = cluster
+        self.namespace = namespace
+        self.resource_type = resource_type
+
+
+class DesiredStateSpec(object):
+    def __init__(self, cluster, namespace, resource):
+        self.cluster = cluster
+        self.namespace = namespace
+        self.resource = resource
 
 
 def obtain_oc_client(oc_map, cluster_info):
@@ -206,10 +225,14 @@ def fetch_provider_route(path, tls_path, tls_version):
 
 
 def fetch_openshift_resource(resource):
+    global _log_lock
+
     provider = resource['provider']
     path = resource['path']
     msg = "Fetching {}: {}".format(provider, path)
+    _log_lock.acquire()
     logging.debug(msg)
+    _log_lock.release()
 
     if provider == 'resource':
         openshift_resource = fetch_provider_resource(path)
@@ -233,70 +256,78 @@ def fetch_openshift_resource(resource):
     return openshift_resource
 
 
-def fetch_current_state(oc, ri, cluster, namespace, managed_types):
-    for resource_type in managed_types:
-        # Initialize cluster/namespace/resource_type in Inventories
-        ri.initialize_resource_type(cluster, namespace, resource_type)
+def fetch_current_state(spec, ri):
+    # Initialize cluster/namespace/resource_type in Inventories
+    ri.initialize_resource_type(spec.cluster,
+                                spec.namespace, spec.resource_type)
 
-        # Fetch current resources
-        for item in oc.get_items(resource_type, namespace=namespace):
-            openshift_resource = OR(item)
-            ri.add_current(
-                cluster,
-                namespace,
-                resource_type,
-                openshift_resource.name,
-                openshift_resource
-            )
+    # Fetch current resources
+    items = spec.oc.get_items(spec.resource_type, namespace=spec.namespace)
+    for item in items:
+        openshift_resource = OR(item)
+        ri.add_current(
+            spec.cluster,
+            spec.namespace,
+            spec.resource_type,
+            openshift_resource.name,
+            openshift_resource
+        )
 
 
-def fetch_desired_state(ri, cluster, namespace, resources):
+def fetch_desired_state(spec, ri):
+    global _log_lock
+
     try:
-        pool = ThreadPool(10)
-        openshift_resources = pool.map(fetch_openshift_resource, resources)
+        openshift_resource = fetch_openshift_resource(spec.resource)
     except (FetchResourceError,
             FetchVaultSecretError,
             UnknownProviderError) as e:
         ri.register_error()
-        msg = "[{}/{}] {}".format(cluster, namespace, e.message)
+        msg = "[{}/{}] {}".format(spec.cluster, spec.namespace, e.message)
+        _log_lock.acquire()
         logging.error(msg)
+        _log_lock.release()
+        return
 
-    for openshift_resource in openshift_resources:
-        # add to inventory
-        try:
-            ri.add_desired(
-                cluster,
-                namespace,
-                openshift_resource.kind,
-                openshift_resource.name,
-                openshift_resource
-            )
-        except KeyError:
-            # This is failing because in the managed_type loop (where the
-            # `initialize_resource_type` method was called), this specific
-            # combination was not initialized, meaning that it shouldn't be
-            # managed. But someone is trying to add it via app-interface
-            ri.register_error()
-            msg = "[{}/{}] unknown kind: {}.".format(
-                cluster, namespace, openshift_resource.kind)
-            logging.error(msg)
-            continue
-        except ResourceKeyExistsError:
-            # This is failing because an attempt to add
-            # a desired resource with the same name and
-            # the same type was already added previously
-            ri.register_error()
-            msg = (
-                "[{}/{}] desired item already exists: {}/{}."
-            ).format(cluster, namespace, openshift_resource.kind,
-                     openshift_resource.name)
-            logging.error(msg)
-            continue
+    # add to inventory
+    try:
+        ri.add_desired(
+            spec.cluster,
+            spec.namespace,
+            openshift_resource.kind,
+            openshift_resource.name,
+            openshift_resource
+        )
+    except KeyError:
+        # This is failing because in the managed_type loop (where the
+        # `initialize_resource_type` method was called), this specific
+        # combination was not initialized, meaning that it shouldn't be
+        # managed. But someone is trying to add it via app-interface
+        ri.register_error()
+        msg = "[{}/{}] unknown kind: {}.".format(
+            spec.cluster, spec.namespace, openshift_resource.kind)
+        _log_lock.acquire()
+        logging.error(msg)
+        _log_lock.release()
+        return
+    except ResourceKeyExistsError:
+        # This is failing because an attempt to add
+        # a desired resource with the same name and
+        # the same type was already added previously
+        ri.register_error()
+        msg = (
+            "[{}/{}] desired item already exists: {}/{}."
+        ).format(spec.cluster, spec.namespace, openshift_resource.kind,
+                 openshift_resource.name)
+        _log_lock.acquire()
+        logging.error(msg)
+        _log_lock.release()
+        return
 
 
-def fetch_data(namespaces_query):
-    ri = ResourceInventory()
-    oc_map = {}
+def init_specs_to_fetch(ri, oc_map, namespaces_query):
+    current_state_specs = []
+    desired_state_specs = []
 
     for namespace_info in namespaces_query:
         # Skip if namespace has no managedResourceTypes
@@ -317,9 +348,32 @@ def fetch_data(namespaces_query):
             logging.error(msg)
             continue
 
-        fetch_current_state(oc, ri, cluster, namespace, managed_types)
+        for resource_type in managed_types:
+            c_spec = CurrentStateSpec(oc, cluster, namespace, resource_type)
+            current_state_specs.append(c_spec)
+
         openshift_resources = namespace_info.get('openshiftResources') or []
-        fetch_desired_state(ri, cluster, namespace, openshift_resources)
+        for openshift_resource in openshift_resources:
+            d_spec = DesiredStateSpec(cluster, namespace, openshift_resource)
+            desired_state_specs.append(d_spec)
+
+    return current_state_specs, desired_state_specs
+
+
+def fetch_data(namespaces_query, thread_pool_size):
+    ri = ResourceInventory()
+    oc_map = {}
+
+    current_state_specs, desired_state_specs = \
+        init_specs_to_fetch(ri, oc_map, namespaces_query)
+
+    pool = ThreadPool(thread_pool_size)
+
+    fetch_current_state_partial = partial(fetch_current_state, ri=ri)
+    pool.map(fetch_current_state_partial, current_state_specs)
+
+    fetch_desired_state_partial = partial(fetch_desired_state, ri=ri)
+    pool.map(fetch_desired_state_partial, desired_state_specs)
 
     return oc_map, ri
 
@@ -398,12 +452,12 @@ def realize_data(dry_run, oc_map, ri):
                 logging.error(msg)
 
 
-def run(dry_run=False):
+def run(dry_run=False, thread_pool_size=10):
     gqlapi = gql.get_api()
 
     namespaces_query = gqlapi.query(NAMESPACES_QUERY)['namespaces']
 
-    oc_map, ri = fetch_data(namespaces_query)
+    oc_map, ri = fetch_data(namespaces_query, thread_pool_size)
     realize_data(dry_run, oc_map, ri)
 
     if ri.has_error_registered():

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -198,6 +198,8 @@ def fetch_provider_vault_secret(path, version, name, labels, annotations):
 
 
 def fetch_provider_route(path, tls_path, tls_version):
+    global _log_lock
+
     openshift_resource = fetch_provider_resource(path)
 
     if tls_path is None or tls_version is None:
@@ -219,7 +221,9 @@ def fetch_provider_route(path, tls_path, tls_version):
         msg = "Route secret '{}' key '{}' not in valid keys {}".format(
             tls_path, k, valid_keys
         )
+        _log_lock.acquire()
         logging.info(msg)
+        _log_lock.release()
 
     return openshift_resource
 

--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -157,19 +157,18 @@ class ResourceInventory(object):
         self._lock = Lock()
 
     def initialize_resource_type(self, cluster, namespace, resource_type):
-        self._lock.acquire()
         self._clusters.setdefault(cluster, {})
         self._clusters[cluster].setdefault(namespace, {})
         self._clusters[cluster][namespace].setdefault(resource_type, {
             'current': {},
             'desired': {}
         })
-        self._lock.release()
 
     def add_desired(self, cluster, namespace, resource_type, name, value):
         self._lock.acquire()
         desired = self._clusters[cluster][namespace][resource_type]['desired']
         if name in desired:
+            self._lock.release()
             raise ResourceKeyExistsError(name)
         desired[name] = value
         self._lock.release()

--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -1,8 +1,9 @@
 import copy
 import hashlib
 import json
-
 import semver
+
+from threading import Lock
 
 
 class ResourceKeyExistsError(Exception):
@@ -153,24 +154,31 @@ class ResourceInventory(object):
     def __init__(self):
         self._clusters = {}
         self._error_registered = False
+        self._lock = Lock()
 
     def initialize_resource_type(self, cluster, namespace, resource_type):
+        self._lock.acquire()
         self._clusters.setdefault(cluster, {})
         self._clusters[cluster].setdefault(namespace, {})
         self._clusters[cluster][namespace].setdefault(resource_type, {
             'current': {},
             'desired': {}
         })
+        self._lock.release()
 
     def add_desired(self, cluster, namespace, resource_type, name, value):
+        self._lock.acquire()
         desired = self._clusters[cluster][namespace][resource_type]['desired']
         if name in desired:
             raise ResourceKeyExistsError(name)
         desired[name] = value
+        self._lock.release()
 
     def add_current(self, cluster, namespace, resource_type, name, value):
+        self._lock.acquire()
         current = self._clusters[cluster][namespace][resource_type]['current']
         current[name] = value
+        self._lock.release()
 
     def __iter__(self):
         for cluster in self._clusters.keys():


### PR DESCRIPTION
The previous parallelism was running only in the `fetch_desired_state` function, and was running in parallel per namespace.

The current state runs both `fetch_current_state` and `fetch_desired_state` in parallel, for all resources in parallel (from all clusters, from all namespaces).

This improves the execution time to be well under a minute!