### PR TITLE
[ocm-groups] don't create/delete groups

### DIFF
--- a/reconcile/ocm_groups.py
+++ b/reconcile/ocm_groups.py
@@ -41,18 +41,6 @@ def fetch_current_state(thread_pool_size):
     return ocm_map, current_state
 
 
-def validate_diffs(diffs):
-    error = False
-    for diff in diffs:
-        if diff['action'] not in ["create_group", "delete_group"]:
-            continue
-        error = True
-        logging.error(list(diff.values()))
-        logging.error("can not create or delete groups via OCM")
-    if error:
-        sys.exit(1)
-
-
 def act(diff, ocm_map):
     cluster = diff['cluster']
     group = diff['group']
@@ -64,8 +52,6 @@ def act(diff, ocm_map):
         ocm.add_user_to_group(cluster, group, user)
     elif action == "del_user_from_group":
         ocm.del_user_from_group(cluster, group, user)
-    else:
-        raise Exception("invalid action: {}".format(action))
 
 
 def run(dry_run=False, thread_pool_size=10):
@@ -79,7 +65,6 @@ def run(dry_run=False, thread_pool_size=10):
                      if s['group'] == 'dedicated-admins']
 
     diffs = openshift_groups.calculate_diff(current_state, desired_state)
-    validate_diffs(diffs)
     openshift_groups.validate_diffs(diffs)
 
     for diff in diffs:

--- a/reconcile/ocm_groups.py
+++ b/reconcile/ocm_groups.py
@@ -68,6 +68,9 @@ def run(dry_run=False, thread_pool_size=10):
     openshift_groups.validate_diffs(diffs)
 
     for diff in diffs:
+        # we do not need to create/delete groups in OCM
+        if diff['action'] in ['create_group', 'delete_group']:
+            continue
         logging.info(list(diff.values()))
 
         if not dry_run:

--- a/reconcile/ocm_groups.py
+++ b/reconcile/ocm_groups.py
@@ -42,18 +42,6 @@ def fetch_current_state(thread_pool_size):
     return ocm_map, current_state
 
 
-def validate_diffs(diffs):
-    error = False
-    for diff in diffs:
-        if diff['action'] not in ["create_group", "delete_group"]:
-            continue
-        error = True
-        logging.error(list(diff.values()))
-        logging.error("can not create or delete groups via OCM")
-    if error:
-        sys.exit(1)
-
-
 def act(diff, ocm_map):
     cluster = diff['cluster']
     group = diff['group']
@@ -65,8 +53,6 @@ def act(diff, ocm_map):
         ocm.add_user_to_group(cluster, group, user)
     elif action == "del_user_from_group":
         ocm.del_user_from_group(cluster, group, user)
-    else:
-        raise Exception("invalid action: {}".format(action))
 
 
 def run(dry_run=False, thread_pool_size=10):
@@ -80,7 +66,6 @@ def run(dry_run=False, thread_pool_size=10):
                      if s['group'] == 'dedicated-admins']
 
     diffs = openshift_groups.calculate_diff(current_state, desired_state)
-    validate_diffs(diffs)
     openshift_groups.validate_diffs(diffs)
 
     for diff in diffs:

--- a/reconcile/ocm_groups.py
+++ b/reconcile/ocm_groups.py
@@ -1,4 +1,3 @@
-import sys
 import logging
 
 import utils.threaded as threaded
@@ -42,6 +41,18 @@ def fetch_current_state(thread_pool_size):
     return ocm_map, current_state
 
 
+def validate_diffs(diffs):
+    error = False
+    for diff in diffs:
+        if diff['action'] not in ["create_group", "delete_group"]:
+            continue
+        error = True
+        logging.error(list(diff.values()))
+        logging.error("can not create or delete groups via OCM")
+    if error:
+        sys.exit(1)
+
+
 def act(diff, ocm_map):
     cluster = diff['cluster']
     group = diff['group']
@@ -53,6 +64,8 @@ def act(diff, ocm_map):
         ocm.add_user_to_group(cluster, group, user)
     elif action == "del_user_from_group":
         ocm.del_user_from_group(cluster, group, user)
+    else:
+        raise Exception("invalid action: {}".format(action))
 
 
 def run(dry_run=False, thread_pool_size=10):
@@ -66,6 +79,7 @@ def run(dry_run=False, thread_pool_size=10):
                      if s['group'] == 'dedicated-admins']
 
     diffs = openshift_groups.calculate_diff(current_state, desired_state)
+    validate_diffs(diffs)
     openshift_groups.validate_diffs(diffs)
 
     for diff in diffs:


### PR DESCRIPTION
The OCM API does not have an endpoint to create/delete groups.

This is probably because groups are "created" when a user is added to them (I did not test this yet).
Assuming this is true, this PR makes the ocm-groups integration ignore group create/delete and only adds/removes users, which is all it should be doing (it shouldn't attempt to create/delete groups).