### PR TITLE
[WIP][openshift-base] remove comparison by desired object

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -268,15 +268,6 @@ def realize_data(dry_run, oc_map, ri,
                         ).format(cluster, namespace, resource_type, name)
                         logging.info(msg)
 
-                    # don't apply if resources match
-                    elif d_item == c_item:
-                        msg = (
-                            "[{}/{}] resource '{}/{}' present "
-                            "and matches desired, skipping."
-                        ).format(cluster, namespace, resource_type, name)
-                        logging.debug(msg)
-                        continue
-
                     # don't apply if sha256sum hashes match
                     elif c_item.sha256sum() == d_item.sha256sum():
                         if c_item.has_valid_sha256sum():


### PR DESCRIPTION
in the base of this logic stands the assumption that if a desired resource does not contain a field, the value of that field in the current resource does not matter.

this was done with the intention of supporting resources with multiple default values, such as Deployments.

this does not work for a situation where a key is removed.

merging this will cause quite a few resources to be re-applied, and maybe even to be continuously re-applied. we will need to fix it in following PRs to improve the comparison logic in openshift_resouce.canonicalize.