### PR TITLE
[gitlab-labeler] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `github`: Configures the teams and members in a GitHub org.
 - `github-owners`: Configures owners in a GitHub org.
 - `github-validator`: Validates GitHub organization settings.
+- `gitlab-labeler`: Guesses and adds labels to merge requests according to changed paths.
 - `gitlab-fork-compliance`: Ensures that forks of App Interface are compliant.
 - `gitlab-housekeeping`: Manage issues and merge requests on GitLab projects.
 - `gitlab-integrations`: Manage integrations on GitLab projects.

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -34,6 +34,7 @@ import reconcile.openshift_saas_deploy_trigger_moving_commits
 import reconcile.openshift_saas_deploy_trigger_configs
 import reconcile.saas_file_owners
 import reconcile.gitlab_ci_skipper
+import reconcile.gitlab_labeler
 import reconcile.saas_file_validator
 import reconcile.quay_membership
 import reconcile.gcr_mirror
@@ -677,6 +678,15 @@ def saas_file_owners(ctx, gitlab_project_id, gitlab_merge_request_id,
 @click.pass_context
 def gitlab_ci_skipper(ctx, gitlab_project_id, gitlab_merge_request_id):
     run_integration(reconcile.gitlab_ci_skipper, ctx.obj,
+                    gitlab_project_id, gitlab_merge_request_id)
+
+
+@integration.command()
+@click.argument('gitlab-project-id')
+@click.argument('gitlab-merge-request-id')
+@click.pass_context
+def gitlab_labeler(ctx, gitlab_project_id, gitlab_merge_request_id):
+    run_integration(reconcile.gitlab_labeler, ctx.obj,
                     gitlab_project_id, gitlab_merge_request_id)
 
 

--- a/reconcile/gitlab_labeler.py
+++ b/reconcile/gitlab_labeler.py
@@ -10,6 +10,11 @@ QONTRACT_INTEGRATION = 'gitlab-labeler'
 
 
 def guess_labels(project_labels, changed_paths):
+    """
+    Guess labels returns a list of labels from the project labels
+    that contain parts of the changed paths.
+    This is the first form of guessing, which will likely be adjusted.
+    """
     not_allowed_labels = MERGE_LABELS_PRIORITY + HOLD_LABELS
     guesses = set()
     for label in project_labels:

--- a/reconcile/gitlab_labeler.py
+++ b/reconcile/gitlab_labeler.py
@@ -1,0 +1,39 @@
+import os
+
+import reconcile.queries as queries
+
+from reconcile.gitlab_housekeeping import MERGE_LABELS_PRIORITY, HOLD_LABELS
+from utils.gitlab_api import GitLabApi
+
+
+QONTRACT_INTEGRATION = 'gitlab-labeler'
+
+
+def guess_labels(project_labels, changed_paths):
+    not_allowed_labels = MERGE_LABELS_PRIORITY + HOLD_LABELS
+    guesses = set()
+    for label in project_labels:
+        if label in not_allowed_labels:
+            continue
+        for path in changed_paths:
+            path_dir = os.path.dirname(path)
+            path_tokens = path_dir.split('/')
+            matches = [t for t in path_tokens if t and t in label]
+            if matches:
+                guesses.add(label)
+
+    return list(guesses)
+
+
+def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None):
+    instance = queries.get_gitlab_instance()
+    settings = queries.get_app_interface_settings()
+    gl = GitLabApi(instance, project_id=gitlab_project_id,
+                   settings=settings)
+    project_labels = gl.get_project_labels()
+    labels = gl.get_merge_request_labels(gitlab_merge_request_id)
+    changed_paths = \
+        gl.get_merge_request_changed_paths(gitlab_merge_request_id)
+    guessed_labels = guess_labels(project_labels, changed_paths)
+    labels_to_add = [l for l in guessed_labels if l not in labels]
+    gl.add_labels_to_merge_request(gitlab_merge_request_id, labels_to_add)

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -656,6 +656,7 @@ Please consult relevant SOPs to verify that the account is secure.
         self.update_labels(merge_request, 'merge-request', labels)
 
     def add_labels_to_merge_request(self, mr_id, labels):
+        """ Adds labels to a Merge Request """
         merge_request = self.project.mergerequests.get(mr_id)
         mr_labels = merge_request.attributes.get('labels')
         mr_labels += labels

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -642,6 +642,9 @@ Please consult relevant SOPs to verify that the account is secure.
         merge_request = self.project.mergerequests.get(mr_id)
         merge_request.notes.create({'body': comment})
 
+    def get_project_labels(self):
+        return [l.name for l in self.project.labels.list()]
+
     def get_merge_request_labels(self, mr_id):
         merge_request = self.project.mergerequests.get(mr_id)
         return merge_request.labels
@@ -651,6 +654,12 @@ Please consult relevant SOPs to verify that the account is secure.
         labels = merge_request.attributes.get('labels')
         labels.append(label)
         self.update_labels(merge_request, 'merge-request', labels)
+
+    def add_labels_to_merge_request(self, mr_id, labels):
+        merge_request = self.project.mergerequests.get(mr_id)
+        mr_labels = merge_request.attributes.get('labels')
+        mr_labels += labels
+        self.update_labels(merge_request, 'merge-request', mr_labels)
 
     def remove_label_from_merge_request(self, mr_id, label):
         merge_request = self.project.mergerequests.get(mr_id)


### PR DESCRIPTION
this integration adds labels to MRs based on the changed paths and on the existing labels in the project.

for example, if the `/services/myservice/` path changed and we have a label containing the word `myservice` - that label will be added.

the integration basically guesses labels and we will probably need to modify the logic or the data in app-interface as we find issues.