### PR TITLE
openshift-resources add cluster.auth to query

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -93,6 +93,10 @@ NAMESPACES_QUERY = """
     cluster {
       name
       serverUrl
+      auth {
+        org
+        team
+      }
       jumpHost {
           hostname
           knownHosts


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-1838

this is to allow us to template an OAuth secret using the auth section of a cluster file.