### PR TITLE
Add jinja2 extension for base64 encoding

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -182,7 +182,7 @@ def lookup_vault_secret(path, key, version=None):
             raise FetchVaultSecretError(msg)
 
     if key not in data:
-        msg = "key {} could not be found in secret".format(key)
+        msg = "key {} could not be found in secret {}".format(key, path)
         raise FetchVaultSecretError(msg)
 
     return data[key]

--- a/utils/jinja2_ext.py
+++ b/utils/jinja2_ext.py
@@ -1,0 +1,25 @@
+import base64
+import textwrap
+
+from jinja2 import nodes
+from jinja2.ext import Extension
+
+
+class B64EncodeExtension(Extension):
+    tags = {'b64encode'}
+
+    def __init__(self, environment):
+        super(B64EncodeExtension, self).__init__(environment)
+
+    def parse(self, parser):
+        lineno = next(parser.stream).lineno
+
+        body = parser.parse_statements(['name:endb64encode'], drop_needle=True)
+
+        return nodes.CallBlock(self.call_method('_b64encode', None),
+                               [], [], body).set_lineno(lineno)
+
+    def _b64encode(self, caller):
+        content = caller()
+        content = textwrap.dedent(content)
+        return base64.b64encode(content)


### PR DESCRIPTION
This also make the jinja2 template engine try kv and kv2 when looking up secrets (only kv2 was implemented before)