### PR TITLE
[openshift-saas-deploy] add option to deploy only specific saas-files and specific envs

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -461,10 +461,17 @@ def openshift_resources(ctx, thread_pool_size, internal, use_jump_host):
 @threaded(default=20)
 @binary(['oc', 'ssh'])
 @environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
+@click.option('--saas-file-name',
+              default='',
+              help='saas-file to act on.')
+@click.option('--env-name',
+              default='',
+              help='environment to deploy to.')
 @click.pass_context
-def openshift_saas_deploy(ctx, thread_pool_size):
+def openshift_saas_deploy(ctx, thread_pool_size, saas_file_name, env_name):
     run_integration(reconcile.openshift_saas_deploy.run,
-                    ctx.obj['dry_run'], thread_pool_size)
+                    ctx.obj['dry_run'], thread_pool_size,
+                    saas_file_name, env_name)
 
 
 @integration.command()

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -14,13 +14,14 @@ QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, defer=None):
+def run(dry_run=False, thread_pool_size=10,
+        saas_file_name='', env_name='', defer=None):
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()
     aws_accounts = queries.get_aws_accounts()
     gl = GitLabApi(instance, settings=settings)
 
-    saas_files = queries.get_saas_files()
+    saas_files = queries.get_saas_files(saas_file_name, env_name)
     saasherder = SaasHerder(
         saas_files,
         thread_pool_size=thread_pool_size,

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -714,6 +714,9 @@ SAAS_FILES_QUERY = """
       targets {
         namespace {
           name
+          environment {
+            name
+          }
           cluster {
             name
             serverUrl
@@ -754,10 +757,26 @@ SAAS_FILES_QUERY = """
 """
 
 
-def get_saas_files():
+def get_saas_files(saas_file_name='', env_name=''):
     """ Returns SaasFile resources defined in app-interface """
     gqlapi = gql.get_api()
-    return gqlapi.query(SAAS_FILES_QUERY)['saas_files']
+    saas_files = gqlapi.query(SAAS_FILES_QUERY)['saas_files']
+
+    for saas_file in saas_files[:]:
+        if saas_file_name:
+            if saas_file['name'] != saas_file_name:
+                saas_files.remove(saas_file)
+                continue
+        if env_name:
+            for rt in saas_file['resourceTemplates']:
+                targets = rt['targets']
+                for target in targets[:]:
+                    namespace = target['namespace']
+                    environment = namespace['environment']
+                    if environment['name'] != env_name:
+                        targets.remove(target)
+
+    return saas_files
 
 
 PERFORMANCE_PARAMETERS_QUERY = """

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -762,6 +762,9 @@ def get_saas_files(saas_file_name='', env_name=''):
     gqlapi = gql.get_api()
     saas_files = gqlapi.query(SAAS_FILES_QUERY)['saas_files']
 
+    if not (saas_file_name or env_name):
+        return saas_files
+
     for saas_file in saas_files[:]:
         if saas_file_name:
             if saas_file['name'] != saas_file_name:


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/APPSRE-1276

Following the work in https://gitlab.cee.redhat.com/service/app-interface/merge_requests/4267

This PR adds the ability to run the openshift-saas-deploy integration for a specific saas-file and for a specific environment targeted from that saas file.

Each target is a namespace, and each namespace is a part of an environment.

This will allow us to create dedicated jenkins jobs that will deploy using this integration, but without dependency on other saas files.

Example:
```
qontract-reconcile --config config.toml --dry-run openshift-saas-deploy --saas-file-name saas-github-mirror --env-name App-SRE-stage
```