### PR TITLE
[openshift-saas-deploy] add support for raw manifests in directory

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -881,6 +881,7 @@ SAAS_FILES_QUERY = """
       name
       url
       path
+      provider
       hash_length
       parameters
       targets {

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -260,8 +260,8 @@ class SaasHerder():
                 resources = oc.process(template, consolidated_parameters)
             except StatusCodeError as e:
                 logging.error(
-                    f"[{saas_file_name}/{resource_template_name}] {html_url}: " +
-                    f"error processing template: {str(e)}")
+                    f"[{saas_file_name}/{resource_template_name}] " +
+                    f"{html_url}: error processing template: {str(e)}")
 
         elif provider == 'directory':
             get_directory_contents_options = {


### PR DESCRIPTION
covers https://issues.redhat.com/browse/APPSRE-1753

this PR adds the ability to specify the `directory` provider in a saas file to indicate that the resources to apply are raw manifests in a directory (applies all resources).