### PR TITLE
[wip][openshift-environments] introduce integration

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -720,15 +720,11 @@ def openshift_namespaces(ctx, thread_pool_size, internal, use_jump_host):
 
 
 @integration.command()
-@threaded()
-@binary(['oc', 'ssh'])
-@internal()
-@use_jump_host()
+@click.argument('gitlab-project-id')
 @click.pass_context
-def openshift_environments(ctx, thread_pool_size, internal, use_jump_host):
+def openshift_environments(ctx, gitlab_project_id):
     run_integration(reconcile.openshift_environments,
-                    ctx.obj, thread_pool_size, internal,
-                    use_jump_host)
+                    ctx.obj, gitlab_project_id)
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -25,6 +25,7 @@ import reconcile.openshift_resources
 import reconcile.openshift_vault_secrets
 import reconcile.openshift_routes
 import reconcile.openshift_namespaces
+import reconcile.openshift_environments
 import reconcile.openshift_network_policies
 import reconcile.openshift_performance_parameters
 import reconcile.openshift_serviceaccount_tokens
@@ -714,6 +715,18 @@ def gitlab_labeler(ctx, gitlab_project_id, gitlab_merge_request_id):
 @click.pass_context
 def openshift_namespaces(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.openshift_namespaces,
+                    ctx.obj, thread_pool_size, internal,
+                    use_jump_host)
+
+
+@integration.command()
+@threaded()
+@binary(['oc', 'ssh'])
+@internal()
+@use_jump_host()
+@click.pass_context
+def openshift_environments(ctx, thread_pool_size, internal, use_jump_host):
+    run_integration(reconcile.openshift_environments,
                     ctx.obj, thread_pool_size, internal,
                     use_jump_host)
 

--- a/reconcile/openshift_environments.py
+++ b/reconcile/openshift_environments.py
@@ -2,19 +2,18 @@ import logging
 
 import reconcile.queries as queries
 
-from utils.defer import defer
+from reconcile import mr_client_gateway
 from utils.mr import CreateEnvironment
 
 
 QONTRACT_INTEGRATION = 'openshift-environments'
 
 
-@defer
-def run(dry_run, thread_pool_size=10, internal=None,
-        use_jump_host=True, defer=None):
+def run(dry_run, gitlab_project_id):
     environments = queries.get_environments()
     target_environments = [e for e in environments if e.get('copy')]
 
+    dir_prefix = 'data'
     actions = []
 
     for target_environment in target_environments:
@@ -23,6 +22,7 @@ def run(dry_run, thread_pool_size=10, internal=None,
         target_environment_copy = target_environment['copy']
         target_cluster = target_environment_copy['target']['cluster']
         target_cluster_name = target_cluster['name']
+        target_cluster_path = target_cluster['path']
         source_environment = \
             target_environment_copy['source']['environment']
         source_environment_name = source_environment['name']
@@ -30,20 +30,29 @@ def run(dry_run, thread_pool_size=10, internal=None,
         for source_namespace in source_namespaces:
             # collect namespaces to create
             source_namespace_name = source_namespace['name']
+            source_namespace_path = source_namespace['path']
+            source_cluster = source_namespace['cluster']
+            source_cluster_name = source_cluster['name']
+            source_cluster_path = source_cluster['path']
+            target_namespace_path = \
+                source_namespace_path.replace(source_cluster_name,
+                                              target_cluster_name)
             if source_namespace_name in target_namespaces:
                 continue
-            logging.info(['create_namespace', target_cluster_name,
-                          source_namespace_name])
+            logging.info(['copy_namespace', source_cluster_name,
+                          target_cluster_name, source_namespace_name])
             action = {
-                'action': 'create_namespace',
-                'source_namespace': source_namespace,
-                'target_cluster': target_cluster
+                'action': 'copy_namespace',
+                'source_namespace_path': dir_prefix + source_namespace_path,
+                'target_namespace_path': dir_prefix + target_namespace_path,
+                'target_cluster_path': target_cluster_path
             }
             actions.append(action)
         # collect saas file targets to create
         saas_files = queries.get_saas_files(env_name=source_environment_name)
         for saas_file in saas_files:
             saas_file_name = saas_file['name']
+            saas_file_path = saas_file['path']
             resource_template = saas_file['resourceTemplates']
             for rt in resource_template:
                 rt_name = rt['name']
@@ -52,18 +61,23 @@ def run(dry_run, thread_pool_size=10, internal=None,
                     rt_namespace = rt_target['namespace']
                     rt_namespace_name = rt_namespace['name']
                     rt_namespace_path = rt_namespace['path']
-                    rt_environment_name = rt_namespace['environment']['name']
-                    if rt_environment_name != source_environment_name:
-                        continue
-                    logging.info(['create_target', saas_file_name,
-                                    rt_name, rt_namespace_name])
+                    rt_cluster_name = rt_namespace['cluster']['name']
+                    target_namespace_path = \
+                        rt_namespace_path.replace(source_cluster_name,
+                                                  target_cluster_name)
+                    logging.info(['copy_target', saas_file_name,
+                                  rt_name, rt_namespace_name])
                     action = {
-                        'action': 'create_target',
-                        'saas_file_name': saas_file_name,
+                        'action': 'copy_target',
+                        'saas_file_name': saas_file_path,
                         'rt_name': rt_name,
-                        'target_namespace_path': rt_namespace_path
+                        'source_namespace_path': dir_prefix + rt_namespace_path,
+                        'target_namespace_path': dir_prefix + target_namespace_path
                     }
                     actions.append(action)
 
-        mr = CreateEnvironment(target_environment_name, actions)
-        # mr.submit(cli=mr_cli)
+        if not dry_run:
+            mr_cli = mr_client_gateway.init(gitlab_project_id=gitlab_project_id,
+                                            sqs_or_gitlab='gitlab')
+            mr = CreateEnvironment(target_environment_name, actions)
+            mr.submit(cli=mr_cli)

--- a/reconcile/openshift_environments.py
+++ b/reconcile/openshift_environments.py
@@ -1,0 +1,69 @@
+import logging
+
+import reconcile.queries as queries
+
+from utils.defer import defer
+from utils.mr import CreateEnvironment
+
+
+QONTRACT_INTEGRATION = 'openshift-environments'
+
+
+@defer
+def run(dry_run, thread_pool_size=10, internal=None,
+        use_jump_host=True, defer=None):
+    environments = queries.get_environments()
+    target_environments = [e for e in environments if e.get('copy')]
+
+    actions = []
+
+    for target_environment in target_environments:
+        target_environment_name = target_environment['name']
+        target_namespaces = target_environment['namespaces']
+        target_environment_copy = target_environment['copy']
+        target_cluster = target_environment_copy['target']['cluster']
+        target_cluster_name = target_cluster['name']
+        source_environment = \
+            target_environment_copy['source']['environment']
+        source_environment_name = source_environment['name']
+        source_namespaces = source_environment['namespaces']
+        for source_namespace in source_namespaces:
+            # collect namespaces to create
+            source_namespace_name = source_namespace['name']
+            if source_namespace_name in target_namespaces:
+                continue
+            logging.info(['create_namespace', target_cluster_name,
+                          source_namespace_name])
+            action = {
+                'action': 'create_namespace',
+                'source_namespace': source_namespace,
+                'target_cluster': target_cluster
+            }
+            actions.append(action)
+        # collect saas file targets to create
+        saas_files = queries.get_saas_files(env_name=source_environment_name)
+        for saas_file in saas_files:
+            saas_file_name = saas_file['name']
+            resource_template = saas_file['resourceTemplates']
+            for rt in resource_template:
+                rt_name = rt['name']
+                rt_targets = rt['targets']
+                for rt_target in rt_targets:
+                    rt_namespace = rt_target['namespace']
+                    rt_namespace_name = rt_namespace['name']
+                    rt_namespace_path = rt_namespace['path']
+                    rt_environment_name = rt_namespace['environment']['name']
+                    if rt_environment_name != source_environment_name:
+                        continue
+                    logging.info(['create_target', saas_file_name,
+                                    rt_name, rt_namespace_name])
+                    action = {
+                        'action': 'create_target',
+                        'saas_file_name': saas_file_name,
+                        'rt_name': rt_name,
+                        'target_namespace_path': rt_namespace_path
+                    }
+                    actions.append(action)
+
+        mr = CreateEnvironment(target_environment_name, actions)
+        # mr.submit(cli=mr_cli)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -571,9 +571,29 @@ ENVIRONMENTS_QUERY = """
     product {
       name
     }
+    copy {
+      source {
+        environment {
+          name
+          namespaces {
+            path
+            name
+          }
+        }
+      }
+      target {
+        cluster {
+          path
+          name
+        }
+      }
+    }
     namespaces {
       name
       app {
+        name
+      }
+      environment {
         name
       }
       cluster {
@@ -909,6 +929,7 @@ SAAS_FILES_QUERY = """
       parameters
       targets {
         namespace {
+          path
           name
           environment {
             name

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -578,6 +578,10 @@ ENVIRONMENTS_QUERY = """
           namespaces {
             path
             name
+            cluster {
+              path
+              name
+            }
           }
         }
       }

--- a/utils/mr/__init__.py
+++ b/utils/mr/__init__.py
@@ -6,6 +6,7 @@ from utils.mr.cluster_ids import CreateUpdateClusterIds
 from utils.mr.cluster_version import CreateUpdateClusterVersion
 from utils.mr.notificator import CreateAppInterfaceNotificator
 from utils.mr.user_maintenance import CreateDeleteUser
+from utils.mr.environment import CreateEnvironment
 
 
 __all__ = [

--- a/utils/mr/environment.py
+++ b/utils/mr/environment.py
@@ -24,5 +24,40 @@ class CreateEnvironment(MergeRequestBase):
 
     def process(self, gitlab_cli):
         for action in self.actions:
-            continue
-            # gitlab_cli...
+            action_type = action['action']
+            if action_type == 'copy_namespace':
+                source_namespace_path = action['source_namespace_path']
+                target_namespace_path = action['target_namespace_path']
+                target_cluster_path = action['target_cluster_path']
+
+                raw_file = gitlab_cli.project.files.get(
+                    file_path=source_namespace_path,
+                    ref=self.main_branch
+                )
+                content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+                content = content.replace()
+                new_content = '---\n'
+                new_content += yaml.dump(content, Dumper=yaml.RoundTripDumper)
+
+                msg = 'Copy namespace'
+                gitlab_cli.create_file(
+                    branch_name=self.branch,
+                    file_path=target_namespace_path,
+                    commit_message=msg,
+                    content=new_content)
+            elif action_type == 'copy_target':
+                continue
+                saas_file_path = action['saas_file_path']
+                rt_name = action['rt_name']
+                source_namespace_path = action['source_namespace_path']
+                target_namespace_path = action['target_namespace_path']
+
+                raw_file = gitlab_cli.project.files.get(
+                    file_path=saas_file_path,
+                    ref=self.main_branch
+                )
+                content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+                new_content = '---\n'
+                new_content += yaml.dump(content, Dumper=yaml.RoundTripDumper)
+                
+

--- a/utils/mr/environment.py
+++ b/utils/mr/environment.py
@@ -1,0 +1,28 @@
+import ruamel.yaml as yaml
+
+from utils.mr.base import MergeRequestBase
+from utils.mr.labels import AUTO_MERGE
+from utils.mr.labels import SKIP_CI
+
+
+class CreateEnvironment(MergeRequestBase):
+
+    name = 'create_environment_mr'
+
+    def __init__(self, environment_name, actions):
+        self.environment_name = environment_name
+        self.actions = actions
+
+        super().__init__()
+
+        self.labels = []
+
+    @property
+    def title(self):
+        return (f'[{self.name}] '
+                f'create environment {self.environment_name}')
+
+    def process(self, gitlab_cli):
+        for action in self.actions:
+            continue
+            # gitlab_cli...


### PR DESCRIPTION
This PR adds a new integration called openshift-environments.

This integration takes an environment file with a `copy` section pointing to an existing environment and to a target cluster (has to be created beforehand) and will copy all definitions relevant to the source environments. This will eventually become a MR to app-interface to add all the definitions.

Such definitions will include (for now):
- namespace files
- saas file targets

Matching app-interface MR: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/9270