### PR TITLE
[sql-query] check resource info is found

### DIFF
--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -165,7 +165,7 @@ def collect_queries(query_name=None):
         if tf_resource_info is None:
             logging.error(
                 ['Could not find rds identifier %s in namespace %s'],
-                 identifier, namespace['name']
+                identifier, namespace['name']
             )
             sys.exit(ExitCodes.ERROR)
 

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -162,6 +162,12 @@ def collect_queries(query_name=None):
         # fo the given identifier
         tf_resource_info = get_tf_resource_info(namespace,
                                                 identifier)
+        if tf_resource_info is None:
+            logging.error(
+                ['Could not find rds identifier %s in namespace %s'],
+                 identifier, namespace['name']
+            )
+            sys.exit(ExitCodes.ERROR)
 
         queries_list.append(
             # building up the final query dictionary


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/APPSRE-2506

this PR adds a check that the terraform resource info is not None, which indicates that the rds identifier does not exist in the specified namespace.