### PR TITLE
[openshift-resources] enable pods recycle

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -497,7 +497,7 @@ def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
     ob.check_unused_resource_types(ri)
 
     ob.realize_data(dry_run, oc_map, ri,
-                    recycle_pods=False)
+                    recycle_pods=True)
 
     if ri.has_error_registered():
         sys.exit(1)


### PR DESCRIPTION
This PR will enable pods recycle in the openshift-resources integration.

If openshift-resources applies a Secret used by a pod, that pod will be recycled (deleted + validated to have come back to life).

WDYT?