### PR TITLE
[github-scanner] fix reading error

### DIFF
--- a/utils/git_secrets.py
+++ b/utils/git_secrets.py
@@ -36,7 +36,7 @@ def scan_history(repo_url, existing_keys, defer=None):
         return []
 
     logging.info('found suspects in {}'.format(repo_url))
-    suspected_files = get_suspected_files(err)
+    suspected_files = get_suspected_files(err.decode('utf-8'))
     leaked_keys = get_leaked_keys(wd, suspected_files, existing_keys)
     if leaked_keys:
         logging.info('found suspected leaked keys: {}'.format(leaked_keys))


### PR DESCRIPTION
Original Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.0-py3.6.egg/utils/threaded.py", line 10, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.0-py3.6.egg/utils/defer.py", line 15, in func_wrapper
    return func(*args, defer=defer, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.0-py3.6.egg/utils/retry.py", line 19, in f_retry
    raise e
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.0-py3.6.egg/utils/retry.py", line 16, in f_retry
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.0-py3.6.egg/utils/git_secrets.py", line 39, in scan_history
    suspected_files = get_suspected_files(err)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.0-py3.6.egg/utils/git_secrets.py", line 56, in get_suspected_files
    for e in error.split('\n'):
TypeError: a bytes-like object is required, not 'str'