### PR TITLE
[sentry-config] reduce number of calls to github

### DIFF
--- a/reconcile/sentry_config.py
+++ b/reconcile/sentry_config.py
@@ -370,6 +370,9 @@ def fetch_desired_state(gqlapi, sentry_instance, ghapi):
     sentryUrl = sentry_instance['consoleUrl']
     result = gqlapi.query(SENTRY_USERS_QUERY)
     for role in result['roles']:
+        if role['sentry_teams'] is None:
+            continue
+
         # Users that should exist
         members = []
 
@@ -385,9 +388,6 @@ def fetch_desired_state(gqlapi, sentry_instance, ghapi):
         for bot in role['bots']:
             append_github_username_members(bot)
             process_user_role(bot, role, sentryUrl)
-
-        if role['sentry_teams'] is None:
-            continue
 
         for team in role['sentry_teams']:
             # Only add users if the team they are a part of is in the same


### PR DESCRIPTION
This PR moves the check for teams in a role to happen before collecting users and bots information.

We currently have 288 users in app-interface.

The total number of users that came up for querying github is:
before this change: 613
after this change: 45

We already have email caching in the integration, so -
The total number of UNIQUE users that came up for querying github is:
before this change: 288
after this change: 45