### PR TITLE
Fix sentry: support multiple instances of the same team

### DIFF
--- a/reconcile/sentry_config.py
+++ b/reconcile/sentry_config.py
@@ -521,7 +521,10 @@ def fetch_desired_state(gqlapi, sentry_instance, ghapi):
                         else:
                             config[field] = project_config[field]
                 team_projects.append(config)
-            projects[team] = team_projects
+            if team in projects:
+                projects[team].extend(team_projects)
+            else:
+                projects[team] = team_projects
     state.init_projects(projects)
     return state
 


### PR DESCRIPTION
When the same team shows up in different places, the data structure is reset
and only the projects from the last definition are taken into account.

This patch add a check to decide if we have to extend the team projects.

Signed-off-by: Amador Pahim <apahim@redhat.com>