### PR TITLE
[ocm-clusters] introduce new integration

### DIFF
--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -192,6 +192,14 @@ integrations:
     limits:
       memory: 200Mi
       cpu: 25m
+- name: ocm-clusters
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 15m
+    limits:
+      memory: 200Mi
+      cpu: 25m
 - name: email-sender
   resources:
     requests:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -2036,6 +2036,50 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile
+    name: qontract-reconcile-ocm-clusters
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile
+      spec:
+        securityContext:
+          runAsUser: ${{USER_ID}}
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          env:
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: ocm-clusters
+          - name: INTEGRATION_EXTRA_ARGS
+            value: ""
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          resources:
+            limits:
+              cpu: 25m
+              memory: 200Mi
+            requests:
+              cpu: 15m
+              memory: 100Mi
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    labels:
+      app: qontract-reconcile
     name: qontract-reconcile-email-sender
   spec:
     replicas: 1

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -38,6 +38,7 @@ import reconcile.aws_garbage_collector
 import reconcile.aws_iam_keys
 import reconcile.aws_support_cases_sos
 import reconcile.ocm_groups
+import reconcile.ocm_clusters
 import reconcile.email_sender
 
 from utils.gql import GqlApiError
@@ -512,6 +513,14 @@ def gitlab_projects(ctx):
 @click.pass_context
 def ocm_groups(ctx, thread_pool_size):
     run_integration(reconcile.ocm_groups.run, ctx.obj['dry_run'],
+                    thread_pool_size)
+
+
+@integration.command()
+@threaded()
+@click.pass_context
+def ocm_clusters(ctx, thread_pool_size):
+    run_integration(reconcile.ocm_clusters.run, ctx.obj['dry_run'],
                     thread_pool_size)
 
 

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -1,0 +1,31 @@
+import sys
+import logging
+
+import reconcile.queries as queries
+
+from utils.ocm import OCMMap
+
+QONTRACT_INTEGRATION = 'ocm-clusters'
+
+
+def run(dry_run=False, thread_pool_size=10):
+    settings = queries.get_app_interface_settings()
+    clusters = queries.get_clusters()
+    clusters = [c for c in clusters if c.get('ocm') is not None]
+    ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
+                     settings=settings)
+    current_state = ocm_map.cluster_specs()
+    desired_state = {c['name']: {'spec': c['spec'], 'network': c['network']}
+                     for c in clusters}
+
+    error = False
+    for k, desired_spec in desired_state.items():
+        current_spec = current_state[k]
+        if current_spec != desired_spec:
+            logging.error(
+                '[%s] desired spec %s is different from current spec %s',
+                k, desired_spec, current_spec)
+            error = True
+
+    if error:
+        sys.exit(1)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -152,6 +152,19 @@ CLUSTERS_QUERY = """
         version
       }
     }
+    spec {
+      provider
+      region
+      major_version
+      multi_az
+      nodes
+      instance_type
+    }
+    network {
+      vpc
+      service
+      pod
+    }
     automationToken {
       path
       field

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -57,11 +57,12 @@ class OCM(object):
             'spec': {
                 'provider': cluster['cloud_provider']['id'],
                 'region': cluster['region']['id'],
-                'major_version': \
+                'major_version':
                     int(cluster['openshift_version'].split('.')[0]),
                 'multi_az': cluster['multi_az'],
                 'nodes': cluster['nodes']['compute'],
-                'instance_type': cluster['nodes']['compute_machine_type']['id'],
+                'instance_type':
+                    cluster['nodes']['compute_machine_type']['id'],
             },
             'network': {
                 'vpc': cluster['network']['machine_cidr'],


### PR DESCRIPTION
This PR adds a new integration called ocm-clusters.

This integration will eventually provision and update clusters via OCM.
Currently it only validates that the cluster spec+network in app-interface matches the same info in OCM.
