### PR TITLE
allow running openshift-resources based integrations per cluster and namespace

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -221,6 +221,22 @@ def vault_output_path(function):
     return function
 
 
+def cluster_name(function):
+    function = click.option('--cluster-name',
+                            help='cluster name to act on.',
+                            default=None)(function)
+
+    return function
+
+
+def namespace_name(function):
+    function = click.option('--namespace-name',
+                            help='namespace name to act on.',
+                            default=None)(function)
+
+    return function
+
+
 def gitlab_project_id(function):
     function = click.option('--gitlab-project-id',
                             help='gitlab project id to submit PRs to. '
@@ -264,7 +280,7 @@ def enable_rebase(**kwargs):
     return f
 
 
-def run_integration(func_container, ctx, *args):
+def run_integration(func_container, ctx, *args, **kwargs):
     try:
         int_name = func_container.QONTRACT_INTEGRATION.replace('_', '-')
     except AttributeError:
@@ -287,7 +303,7 @@ def run_integration(func_container, ctx, *args):
     dry_run = ctx.get('dry_run', False)
 
     try:
-        func_container.run(dry_run, *args)
+        func_container.run(dry_run, *args, **kwargs)
     except RunnerException as e:
         sys.stderr.write(str(e) + "\n")
         sys.exit(ExitCodes.ERROR)
@@ -565,11 +581,16 @@ def aws_support_cases_sos(ctx, gitlab_project_id, thread_pool_size):
 @binary(['oc', 'ssh'])
 @internal()
 @use_jump_host()
+@cluster_name
+@namespace_name
 @click.pass_context
-def openshift_resources(ctx, thread_pool_size, internal, use_jump_host):
+def openshift_resources(ctx, thread_pool_size, internal, use_jump_host,
+                        cluster_name, namespace_name):
     run_integration(reconcile.openshift_resources,
                     ctx.obj, thread_pool_size, internal,
-                    use_jump_host)
+                    use_jump_host,
+                    cluster_name=cluster_name,
+                    namespace_name=namespace_name)
 
 
 @integration.command()
@@ -708,12 +729,15 @@ def openshift_resourcequotas(ctx, thread_pool_size, internal,
 @binary(['oc', 'ssh'])
 @internal()
 @use_jump_host()
+@cluster_name
+@namespace_name
 @click.pass_context
-def openshift_vault_secrets(ctx, thread_pool_size, internal,
-                            use_jump_host):
+def openshift_vault_secrets(ctx, thread_pool_size, internal, use_jump_host,
+                            cluster_name, namespace_name):
     run_integration(reconcile.openshift_vault_secrets,
-                    ctx.obj, thread_pool_size, internal,
-                    use_jump_host)
+                    ctx.obj, thread_pool_size, internal, use_jump_host,
+                    cluster_name=cluster_name,
+                    namespace_name=namespace_name)
 
 
 @integration.command()
@@ -721,12 +745,15 @@ def openshift_vault_secrets(ctx, thread_pool_size, internal,
 @binary(['oc', 'ssh'])
 @internal()
 @use_jump_host()
+@cluster_name
+@namespace_name
 @click.pass_context
-def openshift_routes(ctx, thread_pool_size, internal,
-                     use_jump_host):
+def openshift_routes(ctx, thread_pool_size, internal, use_jump_host,
+                     cluster_name, namespace_name):
     run_integration(reconcile.openshift_routes,
-                    ctx.obj, thread_pool_size, internal,
-                    use_jump_host)
+                    ctx.obj, thread_pool_size, internal, use_jump_host,
+                    cluster_name=cluster_name,
+                    namespace_name=namespace_name)
 
 
 @integration.command()

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -7,8 +7,8 @@ QONTRACT_INTEGRATION = 'openshift_resources'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 9, 3)
 
 
-def run(dry_run, thread_pool_size=10, internal=None,
-        use_jump_host=True, defer=None):
+def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True,
+        cluster_name=None, namespace_name=None, defer=None):
     providers = ['resource', 'resource-template']
     orb.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION
     orb.QONTRACT_INTEGRATION_VERSION = QONTRACT_INTEGRATION_VERSION
@@ -17,7 +17,9 @@ def run(dry_run, thread_pool_size=10, internal=None,
                  thread_pool_size=thread_pool_size,
                  internal=internal,
                  use_jump_host=use_jump_host,
-                 providers=providers)
+                 providers=providers,
+                 cluster_name=cluster_name,
+                 namespace_name=namespace_name)
 
     # check for unused resources types
     # listed under `managedResourceTypes`

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -512,20 +512,13 @@ def fetch_data(namespaces, thread_pool_size, internal, use_jump_host):
 def filter_namespaces_by_cluster_and_namespace(namespaces,
                                                cluster_name,
                                                namespace_name):
-    filtered_namespaces = []
     if cluster_name:
-        filtered_namespaces.extend(
-            [n for n in namespaces
-             if n['cluster']['name'] == cluster_name]
-        )
-    elif namespace_name:
-        filtered_namespaces.extend(
-            [n for n in namespaces
-             if n['name'] == namespace_name]
-        )
-    else:
-        return namespaces
-    return filtered_namespaces
+        namespaces = [n for n in namespaces
+                      if n['cluster']['name'] == cluster_name]
+    if namespace_name:
+        namespaces = [n for n in namespaces
+                      if n['name'] == namespace_name]
+    return namespaces
 
 
 def canonicalize_namespaces(namespaces, providers):

--- a/reconcile/openshift_routes.py
+++ b/reconcile/openshift_routes.py
@@ -6,8 +6,8 @@ QONTRACT_INTEGRATION = 'openshift-routes'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 9, 3)
 
 
-def run(dry_run, thread_pool_size=10, internal=None,
-        use_jump_host=True, defer=None):
+def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True,
+        cluster_name=None, namespace_name=None, defer=None):
     providers = ['route']
     orb.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION
     orb.QONTRACT_INTEGRATION_VERSION = QONTRACT_INTEGRATION_VERSION
@@ -16,4 +16,6 @@ def run(dry_run, thread_pool_size=10, internal=None,
             thread_pool_size=thread_pool_size,
             internal=internal,
             use_jump_host=use_jump_host,
-            providers=providers)
+            providers=providers,
+            cluster_name=cluster_name,
+            namespace_name=namespace_name)

--- a/reconcile/openshift_vault_secrets.py
+++ b/reconcile/openshift_vault_secrets.py
@@ -7,7 +7,8 @@ QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 9, 3)
 
 
 def run(dry_run, thread_pool_size=10, internal=None,
-        use_jump_host=True, defer=None):
+        use_jump_host=True, cluster_name=None,
+        namespace_name=None, defer=None):
     providers = ['vault-secret']
     orb.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION
     orb.QONTRACT_INTEGRATION_VERSION = QONTRACT_INTEGRATION_VERSION
@@ -16,4 +17,6 @@ def run(dry_run, thread_pool_size=10, internal=None,
             thread_pool_size=thread_pool_size,
             internal=internal,
             use_jump_host=use_jump_host,
-            providers=providers)
+            providers=providers,
+            cluster_name=cluster_name,
+            namespace_name=namespace_name)


### PR DESCRIPTION
this PR adds two new flags to be passed to the following integrations:
- openshift-resources
- openshift-vault-secrets
- openshift-routes

the flags are:
- `cluster-name` - only run for a cluster with this name
- `namespace-name` - only run for namespaces with this name

this allows us to run integrations for any particular namespace we choose.
or for all namespaces with that name (think hive).
or for all namespaces in a cluster (think hive).