### PR TITLE
Re-enable github-users integration

### DIFF
--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -60,6 +60,17 @@ integrations:
       memory: 150Mi
       cpu: 25m
   logs: true
+- name: github-users
+  resources:
+    requests:
+      memory: 50Mi
+      cpu: 15m
+    limits:
+      memory: 150Mi
+      cpu: 25m
+  extraEnv:
+  - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
+    secretKey: gitlab_pr_submitter_queue_url
 - name: github-scanner
   resources:
     requests:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -722,6 +722,57 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile
+    name: qontract-reconcile-github-users
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile
+      spec:
+        securityContext:
+          runAsUser: ${{USER_ID}}
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          env:
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: github-users
+          - name: INTEGRATION_EXTRA_ARGS
+            value: ""
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            value: ${GITHUB_API}
+          - name: gitlab_pr_submitter_queue_url
+            valueFrom:
+              secretKeyRef:
+                name: ${APP_INTERFACE_SQS_SECRET_NAME}
+                key: gitlab_pr_submitter_queue_url
+          resources:
+            limits:
+              cpu: 25m
+              memory: 150Mi
+            requests:
+              cpu: 15m
+              memory: 50Mi
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    labels:
+      app: qontract-reconcile
     name: qontract-reconcile-github-scanner
   spec:
     replicas: 1


### PR DESCRIPTION
Now that we have the github-mirror, it's safe to re-enable this
integration.

This reverts d735809233f70e4a3343da2e130db4aae25babc0

Signed-off-by: Amador Pahim <apahim@redhat.com>