### PR TITLE
dashdotdb-cso as a cronjob

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -161,10 +161,6 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
-          {{- if $integration.dashdotdb }}
-          - name: DASHDOTDB_SECRET
-            value: ${DASHDOTDB_SECRET}
-          {{- end }}
           {{- with $integration.extraEnv }}
           {{- range $i, $env := . }}
           - name: {{ $env.secretKey }}
@@ -276,6 +272,10 @@ objects:
                     name: {{ $env.secretName }}
                     key: {{ $env.secretKey }}
               {{- end }}
+              {{- end }}
+              {{- if $integration.dashdotdb }}
+              - name: DASHDOTDB_SECRET
+                value: ${DASHDOTDB_SECRET}
               {{- end }}
               volumeMounts:
               - name: qontract-reconcile-toml

--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -410,17 +410,6 @@ integrations:
     slack: true
     cloudwatch: true
   extraArgs: --no-use-jump-host
-- name: dashdotdb-cso
-  resources:
-    requests:
-      memory: 400Mi
-      cpu: 100m
-    limits:
-      memory: 600Mi
-      cpu: 200m
-  logs:
-    cloudwatch: true
-  dashdotdb: true
 cronjobs:
 - name: aws-ecr-image-pull-secrets
   resources:
@@ -457,3 +446,14 @@ cronjobs:
   extraEnv:
   - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
     secretKey: gitlab_pr_submitter_queue_url
+- name: dashdotdb-cso
+  resources:
+    requests:
+      memory: 400Mi
+      cpu: 100m
+    limits:
+      memory: 600Mi
+      cpu: 200m
+  # once every 6 hours
+  cron: '0 */6 * * *'
+  dashdotdb: true

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -7114,170 +7114,6 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: qontract-reconcile-dashdotdb-cso
-    name: qontract-reconcile-dashdotdb-cso
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: qontract-reconcile-dashdotdb-cso
-    template:
-      metadata:
-        labels:
-          app: qontract-reconcile-dashdotdb-cso
-          component: qontract-reconcile
-      spec:
-        initContainers:
-        - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
-          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
-          resources:
-            requests:
-              memory: 10Mi
-              cpu: 15m
-            limits:
-              memory: 20Mi
-              cpu: 25m
-          env:
-          - name: LOG_GROUP_NAME
-            valueFrom:
-              secretKeyRef:
-                name: ${CLOUDWATCH_SECRET}
-                key: log_group_name
-          command: ["/bin/sh", "-c"]
-          args:
-          - |
-            # generate fluent.conf
-            cat > /fluentd/etc/fluent.conf <<EOF
-            <source>
-              @type tail
-              path /fluentd/log/integration.log
-              pos_file /fluentd/log/integration.log.pos
-              tag integration
-              <parse>
-                @type none
-              </parse>
-            </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <match integration>
-              @type copy
-              <store>
-                @type cloudwatch_logs
-                log_group_name ${LOG_GROUP_NAME}
-                log_stream_name dashdotdb-cso
-                auto_create_stream true
-              </store>
-            </match>
-            EOF
-          volumeMounts:
-          - name: fluentd-config
-            mountPath: /fluentd/etc/
-        containers:
-        - name: int
-          image: ${IMAGE}:${IMAGE_TAG}
-          ports:
-            - name: http
-              containerPort: 9090
-          env:
-          - name: SHARDS
-            value: "1"
-          - name: SHARD_ID
-            value: "0"
-          - name: DRY_RUN
-            value: ${DRY_RUN}
-          - name: INTEGRATION_NAME
-            value: dashdotdb-cso
-          - name: INTEGRATION_EXTRA_ARGS
-            value: ""
-          - name: SLEEP_DURATION_SECS
-            value: ${SLEEP_DURATION_SECS}
-          - name: GITHUB_API
-            valueFrom:
-              configMapKeyRef:
-                name: app-interface
-                key: GITHUB_API
-          - name: SENTRY_DSN
-            valueFrom:
-              configMapKeyRef:
-                name: app-interface
-                key: SENTRY_DSN
-          - name: LOG_FILE
-            value: "${LOG_FILE}"
-          - name: UNLEASH_API_URL
-            valueFrom:
-              secretKeyRef:
-                name: unleash
-                key: API_URL
-          - name: UNLEASH_CLIENT_ACCESS_TOKEN
-            valueFrom:
-              secretKeyRef:
-                name: unleash
-                key: CLIENT_ACCESS_TOKEN
-          - name: DASHDOTDB_SECRET
-            value: ${DASHDOTDB_SECRET}
-          resources:
-            limits:
-              cpu: 200m
-              memory: 600Mi
-            requests:
-              cpu: 100m
-              memory: 400Mi
-          volumeMounts:
-          - name: qontract-reconcile-toml
-            mountPath: /config
-          - name: logs
-            mountPath: /fluentd/log/
-        - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
-          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
-          env:
-          - name: AWS_REGION
-            valueFrom:
-              secretKeyRef:
-                name: ${CLOUDWATCH_SECRET}
-                key: aws_region
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: ${CLOUDWATCH_SECRET}
-                key: aws_access_key_id
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: ${CLOUDWATCH_SECRET}
-                key: aws_secret_access_key
-          resources:
-            requests:
-              memory: 30Mi
-              cpu: 15m
-            limits:
-              memory: 120Mi
-              cpu: 25m
-          volumeMounts:
-          - name: logs
-            mountPath: /fluentd/log/
-          - name: fluentd-config
-            mountPath: /fluentd/etc/
-        volumes:
-        - name: qontract-reconcile-toml
-          secret:
-            secretName: qontract-reconcile-toml
-        - name: logs
-          emptyDir: {}
-        - name: fluentd-config
-          emptyDir: {}
 - apiVersion: batch/v1beta1
   kind: CronJob
   metadata:
@@ -7440,6 +7276,62 @@ objects:
                 requests:
                   cpu: 200m
                   memory: 50Mi
+            restartPolicy: OnFailure
+            volumes:
+            - name: qontract-reconcile-toml
+              secret:
+                secretName: qontract-reconcile-toml
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  metadata:
+    labels:
+      app: qontract-reconcile-dashdotdb-cso
+    name: qontract-reconcile-dashdotdb-cso
+  spec:
+    schedule: "0 */6 * * *"
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: int
+              image: ${IMAGE}:${IMAGE_TAG}
+              env:
+              - name: RUN_ONCE
+                value: 'true'
+              - name: DRY_RUN
+                value: ${DRY_RUN}
+              - name: INTEGRATION_NAME
+                value: dashdotdb-cso
+              - name: INTEGRATION_EXTRA_ARGS
+                value: ""
+              - name: GITHUB_API
+                valueFrom:
+                  configMapKeyRef:
+                    name: app-interface
+                    key: GITHUB_API
+              - name: UNLEASH_API_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: API_URL
+              - name: UNLEASH_CLIENT_ACCESS_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: CLIENT_ACCESS_TOKEN
+              - name: DASHDOTDB_SECRET
+                value: ${DASHDOTDB_SECRET}
+              volumeMounts:
+              - name: qontract-reconcile-toml
+                mountPath: /config
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 600Mi
+                requests:
+                  cpu: 100m
+                  memory: 400Mi
             restartPolicy: OnFailure
             volumes:
             - name: qontract-reconcile-toml


### PR DESCRIPTION
Running as a normal integration (every 2min) is too much. Let's convert
it into a CronJob and run every 6 hours.

Signed-off-by: Amador Pahim <apahim@redhat.com>