### PR TITLE
[github-orgs] allow team membership in unmanaged orgs

### DIFF
--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -151,10 +151,7 @@ class GHApiStore(object):
     def __init__(self, config):
         for org_name, org_config in config['github'].items():
             token = org_config['token']
-            if 'managed_teams' in org_config:
-                managed_teams = org_config['managed_teams']
-            else:
-                managed_teams = None
+            managed_teams = org_config.get('managed_teams', None)
             self._orgs[org_name] = \
                 (Github(token), RawGithubApi(token), managed_teams)
 

--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -70,7 +70,7 @@ def fetch_current_state(gh_api_store):
         managed_teams = gh_api_store.managed_teams(org_name)
         # if 'managedTeams' is not specified
         # we manage all teams
-        is_managed = managed_teams is None
+        is_managed = managed_teams is None or len(managed_teams) == 0
 
         org = g.get_organization(org_name)
 

--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -75,7 +75,7 @@ def fetch_current_state(gh_api_store):
         org = g.get_organization(org_name)
 
         org_members = None
-        if is_managed:  
+        if is_managed:
             org_members = [member.login for member in org.get_members()]
             org_members.extend(raw_gh_api.org_invitations(org_name))
 
@@ -151,8 +151,12 @@ class GHApiStore(object):
     def __init__(self, config):
         for org_name, org_config in config['github'].items():
             token = org_config['token']
-            managed_teams = org_config['managed_teams']
-            self._orgs[org_name] = (Github(token), RawGithubApi(token), managed_teams)
+            if 'managed_teams' in org_config:
+                managed_teams = org_config['managed_teams']
+            else:
+                managed_teams = None
+            self._orgs[org_name] = \
+                (Github(token), RawGithubApi(token), managed_teams)
 
     def orgs(self):
         return self._orgs.keys()


### PR DESCRIPTION
this integration does:
1. migrate the github configuration from config.toml to app-interface (1st commit)
2. adds a github-org schema object, which may define a `managedTeams` field.
  * if this field is defined - we only manage the specified teams
  * if this field is not defined - we manage the entire org
