### PR TITLE
[terraform-resources] do not initiate oc_map on dry-run

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -216,8 +216,11 @@ def populate_oc_resources(spec, ri):
         logging.error(msg)
 
 
-def fetch_current_state(namespaces, thread_pool_size, internal, use_jump_host):
+def fetch_current_state(dry_run, namespaces, thread_pool_size,
+                        internal, use_jump_host):
     ri = ResourceInventory()
+    if dry_run:
+        return ri, None
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces, integration=QONTRACT_INTEGRATION,
                     settings=settings, internal=internal,
@@ -260,16 +263,8 @@ def setup(dry_run, print_only, thread_pool_size, internal,
     namespaces = gqlapi.query(TF_NAMESPACES_QUERY)['namespaces']
     tf_namespaces = [namespace_info for namespace_info in namespaces
                      if namespace_info.get('managedTerraformResources')]
-    if dry_run:
-        ri = ResourceInventory()
-        oc_map = None
-    else:
-        ri, oc_map = fetch_current_state(
-            tf_namespaces,
-            thread_pool_size,
-            internal,
-            use_jump_host
-        )
+    ri, oc_map = fetch_current_state(dry_run, tf_namespaces, thread_pool_size,
+                                     internal, use_jump_host)
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size,
                                          print_only=print_only,
                                          oc_map=oc_map,


### PR DESCRIPTION
since if this is a dry-run we exit before checking openshift resources, there is no need to initiate them.