### PR TITLE
Revert "add support for cluster as vpc peering target"

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -270,7 +270,6 @@ CLUSTERS_QUERY = """
     awsInfrastructureAccess {
       awsGroup {
         account {
-          name
           uid
           terraformUsername
         }
@@ -301,64 +300,15 @@ CLUSTERS_QUERY = """
       vpc_id
       connections {
         name
-        provider
-        ... on ClusterPeeringConnectionAccount_v1 {
-          vpc {
+        vpc {
+          account {
             name
-            account {
-              name
-              uid
-              terraformUsername
-            }
-            vpc_id
-            cidr_block
-            region
+            uid
+            terraformUsername
           }
-        }
-        ... on ClusterPeeringConnectionClusterRequester_v1 {
-          cluster {
-            name
-            network {
-              vpc
-            }
-            spec {
-              region
-            }
-            peering {
-              vpc_id
-              connections {
-                name
-                provider
-                ... on ClusterPeeringConnectionClusterAccepter_v1 {
-                  name
-                  cluster {
-                    name
-                    spec {
-                      region
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-        ... on ClusterPeeringConnectionClusterAccepter_v1 {
-          cluster {
-            name
-            peering {
-              vpc_id
-              connections {
-                name
-                provider
-                ... on ClusterPeeringConnectionClusterRequester_v1 {
-                  name
-                  cluster {
-                    name
-                  }
-                }
-              }
-            }
-          }
+          vpc_id
+          cidr_block
+          region
         }
       }
     }


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#730

This did not work as intended. The peer_owner_id (the account) used in the requester peering has to be the ID of the AWS account that we are peering to.