### PR TITLE
[openshift-serviceaccount-tokens] add support for sharedResources

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -459,7 +459,10 @@ def follow_logs(oc_map, actions, io_dir):
 def aggregate_shared_resources(namespace_info, shared_resources_type):
     """ This function aggregates shared resources of the desired type
     from a shared resources file to the appropriate namespace section. """
-    supported_shared_resources_types = ['openshiftResources']
+    supported_shared_resources_types = [
+        'openshiftResources',
+        'openshiftServiceAccountTokens'
+    ]
     if shared_resources_type not in supported_shared_resources_types:
         raise KeyError(
             f'shared_resource_type must be one of '

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -462,7 +462,7 @@ def aggregate_shared_resources(namespace_info, shared_resources_type):
     supported_shared_resources_types = ['openshiftResources']
     if shared_resources_type not in supported_shared_resources_types:
         raise KeyError(
-            f'shared_resource_type must be one of'
+            f'shared_resource_type must be one of '
             f'{supported_shared_resources_types}.'
         )
     shared_resources = namespace_info.get('sharedResources')

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -454,3 +454,28 @@ def follow_logs(oc_map, actions, io_dir):
 
             oc = oc_map.get(cluster)
             oc.job_logs(namespace, name, follow=True, output=io_dir)
+
+
+def aggregate_shared_resources(namespace_info, shared_resources_type):
+    """ This function aggregates shared resources of the desired type
+    from a shared resources file to the appropriate namespace section. """
+    supported_shared_resources_types = ['openshiftResources']
+    if shared_resources_type not in supported_shared_resources_types:
+        raise KeyError(
+            f'shared_resource_type must be one of'
+            f'{supported_shared_resources_types}.'
+        )
+    shared_resources = namespace_info.get('sharedResources')
+    namespace_type_resources = namespace_info.get(shared_resources_type)
+    if shared_resources:
+        shared_type_resources_items = []
+        for shared_resources_item in shared_resources:
+            shared_type_resources = \
+                shared_resources_item.get(shared_resources_type)
+            if shared_type_resources:
+                shared_type_resources_items.extend(shared_type_resources)
+        if namespace_type_resources:
+            namespace_type_resources.extend(shared_type_resources_items)
+        else:
+            namespace_type_resources = shared_type_resources_items
+            namespace_info[shared_resources_type] = namespace_type_resources

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -548,35 +548,10 @@ def filter_namespaces_by_cluster_and_namespace(namespaces,
     return namespaces
 
 
-def aggregate_shared_resources(namespace_info, shared_resources_type):
-    """ This function aggregates shared resources of the desired type
-    from a shared resources file to the appropriate namespace section. """
-    supported_shared_resources_types = ['openshiftResources']
-    if shared_resources_type not in supported_shared_resources_types:
-        raise KeyError(
-            f'shared_resource_type must be one of'
-            f'{supported_shared_resources_types}.'
-        )
-    shared_resources = namespace_info.get('sharedResources')
-    namespace_type_resources = namespace_info.get(shared_resources_type)
-    if shared_resources:
-        shared_type_resources_items = []
-        for shared_resources_item in shared_resources:
-            shared_type_resources = \
-                shared_resources_item.get(shared_resources_type)
-            if shared_type_resources:
-                shared_type_resources_items.extend(shared_type_resources)
-        if namespace_type_resources:
-            namespace_type_resources.extend(shared_type_resources_items)
-        else:
-            namespace_type_resources = shared_type_resources_items
-            namespace_info[shared_resources_type] = namespace_type_resources
-
-
 def canonicalize_namespaces(namespaces, providers):
     canonicalized_namespaces = []
     for namespace_info in namespaces:
-        aggregate_shared_resources(namespace_info, 'openshiftResources')
+        ob.aggregate_shared_resources(namespace_info, 'openshiftResources')
         openshift_resources = namespace_info.get('openshiftResources')
         if openshift_resources:
             for resource in openshift_resources[:]:

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -548,25 +548,36 @@ def filter_namespaces_by_cluster_and_namespace(namespaces,
     return namespaces
 
 
+def aggregate_shared_resources(namespace_info, shared_resources_type):
+    """ This function aggregates shared resources of the desired type
+    from a shared resources file to the appropriate namespace section. """
+    supported_shared_resources_types = ['openshiftResources']
+    if shared_resources_type not in supported_shared_resources_types:
+        raise KeyError(
+            f'shared_resource_type must be one of'
+            f'{supported_shared_resources_types}.'
+        )
+    shared_resources = namespace_info.get('sharedResources')
+    namespace_type_resources = namespace_info.get(shared_resources_type)
+    if shared_resources:
+        shared_type_resources_items = []
+        for shared_resources_item in shared_resources:
+            shared_type_resources = \
+                shared_resources_item.get(shared_resources_type)
+            if shared_type_resources:
+                shared_type_resources_items.extend(shared_type_resources)
+        if namespace_type_resources:
+            namespace_type_resources.extend(shared_type_resources_items)
+        else:
+            namespace_type_resources = shared_type_resources_items
+            namespace_info[shared_resources_type] = namespace_type_resources
+
+
 def canonicalize_namespaces(namespaces, providers):
     canonicalized_namespaces = []
     for namespace_info in namespaces:
-        shared_resources = namespace_info.get('sharedResources')
+        aggregate_shared_resources(namespace_info, 'openshiftResources')
         openshift_resources = namespace_info.get('openshiftResources')
-        if shared_resources:
-            shared_openshift_resources_items = []
-            for shared_resources_item in shared_resources:
-                shared_openshift_resources = \
-                    shared_resources_item.get('openshiftResources')
-                if shared_openshift_resources:
-                    shared_openshift_resources_items.extend(
-                        shared_openshift_resources
-                    )
-            if openshift_resources:
-                openshift_resources.extend(shared_openshift_resources_items)
-            else:
-                openshift_resources = shared_openshift_resources_items
-                namespace_info['openshiftResources'] = openshift_resources
         if openshift_resources:
             for resource in openshift_resources[:]:
                 if resource['provider'] not in providers:

--- a/reconcile/openshift_serviceaccount_tokens.py
+++ b/reconcile/openshift_serviceaccount_tokens.py
@@ -79,7 +79,7 @@ def write_outputs_to_vault(vault_path, ri):
 def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, vault_output_path='', defer=None):
     namespaces = [namespace_info for namespace_info
-                  in queries.get_namespaces()
+                  in queries.get_serviceaccount_tokens()
                   if namespace_info.get('openshiftServiceAccountTokens')]
     for namespace_info in namespaces:
         if not namespace_info.get('openshiftServiceAccountTokens'):

--- a/reconcile/openshift_serviceaccount_tokens.py
+++ b/reconcile/openshift_serviceaccount_tokens.py
@@ -75,18 +75,25 @@ def write_outputs_to_vault(vault_path, ri):
             vault_client.write(secret)
 
 
+def canonicalize_namespaces(namespaces):
+    canonicalized_namespaces = []
+    for namespace_info in namespaces:
+        ob.aggregate_shared_resources(
+            namespace_info, 'openshiftServiceAccountTokens')
+        openshift_serviceaccount_tokens = \
+            namespace_info.get('openshiftServiceAccountTokens')
+        if openshift_serviceaccount_tokens:
+            canonicalized_namespaces.append(namespace_info)
+            for sat in openshift_serviceaccount_tokens:
+                canonicalized_namespaces.append(sat['namespace'])
+
+    return canonicalized_namespaces
+
+
 @defer
 def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, vault_output_path='', defer=None):
-    namespaces = [namespace_info for namespace_info
-                  in queries.get_serviceaccount_tokens()
-                  if namespace_info.get('openshiftServiceAccountTokens')]
-    for namespace_info in namespaces:
-        if not namespace_info.get('openshiftServiceAccountTokens'):
-            continue
-        for sat in namespace_info['openshiftServiceAccountTokens']:
-            namespaces.append(sat['namespace'])
-
+    namespaces = canonicalize_namespaces(queries.get_serviceaccount_tokens())
     ri, oc_map = ob.fetch_current_state(
         namespaces=namespaces,
         thread_pool_size=thread_pool_size,

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -542,6 +542,45 @@ NAMESPACES_QUERY = """
         scopes
       }
     }
+  }
+}
+"""
+
+
+def get_namespaces():
+    """ Returns all Namespaces """
+    gqlapi = gql.get_api()
+    return gqlapi.query(NAMESPACES_QUERY)['namespaces']
+
+
+SERVICEACCOUNT_TOKENS_QUERY = """
+{
+  namespaces: namespaces_v1 {
+    name
+    cluster {
+      name
+      serverUrl
+      jumpHost {
+          hostname
+          knownHosts
+          user
+          port
+          identity {
+              path
+              field
+              format
+          }
+      }
+      automationToken {
+        path
+        field
+        format
+      }
+      internal
+      disable {
+        integrations
+      }
+    }
     openshiftServiceAccountTokens {
       namespace {
         name
@@ -573,10 +612,10 @@ NAMESPACES_QUERY = """
 """
 
 
-def get_namespaces():
-    """ Returns all Namespaces """
+def get_serviceaccount_tokens():
+    """ Returns all namespaces with ServiceAccount tokens information """
     gqlapi = gql.get_api()
-    return gqlapi.query(NAMESPACES_QUERY)['namespaces']
+    return gqlapi.query(SERVICEACCOUNT_TOKENS_QUERY)['namespaces']
 
 
 PRODUCTS_QUERY = """

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2,6 +2,8 @@ import logging
 
 import utils.gql as gql
 
+from textwrap import indent
+
 
 APP_INTERFACE_SETTINGS_QUERY = """
 {
@@ -553,7 +555,7 @@ def get_namespaces():
     return gqlapi.query(NAMESPACES_QUERY)['namespaces']
 
 
-SERVICEACCOUNT_TOKEN = """
+SA_TOKEN = """
 namespace {
   name
   cluster {
@@ -609,12 +611,17 @@ SERVICEACCOUNT_TOKENS_QUERY = """
         integrations
       }
     }
+    sharedResources {
+      openshiftServiceAccountTokens {
+        %s
+      }
+    }
     openshiftServiceAccountTokens {
       %s
     }
   }
 }
-""" % indent(SERVICEACCOUNT_TOKEN, 6*' '))
+""" % (indent(SA_TOKEN, 8*' '), indent(SA_TOKEN, 6*' '))
 
 
 def get_serviceaccount_tokens():

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -553,6 +553,34 @@ def get_namespaces():
     return gqlapi.query(NAMESPACES_QUERY)['namespaces']
 
 
+SERVICEACCOUNT_TOKEN = """
+namespace {
+  name
+  cluster {
+    name
+    serverUrl
+    jumpHost {
+      hostname
+      knownHosts
+      user
+      port
+      identity {
+        path
+        field
+        format
+      }
+    }
+    automationToken {
+      path
+      field
+      format
+    }
+  }
+}
+serviceAccountName
+"""
+
+
 SERVICEACCOUNT_TOKENS_QUERY = """
 {
   namespaces: namespaces_v1 {
@@ -582,34 +610,11 @@ SERVICEACCOUNT_TOKENS_QUERY = """
       }
     }
     openshiftServiceAccountTokens {
-      namespace {
-        name
-        cluster {
-          name
-          serverUrl
-          jumpHost {
-              hostname
-              knownHosts
-              user
-              port
-              identity {
-                  path
-                  field
-                  format
-              }
-          }
-          automationToken {
-            path
-            field
-            format
-          }
-        }
-      }
-      serviceAccountName
+      %s
     }
   }
 }
-"""
+""" % indent(SERVICEACCOUNT_TOKEN, 6*' '))
 
 
 def get_serviceaccount_tokens():


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2606

Now that we are running multiple instances of the same service, we are duplicating a lot of the content of a namespace file. In addition to openshift resources (#1095), we are duplicating the service account tokens that we want to apply to the namespace.

This PR allows users to define shared resources that can be added to multiple namespace files, thus removing the need to duplicate this content and allow users to update all their namespaces in a single place.

depends on:
- https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/10723
- https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/10727

allows us to do: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/10728

note to the reviewer: commit by commit.