### PR TITLE
ocm exit on empty output

### DIFF
--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -90,6 +90,10 @@ def act(dry_run, diffs, ocm_map):
 def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
     clusters = queries.get_clusters()
     clusters = [c for c in clusters if c.get('machinePools') is not None]
+    if not clusters:
+        logging.debug("No machinePools definitions found in app-interface")
+        sys.exit(0)
+
     ocm_map, current_state = fetch_current_state(clusters)
     desired_state = fetch_desired_state(clusters)
     diffs, err = calculate_diff(current_state, desired_state)

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -80,6 +80,10 @@ def act(dry_run, diffs, ocm_map):
 def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
     clusters = queries.get_clusters()
     clusters = [c for c in clusters if c.get('upgradePolicy') is not None]
+    if not clusters:
+        logging.debug("No upgradePolicy definitions found in app-interface")
+        sys.exit(0)
+
     ocm_map, current_state = fetch_current_state(clusters)
     desired_state = fetch_desired_state(clusters)
     diffs, err = calculate_diff(current_state, desired_state)


### PR DESCRIPTION
this PR changes the ocm-machine-pools and ocm-upgrade-scheduler integrations to exit on empty input (no clusters).