### PR TITLE
[slack-usergroups] add support for PagerDuty as additional source of truth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "botocore>=1.12.159,<=1.13.0",
         "urllib3>=1.21.1,<1.25.0",
         "slackclient>=1.3.2,<1.4.0",
+        "pypd>=1.1.0,<1.2.0",
     ],
 
     test_suite="tests",

--- a/utils/pagerduty_api.py
+++ b/utils/pagerduty_api.py
@@ -1,8 +1,6 @@
-import time
 import pypd
 import datetime
-
-from slackclient import SlackClient
+import requests
 
 import utils.vault_client as vault_client
 
@@ -24,7 +22,7 @@ class PagerDutyApi(object):
                 since=now,
                 until=now,
                 time_zone='UTC')
-        except requests.exceptions.HTTPError as e:
+        except requests.exceptions.HTTPError:
             return None
 
         entries = schedule['final_schedule']['rendered_schedule_entries']

--- a/utils/pagerduty_api.py
+++ b/utils/pagerduty_api.py
@@ -18,19 +18,18 @@ class PagerDutyApi(object):
 
     def get_final_schedule(self, schedule_id):
         now = datetime.datetime.now().strftime("%Y-%m-%d")
-        schedule = pypd.Schedule.fetch(
-            id=schedule_id,
-            since=now,
-            until=now,
-            time_zone='UTC')
+        try:
+            schedule = pypd.Schedule.fetch(
+                id=schedule_id,
+                since=now,
+                until=now,
+                time_zone='UTC')
+        except requests.exceptions.HTTPError as e:
+            return None
+
         entries = schedule['final_schedule']['rendered_schedule_entries']
         if len(entries) != 1:
             return None
-        [entry] = entries
 
-        user_id = entry['user']['id']
-        users = pypd.User.find()
-        user = [u for u in users if u['id'] == user_id]
-        [user] = user
-        redhat_username = user['email'].replace('@redhat.com', '')
-        print(redhat_username)
+        [entry] = entries
+        return entry['user']['summary']

--- a/utils/pagerduty_api.py
+++ b/utils/pagerduty_api.py
@@ -1,0 +1,36 @@
+import time
+import pypd
+import datetime
+
+from slackclient import SlackClient
+
+import utils.vault_client as vault_client
+
+
+class PagerDutyApi(object):
+    """Wrapper around PagerDuty API calls"""
+
+    def __init__(self, token):
+        token_path = token['path']
+        token_field = token['field']
+        pd_api_key = vault_client.read(token_path, token_field)
+        pypd.api_key = pd_api_key
+
+    def get_final_schedule(self, schedule_id):
+        now = datetime.datetime.now().strftime("%Y-%m-%d")
+        schedule = pypd.Schedule.fetch(
+            id=schedule_id,
+            since=now,
+            until=now,
+            time_zone='UTC')
+        entries = schedule['final_schedule']['rendered_schedule_entries']
+        if len(entries) != 1:
+            return None
+        [entry] = entries
+
+        user_id = entry['user']['id']
+        users = pypd.User.find()
+        user = [u for u in users if u['id'] == user_id]
+        [user] = user
+        redhat_username = user['email'].replace('@redhat.com', '')
+        print(redhat_username)


### PR DESCRIPTION
this PR adds the ability to link a slack user group to a pagerduty schedule.
it is still possible to use the role + permission, so if anyone wants to always be in a group regardless of pagerduty, it is possible.