### PR TITLE
[sqs-gateway] use creds obtained from app-interface

### DIFF
--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -34,24 +34,12 @@ integrations:
     memory: 100Mi
   extraEnv:
   - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
-    secretKey: aws_access_key_id
-  - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
-    secretKey: aws_secret_access_key
-  - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
-    secretKey: aws_region
-  - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
     secretKey: gitlab_pr_submitter_queue_url
 - name: github-scanner
   resources:
     cpu: 200m
     memory: 600Mi
   extraEnv:
-  - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
-    secretKey: aws_access_key_id
-  - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
-    secretKey: aws_secret_access_key
-  - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
-    secretKey: aws_region
   - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
     secretKey: gitlab_pr_submitter_queue_url
   extraArgs: --thread-pool-size 1
@@ -60,11 +48,5 @@ integrations:
     cpu: 25m
     memory: 400Mi
   extraEnv:
-  - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
-    secretKey: aws_access_key_id
-  - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
-    secretKey: aws_secret_access_key
-  - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
-    secretKey: aws_region
   - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
     secretKey: gitlab_pr_submitter_queue_url

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -141,21 +141,6 @@ objects:
           - -c
           - while true; do qontract-reconcile --config /config/config.toml ${DRY_RUN} github-users ; sleep ${SLEEP_DURATION_SECS}; done
           env:
-          - name: aws_access_key_id
-            valueFrom:
-              secretKeyRef:
-                name: ${APP_INTERFACE_SQS_SECRET_NAME}
-                key: aws_access_key_id
-          - name: aws_secret_access_key
-            valueFrom:
-              secretKeyRef:
-                name: ${APP_INTERFACE_SQS_SECRET_NAME}
-                key: aws_secret_access_key
-          - name: aws_region
-            valueFrom:
-              secretKeyRef:
-                name: ${APP_INTERFACE_SQS_SECRET_NAME}
-                key: aws_region
           - name: gitlab_pr_submitter_queue_url
             valueFrom:
               secretKeyRef:
@@ -178,21 +163,6 @@ objects:
           - -c
           - while true; do qontract-reconcile --config /config/config.toml ${DRY_RUN} github-scanner --thread-pool-size 1; sleep ${SLEEP_DURATION_SECS}; done
           env:
-          - name: aws_access_key_id
-            valueFrom:
-              secretKeyRef:
-                name: ${APP_INTERFACE_SQS_SECRET_NAME}
-                key: aws_access_key_id
-          - name: aws_secret_access_key
-            valueFrom:
-              secretKeyRef:
-                name: ${APP_INTERFACE_SQS_SECRET_NAME}
-                key: aws_secret_access_key
-          - name: aws_region
-            valueFrom:
-              secretKeyRef:
-                name: ${APP_INTERFACE_SQS_SECRET_NAME}
-                key: aws_region
           - name: gitlab_pr_submitter_queue_url
             valueFrom:
               secretKeyRef:
@@ -215,21 +185,6 @@ objects:
           - -c
           - while true; do qontract-reconcile --config /config/config.toml ${DRY_RUN} aws-support-cases-sos ; sleep ${SLEEP_DURATION_SECS}; done
           env:
-          - name: aws_access_key_id
-            valueFrom:
-              secretKeyRef:
-                name: ${APP_INTERFACE_SQS_SECRET_NAME}
-                key: aws_access_key_id
-          - name: aws_secret_access_key
-            valueFrom:
-              secretKeyRef:
-                name: ${APP_INTERFACE_SQS_SECRET_NAME}
-                key: aws_secret_access_key
-          - name: aws_region
-            valueFrom:
-              secretKeyRef:
-                name: ${APP_INTERFACE_SQS_SECRET_NAME}
-                key: aws_region
           - name: gitlab_pr_submitter_queue_url
             valueFrom:
               secretKeyRef:

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -143,8 +143,7 @@ def github(ctx):
 
 
 @integration.command()
-@environ(['aws_access_key_id', 'aws_secret_access_key', 'aws_region',
-          'gitlab_pr_submitter_queue_url'])
+@environ(['gitlab_pr_submitter_queue_url'])
 @gitlab_project_id
 @threaded()
 @enable_deletion(default=False)
@@ -158,8 +157,7 @@ def github_users(ctx, gitlab_project_id, thread_pool_size,
 
 
 @integration.command()
-@environ(['aws_access_key_id', 'aws_secret_access_key', 'aws_region',
-          'gitlab_pr_submitter_queue_url'])
+@environ(['gitlab_pr_submitter_queue_url'])
 @gitlab_project_id
 @threaded()
 @binary(['git', 'git-secrets'])
@@ -264,8 +262,7 @@ def gitlab_housekeeping(ctx, gitlab_project_id, days_interval,
 
 
 @integration.command()
-@environ(['aws_access_key_id', 'aws_secret_access_key', 'aws_region',
-          'gitlab_pr_submitter_queue_url'])
+@environ(['gitlab_pr_submitter_queue_url'])
 @click.argument('gitlab-project-id')
 @click.pass_context
 def gitlab_pr_submitter(ctx, gitlab_project_id):
@@ -292,8 +289,7 @@ def aws_iam_keys(ctx, thread_pool_size):
 
 
 @integration.command()
-@environ(['aws_access_key_id', 'aws_secret_access_key', 'aws_region',
-          'gitlab_pr_submitter_queue_url'])
+@environ(['gitlab_pr_submitter_queue_url'])
 @gitlab_project_id
 @threaded()
 @click.pass_context

--- a/reconcile/pull_request_gateway.py
+++ b/reconcile/pull_request_gateway.py
@@ -24,7 +24,8 @@ def init(gitlab_project_id=None, override_pr_gateway_type=None):
             raise PullRequestGatewayError('missing gitlab project id')
         return GitLabApi(instance, project_id=gitlab_project_id)
     elif pr_gateway_type == 'sqs':
-        return SQSGateway()
+        accounts = queries.get_aws_accounts()
+        return SQSGateway(accounts)
     else:
         raise PullRequestGatewayError(
             'invalid pull request gateway: {}'.format(pr_gateway_type))

--- a/utils/aws_api.py
+++ b/utils/aws_api.py
@@ -43,6 +43,9 @@ class AWSApi(object):
             self.sessions[account] = session
             self.resources[account] = {}
 
+    def get_session(self, account):
+        return self.sessions[account]
+
     @staticmethod
     def get_vault_tf_secrets(account):
         account_name = account['name']


### PR DESCRIPTION
we may be having trouble with the AWS credentials chain since we set environment variables.
remove usage of environment variables and infer aws account from queue url instead.