### PR TITLE
revert remove of temporary reconcile assistance

### DIFF
--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -209,6 +209,9 @@ class OpenshiftResource(object):
                         (subject['apiGroup'] == '' or
                             subject['apiGroup'] in body['apiVersion']):
                     subject.pop('apiGroup')
+            # TODO: remove this once we have no 3.11 clusters
+            if body['apiVersion'] == 'rbac.authorization.k8s.io/v1':
+                body['apiVersion'] = 'authorization.openshift.io/v1'
 
         if body['kind'] == 'ClusterRoleBinding':
             if 'groupNames' in body:


### PR DESCRIPTION
this keeps the openshift-rolebindings integration sane.