### PR TITLE
[openshift-resources] fix api_resources check to match managedResourceTypeOverrides

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -404,8 +404,12 @@ def fetch_current_state(oc, ri, cluster, namespace, resource_type,
     _log_lock.release()
     if oc is None:
         return
+    # some resource types may be used explicitly (<kind>.<api_group>).
+    # we only take the first token as oc.api_resources contains only the kind.
+    # this is the case created by using `managedResourceTypeOverrides`.
     if oc.api_resources and \
-            resource_type_to_use not in oc.api_resources:
+            resource_type_to_use.split('.')[0].lower() \
+            not in [a.lower() for a in oc.api_resources]:
         msg = \
             f"[{cluster}] cluster has no API resource {resource_type_to_use}."
         logging.warning(msg)


### PR DESCRIPTION
in the openshift-config namespace we use the `managedResourceTypeOverrides` field, which allows us to apply resources which have a `kind` that exists in more then a single api group.

this PR adds a handle for this case when checking if the desired kind exists in `oc api-resources`.