### PR TITLE
[openshift-saas-deploy] enable multiple running instances of the integration

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -215,7 +215,8 @@ def check_unused_resource_types(ri):
 
 
 def realize_data(dry_run, oc_map, ri,
-                 take_over=False):
+                 take_over=False,
+                 mutilple_callers=False):
     enable_deletion = False if ri.has_error_registered() else True
 
     for cluster, namespace, resource_type, data in ri:
@@ -280,9 +281,13 @@ def realize_data(dry_run, oc_map, ri,
             if d_item is not None:
                 continue
 
-            if not c_item.has_qontract_annotations():
-                if not take_over:
-                    continue
+            if c_item.has_qontract_annotations():
+                if mutilple_callers:
+                    if c_item.caller != d_item.caller:
+                        continue
+            elif not take_over:
+                continue
+
             try:
                 delete(dry_run, oc_map, cluster, namespace,
                        resource_type, name, enable_deletion)

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -17,6 +17,9 @@ QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 @defer
 def run(dry_run=False, thread_pool_size=10,
         saas_file_name=None, env_name=None, defer=None):
+    # if saas_file_name and env_name are defined, the integration
+    # is being called from multiple running instances
+    multiple_callers = saas_file_name and env_name
     saas_files = queries.get_saas_files(saas_file_name, env_name)
     if not saas_files:
         logging.error('no saas files found')
@@ -44,7 +47,8 @@ def run(dry_run=False, thread_pool_size=10,
         integration_version=QONTRACT_INTEGRATION_VERSION)
     defer(lambda: oc_map.cleanup())
     saasherder.populate_desired_state(ri)
-    ob.realize_data(dry_run, oc_map, ri)
+    ob.realize_data(dry_run, oc_map, ri,
+                    mutilple_callers=multiple_callers)
     if not dry_run:
         saasherder.slack_notify(aws_accounts, ri)
 

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -298,6 +298,7 @@ class SaasHerder():
                         resource,
                         self.integration,
                         self.integration_version,
+                        caller_name=saas_file_name,
                         error_details=html_url)
                     ri.add_desired(
                         cluster,


### PR DESCRIPTION
This PR adds support for a new feature - `multiple_callers`.

When openshift integrations call `realize_data` with `multiple_callers=True`, the execution assumes that there may be multiple running instances of the integration, and each instance should only handle its own resources.

In our use case, the openshift-saas-deploy integration can now run in multiple instances, modifying the same namespaces from different saas files, and still not get in the way of itself.

We introduce a new annotation that will be used for that purpose - `qontract.caller_name`. This annotation will only be set by the openshift-saas-deploy integration.