### PR TITLE
fix resource delete to due missing caller

### DIFF
--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -137,7 +137,7 @@ class OpenshiftResource(object):
     def caller(self):
         try:
             return self.caller_name or \
-                self.body['annotations']['qontract.caller_name']
+                self.body['metadata']['annotations']['qontract.caller_name']
         except KeyError:
             return None
 


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/APPSRE-2124

since moving to openshift-saas-deploy in a distributed model, we have added support for a `caller` key to be passed to openshift_resource. this key is used to enable deploying to the same namespace from multiple saas files without interfering with one another.

this PR fixes a bug due to which resources in "shared" namespaces were not being deleted.

:facepalm: 