### PR TITLE
Add internal/external/all option for OpenShift related integrations

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -361,10 +361,11 @@ def openshift_namespaces(ctx, thread_pool_size, internal):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@internal()
 @click.pass_context
-def openshift_network_policies(ctx, thread_pool_size):
+def openshift_network_policies(ctx, thread_pool_size, internal):
     run_integration(reconcile.openshift_network_policies.run,
-                    ctx.obj['dry_run'], thread_pool_size)
+                    ctx.obj['dry_run'], thread_pool_size, internal)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -371,10 +371,11 @@ def openshift_network_policies(ctx, thread_pool_size, internal):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@internal()
 @click.pass_context
-def openshift_acme(ctx, thread_pool_size):
+def openshift_acme(ctx, thread_pool_size, internal):
     run_integration(reconcile.openshift_acme.run,
-                    ctx.obj['dry_run'], thread_pool_size)
+                    ctx.obj['dry_run'], thread_pool_size, internal)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -91,6 +91,16 @@ def take_over(**kwargs):
     return f
 
 
+def internal(**kwargs):
+    def f(function):
+        help_msg = 'manage resources in internal or external clusters only.'
+        function = click.option('--internal/--external',
+                                help=help_msg,
+                                default=None)(function)
+        return function
+    return f
+
+
 def terraform(function):
     function = click.option('--print-only/--no-print-only',
                             help='only print the terraform config file.',
@@ -331,10 +341,11 @@ def aws_support_cases_sos(ctx, gitlab_project_id, thread_pool_size):
 @integration.command()
 @threaded(default=20)
 @binary(['oc', 'ssh'])
+@internal()
 @click.pass_context
-def openshift_resources(ctx, thread_pool_size):
+def openshift_resources(ctx, thread_pool_size, internal):
     run_integration(reconcile.openshift_resources.run,
-                    ctx.obj['dry_run'], thread_pool_size)
+                    ctx.obj['dry_run'], thread_pool_size, internal)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -230,10 +230,11 @@ def openshift_groups(ctx, thread_pool_size, internal):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@internal()
 @click.pass_context
-def openshift_users(ctx, thread_pool_size):
+def openshift_users(ctx, thread_pool_size, internal):
     run_integration(reconcile.openshift_users.run, ctx.obj['dry_run'],
-                    thread_pool_size)
+                    thread_pool_size, internal)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -220,10 +220,11 @@ def openshift_rolebindings(ctx, thread_pool_size, internal):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@internal()
 @click.pass_context
-def openshift_groups(ctx, thread_pool_size):
+def openshift_groups(ctx, thread_pool_size, internal):
     run_integration(reconcile.openshift_groups.run, ctx.obj['dry_run'],
-                    thread_pool_size)
+                    thread_pool_size, internal)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -415,13 +415,14 @@ def ldap_users(ctx, gitlab_project_id, thread_pool_size):
 @throughput
 @threaded(default=20)
 @binary(['terraform', 'oc'])
+@internal()
 @enable_deletion(default=False)
 @click.pass_context
 def terraform_resources(ctx, print_only, enable_deletion,
-                        io_dir, thread_pool_size):
+                        io_dir, thread_pool_size, internal):
     run_integration(reconcile.terraform_resources.run,
                     ctx.obj['dry_run'], print_only,
-                    enable_deletion, io_dir, thread_pool_size)
+                    enable_deletion, io_dir, thread_pool_size, internal)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -351,10 +351,11 @@ def openshift_resources(ctx, thread_pool_size, internal):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@internal()
 @click.pass_context
-def openshift_namespaces(ctx, thread_pool_size):
+def openshift_namespaces(ctx, thread_pool_size, internal):
     run_integration(reconcile.openshift_namespaces.run,
-                    ctx.obj['dry_run'], thread_pool_size)
+                    ctx.obj['dry_run'], thread_pool_size, internal)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -382,10 +382,11 @@ def openshift_acme(ctx, thread_pool_size, internal):
 @threaded()
 @take_over()
 @binary(['oc', 'ssh'])
+@internal()
 @click.pass_context
-def openshift_limitranges(ctx, thread_pool_size, take_over):
+def openshift_limitranges(ctx, thread_pool_size, internal, take_over):
     run_integration(reconcile.openshift_limitranges.run,
-                    ctx.obj['dry_run'], thread_pool_size, take_over)
+                    ctx.obj['dry_run'], thread_pool_size, internal, take_over)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -210,10 +210,11 @@ def github_scanner(ctx, gitlab_project_id, thread_pool_size):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@internal()
 @click.pass_context
-def openshift_rolebindings(ctx, thread_pool_size):
+def openshift_rolebindings(ctx, thread_pool_size, internal):
     run_integration(reconcile.openshift_rolebindings.run, ctx.obj['dry_run'],
-                    thread_pool_size)
+                    thread_pool_size, internal)
 
 
 @integration.command()

--- a/reconcile/openshift_acme.py
+++ b/reconcile/openshift_acme.py
@@ -111,7 +111,7 @@ def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
                                    'Role',
                                    'RoleBinding',
                                    'ServiceAccount'],
-                                internal=internal)
+                               internal=internal)
     add_desired_state(namespaces, ri, oc_map)
 
     defer(lambda: oc_map.cleanup())

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -87,11 +87,12 @@ def populate_current_state(spec, ri, integration, integration_version):
 
 def fetch_current_state(namespaces, thread_pool_size,
                         integration, integration_version,
-                        override_managed_types=None):
+                        override_managed_types=None,
+                        internal=None):
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces, integration=integration,
-                    settings=settings)
+                    settings=settings, internal=internal)
     state_specs = \
         init_specs_to_fetch(
             ri,

--- a/reconcile/openshift_limitranges.py
+++ b/reconcile/openshift_limitranges.py
@@ -66,8 +66,11 @@ def construct_resources(namespaces):
     return namespaces
 
 
-def add_desired_state(namespaces, ri):
+def add_desired_state(namespaces, ri, oc_map):
     for namespace in namespaces:
+        cluster = namespace['cluster']['name']
+        if not oc_map.get(cluster):
+            continue
         if 'resources' not in namespace:
             continue
         for resource in namespace["resources"]:
@@ -81,7 +84,8 @@ def add_desired_state(namespaces, ri):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, take_over=True, defer=None):
+def run(dry_run=False, thread_pool_size=10, internal=None,
+        take_over=True, defer=None):
     gqlapi = gql.get_api()
     namespaces = [namespace_info for namespace_info
                   in gqlapi.query(NAMESPACES_QUERY)['namespaces']
@@ -97,9 +101,10 @@ def run(dry_run=False, thread_pool_size=10, take_over=True, defer=None):
         ob.fetch_current_state(namespaces, thread_pool_size,
                                QONTRACT_INTEGRATION,
                                QONTRACT_INTEGRATION_VERSION,
-                               override_managed_types=['LimitRange'])
+                               override_managed_types=['LimitRange'],
+                               internal=internal)
     defer(lambda: oc_map.cleanup())
 
-    add_desired_state(namespaces, ri)
+    add_desired_state(namespaces, ri, oc_map)
     ob.realize_data(dry_run, oc_map, ri, enable_deletion=True,
                     take_over=take_over)

--- a/reconcile/openshift_namespaces.py
+++ b/reconcile/openshift_namespaces.py
@@ -32,6 +32,7 @@ QUERY = """
         field
         format
       }
+      internal
       disable {
         integrations
       }
@@ -43,13 +44,13 @@ QUERY = """
 QONTRACT_INTEGRATION = 'openshift-namespaces'
 
 
-def get_desired_state():
+def get_desired_state(internal):
     gqlapi = gql.get_api()
     namespaces = gqlapi.query(QUERY)['namespaces']
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces, integration=QONTRACT_INTEGRATION,
-                    settings=settings)
+                    settings=settings, internal=internal)
     ob.init_specs_to_fetch(
         ri,
         oc_map,
@@ -79,8 +80,8 @@ def create_new_project(spec, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, defer=None):
-    oc_map, desired_state = get_desired_state()
+def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
+    oc_map, desired_state = get_desired_state(internal)
     defer(lambda: oc_map.cleanup())
     results = threaded.run(check_ns_exists, desired_state, thread_pool_size,
                            oc_map=oc_map)

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -88,6 +88,7 @@ NAMESPACES_QUERY = """
         field
         format
       }
+      internal
       disable {
         integrations
       }
@@ -434,11 +435,11 @@ def fetch_states(spec, ri):
                             spec.parent)
 
 
-def fetch_data(namespaces, thread_pool_size):
+def fetch_data(namespaces, thread_pool_size, internal):
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces, integration=QONTRACT_INTEGRATION,
-                    settings=settings)
+                    settings=settings, internal=internal)
     state_specs = ob.init_specs_to_fetch(ri, oc_map, namespaces)
     threaded.run(fetch_states, state_specs, thread_pool_size, ri=ri)
 
@@ -446,10 +447,10 @@ def fetch_data(namespaces, thread_pool_size):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, defer=None):
+def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
     gqlapi = gql.get_api()
     namespaces = gqlapi.query(NAMESPACES_QUERY)['namespaces']
-    oc_map, ri = fetch_data(namespaces, thread_pool_size)
+    oc_map, ri = fetch_data(namespaces, thread_pool_size, internal)
     defer(lambda: oc_map.cleanup())
 
     # check for unused resources types

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -88,6 +88,7 @@ NAMESPACES_QUERY = """
         field
         format
       }
+      internal
       disable {
         integrations
       }

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -260,11 +260,13 @@ class OC_Map(object):
     the OC client will be initiated to False.
     """
     def __init__(self, clusters=None, namespaces=None,
-                 integration='', e2e_test='', settings=None):
+                 integration='', e2e_test='', settings=None,
+                 internal=None):
         self.oc_map = {}
         self.calling_integration = integration
         self.calling_e2e_test = e2e_test
         self.settings = settings
+        self.internal = internal
 
         if clusters and namespaces:
             raise KeyError('expected only one of clusters or namespaces.')
@@ -284,6 +286,13 @@ class OC_Map(object):
             return
         if self.cluster_disabled(cluster_info):
             return
+        if self.internal is not None:
+            # integration is executed with `--internal` or `--external`
+            # filter out non matching clusters
+            if self.internal and not cluster_info['internal']:
+                return
+            if not self.internal and cluster_info['internal']:
+                return
 
         automation_token = cluster_info.get('automationToken')
         if automation_token is None:

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -217,7 +217,7 @@ class TerraformClient(object):
 
         return data
 
-    def populate_desired_state(self, ri):
+    def populate_desired_state(self, ri, oc_map):
         self.init_outputs()  # get updated output
         for account, output in self.outputs.items():
             formatted_output = self.format_output(
@@ -225,6 +225,8 @@ class TerraformClient(object):
 
             for name, data in formatted_output.items():
                 cluster = data['{}.cluster'.format(self.integration_prefix)]
+                if not oc_map.get(cluster):
+                    continue
                 namespace = \
                     data['{}.namespace'.format(self.integration_prefix)]
                 resource = data['{}.resource'.format(self.integration_prefix)]


### PR DESCRIPTION
This PR adds a new capability for OpenShift related integrations - running them on all resources (default), running only for internal clusters (`--internal`) or running only for external clusters (`--external`).

This new feature is required so we can run our integrations on a cluster without access to internal clusters and ignore any internal clusters, or to run only for internal clusters (integration should run internally as well).

Done as part of https://jira.coreos.com/browse/APPSRE-1206

Currently we can move all our OpenShift related integrations to our cluster, except for `openshift-resources` and `terraform-resources` which should ADDITIONALLY be running internally with the `--internal` flag.

app-interface PR: https://gitlab.cee.redhat.com/service/app-interface/merge_requests/2137

important logic is here: https://github.com/app-sre/qontract-reconcile/pull/347/files#diff-5fbe62e4ee1dc72875e4c91e78c4ea25R289