### PR TITLE
[github] delete empty teams

### DIFF
--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -218,7 +218,7 @@ class RunnerAction(object):
                     gh_team.remove_membership(gh_user)
 
                 members = gh_team.get_members()
-                if members.totalCount == None:
+                if members.totalCount is None:
                     logging.info(["del_team", org, team])
                     gh_team.delete()
 

--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -217,6 +217,11 @@ class RunnerAction(object):
                     gh_user = g.get_user(member)
                     gh_team.remove_membership(gh_user)
 
+                members = gh_team.get_members()
+                if members.totalCount == None:
+                    logging.info(["del_team", org, team])
+                    gh_team.delete()
+
         return action
 
     def create_team(self):


### PR DESCRIPTION
this integration will delete empty teams in real time to avoid complexity for such an uncommon routine.
e.g. it will not let us know in the dry run.