### PR TITLE
[openshift-*] allow taking over resources

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -81,6 +81,16 @@ def threaded(**kwargs):
     return f
 
 
+def take_over(**kwargs):
+    def f(function):
+        help_msg = 'manage resources exclusively (take over existing resources).'
+        function = click.option('--take-over/--no-take-over',
+                                help=help_msg,
+                                default=True)(function)
+        return function
+    return f
+
+
 def terraform(function):
     function = click.option('--print-only/--no-print-only',
                             help='only print the terraform config file.',
@@ -356,11 +366,12 @@ def openshift_acme(ctx, thread_pool_size):
 
 @integration.command()
 @threaded()
+@take_over()
 @binary(['oc', 'ssh'])
 @click.pass_context
-def openshift_limitranges(ctx, thread_pool_size):
+def openshift_limitranges(ctx, thread_pool_size, take_over):
     run_integration(reconcile.openshift_limitranges.run,
-                    ctx.obj['dry_run'], thread_pool_size)
+                    ctx.obj['dry_run'], thread_pool_size, take_over)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -83,7 +83,7 @@ def threaded(**kwargs):
 
 def take_over(**kwargs):
     def f(function):
-        help_msg = 'manage resources exclusively (take over existing resources).'
+        help_msg = 'manage resources exclusively (take over existing ones).'
         function = click.option('--take-over/--no-take-over',
                                 help=help_msg,
                                 default=True)(function)

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -146,7 +146,8 @@ def check_unused_resource_types(ri):
 
 def realize_data(dry_run, oc_map, ri,
                  enable_deletion=True,
-                 recycle_pods=False):
+                 recycle_pods=False,
+                 take_over=False):
     for cluster, namespace, resource_type, data in ri:
         # desired items
         for name, d_item in data['desired'].items():

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -199,8 +199,8 @@ def realize_data(dry_run, oc_map, ri,
                 continue
 
             if not c_item.has_qontract_annotations():
-                continue
-
+                if not take_over:
+                    continue
             try:
                 delete(dry_run, oc_map, cluster, namespace,
                        resource_type, name, enable_deletion)

--- a/reconcile/openshift_limitranges.py
+++ b/reconcile/openshift_limitranges.py
@@ -81,7 +81,7 @@ def add_desired_state(namespaces, ri):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, defer=None):
+def run(dry_run=False, thread_pool_size=10, take_over=True, defer=None):
     gqlapi = gql.get_api()
     namespaces = [namespace_info for namespace_info
                   in gqlapi.query(NAMESPACES_QUERY)['namespaces']
@@ -101,4 +101,4 @@ def run(dry_run=False, thread_pool_size=10, defer=None):
     defer(lambda: oc_map.cleanup())
 
     add_desired_state(namespaces, ri)
-    ob.realize_data(dry_run, oc_map, ri, enable_deletion=True, take_over=True)
+    ob.realize_data(dry_run, oc_map, ri, enable_deletion=True, take_over=take_over)

--- a/reconcile/openshift_limitranges.py
+++ b/reconcile/openshift_limitranges.py
@@ -101,4 +101,5 @@ def run(dry_run=False, thread_pool_size=10, take_over=True, defer=None):
     defer(lambda: oc_map.cleanup())
 
     add_desired_state(namespaces, ri)
-    ob.realize_data(dry_run, oc_map, ri, enable_deletion=True, take_over=take_over)
+    ob.realize_data(dry_run, oc_map, ri, enable_deletion=True,
+                    take_over=take_over)

--- a/reconcile/openshift_limitranges.py
+++ b/reconcile/openshift_limitranges.py
@@ -80,23 +80,6 @@ def add_desired_state(namespaces, ri):
             )
 
 
-def set_delete_state(namespaces, ri):
-    for cluster, namespace, resource_type, data in ri:
-        for name, c_item in data['current'].items():
-
-            # look if resource is present in the ones we want to apply
-            for ns in namespaces:
-                if not ns['name'] == namespace:
-                    continue
-                if not name == ns['limitRanges']['name']:
-                    # if resource is not the one we want to apply...
-                    # set fake annotations as if we owned it
-                    c_item = c_item.annotate()
-                    # re-add to inventory
-                    ri.add_current(cluster, namespace,
-                                   resource_type, name, c_item)
-
-
 @defer
 def run(dry_run=False, thread_pool_size=10, defer=None):
     gqlapi = gql.get_api()
@@ -118,6 +101,4 @@ def run(dry_run=False, thread_pool_size=10, defer=None):
     defer(lambda: oc_map.cleanup())
 
     add_desired_state(namespaces, ri)
-    set_delete_state(namespaces, ri)
-
-    ob.realize_data(dry_run, oc_map, ri, enable_deletion=True)
+    ob.realize_data(dry_run, oc_map, ri, enable_deletion=True, take_over=True)


### PR DESCRIPTION
This PR introduces a new argument to `realize_data` - `take_over`.

If `take_over` is set to `True`, all existing un-managed resources (of the types managed by the running integration) will be taken over and removed if they do not exist in app-interface.

This makes an integration the sole owner of a resource type in a namespace.