### PR TITLE
Add trusted certs bundle to OpenShift client constructor call

### DIFF
--- a/reconcile/openshift_rolebinding.py
+++ b/reconcile/openshift_rolebinding.py
@@ -87,7 +87,7 @@ class ClusterStore(object):
                 )
 
                 api = Openshift(cluster_info['serverUrl'], token,
-                                jump_host=jump_host)
+                                jump_host=jump_host, verify_ssl='/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem')
 
                 _clusters[cluster_name] = {
                     'api': api,


### PR DESCRIPTION
Mitigate SSL trust errors mentioned in : https://github.com/app-sre/qontract-reconcile/issues/112

This is required as the Python requests library with the certifi module has its own ca certs bundle which it trusts inside the virtualenv. This was resulting in errors where we have added custom certs to the host, but they don't show up in the integration run. 