### PR TITLE
[terraform-resources] fix dry-run + print-only password generation issue

### DIFF
--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -2117,7 +2117,6 @@ class TerrascriptClient(object):
             if print_only:
                 print('##### {} #####'.format(name))
                 print(ts.dump())
-                continue
             if existing_dirs is None:
                 wd = tempfile.mkdtemp()
             else:


### PR DESCRIPTION
fixes https://issues.redhat.com/browse/APPSRE-2717

this small `continue` call causes the working_dirs to not get updated. this will lead to empty working_dirs, which will lead to the inability to get the existing state from terraform. this causes a password generation for all DBs in the account (since the oc_map fallback is not available since we are running in dry-run).