### PR TITLE
print unused schemas when running integrations

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -334,8 +334,12 @@ def run_integration(func_container, ctx, *args, **kwargs):
         else:
             raise e
     finally:
+        gqlapi = gql.get_api()
+        unused_schemas = gqlapi.get_unused_schemas()
+        if unused_schemas and not dry_run:
+            logging.warning(
+                f'Integration is not using schemas: {unused_schemas}')
         if ctx.get('dump_schemas_file'):
-            gqlapi = gql.get_api()
             with open(ctx.get('dump_schemas_file'), 'w') as f:
                 f.write(json.dumps(gqlapi.get_queried_schemas()))
 

--- a/utils/gql.py
+++ b/utils/gql.py
@@ -150,6 +150,10 @@ class GqlApi(object):
     def get_queried_schemas(self):
         return list(self._queried_schemas)
 
+    def get_unused_schemas(self):
+        return [s for s in self._valid_schemas
+                if s not in self._queried_schemas]
+
 
 def init(url, token=None, integration=None, validate_schemas=False):
     global _gqlapi


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-2143

this PR adds a check in each integration execution to see if there are any schemas that were not used and log a warning in such case.
we only do this is NON dry-run to prevent cases of an integration only performing certain queries when it is running in full mode.