### PR TITLE
[openshift-saas-deploy] add template url to error message

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -273,7 +273,8 @@ def realize_data(dry_run, oc_map, ri,
                       resource_type, d_item)
             except StatusCodeError as e:
                 ri.register_error()
-                msg = "[{}/{}] {}".format(cluster, namespace, str(e))
+                msg = "[{}/{}] {} (error details: {})".format(
+                    cluster, namespace, str(e), d_item.error_details)
                 logging.error(msg)
 
         # current items

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -218,7 +218,7 @@ class SaasHerder():
                             resource,
                             self.integration,
                             self.integration_version,
-                            error_details=resource_name)
+                            error_details=html_url)
                         ri.add_desired(
                             cluster,
                             namespace,


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-1276

this PR adds the html url of a resource to the error details, so that it can be displayed when apply caused an error. this adds quite a bit of traceability.