### PR TITLE
Adding retry to get_manifest()

### DIFF
--- a/utils/container.py
+++ b/utils/container.py
@@ -2,6 +2,10 @@ import logging
 import re
 import requests
 
+from json.decoder import JSONDecodeError
+
+from utils.retry import retry
+
 
 _LOG = logging.getLogger(__name__)
 
@@ -143,6 +147,7 @@ class Image:
 
         return all_tags
 
+    @retry(exceptions=JSONDecodeError, max_attempts=3)
     def get_manifest(self):
         """
         Goes to the internet to retrieve the image manifest.


### PR DESCRIPTION
Sometimes the registry API sends an incomplete response, causing an
exception when parsing the JSON. Even Skopeo faces that issue:
```
    $ skopeo inspect docker://docker.io/library/memcached:1.4.24
    FATAL[0004] Error parsing image name "docker://docker.io/library/memcached:1.4.24": unexpected EOF
```

Trying again:

```
    $ skopeo inspect docker://docker.io/library/memcached:1.4.24
    {
        "Name": "docker.io/library/memcached",
        "Tag": "1.4.24",
        "Digest": "sha256:a23496a073d3fef620815f8a9224afb6162b7c7213e4faaf05a051c74f157605",
        "RepoTags": [
            "1-alpine",
            "1.4-alpine",
            "1.4.21",
            "1.4.22",
    ...
```

This patch adds to `get_manifest()` the `retry()` decorator, which does not solve the
issue in the registry, but makes the client more resilient.

Signed-off-by: Amador Pahim <apahim@redhat.com>