### PR TITLE
[github-pr-submitter] introduce new integration

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -30,6 +30,7 @@ import reconcile.slack_usergroups
 import reconcile.gitlab_permissions
 import reconcile.gitlab_housekeeping
 import reconcile.gitlab_members
+import reconcile.gitlab_pr_submitter
 import reconcile.aws_garbage_collector
 import reconcile.aws_iam_keys
 import reconcile.aws_support_cases_sos

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -30,7 +30,6 @@ import reconcile.slack_usergroups
 import reconcile.gitlab_permissions
 import reconcile.gitlab_housekeeping
 import reconcile.gitlab_members
-import reconcile.gitlab_pr_submitter
 import reconcile.aws_garbage_collector
 import reconcile.aws_iam_keys
 import reconcile.aws_support_cases_sos
@@ -266,13 +265,11 @@ def gitlab_housekeeping(ctx, gitlab_project_id, days_interval,
 @integration.command()
 @environ(['aws_access_key_id', 'aws_secret_access_key', 'aws_region',
           'gitlab_pr_submitter_queue_url'])
-@gitlab_project_id
-@threaded()
-@binary(['git', 'git-secrets'])
+@click.argument('gitlab-project-id')
 @click.pass_context
-def github_scanner(ctx, gitlab_project_id, thread_pool_size):
-    run_integration(reconcile.github_scanner.run, ctx.obj['dry_run'],
-                    gitlab_project_id, thread_pool_size)
+def gitlab_pr_submitter(ctx, gitlab_project_id):
+    run_integration(reconcile.gitlab_pr_submitter.run, gitlab_project_id,
+                    ctx.obj['dry_run'])
 
 
 @integration.command()
@@ -296,11 +293,12 @@ def aws_iam_keys(ctx, thread_pool_size):
 @integration.command()
 @environ(['aws_access_key_id', 'aws_secret_access_key', 'aws_region',
           'gitlab_pr_submitter_queue_url'])
-@click.argument('gitlab-project-id')
+@gitlab_project_id
+@threaded()
 @click.pass_context
-def gitlab_pr_submitter(ctx, gitlab_project_id):
-    run_integration(reconcile.gitlab_pr_submitter.run, gitlab_project_id,
-                    ctx.obj['dry_run'])
+def aws_support_cases_sos(ctx, gitlab_project_id, thread_pool_size):
+    run_integration(reconcile.aws_support_cases_sos.run, ctx.obj['dry_run'],
+                    gitlab_project_id, thread_pool_size)
 
 
 @integration.command()

--- a/reconcile/gitlab_pr_submitter.py
+++ b/reconcile/gitlab_pr_submitter.py
@@ -1,5 +1,3 @@
-import logging
-
 import reconcile.pull_request_gateway as prg
 
 

--- a/reconcile/gitlab_pr_submitter.py
+++ b/reconcile/gitlab_pr_submitter.py
@@ -2,4 +2,4 @@ import reconcile.pull_request_gateway as prg
 
 
 def run(gitlab_project_id, dry_run=False):
-    prg.submit_to_gitlab(gitlab_project_id)
+    prg.submit_to_gitlab(gitlab_project_id, dry_run)

--- a/reconcile/gitlab_pr_submitter.py
+++ b/reconcile/gitlab_pr_submitter.py
@@ -1,0 +1,7 @@
+import logging
+
+import reconcile.pull_request_gateway as prg
+
+
+def run(gitlab_project_id, dry_run=False):
+    prg.submit_to_gitlab(gitlab_project_id)

--- a/reconcile/pull_request_gateway.py
+++ b/reconcile/pull_request_gateway.py
@@ -1,3 +1,5 @@
+import logging
+
 import reconcile.queries as queries
 
 from utils.sqs_gateway import SQSGateway

--- a/reconcile/pull_request_gateway.py
+++ b/reconcile/pull_request_gateway.py
@@ -8,9 +8,13 @@ class PullRequestGatewayError(Exception):
     pass
 
 
-def init(gitlab_project_id=None):
+def get_pr_gateway_type():
     settings = queries.get_app_interface_settings()
-    pr_gateway_type = settings.get('pullRequestGateway') or 'gitlab'
+    return settings.get('pullRequestGateway') or 'gitlab'
+
+
+def init(gitlab_project_id=None, override_pr_gateway_type=None):
+    pr_gateway_type = override_pr_gateway_type or get_pr_gateway_type()
 
     if pr_gateway_type == 'gitlab':
         instance = queries.get_gitlab_instance()
@@ -19,3 +23,28 @@ def init(gitlab_project_id=None):
         return GitLabApi(instance, project_id=gitlab_project_id)
     elif pr_gateway_type == 'sqs':
         return SQSGateway()
+    else:
+        raise PullRequestGatewayError(
+            'invalid pull request gateway: {}'.format(pr_gateway_type))
+
+
+def submit_to_gitlab(gitlab_project_id):
+    client = init()
+    gl = init(gitlab_project_id=gitlab_project_id,
+              override_pr_gateway_type='gitlab')
+
+    # adding this condition as safety. it is not really needed because
+    # client = init() will fail if the pull request gateway
+    # is 'gitlab' but gitlab_project_id is None
+    if type(client) == type(gl):
+        logging.info('pull request gateway is gitlab, nothing to do')
+        return
+
+    # using while instead of iterating over the queue
+    # since additional messages may be coming in
+    while True:
+        # read message
+        # break if no messages
+        break
+        # submit to gitlab
+        # delete message

--- a/utils/sqs_gateway.py
+++ b/utils/sqs_gateway.py
@@ -30,6 +30,20 @@ class SQSGateway(object):
             MessageBody=json.dumps(body)
         )
 
+    def receive_messages(self, visibility_timeout=30):
+        messages = self.sqs.receive_message(
+            QueueUrl=self.queue_url,
+            VisibilityTimeout=visibility_timeout
+        ).get('Messages', [])
+        return [(m['ReceiptHandle'], json.loads(m['Body']))
+                for m in messages]
+
+    def delete_message(self, receipt_handle):
+        self.sqs.delete_message(
+            QueueUrl=self.queue_url,
+            ReceiptHandle=receipt_handle
+        )
+
     def create_delete_aws_access_key_mr(self, account, path, key):
         body = {
             'pr_type': 'create_delete_aws_access_key_mr',


### PR DESCRIPTION
this integration relays messages from the `pullRequestGateway` (currently only implements `sqs`) to gitlab.

this is a lightweight integration that reads messages from the gateway and submits PRs to app-interface.
this integration should be used when app-interface is unreachable from the location where the following integrations are running:
- github-users
- github-scanner
- aws-support-cases-sos