### PR TITLE
[ocm-aws-infrastructure-access] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `terraform-resources`: Manage AWS Resources using Terraform.
 - `terraform-users`: Manage AWS users using Terraform.
 - `ocm-groups`: Manage membership in OpenShift groups using OpenShift Cluster Manager.
+- `ocm-clusters`: Manages (currently: validates only) clusters desired state with current state in OCM.
+- `ocm-aws-infrastructure-access`: Grants AWS infrastructure access to members in AWS groups via OCM.
 - `email-sender`: Send email notifications to app-interface audience.
 - `service-dependencies`: Validate dependencies are defined for each service.
 - `sentry-config`: Configure and enforce sentry instance configuration.

--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -219,6 +219,14 @@ integrations:
     limits:
       memory: 200Mi
       cpu: 25m
+- name: ocm-aws-infrastructure-access
+  resources:
+    requests:
+      memory: 200Mi
+      cpu: 50m
+    limits:
+      memory: 300Mi
+      cpu: 100m
 - name: email-sender
   resources:
     requests:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -2143,6 +2143,52 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile
+    name: qontract-reconcile-ocm-aws-infrastructure-access
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile
+      spec:
+        securityContext:
+          runAsUser: ${{USER_ID}}
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          env:
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: ocm-aws-infrastructure-access
+          - name: INTEGRATION_EXTRA_ARGS
+            value: ""
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            value: ${GITHUB_API}
+          resources:
+            limits:
+              cpu: 100m
+              memory: 300Mi
+            requests:
+              cpu: 50m
+              memory: 200Mi
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    labels:
+      app: qontract-reconcile
     name: qontract-reconcile-email-sender
   spec:
     replicas: 1

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -43,6 +43,7 @@ import reconcile.aws_iam_keys
 import reconcile.aws_support_cases_sos
 import reconcile.ocm_groups
 import reconcile.ocm_clusters
+import reconcile.ocm_aws_infrastructure_access
 import reconcile.email_sender
 import reconcile.service_dependencies
 import reconcile.sentry_config
@@ -583,6 +584,13 @@ def ocm_groups(ctx, thread_pool_size):
 def ocm_clusters(ctx, thread_pool_size):
     run_integration(reconcile.ocm_clusters.run, ctx.obj['dry_run'],
                     thread_pool_size)
+
+
+@integration.command()
+@click.pass_context
+def ocm_aws_infrastructure_access(ctx):
+    run_integration(reconcile.ocm_aws_infrastructure_access.run,
+                    ctx.obj['dry_run'])
 
 
 @integration.command()

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -43,9 +43,9 @@ def fetch_desired_state():
             aws_account = aws_group['account']
             aws_account_uid = aws_account['uid']
             users = [user['org_username']
-                    for role in aws_group['roles']
-                    for user in role['users']]
-            
+                     for role in aws_group['roles']
+                     for user in role['users']]
+
             for user in users:
                 item = {
                     'cluster': cluster,
@@ -59,12 +59,12 @@ def fetch_desired_state():
             if tf_user:
                 item = {
                     'cluster': cluster,
-                    'user_arn': 
+                    'user_arn':
                         f"arn:aws:iam::{aws_account_uid}:user/{tf_user}",
                     'access_level': 'network-mgmt'
                 }
                 desired_state.append(item)
-        
+
     return desired_state
 
 

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -1,0 +1,99 @@
+import logging
+
+import reconcile.queries as queries
+
+from utils.ocm import OCMMap
+
+QONTRACT_INTEGRATION = 'ocm-aws-infrastructure-access'
+
+
+def fetch_current_state():
+    current_state = []
+    settings = queries.get_app_interface_settings()
+    clusters = [c for c in queries.get_clusters()
+                if c.get('ocm') is not None]
+    ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
+                     settings=settings)
+
+    for cluster_info in clusters:
+        cluster = cluster_info['name']
+        ocm = ocm_map.get(cluster)
+        role_grants = ocm.get_aws_infrastructure_access_role_grants(cluster)
+        for user_arn, access_level in role_grants:
+            item = {
+                'cluster': cluster,
+                'user_arn': user_arn,
+                'access_level': access_level
+            }
+            current_state.append(item)
+
+    return ocm_map, current_state
+
+
+def fetch_desired_state():
+    desired_state = []
+    clusters = [c for c in queries.get_clusters()
+                if c.get('awsInfrastructureAccess') is not None]
+    for cluster_info in clusters:
+        cluster = cluster_info['name']
+        aws_infra_access_items = cluster_info['awsInfrastructureAccess']
+        for aws_infra_access in aws_infra_access_items:
+            aws_group = aws_infra_access['awsGroup']
+            access_level = aws_infra_access['accessLevel']
+            aws_account = aws_group['account']
+            aws_account_uid = aws_account['uid']
+            users = [user['org_username']
+                    for role in aws_group['roles']
+                    for user in role['users']]
+            
+            for user in users:
+                item = {
+                    'cluster': cluster,
+                    'user_arn': f"arn:aws:iam::{aws_account_uid}:user/{user}",
+                    'access_level': access_level
+                }
+                desired_state.append(item)
+
+            # add terraform user account with network management access level
+            tf_user = aws_account.get('terraformUsername')
+            if tf_user:
+                item = {
+                    'cluster': cluster,
+                    'user_arn': 
+                        f"arn:aws:iam::{aws_account_uid}:user/{tf_user}",
+                    'access_level': 'network-mgmt'
+                }
+                desired_state.append(item)
+        
+    return desired_state
+
+
+def act(dry_run, ocm_map, current_state, desired_state):
+    to_add = [d for d in desired_state if d not in current_state]
+    for item in to_add:
+        cluster = item['cluster']
+        user_arn = item['user_arn']
+        access_level = item['access_level']
+        logging.info(['add_user_to_aws_infrastructure_access_role_grants',
+                      cluster, user_arn, access_level])
+        if not dry_run:
+            ocm = ocm_map.get(cluster)
+            ocm.add_user_to_aws_infrastructure_access_role_grants(
+                cluster, user_arn, access_level)
+    to_delete = [c for c in current_state if c not in desired_state]
+    for item in to_delete:
+        cluster = item['cluster']
+        user_arn = item['user_arn']
+        access_level = item['access_level']
+        logging.info(['del_user_from_aws_infrastructure_access_role_grants',
+                      cluster, user_arn, access_level])
+        if not dry_run:
+            ocm = ocm_map.get(cluster)
+            ocm.del_user_from_aws_infrastructure_access_role_grants(
+                cluster, user_arn, access_level)
+
+
+def run(dry_run=False):
+    ocm_map, current_state = fetch_current_state()
+    desired_state = fetch_desired_state()
+    act(dry_run, ocm_map, current_state, desired_state)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -162,6 +162,20 @@ CLUSTERS_QUERY = """
         version
       }
     }
+    awsInfrastructureAccess {
+      awsGroup {
+        account {
+          uid
+          terraformUsername
+        }
+        roles {
+          users {
+            org_username
+          }
+        }
+      }
+      accessLevel
+    }
     spec {
       provider
       region

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -130,6 +130,65 @@ class OCM(object):
               f'groups/{group_id}/users/{user_id}'
         self._delete(api)
 
+    def get_aws_infrastructure_access_role_grants(self, cluster):
+        """Returns a list of AWS users (ARN, access level)
+        who have AWS infrastructure access in a cluster.
+
+        :param cluster: cluster name
+
+        :type cluster: string
+        """
+        cluster_id = self.cluster_ids[cluster]
+        api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
+              f'aws_infrastructure_access_role_grants'
+        role_grants = self._get_json(api)['items']
+        return [(r['user_arn'], r['role']['id']) for r in role_grants]
+
+    def add_user_to_aws_infrastructure_access_role_grants(self, cluster,
+                                                          user_arn,
+                                                          access_level):
+        """
+        Adds a user to AWS infrastructure access in a cluster.
+
+        :param cluster: cluster name
+        :param user_arn: user ARN
+        :param access_level: access level (read-only or network-mgmt)
+
+        :type cluster: string
+        :type user_arn: string
+        :type access_level: string
+        """
+        cluster_id = self.cluster_ids[cluster]
+        api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
+              f'aws_infrastructure_access_role_grants'
+        self._post(api, {'user_arn': user_arn, 'role': {'id': access_level}})
+
+    def del_user_from_aws_infrastructure_access_role_grants(self, cluster,
+                                                            user_arn,
+                                                            access_level):
+        """
+        Deletes a user from AWS infrastructure access in a cluster.
+
+        :param cluster: cluster name
+        :param user_arn: user ARN
+        :param access_level: access level (read-only or network-mgmt)
+
+        :type cluster: string
+        :type user_arn: string
+        :type access_level: string
+        """
+        cluster_id = self.cluster_ids[cluster]
+        api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
+              f'aws_infrastructure_access_role_grants'
+        role_grants = self._get_json(api)['items']
+        for rg in role_grants:
+            if rg['user_arn'] != user_arn:
+                continue
+            if rg['role']['id'] != access_level:
+                continue
+            aws_infrastructure_access_role_grant_id = rg['id']
+            self._delete(f"{api}/{aws_infrastructure_access_role_grant_id}")
+
     @retry(max_attempts=10)
     def _get_json(self, api):
         r = requests.get(f"{self.url}{api}", headers=self.headers)


### PR DESCRIPTION
Covers https://issues.redhat.com/browse/APPSRE-1588

This PR adds a new integration that grants access to AWS infrastructure behind a cluster in OCM.
It uses existing resources of type AWS groups to get users eligible for that access.

matching app-interface MR: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/3501

ref: https://docs.openshift.com/dedicated/4/getting_started/cloud_infrastructure_access/dedicated-aws-access.html