### PR TITLE
pop cannot have default on list

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -212,7 +212,7 @@ def fetch_provider_resource(path, tfunc=None, tvars=None,
             content,
             force_types=None
         )
-        resource['body'].pop('$schema', None)
+        resource['body'].pop('$schema')
     except anymarkup.AnyMarkupError:
         e_msg = "Could not parse data. Skipping resource: {}"
         raise FetchResourceError(e_msg.format(path))


### PR DESCRIPTION
resolves ```10:50:12   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/utils/threaded.py", line 10, in wrapper
10:50:12     return func(*args, **kwargs)
10:50:12   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources.py", line 473, in fetch_states
10:50:12     spec.parent)
10:50:12   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources.py", line 415, in fetch_desired_state
10:50:12     openshift_resource = fetch_openshift_resource(resource, parent)
10:50:12   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources.py", line 374, in fetch_openshift_resource
10:50:12     openshift_resource = fetch_provider_route(path, tls_path, tls_version)
10:50:12   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources.py", line 283, in fetch_provider_route
10:50:12     openshift_resource = fetch_provider_resource(path)
10:50:12   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources.py", line 215, in fetch_provider_resource
10:50:12     resource['body'].pop('$schema', None)
10:50:12 TypeError: pop() takes at most 1 argument (2 given)
10:50:12 ```