### PR TITLE
[ocm-upgrade-scheduler] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `ocm-aws-infrastructure-access`: Grants AWS infrastructure access to members in AWS groups via OCM.
 - `ocm-github-idp`: Manage GitHub Identity Providers in OCM.
 - `ocm-machine-pools`: Manage Machine Pools in OCM.
+- `ocm-upgrade-scheduler`: Manage Upgrade Policy schedules in OCM.
 - `email-sender`: Send email notifications to app-interface audience.
 - `requests-sender`: Send emails to users based on requests submitted to app-interface.
 - `service-dependencies`: Validate dependencies are defined for each service.

--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -383,6 +383,17 @@ integrations:
   logs:
     cloudwatch: true
     slack: true
+- name: ocm-upgrade-scheduler
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 100m
+    limits:
+      memory: 200Mi
+      cpu: 200m
+  logs:
+    cloudwatch: true
+    slack: true
 - name: email-sender
   resources:
     requests:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -6634,6 +6634,186 @@ objects:
   kind: Deployment
   metadata:
     labels:
+      app: qontract-reconcile-ocm-upgrade-scheduler
+    name: qontract-reconcile-ocm-upgrade-scheduler
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile-ocm-upgrade-scheduler
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile-ocm-upgrade-scheduler
+          component: qontract-reconcile
+      spec:
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                key: slack.webhook_url
+                name: app-interface
+          - name: SLACK_CHANNEL
+            value: ${SLACK_CHANNEL}
+          - name: SLACK_ICON_EMOJI
+            value: ${SLACK_ICON_EMOJI}
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type slack
+                webhook_url ${SLACK_WEBHOOK_URL}
+                channel ${SLACK_CHANNEL}
+                icon_emoji ${SLACK_ICON_EMOJI}
+                username sd-app-sre-bot
+                flush_interval 10s
+                message "\`\`\`[ocm-upgrade-scheduler] %s\`\`\`"
+              </store>
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name ocm-upgrade-scheduler
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          ports:
+            - name: http
+              containerPort: 9090
+          env:
+          - name: SHARDS
+            value: "1"
+          - name: SHARD_ID
+            value: "0"
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: ocm-upgrade-scheduler
+          - name: INTEGRATION_EXTRA_ARGS
+            value: ""
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: GITHUB_API
+          - name: SENTRY_DSN
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
+          - name: UNLEASH_API_URL
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: API_URL
+          - name: UNLEASH_CLIENT_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: CLIENT_ACCESS_TOKEN
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
       app: qontract-reconcile-email-sender
     name: qontract-reconcile-email-sender
   spec:

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -72,6 +72,7 @@ import reconcile.aws_support_cases_sos
 import reconcile.ocm_groups
 import reconcile.ocm_clusters
 import reconcile.ocm_machine_pools
+import reconcile.ocm_upgrade_scheduler
 import reconcile.ocm_aws_infrastructure_access
 import reconcile.ocm_github_idp
 import reconcile.email_sender
@@ -980,6 +981,14 @@ def ocm_clusters(ctx, gitlab_project_id, thread_pool_size):
 @click.pass_context
 def ocm_machine_pools(ctx, thread_pool_size):
     run_integration(reconcile.ocm_machine_pools, ctx.obj, thread_pool_size)
+
+
+@integration.command()
+@threaded()
+@click.pass_context
+def ocm_upgrade_scheduler(ctx, thread_pool_size):
+    run_integration(reconcile.ocm_upgrade_scheduler, ctx.obj,
+                    thread_pool_size)
 
 
 @integration.command()

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -1,0 +1,90 @@
+import sys
+import logging
+import json
+
+import reconcile.queries as queries
+
+from utils.ocm import OCMMap
+
+QONTRACT_INTEGRATION = 'ocm-upgrade-scheduler'
+
+
+def fetch_current_state(clusters):
+    settings = queries.get_app_interface_settings()
+    ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
+                     settings=settings)
+
+    current_state = []
+    for cluster in clusters:
+        cluster_name = cluster['name']
+        ocm = ocm_map.get(cluster_name)
+        upgrade_policies = ocm.get_upgrade_policies(cluster_name)
+        for upgrade_policy in upgrade_policies:
+            upgrade_policy['cluster'] = cluster_name
+            current_state.append(upgrade_policy)
+
+    return ocm_map, current_state
+
+
+def fetch_desired_state(clusters):
+    desired_state = []
+    for cluster in clusters:
+        cluster_name = cluster['name']
+        upgrade_policy = cluster['upgradePolicy']
+        upgrade_policy['cluster'] = cluster_name
+        desired_state.append(upgrade_policy)
+
+    return desired_state
+
+
+def calculate_diff(current_state, desired_state):
+    diffs = []
+    err = False
+    for d in desired_state:
+        c = [c for c in current_state
+             if d.items() <= c.items()]
+        if not c:
+            d['action'] = 'create'
+            diffs.append(d)
+
+    for c in current_state:
+        d = [d for d in desired_state
+             if d.items() <= c.items()]
+        if not d:
+            c['action'] = 'delete'
+            diffs.append(c)
+
+    return diffs, err
+
+
+def sort_diffs(diff):
+    if diff['action'] == 'delete':
+        return 1
+    else:
+        return 2
+
+
+def act(dry_run, diffs, ocm_map):
+    diffs.sort(key=sort_diffs)
+    for diff in diffs:
+        action = diff.pop('action')
+        cluster = diff.pop('cluster')
+        logging.info([action, cluster])
+        if not dry_run:
+            ocm = ocm_map.get(cluster)
+            if action == 'create':
+                ocm.create_upgrade_policy(cluster, diff)
+            elif action == 'delete':
+                ocm.delete_upgrade_policy(cluster, diff)
+
+
+def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
+    clusters = queries.get_clusters()
+    clusters = [c for c in clusters if c.get('upgradePolicy') is not None]
+    ocm_map, current_state = fetch_current_state(clusters)
+    desired_state = fetch_desired_state(clusters)
+    diffs, err = calculate_diff(current_state, desired_state)
+    act(dry_run, diffs, ocm_map)
+
+    if err:
+        sys.exit(1)

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -1,6 +1,5 @@
 import sys
 import logging
-import json
 
 import reconcile.queries as queries
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -324,6 +324,10 @@ CLUSTERS_QUERY = """
       upgrade
       provision_shard_id
     }
+    upgradePolicy {
+      schedule_type
+      schedule
+    }
     network {
       vpc
       service

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -404,6 +404,60 @@ class OCM(object):
             f'{machine_pool_id}'
         self._delete(api)
 
+    def get_upgrade_policies(self, cluster):
+        """Returns a list of details of Upgrade Policies
+
+        :param cluster: cluster name
+
+        :type cluster: string
+        """
+        results = []
+        cluster_id = self.cluster_ids.get(cluster)
+        if not cluster_id:
+            return results
+        api = \
+            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/upgrade_policies'
+        items = self._get_json(api).get('items')
+        if not items:
+            return results
+
+        for item in items:
+            desired_keys = ['id', 'schedule_type', 'schedule']
+            result = {k: v for k, v in item.items() if k in desired_keys}
+            results.append(result)
+
+        return results
+
+    def create_upgrade_policy(self, cluster, spec):
+        """Creates a new Upgrade Policy
+
+        :param cluster: cluster name
+        :param spec: required information for creation
+
+        :type cluster: string
+        :type spec: dictionary
+        """
+        cluster_id = self.cluster_ids[cluster]
+        api = \
+            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/upgrade_policies'
+        self._post(api, spec)
+
+    def delete_upgrade_policy(self, cluster, spec):
+        """Deletes an existing Upgrade Policy
+
+        :param cluster: cluster name
+        :param spec: required information for update
+
+        :type cluster: string
+        :type spec: dictionary
+        """
+        cluster_id = self.cluster_ids[cluster]
+        upgrade_policy_id = spec['id']
+        api = \
+            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
+            f'upgrade_policies/{upgrade_policy_id}'
+        self._delete(api)
+
     @retry(max_attempts=10)
     def _get_json(self, api):
         r = requests.get(f"{self.url}{api}", headers=self.headers)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2638

this PR adds an integration to manage upgrade schedules for clusters via OCM.
example usage:
```
upgradePolicy:
  schedule_type: automatic
  schedule: '0 8 * * 2'
```

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/10912