### PR TITLE
Allow for absence of controller attribute in owner ref

### DIFF
--- a/utils/oc.py
+++ b/utils/oc.py
@@ -258,7 +258,7 @@ class OC(object):
     def get_obj_root_owner(self, ns, obj):
         refs = obj['metadata'].get('ownerReferences', [])
         for r in refs:
-            if r['controller']:
+            if r.get('controller'):
                 controller_obj = self.get(ns, r['kind'], r['name'])
                 return self.get_obj_root_owner(ns, controller_obj)
         return obj


### PR DESCRIPTION
Pods with ownerReferences that do not contain 'controller' raise a
KeyError when trying to find the root owner in order to recycle the
deployment.

It seems that the 'controller' attribute does not appear in
ownerReferences of pods that are not running, e.g. *-deploy pods that
were not immediately deleted upon termination of the pod.  Therefore it
seems safe to assume pods without the 'controller' attribute in
ownerReferences can be skipped for recyling.