### PR TITLE
[e2e/default project labels] add monitoring label

### DIFF
--- a/e2e_tests/default_project_labels.py
+++ b/e2e_tests/default_project_labels.py
@@ -28,3 +28,5 @@ def run(defer=None):
                 cluster, project['metadata']['name']))
             assert project['metadata']['labels']['name'] == \
                 project['metadata']['name']
+            monitoring_label = "openshift.io/workload-monitoring"
+            assert project['metadata']['labels'][monitoring_label] == "true"


### PR DESCRIPTION
following https://redhat.service-now.com/surl.do?n=INC1053265

add a check that this label exist on all required namespaces.