### PR TITLE
Increase the memory requests/limits for the github integration

### DIFF
--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -13,10 +13,10 @@ integrations:
 - name: github
   resources:
     requests:
-      memory: 50Mi
+      memory: 100Mi
       cpu: 100m
     limits:
-      memory: 80Mi
+      memory: 150Mi
       cpu: 200m
   logs:
     slack: true

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -309,10 +309,10 @@ objects:
           resources:
             limits:
               cpu: 200m
-              memory: 80Mi
+              memory: 150Mi
             requests:
               cpu: 100m
-              memory: 50Mi
+              memory: 100Mi
           volumeMounts:
           - name: qontract-reconcile-toml
             mountPath: /config


### PR DESCRIPTION
In a typical unconstrained execution, it spikes at 88MB. That spike
should be covered by the requests (with some margin). The limit is set
to 50% above the requests.

Signed-off-by: Amador Pahim <apahim@redhat.com>