### PR TITLE
Pass config option to oc command with /dev/null as value

### DIFF
--- a/utils/oc.py
+++ b/utils/oc.py
@@ -20,7 +20,12 @@ class JSONParsingError(Exception):
 
 class OC(object):
     def __init__(self, server, token, jh=None):
-        oc_base_cmd = ['oc', '--server', server, '--token', token]
+        oc_base_cmd = [
+            'oc',
+            '--config', '/dev/null',
+            '--server', server,
+            '--token', token
+        ]
 
         if jh is not None:
             self.jump_host = JumpHostSSH(jh)


### PR DESCRIPTION
I was investigating why running the openshift-resources integration would sometimes takes multiples minutes (sometimes over 10 minutes) on my local machine

I believe I've isolated the problem to the oc client repeatedly doing lookups on the kubeconfig (the one we have on the jumphost has a few hundreds). This does not seem to happen when connecting directly (locally) however this may very well happen if the user has a large local kubeconfig.

The multiple looks are ampolified when we're querying for many resources, in my case (as seen in the examples below) the command was retrieving nearly 2000 objects

The following line appeared thousands of times when running with `loglevel=8` on a remote jumphost with a somawhat large kubeconfig
```
I1017 17:57:48.014903   22011 loader.go:359] Config loaded from file /home/app-sre-bot/.kube/config
```
In any case, looking at the oc commands we run (with --server and --token), it doesn't seem necessary to load the local kubeconfig (or the jumphost one)

This change adds `--config /dev/null` to the oc commands we execute. This shouldn't have a negative impact other than avoiding parsing the kubeconfig and api object caches. This may cause a few extra API calls to load object schemas instead of fetching from a local cache.

Sometimes, the command would take over 10 minutes to complete. I presume this may happen when the apiserver or etcd is under more stress and the impact is exponential over the many queries the oc client does under the hood.

```
# ssh + oc (simple output, not the full objects)
# time ssh user@jumphost oc --server SERVER --token TOKEN get secrets -n aws-account-operator | wc -l
1941
2.84 real	0.00 user	0.00 sys

# ssh + oc + (simple output, not the full objects)
# time ssh user@jumphost oc --server SERVER --token TOKEN get secrets -n aws-account-operator
<expected output>
1.71 real	0.00 user	0.00 sys

# ssh + oc + json output (extended output, full objects details)
# time ssh user@jumphost oc --server SERVER --token TOKEN get secrets -n aws-account-operator -ojson 
<expected output>
19.53 real	0.01 user	0.05 sys

# ssh + oc + json output with --config /dev/null (extended output, full objects details)
# time ssh user@jumphost oc --config /dev/null --server SERVER --token TOKEN get secrets -n aws-account-operator -ojson 
<expected output>
2.21 real	0.02 user	0.05 sys
```