### PR TITLE
Secret recycle annotation

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -172,8 +172,7 @@ def fetch_current_state(namespaces=None,
     return ri, oc_map
 
 
-def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
-          recycle_pods):
+def apply(dry_run, oc_map, cluster, namespace, resource_type, resource):
     logging.info(['apply', cluster, namespace, resource_type, resource.name])
 
     oc = oc_map.get(cluster)
@@ -188,8 +187,8 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
 
         oc.apply(namespace, annotated.toJSON())
 
-    if recycle_pods:
-        oc.recycle_pods(dry_run, namespace, resource_type, resource.name)
+    # TODO: uncomment this after secrets are applied for the first time
+    # oc.recycle_pods(dry_run, namespace, resource_type, resource)
 
 
 def delete(dry_run, oc_map, cluster, namespace, resource_type, name,
@@ -219,7 +218,6 @@ def check_unused_resource_types(ri):
 
 def realize_data(dry_run, oc_map, ri,
                  enable_deletion=True,
-                 recycle_pods=False,
                  take_over=False):
     for cluster, namespace, resource_type, data in ri:
         # desired items
@@ -261,7 +259,7 @@ def realize_data(dry_run, oc_map, ri,
 
             try:
                 apply(dry_run, oc_map, cluster, namespace,
-                      resource_type, d_item, recycle_pods)
+                      resource_type, d_item)
             except StatusCodeError as e:
                 ri.register_error()
                 msg = "[{}/{}] {}".format(cluster, namespace, str(e))

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -496,8 +496,7 @@ def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
     # only applicable for openshift-resources
     ob.check_unused_resource_types(ri)
 
-    ob.realize_data(dry_run, oc_map, ri,
-                    recycle_pods=False)
+    ob.realize_data(dry_run, oc_map, ri)
 
     if ri.has_error_registered():
         sys.exit(1)

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -247,8 +247,7 @@ def run(dry_run=False, enable_deletion=False):
                              cluster=query['cluster'],
                              namespace=query['namespace']['name'],
                              resource_type='job',
-                             resource=job_resource,
-                             recycle_pods=False)
+                             resource=job_resource)
 
         if not dry_run:
             state[query_name] = time.time()

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -234,8 +234,7 @@ def run(dry_run=False, print_only=False,
 
     tf.populate_desired_state(ri, oc_map)
     ob.realize_data(dry_run, oc_map, ri,
-                    enable_deletion=enable_deletion,
-                    recycle_pods=True)
+                    enable_deletion=enable_deletion)
     disable_keys(dry_run, thread_pool_size,
                  disable_service_account_keys=True)
     if vault_output_path:

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -188,13 +188,13 @@ class OC(object):
         supported_kinds = ['Secret']
         if dep_kind not in supported_kinds:
             logging.debug(['skipping_pod_recycle_unsupported',
-                             namespace, dep_kind])
+                           namespace, dep_kind])
             return
 
         dep_annotations = dep_resource.body['metadata'].get('annotations', {})
         if dep_annotations.get('qontract.recycle') != 'true':
             logging.debug(['skipping_pod_recycle_no_annotation',
-                             namespace, dep_kind])
+                           namespace, dep_kind])
             return
 
         dep_name = dep_resource.name

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -308,6 +308,9 @@ class TerraformClient(object):
             "type": "Opaque",
             "metadata": {
                 "name": name,
+                "annotations": {
+                    "qontract.recycle": "true"
+                }
             },
             "data": {}
         }


### PR DESCRIPTION
This PR adds an ability to specify an annotation on a Secret - `qontract.recycle`.
When this annotation is set to `true`, pods which use this Secret will be recycled.

The annotation will be added to all terraform-resources Secrets to keep recycling pods as before, when `recycle_pods` was passed as `True`.
In order to avoid recycling all pods just by adding this annotation, the recycle_pods call is currently commented out and will be uncommented after all Secrets are updated.

The annotation can be defined on app-interface resources to specify that pods using that Secret should be recycled.