### PR TITLE
Catch exception in populate_oc_resources

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -26,7 +26,7 @@ from threading import Lock
 
 """
 +-----------------------+-------------------------+-------------+
-|   Current \ Desired   |         Present         | Not Present |
+|   Current / Desired   |         Present         | Not Present |
 +=======================+=========================+=============+
 | Present               | Apply if sha256sum      | Delete      |
 | (with annotations)    | is different or if      |             |

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -138,8 +138,8 @@ def populate_oc_resources(spec, ri):
     except StatusCodeError as e:
         msg = 'cluster: {},'
         msg += 'namespace: {},'
-        msg += 'resource: {}'
-        msg += ' exception: {}'
+        msg += 'resource: {},'
+        msg += 'exception: {}'
         msg = msg.format(spec.cluster, spec.namespace, spec.resource, str(e))
         logging.error(msg)
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -136,11 +136,11 @@ def populate_oc_resources(spec, ri):
                 openshift_resource
             )
     except StatusCodeError as e:
-        msg = 'cluster: {}, '
+        msg = 'cluster: {},'
         msg += 'namespace: {},'
         msg += 'resource: {}.'
-        msg = msg.format(spec.cluster, spec.namespace, spec.resource)
-        msg += " Exception: {}".format(str(e))
+        msg += "exception: {}"
+        msg = msg.format(spec.cluster, spec.namespace, spec.resource, str(e))
         logging.error(msg)
 
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -1,6 +1,7 @@
 import sys
 import shutil
 import semver
+import logging
 
 import utils.gql as gql
 import utils.threaded as threaded
@@ -14,6 +15,7 @@ from utils.openshift_resource import ResourceInventory
 from utils.oc import OC_Map
 from utils.defer import defer
 from reconcile.aws_iam_keys import run as disable_keys
+from utils.oc import StatusCodeError
 
 TF_NAMESPACES_QUERY = """
 {
@@ -115,18 +117,34 @@ QONTRACT_TF_PREFIX = 'qrtf'
 def populate_oc_resources(spec, ri):
     if spec.oc is None:
         return
-    for item in spec.oc.get_items(spec.resource,
-                                  namespace=spec.namespace):
-        openshift_resource = OR(item,
-                                QONTRACT_INTEGRATION,
-                                QONTRACT_INTEGRATION_VERSION)
-        ri.add_current(
-            spec.cluster,
-            spec.namespace,
-            spec.resource,
-            openshift_resource.name,
-            openshift_resource
-        )
+
+    logging.debug("[populate_oc_resources] cluster: " + spec.cluster
+                  + " namespace: " + spec.namespace
+                  + " resource: " + spec.resource)
+
+    try:
+        for item in spec.oc.get_items(spec.resource,
+                                      namespace=spec.namespace):
+            openshift_resource = OR(item,
+                                    QONTRACT_INTEGRATION,
+                                    QONTRACT_INTEGRATION_VERSION)
+            ri.add_current(
+                spec.cluster,
+                spec.namespace,
+                spec.resource,
+                openshift_resource.name,
+                openshift_resource
+            )
+    except StatusCodeError as e:
+        logging.error("[populate_oc_resources] :"+str(e))
+        if "You must be logged in to the server (Unauthorized)" in str(e):
+            msg = 'Unauthorized access for '
+            msg += 'cluster: {}, '
+            msg += 'namespace: {},'
+            msg += 'resource: {}.'
+            msg = msg.format(spec.cluster, spec.namespace, spec.resource)
+            msg += " Exception: {}".format(str(e))
+            logging.error(msg)
 
 
 def fetch_current_state(namespaces, thread_pool_size, internal):

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -136,15 +136,12 @@ def populate_oc_resources(spec, ri):
                 openshift_resource
             )
     except StatusCodeError as e:
-        logging.error("[populate_oc_resources] :"+str(e))
-        if "You must be logged in to the server (Unauthorized)" in str(e):
-            msg = 'Unauthorized access for '
-            msg += 'cluster: {}, '
-            msg += 'namespace: {},'
-            msg += 'resource: {}.'
-            msg = msg.format(spec.cluster, spec.namespace, spec.resource)
-            msg += " Exception: {}".format(str(e))
-            logging.error(msg)
+        msg = 'cluster: {}, '
+        msg += 'namespace: {},'
+        msg += 'resource: {}.'
+        msg = msg.format(spec.cluster, spec.namespace, spec.resource)
+        msg += " Exception: {}".format(str(e))
+        logging.error(msg)
 
 
 def fetch_current_state(namespaces, thread_pool_size, internal):

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -138,8 +138,8 @@ def populate_oc_resources(spec, ri):
     except StatusCodeError as e:
         msg = 'cluster: {},'
         msg += 'namespace: {},'
-        msg += 'resource: {}.'
-        msg += "exception: {}"
+        msg += 'resource: {}'
+        msg += ' exception: {}'
         msg = msg.format(spec.cluster, spec.namespace, spec.resource, str(e))
         logging.error(msg)
 

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -33,7 +33,7 @@ class OC(object):
     def __init__(self, server, token, jh=None, settings=None):
         oc_base_cmd = [
             'oc',
-            '--config', '/dev/null',
+            '--kubeconfig', '/dev/null',
             '--server', server,
             '--token', token
         ]


### PR DESCRIPTION
Reconciling openshift-resources breaks if one of the cluster's token has expired.
Also he `-config` flag for OC client has been deprecated and `kubeconfig` is the new flag to use.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>