### PR TITLE
openshift canonicalize - remove metadata.managedFields

### DIFF
--- a/utils/openshift_resource.py
+++ b/utils/openshift_resource.py
@@ -256,6 +256,7 @@ class OpenshiftResource(object):
         body['metadata'].pop('selfLink', None)
         body['metadata'].pop('uid', None)
         body['metadata'].pop('namespace', None)
+        body['metadata'].pop('managedFields', None)
         annotations.pop('kubectl.kubernetes.io/last-applied-configuration',
                         None)
 


### PR DESCRIPTION
https://access.redhat.com/solutions/5332041
https://github.com/kubernetes/kubernetes/issues/90066

the new field `managedFields` which available in OpenShift (we're seeing it first in 4.5.7) makes all our integrations believe they need to reconcile resources over and over. this PR will make the integrations ignore this field.