### PR TITLE
[terraform-*] terraform validate without init

### DIFF
--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -34,7 +34,7 @@ TF_QUERY = """
 """
 
 QONTRACT_INTEGRATION = 'terraform_users'
-QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 4, 1)
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 4, 2)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 
@@ -57,9 +57,9 @@ def setup(print_only, thread_pool_size):
     if err:
         return None, err
 
-    working_dirs = ts.dump(print_only)
+    working_dirs, error = ts.dump(print_only)
 
-    return working_dirs, None
+    return working_dirs, error
 
 
 def send_email_invites(new_users):

--- a/terrascript/__init__.py
+++ b/terrascript/__init__.py
@@ -129,31 +129,14 @@ class Terrascript(object):
         return json.dumps(config, indent=INDENT, sort_keys=SORT, default=_json_default)
 
 
-    def validate(self, delete=True):
+    def validate(self, tmpdir):
         """Validate a Terraform configuration."""
-        import tempfile
         import subprocess
-
-        config = self.dump()
-        tmpdir = tempfile.mkdtemp()
-        tmpfile = tempfile.NamedTemporaryFile(mode='w', dir=tmpdir, suffix='.tf.json', delete=delete)
-
-        tmpfile.write(self.dump())
-        tmpfile.flush()
-
-        # Download plugins
-        proc = subprocess.Popen(['terraform','init'], cwd=tmpdir,
-                                stdout=subprocess.PIPE, stderr=None)
-        proc.communicate()
-        assert proc.returncode == 0
 
         # Validate configuration
         proc = subprocess.Popen(['terraform','validate','-check-variables=false'], cwd=tmpdir,
                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         proc.communicate()
-
-        tmpfile.close()
-        shutil.rmtree(tmpdir)
 
         return proc.returncode == 0
 


### PR DESCRIPTION
the `ts.validate()` function in terrascript was calling `terraform init` for no reason