### PR TITLE
persist tzlocal to version 2.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ setup(
         "prometheus-client~=0.8",
         "sentry-sdk~=0.14",
         "jenkins-job-builder==2.10.1",
+        "tzlocal==2.1",
     ],
 
     test_suite="tests",


### PR DESCRIPTION
since this package was released in a new breaking version, we want to pin it to a previous working version.
breaking version: https://github.com/regebro/tzlocal/releases/tag/3.0b1