### PR TITLE
Adding support for more registries

### DIFF
--- a/utils/container.py
+++ b/utils/container.py
@@ -147,9 +147,9 @@ class Image:
                 break
 
             # Link is given between "<" and ">". Example:
-            # '<v2/app-sre/aws-cli/tags/list?next_page=KkOw&n=50>; rel="next"'
+            # '</v2/app-sre/aws-cli/tags/list?next_page=KkOw&n=50>; rel="next"'
             link = link_header.split('<', 1)[1].split('>', 1)[0]
-            url = f'{self.registry_api}/{link}'
+            url = f'{self.registry_api}{link}'
             response = self._request_get(url)
 
             tags = response.json()['tags']

--- a/utils/container.py
+++ b/utils/container.py
@@ -86,6 +86,13 @@ class Image:
     def __repr__(self):
         return f"{self.__class__.__name__}(url='{self}')"
 
+    def __bool__(self):
+        try:
+            self.get_manifest()
+            return True
+        except requests.exceptions.HTTPError:
+            return False
+
     @staticmethod
     def _get_auth(realm, service, scope):
         """

--- a/utils/container.py
+++ b/utils/container.py
@@ -33,7 +33,6 @@ class Image:
         if self.registry == 'docker.io':
             self.registry_api = 'https://registry-1.docker.io'
         else:
-            # Works for quay.io. Not sure about private registry.
             self.registry_api = f'https://{self.registry}'
 
         self._cache_tags = None

--- a/utils/container.py
+++ b/utils/container.py
@@ -85,7 +85,7 @@ class Image:
                 f':{self.tag}')
 
     def __repr__(self):
-        return f'{self.__class__.__name__}(url={self})'
+        return f"{self.__class__.__name__}(url='{self}')"
 
     @staticmethod
     def _get_auth(realm, service, scope):


### PR DESCRIPTION
Besides some minor fixes, this MR is adding to the `utils.container.Image()` support for additional registries:
- **registry.access.redhat.com**, which has a different Www-Authenticate format (when compared to quay.io and docker.io).
- **registry.redhat.io**, which requires user authentication.

This works now:

```
>>> from utils.container import Image
>>> i = Image('registry.access.redhat.com/rhel7/net-snmp') 
>>> bool(i)
True
```

This also works:

```
>>> from utils.container import Image
>>> i = Image('registry.redhat.io/rhel8/redis-5', username='***', password='***')          
>>> list(i)                                            
['1-9', '1-52', '1-37', '1-25', '1-35', '1', '1-11', '1-13.1561735341', '1-13', '1-45', 'latest']
```