### PR TITLE
Introducing qontract-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 ### tools
 
 - `app-interface-reporter`: Creates service reports and submits PR to App-Interface.
+- `qontract-cli`: A cli tool for qontract (currently very good at getting information).
 
 ## Usage
 

--- a/reconcile/openshift_acme.py
+++ b/reconcile/openshift_acme.py
@@ -1,7 +1,7 @@
 import semver
 
 import anymarkup
-import utils.gql as gql
+import reconcile.queries as queries
 import reconcile.openshift_base as ob
 import reconcile.openshift_resources as openshift_resources
 
@@ -9,7 +9,6 @@ from utils.openshift_resource import OpenshiftResource as OR
 from utils.openshift_resource import ConstructResourceError
 from utils.defer import defer
 
-from reconcile.queries import NAMESPACES_QUERY
 from utils.openshift_acme import (ACME_DEPLOYMENT,
                                   ACME_ROLE,
                                   ACME_ROLEBINDING,
@@ -119,9 +118,8 @@ def add_desired_state(namespaces, ri, oc_map):
 
 @defer
 def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
-    gqlapi = gql.get_api()
     namespaces = [namespace_info for namespace_info
-                  in gqlapi.query(NAMESPACES_QUERY)['namespaces']
+                  in queries.get_namespaces()
                   if namespace_info.get('openshiftAcme')]
 
     namespaces = construct_resources(namespaces)

--- a/reconcile/openshift_limitranges.py
+++ b/reconcile/openshift_limitranges.py
@@ -2,13 +2,11 @@ import logging
 import semver
 import sys
 
-import utils.gql as gql
+import reconcile.queries as queries
 import reconcile.openshift_base as ob
 
 from utils.openshift_resource import OpenshiftResource as OR
 from utils.defer import defer
-
-from reconcile.queries import NAMESPACES_QUERY
 
 QONTRACT_INTEGRATION = 'openshift-limitranges'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
@@ -86,9 +84,8 @@ def add_desired_state(namespaces, ri, oc_map):
 @defer
 def run(dry_run=False, thread_pool_size=10, internal=None,
         take_over=True, defer=None):
-    gqlapi = gql.get_api()
     namespaces = [namespace_info for namespace_info
-                  in gqlapi.query(NAMESPACES_QUERY)['namespaces']
+                  in queries.get_namespaces()
                   if namespace_info.get('limitRanges')]
 
     namespaces = construct_resources(namespaces)

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -1,5 +1,6 @@
 import semver
 
+import utils.gql as gql
 import reconcile.queries as queries
 import reconcile.openshift_base as ob
 

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -1,12 +1,11 @@
 import semver
 
-import utils.gql as gql
+import reconcile.queries as queries
 import reconcile.openshift_base as ob
 
 from utils.openshift_resource import (OpenshiftResource as OR,
                                       ResourceKeyExistsError)
 from utils.defer import defer
-from reconcile.queries import NAMESPACES_QUERY
 
 
 ROLES_QUERY = """
@@ -159,9 +158,8 @@ def fetch_desired_state(ri, oc_map):
 
 @defer
 def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
-    gqlapi = gql.get_api()
     namespaces = [namespace_info for namespace_info
-                  in gqlapi.query(NAMESPACES_QUERY)['namespaces']
+                  in queries.get_namespaces()
                   if namespace_info.get('managedRoles')]
     ri, oc_map = ob.fetch_current_state(
         namespaces=namespaces,

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -98,6 +98,7 @@ AWS_ACCOUNTS_QUERY = """
     path
     name
     uid
+    consoleUrl
     resourcesDefaultRegion
     accountOwners {
       name
@@ -127,6 +128,8 @@ CLUSTERS_QUERY = """
   clusters: clusters_v1 {
     name
     serverUrl
+    consoleUrl
+    kibanaUrl
     managedGroups
     managedClusterRoles
     jumpHost {
@@ -177,6 +180,9 @@ NAMESPACES_QUERY = """
   namespaces: namespaces_v1 {
     name
     managedRoles
+    app {
+      name
+    }
     cluster {
       name
       serverUrl

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -249,6 +249,12 @@ NAMESPACES_QUERY = """
 """
 
 
+def get_namespaces():
+    """ Returns all Namespaces """
+    gqlapi = gql.get_api()
+    return gqlapi.query(NAMESPACES_QUERY)['namespaces']
+
+
 APPS_QUERY = """
 {
   apps: apps_v1 {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-lick>=7.0,<8.0
+Click>=7.0,<8.0
 graphqlclient>=0.2.4,<0.3.0
 toml>=0.10.0,<0.11.0
 jsonpath-rw>=1.4.0,<1.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Click>=7.0,<8.0
+lick>=7.0,<8.0
 graphqlclient>=0.2.4,<0.3.0
 toml>=0.10.0,<0.11.0
 jsonpath-rw>=1.4.0,<1.5.0
@@ -21,3 +21,4 @@ jira>=2.0.0,<2.1.0
 pyOpenSSL>=19.0.0,<20.0.0
 ruamel.yaml>=0.16.5,<0.17.0
 terrascript>=0.6.1,<0.7.0
+tabulate>=0.8.6,<0.9.0

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         "pyOpenSSL>=19.0.0,<20.0.0",
         "ruamel.yaml>=0.16.5,<0.17.0",
         "terrascript>=0.6.1,<0.7.0",
+        "tabulate>=0.8.6,<0.9.0"
     ],
 
     test_suite="tests",

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
             'qontract-reconcile = reconcile.cli:integration',
             'e2e-tests = e2e_tests.cli:test',
             'app-interface-reporter = tools.app_interface_reporter:main',
+            'qontract-cli = tools.qontract_cli:root',
         ],
     },
 )

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1,11 +1,25 @@
 import json
+import yaml
 import click
 
 import utils.gql as gql
 import utils.config as config
 import reconcile.queries as queries
 
+from tabulate import tabulate
+
 from reconcile.cli import config_file
+
+
+def output(function):
+    function = click.option('--output', '-o',
+                            help='output type',
+                            default='table',
+                            type=click.Choice([
+                                'table',
+                                'json',
+                                'yaml']))(function)
+    return function
 
 
 @click.group()
@@ -18,55 +32,91 @@ def root(ctx, configfile):
 
 
 @root.group()
+@output
 @click.pass_context
-def get(ctx):
-    pass
+def get(ctx, output):
+    ctx.obj['output'] = output
 
 
 @get.command()
 @click.pass_context
 def settings(ctx):
     settings = queries.get_app_interface_settings()
-    print(json.dumps(settings))
+    columns = ['vault', 'kubeBinary', 'pullRequestGateway']
+    print_output(ctx.obj['output'], [settings], columns)
 
 
 @get.command()
 @click.pass_context
 def aws_accounts(ctx):
     accounts = queries.get_aws_accounts()
-    print(json.dumps(accounts))
+    columns = ['name', 'consoleUrl']
+    print_output(ctx.obj['output'], accounts, columns)
 
 
 @get.command()
 @click.pass_context
 def clusters(ctx):
     clusters = queries.get_clusters()
-    print(json.dumps(clusters))
+    columns = ['name', 'consoleUrl', 'kibanaUrl']
+    print_output(ctx.obj['output'], clusters, columns)
 
 
 @get.command()
 @click.pass_context
 def namespaces(ctx):
     namespaces = queries.get_namespaces()
-    print(json.dumps(namespaces))
+    columns = ['name', 'cluster.name', 'app.name']
+    print_output(ctx.obj['output'], namespaces, columns)
 
 
 @get.command()
 @click.pass_context
 def services(ctx):
     apps = queries.get_apps()
-    print(json.dumps(apps))
+    columns = []
+    print_output(ctx.obj['output'], apps, columns)
 
 
 @get.command()
 @click.pass_context
 def repos(ctx):
     repos = queries.get_repos()
-    print(json.dumps(repos))
+    columns = []
+    print_output(ctx.obj['output'], repos, columns)
 
 
 @get.command()
 @click.pass_context
 def users(ctx):
     users = queries.get_users()
-    print(json.dumps(users))
+    columns = ['org_username', 'github_username', 'name']
+    print_output(ctx.obj['output'], users, columns)
+
+
+def print_output(output, content, columns=[]):
+    if output == 'table':
+        print_table(content, columns)
+    elif output == 'json':
+        print(json.dumps(content))
+    elif output == 'yaml':
+        print(yaml.dump(content))
+    else:
+        pass  # error
+
+
+def print_table(content, columns):
+    headers = [column.upper() for column in columns]
+    table_data = []
+    for item in content:
+        row_data = []
+        for column in columns:
+            # example: for column 'cluster.name'
+            # cell = item['cluster']['name']
+            cell = item
+            for token in column.split('.'):
+                cell = cell[token]
+            row_data.append(cell)
+        table_data.append(row_data)
+
+    print(tabulate(table_data, headers=headers))

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -104,7 +104,7 @@ def repos(ctx):
 @click.pass_context
 def users(ctx, org_username):
     users = queries.get_users()
-    if name:
+    if org_username:
         users = [u for u in users if u['org_username'] == org_username]
 
     columns = ['org_username', 'github_username', 'name']

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1,0 +1,72 @@
+import json
+import click
+
+import utils.gql as gql
+import utils.config as config
+import reconcile.queries as queries
+
+from reconcile.cli import config_file
+
+
+@click.group()
+@config_file
+@click.pass_context
+def root(ctx, configfile):
+    ctx.ensure_object(dict)
+    config.init_from_toml(configfile)
+    gql.init_from_config()
+
+
+@root.group()
+@click.pass_context
+def get(ctx):
+    pass
+
+
+@get.command()
+@click.pass_context
+def settings(ctx):
+    settings = queries.get_app_interface_settings()
+    print(json.dumps(settings))
+
+
+@get.command()
+@click.pass_context
+def aws_accounts(ctx):
+    accounts = queries.get_aws_accounts()
+    print(json.dumps(accounts))
+
+
+@get.command()
+@click.pass_context
+def clusters(ctx):
+    clusters = queries.get_clusters()
+    print(json.dumps(clusters))
+
+
+@get.command()
+@click.pass_context
+def namespaces(ctx):
+    namespaces = queries.get_namespaces()
+    print(json.dumps(namespaces))
+
+
+@get.command()
+@click.pass_context
+def services(ctx):
+    apps = queries.get_apps()
+    print(json.dumps(apps))
+
+
+@get.command()
+@click.pass_context
+def repos(ctx):
+    repos = queries.get_repos()
+    print(json.dumps(repos))
+
+
+@get.command()
+@click.pass_context
+def users(ctx):
+    users = queries.get_users()
+    print(json.dumps(users))

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -47,25 +47,37 @@ def settings(ctx):
 
 
 @get.command()
+@click.argument('name', default='')
 @click.pass_context
-def aws_accounts(ctx):
+def aws_accounts(ctx, name):
     accounts = queries.get_aws_accounts()
+    if name:
+        accounts = [a for a in accounts if a['name'] == name]
+
     columns = ['name', 'consoleUrl']
     print_output(ctx.obj['output'], accounts, columns)
 
 
 @get.command()
+@click.argument('name', default='')
 @click.pass_context
-def clusters(ctx):
+def clusters(ctx, name):
     clusters = queries.get_clusters()
+    if name:
+        clusters = [c for c in clusters if c['name'] == name]
+
     columns = ['name', 'consoleUrl', 'kibanaUrl']
     print_output(ctx.obj['output'], clusters, columns)
 
 
 @get.command()
+@click.argument('name', default='')
 @click.pass_context
-def namespaces(ctx):
+def namespaces(ctx, name):
     namespaces = queries.get_namespaces()
+    if name:
+        namespaces = [ns for ns in namespaces if ns['name'] == name]
+
     columns = ['name', 'cluster.name', 'app.name']
     print_output(ctx.obj['output'], namespaces, columns)
 
@@ -74,7 +86,7 @@ def namespaces(ctx):
 @click.pass_context
 def services(ctx):
     apps = queries.get_apps()
-    columns = []
+    columns = ['name']
     print_output(ctx.obj['output'], apps, columns)
 
 
@@ -82,14 +94,19 @@ def services(ctx):
 @click.pass_context
 def repos(ctx):
     repos = queries.get_repos()
-    columns = []
+    repos = [{'url': r} for r in repos]
+    columns = ['url']
     print_output(ctx.obj['output'], repos, columns)
 
 
 @get.command()
+@click.argument('org_username', default='')
 @click.pass_context
-def users(ctx):
+def users(ctx, org_username):
     users = queries.get_users()
+    if name:
+        users = [u for u in users if u['org_username'] == org_username]
+
     columns = ['org_username', 'github_username', 'name']
     print_output(ctx.obj['output'], users, columns)
 

--- a/utils/state.py
+++ b/utils/state.py
@@ -48,6 +48,14 @@ class State(object):
         except ClientError:
             return False
 
+    def ls(self):
+        """
+        Returns a list of keys in the state
+        """
+        objects = self.client.list_objects(
+            Bucket=self.bucket, Prefix=self.state_path)['Contents']
+        return [o['Key'].replace(self.state_path, '') for o in objects]
+
     def add(self, key):
         """
         Adds a key to the state and fails if the key already exists
@@ -60,4 +68,18 @@ class State(object):
             raise KeyError(
                 f"[state] key {key} already exists in {self.state_path}")
         self.client.put_object(
+            Bucket=self.bucket, Key=f"{self.state_path}/{key}")
+
+    def rm(self, key):
+        """
+        Removes a key from the state and fails if the key does not exists
+
+        :param key: key to remove
+
+        :type key: string
+        """
+        if not self.exists(key):
+            raise KeyError(
+                f"[state] key {key} does not exists in {self.state_path}")
+        self.client.delete_object(
             Bucket=self.bucket, Key=f"{self.state_path}/{key}")


### PR DESCRIPTION
This PR adds a new tool called `qontract-cli`. As it grows on us, a `q` alias is suggested.

This cli tool is currently really good at getting information, but doesn't do anything else.

Update: the tool now has 2 subcommands -get and state.

Try it:
```
$ q get users
$ q get -o json cluster app-sre
$ q state ls
```