### PR TITLE
[jenkins-job-cleaner] include test jobs

### DIFF
--- a/reconcile/jenkins_job_cleaner.py
+++ b/reconcile/jenkins_job_cleaner.py
@@ -21,7 +21,8 @@ def get_managed_job_names(job_names, managed_projects):
 def get_desired_job_names(instance_name):
     jjb, _ = init_jjb()
     desired_jobs = \
-        jjb.get_all_jobs(instance_name=instance_name)[instance_name]
+        jjb.get_all_jobs(instance_name=instance_name,
+                         include_test=True)[instance_name]
     return [j['name'] for j in desired_jobs]
 
 

--- a/utils/jjb_client.py
+++ b/utils/jjb_client.py
@@ -302,7 +302,8 @@ class JJB(object):
         repo_url_raw = job['properties'][0]['github']['url']
         return repo_url_raw.strip('/').replace('.git', '')
 
-    def get_all_jobs(self, job_types=[''], instance_name=None):
+    def get_all_jobs(self, job_types=[''], instance_name=None,
+                     include_test=False):
         all_jobs = {}
         for name, wd in self.working_dirs.items():
             if instance_name and name != instance_name:
@@ -314,7 +315,7 @@ class JJB(object):
                 job_name = job['name']
                 if not any(job_type in job_name for job_type in job_types):
                     continue
-                if 'test' in job_name:
+                if not include_test and 'test' in job_name:
                     continue
                 # temporarily ignore openshift-saas-deploy jobs
                 if job_name.startswith('openshift-saas-deploy'):


### PR DESCRIPTION
the cleaner should look at all jobs, including ones with `test` in their name :facepalm: 