### PR TITLE
New integration openshift-prometheusrules

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `openshift-limitranges`: Manages OpenShift LimitRange objects.
 - `openshift-namespaces`: Manages OpenShift Namespaces.
 - `openshift-network-policies`: Manages OpenShift NetworkPolicies.
+- `openshift-prometheusrules`: Generates and Managers OpenShift PrometheusRule Objects.
 - `openshift-resources`: Manages OpenShift Resources.
 - `openshift-rolebindings`: Configures Rolebindings in OpenShift clusters.
 - `openshift-users`: Deletion of users from OpenShift clusters.

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,3 +1,18 @@
+FROM centos:7 AS jsonnet-builder
+
+ENV GOPATH /go
+
+RUN yum install -y epel-release && \
+    yum install -y go
+
+RUN mkdir -p /go && chmod -R 777 /go
+
+ENV JSONNET_VERSION 0.14.0
+ENV JSONNET_BUNDLER_VERSION 10e24cb86976782d27a6a821b629919e26bdf882
+
+RUN GO111MODULE=on go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb@${JSONNET_BUNDLER_VERSION}
+RUN GO111MODULE=on go get github.com/google/go-jsonnet/cmd/jsonnet@v${JSONNET_VERSION}
+
 FROM centos:7
 
 ENV LC_ALL=en_US.utf8
@@ -23,6 +38,9 @@ RUN curl https://github.com/awslabs/git-secrets/archive/${GIT_SECRETS_VERSION}.t
     tar -zvxf git-secrets.tar.gz git-secrets-${GIT_SECRETS_VERSION}/git-secrets && \
     mv git-secrets-${GIT_SECRETS_VERSION}/git-secrets /usr/local/bin/git-secrets && \
     rm -rf git-secrets*
+# Add jsonnet deps
+COPY --from=jsonnet-builder /go/bin/jb /usr/local/bin/jb
+COPY --from=jsonnet-builder /go/bin/jsonnet /usr/local/bin/jsonnet
 
 WORKDIR /reconcile
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -15,6 +15,7 @@ import reconcile.openshift_users
 import reconcile.openshift_resources
 import reconcile.openshift_namespaces
 import reconcile.openshift_network_policies
+import reconcile.openshift_prometheusrules
 import reconcile.quay_membership
 import reconcile.quay_repos
 import reconcile.ldap_users
@@ -377,6 +378,16 @@ def openshift_namespaces(ctx, thread_pool_size, internal):
 def openshift_network_policies(ctx, thread_pool_size, internal):
     run_integration(reconcile.openshift_network_policies.run,
                     ctx.obj['dry_run'], thread_pool_size, internal)
+
+
+
+@integration.command()
+@threaded()
+@binary(['oc', 'jb', 'jsonnet'])
+@click.pass_context
+def openshift_prometheusrules(ctx, thread_pool_size):
+    run_integration(reconcile.openshift_prometheusrules.run,
+                    ctx.obj['dry_run'], thread_pool_size)
 
 
 @integration.command()

--- a/reconcile/openshift_prometheusrules.py
+++ b/reconcile/openshift_prometheusrules.py
@@ -1,0 +1,230 @@
+import semver
+
+import utils.gql as gql
+import reconcile.openshift_base as ob
+import utils.jsonnet as jsonnet
+import utils.template as template_utils
+
+from utils.defer import defer
+from utils.openshift_resource import (OpenshiftResource as OR)
+from utils.jb_client import JsonnetBundler
+
+
+class Jinja2TemplateError(Exception):
+    def __init__(self, msg):
+        super(Jinja2TemplateError, self).__init__(
+            "error processing jinja2 template: " + str(msg)
+        )
+
+
+PERFORMANCEPARAMETERS_QUERY = """
+{
+  performance_parameters_v1 {
+    labels
+    name
+    component
+    prometheusLabels
+    namespaces {
+      namespace {
+        name
+      }
+    }
+    app {
+      name
+      namespaces {
+        name
+        cluster {
+          observabilityNamespace {
+            name
+            cluster {
+              name
+              serverUrl
+              jumpHost {
+                hostname
+                knownHosts
+                user
+                port
+                identity {
+                  path
+                  field
+                  format
+                }
+              }
+              automationToken {
+                path
+                field
+                format
+              }
+              disable {
+                integrations
+              }
+            }
+          }
+          name
+          serverUrl
+          jumpHost {
+            hostname
+            knownHosts
+            user
+            port
+            identity {
+              path
+              field
+              format
+            }
+          }
+          automationToken {
+            path
+            field
+            format
+          }
+          disable {
+            integrations
+          }
+        }
+      }
+    }
+    availability {
+      kind
+      metric
+      errorBudget
+      selectors
+    }
+    latency {
+      kind
+      metric
+      threshold
+      percentile
+      selectors
+    }
+    rawRecording {
+      record
+      expr
+      labels
+    }
+    rawAlerting {
+      alert
+      expr
+      for
+      labels
+      annotations {
+        message
+        runbook
+        dashboard
+        link_url
+      }
+    }
+  }
+}
+"""
+
+QONTRACT_INTEGRATION = 'openshift-prometheusrules'
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
+JSONNET_TEMPLATE_FILE = "slo.jsonnet.j2"
+LIBSONNET_TEMPLATE_FILE = "slo.libsonnet.j2"
+
+
+def fetch_desired_state(performance_parameters, ri):
+    jb_client = init_jb_client()
+    defer(lambda: jb_client.cleanup())
+    temp_dir_path = jb_client.get_dir_path()
+    template_env = template_utils.get_package_environment()
+
+    # Iterate over all available Performance Parameters
+    for pp in performance_parameters['performance_parameters_v1']:
+        for namespace in pp['app']['namespaces']:
+            if namespace['cluster']['observabilityNamespace'] is not None:
+
+                libsonnet_file_path = jsonnet.generate_libsonnet_file(
+                  LIBSONNET_TEMPLATE_FILE,
+                  pp,
+                  namespace,
+                  temp_dir_path,
+                  template_env
+                  )
+
+                jsonnet_file_path = jsonnet.generate_jsonnet_file(
+                  JSONNET_TEMPLATE_FILE,
+                  pp,
+                  namespace,
+                  libsonnet_file_path,
+                  temp_dir_path,
+                  template_env
+                  )
+
+                # Generate the manifests
+                output = jsonnet.generate(jsonnet_file_path, temp_dir_path)
+                resource_name = output['metadata']['name']
+
+                openshift_resource = OR(
+                  output,
+                  QONTRACT_INTEGRATION,
+                  QONTRACT_INTEGRATION_VERSION,
+                  error_details=resource_name
+                  )
+
+                cluster = namespace['cluster']
+                cluster_observability_namespace = cluster.get(
+                  'observabilityNamespace'
+                  )
+
+                ri.add_desired(
+                    cluster_observability_namespace['cluster']['name'],
+                    cluster_observability_namespace['name'],
+                    'PrometheusRule',
+                    resource_name,
+                    openshift_resource
+                )
+
+
+def init_jb_client():
+    jsonnetfile = """{
+        "dependencies": [
+            {
+                "name": "slo-libsonnet",
+                "source": {
+                    "git": {
+                        "remote":
+                        "https://github.com/metalmatze/slo-libsonnet",
+                        "subdir": "slo-libsonnet"
+                    }
+                },
+                "version": "037525d64e7ffe3198acfbaa99482cffced8e9c0"
+            }
+        ]
+    }
+    """
+    return JsonnetBundler(jsonnetfile)
+
+
+def get_observability_namespaces(performance_parameters):
+    for pp in performance_parameters['performance_parameters_v1']:
+        observability_namespaces = [
+            ns['cluster']['observabilityNamespace']
+            for ns in pp['app']['namespaces']
+            if ns['cluster']['observabilityNamespace'] is not None
+          ]
+    return observability_namespaces
+
+
+@defer
+def run(dry_run=False, thread_pool_size=10, defer=None):
+
+    gqlapi = gql.get_api()
+
+    performance_parameters = gqlapi.query(PERFORMANCEPARAMETERS_QUERY)
+
+    observability_namespaces = get_observability_namespaces(
+      performance_parameters
+      )
+
+    ri, oc_map = \
+        ob.fetch_current_state(observability_namespaces, thread_pool_size,
+                               QONTRACT_INTEGRATION,
+                               QONTRACT_INTEGRATION_VERSION,
+                               override_managed_types=['PrometheusRule'])
+    defer(lambda: oc_map.cleanup())
+
+    fetch_desired_state(performance_parameters, ri)
+
+    ob.realize_data(dry_run, oc_map, ri)

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setup(
                 "state as defined in the app-interface DB.",
 
     packages=find_packages(exclude=('tests',)),
+    package_data={'templates': ['*.j2']},
+    include_package_data=True,
 
     install_requires=[
         "Click>=7.0,<8.0",

--- a/templates/slo.jsonnet.j2
+++ b/templates/slo.jsonnet.j2
@@ -1,0 +1,28 @@
+local slo = import 'slo-libsonnet/slo.libsonnet';
+local slos = import '{{ libsonnetFile }}';
+
+{
+  apiVersion: 'monitoring.coreos.com/v1',
+  kind: 'PrometheusRule',
+  metadata: {
+    name: '{{ component }}-slo-{{ namespace }}',
+    labels: {{ manifestLabels }},
+  },
+  spec: {
+    groups: [
+      {
+        name: '{{ component }}.slo.rules',
+        rules:
+          local availability = slos.prometheusSLOs.errors {
+            selectors+: {{ selectors }},
+            labels: [
+              'component="{{ component }}"',
+            ],
+          };
+          slo.errorburn(availability).recordingrules +
+          slo.errorburn(availability).alerts +
+          slo.errorbudget(availability).recordingrules,
+      },
+    ],
+  },
+}

--- a/templates/slo.libsonnet.j2
+++ b/templates/slo.libsonnet.j2
@@ -1,0 +1,9 @@
+{
+  prometheusSLOs: {
+    errors: {
+      metric: '{{ metric }}',
+      selectors: [],
+      errorBudget: 1 - {{ errorBudget }},
+    },
+  },
+}

--- a/utils/jb_client.py
+++ b/utils/jb_client.py
@@ -1,0 +1,41 @@
+import logging
+import json
+import subprocess
+import tempfile
+import shutil
+
+
+class JsonnetBundler():
+    """Wrapper around the Jsonnet Bundler utility"""
+
+    def __init__(self, jsonnetfile):
+        """Initialize a jsonnet directory with the provided jsonnetfile"""
+        self.temp_dir_path = tempfile.mkdtemp()
+
+        with open(self.temp_dir_path + "/jsonnetfile.json", 'w') as f:
+            json.dump(json.loads(jsonnetfile), f)
+
+        self.install()
+
+    def get_dir_path(self):
+        return self.temp_dir_path
+
+    def install(self):
+        """Initializes a jsonnet directory with the provided jsonnetfile"""
+        cmd = ['jb', 'install']
+        subprocess.call(cmd, cwd=self.temp_dir_path)
+
+    def update(self):
+        """
+        Run jb update on the given directory
+        """
+        cmd = ['jb', 'update']
+        subprocess.call(cmd, cwd=self.temp_dir_path)
+
+    def cleanup(self):
+        """Removes the temporary directory"""
+        try:
+            shutil.rmtree(self.temp_dir_path)
+        except Exception:
+            logging.debug("Unable to delete temporary jsonnet directory")
+            pass

--- a/utils/jsonnet.py
+++ b/utils/jsonnet.py
@@ -1,0 +1,81 @@
+import json
+import subprocess
+
+
+def generate(jsonnet_file_path, temp_dir_path):
+    """Initializes a jsonnet directory with the provided jsonnetfile"""
+    cmd = ['jsonnet', '-J', 'vendor/', jsonnet_file_path]
+    return json.loads(
+        subprocess.check_output(cmd, cwd=temp_dir_path)
+        )
+
+
+def generate_jsonnet_file(
+  jsonnet_template_filename, pp, namespace,
+  libsonnet_file_path, temp_dir_path, template_env
+  ):
+    """Generate the <component>-slo-<namespace>.jsonnet file"""
+    template = template_env.get_template(jsonnet_template_filename)
+    # Get some template-specific variables
+    component_name = pp['component']
+    namespace_name = namespace['name']
+    manifestLabels = {
+      'role': 'alert-rules',
+    }
+    manifestLabels.update(json.loads(pp['prometheusLabels']))
+    selectors = []
+    for k, v in json.loads(
+      pp['availability'][0].get('selectors')
+      ).iteritems():
+        selectors.append("%s=\"%s\"" % (k, v))
+    jsonnet_file_path = str(
+      temp_dir_path + "/" + component_name +
+      "-slo-" + namespace_name + ".jsonnet"
+      )
+
+    outputText = template.render(
+      libsonnetFile=libsonnet_file_path,
+      component=component_name,
+      namespace=namespace_name,
+      selectors=json.dumps(selectors, ensure_ascii=True),
+      manifestLabels=json.dumps(manifestLabels, ensure_ascii=True)
+      )
+
+    with open(jsonnet_file_path, 'w') as f:
+        f.writelines(outputText)
+    f.close()
+
+    return jsonnet_file_path
+
+
+def generate_libsonnet_file(
+  libsonnet_template_filename, pp, namespace, temp_dir_path, template_env
+  ):
+    """Generate the <component>-slo-<namespace>.libsonnet file"""
+    template = template_env.get_template(libsonnet_template_filename)
+    component_name = pp['component']
+    namespace_name = namespace['name']
+    http_metric_name = pp['availability'][0].get('metric')
+    availability_error_budget = pp['availability'][0].get(
+      'errorBudget'
+      )
+    selectors = []
+    for k, v in json.loads(
+      pp['availability'][0].get('selectors')
+      ).iteritems():
+        selectors.append("%s=\"%s\"" % (k, v))
+
+    outputText = template.render(
+      metric=http_metric_name,
+      selectors=json.dumps(selectors, ensure_ascii=True),
+      errorBudget=availability_error_budget
+      )
+
+    libsonnet_file_path = str(
+      temp_dir_path + "/" + component_name +
+      "-slo-" + namespace_name + ".libsonnet"
+      )
+    with open(libsonnet_file_path, 'w') as f:
+        f.writelines(outputText)
+    f.close()
+    return libsonnet_file_path

--- a/utils/template.py
+++ b/utils/template.py
@@ -1,0 +1,12 @@
+import jinja2
+import os
+import templates
+
+
+def get_package_environment():
+    """Loads templates from the current Python package"""
+    package_templates_dir = os.path.dirname(templates.__file__)
+    template_loader = jinja2.FileSystemLoader(
+      searchpath=package_templates_dir
+      )
+    return jinja2.Environment(loader=template_loader)


### PR DESCRIPTION
What:

This PR introduces a new integration that uses the app schema parameters to generate recording and alerting rules as `PrometheusRule`  CR objects, and applies them to the appropriate namespace as identified from the cluster-namespace combination.

How: 
The integration utilizes the [slo-libsonnet](https://github.com/metalmatze/slo-libsonnet/) library to generate the rules, and then Jsonnet to generate the PrometheusRule CR manifest