### PR TITLE
add config implementation for secret-reader

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -35,6 +35,7 @@ def read(secret):
         raise SecretNotFound(
             f'key not found in config file {path}: {str(e)}')
 
+
 def read_all(secret):
     path = secret['path']
     try:

--- a/utils/config.py
+++ b/utils/config.py
@@ -3,6 +3,10 @@ import toml
 _config = None
 
 
+class SecretNotFound(Exception):
+    pass
+
+
 def get_config():
     global _config
     return _config
@@ -16,3 +20,29 @@ def init(config):
 
 def init_from_toml(configfile):
     return init(toml.load(configfile))
+
+
+def read(secret):
+    path = secret['path']
+    field = secret['field']
+    try:
+        path_tokens = path.split('/')
+        config = get_config()
+        for t in path_tokens:
+            config = config[t]
+        return config[field]
+    except Exception as e:
+        raise SecretNotFound(
+            f'key not found in config file {path}: {str(e)}')
+
+def read_all(secret):
+    path = secret['path']
+    try:
+        path_tokens = path.split('/')
+        config = get_config()
+        for t in path_tokens:
+            config = config[t]
+        return config
+    except Exception as e:
+        raise SecretNotFound(
+            f'secret {path} not found in config file: {str(e)}')

--- a/utils/secret_reader.py
+++ b/utils/secret_reader.py
@@ -1,4 +1,5 @@
 import utils.vault_client as vault_client
+import utils.config as config
 
 
 def read(secret, settings=None):
@@ -22,8 +23,7 @@ def read(secret, settings=None):
     if settings and settings.get('vault'):
         return vault_client.read(secret)
     else:
-        raise NotImplementedError(
-            'reading secrets from a config file is not yet implemented')
+        return config.read(secret)
 
 
 def read_all(secret, settings=None):
@@ -46,5 +46,4 @@ def read_all(secret, settings=None):
     if settings and settings.get('vault'):
         return vault_client.read_all(secret)
     else:
-        raise NotImplementedError(
-            'reading secrets from a config file is not yet implemented')
+        return config.read_all(secret)


### PR DESCRIPTION
finalizes https://jira.coreos.com/browse/APPSRE-1102

to use a configuration file instead of Vault, the tokens need to be present in the config file in the same path as in Vault. for example, the slack-usergroups integration uses these secrets:
```
path: app-sre/creds/slack-app-sre-groups
field: token

path: app-sre/ci-int/pd_api_key
field: pd_api_key
```

this is how it would look like in a config file:
```
[app-sre]
[app-sre.creds]
[app-sre.creds.slack-app-sre-groups]
token = "REDACTED"

[app-sre.ci-int]
[app-sre.ci-int.pd_api_key]
pd_api_key = "REDACTED"
```