### PR TITLE
[saas-file-owners] add note when MR can not be self-serviced

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -276,6 +276,10 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None,
 
     comment_body = '\n'.join(comment_lines.values())
     if comment_body:
+        # if there are still entries in this list - they are not approved
+        if len(changed_paths) != 0:
+            comment_body = comment_body + \
+                '\nNote: this merge request can not be self-serviced.'
         gl.add_comment_to_merge_request(gitlab_merge_request_id, comment_body)
 
     # if there are still entries in this list - they are not approved


### PR DESCRIPTION
if there are changes outside the scope of a saas file owner, let's add a note indicating that the MR can not be self-serviced.