### PR TITLE
[gitlab-housekeeping] introduce new integration

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -20,6 +20,7 @@ import reconcile.jenkins_roles
 import reconcile.jenkins_plugins
 import reconcile.slack_usergroups
 import reconcile.gitlab_permissions
+import reconcile.gitlab_housekeeping
 import reconcile.aws_garbage_collector
 import reconcile.aws_iam_keys
 
@@ -141,6 +142,12 @@ def slack_usergroups(ctx):
 @click.pass_context
 def gitlab_permissions(ctx):
     run_integration(reconcile.gitlab_permissions.run, ctx.obj['dry_run'])
+
+
+@integration.command()
+@click.pass_context
+def gitlab_housekeeping(ctx):
+    run_integration(reconcile.gitlab_housekeeping.run, ctx.obj['dry_run'])
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -145,9 +145,13 @@ def gitlab_permissions(ctx):
 
 
 @integration.command()
+@click.option('--days-interval',
+              default=15,
+              help='interval of days between actions.')
 @click.pass_context
-def gitlab_housekeeping(ctx):
-    run_integration(reconcile.gitlab_housekeeping.run, ctx.obj['dry_run'])
+def gitlab_housekeeping(ctx, days_interval):
+    run_integration(reconcile.gitlab_housekeeping.run, ctx.obj['dry_run'],
+                    days_interval)
 
 
 @integration.command()

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -60,7 +60,8 @@ def handle_stale_issues(dry_run, gl, days_interval):
                     note.attributes.get('updated_at'), DATE_FORMAT)
                  for note in cancel_notes]
             latest_note_date = max(d for d in notes_dates)
-            # if the latest cancel note is under days_interval - remove 'stale' label
+            # if the latest cancel note is under
+            # days_interval - remove 'stale' label
             current_interval = now.date() - latest_note_date.date()
             if current_interval <= timedelta(days=days_interval):
                 logging.info(['remove_label', gl.project.name,

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -1,0 +1,73 @@
+import logging
+
+from datetime import datetime, timedelta
+
+from utils.config import get_config
+from utils.gitlab_api import GitLabApi
+
+
+def get_housekeeping_gitlab_api():
+    config = get_config()
+
+    gitlab_config = config['gitlab']
+    server = gitlab_config['server']
+    token = gitlab_config['token']
+    project_id = gitlab_config['housekeeping']['project_id']
+
+    return GitLabApi(server, token, project_id=project_id, ssl_verify=False)
+
+
+def handle_stale_issues(dry_run, gl):
+    DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+    LABEL = 'stale'
+    DAYS = 30
+
+    issues = gl.get_issues(state='opened')
+    now = datetime.utcnow()
+    for issue in issues:
+        issue_iid = issue.attributes.get('iid')
+        issue_labels = issue.attributes.get('labels')
+        updated_at = issue.attributes.get('updated_at')
+        update_date = datetime.strptime(updated_at, DATE_FORMAT)
+
+        # if issue is over 30d old
+        if now.date() - update_date.date() > timedelta(days=DAYS):
+            # if issue does not have 'stale' label - add it
+            if LABEL not in issue_labels:
+                logging.info(['add_label', gl.project.name, issue_iid, LABEL])
+                if not dry_run:
+                    gl.add_label(issue, LABEL)
+            # if issue has 'stale' label - close it
+            else:
+                logging.info(['close_issue', gl.project.name, issue_iid])
+                if not dry_run:
+                    gl.close_issue(issue)
+        # if issue is under 30d old
+        else:
+            if LABEL not in issue_labels:
+                continue
+
+            # if issue has 'stale' label - check the notes
+            notes = issue.notes.list()
+            cancel_notes = [n for n in notes
+                            if n.attributes.get('body') ==
+                            '/{} cancel'.format(LABEL)]
+            if not cancel_notes:
+                continue
+
+            notes_dates = \
+                [datetime.strptime(
+                    note.attributes.get('updated_at'), DATE_FORMAT)
+                 for note in cancel_notes]
+            latest_note_date = max(d for d in notes_dates)
+            # if the latest cancel note is under 30d - remove 'stale' label
+            if now.date() - latest_note_date.date() <= timedelta(days=DAYS):
+                logging.info(['remove_label', gl.project.name,
+                              issue_iid, LABEL])
+                if not dry_run:
+                    gl.remove_label(issue, LABEL)
+
+
+def run(dry_run=False):
+    gl = get_housekeeping_gitlab_api()
+    handle_stale_issues(dry_run, gl)


### PR DESCRIPTION
this integration does:

iterates over housekeeping and adds `stale` label to stale issues (no activity over 30d) + adds a comment.
after 'stale' is added and 30d more passed - the integration closes the issue.

if after adding 'stale' someone added a note of '/stale cancel' - the integration will remove the label.
