### PR TITLE
[openshift-saas-deploy] check that kind exists in api-resources

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -128,11 +128,17 @@ def init_specs_to_fetch(ri, oc_map,
 
 
 def populate_current_state(spec, ri, integration, integration_version):
-    if spec.oc is None:
+    oc = spec.oc
+    if oc is None:
         return
-    for item in spec.oc.get_items(spec.resource,
-                                  namespace=spec.namespace,
-                                  resource_names=spec.resource_names):
+    api_resources = oc.api_resources
+    if api_resources and spec.resource not in api_resources:
+        msg = f"[{spec.cluster}] cluster has no API resource {spec.resource}."
+        logging.warning(msg)
+        return
+    for item in oc.get_items(spec.resource,
+                             namespace=spec.namespace,
+                             resource_names=spec.resource_names):
         openshift_resource = OR(item,
                                 integration,
                                 integration_version)
@@ -152,7 +158,8 @@ def fetch_current_state(namespaces=None,
                         integration_version=None,
                         override_managed_types=None,
                         internal=None,
-                        use_jump_host=True):
+                        use_jump_host=True,
+                        init_api_resources=False):
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces,
@@ -161,7 +168,8 @@ def fetch_current_state(namespaces=None,
                     settings=settings,
                     internal=internal,
                     use_jump_host=use_jump_host,
-                    thread_pool_size=thread_pool_size)
+                    thread_pool_size=thread_pool_size,
+                    init_api_resources=init_api_resources)
     state_specs = \
         init_specs_to_fetch(
             ri,

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -53,7 +53,8 @@ def run(dry_run, thread_pool_size=10,
         namespaces=saasherder.namespaces,
         thread_pool_size=thread_pool_size,
         integration=QONTRACT_INTEGRATION,
-        integration_version=QONTRACT_INTEGRATION_VERSION)
+        integration_version=QONTRACT_INTEGRATION_VERSION,
+        init_api_resources=True)
     defer(lambda: oc_map.cleanup())
     saasherder.populate_desired_state(ri)
     # if saas_file_name is defined, the integration


### PR DESCRIPTION
we sometimes want to add deployment of CRs which their CRDs have not yet been applied to the cluster.

this PR adds a check that a resource kind under `managedResourceTypes` is also available in `oc api-resources`.
if it doesn't, the integration will not attempt to fetch it's current state.
assuming such a resource will only be available in the template after the CRD has been applied.

example issue that this PR solves: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/6808