### PR TITLE
[ocm-upgrade-scheduler] only get automatic upgrade policies

### DIFF
--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -17,7 +17,8 @@ def fetch_current_state(clusters):
     for cluster in clusters:
         cluster_name = cluster['name']
         ocm = ocm_map.get(cluster_name)
-        upgrade_policies = ocm.get_upgrade_policies(cluster_name)
+        upgrade_policies = \
+            ocm.get_upgrade_policies(cluster_name, schedule_type='automatic')
         for upgrade_policy in upgrade_policies:
             upgrade_policy['cluster'] = cluster_name
             current_state.append(upgrade_policy)

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -405,7 +405,7 @@ class OCM(object):
             f'{machine_pool_id}'
         self._delete(api)
 
-    def get_upgrade_policies(self, cluster):
+    def get_upgrade_policies(self, cluster, schedule_type=None):
         """Returns a list of details of Upgrade Policies
 
         :param cluster: cluster name
@@ -423,6 +423,8 @@ class OCM(object):
             return results
 
         for item in items:
+            if schedule_type and item['schedule_type'] != schedule_type:
+                continue
             desired_keys = ['id', 'schedule_type', 'schedule']
             result = {k: v for k, v in item.items() if k in desired_keys}
             results.append(result)


### PR DESCRIPTION
manual ones will be added by users via the UI and will interfere with the integration for now.