### PR TITLE
rename cloudwatch log stream from pod name to integration name

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -50,10 +50,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           {{- end }}
           command: ["/bin/sh", "-c"]
           args:
@@ -95,7 +91,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name {{ $integration.name }}
                 auto_create_stream true
               </store>
               {{- end }}

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -134,10 +134,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -175,7 +171,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name github
                 auto_create_stream true
               </store>
             </match>
@@ -290,10 +286,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -331,7 +323,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name github-repo-invites
                 auto_create_stream true
               </store>
             </match>
@@ -446,10 +438,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -487,7 +475,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name quay-membership
                 auto_create_stream true
               </store>
             </match>
@@ -646,10 +634,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -687,7 +671,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name quay-repos
                 auto_create_stream true
               </store>
             </match>
@@ -993,10 +977,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -1034,7 +1014,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name openshift-users
                 auto_create_stream true
               </store>
             </match>
@@ -1149,10 +1129,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -1190,7 +1166,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name openshift-groups
                 auto_create_stream true
               </store>
             </match>
@@ -1349,10 +1325,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -1390,7 +1362,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name openshift-clusterrolebindings
                 auto_create_stream true
               </store>
             </match>
@@ -1505,10 +1477,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -1546,7 +1514,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name openshift-rolebindings
                 auto_create_stream true
               </store>
             </match>
@@ -1661,10 +1629,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -1702,7 +1666,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name openshift-network-policies
                 auto_create_stream true
               </store>
             </match>
@@ -1817,10 +1781,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -1858,7 +1818,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name openshift-acme
                 auto_create_stream true
               </store>
             </match>
@@ -2105,10 +2065,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -2146,7 +2102,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name terraform-resources
                 auto_create_stream true
               </store>
             </match>
@@ -2261,10 +2217,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -2302,7 +2254,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name terraform-users
                 auto_create_stream true
               </store>
             </match>
@@ -2593,10 +2545,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -2634,7 +2582,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name email-sender
                 auto_create_stream true
               </store>
             </match>
@@ -2756,10 +2704,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -2797,7 +2741,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name sentry-config
                 auto_create_stream true
               </store>
             </match>
@@ -2912,10 +2856,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -2953,7 +2893,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
+                log_stream_name sql-query
                 auto_create_stream true
               </store>
             </match>
@@ -2991,162 +2931,6 @@ objects:
             requests:
               cpu: 25m
               memory: 100Mi
-          volumeMounts:
-          - name: qontract-reconcile-toml
-            mountPath: /config
-          - name: logs
-            mountPath: /fluentd/log/
-        - name: fluentd
-          image: quay.io/app-sre/fluentd:latest
-          env:
-          - name: AWS_REGION
-            valueFrom:
-              secretKeyRef:
-                name: ${CLOUDWATCH_SECRET}
-                key: aws_region
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: ${CLOUDWATCH_SECRET}
-                key: aws_access_key_id
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: ${CLOUDWATCH_SECRET}
-                key: aws_secret_access_key
-          resources:
-            requests:
-              memory: 30Mi
-              cpu: 15m
-            limits:
-              memory: 120Mi
-              cpu: 25m
-          volumeMounts:
-          - name: logs
-            mountPath: /fluentd/log/
-          - name: fluentd-config
-            mountPath: /fluentd/etc/
-        volumes:
-        - name: qontract-reconcile-toml
-          secret:
-            secretName: qontract-reconcile-toml
-        - name: logs
-          emptyDir: {}
-        - name: fluentd-config
-          emptyDir: {}
-- apiVersion: extensions/v1beta1
-  kind: Deployment
-  metadata:
-    labels:
-      app: qontract-reconcile
-    name: qontract-reconcile-openshift-performance-parameters
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: qontract-reconcile
-    template:
-      metadata:
-        labels:
-          app: qontract-reconcile
-      spec:
-        initContainers:
-        - name: config
-          image: quay.io/app-sre/busybox
-          resources:
-            requests:
-              memory: 10Mi
-              cpu: 15m
-            limits:
-              memory: 20Mi
-              cpu: 25m
-          env:
-          - name: SLACK_WEBHOOK_URL
-            valueFrom:
-              secretKeyRef:
-                key: slack.webhook_url
-                name: app-interface
-          - name: SLACK_CHANNEL
-            value: ${SLACK_CHANNEL}
-          - name: SLACK_ICON_EMOJI
-            value: ${SLACK_ICON_EMOJI}
-          - name: LOG_GROUP_NAME
-            valueFrom:
-              secretKeyRef:
-                name: ${CLOUDWATCH_SECRET}
-                key: log_group_name
-          - name: LOG_STREAM_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          command: ["/bin/sh", "-c"]
-          args:
-          - |
-            # generate fluent.conf
-            cat > /fluentd/etc/fluent.conf <<EOF
-            <source>
-              @type tail
-              path /fluentd/log/integration.log
-              pos_file /fluentd/log/integration.log.pos
-              tag integration
-              <parse>
-                @type none
-              </parse>
-            </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <match integration>
-              @type copy
-              <store>
-                @type slack
-                webhook_url ${SLACK_WEBHOOK_URL}
-                channel ${SLACK_CHANNEL}
-                icon_emoji ${SLACK_ICON_EMOJI}
-                username sd-app-sre-bot
-                flush_interval 10s
-                message "\`\`\`[openshift-performance-parameters] %s\`\`\`"
-              </store>
-              <store>
-                @type cloudwatch_logs
-                log_group_name ${LOG_GROUP_NAME}
-                log_stream_name ${LOG_STREAM_NAME}
-                auto_create_stream true
-              </store>
-            </match>
-            EOF
-          volumeMounts:
-          - name: fluentd-config
-            mountPath: /fluentd/etc/
-        containers:
-        - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
-          env:
-          - name: DRY_RUN
-            value: ${DRY_RUN}
-          - name: INTEGRATION_NAME
-            value: openshift-performance-parameters
-          - name: INTEGRATION_EXTRA_ARGS
-            value: "--no-use-jump-host"
-          - name: SLEEP_DURATION_SECS
-            value: ${SLEEP_DURATION_SECS}
-          - name: GITHUB_API
-            value: ${GITHUB_API}
-          - name: LOG_FILE
-            value: "${LOG_FILE}"
-          resources:
-            limits:
-              cpu: 200m
-              memory: 400Mi
-            requests:
-              cpu: 100m
-              memory: 300Mi
           volumeMounts:
           - name: qontract-reconcile-toml
             mountPath: /config


### PR DESCRIPTION
one of the objectives of logs is to be able to determine what happened when.

the current state does not allow us to know that, since the names of log streams are the name of pods, and we don't know what pod came before another.

this PR renames the log stream to be the integration name, so we have a single place to view logs by each integration, regardless of which pod made these changes.

cc @BumbleFeng @tparikh 