### PR TITLE
[gitlab-housekeeping] add wait-for-pipeline option

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -566,9 +566,13 @@ def gitlab_permissions(ctx, thread_pool_size):
 
 
 @integration.command()
+@click.option('--wait-for-pipeline/--no-wait-for-pipeline',
+              default=False,
+              help='wait for pending/running pipelines before acting.')
 @click.pass_context
-def gitlab_housekeeping(ctx):
-    run_integration(reconcile.gitlab_housekeeping, ctx.obj)
+def gitlab_housekeeping(ctx, wait_for_pipeline):
+    run_integration(reconcile.gitlab_housekeeping, ctx.obj,
+                    wait_for_pipeline)
 
 
 @integration.command()

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -190,7 +190,7 @@ def merge_merge_requests(dry_run, gl, merge_limit, rebase, insist=False,
                 merges += 1
 
 
-def run(dry_run):
+def run(dry_run, wait_for_pipeline):
     default_days_interval = 15
     default_limit = 8
     default_enable_closing = False
@@ -211,8 +211,11 @@ def run(dry_run):
                            'merge-request')
         rebase = hk.get('rebase')
         try:
-            merge_merge_requests(dry_run, gl, limit, rebase, insist=True)
+            merge_merge_requests(dry_run, gl, limit, rebase, insist=True,
+                                 wait_for_pipeline=wait_for_pipeline)
         except Exception:
-            merge_merge_requests(dry_run, gl, limit, rebase)
+            merge_merge_requests(dry_run, gl, limit, rebase,
+                                 wait_for_pipeline=wait_for_pipeline)
         if rebase:
-            rebase_merge_requests(dry_run, gl, limit)
+            rebase_merge_requests(dry_run, gl, limit,
+                                  wait_for_pipeline=wait_for_pipeline)


### PR DESCRIPTION
add argument to indicate if rebase/merge should wait for pending/running pipelines before acting.