### PR TITLE
[APPSRE-2609] Main loop: drop subprocess

### DIFF
--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -2,7 +2,6 @@
 
 import logging
 import os
-import subprocess
 import sys
 import time
 
@@ -11,6 +10,7 @@ from prometheus_client import Gauge
 from prometheus_client import Counter
 
 from reconcile.status import ExitCodes
+from reconcile.cli import integration
 
 
 SHARDS = int(os.environ.get('SHARDS', 1))
@@ -41,31 +41,14 @@ if LOG_FILE is not None:
 LOG.setLevel(logging.INFO)
 
 
-def run_cmd():
-    cmd = ['qontract-reconcile', '--config', '/config/config.toml']
-
+def build_args():
+    args = ['--config', 'config.toml']
     if DRY_RUN is not None:
-        cmd.append(DRY_RUN)
-
-    cmd.append(INTEGRATION_NAME)
-
+        args.append(DRY_RUN)
+    args.append(INTEGRATION_NAME)
     if INTEGRATION_EXTRA_ARGS is not None:
-        cmd.extend(INTEGRATION_EXTRA_ARGS.split())
-
-    process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                               stderr=subprocess.STDOUT)
-
-    # Draining the subprocess STDOUT to the logger as the
-    # subprocess is executed
-    while True:
-        output = process.stdout.readline().decode()
-        # Print all the lines while they are not empty
-        if output:
-            LOG.info(output.strip())
-            continue
-        # With an empty line, check if the process is still running
-        if process.poll() is not None:
-            return process.poll()
+        args.extend(INTEGRATION_EXTRA_ARGS.split())
+    return args
 
 
 if __name__ == "__main__":
@@ -82,7 +65,22 @@ if __name__ == "__main__":
 
     while True:
         start_time = time.monotonic()
-        return_code = run_cmd()
+        # Running the integration via Click, so we don't have to replicate
+        # the CLI logic here
+        try:
+            with integration.make_context(info_name='qontract-reconcile',
+                                          args=build_args()) as ctx:
+                integration.invoke(ctx)
+                return_code = 0
+        # This is for when the integration explicitly
+        # calls sys.exit(N)
+        except SystemExit as exc_obj:
+            return_code = exc_obj.code
+        # We have to be generic since we don't know what can happen
+        # in the integrations, but we want to continue the loop anyway
+        except Exception:
+            return_code = ExitCodes.ERROR
+
         time_spent = time.monotonic() - start_time
 
         run_time.labels(integration=INTEGRATION_NAME,


### PR DESCRIPTION
This patch will drop the subprocess call from the main loop (used to run
the integrations on kubernetes) in favor of a direct call to the Click
entrypoint.

With that, both the Main lopp and the integration execution will happen
in the same Python session, meaning we can more data from the
integration executiuon in the Main loop.

This sets the foundation for instrumenting the integrations to  report
the reconciliation time or any other executions attributes we want to
track.

Signed-off-by: Amador Pahim <apahim@redhat.com>