### PR TITLE
[gitlab-housekeeping] merge and rebase by label priority

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -153,7 +153,7 @@ def merge_merge_requests(dry_run, gl, merge_limit, rebase):
             # running, pending, success, failed, canceled, skipped
             incomplete_pipelines = \
                 [p for p in pipelines
-                if p['status'] in ['running', 'pending']]
+                 if p['status'] in ['running', 'pending']]
             if incomplete_pipelines:
                 continue
 


### PR DESCRIPTION
in addition to merging in reversed order (FIFO), we want to merge according to label priority.

the most important label is `approved` which indicates a tenant is self-servicing a merge.
`automerge` comes next to allow our automations to accomplish their goals. `lgtm` comes last since this is a manual process anyway.