### PR TITLE
[gql quary] reflect conflict when resource is not found

### DIFF
--- a/utils/gql.py
+++ b/utils/gql.py
@@ -66,7 +66,9 @@ class GqlApi(object):
 
         try:
             resources = self.query(query, {'path': path})['resources']
-        except GqlApiError:
+        except GqlApiError as e:
+            if '409' in str(e):
+                raise e
             raise GqlGetResourceError(
                 path,
                 'Resource not found.')


### PR DESCRIPTION
currently when a resource is not found, it may be a result of a data reload.

this PR helps to reflect that better, while preserving the "resource not found" error.