### PR TITLE
speed up AWS related integrations

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -29,7 +29,7 @@ from utils.aggregated_list import RunnerException
 def threaded(function):
     function = click.option('--thread-pool-size',
                             help='number of threads to run in parallel',
-                            default=10)(function)
+                            default=20)(function)
 
     return function
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -26,12 +26,15 @@ import reconcile.aws_iam_keys
 from utils.aggregated_list import RunnerException
 
 
-def threaded(function):
-    function = click.option('--thread-pool-size',
-                            help='number of threads to run in parallel',
-                            default=20)(function)
-
-    return function
+def threaded(**kwargs):
+    def f(function):
+        opt = '--thread-pool-size'
+        msg = 'number of threads to run in parallel.'
+        function = click.option(opt,
+                                default=kwargs.get('default', 10),
+                                help=msg)(function)
+        return function
+    return f
 
 
 def terraform(function):
@@ -142,7 +145,7 @@ def gitlab_permissions(ctx):
 
 @integration.command()
 @throughput
-@threaded
+@threaded(default=10)
 @enable_deletion(default=False)
 @click.pass_context
 def aws_garbage_collector(ctx, thread_pool_size, enable_deletion, io_dir):
@@ -151,7 +154,7 @@ def aws_garbage_collector(ctx, thread_pool_size, enable_deletion, io_dir):
 
 
 @integration.command()
-@threaded
+@threaded(default=10)
 @click.pass_context
 def aws_iam_keys(ctx, thread_pool_size):
     run_integration(reconcile.aws_iam_keys.run, ctx.obj['dry_run'],
@@ -159,7 +162,7 @@ def aws_iam_keys(ctx, thread_pool_size):
 
 
 @integration.command()
-@threaded
+@threaded(default=10)
 @click.pass_context
 def openshift_resources(ctx, thread_pool_size):
     run_integration(reconcile.openshift_resources.run,
@@ -167,7 +170,7 @@ def openshift_resources(ctx, thread_pool_size):
 
 
 @integration.command()
-@threaded
+@threaded(default=10)
 @click.pass_context
 def openshift_namespaces(ctx, thread_pool_size):
     run_integration(reconcile.openshift_namespaces.run,
@@ -187,7 +190,7 @@ def quay_repos(ctx):
 
 
 @integration.command()
-@threaded
+@threaded(default=10)
 @click.pass_context
 def ldap_users(ctx, thread_pool_size):
     run_integration(reconcile.ldap_users.run,
@@ -208,7 +211,7 @@ def openshift_resources_annotate(ctx, cluster, namespace, kind, name):
 @integration.command()
 @terraform
 @throughput
-@threaded
+@threaded(default=20)
 @enable_deletion(default=False)
 @click.pass_context
 def terraform_resources(ctx, print_only, enable_deletion,
@@ -221,7 +224,7 @@ def terraform_resources(ctx, print_only, enable_deletion,
 @integration.command()
 @terraform
 @throughput
-@threaded
+@threaded(default=20)
 @enable_deletion(default=True)
 @click.option('--send-mails/--no-send-mails',
               default=True,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -47,7 +47,7 @@ TF_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'terraform_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 4, 0)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 5, 0)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -34,7 +34,7 @@ TF_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'terraform_users'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 3, 3)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 4, 0)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 

--- a/utils/aws_api.py
+++ b/utils/aws_api.py
@@ -38,7 +38,7 @@ class AWSApi(object):
 
     def update_specs(self, results, key):
         self.specs = \
-            [dict(spec, **{key:value})
+            [dict(spec, **{key: value})
              for spec in self.specs
              for account, value in results
              if spec['account'] == account]
@@ -166,7 +166,8 @@ class AWSApi(object):
                   'client': dynamodb,
                   'resource': resource}
                  for resource in tables_without_owner]
-            results = self.pool.map(self.custom_dynamodb_filter, resource_specs)
+            results = \
+                self.pool.map(self.custom_dynamodb_filter, resource_specs)
             unfiltered = [r for r in results if r is not None]
             self.add_resources(account, 'dynamodb_no_owner', unfiltered)
 
@@ -211,7 +212,6 @@ class AWSApi(object):
 
     def custom_s3_filter(self, resource_spec):
         account = resource_spec['account']
-        session = resource_spec['session']
         s3 = resource_spec['client']
         resource = resource_spec['resource']
         type = 's3 bucket'
@@ -227,7 +227,6 @@ class AWSApi(object):
 
     def custom_sqs_filter(self, resource_spec):
         account = resource_spec['account']
-        session = resource_spec['session']
         sqs = resource_spec['client']
         resource = resource_spec['resource']
         type = 'sqs queue'
@@ -255,7 +254,6 @@ class AWSApi(object):
 
     def custom_rds_filter(self, resource_spec):
         account = resource_spec['account']
-        session = resource_spec['session']
         rds = resource_spec['client']
         resource = resource_spec['resource']
         type = 'rds instance'

--- a/utils/aws_api.py
+++ b/utils/aws_api.py
@@ -112,8 +112,6 @@ class AWSApi(object):
                 continue
             buckets = [b['Name'] for b in buckets_list['Buckets']]
             self.add_resources(account, 's3', buckets)
-            self.add_resources(account, 's3_no_owner', buckets)
-            continue
             buckets_without_owner = \
                 self.get_resources_without_owner(account, buckets)
             resource_specs = \

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -34,6 +34,7 @@ class TerraformClient(object):
         self.integration_version = integration_version
         self.integration_prefix = integration_prefix
         self.working_dirs = working_dirs
+        self.parallelism = thread_pool_size
         self.pool = ThreadPool(thread_pool_size)
         self._log_lock = Lock()
 
@@ -125,7 +126,8 @@ class TerraformClient(object):
     def terraform_plan(self, plan_spec, enable_deletion):
         name = plan_spec['name']
         tf = plan_spec['tf']
-        return_code, stdout, stderr = tf.plan(detailed_exitcode=False)
+        return_code, stdout, stderr = tf.plan(detailed_exitcode=False, 
+                                              parallelism=self.parallelism)
         error = self.check_output(name, return_code, stdout, stderr)
         deletion_detected, deleted_users = \
             self.log_plan_diff(name, stdout, enable_deletion)

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -130,7 +130,7 @@ class TerraformClient(object):
 
     def update_specs(self, results, key):
         self.specs = \
-            [dict(spec, key=value)
+            [dict(spec, **{key:value})
              for spec in self.specs
              for name, value in results
              if spec['name'] == name]
@@ -216,8 +216,6 @@ class TerraformClient(object):
 
     # terraform output
     def output(self):
-        errors = False
-
         results = self.pool.map(self.terraform_output, self.specs)
         self.update_specs(results, key='output')
 

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -126,7 +126,7 @@ class TerraformClient(object):
     def terraform_plan(self, plan_spec, enable_deletion):
         name = plan_spec['name']
         tf = plan_spec['tf']
-        return_code, stdout, stderr = tf.plan(detailed_exitcode=False, 
+        return_code, stdout, stderr = tf.plan(detailed_exitcode=False,
                                               parallelism=self.parallelism)
         error = self.check_output(name, return_code, stdout, stderr)
         deletion_detected, deleted_users = \

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -89,7 +89,8 @@ class TerraformClient(object):
 
     def init_specs(self, working_dirs):
         self.specs = \
-            [{'name': name, 'wd': wd} for name, wd in working_dirs.items()]
+            [{'name': name, 'wd': wd}
+             for name, wd in working_dirs.items()]
 
     def terraform_init(self, spec):
         name = spec['name']

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -57,11 +57,10 @@ class TerraformClient(object):
         self.users = all_users
 
     def get_new_users(self):
-        self.output() # update output after apply
+        self.output()  # update output after apply
         new_users = []
         for spec in self.specs:
             account = spec['name']
-            tf = spec['tf']
             output = spec['output']
             existing_users = self.users[account]
             user_passwords = self.format_output(
@@ -131,7 +130,7 @@ class TerraformClient(object):
 
     def update_specs(self, results, key):
         self.specs = \
-            [dict(spec, **{key:value})
+            [dict(spec, **{key: value})
              for spec in self.specs
              for name, value in results
              if spec['name'] == name]
@@ -230,7 +229,6 @@ class TerraformClient(object):
         data = {}
         for spec in self.specs:
             account = spec['name']
-            tf = spec['tf']
             output = spec['output']
             data[account] = \
                 self.format_output(output, self.OUTPUT_TYPE_SECRETS)
@@ -240,7 +238,6 @@ class TerraformClient(object):
     def populate_desired_state(self, ri):
         for spec in self.specs:
             name = spec['name']
-            tf = spec['tf']
             output = spec['output']
             formatted_output = self.format_output(
                 output, self.OUTPUT_TYPE_SECRETS)

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -38,22 +38,16 @@ class TerraformClient(object):
         self.pool = ThreadPool(thread_pool_size)
         self._log_lock = Lock()
 
-        init_specs = self.init_init_specs(working_dirs)
-        results = self.pool.map(self.terraform_init, init_specs)
+        self.setup()
 
-        self.OUTPUT_TYPE_SECRETS = 'Secrets'
-        self.OUTPUT_TYPE_PASSWORDS = 'enc-passwords'
-        self.OUTPUT_TYPE_CONSOLEURLS = 'console-urls'
-        tfs = {}
-        for name, tf in results:
-            tfs[name] = tf
-        self.tfs = tfs
         if init_users:
             self.init_existing_users()
 
     def init_existing_users(self):
         all_users = {}
-        for account, tf in self.tfs.items():
+        for spec in self.specs:
+            account = spec['name']
+            tf = spec['tf']
             users = []
             output = tf.output()
             user_passwords = self.format_output(
@@ -65,7 +59,9 @@ class TerraformClient(object):
 
     def get_new_users(self):
         new_users = []
-        for account, tf in self.tfs.items():
+        for spec in self.specs:
+            account = spec['name']
+            tf = spec['tf']
             existing_users = self.users[account]
             output = tf.output()
             user_passwords = self.format_output(
@@ -79,12 +75,24 @@ class TerraformClient(object):
                                   user_name, enc_password))
         return new_users
 
-    def init_init_specs(self, working_dirs):
-        return [{'name': name, 'wd': wd} for name, wd in working_dirs.items()]
+    def init_constants(self):
+        self.OUTPUT_TYPE_SECRETS = 'Secrets'
+        self.OUTPUT_TYPE_PASSWORDS = 'enc-passwords'
+        self.OUTPUT_TYPE_CONSOLEURLS = 'console-urls'
 
-    def terraform_init(self, init_spec):
-        name = init_spec['name']
-        wd = init_spec['wd']
+    def setup(self):
+        self.init_constants()
+        self.init_specs(self.working_dirs)
+        results = self.pool.map(self.terraform_init, self.specs)
+        self.update_specs(results)
+
+    def init_specs(self, working_dirs):
+        self.specs = \
+            [{'name': name, 'wd': wd} for name, wd in working_dirs.items()]
+
+    def terraform_init(self, spec):
+        name = spec['name']
+        wd = spec['wd']
         tf = Terraform(working_dir=wd)
         return_code, stdout, stderr = tf.init()
         error = self.check_output(name, return_code, stdout, stderr)
@@ -97,10 +105,9 @@ class TerraformClient(object):
         errors = False
         deletions_detected = False
 
-        plan_specs = self.init_plan_apply_specs()
         terraform_plan_partial = partial(self.terraform_plan,
                                          enable_deletion=enable_deletion)
-        results = self.pool.map(terraform_plan_partial, plan_specs)
+        results = self.pool.map(terraform_plan_partial, self.specs)
 
         self.deleted_users = []
         for deletion_detected, deleted_users, error in results:
@@ -120,12 +127,16 @@ class TerraformClient(object):
         with open(file_path, 'w') as f:
             f.write(json.dumps(self.deleted_users))
 
-    def init_plan_apply_specs(self):
-        return [{'name': name, 'tf': tf} for name, tf in self.tfs.items()]
+    def update_specs(self, results):
+        self.specs = \
+            [dict(spec, tf=tf)
+             for spec in self.specs
+             for name, tf in results
+             if spec['name'] == name]
 
-    def terraform_plan(self, plan_spec, enable_deletion):
-        name = plan_spec['name']
-        tf = plan_spec['tf']
+    def terraform_plan(self, spec, enable_deletion):
+        name = spec['name']
+        tf = spec['tf']
         return_code, stdout, stderr = tf.plan(detailed_exitcode=False,
                                               parallelism=self.parallelism)
         error = self.check_output(name, return_code, stdout, stderr)
@@ -188,25 +199,43 @@ class TerraformClient(object):
     def apply(self):
         errors = False
 
-        self.pool = ThreadPool(1)  # TODO: remove this
-        apply_specs = self.init_plan_apply_specs()
-        results = self.pool.map(self.terraform_apply, apply_specs)
+        results = self.pool.map(self.terraform_apply, self.specs)
 
         for error in results:
             if error:
                 errors = True
         return errors
 
-    def terraform_apply(self, apply_spec):
-        name = apply_spec['name']
-        tf = apply_spec['tf']
+    def terraform_apply(self, spec):
+        name = spec['name']
+        tf = spec['tf']
         return_code, stdout, stderr = tf.apply(auto_approve=True)
+        error = self.check_output(name, return_code, stdout, stderr)
+        return error
+
+    # terraform output
+    def output(self):
+        errors = False
+
+        results = self.pool.map(self.terraform_output, self.specs)
+
+        for error in results:
+            if error:
+                errors = True
+        return errors
+
+    def terraform_output(self, spec):
+        name = spec['name']
+        tf = spec['tf']
+        return_code, stdout, stderr = tf.output()
         error = self.check_output(name, return_code, stdout, stderr)
         return error
 
     def get_terraform_output_secrets(self):
         data = {}
-        for account, tf in self.tfs.items():
+        for spec in self.specs:
+            account = spec['name']
+            tf = spec['tf']
             output = tf.output()
             data[account] = \
                 self.format_output(output, self.OUTPUT_TYPE_SECRETS)
@@ -214,7 +243,9 @@ class TerraformClient(object):
         return data
 
     def populate_desired_state(self, ri):
-        for name, tf in self.tfs.items():
+        for spec in self.specs:
+            name = spec['name']
+            tf = spec['tf']
             output = tf.output()
             formatted_output = self.format_output(
                 output, self.OUTPUT_TYPE_SECRETS)


### PR DESCRIPTION
the point of this PR is to speed things up in the AWS related integrations.

to do this, things changed on several aspects:

* terraform-resources and terraform-users:
  * increase `terraform plan` parallelism to 20 (default is 10)
  * decrease number of calls to `terraform output`

* aws-garbage-collector:
  * each `map` function now runs in parallel for all resources (the `map` functions still run in order)

in addition, all 3 integrations use a `self.specs` property, which gets updated with data throughout the run of the integration (instead of creating separate properties). this helps us especially in the `terraform-*` integrations since it saves us the need to initialize these specs for each terraform action.

it is recommended to review this PR in 3 cycles:
1. review the cli
2. review terraform-* integrations (terraform_client.py)
3. review aws-gc integration (aws_garbage_collector.py)

In addition, i have added a change that attempts to handle the problem we encountered here:
https://ci-int-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/service-app-interface-gl-build-master/515/artifact/reports/reconcile_reports_success/reconcile-terraform-resources.txt