### PR TITLE
[email-sender] introduce new integration

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -97,6 +97,15 @@ objects:
           - name: LOG_FILE
             value: "${LOG_FILE}"
           {{- end }}
+          {{- if $integration.state }}
+          - name: APP_INTERFACE_STATE_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: app-interface
+                key: aws.s3.bucket
+          - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT
+            value: "${APP_INTERFACE_STATE_BUCKET_ACCOUNT}"
+          {{- end }}
           {{- with $integration.extraEnv }}
           {{- range $i, $env := . }}
           - name: {{ $env.secretKey }}
@@ -151,6 +160,8 @@ parameters:
   value: "300"
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
+- name: APP_INTERFACE_STATE_BUCKET_ACCOUNT
+  value: app-sre
 - name: USER_ID
   value: "1000720000"
 - name: LOG_FILE

--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -184,3 +184,13 @@ integrations:
       memory: 200Mi
       cpu: 25m
   logs: true
+- name: email-sender
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 25m
+    limits:
+      memory: 200Mi
+      cpu: 50m
+  logs: true
+  state: true

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -1987,6 +1987,135 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    labels:
+      app: qontract-reconcile
+    name: qontract-reconcile-email-sender
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile
+      spec:
+        securityContext:
+          runAsUser: ${{USER_ID}}
+        initContainers:
+        - name: config
+          image: busybox
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                key: slack.webhook_url
+                name: app-interface
+          - name: SLACK_CHANNEL
+            value: ${SLACK_CHANNEL}
+          - name: SLACK_ICON_EMOJI
+            value: ${SLACK_ICON_EMOJI}
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type slack
+              webhook_url ${SLACK_WEBHOOK_URL}
+              channel ${SLACK_CHANNEL}
+              icon_emoji ${SLACK_ICON_EMOJI}
+              username sd-app-sre-bot
+              flush_interval 10s
+              message "\`\`\`[email-sender] %s\`\`\`"
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          env:
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: email-sender
+          - name: INTEGRATION_EXTRA_ARGS
+            value: ""
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
+          - name: APP_INTERFACE_STATE_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: app-interface
+                key: aws.s3.bucket
+          - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT
+            value: "${APP_INTERFACE_STATE_BUCKET_ACCOUNT}"
+          resources:
+            limits:
+              cpu: 50m
+              memory: 200Mi
+            requests:
+              cpu: 25m
+              memory: 100Mi
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: quay.io/app-sre/fluentd:latest
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 60Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/qontract-reconcile
@@ -1998,6 +2127,8 @@ parameters:
   value: "300"
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
+- name: APP_INTERFACE_STATE_BUCKET_ACCOUNT
+  value: app-sre
 - name: USER_ID
   value: "1000720000"
 - name: LOG_FILE

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -37,6 +37,7 @@ import reconcile.aws_garbage_collector
 import reconcile.aws_iam_keys
 import reconcile.aws_support_cases_sos
 import reconcile.ocm_groups
+import reconcile.email_sender
 
 from utils.gql import GqlApiError
 from utils.aggregated_list import RunnerException
@@ -504,3 +505,10 @@ def gitlab_projects(ctx):
 def ocm_groups(ctx, thread_pool_size):
     run_integration(reconcile.ocm_groups.run, ctx.obj['dry_run'],
                     thread_pool_size)
+
+
+@integration.command()
+@environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
+@click.pass_context
+def email_sender(ctx):
+    run_integration(reconcile.email_sender.run, ctx.obj['dry_run'])

--- a/reconcile/email_sender.py
+++ b/reconcile/email_sender.py
@@ -1,7 +1,6 @@
 import sys
 import logging
 
-# import utils.gql as gql
 import utils.smtp_client as smtp_client
 import reconcile.queries as queries
 
@@ -26,8 +25,8 @@ def collect_to(to):
 
     aliases = to.get('aliases')
     if aliases:
+        # TODO: implement this
         for alias in aliases:
-            # gql = gql.get_api()
             if alias == 'all-users':
                 pass
             elif alias == 'all-service-owners':
@@ -45,22 +44,22 @@ def collect_to(to):
             for service_owner in service_owners:
                 audience.add(service_owner['email'])
 
-    clusters - to.get('clusters')
+    clusters = to.get('clusters')
     if clusters:
+        # TODO: implement this
         for cluster in clusters:
-            # TODO: implement this
             pass
 
     namespaces = to.get('namespaces')
     if namespaces:
+        # TODO: implement this
         for namespace in namespaces:
-            # TODO: implement this
             pass
 
     aws_accounts = to.get('aws_accounts')
     if aws_accounts:
+        # TODO: implement this
         for account in aws_accounts:
-            # TODO: implement this
             pass
 
     roles = to.get('roles')

--- a/reconcile/email_sender.py
+++ b/reconcile/email_sender.py
@@ -110,9 +110,8 @@ def run(dry_run=False):
         logging.info(['send_email', email['name'], email['subject']])
 
         if not dry_run:
-            state.add(email['name'])
-
             names = collect_to(email['to'])
             subject = email['subject']
             body = email['body']
             smtp_client.send_mail(names, subject, body, settings=settings)
+            state.add(email['name'])

--- a/reconcile/email_sender.py
+++ b/reconcile/email_sender.py
@@ -12,13 +12,13 @@ QONTRACT_INTEGRATION = 'email-sender'
 
 def collect_to(to):
     """Collect audience to send email to from to object
-    
+
     Arguments:
         to {dict} -- AppInterfaceEmailAudience_v1 object
-    
+
     Raises:
         AttributeError: Unknown alias
-    
+
     Returns:
         set -- Audience to send email to
     """

--- a/reconcile/email_sender.py
+++ b/reconcile/email_sender.py
@@ -24,37 +24,59 @@ def collect_to(to):
     """
     audience = set()
 
-    for alias in to.get('aliases') or []:
-        # gql = gql.get_api()
-        if alias == 'all-users':
+    aliases = to.get('aliases')
+    if aliases:
+        for alias in aliases:
+            # gql = gql.get_api()
+            if alias == 'all-users':
+                pass
+            elif alias == 'all-service-owners':
+                pass
+            else:
+                raise AttributeError(f"unknown alias: {alias}")
+
+    services = to.get('services')
+    if services:
+        for service in services:
+            service_owners = service.get('serviceOwners')
+            if not service_owners:
+                continue
+
+            for service_owner in service_owners:
+                audience.add(service_owner['email'])
+
+    clusters - to.get('clusters')
+    if clusters:
+        for cluster in clusters:
+            # TODO: implement this
             pass
-        elif alias == 'all-service-owners':
+
+    namespaces = to.get('namespaces')
+    if namespaces:
+        for namespace in namespaces:
+            # TODO: implement this
             pass
-        else:
-            raise AttributeError(f"unknown alias: {alias}")
 
-    for service in to.get('services') or []:
-        for service_owner in service.get('serviceOwners', []):
-            audience.add(service_owner['email'])
+    aws_accounts = to.get('aws_accounts')
+    if aws_accounts:
+        for account in aws_accounts:
+            # TODO: implement this
+            pass
 
-    for cluster in to.get('clusters') or []:
-        # TODO: implement this
-        pass
+    roles = to.get('roles')
+    if roles:
+        for role in roles:
+            users = role.get('users')
+            if not users:
+                continue
 
-    for namespace in to.get('namespaces') or []:
-        # TODO: implement this
-        pass
+            for user in users:
+                audience.add(user['org_username'])
 
-    for account in to.get('aws_accounts') or []:
-        # TODO: implement this
-        pass
-
-    for role in to.get('roles') or []:
-        for user in role.get('users') or []:
+    users = to.get('users')
+    if users:
+        for user in users:
             audience.add(user['org_username'])
-
-    for user in to.get('users') or []:
-        audience.add(user['org_username'])
 
     return audience
 

--- a/reconcile/email_sender.py
+++ b/reconcile/email_sender.py
@@ -1,0 +1,96 @@
+import sys
+import logging
+
+# import utils.gql as gql
+import utils.smtp_client as smtp_client
+import reconcile.queries as queries
+
+from utils.state import State
+
+QONTRACT_INTEGRATION = 'email-sender'
+
+
+def collect_to(to):
+    """Collect audience to send email to from to object
+    
+    Arguments:
+        to {dict} -- AppInterfaceEmailAudience_v1 object
+    
+    Raises:
+        AttributeError: Unknown alias
+    
+    Returns:
+        set -- Audience to send email to
+    """
+    audience = set()
+
+    for alias in to.get('aliases') or []:
+        # gql = gql.get_api()
+        if alias == 'all-users':
+            pass
+        elif alias == 'all-service-owners':
+            pass
+        else:
+            raise AttributeError(f"unknown alias: {alias}")
+
+    for service in to.get('services') or []:
+        for service_owner in service.get('serviceOwners', []):
+            audience.add(service_owner['email'])
+
+    for cluster in to.get('clusters') or []:
+        # TODO: implement this
+        pass
+
+    for namespace in to.get('namespaces') or []:
+        # TODO: implement this
+        pass
+
+    for account in to.get('aws_accounts') or []:
+        # TODO: implement this
+        pass
+
+    for role in to.get('roles') or []:
+        for user in role.get('users') or []:
+            audience.add(user['org_username'])
+
+    for user in to.get('users') or []:
+        audience.add(user['org_username'])
+
+    return audience
+
+
+def run(dry_run=False):
+    settings = queries.get_app_interface_settings()
+    accounts = queries.get_aws_accounts()
+    state = State(
+        integration=QONTRACT_INTEGRATION,
+        accounts=accounts,
+        settings=settings
+    )
+    emails = queries.get_app_interface_emails()
+
+    # validate no 2 emails have the same name
+    email_names = set([e['name'] for e in emails])
+    if len(emails) != len(email_names):
+        logging.error('email names must be unique.')
+        sys.exit(1)
+
+    emails_to_send = [e for e in emails if not state.exists(e['name'])]
+
+    # validate that there is only 1 mail to send
+    # this is a safety net in case state is lost
+    # the solution to such loss is to delete all emails from app-interface
+    if len(emails_to_send) > 1:
+        logging.error('can only send one email at a time.')
+        sys.exit(1)
+
+    for email in emails_to_send:
+        logging.info(['send_email', email['name'], email['subject']])
+
+        if not dry_run:
+            state.add(email['name'])
+
+            names = collect_to(email['to'])
+            subject = email['subject']
+            body = email['body']
+            smtp_client.send_mail(names, subject, body, settings=settings)

--- a/reconcile/github_users.py
+++ b/reconcile/github_users.py
@@ -78,7 +78,7 @@ App-Interface repository: https://gitlab.cee.redhat.com/service/app-interface
     subject = 'App-Interface compliance - GitHub profile'
     body = msg_template
 
-    smtp_client.send_mail(to, subject, body, settings=settings)
+    smtp_client.send_mail([to], subject, body, settings=settings)
 
 
 def run(dry_run=False, gitlab_project_id=None, thread_pool_size=10,

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -59,9 +59,9 @@ APP_INTERFACE_EMAILS_QUERY = """
 
 
 def get_app_interface_emails():
-  """ Returns Email resources defined in app-interface """
-  gqlapi = gql.get_api()
-  return gqlapi.query(APP_INTERFACE_EMAILS_QUERY)['emails']
+    """ Returns Email resources defined in app-interface """
+    gqlapi = gql.get_api()
+    return gqlapi.query(APP_INTERFACE_EMAILS_QUERY)['emails']
 
 
 GITLAB_INSTANCES_QUERY = """

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -22,6 +22,48 @@ def get_app_interface_settings():
     return None
 
 
+APP_INTERFACE_EMAILS_QUERY = """
+{
+  emails: app_interface_emails_v1 {
+    name
+    subject
+    to {
+      aliases
+      services {
+        serviceOwners {
+          email
+        }
+      }
+      clusters {
+        name
+      }
+      namespaces {
+        name
+      }
+      aws_accounts {
+        name
+      }
+      roles {
+        users {
+          org_username
+        }
+      }
+      users {
+        org_username
+      }
+    }
+    body
+  }
+}
+"""
+
+
+def get_app_interface_emails():
+  """ Returns Email resources defined in app-interface """
+  gqlapi = gql.get_api()
+  return gqlapi.query(APP_INTERFACE_EMAILS_QUERY)['emails']
+
+
 GITLAB_INSTANCES_QUERY = """
 {
   instances: gitlabinstance_v1 {

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -53,14 +53,11 @@ class OCM(object):
         """Returns a list of users in a group in a cluster.
         If the group does not exist, None will be returned.
 
-        Arguments:
-            cluster {string} -- cluster name
-            group_id {string} -- group name
+        :param cluster: cluster name
+        :param group_id: group name
 
-        Returns:
-            dict or None -- a dict with a single 'users' key containing
-                            a list of users, or None if the group does
-                            not exist
+        :type cluster: string
+        :type group_id: string
         """
         cluster_id = self.cluster_ids[cluster]
         api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/groups'
@@ -74,12 +71,16 @@ class OCM(object):
         return {'users': [u['id'] for u in users]}
 
     def add_user_to_group(self, cluster, group_id, user):
-        """Adds a user to a group in a cluster.
+        """
+        Adds a user to a group in a cluster.
 
-        Arguments:
-            cluster {string} -- cluster name
-            group_id {string} -- group name
-            user {string} -- user name
+        :param cluster: cluster name
+        :param group_id: group name
+        :param user: user name
+
+        :type cluster: string
+        :type group_id: string
+        :type user: string
         """
         cluster_id = self.cluster_ids[cluster]
         api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
@@ -89,10 +90,13 @@ class OCM(object):
     def del_user_from_group(self, cluster, group_id, user_id):
         """Deletes a user from a group in a cluster.
 
-        Arguments:
-            cluster {string} -- cluster name
-            group_id {string} -- group name
-            user_id {string} -- user name
+        :param cluster: cluster name
+        :param group_id: group name
+        :param user: user name
+
+        :type cluster: string
+        :type group_id: string
+        :type user: string
         """
         cluster_id = self.cluster_ids[cluster]
         api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
@@ -155,13 +159,15 @@ class OCMMap(object):
             raise KeyError('expected one of clusters or namespaces.')
 
     def init_ocm_client(self, cluster_info):
-        """Initiate OCM client.
+        """
+        Initiate OCM client.
         Gets the OCM information and initiates an OCM client.
         Skip initiating OCM if it has already been initialized or if
         the current integration is disabled on it.
 
-        Arguments:
-            cluster_info {dict} -- Graphql cluster query result
+        :param cluster_info: Graphql cluster query result
+
+        :type cluster_info: dict
         """
         if self.cluster_disabled(cluster_info):
             return
@@ -185,13 +191,12 @@ class OCMMap(object):
                 OCM(url, access_token_client_id, access_token_url, token)
 
     def cluster_disabled(self, cluster_info):
-        """Checks if the calling integration is disabled in this cluster.
+        """
+        Checks if the calling integration is disabled in this cluster.
 
-        Arguments:
-            cluster_info {dict} -- Grapqh cluster query result
+        :param cluster_info: Graphql cluster query result
 
-        Returns:
-            bool -- Is calling integration disabled on this cluster
+        :type cluster_info: dict
         """
         try:
             integrations = cluster_info['disable']['integrations']
@@ -203,21 +208,16 @@ class OCMMap(object):
         return False
 
     def get(self, cluster):
-        """Gets an OCM instance by cluster.
+        """
+        Gets an OCM instance by cluster.
 
-        Arguments:
-            cluster {string} -- cluster name
+        :param cluster: cluster name
 
-        Returns:
-            OCM -- OCM instance referenced by this cluster
+        :type cluster: string
         """
         ocm = self.clusters_map[cluster]
         return self.ocm_map.get(ocm, None)
 
     def clusters(self):
-        """Get list of cluster names initiated in the OCM map.
-
-        Returns:
-            list -- cluster names (string)
-        """
+        """Get list of cluster names initiated in the OCM map."""
         return [k for k, v in self.clusters_map.items() if v]

--- a/utils/smtp_client.py
+++ b/utils/smtp_client.py
@@ -68,7 +68,7 @@ def get_smtp_config(path, settings):
     return config
 
 
-def send_mail(name, subject, body, settings=None):
+def send_mail(names, subject, body, settings=None):
     global _client
     global _username
     global _mail_address
@@ -78,9 +78,14 @@ def send_mail(name, subject, body, settings=None):
 
     msg = MIMEMultipart()
     from_name = str(Header('App SRE team automation', 'utf-8'))
-    to = '{}@{}'.format(name, _mail_address)
     msg['From'] = formataddr((from_name, _username))
-    msg['To'] = to
+    to = set()
+    for name in names:
+        if '@' in name:
+            to.add(name)
+        else:
+            to.add(f"{name}@{_mail_address}")
+    msg['To'] = ', '.join(to)
     msg['Subject'] = subject
 
     # add in the message body
@@ -96,6 +101,6 @@ def send_mails(mails, settings=None):
     init_from_config(settings)
     try:
         for name, subject, body in mails:
-            send_mail(name, subject, body)
+            send_mail([name], subject, body)
     finally:
         teardown()

--- a/utils/state.py
+++ b/utils/state.py
@@ -1,0 +1,65 @@
+import os
+import json
+
+from botocore.errorfactory import ClientError
+
+from utils.aws_api import AWSApi
+
+
+class State(object):
+    """
+    A state object to be used by stateful integrations.
+    A stateful integration is one that has to do each action only once,
+    and there is no source of truth to validate against.
+
+    Good example: email-sender should only send each email once
+    Bad example: openshift-resources' source of truth is the clusters
+
+    :param integration: name of calling integration
+    :param accounts: Graphql AWS accounts query results
+    :param settings: App Interface settings
+
+    :type integration: string
+    :type accounts: list
+    :type settings: dict
+    """
+    def __init__(self, integration, accounts, settings=None):
+        """Initiates S3 client from AWSApi."""
+        self.state_path = f"state/{integration}"
+        self.bucket = os.environ['APP_INTERFACE_STATE_BUCKET']
+        account = os.environ['APP_INTERFACE_STATE_BUCKET_ACCOUNT']
+        aws_api = AWSApi(1, accounts, settings=settings)
+        session = aws_api.get_session(account)
+
+        self.client = session.client('s3')
+
+    def exists(self, key):
+        """checks if a key exists in the state
+        
+        Arguments:
+            key {string} -- key to check
+        
+        Returns:
+            bool -- True if key exists in state, else False
+        """
+        try:
+            self.client.head_object(
+                Bucket=self.bucket, Key=f"{self.state_path}/{key}")
+            return True
+        except ClientError:
+            return False
+
+    def add(self, key):
+        """adds a key to the state and fails if the key already exists
+        
+        Arguments:
+            key {string} -- key to add
+        
+        Raises:
+            KeyError: key already exists in the state
+        """
+        if self.exists(key):
+            raise KeyError(
+                f"[state] key {key} already exists in {self.state_path}")
+        self.client.put_object(
+            Bucket=self.bucket, Key=f"{self.state_path}/{key}")

--- a/utils/state.py
+++ b/utils/state.py
@@ -1,5 +1,4 @@
 import os
-import json
 
 from botocore.errorfactory import ClientError
 
@@ -35,10 +34,10 @@ class State(object):
 
     def exists(self, key):
         """checks if a key exists in the state
-        
+
         Arguments:
             key {string} -- key to check
-        
+
         Returns:
             bool -- True if key exists in state, else False
         """
@@ -51,10 +50,10 @@ class State(object):
 
     def add(self, key):
         """adds a key to the state and fails if the key already exists
-        
+
         Arguments:
             key {string} -- key to add
-        
+
         Raises:
             KeyError: key already exists in the state
         """

--- a/utils/state.py
+++ b/utils/state.py
@@ -33,13 +33,12 @@ class State(object):
         self.client = session.client('s3')
 
     def exists(self, key):
-        """checks if a key exists in the state
+        """
+        Checks if a key exists in the state.
 
-        Arguments:
-            key {string} -- key to check
+        :param key: key to check
 
-        Returns:
-            bool -- True if key exists in state, else False
+        :type key: string
         """
         try:
             self.client.head_object(
@@ -49,13 +48,12 @@ class State(object):
             return False
 
     def add(self, key):
-        """adds a key to the state and fails if the key already exists
+        """
+        Adds a key to the state and fails if the key already exists
 
-        Arguments:
-            key {string} -- key to add
+        :param key: key to add
 
-        Raises:
-            KeyError: key already exists in the state
+        :type key: string
         """
         if self.exists(key):
             raise KeyError(


### PR DESCRIPTION
This PR introduces a new integration that allows us to send emails through app-interface.
Matching app-interface PR: https://gitlab.cee.redhat.com/service/app-interface/merge_requests/2531

The biggest challenge was: how do we only send each email only once.
The proposed solution: we use S3 as a simple state for app-interface.

This approach will allow us to implement new integrations that do not have a source of truth that we can fetch current state from. For example, this will allow running SQL queries only once (RDS self service).