### PR TITLE
[vault_client] retry read

### DIFF
--- a/utils/vault_client.py
+++ b/utils/vault_client.py
@@ -2,6 +2,9 @@ import time
 import requests
 import hvac
 import base64
+
+from sretoolbox.utils import retry
+
 from utils.config import get_config
 
 _client = None
@@ -54,6 +57,7 @@ def init_from_config():
     return init(server, role_id, secret_id)
 
 
+@retry()
 def read(secret):
     """Returns a value of a key in a Vault secret.
 
@@ -94,6 +98,7 @@ def write(secret):
         _write_v2(secret_path, data)
 
 
+@retry()
 def read_all(secret):
     """Returns a dictionary of keys and values in a Vault secret.
 


### PR DESCRIPTION
in most cases, vault_client is used via secret_reader, which already uses `retry`.

openshift-resources uses vault_client directly when trying to fetch secrets of provider `vault-secret`.

this PR adds `retry` to vault_client read functions for better resiliency.