### PR TITLE
[e2e-tests] fix race condition between tests

### DIFF
--- a/e2e_tests/dedicated_admin_rolebindings.py
+++ b/e2e_tests/dedicated_admin_rolebindings.py
@@ -8,7 +8,10 @@ import e2e_tests.dedicated_admin_test_base as dat
 def run():
     oc_map = tb.get_oc_map()
     pattern = \
-        r'^(default|logging|(openshift|kube-|ops-|dedicated-|management-).*)$'
+        r'^(default|logging|' + \
+        '(openshift|kube-|ops-|dedicated-|management-|{}).*)$'.format(
+            tb.E2E_NS_PFX
+        )
     for cluster, oc in oc_map.items():
         logging.info("[{}] validating RoleBindings".format(cluster))
 

--- a/e2e_tests/test_base.py
+++ b/e2e_tests/test_base.py
@@ -31,6 +31,8 @@ CLUSTERS_QUERY = """
 }
 """
 
+E2E_NS_PFX = 'e2e-test'
+
 
 def get_oc_map():
     gqlapi = gql.get_api()
@@ -49,8 +51,8 @@ def get_oc_map():
             if v is not False}
 
 def get_test_namespace_name():
-    return 'e2e-test-namespace-{}'.format(
-        datetime.datetime.utcnow().strftime('%Y%m%d%H%M')
+    return '{}-{}'.format(
+        E2E_NS_PFX, datetime.datetime.utcnow().strftime('%Y%m%d%H%M')
     )
 
 def assert_rolebinding(expected_rb, rb):


### PR DESCRIPTION
https://ci-int-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/service-app-interface-gl-periodic-job-e2e-tests/5/console

the `dedicated-admin-rolebindings` test is checking a namespace created and tested by the `create-namespace` test.