### PR TITLE
[service-dependencies] introduce validating integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `terraform-resources`: Manage AWS Resources using Terraform.
 - `terraform-users`: Manage AWS users using Terraform.
 - `ocm-groups`: Manage membership in OpenShift groups using OpenShift Cluster Manager.
+- `email-sender`: Send email notifications to app-interface audience.
+- `service-dependencies`: Validate dependencies are defined for each service.
 
 ### e2e-tests
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -38,6 +38,7 @@ import reconcile.aws_iam_keys
 import reconcile.aws_support_cases_sos
 import reconcile.ocm_groups
 import reconcile.email_sender
+import reconcile.service_dependencies
 
 from utils.gql import GqlApiError
 from utils.aggregated_list import RunnerException
@@ -512,3 +513,9 @@ def ocm_groups(ctx, thread_pool_size):
 @click.pass_context
 def email_sender(ctx):
     run_integration(reconcile.email_sender.run, ctx.obj['dry_run'])
+
+
+@integration.command()
+@click.pass_context
+def service_dependencies(ctx):
+    run_integration(reconcile.service_dependencies.run, ctx.obj['dry_run'])

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -7,6 +7,12 @@ APP_INTERFACE_SETTINGS_QUERY = """
     vault
     kubeBinary
     pullRequestGateway
+    dependencies {
+      type
+      services {
+        name
+      }
+    }
   }
 }
 """

--- a/reconcile/service_dependencies.py
+++ b/reconcile/service_dependencies.py
@@ -46,12 +46,12 @@ def get_desired_dependency_names(app, dependency_map):
     code_components = app.get('codeComponents')
     if code_components:
         gitlab_urls = [cc for cc in code_components
-                        if 'gitlab' in cc['url']]
+                       if 'gitlab' in cc['url']]
         if gitlab_urls:
             required_dep_names.update(
                 get_dependency_names(dependency_map, 'gitlab'))
         github_urls = [cc for cc in code_components
-                        if 'github' in cc['url']]
+                       if 'github' in cc['url']]
         if github_urls:
             required_dep_names.update(
                 get_dependency_names(dependency_map, 'github'))
@@ -66,7 +66,7 @@ def get_desired_dependency_names(app, dependency_map):
         required_dep_names.update(
             get_dependency_names(dependency_map, 'openshift'))
         tf_namespaces = [n for n in namespaces
-                            if n.get('managedTerraformResources')]
+                         if n.get('managedTerraformResources')]
         if tf_namespaces:
             required_dep_names.update(
                 get_dependency_names(dependency_map, 'aws'))
@@ -89,8 +89,8 @@ def run(dry_run=False):
         current_deps = \
             [a['name'] for a in app_deps] if app_deps else []
         desired_deps = get_desired_dependency_names(app, dependency_map)
-        missing_deps = list(desired_deps.difference(current_deps))
 
+        missing_deps = list(desired_deps.difference(current_deps))
         if missing_deps:
             error = True
             msg = f"App '{app_name}' has missing dependencies: {missing_deps}"

--- a/reconcile/service_dependencies.py
+++ b/reconcile/service_dependencies.py
@@ -1,0 +1,100 @@
+import sys
+import logging
+
+import utils.gql as gql
+import reconcile.queries as queries
+
+
+APPS_QUERY = """
+{
+  apps: apps_v1 {
+    name
+    dependencies {
+      name
+    }
+    codeComponents {
+      url
+    }
+    quayRepos {
+      org {
+        name
+      }
+    }
+    namespaces {
+      managedTerraformResources
+    }
+  }
+}
+"""
+
+QONTRACT_INTEGRATION = 'service-dependencies'
+
+
+def get_dependency_names(dependency_map, dep_type):
+    dep_names = []
+    for dm in dependency_map:
+        if dm['type'] != dep_type:
+            continue
+        for service in dm['services']:
+            dep_names.append(service['name'])
+    return dep_names
+
+
+def get_desired_dependency_names(app, dependency_map):
+    required_dep_names = set()
+
+    code_components = app.get('codeComponents')
+    if code_components:
+        gitlab_urls = [cc for cc in code_components
+                        if 'gitlab' in cc['url']]
+        if gitlab_urls:
+            required_dep_names.update(
+                get_dependency_names(dependency_map, 'gitlab'))
+        github_urls = [cc for cc in code_components
+                        if 'github' in cc['url']]
+        if github_urls:
+            required_dep_names.update(
+                get_dependency_names(dependency_map, 'github'))
+
+    quay_repos = app.get('quayRepos')
+    if quay_repos:
+        required_dep_names.update(
+            get_dependency_names(dependency_map, 'quay'))
+
+    namespaces = app.get('namespaces')
+    if namespaces:
+        required_dep_names.update(
+            get_dependency_names(dependency_map, 'openshift'))
+        tf_namespaces = [n for n in namespaces
+                            if n.get('managedTerraformResources')]
+        if tf_namespaces:
+            required_dep_names.update(
+                get_dependency_names(dependency_map, 'aws'))
+
+    return required_dep_names
+
+
+def run(dry_run=False):
+    settings = queries.get_app_interface_settings()
+    dependency_map = settings.get('dependencies')
+    if not dependency_map:
+        sys.exit()
+
+    gqlapi = gql.get_api()
+    apps = gqlapi.query(APPS_QUERY)['apps']
+    error = False
+    for app in apps:
+        app_name = app['name']
+        app_deps = app.get('dependencies')
+        current_deps = \
+            [a['name'] for a in app_deps] if app_deps else []
+        desired_deps = get_desired_dependency_names(app, dependency_map)
+        missing_deps = list(desired_deps.difference(current_deps))
+
+        if missing_deps:
+            error = True
+            msg = f"App '{app_name}' has missing dependencies: {missing_deps}"
+            logging.error(msg)
+
+    if error:
+        sys.exit(1)


### PR DESCRIPTION
covers https://issues.redhat.com/browse/APPSRE-1232

This integration is validating that all services define their dependencies. It does it based on the used resources of that service.

It is currently only validating, but we can enhance it later to submit PRs when a dependency is missing. Definitely a future PR, if at all, as we want service owners to be mindful of their dependencies. 