### PR TITLE
Switch openssl utils to pyOpenSSL

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -254,7 +254,7 @@ def aws_iam_keys(ctx, thread_pool_size):
 
 @integration.command()
 @threaded(default=20)
-@binary(['oc', 'ssh', 'openssl'])
+@binary(['oc', 'ssh'])
 @click.pass_context
 def openshift_resources(ctx, thread_pool_size):
     run_integration(reconcile.openshift_resources.run,

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "jenkins-job-builder>=2.10.1,<2.11.0",
         "Jinja2>=2.10.1,<2.11.0",
         "jira>=2.0.0,<2.1.0",
+        "pyOpenSSL>=19.0.0,<20.0.0",
     ],
 
     test_suite="tests",

--- a/utils/openssl.py
+++ b/utils/openssl.py
@@ -10,4 +10,3 @@ def get_certificate_common_name(certificate):
     cert = crypto.load_certificate(crypto.FILETYPE_PEM, certificate)
     subject = cert.get_subject()
     return subject.CN
-

--- a/utils/openssl.py
+++ b/utils/openssl.py
@@ -1,4 +1,4 @@
-from subprocess import PIPE, Popen
+from OpenSSL import crypto
 
 
 def certificate_matches_host(certificate, host):
@@ -7,12 +7,7 @@ def certificate_matches_host(certificate, host):
 
 
 def get_certificate_common_name(certificate):
-    proc = Popen(
-        ['openssl', 'x509', '-noout', '-subject'],
-        stdin=PIPE,
-        stdout=PIPE,
-        stderr=PIPE
-    )
-    out, err = proc.communicate(certificate)
+    cert = crypto.load_certificate(crypto.FILETYPE_PEM, certificate)
+    subject = cert.get_subject()
+    return subject.CN
 
-    return out.split('/CN=')[1].strip()


### PR DESCRIPTION
Using the `openssl` binary and parsing the output to extract certificate info is error prone.

This PR changes this to use pyOpenSSL instead.

This fixes an issue where on my system running OpenSSL 1.1.1d the output format is different from version 1.0.2k in CentOS 7

OpenSSL 1.1.1d
```
# openssl x509 -noout -subject < crt
subject=C = US, ST = North Carolina, L = Raleigh, O = "Red Hat, Inc.", OU = Developer Tools, CN = *.api.prod-preview.openshift.io
```

OpenSSL 1.0.2k
```
# openssl x509 -noout -subject < crt
subject= /C=US/ST=North Carolina/L=Raleigh/O=Red Hat, Inc./OU=Developer Tools/CN=*.api.prod-preview.openshift.io
```