### PR TITLE
[new integration] ocp-release-ecr-mirror

### DIFF
--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -472,6 +472,14 @@ integrations:
     limits:
       memory: 200Mi
       cpu: 200m
+- name: ocp-release-ecr-mirror
+  resources:
+    requests:
+      memory: 400Mi
+      cpu: 200m
+    limits:
+      memory: 520Mi
+      cpu: 300m
 cronjobs:
 - name: aws-ecr-image-pull-secrets
   resources:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -8597,6 +8597,76 @@ objects:
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: qontract-reconcile-ocp-release-ecr-mirror
+    name: qontract-reconcile-ocp-release-ecr-mirror
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile-ocp-release-ecr-mirror
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile-ocp-release-ecr-mirror
+          component: qontract-reconcile
+      spec:
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          ports:
+            - name: http
+              containerPort: 9090
+          env:
+          - name: SHARDS
+            value: "1"
+          - name: SHARD_ID
+            value: "0"
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: ocp-release-ecr-mirror
+          - name: INTEGRATION_EXTRA_ARGS
+            value: ""
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: GITHUB_API
+          - name: SENTRY_DSN
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: SENTRY_DSN
+          - name: UNLEASH_API_URL
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: API_URL
+          - name: UNLEASH_CLIENT_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: CLIENT_ACCESS_TOKEN
+          resources:
+            limits:
+              cpu: 300m
+              memory: 520Mi
+            requests:
+              cpu: 200m
+              memory: 400Mi
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
 - apiVersion: batch/v1beta1
   kind: CronJob
   metadata:

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -84,6 +84,7 @@ import reconcile.sql_query
 import reconcile.user_validator
 import reconcile.integrations_validator
 import reconcile.dashdotdb_cso
+import reconcile.ocp_release_ecr_mirror
 
 from reconcile.status import ExitCodes
 
@@ -1080,6 +1081,12 @@ def gitlab_fork_compliance(ctx, gitlab_project_id, gitlab_merge_request_id,
 @click.pass_context
 def dashdotdb_cso(ctx, thread_pool_size):
     run_integration(reconcile.dashdotdb_cso, ctx.obj, thread_pool_size)
+
+
+@integration.command()
+@click.pass_context
+def ocp_release_ecr_mirror(ctx):
+    run_integration(reconcile.ocp_release_ecr_mirror, ctx.obj)
 
 
 @integration.command()

--- a/reconcile/ocp_release_ecr_mirror.py
+++ b/reconcile/ocp_release_ecr_mirror.py
@@ -1,0 +1,258 @@
+import base64
+import logging
+import sys
+
+from urllib.parse import urlparse
+
+from sretoolbox.container import Image
+
+from utils.oc import OC
+from utils.oc import OC_Map
+from utils.ocm import OCMMap
+
+from reconcile import queries
+from utils.aws_api import AWSApi
+from reconcile.status import ExitCodes
+
+
+QONTRACT_INTEGRATION = 'ocp-release-ecr-mirror'
+
+LOG = logging.getLogger(__name__)
+
+
+class OcpReleaseEcrMirrorError(Exception):
+    """
+    Used by the OcpReleaseEcrMirror.
+    """
+
+
+class OcpReleaseEcrMirror:
+    def __init__(self, dry_run, instance):
+        self.dry_run = dry_run
+        self.settings = queries.get_app_interface_settings()
+
+        cluster_info = instance['hiveCluster']
+        hive_cluster = instance['hiveCluster']['name']
+
+        # Getting the OCM Client for the hive cluster
+        ocm_map = OCMMap(clusters=[cluster_info],
+                         integration=QONTRACT_INTEGRATION,
+                         settings=self.settings)
+
+        self.ocm_cli = ocm_map.get(hive_cluster)
+        if not self.ocm_cli:
+            raise OcpReleaseEcrMirrorError(f"Can't create ocm client for "
+                                           f"cluster {hive_cluster}")
+
+        # Getting the OC Client for the hive cluster
+        oc_map = OC_Map(clusters=[cluster_info],
+                        integration=QONTRACT_INTEGRATION,
+                        settings=self.settings)
+        self.oc_cli = oc_map.get(hive_cluster)
+        if not self.oc_cli:
+            raise OcpReleaseEcrMirrorError(f"Can't create oc client for "
+                                           f"cluster {hive_cluster}")
+
+        namespace = instance['ecrResourcesNamespace']
+        ocp_release_identifier = instance['ocpReleaseEcrIdentifier']
+        ocp_art_dev_identifier = instance['ocpArtDevEcrIdentifier']
+
+        ocp_release_info = self._get_tf_resource_info(namespace,
+                                                      ocp_release_identifier)
+        if ocp_release_info is None:
+            raise OcpReleaseEcrMirrorError(f"Could not find rds "
+                                           f"identifier "
+                                           f"{ocp_release_identifier} in "
+                                           f"namespace {namespace['name']}")
+
+        ocp_art_dev_info = self._get_tf_resource_info(namespace,
+                                                      ocp_art_dev_identifier)
+        if ocp_art_dev_info is None:
+            raise OcpReleaseEcrMirrorError(f"Could not find rds identifier"
+                                           f" {ocp_art_dev_identifier} in"
+                                           f"namespace {namespace['name']}")
+
+        # Getting the AWS Client for the accounts
+        aws_accounts = [
+            self._get_aws_account_info(account=ocp_release_info['account']),
+            self._get_aws_account_info(account=ocp_art_dev_info['account'])
+        ]
+        self.aws_cli = AWSApi(thread_pool_size=1,
+                              accounts=aws_accounts,
+                              settings=self.settings,
+                              init_ecr_auth_tokens=True)
+        self.aws_cli.map_ecr_resources()
+
+        self.ocp_release_ecr_uri = self._get_image_uri(
+            account=ocp_release_info['account'],
+            repository=ocp_release_identifier
+        )
+        if self.ocp_release_ecr_uri is None:
+            raise OcpReleaseEcrMirrorError(f"Could not find the "
+                                           f"ECR repository "
+                                           f"{ocp_release_identifier}")
+
+        self.ocp_art_dev_ecr_uri = self._get_image_uri(
+            account=ocp_art_dev_info['account'],
+            repository=ocp_art_dev_identifier
+        )
+        if self.ocp_art_dev_ecr_uri is None:
+            raise OcpReleaseEcrMirrorError(f"Could not find the "
+                                           f"ECR repository "
+                                           f"{ocp_art_dev_identifier}")
+
+        # Getting all the credentials
+        quay_creds = self._get_quay_creds()
+        ocp_release_creds = self._get_ecr_creds(
+            account=ocp_release_info['account'],
+            region=ocp_release_info['region']
+        )
+        ocp_art_dev_creds = self._get_ecr_creds(
+            account=ocp_art_dev_info['account'],
+            region=ocp_art_dev_info['region']
+        )
+
+        # Creating a single dictionary with all credentials to be used by the
+        # "oc adm release mirror" command
+        self.registry_creds = {
+            'auths':
+                {
+                    **quay_creds['auths'],
+                    **ocp_release_creds['auths'],
+                    **ocp_art_dev_creds['auths'],
+                }
+        }
+
+    def run(self):
+        ocp_releases = self._get_ocp_releases()
+        if not ocp_releases:
+            raise RuntimeError('No OCP Releases found')
+
+        for ocp_release in ocp_releases:
+            tag = ocp_release.split(':')[-1]
+            dest_ocp_release = f'{self.ocp_release_ecr_uri}:{tag}'
+            self._run_mirror(ocp_release=ocp_release,
+                             dest_ocp_release=dest_ocp_release,
+                             dest_ocp_art_dev=self.ocp_art_dev_ecr_uri)
+
+    def _run_mirror(self, ocp_release, dest_ocp_release, dest_ocp_art_dev):
+        # Checking if the image is already there
+        if self._is_image_there(dest_ocp_release):
+            LOG.info(f'Image {ocp_release} already in '
+                     f'the mirror. Skipping.')
+            return
+
+        LOG.info(f'Mirroring {ocp_release} to {dest_ocp_art_dev} '
+                 f'to_release {dest_ocp_release}')
+
+        if self.dry_run:
+            return
+
+        # Creating a new, bare, OC client since we don't
+        # want to run this against any cluster or via
+        # a jump host
+        oc_cli = OC(server='', token='', jh=None, settings=None,
+                    init_projects=False, init_api_resources=False)
+        oc_cli.release_mirror(from_release=ocp_release,
+                              to=dest_ocp_art_dev,
+                              to_release=dest_ocp_release,
+                              dockerconfig=self.registry_creds)
+
+    def _is_image_there(self, image):
+        image_obj = Image(image)
+
+        for registry, creds in self.registry_creds['auths'].items():
+            # Getting the credentials for the image_obj
+            registry_obj = urlparse(registry)
+            if registry_obj.netloc != image_obj.registry:
+                continue
+            image_obj.auth = (creds['username'], creds['password'])
+
+            # Checking if the image is already
+            # in the registry
+            if image_obj:
+                return True
+
+        return False
+
+    @staticmethod
+    def _get_aws_account_info(account):
+        for account_info in queries.get_aws_accounts():
+            if 'name' not in account_info:
+                continue
+            if account_info['name'] != account:
+                continue
+            return account_info
+
+    def _get_ocp_releases(self):
+        ocp_releases = list()
+        clusterimagesets = self.oc_cli.get_all('clusterimageset')
+        for clusterimageset in clusterimagesets['items']:
+            release_image = clusterimageset['spec']['releaseImage']
+            # There are images in some ClusterImagesSets not coming
+            # from quay.io, e.g.:
+            # registry.svc.ci.openshift.org/ocp/release:4.2.0-0.nightly-2020-11-04-053758
+            # Let's filter out everything not from quay.io
+            if not release_image.startswith('quay.io'):
+                continue
+            ocp_releases.append(release_image)
+        return ocp_releases
+
+    def _get_quay_creds(self):
+        return self.ocm_cli.get_pull_secrets()
+
+    def _get_ecr_creds(self, account, region):
+        if region is None:
+            region = self.aws_cli.accounts[account]['resourcesDefaultRegion']
+        auth_token = f'{account}/{region}'
+        data = self.aws_cli.auth_tokens[auth_token]
+        auth_data = data['authorizationData'][0]
+        server = auth_data['proxyEndpoint']
+        token = auth_data['authorizationToken']
+        password = base64.b64decode(token).decode('utf-8').split(':')[1]
+
+        return {
+            'auths': {
+                server: {
+                    'username': 'AWS',
+                    'password': password,
+                    'email': 'sd-app-sre@redhat.com',
+                    'auth': token
+                }
+            }
+        }
+
+    @staticmethod
+    def _get_tf_resource_info(namespace, identifier):
+        tf_resources = namespace['terraformResources']
+        for tf_resource in tf_resources:
+            if 'identifier' not in tf_resource:
+                continue
+
+            if tf_resource['identifier'] != identifier:
+                continue
+
+            if tf_resource['provider'] != 'ecr':
+                continue
+
+            return {
+                'account': tf_resource['account'],
+                'region': tf_resource.get('region'),
+            }
+
+    def _get_image_uri(self, account, repository):
+        for repo in self.aws_cli.resources[account]['ecr']:
+            if repo['repositoryName'] == repository:
+                return repo['repositoryUri']
+
+
+def run(dry_run):
+    instances = queries.get_ocp_release_ecr_mirror()
+    for instance in instances:
+        try:
+            quay_mirror = OcpReleaseEcrMirror(dry_run,
+                                              instance=instance)
+            quay_mirror.run()
+        except OcpReleaseEcrMirrorError as details:
+            LOG.error(str(details))
+            sys.exit(ExitCodes.ERROR)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1352,3 +1352,85 @@ def get_slack_workspace():
     if len(slack_workspaces) != 1:
         logging.warning('multiple Slack workspaces found.')
     return gqlapi.query(SLACK_WORKSPACES_QUERY)['slack_workspaces'][0]
+
+
+OCP_RELEASE_ECR_MIRROR_QUERY = """
+{
+  ocp_release_ecr_mirror: ocp_release_ecr_mirror_v1 {
+    hiveCluster {
+      name
+      serverUrl
+      jumpHost {
+        hostname
+        knownHosts
+        user
+        port
+        identity {
+          path
+          field
+          format
+        }
+      }
+      managedGroups
+      ocm {
+        name
+        url
+        accessTokenClientId
+        accessTokenUrl
+        offlineToken {
+          path
+          field
+          format
+          version
+        }
+      }
+      automationToken {
+        path
+        field
+        format
+      }
+      internal
+      disable {
+        integrations
+      }
+      auth {
+        team
+      }
+    }
+    ecrResourcesNamespace {
+      name
+      managedTerraformResources
+      terraformResources
+      {
+        provider
+        ... on NamespaceTerraformResourceECR_v1
+        {
+          account
+          region
+          identifier
+          output_resource_name
+        }
+      }
+      cluster
+      {
+        name
+        serverUrl
+        automationToken
+        {
+          path
+          field
+          format
+        }
+        internal
+      }
+    }
+    ocpReleaseEcrIdentifier
+    ocpArtDevEcrIdentifier
+  }
+}
+"""
+
+
+def get_ocp_release_ecr_mirror():
+    gqlapi = gql.get_api()
+    return gqlapi.query(OCP_RELEASE_ECR_MIRROR_QUERY)['ocp_release_ecr_mirror']

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     data_files=[('templates', glob('templates/*.j2'))],
 
     install_requires=[
-        "sretoolbox==0.7.0",
+        "sretoolbox==0.8.0",
         "Click>=7.0,<8.0",
         "graphqlclient>=0.2.4,<0.3.0",
         "toml>=0.10.0,<0.11.0",

--- a/utils/aws_api.py
+++ b/utils/aws_api.py
@@ -192,6 +192,14 @@ class AWSApi(object):
                 zone['records'] = results
             self.set_resouces(account, 'route53', zones)
 
+    def map_ecr_resources(self):
+        for account, s in self.sessions.items():
+            client = s.client('ecr')
+            repositories = self.paginate(client=client,
+                                         method='describe_repositories',
+                                         key='repositories')
+            self.set_resouces(account, 'ecr', repositories)
+
     def paginate(self, client, method, key, params={}):
         """ paginate returns an aggregated list of the specified key
         from all pages returned by executing the client's specified method."""

--- a/utils/oc.py
+++ b/utils/oc.py
@@ -1,6 +1,7 @@
 import os
 import json
 import logging
+import tempfile
 
 import utils.threaded as threaded
 
@@ -202,6 +203,24 @@ class OC(object):
     def create_group(self, group):
         cmd = ['adm', 'groups', 'new', group]
         self._run(cmd)
+
+    def release_mirror(self, from_release, to, to_release, dockerconfig):
+        with tempfile.NamedTemporaryFile() as fp:
+            content = json.dumps(dockerconfig)
+            fp.write(content.encode())
+            fp.seek(0)
+
+            cmd = [
+                'adm',
+                '--registry-config', fp.name,
+                'release', 'mirror',
+                '--from', from_release,
+                '--to', to,
+                '--to-release-image', to_release,
+                '--max-per-registry', '1'
+            ]
+
+            self._run(cmd)
 
     def delete_group(self, group):
         cmd = ['delete', 'group', group]

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -472,19 +472,24 @@ class OCM(object):
             f'/api/clusters_mgmt/v1/clusters/{cluster_id}/provision_shard'
         return self._get_json(api)
 
+    def get_pull_secrets(self,):
+        api = '/api/accounts_mgmt/v1/access_token'
+        return self._post(api)
+
     @retry(max_attempts=10)
     def _get_json(self, api):
         r = requests.get(f"{self.url}{api}", headers=self.headers)
         r.raise_for_status()
         return r.json()
 
-    def _post(self, api, data):
+    def _post(self, api, data=None):
         r = requests.post(f"{self.url}{api}", headers=self.headers, json=data)
         try:
             r.raise_for_status()
         except Exception as e:
             logging.error(r.text)
             raise e
+        return r.json()
 
     def _patch(self, api, data):
         r = requests.patch(


### PR DESCRIPTION
Gets all the ocp-release images specified by all the ClusterImageSet on a given Hive cluster and copies them to the specified ECR mirror repositories.

App Interface Payload:
```
---
$schema: /dependencies/ocp-release-ecr-mirror-1.yml
hiveCluster:
  $ref: /openshift/hivep01ue1/cluster.yml
ecrResourcesNamespace:
  $ref: /services/app-interface/namespaces/app-interface-production.yml
ocpReleaseEcrIdentifier: ocp-release
ocpArtDevEcrIdentifier: ocp-art-dev
```

Debug log:
```
[2020-11-05 13:52:27] [INFO] [ocp_release_ecr_mirror.py:_run_mirror:144] - Image quay.io/openshift-release-dev/ocp-release:4.3.12-x86_64 already in the mirror. Skipping.
[2020-11-05 13:52:40] [INFO] [ocp_release_ecr_mirror.py:_run_mirror:148] - Mirroring quay.io/openshift-release-dev/ocp-release:4.3.13-x86_64 to 950916221866.dkr.ecr.us-east-1.amazonaws.com/ocp-art-dev to_release 950916221866.dkr.ecr.us-east-1.amazonaws.com/ocp-release:4.3.13-x86_64
...
```

Depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/11512