### PR TITLE
preprocess jinja vault path and key

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -154,9 +154,10 @@ class UnknownTemplateTypeError(Exception):
         )
 
 
-def lookup_vault_secret(path, key, version=None, tvars={}):
-    path = process_jinja2_template(path, vars=tvars)
-    key = process_jinja2_template(key, vars=tvars)
+def lookup_vault_secret(path, key, version=None, tvars=None):
+    if tvars is not None:
+        path = process_jinja2_template(path, vars=tvars)
+        key = process_jinja2_template(key, vars=tvars)
     secret = {
         'path': path,
         'field': key,

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -154,7 +154,9 @@ class UnknownTemplateTypeError(Exception):
         )
 
 
-def lookup_vault_secret(path, key, version=None):
+def lookup_vault_secret(path, key, version=None, tvars={}):
+    path = process_jinja2_template(path, vars=tvars)
+    key = process_jinja2_template(key, vars=tvars)
     secret = {
         'path': path,
         'field': key,
@@ -167,7 +169,8 @@ def lookup_vault_secret(path, key, version=None):
 
 
 def process_jinja2_template(body, vars={}, env={}):
-    vars.update({'vault': lookup_vault_secret})
+    vars.update({'vault': lambda p, k, v=None:
+        lookup_vault_secret(p, k, v, vars)})
     try:
         env = jinja2.Environment(
             extensions=[B64EncodeExtension],

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -170,7 +170,7 @@ def lookup_vault_secret(path, key, version=None, tvars={}):
 
 def process_jinja2_template(body, vars={}, env={}):
     vars.update({'vault': lambda p, k, v=None:
-        lookup_vault_secret(p, k, v, vars)})
+                 lookup_vault_secret(p, k, v, vars)})
     try:
         env = jinja2.Environment(
             extensions=[B64EncodeExtension],


### PR DESCRIPTION
there are cases when we want to add templating for the vault path or key to use. this PR implements that.