### PR TITLE
[openshift-rolebindings] refactor to match common patterns

### DIFF
--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -1,4 +1,3 @@
-import logging
 import semver
 
 import utils.gql as gql

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -1,50 +1,14 @@
 import logging
-import sys
-import copy
+import semver
 
 import utils.gql as gql
-import utils.threaded as threaded
 import reconcile.openshift_base as ob
-import reconcile.queries as queries
 
-from utils.aggregated_list import (AggregatedList,
-                                   AggregatedDiffRunner,
-                                   RunnerException)
-from utils.oc import OC_Map
+from utils.openshift_resource import (OpenshiftResource as OR,
+                                      ResourceKeyExistsError)
 from utils.defer import defer
-from utils.openshift_resource import ResourceInventory
+from reconcile.queries import NAMESPACES_QUERY
 
-NAMESPACES_QUERY = """
-{
-  namespaces: namespaces_v1 {
-    name
-    managedRoles
-    cluster {
-      name
-      serverUrl
-      jumpHost {
-          hostname
-          knownHosts
-          user
-          port
-          identity {
-              path
-              field
-              format
-          }
-      }
-      automationToken {
-        path
-        field
-        format
-      }
-      disable {
-        integrations
-      }
-    }
-  }
-}
-"""
 
 ROLES_QUERY = """
 {
@@ -60,6 +24,7 @@ ROLES_QUERY = """
     access {
       namespace {
         name
+        managedRoles
         cluster {
           name
         }
@@ -70,206 +35,123 @@ ROLES_QUERY = """
 }
 """
 
+
 QONTRACT_INTEGRATION = 'openshift-rolebindings'
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 3, 0)
 
 
-def get_rolebindings(spec):
-    rolebindings = spec.oc.get_items('RoleBinding', namespace=spec.namespace)
-    return spec.cluster, spec.namespace, rolebindings
+def construct_user_oc_resource(role, user):
+    name = f"{role}-{user}"
+    body = {
+        "apiVersion": "authorization.openshift.io/v1",
+        "kind": "RoleBinding",
+        "metadata": {
+            "name": name
+        },
+        "roleRef": {
+            "name": role
+        },
+        "subjects": [
+            {"kind": "User",
+             "name": user}
+        ]
+    }
+    return OR(body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION,
+              error_details=name), name
 
 
-def fetch_current_state(thread_pool_size):
-    gqlapi = gql.get_api()
-    namespaces = gqlapi.query(NAMESPACES_QUERY)['namespaces']
-    state = AggregatedList()
-    ri = ResourceInventory()
-    namespaces = [namespace_info for namespace_info
-                  in namespaces
-                  if namespace_info.get('managedRoles')]
-    settings = queries.get_app_interface_settings()
-    oc_map = OC_Map(namespaces=namespaces, integration=QONTRACT_INTEGRATION,
-                    settings=settings)
-
-    state_specs = \
-        ob.init_specs_to_fetch(
-            ri,
-            oc_map,
-            namespaces,
-            override_managed_types=['RoleBinding']
-        )
-    results = threaded.run(get_rolebindings, state_specs, thread_pool_size)
-
-    for cluster, namespace, rolebindings in results:
-        managed_roles = [namespace_info['managedRoles']
-                         for namespace_info in namespaces
-                         if namespace_info['cluster']['name'] == cluster
-                         and namespace_info['name'] == namespace][0]
-        for role in managed_roles:
-
-            users = [
-                subject['name']
-                for rolebinding in rolebindings
-                for subject in rolebinding['subjects']
-                if subject['kind'] == 'User' and
-                rolebinding['roleRef']['name'] == role
-            ]
-
-            state.add({
-                "cluster": cluster,
-                "namespace": namespace,
-                "role": role,
-                "kind": 'User',
-            }, users)
-
-            bots = [
-                subject['namespace'] + '/' + subject['name']
-                for rolebinding in rolebindings
-                for subject in rolebinding['subjects']
-                if subject['kind'] == 'ServiceAccount' and
-                'namespace' in subject and
-                rolebinding['roleRef']['name'] == role
-            ]
-
-            state.add({
-                "cluster": cluster,
-                "namespace": namespace,
-                "role": role,
-                "kind": 'ServiceAccount'
-            }, bots)
-
-    return oc_map, state
+def construct_sa_oc_resource(role, namespace, sa_name):
+    name = f"{role}-{namespace}-{sa_name}"
+    body = {
+        "apiVersion": "authorization.openshift.io/v1",
+        "kind": "RoleBinding",
+        "metadata": {
+            "name": name
+        },
+        "roleRef": {
+            "name": role
+        },
+        "subjects": [
+            {"kind": "ServiceAccount",
+             "name": sa_name,
+             "namespace": namespace}
+        ],
+        "userNames": [
+            f"system:serviceaccount:{namespace}:{sa_name}"
+        ]
+    }
+    return OR(body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION,
+              error_details=name), name
 
 
-def fetch_desired_state(oc_map):
-    gqlapi = gql.get_api()
-    roles = gqlapi.query(ROLES_QUERY)['roles']
-    state = AggregatedList()
-
+def fetch_desired_state(roles, ri):
     for role in roles:
         permissions = [{'cluster': a['namespace']['cluster']['name'],
                         'namespace': a['namespace']['name'],
                         'role': a['role']}
                        for a in role['access'] or []
-                       if None not in [a['namespace'], a['role']]]
+                       if None not in [a['namespace'], a['role']]
+                       and a['namespace'].get('managedRoles')]
         if not permissions:
             continue
-        permissions = [p for p in permissions
-                       if p['cluster'] in oc_map.clusters()]
 
-        users = []
-        service_accounts = []
+        users = [user['github_username']
+                 for user in role['users']]
+        bot_users = [bot['github_username']
+                     for bot in role['bots']
+                     if bot.get('github_username')]
+        users.extend(bot_users)
+        service_accounts = [bot['openshift_serviceaccount']
+                            for bot in role['bots']
+                            if bot.get('openshift_serviceaccount')]
 
-        for user in role['users']:
-            users.append(user['github_username'])
-
-        for bot in role['bots']:
-            if bot['github_username'] is not None:
-                users.append(bot['github_username'])
-            if bot['openshift_serviceaccount'] is not None:
-                service_accounts.append(bot['openshift_serviceaccount'])
-
-        permissions_users = permissions_kind(permissions, u'User')
-        list(map(lambda p: state.add(p, users), permissions_users))
-
-        permissions_sas = permissions_kind(permissions, u'ServiceAccount')
-        list(map(lambda p: state.add(p, service_accounts), permissions_sas))
-
-    return state
-
-
-def permissions_kind(permissions, kind):
-    permissions_copy = copy.deepcopy(permissions)
-    for permission in permissions_copy:
-        permission['kind'] = kind
-    return permissions_copy
-
-
-class RunnerAction(object):
-    def __init__(self, dry_run, oc_map):
-        self.dry_run = dry_run
-        self.oc_map = oc_map
-
-    def manage_role(self, label, method_name):
-        def action(params, items):
-            if len(items) == 0:
-                return True
-
-            status = True
-
-            cluster = params['cluster']
-            namespace = params['namespace']
-            role = params['role']
-            kind = params['kind']
-
-            if not self.dry_run:
-                oc = self.oc_map.get(cluster)
-
-            for member in items:
-                logging.info([
-                    label,
-                    cluster,
-                    namespace,
-                    role,
-                    kind,
-                    member
-                ])
-
-                if not self.dry_run:
-                    f = getattr(oc, method_name)
-                    try:
-                        f(namespace, role, member, kind)
-                    except Exception as e:
-                        logging.error(str(e))
-                        status = False
-
-            return status
-
-        return action
-
-    def add_role(self):
-        return self.manage_role('add_role', 'add_role_to_user')
-
-    def del_role(self):
-        return self.manage_role('del_role', 'remove_role_from_user')
+        for permission in permissions:
+            for user in users:
+                oc_resource, resource_name = \
+                    construct_user_oc_resource(permission['role'], user)
+                try:
+                    ri.add_desired(
+                        permission['cluster'],
+                        permission['namespace'],
+                        'RoleBinding',
+                        resource_name,
+                        oc_resource
+                    )
+                except ResourceKeyExistsError:
+                    # a user may have a Role assigned to them
+                    # from multiple app-interface roles
+                    pass
+            for sa in service_accounts:
+                namespace, sa_name = sa.split('/')
+                oc_resource, resource_name = \
+                    construct_sa_oc_resource(
+                        permission['role'], namespace, sa_name)
+                try:
+                    ri.add_desired(
+                        permission['cluster'],
+                        permission['namespace'],
+                        'RoleBinding',
+                        resource_name,
+                        oc_resource
+                    )
+                except ResourceKeyExistsError:
+                    # a ServiceAccount may have a Role assigned to it
+                    # from multiple app-interface roles
+                    pass
 
 
 @defer
 def run(dry_run=False, thread_pool_size=10, defer=None):
-    oc_map, current_state = fetch_current_state(thread_pool_size)
+    gqlapi = gql.get_api()
+    namespaces = [namespace_info for namespace_info
+                  in gqlapi.query(NAMESPACES_QUERY)['namespaces']
+                  if namespace_info.get('managedRoles')]
+    ri, oc_map = \
+        ob.fetch_current_state(namespaces, thread_pool_size,
+                               QONTRACT_INTEGRATION,
+                               QONTRACT_INTEGRATION_VERSION,
+                               override_managed_types=['RoleBinding'])
     defer(lambda: oc_map.cleanup())
-    desired_state = fetch_desired_state(oc_map)
-
-    # calculate diff
-    diff = current_state.diff(desired_state)
-
-    # Ensure all namespace/roles are well known.
-    # Any item that appears in `diff['insert']` means that it's not listed
-    # as a managedCluster in the cluster datafile.
-    if len(diff['insert']) > 0:
-        unknown_combinations = [
-            "- {}/{}/{}".format(
-                item["params"]["cluster"],
-                item["params"]["namespace"],
-                item["params"]["role"],
-            )
-            for item in diff['insert']
-        ]
-
-        raise RunnerException((
-                "Unknown cluster/namespace/combinations found:\n"
-                "{}"
-            ).format("\n".join(unknown_combinations))
-        )
-
-    # Run actions
-    runner_action = RunnerAction(dry_run, oc_map)
-    runner = AggregatedDiffRunner(diff)
-
-    runner.register("update-insert", runner_action.add_role())
-    runner.register("update-delete", runner_action.del_role())
-    runner.register("delete", runner_action.del_role())
-
-    status = runner.run()
-
-    if status is False:
-        sys.exit(1)
+    roles = gqlapi.query(ROLES_QUERY)['roles']
+    fetch_desired_state(roles, ri)
+    ob.realize_data(dry_run, oc_map, ri)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -68,6 +68,7 @@ NAMESPACES_QUERY = """
 {
   namespaces: namespaces_v1 {
     name
+    managedRoles
     cluster {
       name
       serverUrl

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="reconcile",
-    version="0.2.1",
+    version="0.2.2",
     license="BSD",
 
     author="Red Hat App-SRE Team",

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -150,18 +150,6 @@ class OC(object):
         cmd = ['adm', 'groups', 'remove-users', group, user]
         self._run(cmd)
 
-    def add_role_to_user(self, namespace, role, user, kind):
-        if kind == 'ServiceAccount':
-            user = self.get_service_account_username(user)
-        cmd = ['policy', '-n', namespace, 'add-role-to-user', role, user]
-        self._run(cmd)
-
-    def remove_role_from_user(self, namespace, role, user, kind):
-        if kind == 'ServiceAccount':
-            user = self.get_service_account_username(user)
-        cmd = ['policy', '-n', namespace, 'remove-role-from-user', role, user]
-        self._run(cmd)
-
     @staticmethod
     def get_service_account_username(user):
         namespace = user.split('/')[0]


### PR DESCRIPTION
covers https://jira.coreos.com/browse/APPSRE-1201

this integration should use the same patterns as other openshift integrations.

additional benefits:
1. the rolebindings integration will also work for Kubernetes clusters and not only for OpenShift since it will no longer use the `oc policy` commands.
2. it allows us to manage RoleBindings in a non authoritative manner (manual RoleBindngs can live side by side with ones created by this integration).
3. RoleBindings are annotated with qontract-reconcile annotations like other resources.
4. we are no longer limited to manage a specific Role (view/edit/admin).

Note: in app-interface, `managedRoles` is now boolean instead of a list of Roles we manage.