### PR TITLE
Revert "tf-r-dry-run-no-oc (#1040)"

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -207,18 +207,13 @@ def populate_oc_resources(spec, ri):
         logging.error(msg)
 
 
-def fetch_current_state(dry_run, namespaces, thread_pool_size, internal,
-                        use_jump_host):
-    if dry_run:
-        return None, None
-
+def fetch_current_state(namespaces, thread_pool_size, internal, use_jump_host):
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces, integration=QONTRACT_INTEGRATION,
                     settings=settings, internal=internal,
                     use_jump_host=use_jump_host,
                     thread_pool_size=thread_pool_size)
-
     state_specs = \
         ob.init_specs_to_fetch(
             ri,
@@ -243,7 +238,7 @@ def init_working_dirs(accounts, thread_pool_size,
     return ts, working_dirs
 
 
-def setup(dry_run, print_only, thread_pool_size, internal, use_jump_host,
+def setup(print_only, thread_pool_size, internal, use_jump_host,
           account_name):
     gqlapi = gql.get_api()
     accounts = queries.get_aws_accounts()
@@ -256,7 +251,7 @@ def setup(dry_run, print_only, thread_pool_size, internal, use_jump_host,
     namespaces = gqlapi.query(TF_NAMESPACES_QUERY)['namespaces']
     tf_namespaces = [namespace_info for namespace_info in namespaces
                      if namespace_info.get('managedTerraformResources')]
-    ri, oc_map = fetch_current_state(dry_run, tf_namespaces, thread_pool_size,
+    ri, oc_map = fetch_current_state(tf_namespaces, thread_pool_size,
                                      internal, use_jump_host)
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size,
                                          print_only=print_only,
@@ -301,11 +296,10 @@ def run(dry_run, print_only=False,
         account_name=None, defer=None):
 
     ri, oc_map, tf = \
-        setup(dry_run, print_only, thread_pool_size, internal, use_jump_host,
+        setup(print_only, thread_pool_size, internal, use_jump_host,
               account_name)
 
-    if not dry_run:
-        defer(lambda: oc_map.cleanup())
+    defer(lambda: oc_map.cleanup())
 
     if print_only:
         cleanup_and_exit()


### PR DESCRIPTION
This makes tf-r fail to create a new RDS isntance.

This reverts commit 25e77ab8926c5b0835ee74b7c39c1b406f6a8c53.