### PR TITLE
[terraform-vpc-peerings] cluster vpc_id no longer required

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -305,7 +305,6 @@ CLUSTERS_QUERY = """
       pod
     }
     peering {
-      vpc_id
       connections {
         name
         vpc {
@@ -313,6 +312,10 @@ CLUSTERS_QUERY = """
             name
             uid
             terraformUsername
+            automationToken {
+              path
+              field
+            }
           }
           vpc_id
           cidr_block


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-1819

until now, we had to supply the cluster's VPC ID in order to be able to set VPC peerings.
this PR adds usage of AWS API in the integration to find the cluster's VPC ID according to the CIDR block defined in the cluster file.

this makes the cluster on-boarding much easier, as no one has to login to the cluster's AWS console to find the VPC ID.