### PR TITLE
[openshift-users] run on v4 clusters

### DIFF
--- a/reconcile/openshift_users.py
+++ b/reconcile/openshift_users.py
@@ -24,7 +24,6 @@ def get_cluster_users(cluster, oc_map):
 
 def fetch_current_state(thread_pool_size, internal, use_jump_host):
     clusters = queries.get_clusters(minimal=True)
-    clusters = [c for c in clusters if c.get('ocm') is None]
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(clusters=clusters, integration=QONTRACT_INTEGRATION,
                     settings=settings, internal=internal,


### PR DESCRIPTION
in the past, dedicated-admin did not have permissions to manage users and groups (the reason this logic exists here).

we do now, so let's!