### PR TITLE
[openshift-resources] do not get resources if namespace does not exist

### DIFF
--- a/reconcile/openshift_namespaces.py
+++ b/reconcile/openshift_namespaces.py
@@ -5,7 +5,6 @@ from functools import partial
 import utils.gql as gql
 import reconcile.openshift_resources as openshift_resources
 from utils.openshift_resource import ResourceInventory
-from utils.oc import StatusCodeError
 
 
 QUERY = """

--- a/reconcile/openshift_namespaces.py
+++ b/reconcile/openshift_namespaces.py
@@ -57,15 +57,7 @@ def get_desired_state():
 def check_ns_exists(spec, oc_map):
     cluster = spec['cluster']
     namespace = spec['namespace']
-
-    create = False
-    try:
-        oc_map[cluster].get(namespace, 'Namespace', namespace)
-    except StatusCodeError as e:
-        if 'NotFound' in e.message:
-            create = True
-        else:
-            raise e
+    create = not oc_map[cluster].project_exists(namespace)
 
     return spec, create
 

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -82,7 +82,7 @@ NAMESPACES_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'openshift_resources'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 9, 0)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 9, 1)
 QONTRACT_BASE64_SUFFIX = '_qb64'
 
 _log_lock = Lock()

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -38,8 +38,10 @@ class OC(object):
         cmd = ['get', kind, '-o', 'json']
 
         if 'namespace' in kwargs:
-            cmd.append('-n')
-            cmd.append(kwargs['namespace'])
+            namespace = kwargs['namespace']
+            if not self.project_exists(namespace):
+                return []
+            cmd.extend(['-n', namespace])
 
         if 'labels' in kwargs:
             labels_list = [
@@ -71,6 +73,16 @@ class OC(object):
     def delete(self, namespace, kind, name):
         cmd = ['delete', '-n', namespace, kind, name]
         self._run(cmd)
+
+    def project_exists(self, name):
+        try:
+            self.get(None, 'Project', name)
+        except StatusCodeError as e:
+            if 'NotFound' in e.message:
+                return False
+            else:
+                raise e
+        return True
 
     def new_project(self, namespace):
         cmd = ['new-project', namespace]


### PR DESCRIPTION
in some clusters if the namespace does not exist we will get a `Forbidden` message. this PR adds a check if the namespace exists.

if it doesn't, the `openshift-resources` integration will not query for existing resources - as there aren't any, and instead will return an empty list `[]`.

this change will allow the `openshift-resources` integration to run smoothly even if the namespace does not exist.

when this integration is not running in dry-run mode, it depends on the namespace existing.
this is a valid assumption, as:
1. the `openshift-resources` is running [after](https://gitlab.cee.redhat.com/service/app-interface/blob/master/build_deploy.sh#L165) the `openshift-namespaces` is running.
2. the `openshift-resources` get the context for the resources from the `namespace` file, which indicates that such a namespace should exist at this time.