### PR TITLE
[saas-file-owners] ignore empty comment

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -193,7 +193,8 @@ def run(gitlab_project_id, gitlab_merge_request_id, dry_run=False,
                          if not c.endswith(saas_file_path)]
 
     comment_body = '\n'.join(comment_lines.values())
-    gl.add_comment_to_merge_request(gitlab_merge_request_id, comment_body)
+    if comment_body:
+        gl.add_comment_to_merge_request(gitlab_merge_request_id, comment_body)
 
     # if there are still entries in this list - they are not approved
     if len(changed_paths) != 0:


### PR DESCRIPTION
solves this (lgtm is valid, so no lines should be added to comment, so no comment should be added):
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/exceptions.py", line 259, in wrapped_f
    return f(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/mixins.py", line 204, in create
    server_data = self.gitlab.http_post(path, post_data=data, files=files, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/__init__.py", line 674, in http_post
    **kwargs
  File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/__init__.py", line 564, in http_request
    response_body=result.content,
gitlab.exceptions.GitlabHttpError: 400: 400 (Bad request) "Note {:note=>["can't be blank"]}" not given

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/qontract-reconcile", line 11, in 
    load_entry_point('reconcile==0.2.2', 'console_scripts', 'qontract-reconcile')()
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 543, in saas_file_owners
    ctx.obj['dry_run'], io_dir, compare)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 220, in run_integration
    func_container.run(*args)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/saas_file_owners.py", line 196, in run
    gl.add_comment_to_merge_request(gitlab_merge_request_id, comment_body)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/utils/gitlab_api.py", line 473, in add_comment_to_merge_request
    merge_request.notes.create({'body': body})
  File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/exceptions.py", line 261, in wrapped_f
    raise error(e.error_message, e.response_code, e.response_body)
gitlab.exceptions.GitlabCreateError: 400: 400 (Bad request) "Note {:note=>["can't be blank"]}" not given
```