### PR TITLE
Catch vault secrets not found and raise useful exception

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -263,9 +263,12 @@ def fetch_openshift_resource(resource):
         annotations = {} if ra is None else json.loads(ra)
         rt = resource['type']
         type = 'Opaque' if rt is None else rt
-        openshift_resource = \
-            fetch_provider_vault_secret(path, version, name,
-                                        labels, annotations, type)
+        try:
+            openshift_resource = \
+                fetch_provider_vault_secret(path, version, name,
+                                            labels, annotations, type)
+        except vault_client.SecretVersionNotFound as e:
+            raise FetchVaultSecretError(e)
     elif provider == 'route':
         tls_path = resource['vault_tls_secret_path']
         tls_version = resource['vault_tls_secret_version']


### PR DESCRIPTION
Currently if a vault secret and/or secret version is not found, the integration will show the following exception and fail the integration

```
Traceback (most recent call last):
  File "/usr/bin/qontract-reconcile", line 11, in <module>
    load_entry_point('reconcile==0.1.0', 'console_scripts', 'qontract-reconcile')()
  File "/usr/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/reconcile-0.1.0-py2.7.egg/reconcile/cli.py", line 143, in openshift_resources
    ctx.obj['dry_run'], thread_pool_size)
  File "/usr/lib/python2.7/site-packages/reconcile-0.1.0-py2.7.egg/reconcile/cli.py", line 56, in run_integration
    func(*args)
  File "/usr/lib/python2.7/site-packages/reconcile-0.1.0-py2.7.egg/reconcile/openshift_resources.py", line 499, in run
    oc_map, ri = fetch_data(namespaces_query, thread_pool_size)
  File "/usr/lib/python2.7/site-packages/reconcile-0.1.0-py2.7.egg/reconcile/openshift_resources.py", line 403, in fetch_data
    pool.map(fetch_states_partial, state_specs)
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 250, in map
    return self.map_async(func, iterable, chunksize).get()
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 554, in get
    raise self._value
utils.vault_client.SecretVersionNotFound: version '11' not found for secret with path 'the/secrets/path'.
```

The exception itself doesn't help determine what cluster and namespace this was defined under.

This change adds a try/except so that an error is shown instead. **The integration also continues.**

```
ERROR: [cluster_name/namespace_name] error fetching vault secret: version '11' not found for secret with path 'the/secrets/path'.
```