### PR TITLE
terraform add handle for empty output

### DIFF
--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -9,7 +9,7 @@ import utils.threaded as threaded
 from utils.openshift_resource import OpenshiftResource as OR
 from utils.retry import retry
 
-from python_terraform import Terraform, TerraformCommandError
+from python_terraform import Terraform, IsFlagged, TerraformCommandError
 from threading import Lock
 
 
@@ -90,8 +90,17 @@ class TerraformClient(object):
     def terraform_output(self, spec):
         name = spec['name']
         tf = spec['tf']
-        output = tf.output(raise_on_error=True)
-        return name, output
+        return_code, stdout, stderr = tf.output_cmd(json=IsFlagged)
+        error = self.check_output(name, return_code, stdout, stderr)
+        no_output_error = \
+            'The module root could not be found. There is nothing to output.'
+        if error:
+            if no_output_error in stderr:
+                stdout = '{}'
+            else:
+                raise TerraformCommandError(
+                    return_code, 'output', out=stdout, err=stderr)
+        return name, json.loads(stdout)
 
     # terraform plan
     def plan(self, enable_deletion):


### PR DESCRIPTION
we are currently not handling the onboarding on AWS accounts very well.
at first run, the outputs are empty: https://ci-int-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/service-app-interface-gl-pr-check/4657/artifact/temp/reports/reconcile_reports_fail/reconcile-terraform-users.txt

this PR catches that error and handles it gracefully.

ref: https://github.com/beelit94/python-terraform/blob/develop/python_terraform/__init__.py#L336-L342