### PR TITLE
[saas-file-owners] allow users to be tagged on MRs

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -946,6 +946,7 @@ SAAS_FILES_QUERY = """
     roles {
       users {
         org_username
+        tag_on_merge_requests
       }
     }
   }

--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -40,6 +40,8 @@ def collect_owners():
                 continue
             for owner_user in owner_users:
                 owner_username = owner_user['org_username']
+                if owner_user.get('tag_on_merge_requests'):
+                    owner_username = f'@{owner_username}'
                 owners[saas_file_name].add(owner_username)
 
     # make owners suitable for json dump


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2466

this PR adds an option for a user to define `tag_on_merge_requests: true` in their user file, which will lead to them being pinged on MRs for saas file they own.