### PR TITLE
[openshift-resources] replace instead of apply on UnsupportedMediaType

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -6,7 +6,8 @@ import reconcile.queries as queries
 from utils.oc import OC_Map
 from utils.oc import (StatusCodeError,
                       InvalidValueApplyError,
-                      MetaDataAnnotationsTooLongApplyError)
+                      MetaDataAnnotationsTooLongApplyError,
+                      UnsupportedMediaTypeError)
 from utils.openshift_resource import (OpenshiftResource as OR,
                                       ResourceInventory)
 

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -225,7 +225,8 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
             oc.remove_last_applied_configuration(
                 namespace, resource_type, resource.name)
             oc.apply(namespace, annotated.toJSON())
-        except MetaDataAnnotationsTooLongApplyError:
+        except (MetaDataAnnotationsTooLongApplyError,
+                UnsupportedMediaTypeError):
             oc.replace(namespace, annotated.toJSON())
 
     oc.recycle_pods(dry_run, namespace, resource_type, resource)

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -26,6 +26,10 @@ class MetaDataAnnotationsTooLongApplyError(Exception):
     pass
 
 
+class UnsupportedMediaTypeError(Exception):
+    pass
+
+
 class NoOutputError(Exception):
     pass
 
@@ -416,12 +420,14 @@ class OC(object):
 
         if code != 0:
             err = err.decode('utf-8')
-            if kwargs.get('apply') and 'Invalid value: 0x0' in err:
-                raise InvalidValueApplyError(f"[{self.server}]: {err}")
-            if kwargs.get('apply') and \
-                    'metadata.annotations: Too long' in err:
-                raise MetaDataAnnotationsTooLongApplyError(
-                    f"[{self.server}]: {err}")
+            if kwargs.get('apply'):
+                if 'Invalid value: 0x0' in err:
+                    raise InvalidValueApplyError(f"[{self.server}]: {err}")
+                if 'metadata.annotations: Too long' in err:
+                    raise MetaDataAnnotationsTooLongApplyError(
+                        f"[{self.server}]: {err}")
+                if 'UnsupportedMediaType' in err:
+                    raise UnsupportedMediaTypeError(f"[{self.server}]: {err}")
             if not (allow_not_found and 'NotFound' in err):
                 raise StatusCodeError(f"[{self.server}]: {err}")
 


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/APPSRE-2660

this PR solves an issue with applying EgressNetworkPolicy, as this resource can not be applied, only replaced.