### PR TITLE
[jira-watcher] change from io-dir to s3 state

### DIFF
--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -106,7 +106,7 @@ integrations:
     limits:
       memory: 400Mi
       cpu: 300m
-  extraArgs: --io-dir /tmp/throughput/
+  state: true
   shards: 3
 - name: unleash-watcher
   resources:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -1622,7 +1622,7 @@ objects:
           - name: INTEGRATION_NAME
             value: jira-watcher
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--io-dir /tmp/throughput/"
+            value: ""
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1635,6 +1635,13 @@ objects:
               configMapKeyRef:
                 name: app-interface
                 key: SENTRY_DSN
+          - name: APP_INTERFACE_STATE_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: app-interface
+                key: aws.s3.bucket
+          - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT
+            value: "${APP_INTERFACE_STATE_BUCKET_ACCOUNT}"
           - name: UNLEASH_API_URL
             valueFrom:
               secretKeyRef:
@@ -1692,7 +1699,7 @@ objects:
           - name: INTEGRATION_NAME
             value: jira-watcher
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--io-dir /tmp/throughput/"
+            value: ""
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1705,6 +1712,13 @@ objects:
               configMapKeyRef:
                 name: app-interface
                 key: SENTRY_DSN
+          - name: APP_INTERFACE_STATE_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: app-interface
+                key: aws.s3.bucket
+          - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT
+            value: "${APP_INTERFACE_STATE_BUCKET_ACCOUNT}"
           - name: UNLEASH_API_URL
             valueFrom:
               secretKeyRef:
@@ -1762,7 +1776,7 @@ objects:
           - name: INTEGRATION_NAME
             value: jira-watcher
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--io-dir /tmp/throughput/"
+            value: ""
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1775,6 +1789,13 @@ objects:
               configMapKeyRef:
                 name: app-interface
                 key: SENTRY_DSN
+          - name: APP_INTERFACE_STATE_BUCKET
+            valueFrom:
+              secretKeyRef:
+                name: app-interface
+                key: aws.s3.bucket
+          - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT
+            value: "${APP_INTERFACE_STATE_BUCKET_ACCOUNT}"
           - name: UNLEASH_API_URL
             valueFrom:
               secretKeyRef:

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -520,10 +520,10 @@ def jenkins_webhooks_cleaner(ctx):
 
 
 @integration.command()
-@throughput
+@environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
 @click.pass_context
-def jira_watcher(ctx, io_dir):
-    run_integration(reconcile.jira_watcher, ctx.obj, io_dir)
+def jira_watcher(ctx):
+    run_integration(reconcile.jira_watcher, ctx.obj)
 
 
 @integration.command()

--- a/reconcile/jira_watcher.py
+++ b/reconcile/jira_watcher.py
@@ -149,4 +149,5 @@ def run(dry_run):
         if previous_state:
             diffs = calculate_diff(jira.server, current_state, previous_state)
             act(dry_run, jira_board, diffs)
-        write_state(state, jira.project, current_state)
+        if not dry_run:
+            write_state(state, jira.project, current_state)

--- a/reconcile/jira_watcher.py
+++ b/reconcile/jira_watcher.py
@@ -8,6 +8,7 @@ import reconcile.queries as queries
 from utils.jira_client import JiraClient
 from utils.slack_api import SlackApi
 from utils.sharding import is_in_shard_round_robin
+from utils.state import State
 
 
 QUERY = """
@@ -44,8 +45,7 @@ QUERY = """
 QONTRACT_INTEGRATION = 'jira-watcher'
 
 
-def fetch_current_state(jira_board):
-    settings = queries.get_app_interface_settings()
+def fetch_current_state(jira_board, settings):
     jira = JiraClient(jira_board, settings=settings)
     issues = jira.get_issues()
     return jira, {issue.key: {'status': issue.fields.status.name,
@@ -53,22 +53,8 @@ def fetch_current_state(jira_board):
                   for issue in issues}
 
 
-def get_project_file_path(io_dir, project):
-    dir_path = os.path.join(io_dir, QONTRACT_INTEGRATION)
-    if not os.path.exists(dir_path):
-        os.makedirs(dir_path)
-    return os.path.join(dir_path, project + '.json')
-
-
-def fetch_previous_state(io_dir, project):
-    project_file_path = get_project_file_path(io_dir, project)
-    try:
-        with open(project_file_path, 'r') as f:
-            logging.debug('[{}] previous state found'.format(project))
-            return json.load(f)
-    except IOError:
-        logging.debug('[{}] previous state not found'.format(project))
-        return None
+def fetch_previous_state(state, project):
+    return state.get(project, {})
 
 
 def format_message(server, key, data, event,
@@ -143,21 +129,26 @@ def act(dry_run, jira_board, diffs):
             slack.chat_post_message(diff)
 
 
-def write_state(io_dir, project, state):
-    project_file_path = get_project_file_path(io_dir, project)
-    with open(project_file_path, 'w') as f:
-        json.dump(state, f)
+def write_state(state, project, state_to_write):
+    state.add(project, value=state_to_write, force=True)
 
 
-def run(dry_run, io_dir='throughput/'):
+def run(dry_run):
     gqlapi = gql.get_api()
     jira_boards = gqlapi.query(QUERY)['jira_boards']
+    accounts = queries.get_aws_accounts()
+    settings = queries.get_app_interface_settings()
+    state = State(
+        integration=QONTRACT_INTEGRATION,
+        accounts=accounts,
+        settings=settings
+    )
     for index, jira_board in enumerate(jira_boards):
         if not is_in_shard_round_robin(jira_board['name'], index):
             continue
-        jira, current_state = fetch_current_state(jira_board)
-        previous_state = fetch_previous_state(io_dir, jira.project)
+        jira, current_state = fetch_current_state(jira_board, settings)
+        previous_state = fetch_previous_state(state, jira.project)
         if previous_state:
             diffs = calculate_diff(jira.server, current_state, previous_state)
             act(dry_run, jira_board, diffs)
-        write_state(io_dir, jira.project, current_state)
+        write_state(state, jira.project, current_state)

--- a/reconcile/jira_watcher.py
+++ b/reconcile/jira_watcher.py
@@ -1,5 +1,3 @@
-import os
-import json
 import logging
 
 import utils.gql as gql


### PR DESCRIPTION
instead of using the local fs, we should use s3 state like most other integrations. this will prevent the loss of a state.