### PR TITLE
[WIP][openshift-acme] v2 migration

### DIFF
--- a/reconcile/openshift_acme.py
+++ b/reconcile/openshift_acme.py
@@ -14,7 +14,8 @@ from utils.defer import defer
 from utils.openshift_acme import (ACME_DEPLOYMENT,
                                   ACME_ROLE,
                                   ACME_ROLEBINDING,
-                                  ACME_SERVICEACCOUNT)
+                                  ACME_SERVICEACCOUNT,
+                                  ACME_CONFIGMAP)
 
 
 QONTRACT_INTEGRATION = 'openshift-acme'
@@ -82,6 +83,9 @@ def construct_resources(namespaces):
                 'serviceaccount_name': serviceaccount_name,
                 'namespace_name': namespace_name
             })
+        )
+        namespace["resources"].append(
+            process_template(ACME_CONFIGMAP, {})
         )
 
         # If acme-account Secret is defined, add it to the namespace

--- a/utils/openshift_acme.py
+++ b/utils/openshift_acme.py
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: openshift-acme
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: openshift-acme
@@ -21,6 +21,13 @@ spec:
       - image: %(image)s
         imagePullPolicy: Always
         name: openshift-acme
+        resources:
+          limits:	
+            cpu: 50m	
+            memory: 100Mi	
+          requests:	
+            cpu: 5m	
+            memory: 50Mi
         args:
         - --exposer-image=quay.io/tnozicka/openshift-acme:exposer
         - --loglevel=4


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/APPSRE-1678

This PR changes the deployment manifests of openshift-acme to match the v2 changes in the upstream repo.

This will require a change to the default image in app-interface.

Still wondering what will be a good way to perform the migration.