### PR TITLE
Reconcile prometheus

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -71,7 +71,7 @@ NAMESPACES_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'openshift_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 1)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 2)
 QONTRACT_BASE64_SUFFIX = '_qb64'
 
 _log_lock = Lock()

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -71,7 +71,7 @@ NAMESPACES_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'openshift_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 2)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 4, 0)
 QONTRACT_BASE64_SUFFIX = '_qb64'
 
 _log_lock = Lock()

--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -8,7 +8,7 @@ from utils.openshift_resource import OpenshiftResource
 fxt = Fixtures('openshift_resource')
 
 QONTRACT_INTEGRATION = 'openshift_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 2)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 4, 0)
 
 
 class OR(OpenshiftResource):

--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -8,7 +8,7 @@ from utils.openshift_resource import OpenshiftResource
 fxt = Fixtures('openshift_resource')
 
 QONTRACT_INTEGRATION = 'openshift_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 1)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 3, 2)
 
 
 class OR(OpenshiftResource):

--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -107,6 +107,7 @@ class OpenshiftResource(object):
         # remove openshift specific params
         body['metadata'].pop('creationTimestamp', None)
         body['metadata'].pop('resourceVersion', None)
+        body['metadata'].pop('generation', None)
         body['metadata'].pop('selfLink', None)
         body['metadata'].pop('uid', None)
         body['metadata'].pop('namespace', None)


### PR DESCRIPTION
This PR makes the integration work correctly with ServiceMonitors and PrometheusRules, which have the additional metadata field `generation` - which we now pop during canonicalize.