### PR TITLE
Fix cmd.extend in oc.py OC.get()

### DIFF
--- a/utils/oc.py
+++ b/utils/oc.py
@@ -78,7 +78,7 @@ class OC(object):
     def get(self, namespace, kind, name=None):
         cmd = ['get', '-o', 'json', kind]
         if name:
-            cmd.extend(name)
+            cmd.append(name)
         if namespace is not None:
             cmd.extend(['-n', namespace])
         return self._run_json(cmd)


### PR DESCRIPTION
This fixes a bug introduced by #287 where `List.extend(string)` appends individual characters from the string as array items resulting in unexpected behavior causing no current state to be found

```
['get', '-o', 'json', 'Project', u'a', u'p', u'p', u'-', u's', u'r', u'e', u'-', u'o', u'b', u's', u'e', u'r', u'v', u'a', u'b', u'i', u'l', u'i', u't', u'y', u'-', u's', u't', u'a', u'g', u'e']
```

The fix is to use `List.append `instead which result in the expected `cmd` to be produced

```
['get', 'Role', '-o', 'json', '-n', u'app-sre-observability-stage']
```