### PR TITLE
validate integrations and schemas (introduces a new integration: integrations-validator) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `sentry-config`: Configure and enforce sentry instance configuration.
 - `saas-file-owners`: Adds an `approved` label on merge requests based on approver schema for saas files.
 - `user-validator`: Validate user files.
+- `integrations-validator`: Ensures all integrations are defined in App-Interface.
 
 ### e2e-tests
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -122,7 +122,7 @@ def validate_schemas(function):
     help_msg = 'Fail integration if it queries forbidden schemas'
 
     function = click.option('--validate-schemas/--no-validate-schemas',
-                            default=False,
+                            default=True,
                             help=help_msg)(function)
     return function
 

--- a/reconcile/integrations_validator.py
+++ b/reconcile/integrations_validator.py
@@ -11,7 +11,7 @@ def run(dry_run, integration_commands):
     missing = set(integration_commands) - set(desired_integrations)
 
     for integration in missing:
-        logging.info(['missing_integration', integration])
+        logging.error(['missing_integration', integration])
 
     if missing:
         sys.exit(1)

--- a/reconcile/integrations_validator.py
+++ b/reconcile/integrations_validator.py
@@ -1,0 +1,17 @@
+import sys
+import logging
+import reconcile.queries as queries
+
+QONTRACT_INTEGRATION = 'integrations-validator'
+
+
+def run(dry_run, integration_commands):
+    desired_integrations = [i['name'] for i in queries.get_integrations()]
+
+    missing = set(integration_commands) - set(desired_integrations)
+
+    for integration in missing:
+        logging.info(['missing_integration', integration])
+
+    if missing:
+        sys.exit(1)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -132,6 +132,7 @@ JENKINS_INSTANCES_QUERY = """
 }
 """
 
+
 def get_jenkins_instances():
     """ Returns a list of Jenkins instances """
     gqlapi = gql.get_api()

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -102,6 +102,21 @@ def get_credentials_requests():
     return gqlapi.query(CREDENTIALS_REQUESTS_QUERY)['credentials_requests']
 
 
+INTEGRATIONS_QUERY = """
+{
+    integrations_v1 {
+        name
+        schemas
+    }
+}
+"""
+
+
+def get_integrations():
+    gqlapi = gql.get_api()
+    return gqlapi.query(INTEGRATIONS_QUERY)['integrations_v1']
+
+
 JENKINS_INSTANCES_QUERY = """
 {
   instances: jenkins_instances_v1 {
@@ -116,7 +131,6 @@ JENKINS_INSTANCES_QUERY = """
   }
 }
 """
-
 
 def get_jenkins_instances():
     """ Returns a list of Jenkins instances """

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -102,19 +102,9 @@ def get_credentials_requests():
     return gqlapi.query(CREDENTIALS_REQUESTS_QUERY)['credentials_requests']
 
 
-INTEGRATIONS_QUERY = """
-{
-    integrations: integrations_v1 {
-        name
-        schemas
-    }
-}
-"""
-
-
 def get_integrations():
     gqlapi = gql.get_api()
-    return gqlapi.query(INTEGRATIONS_QUERY)['integrations']
+    return gqlapi.query(gql.INTEGRATIONS_QUERY)['integrations']
 
 
 JENKINS_INSTANCES_QUERY = """

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -104,7 +104,7 @@ def get_credentials_requests():
 
 INTEGRATIONS_QUERY = """
 {
-    integrations_v1 {
+    integrations: integrations_v1 {
         name
         schemas
     }
@@ -114,7 +114,7 @@ INTEGRATIONS_QUERY = """
 
 def get_integrations():
     gqlapi = gql.get_api()
-    return gqlapi.query(INTEGRATIONS_QUERY)['integrations_v1']
+    return gqlapi.query(INTEGRATIONS_QUERY)['integrations']
 
 
 JENKINS_INSTANCES_QUERY = """

--- a/reconcile/status.py
+++ b/reconcile/status.py
@@ -2,3 +2,5 @@ class ExitCodes:
     SUCCESS = 0
     ERROR = 1
     DATA_CHANGED = 3
+    INTEGRATION_NOT_FOUND = 4
+    FORBIDDEN_SCHEMA = 5

--- a/utils/gql.py
+++ b/utils/gql.py
@@ -56,7 +56,7 @@ class GqlApi(object):
         if int_name:
             integrations = self.query(INTEGRATIONS_QUERY)
 
-            for integration in integrations['integrations_v1']:
+            for integration in integrations['integrations']:
                 if integration['name'] == int_name:
                     self._valid_schemas = integration['schemas']
                     break

--- a/utils/gql.py
+++ b/utils/gql.py
@@ -83,6 +83,10 @@ class GqlApi(object):
 
         result = json.loads(result_json)
 
+        # show schemas if log level is debug
+        for s in result['extensions']['schemas']:
+            logging.debug(['schema', s])
+
         # we need to test self._valid_schemas to let through the query that
         # retrieves the schemas in the __init__ method
         if self.validate_schemas and self._valid_schemas:

--- a/utils/gql.py
+++ b/utils/gql.py
@@ -16,18 +16,26 @@ class GqlApiError(Exception):
 
 class GqlApiIntegrationNotFound(Exception):
     def __init__(self, integration):
-        super().__init__(f"integration not found: {integration}")
+        super().__init__(f"""Integration not found: {integration}
+
+        Integration should be defined in App-Interface with the
+        /app-sre/integration-1.yml schema.
+        """)
 
 
 class GqlApiErrorForbiddenSchema(Exception):
     def __init__(self, schema):
-        super().__init__(f"forbidden schema: {schema}")
+        super().__init__(f"""Forbidden schema: {schema}
+
+        The `schemas` parameter in the integration file in App-Interface
+        should be updated to include this schema.
+        """)
 
 
 class GqlGetResourceError(Exception):
     def __init__(self, path, msg):
         super(GqlGetResourceError, self).__init__(
-            "error getting resource from path {}: {}".format(path, str(msg))
+            "Error getting resource from path {}: {}".format(path, str(msg))
         )
 
 

--- a/utils/gql.py
+++ b/utils/gql.py
@@ -5,6 +5,7 @@ import contextlib
 
 from graphqlclient import GraphQLClient
 from utils.config import get_config
+from reconcile.queries import INTEGRATIONS_QUERY
 
 _gqlapi = None
 
@@ -28,16 +29,6 @@ class GqlGetResourceError(Exception):
         super(GqlGetResourceError, self).__init__(
             "error getting resource from path {}: {}".format(path, str(msg))
         )
-
-
-INTEGRATIONS_QUERY = """
-{
-    integrations_v1 {
-        name
-        schemas
-    }
-}
-"""
 
 
 class GqlApi(object):

--- a/utils/gql.py
+++ b/utils/gql.py
@@ -2,6 +2,8 @@ import json
 import requests
 import os
 import contextlib
+import textwrap
+import logging
 
 from graphqlclient import GraphQLClient
 from utils.config import get_config
@@ -16,20 +18,24 @@ class GqlApiError(Exception):
 
 class GqlApiIntegrationNotFound(Exception):
     def __init__(self, integration):
-        super().__init__(f"""Integration not found: {integration}
+        msg = f"""
+        Integration not found: {integration}
 
         Integration should be defined in App-Interface with the
         /app-sre/integration-1.yml schema.
-        """)
+        """
+        super().__init__(textwrap.dedent(msg).strip())
 
 
 class GqlApiErrorForbiddenSchema(Exception):
     def __init__(self, schema):
-        super().__init__(f"""Forbidden schema: {schema}
+        msg = f"""
+        Forbidden schema: {schema}
 
         The `schemas` parameter in the integration file in App-Interface
         should be updated to include this schema.
-        """)
+        """
+        super().__init__(textwrap.dedent(msg).strip())
 
 
 class GqlGetResourceError(Exception):

--- a/utils/gql.py
+++ b/utils/gql.py
@@ -7,9 +7,18 @@ import logging
 
 from graphqlclient import GraphQLClient
 from utils.config import get_config
-from reconcile.queries import INTEGRATIONS_QUERY
 
 _gqlapi = None
+
+
+INTEGRATIONS_QUERY = """
+{
+    integrations: integrations_v1 {
+        name
+        schemas
+    }
+}
+"""
 
 
 class GqlApiError(Exception):


### PR DESCRIPTION
The goal of this PR is twofold:

- ensure that all integrations are defined in App-Interface
- blocks integration from querying schemas if the schema is not defined in the corresponding App-Interface integrtaion file

In order to achieve these two goals the following changes are included in this PR:

**Integration**

> `integrations-validator`: Ensures all integrations are defined in App-Interface.

This integration programmatically iterates through all the integration click commands, and ensures that they exist in App-Interface

**Mandatory schema validation**

Integrations now run with the enabled feature of validating schemas: `--validate-schemas` which is set to True by default.

If necessary this can be disabled with the option `--no-validate-schemas`.

Also, in order to make the developer life easier, all queried schemas will be logged with `DEBUG` level, so developers can run their integrations with `--no-validate-schemas --log-level=DEBUG`.