### PR TITLE
[unleash] use temp dir for cache

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1,9 +1,6 @@
-import os
 import sys
 import logging
 import click
-
-from UnleashClient import UnleashClient
 
 import utils.config as config
 import utils.gql as gql
@@ -66,6 +63,7 @@ from utils.gql import GqlApiError
 from utils.aggregated_list import RunnerException
 from utils.binary import binary
 from utils.environ import environ
+from utils.unleash import get_feature_toggle_state
 
 
 def config_file(function):

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -66,7 +66,6 @@ from utils.gql import GqlApiError
 from utils.aggregated_list import RunnerException
 from utils.binary import binary
 from utils.environ import environ
-from utils.defer import defer
 
 
 def config_file(function):
@@ -205,35 +204,6 @@ def enable_rebase(**kwargs):
                                 help=msg)(function)
         return function
     return f
-
-
-def get_feature_toggle_default(feature_name: str, context: dict) -> bool:
-    return True
-
-
-@defer
-def get_feature_toggle_state(integration_name, defer=None):
-    api_url = os.environ.get('UNLEASH_API_URL')
-    client_access_token = os.environ.get('UNLEASH_CLIENT_ACCESS_TOKEN')
-    if not (api_url and client_access_token):
-        return True
-
-    # hide INFO logging from UnleashClient
-    logger = logging.getLogger()
-    default_logging = logger.level
-    logger.setLevel(logging.ERROR)
-    defer(lambda: logger.setLevel(default_logging))
-
-    headers = {'Authorization': f'Bearer {client_access_token}'}
-    client = UnleashClient(url=api_url,
-                           app_name='qontract-reconcile',
-                           custom_headers=headers)
-    client.initialize_client()
-    defer(lambda: client.destroy())
-
-    state = client.is_enabled(integration_name,
-                              fallback_function=get_feature_toggle_default)
-    return state
 
 
 def run_integration(func_container, *args):

--- a/utils/unleash.py
+++ b/utils/unleash.py
@@ -1,0 +1,43 @@
+import os
+import logging
+import shutil
+
+from UnleashClient import UnleashClient
+
+from utils.defer import defer
+
+
+def get_feature_toggle_default(feature_name: str, context: dict) -> bool:
+    return True
+
+
+@defer
+def get_feature_toggle_state(integration_name, defer=None):
+    api_url = os.environ.get('UNLEASH_API_URL')
+    client_access_token = os.environ.get('UNLEASH_CLIENT_ACCESS_TOKEN')
+    if not (api_url and client_access_token):
+        return True
+
+    # hide INFO logging from UnleashClient
+    logger = logging.getLogger()
+    default_logging = logger.level
+    logger.setLevel(logging.ERROR)
+    defer(lambda: logger.setLevel(default_logging))
+
+    # create temporary cache dir
+    cache_dir = tempfile.mkdtemp()
+    defer(lambda: shutil.rmtree(cache_dir))
+
+    # create Unleash client
+    headers = {'Authorization': f'Bearer {client_access_token}'}
+    client = UnleashClient(url=api_url,
+                           app_name='qontract-reconcile',
+                           custom_headers=headers,
+                           cache_directory=cache_dir)
+    client.initialize_client()
+    defer(lambda: client.destroy())
+
+    # get feature toggle state
+    state = client.is_enabled(integration_name,
+                              fallback_function=get_feature_toggle_default)
+    return state

--- a/utils/unleash.py
+++ b/utils/unleash.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import tempfile
 import shutil
 
 from UnleashClient import UnleashClient


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-1728

use a temp directory as unleash cache directory to avoid:
```
Traceback (most recent call last):
  File "/usr/local/bin/qontract-reconcile", line 11, in <module>
    load_entry_point('reconcile==0.2.2', 'console_scripts', 'qontract-reconcile')()
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 477, in aws_iam_keys
    thread_pool_size)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 241, in run_integration
    unleash_feature_state = get_feature_toggle_state(integration_name)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/utils/defer.py", line 15, in func_wrapper
    return func(*args, defer=defer, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 230, in get_feature_toggle_state
    custom_headers=headers)
  File "/usr/local/lib/python3.6/site-packages/UnleashClient-3.4.2-py3.6.egg/UnleashClient/__init__.py", line 68, in __init__
    self.cache = FileCache(self.unleash_instance_id, app_cache_dir=cache_directory)
  File "/usr/local/lib/python3.6/site-packages/fcache-0.4.7-py3.6.egg/fcache/cache.py", line 121, in __init__
    self.create()
  File "/usr/local/lib/python3.6/site-packages/fcache-0.4.7-py3.6.egg/fcache/cache.py", line 141, in create
    os.makedirs(self.cache_dir)
  File "/usr/lib64/python3.6/os.py", line 210, in makedirs
    makedirs(head, mode, exist_ok)
  File "/usr/lib64/python3.6/os.py", line 210, in makedirs
    makedirs(head, mode, exist_ok)
  File "/usr/lib64/python3.6/os.py", line 220, in makedirs
    mkdir(name, mode)
PermissionError: [Errno 13] Permission denied: '/.cache'
```