### PR TITLE
saas-deploy-trigger-moving-commits: only consider targets that are not disabled

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -20,6 +20,15 @@ def run(dry_run, thread_pool_size=10):
         logging.error('no saas files found')
         sys.exit(1)
 
+    # Remove saas-file targets that are disabled
+    for saas_file in saas_files[:]:
+        resource_templates = saas_file['resourceTemplates']
+        for rt in resource_templates[:]:
+            targets = rt['targets']
+            for target in targets[:]:
+                if target['disable']:
+                    targets.remove(target)
+
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()
     accounts = queries.get_aws_accounts()


### PR DESCRIPTION
This ensures we don't trigger jobs for saas-file targets that are disabled