### PR TITLE
automerge cloud-ingress-operator MRs

### DIFF
--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -420,7 +420,7 @@ Please consult relevant SOPs to verify that the account is secure.
         return self.create_mr(branch_name, target_branch, title, labels=labels)
 
     def create_cloud_ingress_operator_cidr_blocks_mr(self, cidr_blocks):
-        labels = []  # add 'automerge' once this is working
+        labels = ['automerge']
         prefix = 'private-cluster-rhapi-apischeme-updater'
         target_branch = 'master'
         branch_name = \


### PR DESCRIPTION
follow up to https://github.com/openshift/private-cluster-rhapi-apischeme-updater/pull/18

this will cause MRs coming from private-cluster-rhapi-apischeme-updater to cloud-ingress-operator to be automerged.