### PR TITLE
[openshift-saas-deploy-trigger-configs] only trigger on changes in relevant fields

### DIFF
--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -503,14 +503,8 @@ class SaasHerder():
     def sanitize_namespace(namespace):
         """Only keep fields that should trigger a new job."""
         new_job_fields = {
-            # https://gitlab.cee.redhat.com/service/app-interface/-/blob/master
-            # /schemas/openshift/namespace-1.yml
             'namespace': ['name', 'cluster', 'app'],
-            # https://gitlab.cee.redhat.com/service/app-interface/-/blob/master
-            # /schemas/openshift/cluster-1.yml
             'cluster':  ['name', 'serverUrl'],
-            # https://gitlab.cee.redhat.com/service/app-interface/-/blob/master
-            # /schemas/app-sre/app-1.yml
             'app': ['name']
         }
         namespace = {k: v for k, v in namespace.items()

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -505,10 +505,10 @@ class SaasHerder():
                      if k in ['name', 'cluster', 'app']}
         cluster = namespace['cluster']
         namespace['cluster'] = {k: v for k, v in cluster.items()
-                   if k in ['name', 'serverUrl']}
+                                if k in ['name', 'serverUrl']}
         app = namespace['app']
         namespace['app'] = {k: v for k,v in app.items()
-               if k in ['name']}
+                            if k in ['name']}
 
     def update_config(self, job_spec):
         saas_file_name = job_spec['saas_file_name']

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -502,14 +502,25 @@ class SaasHerder():
     @staticmethod
     def sanitize_namespace(namespace):
         """Only keep fields that should trigger a new job."""
+        new_job_fields = {
+            # https://gitlab.cee.redhat.com/service/app-interface/-/blob/master
+            # /schemas/openshift/namespace-1.yml
+            'namespace': ['name', 'cluster', 'app'],
+            # https://gitlab.cee.redhat.com/service/app-interface/-/blob/master
+            # /schemas/openshift/cluster-1.yml
+            'cluster':  ['name', 'serverUrl'],
+            # https://gitlab.cee.redhat.com/service/app-interface/-/blob/master
+            # /schemas/app-sre/app-1.yml
+            'app': ['name']
+        }
         namespace = {k: v for k, v in namespace.items()
-                     if k in ['name', 'cluster', 'app']}
+                     if k in new_job_fields['namespace']}
         cluster = namespace['cluster']
         namespace['cluster'] = {k: v for k, v in cluster.items()
-                                if k in ['name', 'serverUrl']}
+                                if k in new_job_fields['cluster']}
         app = namespace['app']
         namespace['app'] = {k: v for k, v in app.items()
-                            if k in ['name']}
+                            if k in new_job_fields['app']}
         return namespace
 
     def update_config(self, job_spec):

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -473,6 +473,7 @@ class SaasHerder():
                 cluster_name = namespace['cluster']['name']
                 namespace_name = namespace['name']
                 env_name = namespace['environment']['name']
+                self.sanitize_namespace(namespace)
                 # add parent parameters to target config
                 desired_target_config['saas_file_parameters'] = \
                     saas_file_parameters
@@ -496,6 +497,18 @@ class SaasHerder():
                 trigger_specs.append(job_spec)
 
         return trigger_specs
+
+    @staticmethod
+    def sanitize_namespace(namespace):
+        """Only keep fields that should trigger a new job."""
+        namepsace = {k: v for k, v in namespace.items()
+                     if k in ['name', 'cluster', 'app']}
+        cluster = namespace['cluster']
+        namespace['cluster'] = {k: v for k, v in cluster.items()
+                   if k in ['name', 'serverUrl']}
+        app = namespace['app']
+        namespace['app'] = {k: v for k,v in app.items()
+               if k in ['name']}
 
     def update_config(self, job_spec):
         saas_file_name = job_spec['saas_file_name']

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -473,7 +473,8 @@ class SaasHerder():
                 cluster_name = namespace['cluster']['name']
                 namespace_name = namespace['name']
                 env_name = namespace['environment']['name']
-                self.sanitize_namespace(namespace)
+                desired_target_config['namespace'] = \
+                    self.sanitize_namespace(namespace)
                 # add parent parameters to target config
                 desired_target_config['saas_file_parameters'] = \
                     saas_file_parameters
@@ -501,14 +502,15 @@ class SaasHerder():
     @staticmethod
     def sanitize_namespace(namespace):
         """Only keep fields that should trigger a new job."""
-        namepsace = {k: v for k, v in namespace.items()
+        namespace = {k: v for k, v in namespace.items()
                      if k in ['name', 'cluster', 'app']}
         cluster = namespace['cluster']
         namespace['cluster'] = {k: v for k, v in cluster.items()
                                 if k in ['name', 'serverUrl']}
         app = namespace['app']
-        namespace['app'] = {k: v for k,v in app.items()
+        namespace['app'] = {k: v for k, v in app.items()
                             if k in ['name']}
+        return namespace
 
     def update_config(self, job_spec):
         saas_file_name = job_spec['saas_file_name']


### PR DESCRIPTION
currently, even if there is a change to `managedRoles` in a namespace file, a new deployment will be triggered to that namespace.

this PR sanitizes the namespace object to avoid triggering jobs on unrelated changes.