### PR TITLE
Increasing openshift-routes memory

### DIFF
--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -252,10 +252,12 @@ integrations:
 - name: openshift-routes
   resources:
     requests:
-      memory: 300Mi
+      # Known peaks are at 770Mi
+      memory: 800Mi
       cpu: 200m
     limits:
-      memory: 400Mi
+      # Limits 30% above requests
+      memory: 1040Mi
       cpu: 300m
   extraArgs: --no-use-jump-host
   logs:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -4227,10 +4227,10 @@ objects:
           resources:
             limits:
               cpu: 300m
-              memory: 400Mi
+              memory: 1040Mi
             requests:
               cpu: 200m
-              memory: 300Mi
+              memory: 800Mi
           volumeMounts:
           - name: qontract-reconcile-toml
             mountPath: /config


### PR DESCRIPTION
The integration was oom-killed 42 times out of 339 runs in the last 24h.

It currently peaks at ~770Mi. Let's set the requests to 800 and the limits to 30% above that.

![Screenshot from 2020-06-14 23-01-45](https://user-images.githubusercontent.com/4717757/84605230-a7641100-ae93-11ea-8fcb-263bca3a339b.png)