### PR TITLE
[aws-ecr-image-pull-secrets] add url to basic-auth output secret

### DIFF
--- a/reconcile/aws_ecr_image_pull_secrets.py
+++ b/reconcile/aws_ecr_image_pull_secrets.py
@@ -41,7 +41,8 @@ def construct_basic_auth_secret_data(data):
     auth_data = data['authorizationData'][0]
     token = auth_data['authorizationToken']
     password = get_password(token)
-    return {'user': enc_dec('AWS'), 'token': enc_dec(password)}
+    url = enc_dec(auth_data['proxyEndpoint'].replace('https://', ''))
+    return {'user': enc_dec('AWS'), 'token': enc_dec(password), 'url': url}
 
 
 def write_output_to_vault(dry_run, vault_path, account, secret_data, name):


### PR DESCRIPTION
this will allow us to supply the basic-auth output secret to jenkins jobs that need to push images to ECR.

the secret will always contain valid push credentials.