### PR TITLE
[openshift-saas-deploy] use auth_server to check image when it exists

### DIFF
--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -318,8 +318,8 @@ class SaasHerder():
         if not ok:
             logging.warning(
                 "the specified image authentication secret " +
-                f"found in path {auth_image['path']} does not contain " +
-                f"all required keys: {required_keys}"
+                f"found in path {auth_image_secret['path']} " +
+                f"does not contain all required keys: {required_keys}"
             )
             return None
 

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -259,6 +259,7 @@ class SaasHerder():
         if image_auth:
             username = image_auth['user']
             password = image_auth['token']
+            auth_server = image_auth.get('url')
         else:
             username = None
             password = None
@@ -269,7 +270,12 @@ class SaasHerder():
                 logging.error(
                     f"{error_prefix} Image is not in imagePatterns: {image}")
             try:
-                valid = Image(image, username=username, password=password)
+                valid = Image(
+                    image,
+                    username=username,
+                    password=password,
+                    auth_server=auth_server
+                )
                 if not valid:
                     error = True
                     logging.error(


### PR DESCRIPTION
currently we only allow to supply a single image authentication secret in a saas file. moving forward, we will probably need to allow a list quite soon.

even now, not all images in a saas file require authentication, and specifically some of them (and sometimes most of them) do not require the authentication specified in the image auth section.

sretoolbox's `Image` already supports an `auth_server` argument. using it, it will decide if the image that is currently checked belongs to the server to which we authenticate to. if not equal, the image check will be done without authentication.

this speeds up saas file deployments, as it reduces the number of authentication calls.