### PR TITLE
Add jinja2 templating for resources

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -324,7 +324,7 @@ def fetch_openshift_resource(resource, parent):
         if resource['variables']:
             tv = anymarkup.parse(resource['variables'], force_types=None)
         tv['resource'] = resource
-        tv['resource']['parent'] = parent
+        tv['resource']['namespace'] = parent
         tt = resource['type']
         tt = 'jinja2' if tt is None else tt
         if tt == 'jinja2':

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         "slackclient>=1.3.2,<1.4.0",
         "pypd>=1.1.0,<1.2.0",
         "jenkins-job-builder>=2.10.1,<2.11.0",
+        "Jinja2>=2.10.1,<2.11.0",
     ],
 
     test_suite="tests",


### PR DESCRIPTION
This PR adds support for Jinja2 template processing on resource files prior to processing them.

I've tried to design the feature so that it is easy to add more kinds of (template) processing. A potential future candidate for this may be processing `jsonnet` templates to render OpenShift resources and then reconcile them

As part of the PR, I've also added a custom `vault` function in Jinja2 which allows retrieving secrets from vault

This can be useful to retrieve information from vault to apply on one or more resources

Example
```yaml
apiVersion: v1
kind: Deployment
metadata:
  name: myapp
spec:
  ...
  template:
    spec:
      containers:
      - image: '{{ vault('some/vault/path', 'image', 1) }}'
        ...
```