### PR TITLE
[terraform-resources] take subnet and security group from app-interface

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -47,7 +47,7 @@ TF_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'terraform_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 3, 0)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 3, 1)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -317,14 +317,6 @@ class TerrascriptClient(object):
 
         # rds instance
         # Ref: https://www.terraform.io/docs/providers/aws/r/db_instance.html
-        try:
-            variables = self.variables[account]
-            values['db_subnet_group_name'] = variables['rds-subnet-group']
-            values['vpc_security_group_ids'] = \
-                variables['rds-security-groups'].split(',')
-        except KeyError as e:
-            logging.error("could not get an account variable: " + e.msg)
-            return
         values['password'] = \
             self.determine_rds_db_password(namespace_info,
                                            output_resource_name)


### PR DESCRIPTION
these variables are moved out of vault and into app-interface:

* db_subnet_group_name
* vpc_security_group_ids