### PR TITLE
[openshift-saas-deploy] only use jenkins instances in saas files

### DIFF
--- a/reconcile/jenkins_plugins.py
+++ b/reconcile/jenkins_plugins.py
@@ -22,7 +22,7 @@ INSTANCES_QUERY = """
 QONTRACT_INTEGRATION = 'jenkins-plugins'
 
 
-def get_jenkins_map(plugins_only=False):
+def get_jenkins_map(plugins_only=False, desired_instances=None):
     gqlapi = gql.get_api()
     jenkins_instances = gqlapi.query(INSTANCES_QUERY)['instances']
     settings = queries.get_app_interface_settings()
@@ -30,6 +30,8 @@ def get_jenkins_map(plugins_only=False):
     jenkins_map = {}
     for instance in jenkins_instances:
         instance_name = instance['name']
+        if desired_instances and instance_name not in desired_instances:
+            continue
         if instance_name in jenkins_map:
             continue
         if plugins_only and not instance['plugins']:

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -24,7 +24,9 @@ def run(dry_run, thread_pool_size=10,
         sys.exit(1)
 
     instance = queries.get_gitlab_instance()
-    jenkins_map = jenkins_base.get_jenkins_map()
+    desired_jenkins_instances = [s['instance']['name'] for s in saas_files]
+    jenkins_map = jenkins_base.get_jenkins_map(
+        desired_instances=desired_jenkins_instances)
     settings = queries.get_app_interface_settings()
     try:
         gl = GitLabApi(instance, settings=settings)


### PR DESCRIPTION
this is to allow jobs to run in ci-ext without asking for creds for ci-int, which are not permitted.