### PR TITLE
add support for cluster as vpc peering target

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -279,8 +279,13 @@ CLUSTERS_QUERY = """
     awsInfrastructureAccess {
       awsGroup {
         account {
+          name
           uid
           terraformUsername
+          automationToken {
+            path
+            field
+          }
         }
         roles {
           users {
@@ -308,19 +313,59 @@ CLUSTERS_QUERY = """
     peering {
       connections {
         name
-        vpc {
-          account {
+        provider
+        ... on ClusterPeeringConnectionAccount_v1 {
+          vpc {
+            account {
+              name
+              uid
+              terraformUsername
+              automationToken {
+                path
+                field
+              }
+            }
+            vpc_id
+            cidr_block
+            region
+          }
+        }
+        ... on ClusterPeeringConnectionClusterRequester_v1 {
+          cluster {
             name
-            uid
-            terraformUsername
-            automationToken {
-              path
-              field
+            network {
+              vpc
+            }
+            spec {
+              region
+            }
+            awsInfrastructureAccess {
+              awsGroup {
+                account {
+                  name
+                  uid
+                  terraformUsername
+                  automationToken {
+                    path
+                    field
+                  }
+                }
+              }
+              accessLevel
+            }
+            peering {
+              connections {
+                name
+                provider
+                ... on ClusterPeeringConnectionClusterAccepter_v1 {
+                  name
+                  cluster {
+                    name
+                  }
+                }
+              }
             }
           }
-          vpc_id
-          cidr_block
-          region
         }
       }
     }

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -15,13 +15,156 @@ QONTRACT_INTEGRATION = 'terraform_vpc_peerings'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 
 
-def fetch_desired_state(settings):
+def find_matching_peering(from_cluster, peering, to_cluster, desired_provider):
+    """
+    Ensures there is a matching peering with the desired provider type
+    going from the destination (to) cluster back to this one (from)
+    """
+    peering_info = to_cluster['peering']
+    peer_connections = peering_info['connections']
+    for peer_connection in peer_connections:
+            if not peer_connection['provider'] == desired_provider:
+                continue
+            if not peer_connection['cluster']:
+                continue
+            if from_cluster['name'] == peer_connection['cluster']['name']:
+                return peer_connection
+    return None
+
+
+def aws_account_from_infrastructure_access(cluster, access_level, ocm_map):
+    """
+    Generate an AWS account object from a cluster's awsInfrastructureAccess
+    groups and access levels
+    """
+    ocm = ocm_map.get(cluster['name'])
+    account = None
+    for awsAccess in cluster['awsInfrastructureAccess']:
+        if awsAccess.get('accessLevel', "") == access_level:
+            account = {
+                'name': awsAccess['awsGroup']['account']['name'],
+                'uid': awsAccess['awsGroup']['account']['uid'],
+                'terraformUsername':
+                    awsAccess['awsGroup']['account']['terraformUsername'],
+                'automationToken':
+                    awsAccess['awsGroup']['account']['automationToken'],
+                'assume_role':
+                    ocm.get_aws_infrastructure_access_terraform_assume_role(
+                        cluster['name'],
+                        awsAccess['awsGroup']['account']['uid'],
+                        awsAccess['awsGroup']['account']['terraformUsername'],
+                    )
+            }
+    return account
+
+
+def build_desired_state_cluster(clusters, ocm_map, settings):
+    """
+    Fetch state for VPC peerings between two OCM clusters
+    """
     desired_state = []
     error = False
-    clusters = [c for c in queries.get_clusters()
-                if c.get('peering') is not None]
-    ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
-                     settings=settings)
+
+    for cluster_info in clusters:
+        cluster_name = cluster_info['name']
+
+        # Find an aws account with the "network-mgmt" access level on the
+        # requester cluster and use that as the account for the requester
+        req_aws = aws_account_from_infrastructure_access(cluster_info,
+                                                         'network-mgmt',
+                                                         ocm_map)
+        if not req_aws:
+            msg = f"could not find an AWS account with the " \
+                  f"'network-mgmt' access level on the cluster {cluster_name}"
+            logging.error(msg)
+            error = True
+            continue
+        req_aws['assume_region'] = cluster_info['spec']['region']
+        req_aws['assume_cidr'] = cluster_info['network']['vpc']
+
+        peering_info = cluster_info['peering']
+        peer_connections = peering_info['connections']
+        for peer_connection in peer_connections:
+            # We only care about cluster-vpc-requester peering providers
+            if not peer_connection['provider'] == 'cluster-vpc-requester':
+                continue
+
+            peer_connection_name = peer_connection['name']
+            peer_cluster = peer_connection['cluster']
+            peer_cluster_name = peer_cluster['name']
+
+            # Ensure we have a matching peering connection
+            peer_info = find_matching_peering(cluster_info,
+                                              peer_connection,
+                                              peer_cluster,
+                                              'cluster-vpc-accepter')
+            if not peer_info:
+                msg = f"could not find a matching peering connection for " \
+                      f"cluster {cluster_name}, " \
+                      f"connection {peer_connection_name}"
+                logging.error(msg)
+                error = True
+                continue
+
+            aws_api = AWSApi(1, [req_aws], settings=settings)
+            requester_vpc_id = aws_api.get_cluster_vpc_id(req_aws)
+            if requester_vpc_id is None:
+                msg = f'[{cluster_name} could not find VPC ID for cluster'
+                logging.error(msg)
+                error = True
+                continue
+            requester = {
+                'cidr_block': cluster_info['network']['vpc'],
+                'region': cluster_info['spec']['region'],
+                'vpc_id': requester_vpc_id,
+                'account': req_aws
+            }
+
+            # Find an aws account with the "network-mgmt" access level on the
+            # peer cluster and use that as the account for the accepter
+            acc_aws = aws_account_from_infrastructure_access(peer_cluster,
+                                                             'network-mgmt',
+                                                             ocm_map)
+            if not acc_aws:
+                msg = "could not find an AWS account with the " \
+                    "'network-mgmt' access level on the cluster"
+                logging.error(msg)
+                error = True
+                continue
+            acc_aws['assume_region'] = peer_cluster['spec']['region']
+            acc_aws['assume_cidr'] = peer_cluster['network']['vpc']
+
+            aws_api = AWSApi(1, [acc_aws], settings=settings)
+            accepter_vpc_id = aws_api.get_cluster_vpc_id(acc_aws)
+            if accepter_vpc_id is None:
+                msg = f'[{peer_cluster_name} could not find VPC ID for cluster'
+                logging.error(msg)
+                error = True
+                continue
+            accepter = {
+                'cidr_block': peer_cluster['network']['vpc'],
+                'region': peer_cluster['spec']['region'],
+                'vpc_id': accepter_vpc_id,
+                'account': acc_aws
+            }
+
+            item = {
+                'connection_name': peer_connection['name'],
+                'requester': requester,
+                'accepter': accepter,
+            }
+            desired_state.append(item)
+
+    return desired_state, error
+
+
+def build_desired_state_vpc(clusters, ocm_map, settings):
+    """
+    Fetch state for VPC peerings between a cluster and a VPC (account)
+    """
+    desired_state = []
+    error = False
+
     for cluster_info in clusters:
         cluster = cluster_info['name']
         ocm = ocm_map.get(cluster)
@@ -33,6 +176,10 @@ def fetch_desired_state(settings):
         }
         peer_connections = peering_info['connections']
         for peer_connection in peer_connections:
+            # We only care about account-vpc peering providers
+            if not peer_connection['provider'] == 'account-vpc':
+                continue
+
             connection_name = peer_connection['name']
             peer_vpc = peer_connection['vpc']
             # accepter is the peered AWS account
@@ -69,7 +216,6 @@ def fetch_desired_state(settings):
                 'accepter': accepter,
             }
             desired_state.append(item)
-
     return desired_state, error
 
 
@@ -77,18 +223,35 @@ def fetch_desired_state(settings):
 def run(dry_run=False, print_only=False,
         enable_deletion=False, thread_pool_size=10, defer=None):
     settings = queries.get_app_interface_settings()
-    desired_state, error = fetch_desired_state(settings)
-    if error:
+    clusters = [c for c in queries.get_clusters()
+                if c.get('peering') is not None]
+    ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
+                     settings=settings)
+
+    # Fetch desired state for cluster-to-vpc(account) VPCs
+    desired_state_vpc, err = \
+        build_desired_state_vpc(clusters, ocm_map, settings)
+    if err:
         sys.exit(1)
+
+    # Fetch desired state for cluster-to-cluster VPCs
+    desired_state_cluster, err = \
+        build_desired_state_cluster(clusters, ocm_map, settings)
+    if err:
+        sys.exit(1)
+
+    desired_state = desired_state_vpc + desired_state_cluster
 
     # check there are no repeated vpc connection names
     connection_names = [c['connection_name'] for c in desired_state]
     if len(set(connection_names)) != len(connection_names):
-        logging.error("duplicated vpc connection names found")
+        logging.error("duplicate vpc connection names found")
         sys.exit(1)
 
     participating_accounts = \
-        [item['account'] for item in desired_state]
+        [item['requester']['account'] for item in desired_state]
+    participating_accounts += \
+        [item['accepter']['account'] for item in desired_state]
     participating_account_names = \
         [a['name'] for a in participating_accounts]
     accounts = [a for a in queries.get_aws_accounts()

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -141,6 +141,7 @@ def build_desired_state_cluster(clusters, ocm_map, settings):
                 logging.error(msg)
                 error = True
                 continue
+            requester['peer_owner_id'] = acc_aws['assume_role'].split(':')[4]
             accepter = {
                 'cidr_block': peer_cluster['network']['vpc'],
                 'region': peer_cluster['spec']['region'],

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -60,13 +60,13 @@ def fetch_desired_state(settings):
                 logging.error(f'[{cluster} could not find VPC ID for cluster')
                 error = True
                 continue
-            requester['vpc_id'] = aws_api.get_cluster_vpc_id(account)
-            # assume_region is the region in which the requester resides
+            requester['vpc_id'] = requester_vpc_id
+            requester['account'] = account
+            accepter['account'] = account
             item = {
                 'connection_name': connection_name,
                 'requester': requester,
                 'accepter': accepter,
-                'account': account
             }
             desired_state.append(item)
 

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -344,7 +344,7 @@ class TerrascriptClient(object):
 
             # Accepter's side of the connection.
             values = {
-                'provider': 'aws.' + acc_alias, 
+                'provider': 'aws.' + acc_alias,
                 'vpc_peering_connection_id':
                     '${aws_vpc_peering_connection.' + identifier + '.id}',
                 'auto_accept': True,

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -311,21 +311,22 @@ class TerrascriptClient(object):
             connection_name = item['connection_name']
             requester = item['requester']
             accepter = item['accepter']
-            account = item['account']
-            account_name = account['name']
+
+            req_account = requester['account']
+            req_account_name = req_account['name']
             # arn:aws:iam::12345:role/role-1 --> 12345
-            alias = account['assume_role'].split(':')[4]
+            req_alias = req_account['assume_role'].split(':')[4]
 
             # Requester's side of the connection - the cluster's account
             identifier = f"{requester['vpc_id']}-{accepter['vpc_id']}"
             values = {
                 # adding the alias to the provider will add this resource
                 # to the cluster's AWS account
-                'provider': 'aws.' + alias,
+                'provider': 'aws.' + req_alias,
                 'vpc_id': requester['vpc_id'],
                 'peer_vpc_id': accepter['vpc_id'],
                 'peer_region': accepter['region'],
-                'peer_owner_id': account['uid'],
+                'peer_owner_id': req_account['uid'],
                 'auto_accept': False,
                 'tags': {
                     'managed_by_integration': self.integration,
@@ -334,10 +335,16 @@ class TerrascriptClient(object):
                 }
             }
             tf_resource = aws_vpc_peering_connection(identifier, **values)
-            self.add_resource(account_name, tf_resource)
+            self.add_resource(req_account_name, tf_resource)
+
+            acc_account = accepter['account']
+            acc_account_name = acc_account['name']
+            # arn:aws:iam::12345:role/role-1 --> 12345
+            acc_alias = acc_account['assume_role'].split(':')[4]
 
             # Accepter's side of the connection.
             values = {
+                'provider': 'aws.' + acc_alias, 
                 'vpc_peering_connection_id':
                     '${aws_vpc_peering_connection.' + identifier + '.id}',
                 'auto_accept': True,
@@ -347,11 +354,11 @@ class TerrascriptClient(object):
                     'Name': connection_name
                 }
             }
-            if self._multiregion_account_(account_name):
+            if self._multiregion_account_(acc_account_name):
                 values['provider'] = 'aws.' + accepter['region']
             tf_resource = \
                 aws_vpc_peering_connection_accepter(identifier, **values)
-            self.add_resource(account_name, tf_resource)
+            self.add_resource(acc_account_name, tf_resource)
 
     def populate_resources(self, namespaces, existing_secrets):
         self.init_populate_specs(namespaces)

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -334,6 +334,9 @@ class TerrascriptClient(object):
                     'Name': connection_name
                 }
             }
+            req_peer_owner_id = requester.get('peer_owner_id')
+            if req_peer_owner_id:
+                values['peer_owner_id'] = req_peer_owner_id
             tf_resource = aws_vpc_peering_connection(identifier, **values)
             self.add_resource(req_account_name, tf_resource)
 


### PR DESCRIPTION
This PR adds the ability to peer an OCM cluster to another OCM cluster

Notes for the reviewer:
- I changed `populate_vpc_peerings` in `terraform_client.py` so that each the requester and accepter have their own account. This is to accomodate the fact a cluster-to-cluster peering use two different accounts/roles to create the requester and accepter objects on each respective account
- The code makes a few assumptions, such as the presence of some dict keys, which come from the graphql query results and required fields in the schemas. As such the code doesn't currently check for the presence of these keys which IMO would be a bit redundant
- Please checkout and run the integration locally. Note that you will also need https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/4611 as there are schema changes.
- When you run the integration locally, note that a few existing peerings have changes in the resulting terraform spec. This is because of the addition of the `provider` field on the accepter dict in `populate_vpc_peerings`. From my findings this is OK, as without this they defaulted to the `__DEFAULT__` provider, which has the same credentials as the one that is now being specified. The resulting terraform spec doesn not cause a change in the plan.