### PR TITLE
[ocm-clusters] add support for provision_shard_id

### DIFF
--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -85,7 +85,7 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
                     mr.submit(cli=mr_cli)
 
             # exclude params we don't want to check in the specs
-            for k in ['id', 'external_id']:
+            for k in ['id', 'external_id', 'provision_shard_id']:
                 current_spec['spec'].pop(k, None)
                 desired_spec['spec'].pop(k, None)
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -316,6 +316,7 @@ CLUSTERS_QUERY = """
       load_balancers
       private
       upgrade
+      provision_shard_id
     }
     network {
       vpc

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -131,6 +131,10 @@ class OCM(object):
             }
         }
 
+        provision_shard_id = cluster_spec.get('provision_shard_id')
+        if provision_shard_id:
+            ocm['properties']['provision_shard_id'] = provision_shard_id
+
         self._post(api, ocm_spec)
 
     def get_group_if_exists(self, cluster, group_id):

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -133,7 +133,7 @@ class OCM(object):
 
         provision_shard_id = cluster_spec.get('provision_shard_id')
         if provision_shard_id:
-            ocm['properties']['provision_shard_id'] = provision_shard_id
+            ocm_spec['properties']['provision_shard_id'] = provision_shard_id
 
         self._post(api, ocm_spec)
 


### PR DESCRIPTION
depends on https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/merge_requests/2140 reaching production

this PR adds the ability to provision clusters in specific hive shards according to their id, as defined here: https://gitlab.cee.redhat.com/service/app-interface/-/blob/96ea6b2233a9416c7d3126d0462ac7bed7280d5c/data/services/ocm/namespaces/uhc-production.yml#L50