### PR TITLE
[APPSRE-2596] Fix "Request Entity Too Large"

### DIFF
--- a/reconcile/dashdotdb_cso.py
+++ b/reconcile/dashdotdb_cso.py
@@ -39,10 +39,16 @@ class DashdotdbCSO:
         imagemanifestvuln = manifest['data']
 
         response = None
-        if not self.dry_run:
+
+        LOG.info('CSO: syncing cluster %s', cluster)
+
+        if self.dry_run:
+            return response
+
+        for item in imagemanifestvuln['items']:
             endpoint = (f'{self.dashdotdb_url}/api/v1/'
                         f'imagemanifestvuln/{cluster}')
-            response = requests.post(url=endpoint, json=imagemanifestvuln,
+            response = requests.post(url=endpoint, json=item,
                                      auth=(self.dashdotdb_user,
                                            self.dashdotdb_pass))
             try:


### PR DESCRIPTION
The API was expecting a List of all imagemanifestvuln from a given
cluster, but that list is just way too big.

Now the API expects each imagemanifestvuln object individually. This
patch is the client implementation for that. Now we loop all the items
in the big imagemanifestvuln list and post them one by one.

Depends on https://github.com/app-sre/dashdotdb/pull/30