### PR TITLE
[gitlab-labeler] add 'saas' in ignore_tokens

### DIFF
--- a/reconcile/gitlab_labeler.py
+++ b/reconcile/gitlab_labeler.py
@@ -17,7 +17,7 @@ def guess_labels(project_labels, changed_paths):
     This is the first form of guessing, which will likely be adjusted.
     """
     not_allowed_labels = MERGE_LABELS_PRIORITY + HOLD_LABELS
-    ignore_tokens = ['cicd']
+    ignore_tokens = ['cicd', 'saas']
     guesses = set()
     for label in project_labels:
         if label in not_allowed_labels:


### PR DESCRIPTION
Fix all saas file change get labeled to `tenant-dsass`

Signed-off-by: Feng Huang <fehuang@redhat.com>