### PR TITLE
[jjb] use jenkins-jobs cli instead of package on update

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -3,11 +3,13 @@ FROM centos:7
 ENV LC_ALL=en_US.utf8
 ENV LANG=en_US.utf8
 ENV TF_VERSION=0.11.14
+ENV JJB_VERSION=2.10.1
 
 RUN yum install -y centos-release-openshift-origin && \
     yum install -y epel-release && \
     yum install -y python2-pip origin-clients openssh-clients && \
     pip install --upgrade pip setuptools && \
+    pip install jenkins-job-builder==${JJB_VERSION} && \
     yum clean all
 
 RUN yum install -y unzip && \

--- a/utils/jjb_client.py
+++ b/utils/jjb_client.py
@@ -178,7 +178,7 @@ class JJB(object):
 
             os.environ['PYTHONHTTPSVERIFY'] = self.python_https_verify
             cmd = ['jenkins-jobs', '--conf', ini_path,
-                    'update', config_path, '--delete-old']
+                   'update', config_path, '--delete-old']
             subprocess.call(cmd)
 
     def get_jjb(self, args):

--- a/utils/jjb_client.py
+++ b/utils/jjb_client.py
@@ -4,6 +4,7 @@ import yaml
 import tempfile
 import logging
 import filecmp
+import subprocess
 import xml.etree.ElementTree as et
 import utils.vault_client as vault_client
 
@@ -175,11 +176,12 @@ class JJB(object):
             ini_path = '{}/{}.ini'.format(wd, name)
             config_path = '{}/config.yaml'.format(wd)
 
-            args = ['--conf', ini_path, 'update', config_path, '--delete-old']
-            self.execute(args)
+            os.environ['PYTHONHTTPSVERIFY'] = self.python_https_verify
+            cmd = ['jenkins-jobs', '--conf', ini_path,
+                    'update', config_path, '--delete-old']
+            subprocess.call(cmd)
 
     def get_jjb(self, args):
-        os.environ['PYTHONHTTPSVERIFY'] = self.python_https_verify
         from jenkins_jobs.cli.entry import JenkinsJobs
         return JenkinsJobs(args)
 


### PR DESCRIPTION
when using the python package, whenever the integration is run - ci-int jenkins prometheus metrics are missing for a short while, which causes our alerts to "flap".

until we decide (if we decide) to look into it - this solves it.