### PR TITLE
[sql-query] add support for CronJob

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -944,6 +944,7 @@ APP_INTERFACE_SQL_QUERIES_QUERY = """
       db_password
     }
     output
+    schedule
     query
   }
 }

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -186,18 +186,24 @@ def collect_queries(query_name=None):
             )
             sys.exit(ExitCodes.ERROR)
 
-        queries_list.append(
-            # building up the final query dictionary
-            {
-                'name': name,
-                'namespace': namespace,
-                'identifier': sql_query['identifier'],
-                'db_conn': db_conn,
-                'output': output,
-                'query': sql_query['query'].replace("'", "''"),
-                **tf_resource_info,
-            }
-        )
+        # building up the final query dictionary
+        item = {
+            'name': name,
+            'namespace': namespace,
+            'identifier': sql_query['identifier'],
+            'db_conn': db_conn,
+            'output': output,
+            'query': sql_query['query'].replace("'", "''"),
+            **tf_resource_info,
+        }
+
+        # If schedule is defined
+        # this should be a CronJob
+        schedule = sql_query.get('schedule')
+        if schedule:
+            item['schedule'] = schedule
+
+        queries_list.append(item)
 
     return queries_list
 

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -75,6 +75,7 @@ metadata:
   name: {{ JOB_NAME }}
 spec:
   schedule: "{{ SCHEDULE }}"
+  concurrencyPolicy: "Forbid"
   jobTemplate:
     %s
 """ % (indent(JOB_SPEC, 4*' '))

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -286,7 +286,7 @@ def process_template(query):
     if schedule:
         template_to_render = CRONJOB_TEMPLATE
         render_kwargs['SCHEDULE'] = schedule
-        
+
     template = jinja2.Template(template_to_render)
     job_yaml = template.render(**render_kwargs)
     return job_yaml


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2715
depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/11665

this PR adds support for recurring sql queries. if a `schedule` field exists in the sql-query object, the resource will be a `CronJob` instead of a `Job` and will not be deleted.