### PR TITLE
remove gitlabOwners until schema is updated

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -325,7 +325,6 @@ APPS_QUERY = """
     codeComponents {
       url
       resource
-      gitlabOwners
     }
   }
 }


### PR DESCRIPTION
this causes some failures.
let's restore this when the schema is updated.

cc @apahim 