### PR TITLE
Added error handling for openshift_resources

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -187,7 +187,12 @@ def run_integration(func, *args):
 
 def init_log_level(log_level):
     level = getattr(logging, log_level) if log_level else logging.INFO
-    logging.basicConfig(format='%(levelname)s: %(message)s', level=level)
+    format = '[%(asctime)s] [%(levelname)s] '
+    format += '[%(filename)s:%(funcName)s:%(lineno)d] '
+    format += '- %(message)s'
+    logging.basicConfig(format=format,
+                        datefmt='%Y-%m-%d %H:%M:%S',
+                        level=level)
 
 
 @click.group()

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -14,6 +14,7 @@ import reconcile.openshift_base as ob
 import reconcile.queries as queries
 
 from utils.oc import OC_Map
+from utils.oc import StatusCodeError
 from utils.defer import defer
 from utils.openshift_resource import (OpenshiftResource as OR,
                                       ConstructResourceError,
@@ -460,15 +461,28 @@ def fetch_desired_state(oc, ri, cluster, namespace, resource, parent):
 
 
 def fetch_states(spec, ri):
-    if spec.type == "current":
-        fetch_current_state(spec.oc, ri, spec.cluster,
-                            spec.namespace, spec.resource,
-                            spec.resource_type_override,
-                            spec.resource_names)
-    if spec.type == "desired":
-        fetch_desired_state(spec.oc, ri, spec.cluster,
-                            spec.namespace, spec.resource,
-                            spec.parent)
+    try:
+
+        if spec.type == "current":
+            fetch_current_state(spec.oc, ri, spec.cluster,
+                                spec.namespace, spec.resource,
+                                spec.resource_type_override,
+                                spec.resource_names)
+        if spec.type == "desired":
+            fetch_desired_state(spec.oc, ri, spec.cluster,
+                                spec.namespace, spec.resource,
+                                spec.parent)
+
+    except StatusCodeError as e:
+        msg = 'cluster: {},'
+        msg += 'namespace: {},'
+        msg += 'resource_names: {},'
+        msg += 'exception: {}'
+        msg = msg.format(spec.cluster,
+                         spec.namespace,
+                         spec.resource_names,
+                         str(e))
+        logging.error(msg)
 
 
 def fetch_data(namespaces, thread_pool_size, internal):


### PR DESCRIPTION
openshift_resources will now log error and let the pipeline continue. This PR also modified the log message format. Log messages will now include timestamp, filename, function name, and line number.

Signed-off-by: Tejas Parikh <tparikh@redhat.com>