### PR TITLE
Just check for qontract.recycle to be the string "true"

### DIFF
--- a/utils/oc.py
+++ b/utils/oc.py
@@ -212,8 +212,6 @@ class OC(object):
         qontract_recycle = dep_annotations.get('qontract.recycle')
         if qontract_recycle is True:
             raise RecyclePodsInvalidAnnotationValue('should be "true"')
-        if not isinstance(qontract_recycle, str):
-            raise RecyclePodsInvalidAnnotationValue('should be a string')
         if qontract_recycle != 'true':
             logging.debug(['skipping_pod_recycle_no_annotation',
                            namespace, dep_kind])


### PR DESCRIPTION
It can be `None` if unset, so the checks will become a bit convoluted. It
is valuable to keep the check to be the string `"true"` to give
information in case of error.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>