### PR TITLE
[terraform-resources] add support for cloudwatch log groups

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -97,6 +97,13 @@ TF_NAMESPACES_QUERY = """
         output_resource_name
         storage_class
       }
+      ... on NamespaceTerraformResourceCloudWatch_v1 {
+        account
+        region
+        identifier
+        defaults
+        output_resource_name
+      }
     }
     cluster {
       name

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -1291,7 +1291,7 @@ class TerrascriptClient(object):
             "Statement": [
                 {
                     "Action": [
-                        "logs:CreateLogStream"
+                        "logs:CreateLogStream",
                         "logs:PutLogEvents"
                     ],
                     "Effect": "Allow",

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -1291,10 +1291,8 @@ class TerrascriptClient(object):
             "Statement": [
                 {
                     "Action": [
-                        "logs:CreateLogStream",
-                        "logs:DescribeLogStreams",
-                        "logs:PutLogEvents",
-                        "logs:GetLogEvents"
+                        "logs:CreateLogStream"
+                        "logs:PutLogEvents"
                     ],
                     "Effect": "Allow",
                     "Resource":
@@ -1324,7 +1322,7 @@ class TerrascriptClient(object):
         retention_in_days = \
             values.get('retention_in_days') or default_retention_in_days
         if retention_in_days not in allowed_retention_in_days:
-            logging.warning(
+            logging.error(
                 f"[{account}] log group {identifier} " +
                 f"retention_in_days '{retention_in_days}' " +
                 f"must be one of {allowed_retention_in_days}. " +

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -1251,7 +1251,9 @@ class TerrascriptClient(object):
         values = {
             'name': identifier,
             'tags': common_values['tags'],
-            'retention_in_days': self._get_retention_in_days(common_values)
+            'retention_in_days':
+                self._get_retention_in_days(
+                    common_values, account, identifier)
         }
 
         region = common_values['region'] or self.default_regions.get(account)
@@ -1285,17 +1287,18 @@ class TerrascriptClient(object):
 
         # iam user policy for log group
         policy = {
-            "Version":"2012-10-17",
-            "Statement":[
+            "Version": "2012-10-17",
+            "Statement": [
                 {
-                "Action": [
-                    "logs:CreateLogStream",
-                    "logs:DescribeLogStreams",
-                    "logs:PutLogEvents",
-                    "logs:GetLogEvents"
-                ],
-                "Effect": "Allow",
-                "Resource": "${" + log_group_tf_resource.fullname + ".arn}:*"
+                    "Action": [
+                        "logs:CreateLogStream",
+                        "logs:DescribeLogStreams",
+                        "logs:PutLogEvents",
+                        "logs:GetLogEvents"
+                    ],
+                    "Effect": "Allow",
+                    "Resource":
+                        "${" + log_group_tf_resource.fullname + ".arn}:*"
                 }
             ]
         }
@@ -1312,7 +1315,7 @@ class TerrascriptClient(object):
             self.add_resource(account, tf_resource)
 
     @staticmethod
-    def _get_retention_in_days(values):
+    def _get_retention_in_days(values, account, identifier):
         default_retention_in_days = 14
         allowed_retention_in_days = \
             [1, 3, 5, 7, 14, 30, 60, 90, 120, 150,


### PR DESCRIPTION
Covers https://issues.redhat.com/browse/APPSRE-1614

This PR adds support in terraform-resorces for a new provider: `cloudwatch`.

This provider will add:
- CloudWatch log group
- IAM user (+access key)
- IAM user policy (to allow log group access)

Matching app-interface MR: https://gitlab.cee.redhat.com/service/app-interface/merge_requests/3786