### PR TITLE
[ocm-clusters] submit cluster version update MRs and install from initial_version

### DIFF
--- a/helm/qontract-reconcile/values.yaml
+++ b/helm/qontract-reconcile/values.yaml
@@ -327,6 +327,9 @@ integrations:
       cpu: 200m
   logs:
     slack: true
+  extraEnv:
+  - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
+    secretKey: gitlab_pr_submitter_queue_url
 - name: ocm-aws-infrastructure-access
   resources:
     requests:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -5838,6 +5838,11 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+          - name: gitlab_pr_submitter_queue_url
+            valueFrom:
+              secretKeyRef:
+                name: ${APP_INTERFACE_SQS_SECRET_NAME}
+                key: gitlab_pr_submitter_queue_url
           resources:
             limits:
               cpu: 200m

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -896,10 +896,13 @@ def ocm_groups(ctx, thread_pool_size):
 
 
 @integration.command()
+@environ(['gitlab_pr_submitter_queue_url'])
+@gitlab_project_id
 @threaded()
 @click.pass_context
-def ocm_clusters(ctx, thread_pool_size):
-    run_integration(reconcile.ocm_clusters, ctx.obj, thread_pool_size)
+def ocm_clusters(ctx, gitlab_project_id, thread_pool_size):
+    run_integration(reconcile.ocm_clusters, ctx.obj,
+                    gitlab_project_id, thread_pool_size)
 
 
 @integration.command()

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -54,7 +54,7 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
                 error = True
             if current_spec != desired_spec:
                 logging.error(
-                    '[%s] desired spec %s is different ' + 
+                    '[%s] desired spec %s is different ' +
                     'from current spec %s',
                     cluster_name, desired_spec, current_spec)
                 error = True

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -20,6 +20,8 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
     desired_state = {c['name']: {'spec': c['spec'], 'network': c['network']}
                      for c in clusters}
 
+    if not dry_run:
+        gw = prg.init(gitlab_project_id=gitlab_project_id)
     error = False
     for cluster_name, desired_spec in desired_state.items():
         current_spec = current_state.get(cluster_name)
@@ -28,8 +30,6 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
             desired_spec['spec'].pop('initial_version')
             desired_version = desired_spec['spec'].pop('version')
             current_version = current_spec['spec'].pop('version')
-            if cluster_name == 'app-sre-stage-01':
-                current_version = '4.5.0'
             compare_result = semver.compare(current_version, desired_version)
             if compare_result > 0:
                 # current version is larger due to an upgrade.
@@ -40,7 +40,6 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
                     'version will be updated automatically in app-interface.',
                     cluster_name, desired_version, current_version)
                 if not dry_run:
-                    gw = prg.init(gitlab_project_id=gitlab_project_id)
                     cluster_path = 'data' + \
                         [c['path'] for c in clusters
                          if c['name'] == cluster_name][0]

--- a/reconcile/pull_request_gateway.py
+++ b/reconcile/pull_request_gateway.py
@@ -11,6 +11,7 @@ PR_TYPES = {
     'create_delete_aws_access_key_mr': ['account', 'path', 'key'],
     'create_delete_user_mr': ['username', 'paths'],
     'create_app_interface_reporter_mr': ['reports'],
+    'create_update_cluster_version_mr': ['cluster_name', 'path', 'version'],
 }
 
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -247,6 +247,7 @@ def get_aws_accounts():
 CLUSTERS_QUERY = """
 {
   clusters: clusters_v1 {
+    path
     name
     serverUrl
     consoleUrl

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -304,6 +304,7 @@ CLUSTERS_QUERY = """
       provider
       region
       version
+      initial_version
       multi_az
       nodes
       instance_type

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -292,8 +292,7 @@ Please consult relevant SOPs to verify that the account is secure.
                                          cluster_name,
                                          path,
                                          version):
-        # labels = ['automerge']
-        labels = ['do-not-merge/hold']
+        labels = ['automerge']
         prefix = 'qontract-reconcile'
         target_branch = 'master'
         branch_name = \

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -288,6 +288,45 @@ Please consult relevant SOPs to verify that the account is secure.
 
         return self.create_mr(branch_name, target_branch, title, labels=labels)
 
+    def create_update_cluster_version_mr(self,
+                                         cluster_name,
+                                         path,
+                                         version):
+        # labels = ['automerge']
+        labels = ['do-not-merge/hold']
+        prefix = 'qontract-reconcile'
+        target_branch = 'master'
+        branch_name = \
+            f'{prefix}-update-cluster-version-' + \
+            f'{cluster_name}-{version}-{str(uuid.uuid4())[0:6]}'
+        title = \
+            f'[{prefix}] update cluster {cluster_name} version to {version}'
+
+        if self.mr_exists(title):
+            return
+
+        self.create_branch(branch_name, target_branch)
+
+        msg = 'update cluster version'
+        path = path.lstrip('/')
+        f = self.project.files.get(file_path=path, ref=target_branch)
+        content = yaml.load(f.decode(), Loader=yaml.RoundTripLoader)
+        content['spec']['version'] = version
+        new_content = '---\n' + \
+            yaml.dump(content, Dumper=yaml.RoundTripDumper)
+        try:
+            self.update_file(branch_name, path, msg, new_content)
+        except gitlab.exceptions.GitlabCreateError as e:
+            self.delete_branch(branch_name)
+            if str(e) != "400: A file with this name doesn't exist":
+                raise e
+            logging.info(
+                "File {} does not exist, not opening MR".format(path)
+            )
+            return
+
+        return self.create_mr(branch_name, target_branch, title, labels=labels)
+
     def get_project_maintainers(self, repo_url=None):
         if repo_url is None:
             project = self.project

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -102,7 +102,7 @@ class OCM(object):
                 'id': cluster_spec['region']
             },
             'version': {
-                'id': 'openshift-v' + cluster_spec['version']
+                'id': 'openshift-v' + cluster_spec['initial_version']
             },
             'multi_az': cluster_spec['multi_az'],
             'nodes': {

--- a/utils/sqs_gateway.py
+++ b/utils/sqs_gateway.py
@@ -73,3 +73,12 @@ class SQSGateway(object):
             'reports': reports
         }
         self.send_message(body)
+
+    def create_update_cluster_version_mr(self, cluster_name, path, version):
+        body = {
+            'pr_type': 'create_update_cluster_version_mr',
+            'cluster_name': cluster_name,
+            'path': path,
+            'version': version
+        }
+        self.send_message(body)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2273

with this PR, ocm-clusters does not fail when cluster version is different - it will submit a MR to update the version in app-interface if the current version is larger. in addition, a cluster creation is now done based on the version defined in `initial_version` instead of `version`, as the latter will be used to track the current version.