### PR TITLE
[openshift] skip equal compare in specific cases

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -293,7 +293,10 @@ def realize_data(dry_run, oc_map, ri,
                         logging.info(msg)
 
                     # don't apply if resources match
-                    elif d_item == c_item:
+                    # if there is a caller (saas file) and this is a take over
+                    # we skip the equal compare as it's not covering
+                    # cases of a removed label (for example)
+                    elif not (caller and take_over) and d_item == c_item:
                         msg = (
                             "[{}/{}] resource '{}/{}' present "
                             "and matches desired, skipping."

--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -363,6 +363,7 @@ class OpenshiftResource(object):
         annotations.pop('qontract.integration_version', None)
         annotations.pop('qontract.sha256sum', None)
         annotations.pop('qontract.update', None)
+        annotations.pop('qontract.caller_name', None)
 
         return body
 


### PR DESCRIPTION
in cases where we deploy from a saas file and it defines that it is taking over, we should skip the equal resource compare to avoid any misses to apply (when a label is removed for example).

this is mostly about ClusterImageSets, but we can revisit this later.