### PR TITLE
[slack-usergroups] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Tool to reconcile services with their desired state as defined in the app-interf
 - `qontract-reconcile jenkins-plugins`: Manage Jenkins plugins installation via REST API.
 - `qontract-reconcile aws-garbage-collector`: Delete orphan AWS resources.
 - `qontract-reconcile aws-iam-keys`: Delete IAM access keys by access key ID.
+- `qontract-reconcile slack-usergroups`: Manage Slack User Groups (channels and users).
 
 ## Usage
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -18,6 +18,7 @@ import reconcile.terraform_users
 import reconcile.github_repo_invites
 import reconcile.jenkins_roles
 import reconcile.jenkins_plugins
+import reconcile.slack_usergroups
 import reconcile.aws_garbage_collector
 import reconcile.aws_iam_keys
 
@@ -124,6 +125,12 @@ def jenkins_roles(ctx):
 @click.pass_context
 def jenkins_plugins(ctx):
     run_integration(reconcile.jenkins_plugins.run, ctx.obj['dry_run'])
+
+
+@integration.command()
+@click.pass_context
+def slack_usergroups(ctx):
+    run_integration(reconcile.slack_usergroups.run, ctx.obj['dry_run'])
 
 
 @integration.command()

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -63,7 +63,7 @@ def get_slack_map():
 
         workspace_spec = {
             "slack": SlackApi(workspace['token']),
-            "manged_usergroups": workspace['managedUsergroups']
+            "managed_usergroups": workspace['managedUsergroups']
         }
         slack_map[workspace_name] = workspace_spec
 
@@ -75,7 +75,7 @@ def get_current_state(slack_map):
 
     for workspace, spec in slack_map.items():
         slack = spec['slack']
-        managed_usergroups = spec['manged_usergroups']
+        managed_usergroups = spec['managed_usergroups']
         for ug in managed_usergroups:
             users, channels = slack.describe_usergroup(ug)
             current_state.append({

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -175,8 +175,8 @@ def act(desired_state, slack_map):
     for state in desired_state:
         workspace = state['workspace']
         ugid = state['usergroup_id']
-        users = ','.join(state['users'].keys())
-        channels = ','.join(state['channels'].keys())
+        users = state['users'].keys()
+        channels = state['channels'].keys()
         slack = slack_map[workspace]['slack']
         slack.update_usergroup_users(ugid, users)
         slack.update_usergroup_channels(ugid, channels)

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -1,0 +1,193 @@
+import logging
+
+import utils.gql as gql
+
+from utils.slack_api import SlackApi
+
+
+PERMISSIONS_QUERY = """
+{
+  permissions: permissions_v1 {
+    service
+    ...on PermissionSlackUsergroup_v1 {
+      handle
+      workspace {
+        name
+        token {
+          path
+          field
+        }
+        managedUsergroups
+      }
+    }
+  }
+}
+"""
+
+ROLES_QUERY = """
+{
+  roles: roles_v1 {
+    name
+    users {
+      slack_username
+    }
+    permissions {
+      service
+      ...on PermissionSlackUsergroup_v1 {
+        handle
+        workspace {
+          name
+          managedUsergroups
+        }
+        channels
+      }
+    }
+  }
+}
+"""
+
+
+def get_slack_map():
+    gqlapi = gql.get_api()
+    permissions = gqlapi.query(PERMISSIONS_QUERY)['permissions']
+
+    slack_permissions = \
+        [p for p in permissions if p['service'] == 'slack-usergroup']
+
+    slack_map = {}
+    for sp in slack_permissions:
+        workspace = sp['workspace']
+        workspace_name = workspace['name']
+        if workspace_name in slack_map:
+            continue
+
+        workspace_spec = {
+            "slack": SlackApi(workspace['token']),
+            "manged_usergroups": workspace['managedUsergroups']
+        }
+        slack_map[workspace_name] = workspace_spec
+
+    return slack_map
+
+
+def get_current_state(slack_map):
+    current_state = []
+
+    for workspace, spec in slack_map.items():
+        slack = spec['slack']
+        managed_usergroups = spec['manged_usergroups']
+        for ug in managed_usergroups:
+            users, channels = slack.describe_usergroup(ug)
+            current_state.append({
+                "workspace": workspace,
+                "usergroup": ug,
+                "users": users,
+                "channels": channels,
+            })
+
+    return current_state
+
+
+def get_desired_state(slack_map):
+    gqlapi = gql.get_api()
+    roles = gqlapi.query(ROLES_QUERY)['roles']
+
+    desired_state = []
+    for r in roles:
+        for p in r['permissions']:
+            if p['service'] != 'slack-usergroup':
+                continue
+
+            workspace = p['workspace']
+            managed_usergroups = workspace['managedUsergroups']
+            if managed_usergroups is None:
+                continue
+
+            workspace_name = workspace['name']
+            usergroup = p['handle']
+            if usergroup not in managed_usergroups:
+                logging.warning(
+                    '[{}] usergroup {} not in managed usergroups {}'.format(
+                        workspace_name,
+                        usergroup,
+                        managed_usergroups
+                    ))
+                continue
+
+            slack = slack_map[workspace_name]['slack']
+            ugid = slack.get_usergroup_id(usergroup)
+            users_names = [u['slack_username'] for u in r['users']]
+            users = slack.get_users_by_names(users_names)
+
+            channel_names = [] if p['channels'] is None else p['channels']
+            channels = slack.get_channels_by_names(channel_names)
+
+            desired_state.append({
+                "workspace": workspace_name,
+                "usergroup": usergroup,
+                "usergroup_id": ugid,
+                "users": users,
+                "channels": channels,
+            })
+
+    return desired_state
+
+
+def print_diff(current_state, desired_state):
+    for d_state in desired_state:
+        workspace = d_state['workspace']
+        usergroup = d_state['usergroup']
+        c_state = [c for c in current_state
+                   if c['workspace'] == workspace
+                   and c['usergroup'] == usergroup]
+        # at this point we have a single current state item
+        # thanks to the logic in get_desired_state
+        [c_state] = c_state
+
+        channels_to_add = subtract_state(d_state, c_state, 'channels')
+        for c in channels_to_add:
+            logging.info(['add_channel_to_usergroup',
+                          workspace, usergroup, c])
+
+        channels_to_del = subtract_state(c_state, d_state, 'channels')
+        for c in channels_to_del:
+            logging.info(['del_channel_from_usergroup',
+                          workspace, usergroup, c])
+
+        users_to_add = subtract_state(d_state, c_state, 'users')
+        for u in users_to_add:
+            logging.info(['add_user_to_usergroup',
+                          workspace, usergroup, u])
+
+        users_to_del = subtract_state(c_state, d_state, 'users')
+        for u in users_to_del:
+            logging.info(['del_user_from_usergroup',
+                          workspace, usergroup, u])
+
+
+def subtract_state(from_state, subtract_state, type):
+    f = from_state[type]
+    s = subtract_state[type]
+    return [v for k, v in f.items() if k not in s.keys()]
+
+
+def act(desired_state, slack_map):
+    for state in desired_state:
+        workspace = state['workspace']
+        ugid = state['usergroup_id']
+        users = ','.join(state['users'].keys())
+        channels = ','.join(state['channels'].keys())
+        slack = slack_map[workspace]['slack']
+        slack.update_usergroup_users(ugid, users)
+        slack.update_usergroup_channels(ugid, channels)
+
+
+def run(dry_run=False):
+    slack_map = get_slack_map()
+    current_state = get_current_state(slack_map)
+    desired_state = get_desired_state(slack_map)
+
+    print_diff(current_state, desired_state)
+
+    if not dry_run:
+        act(desired_state, slack_map)

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "boto3>=1.9.0,<=1.10.0",
         "botocore>=1.12.159,<=1.13.0",
         "urllib3>=1.21.1,<1.25.0",
+        "slackclient>=1.3.2,<1.4.0",
     ],
 
     test_suite="tests",

--- a/utils/slack_api.py
+++ b/utils/slack_api.py
@@ -1,0 +1,108 @@
+import time
+
+from slackclient import SlackClient
+
+import utils.vault_client as vault_client
+
+
+class UsergroupNotFoundException(Exception):
+    pass
+
+
+class SlackApi(object):
+    """Wrapper around Slack API calls"""
+
+    def __init__(self, token):
+        token_path = token['path']
+        token_field = token['field']
+        token = vault_client.read(token_path, token_field)
+        self.sc = SlackClient(token)
+        self.results = {}
+
+    def describe_usergroup(self, handle):
+        usergroup = self.get_usergroup(handle)
+        usergroup_id = usergroup['id']
+
+        users_ids = self.get_usergroup_users(usergroup_id)
+        users = self.get_users_by_ids(users_ids)
+
+        channels_ids = usergroup['prefs']['channels']
+        channels = self.get_channels_by_ids(channels_ids)
+
+        return users, channels
+
+    def get_usergroup_id(self, handle):
+        usergroup = self.get_usergroup(handle)
+        return usergroup['id']
+
+    def get_usergroup(self, handle):
+        result = self.sc.api_call(
+            "usergroups.list",
+        )
+        usergroup = [g for g in result['usergroups'] if g['handle'] == handle]
+        if len(usergroup) != 1:
+            raise UsergroupNotFoundException(handle)
+        [usergroup] = usergroup
+        return usergroup
+
+    def update_usergroup_channels(self, id, channels):
+        self.sc.api_call(
+            "usergroups.update",
+            usergroup=id,
+            channels=channels,
+        )
+
+    def get_usergroup_users(self, id):
+        self.sc.api_call(
+            "usergroups.users.list",
+            usergroup=id,
+        )
+
+    def update_usergroup_users(self, id, users):
+        result = self.sc.api_call(
+            "usergroups.users.update",
+            usergroup=id,
+            users=users,
+        )
+        return result
+
+    def get_channels_by_names(self, channels_names):
+        return {k: v for k, v in self.get('channels').items()
+                if v in channels_names}
+
+    def get_channels_by_ids(self, channels_ids):
+        return {k: v for k, v in self.get('channels').items()
+                if k in channels_ids}
+
+    def get_users_by_names(self, users_names):
+        return {k: v for k, v in self.get('users').items()
+                if v in users_names}
+
+    def get_users_by_ids(self, users_ids):
+        return {k: v for k, v in self.get('users').items()
+                if k in users_ids}
+
+    def get(self, type):
+        result_key = 'members' if type == 'users' else type
+        results = {}
+        cursor = ''
+
+        if type in self.results:
+            return self.results[type]
+
+        while True:
+            result = self.sc.api_call(
+                "{}.list".format(type),
+                cursor=cursor
+            )
+            if 'error' in result and result['error'] == 'ratelimited':
+                time.sleep(1)
+                continue
+            for r in result[result_key]:
+                results[r['id']] = r['name']
+            cursor = result['response_metadata']['next_cursor']
+            if cursor == '':
+                break
+
+        self.results[type] = results
+        return results

--- a/utils/slack_api.py
+++ b/utils/slack_api.py
@@ -45,7 +45,8 @@ class SlackApi(object):
         [usergroup] = usergroup
         return usergroup
 
-    def update_usergroup_channels(self, id, channels):
+    def update_usergroup_channels(self, id, channels_list):
+        channels = ','.join(channels_list)
         self.sc.api_call(
             "usergroups.update",
             usergroup=id,
@@ -53,18 +54,19 @@ class SlackApi(object):
         )
 
     def get_usergroup_users(self, id):
-        self.sc.api_call(
+        result = self.sc.api_call(
             "usergroups.users.list",
             usergroup=id,
         )
+        return result['users']
 
-    def update_usergroup_users(self, id, users):
-        result = self.sc.api_call(
+    def update_usergroup_users(self, id, users_list):
+        users = ','.join(users_list)
+        self.sc.api_call(
             "usergroups.users.update",
             usergroup=id,
             users=users,
         )
-        return result
 
     def get_channels_by_names(self, channels_names):
         return {k: v for k, v in self.get('channels').items()


### PR DESCRIPTION
this integration does:

* reconciles channels for user groups
* reconciles users for user groups

this integration does not:

* create user groups/channels/users
* add/remove users from channels

by using the a user group, members will be added automatically to newly added channels, so the order will be first to update channels and only then to update users.