### PR TITLE
remove last-applied-configuration annotation on 0x0

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -217,7 +217,13 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
                 logging.warning(msg)
                 return
 
-        oc.apply(namespace, annotated.toJSON())
+        try:
+            oc.apply(namespace, annotated.toJSON())
+        except StatusCodeError as e:
+            if 'Invalid value: 0x0' in str(e):
+                oc.remove_last_applied_configuration(
+                    namespace, resource_type, resource.name)
+                oc.apply(namespace, annotated.toJSON())
 
     oc.recycle_pods(dry_run, namespace, resource_type, resource)
 

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -140,6 +140,11 @@ class OC(object):
         result = self._run(cmd, stdin=json.dumps(template, sort_keys=True))
         return json.loads(result)['items']
 
+    def remove_last_applied_configuration(self, namespace, kind, name):
+        cmd = ['annotate', kind, name,
+               'kubectl.kubernetes.io/last-applied-configuration-']
+        self._run(cmd)
+
     def apply(self, namespace, resource):
         cmd = ['apply', '-n', namespace, '-f', '-']
         self._run(cmd, stdin=resource)


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/APPSRE-2064

this PR adds a check if `oc apply` failed due to this issue, and if so - it will remove the annotation and re-apply.