### PR TITLE
Add 'roles' CLI command

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -399,6 +399,58 @@ USERS_QUERY = """
 """
 
 
+ROLES_QUERY = """
+{
+  users: users_v1 {
+    name
+    org_username
+    labels
+    roles {
+      name
+      path
+      permissions {
+        name
+        path
+        service
+        ... on PermissionGithubOrgTeam_v1 {
+          org
+          team
+        }
+        ... on PermissionQuayOrgTeam_v1 {
+          org
+          team
+        }
+      } access {
+        cluster {
+          name
+          path
+        }
+        clusterRole
+        namespace {
+          name
+        }
+        role
+      } aws_groups {
+        name
+        path
+        account {
+          name
+        }
+        policies
+      } owned_saas_files {
+        name
+      }
+    }
+  }
+}
+"""
+
+
+def get_roles():
+    gqlapi = gql.get_api()
+    return gqlapi.query(ROLES_QUERY)['users']
+
+
 def get_users():
     """ Returnes all Users. """
     gqlapi = gql.get_api()


### PR DESCRIPTION
This will print a table of a user's roles.  The listing is not complete,
but the function can be easily added to to include more access
integrations.

Example invocation:

qontract-cli --config config.toml get roles klape