### PR TITLE
Fix openshift-clusterrolebindings broken across v3/v4

### DIFF
--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -37,14 +37,16 @@ QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 
 def construct_user_oc_resource(role, user):
     name = f"{role}-{user}"
+    # Note: In OpenShift 4.x this resource is in rbac.authorization.k8s.io/v1
     body = {
-        "apiVersion": "authorization.openshift.io/v1",
+        "apiVersion": "rbac.authorization.k8s.io/v1",
         "kind": "ClusterRoleBinding",
         "metadata": {
             "name": name
         },
         "roleRef": {
-            "name": role
+            "name": role,
+            "kind": "ClusterRole"
         },
         "subjects": [
             {"kind": "User",
@@ -57,14 +59,16 @@ def construct_user_oc_resource(role, user):
 
 def construct_sa_oc_resource(role, namespace, sa_name):
     name = f"{role}-{namespace}-{sa_name}"
+    # Note: In OpenShift 4.x this resource is in rbac.authorization.k8s.io/v1
     body = {
-        "apiVersion": "authorization.openshift.io/v1",
+        "apiVersion": "rbac.authorization.k8s.io/v1",
         "kind": "ClusterRoleBinding",
         "metadata": {
             "name": name
         },
         "roleRef": {
-            "name": role
+            "name": role,
+            "kind": "ClusterRole"
         },
         "subjects": [
             {"kind": "ServiceAccount",

--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -264,9 +264,20 @@ class OpenshiftResource(object):
                 body['apiVersion'] = 'authorization.openshift.io/v1'
 
         if body['kind'] == 'ClusterRoleBinding':
+            # TODO: remove this once we have no 3.11 clusters
+            if body['apiVersion'] == 'authorization.openshift.io/v1':
+                body['apiVersion'] = 'rbac.authorization.k8s.io/v1'
+            if 'userNames' in body:
+                body.pop('userNames')
+            if 'roleRef' in body:
+                roleRef = body['roleRef']
+                if 'apiGroup' in roleRef and \
+                        roleRef['apiGroup'] in body['apiVersion']:
+                    roleRef.pop('apiGroup')
+                if 'kind' in roleRef:
+                    roleRef.pop('kind')
             if 'groupNames' in body:
                 body.pop('groupNames')
-
         if body['kind'] == 'Service':
             spec = body['spec']
             if spec.get('sessionAffinity') == 'None':


### PR DESCRIPTION
OpenShift v3 vs v4 have different Kubernetes versions, so the apiVersion of ClusterRolebindings is not inter compatible