### PR TITLE
[jenkins-job-builder] introduce new integration

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -19,6 +19,7 @@ import reconcile.terraform_users
 import reconcile.github_repo_invites
 import reconcile.jenkins_roles
 import reconcile.jenkins_plugins
+import reconcile.jenkins_job_builder
 import reconcile.slack_usergroups
 import reconcile.gitlab_permissions
 import reconcile.gitlab_housekeeping
@@ -152,6 +153,12 @@ def jenkins_roles(ctx):
 @click.pass_context
 def jenkins_plugins(ctx):
     run_integration(reconcile.jenkins_plugins.run, ctx.obj['dry_run'])
+
+
+@integration.command()
+@click.pass_context
+def jenkins_job_builder(ctx):
+    run_integration(reconcile.jenkins_job_builder.run, ctx.obj['dry_run'])
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -156,9 +156,14 @@ def jenkins_plugins(ctx):
 
 
 @integration.command()
+@throughput
+@click.option('--compare/--no-compare',
+              default=True,
+              help='compare between current and desired state.')
 @click.pass_context
-def jenkins_job_builder(ctx):
-    run_integration(reconcile.jenkins_job_builder.run, ctx.obj['dry_run'])
+def jenkins_job_builder(ctx, io_dir, compare):
+    run_integration(reconcile.jenkins_job_builder.run, ctx.obj['dry_run'],
+                    io_dir, compare)
 
 
 @integration.command()

--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -1,20 +1,29 @@
 import sys
 
+from jenkins_jobs.builder import JenkinsManager
+from jenkins_jobs.parser import YamlParser
+from jenkins_jobs.registry import ModuleRegistry
 from jenkins_jobs.cli.entry import JenkinsJobs
 from jenkins_jobs.cli.subcommand.test import TestSubCommand
 
 def run(dry_run=False):
     argv = ['--conf', '/home/mafriedm/.config/jjb/ci-int.ini', 'test', 'jjb-ci-int.yaml']
     jjb = JenkinsJobs(argv)
-    test = TestSubCommand()
 
-    _, xml_jobs, _ = test._generate_xmljobs(
-        jjb.options, jjb.jjb_config)
+    builder = JenkinsManager(jjb.jjb_config)
+    registry = ModuleRegistry(jjb.jjb_config, builder.plugins_list)
+    parser = YamlParser(jjb.jjb_config)
+    parser.load_files(jjb.options.path)
 
-    for job in xml_jobs:
-        print(job.name)
+
+    jobs, views = parser.expandYaml(
+        registry, jjb.options.names)
+
+    for job in jobs:
+        print(job['name'])
         try:
-            project_url = job.xml[9][0][0].text
+            project_url = job['properties'][0]['github']['url']
             print(project_url)
-        except:
-            print("NO PROJECT URL")
+        except KeyError:
+            print('###################################')
+            continue

--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -1,29 +1,75 @@
-import sys
+import shutil
+import yaml
+import tempfile
 
-from jenkins_jobs.builder import JenkinsManager
-from jenkins_jobs.parser import YamlParser
-from jenkins_jobs.registry import ModuleRegistry
+import utils.gql as gql
+import utils.vault_client as vault_client
+
+from os import path
+
 from jenkins_jobs.cli.entry import JenkinsJobs
-from jenkins_jobs.cli.subcommand.test import TestSubCommand
+
+
+QUERY = """
+{
+  jenkins_configs: jenkins_configs_v1 {
+    path
+    instance {
+      name
+      token {
+        path
+        field
+      }
+    }
+    config
+  }
+}
+"""
+
+
+def collect_jenkins_configs():
+    gqlapi = gql.get_api()
+    configs = gqlapi.query(QUERY)['jenkins_configs']
+    instances = {c['instance']['name']: c['instance']['token']
+                 for c in configs}
+
+    working_dirs = {}
+    for name, token in instances.items():
+        wd = tempfile.mkdtemp()
+        ini = vault_client.read(token['path'], token['field'])
+        ini_file_path = '{}/{}.ini'.format(wd, name)
+        with open(ini_file_path, 'w') as f:
+            f.write(ini)
+        working_dirs[name] = wd
+
+    configs.sort(key=sort_by_path)
+
+    for c in configs:
+        instance_name = c['instance']['name']
+        config_file_path = \
+            '{}/config.yaml'.format(working_dirs[instance_name])
+        with open(config_file_path, 'a') as f:
+            yaml.dump(yaml.load(c['config'], Loader=yaml.FullLoader), f)
+
+    return working_dirs
+
+
+def sort_by_path(config):
+    return path.basename(config['path'])
+
+
+def cleanup(working_dirs):
+    for wd in working_dirs.values():
+        shutil.rmtree(wd)
+
 
 def run(dry_run=False):
-    argv = ['--conf', '/home/mafriedm/.config/jjb/ci-int.ini', 'test', 'jjb-ci-int.yaml']
-    jjb = JenkinsJobs(argv)
-
-    builder = JenkinsManager(jjb.jjb_config)
-    registry = ModuleRegistry(jjb.jjb_config, builder.plugins_list)
-    parser = YamlParser(jjb.jjb_config)
-    parser.load_files(jjb.options.path)
-
-
-    jobs, views = parser.expandYaml(
-        registry, jjb.options.names)
-
-    for job in jobs:
-        print(job['name'])
-        try:
-            project_url = job['properties'][0]['github']['url']
-            print(project_url)
-        except KeyError:
-            print('###################################')
-            continue
+    working_dirs = collect_jenkins_configs()
+    for name, wd in working_dirs.items():
+        ini_path = '{}/{}.ini'.format(wd, name)
+        config_path = '{}/config.yaml'.format(wd)
+        argv = ['--conf', ini_path, 'test', config_path]
+        print(name)
+        jjb = JenkinsJobs(argv)
+        a = jjb.execute()
+    cleanup(working_dirs)

--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -1,0 +1,20 @@
+import sys
+
+from jenkins_jobs.cli.entry import JenkinsJobs
+from jenkins_jobs.cli.subcommand.test import TestSubCommand
+
+def run(dry_run=False):
+    argv = ['--conf', '/home/mafriedm/.config/jjb/ci-int.ini', 'test', 'jjb-ci-int.yaml']
+    jjb = JenkinsJobs(argv)
+    test = TestSubCommand()
+
+    _, xml_jobs, _ = test._generate_xmljobs(
+        jjb.options, jjb.jjb_config)
+
+    for job in xml_jobs:
+        print(job.name)
+        try:
+            project_url = job.xml[9][0][0].text
+            print(project_url)
+        except:
+            print("NO PROJECT URL")

--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -13,7 +13,6 @@ from jenkins_jobs.cli.entry import JenkinsJobs
 QUERY = """
 {
   jenkins_configs: jenkins_configs_v1 {
-    path
     instance {
       name
       token {
@@ -21,6 +20,7 @@ QUERY = """
         field
       }
     }
+    type
     config
   }
 }
@@ -42,7 +42,7 @@ def collect_jenkins_configs():
             f.write(ini)
         working_dirs[name] = wd
 
-    configs.sort(key=sort_by_path)
+    configs.sort(key=sort_by_type)
 
     for c in configs:
         instance_name = c['instance']['name']
@@ -54,8 +54,17 @@ def collect_jenkins_configs():
     return working_dirs
 
 
-def sort_by_path(config):
-    return path.basename(config['path'])
+def sort_by_type(config):
+    if config['type'] == 'common':
+        return 00
+    elif config['type'] == 'views':
+        return 10
+    elif config['type'] == 'secrets':
+        return 20
+    elif config['type'] == 'job-templates':
+        return 30
+    elif config['type'] == 'jobs':
+        return 40
 
 
 def cleanup(working_dirs):

--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -1,14 +1,6 @@
-import os
-import shutil
-import yaml
-import tempfile
-
 import utils.gql as gql
-import utils.vault_client as vault_client
 
-from os import path
-
-from jenkins_jobs.cli.entry import JenkinsJobs
+from utils.jjb_client import JJB
 
 
 QUERY = """
@@ -30,94 +22,18 @@ QUERY = """
 """
 
 
-class FetchResourceError(Exception):
-    def __init__(self, msg):
-        super(FetchResourceError, self).__init__(
-            "error fetching resource: " + str(msg)
-        )
-
-
-def collect_jenkins_configs():
+def init_jjb():
     gqlapi = gql.get_api()
     configs = gqlapi.query(QUERY)['jenkins_configs']
-    instances = {c['instance']['name']: c['instance']['token']
-                 for c in configs}
-
-    working_dirs = {}
-    for name, token in instances.items():
-        wd = tempfile.mkdtemp()
-        ini = vault_client.read(token['path'], token['field'])
-        ini = ini.replace('"', '')
-        ini = ini.replace('false', 'False')
-        ini_file_path = '{}/{}.ini'.format(wd, name)
-        with open(ini_file_path, 'w') as f:
-            f.write(ini)
-            f.write('\n')
-        working_dirs[name] = wd
-
-    sort(configs)
-
-    for c in configs:
-        instance_name = c['instance']['name']
-        config = c['config']
-        config_file_path = \
-            '{}/config.yaml'.format(working_dirs[instance_name])
-        if config:
-            with open(config_file_path, 'a') as f:
-                yaml.dump(yaml.load(config, Loader=yaml.FullLoader), f)
-                f.write('\n')
-        else:
-            config_path = c['config_path']
-            # get config data
-            try:
-                config_resource = gqlapi.get_resource(config_path)
-                config = config_resource['content']
-            except gql.GqlApiError as e:
-                raise FetchResourceError(e.message)
-            with open(config_file_path, 'a') as f:
-                f.write(config)
-                f.write('\n')
-
-    return working_dirs
+    return JJB(configs, ssl_verify=False)
 
 
-def sort(configs):
-    configs.sort(key=sort_by_name)
-    configs.sort(key=sort_by_type)
+def run(dry_run=False, io_dir='throughput/', compare=True):
+    jjb = init_jjb()
 
+    if dry_run:
+        jjb.test(io_dir, compare=compare)
+    else:
+        jjb.update()
 
-def sort_by_type(config):
-    if config['type'] == 'common':
-        return 00
-    elif config['type'] == 'views':
-        return 10
-    elif config['type'] == 'secrets':
-        return 20
-    elif config['type'] == 'job-templates':
-        return 30
-    elif config['type'] == 'jobs':
-        return 40
-
-
-def sort_by_name(config):
-    return config['name']
-
-
-def cleanup(working_dirs):
-    for wd in working_dirs.values():
-        shutil.rmtree(wd)
-
-
-def run(dry_run=False):
-    working_dirs = collect_jenkins_configs()
-    for name, wd in working_dirs.items():
-        ini_path = '{}/{}.ini'.format(wd, name)
-        config_path = '{}/config.yaml'.format(wd)
-
-        if not dry_run:
-            os.environ['PYTHONHTTPSVERIFY'] = '0'
-            argv = ['--conf', ini_path, 'update', config_path]
-            jjb = JenkinsJobs(argv)
-            a = jjb.execute()
-
-    cleanup(working_dirs)
+    jjb.cleanup()

--- a/reconcile/jenkins_plugins.py
+++ b/reconcile/jenkins_plugins.py
@@ -28,6 +28,9 @@ def get_jenkins_map():
         instance_name = instance['name']
         if instance_name in jenkins_map:
             continue
+        instance_plugins = instance['plugins']
+        if not instance_plugins:
+            continue
 
         token = instance['token']
         jenkins = JenkinsApi(token, False)
@@ -56,7 +59,7 @@ def get_desired_state():
 
     desired_state = []
     for instance in jenkins_instances:
-        for plugin in instance['plugins']:
+        for plugin in instance['plugins'] or []:
             desired_state.append({
                 "instance": instance['name'],
                 "plugin": plugin

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "urllib3>=1.21.1,<1.25.0",
         "slackclient>=1.3.2,<1.4.0",
         "pypd>=1.1.0,<1.2.0",
+        "jenkins-job-builder>=2.10.1,<2.11.0",
     ],
 
     test_suite="tests",

--- a/utils/jjb_client.py
+++ b/utils/jjb_client.py
@@ -1,0 +1,171 @@
+import os
+import shutil
+import yaml
+import tempfile
+import logging
+import filecmp
+import xml.etree.ElementTree as et
+import utils.vault_client as vault_client
+
+import utils.gql as gql
+
+from os import path
+
+from jenkins_jobs.cli.entry import JenkinsJobs
+
+
+class FetchResourceError(Exception):
+    def __init__(self, msg):
+        super(FetchResourceError, self).__init__(
+            "error fetching resource: " + str(msg)
+        )
+
+
+class JJB(object):
+    """Wrapper around Jenkins Jobs"""
+
+    def __init__(self, configs, ssl_verify=True):
+        self.collect_configs(configs)
+        self.python_https_verify = str(int(ssl_verify))
+        self.default_logging = logging.getLogger().level
+
+    def collect_configs(self, configs):
+        gqlapi = gql.get_api()
+        instances = {c['instance']['name']: c['instance']['token']
+                     for c in configs}
+
+        working_dirs = {}
+        for name, token in instances.items():
+            wd = tempfile.mkdtemp()
+            ini = vault_client.read(token['path'], token['field'])
+            ini = ini.replace('"', '')
+            ini = ini.replace('false', 'False')
+            ini_file_path = '{}/{}.ini'.format(wd, name)
+            with open(ini_file_path, 'w') as f:
+                f.write(ini)
+                f.write('\n')
+            working_dirs[name] = wd
+
+        self.sort(configs)
+
+        for c in configs:
+            instance_name = c['instance']['name']
+            config = c['config']
+            config_file_path = \
+                '{}/config.yaml'.format(working_dirs[instance_name])
+            if config:
+                with open(config_file_path, 'a') as f:
+                    yaml.dump(yaml.load(config, Loader=yaml.FullLoader), f)
+                    f.write('\n')
+            else:
+                config_path = c['config_path']
+                # get config data
+                try:
+                    config_resource = gqlapi.get_resource(config_path)
+                    config = config_resource['content']
+                except gql.GqlApiError as e:
+                    raise FetchResourceError(e.message)
+                with open(config_file_path, 'a') as f:
+                    f.write(config)
+                    f.write('\n')
+
+        self.working_dirs = working_dirs
+
+    def sort(self, configs):
+        configs.sort(key=self.sort_by_name)
+        configs.sort(key=self.sort_by_type)
+
+    def sort_by_type(self, config):
+        if config['type'] == 'common':
+            return 00
+        elif config['type'] == 'views':
+            return 10
+        elif config['type'] == 'secrets':
+            return 20
+        elif config['type'] == 'job-templates':
+            return 30
+        elif config['type'] == 'jobs':
+            return 40
+
+    def sort_by_name(self, config):
+        return config['name']
+
+    def test(self, io_dir, compare):
+        for name, wd in self.working_dirs.items():
+            ini_path = '{}/{}.ini'.format(wd, name)
+            config_path = '{}/config.yaml'.format(wd)
+
+            fetch_state = 'desired' if compare else 'current'
+            output_dir = path.join(io_dir, 'jjb', fetch_state, name)
+            args = ['--conf', ini_path,
+                    'test', config_path,
+                    '-o', output_dir,
+                    '--config-xml']
+            self.execute(args)
+
+        if compare:
+            self.print_diffs(io_dir)
+
+    def print_diffs(self, io_dir):
+        current_path = path.join(io_dir, 'jjb', 'current')
+        current_files = self.get_files(current_path)
+        desired_path = path.join(io_dir, 'jjb', 'desired')
+        desired_files = self.get_files(desired_path)
+
+        create = self.compare_files(desired_files, current_files)
+        delete = self.compare_files(current_files, desired_files)
+        common = self.compare_files(desired_files, current_files, in_op=True)
+
+        self.print_diff(create, desired_path, 'create')
+        self.print_diff(delete, current_path, 'delete')
+        self.print_diff(common, desired_path, 'update')
+
+    def print_diff(self, files, replace_path, action):
+        for f in files:
+            if action == 'update':
+                ft = self.toggle_cd(f)
+                equal = filecmp.cmp(f, ft)
+                if equal:
+                    continue
+
+            instance, item, _ = f.replace(replace_path + '/', '').split('/')
+            item_type = et.parse(f).getroot().tag
+            item_type = item_type.replace('hudson.model.ListView', 'view')
+            item_type = item_type.replace('project', 'job')
+            logging.info([action, item_type, instance, item])
+
+    def compare_files(self, from_files, subtract_files, in_op=False):
+        return [f for f in from_files
+                if (self.toggle_cd(f) in subtract_files) is in_op]
+
+    def get_files(self, search_path):
+        return [path.join(root, f)
+                for root, _, files in os.walk(search_path)
+                for f in files]
+
+    def toggle_cd(self, file_name):
+        if 'desired' in file_name:
+            return file_name.replace('desired', 'current')
+        else:
+            return file_name.replace('current', 'desired')
+
+    def update(self):
+        working_dirs = collect_jenkins_configs()
+        for name, wd in self.working_dirs.items():
+            ini_path = '{}/{}.ini'.format(wd, name)
+            config_path = '{}/config.yaml'.format(wd)
+
+            args = ['--conf', ini_path, 'update', config_path, '--delete-old']
+            self.execute(args)
+
+    def execute(self, args):
+        os.environ['PYTHONHTTPSVERIFY'] = self.python_https_verify
+
+        jjb = JenkinsJobs(args)
+        logging.getLogger().setLevel(logging.ERROR)
+        jjb.execute()
+        logging.getLogger().setLevel(self.default_logging)
+
+    def cleanup(self):
+        for wd in self.working_dirs.values():
+            shutil.rmtree(wd)

--- a/utils/jjb_client.py
+++ b/utils/jjb_client.py
@@ -150,7 +150,6 @@ class JJB(object):
             return file_name.replace('current', 'desired')
 
     def update(self):
-        working_dirs = collect_jenkins_configs()
         for name, wd in self.working_dirs.items():
             ini_path = '{}/{}.ini'.format(wd, name)
             config_path = '{}/config.yaml'.format(wd)


### PR DESCRIPTION
this integration is running jenkins-jobs to apply job configurations to jenkins.

when this integration is working in dry-run mode, it is executing `jenkins-jobs test`.
when it is not in dry run mode, it is executing `jenkins-jobs update`.

to be able to show diffs between the current state and the desired state, this integration needs to be executed twice:

1. execute with a config file pointing to prod (current state) and add the `--no-compare` flag, to indicate that this should only collect data
2. execute with a config file pointing to a local server (in a PR) (desired state). this run will fetch the desired state and compare it to the current state.

1 + 2 are not required when running this integration in a non dry-run mode, but only a single execution.

the ability to run integrations twice, first querying production and then querying the local server is already enabled[[1](https://gitlab.cee.redhat.com/service/app-interface/merge_requests/965/diffs#a5c3b3b8337ffd291fedf7a9fa32e2edead57400_149_136)]