### PR TITLE
aws_route53: exclude records matching items in unmanaged_record_names

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1185,6 +1185,7 @@ DNS_ZONES_QUERY = """
         field
       }
     }
+    unmanaged_record_names
     records {
       type
       ... on DnsRecordCommon_v1 {

--- a/utils/aws/route53/__init__.py
+++ b/utils/aws/route53/__init__.py
@@ -181,6 +181,17 @@ class Zone(object):
                 f"Refusing to add duplicate {record} to {self}")
         self._records.append(record)
 
+    def remove_record(self, record_name):
+        """
+        Remove a record to the zone based on the record name
+
+        :param record_name: name of the record to remove
+        :type record: str
+        """
+        for record in self._records:
+            if record.name == record_name:
+                self._records.remove(record)
+
     def __eq__(self, other):
         if not isinstance(other, Zone):
             return False


### PR DESCRIPTION
This PR adds the ability to specify a list of regexes via `unmanaged_record_names` in a zone file.

The regex in this list will be compiled and records will be checked for a `fullmatch` against the list of regexes. If the record name is found, it is then removed from both the current and the desired state.

This will allow us to add records in AWS outside of the integration flow, without having the integration remove them

This is a quick fix to an immediate problem. Longer term we may want to add state management to the integration instead.