### PR TITLE
Log stack trace alongside the error message

### DIFF
--- a/reconcile/openshift_acme.py
+++ b/reconcile/openshift_acme.py
@@ -150,9 +150,6 @@ def run(dry_run=False, thread_pool_size=10, internal=None,
 
         ob.realize_data(dry_run, oc_map, ri)
 
-    except Exception as e:
-        msg = 'There was problem running openshift acme reconcile.'
-        msg += ' Exception: {}'
-        msg = msg.format(str(e))
-        logging.error(msg)
+    except Exception:
+        logging.exception('Exception reconciling openshift acme')
         sys.exit(1)

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -237,9 +237,6 @@ def run(dry_run=False, thread_pool_size=10, internal=None,
             if not dry_run:
                 act(diff, oc_map)
 
-    except Exception as e:
-        msg = 'There was problem running openshift groups reconcile.'
-        msg += ' Exception: {}'
-        msg = msg.format(str(e))
-        logging.error(msg)
+    except Exception:
+        logging.exception('Exception reconciling openshift groups.')
         sys.exit(1)

--- a/reconcile/openshift_network_policies.py
+++ b/reconcile/openshift_network_policies.py
@@ -129,9 +129,6 @@ def run(dry_run=False, thread_pool_size=10, internal=None,
         fetch_desired_state(namespaces, ri, oc_map)
         ob.realize_data(dry_run, oc_map, ri)
 
-    except Exception as e:
-        msg = 'There was problem running openshift network policies reconcile.'
-        msg += ' Exception: {}'
-        msg = msg.format(str(e))
-        logging.error(msg)
+    except Exception:
+        logging.exception('Exception reconciling openshift network policies')
         sys.exit(1)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -288,11 +288,8 @@ def run(dry_run=False, print_only=False,
         if vault_output_path:
             write_outputs_to_vault(vault_output_path, ri)
 
-    except Exception as e:
-        msg = 'There was problem running terraform resource reconcile.'
-        msg += ' Exception: {}'
-        msg = msg.format(str(e))
-        logging.error(msg)
+    except Exception:
+        logging.exception('Exception reconciling terraform resource')
         sys.exit(1)
 
     cleanup_and_exit(tf)


### PR DESCRIPTION
When we started catching these exceptions and logging errors, we were not getting stack trace. By using logging.exception() right after except, we will now get the error message and a stack trace.