### PR TITLE
add support for cluster as vpc peering target

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -270,6 +270,7 @@ CLUSTERS_QUERY = """
     awsInfrastructureAccess {
       awsGroup {
         account {
+          name
           uid
           terraformUsername
         }
@@ -300,32 +301,64 @@ CLUSTERS_QUERY = """
       vpc_id
       connections {
         name
-        vpc {
-          account {
+        provider
+        ... on ClusterPeeringConnectionAccount_v1 {
+          vpc {
             name
-            uid
-            terraformUsername
-          }
-          vpc_id
-          cidr_block
-          region
-        }
-        cluster {
-          name
-          spec {
+            account {
+            	name
+            	uid
+            	terraformUsername
+            }
+            vpc_id
+            cidr_block
             region
           }
-          network {
-            vpc
-          }
-          peering {
-            vpc_id
+        }
+        ... on ClusterPeeringConnectionClusterRequester_v1 {
+          cluster {
+            name
+            network {
+              vpc
+            }
+            spec {
+              region
+            }
+            peering {
+              vpc_id
+              connections {
+                name
+                provider
+                ... on ClusterPeeringConnectionClusterAccepter_v1 {
+                  name
+                  cluster {
+                    name
+                    spec {
+                      region
+                    }
+                  }
+                }
+              }
+            }
           }
         }
-        usingAccount {
-          name
-          uid
-          terraformUsername
+        ... on ClusterPeeringConnectionClusterAccepter_v1 {
+          cluster {
+            name
+            peering {
+              vpc_id
+              connections {
+                name
+                provider
+                ... on ClusterPeeringConnectionClusterRequester_v1 {
+                  name
+                  cluster {
+                    name
+                  }
+                }
+              }
+            }
+          }
         }
       }
     }

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -312,18 +312,6 @@ CLUSTERS_QUERY = """
         }
         cluster {
           name
-          ocm {
-            name
-            url
-            accessTokenClientId
-            accessTokenUrl
-            offlineToken {
-              path
-              field
-              format
-              version
-            }
-          }
           spec {
             region
           }

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -306,9 +306,9 @@ CLUSTERS_QUERY = """
           vpc {
             name
             account {
-            	name
-            	uid
-            	terraformUsername
+              name
+              uid
+              terraformUsername
             }
             vpc_id
             cidr_block

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -310,6 +310,35 @@ CLUSTERS_QUERY = """
           cidr_block
           region
         }
+        cluster {
+          name
+          ocm {
+            name
+            url
+            accessTokenClientId
+            accessTokenUrl
+            offlineToken {
+              path
+              field
+              format
+              version
+            }
+          }
+          spec {
+            region
+          }
+          network {
+            vpc
+          }
+          peering {
+            vpc_id
+          }
+        }
+        usingAccount {
+          name
+          uid
+          terraformUsername
+        }
       }
     }
     automationToken {

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -100,6 +100,10 @@ def build_desired_state_cluster(clusters, ocm_map):
                     awsAccount['uid'],
                     awsAccount['terraformUsername']
                 )
+            if not awsAccount['assume_role']:
+                msg = f"could not find a terraform AWS role for {cluster}"
+                return None, msg
+            
             awsAccount['assume_region'] = peer_region
             item = {
                 'connection_name': connection_name,

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -192,7 +192,8 @@ def run(dry_run=False, print_only=False,
     # check there are no repeated vpc connection names
     connection_names = [c['connection_name'] for c in desired_state]
     if len(set(connection_names)) != len(connection_names):
-        logging.error("duplicated vpc connection names found")
+        logging.error("duplicate vpc connection names found")
+        sys.exit(1)
 
     participating_accounts = [item['account'] for item in desired_state]
     participating_account_names = \

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 import semver
 import sys
 
@@ -14,12 +15,27 @@ QONTRACT_INTEGRATION = 'terraform_vpc_peerings'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 
 
-def fetch_desired_state(settings):
+def ensure_matching_cluster_peering(from_cluster, peering, to_cluster,
+                                  desired_provider):
+    peering_info = to_cluster['peering']
+    peer_connections = peering_info['connections']
+    for peer_connection in peer_connections:
+            if not peer_connection['provider'] == desired_provider:
+                continue
+            if not peer_connection['cluster']:
+                continue
+            if from_cluster['name'] == peer_connection['cluster']['name']:
+                return True, ""
+    msg = f"peering {peering['name']} of type {peering['provider']} " \
+          f"for cluster {from_cluster['name']} doesn't have a matching " \
+          f"peering type {desired_provider} from cluster {to_cluster['name']}"
+    return False, msg
+
+def build_desired_state_cluster(clusters, ocm_map):
+    """
+    Fetch state for VPC peerings between two clusters
+    """
     desired_state = []
-    clusters = [c for c in queries.get_clusters()
-                if c.get('peering') is not None]
-    ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
-                     settings=settings)
 
     for cluster_info in clusters:
         cluster = cluster_info['name']
@@ -33,90 +49,138 @@ def fetch_desired_state(settings):
         }
         peer_connections = peering_info['connections']
         for peer_connection in peer_connections:
-            # VPC and Cluster cannot be specified at the same time
-            # for a VPC connection
-            if peer_connection['vpc'] and peer_connection['cluster']:
-                msg = f"cannot set vpc and cluster at the same time" \
-                      f"for a peering connection (cluster: {cluster})"
-                raise Exception(msg)
-            # Peer the cluster with a standalone AWS VPC
-            elif peer_connection['vpc']:
-                connection_name = peer_connection['name']
-                peer_vpc = peer_connection['vpc']
-                # accepter is the peered AWS account
-                accepter = {
-                    'vpc_id': peer_vpc['vpc_id'],
-                    'cidr_block': peer_vpc['cidr_block'],
-                    'region': peer_vpc['region']
-                }
-                account = peer_vpc['account']
-                # assume_role is the role to assume to provision the
-                # peering connection request, through the accepter AWS account.
-                # this may change in the future -
-                # in case we add support for peerings between clusters.
-                account['assume_role'] = \
-                    ocm.get_aws_infrastructure_access_terraform_assume_role(
-                        cluster,
-                        peer_vpc['account']['uid'],
-                        peer_vpc['account']['terraformUsername']
-                    )
-                # assume_region is the region in which the requester resides
-                account['assume_region'] = requester['region']
-                item = {
-                    'connection_name': connection_name,
-                    'requester': requester,
-                    'accepter': accepter,
-                    'account': account
-                }
-                desired_state.append(item)
-            # Peer the cluster with another cluster (v4, ocm)
-            elif peer_connection['cluster']:
-                connection_name = peer_connection['name']
-                # peer cluster VPC info
-                peer_vpc_id = peer_connection['cluster']['peering']['vpc_id']
-                peer_vpc_cidr = peer_connection['cluster']['network']['vpc']
-                peer_region = peer_connection['cluster']['spec']['region']
-                # aws account used accepting the peering
-                peering_account = peer_connection['usingAccount']
-                # accepter is the target AWS account VPC
-                accepter = {
-                    'vpc_id': peer_vpc_id,
-                    'cidr_block': peer_vpc_cidr,
-                    'region': peer_region,
-                }
-                p_ocm = ocm_map.get(peer_connection['cluster']['name'])
-                peering_account['assume_role'] = \
-                    p_ocm.get_aws_infrastructure_access_terraform_assume_role(
-                        peer_connection['cluster']['name'],
-                        peering_account['uid'],
-                        peering_account['terraformUsername']
-                    )
-                peering_account['assume_region'] = peer_region
-                item = {
-                    'connection_name': connection_name,
-                    'requester': requester,
-                    'accepter': accepter,
-                    'account': peering_account
-                }
-                desired_state.append(item)
+            # We only care about cluster-vpc-requester peering providers
+            if not peer_connection['provider'] == 'cluster-vpc-requester':
+                continue
 
-    return desired_state
+            # Ensure we have a matching peering connection set as cluster-vpc-accepter from the peer cluster
+            found, msg = ensure_matching_cluster_peering(cluster_info, peer_connection, peer_connection['cluster'], 'cluster-vpc-accepter')
+            if not found:
+                return None, msg
 
+            connection_name = peer_connection['name']
+            # peer cluster VPC info
+            peer_vpc_id = peer_connection['cluster']['peering']['vpc_id']
+            peer_vpc_cidr = peer_connection['cluster']['network']['vpc']
+            peer_region = peer_connection['cluster']['spec']['region']
+            # accepter is the target AWS account VPC
+            accepter = {
+                'vpc_id': peer_vpc_id,
+                'cidr_block': peer_vpc_cidr,
+                'region': peer_region,
+            }
+
+            # Find an aws account with the "network-mgmt" access level
+            awsAccount = None
+            for awsAccess in cluster_info['awsInfrastructureAccess']:
+                if awsAccess.get('accessLevel', "") == "network-mgmt":
+                    awsAccount = {
+                        'name': awsAccess['awsGroup']['account']['name'],
+                        'uid': awsAccess['awsGroup']['account']['uid'],
+                        'terraformUsername': awsAccess['awsGroup']['account']['terraformUsername'],
+                    }
+            if not awsAccount:
+                return None, "could not find an AWS account with the 'network-mgmt' access level on the cluster"
+            
+            # find role to use for aws access
+            awsAccount['assume_role'] = \
+                ocm.get_aws_infrastructure_access_terraform_assume_role(
+                    cluster,
+                    awsAccount['uid'],
+                    awsAccount['terraformUsername']
+                )
+            awsAccount['assume_region'] = peer_region
+            item = {
+                'connection_name': connection_name,
+                'requester': requester,
+                'accepter': accepter,
+                'account': awsAccount
+            }
+
+            desired_state.append(item)
+
+    return desired_state, None
+
+def build_desired_state_vpc(clusters, ocm_map):
+    """
+    Fetch state for VPC peerings between a cluster and a VPC (account)
+    """
+    desired_state = []
+
+    for cluster_info in clusters:
+        cluster = cluster_info['name']
+        ocm = ocm_map.get(cluster)
+        peering_info = cluster_info['peering']
+        # requester is the cluster's AWS account
+        requester = {
+            'vpc_id': peering_info['vpc_id'],
+            'cidr_block': cluster_info['network']['vpc'],
+            'region': cluster_info['spec']['region']
+        }
+        peer_connections = peering_info['connections']
+        for peer_connection in peer_connections:
+            # We only care about account-vpc peering providers
+            if not peer_connection['provider'] == 'account-vpc':
+                continue
+            connection_name = peer_connection['name']
+            peer_vpc = peer_connection['vpc']
+            # accepter is the peered AWS account
+            accepter = {
+                'vpc_id': peer_vpc['vpc_id'],
+                'cidr_block': peer_vpc['cidr_block'],
+                'region': peer_vpc['region']
+            }
+            account = peer_vpc['account']
+            # assume_role is the role to assume to provision the
+            # peering connection request, through the accepter AWS account.
+            # this may change in the future -
+            # in case we add support for peerings between clusters.
+            account['assume_role'] = \
+                ocm.get_aws_infrastructure_access_terraform_assume_role(
+                    cluster,
+                    peer_vpc['account']['uid'],
+                    peer_vpc['account']['terraformUsername']
+                )
+            # assume_region is the region in which the requester resides
+            account['assume_region'] = requester['region']
+            item = {
+                'connection_name': connection_name,
+                'requester': requester,
+                'accepter': accepter,
+                'account': account
+            }
+            desired_state.append(item)
+    return desired_state, None
 
 @defer
 def run(dry_run=False, print_only=False,
         enable_deletion=False, thread_pool_size=10, defer=None):
     settings = queries.get_app_interface_settings()
-    desired_state = fetch_desired_state(settings)
+    clusters = [c for c in queries.get_clusters()
+                if c.get('peering') is not None]
+    ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
+                     settings=settings)
+
+    # Fetch desired state for cluster-to-vpc(account) VPCs
+    desired_state_vpc, err = build_desired_state_vpc(clusters, ocm_map)
+    if err:
+        logging.error(err)
+        sys.exit(1)
+
+    # Fetch desired state for cluster-to-cluster VPCs
+    desired_state_cluster, err = build_desired_state_cluster(clusters, ocm_map)
+    if err:
+        logging.error(err)
+        sys.exit(1)
+
+    desired_state = desired_state_vpc + desired_state_cluster
 
     # check there are no repeated vpc connection names
     connection_names = [c['connection_name'] for c in desired_state]
     if len(set(connection_names)) != len(connection_names):
         logging.error("duplicated vpc connection names found")
-        sys.exit(1)
 
-    participating_accounts = \
-        [item['account'] for item in desired_state]
+    participating_accounts = [item['account'] for item in desired_state]
     participating_account_names = \
         [a['name'] for a in participating_accounts]
     accounts = [a for a in queries.get_aws_accounts()

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -103,7 +103,7 @@ def build_desired_state_cluster(clusters, ocm_map):
             if not awsAccount['assume_role']:
                 msg = f"could not find a terraform AWS role for {cluster}"
                 return None, msg
-            
+
             awsAccount['assume_region'] = peer_region
             item = {
                 'connection_name': connection_name,

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 import semver
 import sys
 

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -33,7 +33,8 @@ def fetch_desired_state(settings):
         }
         peer_connections = peering_info['connections']
         for peer_connection in peer_connections:
-            # Failsafe in case both a vpc and a cluster is specified for a peering connection
+            # VPC and Cluster cannot be specified at the same time
+            # for a VPC connection
             if peer_connection['vpc'] and peer_connection['cluster']:
                 msg = f"cannot set vpc and cluster at the same time" \
                       f"for a peering connection (cluster: {cluster})"
@@ -83,9 +84,9 @@ def fetch_desired_state(settings):
                     'cidr_block': peer_vpc_cidr,
                     'region': peer_region,
                 }
-                peer_ocm = ocm_map.get(peer_connection['cluster']['name'])
+                p_ocm = ocm_map.get(peer_connection['cluster']['name'])
                 peering_account['assume_role'] = \
-                    peer_ocm.get_aws_infrastructure_access_terraform_assume_role(
+                    p_ocm.get_aws_infrastructure_access_terraform_assume_role(
                         peer_connection['cluster']['name'],
                         peering_account['uid'],
                         peering_account['terraformUsername']


### PR DESCRIPTION
This updates the terraform_vpc_peerings integration to support targetting clusters as VPC peering targets