### PR TITLE
[terraform-resources] introduce ouput_resource_name field

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -23,12 +23,14 @@ TF_QUERY = """
         identifier
         defaults
         overrides
+        output_resource_name
       }
       ... on NamespaceTerraformResourceS3_v1 {
         account
         identifier
         defaults
         overrides
+        output_resource_name
       }
     }
     cluster {
@@ -45,7 +47,7 @@ TF_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'terraform_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 2, 4)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 3, 0)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -210,7 +210,8 @@ class TerraformClient(object):
 
             for name, data in formatted_output.items():
                 cluster = data['{}.cluster'.format(self.integration_prefix)]
-                namespace = data['{}.namespace'.format(self.integration_prefix)]
+                namespace = \
+                    data['{}.namespace'.format(self.integration_prefix)]
                 resource = data['{}.resource'.format(self.integration_prefix)]
                 output_resource_name = data['{}.output_resource_name'.format(
                     self.integration_prefix)]

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -209,12 +209,18 @@ class TerraformClient(object):
                 output, self.OUTPUT_TYPE_SECRETS)
 
             for name, data in formatted_output.items():
-                oc_resource = self.construct_oc_resource(name, data)
+                cluster = data['{}.cluster'.format(self.integration_prefix)]
+                namespace = data['{}.namespace'.format(self.integration_prefix)]
+                resource = data['{}.resource'.format(self.integration_prefix)]
+                output_resource_name = data['{}.output_resource_name'.format(
+                    self.integration_prefix)]
+                oc_resource = \
+                    self.construct_oc_resource(output_resource_name, data)
                 ri.add_desired(
-                    data['{}.cluster'.format(self.integration_prefix)],
-                    data['{}.namespace'.format(self.integration_prefix)],
-                    data['{}.resource'.format(self.integration_prefix)],
-                    name,
+                    cluster,
+                    namespace,
+                    resource,
+                    output_resource_name,
                     oc_resource
                 )
 


### PR DESCRIPTION
this PR adds the ability to define `output_resource_name` to explicitly define what will be the name of the generated OpenShift resource (Secret in this case).

this will add the ability to define the same output resource name in different namespaces, allowing for simpler templating.