### PR TITLE
[ocm-clusters] add usage of dryRun

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `terraform-users`: Manage AWS users using Terraform.
 - `terraform-vpc-peerings`: Manage VPC peerings between OSDv4 clusters and AWS accounts.
 - `ocm-groups`: Manage membership in OpenShift groups using OpenShift Cluster Manager.
-- `ocm-clusters`: Manages (currently: validates only) clusters desired state with current state in OCM.
+- `ocm-clusters`: Manages clusters via OCM.
 - `ocm-aws-infrastructure-access`: Grants AWS infrastructure access to members in AWS groups via OCM.
 - `ocm-github-idp`: Manage GitHub Identity Providers in OCM.
 - `ocm-machine-pools`: Manage Machine Pools in OCM.

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -104,9 +104,8 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
             if cluster_name in pending_state:
                 continue
             logging.info(['create_cluster', cluster_name])
-            if not dry_run:
-                ocm = ocm_map.get(cluster_name)
-                ocm.create_cluster(cluster_name, desired_spec)
+            ocm = ocm_map.get(cluster_name)
+            ocm.create_cluster(cluster_name, desired_spec, dry_run)
 
     create_update_mr = False
     for cluster_name, cluster_updates in clusters_updates.items():

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -85,7 +85,7 @@ class OCM(object):
         }
         return ocm_spec
 
-    def create_cluster(self, name, cluster):
+    def create_cluster(self, name, cluster, dry_run):
         """
         Creates a cluster.
 
@@ -96,6 +96,8 @@ class OCM(object):
         :type cluster: dict
         """
         api = f'/api/clusters_mgmt/v1/clusters'
+        if dry_run:
+            api = api + '?dryRun=true'
         cluster_spec = cluster['spec']
         cluster_network = cluster['network']
         ocm_spec = {

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -98,8 +98,6 @@ class OCM(object):
         :type dry_run: bool
         """
         api = f'/api/clusters_mgmt/v1/clusters'
-        if dry_run:
-            api = api + '?dryRun=true'
         cluster_spec = cluster['spec']
         cluster_network = cluster['network']
         ocm_spec = {
@@ -142,7 +140,11 @@ class OCM(object):
             ocm_spec.setdefault('properties', {})
             ocm_spec['properties']['provision_shard_id'] = provision_shard_id
 
-        self._post(api, ocm_spec)
+        params = {}
+        if dry_run:
+            params['dryRun'] = 'true'
+
+        self._post(api, ocm_spec, params)
 
     def get_group_if_exists(self, cluster, group_id):
         """Returns a list of users in a group in a cluster.
@@ -494,8 +496,9 @@ class OCM(object):
 
     def create_kafka_cluster(self, data):
         """Creates (async) a Kafka cluster """
-        api = '/api/managed-services-api/v1/kafkas?async=true'
-        self._post(api, data)
+        api = '/api/managed-services-api/v1/kafkas'
+        params = {'async': 'true'}
+        self._post(api, data, params)
 
     def _init_addons(self):
         """Returns a list of Addons """
@@ -554,8 +557,13 @@ class OCM(object):
         r.raise_for_status()
         return r.json()
 
-    def _post(self, api, data=None):
-        r = requests.post(f"{self.url}{api}", headers=self.headers, json=data)
+    def _post(self, api, data=None, params=None):
+        r = requests.post(
+            f"{self.url}{api}",
+            headers=self.headers,
+            json=data,
+            params=params
+        )
         try:
             r.raise_for_status()
         except Exception as e:

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -569,6 +569,8 @@ class OCM(object):
         except Exception as e:
             logging.error(r.text)
             raise e
+        if r.status_code == requests.codes.no_content:
+            return None
         return r.json()
 
     def _patch(self, api, data):

--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -91,9 +91,11 @@ class OCM(object):
 
         :param name: name of the cluster
         :param cluster: a dictionary representing a cluster desired state
+        :param dry_run: do not execute for real
 
         :type name: string
         :type cluster: dict
+        :type dry_run: bool
         """
         api = f'/api/clusters_mgmt/v1/clusters'
         if dry_run:


### PR DESCRIPTION
following https://gitlab.cee.redhat.com/service/uhc-clusters-service/-/commit/ce4bd1ebfdb7af4221ad47c0430726bf0b25b24c

there is now support for quota and preflight checks in OCM. this PR adds usage of those in dry-run.