### PR TITLE
link terraform integrations to aws-gc

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@ build
 .pytest_cache
 .tox
 venv
+throughput
 
 **/__pycache__
 **/*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 build
 dist
 venv
+throughput

--- a/reconcile/aws_garbage_collector.py
+++ b/reconcile/aws_garbage_collector.py
@@ -1,7 +1,8 @@
 from utils.aws_api import AWSApi
 
 
-def run(dry_run=False, thread_pool_size=10, enable_deletion=False, io_dir='throughput/'):
+def run(dry_run=False, thread_pool_size=10,
+        enable_deletion=False, io_dir='throughput/'):
     aws = AWSApi(thread_pool_size)
     if dry_run:
         aws.simulate_deleted_users(io_dir)

--- a/reconcile/aws_garbage_collector.py
+++ b/reconcile/aws_garbage_collector.py
@@ -1,7 +1,9 @@
 from utils.aws_api import AWSApi
 
 
-def run(dry_run=False, thread_pool_size=10, enable_deletion=False):
+def run(dry_run=False, thread_pool_size=10, enable_deletion=False, io_dir='throughput/'):
     aws = AWSApi(thread_pool_size)
+    if dry_run:
+        aws.simulate_deleted_users(io_dir)
     aws.map_resources()
     aws.delete_resources_without_owner(dry_run, enable_deletion)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -40,6 +40,14 @@ def terraform(function):
     return function
 
 
+def throughput(function):
+    function = click.option('--io-dir',
+                            help='directory of input/output files.',
+                            default='throughput/')(function)
+
+    return function
+
+
 def enable_deletion(**kwargs):
     def f(function):
         opt = '--enable-deletion/--no-enable-deletion'
@@ -119,12 +127,13 @@ def jenkins_plugins(ctx):
 
 
 @integration.command()
+@throughput
 @threaded
 @enable_deletion(default=False)
 @click.pass_context
-def aws_garbage_collector(ctx, thread_pool_size, enable_deletion):
+def aws_garbage_collector(ctx, thread_pool_size, enable_deletion, io_dir):
     run_integration(reconcile.aws_garbage_collector.run, ctx.obj['dry_run'],
-                    thread_pool_size, enable_deletion)
+                    thread_pool_size, enable_deletion, io_dir)
 
 
 @integration.command()
@@ -184,29 +193,32 @@ def openshift_resources_annotate(ctx, cluster, namespace, kind, name):
 
 @integration.command()
 @terraform
+@throughput
 @threaded
 @enable_deletion(default=False)
 @click.pass_context
-def terraform_resources(ctx, print_only, enable_deletion, thread_pool_size):
+def terraform_resources(ctx, print_only, enable_deletion,
+                        io_dir, thread_pool_size):
     run_integration(reconcile.terraform_resources.run,
                     ctx.obj['dry_run'], print_only,
-                    enable_deletion, thread_pool_size)
+                    enable_deletion, io_dir, thread_pool_size)
 
 
 @integration.command()
 @terraform
+@throughput
 @threaded
 @enable_deletion(default=True)
 @click.option('--send-mails/--no-send-mails',
               default=True,
               help='send email invitation to new users.')
 @click.pass_context
-def terraform_users(ctx, print_only, enable_deletion,
+def terraform_users(ctx, print_only, enable_deletion, io_dir,
                     thread_pool_size, send_mails):
     run_integration(reconcile.terraform_users.run,
                     ctx.obj['dry_run'], print_only,
-                    enable_deletion, thread_pool_size,
-                    send_mails)
+                    enable_deletion, io_dir,
+                    thread_pool_size, send_mails)
 
 
 @integration.command()

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -118,7 +118,8 @@ def cleanup_and_exit(tf=None, status=False):
 
 
 def run(dry_run=False, print_only=False,
-        enable_deletion=False, thread_pool_size=10):
+        enable_deletion=False, io_dir='throughput/',
+        thread_pool_size=10):
     ri, oc_map, working_dirs = setup(print_only, thread_pool_size)
     if print_only:
         cleanup_and_exit()
@@ -135,8 +136,11 @@ def run(dry_run=False, print_only=False,
     deletions_detected, err = tf.plan(enable_deletion)
     if err:
         cleanup_and_exit(tf, err)
-    if deletions_detected and not enable_deletion:
-        cleanup_and_exit(tf, deletions_detected)
+    if deletions_detected:
+        if enable_deletion:
+            tf.dump_deleted_users(io_dir)
+        else:
+            cleanup_and_exit(tf, deletions_detected)
 
     if dry_run:
         cleanup_and_exit(tf)

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -98,8 +98,8 @@ def cleanup_and_exit(tf=None, status=False):
 
 
 def run(dry_run=False, print_only=False,
-        enable_deletion=False, thread_pool_size=10,
-        send_mails=True):
+        enable_deletion=False, io_dir='throughput/',
+        thread_pool_size=10, send_mails=True):
     working_dirs, err = setup(print_only, thread_pool_size)
     if err:
         cleanup_and_exit(status=err)
@@ -119,8 +119,11 @@ def run(dry_run=False, print_only=False,
     deletions_detected, err = tf.plan(enable_deletion)
     if err:
         cleanup_and_exit(tf, err)
-    if deletions_detected and not enable_deletion:
-        cleanup_and_exit(tf, deletions_detected)
+    if deletions_detected:
+        if enable_deletion:
+            tf.dump_deleted_users(io_dir)
+        else:
+            cleanup_and_exit(tf, deletions_detected)
 
     if dry_run:
         cleanup_and_exit(tf)

--- a/utils/aws_api.py
+++ b/utils/aws_api.py
@@ -1,6 +1,8 @@
 import logging
 import boto3
 import botocore
+import json
+import os
 
 import utils.vault_client as vault_client
 
@@ -58,6 +60,21 @@ class AWSApi(object):
             iam = s.client('iam')
             users = [u['UserName'] for u in iam.list_users()['Users']]
             self.users[account] = users
+
+    def simulate_deleted_users(self, io_dir):
+        src_integrations = ['terraform_resources', 'terraform_users']
+        if not os.path.exists(io_dir):
+            return
+        for i in src_integrations:
+            file_path = os.path.join(io_dir, i + '.json')
+            if not os.path.exists(file_path):
+                continue
+            with open(file_path, 'r') as f:  
+                deleted_users = json.load(f)
+            for deleted_user in deleted_users:
+                delete_from_account = deleted_user['account']
+                delete_user = deleted_user['user']
+                self.users[delete_from_account].remove(delete_user)
 
     def map_resources(self):
         self.resources = {}

--- a/utils/aws_api.py
+++ b/utils/aws_api.py
@@ -69,7 +69,7 @@ class AWSApi(object):
             file_path = os.path.join(io_dir, i + '.json')
             if not os.path.exists(file_path):
                 continue
-            with open(file_path, 'r') as f:  
+            with open(file_path, 'r') as f:
                 deleted_users = json.load(f)
             for deleted_user in deleted_users:
                 delete_from_account = deleted_user['account']

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -117,7 +117,7 @@ class TerraformClient(object):
             os.makedirs(io_dir)
         file_path = os.path.join(io_dir, self.integration + '.json')
         with open(file_path, 'w') as f:
-            f.write(json.dumps(self.deleted_users)) 
+            f.write(json.dumps(self.deleted_users))
 
     def init_plan_apply_specs(self):
         return [{'name': name, 'tf': tf} for name, tf in self.tfs.items()]


### PR DESCRIPTION
this PR does:
* `terraform-uesrs` and `terraform-resources` will output a file with users who are to be deleted.
* `aws-garbage-collector` will pick up those outputs (if running in dry_run only) and act as if these users do not exist.

the purpose is to have a clear view of what resources are going to be deleted when removing a user. instead of waiting for the next run and possibly losing needed resources.

this means that the `aws-gc` integration should run after both terraform integrations are complete.