### PR TITLE
[openshift-saas-deploy] trigger by moving commits integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `openshift-resources`: Manages OpenShift Resources.
 - `openshift-rolebindings`: Configures Rolebindings in OpenShift clusters.
 - `openshift-saas-deploy`: Manage OpenShift resources defined in Saas files (SaasHerder).
+- `openshift-saas-deploy-trigger-moving-commits`: Trigger jobs in Jenkins when a commit changed for a ref.
 - `openshift-serviceaccount-tokens`: Use OpenShift ServiceAccount tokens across namespaces/clusters.
 - `openshift-users`: Deletion of users from OpenShift clusters.
 - `quay-membership`: Configures the teams and members in Quay.

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -21,6 +21,7 @@ import reconcile.openshift_network_policies
 import reconcile.openshift_performance_parameters
 import reconcile.openshift_serviceaccount_tokens
 import reconcile.openshift_saas_deploy
+import reconcile.openshift_saas_deploy_trigger_moving_commits
 import reconcile.owner_approvals
 import reconcile.quay_membership
 import reconcile.quay_mirror
@@ -471,6 +472,16 @@ def openshift_saas_deploy(ctx, thread_pool_size, saas_file_name, env_name):
     run_integration(reconcile.openshift_saas_deploy.run,
                     ctx.obj['dry_run'], thread_pool_size,
                     saas_file_name, env_name)
+
+
+@integration.command()
+@environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
+@threaded()
+@click.pass_context
+def openshift_saas_deploy_trigger_moving_commits(ctx, thread_pool_size):
+    run_integration(
+        reconcile.openshift_saas_deploy_trigger_moving_commits.run,
+        ctx.obj['dry_run'], thread_pool_size)
 
 
 @integration.command()

--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -30,6 +30,11 @@ QUERY = """
 """
 
 
+def get_openshift_saas_deploy_job_name(saas_file_name, env_name, settings):
+    job_template_name = settings['saasDeployJobTemplate']
+    return f"{job_template_name}-{saas_file_name}-{env_name}"
+
+
 def collect_saas_file_configs():
     # collect a list of jobs per saas file per environment.
     # each saas_file_config should have the structure described
@@ -52,8 +57,8 @@ def collect_saas_file_configs():
                 namespace = target['namespace']
                 env_name = namespace['environment']['name']
                 app_name = namespace['app']['name']
-
-                jc_name = f"{job_template_name}-{saas_file_name}-{env_name}"
+                jc_name = get_openshift_saas_deploy_job_name(
+                    saas_file_name, env_name)
                 existing_configs = \
                     [c for c in saas_file_configs if c['name'] == jc_name]
                 if existing_configs:

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -3,7 +3,6 @@ import semver
 import logging
 
 import reconcile.queries as queries
-import reconcile.openshift_base as ob
 import reconcile.jenkins_plugins as jenkins_base
 
 from utils.gitlab_api import GitLabApi

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -1,0 +1,61 @@
+import sys
+import semver
+import logging
+
+import reconcile.queries as queries
+import reconcile.openshift_base as ob
+import reconcile.jenkins_plugins as jenkins_base
+
+from utils.gitlab_api import GitLabApi
+from utils.saasherder import SaasHerder
+from reconcile.jenkins_job_builder import get_openshift_saas_deploy_job_name
+
+
+QONTRACT_INTEGRATION = 'openshift-saas-deploy-trigger-moving-commits'
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
+
+
+def run(dry_run=False, thread_pool_size=10):
+    saas_files = queries.get_saas_files()
+    if not saas_files:
+        logging.error('no saas files found')
+        sys.exit(1)
+
+    instance = queries.get_gitlab_instance()
+    settings = queries.get_app_interface_settings()
+    accounts = queries.get_aws_accounts()
+    gl = GitLabApi(instance, settings=settings)
+    jenkins_map = jenkins_base.get_jenkins_map()
+
+    saasherder = SaasHerder(
+        saas_files,
+        thread_pool_size=thread_pool_size,
+        gitlab=gl,
+        integration=QONTRACT_INTEGRATION,
+        integration_version=QONTRACT_INTEGRATION_VERSION,
+        settings=settings,
+        accounts=accounts)
+    if not saasherder.valid:
+        sys.exit(1)
+
+    trigger_specs = saasherder.get_moving_commits_diff(dry_run)
+    already_triggered = []
+    for job_spec in trigger_specs:
+        saas_file_name = job_spec['saas_file_name']
+        env_name = job_spec['env_name']
+        instance_name = job_spec['instance_name']
+        job_name = get_openshift_saas_deploy_job_name(
+            saas_file_name, env_name, settings)
+        if job_name not in already_triggered:
+            logging.info(['trigger_job', instance_name, job_name])
+
+        if not dry_run:
+            jenkins = jenkins_map[instance_name]
+            try:
+                if job_name not in already_triggered:
+                    jenkins.trigger_job(job_name)
+                    already_triggered.append(job_name)
+                saasherder.update_moving_commit(job_spec)
+            except Exception:
+                logging.error(
+                    f"could not trigger job {job_name} in {instance_name}.")

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -777,6 +777,7 @@ SAAS_FILES_QUERY = """
         }
         ref
         parameters
+        upstream
       }
     }
     roles {

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -370,11 +370,35 @@ def ls(ctx, integration):
 @click.argument('integration')
 @click.argument('key')
 @click.pass_context
+def get(ctx, integration, key):
+    settings = queries.get_app_interface_settings()
+    accounts = queries.get_aws_accounts()
+    state = State(integration, accounts, settings=settings)
+    value = state.get(key)
+    print(value)
+
+
+@state.command()
+@click.argument('integration')
+@click.argument('key')
+@click.pass_context
 def add(ctx, integration, key):
     settings = queries.get_app_interface_settings()
     accounts = queries.get_aws_accounts()
     state = State(integration, accounts, settings=settings)
     state.add(key)
+
+
+@state.command()
+@click.argument('integration')
+@click.argument('key')
+@click.argument('value')
+@click.pass_context
+def set(ctx, integration, key, value):
+    settings = queries.get_app_interface_settings()
+    accounts = queries.get_aws_accounts()
+    state = State(integration, accounts, settings=settings)
+    state.add(key, value=value, force=True)
 
 
 @state.command()

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -396,7 +396,6 @@ class SaasHerder():
 
     def update_moving_commit(self, job_spec):
         saas_file_name = job_spec['saas_file_name']
-        env_name = job_spec['env_name']
         rt_name = job_spec['rt_name']
         namespace_name = job_spec['namespace_name']
         ref = job_spec['ref']

--- a/utils/state.py
+++ b/utils/state.py
@@ -57,7 +57,7 @@ class State(object):
             Bucket=self.bucket, Prefix=self.state_path)['Contents']
         return [o['Key'].replace(self.state_path, '') for o in objects]
 
-    def add(self, key, value=None):
+    def add(self, key, value=None, force=False):
         """
         Adds a key/value to the state and fails if the key already exists
 
@@ -66,7 +66,7 @@ class State(object):
 
         :type key: string
         """
-        if self.exists(key):
+        if self.exists(key) and not force:
             raise KeyError(f"[state] key {key} already "
                            f"exists in {self.state_path}")
         self[key] = value


### PR DESCRIPTION
This PR adds an integration called `openshift-saas-deploy-trigger-moving-commits`.

Whenever a commit is changed under a ref in a saas file (a new PR is merged to `master` for example), this integration will trigger the correct jobs in Jenkins to perform the required deployment operations.

If such a job has an `upstream` field, it will not be triggered, but rather listen to another job and execute after it (enabling image build to be synced).