### PR TITLE
Listing all members

### DIFF
--- a/reconcile/gitlab_fork_compliance.py
+++ b/reconcile/gitlab_fork_compliance.py
@@ -58,8 +58,9 @@ class GitlabForkCompliance:
         # who are not
         group = self.gl_cli.gl.groups.get(self.maintainers_group)
         maintainers = group.members.list()
+        project_members = self.src.project.members.all(all=True)
         for member in maintainers:
-            if member in self.src.project.members.list():
+            if member in project_members:
                 continue
             LOG.info([f'adding {member.username} as maintainer'])
             user_payload = {'user_id': member.id,


### PR DESCRIPTION
Fixing the issue with members of the source project not being listed.

Yep, we have to call `all()` and pass `all=True` to it:

https://github.com/python-gitlab/python-gitlab/blob/master/gitlab/v4/objects.py#L1094-L1098

Signed-off-by: Amador Pahim <apahim@redhat.com>