### PR TITLE
Improve container.Image interface

### DIFF
--- a/utils/container.py
+++ b/utils/container.py
@@ -40,13 +40,13 @@ class Image:
                 'service': self.registry.split(':')[0]  # Removing the port
             }
 
-        self._tags = None
+        self._cache_tags = None
 
     @property
-    def tags(self):
-        if self._tags is None:
-            self._tags = self._get_all_tags()
-        return self._tags
+    def _tags(self):
+        if self._cache_tags is None:
+            self._cache_tags = self.get_tags()
+        return self._cache_tags
 
     def __eq__(self, other):
         # Two instances are considered equal if both of their
@@ -68,14 +68,14 @@ class Image:
         return Image(url=str(self), tag_override=str(item))
 
     def __iter__(self):
-        for tag in self.tags:
+        for tag in self._tags:
             yield tag
 
     def __len__(self):
-        return len(self.tags)
+        return len(self._tags)
 
     def __contains__(self, item):
-        return item in self.tags
+        return item in self._tags
 
     def __str__(self):
         return (f'{self.scheme}'
@@ -99,7 +99,7 @@ class Image:
         response.raise_for_status()
         return response.json()['token']
 
-    def _get_all_tags(self):
+    def get_tags(self):
         """
         Goes to the internet to retrieve all the image tags.
         """

--- a/utils/container.py
+++ b/utils/container.py
@@ -45,7 +45,11 @@ class Image:
     @property
     def _tags(self):
         if self._cache_tags is None:
-            self._cache_tags = self.get_tags()
+            try:
+                self._cache_tags = self.get_tags()
+            except requests.exceptions.HTTPError:
+                self._cache_tags = []
+
         return self._cache_tags
 
     def __eq__(self, other):


### PR DESCRIPTION
Apart from the small interface improvement, the main point of this PR is to allow the mirror to be specified togheter with a new quay repository in the app-interface.

When a new repository is specified, if a mirror is also there, currently the quay-mirror integration will crash in the MR CI for not being able to acquire the tags.

This patch fixes it by making sure that the _tags property will return an empty list when the image repository is not available, which also makes sense in terms of interface.