### PR TITLE
Revert support for named secrets in openshift-acme

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -244,7 +244,6 @@ NAMESPACES_QUERY = """
         path
         version
       }
-      acmeSecrets
     }
     managedResourceNames {
       resource

--- a/utils/openshift_acme.py
+++ b/utils/openshift_acme.py
@@ -2,7 +2,7 @@ ACME_DEPLOYMENT = """
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ deployment_name }}
+  name: %(deployment_name)s
   labels:
     app: openshift-acme
 spec:
@@ -36,7 +36,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: {{ image }}
+        image: %(image)s
         imagePullPolicy: Always
         name: openshift-acme
         ports:
@@ -59,8 +59,8 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext: {}
-      serviceAccount: {{ serviceaccount_name }}
-      serviceAccountName: {{ serviceaccount_name }}
+      serviceAccount: %(serviceaccount_name)s
+      serviceAccountName: %(serviceaccount_name)s
       terminationGracePeriodSeconds: 30
       volumes:
       - name: podinfo
@@ -77,16 +77,16 @@ ACME_SERVICEACCOUNT = """
 kind: ServiceAccount
 apiVersion: v1
 metadata:
-  name: {{ serviceaccount_name }}
+  name: %(serviceaccount_name)s
   labels:
     app: openshift-acme
 """
 
 ACME_ROLE = """
-apiVersion: {{ role_api_version }}
+apiVersion: %(role_api_version)s
 kind: Role
 metadata:
-  name: {{ role_name }}
+  name: %(role_name)s
   labels:
     app: openshift-acme
 rules:
@@ -127,12 +127,6 @@ rules:
   - ""
   resources:
   - secrets
-  {% if acme_secrets %}
-  resourceNames:
-  {% for acme_secret in acme_secrets %}
-  - {{ acme_secret }}
-  {% endfor %}
-  {% endif %}
   verbs:
   - create
   - delete
@@ -144,16 +138,16 @@ rules:
 """
 
 ACME_ROLEBINDING = """
-apiVersion: {{ rolebinding_api_version }}
+apiVersion: %(rolebinding_api_version)s
 groupNames: null
 kind: RoleBinding
 metadata:
-  name: {{ rolebinding_name }}
+  name: %(rolebinding_name)s
 roleRef:
   kind: Role
-  name: {{ role_name }}
-  namespace: {{ namespace_name }}
+  name: %(role_name)s
+  namespace: %(namespace_name)s
 subjects:
 - kind: ServiceAccount
-  name: {{ serviceaccount_name }}
+  name: %(serviceaccount_name)s
 """


### PR DESCRIPTION
This reverts PR (#536) as openshift-acme needs to be able to delete any
secret in the namespace it's running.

See https://issues.redhat.com/browse/APPSRE-1435

cc @maorfr 

This reverts commit f916267f60fe652289cf8bcbceae0e9c192fe32b.