### PR TITLE
[cli] Add Products and Environments

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -385,6 +385,52 @@ def get_namespaces():
     return gqlapi.query(NAMESPACES_QUERY)['namespaces']
 
 
+PRODUCTS_QUERY = """
+{
+  products: products_v1 {
+    path
+    name
+    description
+  }
+}
+"""
+
+
+def get_products():
+    """ Returns all Products """
+    gqlapi = gql.get_api()
+    return gqlapi.query(PRODUCTS_QUERY)['products']
+
+
+ENVIRONMENTS_QUERY = """
+{
+  environments: environments_v1 {
+    path
+    name
+    description
+    product {
+      name
+    }
+    namespaces {
+      name
+      app {
+        name
+      }
+      cluster {
+        name
+      }
+    }
+  }
+}
+"""
+
+
+def get_environments():
+    """ Returns all Products """
+    gqlapi = gql.get_api()
+    return gqlapi.query(ENVIRONMENTS_QUERY)['environments']
+
+
 APPS_QUERY = """
 {
   apps: apps_v1 {

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -391,6 +391,10 @@ PRODUCTS_QUERY = """
     path
     name
     description
+    environments {
+      name
+      description
+    }
   }
 }
 """

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -131,6 +131,23 @@ def products(ctx):
     print_output(ctx.obj['output'], products, columns)
 
 
+@describe.command()
+@click.argument('name')
+@click.pass_context
+def product(ctx, name):
+    products = queries.get_products()
+    products = [p for p in products
+                if p['name'].lower() == name.lower()]
+    if len(products) != 1:
+        print(f"{name} error")
+        sys.exit(1)
+
+    product = products[0]
+    environments = product['environments']
+    columns = ['name', 'description']
+    print_output(ctx.obj['output'], environments, columns)
+
+
 @get.command()
 @click.pass_context
 def environments(ctx):

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -43,6 +43,13 @@ def get(ctx, output):
     ctx.obj['output'] = output
 
 
+@root.group()
+@output
+@click.pass_context
+def describe(ctx, output):
+    ctx.obj['output'] = output
+
+
 @get.command()
 @click.pass_context
 def settings(ctx):
@@ -112,6 +119,39 @@ def namespaces(ctx, name):
     if name:
         namespaces = [ns for ns in namespaces if ns['name'] == name]
 
+    columns = ['name', 'cluster.name', 'app.name']
+    print_output(ctx.obj['output'], namespaces, columns)
+
+
+@get.command()
+@click.pass_context
+def products(ctx):
+    products = queries.get_products()
+    columns = ['name', 'description']
+    print_output(ctx.obj['output'], products, columns)
+
+
+@get.command()
+@click.pass_context
+def environments(ctx):
+    environments = queries.get_environments()
+    columns = ['name', 'description', 'product.name']
+    print_output(ctx.obj['output'], environments, columns)
+
+
+@describe.command()
+@click.argument('name')
+@click.pass_context
+def environment(ctx, name):
+    environments = queries.get_environments()
+    environments = [e for e in environments
+                    if e['name'].lower() == name.lower()]
+    if len(environments) != 1:
+        print(f"{name} error")
+        sys.exit(1)
+
+    environment = environments[0]
+    namespaces = environment['namespaces']
     columns = ['name', 'cluster.name', 'app.name']
     print_output(ctx.obj['output'], namespaces, columns)
 


### PR DESCRIPTION
This PR adds the following commands to qontract-cli:
```
get products
describe product <name> - shows a list of namespaces which belong to the product
get environments
describe environment <name> - shows a list of namespaces which compose the environment
```