### PR TITLE
[saas-file-owners] print if this is a valid saas file changes MR only

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -268,6 +268,11 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None,
     valid_saas_file_changes_only = is_saas_file_changes_only and is_valid_diff
     write_diffs_to_file(io_dir, diffs, valid_saas_file_changes_only)
 
+    # print 'yes' or 'no' to allow pr-check to understand if changes
+    # are only valid saas file changes (and exclude other integrations)
+    output = 'yes' if valid_saas_file_changes_only else 'no'
+    print(output)
+
     labels = gl.get_merge_request_labels(gitlab_merge_request_id)
     if valid_saas_file_changes_only and saas_label not in labels:
         gl.add_label_to_merge_request(gitlab_merge_request_id, saas_label)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2591

we will use this output to better select which integrations we want to run in https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/hack/select-integrations.py.

for example, if this MR contains valid saas file changes only (updating a `ref` for example), there is no reason to run the jjb integrations, as this MR will not create/delete any jobs.