### PR TITLE
[openshift-saas-deploy] exit 0 on no namespaces

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -40,6 +40,9 @@ def run(dry_run=False, thread_pool_size=10,
         settings=settings)
     if not saasherder.valid:
         sys.exit(1)
+    if len(saasherder.namespaces) == 0:
+        logging.warning('no targets found')
+        sys.exit(0)
 
     ri, oc_map = ob.fetch_current_state(
         namespaces=saasherder.namespaces,

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -38,10 +38,11 @@ class SaasHerder():
         self.namespaces = self._collect_namespaces()
         # each namespace is in fact a target,
         # so we can use it to calculate.
+        divisor = len(self.namespaces) or 1
         self.available_thread_pool_size = \
             threaded.estimate_available_thread_pool_size(
                 self.thread_pool_size,
-                len(self.namespaces))
+                divisor)
         if accounts:
             self._initiate_state(accounts)
 


### PR DESCRIPTION
in a case where a job only deploys to a single target and that target is disabled, openshift-saas-deploy should exit cleanly.