### PR TITLE
add openshift resource name validation

### DIFF
--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -3,6 +3,7 @@ import hashlib
 import json
 import semver
 import datetime
+import re
 
 from threading import Lock
 
@@ -42,6 +43,16 @@ class OpenshiftResource(object):
         except (KeyError, TypeError) as e:
             msg = "resource invalid data ({}). details: {}".format(
                 e.__class__.__name__, self.error_details)
+            raise ConstructResourceError(msg)
+
+        r = '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
+        if not re.search(r'^{}$'.format(r), self.name):
+            msg = f"The {self.kind} \"{self.name}\" is invalid: " + \
+                f"metadata.name: Invalid value: \"{self.name}\": " + \
+                f"a DNS-1123 subdomain must consist of lower case " + \
+                f"alphanumeric characters, '-' or '.', and must start " + \
+                f"and end with an alphanumeric character (e.g. " + \
+                f"'example.com', regex used for validation is '{r}')"
             raise ConstructResourceError(msg)
 
     def has_qontract_annotations(self):


### PR DESCRIPTION
covers https://jira.coreos.com/browse/APPSRE-1227

This PR adds a name validation for openshift resources.
If this starts getting out of hand we will need to use a 3rd party tool, as suggested on the issue.

This should be good enough for now.
chose not to include the `^` and `$` in the pattern to make the error message identical to the `oc` output.

```
$ cat test.yaml 
apiVersion: v1
kind: ConfigMap
metadata:
  name: Test
data:
  key: value
$ oc apply -f test.yaml --dry-run --validate
configmap/Test created (dry run)
$ oc apply -f test.yaml 
The ConfigMap "Test" is invalid: metadata.name: Invalid value: "Test": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

```
$ qontract-reconcile --config config.debug.toml --dry-run openshift-resources
ERROR: [<clustre>/<namespace>] error fetching resource: error constructing openshift resource: The ConfigMap "Test" is invalid: metadata.name: Invalid value: "Test": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```