### PR TITLE
terraform support for iam users

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -33,6 +33,14 @@ server = "ldap://ldap.example.com"
 # (optional) user search point
 base_dn = "ou=users,dc=example,dc=com"
 
+[smtp]
+# This section is required by `qontract-reconcile terraform-resources`
+
+# (mandatory) path to smtp credentials in vault
+secret_path = 'secrets/path/to/smtp/creds'
+# (mandatory) mail address to send mails to
+mail_address = 'example.com'
+
 [app-interface]
 # This section is required by `qontract-reconcile ldap-users`
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -169,6 +169,7 @@ def run(dry_run=False, print_only=False, enable_deletion=False):
 
     tf.populate_desired_state(ri)
     openshift_resources.realize_data(dry_run, oc_map, ri)
-    # send aws invites
+
+    new_users = tf.get_new_users()
 
     cleanup_and_exit(tf)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -8,7 +8,7 @@ from utils.terrascript_client import TerrascriptClient as Terrascript
 from utils.terraform_client import OR, TerraformClient as Terraform
 from utils.openshift_resource import ResourceInventory
 
-TF_QUERY = """
+TF_RESOURCES_QUERY = """
 {
   namespaces: namespaces_v1 {
     name
@@ -41,12 +41,34 @@ TF_QUERY = """
 }
 """
 
+TF_USERS_QUERY = """
+{
+  roles: roles_v1 {
+    users {
+      redhat_username
+      github_username
+      public_gpg_key
+    }
+    aws_groups {
+      ...on AWSGroup_v1 {
+        name
+        policies
+        account {
+          name
+          consoleUrl
+        }
+      }
+    }
+  }
+}
+"""
+
 QONTRACT_INTEGRATION = 'terraform_resources'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 1)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 
-def adjust_tf_query(tf_query):
+def adjust_tf_resources_query(tf_query):
     out_tf_query = []
     for namespace_info in tf_query:
         managed_terraform_resources = \
@@ -59,10 +81,27 @@ def adjust_tf_query(tf_query):
     return out_tf_query
 
 
-def get_tf_query():
+def get_tf_resources_query():
     gqlapi = gql.get_api()
-    tf_query = gqlapi.query(TF_QUERY)['namespaces']
-    return adjust_tf_query(tf_query)
+    tf_query = gqlapi.query(TF_RESOURCES_QUERY)['namespaces']
+    return adjust_tf_resources_query(tf_query)
+
+
+def adjust_tf_users_query(tf_query):
+    return [r for r in tf_query if r['aws_groups'] is not None]
+
+
+def get_tf_users_query():
+    gqlapi = gql.get_api()
+    tf_query = gqlapi.query(TF_USERS_QUERY)['roles']
+    adjusted = adjust_tf_users_query(tf_query)
+    # create groups - remove duplicates and add resources (group, attachment)
+    # create users - remove duplicates and add resources (users, group_attachment)
+    for role in adjusted:
+        groups = role['aws_groups']
+        print(groups)
+        users = role['users']
+        print(users)
 
 
 def populate_oc_resources(spec, ri):
@@ -91,12 +130,15 @@ def fetch_current_state(tf_query):
 
 
 def setup(print_only):
-    tf_query = get_tf_query()
-    ri, oc_map = fetch_current_state(tf_query)
+    tf_users_query = get_tf_users_query()
+    sys.exit()
+    tf_resources_query = get_tf_resources_query()
+    ri, oc_map = fetch_current_state(tf_resources_query)
     ts = Terrascript(QONTRACT_INTEGRATION,
                      QONTRACT_TF_PREFIX,
                      oc_map)
-    ts.populate(tf_query)
+    ts.populate_users(tf_users_query)
+    ts.populate_resources(tf_resources_query)
     working_dirs = ts.dump(print_only)
 
     return ri, oc_map, working_dirs

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -3,6 +3,7 @@ import semver
 
 import utils.gql as gql
 import reconcile.openshift_resources as openshift_resources
+import utils.smtp_client as smtp_client
 
 from utils.terrascript_client import TerrascriptClient as Terrascript
 from utils.terraform_client import OR, TerraformClient as Terraform
@@ -135,6 +136,32 @@ def setup(print_only):
     return ri, oc_map, working_dirs
 
 
+def send_email_invites(new_users):
+    msg_template = '''
+You have been invited to join the {} AWS account!
+Below you will find credentials for the first sign in (You will be requested to change your password).
+The password is encrypted with your public gpg key. To decrypt the password:
+
+echo <password> | base64 -d | gpg -d - && echo
+(you will be asked to provide your passphrase to unlock the secret)
+
+Details:
+
+Console URL: {}
+Username: {}
+Encrypted password: {}
+
+'''
+    mails = []
+    for account, console_url, user_name, enc_password in new_users:
+        to = user_name
+        subject = 'Invitation to join the {} AWS account'.format(account)
+        body = msg_template.format(account, console_url, user_name, enc_password)
+        mails.append((to, subject, body))
+
+    smtp_client.send_mails(mails)
+
+
 def cleanup_and_exit(tf=None, status=False):
     if tf is not None:
         tf.cleanup()
@@ -171,5 +198,6 @@ def run(dry_run=False, print_only=False, enable_deletion=False):
     openshift_resources.realize_data(dry_run, oc_map, ri)
 
     new_users = tf.get_new_users()
+    send_email_invites(new_users)
 
     cleanup_and_exit(tf)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -41,12 +41,11 @@ TF_RESOURCES_QUERY = """
 }
 """
 
-TF_USERS_QUERY = """
+TF_IAM_QUERY = """
 {
   roles: roles_v1 {
     users {
       redhat_username
-      github_username
       public_gpg_key
     }
     aws_groups {
@@ -87,21 +86,14 @@ def get_tf_resources_query():
     return adjust_tf_resources_query(tf_query)
 
 
-def adjust_tf_users_query(tf_query):
+def adjust_tf_iam_query(tf_query):
     return [r for r in tf_query if r['aws_groups'] is not None]
 
 
-def get_tf_users_query():
+def get_tf_iam_query():
     gqlapi = gql.get_api()
-    tf_query = gqlapi.query(TF_USERS_QUERY)['roles']
-    adjusted = adjust_tf_users_query(tf_query)
-    # create groups - remove duplicates and add resources (group, attachment)
-    # create users - remove duplicates and add resources (users, group_attachment)
-    for role in adjusted:
-        groups = role['aws_groups']
-        print(groups)
-        users = role['users']
-        print(users)
+    tf_query = gqlapi.query(TF_IAM_QUERY)['roles']
+    return adjust_tf_iam_query(tf_query)
 
 
 def populate_oc_resources(spec, ri):
@@ -130,14 +122,13 @@ def fetch_current_state(tf_query):
 
 
 def setup(print_only):
-    tf_users_query = get_tf_users_query()
-    sys.exit()
+    tf_iam_query = get_tf_iam_query()
     tf_resources_query = get_tf_resources_query()
     ri, oc_map = fetch_current_state(tf_resources_query)
     ts = Terrascript(QONTRACT_INTEGRATION,
                      QONTRACT_TF_PREFIX,
                      oc_map)
-    ts.populate_users(tf_users_query)
+    ts.populate_iam(tf_iam_query)
     ts.populate_resources(tf_resources_query)
     working_dirs = ts.dump(print_only)
 
@@ -178,5 +169,6 @@ def run(dry_run=False, print_only=False, enable_deletion=False):
 
     tf.populate_desired_state(ri)
     openshift_resources.realize_data(dry_run, oc_map, ri)
+    # send aws invites
 
     cleanup_and_exit(tf)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -64,7 +64,7 @@ TF_IAM_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'terraform_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 1)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 2, 0)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 
@@ -139,7 +139,9 @@ def setup(print_only):
 def send_email_invites(new_users):
     msg_template = '''
 You have been invited to join the {} AWS account!
-Below you will find credentials for the first sign in (You will be requested to change your password).
+Below you will find credentials for the first sign in.
+You will be requested to change your password.
+
 The password is encrypted with your public gpg key. To decrypt the password:
 
 echo <password> | base64 -d | gpg -d - && echo
@@ -156,7 +158,8 @@ Encrypted password: {}
     for account, console_url, user_name, enc_password in new_users:
         to = user_name
         subject = 'Invitation to join the {} AWS account'.format(account)
-        body = msg_template.format(account, console_url, user_name, enc_password)
+        body = msg_template.format(account, console_url,
+                                   user_name, enc_password)
         mails.append((to, subject, body))
 
     smtp_client.send_mails(mails)

--- a/utils/smtp_client.py
+++ b/utils/smtp_client.py
@@ -11,6 +11,8 @@ from email.utils import formataddr
 
 _client = None
 _username = None
+_mail_address = None
+
 
 def init(host, port, username, password):
     global _client
@@ -36,6 +38,7 @@ def teardown():
 
 def init_from_config():
     global _username
+    global _mail_address
 
     config = get_config()
 
@@ -46,6 +49,7 @@ def init_from_config():
     port = smtp_config['port']
     _username = smtp_config['username']
     password = smtp_config['password']
+    _mail_address = config['smtp']['mail_address']
 
     return init(host, port, _username, password)
 
@@ -53,17 +57,18 @@ def init_from_config():
 def send_mail(name, subject, body):
     global _client
     global _username
+    global _mail_address
 
     msg = MIMEMultipart()
     from_name = str(Header('App SRE team automation', 'utf-8'))
-    to = '{}@redhat.com'.format(name)
+    to = '{}@{}'.format(name, _mail_address)
     msg['From'] = formataddr((from_name, _username))
     msg['To'] = to
     msg['Subject'] = subject
-    
+
     # add in the message body
     msg.attach(MIMEText(body, 'plain'))
-    
+
     # send the message via the server set up earlier.
     _client.sendmail(_username, to, msg.as_string())
 

--- a/utils/smtp_client.py
+++ b/utils/smtp_client.py
@@ -1,0 +1,77 @@
+import smtplib
+
+import utils.vault_client as vault_client
+
+from utils.config import get_config
+
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from email.header import Header
+from email.utils import formataddr
+
+_client = None
+_username = None
+
+def init(host, port, username, password):
+    global _client
+
+    if _client is None:
+        s = smtplib.SMTP(
+            host=host,
+            port=str(port)
+        )
+        s.send
+        s.starttls()
+        s.login(username, password)
+        _client = s
+
+    return _client
+
+
+def teardown():
+    global _client
+
+    _client.quit()
+
+
+def init_from_config():
+    global _username
+
+    config = get_config()
+
+    config = get_config()
+    smtp_secret_path = config['smtp']['secret_path']
+    smtp_config = vault_client.read_all(smtp_secret_path)
+    host = smtp_config['server']
+    port = smtp_config['port']
+    _username = smtp_config['username']
+    password = smtp_config['password']
+
+    return init(host, port, _username, password)
+
+
+def send_mail(name, subject, body):
+    global _client
+    global _username
+
+    msg = MIMEMultipart()
+    from_name = str(Header('App SRE team automation', 'utf-8'))
+    to = '{}@redhat.com'.format(name)
+    msg['From'] = formataddr((from_name, _username))
+    msg['To'] = to
+    msg['Subject'] = subject
+    
+    # add in the message body
+    msg.attach(MIMEText(body, 'plain'))
+    
+    # send the message via the server set up earlier.
+    _client.sendmail(_username, to, msg.as_string())
+
+
+def send_mails(mails):
+    global _client
+
+    init_from_config()
+    for name, subject, body in mails:
+        send_mail(name, subject, body)
+    teardown()

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -58,7 +58,7 @@ class TerraformClient(object):
         self.users = all_users
 
     def get_new_users(self):
-        new_users = []        
+        new_users = []
         for account, tf in self.tfs.items():
             existing_users = self.users[account]
             output = tf.output()
@@ -69,7 +69,8 @@ class TerraformClient(object):
             for user_name, enc_password in user_passwords.items():
                 if user_name in existing_users:
                     continue
-                new_users.append((account, console_urls[account], user_name, enc_password))
+                new_users.append((account, console_urls[account],
+                                  user_name, enc_password))
         return new_users
 
     def plan(self, enable_deletion):
@@ -151,6 +152,9 @@ class TerraformClient(object):
     def format_output(self, output, type):
         # data is a dictionary of dictionaries
         data = {}
+        if output is None:
+            return data
+
         enc_pass_pfx = '{}.{}'.format(
             self.integration_prefix, self.OUTPUT_TYPE_PASSWORDS)
         console_urls_pfx = '{}.{}'.format(

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -76,7 +76,10 @@ class TerrascriptClient(object):
             secrets[name] = secret
         return secrets
 
-    def populate(self, tf_query):
+    def populate_users(self, tf_query):
+        print(tf_query)
+
+    def populate_resources(self, tf_query):
         for namespace_info in tf_query:
             # Skip if namespace has no terraformResources
             tf_resources = namespace_info.get('terraformResources')

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -92,21 +92,24 @@ class TerrascriptClient(object):
                     groups[account_name] = {}
                 if group_name not in groups[account_name]:
                     # Ref: https://www.terraform.io/docs/providers/aws/r/iam_group.html
-                    resource = aws_iam_group(
+                    tf_iam_group = aws_iam_group(
                         group_name,
                         name=group_name
                     )
-                    self.add_resource(account_name, resource)
+                    self.add_resource(account_name, tf_iam_group)
                     for policy in group_policies:
                         # Ref: https://www.terraform.io/docs/providers/aws/r/iam_group_policy_attachment.html
                         # this may change in the near future to include inline policies
                         # and not only managed policies, as it is currently
-                        resource = aws_iam_group_policy_attachment(
-                            group_name + '-' + policy,
-                            group=group_name,
-                            policy_arn='arn:aws:iam::aws:policy/' + policy
-                        )
-                        self.add_resource(account_name, resource)
+                        tf_iam_group_policy_attachment = \
+                            aws_iam_group_policy_attachment(
+                                group_name + '-' + policy,
+                                group=group_name,
+                                policy_arn='arn:aws:iam::aws:policy/' + policy,
+                                depends_on=[tf_iam_group]
+                            )
+                        self.add_resource(account_name,
+                                          tf_iam_group_policy_attachment)
                     groups[account_name][group_name] = 'Done'
         return groups
 
@@ -115,9 +118,20 @@ class TerrascriptClient(object):
             aws_groups = role['aws_groups']
             users = role['users']
             for ig in range(len(aws_groups)):
+                group_name = aws_groups[ig]['name']
+                account_name = aws_groups[ig]['account']['name']
+                account_console_url = aws_groups[ig]['account']['consoleUrl']
+
+                # we want to include the console url in the outputs
+                # to be used later to generate the email invitations
+                output_name = '{}.console-urls[{}]'.format(
+                    self.integration_prefix, account_name
+                )
+                output_value = account_console_url
+                tf_output = output(output_name, value=output_value)
+                self.add_resource(account_name, tf_output)
+
                 for iu in range(len(users)):
-                    account_name = aws_groups[ig]['account']['name']
-                    group_name = aws_groups[ig]['name']
                     user_name = users[iu]['redhat_username']
                     user_public_gpg_key = users[iu]['public_gpg_key']
                     if user_public_gpg_key is None:
@@ -126,6 +140,7 @@ class TerrascriptClient(object):
                                 user_name)
                         logging.info(msg)
                         continue
+
                     # Ref: https://www.terraform.io/docs/providers/aws/r/iam_user.html
                     tf_iam_user = aws_iam_user(
                         user_name,
@@ -136,25 +151,30 @@ class TerrascriptClient(object):
                         }
                     )
                     self.add_resource(account_name, tf_iam_user)
+
                     # Ref: https://www.terraform.io/docs/providers/aws/r/iam_group_membership.html
                     tf_iam_user_group_membership = \
                         aws_iam_user_group_membership(
                             user_name + '-' + group_name,
                             user=user_name,
-                            groups=[group_name]
+                            groups=[group_name],
+                            depends_on=[tf_iam_user]
                         )
-                    # Ref: https://www.terraform.io/docs/providers/aws/r/iam_user_login_profile.html
                     self.add_resource(account_name, tf_iam_user_group_membership)
+
+                    # Ref: https://www.terraform.io/docs/providers/aws/r/iam_user_login_profile.html
                     tf_iam_user_login_profile = aws_iam_user_login_profile(
                         user_name,
                         user=user_name,
-                        pgp_key=base64.b64encode(user_public_gpg_key)
+                        pgp_key=user_public_gpg_key,
+                        depends_on=[tf_iam_user]
                     )
                     self.add_resource(account_name, tf_iam_user_login_profile)
+
                     # we want the outputs to be formed into a mail invitation
                     # for each new user. we form an output of the form
-                    # 'qrtf.enc-password[user_name] = <encrypted password>
-                    output_name = '{}.enc-password[{}]'.format(
+                    # 'qrtf.enc-passwords[user_name] = <encrypted password>
+                    output_name = '{}.enc-passwords[{}]'.format(
                         self.integration_prefix, user_name)
                     output_value = '${' + tf_iam_user_login_profile.fullname \
                         + '.encrypted_password}'

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -82,6 +82,10 @@ class TerrascriptClient(object):
     def populate_iam_groups(self, tf_query):
         groups = {}
         for role in tf_query:
+            users = role['users']
+            if len(users) == 0:
+                continue
+
             aws_groups = role['aws_groups']
             for aws_group in aws_groups:
                 group_name = aws_group['name']
@@ -91,16 +95,17 @@ class TerrascriptClient(object):
                 if account_name not in groups:
                     groups[account_name] = {}
                 if group_name not in groups[account_name]:
-                    # Ref: https://www.terraform.io/docs/providers/aws/r/iam_group.html
+                    # Ref: terraform aws iam_group
                     tf_iam_group = aws_iam_group(
                         group_name,
                         name=group_name
                     )
                     self.add_resource(account_name, tf_iam_group)
                     for policy in group_policies:
-                        # Ref: https://www.terraform.io/docs/providers/aws/r/iam_group_policy_attachment.html
-                        # this may change in the near future to include inline policies
-                        # and not only managed policies, as it is currently
+                        # Ref: terraform aws iam_group_policy_attachment
+                        # this may change in the near future
+                        # to include inline policies and not
+                        # only managed policies, as it is currently
                         tf_iam_group_policy_attachment = \
                             aws_iam_group_policy_attachment(
                                 group_name + '-' + policy,
@@ -115,8 +120,11 @@ class TerrascriptClient(object):
 
     def populate_iam_users(self, tf_query):
         for role in tf_query:
-            aws_groups = role['aws_groups']
             users = role['users']
+            if len(users) == 0:
+                continue
+
+            aws_groups = role['aws_groups']
             for ig in range(len(aws_groups)):
                 group_name = aws_groups[ig]['name']
                 account_name = aws_groups[ig]['account']['name']
@@ -133,26 +141,19 @@ class TerrascriptClient(object):
 
                 for iu in range(len(users)):
                     user_name = users[iu]['redhat_username']
-                    user_public_gpg_key = users[iu]['public_gpg_key']
-                    if user_public_gpg_key is None:
-                        msg = \
-                            'user {} does not have a public gpg key.'.format(
-                                user_name)
-                        logging.info(msg)
-                        continue
 
-                    # Ref: https://www.terraform.io/docs/providers/aws/r/iam_user.html
+                    # Ref: terraform aws iam_user
                     tf_iam_user = aws_iam_user(
                         user_name,
                         name=user_name,
                         force_destroy=True,
-                        tags = {
+                        tags={
                             'managed_by_integration': self.integration
                         }
                     )
                     self.add_resource(account_name, tf_iam_user)
 
-                    # Ref: https://www.terraform.io/docs/providers/aws/r/iam_group_membership.html
+                    # Ref: terraform aws iam_group_membership
                     tf_iam_user_group_membership = \
                         aws_iam_user_group_membership(
                             user_name + '-' + group_name,
@@ -160,9 +161,22 @@ class TerrascriptClient(object):
                             groups=[group_name],
                             depends_on=[tf_iam_user]
                         )
-                    self.add_resource(account_name, tf_iam_user_group_membership)
+                    self.add_resource(account_name,
+                                      tf_iam_user_group_membership)
 
-                    # Ref: https://www.terraform.io/docs/providers/aws/r/iam_user_login_profile.html
+                    # if user does not have a gpg key,
+                    # a password will not be created.
+                    # a gpg key may be added at a later time,
+                    # and a password will be generated
+                    user_public_gpg_key = users[iu]['public_gpg_key']
+                    if user_public_gpg_key is None:
+                        msg = \
+                            'user {} does not have a public gpg key ' + \
+                            'and will be created without a password.'.format(
+                                user_name)
+                        logging.warning(msg)
+                        continue
+                    # Ref: terraform aws iam_user_login_profile
                     tf_iam_user_login_profile = aws_iam_user_login_profile(
                         user_name,
                         user=user_name,


### PR DESCRIPTION
this PR adds support for management of users through app-interface.

high level flow:
* user submits a merge request to app-interface to be added to an aws group (via a role)
* terraform adds that group if it doesn't exist
* terraform associates the user to the group
* terraform issues a new password for the user
* integration encrypts the password with the user's public gpg key
* integration sends an invitation e-mail to the user with the required information

the integration will not send an invitation e-mail twice. if a user did not receive the invitation - we can just delete him and re-add him.