### PR TITLE
add group dependency to group membership

### DIFF
--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -27,7 +27,7 @@ TF_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'terraform_users'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 1)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -179,12 +179,16 @@ class TerrascriptClient(object):
                     self.add_resource(account_name, tf_iam_user)
 
                     # Ref: terraform aws iam_group_membership
+                    tf_iam_group = aws_iam_group(
+                        group_name,
+                        name=group_name
+                    )
                     tf_iam_user_group_membership = \
                         aws_iam_user_group_membership(
                             user_name + '-' + group_name,
                             user=user_name,
                             groups=[group_name],
-                            depends_on=[tf_iam_user]
+                            depends_on=[tf_iam_user, tf_iam_group]
                         )
                     self.add_resource(account_name,
                                       tf_iam_user_group_membership)


### PR DESCRIPTION
This is to avoid cases such as:
```
aws_iam_user_group_membership.username-groupname: NoSuchEntity: The group with name groupname cannot be found.
```
This is a result of a race condition between the group creation and the group membership creation.

This is a quick fix, and a refactor will probably be required as we move forward.