### PR TITLE
[terraform-vpc-peerings] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `sql-query`: Runs SQL Queries against app-interface RDS resources.
 - `terraform-resources`: Manage AWS Resources using Terraform.
 - `terraform-users`: Manage AWS users using Terraform.
+- `terraform-vpc-peerings`: Manage VPC peerings between OSDv4 clusters and AWS accounts.
 - `ocm-groups`: Manage membership in OpenShift groups using OpenShift Cluster Manager.
 - `ocm-clusters`: Manages (currently: validates only) clusters desired state with current state in OCM.
 - `ocm-aws-infrastructure-access`: Grants AWS infrastructure access to members in AWS groups via OCM.

--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -221,6 +221,14 @@ integrations:
   extraArgs: --io-dir /tmp/throughput/
   logs:
     slack: true
+- name: terraform-vpc-peerings
+  resources:
+    requests:
+      memory: 600Mi
+      cpu: 200m
+    limits:
+      memory: 1000Mi
+      cpu: 400m
 - name: ocm-groups
   resources:
     requests:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -1929,6 +1929,50 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile
+    name: qontract-reconcile-terraform-vpc-peerings
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile
+      spec:
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          env:
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: terraform-vpc-peerings
+          - name: INTEGRATION_EXTRA_ARGS
+            value: ""
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            value: ${GITHUB_API}
+          resources:
+            limits:
+              cpu: 400m
+              memory: 1000Mi
+            requests:
+              cpu: 200m
+              memory: 600Mi
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+- apiVersion: extensions/v1beta1
+  kind: Deployment
+  metadata:
+    labels:
+      app: qontract-reconcile
     name: qontract-reconcile-ocm-groups
   spec:
     replicas: 1

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -25,6 +25,7 @@ import reconcile.quay_repos
 import reconcile.ldap_users
 import reconcile.terraform_resources
 import reconcile.terraform_users
+import reconcile.terraform_vpc_peerings
 import reconcile.github_repo_invites
 import reconcile.jenkins_roles
 import reconcile.jenkins_plugins
@@ -578,6 +579,19 @@ def terraform_users(ctx, print_only, enable_deletion, io_dir,
                     ctx.obj['dry_run'], print_only,
                     enable_deletion, io_dir,
                     thread_pool_size, send_mails)
+
+
+@integration.command()
+@terraform
+@threaded()
+@binary(['terraform'])
+@enable_deletion(default=False)
+@click.pass_context
+def terraform_vpc_peerings(ctx, print_only, enable_deletion,
+                           thread_pool_size):
+    run_integration(reconcile.terraform_vpc_peerings.run,
+                    ctx.obj['dry_run'], print_only,
+                    enable_deletion, thread_pool_size)
 
 
 @integration.command()

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -199,7 +199,7 @@ CLUSTERS_QUERY = """
           uid
           terraformUsername
         }
-        id
+        vpc_id
         cidr_block
         region
       }

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -191,6 +191,19 @@ CLUSTERS_QUERY = """
       service
       pod
     }
+    peering {
+      vpc_id
+      connections {
+        account {
+          name
+          uid
+          terraformUsername
+        }
+        id
+        cidr_block
+        region
+      }
+    }
     automationToken {
       path
       field

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -33,18 +33,23 @@ def fetch_desired_state(settings):
             accepter['vpc_id'] = peer_vpc['id']
             accepter['cidr_block'] = peer_vpc['cidr_block']
             accepter['region'] = peer_vpc['region']
-            accepter['account'] = peer_vpc['account']
+            account = {}
+            account = peer_vpc['account']
             # assume_role is the role to assume to provision the
             # peering connection request, through the accepter AWS account.
             # this may change in the future -
             # in case we add support for peerings between clusters.
-            accepter['account']['assume_role'] = \
+            account['assume_role'] = \
                 ocm.get_aws_infrastructure_access_terraform_assume_role(
                     cluster,
                     peer_vpc['account']['uid'],
                     peer_vpc['account']['terraformUsername']
                 )
-            item = {'requester': requester, 'accepter': accepter}
+            item = {
+                'requester': requester,
+                'accepter': accepter,
+                'account': account
+            }
             desired_state.append(item)
 
     return desired_state
@@ -55,7 +60,7 @@ def run(dry_run=False, print_only=False,
     settings = queries.get_app_interface_settings()
     desired_state = fetch_desired_state(settings)
     participating_accounts = \
-        [item['accepter']['account'] for item in desired_state]
+        [item['account'] for item in desired_state]
     participating_account_names = \
         [a['name'] for a in participating_accounts]
     accounts = [a for a in queries.get_aws_accounts()

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -4,12 +4,54 @@ import reconcile.queries as queries
 
 from utils.terrascript_client import TerrascriptClient as Terrascript
 from utils.terraform_client import TerraformClient as Terraform
+from utils.ocm import OCMMap
 
 
 QONTRACT_INTEGRATION = 'terraform-vpc-peerings'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 
 
+def fetch_desired_state():
+    desired_state = []
+    clusters = [c for c in queries.get_clusters()
+                if c.get('peering') is not None]
+    settings = queries.get_app_interface_settings()
+    ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
+                     settings=settings)
+    for cluster_info in clusters:
+        cluster = cluster_info['name']
+        ocm = ocm_map.get(cluster)
+        peering_info = cluster_info['peering']
+        # requester is the cluster's AWS account
+        requester = {}
+        requester['vpc_id'] = peering_info['vpc_id']
+        requester['cidr_block'] = cluster_info['network']['vpc']
+        requester['region'] = cluster_info['spec']['region']
+        peer_connections = peering_info['connections']
+        for peer_vpc in peer_connections:
+            # accepter is the peered AWS account
+            accepter = {}
+            accepter['vpc_id'] = peer_vpc['id']
+            accepter['cidr_block'] = peer_vpc['cidr_block']
+            accepter['region'] = peer_vpc['region']
+            accepter['account'] = peer_vpc['account']
+            # assume_role is the role to assume to provision the
+            # peering connection request, through the accepter AWS account.
+            # this may change in the future -
+            # in case we add support for peerings between clusters.
+            accepter['account']['assume_role'] = \
+                ocm.get_aws_infrastructure_access_terraform_assume_role(
+                    cluster,
+                    peer_vpc['account']['uid'],
+                    peer_vpc['account']['terraformUsername']
+                )
+            item = {'requester': requester, 'accepter': accepter}
+            desired_state.append(item)
+
+    return desired_state
+
+
 def run(dry_run=False, print_only=False,
         enable_deletion=False, thread_pool_size=10):
-    print('hello there!')
+    desired_state = fetch_desired_state()
+    print(desired_state)

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -1,0 +1,15 @@
+import semver
+
+import reconcile.queries as queries
+
+from utils.terrascript_client import TerrascriptClient as Terrascript
+from utils.terraform_client import TerraformClient as Terraform
+
+
+QONTRACT_INTEGRATION = 'terraform-vpc-peerings'
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
+
+
+def run(dry_run=False, print_only=False,
+        enable_deletion=False, thread_pool_size=10):
+    print('hello there!')

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -66,4 +66,6 @@ def run(dry_run=False, print_only=False,
                      thread_pool_size,
                      accounts,
                      settings=settings)
+    ts.populate_additional_providers(participating_accounts)
+    ts.populate_vpc_peerings(desired_state)
     print(ts.dump())

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -32,7 +32,7 @@ def fetch_desired_state(settings):
         for peer_vpc in peer_connections:
             # accepter is the peered AWS account
             accepter = {}
-            accepter['vpc_id'] = peer_vpc['id']
+            accepter['vpc_id'] = peer_vpc['vpc_id']
             accepter['cidr_block'] = peer_vpc['cidr_block']
             accepter['region'] = peer_vpc['region']
             account = {}

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -24,18 +24,19 @@ def fetch_desired_state(settings):
         ocm = ocm_map.get(cluster)
         peering_info = cluster_info['peering']
         # requester is the cluster's AWS account
-        requester = {}
-        requester['vpc_id'] = peering_info['vpc_id']
-        requester['cidr_block'] = cluster_info['network']['vpc']
-        requester['region'] = cluster_info['spec']['region']
+        requester = {
+            'vpc_id': peering_info['vpc_id'],
+            'cidr_block': cluster_info['network']['vpc'],
+            'region': cluster_info['spec']['region']
+        }
         peer_connections = peering_info['connections']
         for peer_vpc in peer_connections:
             # accepter is the peered AWS account
-            accepter = {}
-            accepter['vpc_id'] = peer_vpc['vpc_id']
-            accepter['cidr_block'] = peer_vpc['cidr_block']
-            accepter['region'] = peer_vpc['region']
-            account = {}
+            accepter = {
+                'vpc_id': peer_vpc['vpc_id'],
+                'cidr_block': peer_vpc['cidr_block'],
+                'region': peer_vpc['region']
+            }
             account = peer_vpc['account']
             # assume_role is the role to assume to provision the
             # peering connection request, through the accepter AWS account.

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -83,10 +83,11 @@ def run(dry_run=False, print_only=False,
                    "",
                    working_dirs,
                    thread_pool_size)
-    defer(lambda: tf.cleanup())
 
     if tf is None:
         sys.exit(1)
+
+    defer(lambda: tf.cleanup())
 
     deletions_detected, err = tf.plan(enable_deletion)
     if err:

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -68,7 +68,7 @@ def run(dry_run=False, print_only=False,
         [a['name'] for a in participating_accounts]
     accounts = [a for a in queries.get_aws_accounts()
                 if a['name'] in participating_account_names]
-    
+
     ts = Terrascript(QONTRACT_INTEGRATION,
                      "",
                      thread_pool_size,

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -76,7 +76,10 @@ def run(dry_run=False, print_only=False,
                      settings=settings)
     ts.populate_additional_providers(participating_accounts)
     ts.populate_vpc_peerings(desired_state)
-    working_dirs = ts.dump()
+    working_dirs = ts.dump(print_only=print_only)
+
+    if print_only:
+        sys.exit()
 
     tf = Terraform(QONTRACT_INTEGRATION,
                    QONTRACT_INTEGRATION_VERSION,

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -281,7 +281,19 @@ class TerrascriptClient(object):
 
     def populate_additional_providers(self, accounts):
         for account in accounts:
-            continue
+            account_name = account['name']
+            assume_role = account['assume_role']
+            # arn:aws:iam::12345:role/role-1 --> 12345
+            alias = assume_role.split(':')[4]
+            ts = self.tss[account_name]
+            config = self.configs[account_name]
+            ts += provider('aws',
+                           access_key=config['aws_access_key_id'],
+                           secret_key=config['aws_secret_access_key'],
+                           version=config['aws_provider_version'],
+                           region=config['region'],
+                           alias=alias,
+                           assume_role={'role_arn': assume_role})
 
     def populate_vpc_peerings(self, desired_state):
         for item in desired_state:

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -279,6 +279,15 @@ class TerrascriptClient(object):
         if err:
             return err
 
+    def populate_additional_providers(self, accounts):
+        for account in accounts:
+            continue
+
+    def populate_vpc_peerings(self, desired_state):
+        for item in desired_state:
+            requester = item['requester']
+            accepter = item['accepter']
+
     def populate_resources(self, namespaces, existing_secrets):
         for spec in self.init_populate_specs(namespaces):
             self.populate_tf_resources(spec, existing_secrets)

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -323,7 +323,7 @@ class TerrascriptClient(object):
 
             # Accepter's side of the connection.
             values = {
-                'vpc_peering_connection_id': 
+                'vpc_peering_connection_id':
                     '${aws_vpc_peering_connection.' + identifier + '.id}',
                 'auto_accept': True
             }

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -316,7 +316,12 @@ class TerrascriptClient(object):
                 'peer_vpc_id': accepter['vpc_id'],
                 'peer_region': accepter['region'],
                 'peer_owner_id': account['uid'],
-                'auto_accept': False
+                'auto_accept': False,
+                'tags': {
+                    'managed_by_integration': self.integration,
+                    # <accepter account uid>-<accepter account vpc id>
+                    'Name': f"{account['uid']}-{accepter['vpc_id']}"
+                }
             }
             tf_resource = aws_vpc_peering_connection(identifier, **values)
             self.add_resource(account_name, tf_resource)
@@ -325,7 +330,12 @@ class TerrascriptClient(object):
             values = {
                 'vpc_peering_connection_id':
                     '${aws_vpc_peering_connection.' + identifier + '.id}',
-                'auto_accept': True
+                'auto_accept': True,
+                'tags': {
+                    'managed_by_integration': self.integration,
+                    # <requester account uid>-<requester account vpc id>
+                    'Name': f"{alias}-{requester['vpc_id']}"
+                }
             }
             tf_resource = \
                 aws_vpc_peering_connection_accepter(identifier, **values)


### PR DESCRIPTION
this PR adds an integration that creates VPC peering between OSDv4 cluster VPCs and AWS accounts managed in app-interface.

This is currently a manual step done during cluster provisioning.

covers https://issues.redhat.com/browse/APPSRE-1586

matching app-interface MR: https://gitlab.cee.redhat.com/service/app-interface/merge_requests/3503