### PR TITLE
[slack-usergroups] do not depend on PagerDuty name

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -673,6 +673,7 @@ USERS_QUERY = """
     org_username
     github_username
     slack_username
+    pagerduty_username
     public_gpg_key
   }
 }

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -673,7 +673,6 @@ USERS_QUERY = """
     org_username
     github_username
     slack_username
-    pagerduty_name
     public_gpg_key
   }
 }

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -38,6 +38,7 @@ ROLES_QUERY = """
       name
       org_username
       slack_username
+      pagerduty_username
     }
     permissions {
       service
@@ -131,7 +132,7 @@ def get_slack_username(user):
 
 
 def get_pagerduty_name(user):
-    return user['org_username']
+    return user['pagerduty_username'] or user['org_username']
 
 
 def get_slack_usernames_from_pagerduty(pagerduties, users, usergroup):
@@ -163,8 +164,9 @@ def get_slack_usernames_from_pagerduty(pagerduties, users, usergroup):
              if pagerduty_name not in all_pagerduty_names]
         if not_found_pagerduty_names:
             msg = (
-                '[{}] org_usernames not found in app-interface: {} '
-                '(hint: create a user file if one does not exist.'
+                '[{}] PagerDuty username not found in app-interface: {} '
+                '(hint: user files should contain '
+                'pagerduty_username if it is different then org_username)'
             ).format(usergroup, not_found_pagerduty_names)
             logging.warning(msg)
         all_slack_usernames.extend(slack_usernames)

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -38,7 +38,6 @@ ROLES_QUERY = """
       name
       org_username
       slack_username
-      pagerduty_name
     }
     permissions {
       service
@@ -132,7 +131,7 @@ def get_slack_username(user):
 
 
 def get_pagerduty_name(user):
-    return user['pagerduty_name'] or user['name']
+    return user['org_username']
 
 
 def get_slack_usernames_from_pagerduty(pagerduties, users, usergroup):
@@ -164,9 +163,8 @@ def get_slack_usernames_from_pagerduty(pagerduties, users, usergroup):
              if pagerduty_name not in all_pagerduty_names]
         if not_found_pagerduty_names:
             msg = (
-                '[{}] PagerDuty names not found in app-interface: {} '
-                '(hint: user files should contain '
-                'pagerduty_name if it is different then name)'
+                '[{}] org_usernames not found in app-interface: {} '
+                '(hint: create a user file if one does not exist.'
             ).format(usergroup, not_found_pagerduty_names)
             logging.warning(msg)
         all_slack_usernames.extend(slack_usernames)

--- a/utils/pagerduty_api.py
+++ b/utils/pagerduty_api.py
@@ -5,6 +5,10 @@ import requests
 import utils.secret_reader as secret_reader
 
 
+class PagerDutyUserNotFoundException(Exception):
+    pass
+
+
 class PagerDutyApi(object):
     """Wrapper around PagerDuty API calls"""
 
@@ -34,7 +38,8 @@ class PagerDutyApi(object):
             if user.id == user_id:
                 return user.email.split('@')[0]
 
-        return None
+        # should never be reached as user_id comes from PagerDuty API itself
+        raise PagerDutyUserNotFoundException(user_id)
 
     def get_schedule_users(self, schedule_id, now):
         s = pypd.Schedule.fetch(


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2057

instead of using the user's name field (which may contain special chars) we use the user's id and get his email (organization username).