### PR TITLE
[gitlab-permissions] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Tool to reconcile services with their desired state as defined in the app-interf
 - `qontract-reconcile aws-garbage-collector`: Delete orphan AWS resources.
 - `qontract-reconcile aws-iam-keys`: Delete IAM access keys by access key ID.
 - `qontract-reconcile slack-usergroups`: Manage Slack User Groups (channels and users).
+- `qontract-reconcile gitlab-permissions`: Manage permissions on GitLab projects.
 
 ## Usage
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -19,6 +19,7 @@ import reconcile.github_repo_invites
 import reconcile.jenkins_roles
 import reconcile.jenkins_plugins
 import reconcile.slack_usergroups
+import reconcile.gitlab_permissions
 import reconcile.aws_garbage_collector
 import reconcile.aws_iam_keys
 
@@ -131,6 +132,12 @@ def jenkins_plugins(ctx):
 @click.pass_context
 def slack_usergroups(ctx):
     run_integration(reconcile.slack_usergroups.run, ctx.obj['dry_run'])
+
+
+@integration.command()
+@click.pass_context
+def gitlab_permissions(ctx):
+    run_integration(reconcile.gitlab_permissions.run, ctx.obj['dry_run'])
 
 
 @integration.command()

--- a/reconcile/gitlab_permissions.py
+++ b/reconcile/gitlab_permissions.py
@@ -1,0 +1,51 @@
+import logging
+
+import utils.gql as gql
+from utils.config import get_config
+from utils.gitlab_api import GitLabApi
+
+
+APPS_QUERY = """
+{
+  apps: apps_v1 {
+    codeComponents {
+        url
+    }
+  }
+}
+"""
+
+
+def get_gitlab_repos(server):
+    gqlapi = gql.get_api()
+    apps = gqlapi.query(APPS_QUERY)['apps']
+
+    code_components_lists = [a['codeComponents'] for a in apps
+                             if a['codeComponents'] is not None]
+    code_components = [item for sublist in code_components_lists
+                       for item in sublist]
+    repos = [c['url'] for c in code_components if c['url'].startswith(server)]
+
+    return repos
+
+
+def get_gitlab_api():
+    config = get_config()
+
+    gitlab_config = config['gitlab']
+    server = gitlab_config['server']
+    token = gitlab_config['token']
+
+    return GitLabApi(server, token, ssl_verify=False)
+
+
+def run(dry_run=False):
+    gl = get_gitlab_api()
+    repos = get_gitlab_repos(gl.server)
+    for r in repos:
+        is_admin, users = gl.get_project_users(r)
+        if not is_admin:
+            logging.error("'{}' is not shared with {} as 'Maintainer'".format(
+                r, gl.user.username
+            ))
+            continue

--- a/reconcile/ldap_users.py
+++ b/reconcile/ldap_users.py
@@ -36,11 +36,12 @@ def init_users():
 def get_app_interface_gitlab_api():
     config = get_config()
 
-    server = config['app-interface']['server']
-    token = config['app-interface']['token']
-    project_id = config['app-interface']['project_id']
+    gitlab_config = config['gitlab']
+    server = gitlab_config['server']
+    token = gitlab_config['token']
+    project_id = gitlab_config['app-interface']['project_id']
 
-    return GitLabApi(server, token, project_id, False)
+    return GitLabApi(server, token, project_id=project_id, ssl_verify=False)
 
 
 def init_user_spec(user):

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -105,10 +105,14 @@ class GitLabApi(object):
 
     def add_project_member(self, repo_url, user):
         project = self.get_project(repo_url)
-        project.members.create({
-            'user_id': user.id,
-            'access_level': gitlab.MAINTAINER_ACCESS
-        })
+        try:
+            project.members.create({
+                'user_id': user.id,
+                'access_level': gitlab.MAINTAINER_ACCESS
+            })
+        except gitlab.exceptions.GitlabCreateError:
+            member = project.members.get(user.id)
+            member.access_level = gitlab.MAINTAINER_ACCESS
 
     def get_project(self, repo_url):
         repo = repo_url.replace(self.server + '/', '')


### PR DESCRIPTION
this integration does:

for all GitLab repositories in app-interface:
* verifies that the user who's token is used has Maintainer access level
* adds all users from the `app-sre` gitlab group to all gitlab `codeComponents`

i chose to add members one by one and not add the group as this group is not selectable in the scope outside `service` and we may have repos outside it in the future.