### PR TITLE
add rds to ignore_tokens

### DIFF
--- a/reconcile/gitlab_labeler.py
+++ b/reconcile/gitlab_labeler.py
@@ -17,7 +17,7 @@ def guess_labels(project_labels, changed_paths):
     This is the first form of guessing, which will likely be adjusted.
     """
     not_allowed_labels = MERGE_LABELS_PRIORITY + HOLD_LABELS
-    ignore_tokens = ['cicd', 'saas']
+    ignore_tokens = ['cicd', 'saas', 'rds']
     guesses = set()
     for label in project_labels:
         if label in not_allowed_labels:


### PR DESCRIPTION
Fix rds file get labeled with `tenant-telemeter-ocp-dashboards`

Signed-off-by: Feng Huang <fehuang@redhat.com>