### PR TITLE
[openshift-saas-deploy] add option to disable deployment to a target

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -851,6 +851,7 @@ SAAS_FILES_QUERY = """
         ref
         parameters
         upstream
+        disable
       }
     }
     roles {

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -75,6 +75,12 @@ class SaasHerder():
                 targets = rt['targets']
                 for target in targets:
                     namespace = target['namespace']
+                    if target.get('disable'):
+                        logging.warning(
+                            f"[{saas_file['name']}/{rt['name']}] target " +
+                            f"{namespace['cluster']['name']}/" +
+                            f"{namespace['name']} is disabled.")
+                        continue
                     # managedResourceTypes is defined per saas_file
                     # add it to each namespace in the current saas_file
                     namespace['managedResourceTypes'] = managed_resource_types
@@ -328,6 +334,9 @@ class SaasHerder():
 
             # iterate over targets (each target is a namespace)
             for target in rt['targets']:
+                if target.get('disable'):
+                    # a warning is logged during SaasHerder initiation
+                    continue
                 cluster, namespace = \
                     self._get_cluster_and_namespace(target)
                 process_template_options = {


### PR DESCRIPTION
this PR adds a way to disable deployments in openshift-saas-deploy to specified targets.

the actual job in Jenkins will still be enabled, but the target will be skipped during execution.

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/5471