### PR TITLE
[slack-cluster-usergroups] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `quay-mirror`: Mirrors external images into Quay.
 - `quay-repos`: Creates and Manages Quay Repos.
 - `slack-usergroups`: Manage Slack User Groups (channels and users).
+- `slack-cluster-usergroups`: Manage Slack User Groups (channels and users) for OpenShift users notifications.
 - `sql-query`: Runs SQL Queries against app-interface RDS resources.
 - `terraform-resources`: Manage AWS Resources using Terraform.
 - `terraform-users`: Manage AWS users using Terraform.

--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -487,3 +487,14 @@ cronjobs:
   # once every 6 hours
   cron: '0 */6 * * *'
   dashdotdb: true
+- name: slack-cluster-usergroups
+  resources:
+    requests:
+      memory: 80Mi
+      cpu: 100m
+    limits:
+      memory: 200Mi
+      cpu: 200m
+  logs:
+    slack: true
+    cloudwatch: true

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -7671,6 +7671,60 @@ objects:
             - name: qontract-reconcile-toml
               secret:
                 secretName: qontract-reconcile-toml
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  metadata:
+    labels:
+      app: qontract-reconcile-slack-cluster-usergroups
+    name: qontract-reconcile-slack-cluster-usergroups
+  spec:
+    schedule: ""
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: int
+              image: ${IMAGE}:${IMAGE_TAG}
+              env:
+              - name: RUN_ONCE
+                value: 'true'
+              - name: DRY_RUN
+                value: ${DRY_RUN}
+              - name: INTEGRATION_NAME
+                value: slack-cluster-usergroups
+              - name: INTEGRATION_EXTRA_ARGS
+                value: ""
+              - name: GITHUB_API
+                valueFrom:
+                  configMapKeyRef:
+                    name: app-interface
+                    key: GITHUB_API
+              - name: UNLEASH_API_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: API_URL
+              - name: UNLEASH_CLIENT_ACCESS_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: CLIENT_ACCESS_TOKEN
+              volumeMounts:
+              - name: qontract-reconcile-toml
+                mountPath: /config
+              resources:
+                limits:
+                  cpu: 200m
+                  memory: 200Mi
+                requests:
+                  cpu: 100m
+                  memory: 80Mi
+            restartPolicy: OnFailure
+            volumes:
+            - name: qontract-reconcile-toml
+              secret:
+                secretName: qontract-reconcile-toml
 - apiVersion: v1
   kind: Service
   metadata:

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -56,6 +56,7 @@ import reconcile.jira_watcher
 import reconcile.unleash_watcher
 import reconcile.openshift_upgrade_watcher
 import reconcile.slack_usergroups
+import reconcile.slack_cluster_usergroups
 import reconcile.gitlab_integrations
 import reconcile.gitlab_permissions
 import reconcile.gitlab_housekeeping
@@ -549,6 +550,12 @@ def openshift_upgrade_watcher(ctx, thread_pool_size, internal, use_jump_host):
 @click.pass_context
 def slack_usergroups(ctx):
     run_integration(reconcile.slack_usergroups, ctx.obj)
+
+
+@integration.command()
+@click.pass_context
+def slack_cluster_usergroups(ctx):
+    run_integration(reconcile.slack_cluster_usergroups, ctx.obj)
 
 
 @integration.command()

--- a/reconcile/jira_watcher.py
+++ b/reconcile/jira_watcher.py
@@ -108,7 +108,9 @@ def calculate_diff(server, current_state, previous_state):
 def init_slack(jira_board):
     settings = queries.get_app_interface_settings()
     slack_info = jira_board['slack']
-    slack_integrations = slack_info['workspace']['integrations']
+    workspace = slack_info['workspace']
+    workspace_name = workspace['name']
+    slack_integrations = workspace['integrations']
     jira_config = \
         [i for i in slack_integrations if i['name'] == QONTRACT_INTEGRATION]
     [jira_config] = jira_config
@@ -119,7 +121,8 @@ def init_slack(jira_board):
     username = jira_config['username']
     channel = slack_info.get('channel') or default_channel
 
-    slack = SlackApi(token,
+    slack = SlackApi(workspace_name,
+                     token,
                      settings=settings,
                      init_usergroups=False,
                      channel=channel,

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -92,7 +92,8 @@ def run(dry_run, thread_pool_size=10, io_dir='throughput/',
         saas_file = saasherder.saas_files[0]
         slack_info = saas_file.get('slack')
         if slack_info and actions and slack_info.get('output') == 'events':
-            slack = init_slack(slack_info, QONTRACT_INTEGRATION)
+            slack = init_slack(slack_info, QONTRACT_INTEGRATION,
+                               init_usergroups=False)
             for action in actions:
                 message = \
                     f"[{action['cluster']}] " + \

--- a/reconcile/openshift_upgrade_watcher.py
+++ b/reconcile/openshift_upgrade_watcher.py
@@ -61,6 +61,7 @@ def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True,
             if not dry_run:
                 state.add(state_key)
                 slack.chat_post_message(
-                    f'Heads up! cluster `{cluster}` is currently ' +
+                    f'Heads up <@{cluster}-cluster>! ' +
+                    f'cluster `{cluster}` is currently ' +
                     f'being upgraded to version `{version}`'
                 )

--- a/reconcile/openshift_upgrade_watcher.py
+++ b/reconcile/openshift_upgrade_watcher.py
@@ -31,7 +31,8 @@ def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True,
     )
 
     if not dry_run:
-        slack = init_slack_workspace(QONTRACT_INTEGRATION)
+        slack = init_slack_workspace(QONTRACT_INTEGRATION,
+                                     init_usergroups=False)
 
     now = datetime.utcnow()
     for cluster in oc_map.clusters():

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -432,6 +432,9 @@ CLUSTERS_MINIMAL_QUERY = """
     disable {
       integrations
     }
+    auth {
+      team
+    }
   }
 }
 """
@@ -730,6 +733,7 @@ USERS_QUERY = """
     slack_username
     pagerduty_username
     public_gpg_key
+    tag_on_cluster_updates
   }
 }
 """

--- a/reconcile/sentry_helper.py
+++ b/reconcile/sentry_helper.py
@@ -52,7 +52,8 @@ def run(dry_run):
     )
     user_names = get_sentry_users_from_mails(mails)
     if not dry_run:
-        slack = init_slack_workspace(QONTRACT_INTEGRATION)
+        slack = init_slack_workspace(QONTRACT_INTEGRATION,
+                                     init_usergroups=False)
     for user_name in user_names:
         guesses = guess_user(user_name, users)
         if not guesses:

--- a/reconcile/slack_base.py
+++ b/reconcile/slack_base.py
@@ -5,6 +5,7 @@ from utils.slack_api import SlackApi
 
 def init_slack(slack_info, integration):
     settings = queries.get_app_interface_settings()
+    workspace_name = slack_info['workspace']['name']
     slack_integrations = slack_info['workspace']['integrations']
     slack_config = \
         [i for i in slack_integrations if i['name'] == integration]
@@ -19,6 +20,7 @@ def init_slack(slack_info, integration):
     slack = SlackApi(token,
                      settings=settings,
                      init_usergroups=False,
+                     workspace_name=workspace_name,
                      channel=channel,
                      icon_emoji=icon_emoji,
                      username=username)

--- a/reconcile/slack_base.py
+++ b/reconcile/slack_base.py
@@ -17,10 +17,10 @@ def init_slack(slack_info, integration, init_usergroups=True):
     username = slack_config['username']
     channel = slack_info.get('channel') or default_channel
 
-    slack = SlackApi(token,
+    slack = SlackApi(workspace_name,
+                     token,
                      settings=settings,
                      init_usergroups=init_usergroups,
-                     workspace_name=workspace_name,
                      channel=channel,
                      icon_emoji=icon_emoji,
                      username=username)

--- a/reconcile/slack_base.py
+++ b/reconcile/slack_base.py
@@ -3,7 +3,7 @@ import reconcile.queries as queries
 from utils.slack_api import SlackApi
 
 
-def init_slack(slack_info, integration):
+def init_slack(slack_info, integration, init_usergroups=True):
     settings = queries.get_app_interface_settings()
     workspace_name = slack_info['workspace']['name']
     slack_integrations = slack_info['workspace']['integrations']
@@ -19,7 +19,7 @@ def init_slack(slack_info, integration):
 
     slack = SlackApi(token,
                      settings=settings,
-                     init_usergroups=False,
+                     init_usergroups=init_usergroups,
                      workspace_name=workspace_name,
                      channel=channel,
                      icon_emoji=icon_emoji,
@@ -28,6 +28,7 @@ def init_slack(slack_info, integration):
     return slack
 
 
-def init_slack_workspace(integration):
+def init_slack_workspace(integration, init_usergroups=True):
     workspace = queries.get_slack_workspace()
-    return init_slack({'workspace': workspace}, integration)
+    return init_slack({'workspace': workspace}, integration,
+                      init_usergroups=init_usergroups)

--- a/reconcile/slack_cluster_usergroups.py
+++ b/reconcile/slack_cluster_usergroups.py
@@ -64,11 +64,7 @@ def run(dry_run):
     slack.initiate_usergroups()
     desired_state = get_desired_state(slack)
     usergroups = [d['usergroup'] for d in desired_state]
-    print(usergroups)
     current_state = get_current_state(slack, usergroups)
-    print(current_state)
-    import sys
-    sys.exit()
     slack_usergroups.print_diff(current_state, desired_state)
 
     if not dry_run:

--- a/reconcile/slack_cluster_usergroups.py
+++ b/reconcile/slack_cluster_usergroups.py
@@ -1,0 +1,77 @@
+import logging
+
+import utils.smtp_client as smtp_client
+import reconcile.queries as queries
+import reconcile.openshift_users as openshift_users
+import reconcile.slack_usergroups as slack_usergroups
+
+from reconcile.slack_base import init_slack_workspace
+from utils.state import State
+
+QONTRACT_INTEGRATION = 'slack-cluster-usergroups'
+
+
+def get_desired_state(slack):
+    desired_state = []
+    all_users = queries.get_users()
+    all_clusters = queries.get_clusters(minimal=True)
+    clusters = [c for c in all_clusters
+                if c.get('auth') and c['auth'].get('team')
+                and c.get('ocm')]
+    openshift_users_desired_state = \
+        openshift_users.fetch_desired_state(oc_map=None)
+    for cluster in clusters:
+        cluster_name = cluster['name']
+        cluster_users = [u['user'] for u in openshift_users_desired_state
+                         if u['cluster'] == cluster_name]
+        usergroup = cluster['auth']['team']
+        ugid = slack.get_usergroup_id(usergroup)
+        user_names = [slack_usergroups.get_slack_username(u) for u in all_users
+                      if u['github_username'] in cluster_users
+                      and u.get('tag_on_cluster_updates') is not False]
+        users = slack.get_users_by_names(user_names)
+        channels = slack.get_channels_by_names([slack.chat_kwargs['channel']])
+        desired_state.append({
+            "workspace": slack.workspace_name,
+            "usergroup": usergroup,
+            "usergroup_id": ugid,
+            "users": users,
+            "channels": channels,
+            "description": f'Users with access to the {cluster_name} cluster',
+        })
+
+    return desired_state
+
+
+def get_current_state(slack, usergroups):
+    current_state = []
+
+    for ug in usergroups:
+        users, channels, description = slack.describe_usergroup(ug)
+        current_state.append({
+            "workspace": slack.workspace_name,
+            "usergroup": ug,
+            "users": users,
+            "channels": channels,
+            "description": description,
+        })
+
+    return current_state
+
+
+def run(dry_run):
+    slack = init_slack_workspace(QONTRACT_INTEGRATION)
+    slack.initiate_usergroups()
+    desired_state = get_desired_state(slack)
+    usergroups = [d['usergroup'] for d in desired_state]
+    print(usergroups)
+    current_state = get_current_state(slack, usergroups)
+    print(current_state)
+    import sys
+    sys.exit()
+    slack_usergroups.print_diff(current_state, desired_state)
+
+    if not dry_run:
+        # just so we can re-use the logic from slack_usergroups
+        slack_map = {slack.workspace_name: {'slack': slack}}
+        slack_usergroups.act(desired_state, slack_map)

--- a/reconcile/slack_cluster_usergroups.py
+++ b/reconcile/slack_cluster_usergroups.py
@@ -1,12 +1,8 @@
-import logging
-
-import utils.smtp_client as smtp_client
 import reconcile.queries as queries
 import reconcile.openshift_users as openshift_users
 import reconcile.slack_usergroups as slack_usergroups
 
 from reconcile.slack_base import init_slack_workspace
-from utils.state import State
 
 QONTRACT_INTEGRATION = 'slack-cluster-usergroups'
 

--- a/reconcile/slack_cluster_usergroups.py
+++ b/reconcile/slack_cluster_usergroups.py
@@ -64,7 +64,6 @@ def get_current_state(slack, usergroups):
 
 def run(dry_run):
     slack = init_slack_workspace(QONTRACT_INTEGRATION)
-    slack.initiate_usergroups()
     desired_state = get_desired_state(slack)
     usergroups = [d['usergroup'] for d in desired_state]
     current_state = get_current_state(slack, usergroups)

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -100,7 +100,10 @@ def get_slack_map():
             continue
 
         workspace_spec = {
-            "slack": SlackApi(workspace['token'], settings=settings),
+            "slack": SlackApi(
+                workspace_name,
+                workspace['token'],
+                settings=settings),
             "managed_usergroups": workspace['managedUsergroups']
         }
         slack_map[workspace_name] = workspace_spec

--- a/reconcile/unleash_watcher.py
+++ b/reconcile/unleash_watcher.py
@@ -73,7 +73,9 @@ def init_slack_map(unleash_instance):
     slack_notifications = unleash_instance['notifications']['slack']
     slack_map = {}
     for slack_info in slack_notifications:
-        slack_integrations = slack_info['workspace']['integrations']
+        workspace = slack_info['workspace']
+        workspace_name = workspace['name']
+        slack_integrations = workspace['integrations']
         slack_config = \
             [i for i in slack_integrations
              if i['name'] == QONTRACT_INTEGRATION]
@@ -84,7 +86,8 @@ def init_slack_map(unleash_instance):
         icon_emoji = slack_info['icon_emoji']
         username = slack_info['username']
 
-        slack = SlackApi(token,
+        slack = SlackApi(workspace_name,
+                         token,
                          settings=settings,
                          init_usergroups=False,
                          channel=channel,

--- a/utils/slack_api.py
+++ b/utils/slack_api.py
@@ -20,7 +20,7 @@ class SlackApi(object):
         self.results = {}
         self.chat_kwargs = chat_kwargs
         if init_usergroups:
-            self.initiate_usergroups()
+            self._initiate_usergroups()
         self.workspace_name = workspace_name or ''
 
     def chat_post_message(self, text):
@@ -47,7 +47,7 @@ class SlackApi(object):
         return usergroup['id']
 
     @retry()
-    def initiate_usergroups(self):
+    def _initiate_usergroups(self):
         result = self.sc.api_call(
             "usergroups.list",
             include_users=True

--- a/utils/slack_api.py
+++ b/utils/slack_api.py
@@ -14,13 +14,14 @@ class SlackApi(object):
     """Wrapper around Slack API calls"""
 
     def __init__(self, token, settings=None, init_usergroups=True,
-                 **chat_kwargs):
+                 workspace_name=None, **chat_kwargs):
         slack_token = secret_reader.read(token, settings=settings)
         self.sc = SlackClient(slack_token)
         self.results = {}
         self.chat_kwargs = chat_kwargs
         if init_usergroups:
             self.initiate_usergroups()
+        self.workspace_name = workspace_name or ''
 
     def chat_post_message(self, text):
         self.sc.api_call(

--- a/utils/slack_api.py
+++ b/utils/slack_api.py
@@ -13,15 +13,17 @@ class UsergroupNotFoundException(Exception):
 class SlackApi(object):
     """Wrapper around Slack API calls"""
 
-    def __init__(self, token, settings=None, init_usergroups=True,
-                 workspace_name=None, **chat_kwargs):
+    def __init__(self, workspace_name, token,
+                 settings=None,
+                 init_usergroups=True,
+                 **chat_kwargs):
+        self.workspace_name = workspace_name
         slack_token = secret_reader.read(token, settings=settings)
         self.sc = SlackClient(slack_token)
         self.results = {}
         self.chat_kwargs = chat_kwargs
         if init_usergroups:
             self._initiate_usergroups()
-        self.workspace_name = workspace_name or ''
 
     def chat_post_message(self, text):
         self.sc.api_call(


### PR DESCRIPTION
this integration adds all users with access to a certain cluster to a slack usergroup named <cluster_name>-cluster (same as .auth.team in a cluster file).

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/10072