### PR TITLE
disable aws-iam-keys integration

### DIFF
--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -7,14 +7,6 @@ integrations:
     limits:
       memory: 400Mi
       cpu: 50m
-- name: aws-iam-keys
-  resources:
-    requests:
-      memory: 100Mi
-      cpu: 15m
-    limits:
-      memory: 200Mi
-      cpu: 25m
 - name: github
   resources:
     requests:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -38,22 +38,6 @@ objects:
           volumeMounts:
           - name: qontract-reconcile-toml
             mountPath: /config
-        - name: aws-iam-keys
-          image: ${IMAGE}:${IMAGE_TAG}
-          command:
-          - /bin/sh
-          - -c
-          - while true; do qontract-reconcile --config /config/config.toml ${DRY_RUN} aws-iam-keys ; sleep ${SLEEP_DURATION_SECS}; done
-          resources:
-            limits:
-              cpu: 25m
-              memory: 200Mi
-            requests:
-              cpu: 15m
-              memory: 100Mi
-          volumeMounts:
-          - name: qontract-reconcile-toml
-            mountPath: /config
         - name: github
           image: ${IMAGE}:${IMAGE_TAG}
           command:


### PR DESCRIPTION
moving it to build master to control its flow with terraform-resources.
when terraform-resources is running on the cluster, we can move it back.