### PR TITLE
[terraform-vpc-peerings] add routes capability

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -320,6 +320,7 @@ CLUSTERS_QUERY = """
       connections {
         name
         provider
+        manageRoutes
         ... on ClusterPeeringConnectionAccount_v1 {
           vpc {
             account {
@@ -363,6 +364,7 @@ CLUSTERS_QUERY = """
               connections {
                 name
                 provider
+                manageRoutes
                 ... on ClusterPeeringConnectionClusterAccepter_v1 {
                   name
                   cluster {

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -220,7 +220,7 @@ def build_desired_state_vpc(clusters, ocm_map, settings):
                 aws_api.get_cluster_vpc_id(
                     account,
                     route_tables=peer_connection.get('manageRoutes')
-            )
+                )
 
             if requester_vpc_id is None:
                 logging.error(f'[{cluster} could not find VPC ID for cluster')

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -360,7 +360,7 @@ class TerrascriptClient(object):
                         'route_table_id': route_table_id,
                         'destination_cidr_block': accepter['cidr_block'],
                         'vpc_peering_connection_id':
-                            '${aws_vpc_peering_connection.' + \
+                            '${aws_vpc_peering_connection.' +
                             identifier + '.id}'
                     }
                     route_identifier = f'{identifier}-{route_table_id}'
@@ -400,7 +400,7 @@ class TerrascriptClient(object):
                         'route_table_id': route_table_id,
                         'destination_cidr_block': requester['cidr_block'],
                         'vpc_peering_connection_id':
-                            '${aws_vpc_peering_connection_accepter.' + \
+                            '${aws_vpc_peering_connection_accepter.' +
                             identifier + '.id}'
                     }
                     if connection_provider == 'account-vpc':

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -40,6 +40,7 @@ from terrascript.aws.r import (aws_db_instance, aws_db_parameter_group,
                                aws_cloudfront_distribution,
                                aws_vpc_peering_connection,
                                aws_vpc_peering_connection_accepter,
+                               aws_route,
                                aws_cloudwatch_log_group, aws_kms_key,
                                aws_kms_alias,
                                aws_elasticsearch_domain,
@@ -350,6 +351,22 @@ class TerrascriptClient(object):
             tf_resource = aws_vpc_peering_connection(identifier, **values)
             self.add_resource(req_account_name, tf_resource)
 
+            # add routes to existing route tables
+            route_table_ids = requester.get('route_table_ids')
+            if route_table_ids:
+                for route_table_id in route_table_ids:
+                    values = {
+                        'provider': 'aws.' + req_alias,
+                        'route_table_id': route_table_id,
+                        'destination_cidr_block': accepter['cidr_block'],
+                        'vpc_peering_connection_id':
+                            '${aws_vpc_peering_connection.' + \
+                            identifier + '.id}'
+                    }
+                    route_identifier = f'{identifier}-{route_table_id}'
+                    tf_resource = aws_route(route_identifier, **values)
+                    self.add_resource(req_account_name, tf_resource)
+
             acc_account = accepter['account']
             acc_account_name = acc_account['name']
             # arn:aws:iam::12345:role/role-1 --> 12345
@@ -374,6 +391,26 @@ class TerrascriptClient(object):
             tf_resource = \
                 aws_vpc_peering_connection_accepter(identifier, **values)
             self.add_resource(acc_account_name, tf_resource)
+
+            # add routes to existing route tables
+            route_table_ids = accepter.get('route_table_ids')
+            if route_table_ids:
+                for route_table_id in route_table_ids:
+                    values = {
+                        'route_table_id': route_table_id,
+                        'destination_cidr_block': requester['cidr_block'],
+                        'vpc_peering_connection_id':
+                            '${aws_vpc_peering_connection_accepter.' + \
+                            identifier + '.id}'
+                    }
+                    if connection_provider == 'account-vpc':
+                        if self._multiregion_account_(acc_account_name):
+                            values['provider'] = 'aws.' + accepter['region']
+                    else:
+                        values['provider'] = 'aws.' + acc_alias
+                    route_identifier = f'{identifier}-{route_table_id}'
+                    tf_resource = aws_route(route_identifier, **values)
+                    self.add_resource(acc_account_name, tf_resource)
 
     def populate_resources(self, namespaces, existing_secrets):
         self.init_populate_specs(namespaces)


### PR DESCRIPTION
covers https://issues.redhat.com/browse/APPSRE-1861

this PR adds the ability to manage routes in existing route tables in a cluster's aws account.
that cluster can be a requester, an accepter or the requester in an `account-vpc` connection. it all works.

issues:
- for now, it only works with creating new routes (i am still unable to import all the existing routes which were created manually).
- since we don't have permissions to delete routes, we can't "unmanage" routes (this will involve removing routes from the state).

for that reason i have added a selective `manageRoutes` field to be used.