### PR TITLE
[openshift-groups] don't delete groups

### DIFF
--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -212,7 +212,7 @@ def act(diff, oc_map):
     elif action == "del_user_from_group":
         oc.del_user_from_group(group, user)
     elif action == "delete_group":
-        oc.delete_group(group)
+        logging.debug('skipping group deletion')
     else:
         raise Exception("invalid action: {}".format(action))
 


### PR DESCRIPTION
most of the groups we manage are either built-in (dedicated-admins/dedicated-readers) or are created by external resources (operators).

it's usually not the right move to delete groups (we've never really had to delete a group).

disabling this option for now, we can re-evaluate again later.

cc @jmelis 