### PR TITLE
[aws-ecr-image-pull-secrets] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 
 - `aws-garbage-collector`: Delete orphan AWS resources.
 - `aws-iam-keys`: Delete IAM access keys by access key ID.
+- `aws-ecr-image-pull-secrets`: Generate AWS ECR image pull secrets and store them in Vault.
 - `aws-support-cases-sos`: Scan AWS support cases for reports of leaked keys and remove them (only submits PR)
 - `github-repo-invites`: Accept GitHub repository invitations for known repositories.
 - `github-scanner`: Scan GitHub repositories for leaked keys and remove them (only submits PR).

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -204,6 +204,55 @@ objects:
           emptyDir: {}
         {{- end }}
 {{- end }}
+{{- range $i, $integration := .Values.cronjobs }}
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  metadata:
+    labels:
+      app: qontract-reconcile-{{ $integration.name }}
+    name: qontract-reconcile-{{ $integration.name }}
+  spec:
+    schedule: "{{ $integration.cron }}"
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: int
+              image: ${IMAGE}:${IMAGE_TAG}
+              env:
+              - name: DRY_RUN
+                value: ${DRY_RUN}
+              - name: INTEGRATION_NAME
+                value: {{ $integration.name }}
+              - name: INTEGRATION_EXTRA_ARGS
+                value: "{{ $integration.extraArgs }}"
+              - name: GITHUB_API
+                valueFrom:
+                  configMapKeyRef:
+                    name: app-interface
+                    key: GITHUB_API
+              - name: UNLEASH_API_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: API_URL
+              - name: UNLEASH_CLIENT_ACCESS_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: CLIENT_ACCESS_TOKEN
+              volumeMounts:
+              - name: qontract-reconcile-toml
+                mountPath: /config
+              resources:
+{{ toYaml $integration.resources | indent 16 }}
+            restartPolicy: OnFailure
+            volumes:
+            - name: qontract-reconcile-toml
+              secret:
+                secretName: qontract-reconcile-toml
+{{- end }}
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/qontract-reconcile

--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -398,3 +398,14 @@ integrations:
     slack: true
     cloudwatch: true
   extraArgs: --no-use-jump-host
+cronjobs:
+- name: aws-ecr-image-pull-secrets
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 200m
+    limits:
+      memory: 200Mi
+      cpu: 300m
+  cron: '0 */6 * * *'
+  extraArgs: --vault-output-path app-sre/integrations-output

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -5412,6 +5412,58 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  metadata:
+    labels:
+      app: qontract-reconcile-aws-ecr-image-pull-secrets
+    name: qontract-reconcile-aws-ecr-image-pull-secrets
+  spec:
+    schedule: "0 */6 * * *"
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: int
+              image: ${IMAGE}:${IMAGE_TAG}
+              env:
+              - name: DRY_RUN
+                value: ${DRY_RUN}
+              - name: INTEGRATION_NAME
+                value: aws-ecr-image-pull-secrets
+              - name: INTEGRATION_EXTRA_ARGS
+                value: "--vault-output-path app-sre/integrations-output"
+              - name: GITHUB_API
+                valueFrom:
+                  configMapKeyRef:
+                    name: app-interface
+                    key: GITHUB_API
+              - name: UNLEASH_API_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: API_URL
+              - name: UNLEASH_CLIENT_ACCESS_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: CLIENT_ACCESS_TOKEN
+              volumeMounts:
+              - name: qontract-reconcile-toml
+                mountPath: /config
+              resources:
+                limits:
+                  cpu: 300m
+                  memory: 200Mi
+                requests:
+                  cpu: 200m
+                  memory: 100Mi
+            restartPolicy: OnFailure
+            volumes:
+            - name: qontract-reconcile-toml
+              secret:
+                secretName: qontract-reconcile-toml
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/qontract-reconcile

--- a/reconcile/aws_ecr_image_pull_secrets.py
+++ b/reconcile/aws_ecr_image_pull_secrets.py
@@ -1,0 +1,52 @@
+import base64
+import json
+import logging
+
+import reconcile.queries as queries
+import utils.vault_client as vault_client
+
+from utils.aws_api import AWSApi
+
+QONTRACT_INTEGRATION = 'aws-ecr-image-pull-secrets'
+
+
+def enc_dec(data):
+    return base64.b64encode(data.encode('utf-8')).decode('utf-8')
+
+
+def construct_secret_data(data):
+    auth_data = data['authorizationData'][0]
+    server = auth_data['proxyEndpoint']
+    token = auth_data['authorizationToken']
+    data = {
+        'auths': {
+            server: {
+                'username': 'AWS',
+                'password': token,
+                'email': '',
+                'auth': enc_dec(f'AWS:{token}')
+            }
+        }
+    }
+
+    return {'.dockerconfigjson': enc_dec(json.dumps(data))}
+
+
+def write_output_to_vault(dry_run, vault_path, account, secret_data):
+    integration_name = QONTRACT_INTEGRATION
+    secret_path = f"{vault_path}/{integration_name}/{account}"
+    secret = {'path': secret_path, 'data': secret_data}
+    logging.info(['write_secret', secret_path])
+    if not dry_run:
+        vault_client.write(secret)
+
+
+def run(dry_run=False, vault_output_path=''):
+    accounts = [a for a in queries.get_aws_accounts() if a.get('ecrs')]
+    settings = queries.get_app_interface_settings()
+    aws = AWSApi(1, accounts, settings=settings)
+    tokens = aws.get_ecr_auth_tokens()
+    for account, data in tokens.items():
+        secret_data = construct_secret_data(data)
+        write_output_to_vault(dry_run, vault_output_path,
+                              account, secret_data)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -52,6 +52,7 @@ import reconcile.gitlab_pr_submitter
 import reconcile.gitlab_projects
 import reconcile.aws_garbage_collector
 import reconcile.aws_iam_keys
+import reconcile.aws_ecr_image_pull_secrets
 import reconcile.aws_support_cases_sos
 import reconcile.ocm_groups
 import reconcile.ocm_clusters
@@ -459,6 +460,14 @@ def aws_garbage_collector(ctx, thread_pool_size, io_dir):
 def aws_iam_keys(ctx, thread_pool_size):
     run_integration(reconcile.aws_iam_keys, ctx.obj['dry_run'],
                     thread_pool_size)
+
+
+@integration.command()
+@vault_output_path
+@click.pass_context
+def aws_ecr_image_pull_secrets(ctx, vault_output_path):
+    run_integration(reconcile.aws_ecr_image_pull_secrets, ctx.obj['dry_run'],
+                    vault_output_path)
 
 
 @integration.command()

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -224,6 +224,9 @@ AWS_ACCOUNTS_QUERY = """
       integrations
     }
     deleteKeys
+    ecrs {
+      region
+    }
   }
 }
 """

--- a/utils/aws_api.py
+++ b/utils/aws_api.py
@@ -536,3 +536,12 @@ class AWSApi(object):
                 logging.error(msg.format(account, str(e)))
 
         return all_support_cases
+
+    def get_ecr_auth_tokens(self):
+        auth_tokens = {}
+        for account, s in self.sessions.items():
+            ecr = s.client('ecr')
+            token = ecr.get_authorization_token()
+            auth_tokens[account] = token
+
+        return auth_tokens


### PR DESCRIPTION
this integration generates image pull secrets for AWS ECR and stores them in vault.

the plan is to consume these secrets into namespaces using openshift-vault-secrets.

this integration will run once every 6 hours in a CronJob.