### PR TITLE
[jenkins-job-builder] fix upstream error

### DIFF
--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -74,7 +74,7 @@ def collect_saas_file_configs():
             repo_urls.add(url)
             for target in resource_template['targets']:
                 env_name = target['namespace']['environment']['name']
-                upstream = target.get('upstream', '')
+                upstream = target.get('upstream') or ''
                 final_job_template_name = \
                     f'{job_template_name}-with-upstream' if upstream \
                     else job_template_name


### PR DESCRIPTION
this PR makes the default `upstream` value a string instead of None in case `upstream` is not defined on the first job.

fixes:
```
Traceback (most recent call last):
  File "/usr/local/bin/qontract-reconcile", line 33, in <module>
    sys.exit(load_entry_point('reconcile==0.2.2', 'console_scripts', 'qontract-reconcile')())
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 506, in jenkins_job_cleaner
    run_integration(reconcile.jenkins_job_cleaner, ctx.obj)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 319, in run_integration
    func_container.run(dry_run, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/jenkins_job_cleaner.py", line 46, in run
    desired_job_names = get_desired_job_names(instance_name)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/jenkins_job_cleaner.py", line 22, in get_desired_job_names
    jjb, _ = init_jjb()
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/jenkins_job_builder.py", line 156, in init_jjb
    configs, settings, additional_repo_urls = collect_configs()
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/jenkins_job_builder.py", line 149, in collect_configs
    collect_saas_file_configs()
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/jenkins_job_builder.py", line 93, in collect_saas_file_configs
    project['upstream'] += f',{upstream}'
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'str'
```

cc @apahim 