### PR TITLE
[jenkins-webhooks-cleaner] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `jenkins-plugins`: Manage Jenkins plugins installation via REST API.
 - `jenkins-roles`: Manage Jenkins roles association via REST API.
 - `jenkins-webhooks`: Manage web hooks to Jenkins jobs.
-- `jenkins-webhooks-cleanup`: Remove webhooks to previous Jenkins instances.
+- `jenkins-webhooks-cleaner`: Remove webhooks to previous Jenkins instances.
 - `jira-watcher`: Watch for changes in Jira boards and notify on Slack.
 - `ldap-users`: Removes users which are not found in LDAP search.
 - `openshift-acme`: Manages openshift-acme deployments (https://github.com/tnozicka/openshift-acme)

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `jenkins-plugins`: Manage Jenkins plugins installation via REST API.
 - `jenkins-roles`: Manage Jenkins roles association via REST API.
 - `jenkins-webhooks`: Manage web hooks to Jenkins jobs.
+- `jenkins-webhooks-cleanup`: Remove webhooks to previous Jenkins instances.
 - `jira-watcher`: Watch for changes in Jira boards and notify on Slack.
 - `ldap-users`: Removes users which are not found in LDAP search.
 - `openshift-acme`: Manages openshift-acme deployments (https://github.com/tnozicka/openshift-acme)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -36,6 +36,7 @@ import reconcile.jenkins_roles
 import reconcile.jenkins_plugins
 import reconcile.jenkins_job_builder
 import reconcile.jenkins_webhooks
+import reconcile.jenkins_webhooks_cleaner
 import reconcile.jira_watcher
 import reconcile.slack_usergroups
 import reconcile.gitlab_integrations
@@ -374,6 +375,12 @@ def jenkins_job_builder(ctx, io_dir, compare):
 @click.pass_context
 def jenkins_webhooks(ctx):
     run_integration(reconcile.jenkins_webhooks, ctx.obj['dry_run'])
+
+
+@integration.command()
+@click.pass_context
+def jenkins_webhooks_cleaner(ctx):
+    run_integration(reconcile.jenkins_webhooks_cleaner, ctx.obj['dry_run'])
 
 
 @integration.command()

--- a/reconcile/jenkins_webhooks_cleaner.py
+++ b/reconcile/jenkins_webhooks_cleaner.py
@@ -1,0 +1,25 @@
+import logging
+
+import reconcile.queries as queries
+
+from utils.gitlab_api import GitLabApi
+
+QONTRACT_INTEGRATION = 'jenkins-webhooks-cleaner'
+
+
+def run(dry_run=False):
+    instance = queries.get_gitlab_instance()
+    settings = queries.get_app_interface_settings()
+    gl = GitLabApi(instance, settings=settings)
+    previous_urls = queries.get_jenkins_instances_previous_urls()
+    repos = queries.get_repos(server=gl.server)
+
+    for repo in repos:
+        hooks = gl.get_project_hooks(repo)
+        for hook in hooks:
+            hook_url = hook.url
+            for previous_url in previous_urls:
+                if hook_url.startswith(previous_url):
+                    logging.info(['delete_hook', repo, hook_url])
+                    if not dry_run:
+                        hook.delete()

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -102,6 +102,38 @@ def get_credentials_requests():
     return gqlapi.query(CREDENTIALS_REQUESTS_QUERY)['credentials_requests']
 
 
+JENKINS_INSTANCES_QUERY = """
+{
+  instances: jenkins_instances_v1 {
+    name
+    serverUrl
+    token {
+      path
+      field
+    }
+    previousUrls
+    plugins
+  }
+}
+"""
+
+
+def get_jenkins_instances():
+    """ Returns a list of Jenkins instances """
+    gqlapi = gql.get_api()
+    return gqlapi.query(JENKINS_INSTANCES_QUERY)['instances']
+
+
+def get_jenkins_instances_previous_urls():
+    instances = get_jenkins_instances()
+    all_previous_urls = []
+    for instance in instances:
+        previous_urls = instance.get('previousUrls')
+        if previous_urls:
+            all_previous_urls.extend(previous_urls)
+    return all_previous_urls
+
+
 GITLAB_INSTANCES_QUERY = """
 {
   instances: gitlabinstance_v1 {


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-1210

this PR adds a new integration that removes webhooks in gitlab projects to previous jenkins instances.