### PR TITLE
Adding "copy_all" to the skopeo copy call

### DIFF
--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -76,7 +76,8 @@ class QuayMirror:
                     self.skopeo_cli.copy(src_image=item['mirror_url'],
                                          src_creds=item['mirror_creds'],
                                          dst_image=item['image_url'],
-                                         dest_creds=self.push_creds[org])
+                                         dest_creds=self.push_creds[org],
+                                         copy_all=True)
                 except SkopeoCmdError as details:
                     _LOG.error('[%s]', details)
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     data_files=[('templates', glob('templates/*.j2'))],
 
     install_requires=[
-        "sretoolbox==0.8.1",
+        "sretoolbox==0.9.0",
         "Click>=7.0,<8.0",
         "graphqlclient>=0.2.4,<0.3.0",
         "toml>=0.10.0,<0.11.0",


### PR DESCRIPTION
This will make Skopeo copy all the architectures of a given image/tag
instead of only the architecture of the OS Skopeo is running on.

Depends on: https://github.com/app-sre/sretoolbox/pull/22