### PR TITLE
[new-tool] app-interface-reporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 A tool to reconcile services with their desired state as defined in App-Interface.
 In addition, e2e tests are available to detect potential problems reconciling services with their desired state.
+Additional tools that use the libraries created by the reconciliations are also hosted here.
 
 ## Subcommands
 
@@ -12,10 +13,10 @@ In addition, e2e tests are available to detect potential problems reconciling se
 - `aws-garbage-collector`: Delete orphan AWS resources.
 - `aws-iam-keys`: Delete IAM access keys by access key ID.
 - `aws-support-cases-sos`: Scan AWS support cases for reports of leaked keys and remove them (only submits PR)
-- `github`: Configures the teams and members in a GitHub org.
 - `github-repo-invites`: Accept GitHub repository invitations for known repositories.
 - `github-scanner`: Scan GitHub repositories for leaked keys and remove them (only submits PR).
 - `github-users`: Validate compliance of GitHub user profiles.
+- `github`: Configures the teams and members in a GitHub org.
 - `gitlab-housekeeping`: Manage issues and merge requests on GitLab projects.
 - `gitlab-members` : Manage GitLab group members.
 - `gitlab-permissions`: Manage permissions on GitLab projects.
@@ -29,8 +30,8 @@ In addition, e2e tests are available to detect potential problems reconciling se
 - `openshift-groups`: Manages OpenShift Groups.
 - `openshift-namespaces`: Manages OpenShift Namespaces.
 - `openshift-network-policies`: Manages OpenShift NetworkPolicies.
-- `openshift-resources`: Manages OpenShift Resources.
 - `openshift-resources-annotate`: Annotates OpenShift Resources so they can be used by the `openshift-resources` integration.
+- `openshift-resources`: Manages OpenShift Resources.
 - `openshift-rolebinding`: Configures Rolebindings in OpenShift clusters.
 - `openshift-users`: Deletion of users from OpenShift clusters.
 - `quay-membership`: Configures the teams and members in Quay.
@@ -43,6 +44,10 @@ In addition, e2e tests are available to detect potential problems reconciling se
 
 - `create-namespace`: A test to create a namespace and verify that required `RoleBinding`s are created as well to be able to reconcile them.
 - `dedicated-admin-rolebindings`: A test to verify that all required namespaces have the required `RoleBinding`s to be able to reconcile them.
+
+### tools
+
+- `app-interface-reporter`: Creates service reports and submits PR to App-Interface.
 
 ## Usage
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -40,6 +40,36 @@ from utils.binary import binary
 from utils.environ import environ
 
 
+def config_file(function):
+    help_msg = 'Path to configuration file in toml format.'
+    function = click.option('--config', 'configfile',
+                            required=True,
+                            help=help_msg)(function)
+    return function
+
+
+def log_level(function):
+    function = click.option('--log-level',
+                            help='log-level of the command. Defaults to INFO.',
+                            type=click.Choice([
+                                'DEBUG',
+                                'INFO',
+                                'WARNING',
+                                'ERROR',
+                                'CRITICAL']))(function)
+    return function
+
+
+def dry_run(function):
+    help_msg = ('If `true`, it will only print the planned actions '
+                'that would be performed, without executing them.')
+
+    function = click.option('--dry-run/--no-dry-run',
+                            default=False,
+                            help=help_msg)(function)
+    return function
+
+
 def threaded(**kwargs):
     def f(function):
         opt = '--thread-pool-size'
@@ -108,21 +138,9 @@ def run_integration(func, *args):
 
 
 @click.group()
-@click.option('--config', 'configfile',
-              required=True,
-              help='Path to configuration file in toml format.')
-@click.option('--dry-run/--no-dry-run',
-              default=False,
-              help='If `true`, it will only print the planned actions '
-                   'that would be performed, without executing them.')
-@click.option('--log-level',
-              help='log-level of the command. Defaults to INFO.',
-              type=click.Choice([
-                  'DEBUG',
-                  'INFO',
-                  'WARNING',
-                  'ERROR',
-                  'CRITICAL']))
+@config_file
+@dry_run
+@log_level
 @click.pass_context
 def integration(ctx, configfile, dry_run, log_level):
     ctx.ensure_object(dict)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -137,6 +137,11 @@ def run_integration(func, *args):
         sys.exit(1)
 
 
+def init_log_level(log_level):
+    level = getattr(logging, log_level) if log_level else logging.INFO
+    logging.basicConfig(format='%(levelname)s: %(message)s', level=level)
+
+
 @click.group()
 @config_file
 @dry_run
@@ -145,11 +150,8 @@ def run_integration(func, *args):
 def integration(ctx, configfile, dry_run, log_level):
     ctx.ensure_object(dict)
 
-    level = getattr(logging, log_level) if log_level else logging.INFO
-    logging.basicConfig(format='%(levelname)s: %(message)s', level=level)
-
+    init_log_level(log_level)
     config.init_from_toml(configfile)
-
     gql.init_from_config()
     ctx.obj['dry_run'] = dry_run
 

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
         'console_scripts': [
             'qontract-reconcile = reconcile.cli:integration',
             'e2e-tests = e2e_tests.cli:test',
+            'app-interface-reporter = tools.app_interface_reporter:main',
         ],
     },
 )

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -1,2 +1,11 @@
-def main():
+import click
+
+from reconcile.cli import config_file, log_level, dry_run
+
+
+@click.command()
+@config_file
+@dry_run
+@log_level
+def main(configfile, dry_run, log_level):
     print('app-interface-exporter')

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -1,0 +1,2 @@
+def main():
+    print('app-interface-exporter')

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -90,4 +90,4 @@ def main(configfile, dry_run, log_level, gitlab_project_id):
         gw = prg.init(gitlab_project_id=gitlab_project_id,
                       override_pr_gateway_type='gitlab')
         mr = gw.create_app_interface_reporter_mr(reports)
-        logging.info(['create_mr', mr.web_url])
+        logging.info(['created_mr', mr.web_url])

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -1,6 +1,12 @@
 import click
 
-from reconcile.cli import config_file, log_level, dry_run
+from reconcile.cli import (config_file,
+                           log_level,
+                           dry_run,
+                           init_log_level)
+
+import utils.config as config
+import utils.gql as gql
 
 
 @click.command()
@@ -8,4 +14,7 @@ from reconcile.cli import config_file, log_level, dry_run
 @dry_run
 @log_level
 def main(configfile, dry_run, log_level):
-    print('app-interface-exporter')
+    config.init_from_toml(configfile)
+    init_log_level(log_level)
+    config.init_from_toml(configfile)
+    gql.init_from_config()

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -1,20 +1,93 @@
+import logging
+from datetime import datetime
+
 import click
+import yaml
 
-from reconcile.cli import (config_file,
-                           log_level,
-                           dry_run,
-                           init_log_level)
-
+import reconcile.pull_request_gateway as prg
 import utils.config as config
 import utils.gql as gql
+from reconcile.cli import (
+    config_file,
+    log_level,
+    dry_run,
+    init_log_level,
+    gitlab_project_id
+)
+
+APPS_QUERY = """
+{
+  apps: apps_v1 {
+    path
+    name
+  }
+}
+"""
+
+
+class Report(object):
+    def __init__(self, app, date):
+        # standard date format
+        if hasattr(date, 'strftime'):
+            date = date.strftime('%Y-%m-%d')
+
+        self.app = app
+        self.date = date
+
+    @property
+    def path(self):
+        return 'data/reports/{}/{}.yml'.format(
+            self.app['name'],
+            self.date
+        )
+
+    def content(self):
+        return {
+            '$schema': '/app-sre/report-1.yml',
+            'labels': {'app': self.app['name']},
+            'name': self.app['name'],
+            'app': {'$ref': self.app['path']},
+            'date': self.date,
+            'content': 'report for {} on {}'.format(
+                self.app['name'],
+                self.date
+            )
+        }
+
+    def to_yaml(self):
+        return yaml.safe_dump(self.content())
+
+    def to_message(self):
+        return {
+            'file_path': self.path,
+            'content': self.to_yaml()
+        }
 
 
 @click.command()
 @config_file
 @dry_run
 @log_level
-def main(configfile, dry_run, log_level):
+# TODO: @environ(['gitlab_pr_submitter_queue_url'])
+@gitlab_project_id
+def main(configfile, dry_run, log_level, gitlab_project_id):
     config.init_from_toml(configfile)
     init_log_level(log_level)
     config.init_from_toml(configfile)
     gql.init_from_config()
+    gqlapi = gql.get_api()
+
+    now = datetime.now()
+
+    apps = gqlapi.query(APPS_QUERY)['apps']
+
+    reports = [Report(app, now).to_message() for app in apps]
+
+    for report in reports:
+        logging.info(['create_report', report['file_path']])
+
+    if not dry_run:
+        gw = prg.init(gitlab_project_id=gitlab_project_id,
+                      override_pr_gateway_type='gitlab')
+        mr = gw.create_app_interface_reporter_mr(reports)
+        logging.info(['create_mr', mr.web_url])

--- a/utils/sqs_gateway.py
+++ b/utils/sqs_gateway.py
@@ -66,3 +66,10 @@ class SQSGateway(object):
             'paths': paths
         }
         self.send_message(body)
+
+    def create_app_interface_reporter_mr(self, reports):
+        body = {
+            'pr_type': 'create_app_interface_reporter_mr',
+            'reports': reports
+        }
+        self.send_message(body)


### PR DESCRIPTION
This tools generates reports for all the services defined in app-interface and
submits a PR to App-Interface to commit them in the repo (auto-merge).

The core functionality is:
- Get the list of apps from app-interface.
- Generate a report for each app.
- The reports currently contain a dummy content, which will be extended.

Additionally the following things were changed:
- Support for tools in project
- Extract some decorators from cli so they can be reused
- create_mr methods in gitlab_api now return the actual object
- pull request gateway code was cleaned up a bit
- a new create_mr method was added to the gitlab_api
- a generic create_commit function was created in gitlab_api

TODO:
- The foundations to run this via SQS have been written, but probably a few
  changes will need to be added in the main tool itself.
