### PR TITLE
gitlab upgrade fixes

### DIFF
--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -237,6 +237,7 @@ class GitLabApi(object):
 
         # add key to deleteKeys list to be picked up by aws-iam-keys
         msg = 'add key to deleteKeys'
+        path = path.lstrip('/')
         f = self.project.files.get(file_path=path, ref=target_branch)
         content = yaml.load(f.decode(), Loader=yaml.RoundTripLoader)
         content.setdefault('deleteKeys', [])
@@ -556,6 +557,7 @@ Please consult relevant SOPs to verify that the account is secure.
         Wrapper around Gitlab.files.get() with exception handling.
         """
         try:
+            path = path.lstrip('/')
             return self.project.files.get(file_path=path, ref=ref)
         except gitlab.exceptions.GitlabGetError:
             return None

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -118,7 +118,7 @@ class SaasHerder():
             if not self.gitlab:
                 raise Exception('gitlab is not initialized')
             project = self.gitlab.get_project(url)
-            f = project.files.get(file_path=path, ref=ref)
+            f = project.files.get(file_path=path.lstrip('/'), ref=ref)
             html_url = os.path.join(url, 'blob', ref, path)
             return f.decode(), html_url
 


### PR DESCRIPTION
following a gitlab upgrade, the `project.files.get` is broken if path is passed with a leading `/`.