### PR TITLE
[WIP] New integration: openshift-clusterrolebinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ In addition, e2e tests are available to detect potential problems reconciling se
 
 - `aws-garbage-collector`: Delete orphan AWS resources.
 - `aws-iam-keys`: Delete IAM access keys by access key ID.
+- `aws-support-cases-sos`: Scan AWS support cases for reports of leaked keys and remove them (only submits PR)
 - `github`: Configures the teams and members in a GitHub org.
 - `github-repo-invites`: Accept GitHub repository invitations for known repositories.
+- `github-scanner`: Scan GitHub repositories for leaked keys and remove them (only submits PR).
 - `github-users`: Validate compliance of GitHub user profiles.
 - `gitlab-housekeeping`: Manage issues and merge requests on GitLab projects.
 - `gitlab-members` : Manage GitLab group members.

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -7,6 +7,7 @@ import utils.gql as gql
 import reconcile.github_org
 import reconcile.github_users
 import reconcile.github_scanner
+import reconcile.openshift_clusterrolebindings
 import reconcile.openshift_rolebindings
 import reconcile.openshift_groups
 import reconcile.openshift_users
@@ -150,6 +151,15 @@ def github_users(ctx, gitlab_project_id, thread_pool_size,
 def github_scanner(ctx, gitlab_project_id, thread_pool_size):
     run_integration(reconcile.github_scanner.run, gitlab_project_id,
                     ctx.obj['dry_run'], thread_pool_size)
+
+
+@integration.command()
+@threaded()
+@binary(['oc', 'ssh'])
+@click.pass_context
+def openshift_clusterrolebindings(ctx, thread_pool_size):
+    run_integration(reconcile.openshift_clusterrolebindings.run, ctx.obj['dry_run'],
+                    thread_pool_size)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -158,7 +158,8 @@ def github_scanner(ctx, gitlab_project_id, thread_pool_size):
 @binary(['oc', 'ssh'])
 @click.pass_context
 def openshift_clusterrolebindings(ctx, thread_pool_size):
-    run_integration(reconcile.openshift_clusterrolebindings.run, ctx.obj['dry_run'],
+    run_integration(reconcile.openshift_clusterrolebindings.run,
+                    ctx.obj['dry_run'],
                     thread_pool_size)
 
 

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -50,7 +50,11 @@ def init_cluster_specs_to_fetch(clusters, ri, oc_map,
 
         for resource_type in managed_types:
             ri.initialize_resource_type(cluster_name, None, resource_type)
-            c_spec = StateSpec("current", oc, cluster_name, None, resource_type)
+            c_spec = StateSpec("current",
+                               oc,
+                               cluster_name,
+                               None,
+                               resource_type)
             state_specs.append(c_spec)
 
     return state_specs

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -86,6 +86,10 @@ def run(dry_run=False, thread_pool_size=10, defer=None):
     clusters = [cluster for cluster
                 in gqlapi.query(CLUSTERROLEBINDINGS_QUERY)['clusters']
                 if cluster.get('clusterRoleBindings')]
+
+    if not clusters:
+        return
+
     ri, oc_map = \
         ob.fetch_current_state(
             clusters=clusters,

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -1,0 +1,225 @@
+import semver
+
+import utils.gql as gql
+import utils.threaded as threaded
+import reconcile.openshift_base as ob
+
+from utils.oc import OC_Map
+from utils.defer import defer
+from utils.openshift_resource import OpenshiftResource as OR
+
+
+CLUSTERROLEBINDINGS_QUERY = """
+{
+  clusters: clusters_v1 {
+    name
+    serverUrl
+    jumpHost {
+      hostname
+      knownHosts
+      user
+      port
+      identity {
+        path
+        field
+        format
+      }
+    }
+    automationToken {
+      path
+      field
+      format
+    }
+    disable {
+      integrations
+    }
+    clusterRoleBindings {
+      name
+      roleRef {
+        name
+      }
+      subjects {
+        kind
+        name
+        namespace
+      }
+      userNames
+    }
+  }
+}
+"""
+
+QONTRACT_INTEGRATION = 'openshift-clusterrolebindings'
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
+
+
+def get_cluster_state(cluster, oc_map):
+    results = []
+    oc = oc_map.get(cluster["name"])
+    crbs = oc.get_all('ClusterRoleBinding')
+    for crb in crbs["items"]:
+        results.append({
+            "cluster": cluster['name'],
+            "clusterrolebinding": crb,
+        })
+    return results
+
+
+def fetch_current_state(clusters, thread_pool_size):
+    current_state = []
+    oc_map = OC_Map(clusters=clusters, integration=QONTRACT_INTEGRATION)
+    results = threaded.run(get_cluster_state,
+                           clusters,
+                           thread_pool_size,
+                           oc_map=oc_map)
+    for sublist in results:
+        for item in sublist:
+            item['clusterrolebinding']['name'] = \
+                item['clusterrolebinding']['metadata']['name']
+            item['clusterrolebinding'].pop('kind')
+            item['clusterrolebinding'].pop('apiVersion')
+            item['clusterrolebinding'].pop('metadata')
+            current_state.append({
+                'cluster': item['cluster'],
+                'clusterrolebinding': item['clusterrolebinding']
+            })
+    return oc_map, current_state
+
+
+def fetch_desired_state(clusters, ri):
+    for cluster in clusters:
+        cluster_name = cluster['name']
+        crbs = cluster['clusterRoleBindings']
+        for crb in crbs:
+            manifest = {
+                'apiVersion': '',
+                'kind': 'ClusterRoleBinding',
+                'metadata': {
+                    'name': crb['name']
+                },
+                'roleRef': crb['roleRef'],
+                'subjects': crb['subjects'],
+                'userNames': crb['userNames']
+            }
+            oc_resource = OR(manifest,
+                             QONTRACT_INTEGRATION_VERSION,
+                             QONTRACT_INTEGRATION,
+                             error_details=crb['name'])
+            ri.add_desired(
+                cluster_name,
+                None,
+                'ClusterRoleBinding',
+                crb['name'],
+                oc_resource
+            )
+
+
+def obj_intersect_equal(obj1, obj2):
+    if obj1.__class__ != obj2.__class__:
+        return False
+
+    if isinstance(obj1, dict):
+        for k, v in obj1.items():
+            if not obj_intersect_equal(v, obj2.get(k)):
+                return False
+    elif isinstance(obj1, list):
+        if len(obj1) != len(obj2):
+            return False
+
+        for i in range(len(obj1)):
+            if obj1[i] != obj2[i]:
+                return False
+    else:
+        if obj1 != obj2:
+            return False
+
+    return True
+
+
+def calculate_diff(current, desired):
+    diff = []
+
+    for d_state in desired:
+        d_crb = d_state['clusterrolebinding']
+        d_crb_name = d_crb['name']
+
+        found = False
+        for c_state in current:
+            c_crb = c_state['clusterrolebinding']
+            c_crb_name = c_crb['name']
+            if c_crb_name != d_crb_name:
+                continue
+            found = True
+            break
+        if found:
+            details = []
+            if c_crb['roleRef']['name'] != d_crb['roleRef']['name']:
+                details.extend([
+                    'roleRef', [
+                        'before', c_crb['roleRef']['name'],
+                        'after', d_crb['roleRef']['name']
+                    ]
+                ])
+            if not obj_intersect_equal(c_crb['subjects'], d_crb['subjects']):
+                details.extend([
+                    'subjects', [
+                        'before', c_crb['subjects'],
+                        'after', d_crb['subjects']
+                    ]
+                ])
+            if not obj_intersect_equal(c_crb['userNames'], d_crb['userNames']):
+                details.extend([
+                    'userNames', [
+                        'before', c_crb['userNames'],
+                        'after', d_crb['userNames']
+                    ]
+                ])
+            diff.append({
+                'action': 'update_clusterrolebinding',
+                'cluster': d_state['cluster'],
+                'clusterrolebinding': d_state['clusterrolebinding'],
+                'details': details
+            })
+        else:
+            diff.append({
+                'action': 'add_clusterrolebinding',
+                'cluster': d_state['cluster'],
+                'clusterrolebinding': d_state['clusterrolebinding'],
+                'details': None
+            })
+
+    return diff
+
+
+def has_duplicates(desired):
+    clusters = {}
+    for d in desired:
+        d_cluster = d['cluster']
+        if d['clusterrolebinding']['name'] in clusters.get(d_cluster, []):
+            return {
+                'cluster': d_cluster,
+                'name': d['clusterrolebinding']['name']
+            }
+        clusters.setdefault(d_cluster, []).append(
+            d['clusterrolebinding']['name']
+        )
+    return False
+
+
+@defer
+def run(dry_run=False, thread_pool_size=10, defer=None):
+    gqlapi = gql.get_api()
+
+    clusters = [cluster for cluster
+                in gqlapi.query(CLUSTERROLEBINDINGS_QUERY)['clusters']
+                if cluster.get('clusterRoleBindings')]
+    ri, oc_map = \
+        ob.fetch_current_state(
+            clusters=clusters,
+            thread_pool_size=thread_pool_size,
+            integration=QONTRACT_INTEGRATION,
+            integration_version=QONTRACT_INTEGRATION_VERSION,
+            override_managed_types=['ClusterRoleBinding'])
+    defer(lambda: oc_map.cleanup())
+    fetch_desired_state(clusters, ri)
+    ob.realize_data(dry_run, oc_map, ri)

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -1,10 +1,8 @@
 import semver
 
 import utils.gql as gql
-import utils.threaded as threaded
 import reconcile.openshift_base as ob
 
-from utils.oc import OC_Map
 from utils.defer import defer
 from utils.openshift_resource import OpenshiftResource as OR
 
@@ -53,39 +51,6 @@ QONTRACT_INTEGRATION = 'openshift-clusterrolebindings'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 
 
-def get_cluster_state(cluster, oc_map):
-    results = []
-    oc = oc_map.get(cluster["name"])
-    crbs = oc.get_all('ClusterRoleBinding')
-    for crb in crbs["items"]:
-        results.append({
-            "cluster": cluster['name'],
-            "clusterrolebinding": crb,
-        })
-    return results
-
-
-def fetch_current_state(clusters, thread_pool_size):
-    current_state = []
-    oc_map = OC_Map(clusters=clusters, integration=QONTRACT_INTEGRATION)
-    results = threaded.run(get_cluster_state,
-                           clusters,
-                           thread_pool_size,
-                           oc_map=oc_map)
-    for sublist in results:
-        for item in sublist:
-            item['clusterrolebinding']['name'] = \
-                item['clusterrolebinding']['metadata']['name']
-            item['clusterrolebinding'].pop('kind')
-            item['clusterrolebinding'].pop('apiVersion')
-            item['clusterrolebinding'].pop('metadata')
-            current_state.append({
-                'cluster': item['cluster'],
-                'clusterrolebinding': item['clusterrolebinding']
-            })
-    return oc_map, current_state
-
-
 def fetch_desired_state(clusters, ri):
     for cluster in clusters:
         cluster_name = cluster['name']
@@ -112,98 +77,6 @@ def fetch_desired_state(clusters, ri):
                 crb['name'],
                 oc_resource
             )
-
-
-def obj_intersect_equal(obj1, obj2):
-    if obj1.__class__ != obj2.__class__:
-        return False
-
-    if isinstance(obj1, dict):
-        for k, v in obj1.items():
-            if not obj_intersect_equal(v, obj2.get(k)):
-                return False
-    elif isinstance(obj1, list):
-        if len(obj1) != len(obj2):
-            return False
-
-        for i in range(len(obj1)):
-            if obj1[i] != obj2[i]:
-                return False
-    else:
-        if obj1 != obj2:
-            return False
-
-    return True
-
-
-def calculate_diff(current, desired):
-    diff = []
-
-    for d_state in desired:
-        d_crb = d_state['clusterrolebinding']
-        d_crb_name = d_crb['name']
-
-        found = False
-        for c_state in current:
-            c_crb = c_state['clusterrolebinding']
-            c_crb_name = c_crb['name']
-            if c_crb_name != d_crb_name:
-                continue
-            found = True
-            break
-        if found:
-            details = []
-            if c_crb['roleRef']['name'] != d_crb['roleRef']['name']:
-                details.extend([
-                    'roleRef', [
-                        'before', c_crb['roleRef']['name'],
-                        'after', d_crb['roleRef']['name']
-                    ]
-                ])
-            if not obj_intersect_equal(c_crb['subjects'], d_crb['subjects']):
-                details.extend([
-                    'subjects', [
-                        'before', c_crb['subjects'],
-                        'after', d_crb['subjects']
-                    ]
-                ])
-            if not obj_intersect_equal(c_crb['userNames'], d_crb['userNames']):
-                details.extend([
-                    'userNames', [
-                        'before', c_crb['userNames'],
-                        'after', d_crb['userNames']
-                    ]
-                ])
-            diff.append({
-                'action': 'update_clusterrolebinding',
-                'cluster': d_state['cluster'],
-                'clusterrolebinding': d_state['clusterrolebinding'],
-                'details': details
-            })
-        else:
-            diff.append({
-                'action': 'add_clusterrolebinding',
-                'cluster': d_state['cluster'],
-                'clusterrolebinding': d_state['clusterrolebinding'],
-                'details': None
-            })
-
-    return diff
-
-
-def has_duplicates(desired):
-    clusters = {}
-    for d in desired:
-        d_cluster = d['cluster']
-        if d['clusterrolebinding']['name'] in clusters.get(d_cluster, []):
-            return {
-                'cluster': d_cluster,
-                'name': d['clusterrolebinding']['name']
-            }
-        clusters.setdefault(d_cluster, []).append(
-            d['clusterrolebinding']['name']
-        )
-    return False
 
 
 @defer

--- a/reconcile/openshift_network_policies.py
+++ b/reconcile/openshift_network_policies.py
@@ -109,10 +109,12 @@ def run(dry_run=False, thread_pool_size=10, defer=None):
                   in gqlapi.query(NAMESPACES_QUERY)['namespaces']
                   if namespace_info.get('networkPoliciesAllow')]
     ri, oc_map = \
-        ob.fetch_current_state(namespaces, thread_pool_size,
-                               QONTRACT_INTEGRATION,
-                               QONTRACT_INTEGRATION_VERSION,
-                               override_managed_types=['NetworkPolicy'])
+        ob.fetch_current_state(
+            namespaces=namespaces,
+            thread_pool_size=thread_pool_size,
+            integration=QONTRACT_INTEGRATION,
+            integration_version=QONTRACT_INTEGRATION_VERSION,
+            override_managed_types=['NetworkPolicy'])
     defer(lambda: oc_map.cleanup())
     fetch_desired_state(namespaces, ri)
     ob.realize_data(dry_run, oc_map, ri)

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -44,7 +44,7 @@ class OC(object):
     def get_items(self, kind, **kwargs):
         cmd = ['get', kind, '-o', 'json']
 
-        if 'namespace' in kwargs:
+        if 'namespace' in kwargs and kwargs['namespace']:
             namespace = kwargs['namespace']
             if not self.project_exists(namespace):
                 return []
@@ -69,7 +69,7 @@ class OC(object):
 
     def get(self, namespace, kind, name):
         cmd = ['get', '-o', 'json', kind, name]
-        if namespace is not None:
+        if namespace is not None and namespace != '_':
             cmd.extend(['-n', namespace])
         return self._run_json(cmd)
 
@@ -80,11 +80,15 @@ class OC(object):
         return self._run_json(cmd)
 
     def apply(self, namespace, resource):
-        cmd = ['apply', '-n', namespace, '-f', '-']
+        cmd = ['apply', '-f', '-']
+        if namespace is not None and namespace != '_':
+            cmd.extend(['-n', namespace])
         self._run(cmd, stdin=resource)
 
     def delete(self, namespace, kind, name):
-        cmd = ['delete', '-n', namespace, kind, name]
+        cmd = ['delete', kind, name]
+        if namespace is not None and namespace != '_':
+            cmd.extend(['-n', namespace])
         self._run(cmd)
 
     def project_exists(self, name):

--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -169,7 +169,7 @@ class OpenshiftResource(object):
                         not rule['attributeRestrictions']:
                     rule.pop('attributeRestrictions')
 
-        if body['kind'] == 'RoleBinding':
+        if body['kind'] in ('ClusterRoleBinding', 'RoleBinding'):
             if 'groupNames' in body:
                 body.pop('groupNames')
             if 'userNames' in body:
@@ -217,6 +217,8 @@ class ResourceInventory(object):
         self._lock = Lock()
 
     def initialize_resource_type(self, cluster, namespace, resource_type):
+        if namespace is None:
+            namespace = '_'
         self._clusters.setdefault(cluster, {})
         self._clusters[cluster].setdefault(namespace, {})
         self._clusters[cluster][namespace].setdefault(resource_type, {
@@ -225,6 +227,8 @@ class ResourceInventory(object):
         })
 
     def add_desired(self, cluster, namespace, resource_type, name, value):
+        if namespace is None:
+            namespace = '_'
         with self._lock:
             desired = \
                 self._clusters[cluster][namespace][resource_type]['desired']
@@ -233,6 +237,8 @@ class ResourceInventory(object):
             desired[name] = value
 
     def add_current(self, cluster, namespace, resource_type, name, value):
+        if namespace is None:
+            namespace = '_'
         with self._lock:
             current = \
                 self._clusters[cluster][namespace][resource_type]['current']


### PR DESCRIPTION
This is a first stab at a ClusterRoleBinding integration

This allows setting ClusterRoleBindings under a cluster definition as such:
```yaml
clusterRoleBindings:
- name: testjfc
  roleRef:
    name: testjfc
  subjects:
  - kind: ServiceAccount
    name: my-sa
    namespace: my-ns
  userNames:
  - system:serviceaccount:my-ns:my-sa
- name: my-cool-crb
  roleRef:
    name: my-cool-cr
  subjects:
  - kind: User
    name: foo
  - kind: User
    name: bar
  userNames:
  - foo
  - bar
```

It uses the usual openshift_resources functions so qontract annotations are set. It'll happily start to manage existing ClusterRoleBindings if told to.

Notes for reviewers:
- I did some not-so-greatcode gymnastics in `utils/oc.py` and `utils/openshift_resource.py` where I check or set the namespace name to `_` (underscore) for global/cluster-scoped resources to avoid having to do a larger refactor.
- I had to refactor `fetch_current_state` and `init_specs_to_fetch` to teach them how to handle cluster-scoped resources. I think I've updated all code that used these functions.

