### PR TITLE
[openshift-resources] check that kind exists in api-resources

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -19,7 +19,8 @@ def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True,
                  use_jump_host=use_jump_host,
                  providers=providers,
                  cluster_name=cluster_name,
-                 namespace_name=namespace_name)
+                 namespace_name=namespace_name,
+                 init_api_resources=True)
 
     # check for unused resources types
     # listed under `managedResourceTypes`

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -496,13 +496,15 @@ def fetch_states(spec, ri):
         logging.error(msg)
 
 
-def fetch_data(namespaces, thread_pool_size, internal, use_jump_host):
+def fetch_data(namespaces, thread_pool_size, internal, use_jump_host,
+               init_api_resources=False):
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces, integration=QONTRACT_INTEGRATION,
                     settings=settings, internal=internal,
                     use_jump_host=use_jump_host,
-                    thread_pool_size=thread_pool_size)
+                    thread_pool_size=thread_pool_size,
+                    init_api_resources=init_api_resources)
     state_specs = ob.init_specs_to_fetch(ri, oc_map, namespaces=namespaces)
     threaded.run(fetch_states, state_specs, thread_pool_size, ri=ri)
 
@@ -544,6 +546,7 @@ def canonicalize_namespaces(namespaces, providers):
 def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, providers=[],
         cluster_name=None, namespace_name=None,
+        init_api_resources=False,
         defer=None):
     gqlapi = gql.get_api()
     namespaces = [namespace_info for namespace_info
@@ -559,7 +562,8 @@ def run(dry_run, thread_pool_size=10, internal=None,
         )
     namespaces = canonicalize_namespaces(namespaces, providers)
     oc_map, ri = \
-        fetch_data(namespaces, thread_pool_size, internal, use_jump_host)
+        fetch_data(namespaces, thread_pool_size, internal, use_jump_host,
+                   init_api_resources=init_api_resources)
     defer(lambda: oc_map.cleanup())
 
     ob.realize_data(dry_run, oc_map, ri)


### PR DESCRIPTION
based on the work in #950.

we sometimes want to add resources of CRs which their CRDs have not yet been applied to the cluster.

this PR adds a check that a resource kind under managedResourceTypes is also available in oc api-resources.
if it doesn't, the integration will not attempt to fetch it's current state.
assuming such a resource will only be available in the template after the CRD has been applied.

example issue that this PR solves:
- https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/7101
- https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/7104