### PR TITLE
[app-interface-reporter] fix aliases section

### DIFF
--- a/templates/email.yml.j2
+++ b/templates/email.yml.j2
@@ -13,7 +13,7 @@ to:
 {% if ALIASES is defined %}
   aliases:
 {%  for alias in ALIASES %}
-    - $ref: "{{ alias }}"
+    - {{ alias }}
 {% endfor %}
 {% endif %}
 {% if AWS_ACCOUNTS is defined %}


### PR DESCRIPTION
as observed in https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/10036, the aliases section is using refs. as aliases are plain strings, we only need to list the aliases themselves.