### PR TITLE
[app-interface-reporter] add email notification

### DIFF
--- a/reconcile/email_sender.py
+++ b/reconcile/email_sender.py
@@ -31,7 +31,8 @@ def collect_to(to):
                 users = queries.get_users()
                 to['users'] = users
             elif alias == 'all-service-owners':
-                pass
+                services = queries.get_apps()
+                to['services'] = services
             else:
                 raise AttributeError(f"unknown alias: {alias}")
 

--- a/reconcile/email_sender.py
+++ b/reconcile/email_sender.py
@@ -25,7 +25,6 @@ def collect_to(to):
 
     aliases = to.get('aliases')
     if aliases:
-        # TODO: implement this
         for alias in aliases:
             if alias == 'all-users':
                 users = queries.get_users()

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -285,6 +285,10 @@ APPS_QUERY = """
   apps: apps_v1 {
     path
     name
+    serviceOwners {
+      name
+      email
+    }
     codeComponents {
       url
       resource
@@ -295,7 +299,7 @@ APPS_QUERY = """
 
 
 def get_apps():
-    """ Returns all apps along with their codeComponents """
+    """ Returns all Apps. """
     gqlapi = gql.get_api()
     return gqlapi.query(APPS_QUERY)['apps']
 

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -442,7 +442,22 @@ def main(configfile, dry_run, log_level, gitlab_project_id, reports_path):
                 f.write(report['content'])
 
     if not dry_run:
+        email_schema = '/app-interface/app-interface-email-1.yml'
+        email_body = """Hello,
+
+A new report by the App SRE team is now available at:
+https://visual-app-interface.devshift.net/reports
+
+You can use the Search bar to search by App.
+
+You can also view reports per service here:
+https://visual-app-interface.devshift.net/services
+
+
+Having problems? Ping us on #sd-app-sre on Slack!
+"""
         gw = prg.init(gitlab_project_id=gitlab_project_id,
                       override_pr_gateway_type='gitlab')
-        mr = gw.create_app_interface_reporter_mr(reports)
+        mr = gw.create_app_interface_reporter_mr(
+            reports, email_schema, email_body, reports_path)
         logging.info(['created_mr', mr.web_url])

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import textwrap
 
 from datetime import datetime, timezone
 from dateutil.relativedelta import relativedelta
@@ -443,21 +444,22 @@ def main(configfile, dry_run, log_level, gitlab_project_id, reports_path):
 
     if not dry_run:
         email_schema = '/app-interface/app-interface-email-1.yml'
-        email_body = """Hello,
+        email_body = """\
+            Hello,
 
-A new report by the App SRE team is now available at:
-https://visual-app-interface.devshift.net/reports
+            A new report by the App SRE team is now available at:
+            https://visual-app-interface.devshift.net/reports
 
-You can use the Search bar to search by App.
+            You can use the Search bar to search by App.
 
-You can also view reports per service here:
-https://visual-app-interface.devshift.net/services
+            You can also view reports per service here:
+            https://visual-app-interface.devshift.net/services
 
 
-Having problems? Ping us on #sd-app-sre on Slack!
-"""
+            Having problems? Ping us on #sd-app-sre on Slack!
+            """
         gw = prg.init(gitlab_project_id=gitlab_project_id,
                       override_pr_gateway_type='gitlab')
         mr = gw.create_app_interface_reporter_mr(
-            reports, email_schema, email_body, reports_path)
+            reports, email_schema, textwrap.dedent(email_body), reports_path)
         logging.info(['created_mr', mr.web_url])


### PR DESCRIPTION
covers https://issues.redhat.com/browse/APPSRE-1081

This PR adds an email notification of App SRE monthly reports.
It creates an email to be picked up by email-sender (#418), which will be sent to `all-service-owners`.
Tthis PR also adds the `all-service-owners` alias implementation.

Everything in this PR is negotiable, as this is an implementation suggestion.