### PR TITLE
[slack_api] retry update_usergroup

### DIFF
--- a/utils/slack_api.py
+++ b/utils/slack_api.py
@@ -66,6 +66,7 @@ class SlackApi(object):
         [usergroup] = usergroup
         return usergroup
 
+    @retry()
     def update_usergroup(self, id, channels_list, description):
         channels = ','.join(channels_list)
         self.sc.api_call(


### PR DESCRIPTION
retry `update_usergroup` to reduce flakiness such as:
https://ci.int.devshift.net/job/qontract-reconcile-timed-slack-usergroups/29169/console