### PR TITLE
[openshift-*] compare resources recursively by desired item

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -232,6 +232,15 @@ def realize_data(dry_run, oc_map, ri,
                     ).format(cluster, namespace, resource_type, name)
                     logging.info(msg)
 
+                # don't apply if resources match
+                elif d_item == c_item:
+                    msg = (
+                        "[{}/{}] resource '{}/{}' present "
+                        "and matches desired, skipping."
+                    ).format(cluster, namespace, resource_type, name)
+                    logging.debug(msg)
+                    continue
+
                 # don't apply if sha256sum hashes match
                 elif c_item.sha256sum() == d_item.sha256sum():
                     if c_item.has_valid_sha256sum():

--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -34,10 +34,11 @@ class OpenshiftResource(object):
     def obj_intersect_equal(self, obj1, obj2):
         if obj1.__class__ != obj2.__class__:
             return False
-        elif isinstance(obj1, dict):
+
+        if isinstance(obj1, dict):
             for obj1_k, obj1_v in obj1.items():
                 obj2_v = obj2.get(obj1_k, None)
-                if not obj2_v:
+                if obj2_v is None:
                     return False
                 if obj1_k == 'cpu':
                     equal = self.cpu_equal(obj1_v, obj2_v)
@@ -45,15 +46,16 @@ class OpenshiftResource(object):
                         return False
                 elif not self.obj_intersect_equal(obj1_v, obj2_v):
                     return False
-        elif isinstance(obj1, list):
+
+        if isinstance(obj1, list):
             if len(obj1) != len(obj2):
                 return False
             for i in range(len(obj1)):
                 if not self.obj_intersect_equal(obj1[i], obj2[i]):
                     return False
-        else:
-            if obj1 != obj2:
-                return False
+
+        if obj1 != obj2:
+            return False
 
         return True
 


### PR DESCRIPTION
based on a suggestion by the glorious @jmelis:
https://gist.github.com/jmelis/594ca4fc7566159c4efbce8e80c4bc3f

compare resources only by the desired resource and the attributes it has. in case default values are added by k8s, they are ignored in this comparison.