### PR TITLE
Improve tracebacks for exceptions raised from inside a thread

### DIFF
--- a/utils/threaded.py
+++ b/utils/threaded.py
@@ -1,6 +1,16 @@
 from multiprocessing.dummy import Pool as ThreadPool
 from functools import partial
 
+def full_traceback(func):
+    import traceback, functools
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            msg = "{}\n\nOriginal {}".format(e, traceback.format_exc())
+            raise type(e)(msg)
+    return wrapper
 
 def run(func, iterable, thread_pool_size, **kwargs):
     """run executes a function for each item in the input iterable.
@@ -8,5 +18,5 @@ def run(func, iterable, thread_pool_size, **kwargs):
     kwargs are passed to the input function (optional)."""
 
     pool = ThreadPool(thread_pool_size)
-    func_partial = partial(func, **kwargs)
+    func_partial = partial(full_traceback(func), **kwargs)
     return pool.map(func_partial, iterable)


### PR DESCRIPTION
This is an attempt at improving the tracebacks returned when code running inside a thread raises an exception

Currently, the exception does not return any info on the exception that occurred inside the thread.

*Before (no context on the IndexError: list index out of range)*
```
Traceback (most recent call last):
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/bin/qontract-reconcile", line 11, in <module>
    load_entry_point('reconcile', 'console_scripts', 'qontract-reconcile')()
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/utils/binary.py", line 14, in f_binary
    f(*args, **kwargs)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/reconcile/cli.py", line 261, in openshift_resources
    ctx.obj['dry_run'], thread_pool_size)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/reconcile/cli.py", line 89, in run_integration
    func(*args)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/utils/defer.py", line 15, in func_wrapper
    return func(*args, defer=defer, **kwargs)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/reconcile/openshift_resources.py", line 449, in run
    oc_map, ri = fetch_data(namespaces, thread_pool_size)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/reconcile/openshift_resources.py", line 440, in fetch_data
    threaded.run(fetch_states, state_specs, thread_pool_size, ri=ri)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/utils/threaded.py", line 23, in run
    return pool.map(func_partial, iterable)
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 253, in map
    return self.map_async(func, iterable, chunksize).get()
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 572, in get
    raise self._value
IndexError: list index out of range
```

*After (original traceback is returned)*
```
Traceback (most recent call last):
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/bin/qontract-reconcile", line 11, in <module>
    load_entry_point('reconcile', 'console_scripts', 'qontract-reconcile')()
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/utils/binary.py", line 14, in f_binary
    f(*args, **kwargs)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/venv/lib/python2.7/site-packages/Click-7.0-py2.7.egg/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/reconcile/cli.py", line 261, in openshift_resources
    ctx.obj['dry_run'], thread_pool_size)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/reconcile/cli.py", line 89, in run_integration
    func(*args)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/utils/defer.py", line 15, in func_wrapper
    return func(*args, defer=defer, **kwargs)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/reconcile/openshift_resources.py", line 449, in run
    oc_map, ri = fetch_data(namespaces, thread_pool_size)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/reconcile/openshift_resources.py", line 440, in fetch_data
    threaded.run(fetch_states, state_specs, thread_pool_size, ri=ri)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/utils/threaded.py", line 22, in run
    return pool.map(func_partial, iterable)
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 253, in map
    return self.map_async(func, iterable, chunksize).get()
  File "/usr/lib64/python2.7/multiprocessing/pool.py", line 572, in get
    raise self._value
IndexError: list index out of range

Original Traceback (most recent call last):
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/utils/threaded.py", line 9, in wrapper
    return func(*args, **kwargs)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/reconcile/openshift_resources.py", line 433, in fetch_states
    spec.parent)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/reconcile/openshift_resources.py", line 378, in fetch_desired_state
    openshift_resource = fetch_openshift_resource(resource, parent)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/reconcile/openshift_resources.py", line 342, in fetch_openshift_resource
    openshift_resource = fetch_provider_route(path, tls_path, tls_version)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/reconcile/openshift_resources.py", line 282, in fetch_provider_route
    match = openssl.certificate_matches_host(certificate, host)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/utils/openssl.py", line 5, in certificate_matches_host
    common_name = get_certificate_common_name(certificate)
  File "/home/jfchevrette/src/github.com/app-sre/qontract-reconcile/utils/openssl.py", line 18, in get_certificate_common_name
    return out.split('/CN=')[1].strip()
IndexError: list index out of range
```