### PR TITLE
[terraform-resources] reset db password #2

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -33,6 +33,7 @@ provider
   enhanced_monitoring
   replica_source
   output_resource_db_name
+  reset_password
 }
 ... on NamespaceTerraformResourceS3_v1 {
   account

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -621,12 +621,13 @@ class TerrascriptClient(object):
                 password = self.generate_random_password()
             else:
                 try:
+                    existing_secret = existing_secrets[account][output_prefix]
                     password = \
-                        existing_secrets[account][output_prefix]['db.password']
+                        existing_secret['db.password']
                 except KeyError:
                     password = \
                         self.determine_db_password(namespace_info,
-                                                output_resource_name)
+                                                   output_resource_name)
         else:
             password = ""
         values['password'] = password

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -605,8 +605,8 @@ class TerrascriptClient(object):
                 "${" + role_tf_resource.fullname + ".arn}"
 
         reset_password = False
+        reset_password_current_value = values.pop('reset_password', None)
         if self._db_needs_auth_(values):
-            reset_password_current_value = values.pop('reset_password', None)
             if reset_password_current_value:
                 try:
                     existing_secret = existing_secrets[account][output_prefix]


### PR DESCRIPTION
this PR adds an option to define `reset_password` on an rds provider, which will lead to the reset of the DB password.
this PR uses the terraform state.