### PR TITLE
[aws-gc] add rds snapshots

### DIFF
--- a/utils/aws_api.py
+++ b/utils/aws_api.py
@@ -164,7 +164,8 @@ class AWSApi(object):
                  if t['DBInstanceIdentifier'] not in
                  self.resources[account]['rds']]
             unfiltered_snapshots = \
-                self.custom_rds_snapshot_filter(account, rds, snapshots_without_db)
+                self.custom_rds_snapshot_filter(account, rds,
+                                                snapshots_without_db)
             self.resources[account]['rds_snapshots_no_owner'] = \
                 unfiltered_snapshots
 


### PR DESCRIPTION
adds garbage collection of rds db snapshots without an existing db instance

refs:
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html#RDS.Client.describe_db_snapshots
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds.html#RDS.Client.delete_db_snapshots