### PR TITLE
use explicit bot labels

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -9,8 +9,8 @@ import reconcile.queries as queries
 from utils.gitlab_api import GitLabApi
 
 
-MERGE_LABELS_PRIORITY = ['approved', 'automerge', 'lgtm']
-HOLD_LABELS = ['awaiting-approval', 'blocked/bot-access', 'hold',
+MERGE_LABELS_PRIORITY = ['bot/approved', 'approved', 'automerge', 'lgtm']
+HOLD_LABELS = ['awaiting-approval', 'blocked/bot-access', 'hold', 'bot/hold',
                'do-not-merge/hold', 'do-not-merge/pending-review']
 
 QONTRACT_INTEGRATION = 'gitlab-housekeeping'

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -9,7 +9,8 @@ import reconcile.queries as queries
 from utils.gitlab_api import GitLabApi
 
 
-MERGE_LABELS_PRIORITY = ['bot/approved', 'approved', 'automerge', 'lgtm']
+MERGE_LABELS_PRIORITY = ['bot/approved', 'approved', 'bot/automerge',
+                         'automerge', 'lgtm']
 HOLD_LABELS = ['awaiting-approval', 'blocked/bot-access', 'hold', 'bot/hold',
                'do-not-merge/hold', 'do-not-merge/pending-review']
 

--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -214,6 +214,8 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None,
         write_baseline_to_file(io_dir, baseline)
         return
 
+    approved_label = 'bot/approved'
+    hold_label = 'bot/hold'
     gl = init_gitlab(gitlab_project_id)
     baseline = read_baseline_from_file(io_dir)
     owners = baseline['owners']
@@ -230,11 +232,11 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None,
 
     if desired_state == current_state:
         gl.remove_label_from_merge_request(
-            gitlab_merge_request_id, 'approved')
+            gitlab_merge_request_id, approved_label)
         return
     if not is_valid_diff:
         gl.remove_label_from_merge_request(
-            gitlab_merge_request_id, 'approved')
+            gitlab_merge_request_id, approved_label)
         return
 
     comments = gl.get_merge_request_comments(gitlab_merge_request_id)
@@ -246,13 +248,13 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None,
         valid_lgtm, hold = check_if_lgtm(saas_file_owners, comments)
         if hold:
             gl.add_label_to_merge_request(
-                gitlab_merge_request_id, 'hold')
+                gitlab_merge_request_id, hold_label)
         else:
             gl.remove_label_from_merge_request(
-                gitlab_merge_request_id, 'hold')
+                gitlab_merge_request_id, hold_label)
         if not valid_lgtm:
             gl.remove_label_from_merge_request(
-                gitlab_merge_request_id, 'approved')
+                gitlab_merge_request_id, approved_label)
             comment_line_body = \
                 f"- changes to saas file '{saas_file_name}' " + \
                 f"require approval (`/lgtm`) from one of: {saas_file_owners}."
@@ -271,8 +273,8 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None,
     # if there are still entries in this list - they are not approved
     if len(changed_paths) != 0:
         gl.remove_label_from_merge_request(
-            gitlab_merge_request_id, 'approved')
+            gitlab_merge_request_id, approved_label)
         return
 
-    # add 'approved' label to merge request!
-    gl.add_label_to_merge_request(gitlab_merge_request_id, 'approved')
+    # add approved label to merge request!
+    gl.add_label_to_merge_request(gitlab_merge_request_id, approved_label)

--- a/utils/mr/labels.py
+++ b/utils/mr/labels.py
@@ -1,3 +1,3 @@
-AUTO_MERGE = 'automerge'
-SKIP_CI = 'skip-ci'
+AUTO_MERGE = 'bot/automerge'
+SKIP_CI = 'bot/skip-ci'
 DO_NOT_MERGE = 'do-not-merge/hold'


### PR DESCRIPTION
to make it clear that these labels are used by bots and not by humans, instead of using:
- `approved`
- `hold`
- `automerge`
- `skip-ci`
we will now use:
- `bot/approved`
- `bot/hold`
- `bot/automerge`
- `bot/skip-ci`

we may remove the usage of the previous labels after this change.