### PR TITLE
[openshift-resources] sort by type

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import base64
 import json
-
+import operator
 import anymarkup
 import jinja2
 import semver
@@ -504,7 +504,7 @@ def init_specs_to_fetch(ri, oc_map, namespaces,
                                openshift_resource, namespace_info)
             state_specs.append(d_spec)
 
-    return state_specs
+    return sorted(state_specs, key=operator.attrgetter('type'))
 
 
 def fetch_data(namespaces, thread_pool_size):

--- a/utils/threaded.py
+++ b/utils/threaded.py
@@ -9,4 +9,4 @@ def run(func, iterable, thread_pool_size, **kwargs):
 
     pool = ThreadPool(thread_pool_size)
     func_partial = partial(func, **kwargs)
-    return pool.map(func_partial, iterable)
+    return pool.map(func_partial, iterable, chunksize=1)

--- a/utils/vault_client.py
+++ b/utils/vault_client.py
@@ -1,5 +1,6 @@
 import time
 import requests
+import logging
 import hvac
 import base64
 from utils.config import get_config
@@ -27,6 +28,7 @@ def init(server, role_id, secret_id):
     global _client
 
     if _client is None:
+        logging.getLogger("urllib3").setLevel(logging.ERROR)
         client = hvac.Client(url=server)
 
         authenticated = False


### PR DESCRIPTION
This PR sorts the resources to fetch according to their type (`current` - oc get, or `desired` - graphql+vault queries).

since calls to clusters tend to take longer then to fetch resources from graphql and vault, we have a tail of `current` calls that make the integration be a bit slower. by sorting them and running them concurrently but in order (`chunksize=1`), we loose the tail.

that's the theory at least.

also disabled the `WARNING` level logs from vault_client, to hide these warnings: `Connection pool is full, discarding connection`, which means:

> a connection is dropped (because the pool is full); however, the same connection will be re-tried later on when connection pool becomes available
ref: https://stackoverflow.com/questions/53765366/urllib3-connectionpool-connection-pool-is-full-discarding-connection

this will probably be better handled by increasing the connection pool size for vault, which can be added in a future iteration.
ref: https://hvac.readthedocs.io/en/stable/advanced_usage.html#custom-requests-http-adapter