### PR TITLE
labels metdata doesn't always exist.. why are we even checking this?

### DIFF
--- a/e2e_tests/default_project_labels.py
+++ b/e2e_tests/default_project_labels.py
@@ -30,4 +30,4 @@ def run(defer=None):
                 assert project['metadata']['labels']['name'] == \
                     project['metadata']['name']
                 monitoring_label = "openshift.io/workload-monitoring"
-                assert project['metadata']['labels'][monitoring_label] == "true"
+                assert project['metadata']['labels'][monitoring_label] == "true"  # noqa: #E501

--- a/e2e_tests/default_project_labels.py
+++ b/e2e_tests/default_project_labels.py
@@ -26,7 +26,8 @@ def run(defer=None):
         for project in projects:
             logging.info("[{}/{}] validating default Project labels".format(
                 cluster, project['metadata']['name']))
-            assert project['metadata']['labels']['name'] == \
-                project['metadata']['name']
-            monitoring_label = "openshift.io/workload-monitoring"
-            assert project['metadata']['labels'][monitoring_label] == "true"
+            if project['metadata'].get('labels'):
+                assert project['metadata']['labels']['name'] == \
+                    project['metadata']['name']
+                monitoring_label = "openshift.io/workload-monitoring"
+                assert project['metadata']['labels'][monitoring_label] == "true"


### PR DESCRIPTION
   assert project['metadata']['labels']['name'] == \
KeyError: 'labels'