### PR TITLE
[ocm-github-idp] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `ocm-groups`: Manage membership in OpenShift groups using OpenShift Cluster Manager.
 - `ocm-clusters`: Manages (currently: validates only) clusters desired state with current state in OCM.
 - `ocm-aws-infrastructure-access`: Grants AWS infrastructure access to members in AWS groups via OCM.
+- `ocm-github-idp`: Manage GitHub Identity Providers in OCM.
 - `email-sender`: Send email notifications to app-interface audience.
 - `requests-sender`: Send emails to users based on requests submitted to app-interface.
 - `service-dependencies`: Validate dependencies are defined for each service.

--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -327,6 +327,17 @@ integrations:
       cpu: 100m
   logs:
     slack: true
+- name: ocm-github-idp
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 100m
+    limits:
+      memory: 200Mi
+      cpu: 200m
+  extraArgs: --vault-input-path app-sre/integrations-input
+  logs:
+    cloudwatch: true
 - name: email-sender
   resources:
     requests:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -4480,6 +4480,155 @@ objects:
   kind: Deployment
   metadata:
     labels:
+      app: qontract-reconcile-ocm-github-idp
+    name: qontract-reconcile-ocm-github-idp
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile-ocm-github-idp
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile-ocm-github-idp
+      spec:
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name ocm-github-idp
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          env:
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: ocm-github-idp
+          - name: INTEGRATION_EXTRA_ARGS
+            value: "--vault-input-path app-sre/ci-int/github-oauth"
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: GITHUB_API
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
+          - name: UNLEASH_API_URL
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: API_URL
+          - name: UNLEASH_CLIENT_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: CLIENT_ACCESS_TOKEN
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
       app: qontract-reconcile-email-sender
     name: qontract-reconcile-email-sender
   spec:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -4554,7 +4554,7 @@ objects:
           - name: INTEGRATION_NAME
             value: ocm-github-idp
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--vault-input-path app-sre/ci-int/github-oauth"
+            value: "--vault-input-path app-sre/integrations-input"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -58,6 +58,7 @@ import reconcile.aws_support_cases_sos
 import reconcile.ocm_groups
 import reconcile.ocm_clusters
 import reconcile.ocm_aws_infrastructure_access
+import reconcile.ocm_github_idp
 import reconcile.email_sender
 import reconcile.requests_sender
 import reconcile.service_dependencies
@@ -155,6 +156,14 @@ def throughput(function):
     function = click.option('--io-dir',
                             help='directory of input/output files.',
                             default='throughput/')(function)
+
+    return function
+
+
+def vault_input_path(function):
+    function = click.option('--vault-input-path',
+                            help='path in Vault to find input resources.',
+                            default='')(function)
 
     return function
 
@@ -778,6 +787,14 @@ def ocm_clusters(ctx, thread_pool_size):
 def ocm_aws_infrastructure_access(ctx):
     run_integration(reconcile.ocm_aws_infrastructure_access,
                     ctx.obj['dry_run'])
+
+
+@integration.command()
+@vault_input_path
+@click.pass_context
+def ocm_github_idp(ctx, vault_input_path):
+    run_integration(reconcile.ocm_github_idp,
+                    ctx.obj['dry_run'], vault_input_path)
 
 
 @integration.command()

--- a/reconcile/ocm_github_idp.py
+++ b/reconcile/ocm_github_idp.py
@@ -85,7 +85,8 @@ def run(dry_run=False, vault_input_path=''):
                 if c.get('ocm') is not None
                 and c.get('auth') is not None]
     ocm_map, current_state = fetch_current_state(clusters, settings)
-    desired_state, error = fetch_desired_state(clusters, vault_input_path, settings)
+    desired_state, error = \
+        fetch_desired_state(clusters, vault_input_path, settings)
     if error:
         sys.exit(1)
     act(dry_run, ocm_map, current_state, desired_state)

--- a/reconcile/ocm_github_idp.py
+++ b/reconcile/ocm_github_idp.py
@@ -1,0 +1,91 @@
+import sys
+import logging
+
+import reconcile.queries as queries
+
+from utils.ocm import OCMMap
+from utils import secret_reader
+
+QONTRACT_INTEGRATION = 'ocm-github-idp'
+
+
+def fetch_current_state(clusters, settings):
+    current_state = []
+    ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
+                     settings=settings)
+
+    for cluster_info in clusters:
+        cluster = cluster_info['name']
+        ocm = ocm_map.get(cluster)
+        idps = ocm.get_github_idp_teams(cluster)
+        current_state.extend(idps)
+
+    return ocm_map, current_state
+
+
+def fetch_desired_state(clusters, vault_input_path, settings):
+    desired_state = []
+    error = False
+    for cluster_info in clusters:
+        cluster = cluster_info['name']
+        auth = cluster_info['auth']
+        service = auth['service']
+        if service != 'github-org-team':
+            # currently not supported
+            continue
+        org = auth['org']
+        team = auth['team']
+        secret_path = f'{vault_input_path}/{QONTRACT_INTEGRATION}/' + \
+            f'{service}/{org}/{team}'
+        secret = {'path': secret_path}
+        try:
+            oauth_data = secret_reader.read_all(secret, settings=settings)
+            client_id = oauth_data['client-id']
+            client_secret = oauth_data['client-secret']
+        except Exception:
+            logging.error(f"unable to read secret in path {secret['path']}")
+            error = True
+            continue
+        item = {
+            'cluster': cluster,
+            'name': f'github-{org}',
+            'client_id': client_id,
+            'client_secret': client_secret,
+            'teams': [f'{org}/{team}']
+        }
+        desired_state.append(item)
+
+    return desired_state, error
+
+
+def sanitize(state):
+    return {k: v for k, v in state.items() if k != 'client_secret'}
+
+
+def act(dry_run, ocm_map, current_state, desired_state):
+    to_add = [d for d in desired_state
+              if sanitize(d) not in current_state]
+    for item in to_add:
+        cluster = item['cluster']
+        idp_name = item['name']
+        team = item['teams'][0]
+        logging.info(['create_github_idp', cluster, idp_name, team])
+
+        if not dry_run:
+            ocm = ocm_map.get(cluster)
+            ocm.create_github_idp_teams(item)
+
+
+def run(dry_run=False, vault_input_path=''):
+    if not vault_input_path:
+        logging.error('must supply vault input path')
+        sys.exit(1)
+    settings = queries.get_app_interface_settings()
+    clusters = [c for c in queries.get_clusters()
+                if c.get('ocm') is not None
+                and c.get('auth') is not None]
+    ocm_map, current_state = fetch_current_state(clusters, settings)
+    desired_state, error = fetch_desired_state(clusters, vault_input_path, settings)
+    if error:
+        sys.exit(1)
+    act(dry_run, ocm_map, current_state, desired_state)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -258,6 +258,11 @@ CLUSTERS_QUERY = """
         format
       }
     }
+    auth {
+      service
+      org
+      team
+    }
     ocm {
       name
       url


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-1819

this integration will create github IDPs in OCM, based on the `auth` data in a cluster file.
Vault secrets with github OAuth apps client-id and client-secret should pre-exist (manually :cry:)

this integration only creates new IDPs, allowing us to keep managing manually as well.