### PR TITLE
[jenkins-job-cleaner] introduce integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `gitlab-permissions`: Manage permissions on GitLab projects.
 - `gitlab-projects`: Create GitLab projects.
 - `jenkins-job-builder`: Manage Jenkins jobs configurations using jenkins-jobs
+- `jenkins-job-cleaner`: Delete Jenkins jobs in multiple tenant instances.
 - `jenkins-plugins`: Manage Jenkins plugins installation via REST API.
 - `jenkins-roles`: Manage Jenkins roles association via REST API.
 - `jenkins-webhooks`: Manage web hooks to Jenkins jobs.

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -49,6 +49,7 @@ import reconcile.github_repo_permissions_validator
 import reconcile.jenkins_roles
 import reconcile.jenkins_plugins
 import reconcile.jenkins_job_builder
+import reconcile.jenkins_job_cleaner
 import reconcile.jenkins_webhooks
 import reconcile.jenkins_webhooks_cleaner
 import reconcile.jira_watcher
@@ -497,6 +498,12 @@ def jenkins_plugins(ctx):
 def jenkins_job_builder(ctx, io_dir, compare):
     run_integration(reconcile.jenkins_job_builder, ctx.obj,
                     io_dir, compare)
+
+
+@integration.command()
+@click.pass_context
+def jenkins_job_cleaner(ctx):
+    run_integration(reconcile.jenkins_job_cleaner, ctx.obj)
 
 
 @integration.command()

--- a/reconcile/jenkins_job_cleaner.py
+++ b/reconcile/jenkins_job_cleaner.py
@@ -1,0 +1,52 @@
+import logging
+
+import reconcile.queries as queries
+
+from reconcile.jenkins_job_builder import init_jjb
+from utils.jenkins_api import JenkinsApi
+
+QONTRACT_INTEGRATION = 'jenkins-job-cleaner'
+
+
+def get_managed_job_names(job_names, managed_projects):
+    managed_jobs = set()
+    for job_name in job_names:
+        for managed_project in managed_projects:
+            if job_name.startswith(managed_project):
+                managed_jobs.add(job_name)
+
+    return list(managed_jobs)
+
+
+def get_desired_job_names(instance_name):
+    jjb, _ = init_jjb()
+    desired_jobs = \
+        jjb.get_all_jobs(instance_name=instance_name)[instance_name]
+    return [j['name'] for j in desired_jobs]
+
+
+def run(dry_run):
+    jenkins_instances = queries.get_jenkins_instances()
+    settings = queries.get_app_interface_settings()
+
+    for instance in jenkins_instances:
+        if instance.get('deleteMethod') != 'manual':
+            continue
+        managed_projects = instance.get('managedProjects')
+        if not managed_projects:
+            continue
+
+        instance_name = instance['name']
+        token = instance['token']
+        jenkins = JenkinsApi(token, ssl_verify=False, settings=settings)
+        all_job_names = jenkins.get_job_names()
+        managed_job_names = \
+            get_managed_job_names(all_job_names, managed_projects)
+        desired_job_names = get_desired_job_names(instance_name)
+        delete_job_names = [j for j in managed_job_names
+                            if j not in desired_job_names]
+
+        for job_name in delete_job_names:
+            logging.info(['delete_job', instance_name, job_name])
+            if not dry_run:
+                jenkins.delete_job(job_name)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -120,6 +120,8 @@ JENKINS_INSTANCES_QUERY = """
     }
     previousUrls
     plugins
+    deleteMethod
+    managedProjects
   }
 }
 """


### PR DESCRIPTION
this PR adds a new integration: jenkins-job-cleaner

this integration iterates through jenkins instances with a `deleteMethod: manual` and compares the existing jobs in the instance to the desired jobs calculated by jenkins-job-builder. for each such found job, if the job name starts with one of the `managedProjects` of the intsance - the integration will delete the job.

this ensures that we can only delete our own jobs in a multi-tenant jenkins instance.