### PR TITLE
[github] do not depend on automationToken

### DIFF
--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -11,7 +11,6 @@ import reconcile.queries as queries
 
 from utils.aggregated_list import AggregatedList, AggregatedDiffRunner
 from utils.raw_github_api import RawGithubApi
-from utils.oc import OC_Map
 from utils.defer import defer
 
 
@@ -186,10 +185,8 @@ def fetch_desired_state(infer_clusters=True):
 
     clusters = gqlapi.query(CLUSTERS_QUERY)['clusters']
     settings = queries.get_app_interface_settings()
-    oc_map = OC_Map(clusters=clusters, settings=settings)
-    defer(lambda: oc_map.cleanup())
     openshift_users_desired_state = \
-        openshift_users.fetch_desired_state(oc_map)
+        openshift_users.fetch_desired_state(oc_map=None)
     for cluster in clusters:
         if not cluster['auth']:
             continue

--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -11,7 +11,6 @@ import reconcile.queries as queries
 
 from utils.aggregated_list import AggregatedList, AggregatedDiffRunner
 from utils.raw_github_api import RawGithubApi
-from utils.defer import defer
 
 
 GH_BASE_URL = os.environ.get('GITHUB_API', 'https://api.github.com')
@@ -184,7 +183,6 @@ def fetch_desired_state(infer_clusters=True):
         return state
 
     clusters = gqlapi.query(CLUSTERS_QUERY)['clusters']
-    settings = queries.get_app_interface_settings()
     openshift_users_desired_state = \
         openshift_users.fetch_desired_state(oc_map=None)
     for cluster in clusters:

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -101,7 +101,7 @@ def fetch_desired_state(oc_map):
         for a in r['access'] or []:
             if None in [a['cluster'], a['group']]:
                 continue
-            if a['cluster']['name'] not in oc_map.clusters():
+            if oc_map and a['cluster']['name'] not in oc_map.clusters():
                 continue
 
             for u in r['users']:

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -110,7 +110,7 @@ def fetch_desired_state(ri, oc_map):
 
         for permission in permissions:
             cluster = permission['cluster']
-            if not oc_map.get(cluster):
+            if oc_map and not oc_map.get(cluster):
                 continue
             for user in users:
                 # used by openshift-users and github integrations


### PR DESCRIPTION
currently, to run the github integration we need an automationToken so we can initialize an oc client for each cluster.

the reason we are initializing an oc client for each cluster (oc_map) is because the integration relies on logic from other integrations (openshift-rolebindings and openshift-groups) which REQUIRE an oc client.
the github integration, however, does not care about this. it will add users to github teams for cluster access, even if that cluster does not have an automationToken.

this makes sense because in the cluster on-boarding process we first want to allow access for users to the console, and only after that we are able to create the bot SA to add the automationToken.

tl;dr - another chicken/egg situation solved.