### PR TITLE
[openshift-saas-deploy] allow execution without access to gitlab

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -24,7 +24,12 @@ def run(dry_run=False, thread_pool_size=10,
 
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()
-    gl = GitLabApi(instance, settings=settings)
+    try:
+        gl = GitLabApi(instance, settings=settings)
+    except Exception:
+        # allow execution without access to gitlab
+        # as long as there are no access attempts.
+        gl = None
 
     saasherder = SaasHerder(
         saas_files,

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -93,6 +93,8 @@ class SaasHerder():
             f = repo.get_contents(path, ref)
             return f.decoded_content, f.html_url
         elif 'gitlab' in url:
+            if not self.gitlab:
+                raise Exception('gitlab is not initialized')
             project = self.gitlab.get_project(url)
             f = project.files.get(file_path=path, ref=ref)
             html_url = os.path.join(url, 'blob', ref, path)
@@ -110,6 +112,8 @@ class SaasHerder():
             commit = repo.get_commit(sha=ref)
             commit_sha = commit.sha
         elif 'gitlab' in url:
+            if not self.gitlab:
+                raise Exception('gitlab is not initialized')
             project = self.gitlab.get_project(url)
             commits = project.commits.list(ref_name=ref)
             commit_sha = commits[0].id


### PR DESCRIPTION
to allow executing the integration externally, as long as there are no access attempts to gitlab - this should work just fine!