### PR TITLE
Fixing bool() exception handler

### DIFF
--- a/utils/container.py
+++ b/utils/container.py
@@ -107,7 +107,7 @@ class Image:
         try:
             self.get_manifest()
             return True
-        except requests.exceptions.HTTPError:
+        except ImageManifestError:
             return False
 
     def _raise_for_status(self, response, error_msg=None):


### PR DESCRIPTION
get_manifest() raises its own custom exception now. Let's
adapt to that.

Signed-off-by: Amador Pahim <apahim@redhat.com>