### PR TITLE
[openshift-*] consider managedResourceNames in all integrations

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -129,7 +129,8 @@ def populate_current_state(spec, ri, integration, integration_version):
     if spec.oc is None:
         return
     for item in spec.oc.get_items(spec.resource,
-                                  namespace=spec.namespace):
+                                  namespace=spec.namespace,
+                                  resource_names=spec.resource_names):
         openshift_resource = OR(item,
                                 integration,
                                 integration_version)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -245,6 +245,10 @@ NAMESPACES_QUERY = """
         version
       }
     }
+    managedResourceNames {
+      resource
+      resourceNames
+    }
     limitRanges {
       name
       limits {


### PR DESCRIPTION
currently `managedResourceNames` is only taken into consideration in openshift-resources.

this change adds it to all openshift integrations.