### PR TITLE
[openshift-resources] allow to manage resources in a limited namespace

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -63,7 +63,7 @@ def init_specs_to_fetch(ri, oc_map,
                 resource_names = \
                     [mrn['resourceNames'] for mrn in managed_resource_names
                      if mrn['resource'] == resource_type] \
-                     if managed_resource_names else None
+                    if managed_resource_names else None
                 # If not None, there is a single element in the list
                 if resource_names:
                     [resource_names] = resource_names

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -10,13 +10,15 @@ from utils.openshift_resource import (OpenshiftResource as OR,
 
 
 class StateSpec(object):
-    def __init__(self, type, oc, cluster, namespace, resource, parent=None):
+    def __init__(self, type, oc, cluster, namespace, resource, parent=None,
+                 resource_names=None):
         self.type = type
         self.oc = oc
         self.cluster = cluster
         self.namespace = namespace
         self.resource = resource
         self.parent = parent
+        self.resource_names = resource_names
 
 
 def init_specs_to_fetch(ri, oc_map,
@@ -51,12 +53,23 @@ def init_specs_to_fetch(ri, oc_map,
                 continue
 
             namespace = namespace_info['name']
+            managed_resource_names = \
+                namespace_info.get('managedResourceNames')
 
             # Initialize current state specs
             for resource_type in managed_types:
                 ri.initialize_resource_type(cluster, namespace, resource_type)
+                # Handle case of specific managed resources
+                resource_names = \
+                    [mrn['resourceNames'] for mrn in managed_resource_names
+                     if mrn['resource'] == resource_type] \
+                     if managed_resource_names else None
+                # If not None, there is a single element in the list
+                if resource_names:
+                    [resource_names] = resource_names
                 c_spec = StateSpec("current", oc, cluster, namespace,
-                                   resource_type)
+                                   resource_type,
+                                   resource_names=resource_names)
                 state_specs.append(c_spec)
 
             # Initialize desired state specs

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -45,6 +45,10 @@ NAMESPACES_QUERY = """
   namespaces: namespaces_v1 {
     name
     managedResourceTypes
+    managedResourceNames {
+      resource
+      resourceNames
+    }
     openshiftResources {
       provider
       ... on NamespaceOpenshiftResourceResource_v1 {
@@ -365,7 +369,8 @@ def fetch_openshift_resource(resource, parent):
     return openshift_resource
 
 
-def fetch_current_state(oc, ri, cluster, namespace, resource_type):
+def fetch_current_state(oc, ri, cluster, namespace, resource_type,
+                        resource_names=None):
     global _log_lock
 
     msg = "Fetching {}s from {}/{}".format(resource_type, cluster, namespace)
@@ -374,7 +379,8 @@ def fetch_current_state(oc, ri, cluster, namespace, resource_type):
     _log_lock.release()
     if oc is None:
         return
-    for item in oc.get_items(resource_type, namespace=namespace):
+    for item in oc.get_items(resource_type, namespace=namespace,
+                             resource_names=resource_names):
         openshift_resource = OR(item,
                                 QONTRACT_INTEGRATION,
                                 QONTRACT_INTEGRATION_VERSION)
@@ -445,7 +451,8 @@ def fetch_desired_state(oc, ri, cluster, namespace, resource, parent):
 def fetch_states(spec, ri):
     if spec.type == "current":
         fetch_current_state(spec.oc, ri, spec.cluster,
-                            spec.namespace, spec.resource)
+                            spec.namespace, spec.resource,
+                            spec.resource_names)
     if spec.type == "desired":
         fetch_desired_state(spec.oc, ri, spec.cluster,
                             spec.namespace, spec.resource,


### PR DESCRIPTION
Covers https://jira.coreos.com/browse/APPSRE-1349

This PR adds support for management of resources in namespaces with limited permissions.

Example addition to namespace file:
```
managedResourceNames:
# https://github.com/openshift/managed-cluster-config/blob/master/deploy/osd-customer-monitoring/05-role.yaml#L24-L37
- resource: Secret
  resourceNames:
    - alertmanager-config
    - alertmanager-main
```