### PR TITLE
[owner-approval] change file ownership

### DIFF
--- a/reconcile/owner_approvals.py
+++ b/reconcile/owner_approvals.py
@@ -3,6 +3,8 @@ import json
 import copy
 
 import reconcile.queries as queries
+import utils.throughput as throughput
+
 from utils.gitlab_api import GitLabApi
 
 
@@ -74,6 +76,7 @@ def write_baseline_to_file(io_dir, baseline):
     file_path = get_baseline_file_path(io_dir)
     with open(file_path, 'w') as f:
         f.write(json.dumps(baseline))
+    throughput.change_files_ownership(io_dir)
 
 
 def read_baseline_from_file(io_dir):

--- a/utils/jjb_client.py
+++ b/utils/jjb_client.py
@@ -7,8 +7,10 @@ import filecmp
 import subprocess
 import difflib
 import xml.etree.ElementTree as et
+
 import utils.secret_reader as secret_reader
 import utils.gql as gql
+import utils.throughput as throughput
 
 from os import path
 from contextlib import contextmanager
@@ -117,20 +119,10 @@ class JJB(object):
                     '-o', output_dir,
                     '--config-xml']
             self.execute(args)
-            self.change_files_ownership(io_dir)
+            throughput.change_files_ownership(io_dir)
 
         if compare:
             self.print_diffs(io_dir)
-
-    def change_files_ownership(self, io_dir):
-        stat_info = os.stat(io_dir)
-        uid = stat_info.st_uid
-        gid = stat_info.st_gid
-        for root, dirs, files in os.walk(io_dir):
-            for d in dirs:
-                os.chown(path.join(root, d), uid, gid)
-            for f in files:
-                os.chown(path.join(root, f), uid, gid)
 
     def print_diffs(self, io_dir):
         current_path = path.join(io_dir, 'jjb', 'current')

--- a/utils/throughput.py
+++ b/utils/throughput.py
@@ -7,6 +7,6 @@ def change_files_ownership(directory):
     gid = stat_info.st_gid
     for root, dirs, files in os.walk(directory):
         for d in dirs:
-            os.chown(path.join(root, d), uid, gid)
+            os.chown(os.path.join(root, d), uid, gid)
         for f in files:
-            os.chown(path.join(root, f), uid, gid)
+            os.chown(os.path.join(root, f), uid, gid)

--- a/utils/throughput.py
+++ b/utils/throughput.py
@@ -1,0 +1,12 @@
+import os
+
+
+def change_files_ownership(directory):
+    stat_info = os.stat(directory)
+    uid = stat_info.st_uid
+    gid = stat_info.st_gid
+    for root, dirs, files in os.walk(directory):
+        for d in dirs:
+            os.chown(path.join(root, d), uid, gid)
+        for f in files:
+            os.chown(path.join(root, f), uid, gid)


### PR DESCRIPTION
covers https://issues.redhat.com/browse/APPSRE-1643

We're seeing app-interface jenkins jobs failing with the following error:
https://ci-int-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/service-app-interface-gl-pr-check/9931/console

This is caused by the owner-approval integration, which is executed twice and uses a file on the file system to send information from the first iteration to the second iteration.

The file ownership should be changed so it can be deleted.