### PR TITLE
[unleash-watcher] use state instead of io-dir

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -485,10 +485,10 @@ def jira_watcher(ctx, io_dir):
 
 
 @integration.command()
-@throughput
+@environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
 @click.pass_context
-def unleash_watcher(ctx, io_dir):
-    run_integration(reconcile.unleash_watcher, ctx.obj, io_dir)
+def unleash_watcher(ctx):
+    run_integration(reconcile.unleash_watcher, ctx.obj)
 
 
 @integration.command()

--- a/utils/state.py
+++ b/utils/state.py
@@ -103,6 +103,13 @@ class State(object):
                 return args[0]
             raise
 
+    def get_all(self, path):
+        """
+        Gets all keys and values from the state in the specified path.
+        """
+        return {k.replace(f'/{path}/', ''): self.get(k.lstrip('/'))
+                for k in self.ls()}
+
     def __getitem__(self, item):
         try:
             response = self.client.get_object(Bucket=self.bucket,


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2249

we don't want to miss events because of a pod restart, so let's use state instead of io-dir.