### PR TITLE
[openshift-*] handle cleanup of oc_map (jump host)

### DIFF
--- a/e2e_tests/create_namespace.py
+++ b/e2e_tests/create_namespace.py
@@ -4,9 +4,13 @@ import logging
 import e2e_tests.test_base as tb
 import e2e_tests.dedicated_admin_test_base as dat
 
+from utils.defer import defer
 
+
+@defer
 def run():
     oc_map = tb.get_oc_map()
+    defer(lambda: oc_map.cleanup())
 
     ns_to_create = tb.get_test_namespace_name()
     expected_rolebindings = dat.get_expected_rolebindings()

--- a/e2e_tests/create_namespace.py
+++ b/e2e_tests/create_namespace.py
@@ -8,7 +8,7 @@ from utils.defer import defer
 
 
 @defer
-def run():
+def run(defer=None):
     oc_map = tb.get_oc_map()
     defer(lambda: oc_map.cleanup())
 

--- a/e2e_tests/dedicated_admin_rolebindings.py
+++ b/e2e_tests/dedicated_admin_rolebindings.py
@@ -8,7 +8,7 @@ from utils.defer import defer
 
 
 @defer
-def run():
+def run(defer=None):
     oc_map = tb.get_oc_map()
     defer(lambda: oc_map.cleanup())
     pattern = \

--- a/e2e_tests/dedicated_admin_rolebindings.py
+++ b/e2e_tests/dedicated_admin_rolebindings.py
@@ -4,9 +4,13 @@ import logging
 import e2e_tests.test_base as tb
 import e2e_tests.dedicated_admin_test_base as dat
 
+from utils.defer import defer
 
+
+@defer
 def run():
     oc_map = tb.get_oc_map()
+    defer(lambda: oc_map.cleanup())
     pattern = \
         r'^(default|logging|' + \
         '(openshift|kube-|ops-|dedicated-|management-|{}).*)$'.format(

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -237,7 +237,7 @@ def act(diff, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10):
+def run(dry_run=False, thread_pool_size=10, defer=None):
     oc_map, current_state = fetch_current_state(thread_pool_size)
     defer(lambda: oc_map.cleanup())
     desired_state = fetch_desired_state()

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -7,6 +7,7 @@ from functools import partial
 import utils.gql as gql
 
 from utils.oc import OC_Map
+from utils.defer import defer
 
 CLUSTERS_QUERY = """
 {
@@ -235,8 +236,10 @@ def act(diff, oc_map):
         raise Exception("invalid action: {}".format(action))
 
 
+@defer
 def run(dry_run=False, thread_pool_size=10):
     oc_map, current_state = fetch_current_state(thread_pool_size)
+    defer(lambda: oc_map.cleanup())
     desired_state = fetch_desired_state()
 
     diffs = calculate_diff(current_state, desired_state)

--- a/reconcile/openshift_namespaces.py
+++ b/reconcile/openshift_namespaces.py
@@ -8,7 +8,7 @@ import reconcile.openshift_resources as openshift_resources
 
 from utils.openshift_resource import ResourceInventory
 from utils.oc import OC_Map
-
+from utils.defer import defer
 
 QUERY = """
 {
@@ -71,8 +71,10 @@ def create_new_project(spec, oc_map):
     oc_map.get(cluster).new_project(namespace)
 
 
+@defer
 def run(dry_run=False, thread_pool_size=10):
     oc_map, desired_state = get_desired_state()
+    defer(lambda: oc_map.cleanup())
 
     pool = ThreadPool(thread_pool_size)
     check_ns_exists_partial = \

--- a/reconcile/openshift_namespaces.py
+++ b/reconcile/openshift_namespaces.py
@@ -72,7 +72,7 @@ def create_new_project(spec, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10):
+def run(dry_run=False, thread_pool_size=10, defer=None):
     oc_map, desired_state = get_desired_state()
     defer(lambda: oc_map.cleanup())
 

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -577,7 +577,7 @@ def realize_data(dry_run, oc_map, ri, enable_deletion=True):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10):
+def run(dry_run=False, thread_pool_size=10, defer=None):
     gqlapi = gql.get_api()
     namespaces = gqlapi.query(NAMESPACES_QUERY)['namespaces']
     oc_map, ri = fetch_data(namespaces, thread_pool_size)

--- a/reconcile/openshift_rolebinding.py
+++ b/reconcile/openshift_rolebinding.py
@@ -9,6 +9,7 @@ from utils.aggregated_list import (AggregatedList,
                                    AggregatedDiffRunner,
                                    RunnerException)
 from utils.oc import OC_Map
+from utils.defer import defer
 from utils.openshift_resource import ResourceInventory
 
 from multiprocessing.dummy import Pool as ThreadPool
@@ -220,6 +221,7 @@ class RunnerAction(object):
         return self.manage_role('del_role', 'remove_role_from_user')
 
 
+@defer
 def run(dry_run=False, thread_pool_size=10):
     gqlapi = gql.get_api()
 
@@ -227,6 +229,7 @@ def run(dry_run=False, thread_pool_size=10):
     roles = gqlapi.query(ROLES_QUERY)['roles']
 
     oc_map, current_state = fetch_current_state(namespaces, thread_pool_size)
+    defer(lambda: oc_map.cleanup())
     desired_state = fetch_desired_state(roles)
 
     # calculate diff

--- a/reconcile/openshift_rolebinding.py
+++ b/reconcile/openshift_rolebinding.py
@@ -222,7 +222,7 @@ class RunnerAction(object):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10):
+def run(dry_run=False, thread_pool_size=10, defer=None):
     gqlapi = gql.get_api()
 
     namespaces = gqlapi.query(NAMESPACES_QUERY)['namespaces']

--- a/reconcile/openshift_users.py
+++ b/reconcile/openshift_users.py
@@ -6,6 +6,7 @@ import utils.gql as gql
 import reconcile.openshift_groups as openshift_groups
 
 from utils.oc import OC_Map
+from utils.defer import defer
 
 CLUSTERS_QUERY = """
 {
@@ -145,8 +146,10 @@ def act(diff, oc_map):
         raise Exception("invalid action: {}".format(action))
 
 
+@defer
 def run(dry_run=False, thread_pool_size=10):
     oc_map, current_state = fetch_current_state(thread_pool_size)
+    defer(lambda: oc_map.cleanup())
     desired_state = fetch_desired_state()
 
     diffs = calculate_diff(current_state, desired_state)

--- a/reconcile/openshift_users.py
+++ b/reconcile/openshift_users.py
@@ -147,7 +147,7 @@ def act(diff, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10):
+def run(dry_run=False, thread_pool_size=10, defer=None):
     oc_map, current_state = fetch_current_state(thread_pool_size)
     defer(lambda: oc_map.cleanup())
     desired_state = fetch_desired_state()

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -140,7 +140,7 @@ def cleanup_and_exit(tf=None, status=False, working_dirs={}):
 @defer
 def run(dry_run=False, print_only=False,
         enable_deletion=False, io_dir='throughput/',
-        thread_pool_size=10):
+        thread_pool_size=10, defer=None):
     ri, oc_map, tf = setup(print_only, thread_pool_size)
     defer(lambda: oc_map.cleanup())
     if print_only:

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -9,6 +9,7 @@ from utils.terrascript_client import TerrascriptClient as Terrascript
 from utils.terraform_client import OR, TerraformClient as Terraform
 from utils.openshift_resource import ResourceInventory
 from utils.oc import OC_Map
+from utils.defer import defer
 
 from multiprocessing.dummy import Pool as ThreadPool
 from functools import partial
@@ -136,10 +137,12 @@ def cleanup_and_exit(tf=None, status=False, working_dirs={}):
     sys.exit(status)
 
 
+@defer
 def run(dry_run=False, print_only=False,
         enable_deletion=False, io_dir='throughput/',
         thread_pool_size=10):
     ri, oc_map, tf = setup(print_only, thread_pool_size)
+    defer(lambda: oc_map.cleanup())
     if print_only:
         cleanup_and_exit()
     if tf is None:

--- a/utils/defer.py
+++ b/utils/defer.py
@@ -3,14 +3,15 @@ from functools import wraps
 
 # source: https://towerbabbel.com/go-defer-in-python/
 def defer(func):
-  @wraps(func)
-  def func_wrapper(*args, **kwargs):
-    deferred = []
-    defer = lambda f: deferred.append(f)
-    try:
-      return func(*args, defer=defer, **kwargs)
-    finally:
-      deferred.reverse()
-      for f in deferred:
-        f()
-  return func_wrapper
+    @wraps(func)
+    def func_wrapper(*args, **kwargs):
+        deferred = []
+
+        def defer(f): return deferred.append(f)
+        try:
+            return func(*args, defer=defer, **kwargs)
+        finally:
+            deferred.reverse()
+            for f in deferred:
+                f()
+    return func_wrapper

--- a/utils/defer.py
+++ b/utils/defer.py
@@ -1,0 +1,16 @@
+from functools import wraps
+
+
+# source: https://towerbabbel.com/go-defer-in-python/
+def defer(func):
+  @wraps(func)
+  def func_wrapper(*args, **kwargs):
+    deferred = []
+    defer = lambda f: deferred.append(f)
+    try:
+      return func(*args, defer=defer, **kwargs)
+    finally:
+      deferred.reverse()
+      for f in deferred:
+        f()
+  return func_wrapper

--- a/utils/defer.py
+++ b/utils/defer.py
@@ -3,6 +3,9 @@ from functools import wraps
 
 # source: https://towerbabbel.com/go-defer-in-python/
 def defer(func):
+    """Defer code execution until the surrounding function returns.
+    Useful for registering cleanup work.
+    """
     @wraps(func)
     def func_wrapper(*args, **kwargs):
         deferred = []


### PR DESCRIPTION
when initializing oc_map, temporary directories are created for jump host configurations.
this PR adds a cleanup of those directories.
covers https://jira.coreos.com/browse/APPSRE-605