### PR TITLE
Adds dump-schemas functionality

### DIFF
--- a/reconcile/aws_ecr_image_pull_secrets.py
+++ b/reconcile/aws_ecr_image_pull_secrets.py
@@ -54,7 +54,7 @@ def write_output_to_vault(dry_run, vault_path, account, secret_data, name):
         vault_client.write(secret)
 
 
-def run(dry_run=False, vault_output_path=''):
+def run(dry_run, vault_output_path=''):
     accounts = [a for a in queries.get_aws_accounts() if a.get('ecrs')]
     settings = queries.get_app_interface_settings()
     aws = AWSApi(1, accounts, settings=settings, init_ecr_auth_tokens=True)

--- a/reconcile/aws_garbage_collector.py
+++ b/reconcile/aws_garbage_collector.py
@@ -5,7 +5,7 @@ from utils.aws_api import AWSApi
 QONTRACT_INTEGRATION = 'aws-garbage-collector'
 
 
-def run(dry_run=False, thread_pool_size=10, io_dir='throughput/'):
+def run(dry_run, thread_pool_size=10, io_dir='throughput/'):
     accounts = [a for a in queries.get_aws_accounts()
                 if a.get('garbageCollection')]
     settings = queries.get_app_interface_settings()

--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -41,7 +41,7 @@ def cleanup(working_dirs):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10,
+def run(dry_run, thread_pool_size=10,
         disable_service_account_keys=False, defer=None):
     accounts = queries.get_aws_accounts()
     settings = queries.get_app_interface_settings()

--- a/reconcile/aws_support_cases_sos.py
+++ b/reconcile/aws_support_cases_sos.py
@@ -46,7 +46,7 @@ def act(dry_run, gitlab_project_id, accounts, keys_to_delete):
             gw.create_delete_aws_access_key_mr(account, path, key)
 
 
-def run(dry_run=False, gitlab_project_id=None, thread_pool_size=10,
+def run(dry_run, gitlab_project_id=None, thread_pool_size=10,
         enable_deletion=False):
     accounts = queries.get_aws_accounts()
     settings = queries.get_app_interface_settings()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -75,7 +75,8 @@ import reconcile.user_validator
 
 from reconcile.status import ExitCodes
 
-from utils.gql import GqlApiError
+from utils.gql import (GqlApiError, GqlApiErrorForbiddenSchema,
+                       GqlApiIntegrationNotFound)
 from utils.aggregated_list import RunnerException
 from utils.binary import binary
 from utils.environ import environ
@@ -253,8 +254,10 @@ def enable_rebase(**kwargs):
 
 
 def run_integration(func_container, ctx, *args):
-    integration_name = func_container.QONTRACT_INTEGRATION.replace('_', '-')
-    unleash_feature_state = get_feature_toggle_state(integration_name)
+    int_name = func_container.QONTRACT_INTEGRATION.replace('_', '-')
+    gql.init_from_config(sha_url=ctx['gql_sha_url'], integration=int_name)
+
+    unleash_feature_state = get_feature_toggle_state(int_name)
     if not unleash_feature_state:
         logging.info('Integration toggle is disabled, skipping integration.')
         sys.exit(ExitCodes.SUCCESS)
@@ -266,6 +269,12 @@ def run_integration(func_container, ctx, *args):
     except RunnerException as e:
         sys.stderr.write(str(e) + "\n")
         sys.exit(ExitCodes.ERROR)
+    except GqlApiIntegrationNotFound as e:
+        sys.stderr.write(str(e) + "\n")
+        sys.exit(ExitCodes.INTEGRATION_NOT_FOUND)
+    except GqlApiErrorForbiddenSchema as e:
+        sys.stderr.write(str(e) + "\n")
+        sys.exit(ExitCodes.FORBIDDEN_SCHEMA)
     except GqlApiError as e:
         if '409' in str(e):
             logging.error(f'Data changed during execution. This is fine.')
@@ -304,9 +313,9 @@ def integration(ctx, configfile, dry_run, dump_schemas, log_level,
 
     init_log_level(log_level)
     config.init_from_toml(configfile)
-    gql.init_from_config(sha_url=gql_sha_url)
     ctx.obj['dry_run'] = dry_run
     ctx.obj['dump_schemas'] = dump_schemas
+    ctx.obj['gql_sha_url'] = gql_sha_url
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -242,15 +242,17 @@ def enable_rebase(**kwargs):
     return f
 
 
-def run_integration(func_container, *args):
+def run_integration(func_container, ctx, *args):
     integration_name = func_container.QONTRACT_INTEGRATION.replace('_', '-')
     unleash_feature_state = get_feature_toggle_state(integration_name)
     if not unleash_feature_state:
         logging.info('Integration toggle is disabled, skipping integration.')
         sys.exit(ExitCodes.SUCCESS)
 
+    dry_run = ctx.get('dry_run', False)
+
     try:
-        func_container.run(*args)
+        func_container.run(dry_run, *args)
     except RunnerException as e:
         sys.stderr.write(str(e) + "\n")
         sys.exit(ExitCodes.ERROR)
@@ -292,13 +294,13 @@ def integration(ctx, configfile, dry_run, log_level, gql_sha_url):
 @integration.command()
 @click.pass_context
 def github(ctx):
-    run_integration(reconcile.github_org, ctx.obj['dry_run'])
+    run_integration(reconcile.github_org, ctx.obj)
 
 
 @integration.command()
 @click.pass_context
 def github_owners(ctx):
-    run_integration(reconcile.github_owners, ctx.obj['dry_run'])
+    run_integration(reconcile.github_owners, ctx.obj)
 
 
 @integration.command()
@@ -310,7 +312,7 @@ def github_owners(ctx):
 @click.pass_context
 def github_users(ctx, gitlab_project_id, thread_pool_size,
                  enable_deletion, send_mails):
-    run_integration(reconcile.github_users, ctx.obj['dry_run'],
+    run_integration(reconcile.github_users, ctx.obj,
                     gitlab_project_id, thread_pool_size,
                     enable_deletion, send_mails)
 
@@ -322,14 +324,14 @@ def github_users(ctx, gitlab_project_id, thread_pool_size,
 @binary(['git', 'git-secrets'])
 @click.pass_context
 def github_scanner(ctx, gitlab_project_id, thread_pool_size):
-    run_integration(reconcile.github_scanner, ctx.obj['dry_run'],
+    run_integration(reconcile.github_scanner, ctx.obj,
                     gitlab_project_id, thread_pool_size)
 
 
 @integration.command()
 @click.pass_context
 def github_validator(ctx):
-    run_integration(reconcile.github_validator, ctx.obj['dry_run'])
+    run_integration(reconcile.github_validator, ctx.obj)
 
 
 @integration.command()
@@ -341,7 +343,7 @@ def github_validator(ctx):
 def openshift_clusterrolebindings(ctx, thread_pool_size, internal,
                                   use_jump_host):
     run_integration(reconcile.openshift_clusterrolebindings,
-                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    ctx.obj, thread_pool_size, internal,
                     use_jump_host)
 
 
@@ -352,7 +354,7 @@ def openshift_clusterrolebindings(ctx, thread_pool_size, internal,
 @use_jump_host()
 @click.pass_context
 def openshift_rolebindings(ctx, thread_pool_size, internal, use_jump_host):
-    run_integration(reconcile.openshift_rolebindings, ctx.obj['dry_run'],
+    run_integration(reconcile.openshift_rolebindings, ctx.obj,
                     thread_pool_size, internal, use_jump_host)
 
 
@@ -363,7 +365,7 @@ def openshift_rolebindings(ctx, thread_pool_size, internal, use_jump_host):
 @use_jump_host()
 @click.pass_context
 def openshift_groups(ctx, thread_pool_size, internal, use_jump_host):
-    run_integration(reconcile.openshift_groups, ctx.obj['dry_run'],
+    run_integration(reconcile.openshift_groups, ctx.obj,
                     thread_pool_size, internal, use_jump_host)
 
 
@@ -374,7 +376,7 @@ def openshift_groups(ctx, thread_pool_size, internal, use_jump_host):
 @use_jump_host()
 @click.pass_context
 def openshift_users(ctx, thread_pool_size, internal, use_jump_host):
-    run_integration(reconcile.openshift_users, ctx.obj['dry_run'],
+    run_integration(reconcile.openshift_users, ctx.obj,
                     thread_pool_size, internal, use_jump_host)
 
 
@@ -388,20 +390,20 @@ def openshift_users(ctx, thread_pool_size, internal, use_jump_host):
 def openshift_serviceaccount_tokens(ctx, thread_pool_size, internal,
                                     use_jump_host, vault_output_path):
     run_integration(reconcile.openshift_serviceaccount_tokens,
-                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    ctx.obj, thread_pool_size, internal,
                     use_jump_host, vault_output_path)
 
 
 @integration.command()
 @click.pass_context
 def jenkins_roles(ctx):
-    run_integration(reconcile.jenkins_roles, ctx.obj['dry_run'])
+    run_integration(reconcile.jenkins_roles, ctx.obj)
 
 
 @integration.command()
 @click.pass_context
 def jenkins_plugins(ctx):
-    run_integration(reconcile.jenkins_plugins, ctx.obj['dry_run'])
+    run_integration(reconcile.jenkins_plugins, ctx.obj)
 
 
 @integration.command()
@@ -411,53 +413,53 @@ def jenkins_plugins(ctx):
               help='compare between current and desired state.')
 @click.pass_context
 def jenkins_job_builder(ctx, io_dir, compare):
-    run_integration(reconcile.jenkins_job_builder, ctx.obj['dry_run'],
+    run_integration(reconcile.jenkins_job_builder, ctx.obj,
                     io_dir, compare)
 
 
 @integration.command()
 @click.pass_context
 def jenkins_webhooks(ctx):
-    run_integration(reconcile.jenkins_webhooks, ctx.obj['dry_run'])
+    run_integration(reconcile.jenkins_webhooks, ctx.obj)
 
 
 @integration.command()
 @click.pass_context
 def jenkins_webhooks_cleaner(ctx):
-    run_integration(reconcile.jenkins_webhooks_cleaner, ctx.obj['dry_run'])
+    run_integration(reconcile.jenkins_webhooks_cleaner, ctx.obj)
 
 
 @integration.command()
 @throughput
 @click.pass_context
 def jira_watcher(ctx, io_dir):
-    run_integration(reconcile.jira_watcher, ctx.obj['dry_run'], io_dir)
+    run_integration(reconcile.jira_watcher, ctx.obj, io_dir)
 
 
 @integration.command()
 @click.pass_context
 def slack_usergroups(ctx):
-    run_integration(reconcile.slack_usergroups, ctx.obj['dry_run'])
+    run_integration(reconcile.slack_usergroups, ctx.obj)
 
 
 @integration.command()
 @click.pass_context
 def gitlab_integrations(ctx):
-    run_integration(reconcile.gitlab_integrations, ctx.obj['dry_run'])
+    run_integration(reconcile.gitlab_integrations, ctx.obj)
 
 
 @integration.command()
 @threaded()
 @click.pass_context
 def gitlab_permissions(ctx, thread_pool_size):
-    run_integration(reconcile.gitlab_permissions, ctx.obj['dry_run'],
+    run_integration(reconcile.gitlab_permissions, ctx.obj,
                     thread_pool_size)
 
 
 @integration.command()
 @click.pass_context
 def gitlab_housekeeping(ctx):
-    run_integration(reconcile.gitlab_housekeeping, ctx.obj['dry_run'])
+    run_integration(reconcile.gitlab_housekeeping, ctx.obj)
 
 
 @integration.command()
@@ -465,8 +467,7 @@ def gitlab_housekeeping(ctx):
 @click.argument('gitlab-project-id')
 @click.pass_context
 def gitlab_pr_submitter(ctx, gitlab_project_id):
-    run_integration(reconcile.gitlab_pr_submitter, gitlab_project_id,
-                    ctx.obj['dry_run'])
+    run_integration(reconcile.gitlab_pr_submitter, ctx.obj, gitlab_project_id)
 
 
 @integration.command()
@@ -474,7 +475,7 @@ def gitlab_pr_submitter(ctx, gitlab_project_id):
 @threaded()
 @click.pass_context
 def aws_garbage_collector(ctx, thread_pool_size, io_dir):
-    run_integration(reconcile.aws_garbage_collector, ctx.obj['dry_run'],
+    run_integration(reconcile.aws_garbage_collector, ctx.obj,
                     thread_pool_size, io_dir)
 
 
@@ -482,7 +483,7 @@ def aws_garbage_collector(ctx, thread_pool_size, io_dir):
 @threaded()
 @click.pass_context
 def aws_iam_keys(ctx, thread_pool_size):
-    run_integration(reconcile.aws_iam_keys, ctx.obj['dry_run'],
+    run_integration(reconcile.aws_iam_keys, ctx.obj,
                     thread_pool_size)
 
 
@@ -490,7 +491,7 @@ def aws_iam_keys(ctx, thread_pool_size):
 @vault_output_path
 @click.pass_context
 def aws_ecr_image_pull_secrets(ctx, vault_output_path):
-    run_integration(reconcile.aws_ecr_image_pull_secrets, ctx.obj['dry_run'],
+    run_integration(reconcile.aws_ecr_image_pull_secrets, ctx.obj,
                     vault_output_path)
 
 
@@ -500,7 +501,7 @@ def aws_ecr_image_pull_secrets(ctx, vault_output_path):
 @threaded()
 @click.pass_context
 def aws_support_cases_sos(ctx, gitlab_project_id, thread_pool_size):
-    run_integration(reconcile.aws_support_cases_sos, ctx.obj['dry_run'],
+    run_integration(reconcile.aws_support_cases_sos, ctx.obj,
                     gitlab_project_id, thread_pool_size)
 
 
@@ -512,7 +513,7 @@ def aws_support_cases_sos(ctx, gitlab_project_id, thread_pool_size):
 @click.pass_context
 def openshift_resources(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.openshift_resources,
-                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    ctx.obj, thread_pool_size, internal,
                     use_jump_host)
 
 
@@ -528,7 +529,7 @@ def openshift_resources(ctx, thread_pool_size, internal, use_jump_host):
 @click.pass_context
 def openshift_saas_deploy(ctx, thread_pool_size, saas_file_name, env_name):
     run_integration(reconcile.openshift_saas_deploy,
-                    ctx.obj['dry_run'], thread_pool_size,
+                    ctx.obj, thread_pool_size,
                     saas_file_name, env_name)
 
 
@@ -539,13 +540,13 @@ def openshift_saas_deploy(ctx, thread_pool_size, saas_file_name, env_name):
 @click.pass_context
 def openshift_saas_deploy_wrapper(ctx, thread_pool_size, io_dir):
     run_integration(reconcile.openshift_saas_deploy_wrapper,
-                    ctx.obj['dry_run'], thread_pool_size, io_dir)
+                    ctx.obj, thread_pool_size, io_dir)
 
 
 @integration.command()
 @click.pass_context
 def saas_file_validator(ctx):
-    run_integration(reconcile.saas_file_validator, ctx.obj['dry_run'])
+    run_integration(reconcile.saas_file_validator, ctx.obj)
 
 
 @integration.command()
@@ -555,7 +556,7 @@ def saas_file_validator(ctx):
 def openshift_saas_deploy_trigger_moving_commits(ctx, thread_pool_size):
     run_integration(
         reconcile.openshift_saas_deploy_trigger_moving_commits,
-        ctx.obj['dry_run'], thread_pool_size)
+        ctx.obj, thread_pool_size)
 
 
 @integration.command()
@@ -565,7 +566,7 @@ def openshift_saas_deploy_trigger_moving_commits(ctx, thread_pool_size):
 def openshift_saas_deploy_trigger_configs(ctx, thread_pool_size):
     run_integration(
         reconcile.openshift_saas_deploy_trigger_configs,
-        ctx.obj['dry_run'], thread_pool_size)
+        ctx.obj, thread_pool_size)
 
 
 @integration.command()
@@ -578,9 +579,9 @@ def openshift_saas_deploy_trigger_configs(ctx, thread_pool_size):
 @click.pass_context
 def saas_file_owners(ctx, gitlab_project_id, gitlab_merge_request_id,
                      io_dir, compare):
-    run_integration(reconcile.saas_file_owners,
+    run_integration(reconcile.saas_file_owners, ctx.obj,
                     gitlab_project_id, gitlab_merge_request_id,
-                    ctx.obj['dry_run'], io_dir, compare)
+                    io_dir, compare)
 
 
 @integration.command()
@@ -591,7 +592,7 @@ def saas_file_owners(ctx, gitlab_project_id, gitlab_merge_request_id,
 @click.pass_context
 def openshift_namespaces(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.openshift_namespaces,
-                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    ctx.obj, thread_pool_size, internal,
                     use_jump_host)
 
 
@@ -603,7 +604,7 @@ def openshift_namespaces(ctx, thread_pool_size, internal, use_jump_host):
 @click.pass_context
 def openshift_network_policies(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.openshift_network_policies,
-                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    ctx.obj, thread_pool_size, internal,
                     use_jump_host)
 
 
@@ -615,7 +616,7 @@ def openshift_network_policies(ctx, thread_pool_size, internal, use_jump_host):
 @click.pass_context
 def openshift_acme(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.openshift_acme,
-                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    ctx.obj, thread_pool_size, internal,
                     use_jump_host)
 
 
@@ -629,7 +630,7 @@ def openshift_acme(ctx, thread_pool_size, internal, use_jump_host):
 def openshift_limitranges(ctx, thread_pool_size, internal,
                           use_jump_host, take_over):
     run_integration(reconcile.openshift_limitranges,
-                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    ctx.obj, thread_pool_size, internal,
                     use_jump_host, take_over)
 
 
@@ -643,7 +644,7 @@ def openshift_limitranges(ctx, thread_pool_size, internal,
 def openshift_resourcequotas(ctx, thread_pool_size, internal,
                              use_jump_host, take_over):
     run_integration(reconcile.openshift_resourcequotas,
-                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    ctx.obj, thread_pool_size, internal,
                     use_jump_host, take_over)
 
 
@@ -656,7 +657,7 @@ def openshift_resourcequotas(ctx, thread_pool_size, internal,
 def openshift_vault_secrets(ctx, thread_pool_size, internal,
                             use_jump_host):
     run_integration(reconcile.openshift_vault_secrets,
-                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    ctx.obj, thread_pool_size, internal,
                     use_jump_host)
 
 
@@ -669,7 +670,7 @@ def openshift_vault_secrets(ctx, thread_pool_size, internal,
 def openshift_routes(ctx, thread_pool_size, internal,
                      use_jump_host):
     run_integration(reconcile.openshift_routes,
-                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    ctx.obj, thread_pool_size, internal,
                     use_jump_host)
 
 
@@ -682,34 +683,34 @@ def openshift_routes(ctx, thread_pool_size, internal,
 def openshift_performance_parameters(ctx, thread_pool_size, internal,
                                      use_jump_host):
     run_integration(reconcile.openshift_performance_parameters,
-                    ctx.obj['dry_run'], thread_pool_size, internal,
+                    ctx.obj, thread_pool_size, internal,
                     use_jump_host)
 
 
 @integration.command()
 @click.pass_context
 def quay_membership(ctx):
-    run_integration(reconcile.quay_membership, ctx.obj['dry_run'])
+    run_integration(reconcile.quay_membership, ctx.obj)
 
 
 @integration.command()
 @click.pass_context
 @binary(['skopeo'])
 def gcr_mirror(ctx):
-    run_integration(reconcile.gcr_mirror, ctx.obj['dry_run'])
+    run_integration(reconcile.gcr_mirror, ctx.obj)
 
 
 @integration.command()
 @click.pass_context
 @binary(['skopeo'])
 def quay_mirror(ctx):
-    run_integration(reconcile.quay_mirror, ctx.obj['dry_run'])
+    run_integration(reconcile.quay_mirror, ctx.obj)
 
 
 @integration.command()
 @click.pass_context
 def quay_repos(ctx):
-    run_integration(reconcile.quay_repos, ctx.obj['dry_run'])
+    run_integration(reconcile.quay_repos, ctx.obj)
 
 
 @integration.command()
@@ -717,14 +718,14 @@ def quay_repos(ctx):
 @threaded()
 @click.pass_context
 def ldap_users(ctx, gitlab_project_id, thread_pool_size):
-    run_integration(reconcile.ldap_users, gitlab_project_id,
-                    ctx.obj['dry_run'], thread_pool_size)
+    run_integration(reconcile.ldap_users, ctx.obj, gitlab_project_id,
+                    thread_pool_size)
 
 
 @integration.command()
 @click.pass_context
 def user_validator(ctx):
-    run_integration(reconcile.user_validator, ctx.obj['dry_run'])
+    run_integration(reconcile.user_validator, ctx.obj)
 
 
 @integration.command()
@@ -744,7 +745,7 @@ def terraform_resources(ctx, print_only, enable_deletion,
                         io_dir, thread_pool_size, internal, use_jump_host,
                         light, vault_output_path):
     run_integration(reconcile.terraform_resources,
-                    ctx.obj['dry_run'], print_only,
+                    ctx.obj, print_only,
                     enable_deletion, io_dir, thread_pool_size,
                     internal, use_jump_host, light, vault_output_path)
 
@@ -760,7 +761,7 @@ def terraform_resources(ctx, print_only, enable_deletion,
 def terraform_users(ctx, print_only, enable_deletion, io_dir,
                     thread_pool_size, send_mails):
     run_integration(reconcile.terraform_users,
-                    ctx.obj['dry_run'], print_only,
+                    ctx.obj, print_only,
                     enable_deletion, io_dir,
                     thread_pool_size, send_mails)
 
@@ -774,14 +775,14 @@ def terraform_users(ctx, print_only, enable_deletion, io_dir,
 def terraform_vpc_peerings(ctx, print_only, enable_deletion,
                            thread_pool_size):
     run_integration(reconcile.terraform_vpc_peerings,
-                    ctx.obj['dry_run'], print_only,
+                    ctx.obj, print_only,
                     enable_deletion, thread_pool_size)
 
 
 @integration.command()
 @click.pass_context
 def github_repo_invites(ctx):
-    run_integration(reconcile.github_repo_invites, ctx.obj['dry_run'])
+    run_integration(reconcile.github_repo_invites, ctx.obj)
 
 
 @integration.command()
@@ -790,77 +791,72 @@ def github_repo_invites(ctx):
 @click.pass_context
 def github_repo_permissions_validator(ctx, instance_name, bot_token_org_name):
     run_integration(reconcile.github_repo_permissions_validator,
-                    ctx.obj['dry_run'],
-                    instance_name, bot_token_org_name)
+                    ctx.obj, instance_name, bot_token_org_name)
 
 
 @integration.command()
 @click.pass_context
 def gitlab_members(ctx):
-    run_integration(reconcile.gitlab_members, ctx.obj['dry_run'])
+    run_integration(reconcile.gitlab_members, ctx.obj)
 
 
 @integration.command()
 @click.pass_context
 def gitlab_projects(ctx):
-    run_integration(reconcile.gitlab_projects, ctx.obj['dry_run'])
+    run_integration(reconcile.gitlab_projects, ctx.obj)
 
 
 @integration.command()
 @threaded()
 @click.pass_context
 def ocm_groups(ctx, thread_pool_size):
-    run_integration(reconcile.ocm_groups, ctx.obj['dry_run'],
-                    thread_pool_size)
+    run_integration(reconcile.ocm_groups, ctx.obj, thread_pool_size)
 
 
 @integration.command()
 @threaded()
 @click.pass_context
 def ocm_clusters(ctx, thread_pool_size):
-    run_integration(reconcile.ocm_clusters, ctx.obj['dry_run'],
-                    thread_pool_size)
+    run_integration(reconcile.ocm_clusters, ctx.obj, thread_pool_size)
 
 
 @integration.command()
 @click.pass_context
 def ocm_aws_infrastructure_access(ctx):
-    run_integration(reconcile.ocm_aws_infrastructure_access,
-                    ctx.obj['dry_run'])
+    run_integration(reconcile.ocm_aws_infrastructure_access, ctx.obj)
 
 
 @integration.command()
 @vault_input_path
 @click.pass_context
 def ocm_github_idp(ctx, vault_input_path):
-    run_integration(reconcile.ocm_github_idp,
-                    ctx.obj['dry_run'], vault_input_path)
+    run_integration(reconcile.ocm_github_idp, ctx.obj, vault_input_path)
 
 
 @integration.command()
 @environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
 @click.pass_context
 def email_sender(ctx):
-    run_integration(reconcile.email_sender, ctx.obj['dry_run'])
+    run_integration(reconcile.email_sender, ctx.obj)
 
 
 @integration.command()
 @environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
 @click.pass_context
 def requests_sender(ctx):
-    run_integration(reconcile.requests_sender, ctx.obj['dry_run'])
+    run_integration(reconcile.requests_sender, ctx.obj)
 
 
 @integration.command()
 @click.pass_context
 def service_dependencies(ctx):
-    run_integration(reconcile.service_dependencies, ctx.obj['dry_run'])
+    run_integration(reconcile.service_dependencies, ctx.obj)
 
 
 @integration.command()
 @click.pass_context
 def sentry_config(ctx):
-    run_integration(reconcile.sentry_config, ctx.obj['dry_run'])
+    run_integration(reconcile.sentry_config, ctx.obj)
 
 
 @integration.command()
@@ -868,23 +864,22 @@ def sentry_config(ctx):
 @enable_deletion(default=False)
 @click.pass_context
 def sql_query(ctx, enable_deletion):
-    run_integration(reconcile.sql_query, ctx.obj['dry_run'],
-                    enable_deletion)
+    run_integration(reconcile.sql_query, ctx.obj, enable_deletion)
 
 
 @integration.command()
 @click.pass_context
 def gitlab_owners(ctx):
-    run_integration(reconcile.gitlab_owners,
-                    ctx.obj['dry_run'])
+    run_integration(reconcile.gitlab_owners, ctx.obj)
 
 
 @integration.command()
 @click.argument('gitlab-project-id')
 @click.argument('gitlab-merge-request-id')
 @click.argument('gitlab-maintainers-group')
-def gitlab_fork_compliance(gitlab_project_id, gitlab_merge_request_id,
+@click.pass_context
+def gitlab_fork_compliance(ctx, gitlab_project_id, gitlab_merge_request_id,
                            gitlab_maintainers_group):
-    run_integration(reconcile.gitlab_fork_compliance,
+    run_integration(reconcile.gitlab_fork_compliance, ctx.obj,
                     gitlab_project_id, gitlab_merge_request_id,
                     gitlab_maintainers_group)

--- a/reconcile/email_sender.py
+++ b/reconcile/email_sender.py
@@ -85,7 +85,7 @@ def collect_to(to):
     return audience
 
 
-def run(dry_run=False):
+def run(dry_run):
     settings = queries.get_app_interface_settings()
     accounts = queries.get_aws_accounts()
     state = State(

--- a/reconcile/gcr_mirror.py
+++ b/reconcile/gcr_mirror.py
@@ -183,6 +183,6 @@ class QuayMirror:
         return creds
 
 
-def run(dry_run=False):
+def run(dry_run):
     gcr_mirror = QuayMirror(dry_run)
     gcr_mirror.run()

--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -366,7 +366,7 @@ def service_is(service):
     return lambda params: params.get("service") == service
 
 
-def run(dry_run=False):
+def run(dry_run):
     config = get_config()
     gh_api_store = GHApiStore(config)
 

--- a/reconcile/github_owners.py
+++ b/reconcile/github_owners.py
@@ -61,7 +61,7 @@ def fetch_desired_state():
     return desired_state
 
 
-def run(dry_run=True):
+def run(dry_run):
     base_url = os.environ.get('GITHUB_API', 'https://api.github.com')
     desired_state = fetch_desired_state()
 

--- a/reconcile/github_scanner.py
+++ b/reconcile/github_scanner.py
@@ -35,7 +35,7 @@ def get_all_repos_to_scan(repos):
     return all_repos
 
 
-def run(dry_run=False, gitlab_project_id=None, thread_pool_size=10):
+def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
     accounts = queries.get_aws_accounts()
     settings = queries.get_app_interface_settings()
     aws = AWSApi(thread_pool_size, accounts, settings=settings)

--- a/reconcile/github_users.py
+++ b/reconcile/github_users.py
@@ -70,7 +70,7 @@ App-Interface repository: https://gitlab.cee.redhat.com/service/app-interface
     smtp_client.send_mail([to], subject, body, settings=settings)
 
 
-def run(dry_run=False, gitlab_project_id=None, thread_pool_size=10,
+def run(dry_run, gitlab_project_id=None, thread_pool_size=10,
         enable_deletion=False, send_mails=False):
     users = queries.get_users()
     g = init_github()

--- a/reconcile/github_validator.py
+++ b/reconcile/github_validator.py
@@ -10,7 +10,7 @@ from github import Github
 QONTRACT_INTEGRATION = 'github-validator'
 
 
-def run(dry_run=False):
+def run(dry_run):
     base_url = os.environ.get('GITHUB_API', 'https://api.github.com')
     orgs = queries.get_github_orgs()
     settings = queries.get_app_interface_settings()

--- a/reconcile/gitlab_fork_compliance.py
+++ b/reconcile/gitlab_fork_compliance.py
@@ -110,6 +110,6 @@ class GitlabForkCompliance:
         self.mr.notes.create({'body': comment})
 
 
-def run(project_id, mr_id, maintainers_group):
+def run(dry_run, project_id, mr_id, maintainers_group):
     gfc = GitlabForkCompliance(project_id, mr_id, maintainers_group)
     gfc.run()

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -169,7 +169,7 @@ def merge_merge_requests(dry_run, gl, merge_limit, rebase):
                 merges += 1
 
 
-def run(dry_run=False):
+def run(dry_run):
     default_days_interval = 15
     default_limit = 8
     default_enable_closing = False

--- a/reconcile/gitlab_integrations.py
+++ b/reconcile/gitlab_integrations.py
@@ -8,7 +8,7 @@ from utils.gitlab_api import GitLabApi
 QONTRACT_INTEGRATION = 'gitlab-integrations'
 
 
-def run(dry_run=False):
+def run(dry_run):
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()
     gl = GitLabApi(instance, settings=settings)

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -139,7 +139,7 @@ def act(diff, gl):
         gl.change_access(group, user, access)
 
 
-def run(dry_run=False):
+def run(dry_run):
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()
     gl = GitLabApi(instance, settings=settings)

--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -159,7 +159,7 @@ class MRApproval:
         return APPROVAL_LABEL in labels
 
 
-def run(dry_run=False):
+def run(dry_run):
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()
     repos = queries.get_repos_gitlab_owner(server=instance['url'])

--- a/reconcile/gitlab_permissions.py
+++ b/reconcile/gitlab_permissions.py
@@ -23,7 +23,7 @@ def get_members_to_add(repo, gl, app_sre):
     return members_to_add
 
 
-def run(dry_run=False, thread_pool_size=10):
+def run(dry_run, thread_pool_size=10):
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()
     gl = GitLabApi(instance, settings=settings)

--- a/reconcile/gitlab_pr_submitter.py
+++ b/reconcile/gitlab_pr_submitter.py
@@ -3,5 +3,5 @@ import reconcile.pull_request_gateway as prg
 QONTRACT_INTEGRATION = 'gitlab-pr-submitter'
 
 
-def run(gitlab_project_id, dry_run=False):
+def run(dry_run, gitlab_project_id):
     prg.submit_to_gitlab(gitlab_project_id, dry_run)

--- a/reconcile/gitlab_projects.py
+++ b/reconcile/gitlab_projects.py
@@ -8,7 +8,7 @@ from utils.gitlab_api import GitLabApi
 QONTRACT_INTEGRATION = 'gitlab-projects'
 
 
-def run(dry_run=False):
+def run(dry_run):
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()
     code_components = queries.get_code_components()

--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -141,7 +141,7 @@ def validate_repos_and_admins(jjb):
 
 
 @defer
-def run(dry_run=False, io_dir='throughput/', compare=True, defer=None):
+def run(dry_run, io_dir='throughput/', compare=True, defer=None):
     jjb = init_jjb()
     defer(lambda: jjb.cleanup())
     if compare:

--- a/reconcile/jenkins_plugins.py
+++ b/reconcile/jenkins_plugins.py
@@ -112,7 +112,7 @@ def act(diff, jenkins_map):
         raise Exception("invalid action: {}".format(action))
 
 
-def run(dry_run=False):
+def run(dry_run):
     jenkins_map = get_jenkins_map(plugins_only=True)
     current_state = get_current_state(jenkins_map)
     desired_state = get_desired_state()

--- a/reconcile/jenkins_roles.py
+++ b/reconcile/jenkins_roles.py
@@ -169,7 +169,7 @@ def act(diff, jenkins_map):
         raise Exception("invalid action: {}".format(action))
 
 
-def run(dry_run=False):
+def run(dry_run):
     jenkins_map = get_jenkins_map()
     current_state = get_current_state(jenkins_map)
     desired_state = get_desired_state()

--- a/reconcile/jenkins_webhooks.py
+++ b/reconcile/jenkins_webhooks.py
@@ -36,7 +36,7 @@ def get_hooks_to_add(desired_state, gl):
     return diff
 
 
-def run(dry_run=False):
+def run(dry_run):
     jjb = init_jjb()
     gl = get_gitlab_api()
 

--- a/reconcile/jenkins_webhooks_cleaner.py
+++ b/reconcile/jenkins_webhooks_cleaner.py
@@ -7,7 +7,7 @@ from utils.gitlab_api import GitLabApi
 QONTRACT_INTEGRATION = 'jenkins-webhooks-cleaner'
 
 
-def run(dry_run=False):
+def run(dry_run):
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()
     gl = GitLabApi(instance, settings=settings)

--- a/reconcile/jira_watcher.py
+++ b/reconcile/jira_watcher.py
@@ -145,7 +145,7 @@ def write_state(io_dir, project, state):
         json.dump(state, f)
 
 
-def run(dry_run=False, io_dir='throughput/'):
+def run(dry_run, io_dir='throughput/'):
     gqlapi = gql.get_api()
     jira_boards = gqlapi.query(QUERY)['jira_boards']
     for jira_board in jira_boards:

--- a/reconcile/ldap_users.py
+++ b/reconcile/ldap_users.py
@@ -35,7 +35,7 @@ def init_user_spec(user):
     return (username, delete, paths)
 
 
-def run(gitlab_project_id, dry_run=False, thread_pool_size=10):
+def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
     users = init_users()
     user_specs = threaded.run(init_user_spec, users, thread_pool_size)
     users_to_delete = [(username, paths) for username, delete, paths

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -93,7 +93,7 @@ def act(dry_run, ocm_map, current_state, desired_state):
                 cluster, user_arn, access_level)
 
 
-def run(dry_run=False):
+def run(dry_run):
     ocm_map, current_state = fetch_current_state()
     desired_state = fetch_desired_state()
     act(dry_run, ocm_map, current_state, desired_state)

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -8,7 +8,7 @@ from utils.ocm import OCMMap
 QONTRACT_INTEGRATION = 'ocm-clusters'
 
 
-def run(dry_run=False, thread_pool_size=10):
+def run(dry_run, thread_pool_size=10):
     settings = queries.get_app_interface_settings()
     clusters = queries.get_clusters()
     clusters = [c for c in clusters if c.get('ocm') is not None]

--- a/reconcile/ocm_github_idp.py
+++ b/reconcile/ocm_github_idp.py
@@ -76,7 +76,7 @@ def act(dry_run, ocm_map, current_state, desired_state):
             ocm.create_github_idp_teams(item)
 
 
-def run(dry_run=False, vault_input_path=''):
+def run(dry_run, vault_input_path=''):
     if not vault_input_path:
         logging.error('must supply vault input path')
         sys.exit(1)

--- a/reconcile/ocm_groups.py
+++ b/reconcile/ocm_groups.py
@@ -69,7 +69,7 @@ def act(diff, ocm_map):
         raise Exception("invalid action: {}".format(action))
 
 
-def run(dry_run=False, thread_pool_size=10):
+def run(dry_run, thread_pool_size=10):
     ocm_map, current_state = fetch_current_state(thread_pool_size)
     desired_state = openshift_groups.fetch_desired_state(oc_map=ocm_map)
 

--- a/reconcile/openshift_acme.py
+++ b/reconcile/openshift_acme.py
@@ -119,7 +119,7 @@ def add_desired_state(namespaces, ri, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, defer=None):
 
     try:

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -160,7 +160,7 @@ def fetch_desired_state(ri, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, defer=None):
     clusters = [cluster_info for cluster_info
                 in queries.get_clusters()

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -219,7 +219,7 @@ def act(diff, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, defer=None):
 
     try:

--- a/reconcile/openshift_limitranges.py
+++ b/reconcile/openshift_limitranges.py
@@ -82,7 +82,7 @@ def add_desired_state(namespaces, ri, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, take_over=True, defer=None):
     namespaces = [namespace_info for namespace_info
                   in queries.get_namespaces()

--- a/reconcile/openshift_namespaces.py
+++ b/reconcile/openshift_namespaces.py
@@ -107,7 +107,7 @@ def create_new_project(spec, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, defer=None):
     oc_map, desired_state = get_desired_state(internal, use_jump_host,
                                               thread_pool_size)

--- a/reconcile/openshift_network_policies.py
+++ b/reconcile/openshift_network_policies.py
@@ -108,7 +108,7 @@ def fetch_desired_state(namespaces, ri, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, defer=None):
 
     try:

--- a/reconcile/openshift_performance_parameters.py
+++ b/reconcile/openshift_performance_parameters.py
@@ -174,7 +174,7 @@ def fetch_desired_state(performance_parameters, ri):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, defer=None):
     performance_parameters = queries.get_performance_parameters()
     observability_namespaces = [

--- a/reconcile/openshift_resourcequotas.py
+++ b/reconcile/openshift_resourcequotas.py
@@ -63,7 +63,7 @@ def fetch_desired_state(namespaces, ri, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, take_over=True, defer=None):
     try:
         namespaces = [namespace_info for namespace_info

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -7,7 +7,7 @@ QONTRACT_INTEGRATION = 'openshift_resources'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 9, 3)
 
 
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, defer=None):
     providers = ['resource', 'resource-template']
     orb.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -528,7 +528,7 @@ def conicalize_namespaces(namespaces, providers):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, providers=[], defer=None):
     gqlapi = gql.get_api()
     namespaces = gqlapi.query(NAMESPACES_QUERY)['namespaces']

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -159,7 +159,7 @@ def fetch_desired_state(ri, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, defer=None):
     namespaces = [namespace_info for namespace_info
                   in queries.get_namespaces()

--- a/reconcile/openshift_routes.py
+++ b/reconcile/openshift_routes.py
@@ -6,7 +6,7 @@ QONTRACT_INTEGRATION = 'openshift-routes'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 9, 3)
 
 
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, defer=None):
     providers = ['route']
     orb.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -15,7 +15,7 @@ QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10,
+def run(dry_run, thread_pool_size=10,
         saas_file_name=None, env_name=None, defer=None):
     saas_files = queries.get_saas_files(saas_file_name, env_name)
     if not saas_files:

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -14,7 +14,7 @@ QONTRACT_INTEGRATION = 'openshift-saas-deploy-trigger-configs'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 
 
-def run(dry_run=False, thread_pool_size=10):
+def run(dry_run, thread_pool_size=10):
     saas_files = queries.get_saas_files()
     if not saas_files:
         logging.error('no saas files found')

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -14,7 +14,7 @@ QONTRACT_INTEGRATION = 'openshift-saas-deploy-trigger-moving-commits'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 
 
-def run(dry_run=False, thread_pool_size=10):
+def run(dry_run, thread_pool_size=10):
     saas_files = queries.get_saas_files()
     if not saas_files:
         logging.error('no saas files found')

--- a/reconcile/openshift_saas_deploy_wrapper.py
+++ b/reconcile/openshift_saas_deploy_wrapper.py
@@ -19,7 +19,7 @@ def osd_run_wrapper(diff, dry_run, available_thread_pool_size):
             env_name=env_name)
 
 
-def run(dry_run=False, thread_pool_size=10, io_dir='throughput/'):
+def run(dry_run, thread_pool_size=10, io_dir='throughput/'):
     saas_file_owners_diffs = read_saas_file_owners_diffs(io_dir)
     if len(saas_file_owners_diffs) == 0:
         return

--- a/reconcile/openshift_serviceaccount_tokens.py
+++ b/reconcile/openshift_serviceaccount_tokens.py
@@ -67,7 +67,7 @@ def write_outputs_to_vault(vault_path, ri):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, vault_output_path='', defer=None):
     namespaces = [namespace_info for namespace_info
                   in queries.get_namespaces()

--- a/reconcile/openshift_users.py
+++ b/reconcile/openshift_users.py
@@ -127,7 +127,7 @@ def act(diff, oc_map):
 
 
 @defer
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, defer=None):
     oc_map, current_state = \
         fetch_current_state(thread_pool_size, internal, use_jump_host)

--- a/reconcile/openshift_vault_secrets.py
+++ b/reconcile/openshift_vault_secrets.py
@@ -6,7 +6,7 @@ QONTRACT_INTEGRATION = 'openshift-vault-secrets'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 9, 3)
 
 
-def run(dry_run=False, thread_pool_size=10, internal=None,
+def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, defer=None):
     providers = ['vault-secret']
     orb.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION

--- a/reconcile/quay_membership.py
+++ b/reconcile/quay_membership.py
@@ -162,7 +162,7 @@ def get_quay_api_store():
     return store
 
 
-def run(dry_run=False):
+def run(dry_run):
     quay_api_store = get_quay_api_store()
 
     current_state = fetch_current_state(quay_api_store)

--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -183,6 +183,6 @@ class QuayMirror:
         return creds
 
 
-def run(dry_run=False):
+def run(dry_run):
     quay_mirror = QuayMirror(dry_run)
     quay_mirror.run()

--- a/reconcile/quay_repos.py
+++ b/reconcile/quay_repos.py
@@ -209,7 +209,7 @@ def get_quay_api_store():
     return store
 
 
-def run(dry_run=False):
+def run(dry_run):
     quay_api_store = get_quay_api_store()
 
     current_state = fetch_current_state(quay_api_store)

--- a/reconcile/requests_sender.py
+++ b/reconcile/requests_sender.py
@@ -46,7 +46,7 @@ def get_ecrypted_credentials(credentials_name, user, settings):
     return encrypted_credentials
 
 
-def run(dry_run=False):
+def run(dry_run):
     settings = queries.get_app_interface_settings()
     accounts = queries.get_aws_accounts()
     state = State(

--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -201,7 +201,7 @@ def check_saas_files_changes_only(changed_paths, diffs):
     return len(non_saas_file_changed_paths) == 0
 
 
-def run(gitlab_project_id, gitlab_merge_request_id, dry_run=False,
+def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None,
         io_dir='throughput/', compare=True):
     if not compare:
         # baseline is the current state and the owners.

--- a/reconcile/saas_file_validator.py
+++ b/reconcile/saas_file_validator.py
@@ -9,7 +9,7 @@ QONTRACT_INTEGRATION = 'saas-file-validator'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 
 
-def run(dry_run=False):
+def run(dry_run):
     saas_files = queries.get_saas_files()
     settings = queries.get_app_interface_settings()
     saasherder = SaasHerder(

--- a/reconcile/sentry_config.py
+++ b/reconcile/sentry_config.py
@@ -555,7 +555,7 @@ def get_github_email(gh, user):
         return email
 
 
-def run(dry_run=False):
+def run(dry_run):
     settings = queries.get_app_interface_settings()
     gqlapi = gql.get_api()
     github = init_github()

--- a/reconcile/service_dependencies.py
+++ b/reconcile/service_dependencies.py
@@ -74,7 +74,7 @@ def get_desired_dependency_names(app, dependency_map):
     return required_dep_names
 
 
-def run(dry_run=False):
+def run(dry_run):
     settings = queries.get_app_interface_settings()
     dependency_map = settings.get('dependencies')
     if not dependency_map:

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -330,7 +330,7 @@ def act(desired_state, slack_map):
         slack.update_usergroup(ugid, channels, description)
 
 
-def run(dry_run=False):
+def run(dry_run):
     slack_map = get_slack_map()
     current_state = get_current_state(slack_map)
     desired_state = get_desired_state(slack_map)

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -218,7 +218,7 @@ def process_template(query):
     return job_yaml
 
 
-def run(dry_run=False, enable_deletion=False):
+def run(dry_run, enable_deletion=False):
     settings = queries.get_app_interface_settings()
     accounts = queries.get_aws_accounts()
     state = State(integration=QONTRACT_INTEGRATION,

--- a/reconcile/status.py
+++ b/reconcile/status.py
@@ -2,3 +2,5 @@ class ExitCodes:
     SUCCESS = 0
     ERROR = 1
     DATA_CHANGED = 3
+    INTEGRATION_NOT_FOUND = 4
+    FORBIDDEN_SCHEMA = 5

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -251,7 +251,7 @@ def write_outputs_to_vault(vault_path, ri):
 
 
 @defer
-def run(dry_run=False, print_only=False,
+def run(dry_run, print_only=False,
         enable_deletion=False, io_dir='throughput/',
         thread_pool_size=10, internal=None, use_jump_host=True,
         light=False, vault_output_path='', defer=None):

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -98,7 +98,7 @@ def cleanup_and_exit(tf=None, status=False):
     sys.exit(status)
 
 
-def run(dry_run=False, print_only=False,
+def run(dry_run, print_only=False,
         enable_deletion=False, io_dir='throughput/',
         thread_pool_size=10, send_mails=True):
     working_dirs = setup(print_only, thread_pool_size)

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -221,7 +221,7 @@ def build_desired_state_vpc(clusters, ocm_map, settings):
 
 
 @defer
-def run(dry_run=False, print_only=False,
+def run(dry_run, print_only=False,
         enable_deletion=False, thread_pool_size=10, defer=None):
     settings = queries.get_app_interface_settings()
     clusters = [c for c in queries.get_clusters()

--- a/reconcile/user_validator.py
+++ b/reconcile/user_validator.py
@@ -42,7 +42,7 @@ def validate_users_gpg_key(users):
     return ok
 
 
-def run(dry_run=False):
+def run(dry_run):
     users = queries.get_users()
 
     single_path_ok = validate_users_single_path(users)

--- a/utils/gql.py
+++ b/utils/gql.py
@@ -21,6 +21,8 @@ class GqlGetResourceError(Exception):
 
 
 class GqlApi(object):
+    _called_schemas = set([])
+
     def __init__(self, url, token=None):
         self.url = url
         self.token = token
@@ -42,6 +44,12 @@ class GqlApi(object):
                 'Could not connect to GraphQL server ({})'.format(e))
 
         result = json.loads(result_json)
+
+        try:
+            schemas = result['extensions']['schemas']
+            self._called_schemas.update(schemas)
+        except KeyError:
+            pass
 
         if 'errors' in result:
             raise GqlApiError(result['errors'])
@@ -114,3 +122,13 @@ def get_api():
         raise GqlApiError("gql module has not been initialized.")
 
     return _gqlapi
+
+
+def get_called_schemas():
+    global _gqlapi
+    return list(_gqlapi._called_schemas)
+
+
+def clear_called_schemas():
+    global _gqlapi
+    _gqlapi._called_schemas = set([])


### PR DESCRIPTION
The `--dump-schemas` option will dump all the schemas traversed by the gql api to a file. This is necessary in order to verify what schemas does an integration depend on.

A big refactor has been needed in this PR. The entrypoints for all integrations is `def run(...)` with an arbitrary list of arguments defined per integration. The contract has now changed, so that the entrypoint is always `def run(dry_run, ...)`. I needed to do this because it was necessary in order to pass the context object to the `run_integration` method. With this change we can now add additional global options, like `--dump-schemas`.

This functionality depends on this PR:
https://github.com/app-sre/qontract-server/pull/81

EDIT: I have added an additional functionality. When the integration starts it will query app-interface for the allowed schemas, and if it tries to perform a query that depends on an unlisted schema, the integration will immediately exit with a defined exit code.
