### PR TITLE
[github-users] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Tool to reconcile services with their desired state as defined in the app-interf
 
 - `qontract-reconcile aws-garbage-collector`: Delete orphan AWS resources.
 - `qontract-reconcile aws-iam-keys`: Delete IAM access keys by access key ID.
+- `qontract-reconcile github-users`: Validate compliance of GitHub user profiles.
 - `qontract-reconcile gitlab-housekeeping`: Manage issues on GitLab projects.
 - `qontract-reconcile gitlab-permissions`: Manage permissions on GitLab projects.
 - `qontract-reconcile jenkins-plugins`: Manage Jenkins plugins installation via REST API.

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -5,6 +5,7 @@ import click
 import utils.config as config
 import utils.gql as gql
 import reconcile.github_org
+import reconcile.github_users
 import reconcile.openshift_rolebinding
 import reconcile.openshift_groups
 import reconcile.openshift_resources
@@ -106,6 +107,12 @@ def integration(ctx, configfile, dry_run, log_level):
 @click.pass_context
 def github(ctx):
     run_integration(reconcile.github_org.run, ctx.obj['dry_run'])
+
+
+@integration.command()
+@click.pass_context
+def github_users(ctx):
+    run_integration(reconcile.github_users.run, ctx.obj['dry_run'])
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -66,6 +66,17 @@ def enable_deletion(**kwargs):
     return f
 
 
+def send_mails(**kwargs):
+    def f(function):
+        opt = '--send-mails/--no-send-mails'
+        msg = 'send email notification to users.'
+        function = click.option(opt,
+                                default=kwargs.get('default', False),
+                                help=msg)(function)
+        return function
+    return f
+
+
 def run_integration(func, *args):
     try:
         func(*args)
@@ -110,9 +121,13 @@ def github(ctx):
 
 
 @integration.command()
+@threaded(default=10)
+@enable_deletion(default=False)
+@send_mails(default=False)
 @click.pass_context
-def github_users(ctx):
-    run_integration(reconcile.github_users.run, ctx.obj['dry_run'])
+def github_users(ctx, thread_pool_size, enable_deletion, send_mails):
+    run_integration(reconcile.github_users.run, ctx.obj['dry_run'],
+                    thread_pool_size, enable_deletion, send_mails)
 
 
 @integration.command()
@@ -245,9 +260,7 @@ def terraform_resources(ctx, print_only, enable_deletion,
 @throughput
 @threaded(default=20)
 @enable_deletion(default=True)
-@click.option('--send-mails/--no-send-mails',
-              default=True,
-              help='send email invitation to new users.')
+@send_mails(default=True)
 @click.pass_context
 def terraform_users(ctx, print_only, enable_deletion, io_dir,
                     thread_pool_size, send_mails):

--- a/reconcile/github_users.py
+++ b/reconcile/github_users.py
@@ -1,18 +1,23 @@
+import re
 import logging
-from github import Github
-from github.GithubObject import NotSet
 
 import utils.gql as gql
 
-from utils.aggregated_list import AggregatedList, AggregatedDiffRunner
 from utils.config import get_config
-from utils.raw_github_api import RawGithubApi
+from reconcile.ldap_users import get_app_interface_gitlab_api
+from reconcile.ldap_users import init_users as init_users_and_paths
+
+from github import Github
+from multiprocessing.dummy import Pool as ThreadPool
+from functools import partial
+
 
 QUERY = """
 {
   users: users_v1 {
     redhat_username
     github_username
+    path
   }
 }
 """
@@ -30,9 +35,45 @@ def init_github():
     return Github(token)
 
 
-def run(dry_run=False):
+def get_user_company(user, github):
+    gh_user = github.get_user(login=user['github_username'])
+    return user['redhat_username'], gh_user.company
+
+
+def get_users_to_delete(results):
+    pattern = r'^.*[Rr]ed ?[Hh]at.*$'
+    redhat_usernames_to_delete = [u for u, c in results
+                                  if c is None
+                                  or not re.search(pattern, c)]
+    users_and_paths = init_users_and_paths()
+    return [u for u in users_and_paths
+            if u['username'] in redhat_usernames_to_delete]
+
+
+def run(dry_run=False, thread_pool_size=10,
+        enable_deletion=False, send_mails=False):
     users = fetch_users()
     g = init_github()
-    for user in users:
-        gh_user = g.get_user(login=user['github_username'])
-        print(gh_user.company)
+
+    pool = ThreadPool(thread_pool_size)
+    get_user_company_partial = partial(get_user_company, github=g)
+    results = pool.map(get_user_company_partial, users)
+
+    users_to_delete = get_users_to_delete(results)
+
+    if not dry_run and enable_deletion:
+        gl = get_app_interface_gitlab_api()
+
+    for user in users_to_delete:
+        username = user['username']
+        paths = user['paths']
+        logging.info(['delete_user', username])
+
+        if not dry_run:
+            if enable_deletion:
+                gl.create_delete_user_mr(username, paths)
+            else:
+                msg = ('\'delete\' action is not enabled. '
+                      'Please run the integration manually '
+                      'with the \'--enable-deletion\' flag.')
+                logging.warning(msg)

--- a/reconcile/github_users.py
+++ b/reconcile/github_users.py
@@ -1,0 +1,38 @@
+import logging
+from github import Github
+from github.GithubObject import NotSet
+
+import utils.gql as gql
+
+from utils.aggregated_list import AggregatedList, AggregatedDiffRunner
+from utils.config import get_config
+from utils.raw_github_api import RawGithubApi
+
+QUERY = """
+{
+  users: users_v1 {
+    redhat_username
+    github_username
+  }
+}
+"""
+
+
+def fetch_users():
+    gqlapi = gql.get_api()
+    return gqlapi.query(QUERY)['users']
+
+
+def init_github():
+    config = get_config()
+    github_config = config['github']
+    token = github_config['app-sre']['token']
+    return Github(token)
+
+
+def run(dry_run=False):
+    users = fetch_users()
+    g = init_github()
+    for user in users:
+        gh_user = g.get_user(login=user['github_username'])
+        print(gh_user.company)

--- a/utils/smtp_client.py
+++ b/utils/smtp_client.py
@@ -59,6 +59,9 @@ def send_mail(name, subject, body):
     global _username
     global _mail_address
 
+    if _client is None:
+        init_from_config()
+
     msg = MIMEMultipart()
     from_name = str(Header('App SRE team automation', 'utf-8'))
     to = '{}@{}'.format(name, _mail_address)


### PR DESCRIPTION
this integration does:

for each user in app-interface, the integration checks that "Red Hat" is present in the user's GitHub profile under the Company field. if this is false, the integration will delete the user (submit a MR) file from app-interface.

to actually perform deletions - use the `--enable-deletion` flag.
to send mail notifications to users - use the `--send-mails` flag (overrides `--enable-deletion`).
* both these flags only work if `dry-run` is false.