### PR TITLE
Add option to run OpenShift related integrations without using a jump host

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -35,15 +35,5 @@ COPY setup.py .
 
 RUN python3 setup.py install
 
-# required to run ssh on OpenShift
-ENV PROD_USER_ID=1000640000
-RUN useradd -l -u ${PROD_USER_ID} reconcile
-ENV PROD_USER_ID_V3=1001450000
-RUN useradd -l -u ${PROD_USER_ID_V3} reconcile-v3
-ENV STAGE_USER_ID=1000720000
-RUN useradd -l -u ${STAGE_USER_ID} reconcile-stage
-ENV STAGE_USER_ID_V3=1031160000
-RUN useradd -l -u ${STAGE_USER_ID_V3} reconcile-stage-v3
-
 COPY dockerfiles/hack/run-integration.sh /run-integration.sh
 CMD [ "/run-integration.sh" ]

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -21,8 +21,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: {{ "${{USER_ID}}" }}
         {{- if $integration.logs }}
         initContainers:
         - name: config
@@ -164,8 +162,6 @@ parameters:
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT
   value: app-sre
-- name: USER_ID
-  value: "1000720000"
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -162,6 +162,8 @@ parameters:
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT
   value: app-sre
+- name: USER_ID
+  value: dummy
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -102,6 +102,7 @@ integrations:
     limits:
       memory: 300Mi
       cpu: 40m
+  extraArgs: --no-use-jump-host
   logs: true
 - name: openshift-groups
   resources:
@@ -111,6 +112,7 @@ integrations:
     limits:
       memory: 400Mi
       cpu: 150m
+  extraArgs: --no-use-jump-host
   logs: true
 - name: openshift-namespaces
   resources:
@@ -120,7 +122,7 @@ integrations:
     limits:
       memory: 400Mi
       cpu: 350m
-  extraArgs: --external
+  extraArgs: --external --no-use-jump-host
 - name: openshift-clusterrolebindings
   resources:
     requests:
@@ -129,6 +131,7 @@ integrations:
     limits:
       memory: 400Mi
       cpu: 250m
+  extraArgs: --no-use-jump-host
   logs: true
 - name: openshift-rolebindings
   resources:
@@ -138,6 +141,7 @@ integrations:
     limits:
       memory: 400Mi
       cpu: 300m
+  extraArgs: --no-use-jump-host
   logs: true
 - name: openshift-network-policies
   resources:
@@ -147,6 +151,7 @@ integrations:
     limits:
       memory: 400Mi
       cpu: 200m
+  extraArgs: --no-use-jump-host
   logs: true
 - name: openshift-acme
   resources:
@@ -156,6 +161,7 @@ integrations:
     limits:
       memory: 400Mi
       cpu: 200m
+  extraArgs: --no-use-jump-host
   logs: true
 - name: openshift-limitranges
   resources:
@@ -165,6 +171,7 @@ integrations:
     limits:
       memory: 100Mi
       cpu: 150m
+  extraArgs: --no-use-jump-host
 - name: openshift-resources
   resources:
     requests:
@@ -173,7 +180,7 @@ integrations:
     limits:
       memory: 800Mi
       cpu: 1000m
-  extraArgs: --external
+  extraArgs: --external --no-use-jump-host
 - name: openshift-serviceaccount-tokens
   resources:
     requests:
@@ -182,7 +189,7 @@ integrations:
     limits:
       memory: 600Mi
       cpu: 200m
-  extraArgs: --vault-output-path app-sre/integrations-output
+  extraArgs: --no-use-jump-host --vault-output-path app-sre/integrations-output
 - name: terraform-resources
   resources:
     requests:
@@ -191,7 +198,7 @@ integrations:
     limits:
       memory: 1000Mi
       cpu: 400m
-  extraArgs: --external --vault-output-path app-sre/integrations-output
+  extraArgs: --external --no-use-jump-host--vault-output-path app-sre/integrations-output
   logs: true
 - name: terraform-users
   resources:

--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -198,7 +198,7 @@ integrations:
     limits:
       memory: 1000Mi
       cpu: 400m
-  extraArgs: --external --no-use-jump-host--vault-output-path app-sre/integrations-output
+  extraArgs: --external --no-use-jump-host --vault-output-path app-sre/integrations-output
   logs: true
 - name: terraform-users
   resources:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -953,7 +953,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-users
           - name: INTEGRATION_EXTRA_ARGS
-            value: ""
+            value: "--no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1077,7 +1077,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-groups
           - name: INTEGRATION_EXTRA_ARGS
-            value: ""
+            value: "--no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1145,7 +1145,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-namespaces
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--external"
+            value: "--external --no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1247,7 +1247,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-clusterrolebindings
           - name: INTEGRATION_EXTRA_ARGS
-            value: ""
+            value: "--no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1371,7 +1371,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-rolebindings
           - name: INTEGRATION_EXTRA_ARGS
-            value: ""
+            value: "--no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1495,7 +1495,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-network-policies
           - name: INTEGRATION_EXTRA_ARGS
-            value: ""
+            value: "--no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1619,7 +1619,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-acme
           - name: INTEGRATION_EXTRA_ARGS
-            value: ""
+            value: "--no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1687,7 +1687,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-limitranges
           - name: INTEGRATION_EXTRA_ARGS
-            value: ""
+            value: "--no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1733,7 +1733,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-resources
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--external"
+            value: "--external --no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1779,7 +1779,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-serviceaccount-tokens
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--vault-output-path app-sre/integrations-output"
+            value: "--no-use-jump-host --vault-output-path app-sre/integrations-output"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1881,7 +1881,7 @@ objects:
           - name: INTEGRATION_NAME
             value: terraform-resources
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--external --vault-output-path app-sre/integrations-output"
+            value: "--external --no-use-jump-host--vault-output-path app-sre/integrations-output"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -21,8 +21,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -67,8 +65,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -113,8 +109,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -237,8 +231,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -361,8 +353,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -485,8 +475,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -609,8 +597,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -733,8 +719,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -784,8 +768,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -835,8 +817,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -886,8 +866,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -1010,8 +988,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -1134,8 +1110,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -1180,8 +1154,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -1304,8 +1276,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -1428,8 +1398,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -1552,8 +1520,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -1676,8 +1642,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -1722,8 +1686,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -1768,8 +1730,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -1814,8 +1774,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -1881,7 +1839,7 @@ objects:
           - name: INTEGRATION_NAME
             value: terraform-resources
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--external --no-use-jump-host--vault-output-path app-sre/integrations-output"
+            value: "--external --no-use-jump-host --vault-output-path app-sre/integrations-output"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1938,8 +1896,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -2062,8 +2018,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -2108,8 +2062,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -2154,8 +2106,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -2200,8 +2150,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -2331,8 +2279,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -2455,8 +2401,6 @@ objects:
         labels:
           app: qontract-reconcile
       spec:
-        securityContext:
-          runAsUser: ${{USER_ID}}
         initContainers:
         - name: config
           image: quay.io/app-sre/busybox
@@ -2583,8 +2527,6 @@ parameters:
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT
   value: app-sre
-- name: USER_ID
-  value: "1000720000"
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -2527,6 +2527,8 @@ parameters:
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT
   value: app-sre
+- name: USER_ID
+  value: dummy
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -116,6 +116,16 @@ def internal(**kwargs):
     return f
 
 
+def use_jump_host(**kwargs):
+    def f(function):
+        help_msg = 'use jump host if defined.'
+        function = click.option('--use-jump-host/--no-use-jump-host',
+                                help=help_msg,
+                                default=True)(function)
+        return function
+    return f
+
+
 def terraform(function):
     function = click.option('--print-only/--no-print-only',
                             help='only print the terraform config file.',
@@ -258,53 +268,60 @@ def github_scanner(ctx, gitlab_project_id, thread_pool_size):
 @threaded()
 @binary(['oc', 'ssh'])
 @internal()
+@use_jump_host()
 @click.pass_context
-def openshift_clusterrolebindings(ctx, thread_pool_size, internal):
+def openshift_clusterrolebindings(ctx, thread_pool_size, internal,
+                                  use_jump_host):
     run_integration(reconcile.openshift_clusterrolebindings.run,
-                    ctx.obj['dry_run'], thread_pool_size, internal)
+                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    use_jump_host)
 
 
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
 @internal()
+@use_jump_host()
 @click.pass_context
-def openshift_rolebindings(ctx, thread_pool_size, internal):
+def openshift_rolebindings(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.openshift_rolebindings.run, ctx.obj['dry_run'],
-                    thread_pool_size, internal)
+                    thread_pool_size, internal, use_jump_host)
 
 
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
 @internal()
+@use_jump_host()
 @click.pass_context
-def openshift_groups(ctx, thread_pool_size, internal):
+def openshift_groups(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.openshift_groups.run, ctx.obj['dry_run'],
-                    thread_pool_size, internal)
+                    thread_pool_size, internal, use_jump_host)
 
 
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
 @internal()
+@use_jump_host()
 @click.pass_context
-def openshift_users(ctx, thread_pool_size, internal):
+def openshift_users(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.openshift_users.run, ctx.obj['dry_run'],
-                    thread_pool_size, internal)
+                    thread_pool_size, internal, use_jump_host)
 
 
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
 @internal()
+@use_jump_host()
 @vault_output_path
 @click.pass_context
 def openshift_serviceaccount_tokens(ctx, thread_pool_size, internal,
-                                    vault_output_path):
+                                    use_jump_host, vault_output_path):
     run_integration(reconcile.openshift_serviceaccount_tokens.run,
                     ctx.obj['dry_run'], thread_pool_size, internal,
-                    vault_output_path)
+                    use_jump_host, vault_output_path)
 
 
 @integration.command()
@@ -416,10 +433,12 @@ def aws_support_cases_sos(ctx, gitlab_project_id, thread_pool_size):
 @threaded(default=20)
 @binary(['oc', 'ssh'])
 @internal()
+@use_jump_host()
 @click.pass_context
-def openshift_resources(ctx, thread_pool_size, internal):
+def openshift_resources(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.openshift_resources.run,
-                    ctx.obj['dry_run'], thread_pool_size, internal)
+                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    use_jump_host)
 
 
 @integration.command()
@@ -450,30 +469,36 @@ def owner_approvals(ctx, gitlab_project_id, gitlab_merge_request_id,
 @threaded()
 @binary(['oc', 'ssh'])
 @internal()
+@use_jump_host()
 @click.pass_context
-def openshift_namespaces(ctx, thread_pool_size, internal):
+def openshift_namespaces(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.openshift_namespaces.run,
-                    ctx.obj['dry_run'], thread_pool_size, internal)
+                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    use_jump_host)
 
 
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
 @internal()
+@use_jump_host()
 @click.pass_context
-def openshift_network_policies(ctx, thread_pool_size, internal):
+def openshift_network_policies(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.openshift_network_policies.run,
-                    ctx.obj['dry_run'], thread_pool_size, internal)
+                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    use_jump_host)
 
 
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
 @internal()
+@use_jump_host()
 @click.pass_context
-def openshift_acme(ctx, thread_pool_size, internal):
+def openshift_acme(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.openshift_acme.run,
-                    ctx.obj['dry_run'], thread_pool_size, internal)
+                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    use_jump_host)
 
 
 @integration.command()
@@ -481,10 +506,13 @@ def openshift_acme(ctx, thread_pool_size, internal):
 @take_over()
 @binary(['oc', 'ssh'])
 @internal()
+@use_jump_host()
 @click.pass_context
-def openshift_limitranges(ctx, thread_pool_size, internal, take_over):
+def openshift_limitranges(ctx, thread_pool_size, internal,
+                          use_jump_host, take_over):
     run_integration(reconcile.openshift_limitranges.run,
-                    ctx.obj['dry_run'], thread_pool_size, internal, take_over)
+                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    use_jump_host, take_over)
 
 
 @integration.command()
@@ -522,18 +550,19 @@ def ldap_users(ctx, gitlab_project_id, thread_pool_size):
 @threaded(default=20)
 @binary(['terraform', 'oc'])
 @internal()
+@use_jump_host()
 @enable_deletion(default=False)
 @click.option('--light/--full',
               default=False,
               help='run without executing terraform plan and apply.')
 @click.pass_context
 def terraform_resources(ctx, print_only, enable_deletion,
-                        io_dir, thread_pool_size, internal, light,
-                        vault_output_path):
+                        io_dir, thread_pool_size, internal, use_jump_host,
+                        light, vault_output_path):
     run_integration(reconcile.terraform_resources.run,
                     ctx.obj['dry_run'], print_only,
                     enable_deletion, io_dir, thread_pool_size,
-                    internal, light, vault_output_path)
+                    internal, use_jump_host, light, vault_output_path)
 
 
 @integration.command()

--- a/reconcile/openshift_acme.py
+++ b/reconcile/openshift_acme.py
@@ -117,7 +117,8 @@ def add_desired_state(namespaces, ri, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
+def run(dry_run=False, thread_pool_size=10, internal=None,
+        use_jump_host=True, defer=None):
     namespaces = [namespace_info for namespace_info
                   in queries.get_namespaces()
                   if namespace_info.get('openshiftAcme')]
@@ -135,7 +136,8 @@ def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
             'RoleBinding',
             'ServiceAccount',
             'Secret'],
-        internal=internal)
+        internal=internal,
+        use_jump_host=use_jump_host)
     add_desired_state(namespaces, ri, oc_map)
 
     defer(lambda: oc_map.cleanup())

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -149,14 +149,16 @@ def fetch_current_state(namespaces=None,
                         integration=None,
                         integration_version=None,
                         override_managed_types=None,
-                        internal=None):
+                        internal=None,
+                        use_jump_host=True):
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces,
                     clusters=clusters,
                     integration=integration,
                     settings=settings,
-                    internal=internal)
+                    internal=internal,
+                    use_jump_host=use_jump_host)
     state_specs = \
         init_specs_to_fetch(
             ri,

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -159,7 +159,8 @@ def fetch_desired_state(ri, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
+def run(dry_run=False, thread_pool_size=10, internal=None,
+        use_jump_host=True, defer=None):
     clusters = [cluster_info for cluster_info
                 in queries.get_clusters()
                 if cluster_info.get('managedClusterRoles')]
@@ -169,7 +170,8 @@ def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
         integration=QONTRACT_INTEGRATION,
         integration_version=QONTRACT_INTEGRATION_VERSION,
         override_managed_types=['ClusterRoleBinding'],
-        internal=internal)
+        internal=internal,
+        use_jump_host=use_jump_host)
     defer(lambda: oc_map.cleanup())
     fetch_desired_state(ri, oc_map)
     ob.realize_data(dry_run, oc_map, ri)

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -74,13 +74,14 @@ def create_groups_list(clusters, oc_map):
     return groups_list
 
 
-def fetch_current_state(thread_pool_size, internal):
+def fetch_current_state(thread_pool_size, internal, use_jump_host):
     clusters = queries.get_clusters()
     clusters = [c for c in clusters if c.get('ocm') is None]
     current_state = []
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(clusters=clusters, integration=QONTRACT_INTEGRATION,
-                    settings=settings, internal=internal)
+                    settings=settings, internal=internal,
+                    use_jump_host=use_jump_host)
 
     groups_list = create_groups_list(clusters, oc_map)
     results = threaded.run(get_cluster_state, groups_list, thread_pool_size,
@@ -217,8 +218,10 @@ def act(diff, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
-    oc_map, current_state = fetch_current_state(thread_pool_size, internal)
+def run(dry_run=False, thread_pool_size=10, internal=None,
+        use_jump_host=True, defer=None):
+    oc_map, current_state = \
+        fetch_current_state(thread_pool_size, internal, use_jump_host)
     defer(lambda: oc_map.cleanup())
     desired_state = fetch_desired_state(oc_map)
 

--- a/reconcile/openshift_limitranges.py
+++ b/reconcile/openshift_limitranges.py
@@ -83,7 +83,7 @@ def add_desired_state(namespaces, ri, oc_map):
 
 @defer
 def run(dry_run=False, thread_pool_size=10, internal=None,
-        take_over=True, defer=None):
+        use_jump_host=True, take_over=True, defer=None):
     namespaces = [namespace_info for namespace_info
                   in queries.get_namespaces()
                   if namespace_info.get('limitRanges')]
@@ -100,7 +100,8 @@ def run(dry_run=False, thread_pool_size=10, internal=None,
         integration=QONTRACT_INTEGRATION,
         integration_version=QONTRACT_INTEGRATION_VERSION,
         override_managed_types=['LimitRange'],
-        internal=internal)
+        internal=internal,
+        use_jump_host=use_jump_host)
     defer(lambda: oc_map.cleanup())
 
     add_desired_state(namespaces, ri, oc_map)

--- a/reconcile/openshift_namespaces.py
+++ b/reconcile/openshift_namespaces.py
@@ -45,13 +45,14 @@ QUERY = """
 QONTRACT_INTEGRATION = 'openshift-namespaces'
 
 
-def get_desired_state(internal):
+def get_desired_state(internal, use_jump_host):
     gqlapi = gql.get_api()
     namespaces = gqlapi.query(QUERY)['namespaces']
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces, integration=QONTRACT_INTEGRATION,
-                    settings=settings, internal=internal)
+                    settings=settings, internal=internal,
+                    use_jump_host=use_jump_host)
     ob.init_specs_to_fetch(
         ri,
         oc_map,
@@ -92,8 +93,9 @@ def create_new_project(spec, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
-    oc_map, desired_state = get_desired_state(internal)
+def run(dry_run=False, thread_pool_size=10, internal=None,
+        use_jump_host=True, defer=None):
+    oc_map, desired_state = get_desired_state(internal, use_jump_host)
     defer(lambda: oc_map.cleanup())
     results = threaded.run(check_ns_exists, desired_state, thread_pool_size,
                            oc_map=oc_map)

--- a/reconcile/openshift_network_policies.py
+++ b/reconcile/openshift_network_policies.py
@@ -106,7 +106,8 @@ def fetch_desired_state(namespaces, ri, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
+def run(dry_run=False, thread_pool_size=10, internal=None,
+        use_jump_host=True, defer=None):
     gqlapi = gql.get_api()
     namespaces = [namespace_info for namespace_info
                   in gqlapi.query(NAMESPACES_QUERY)['namespaces']
@@ -117,7 +118,8 @@ def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
         integration=QONTRACT_INTEGRATION,
         integration_version=QONTRACT_INTEGRATION_VERSION,
         override_managed_types=['NetworkPolicy'],
-        internal=internal)
+        internal=internal,
+        use_jump_host=use_jump_host)
     defer(lambda: oc_map.cleanup())
     fetch_desired_state(namespaces, ri, oc_map)
     ob.realize_data(dry_run, oc_map, ri)

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -485,11 +485,12 @@ def fetch_states(spec, ri):
         logging.error(msg)
 
 
-def fetch_data(namespaces, thread_pool_size, internal):
+def fetch_data(namespaces, thread_pool_size, internal, use_jump_host):
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces, integration=QONTRACT_INTEGRATION,
-                    settings=settings, internal=internal)
+                    settings=settings, internal=internal,
+                    use_jump_host=use_jump_host)
     state_specs = ob.init_specs_to_fetch(ri, oc_map, namespaces=namespaces)
     threaded.run(fetch_states, state_specs, thread_pool_size, ri=ri)
 
@@ -497,10 +498,12 @@ def fetch_data(namespaces, thread_pool_size, internal):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
+def run(dry_run=False, thread_pool_size=10, internal=None,
+        use_jump_host=True, defer=None):
     gqlapi = gql.get_api()
     namespaces = gqlapi.query(NAMESPACES_QUERY)['namespaces']
-    oc_map, ri = fetch_data(namespaces, thread_pool_size, internal)
+    oc_map, ri = \
+        fetch_data(namespaces, thread_pool_size, internal, use_jump_host)
     defer(lambda: oc_map.cleanup())
 
     # check for unused resources types

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -158,7 +158,8 @@ def fetch_desired_state(ri, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
+def run(dry_run=False, thread_pool_size=10, internal=None,
+        use_jump_host=True, defer=None):
     namespaces = [namespace_info for namespace_info
                   in queries.get_namespaces()
                   if namespace_info.get('managedRoles')]
@@ -168,7 +169,8 @@ def run(dry_run=False, thread_pool_size=10, internal=None, defer=None):
         integration=QONTRACT_INTEGRATION,
         integration_version=QONTRACT_INTEGRATION_VERSION,
         override_managed_types=['RoleBinding'],
-        internal=internal)
+        internal=internal,
+        use_jump_host=use_jump_host)
     defer(lambda: oc_map.cleanup())
     fetch_desired_state(ri, oc_map)
     ob.realize_data(dry_run, oc_map, ri)

--- a/reconcile/openshift_serviceaccount_tokens.py
+++ b/reconcile/openshift_serviceaccount_tokens.py
@@ -67,7 +67,7 @@ def write_outputs_to_vault(vault_path, ri):
 
 @defer
 def run(dry_run=False, thread_pool_size=10, internal=None,
-        vault_output_path='', defer=None):
+        use_jump_host=True, vault_output_path='', defer=None):
     namespaces = [namespace_info for namespace_info
                   in queries.get_namespaces()
                   if namespace_info.get('openshiftServiceAccountTokens')]
@@ -83,7 +83,8 @@ def run(dry_run=False, thread_pool_size=10, internal=None,
         integration=QONTRACT_INTEGRATION,
         integration_version=QONTRACT_INTEGRATION_VERSION,
         override_managed_types=['Secret'],
-        internal=internal)
+        internal=internal,
+        use_jump_host=use_jump_host)
     defer(lambda: oc_map.cleanup())
     fetch_desired_state(namespaces, ri, oc_map)
     ob.realize_data(dry_run, oc_map, ri)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -146,11 +146,12 @@ def populate_oc_resources(spec, ri):
         logging.error(msg)
 
 
-def fetch_current_state(namespaces, thread_pool_size, internal):
+def fetch_current_state(namespaces, thread_pool_size, internal, use_jump_host):
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces, integration=QONTRACT_INTEGRATION,
-                    settings=settings, internal=internal)
+                    settings=settings, internal=internal,
+                    use_jump_host=use_jump_host)
     state_specs = \
         ob.init_specs_to_fetch(
             ri,
@@ -175,14 +176,15 @@ def init_working_dirs(accounts, thread_pool_size,
     return ts, working_dirs
 
 
-def setup(print_only, thread_pool_size, internal):
+def setup(print_only, thread_pool_size, internal, use_jump_host):
     gqlapi = gql.get_api()
     accounts = queries.get_aws_accounts()
     settings = queries.get_app_interface_settings()
     namespaces = gqlapi.query(TF_NAMESPACES_QUERY)['namespaces']
     tf_namespaces = [namespace_info for namespace_info in namespaces
                      if namespace_info.get('managedTerraformResources')]
-    ri, oc_map = fetch_current_state(tf_namespaces, thread_pool_size, internal)
+    ri, oc_map = fetch_current_state(tf_namespaces, thread_pool_size,
+                                     internal, use_jump_host)
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size,
                                          print_only=print_only,
                                          oc_map=oc_map,
@@ -221,9 +223,10 @@ def write_outputs_to_vault(vault_path, ri):
 @defer
 def run(dry_run=False, print_only=False,
         enable_deletion=False, io_dir='throughput/',
-        thread_pool_size=10, internal=None, light=False,
-        vault_output_path='', defer=None):
-    ri, oc_map, tf = setup(print_only, thread_pool_size, internal)
+        thread_pool_size=10, internal=None, use_jump_host=True,
+        light=False, vault_output_path='', defer=None):
+    ri, oc_map, tf = \
+        setup(print_only, thread_pool_size, internal, use_jump_host)
     defer(lambda: oc_map.cleanup())
     if print_only:
         cleanup_and_exit()

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -311,12 +311,13 @@ class OC_Map(object):
     """
     def __init__(self, clusters=None, namespaces=None,
                  integration='', e2e_test='', settings=None,
-                 internal=None):
+                 internal=None, use_jump_host=True):
         self.oc_map = {}
         self.calling_integration = integration
         self.calling_e2e_test = e2e_test
         self.settings = settings
         self.internal = internal
+        self.use_jump_host = use_jump_host
 
         if clusters and namespaces:
             raise KeyError('expected only one of clusters or namespaces.')
@@ -350,7 +351,10 @@ class OC_Map(object):
         else:
             server_url = cluster_info['serverUrl']
             token = secret_reader.read(automation_token, self.settings)
-            jump_host = cluster_info.get('jumpHost')
+            if self.use_jump_host:
+                jump_host = cluster_info.get('jumpHost')
+            else:
+                jump_host = None
             self.oc_map[cluster] = OC(server_url, token, jump_host,
                                       settings=self.settings)
 


### PR DESCRIPTION
The OpenShift integrations are using a jump host to be able to reach private clusters.

In case the integrations are running in an environment with access to those clusters (by VPC peering for example), using the jump host is not required.

This PR adds a `--use-jump-host/--no-use-jump-host` option (defaults to True - use a jump host).

Since our jump host implementation relies on SSH, and to use SSH in a container in OpenShift a valid user must exist, this PR removes the need to have such user(s), hence the Dockerfile change.

This just may work!