### PR TITLE
[openshift-resources] add support for openshift shared resources

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -82,7 +82,7 @@ NAMESPACES_QUERY = """
       resource
       resourceNames
     }
-    openshiftSharedResources {
+    sharedResources {
       openshiftResources {
         %s
       }
@@ -551,19 +551,21 @@ def filter_namespaces_by_cluster_and_namespace(namespaces,
 def canonicalize_namespaces(namespaces, providers):
     canonicalized_namespaces = []
     for namespace_info in namespaces:
-        openshift_shared_resources = \
-            namespace_info.get('openshiftSharedResources')
+        shared_resources = namespace_info.get('sharedResources')
         openshift_resources = namespace_info.get('openshiftResources')
-        if openshift_shared_resources:
-            openshift_shared_resources_items = []
-            for openshift_shared_resources_item in openshift_shared_resources:
-                openshift_shared_resources_items.extend(
-                    openshift_shared_resources_item['openshiftResources']
-                )
+        if shared_resources:
+            shared_openshift_resources_items = []
+            for shared_resources_item in shared_resources:
+                shared_openshift_resources = \
+                    shared_resources_item.get('openshiftResources')
+                if shared_openshift_resources:
+                    shared_openshift_resources_items.extend(
+                        shared_openshift_resources
+                    )
             if openshift_resources:
-                openshift_resources.extend(openshift_shared_resources_items)
+                openshift_resources.extend(shared_openshift_resources_items)
             else:
-                openshift_resources = openshift_shared_resources_items
+                openshift_resources = shared_openshift_resources_items
                 namespace_info['openshiftResources'] = openshift_resources
         if openshift_resources:
             for resource in openshift_resources[:]:

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -558,7 +558,7 @@ def canonicalize_namespaces(namespaces, providers):
             openshift_shared_resources_items = []
             for openshift_shared_resources_item in openshift_shared_resources:
                 openshift_shared_resources_items.extend(
-                    openshift_resources_item['openshiftResources']
+                    openshift_shared_resources_item['openshiftResources']
                 )
             if openshift_resources:
                 openshift_resources.extend(openshift_shared_resources_items)

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -25,6 +25,7 @@ from utils.jinja2_ext import B64EncodeExtension
 from reconcile.exceptions import FetchResourceError
 
 from threading import Lock
+from textwrap import indent
 
 """
 +-----------------------+-------------------------+-------------+
@@ -42,6 +43,32 @@ from threading import Lock
 +-----------------------+-------------------------+-------------+
 """
 
+OPENSHIFT_RESOURCE = """
+provider
+... on NamespaceOpenshiftResourceResource_v1 {
+  path
+  validate_json
+}
+... on NamespaceOpenshiftResourceResourceTemplate_v1 {
+  path
+  type
+  variables
+}
+... on NamespaceOpenshiftResourceVaultSecret_v1 {
+  path
+  version
+  name
+  labels
+  annotations
+  type
+}
+... on NamespaceOpenshiftResourceRoute_v1 {
+  path
+  vault_tls_secret_path
+  vault_tls_secret_version
+}
+"""
+
 NAMESPACES_QUERY = """
 {
   namespaces: namespaces_v1 {
@@ -55,30 +82,13 @@ NAMESPACES_QUERY = """
       resource
       resourceNames
     }
+    openshiftSharedResources {
+      openshiftResources {
+        %s
+      }
+    }
     openshiftResources {
-      provider
-      ... on NamespaceOpenshiftResourceResource_v1 {
-        path
-        validate_json
-      }
-      ... on NamespaceOpenshiftResourceResourceTemplate_v1 {
-        path
-        type
-        variables
-      }
-      ... on NamespaceOpenshiftResourceVaultSecret_v1 {
-        path
-        version
-        name
-        labels
-        annotations
-        type
-      }
-      ... on NamespaceOpenshiftResourceRoute_v1 {
-        path
-        vault_tls_secret_path
-        vault_tls_secret_version
-      }
+      %s
     }
     cluster {
       name
@@ -109,7 +119,7 @@ NAMESPACES_QUERY = """
     }
   }
 }
-"""
+""" % (indent(OPENSHIFT_RESOURCE, 8*' '), indent(OPENSHIFT_RESOURCE, 6*' '))
 
 QONTRACT_INTEGRATION = 'openshift_resources_base'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(1, 9, 2)
@@ -541,7 +551,20 @@ def filter_namespaces_by_cluster_and_namespace(namespaces,
 def canonicalize_namespaces(namespaces, providers):
     canonicalized_namespaces = []
     for namespace_info in namespaces:
+        openshift_shared_resources = \
+            namespace_info.get('openshiftSharedResources')
         openshift_resources = namespace_info.get('openshiftResources')
+        if openshift_shared_resources:
+            openshift_shared_resources_items = []
+            for openshift_shared_resources_item in openshift_shared_resources:
+                openshift_shared_resources_items.extend(
+                    openshift_resources_item['openshiftResources']
+                )
+            if openshift_resources:
+                openshift_resources.extend(openshift_shared_resources_items)
+            else:
+                openshift_resources = openshift_shared_resources_items
+                namespace_info['openshiftResources'] = openshift_resources
         if openshift_resources:
             for resource in openshift_resources[:]:
                 if resource['provider'] not in providers:


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/APPSRE-2524

Dpends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/9822

Now that we are running multiple instances of the same service, we are duplicating a lot of the content of a namespace file. Mostly we are duplicating the openshift resources that we want to apply to the namespace.

This PR allows users to define shared resources that can be added to multiple namespace files, thus removing the need to duplicate this content and allow users to update all their namespaces in a single place.

The lack in this ability recently led to 2 namespace files overriding each other and causing a service misconfiguration.