### PR TITLE
Fix policy group name

### DIFF
--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -171,7 +171,7 @@ class TerrascriptClient(object):
                         # only managed policies, as it is currently
                         tf_iam_group_policy_attachment = \
                             aws_iam_group_policy_attachment(
-                                group_name + '-' + policy,
+                                group_name + '-' + policy.replace('/', '_'),
                                 group=group_name,
                                 policy_arn='arn:aws:iam::aws:policy/' + policy,
                                 depends_on=[tf_iam_group]


### PR DESCRIPTION
The policy might contain "/", but that is not accepted
in the group name.

Signed-off-by: Amador Pahim <apahim@redhat.com>