### PR TITLE
[terraform-resources] do not depend solely on openshift secret

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -416,7 +416,16 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource):
         oc_map[cluster].apply(namespace, annotated.toJSON())
 
 
-def delete(dry_run, oc_map, cluster, namespace, resource_type, name):
+def delete(dry_run, oc_map, cluster, namespace, resource_type, name,
+           enable_deletion):
+    # this section is only relevant for the terraform integrations
+    if not enable_deletion:
+        logging.error(['delete', cluster, namespace, resource_type, name])
+        logging.error('\'delete\' action is not enabled. ' +
+                      'Please run the integration manually ' +
+                      'with the \'--enable-deletion\' flag.')
+        return
+        
     logging.info(['delete', cluster, namespace, resource_type, name])
 
     if not dry_run:
@@ -481,14 +490,8 @@ def realize_data(dry_run, oc_map, ri, enable_deletion=True):
                 continue
 
             try:
-                if enable_deletion:
-                    delete(dry_run, oc_map, cluster, namespace,
-                           resource_type, name)
-                # this section is only relevant for the terraform integrations
-                else:
-                    logging.error('\'delete\' action is not enabled. ' +
-                                  'Please run the integration manually ' +
-                                  'with the \'--enable-deletion\' flag.')
+                delete(dry_run, oc_map, cluster, namespace,
+                       resource_type, name, enable_deletion)
             except StatusCodeError as e:
                 ri.register_error()
                 msg = "[{}/{}] {}".format(cluster, namespace, e.message)

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -425,7 +425,7 @@ def delete(dry_run, oc_map, cluster, namespace, resource_type, name,
                       'Please run the integration manually ' +
                       'with the \'--enable-deletion\' flag.')
         return
-        
+
     logging.info(['delete', cluster, namespace, resource_type, name])
 
     if not dry_run:

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -34,7 +34,7 @@ TF_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'terraform_users'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 3, 2)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 3, 3)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -202,6 +202,15 @@ class TerraformClient(object):
         error = self.check_output(name, return_code, stdout, stderr)
         return error
 
+    def get_terraform_output_secrets(self):
+        data = {}
+        for account, tf in self.tfs.items():
+            output = tf.output()
+            data[account] = \
+                self.format_output(output, self.OUTPUT_TYPE_SECRETS)
+
+        return data
+
     def populate_desired_state(self, ri):
         for name, tf in self.tfs.items():
             output = tf.output()


### PR DESCRIPTION
when the terraform-resources integration attempts to create a resource, it constructs the terraform configuration according to the definitions in app-interface. one of the configurations is the desired password for RDS instances.

since the terraform-resources integration generates secrets in openshift, the integration relied on those secrets to obtain the current password from the output openshift secret, so that the password of the RDS instance will not be changed.

this PR changes the behavior to obtain the password from the last applied terraform configuration using `terraform output`. in case the secrets are deleted from openshift, the integration will recover in the next run without any changes to existing infrastructure.

important to note that in case a matching output is not found in the last applied terraform configuration, the integration will still attempt to obtain the password from an openshift secret, in order to allow importing of existing RDS instances into app-interface.