### PR TITLE
[aws-garbage-collector] enable deletion, add opt in

### DIFF
--- a/reconcile/aws_garbage_collector.py
+++ b/reconcile/aws_garbage_collector.py
@@ -3,12 +3,12 @@ import reconcile.queries as queries
 from utils.aws_api import AWSApi
 
 
-def run(dry_run=False, thread_pool_size=10,
-        enable_deletion=False, io_dir='throughput/'):
-    accounts = queries.get_aws_accounts()
+def run(dry_run=False, thread_pool_size=10, io_dir='throughput/'):
+    accounts = [a for a in queries.get_aws_accounts()
+                if a.get('garbageCollection')]
     settings = queries.get_app_interface_settings()
     aws = AWSApi(thread_pool_size, accounts, settings=settings)
     if dry_run:
         aws.simulate_deleted_users(io_dir)
     aws.map_resources()
-    aws.delete_resources_without_owner(dry_run, enable_deletion)
+    aws.delete_resources_without_owner(dry_run)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -420,11 +420,10 @@ def gitlab_pr_submitter(ctx, gitlab_project_id):
 @integration.command()
 @throughput
 @threaded()
-@enable_deletion(default=False)
 @click.pass_context
-def aws_garbage_collector(ctx, thread_pool_size, enable_deletion, io_dir):
+def aws_garbage_collector(ctx, thread_pool_size, io_dir):
     run_integration(reconcile.aws_garbage_collector.run, ctx.obj['dry_run'],
-                    thread_pool_size, enable_deletion, io_dir)
+                    thread_pool_size, io_dir)
 
 
 @integration.command()

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -157,6 +157,7 @@ AWS_ACCOUNTS_QUERY = """
       path
       field
     }
+    garbageCollection
     disable {
       integrations
     }

--- a/utils/aws_api.py
+++ b/utils/aws_api.py
@@ -334,20 +334,13 @@ class AWSApi(object):
 
         return ''
 
-    def delete_resources_without_owner(self, dry_run, enable_deletion):
-        warning_message = '\'delete\' action is not enabled. ' + \
-                          'Please run the integration manually ' + \
-                          'with the \'--enable-deletion\' flag.'
-
+    def delete_resources_without_owner(self, dry_run):
         for account, s in self.sessions.items():
             for rt in self.resource_types:
                 for r in self.resources[account].get(rt + '_no_owner', []):
                     logging.info(['delete_resource', account, rt, r])
                     if not dry_run:
-                        if enable_deletion:
-                            self.delete_resource(s, rt, r)
-                        else:
-                            logging.warning(warning_message)
+                        self.delete_resource(s, rt, r)
 
     def delete_resource(self, session, resource_type, resource_name):
         if resource_type == 's3':


### PR DESCRIPTION
This PR changes aws-garbage-collector to be an opt in feature (must specify `garbageCollection: true` in an aws account file, and enabling resource deletion.