### PR TITLE
add logs:CreateLogGroup permission to cloudwatch provider

### DIFF
--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -1505,6 +1505,7 @@ class TerrascriptClient(object):
             "Statement": [
                 {
                     "Action": [
+                        "logs:CreateLogGroup",
                         "logs:DescribeLogStreams",
                         "logs:CreateLogStream",
                         "logs:PutLogEvents"


### PR DESCRIPTION
covers https://projects.engineering.redhat.com/browse/RHCLOUD-6817

since we give permissions for the specific log group, adding this shouldn't be harmful despite the fact that app-interface is creating these log groups.