### PR TITLE
[gitlab-ci-skipper] introduce integration + ocm-clusters fix

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -676,7 +676,7 @@ def saas_file_owners(ctx, gitlab_project_id, gitlab_merge_request_id,
 @click.argument('gitlab-merge-request-id')
 @click.pass_context
 def gitlab_ci_skipper(ctx, gitlab_project_id, gitlab_merge_request_id,
-                     io_dir):
+                      io_dir):
     run_integration(reconcile.gitlab_ci_skipper, ctx.obj,
                     gitlab_project_id, gitlab_merge_request_id,
                     io_dir)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -33,6 +33,7 @@ import reconcile.openshift_saas_deploy_wrapper
 import reconcile.openshift_saas_deploy_trigger_moving_commits
 import reconcile.openshift_saas_deploy_trigger_configs
 import reconcile.saas_file_owners
+import reconcile.gitlab_ci_skipper
 import reconcile.saas_file_validator
 import reconcile.quay_membership
 import reconcile.gcr_mirror
@@ -667,6 +668,18 @@ def saas_file_owners(ctx, gitlab_project_id, gitlab_merge_request_id,
     run_integration(reconcile.saas_file_owners, ctx.obj,
                     gitlab_project_id, gitlab_merge_request_id,
                     io_dir, compare)
+
+
+@integration.command()
+@throughput
+@click.argument('gitlab-project-id')
+@click.argument('gitlab-merge-request-id')
+@click.pass_context
+def gitlab_ci_skipper(ctx, gitlab_project_id, gitlab_merge_request_id,
+                     io_dir):
+    run_integration(reconcile.gitlab_ci_skipper, ctx.obj,
+                    gitlab_project_id, gitlab_merge_request_id,
+                    io_dir)
 
 
 @integration.command()

--- a/reconcile/gitlab_ci_skipper.py
+++ b/reconcile/gitlab_ci_skipper.py
@@ -1,0 +1,38 @@
+import os
+
+import reconcile.queries as queries
+import utils.throughput as throughput
+
+from utils.gitlab_api import GitLabApi
+
+
+QONTRACT_INTEGRATION = 'gitlab-ci-skipper'
+
+
+def get_output_file_path(io_dir):
+    dir_path = os.path.join(io_dir, QONTRACT_INTEGRATION)
+    if not os.path.exists(dir_path):
+        os.makedirs(dir_path)
+    return os.path.join(dir_path, 'output')
+
+
+def write_output_to_file(io_dir, output):
+    file_path = get_output_file_path(io_dir)
+    with open(file_path, 'w') as f:
+        f.write(output)
+    throughput.change_files_ownership(io_dir)
+
+
+def init_gitlab(gitlab_project_id):
+    instance = queries.get_gitlab_instance()
+    settings = queries.get_app_interface_settings()
+    return GitLabApi(instance, project_id=gitlab_project_id,
+                     settings=settings)
+
+
+def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None,
+        io_dir='throughput/'):
+    gl = init_gitlab(gitlab_project_id)
+    labels = gl.get_merge_request_labels(gitlab_merge_request_id)
+    output = 'yes' if 'skip-ci' in labels else 'no'
+    write_output_to_file(io_dir, output)

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -340,7 +340,7 @@ Please consult relevant SOPs to verify that the account is secure.
                                          cluster_name,
                                          path,
                                          version):
-        labels = ['automerge']
+        labels = ['automerge', 'skip-ci']
         prefix = 'qontract-reconcile'
         target_branch = 'master'
         branch_name = \
@@ -380,7 +380,7 @@ Please consult relevant SOPs to verify that the account is secure.
                                      cluster_name,
                                      path,
                                      cluster_id, external_id):
-        labels = ['automerge']
+        labels = ['automerge', 'skip-ci']
         prefix = 'qontract-reconcile'
         target_branch = 'master'
         branch_name = \
@@ -398,6 +398,9 @@ Please consult relevant SOPs to verify that the account is secure.
         path = path.lstrip('/')
         f = self.project.files.get(file_path=path, ref=target_branch)
         content = yaml.load(f.decode(), Loader=yaml.RoundTripLoader)
+        if content['spec'].get('id') == cluster_id and \
+                content['spec'].get('external_id') == external_id:
+            return
         content['spec']['id'] = cluster_id
         content['spec']['external_id'] = external_id
         new_content = '---\n' + \


### PR DESCRIPTION
this integration checks if a `skip-ci` label exists on the MR and prints `yes` or `no` accordingly.
if the answer is `yes` - we can skip integrations in manual_reconcile.sh.

this also fixes ocm-clusters to not submit empty MRs.