### PR TITLE
[gitlab-housekeeping] skip empty MRs

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -99,6 +99,8 @@ def rebase_merge_requests(dry_run, gl, rebase_limit, wait_for_pipeline=False):
                 continue
             if mr.work_in_progress:
                 continue
+            if len(mr.commits()) == 0:
+                continue
 
             labels = mr.attributes.get('labels')
             if not labels:
@@ -146,6 +148,8 @@ def merge_merge_requests(dry_run, gl, merge_limit, rebase, insist=False,
             if mr.merge_status == 'cannot_be_merged':
                 continue
             if mr.work_in_progress:
+                continue
+            if len(mr.commits()) == 0:
                 continue
 
             labels = mr.attributes.get('labels')


### PR DESCRIPTION
gitlab-housekeeping may get jammed trying to rebase/merge an empty MR (without commits). this will make the integration skip such MRs.

example that this solves: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/10612
this one had commits but the changes were merged in another MR, causing it to be empty.