### PR TITLE
use oc replace when last-applied-configuration annotation is too long

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -4,7 +4,9 @@ import utils.threaded as threaded
 import reconcile.queries as queries
 
 from utils.oc import OC_Map
-from utils.oc import StatusCodeError, InvalidValueApplyError
+from utils.oc import (StatusCodeError,
+                      InvalidValueApplyError,
+                      MetaDataAnnotationsTooLongApplyError)
 from utils.openshift_resource import (OpenshiftResource as OR,
                                       ResourceInventory)
 
@@ -223,6 +225,8 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
             oc.remove_last_applied_configuration(
                 namespace, resource_type, resource.name)
             oc.apply(namespace, annotated.toJSON())
+        except MetaDataAnnotationsTooLongApplyError:
+            oc.replace(namespace, annotated.toJSON())
 
     oc.recycle_pods(dry_run, namespace, resource_type, resource)
 

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -22,6 +22,10 @@ class InvalidValueApplyError(Exception):
     pass
 
 
+class MetaDataAnnotationsTooLongApplyError(Exception):
+    pass
+
+
 class NoOutputError(Exception):
     pass
 
@@ -151,6 +155,10 @@ class OC(object):
 
     def apply(self, namespace, resource):
         cmd = ['apply', '-n', namespace, '-f', '-']
+        self._run(cmd, stdin=resource, apply=True)
+
+    def replace(self, namespace, resource):
+        cmd = ['replace', '-n', namespace, '-f', '-']
         self._run(cmd, stdin=resource, apply=True)
 
     def delete(self, namespace, kind, name):
@@ -410,6 +418,10 @@ class OC(object):
             err = err.decode('utf-8')
             if kwargs.get('apply') and 'Invalid value: 0x0' in err:
                 raise InvalidValueApplyError(f"[{self.server}]: {err}")
+            if kwargs.get('apply') and \
+                    'metadata.annotations: Too long' in err:
+                raise MetaDataAnnotationsTooLongApplyError(
+                    f"[{self.server}]: {err}")
             if not (allow_not_found and 'NotFound' in err):
                 raise StatusCodeError(f"[{self.server}]: {err}")
 


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/APPSRE-2631

this PR adds a handle to the case where the last-applied-configuration annotation is too long, in which case we should use `oc replace` instead of `oc apply`.