### PR TITLE
[slack-usergroups] add retry to get_usergroup

### DIFF
--- a/utils/slack_api.py
+++ b/utils/slack_api.py
@@ -3,6 +3,7 @@ import time
 from slackclient import SlackClient
 
 import utils.vault_client as vault_client
+from utils.retry import retry
 
 
 class UsergroupNotFoundException(Exception):
@@ -34,6 +35,7 @@ class SlackApi(object):
         usergroup = self.get_usergroup(handle)
         return usergroup['id']
 
+    @retry()
     def get_usergroup(self, handle):
         result = self.sc.api_call(
             "usergroups.list",


### PR DESCRIPTION
we have been seeing this more frequently lately:
https://ci-int-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/service-app-interface-gl-build-master/1118/artifact/reports/reconcile_reports_fail/reconcile-slack-usergroups.txt
