### PR TITLE
Fix warning "Connection pool is full, discarding connection: ..."

### DIFF
--- a/utils/vault_client.py
+++ b/utils/vault_client.py
@@ -30,7 +30,15 @@ def init(server, role_id, secret_id):
     global _client
 
     if _client is None:
-        client = hvac.Client(url=server)
+        # This is a threaded world. Let's define a big
+        # connections pool to live in that world
+        # (this avoids the warning "Connection pool is
+        # full, discarding connection: vault.devshift.net")
+        session = requests.Session()
+        adapter = requests.adapters.HTTPAdapter(pool_connections=100,
+                                                pool_maxsize=100)
+        session.mount('https://', adapter)
+        client = hvac.Client(url=server, session=session)
 
         authenticated = False
         for i in range(0, 3):


### PR DESCRIPTION
requests has a default connection pool of 10. Creating
multiple threads will consume from that same pool, since
the underlying implementation of the requests pool is a singletown.

Let's limit our thread_pool_size to the requests connection pool
size so we don't exhaust it.

Signed-off-by: Amador Pahim <apahim@redhat.com>