### PR TITLE
[openshift-saas-deploy] skip compare when running in non dry-run mode

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -52,7 +52,8 @@ def run(dry_run=False, thread_pool_size=10,
     # is being called from multiple running instances
     ob.realize_data(dry_run, oc_map, ri,
                     caller=saas_file_name,
-                    wait_for_namespace=True)
+                    wait_for_namespace=True,
+                    no_dry_run_skip_compare=True)
 
     if ri.has_error_registered():
         sys.exit(1)


### PR DESCRIPTION
for multiple reasons, let's just apply all resources in every execution:
1. better user experience (why wasn't this Service applied?)
2. faster execution (even if by a bit)
3. avoids errors in our internal compare logic