### PR TITLE
graphql server endpoint with sha

### DIFF
--- a/reconcile/test/test_github_org.py
+++ b/reconcile/test/test_github_org.py
@@ -72,7 +72,7 @@ def get_items_by_params(state, params):
 class TestGithubOrg(object):
     def setup_method(self, method):
         config.init_from_toml(fxt.path('config.toml'))
-        gql.init_from_config()
+        gql.init_from_config(sha_url=False)
 
     def do_current_state_test(self, path):
         fixture = fxt.get_anymarkup(path)

--- a/reconcile/test/test_quay_membership.py
+++ b/reconcile/test/test_quay_membership.py
@@ -30,7 +30,7 @@ class QuayApiMock(object):
 class TestQuayMembership(object):
     def setup_method(self, method):
         config.init_from_toml(fxt.path('config.toml'))
-        gql.init_from_config()
+        gql.init_from_config(sha_url=False)
 
     def do_current_state_test(self, path):
         fixture = fxt.get_anymarkup(path)

--- a/reconcile/test/test_quay_repos.py
+++ b/reconcile/test/test_quay_repos.py
@@ -30,7 +30,7 @@ class QuayApiMock(object):
 class TestQuayRepos(object):
     def setup_method(self, method):
         config.init_from_toml(fxt.path('config.toml'))
-        gql.init_from_config()
+        gql.init_from_config(sha_url=False)
 
     def do_current_state_test(self, path):
         fixture = fxt.get_anymarkup(path)

--- a/utils/gql.py
+++ b/utils/gql.py
@@ -87,14 +87,15 @@ def get_sha_url(server, token=None):
     return f'{server}/{sha}'
 
 
-def init_from_config():
+def init_from_config(sha_url=True):
     config = get_config()
 
     server = config['graphql']['server']
     token = config['graphql'].get('token')
-    server_with_sha = get_sha_url(server, token)
+    if sha_url:
+        server = get_sha_url(server, token)
 
-    return init(server_with_sha, token)
+    return init(server, token)
 
 
 def get_api():

--- a/utils/gql.py
+++ b/utils/gql.py
@@ -1,4 +1,5 @@
 import json
+import requests
 
 from graphqlclient import GraphQLClient
 from utils.config import get_config
@@ -78,13 +79,22 @@ def init(url, token=None):
     return _gqlapi
 
 
+def get_sha_url(server, token=None):
+    sha_endpoint = server.replace('graphql', 'sha256')
+    headers = {'Authorization': token} if token else None
+    r = requests.get(sha_endpoint, headers=headers)
+    sha = r.content.decode('utf-8')
+    return f'{server}/{sha}'
+
+
 def init_from_config():
     config = get_config()
 
     server = config['graphql']['server']
     token = config['graphql'].get('token')
+    server_with_sha = get_sha_url(server, token)
 
-    return init(server, token)
+    return init(server_with_sha, token)
 
 
 def get_api():

--- a/utils/gql.py
+++ b/utils/gql.py
@@ -84,7 +84,8 @@ def get_sha_url(server, token=None):
     headers = {'Authorization': token} if token else None
     r = requests.get(sha_endpoint, headers=headers)
     sha = r.content.decode('utf-8')
-    return f'{server}/{sha}'
+    gql_sha_endpoint = server.replace('graphql', 'graphqlsha')
+    return f'{gql_sha_endpoint}/{sha}'
 
 
 def init_from_config(sha_url=True):


### PR DESCRIPTION
covers https://jira.coreos.com/browse/APPSRE-1206

To be able to run integrations without concern that the data may be reloaded at run time, expose the graphql endpoint at a url that includes the sha256 sum of the current bundle.

when data is reloaded, the endpoint changes and running integrations will fail if they are still performing graphql queries. this is the expected result.

depends on https://github.com/app-sre/qontract-server/pull/63