### PR TITLE
[terraform-resources] rds determine password in dry-run without oc

### DIFF
--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -803,6 +803,8 @@ class TerrascriptClient(object):
         cluster, namespace = self.unpack_namespace_info(namespace_info)
         try:
             oc = self.oc_map.get(cluster)
+            if not oc:
+                return None
             return oc.get(namespace, 'Secret', resource_name)
         except StatusCodeError as e:
             if str(e).startswith('Error from server (NotFound):'):


### PR DESCRIPTION
since #1143, we no longer initiate oc_map in dry-run, this is bound to fail for a new DB (that it's password is not in the state yet).