### PR TITLE
[jenkins-job-builder] change from compare/no-compare to state

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -492,14 +492,11 @@ def jenkins_plugins(ctx):
 
 
 @integration.command()
+@environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
 @throughput
-@click.option('--compare/--no-compare',
-              default=True,
-              help='compare between current and desired state.')
 @click.pass_context
-def jenkins_job_builder(ctx, io_dir, compare):
-    run_integration(reconcile.jenkins_job_builder, ctx.obj,
-                    io_dir, compare)
+def jenkins_job_builder(ctx, io_dir):
+    run_integration(reconcile.jenkins_job_builder, ctx.obj, io_dir)
 
 
 @integration.command()


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2591

the way we currently use the jjb integration (in dry-run mode) is by running it twice: first time to read the current state from the production endpoint and a second time to read the desired state from the local endpoint and print the diffs.

this means that every MR is running the 1st execution even if the jjb integration is not selected for execution afterwards.

this PR changes the way we run the jjb integration - we run it once, like every other integration. that's it.
it will collect the current state from `State` instead.

we tried to read the current state from Jenkins itself, but the JJB defintions and the queried jobs from Jenkins are different to a degree we can't "patch" them to look alike (was attempted a few times in https://issues.redhat.com/browse/APPSRE-1854).