### PR TITLE
[openshift-saas-deploy] add support for takeover

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -61,7 +61,8 @@ def run(dry_run, thread_pool_size=10,
     ob.realize_data(dry_run, oc_map, ri,
                     caller=saas_file_name,
                     wait_for_namespace=True,
-                    no_dry_run_skip_compare=True)
+                    no_dry_run_skip_compare=True,
+                    take_over=saasherder.take_over)
 
     if ri.has_error_registered():
         sys.exit(1)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -869,6 +869,7 @@ SAAS_FILES_QUERY = """
       channel
     }
     managedResourceTypes
+    takeover
     imagePatterns
     authentication {
       code {

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -45,6 +45,10 @@ class SaasHerder():
             threaded.estimate_available_thread_pool_size(
                 self.thread_pool_size,
                 divisor)
+        # if called by a single saas file,it may
+        # specify that it manages resources exclusively.
+        self.take_over = \
+            len(self.saas_files) == 1 and self.saas_files[0].get('takeover')
         if accounts:
             self._initiate_state(accounts)
 


### PR DESCRIPTION
in case we want to exclusively manage resources defined in a saas file, we can now add `takeover: true` in the saas file.

this uses the existing functionality in openshift_base.realize_data.