### PR TITLE
extract terraform/aws secrets from config

### DIFF
--- a/reconcile/aws_garbage_collector.py
+++ b/reconcile/aws_garbage_collector.py
@@ -1,9 +1,14 @@
+import utils.gql as gql
+
+from reconcile.queries import AWS_ACCOUNTS_QUERY
 from utils.aws_api import AWSApi
 
 
 def run(dry_run=False, thread_pool_size=10,
         enable_deletion=False, io_dir='throughput/'):
-    aws = AWSApi(thread_pool_size)
+    gqlapi = gql.get_api()
+    accounts = gqlapi.query(AWS_ACCOUNTS_QUERY)['accounts']
+    aws = AWSApi(thread_pool_size, accounts)
     if dry_run:
         aws.simulate_deleted_users(io_dir)
     aws.map_resources()

--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -1,27 +1,18 @@
 import utils.gql as gql
 
+from reconcile.queries import AWS_ACCOUNTS_QUERY
 from utils.aws_api import AWSApi
 
-QUERY = """
-{
-  accounts: awsaccounts_v1 {
-    name
-    deleteKeys
-  }
-}
-"""
 
-
-def fetch_keys_to_delete():
-    gqlapi = gql.get_api()
-    accounts = gqlapi.query(QUERY)['accounts']
-
+def get_keys_to_delete(accounts):
     return {account['name']: account['deleteKeys']
             for account in accounts
             if account['deleteKeys'] not in (None, [])}
 
 
 def run(dry_run=False, thread_pool_size=10, enable_deletion=False):
-    aws = AWSApi(thread_pool_size)
-    keys_to_delete = fetch_keys_to_delete()
+    gqlapi = gql.get_api()
+    accounts = gqlapi.query(AWS_ACCOUNTS_QUERY)['accounts']
+    aws = AWSApi(thread_pool_size, accounts)
+    keys_to_delete = get_keys_to_delete(accounts)
     aws.delete_keys(dry_run, keys_to_delete)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -11,3 +11,15 @@ GITLAB_INSTANCES_QUERY = """
   }
 }
 """
+
+AWS_ACCOUNTS_QUERY = """
+{
+  accounts: awsaccounts_v1 {
+    name
+    automationToken {
+      path
+      field
+    }
+  }
+}
+"""

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -20,6 +20,7 @@ AWS_ACCOUNTS_QUERY = """
       path
       field
     }
+    deleteKeys
   }
 }
 """

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -6,23 +6,12 @@ import utils.gql as gql
 import utils.threaded as threaded
 import reconcile.openshift_resources as openshift_resources
 
+from reconcile.queries import AWS_ACCOUNTS_QUERY
 from utils.terrascript_client import TerrascriptClient as Terrascript
 from utils.terraform_client import OR, TerraformClient as Terraform
 from utils.openshift_resource import ResourceInventory
 from utils.oc import OC_Map
 from utils.defer import defer
-
-AWS_ACCOUNTS_QUERY = """
-{
-  accounts: awsaccounts_v1 {
-    name
-    automationToken {
-      path
-      field
-    }
-  }
-}
-"""
 
 TF_NAMESPACES_QUERY = """
 {

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -74,7 +74,8 @@ class TerrascriptClient(object):
                                self.thread_pool_size)
         self.configs = {account: secret for account, secret in results}
 
-    def get_vault_tf_secrets(self, account):
+    @staticmethod
+    def get_vault_tf_secrets(account):
         account_name = account['name']
         automation_token = account['automationToken']
         secret = vault_client.read_all(automation_token)

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -41,12 +41,12 @@ class UnknownProviderError(Exception):
 
 class TerrascriptClient(object):
     def __init__(self, integration, integration_prefix,
-                 thread_pool_size, oc_map=None):
+                 thread_pool_size, accounts, oc_map=None):
         self.integration = integration
         self.integration_prefix = integration_prefix
         self.oc_map = oc_map
         self.thread_pool_size = thread_pool_size
-        self.populate_configs_and_vars_from_vault()
+        self.populate_configs_from_vault(accounts)
         tss = {}
         locks = {}
         for name, config in self.configs.items():
@@ -69,44 +69,16 @@ class TerrascriptClient(object):
         self.tss = tss
         self.locks = locks
 
-    def populate_configs_and_vars_from_vault(self):
-        self.init_accounts()
-
-        vault_specs = self.init_vault_tf_secret_specs()
-        results = threaded.run(self.get_vault_tf_secrets, vault_specs,
+    def populate_configs_from_vault(self, accounts):
+        results = threaded.run(self.get_vault_tf_secrets, accounts,
                                self.thread_pool_size)
+        self.configs = {account: secret for account, secret in results}
 
-        self.configs = {}
-        self.variables = {}
-        for account, type, secret in results:
-            if type == 'config':
-                self.configs[account] = secret
-            if type == 'variables':
-                self.variables[account] = secret
-
-    def init_accounts(self):
-        config = get_config()
-        accounts = config['terraform']
-        self.accounts = accounts.items()
-
-    def init_vault_tf_secret_specs(self):
-        vault_specs = []
-        for account, data in self.accounts:
-            for type in ('config', 'variables'):
-                init_spec = {'account': account,
-                             'data': data,
-                             'type': type}
-                vault_specs.append(init_spec)
-        return vault_specs
-
-    def get_vault_tf_secrets(self, init_spec):
-        account = init_spec['account']
-        data = init_spec['data']
-        type = init_spec['type']
-        secret = vault_client.read_all(
-            {'path': '{}/{}'.format(data['secrets_path'], type)}
-        )
-        return (account, type, secret)
+    def get_vault_tf_secrets(self, account):
+        account_name = account['name']
+        automation_token = account['automationToken']
+        secret = vault_client.read_all(automation_token)
+        return (account_name, secret)
 
     def get_tf_iam_group(self, group_name):
         return aws_iam_group(
@@ -249,15 +221,13 @@ class TerrascriptClient(object):
                 for ip in range(len(user_policies)):
                     policy_name = user_policies[ip]['name']
                     account_name = aws_groups[ig]['account']['name']
+                    account_uid = aws_groups[ig]['account']['uid']
                     for iu in range(len(users)):
                         # replace known keys with values
                         user_name = users[iu]['redhat_username']
                         policy = user_policies[ip]['policy']
                         policy = policy.replace('${aws:username}', user_name)
-                        policy = policy.replace(
-                            '${aws:accountid}',
-                            self.variables[account_name]['uid']
-                        )
+                        policy = policy.replace('${aws:accountid}', account_uid)
 
                         # Ref: terraform aws iam_user_policy
                         tf_iam_user = self.get_tf_iam_user(user_name)

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -10,7 +10,6 @@ import utils.gql as gql
 import utils.threaded as threaded
 import utils.vault_client as vault_client
 
-from utils.config import get_config
 from utils.oc import StatusCodeError
 from utils.gpg import gpg_key_valid
 
@@ -228,7 +227,8 @@ class TerrascriptClient(object):
                         user_name = users[iu]['redhat_username']
                         policy = user_policies[ip]['policy']
                         policy = policy.replace('${aws:username}', user_name)
-                        policy = policy.replace('${aws:accountid}', account_uid)
+                        policy = \
+                            policy.replace('${aws:accountid}', account_uid)
 
                         # Ref: terraform aws iam_user_policy
                         tf_iam_user = self.get_tf_iam_user(user_name)


### PR DESCRIPTION
we currently have this in the config file:
```
[terraform]
[terraform.aws1]
secrets_path = 'creds/terraform/aws1'
[terraform.aws2]
secrets_path = 'creds/terraform/aws2'
```

this PR makes this config redundant by moving it to app-interface aws account objects.