### PR TITLE
[openshift-serviceaccount-tokens] write to shared resources location

### DIFF
--- a/reconcile/openshift_serviceaccount_tokens.py
+++ b/reconcile/openshift_serviceaccount_tokens.py
@@ -60,9 +60,18 @@ def write_outputs_to_vault(vault_path, ri):
     integration_name = QONTRACT_INTEGRATION.replace('_', '-')
     for cluster, namespace, _, data in ri:
         for name, d_item in data['desired'].items():
+            body_data = d_item.body['data']
+            # write secret to per-namespace location
             secret_path = \
-              f"{vault_path}/{integration_name}/{cluster}/{namespace}/{name}"
-            secret = {'path': secret_path, 'data': d_item.body['data']}
+                f"{vault_path}/{integration_name}/" + \
+                f"{cluster}/{namespace}/{name}"
+            secret = {'path': secret_path, 'data': body_data}
+            vault_client.write(secret)
+            # write secret to shared-resources location
+            secret_path = \
+                f"{vault_path}/{integration_name}/" + \
+                f"shared-resources/{namespace}/{name}"
+            secret = {'path': secret_path, 'data': body_data}
             vault_client.write(secret)
 
 

--- a/reconcile/openshift_serviceaccount_tokens.py
+++ b/reconcile/openshift_serviceaccount_tokens.py
@@ -63,12 +63,14 @@ def write_outputs_to_vault(vault_path, ri):
             body_data = d_item.body['data']
             # write secret to per-namespace location
             secret_path = \
-              f"{vault_path}/{integration_name}/{cluster}/{namespace}/{name}"
+                f"{vault_path}/{integration_name}/" + \
+                f"{cluster}/{namespace}/{name}"
             secret = {'path': secret_path, 'data': body_data}
             vault_client.write(secret)
             # write secret to shared-resources location
             secret_path = \
-              f"{vault_path}/{integration_name}/shared-resources/{name}"
+                f"{vault_path}/{integration_name}/" + \
+                f"shared-resources/{name}"
             secret = {'path': secret_path, 'data': body_data}
             vault_client.write(secret)
 

--- a/reconcile/openshift_serviceaccount_tokens.py
+++ b/reconcile/openshift_serviceaccount_tokens.py
@@ -63,14 +63,12 @@ def write_outputs_to_vault(vault_path, ri):
             body_data = d_item.body['data']
             # write secret to per-namespace location
             secret_path = \
-                f"{vault_path}/{integration_name}/" + \
-                f"{cluster}/{namespace}/{name}"
+              f"{vault_path}/{integration_name}/{cluster}/{namespace}/{name}"
             secret = {'path': secret_path, 'data': body_data}
             vault_client.write(secret)
             # write secret to shared-resources location
             secret_path = \
-                f"{vault_path}/{integration_name}/" + \
-                f"shared-resources/{namespace}/{name}"
+              f"{vault_path}/{integration_name}/shared-resources/{name}"
             secret = {'path': secret_path, 'data': body_data}
             vault_client.write(secret)
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2606

we want to write all output secrets to the shared location so it's easier to migrate apps between clusters.
in a follow up PR we will do the work to support `openshiftServiceAccountTokens` in the integration.

allows us to do: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/10729