### PR TITLE
retry apply on error if it's not an invalid value error

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -219,7 +219,7 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
 
         try:
             oc.apply(namespace, annotated.toJSON())
-        except InvalidValueApplyError as e:
+        except InvalidValueApplyError:
             oc.remove_last_applied_configuration(
                 namespace, resource_type, resource.name)
             oc.apply(namespace, annotated.toJSON())

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -4,7 +4,7 @@ import utils.threaded as threaded
 import reconcile.queries as queries
 
 from utils.oc import OC_Map
-from utils.oc import StatusCodeError, ApplyError
+from utils.oc import StatusCodeError, InvalidValueApplyError
 from utils.openshift_resource import (OpenshiftResource as OR,
                                       ResourceInventory)
 
@@ -219,13 +219,10 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
 
         try:
             oc.apply(namespace, annotated.toJSON())
-        except ApplyError as e:
-            if 'Invalid value: 0x0' in str(e):
-                oc.remove_last_applied_configuration(
-                    namespace, resource_type, resource.name)
-                oc.apply(namespace, annotated.toJSON())
-            else:
-                raise StatusCodeError(str(e))
+        except InvalidValueApplyError as e:
+            oc.remove_last_applied_configuration(
+                namespace, resource_type, resource.name)
+            oc.apply(namespace, annotated.toJSON())
 
     oc.recycle_pods(dry_run, namespace, resource_type, resource)
 

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -18,7 +18,7 @@ class StatusCodeError(Exception):
     pass
 
 
-class ApplyError(Exception):
+class InvalidValueApplyError(Exception):
     pass
 
 
@@ -401,8 +401,8 @@ class OC(object):
 
         if code != 0:
             err = err.decode('utf-8')
-            if kwargs.get('apply'):
-                raise ApplyError(f"[{self.server}]: {err}")
+            if kwargs.get('apply') and 'Invalid value: 0x0' in err:
+                raise InvalidValueApplyError(f"[{self.server}]: {err}")
             if not (allow_not_found and 'NotFound' in err):
                 raise StatusCodeError(f"[{self.server}]: {err}")
 


### PR DESCRIPTION
in some cases when we apply resources we get an invalid value error `Invalid Value 0x0`, which can be handled by removing the last applied configuration annotation.

this PR changes the way the `apply` method works, and makes it retry apply actions which got an error which is not the invalid value error.

this should allow us to apply resource types which depend on the previously applied resources. for example, an operator creating a CR - with this change we should be able to apply both resource types from the same saas file, as long as the dependant CR is listed after the creating resources under `managedResourceTypes`.