### PR TITLE
Unifying tox envs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,12 @@
 [tox]
-envlist = flake8, py36
+envlist = py36
 
 [testenv]
-commands = pytest
+commands =
+    flake8 utils reconcile tools e2e_tests
+    pytest
 deps =
     pytest==3.9.2
     mock==2.0.0
     anymarkup==0.7.0
-
-[testenv:flake8]
-commands = flake8 utils reconcile tools e2e_tests selftests
-deps = flake8==3.5.0
+    flake8==3.5.0


### PR DESCRIPTION
No need for separate envs. This will speed up the CI.

Signed-off-by: Amador Pahim <apahim@redhat.com>