### PR TITLE
aws disable integrations

### DIFF
--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -18,6 +18,13 @@ def init_tf_working_dirs(accounts, thread_pool_size):
     # copied here to avoid circular dependency
     QONTRACT_INTEGRATION = 'terraform_resources'
     QONTRACT_TF_PREFIX = 'qrtf'
+    # if the terraform-resources integration is disabled
+    # for an account, it means that Terrascript will not
+    # initiate that account's config and will not create
+    # a working directory for it. this means that we are
+    # not able to recycle access keys belonging to users
+    # created by terraform-resources, but it is disabled
+    # tl;dr - we are good. how cool is this alignment...
     ts = Terrascript(QONTRACT_INTEGRATION,
                      QONTRACT_TF_PREFIX,
                      thread_pool_size,

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -52,6 +52,9 @@ AWS_ACCOUNTS_QUERY = """
       path
       field
     }
+    disable {
+      integrations
+    }
     deleteKeys
   }
 }


### PR DESCRIPTION
this PR adds the ability to disable the following integrations from running for specific aws accounts:
- terraform-resources
- terraform-users
