### PR TITLE
distribute shards

### DIFF
--- a/reconcile/openshift_network_policies.py
+++ b/reconcile/openshift_network_policies.py
@@ -118,8 +118,13 @@ def run(dry_run=False, thread_pool_size=10, internal=None,
         for namespace_info in gqlapi.query(NAMESPACES_QUERY)['namespaces']:
             if not namespace_info.get('networkPoliciesAllow'):
                 continue
-            if not is_in_shard(namespace_info['name']):
+
+            shard_key = (f"{namespace_info['cluster']['name']}/"
+                         f"{namespace_info['name']}")
+
+            if not is_in_shard(shard_key):
                 continue
+
             namespaces.append(namespace_info)
 
         ri, oc_map = ob.fetch_current_state(


### PR DESCRIPTION
Shard 2 is running consistently slower than shard 0. I think this is because we are not sharding on the correct key.

![image](https://user-images.githubusercontent.com/126666/84533626-cbcfba00-ace8-11ea-9679-c4209340ce95.png)

Right now we are sharding based on the namespace name only, and we have many instances of the same name, and those are all sharded to same instance:

```
$ q get -o json namespaces|jq -r '.[].name'|sort |uniq -c |sort -k1 -n|tail
      3 redacted
      3 redacted
      3 redacted
      3 redacted
      3 redacted
      5 redacted
      5 redacted
     12 redacted
     13 redacted
     13 redacted
```

Since it's preferable to shard on unique keys, I propose this patch, with this we will favour shards to run similar workloads.