### PR TITLE
remove logging from slack-cluster-usergroups

### DIFF
--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -448,9 +448,6 @@ integrations:
     limits:
       memory: 200Mi
       cpu: 200m
-  logs:
-    slack: true
-    cloudwatch: true
 cronjobs:
 - name: aws-ecr-image-pull-secrets
   resources:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -7465,77 +7465,6 @@ objects:
           app: qontract-reconcile-slack-cluster-usergroups
           component: qontract-reconcile
       spec:
-        initContainers:
-        - name: config
-          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
-          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
-          resources:
-            requests:
-              memory: 10Mi
-              cpu: 15m
-            limits:
-              memory: 20Mi
-              cpu: 25m
-          env:
-          - name: SLACK_WEBHOOK_URL
-            valueFrom:
-              secretKeyRef:
-                key: slack.webhook_url
-                name: app-interface
-          - name: SLACK_CHANNEL
-            value: ${SLACK_CHANNEL}
-          - name: SLACK_ICON_EMOJI
-            value: ${SLACK_ICON_EMOJI}
-          - name: LOG_GROUP_NAME
-            valueFrom:
-              secretKeyRef:
-                name: ${CLOUDWATCH_SECRET}
-                key: log_group_name
-          command: ["/bin/sh", "-c"]
-          args:
-          - |
-            # generate fluent.conf
-            cat > /fluentd/etc/fluent.conf <<EOF
-            <source>
-              @type tail
-              path /fluentd/log/integration.log
-              pos_file /fluentd/log/integration.log.pos
-              tag integration
-              <parse>
-                @type none
-              </parse>
-            </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <match integration>
-              @type copy
-              <store>
-                @type slack
-                webhook_url ${SLACK_WEBHOOK_URL}
-                channel ${SLACK_CHANNEL}
-                icon_emoji ${SLACK_ICON_EMOJI}
-                username sd-app-sre-bot
-                flush_interval 10s
-                message "\`\`\`[slack-cluster-usergroups] %s\`\`\`"
-              </store>
-              <store>
-                @type cloudwatch_logs
-                log_group_name ${LOG_GROUP_NAME}
-                log_stream_name slack-cluster-usergroups
-                auto_create_stream true
-              </store>
-            </match>
-            EOF
-          volumeMounts:
-          - name: fluentd-config
-            mountPath: /fluentd/etc/
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -7565,8 +7494,6 @@ objects:
               configMapKeyRef:
                 name: app-interface
                 key: SENTRY_DSN
-          - name: LOG_FILE
-            value: "${LOG_FILE}"
           - name: UNLEASH_API_URL
             valueFrom:
               secretKeyRef:
@@ -7587,47 +7514,10 @@ objects:
           volumeMounts:
           - name: qontract-reconcile-toml
             mountPath: /config
-          - name: logs
-            mountPath: /fluentd/log/
-        - name: fluentd
-          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
-          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
-          env:
-          - name: AWS_REGION
-            valueFrom:
-              secretKeyRef:
-                name: ${CLOUDWATCH_SECRET}
-                key: aws_region
-          - name: AWS_ACCESS_KEY_ID
-            valueFrom:
-              secretKeyRef:
-                name: ${CLOUDWATCH_SECRET}
-                key: aws_access_key_id
-          - name: AWS_SECRET_ACCESS_KEY
-            valueFrom:
-              secretKeyRef:
-                name: ${CLOUDWATCH_SECRET}
-                key: aws_secret_access_key
-          resources:
-            requests:
-              memory: 30Mi
-              cpu: 15m
-            limits:
-              memory: 120Mi
-              cpu: 25m
-          volumeMounts:
-          - name: logs
-            mountPath: /fluentd/log/
-          - name: fluentd-config
-            mountPath: /fluentd/etc/
         volumes:
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
-        - name: logs
-          emptyDir: {}
-        - name: fluentd-config
-          emptyDir: {}
 - apiVersion: batch/v1beta1
   kind: CronJob
   metadata:


### PR DESCRIPTION
it's not really needed to overload the reconcile channel (especially since it's going to be disabled for a week or so)