### PR TITLE
[openshift-saas-deploy] add option to get input from io-dir

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -30,6 +30,7 @@ import reconcile.openshift_saas_deploy
 import reconcile.openshift_saas_deploy_trigger_moving_commits
 import reconcile.openshift_saas_deploy_trigger_configs
 import reconcile.saas_file_owners
+import reconcile.saas_file_validator
 import reconcile.quay_membership
 import reconcile.gcr_mirror
 import reconcile.quay_mirror
@@ -172,12 +173,15 @@ def terraform(function):
     return function
 
 
-def throughput(function):
-    function = click.option('--io-dir',
-                            help='directory of input/output files.',
-                            default='throughput/')(function)
-
-    return function
+def throughput(**kwargs):
+    def f(function):
+        opt = '--io-dir'
+        msg = 'directory of input/output files.'
+        function = click.option(opt,
+                                default=kwargs.get('default', 'throughput/'),
+                                help=msg)(function)
+        return function
+    return f
 
 
 def vault_input_path(function):
@@ -402,7 +406,7 @@ def jenkins_plugins(ctx):
 
 
 @integration.command()
-@throughput
+@throughput()
 @click.option('--compare/--no-compare',
               default=True,
               help='compare between current and desired state.')
@@ -425,7 +429,7 @@ def jenkins_webhooks_cleaner(ctx):
 
 
 @integration.command()
-@throughput
+@throughput()
 @click.pass_context
 def jira_watcher(ctx, io_dir):
     run_integration(reconcile.jira_watcher, ctx.obj['dry_run'], io_dir)
@@ -467,7 +471,7 @@ def gitlab_pr_submitter(ctx, gitlab_project_id):
 
 
 @integration.command()
-@throughput
+@throughput()
 @threaded()
 @click.pass_context
 def aws_garbage_collector(ctx, thread_pool_size, io_dir):
@@ -516,6 +520,7 @@ def openshift_resources(ctx, thread_pool_size, internal, use_jump_host):
 @integration.command()
 @threaded(default=20)
 @binary(['oc', 'ssh'])
+@throughput(default=None)
 @click.option('--saas-file-name',
               default=None,
               help='saas-file to act on.')
@@ -523,10 +528,16 @@ def openshift_resources(ctx, thread_pool_size, internal, use_jump_host):
               default=None,
               help='environment to deploy to.')
 @click.pass_context
-def openshift_saas_deploy(ctx, thread_pool_size, saas_file_name, env_name):
+def openshift_saas_deploy(ctx, thread_pool_size, saas_file_name, env_name, io_dir):
     run_integration(reconcile.openshift_saas_deploy,
                     ctx.obj['dry_run'], thread_pool_size,
-                    saas_file_name, env_name)
+                    saas_file_name, env_name, io_dir)
+
+
+@integration.command()
+@click.pass_context
+def saas_file_validator(ctx):
+    run_integration(reconcile.saas_file_validator, ctx.obj['dry_run'])
 
 
 @integration.command()
@@ -550,7 +561,7 @@ def openshift_saas_deploy_trigger_configs(ctx, thread_pool_size):
 
 
 @integration.command()
-@throughput
+@throughput()
 @click.argument('gitlab-project-id')
 @click.argument('gitlab-merge-request-id')
 @click.option('--compare/--no-compare',
@@ -710,7 +721,7 @@ def user_validator(ctx):
 
 @integration.command()
 @terraform
-@throughput
+@throughput()
 @vault_output_path
 @threaded(default=20)
 @binary(['terraform', 'oc'])
@@ -732,7 +743,7 @@ def terraform_resources(ctx, print_only, enable_deletion,
 
 @integration.command()
 @terraform
-@throughput
+@throughput()
 @threaded(default=20)
 @binary(['terraform', 'gpg'])
 @enable_deletion(default=True)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -528,7 +528,8 @@ def openshift_resources(ctx, thread_pool_size, internal, use_jump_host):
               default=None,
               help='environment to deploy to.')
 @click.pass_context
-def openshift_saas_deploy(ctx, thread_pool_size, saas_file_name, env_name, io_dir):
+def openshift_saas_deploy(ctx, thread_pool_size, saas_file_name, env_name,
+                          io_dir):
     run_integration(reconcile.openshift_saas_deploy,
                     ctx.obj['dry_run'], thread_pool_size,
                     saas_file_name, env_name, io_dir)

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -8,6 +8,8 @@ import reconcile.openshift_base as ob
 from utils.gitlab_api import GitLabApi
 from utils.saasherder import SaasHerder
 from utils.defer import defer
+from reconcile.saas_file_owners import read_diffs_from_file as \
+    read_saas_file_owners_diffs
 
 
 QONTRACT_INTEGRATION = 'openshift-saas-deploy'
@@ -16,8 +18,23 @@ QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 
 @defer
 def run(dry_run=False, thread_pool_size=10,
-        saas_file_name=None, env_name=None, defer=None):
-    saas_files = queries.get_saas_files(saas_file_name, env_name)
+        saas_file_name=None, env_name=None, io_dir=None, defer=None):
+    if io_dir:
+        validate_saas_files = False
+        if saas_file_name or env_name:
+            logging.error('can not use io-dir and saas-file-name or env-name')
+            sys.exit(1)
+        saas_file_owners_diffs = read_saas_file_owners_diffs(io_dir)
+        saas_files = []
+        for diff in saas_file_owners_diffs:
+            diff_saas_file = queries.get_saas_files(
+                diff['saas_file_name'], diff['environment'])
+            saas_files.extend(diff_saas_file)
+        if not saas_files:
+            sys.exit()
+    else:
+        validate_saas_files = True
+        saas_files = queries.get_saas_files(saas_file_name, env_name)
     if not saas_files:
         logging.error('no saas files found')
         sys.exit(1)
@@ -37,8 +54,9 @@ def run(dry_run=False, thread_pool_size=10,
         gitlab=gl,
         integration=QONTRACT_INTEGRATION,
         integration_version=QONTRACT_INTEGRATION_VERSION,
-        settings=settings)
-    if not saasherder.valid:
+        settings=settings,
+        validate_saas_files=validate_saas_files)
+    if validate_saas_files and not saasherder.valid:
         sys.exit(1)
 
     ri, oc_map = ob.fetch_current_state(

--- a/reconcile/saas_file_validator.py
+++ b/reconcile/saas_file_validator.py
@@ -1,0 +1,24 @@
+import sys
+import semver
+
+import reconcile.queries as queries
+
+from utils.saasherder import SaasHerder
+
+QONTRACT_INTEGRATION = 'saas-file-validator'
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
+
+
+def run(dry_run=False):
+    saas_files = queries.get_saas_files()
+    settings = queries.get_app_interface_settings()
+    saasherder = SaasHerder(
+        saas_files,
+        thread_pool_size=1,
+        gitlab=None,
+        integration=QONTRACT_INTEGRATION,
+        integration_version=QONTRACT_INTEGRATION_VERSION,
+        settings=settings,
+        validate_saas_files=True)
+    if not saasherder.valid:
+        sys.exit(1)

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -25,11 +25,13 @@ class SaasHerder():
                  integration,
                  integration_version,
                  settings,
-                 accounts=None):
+                 accounts=None,
+                 validate_saas_files=True):
         self.saas_files = saas_files
-        self._validate_saas_files()
-        if not self.valid:
-            return
+        if validate_saas_files:
+            self._validate_saas_files()
+            if not self.valid:
+                return
         self.thread_pool_size = thread_pool_size
         self.gitlab = gitlab
         self.integration = integration


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2113

this PR adds an option to pass the `--io-dir` argument to openshift-saas-deploy and let it run only on the input in that directory.
input is a file called `diffs.json`, containing a list of dictionaries, each of them with 2 keys: `saas_file_name` and `environment`. the input file is generated by the saas-file-owners integration, which should be executed before openshift-saas-deploy.

when io-dir is passed, saas-file-name and env-name may not be passed.

in addition, since openshift-saas-deploy will not be using io-dir in our pr checks, we still need to validate all our saas files, so adding a very simple saas-file-validator integration.