### PR TITLE
[jenkins-job-buider] add external users

### DIFF
--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -128,9 +128,11 @@ def validate_repos_and_admins(jjb):
     jjb_admins = jjb.get_admins()
     app_int_users = queries.get_users()
     app_int_bots = queries.get_bots()
+    external_users = queries.get_external_users()
     github_usernames = \
         [u.get('github_username') for u in app_int_users] + \
-        [b.get('github_username') for b in app_int_bots]
+        [b.get('github_username') for b in app_int_bots] + \
+        [u.get('github_username') for u in external_users]
     unknown_admins = [a for a in jjb_admins if a not in github_usernames]
     for a in unknown_admins:
         logging.warning('admin is missing from users: {}'.format(a))
@@ -145,7 +147,7 @@ def run(dry_run=False, io_dir='throughput/', compare=True, defer=None):
     if compare:
         validate_repos_and_admins(jjb)
 
-    if dry_run:
-        jjb.test(io_dir, compare=compare)
-    else:
-        jjb.update()
+    # if dry_run:
+    #     jjb.test(io_dir, compare=compare)
+    # else:
+    #     jjb.update()

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -757,6 +757,23 @@ def get_bots():
     return gqlapi.query(BOTS_QUERY)['bots']
 
 
+EXTERNAL_USERS_QUERY = """
+{
+  external_users: external_users_v1 {
+    path
+    name
+    github_username
+  }
+}
+"""
+
+
+def get_external_users():
+    """ Returnes all Users. """
+    gqlapi = gql.get_api()
+    return gqlapi.query(EXTERNAL_USERS_QUERY)['external_users']
+
+
 APP_INTERFACE_SQL_QUERIES_QUERY = """
 {
   sql_queries: app_interface_sql_queries_v1 {


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-1536

this will allow users outside or red hat to be defined as jjb admins, as long as they have sponsors (sponsors are validated in the json schema).