### PR TITLE
[openshift-saas-deploy-trigger-configs] skip trigger when upstream is building

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -53,6 +53,17 @@ def run(dry_run=False, thread_pool_size=10):
 
         if not dry_run:
             jenkins = jenkins_map[instance_name]
+            upstream = job_spec['target_config'].get('upstream')
+            if upstream and jenkins.is_job_running(upstream):
+                # if upstream job is defined and it is currently running,
+                # triggering the job may result in an image that was not
+                # built yet. we can skip triggering this job since it will
+                # be triggered when the upstream job succeeds. if it fails,
+                # we are better off not attempting to deploy. tl;dr - we
+                # skip triggering a job that it's upstream job is running.
+                # we use already_triggered even though the job was not
+                # triggered, but this will achieve the desired outcome.
+                already_triggered.append(job_name)
             try:
                 if job_name not in already_triggered:
                     jenkins.trigger_job(job_name)

--- a/utils/jenkins_api.py
+++ b/utils/jenkins_api.py
@@ -118,6 +118,17 @@ class JenkinsApi(object):
         return [b['result'] for b in res.json()['builds']
                 if time_limit < self.timestamp_seconds(b['timestamp'])]
 
+    def is_job_running(self, job_name):
+        url = f"{self.url}/job/{job_name}/lastBuild/api/json"
+        res = requests.get(
+            url,
+            verify=self.ssl_verify,
+            auth=(self.user, self.password)
+        )
+
+        res.raise_for_status()
+        return res.json()['building'] is True
+
     def trigger_job(self, job_name):
         try:
             crumb_url = f"{self.url}/crumbIssuer/api/json"


### PR DESCRIPTION
openshift-saas-deploy-trigger-configs triggers deployment jobs when a configuration changes.
however, if a configuration change occurs while a target's upstream job is running, it may mean that an image is in the process of being built, and we will be unable to deploy.

in such a case, it makes sense to assume that the deployment will be triggered by the upstream job upon success (as they are linked in jenkins). if the job fails, it's better that we didn't deploy.

the integration should skip triggering jobs who's upstream job is currently running. this PR does just that.