### PR TITLE
[slack-usergroups] add github as source

### DIFF
--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -173,7 +173,7 @@ def get_slack_usernames_from_github_owners(github_owners, users):
             )['approvers']
         except (anymarkup.AnyMarkupError, KeyError):
             msg = "Could not parse data. Skipping owners file: {}"
-            logging.warning(e_msg.format(owners_file))
+            logging.warning(msg.format(owners_file))
             continue
 
         if not github_users:


### PR DESCRIPTION
like we can have slack usergroup members be based on pagerduty (schedules and escalation policies) - this PR adds the ability to base the members on github OWNERS files!