### PR TITLE
[openshift-resources] add cluster .spec.version to query

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -94,6 +94,9 @@ NAMESPACES_QUERY = """
               format
           }
       }
+      spec {
+        version
+      }
       automationToken {
         path
         field


### PR DESCRIPTION
this will allow us to use the cluster's version in templating resources.