### PR TITLE
[ocm-clusters] add support for channel

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -306,6 +306,7 @@ CLUSTERS_QUERY = """
       external_id
       provider
       region
+      channel
       version
       initial_version
       multi_az

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -64,6 +64,7 @@ class OCM(object):
                 'external_id': cluster['external_id'],
                 'provider': cluster['cloud_provider']['id'],
                 'region': cluster['region']['id'],
+                'channel': cluster['version']['channel_group']
                 'version': cluster['openshift_version'],
                 'multi_az': cluster['multi_az'],
                 'nodes': cluster['nodes']['compute'],
@@ -104,7 +105,8 @@ class OCM(object):
                 'id': cluster_spec['region']
             },
             'version': {
-                'id': 'openshift-v' + cluster_spec['initial_version']
+                'id': 'openshift-v' + cluster_spec['initial_version'],
+                'channel_group': cluster_spec['channel']
             },
             'multi_az': cluster_spec['multi_az'],
             'nodes': {

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -64,7 +64,7 @@ class OCM(object):
                 'external_id': cluster['external_id'],
                 'provider': cluster['cloud_provider']['id'],
                 'region': cluster['region']['id'],
-                'channel': cluster['version']['channel_group']
+                'channel': cluster['version']['channel_group'],
                 'version': cluster['openshift_version'],
                 'multi_az': cluster['multi_az'],
                 'nodes': cluster['nodes']['compute'],


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2162

this PR adds support for OCM's API channel_group field, with which we can provision clusters in channels other then `stable` (in our case, `fast`).