### PR TITLE
[vault_client] consolidate all read functions to be KV engine agnostic

### DIFF
--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -54,13 +54,7 @@ def get_config():
     config = {'github': {}}
     for org in orgs:
         org_name = org['name']
-        org_token = org['token']
-        try:
-            token = vault_client.read(org_token['path'], org_token['field'])
-        except vault_client.SecretNotFound:
-            token = vault_client.read_all_v2(
-                org_token['path'],
-                org_token['version'])[org_token['field']]
+        token = vault_client.read(org['token'])
         org_config = {'token': token, 'managed_teams': org['managedTeams']}
         config['github'][org_name] = org_config
 

--- a/reconcile/github_repo_invites.py
+++ b/reconcile/github_repo_invites.py
@@ -20,10 +20,10 @@ REPOS_QUERY = """
 
 
 def run(dry_run):
-    config = get_config()
+    config = get_config()['github-repo-invites']
     token = vault_client.read(
-        config['github-repo-invites']['secret_path'],
-        config['github-repo-invites']['secret_field'])
+        {'path': config['secret_path'],
+         'field': config['secret_field']})
 
     g = utils.raw_github_api.RawGithubApi(token)
 

--- a/reconcile/openshift_resources_annotate.py
+++ b/reconcile/openshift_resources_annotate.py
@@ -36,7 +36,7 @@ def get_oc(cluster):
         if at is None:
             return None
         else:
-            token = vault_client.read(at['path'], at['field'])
+            token = vault_client.read(at)
             return utils.oc.OC(cluster_info['serverUrl'], token)
 
     return None

--- a/reconcile/openshift_rolebinding.py
+++ b/reconcile/openshift_rolebinding.py
@@ -81,10 +81,7 @@ class ClusterStore(object):
                 continue
 
             if _clusters.get(cluster_name) is None:
-                token = vault_client.read(
-                    automation_token['path'],
-                    automation_token['field'],
-                )
+                token = vault_client.read(automation_token)
 
                 api = Openshift(cluster_info['serverUrl'], token,
                                 jump_host=jump_host)

--- a/reconcile/quay_membership.py
+++ b/reconcile/quay_membership.py
@@ -151,17 +151,8 @@ def get_quay_api_store():
     result = gqlapi.query(QUAY_ORG_CATALOG_QUERY)
 
     for org_data in result['quay_orgs']:
-        token_path = org_data['automationToken']['path']
-        token_field = org_data['automationToken']['field']
-        try:
-            token = vault_client.read(token_path, token_field)
-        except vault_client.SecretNotFound:
-            token = vault_client.read_all_v2(
-                org_data['automationToken']['path'],
-                org_data['automationToken']['version']
-            )[org_data['automationToken']['field']]
-
         name = org_data['name']
+        token = vault_client.read(org_data['automationToken'])
         managed_teams = org_data.get('managedTeams')
 
         store[name] = {}

--- a/reconcile/quay_repos.py
+++ b/reconcile/quay_repos.py
@@ -183,19 +183,8 @@ def get_quay_api_store():
     result = gqlapi.query(QUAY_ORG_CATALOG_QUERY)
 
     for org_data in result['quay_orgs']:
-        token_path = org_data['automationToken']['path']
-        token_field = org_data['automationToken']['field']
-        token_version = org_data['automationToken']['version']
-        try:
-            token = vault_client.read(token_path, token_field)
-        except vault_client.SecretNotFound:
-            token = vault_client.read_all_v2(
-                token_path,
-                token_version
-            )[token_field]
-
         name = org_data['name']
-
+        token = vault_client.read(org_data['automationToken'])
         store[name] = QuayApi(token, name)
 
     return store

--- a/utils/aws_api.py
+++ b/utils/aws_api.py
@@ -50,8 +50,9 @@ class AWSApi(object):
     def get_vault_tf_secrets(self, init_spec):
         account = init_spec['account']
         data = init_spec['data']
-        secrets_path = data['secrets_path']
-        secret = vault_client.read_all(secrets_path + '/config')
+        secret = vault_client.read_all(
+            {'path': '{}/{}'.format(data['secrets_path'], 'config')}
+        )
         return (account, secret)
 
     def init_users(self):

--- a/utils/jenkins_api.py
+++ b/utils/jenkins_api.py
@@ -9,9 +9,7 @@ class JenkinsApi(object):
     """Wrapper around Jenkins API calls"""
 
     def __init__(self, token, ssl_verify=True):
-        token_path = token['path']
-        token_field = token['field']
-        token_config = vault_client.read(token_path, token_field)
+        token_config = vault_client.read(token)
         config = toml.loads(token_config)
 
         self.url = config['jenkins']['url']

--- a/utils/jjb_client.py
+++ b/utils/jjb_client.py
@@ -46,7 +46,7 @@ class JJB(object):
             token = data['token']
             server_url = data['serverUrl']
             wd = tempfile.mkdtemp()
-            ini = vault_client.read(token['path'], token['field'])
+            ini = vault_client.read(token)
             ini = ini.replace('"', '')
             ini = ini.replace('false', 'False')
             ini_file_path = '{}/{}.ini'.format(wd, name)

--- a/utils/jump_host.py
+++ b/utils/jump_host.py
@@ -1,5 +1,4 @@
 import tempfile
-import base64
 import shutil
 import os
 import requests
@@ -36,11 +35,7 @@ class JumpHostBase(object):
         self.init_identity_file()
 
     def get_identity_from_vault(self, jh):
-        jh_identity = jh['identity']
-        identity = \
-            vault_client.read(jh_identity['path'], jh_identity['field'])
-        if jh_identity['format'] == 'base64':
-            identity = base64.b64decode(identity)
+        identity = vault_client.read(jh['identity'])
         return identity
 
     def init_identity_file(self):

--- a/utils/pagerduty_api.py
+++ b/utils/pagerduty_api.py
@@ -9,9 +9,7 @@ class PagerDutyApi(object):
     """Wrapper around PagerDuty API calls"""
 
     def __init__(self, token):
-        token_path = token['path']
-        token_field = token['field']
-        pd_api_key = vault_client.read(token_path, token_field)
+        pd_api_key = vault_client.read(token)
         pypd.api_key = pd_api_key
 
     def get_pagerduty_users(self, resource_type, resource_id):

--- a/utils/slack_api.py
+++ b/utils/slack_api.py
@@ -13,10 +13,8 @@ class SlackApi(object):
     """Wrapper around Slack API calls"""
 
     def __init__(self, token):
-        token_path = token['path']
-        token_field = token['field']
-        token = vault_client.read(token_path, token_field)
-        self.sc = SlackClient(token)
+        slack_token = vault_client.read(token)
+        self.sc = SlackClient(slack_token)
         self.results = {}
 
     def describe_usergroup(self, handle):

--- a/utils/smtp_client.py
+++ b/utils/smtp_client.py
@@ -56,12 +56,7 @@ def config_from_vault(vault_path):
     config = {}
 
     required_keys = ('password', 'port', 'require_tls', 'server', 'username')
-
-    try:
-        data = vault_client.read_all(vault_path)
-    except vault_client.SecretNotFound as e:
-        raise Exception("Could not retrieve SMTP config from vault: {}"
-                        .format(e))
+    data = vault_client.read_all({'path': vault_path})
 
     try:
         for k in required_keys:

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -104,8 +104,9 @@ class TerrascriptClient(object):
         account = init_spec['account']
         data = init_spec['data']
         type = init_spec['type']
-        secrets_path = data['secrets_path']
-        secret = vault_client.read_all(secrets_path + '/' + type)
+        secret = vault_client.read_all(
+            {'path': '{}/{}'.format(data['secrets_path'], type)}
+        )
         return (account, type, secret)
 
     def get_tf_iam_group(self, group_name):

--- a/utils/vault_client.py
+++ b/utils/vault_client.py
@@ -61,7 +61,7 @@ def read(secret):
     * path - path to the secret in Vault
     * field - the key to read from the secret
     * format (optional) - plain or base64 (defaults to plain)
-    * version (optional) - the version of the secret to read from (if this is a v2 KV engine)
+    * version (optional) - secret version to read (if this is a v2 KV engine)
     """
     secret_path = secret['path']
     secret_field = secret['field']
@@ -81,7 +81,7 @@ def read_all(secret):
 
     The input secret is a dictionary which contains the following fields:
     * path - path to the secret in Vault
-    * version (optional) - the version of the secret to read from (if this is a v2 KV engine)
+    * version (optional) - secret version to read (if this is a v2 KV engine)
     """
     secret_path = secret['path']
     secret_version = secret.get('version')

--- a/utils/vault_client.py
+++ b/utils/vault_client.py
@@ -69,9 +69,9 @@ def read(secret):
     secret_version = secret.get('version')
 
     try:
-        data = read_v1(secret_path, secret_field)
+        data = _read_v1(secret_path, secret_field)
     except Exception:
-        data = read_v2(secret_path, secret_field, secret_version)
+        data = _read_v2(secret_path, secret_field, secret_version)
 
     return base64.b64decode(data) if secret_format == 'base64' else data
 
@@ -86,15 +86,15 @@ def read_all(secret):
     secret_path = secret['path']
     secret_version = secret.get('version')
     try:
-        data = read_all_v1(secret_path)
+        data = _read_all_v1(secret_path)
     except Exception:
-        data = read_all_v2(secret_path, secret_version)
+        data = _read_all_v2(secret_path, secret_version)
 
     return data
 
 
-def read_v1(path, field):
-    data = read_all_v1(path)
+def _read_v1(path, field):
+    data = _read_all_v1(path)
     try:
         secret_field = data[field]
     except KeyError:
@@ -103,7 +103,7 @@ def read_v1(path, field):
     return secret_field
 
 
-def read_all_v1(path):
+def _read_all_v1(path):
     global _client
     init_from_config()
 
@@ -115,8 +115,8 @@ def read_all_v1(path):
     return secret['data']
 
 
-def read_v2(path, field, version):
-    data = read_all_v2(path, version)
+def _read_v2(path, field, version):
+    data = _read_all_v2(path, version)
     try:
         secret_field = data[field]
     except KeyError:
@@ -125,7 +125,7 @@ def read_v2(path, field, version):
     return secret_field
 
 
-def read_all_v2(path, version):
+def _read_all_v2(path, version):
     global _client
     init_from_config()
 


### PR DESCRIPTION
To review this PR, start from looking at the function changes in vault_client.py.

the `read` and `read_all` functions are now KV version agnostic.