### PR TITLE
[openshift-saas-deploy] introduce wrapper for io-dir

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -27,6 +27,7 @@ import reconcile.openshift_network_policies
 import reconcile.openshift_performance_parameters
 import reconcile.openshift_serviceaccount_tokens
 import reconcile.openshift_saas_deploy
+import reconcile.openshift_saas_deploy_wrapper
 import reconcile.openshift_saas_deploy_trigger_moving_commits
 import reconcile.openshift_saas_deploy_trigger_configs
 import reconcile.saas_file_owners
@@ -173,15 +174,12 @@ def terraform(function):
     return function
 
 
-def throughput(**kwargs):
-    def f(function):
-        opt = '--io-dir'
-        msg = 'directory of input/output files.'
-        function = click.option(opt,
-                                default=kwargs.get('default', 'throughput/'),
-                                help=msg)(function)
-        return function
-    return f
+def throughput(function):
+    function = click.option('--io-dir',
+                            help='directory of input/output files.',
+                            default='throughput/')(function)
+
+    return function
 
 
 def vault_input_path(function):
@@ -406,7 +404,7 @@ def jenkins_plugins(ctx):
 
 
 @integration.command()
-@throughput()
+@throughput
 @click.option('--compare/--no-compare',
               default=True,
               help='compare between current and desired state.')
@@ -429,7 +427,7 @@ def jenkins_webhooks_cleaner(ctx):
 
 
 @integration.command()
-@throughput()
+@throughput
 @click.pass_context
 def jira_watcher(ctx, io_dir):
     run_integration(reconcile.jira_watcher, ctx.obj['dry_run'], io_dir)
@@ -471,7 +469,7 @@ def gitlab_pr_submitter(ctx, gitlab_project_id):
 
 
 @integration.command()
-@throughput()
+@throughput
 @threaded()
 @click.pass_context
 def aws_garbage_collector(ctx, thread_pool_size, io_dir):
@@ -520,7 +518,6 @@ def openshift_resources(ctx, thread_pool_size, internal, use_jump_host):
 @integration.command()
 @threaded(default=20)
 @binary(['oc', 'ssh'])
-@throughput(default=None)
 @click.option('--saas-file-name',
               default=None,
               help='saas-file to act on.')
@@ -528,11 +525,20 @@ def openshift_resources(ctx, thread_pool_size, internal, use_jump_host):
               default=None,
               help='environment to deploy to.')
 @click.pass_context
-def openshift_saas_deploy(ctx, thread_pool_size, saas_file_name, env_name,
-                          io_dir):
+def openshift_saas_deploy(ctx, thread_pool_size, saas_file_name, env_name):
     run_integration(reconcile.openshift_saas_deploy,
                     ctx.obj['dry_run'], thread_pool_size,
-                    saas_file_name, env_name, io_dir)
+                    saas_file_name, env_name)
+
+
+@integration.command()
+@threaded(default=20)
+@binary(['oc', 'ssh'])
+@throughput
+@click.pass_context
+def openshift_saas_deploy_wrapper(ctx, thread_pool_size, io_dir):
+    run_integration(reconcile.openshift_saas_deploy_wrapper,
+                    ctx.obj['dry_run'], thread_pool_size, io_dir)
 
 
 @integration.command()
@@ -562,7 +568,7 @@ def openshift_saas_deploy_trigger_configs(ctx, thread_pool_size):
 
 
 @integration.command()
-@throughput()
+@throughput
 @click.argument('gitlab-project-id')
 @click.argument('gitlab-merge-request-id')
 @click.option('--compare/--no-compare',
@@ -722,7 +728,7 @@ def user_validator(ctx):
 
 @integration.command()
 @terraform
-@throughput()
+@throughput
 @vault_output_path
 @threaded(default=20)
 @binary(['terraform', 'oc'])
@@ -744,7 +750,7 @@ def terraform_resources(ctx, print_only, enable_deletion,
 
 @integration.command()
 @terraform
-@throughput()
+@throughput
 @threaded(default=20)
 @binary(['terraform', 'gpg'])
 @enable_deletion(default=True)

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -18,23 +18,8 @@ QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 
 @defer
 def run(dry_run=False, thread_pool_size=10,
-        saas_file_name=None, env_name=None, io_dir=None, defer=None):
-    if io_dir:
-        validate_saas_files = False
-        if saas_file_name or env_name:
-            logging.error('can not use io-dir and saas-file-name or env-name')
-            sys.exit(1)
-        saas_file_owners_diffs = read_saas_file_owners_diffs(io_dir)
-        saas_files = []
-        for diff in saas_file_owners_diffs:
-            diff_saas_file = queries.get_saas_files(
-                diff['saas_file_name'], diff['environment'])
-            saas_files.extend(diff_saas_file)
-        if not saas_files:
-            sys.exit()
-    else:
-        validate_saas_files = True
-        saas_files = queries.get_saas_files(saas_file_name, env_name)
+        saas_file_name=None, env_name=None, defer=None):
+    saas_files = queries.get_saas_files(saas_file_name, env_name)
     if not saas_files:
         logging.error('no saas files found')
         sys.exit(1)
@@ -54,9 +39,8 @@ def run(dry_run=False, thread_pool_size=10,
         gitlab=gl,
         integration=QONTRACT_INTEGRATION,
         integration_version=QONTRACT_INTEGRATION_VERSION,
-        settings=settings,
-        validate_saas_files=validate_saas_files)
-    if validate_saas_files and not saasherder.valid:
+        settings=settings)
+    if not saasherder.valid:
         sys.exit(1)
 
     ri, oc_map = ob.fetch_current_state(

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -8,8 +8,6 @@ import reconcile.openshift_base as ob
 from utils.gitlab_api import GitLabApi
 from utils.saasherder import SaasHerder
 from utils.defer import defer
-from reconcile.saas_file_owners import read_diffs_from_file as \
-    read_saas_file_owners_diffs
 
 
 QONTRACT_INTEGRATION = 'openshift-saas-deploy'

--- a/reconcile/openshift_saas_deploy_wrapper.py
+++ b/reconcile/openshift_saas_deploy_wrapper.py
@@ -1,0 +1,31 @@
+import semver
+
+import reconcile.openshift_saas_deploy as osd
+import utils.threaded as threaded
+
+from reconcile.saas_file_owners import read_diffs_from_file as \
+    read_saas_file_owners_diffs
+
+QONTRACT_INTEGRATION = 'openshift-saas-deploy-wrapper'
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
+
+
+def osd_run_wrapper(diff, dry_run, available_thread_pool_size):
+    saas_file_name = diff['saas_file_name']
+    env_name = diff['environment']
+    osd.run(dry_run=dry_run,
+            thread_pool_size=available_thread_pool_size,
+            saas_file_name=saas_file_name,
+            env_name=env_name)
+
+
+def run(dry_run=False, thread_pool_size=10, io_dir='throughput/'):
+    saas_file_owners_diffs = read_saas_file_owners_diffs(io_dir)
+    available_thread_pool_size = \
+        threaded.estimate_available_thread_pool_size(
+            thread_pool_size,
+            len(saas_file_owners_diffs))
+
+    threaded.run(osd_run_wrapper, saas_file_owners_diffs, thread_pool_size,
+                 dry_run=dry_run,
+                 available_thread_pool_size=available_thread_pool_size)

--- a/utils/threaded.py
+++ b/utils/threaded.py
@@ -22,3 +22,12 @@ def run(func, iterable, thread_pool_size, **kwargs):
     pool = ThreadPool(thread_pool_size)
     func_partial = functools.partial(full_traceback(func), **kwargs)
     return pool.map(func_partial, iterable)
+
+
+def estimate_available_thread_pool_size(thread_pool_size, targets_len):
+    # if there are 20 threads and only 3 targets,
+    # each thread can use ~20/3 threads internally.
+    # if there are 20 threads and 100 targts,
+    # each thread can use 1 thread internally.
+    available_thread_pool_size = int(thread_pool_size / targets_len)
+    return max(available_thread_pool_size, 1)


### PR DESCRIPTION
partially reverts #865.

this PR adds a wrapper integration around openshift-saas-deploy.

the reason for this change is that we want to use saas_file_name as the caller. this is to prevent false prints of resources that are about to be deleted in case there is more then a single saas file deploying to each namespace.