### PR TITLE
[terraform-resources] add support for sqs

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -28,6 +28,8 @@ AWS_ACCOUNTS_QUERY = """
   accounts: awsaccounts_v1 {
     path
     name
+    uid
+    resourcesDefaultRegion
     automationToken {
       path
       field

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -49,6 +49,15 @@ TF_NAMESPACES_QUERY = """
         user_policy
         output_resource_name
       }
+      ... on NamespaceTerraformResourceSQS_v1 {
+        account
+        region
+        identifier
+        defaults
+        overrides
+        output_resource_name
+        queues
+      }
     }
     cluster {
       name


### PR DESCRIPTION
defined in app-interface as follows:
```
terraformResources:
- provider: sqs
  account: app-sre
  identifier: app-interface-stage-sqs
  defaults: /terraform/resources/sqs-1.yml
  output_resource_name: app-interface-sqs
  queues:
  - app-interface-stage-pr-submitter
```