### PR TITLE
[openshift-saas-deploy] improve parallelism model

### DIFF
--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -214,8 +214,7 @@ class SaasHerder():
                 f"error processing template: {str(e)}")
         return resources, html_url
 
-    @staticmethod
-    def _collect_images(resource):
+    def _collect_images(self, resource):
         images = set()
         # resources with pod templates
         try:

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -94,7 +94,7 @@ class SaasHerder():
         # each thread can use ~20/3 threads internally.
         # if there are 20 threads and 100 targts,
         # each thread can use 1 thread internally.
-        # 
+        #
         # each namespace is in fact a target,
         # so we can use it to calculate.
         thread_pool_size = int(

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -246,6 +246,29 @@ class SaasHerder():
 
         return images
 
+    @staticmethod
+    def _check_image(image, image_patterns, image_auth, error_prefix):
+        print('check image start: ' + image)
+        error = False
+        if image_patterns and \
+                not any(image.startswith(p) for p in image_patterns):
+            error = True
+            logging.error(
+                f"{error_prefix} Image is not in imagePatterns: {image}")
+        try:
+            valid = Image(image, **image_auth)
+            if not valid:
+                error = True
+                logging.error(
+                    f"{error_prefix} Image does not exist: {image}")
+        except Exception as e:
+            error = True
+            logging.error(f"{error_prefix} Image is invalid: {image}. " +
+                          f"details: {str(e)}")
+
+        print('check image end: ' + image)
+        return error
+
     def _check_images(self, options):
         saas_file_name = options['saas_file_name']
         resource_template_name = options['resource_template_name']
@@ -259,22 +282,9 @@ class SaasHerder():
         images = self._collect_images(resources)
 
         for image in images:
-            if image_patterns and \
-                    not any(image.startswith(p) for p in image_patterns):
+            image_error = self._check_image(image, image_patterns, image_auth, error_prefix)
+            if image_error:
                 error = True
-                logging.error(
-                    f"{error_prefix} Image is not in imagePatterns: {image}")
-            try:
-                valid = Image(image, **image_auth)
-                if not valid:
-                    error = True
-                    logging.error(
-                        f"{error_prefix} Image does not exist: {image}")
-                    continue
-            except Exception:
-                error = True
-                logging.error(f"{error_prefix} Image is invalid: {image}")
-                continue
         return error
 
     def _initiate_github(self, saas_file):

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -278,7 +278,16 @@ class SaasHerder():
             f"[{saas_file_name}/{resource_template_name}] {html_url}:"
         images = self._collect_images(resources)
 
-        errors = threaded.run(self._check_image, images, self.thread_pool_size,
+        # get a sane number of thread pool size to use
+        # when working on a low number of saas files.
+        thread_pool_size = int(
+            self.thread_pool_size /
+            len(self.saas_files) /
+            len(self.namespaces)
+        )
+        thread_pool_size = max(thread_pool_size, 1)
+
+        errors = threaded.run(self._check_image, images, thread_pool_size,
                               image_patterns=image_patterns,
                               image_auth=image_auth,
                               error_prefix=error_prefix)


### PR DESCRIPTION
openshift-saas-deploy currently works in parallel per saas file. this is ~fine for deploying multiple saas files, but has no impact when deploying a single saas file.

this PR updates the behavior to first initiate a list of specs to fetch when populating the desired state, and populate all specs in parallel. each spec represents the `target` level, so in fact this is changing the parallelism from per saas file to per target.

this PR also changes the image check to happen only once per target and not once per every resource in the target.

in addition, images are checked in parallel (a sane pool size is estimated by number of saas files and total number of namespaces, which represent targets). for a saas file with many images such as telemeter, this reduces the execution time from ~2m to ~20s.