### PR TITLE
Check status code of members response

### DIFF
--- a/utils/quay_api.py
+++ b/utils/quay_api.py
@@ -29,6 +29,9 @@ class QuayApi(object):
             self.API_URL, self.organization, self.team)
 
         r = requests.get(url, headers=self.auth_header)
+        if not r.ok:
+            raise RequestsException(r)
+
         body = r.json()
 
         # Using a set because members may be repeated


### PR DESCRIPTION
This avoids hitting a KeyError when iterating over members if the quay team does not yet exist:

```
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/quay_membership.py", line 163, in run
    current_state = fetch_current_state(quay_api_store)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/quay_membership.py", line 56, in fetch_current_state
    members = quay_api.list_team_members()
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/utils/quay_api.py", line 36, in list_team_members
    for member in body[u'members']:
KeyError: 'members'
```

Instead the 404 response from quay should clue us in to what went wrong.