### PR TITLE
[owner-approvals] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `email-sender`: Send email notifications to app-interface audience.
 - `service-dependencies`: Validate dependencies are defined for each service.
 - `sentry-config`: Configure and enforce sentry instance configuration.
+- `owner-approvals`: Adds an `approved` label on merge requests based on approver schema.
 
 ### e2e-tests
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -18,6 +18,7 @@ import reconcile.openshift_namespaces
 import reconcile.openshift_network_policies
 import reconcile.openshift_serviceaccount_tokens
 import reconcile.openshift_saas_deploy
+import reconcile.owner_approvals
 import reconcile.quay_membership
 import reconcile.quay_mirror
 import reconcile.quay_repos
@@ -415,6 +416,17 @@ def openshift_resources(ctx, thread_pool_size, internal):
 def openshift_saas_deploy(ctx, thread_pool_size, internal):
     run_integration(reconcile.openshift_saas_deploy.run,
                     ctx.obj['dry_run'], thread_pool_size, internal)
+
+
+@integration.command()
+@throughput
+@click.option('--compare/--no-compare',
+              default=True,
+              help='compare between current and desired state.')
+@click.pass_context
+def owner_approvals(ctx, io_dir, compare):
+    run_integration(reconcile.owner_approvals.run, ctx.obj['dry_run'],
+                    io_dir, compare)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -420,13 +420,17 @@ def openshift_saas_deploy(ctx, thread_pool_size, internal):
 
 @integration.command()
 @throughput
+@click.argument('gitlab-project-id')
+@click.argument('gitlab-merge-request-id')
 @click.option('--compare/--no-compare',
               default=True,
               help='compare between current and desired state.')
 @click.pass_context
-def owner_approvals(ctx, io_dir, compare):
-    run_integration(reconcile.owner_approvals.run, ctx.obj['dry_run'],
-                    io_dir, compare)
+def owner_approvals(ctx, gitlab_project_id, gitlab_merge_request_id,
+                    io_dir, compare):
+    run_integration(reconcile.owner_approvals.run,
+                    gitlab_project_id, gitlab_merge_request_id,
+                    ctx.obj['dry_run'], io_dir, compare)
 
 
 @integration.command()

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -77,7 +77,7 @@ def handle_stale_items(dry_run, gl, days_interval, enable_closing, item_type):
 
 
 def rebase_merge_requests(dry_run, gl, rebase_limit):
-    REBASE_LABELS = ['lgtm', 'automerge']
+    REBASE_LABELS = ['lgtm', 'automerge', 'approved']
     mrs = gl.get_merge_requests(state='opened')
     rebases = 0
     for mr in reversed(mrs):
@@ -110,7 +110,7 @@ def rebase_merge_requests(dry_run, gl, rebase_limit):
 
 
 def merge_merge_requests(dry_run, gl, merge_limit):
-    MERGE_LABELS = ['lgtm', 'automerge']
+    MERGE_LABELS = ['lgtm', 'automerge', 'approved']
 
     mrs = gl.get_merge_requests(state='opened')
     merges = 0

--- a/reconcile/owner_approvals.py
+++ b/reconcile/owner_approvals.py
@@ -1,0 +1,56 @@
+import os
+import json
+
+import reconcile.queries as queries
+
+
+QONTRACT_INTEGRATION = 'owner-approvals'
+
+
+def get_owners_file_path(io_dir):
+    dir_path = os.path.join(io_dir, QONTRACT_INTEGRATION)
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path)
+    return os.path.join(dir_path, 'owners.json')
+
+
+def collect_owners_to_file(io_dir):
+    owners = {}
+    apps = queries.get_apps()
+    for app in apps:
+        app_name = app['name']
+        owners[app_name] = set()
+        owner_roles = app.get('owner_roles')
+        if not owner_roles:
+            continue
+        for owner_role in owner_roles:
+            owner_users = owner_role.get('users')
+            if not owner_users:
+                continue
+            for owner_user in owner_users:
+                owner_username = owner_user['org_username']
+                owners[app_name].add(owner_username)
+
+    # make owners suitable for json dump
+    for k in owners:
+        owners[k] = list(owners[k])
+
+    # write owners to throughput file
+    file_path = get_owners_file_path(io_dir)
+    with open(file_path, 'w') as f:
+        f.write(json.dumps(owners))
+
+
+def read_owners_from_file(io_dir):
+    file_path = get_owners_file_path(io_dir)
+    with open(file_path, 'r') as f:
+        owners = json.load(f)
+    return owners
+
+
+def run(dry_run=False, io_dir='throughput/', compare=True):
+    if not compare:
+        collect_owners_to_file(io_dir)
+        return
+
+    owners = read_owners_from_file(io_dir)

--- a/reconcile/owner_approvals.py
+++ b/reconcile/owner_approvals.py
@@ -127,11 +127,10 @@ def run(gitlab_project_id, gitlab_merge_request_id, dry_run=False,
             gitlab_merge_request_id, 'approved')
         return
 
-
     comments = gl.get_merge_request_comments(gitlab_merge_request_id)
     lgtm_users = [c['username'] for c in comments
-                  for l in c['body'].split('\n')
-                  if l == '/lgtm']
+                  for line in c['body'].split('\n')
+                  if line == '/lgtm']
     if len(lgtm_users) == 0:
         gl.remove_label_from_merge_request(
             gitlab_merge_request_id, 'approved')

--- a/reconcile/owner_approvals.py
+++ b/reconcile/owner_approvals.py
@@ -7,14 +7,14 @@ import reconcile.queries as queries
 QONTRACT_INTEGRATION = 'owner-approvals'
 
 
-def get_owners_file_path(io_dir):
+def get_baseline_file_path(io_dir):
     dir_path = os.path.join(io_dir, QONTRACT_INTEGRATION)
     if not os.path.exists(dir_path):
         os.makedirs(dir_path)
-    return os.path.join(dir_path, 'owners.json')
+    return os.path.join(dir_path, 'baseline.json')
 
 
-def collect_owners_to_file(io_dir):
+def collect_owners():
     owners = {}
     apps = queries.get_apps()
     for app in apps:
@@ -35,22 +35,57 @@ def collect_owners_to_file(io_dir):
     for k in owners:
         owners[k] = list(owners[k])
 
-    # write owners to throughput file
-    file_path = get_owners_file_path(io_dir)
-    with open(file_path, 'w') as f:
-        f.write(json.dumps(owners))
-
-
-def read_owners_from_file(io_dir):
-    file_path = get_owners_file_path(io_dir)
-    with open(file_path, 'r') as f:
-        owners = json.load(f)
     return owners
+
+
+def collect_state():
+    state = []
+    saas_files = queries.get_saas_files()
+    for sf in saas_files:
+        app = sf['app']['name']
+        resource_templates = sf['resourceTemplates']
+        for rt in resource_templates:
+            rt_name = rt['name']
+            for target in rt['targets']:
+                namespace = target['namespace']['name']
+                cluster = target['namespace']['cluster']['name']
+                target_hash = target['hash']
+                state.append({
+                    'app': app,
+                    'name': rt_name,
+                    'cluster': cluster,
+                    'namespace': namespace,
+                    'hash': target_hash
+                })
+    return state
+
+
+def collect_baseline():
+    owners = collect_owners()
+    state = collect_state()
+    return {'owners': owners, 'state': state}
+
+
+def write_baseline_to_file(io_dir, baseline):
+    file_path = get_baseline_file_path(io_dir)
+    with open(file_path, 'w') as f:
+        f.write(json.dumps(baseline))
+
+
+def read_baseline_from_file(io_dir):
+    file_path = get_baseline_file_path(io_dir)
+    with open(file_path, 'r') as f:
+        baseline = json.load(f)
+    return baseline
 
 
 def run(dry_run=False, io_dir='throughput/', compare=True):
     if not compare:
-        collect_owners_to_file(io_dir)
-        return
+        # baseline is the current state and the owners.
+        # this should be queried from the production endpoint
+        # to prevent privlige escalation and to compare the states
+        baseline = collect_baseline()
+        write_baseline_to_file(io_dir, baseline)
 
-    owners = read_owners_from_file(io_dir)
+    baseline = read_baseline_from_file(io_dir)
+    print(json.dumps(baseline))

--- a/reconcile/owner_approvals.py
+++ b/reconcile/owner_approvals.py
@@ -107,7 +107,7 @@ def run(gitlab_project_id, gitlab_merge_request_id, dry_run=False,
     if not compare:
         # baseline is the current state and the owners.
         # this should be queried from the production endpoint
-        # to prevent privlige escalation and to compare the states
+        # to prevent privilege escalation and to compare the states
         baseline = collect_baseline()
         write_baseline_to_file(io_dir, baseline)
         return

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -458,6 +458,7 @@ SAAS_FILES_QUERY = """
     }
     managedResourceTypes
     resourceTemplates {
+      name
       url
       path
       hash_length

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -325,6 +325,11 @@ APPS_QUERY = """
       url
       resource
     }
+    owner_roles {
+      users {
+        org_username
+      }
+    }
   }
 }
 """

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -452,6 +452,7 @@ def get_app_interface_sql_queries():
 SAAS_FILES_QUERY = """
 {
   saas_files: saas_files_v1 {
+    path
     name
     app {
       name


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-707

This PR introduces a new integrations called owner-approvals.

This integration will assist in allowing external users (non App SRE) to approve changes to their apps.
The start will be only for saas files.

The flow is:
1. run owner-approvals with `--no-compare` to only collect approvers from the production graphql endpoint (prevent privilege escalation).
2. run owner-approvals again, to determine if this change is approved by an owner.

app-interface MR: https://gitlab.cee.redhat.com/service/app-interface/merge_requests/3309