### PR TITLE
add email notification when aws key leak is found

### DIFF
--- a/reconcile/email_sender.py
+++ b/reconcile/email_sender.py
@@ -59,7 +59,7 @@ def collect_to(to):
     aws_accounts = to.get('aws_accounts')
     if aws_accounts:
         for account in aws_accounts:
-            account_owners = service.get('accountOwners')
+            account_owners = account.get('accountOwners')
             if not account_owners:
                 continue
 

--- a/reconcile/email_sender.py
+++ b/reconcile/email_sender.py
@@ -58,9 +58,13 @@ def collect_to(to):
 
     aws_accounts = to.get('aws_accounts')
     if aws_accounts:
-        # TODO: implement this
         for account in aws_accounts:
-            pass
+            account_owners = service.get('accountOwners')
+            if not account_owners:
+                continue
+
+            for account_owner in account_owners:
+                audience.add(account_owner['email'])
 
     roles = to.get('roles')
     if roles:

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -41,7 +41,9 @@ APP_INTERFACE_EMAILS_QUERY = """
         name
       }
       aws_accounts {
-        name
+        accountOwners {
+          email
+        }
       }
       roles {
         users {
@@ -97,6 +99,10 @@ AWS_ACCOUNTS_QUERY = """
     name
     uid
     resourcesDefaultRegion
+    accountOwners {
+      name
+      email
+    }
     automationToken {
       path
       field

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -215,8 +215,7 @@ class GitLabApi(object):
             return
 
         # add a new email to be picked up by email-sender
-        body = """
-Hello,
+        body = """Hello,
 
 This is an automated notification.
 

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -1,3 +1,4 @@
+import os
 import logging
 import uuid
 import gitlab
@@ -5,6 +6,7 @@ import urllib3
 import ruamel.yaml as yaml
 
 from datetime import datetime
+from ruamel.yaml.scalarstring import PreservedScalarString as pss
 
 import utils.secret_reader as secret_reader
 
@@ -51,6 +53,20 @@ class GitLabApi(object):
             'commit_message': commit_message,
             'actions': actions
         })
+
+    def create_file(self, branch_name, file_path, commit_message, content):
+        data = {
+            'branch': branch_name,
+            'commit_message': commit_message,
+            'actions': [
+                {
+                    'action': 'create',
+                    'file_path': file_path,
+                    'content': content
+                }
+            ]
+        }
+        self.project.commits.create(data)
 
     def delete_file(self, branch_name, file_path, commit_message):
         data = {
@@ -179,6 +195,8 @@ class GitLabApi(object):
 
         self.create_branch(branch_name, target_branch)
 
+        # add key to deleteKeys list to be picked up by aws-iam-keys
+        msg = 'add key to deleteKeys'
         f = self.project.files.get(file_path=path, ref=target_branch)
         content = yaml.load(f.decode(), Loader=yaml.RoundTripLoader)
         content.setdefault('deleteKeys', [])
@@ -186,7 +204,7 @@ class GitLabApi(object):
         new_content = '---\n' + \
             yaml.dump(content, Dumper=yaml.RoundTripDumper)
         try:
-            self.update_file(branch_name, path, title, new_content)
+            self.update_file(branch_name, path, msg, new_content)
         except gitlab.exceptions.GitlabCreateError as e:
             self.delete_branch(branch_name)
             if str(e) != "400: A file with this name doesn't exist":
@@ -195,6 +213,38 @@ class GitLabApi(object):
                 "File {} does not exist, not opening MR".format(path)
             )
             return
+
+        # add a new email to be picked up by email-sender
+        body = \
+"""Hello,
+
+This is an automated notification.
+
+An AWS access key leak was detected and is being mitigatd.
+Information:
+Account: {}
+Access key: {}
+
+Please consult relevant SOPs to verify that the account is secure.
+"""
+        msg = 'add email notification'
+        name = f"{account}-{key}"
+        email_path = f"{os.path.dirname(path)}/emails/{name}.yml"
+        ref = path[4:] if path.startswith('data') else path
+        email = {
+            # TODO: extract the schema value from utils
+            '$schema': '/app-interface/app-interface-email-1.yml',
+            'labels': {},
+            'name': name,
+            'subject': title,
+            'to': {
+                'aws_accounts': [{'$ref': ref}]
+            },
+            'body': pss(body.format(account, key))
+        }
+        content = '---\n' + \
+            yaml.dump(email, Dumper=yaml.RoundTripDumper)
+        self.create_file(branch_name, email_path, msg, content)
 
         return self.create_mr(branch_name, target_branch, title, labels=labels)
 

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -215,8 +215,8 @@ class GitLabApi(object):
             return
 
         # add a new email to be picked up by email-sender
-        body = \
-"""Hello,
+        body = """
+Hello,
 
 This is an automated notification.
 


### PR DESCRIPTION
covers https://issues.redhat.com/browse/APPSRE-1176
depends on https://gitlab.cee.redhat.com/service/app-interface/merge_requests/2543

When an AWS key leak is detected, a PR is created in app-interface to recycle that key.
This PR adds an email to that PR to notify account owners defined in app-interface.
This email will be picked up and sent by email-sender (#418).

Example of a PR: https://gitlab.cee.redhat.com/service/app-interface/merge_requests/2542/diffs