### PR TITLE
allow resource install only

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -42,7 +42,7 @@ TF_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'terraform_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 1)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 2)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 

--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -8,13 +8,14 @@ from utils.openshift_resource import OpenshiftResource
 fxt = Fixtures('openshift_resource')
 
 QONTRACT_INTEGRATION = 'openshift_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 5, 0)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 6, 0)
 
 
 class OR(OpenshiftResource):
-    def __init__(self, body):
+    def __init__(self, body, install_only=None):
         super(OR, self).__init__(
-            body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION
+            body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION,
+            install_only
         )
 
 
@@ -46,6 +47,18 @@ class TestOpenshiftResource(object):
 
         assert OR(resources[0]).annotate().sha256sum() == \
             OR(resources[1]).annotate().sha256sum()
+
+    def test_install_only_annotation(self):
+        resource = fxt.get_anymarkup('annotates_resource.yml')
+
+        openshift_resource = OR(resource)
+        assert openshift_resource.has_install_only_annotation() is False
+
+        openshift_resource = OR(resource, False)
+        assert openshift_resource.has_install_only_annotation() is False
+
+        openshift_resource = OR(resource, True)
+        assert openshift_resource.has_install_only_annotation() is True
 
     def test_sha256sum(self):
         resource = fxt.get_anymarkup('sha256sum.yml')

--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -89,7 +89,7 @@ class OpenshiftResource(object):
 
         # add install_only to sha256sum calculation
         if self.install_only:
-            annotations['qontract.install_only'] = 'true'
+            annotations['qontract.install_only'] = 'true'  # yaml true
 
         # calculate sha256sum of canonical body
         canonical_body = self.canonicalize(body)

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -17,7 +17,8 @@ class ConstructResourceError(Exception):
 class OR(OpenshiftResource):
     def __init__(self, body, integration, integration_version):
         super(OR, self).__init__(
-            body, integration, integration_version
+            body, integration, integration_version,
+            install_only=None
         )
 
 


### PR DESCRIPTION
this PR adds support for `install_only` field to define a resource which will only be installed, but not reconciled (allows manual changes to such resource).
default value is false.

the use case is to bootstrap apps that will later manage a resource.
maybe the best approach is to allow the apps to create the resource, but this is an alternative.