### PR TITLE
[aws-support-cases-sos] introduce new integration

### DIFF
--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -4,7 +4,7 @@ ENV LC_ALL=en_US.utf8
 ENV LANG=en_US.utf8
 
 RUN yum install -y epel-release && \
-    yum install -y python34 python36 python2-pip && \
+    yum install -y python36 python2-pip && \
     pip install --upgrade pip && \
     pip install tox
 

--- a/reconcile/aws_support_cases_sos.py
+++ b/reconcile/aws_support_cases_sos.py
@@ -1,7 +1,11 @@
+import logging
+
 import utils.gql as gql
 
 from reconcile.queries import AWS_ACCOUNTS_QUERY
+from reconcile.queries import GITLAB_INSTANCES_QUERY
 from utils.aws_api import AWSApi
+from utils.gitlab_api import GitLabApi
 
 
 def get_deleted_keys(accounts):
@@ -25,7 +29,7 @@ def get_keys_to_delete(aws_support_cases):
     return keys
 
 
-def run(dry_run=False, thread_pool_size=10, enable_deletion=False):
+def run(gitlab_project_id, dry_run=False, thread_pool_size=10, enable_deletion=False):
     gqlapi = gql.get_api()
     accounts = gqlapi.query(AWS_ACCOUNTS_QUERY)['accounts']
     aws = AWSApi(thread_pool_size, accounts)
@@ -36,6 +40,15 @@ def run(dry_run=False, thread_pool_size=10, enable_deletion=False):
     keys_to_delete = [ktd for ktd in keys_to_delete_from_cases
                       if ktd['key'] not in deleted_keys[ktd['account']]
                       and ktd['key'] in existing_keys[ktd['account']]]
+
+    if not dry_run and keys_to_delete:
+        # assuming a single GitLab instance for now
+        instance = gqlapi.query(GITLAB_INSTANCES_QUERY)['instances'][0]
+        gl = GitLabApi(instance, project_id=gitlab_project_id)
+
     for k in keys_to_delete:
-        print(k['account'])
-        print(k['key'])
+        logging.info(['delete_aws_access_key', k['account'], k['key']])
+        if not dry_run:
+            path = 'data' + \
+                [a['path'] for a in accounts if a['name'] == k['account']][0]
+            gl.create_delete_aws_access_key_mr(account, path, k['key'])

--- a/reconcile/aws_support_cases_sos.py
+++ b/reconcile/aws_support_cases_sos.py
@@ -29,7 +29,8 @@ def get_keys_to_delete(aws_support_cases):
     return keys
 
 
-def run(gitlab_project_id, dry_run=False, thread_pool_size=10, enable_deletion=False):
+def run(gitlab_project_id, dry_run=False, thread_pool_size=10,
+        enable_deletion=False):
     gqlapi = gql.get_api()
     accounts = gqlapi.query(AWS_ACCOUNTS_QUERY)['accounts']
     aws = AWSApi(thread_pool_size, accounts)

--- a/reconcile/aws_support_cases_sos.py
+++ b/reconcile/aws_support_cases_sos.py
@@ -47,8 +47,10 @@ def run(gitlab_project_id, dry_run=False, thread_pool_size=10, enable_deletion=F
         gl = GitLabApi(instance, project_id=gitlab_project_id)
 
     for k in keys_to_delete:
-        logging.info(['delete_aws_access_key', k['account'], k['key']])
+        account = k['account']
+        key = k['key']
+        logging.info(['delete_aws_access_key', account, key])
         if not dry_run:
             path = 'data' + \
-                [a['path'] for a in accounts if a['name'] == k['account']][0]
-            gl.create_delete_aws_access_key_mr(account, path, k['key'])
+                [a['path'] for a in accounts if a['name'] == account][0]
+            gl.create_delete_aws_access_key_mr(account, path, key)

--- a/reconcile/aws_support_cases_sos.py
+++ b/reconcile/aws_support_cases_sos.py
@@ -17,6 +17,9 @@ def get_deleted_keys(accounts):
 def get_keys_to_delete(aws_support_cases):
     search_pattern = 'We have become aware that the AWS Access Key '
     keys = []
+    # ref:
+    # https://boto3.amazonaws.com/v1/documentation/api/latest/
+    # reference/services/support.html#Support.Client.describe_cases
     for account, cases in aws_support_cases.items():
         for case in cases:
             comms = case['recentCommunications']['communications']

--- a/reconcile/aws_support_cases_sos.py
+++ b/reconcile/aws_support_cases_sos.py
@@ -1,0 +1,41 @@
+import utils.gql as gql
+
+from reconcile.queries import AWS_ACCOUNTS_QUERY
+from utils.aws_api import AWSApi
+
+
+def get_deleted_keys(accounts):
+    return {account['name']: account['deleteKeys']
+            for account in accounts
+            if account['deleteKeys'] not in (None, [])}
+
+
+def get_keys_to_delete(aws_support_cases):
+    search_pattern = 'We have become aware that the AWS Access Key '
+    keys = []
+    for account, cases in aws_support_cases.items():
+        for case in cases:
+            comms = case['recentCommunications']['communications']
+            for comm in comms:
+                body = comm['body']
+                split = body.split(search_pattern, 1)
+                if len(split) == 2:  # sentence is found, get the key
+                    key = split[1].split(' ')[0]
+                    keys.append({'account': account, 'key': key})
+    return keys
+
+
+def run(dry_run=False, thread_pool_size=10, enable_deletion=False):
+    gqlapi = gql.get_api()
+    accounts = gqlapi.query(AWS_ACCOUNTS_QUERY)['accounts']
+    aws = AWSApi(thread_pool_size, accounts)
+    deleted_keys = get_deleted_keys(accounts)
+    existing_keys = aws.get_users_keys()
+    aws_support_cases = aws.get_support_cases()
+    keys_to_delete_from_cases = get_keys_to_delete(aws_support_cases)
+    keys_to_delete = [ktd for ktd in keys_to_delete_from_cases
+                      if ktd['key'] not in deleted_keys[ktd['account']]
+                      and ktd['key'] in existing_keys[ktd['account']]]
+    for k in keys_to_delete:
+        print(k['account'])
+        print(k['key'])

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -254,11 +254,12 @@ def aws_iam_keys(ctx, thread_pool_size):
 
 
 @integration.command()
+@click.argument('gitlab-project-id')
 @threaded()
 @click.pass_context
-def aws_support_cases_sos(ctx, thread_pool_size):
-    run_integration(reconcile.aws_support_cases_sos.run, ctx.obj['dry_run'],
-                    thread_pool_size)
+def aws_support_cases_sos(ctx, gitlab_project_id, thread_pool_size):
+    run_integration(reconcile.aws_support_cases_sos.run, gitlab_project_id,
+                    ctx.obj['dry_run'], thread_pool_size)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -30,6 +30,7 @@ import reconcile.gitlab_housekeeping
 import reconcile.gitlab_members
 import reconcile.aws_garbage_collector
 import reconcile.aws_iam_keys
+import reconcile.aws_support_cases_sos
 
 from utils.aggregated_list import RunnerException
 from utils.binary import binary
@@ -249,6 +250,14 @@ def aws_garbage_collector(ctx, thread_pool_size, enable_deletion, io_dir):
 @click.pass_context
 def aws_iam_keys(ctx, thread_pool_size):
     run_integration(reconcile.aws_iam_keys.run, ctx.obj['dry_run'],
+                    thread_pool_size)
+
+
+@integration.command()
+@threaded()
+@click.pass_context
+def aws_support_cases_sos(ctx, thread_pool_size):
+    run_integration(reconcile.aws_support_cases_sos.run, ctx.obj['dry_run'],
                     thread_pool_size)
 
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -15,6 +15,7 @@ GITLAB_INSTANCES_QUERY = """
 AWS_ACCOUNTS_QUERY = """
 {
   accounts: awsaccounts_v1 {
+    path
     name
     automationToken {
       path

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.6',
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(
         "Jinja2>=2.10.1,<2.11.0",
         "jira>=2.0.0,<2.1.0",
         "pyOpenSSL>=19.0.0,<20.0.0",
+        "ruamel.yaml>=0.16.5,<0.17.0",
     ],
 
     test_suite="tests",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8, py27, py34, py36
+envlist = flake8, py27, py36
 
 [testenv]
 commands = pytest

--- a/utils/aws_api.py
+++ b/utils/aws_api.py
@@ -426,7 +426,7 @@ class AWSApi(object):
         return [uk['AccessKeyId'] for uk in key_list]
 
     def get_support_cases(self):
-        self.support_cases = {}
+        all_support_cases = {}
         for account, s in self.sessions.items():
             try:
                 support = s.client('support')
@@ -434,9 +434,9 @@ class AWSApi(object):
                     includeResolvedCases=True,
                     includeCommunications=True
                 )['cases']
-                self.support_cases[account] = support_cases
-            except Exception:
-                msg = '[{}] error getting support cases, check support level'
-                logging.error(msg.format(account))
+                all_support_cases[account] = support_cases
+            except Exception as e:
+                msg = '[{}] error getting support cases. details: {}'
+                logging.error(msg.format(account, e.message))
 
-        return self.support_cases
+        return all_support_cases

--- a/utils/aws_api.py
+++ b/utils/aws_api.py
@@ -424,3 +424,19 @@ class AWSApi(object):
     def get_user_keys(self, iam, user):
         key_list = iam.list_access_keys(UserName=user)['AccessKeyMetadata']
         return [uk['AccessKeyId'] for uk in key_list]
+
+    def get_support_cases(self):
+        self.support_cases = {}
+        for account, s in self.sessions.items():
+            try:
+                support = s.client('support')
+                support_cases = support.describe_cases(
+                    includeResolvedCases=True,
+                    includeCommunications=True
+                )['cases']
+                self.support_cases[account] = support_cases
+            except Exception:
+                msg = '[{}] error getting support cases, check support level'
+                logging.error(msg.format(account))
+
+        return self.support_cases

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -136,7 +136,8 @@ class GitLabApi(object):
         content = yaml.load(f.decode(), Loader=yaml.RoundTripLoader)
         content.setdefault('deleteKeys', [])
         content['deleteKeys'].append(key)
-        new_content = yaml.dump(content, Dumper=yaml.RoundTripDumper)
+        new_content = '---\n' + \
+            yaml.dump(content, Dumper=yaml.RoundTripDumper)
         try:
             self.update_file(branch_name, path, title, new_content)
         except gitlab.exceptions.GitlabCreateError as e:

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -44,7 +44,21 @@ class GitLabApi(object):
                 {
                     'action': 'delete',
                     'file_path': file_path
-                    }
+                }
+            ]
+        }
+        self.project.commits.create(data)
+
+    def update_file(self, branch_name, file_path, commit_message, content):
+        data = {
+            'branch': branch_name,
+            'commit_message': commit_message,
+            'actions': [
+                {
+                    'action': 'update',
+                    'file_path': file_path,
+                    'content': content
+                }
             ]
         }
         self.project.commits.create(data)
@@ -101,6 +115,36 @@ class GitLabApi(object):
                 return
 
         self.create_mr(branch_name, target_branch, title, labels=LABELS)
+
+    def create_delete_aws_access_key_mr(self, account, path, key):
+        prefix = 'qontract-reconcile'
+        target_branch = 'master'
+        branch_name = '{}-delete-aws-access-key-{}-{}-{}'.format(
+            prefix,
+            account,
+            key,
+            str(uuid.uuid4())[0:6]
+        )
+        title = '[{}] delete {} AWS access key {}'.format(prefix, account, key)
+
+        if self.mr_exists(title):
+            return
+
+        # self.create_branch(branch_name, target_branch)
+
+        # content = get_new_content()
+        # try:
+        #     self.update_file(branch_name, path, title, content)
+        # except gitlab.exceptions.GitlabCreateError as e:
+        #     self.delete_branch(branch_name)
+        #     if str(e) != "400: A file with this name doesn't exist":
+        #         raise e
+        #     logging.info(
+        #         "File {} does not exist, not opening MR".format(path)
+        #     )
+        #     return
+
+        # self.create_mr(branch_name, target_branch, title)
 
     def get_project_maintainers(self, repo_url):
         project = self.get_project(repo_url)

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -132,8 +132,8 @@ class GitLabApi(object):
 
         self.create_branch(branch_name, target_branch)
 
-        with open(path, 'r') as f:  # TODO: this is wrong
-            content = yaml.safe_load(f.read())
+        f = self.project.files.get(file_path=path, ref=target_branch)
+        content = yaml.safe_load(f.decode())
         content.setdefault('deleteKeys', [])
         content['deleteKeys'].append(key)
         try:


### PR DESCRIPTION
This PR introduces a new integration called aws-support-cases-sos.

This integration iterates over support cases in AWS support center to find support cases reporting of leaked AWS access keys. For each found key, the integration will submit a PR to app-interface to remove that key from the account (will be handled by aws-iam-keys integration upon merge).

Future work will include searching the page where the leak was detected for leaked GitHub tokens, and if those exist - the PR to app-interface will be one that removes the user completely.

**NOTE** This PR removes python 3.4 from tests due to incompatibility with ruamel.yaml.