### PR TITLE
[qontract-cli] add saas-dev command

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -791,14 +791,14 @@ SAAS_FILES_QUERY = """
 """
 
 
-def get_saas_files(saas_file_name=None, env_name=None):
+def get_saas_files(saas_file_name=None, env_name=None, app_name=None):
     """ Returns SaasFile resources defined in app-interface """
     gqlapi = gql.get_api()
     saas_files = gqlapi.query(SAAS_FILES_QUERY)['saas_files']
 
-    if saas_file_name is None and env_name is None:
+    if saas_file_name is None and env_name is None and app_name is None:
         return saas_files
-    if saas_file_name == '' or env_name == '':
+    if saas_file_name == '' or env_name == '' or app_name == '':
         return []
 
     for saas_file in saas_files[:]:
@@ -817,6 +817,13 @@ def get_saas_files(saas_file_name=None, env_name=None):
                         targets.remove(target)
                 if not targets:
                     resource_templates.remove(rt)
+            if not resource_templates:
+                saas_files.remove(saas_file)
+                continue
+        if app_name:
+            if saas_file['app']['name'] != app_name:
+                saas_files.remove(saas_file)
+                continue
 
     return saas_files
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -461,19 +461,23 @@ def saas_dev(ctx, app_name=None, saas_file_name=None, env_name=None):
         sys.exit(1)
     for saas_file in saas_files:
         print('# saas file: ' + saas_file['name'])
-        saas_file_parameters = json.loads(saas_file.get('parameters') or '{}')
+        saas_file_parameters = \
+            json.loads(saas_file.get('parameters') or '{}')
         for rt in saas_file['resourceTemplates']:
             print('## resource template: ' + rt['name'])
             url = rt['url']
             path = rt['path']
-            rt_parameters = json.loads(rt.get('parameters') or '{}')
+            rt_parameters = \
+                json.loads(rt.get('parameters') or '{}')
             for target in rt['targets']:
-                target_parameters = json.loads(target.get('parameters') or '{}')
+                target_parameters = \
+                    json.loads(target.get('parameters') or '{}')
                 environment = target['namespace']['environment']
                 if environment['name'] != env_name:
                     continue
                 ref = target['ref']
-                environment_parameters = json.loads(environment.get('parameters') or '{}')
+                environment_parameters = \
+                    json.loads(environment.get('parameters') or '{}')
                 parameters = {}
                 parameters.update(environment_parameters)
                 parameters.update(saas_file_parameters)
@@ -482,12 +486,14 @@ def saas_dev(ctx, app_name=None, saas_file_name=None, env_name=None):
                 parameters_cmd = ''
                 for k, v in parameters.items():
                     parameters_cmd += f" -p {k}={v}"
-                raw_url = url.replace('github.com', 'raw.githubusercontent.com')
+                raw_url = \
+                    url.replace('github.com', 'raw.githubusercontent.com')
                 if 'gitlab' in raw_url:
                     raw_url += '/raw'
                 raw_url += '/' + ref
                 raw_url += path
-                cmd = f"oc process --local --ignore-unknown-parameters {parameters_cmd} -f {raw_url}"
+                cmd = "oc process --local --ignore-unknown-parameters" + \
+                    f"{parameters_cmd} -f {raw_url}"
                 print(cmd)
 
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -457,7 +457,7 @@ def saas_dev(ctx, app_name=None, saas_file_name=None, env_name=None):
         return
     saas_files = queries.get_saas_files(saas_file_name, env_name, app_name)
     if not saas_files:
-        logging.error('no saas files found')
+        print('no saas files found')
         sys.exit(1)
     for saas_file in saas_files:
         print('# saas file: ' + saas_file['name'])


### PR DESCRIPTION
covers https://issues.redhat.com/browse/APPSRE-1883

This PR adds a command to qontract-cli to allow developers to deploy templates as deployed via app-interface.

```
(venv) $ q saas-dev --help
Usage: qontract-cli saas-dev [OPTIONS]

Options:
  --app-name TEXT        app to act on.
  --saas-file-name TEXT  saas-file to act on.
  --env-name TEXT        environment to use for parameters.
  --help                 Show this message and exit.
```