### PR TITLE
detect manual changes

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -418,21 +418,20 @@ def realize_data(dry_run, oc_map, ri):
                     continue
 
                 # don't apply if sha256sum hashes match
-                if c_item.sha256sum() == d_item.sha256sum() and \
-                        c_item.has_valid_sha256sum():
-                    msg = (
-                        "[{}/{}] resource '{}/{}' present "
-                        "and hashes match, skipping."
-                    ).format(cluster, namespace, resource_type, name)
-                    logging.debug(msg)
-                    continue
-
-                if not c_item.has_valid_sha256sum():
-                    msg = (
-                        "[{}/{}] resource '{}/{}' present "
-                        "and has stale sha256sum due to manual changes."
-                    ).format(cluster, namespace, resource_type, name)
-                    logging.info(msg)
+                if c_item.sha256sum() == d_item.sha256sum():
+                    if c_item.has_valid_sha256sum():
+                        msg = (
+                            "[{}/{}] resource '{}/{}' present "
+                            "and hashes match, skipping."
+                        ).format(cluster, namespace, resource_type, name)
+                        logging.debug(msg)
+                        continue
+                    else:
+                        msg = (
+                            "[{}/{}] resource '{}/{}' present "
+                            "and has stale sha256sum due to manual changes."
+                        ).format(cluster, namespace, resource_type, name)
+                        logging.info(msg)
 
                 logging.debug("CURRENT: " +
                               OR.serialize(OR.canonicalize(c_item.body)))

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -69,7 +69,7 @@ NAMESPACES_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'openshift_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 0)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 1)
 QONTRACT_BASE64_SUFFIX = '_qb64'
 
 _log_lock = Lock()

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -416,7 +416,8 @@ def realize_data(dry_run, oc_map, ri):
                     continue
 
                 # don't apply if sha256sum hashes match
-                if c_item.sha256sum() == d_item.sha256sum():
+                if c_item.sha256sum() == d_item.sha256sum() and \
+                        c_item.has_valid_sha256sum():
                     msg = (
                         "[{}/{}] resource '{}/{}' present "
                         "and hashes match, skipping."

--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -60,8 +60,12 @@ class TestOpenshiftResource(object):
         assert annotated.sha256sum() == \
             '1366d8ef31f0d83419d25b446e61008b16348b9efee2216873856c49cede6965'
 
+        assert annotated.has_valid_sha256sum()
+
         annotated.body['metadata']['annotations']['qontract.sha256sum'] = \
             'test'
 
         assert annotated.sha256sum() == \
             '1366d8ef31f0d83419d25b446e61008b16348b9efee2216873856c49cede6965'
+
+        assert not annotated.has_valid_sha256sum()

--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -63,4 +63,5 @@ class TestOpenshiftResource(object):
         annotated.body['metadata']['annotations']['qontract.sha256sum'] = \
             'test'
 
-        assert annotated.sha256sum() == 'test'
+        assert annotated.sha256sum() == \
+            '1366d8ef31f0d83419d25b446e61008b16348b9efee2216873856c49cede6965'

--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -8,7 +8,7 @@ from utils.openshift_resource import OpenshiftResource
 fxt = Fixtures('openshift_resource')
 
 QONTRACT_INTEGRATION = 'openshift_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 0)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 1)
 
 
 class OR(OpenshiftResource):

--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -80,10 +80,7 @@ class OpenshiftResource(object):
                                  self.integration_version)
 
     def sha256sum(self):
-        if self.has_qontract_annotations():
-            body = self.body
-        else:
-            body = self.annotate().body
+        body = self.annotate().body
 
         annotations = body['metadata']['annotations']
         return annotations['qontract.sha256sum']

--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -49,6 +49,14 @@ class OpenshiftResource(object):
 
         return True
 
+    def has_valid_sha256sum(self):
+        try:
+            current_sha256sum = \
+                self.body['metadata']['annotations']['qontract.sha256sum']
+            return current_sha256sum == self.sha256sum()
+        except KeyError:
+            return False
+
     def annotate(self):
         """
         Creates a OpenshiftResource with the qontract annotations, and removes


### PR DESCRIPTION
Currently, if a manual change is done on an object in the cluster, the sha256sum will not change, and the integration will not detect that change. The current result is that manual changes persist through a run of the integration.

The expected result is that manual changes are detected and reconciled back to their previous state.

This PR makes it so that the sha256sum is calculated even for existing objects which have the sha256sum annotation, which will detect manual changes.