### PR TITLE
[openshift-serviceaccount-tokens] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `openshift-network-policies`: Manages OpenShift NetworkPolicies.
 - `openshift-resources`: Manages OpenShift Resources.
 - `openshift-rolebindings`: Configures Rolebindings in OpenShift clusters.
+- `openshift-serviceaccount-tokens`: Use OpenShift ServiceAccount tokens across namespaces/clusters.
 - `openshift-users`: Deletion of users from OpenShift clusters.
 - `quay-membership`: Configures the teams and members in Quay.
 - `quay-mirror`: Mirrors external images into Quay.

--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -164,6 +164,15 @@ integrations:
       cpu: 1000m
   extraArgs: --external
   logs: true
+- name: openshift-serviceaccount-tokens
+  resources:
+    requests:
+      memory: 200Mi
+      cpu: 100m
+    limits:
+      memory: 400Mi
+      cpu: 200m
+  extraArgs: --vault-output-path app-sre/integrations-output
 - name: terraform-resources
   resources:
     requests:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -1748,6 +1748,50 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile
+    name: qontract-reconcile-openshift-serviceaccount-tokens
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile
+      spec:
+        securityContext:
+          runAsUser: ${{USER_ID}}
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          env:
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: openshift-serviceaccount-tokens
+          - name: INTEGRATION_EXTRA_ARGS
+            value: "--vault-output-path app-sre/integrations-output"
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          resources:
+            limits:
+              cpu: 200m
+              memory: 400Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    labels:
+      app: qontract-reconcile
     name: qontract-reconcile-terraform-resources
   spec:
     replicas: 1

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -16,6 +16,7 @@ import reconcile.openshift_users
 import reconcile.openshift_resources
 import reconcile.openshift_namespaces
 import reconcile.openshift_network_policies
+import reconcile.openshift_serviceaccount_tokens
 import reconcile.quay_membership
 import reconcile.quay_mirror
 import reconcile.quay_repos
@@ -271,6 +272,19 @@ def openshift_groups(ctx, thread_pool_size, internal):
 def openshift_users(ctx, thread_pool_size, internal):
     run_integration(reconcile.openshift_users.run, ctx.obj['dry_run'],
                     thread_pool_size, internal)
+
+
+@integration.command()
+@threaded()
+@binary(['oc', 'ssh'])
+@internal()
+@vault_output_path
+@click.pass_context
+def openshift_serviceaccount_tokens(ctx, thread_pool_size, internal,
+                                    vault_output_path):
+    run_integration(reconcile.openshift_serviceaccount_tokens.run,
+                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    vault_output_path)
 
 
 @integration.command()

--- a/reconcile/openshift_serviceaccount_tokens.py
+++ b/reconcile/openshift_serviceaccount_tokens.py
@@ -1,0 +1,92 @@
+import semver
+import base64
+
+import utils.gql as gql
+import reconcile.queries as queries
+import reconcile.openshift_base as ob
+
+from utils.openshift_resource import (OpenshiftResource as OR,
+                                      ResourceKeyExistsError)
+from utils.defer import defer
+
+
+QONTRACT_INTEGRATION = 'openshift-serviceaccount-tokens'
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
+
+
+def construct_sa_token_oc_resource(name, sa_name, sa_token):
+    body = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "type": "Opaque",
+        "metadata": {
+            "name": name,
+        },
+        "data": {
+            "token": base64.b64encode(sa_token).decode('utf-8')
+        }
+    }
+    return OR(body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION,
+              error_details=name)
+
+
+def fetch_desired_state(namespaces, ri, oc_map):
+    for namespace_info in namespaces:
+        if not namespace_info.get('openshiftServiceAccountTokens'):
+            continue
+        namespace_name = namespace_info['name']
+        cluster_name = namespace_info['cluster']['name']
+        for sat in namespace_info['openshiftServiceAccountTokens']:
+            sa_name = sat['serviceAccountName']
+            sa_namespace_info = sat['namespace']
+            sa_namespace_name = sa_namespace_info['name']
+            sa_cluster_name = sa_namespace_info['cluster']['name']
+            oc = oc_map.get(sa_cluster_name)
+            sa_token = oc.sa_get_token(sa_namespace_name, sa_name)
+            oc_resource_name = \
+                f"{sa_cluster_name}-{sa_namespace_name}-{sa_name}"
+            oc_resource = construct_sa_token_oc_resource(
+                oc_resource_name, sa_name, sa_token)
+            ri.add_desired(
+                cluster_name,
+                namespace_name,
+                'Secret',
+                oc_resource_name,
+                oc_resource
+            )
+
+
+def write_outputs_to_vault(vault_path, ri):
+    integration_name = QONTRACT_INTEGRATION.replace('_', '-')
+    for cluster, namespace, _, data in ri:
+        for name, d_item in data['desired'].items():
+            secret_path = \
+              f"{vault_path}/{integration_name}/{cluster}/{namespace}/{name}"
+            secret = {'path': secret_path, 'data': d_item.body['data']}
+            vault_client.write(secret)
+
+
+@defer
+def run(dry_run=False, thread_pool_size=10, internal=None,
+        vault_output_path='', defer=None):
+    namespaces = [namespace_info for namespace_info
+                  in queries.get_namespaces()
+                  if namespace_info.get('openshiftServiceAccountTokens')]
+    for namespace_info in namespaces:
+        if not namespace_info.get('openshiftServiceAccountTokens'):
+            continue
+        for sat in namespace_info['openshiftServiceAccountTokens']:
+            namespaces.append(sat['namespace'])
+
+    ri, oc_map = ob.fetch_current_state(
+        namespaces=namespaces,
+        thread_pool_size=thread_pool_size,
+        integration=QONTRACT_INTEGRATION,
+        integration_version=QONTRACT_INTEGRATION_VERSION,
+        override_managed_types=['Secret'],
+        internal=internal)
+    defer(lambda: oc_map.cleanup())
+    fetch_desired_state(namespaces, ri, oc_map)
+    ob.realize_data(dry_run, oc_map, ri)
+    if vault_output_path:
+        write_outputs_to_vault(vault_output_path, ri)

--- a/reconcile/openshift_serviceaccount_tokens.py
+++ b/reconcile/openshift_serviceaccount_tokens.py
@@ -1,12 +1,11 @@
 import semver
 import base64
 
-import utils.gql as gql
+import utils.vault_client as vault_client
 import reconcile.queries as queries
 import reconcile.openshift_base as ob
 
-from utils.openshift_resource import (OpenshiftResource as OR,
-                                      ResourceKeyExistsError)
+from utils.openshift_resource import OpenshiftResource as OR
 from utils.defer import defer
 
 
@@ -88,5 +87,5 @@ def run(dry_run=False, thread_pool_size=10, internal=None,
     defer(lambda: oc_map.cleanup())
     fetch_desired_state(namespaces, ri, oc_map)
     ob.realize_data(dry_run, oc_map, ri)
-    if vault_output_path:
+    if not dry_run and vault_output_path:
         write_outputs_to_vault(vault_output_path, ri)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -269,6 +269,32 @@ NAMESPACES_QUERY = """
         type
       }
     }
+    openshiftServiceAccountTokens {
+      namespace {
+        name
+        cluster {
+          name
+          serverUrl
+          jumpHost {
+              hostname
+              knownHosts
+              user
+              port
+              identity {
+                  path
+                  field
+                  format
+              }
+          }
+          automationToken {
+            path
+            field
+            format
+          }
+        }
+      }
+      serviceAccountName
+    }
   }
 }
 """

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -167,6 +167,10 @@ class OC(object):
         cmd = ['adm', 'groups', 'remove-users', group, user]
         self._run(cmd)
 
+    def sa_get_token(self, namespace, name):
+        cmd = ['sa', '-n', namespace, 'get-token', name]
+        return self._run(cmd)
+
     @staticmethod
     def get_service_account_username(user):
         namespace = user.split('/')[0]


### PR DESCRIPTION
covers https://issues.redhat.com/browse/APPSRE-929

depends on https://gitlab.cee.redhat.com/service/app-interface/merge_requests/3006

this PR adds a new integration that takes ServiceAccount tokens from a namespace and places them in a Secret in a different namespace (could be a different cluster as well) to be consumed by other applications.

the output can also go to Vault to be consumed in templating.