### PR TITLE
fix metadata.resourceVersion: Invalid value issue

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -71,7 +71,7 @@ NAMESPACES_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'openshift_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 1)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 2)
 QONTRACT_BASE64_SUFFIX = '_qb64'
 
 _log_lock = Lock()

--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -8,7 +8,7 @@ from utils.openshift_resource import OpenshiftResource
 fxt = Fixtures('openshift_resource')
 
 QONTRACT_INTEGRATION = 'openshift_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 1)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 2)
 
 
 class OR(OpenshiftResource):

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -46,7 +46,7 @@ class OC(object):
         return items
 
     def get(self, namespace, kind, name):
-        cmd = ['get', '--export=true', '-o', 'json', '-n', namespace, kind,
+        cmd = ['get', '-o', 'json', '-n', namespace, kind,
                name]
         return self._run_json(cmd)
 

--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -67,12 +67,21 @@ class OpenshiftResource(object):
                 annotations.
         """
 
+        # keep resourceVersion to restore
+        resource_version = None
+        if 'resourceVersion' in self.body['metadata']:
+            resource_version = self.body['metadata']['resourceVersion']
+
         # calculate sha256sum of canonical body
         canonical_body = self.canonicalize(self.body)
         sha256sum = self.calculate_sha256sum(self.serialize(canonical_body))
 
         # create new body object
         body = copy.deepcopy(self.body)
+
+        # restore resourceVersion
+        if resource_version is not None:
+            body['metadata'].setdefault('resourceVersion', resource_version)
 
         # create annotations if not present
         body['metadata'].setdefault('annotations', {})


### PR DESCRIPTION
Some resources require that when applying them one must specify the current resourceVersion. if not defined (or defined with the wrong version):
```
The <resourceType> <resourceName> is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update
```
I have encountered that when migrating Secrets, and @aditya-konarde is encountering this now when migrating ServiceMonitors.

The resourceVersion field is automatically generated when you apply a resource, and in some cases, if we want to apply the same resource, the resourceVersion field must be equal to the one in the cluster.

This PR handles all the above by doing:
* before canonicalizing the resource, the resourceVersion will be kept, and re-added after the sha calculation. this will allow for backwards compatibility with existing sha256sums.
* in case this is a generated resource (desired item) nothing changes.
* we remove the `--export=true` because that outputs the resourceVersion field as "". imo this is fine as we canonicalize the resources anyway.