### PR TITLE
[gitlab-api] add create_mr function for cloud-ingress-operator

### DIFF
--- a/reconcile/pull_request_gateway.py
+++ b/reconcile/pull_request_gateway.py
@@ -15,6 +15,8 @@ PR_TYPES = {
     'create_update_cluster_ids_mr': ['cluster_name', 'path', 'cluster_id',
                                      'cluster_external_id'],
     'create_app_interface_notificator_mr': ['notification']
+    'create_app_interface_notificator_mr': ['notification'],
+    'create_cloud_ingress_operator_cidr_blocks_mr': ['cidr_blocks']
 }
 
 
@@ -33,10 +35,11 @@ def init(gitlab_project_id=None, override_pr_gateway_type=None):
     if pr_gateway_type == 'gitlab':
         instance = queries.get_gitlab_instance()
         settings = queries.get_app_interface_settings()
+        saas_files = queries.get_saas_files_minimal()
         if gitlab_project_id is None:
             raise PullRequestGatewayError('missing gitlab project id')
         return GitLabApi(instance, project_id=gitlab_project_id,
-                         settings=settings)
+                         settings=settings, saas_files=saas_files)
     elif pr_gateway_type == 'sqs':
         accounts = queries.get_aws_accounts()
         settings = queries.get_app_interface_settings()

--- a/reconcile/pull_request_gateway.py
+++ b/reconcile/pull_request_gateway.py
@@ -14,7 +14,6 @@ PR_TYPES = {
     'create_update_cluster_version_mr': ['cluster_name', 'path', 'version'],
     'create_update_cluster_ids_mr': ['cluster_name', 'path', 'cluster_id',
                                      'cluster_external_id'],
-    'create_app_interface_notificator_mr': ['notification']
     'create_app_interface_notificator_mr': ['notification'],
     'create_cloud_ingress_operator_cidr_blocks_mr': ['cidr_blocks']
 }

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -999,7 +999,6 @@ SAAS_FILES_MINIMAL_QUERY = """
 """
 
 
-
 def get_saas_files_minimal():
     """ Returns SaasFile resources defined in app-interface """
     gqlapi = gql.get_api()

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -989,6 +989,23 @@ def get_saas_files(saas_file_name=None, env_name=None, app_name=None):
     return saas_files
 
 
+SAAS_FILES_MINIMAL_QUERY = """
+{
+  saas_files: saas_files_v1 {
+    path
+    name
+  }
+}
+"""
+
+
+
+def get_saas_files_minimal():
+    """ Returns SaasFile resources defined in app-interface """
+    gqlapi = gql.get_api()
+    return gqlapi.query(SAAS_FILES_MINIMAL_QUERY)['saas_files']
+
+
 PERFORMANCE_PARAMETERS_QUERY = """
 {
   performance_parameters_v1 {


### PR DESCRIPTION
part of https://issues.redhat.com/browse/OSD-4840

this PR adds an option to receive an MR request through SQS gateway to update CIDR blocks for cloud-ingress-operator.
the message to the queue should be of the form:

```
{'pr_type': 'create_cloud_ingress_operator_cidr_blocks_mr', 'cidr_blocks': ['x.x.x.x/xx', 'y.y.y.y/yy']}
```

this message in the SQS queue will result in a MR to app-interface similar to this one:
https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/8060

requests will be sent from the private-cluster-rhapi-apischeme-updater CronJob:
https://github.com/openshift/private-cluster-rhapi-apischeme-updater/pull/18