### PR TITLE
[terraform-resources] change resources tags

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -155,6 +155,15 @@ TF_NAMESPACES_QUERY = """
     terraformResources {
       %s
     }
+    app {
+      name
+      parentApp {
+        name
+      }
+    }
+    environment {
+      name
+    }
     cluster {
       name
       serverUrl

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -2198,17 +2198,19 @@ class TerrascriptClient(object):
         return values
 
     def get_resource_tags(self, namespace_info):
-        cluster, namespace = self.unpack_namespace_info(namespace_info)
+        app, environment = self.unpack_namespace_info(namespace_info)
         return {
             'managed_by_integration': self.integration,
-            'cluster': cluster,
-            'namespace': namespace
+            'app': app,
+            'environment': environment
         }
 
     def unpack_namespace_info(self, namespace_info):
-        cluster = namespace_info['cluster']['name']
-        namespace = namespace_info['name']
-        return cluster, namespace
+        app_info = namespace_info['app']
+        parent_app_info = app_info.get('parentApp')
+        app = parent_app_info['name'] if parent_app_info else app_info['name']
+        environment = namespace_info['environment']['name']
+        return app, environment
 
     @staticmethod
     def validate_elasticsearch_version(version):


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2614

as part of moving `terraformResources` to shared resources files, we can no longer use the cluster and namespace tags, as these will be different in each namespace including these resources.

we can assume that a terraform resource will not be used across different environments, and mostly will not be used across different apps. in case it is, we assume there will be a shared parentApp and we will use that.

this change will only change the tags on the resources.

the best reason to use these tags is for billing calculations, and using the `parentApp` is likely the best tag to choose in this case.