### PR TITLE
Don't fail on unreachable cluster retry & move on

### DIFF
--- a/utils/jsonnet.py
+++ b/utils/jsonnet.py
@@ -21,7 +21,7 @@ def generate_object(jsonnet_string):
     try:
         jsonnet_bundler_dir = os.environ['JSONNET_VENDOR_DIR']
     except KeyError as e:
-        raise JsonnetError('JSONNET_VENDOR_DIR not set')
+        raise JsonnetError(f'JSONNET_VENDOR_DIR not set: {e}')
 
     cmd = ['jsonnet', '-J', jsonnet_bundler_dir, path]
     status = run(cmd, stdout=PIPE, stderr=PIPE)

--- a/utils/jsonnet.py
+++ b/utils/jsonnet.py
@@ -20,8 +20,8 @@ def generate_object(jsonnet_string):
 
     try:
         jsonnet_bundler_dir = os.environ['JSONNET_VENDOR_DIR']
-    except KeyError as e:
-        raise JsonnetError(f'JSONNET_VENDOR_DIR not set: {e}')
+    except KeyError:
+        raise JsonnetError('JSONNET_VENDOR_DIR not set')
 
     cmd = ['jsonnet', '-J', jsonnet_bundler_dir, path]
     status = run(cmd, stdout=PIPE, stderr=PIPE)

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -230,7 +230,10 @@ class OC(object):
         # oc api-resources only has name or wide output
         # and we need to get the KIND, which is the last column
         cmd = ['api-resources', '--no-headers']
-        results = self._run(cmd).decode('utf-8').split('\n')
+        if self._run(cmd) == '{}':
+            results = '{}'
+        else:
+            results = self._run(cmd).decode('utf-8').split('\n')   
         return [r.split()[-1] for r in results]
 
     @retry(exceptions=(JobNotRunningError), max_attempts=20)
@@ -423,14 +426,14 @@ class OC(object):
                 raise MetaDataAnnotationsTooLongApplyError(
                     f"[{self.server}]: {err}")
             if not (allow_not_found and 'NotFound' in err):
-                raise StatusCodeError(f"[{self.server}]: {err}")
+                logging.error(StatusCodeError(f"[{self.server}]: {err}"))
 
         if not out:
             if allow_not_found:
                 return '{}'
             else:
-                raise NoOutputError(err)
-
+                logging.error(NoOutputError(err))
+                return '{}'
         return out.strip()
 
     def _run_json(self, cmd, allow_not_found=False):

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -516,14 +516,14 @@ class OC_Map(object):
                 jump_host = None
             try:
                 oc_client = OC(server_url, token, jump_host,
-                    settings=self.settings,
-                    init_projects=self.init_projects,
-                    init_api_resources=self.init_api_resources)
+                               settings=self.settings,
+                               init_projects=self.init_projects,
+                               init_api_resources=self.init_api_resources)
                 self.set_oc(cluster, oc_client)
             except StatusCodeError:
-                    logging.info('Cluster unreachable: ' + cluster)
-                    pass
-    
+                logging.info('Cluster unreachable: ' + cluster)
+                pass
+
     def set_oc(self, cluster, value):
         with self._lock:
             self.oc_map[cluster] = value

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -521,7 +521,7 @@ class OC_Map(object):
                     init_api_resources=self.init_api_resources)
                 self.set_oc(cluster, oc_client)
             except StatusCodeError:
-                logging.info
+                logging.info('Cluster unreachable: ' + cluster)
                 pass
 
     def set_oc(self, cluster, value):

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -523,7 +523,7 @@ class OC_Map(object):
             except StatusCodeError:
                 logging.info('Cluster unreachable: ' + cluster)
                 pass
-
+            
     def set_oc(self, cluster, value):
         with self._lock:
             self.oc_map[cluster] = value

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -516,8 +516,7 @@ class OC_Map(object):
                                init_api_resources=self.init_api_resources)
                 self.set_oc(cluster, oc_client)
             except StatusCodeError:
-                logging.info('Cluster unreachable: ' + cluster)
-                pass
+                logging.info('Cluster unreachable: %s', cluster)
 
     def set_oc(self, cluster, value):
         with self._lock:

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -50,10 +50,6 @@ class JobNotRunningError(Exception):
     pass
 
 
-class ClusterUnreachable(Exception):
-    pass
-
-
 class OC(object):
     def __init__(self, server, token, jh=None, settings=None,
                  init_projects=False, init_api_resources=False):

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -233,7 +233,7 @@ class OC(object):
         if self._run(cmd) == '{}':
             results = '{}'
         else:
-            results = self._run(cmd).decode('utf-8').split('\n')   
+            results = self._run(cmd).decode('utf-8').split('\n')
         return [r.split()[-1] for r in results]
 
     @retry(exceptions=(JobNotRunningError), max_attempts=20)

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -240,7 +240,6 @@ class OC(object):
         return [r.split()[-1] for r in results]
 
     def get_cluster_info(self):
-        # get cluster-info to check that the cluster is reachable
         cmd = ['cluster-info']
         return self._run(cmd)
 

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -516,7 +516,7 @@ class OC_Map(object):
                                init_api_resources=self.init_api_resources)
                 self.set_oc(cluster, oc_client)
             except StatusCodeError:
-                logging.info('Cluster unreachable: %s', cluster)
+                logging.error('Cluster unreachable: %s', cluster)
 
     def set_oc(self, cluster, value):
         with self._lock:

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -521,9 +521,9 @@ class OC_Map(object):
                     init_api_resources=self.init_api_resources)
                 self.set_oc(cluster, oc_client)
             except StatusCodeError:
-                logging.info('Cluster unreachable: ' + cluster)
-                pass
-            
+                    logging.info('Cluster unreachable: ' + cluster)
+                    pass
+    
     def set_oc(self, cluster, value):
         with self._lock:
             self.oc_map[cluster] = value


### PR DESCRIPTION
Instead of raise log the error on an unreachable cluster and move on to the next cluster after retries