### PR TITLE
[slack-cluster-usergroups] do not include users with tagged roles

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -733,7 +733,6 @@ USERS_QUERY = """
     slack_username
     pagerduty_username
     public_gpg_key
-    tag_on_cluster_updates
   }
 }
 """
@@ -744,6 +743,9 @@ ROLES_QUERY = """
   users: users_v1 {
     name
     org_username
+    github_username
+    slack_username
+    tag_on_cluster_updates
     labels
     roles {
       name
@@ -760,7 +762,9 @@ ROLES_QUERY = """
           org
           team
         }
-      } access {
+      }
+      tag_on_cluster_updates
+      access {
         cluster {
           name
           path
@@ -768,16 +772,21 @@ ROLES_QUERY = """
         clusterRole
         namespace {
           name
+          cluster {
+            name
+          }
         }
         role
-      } aws_groups {
+      }
+      aws_groups {
         name
         path
         account {
           name
         }
         policies
-      } owned_saas_files {
+      }
+      owned_saas_files {
         name
       }
     }

--- a/reconcile/slack_cluster_usergroups.py
+++ b/reconcile/slack_cluster_usergroups.py
@@ -46,7 +46,7 @@ def include_user(user, cluster_name, cluster_users):
                         role_result = role_result or False
                     else:
                         role_result = True
-        
+
     result = False if role_result is False else True
     return result
 

--- a/reconcile/slack_cluster_usergroups.py
+++ b/reconcile/slack_cluster_usergroups.py
@@ -10,9 +10,50 @@ from utils.slack_api import UsergroupNotFoundException
 QONTRACT_INTEGRATION = 'slack-cluster-usergroups'
 
 
+def include_user(user, cluster_name, cluster_users):
+    # if user does not have access to the cluster
+    if user['github_username'] not in cluster_users:
+        return False
+    # do nothing when tag_on_cluster_updates is not defined
+    tag_on_cluster_updates = user.get('tag_on_cluster_updates')
+    if tag_on_cluster_updates is True:
+        return True
+    elif tag_on_cluster_updates is False:
+        return False
+
+    # if a user has access via a role
+    # check if that role grants access to the current cluster
+    # if all roles that grant access to the current cluster also
+    # have 'tag_on_cluster_updates: false' - remove the user
+    role_result = None
+    for role in user['roles']:
+        access = role.get('access')
+        if not access:
+            continue
+        for a in access:
+            cluster = a.get('cluster')
+            if cluster:
+                if cluster['name'] == cluster_name:
+                    if role.get('tag_on_cluster_updates') is False:
+                        role_result = role_result or False
+                    else:
+                        role_result = True
+                continue
+            namespace = a.get('namespace')
+            if namespace:
+                if namespace['cluster']['name'] == cluster_name:
+                    if role.get('tag_on_cluster_updates') is False:
+                        role_result = role_result or False
+                    else:
+                        role_result = True
+        
+    result = False if role_result is False else True
+    return result
+
+
 def get_desired_state(slack):
     desired_state = []
-    all_users = queries.get_users()
+    all_users = queries.get_roles()
     all_clusters = queries.get_clusters(minimal=True)
     clusters = [c for c in all_clusters
                 if c.get('auth') and c['auth'].get('team')
@@ -29,9 +70,9 @@ def get_desired_state(slack):
         except UsergroupNotFoundException:
             logging.warning(f'Usergroup {usergroup} not found')
             continue
-        user_names = [slack_usergroups.get_slack_username(u) for u in all_users
-                      if u['github_username'] in cluster_users
-                      and u.get('tag_on_cluster_updates') is not False]
+        user_names = [slack_usergroups.get_slack_username(u)
+                      for u in all_users
+                      if include_user(u, cluster_name, cluster_users)]
         users = slack.get_users_by_names(user_names)
         channels = slack.get_channels_by_names([slack.chat_kwargs['channel']])
         desired_state.append({


### PR DESCRIPTION
if a user has a role with `tag_on_cluster_updates: false` - exclude them from the user group.
unless there is another role granting access to the same cluster without `tag_on_cluster_updates: false`.

we preserve the previous functionality -
if a user defines `tag_on_cluster_updates: false` on their user file - they are excluded in any case.