### PR TITLE
[jenkins-webhooks] introduce new integration

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -20,6 +20,7 @@ import reconcile.github_repo_invites
 import reconcile.jenkins_roles
 import reconcile.jenkins_plugins
 import reconcile.jenkins_job_builder
+import reconcile.jenkins_webhooks
 import reconcile.slack_usergroups
 import reconcile.gitlab_permissions
 import reconcile.gitlab_housekeeping
@@ -164,6 +165,12 @@ def jenkins_plugins(ctx):
 def jenkins_job_builder(ctx, io_dir, compare):
     run_integration(reconcile.jenkins_job_builder.run, ctx.obj['dry_run'],
                     io_dir, compare)
+
+
+@integration.command()
+@click.pass_context
+def jenkins_webhooks(ctx):
+    run_integration(reconcile.jenkins_webhooks.run, ctx.obj['dry_run'])
 
 
 @integration.command()

--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -9,6 +9,7 @@ QUERY = """
     name
     instance {
       name
+      serverUrl
       token {
         path
         field

--- a/reconcile/jenkins_webhooks.py
+++ b/reconcile/jenkins_webhooks.py
@@ -30,7 +30,7 @@ def get_hooks_to_add(desired_state, gl):
                 }
                 if item in desired_hooks:
                     desired_hooks.remove(item)
-        except:
+        except Exception:
             logging.warning('no access to project: ' + project_url)
             diff[project_url] = []
 
@@ -46,7 +46,8 @@ def run(dry_run=False):
 
     for project_url, hooks in diff.items():
         for h in hooks:
-            logging.info(['create_hook', project_url, h['trigger'], h['job_url']])
+            logging.info(['create_hook', project_url,
+                          h['trigger'], h['job_url']])
 
             if not dry_run:
                 gl.create_project_hook(project_url, h)

--- a/reconcile/jenkins_webhooks.py
+++ b/reconcile/jenkins_webhooks.py
@@ -1,0 +1,32 @@
+from utils.config import get_config
+from utils.gitlab_api import GitLabApi
+from reconcile.jenkins_job_builder import init_jjb
+
+
+def get_gitlab_api():
+    config = get_config()
+
+    gitlab_config = config['gitlab']
+    server = gitlab_config['server']
+    token = gitlab_config['token']
+
+    return GitLabApi(server, token, ssl_verify=False)
+
+
+def run(dry_run=False):
+    jjb = init_jjb()
+    data = jjb.get_job_webhooks_data()
+
+    gl = get_gitlab_api()
+
+    for d in data:
+        print(d['job_name'])
+        hooks = gl.get_project_hooks(d['repo_url'])
+        print(hooks)
+
+
+# trigger-merge-request - True or False
+# trigger-open-merge-request-push - source or never
+# add-note-merge-request - True or False
+# add-vote-merge-request - True or False
+# add-ci-message - True or False

--- a/reconcile/jenkins_webhooks.py
+++ b/reconcile/jenkins_webhooks.py
@@ -1,3 +1,6 @@
+import copy
+import logging
+
 from utils.config import get_config
 from utils.gitlab_api import GitLabApi
 from reconcile.jenkins_job_builder import init_jjb
@@ -13,20 +16,37 @@ def get_gitlab_api():
     return GitLabApi(server, token, ssl_verify=False)
 
 
+def get_hooks_to_add(desired_state, gl):
+    diff = copy.deepcopy(desired_state)
+    for project_url, desired_hooks in diff.items():
+        try:
+            current_hooks = gl.get_project_hooks(project_url)
+            for h in current_hooks:
+                job_url = h.url
+                trigger = 'mr' if h.merge_requests_events else 'push'
+                item = {
+                    'job_url': job_url.strip('/'),
+                    'trigger': trigger,
+                }
+                if item in desired_hooks:
+                    desired_hooks.remove(item)
+        except:
+            logging.warning('no access to project: ' + project_url)
+            diff[project_url] = []
+
+    return diff
+
+
 def run(dry_run=False):
     jjb = init_jjb()
-    data = jjb.get_job_webhooks_data()
-
     gl = get_gitlab_api()
 
-    for d in data:
-        print(d['job_name'])
-        hooks = gl.get_project_hooks(d['repo_url'])
-        print(hooks)
+    desired_state = jjb.get_job_webhooks_data()
+    diff = get_hooks_to_add(desired_state, gl)
 
+    for project_url, hooks in diff.items():
+        for h in hooks:
+            logging.info(['create_hook', project_url, h['trigger'], h['job_url']])
 
-# trigger-merge-request - True or False
-# trigger-open-merge-request-push - source or never
-# add-note-merge-request - True or False
-# add-vote-merge-request - True or False
-# add-ci-message - True or False
+            if not dry_run:
+                gl.create_project_hook(project_url, h)

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -154,3 +154,7 @@ class GitLabApi(object):
     def close_issue(self, issue):
         issue.state_event = 'close'
         issue.save()
+
+    def get_project_hooks(self, repo_url):
+        p = self.get_project(repo_url)
+        return p.hooks.list()

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -157,4 +157,17 @@ class GitLabApi(object):
 
     def get_project_hooks(self, repo_url):
         p = self.get_project(repo_url)
-        return p.hooks.list()
+        return p.hooks.list(per_page=100)
+
+    def create_project_hook(self, repo_url, data):
+        p = self.get_project(repo_url)
+        url = data['job_url']
+        trigger = data['trigger']
+        hook = {
+            'url': url,
+            'enable_ssl_verification': 1,
+            'note_events': int(trigger == 'mr'),
+            'push_events': int(trigger == 'push'),
+            'merge_requests_events': int(trigger == 'mr'),
+        }
+        p.hooks.create(hook)

--- a/utils/jjb_client.py
+++ b/utils/jjb_client.py
@@ -12,6 +12,10 @@ import utils.gql as gql
 from os import path
 from contextlib import contextmanager
 
+from jenkins_jobs.builder import JenkinsManager
+from jenkins_jobs.parser import YamlParser
+from jenkins_jobs.registry import ModuleRegistry
+
 
 class FetchResourceError(Exception):
     def __init__(self, msg):
@@ -167,11 +171,13 @@ class JJB(object):
             args = ['--conf', ini_path, 'update', config_path, '--delete-old']
             self.execute(args)
 
-    def execute(self, args):
-        from jenkins_jobs.cli.entry import JenkinsJobs
+    def get_jjb(self, args):
         os.environ['PYTHONHTTPSVERIFY'] = self.python_https_verify
+        from jenkins_jobs.cli.entry import JenkinsJobs
+        return JenkinsJobs(args)
 
-        jjb = JenkinsJobs(args)
+    def execute(self, args):
+        jjb = self.get_jjb(args)
         with self.toggle_logger():
             jjb.execute()
 
@@ -192,3 +198,38 @@ class JJB(object):
     def cleanup(self):
         for wd in self.working_dirs.values():
             shutil.rmtree(wd)
+
+    def get_job_webhooks_data(self):
+        job_webhooks_data = []
+        for name, wd in self.working_dirs.items():
+            ini_path = '{}/{}.ini'.format(wd, name)
+            config_path = '{}/config.yaml'.format(wd)
+
+            args = ['--conf', ini_path, 'test', config_path]
+            jjb = self.get_jjb(args)
+            builder = JenkinsManager(jjb.jjb_config)
+            registry = ModuleRegistry(jjb.jjb_config, builder.plugins_list)
+            parser = YamlParser(jjb.jjb_config)
+            parser.load_files(jjb.options.path)
+
+            jobs, _ = parser.expandYaml(
+                registry, jjb.options.names)
+
+            for job in jobs:
+                try:
+                    project_url_raw = job['properties'][0]['github']['url']
+                    if 'https://github.com' in project_url_raw:
+                        continue
+                    project_url = project_url_raw.strip('/').replace('.git', '')
+                    gitlab_triggers = job['triggers'][0]['gitlab']
+                    mr_trigger = gitlab_triggers['trigger-merge-request']
+                    trigger = 'pr-check' if mr_trigger else 'build-master'
+                    item = {
+                        'job_name': job['name'],
+                        'repo_url': project_url,
+                        'trigger': trigger,
+                    }
+                    job_webhooks_data.append(item)
+                except KeyError:
+                    continue
+        return job_webhooks_data

--- a/utils/jjb_client.py
+++ b/utils/jjb_client.py
@@ -34,9 +34,10 @@ class JJB(object):
 
     def collect_configs(self, configs):
         gqlapi = gql.get_api()
-        instances = {c['instance']['name']: {'serverUrl': c['instance']['serverUrl'],
-                                             'token': c['instance']['token']}
-                     for c in configs}
+        instances = \
+            {c['instance']['name']: {'serverUrl': c['instance']['serverUrl'],
+                                     'token': c['instance']['token']}
+             for c in configs}
 
         working_dirs = {}
         instance_urls = {}
@@ -227,7 +228,8 @@ class JJB(object):
                     if 'https://github.com' in project_url_raw:
                         continue
                     job_url = \
-                        '{}/project/{}'.format(self.instances[name], job['name'])
+                        '{}/project/{}'.format(self.instances[name],
+                                               job['name'])
                     project_url = \
                         project_url_raw.strip('/').replace('.git', '')
                     gitlab_triggers = job['triggers'][0]['gitlab']


### PR DESCRIPTION
this integration does:

gets the list of jobs that exist in jjb, and for each job it checks if this job should be triggered (if at all) by a merge request or by a push, and adds that webhook to the project.

* currently only supports gitlab.

this integration does not:
* delete webhooks (allowing users to add additional hooks manually)