### PR TITLE
[gitlab-*] move token out of config file and add it as a token in the gitlab instance file

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -208,14 +208,15 @@ def gitlab_permissions(ctx, thread_pool_size):
 
 
 @integration.command()
+@click.argument('project-id')
 @click.option('--days-interval',
               default=15,
               help='interval of days between actions.')
 @enable_deletion(default=False)
 @click.pass_context
-def gitlab_housekeeping(ctx, days_interval, enable_deletion):
-    run_integration(reconcile.gitlab_housekeeping.run, ctx.obj['dry_run'],
-                    days_interval, enable_deletion)
+def gitlab_housekeeping(ctx, project_id, days_interval, enable_deletion):
+    run_integration(reconcile.gitlab_housekeeping.run, project_id,
+                    ctx.obj['dry_run'], days_interval, enable_deletion)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -126,13 +126,16 @@ def github(ctx):
 
 
 @integration.command()
+@click.argument('project-id')
 @threaded()
 @enable_deletion(default=False)
 @send_mails(default=False)
 @click.pass_context
-def github_users(ctx, thread_pool_size, enable_deletion, send_mails):
-    run_integration(reconcile.github_users.run, ctx.obj['dry_run'],
-                    thread_pool_size, enable_deletion, send_mails)
+def github_users(ctx, project_id, thread_pool_size,
+                 enable_deletion, send_mails):
+    run_integration(reconcile.github_users.run, project_id,
+                    ctx.obj['dry_run'], thread_pool_size,
+                    enable_deletion, send_mails)
 
 
 @integration.command()
@@ -264,10 +267,11 @@ def quay_repos(ctx):
 
 
 @integration.command()
+@click.argument('project-id')
 @threaded()
 @click.pass_context
-def ldap_users(ctx, thread_pool_size):
-    run_integration(reconcile.ldap_users.run,
+def ldap_users(ctx, project_id, thread_pool_size):
+    run_integration(reconcile.ldap_users.run, project_id,
                     ctx.obj['dry_run'], thread_pool_size)
 
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -126,14 +126,14 @@ def github(ctx):
 
 
 @integration.command()
-@click.argument('project-id')
+@click.argument('gitlab-project-id')
 @threaded()
 @enable_deletion(default=False)
 @send_mails(default=False)
 @click.pass_context
-def github_users(ctx, project_id, thread_pool_size,
+def github_users(ctx, gitlab_project_id, thread_pool_size,
                  enable_deletion, send_mails):
-    run_integration(reconcile.github_users.run, project_id,
+    run_integration(reconcile.github_users.run, gitlab_project_id,
                     ctx.obj['dry_run'], thread_pool_size,
                     enable_deletion, send_mails)
 
@@ -208,14 +208,15 @@ def gitlab_permissions(ctx, thread_pool_size):
 
 
 @integration.command()
-@click.argument('project-id')
+@click.argument('gitlab-project-id')
 @click.option('--days-interval',
               default=15,
               help='interval of days between actions.')
 @enable_deletion(default=False)
 @click.pass_context
-def gitlab_housekeeping(ctx, project_id, days_interval, enable_deletion):
-    run_integration(reconcile.gitlab_housekeeping.run, project_id,
+def gitlab_housekeeping(ctx, gitlab_project_id, days_interval,
+                        enable_deletion):
+    run_integration(reconcile.gitlab_housekeeping.run, gitlab_project_id,
                     ctx.obj['dry_run'], days_interval, enable_deletion)
 
 
@@ -268,11 +269,11 @@ def quay_repos(ctx):
 
 
 @integration.command()
-@click.argument('project-id')
+@click.argument('gitlab-project-id')
 @threaded()
 @click.pass_context
-def ldap_users(ctx, project_id, thread_pool_size):
-    run_integration(reconcile.ldap_users.run, project_id,
+def ldap_users(ctx, gitlab_project_id, thread_pool_size):
+    run_integration(reconcile.ldap_users.run, gitlab_project_id,
                     ctx.obj['dry_run'], thread_pool_size)
 
 

--- a/reconcile/github_users.py
+++ b/reconcile/github_users.py
@@ -5,8 +5,8 @@ import utils.gql as gql
 import utils.smtp_client as smtp_client
 
 from reconcile.github_org import get_config
-from reconcile.ldap_users import get_app_interface_gitlab_api
 from reconcile.ldap_users import init_users as init_users_and_paths
+from reconcile.queries import GITLAB_INSTANCES_QUERY
 
 from github import Github
 from github.GithubException import GithubException
@@ -81,7 +81,7 @@ App-Interface repository: https://gitlab.cee.redhat.com/service/app-interface
     smtp_client.send_mail(to, subject, body)
 
 
-def run(dry_run=False, thread_pool_size=10,
+def run(project_id, dry_run=False, thread_pool_size=10,
         enable_deletion=False, send_mails=False):
     users = fetch_users()
     g = init_github()
@@ -93,7 +93,10 @@ def run(dry_run=False, thread_pool_size=10,
     users_to_delete = get_users_to_delete(results)
 
     if not dry_run and enable_deletion:
-        gl = get_app_interface_gitlab_api()
+        gqlapi = gql.get_api()
+        # assuming a single GitLab instance for now
+        instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
+        gl = GitLabApi(instance, project_id=project_id, ssl_verify=False)
 
     for user in users_to_delete:
         username = user['username']

--- a/reconcile/github_users.py
+++ b/reconcile/github_users.py
@@ -97,8 +97,7 @@ def run(gitlab_project_id, dry_run=False, thread_pool_size=10,
         gqlapi = gql.get_api()
         # assuming a single GitLab instance for now
         instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
-        gl = GitLabApi(instance, project_id=gitlab_project_id,
-                       ssl_verify=False)
+        gl = GitLabApi(instance, project_id=gitlab_project_id)
 
     for user in users_to_delete:
         username = user['username']

--- a/reconcile/github_users.py
+++ b/reconcile/github_users.py
@@ -6,6 +6,7 @@ import utils.smtp_client as smtp_client
 
 from reconcile.github_org import get_config
 from reconcile.ldap_users import init_users as init_users_and_paths
+from utils.gitlab_api import GitLabApi
 from reconcile.queries import GITLAB_INSTANCES_QUERY
 
 from github import Github

--- a/reconcile/github_users.py
+++ b/reconcile/github_users.py
@@ -82,7 +82,7 @@ App-Interface repository: https://gitlab.cee.redhat.com/service/app-interface
     smtp_client.send_mail(to, subject, body)
 
 
-def run(project_id, dry_run=False, thread_pool_size=10,
+def run(gitlab_project_id, dry_run=False, thread_pool_size=10,
         enable_deletion=False, send_mails=False):
     users = fetch_users()
     g = init_github()
@@ -97,7 +97,8 @@ def run(project_id, dry_run=False, thread_pool_size=10,
         gqlapi = gql.get_api()
         # assuming a single GitLab instance for now
         instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
-        gl = GitLabApi(instance, project_id=project_id, ssl_verify=False)
+        gl = GitLabApi(instance, project_id=gitlab_project_id,
+                       ssl_verify=False)
 
     for user in users_to_delete:
         username = user['username']

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -2,19 +2,10 @@ import logging
 
 from datetime import datetime, timedelta
 
-from utils.config import get_config
+import utils.gql as gql
+
 from utils.gitlab_api import GitLabApi
-
-
-def get_housekeeping_gitlab_api():
-    config = get_config()
-
-    gitlab_config = config['gitlab']
-    server = gitlab_config['server']
-    token = gitlab_config['token']
-    project_id = gitlab_config['housekeeping']['project_id']
-
-    return GitLabApi(server, token, project_id=project_id, ssl_verify=False)
+from reconcile.queries import GITLAB_INSTANCES_QUERY
 
 
 def handle_stale_issues(dry_run, gl, days_interval, enable_close_issues):
@@ -77,6 +68,9 @@ def handle_stale_issues(dry_run, gl, days_interval, enable_close_issues):
                     gl.remove_label(issue, LABEL)
 
 
-def run(dry_run=False, days_interval=15, enable_close_issues=False):
-    gl = get_housekeeping_gitlab_api()
+def run(project_id, dry_run=False, days_interval=15, enable_close_issues=False):
+    gqlapi = gql.get_api()
+    # assuming a single GitLab instance for now
+    instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
+    gl = GitLabApi(instance, project_id=project_id, ssl_verify=False)
     handle_stale_issues(dry_run, gl, days_interval, enable_close_issues)

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -73,5 +73,5 @@ def run(gitlab_project_id, dry_run=False, days_interval=15,
     gqlapi = gql.get_api()
     # assuming a single GitLab instance for now
     instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
-    gl = GitLabApi(instance, project_id=gitlab_project_id, ssl_verify=False)
+    gl = GitLabApi(instance, project_id=gitlab_project_id)
     handle_stale_issues(dry_run, gl, days_interval, enable_close_issues)

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -68,7 +68,8 @@ def handle_stale_issues(dry_run, gl, days_interval, enable_close_issues):
                     gl.remove_label(issue, LABEL)
 
 
-def run(project_id, dry_run=False, days_interval=15, enable_close_issues=False):
+def run(project_id, dry_run=False, days_interval=15,
+        enable_close_issues=False):
     gqlapi = gql.get_api()
     # assuming a single GitLab instance for now
     instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -68,10 +68,10 @@ def handle_stale_issues(dry_run, gl, days_interval, enable_close_issues):
                     gl.remove_label(issue, LABEL)
 
 
-def run(project_id, dry_run=False, days_interval=15,
+def run(gitlab_project_id, dry_run=False, days_interval=15,
         enable_close_issues=False):
     gqlapi = gql.get_api()
     # assuming a single GitLab instance for now
     instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
-    gl = GitLabApi(instance, project_id=project_id, ssl_verify=False)
+    gl = GitLabApi(instance, project_id=gitlab_project_id, ssl_verify=False)
     handle_stale_issues(dry_run, gl, days_interval, enable_close_issues)

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -3,19 +3,7 @@ import logging
 import utils.gql as gql
 
 from utils.gitlab_api import GitLabApi
-
-INSTANCES_QUERY = """
-{
-  instances: gitlabinstance_v1 {
-    url
-    token {
-      path
-      field
-    }
-    managedGroups
-  }
-}
-"""
+from reconcile.queries import GITLAB_INSTANCES_QUERY
 
 USERS_QUERY = """
 {
@@ -151,7 +139,7 @@ def act(diff, gl):
 def run(dry_run=False):
     gqlapi = gql.get_api()
     # assuming a single GitLab instance for now
-    instance = gqlapi.query(INSTANCES_QUERY)['instances'][0]
+    instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
     gl = GitLabApi(instance, ssl_verify=False)
     current_state = get_current_state(instance, gl)
     desired_state = get_desired_state(gqlapi, instance, gl)

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -140,7 +140,7 @@ def run(dry_run=False):
     gqlapi = gql.get_api()
     # assuming a single GitLab instance for now
     instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
-    gl = GitLabApi(instance, ssl_verify=False)
+    gl = GitLabApi(instance)
     current_state = get_current_state(instance, gl)
     desired_state = get_desired_state(gqlapi, instance, gl)
     diffs = calculate_diff(current_state, desired_state)

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -1,12 +1,16 @@
 import logging
 
 import utils.gql as gql
-from utils.config import get_config
 from utils.gitlab_api import GitLabApi
 
-GROUPS_QUERY = """
+INSTANCES_QUERY = """
 {
-  instances: gitlabinstance_v1{
+  instances: gitlabinstance_v1 {
+    url
+    token {
+      path
+      field
+    }
     managedGroups
   }
 }
@@ -14,11 +18,11 @@ GROUPS_QUERY = """
 
 USERS_QUERY = """
 {
-  users: users_v1{
+  users: users_v1 {
     redhat_username
-      roles{
-        permissions{
-          ... on PermissionGitlabGroupMembership_v1{
+      roles {
+        permissions {
+          ... on PermissionGitlabGroupMembership_v1 {
             name
             group
             access
@@ -31,11 +35,11 @@ USERS_QUERY = """
 
 BOTS_QUERY = """
 {
-  bots: bots_v1{
+  bots: bots_v1 {
     redhat_username
-      roles{
-        permissions{
-          ... on PermissionGitlabGroupMembership_v1{
+      roles {
+        permissions {
+          ... on PermissionGitlabGroupMembership_v1 {
             name
             group
             access
@@ -47,27 +51,15 @@ BOTS_QUERY = """
 """
 
 
-def get_gitlab_api():
-    config = get_config()
-    gitlab_config = config['gitlab']
-    server = gitlab_config['server']
-    token = gitlab_config['token']
-    return GitLabApi(server, token, ssl_verify=False)
+def get_current_state(instance, gl):
+    return {g: gl.get_group_members(g)
+            for g in instance['managedGroups']}
 
 
-def create_groups_dict(gqlapi):
-    instances = gqlapi.query(GROUPS_QUERY)['instances']
-    groups_dict = {}
-    for i in instances:
-        for g in i['managedGroups']:
-            groups_dict[g] = []
-    return groups_dict
-
-
-def get_desired_state(gqlapi, gl):
+def get_desired_state(gqlapi, instance, gl):
     users = gqlapi.query(USERS_QUERY)['users']
     bots = gqlapi.query(BOTS_QUERY)['bots']
-    desired_group_members = create_groups_dict(gqlapi)
+    desired_group_members = {g: [] for g in instance['managedGroups']}
     for g in desired_group_members:
         for u in users:
             for r in u['roles']:
@@ -84,13 +76,6 @@ def get_desired_state(gqlapi, gl):
                         item = {"user": user, "access_level": p['access']}
                         desired_group_members[g].append(item)
     return desired_group_members
-
-
-def get_current_state(gqlapi, gl):
-    current_group_members = create_groups_dict(gqlapi)
-    for g in current_group_members:
-        current_group_members[g] = gl.get_group_members(g)
-    return current_group_members
 
 
 def calculate_diff(current_state, desired_state):
@@ -164,9 +149,11 @@ def act(diff, gl):
 
 def run(dry_run=False):
     gqlapi = gql.get_api()
-    gl = get_gitlab_api()
-    current_state = get_current_state(gqlapi, gl)
-    desired_state = get_desired_state(gqlapi, gl)
+    # assuming a single GitLab instance for now
+    instance = gqlapi.query(INSTANCES_QUERY)['instances'][0]
+    gl = GitLabApi(instance, ssl_verify=False)
+    current_state = get_current_state(instance, gl)
+    desired_state = get_desired_state(gqlapi, instance, gl)
     diffs = calculate_diff(current_state, desired_state)
 
     for diff in diffs:

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -1,6 +1,7 @@
 import logging
 
 import utils.gql as gql
+
 from utils.gitlab_api import GitLabApi
 
 INSTANCES_QUERY = """

--- a/reconcile/gitlab_permissions.py
+++ b/reconcile/gitlab_permissions.py
@@ -48,7 +48,7 @@ def run(dry_run=False, thread_pool_size=10):
     gqlapi = gql.get_api()
     # assuming a single GitLab instance for now
     instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
-    gl = GitLabApi(instance, ssl_verify=False)
+    gl = GitLabApi(instance)
     repos = get_gitlab_repos(gqlapi, gl.server)
     app_sre = gl.get_app_sre_group_users()
     pool = ThreadPool(thread_pool_size)

--- a/reconcile/gitlab_permissions.py
+++ b/reconcile/gitlab_permissions.py
@@ -3,22 +3,10 @@ import logging
 import utils.gql as gql
 
 from utils.gitlab_api import GitLabApi
+from reconcile.queries import GITLAB_INSTANCES_QUERY
 
 from multiprocessing.dummy import Pool as ThreadPool
 from functools import partial
-
-INSTANCES_QUERY = """
-{
-  instances: gitlabinstance_v1 {
-    url
-    token {
-      path
-      field
-    }
-    managedGroups
-  }
-}
-"""
 
 APPS_QUERY = """
 {
@@ -59,7 +47,7 @@ def get_members_to_add(repo, gl, app_sre):
 def run(dry_run=False, thread_pool_size=10):
     gqlapi = gql.get_api()
     # assuming a single GitLab instance for now
-    instance = gqlapi.query(INSTANCES_QUERY)['instances'][0]
+    instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
     gl = GitLabApi(instance, ssl_verify=False)
     repos = get_gitlab_repos(gqlapi, gl.server)
     app_sre = gl.get_app_sre_group_users()

--- a/reconcile/jenkins_webhooks.py
+++ b/reconcile/jenkins_webhooks.py
@@ -1,19 +1,18 @@
 import copy
 import logging
 
-from utils.config import get_config
+import utils.gql as gql
+
 from utils.gitlab_api import GitLabApi
 from reconcile.jenkins_job_builder import init_jjb
+from reconcile.queries import GITLAB_INSTANCES_QUERY
 
 
 def get_gitlab_api():
-    config = get_config()
-
-    gitlab_config = config['gitlab']
-    server = gitlab_config['server']
-    token = gitlab_config['token']
-
-    return GitLabApi(server, token, ssl_verify=False)
+    gqlapi = gql.get_api()
+    # assuming a single GitLab instance for now
+    instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
+    return GitLabApi(instance, ssl_verify=False)
 
 
 def get_hooks_to_add(desired_state, gl):

--- a/reconcile/jenkins_webhooks.py
+++ b/reconcile/jenkins_webhooks.py
@@ -12,7 +12,7 @@ def get_gitlab_api():
     gqlapi = gql.get_api()
     # assuming a single GitLab instance for now
     instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
-    return GitLabApi(instance, ssl_verify=False)
+    return GitLabApi(instance)
 
 
 def get_hooks_to_add(desired_state, gl):

--- a/reconcile/ldap_users.py
+++ b/reconcile/ldap_users.py
@@ -3,8 +3,8 @@ import logging
 import utils.gql as gql
 import utils.ldap_client as ldap_client
 
-from utils.config import get_config
 from utils.gitlab_api import GitLabApi
+from reconcile.queries import GITLAB_INSTANCES_QUERY
 
 from multiprocessing.dummy import Pool as ThreadPool
 from collections import defaultdict
@@ -33,17 +33,6 @@ def init_users():
             for username, paths in users.items()]
 
 
-def get_app_interface_gitlab_api():
-    config = get_config()
-
-    gitlab_config = config['gitlab']
-    server = gitlab_config['server']
-    token = gitlab_config['token']
-    project_id = gitlab_config['app-interface']['project_id']
-
-    return GitLabApi(server, token, project_id=project_id, ssl_verify=False)
-
-
 def init_user_spec(user):
     username = user['username']
     paths = user['paths']
@@ -55,7 +44,7 @@ def init_user_spec(user):
     return (username, delete, paths)
 
 
-def run(dry_run=False, thread_pool_size=10):
+def run(project_id, dry_run=False, thread_pool_size=10):
     users = init_users()
     pool = ThreadPool(thread_pool_size)
     user_specs = pool.map(init_user_spec, users)
@@ -63,7 +52,10 @@ def run(dry_run=False, thread_pool_size=10):
                        in user_specs if delete]
 
     if not dry_run:
-        gl = get_app_interface_gitlab_api()
+        gqlapi = gql.get_api()
+        # assuming a single GitLab instance for now
+        instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
+        gl = GitLabApi(instance, project_id=project_id, ssl_verify=False)
 
     for username, paths in users_to_delete:
         logging.info(['delete_user', username])

--- a/reconcile/ldap_users.py
+++ b/reconcile/ldap_users.py
@@ -55,8 +55,7 @@ def run(gitlab_project_id, dry_run=False, thread_pool_size=10):
         gqlapi = gql.get_api()
         # assuming a single GitLab instance for now
         instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
-        gl = GitLabApi(instance, project_id=gitlab_project_id,
-                       ssl_verify=False)
+        gl = GitLabApi(instance, project_id=gitlab_project_id)
 
     for username, paths in users_to_delete:
         logging.info(['delete_user', username])

--- a/reconcile/ldap_users.py
+++ b/reconcile/ldap_users.py
@@ -44,7 +44,7 @@ def init_user_spec(user):
     return (username, delete, paths)
 
 
-def run(project_id, dry_run=False, thread_pool_size=10):
+def run(gitlab_project_id, dry_run=False, thread_pool_size=10):
     users = init_users()
     pool = ThreadPool(thread_pool_size)
     user_specs = pool.map(init_user_spec, users)
@@ -55,7 +55,8 @@ def run(project_id, dry_run=False, thread_pool_size=10):
         gqlapi = gql.get_api()
         # assuming a single GitLab instance for now
         instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
-        gl = GitLabApi(instance, project_id=project_id, ssl_verify=False)
+        gl = GitLabApi(instance, project_id=gitlab_project_id,
+                       ssl_verify=False)
 
     for username, paths in users_to_delete:
         logging.info(['delete_user', username])

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1,0 +1,12 @@
+GITLAB_INSTANCES_QUERY = """
+{
+  instances: gitlabinstance_v1 {
+    url
+    token {
+      path
+      field
+    }
+    managedGroups
+  }
+}
+"""

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -7,6 +7,7 @@ GITLAB_INSTANCES_QUERY = """
       field
     }
     managedGroups
+    sslVerify
   }
 }
 """

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -16,6 +16,9 @@ class GitLabApi(object):
     def __init__(self, instance, project_id=None, ssl_verify=True):
         self.server = instance['url']
         token = vault_client.read(instance['token'])
+        ssl_verify = instance['sslVerify']
+        if ssl_verify is None:
+            ssl_verify = True
         self.gl = gitlab.Gitlab(self.server, private_token=token,
                                 ssl_verify=ssl_verify)
         self.gl.auth()

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -4,6 +4,8 @@ import gitlab
 import urllib3
 import uuid
 
+import utils.vault_client as vault_client
+
 
 # The following line will supress
 # `InsecureRequestWarning: Unverified HTTPS request is being made`
@@ -11,8 +13,9 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class GitLabApi(object):
-    def __init__(self, server, token, project_id=None, ssl_verify=True):
-        self.server = server
+    def __init__(self, instance, project_id=None, ssl_verify=True):
+        self.server = instance['url']
+        token = vault_client.read(instance['token'])
         self.gl = gitlab.Gitlab(self.server, private_token=token,
                                 ssl_verify=ssl_verify)
         self.gl.auth()


### PR DESCRIPTION
covers https://jira.coreos.com/browse/APPSRE-938

this PR does:

* removes the need for a `gitlab` section in the config file - it will be consumed through app-interface.
* updates integrations to consume token from app-interface
* updates gitlab api to get the instance query result instead of a server and a token
* adds a `queries.py` file for common queries (long needed)
* more then just a bit of a refactor to gitlab-members

Notes for the reviewer: i suggest to review this commit by commit.