### PR TITLE
[gitlab-housekeeping] add rebase of merge requests

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -89,7 +89,7 @@ def rebase_merge_requests(dry_run, gl):
         result = gl.project.repository_compare(mr.sha, head)
         if len(result['commits']) == 0:  # rebased
             continue
-        
+
         logging.info(['rebase', gl.project.name, mr.iid])
         if not dry_run:
             mr.rebase()

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -90,8 +90,7 @@ def rebase_merge_requests(dry_run, gl):
         if len(result['commits']) == 0:  # rebased
             continue
         
-        mr_iid = mr.attributes.get('iid')
-        logging.info(['rebase', gl.project.name, mr_iid])
+        logging.info(['rebase', gl.project.name, mr.iid])
         if not dry_run:
             mr.rebase()
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "hvac>=0.7.0,<0.8.0",
         "ldap3>=2.5.2,<2.6.0",
         "anymarkup>=0.7.0,<0.8.0",
-        "python-gitlab>=1.7.0,<1.8.0",
+        "python-gitlab>=1.11.0,<1.12.0",
         "semver>=2.8.0,<2.9.0",
         "python-terraform>=0.10.0,<0.11.0",
         "boto3>=1.9.0,<=1.10.0",


### PR DESCRIPTION
This PR adds a rebase of merge requests to housekeeping to keep all MRs rebased at all times.
It also changes the way `stale` items are calculated - changing it from update date of the item to the latest note added on the item (to ignore rebases).