### PR TITLE
[ocm_clusters] Add extended_dedicated_admin to spec (and improve diff/logging)

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -816,10 +816,13 @@ def ocm_groups(ctx, thread_pool_size):
 
 @integration.command()
 @threaded()
+@binary(['oc', 'ssh'])
+@internal()
+@use_jump_host()
 @click.pass_context
-def ocm_clusters(ctx, thread_pool_size):
+def ocm_clusters(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.ocm_clusters, ctx.obj['dry_run'],
-                    thread_pool_size)
+                    thread_pool_size, internal, use_jump_host)
 
 
 @integration.command()

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -3,29 +3,56 @@ import logging
 
 import reconcile.queries as queries
 
+from utils.oc import OC_Map
 from utils.ocm import OCMMap
+
+from deepdiff import DeepDiff
+
 
 QONTRACT_INTEGRATION = 'ocm-clusters'
 
 
-def run(dry_run=False, thread_pool_size=10):
+def current_extended_dedicated_admin_state(oc_map, current_state):
+    for cluster in current_state:
+        oc = oc_map.get(cluster)
+        res = oc.get(None, 'ClusterRole', 'dedicated-admins-manage-operators', allow_not_found=True)
+        current_state[cluster]['spec']['extended_dedicated_admin'] = True if res else False
+    return current_state
+
+def run(dry_run=False, thread_pool_size=10, internal=None, use_jump_host=True):
     settings = queries.get_app_interface_settings()
     clusters = queries.get_clusters()
     clusters = [c for c in clusters if c.get('ocm') is not None]
+    oc_map = OC_Map(clusters=clusters, integration=QONTRACT_INTEGRATION,
+                    settings=settings, internal=internal,
+                    use_jump_host=use_jump_host,
+                    thread_pool_size=thread_pool_size)
     ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
                      settings=settings)
+
     current_state = ocm_map.cluster_specs()
+    current_state = current_extended_dedicated_admin_state(oc_map, current_state)
+
     desired_state = {c['name']: {'spec': c['spec'], 'network': c['network']}
                      for c in clusters}
+    for c in desired_state:
+        if desired_state[c]['spec'].get('extended_dedicated_admin') is None:
+            desired_state[c]['spec']['extended_dedicated_admin'] = False
 
     error = False
-    for k, desired_spec in desired_state.items():
-        current_spec = current_state[k]
-        if current_spec != desired_spec:
-            logging.error(
-                '[%s] desired spec %s is different from current spec %s',
-                k, desired_spec, current_spec)
+    for cluster, desired_spec in desired_state.items():
+        current_spec = current_state[cluster]
+        ddiff = DeepDiff(desired_spec, current_spec, ignore_order=True, view='tree')
+        if ddiff:
             error = True
+            logging.error(
+                f'[{cluster}] app-interface (desired) spec is different from '
+                f'the spec returned by OCM (current)'
+            )
+            for changed in ddiff.get('values_changed', []):
+                logging.error(f'  path: {changed.path()}')
+                logging.error(f'    desired: {changed.t1}')
+                logging.error(f'    current: {changed.t2}')
 
     if error:
         sys.exit(1)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -304,6 +304,7 @@ CLUSTERS_QUERY = """
       instance_type
       storage
       load_balancers
+      extended_dedicated_admin
     }
     network {
       vpc

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "prometheus-client~=0.8",
         "sentry-sdk~=0.14",
         "jenkins-job-builder==2.10.1",
+        "deepdiff~=5.0",
     ],
 
     test_suite="tests",

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -105,13 +105,13 @@ class OC(object):
 
         return items
 
-    def get(self, namespace, kind, name=None):
+    def get(self, namespace, kind, name=None, allow_not_found=False):
         cmd = ['get', '-o', 'json', kind]
         if name:
             cmd.append(name)
         if namespace is not None:
             cmd.extend(['-n', namespace])
-        return self._run_json(cmd)
+        return self._run_json(cmd, allow_not_found=allow_not_found)
 
     def get_all(self, kind, all_namespaces=False):
         cmd = ['get', '-o', 'json', kind]


### PR DESCRIPTION
### Overview

This PR has a few changes. They did not have to come together but they both are fairly minor. I can split this into two PRs if absolutely needed
- Add checking for extended_dedicated_admin in desired spec and on the cluster
- Improve logging using deepdiff package
- Improve the OCMap.get() function

### Add checking for extended_dedicated_admin in desired spec and on the cluster

OCM currently does not appear to expose this. Furthermore, the API to list syncsets is restricted to us at this time (ex: `/api/clusters_mgmt/v1/clusters/<ID>/external_configuration/syncsets`). It is unknown if this endpoint would tell if the `ccs-dedicated-admin` SSS is applied to the cluster or not. (potential for future improvement here)

Because of the above apparent limitation, the proposed code uses the OCMap class to check if a `ClusterRole` called `dedicated-admins-manage-operators` is available on the cluster. This is the resource that the SSS applies as [seen here](https://github.com/openshift/managed-cluster-config/tree/cc3818630efa392c7228a45253db52b1d1712378/deploy/ccs-dedicated-admins)

Using OCMap to check for the ClusterRole increases the runtime of the `ocm_clusters` from `3 seconds` (average over 10 runs) to `8 seconds` (average over 10 runs) for the current dataset of `15` OCM clusters

This change depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/6114

### Improve logging using deepdiff package

This refactors the diffing of the current and desired states using the [deepdiff](https://pypi.org/project/deepdiff/) package. This provides a much better output that clearly shows that path has changes.

Previous output
```
[2020-07-03 15:37:32] [ERROR] [ocm_clusters.py:run:25] - [clustername] desired spec {'spec': {'provider': 'aws', 'region': 'us-east-1', 'major_version': 4, 'multi_az': True, 'nodes': 9, 'instance_type': 'm5.2xlarge', 'storage': 600, 'load_balancers': 0}, 'network': {'vpc': '10.116.0.0/16', 'service': '10.122.0.0/16', 'pod': '10.128.0.0/14'}} is different from current spec {'spec': {'provider': 'aws', 'region': 'us-east-1', 'major_version': 4, 'multi_az': True, 'nodes': 9, 'instance_type': 'm5.2xlarge', 'storage': 600, 'load_balancers': 0}, 'network': {'vpc': '10.116.0.0/16', 'service': '10.122.0.0/16', 'pod': '10.128.0.0/14'}}
```

New output
```
[2020-07-03 16:30:40] [ERROR] [ocm_clusters.py:run:48] - [clustername] app-interface (desired) spec is different from the spec returned by OCM (current)
[2020-07-03 16:25:20] [ERROR] [ocm_clusters.py:run:55] -   path: root['network']['service']
[2020-07-03 16:25:20] [ERROR] [ocm_clusters.py:run:56] -     desired: 172.30.1.0/16
[2020-07-03 16:25:20] [ERROR] [ocm_clusters.py:run:57] -     current: 172.30.0.0/16
[2020-07-03 16:25:20] [ERROR] [ocm_clusters.py:run:55] -   path: root['spec']['nodes']
[2020-07-03 16:25:20] [ERROR] [ocm_clusters.py:run:56] -     desired: 5
[2020-07-03 16:25:20] [ERROR] [ocm_clusters.py:run:57] -     current: 4
[2020-07-03 16:25:20] [ERROR] [ocm_clusters.py:run:55] -   path: root['spec']['storage']
[2020-07-03 16:25:20] [ERROR] [ocm_clusters.py:run:56] -     desired: 100
[2020-07-03 16:25:20] [ERROR] [ocm_clusters.py:run:57] -     current: 600
```

### Improve the OCMap.get() function

This enables using the `allow_not_found` flag on the `get` function. This is required otherwise when resources are not found, the code [here](https://github.com/app-sre/qontract-reconcile/blob/da745f1ebe7dbfbaccf5099f318378855ebaf9d6/utils/oc.py#L336) would go into the retry decorator loop for no reason. This doesn't change the default bevior and may provide an opportunity to improve runtime of other integrations that did get into this retry loop for no reason when resources are simply not present.