### PR TITLE
Clean up github api exception messages

### DIFF
--- a/utils/raw_github_api.py
+++ b/utils/raw_github_api.py
@@ -31,8 +31,7 @@ class RawGithubApi(object):
         try:
             res.raise_for_status()
         except Exception as e:
-            raise Exception("query: %s %s\n%s" %
-                            (self.BASE_URL + url, h, e.message))
+            raise Exception(e.message)
 
         result = res.json()
 
@@ -50,8 +49,7 @@ class RawGithubApi(object):
                     try:
                         res.raise_for_status()
                     except Exception as e:
-                        raise Exception("query: %s %s\n%s" %
-                                        (req_url, h, e.message))
+                        raise Exception(e.message)
 
                     for element in res.json():
                         elements.append(element)
@@ -64,8 +62,7 @@ class RawGithubApi(object):
                     try:
                         res.raise_for_status()
                     except Exception as e:
-                        raise Exception("query: %s %s\n%s" %
-                                        (req_url, h, e.message))
+                        raise Exception(e.message)
 
                     for element in res.json():
                         elements.append(element)


### PR DESCRIPTION
This cleans up the exception messages such that
1) Headers are not printed anymore (would expose Authorization token)
2) request URL is not printed anymore - it is already included in Requests exception messages

It would also be possible to sanitize the headers before printing them but this seemed a bit pointless as we only have 2 headers: Authorization and Accept which don't need to be shown on exceptions really.