### PR TITLE
[WIP] fix tf per account

### DIFF
--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -42,8 +42,13 @@ def cleanup(working_dirs):
 
 @defer
 def run(dry_run, thread_pool_size=10,
-        disable_service_account_keys=False, defer=None):
+        disable_service_account_keys=False, defer=None, account_name=None):
     accounts = queries.get_aws_accounts()
+    if account_name:
+        accounts = [n for n in accounts
+                    if n['name'] == account_name]
+        if not accounts:
+            raise ValueError(f"aws account {account_name} is not found")
     settings = queries.get_app_interface_settings()
     aws = AWSApi(thread_pool_size, accounts, settings=settings)
     keys_to_delete = get_keys_to_delete(accounts)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -579,9 +579,10 @@ def aws_garbage_collector(ctx, thread_pool_size, io_dir):
 @integration.command()
 @threaded()
 @click.pass_context
-def aws_iam_keys(ctx, thread_pool_size):
+@account_name
+def aws_iam_keys(ctx, thread_pool_size, account_name):
     run_integration(reconcile.aws_iam_keys, ctx.obj,
-                    thread_pool_size)
+                    thread_pool_size, account_name=account_name)
 
 
 @integration.command()

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -443,13 +443,13 @@ class TerrascriptClient(object):
                     tf_resource = aws_route(route_identifier, **values)
                     self.add_resource(acc_account_name, tf_resource)
 
-    def populate_resources(self, namespaces, existing_secrets, account_name):
-        self.init_populate_specs(namespaces, account_name)
+    def populate_resources(self, namespaces, existing_secrets, account_names):
+        self.init_populate_specs(namespaces, account_names)
         for specs in self.account_resources.values():
             for spec in specs:
                 self.populate_tf_resources(spec, existing_secrets)
 
-    def init_populate_specs(self, namespaces, account_name):
+    def init_populate_specs(self, namespaces, account_names):
         self.account_resources = {}
         for namespace_info in namespaces:
             # Skip if namespace has no terraformResources
@@ -460,8 +460,8 @@ class TerrascriptClient(object):
                 populate_spec = {'resource': resource,
                                  'namespace_info': namespace_info}
                 account = resource['account']
-                # Skip if account_name is specified
-                if account_name and account != account_name:
+                # Skip if accounts are specified
+                if account not in account_names:
                     continue
                 if account not in self.account_resources:
                     self.account_resources[account] = []


### PR DESCRIPTION
1. Run disable_keys per account
2. Skip populate_oc_resources for dry-run but keep oc_map for rds determine_db_password
3. Filter tf_namespaces with aws account
4. Filter ResourceInventory with aws account

Merge after https://github.com/app-sre/qontract-reconcile/pull/1074

Signed-off-by: Feng Huang <fehuang@redhat.com>