### PR TITLE
[gitlab-owners] change label to bot/approved

### DIFF
--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -10,7 +10,7 @@ from utils.repo_owners import RepoOwners
 
 QONTRACT_INTEGRATION = 'gitlab-owners'
 
-APPROVAL_LABEL = 'approved'
+APPROVAL_LABEL = 'bot/approved'
 
 _LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
to allow for self documented labels, same as we did for app-interface.