### PR TITLE
[openshift-rolebinding] add user existence check before acting

### DIFF
--- a/reconcile/openshift_rolebinding.py
+++ b/reconcile/openshift_rolebinding.py
@@ -245,7 +245,6 @@ class RunnerAction(object):
                             ))
                         continue
 
-
                 if not self.dry_run:
                     f = getattr(api, method_name)
                     try:

--- a/reconcile/openshift_rolebinding.py
+++ b/reconcile/openshift_rolebinding.py
@@ -219,8 +219,7 @@ class RunnerAction(object):
             role = params['role']
             kind = params['kind']
 
-            if not self.dry_run:
-                api = self.cluster_store.api(cluster)
+            api = self.cluster_store.api(cluster)
 
             for member in items:
                 logging.info([
@@ -231,6 +230,21 @@ class RunnerAction(object):
                     kind,
                     member
                 ])
+                if kind == 'User':
+                    try:
+                        api.get_user(member)
+                    except Exception as e:
+                        logging.warning(
+                            'user {} not found in cluster {}, '
+                            'skipping user. '
+                            'has user signed in for the first time? '
+                            '({})'.format(
+                                member,
+                                cluster,
+                                e.message
+                            ))
+                        continue
+
 
                 if not self.dry_run:
                     f = getattr(api, method_name)


### PR DESCRIPTION
in case user is not found in the cluster, the attempt to add a role to them will result in a 400 HTTP status code.
this PR checks that the user exists before attempting to add a role to them.
if user is not found, it is likely that they had not yet logged in to the cluster for the first time.

since we do not want our integrations to depend on user sign in, we log a warning and continue.