### PR TITLE
[VaultClient] add cache

### DIFF
--- a/utils/vault.py
+++ b/utils/vault.py
@@ -29,6 +29,12 @@ class VaultConnectionError(Exception):
 
 
 class _VaultClient:
+    """
+    A class representing a Vault client. Allows read/write operations.
+    The client caches read requests in-memory if the request is made
+    to a versioned KV engine (v2), since that includes both a path
+    and a version (no invalidation required).
+    """
     def __init__(self):
         config = get_config()
 

--- a/utils/vault.py
+++ b/utils/vault.py
@@ -105,18 +105,9 @@ class _VaultClient:
         return data
 
     def _read_all_v1(self, path):
-        cache_key = path
-        cache_value = self._cache.get(cache_key)
-        if cache_value is not None:
-            logging.debug('Vault v1 cache hit')
-            return cache_value
-
         secret = self._client.read(path)
         if secret is None or 'data' not in secret:
             raise SecretNotFound(path)
-
-        data = secret['data']
-        self._cache[cache_key] = data
         return secret['data']
 
     @retry()

--- a/utils/vault.py
+++ b/utils/vault.py
@@ -79,7 +79,7 @@ class _VaultClient:
     def _read_all_v2(self, path, version):
         cache_key = (path, version)
         cache_value = self._cache.get(cache_key)
-        if cache_value:
+        if cache_value is not None:
             logging.debug('Vault v2 cache hit')
             return cache_value
 
@@ -107,7 +107,7 @@ class _VaultClient:
     def _read_all_v1(self, path):
         cache_key = path
         cache_value = self._cache.get(cache_key)
-        if cache_value:
+        if cache_value is not None:
             logging.debug('Vault v1 cache hit')
             return cache_value
 

--- a/utils/vault.py
+++ b/utils/vault.py
@@ -2,6 +2,7 @@ import time
 import requests
 import hvac
 import base64
+import logging
 
 from hvac.exceptions import InvalidPath
 from requests.adapters import HTTPAdapter
@@ -44,6 +45,7 @@ class _VaultClient:
                               pool_maxsize=100)
         session.mount('https://', adapter)
         self._client = hvac.Client(url=server, session=session)
+        self._cache = {}
 
         authenticated = False
         for i in range(0, 3):
@@ -75,6 +77,12 @@ class _VaultClient:
         return data
 
     def _read_all_v2(self, path, version):
+        cache_key = (path, version)
+        cache_value = self._cache.get(cache_key)
+        if cache_value:
+            logging.debug('Vault v2 cache hit')
+            return cache_value
+
         path_split = path.split('/')
         mount_point = path_split[0]
         read_path = '/'.join(path_split[1:])
@@ -91,12 +99,24 @@ class _VaultClient:
         if secret is None or 'data' not in secret \
                 or 'data' not in secret['data']:
             raise SecretNotFound(path)
-        return secret['data']['data']
+
+        data = secret['data']['data']
+        self._cache[cache_key] = data
+        return data
 
     def _read_all_v1(self, path):
+        cache_key = path
+        cache_value = self._cache.get(cache_key)
+        if cache_value:
+            logging.debug('Vault v1 cache hit')
+            return cache_value
+
         secret = self._client.read(path)
         if secret is None or 'data' not in secret:
             raise SecretNotFound(path)
+
+        data = secret['data']
+        self._cache[cache_key] = data
         return secret['data']
 
     @retry()


### PR DESCRIPTION
This PR adds a cache to VaultClient, which will prevent getting the same data multiple times.

In openshift-resources alone, this saved ~1k of calls to Vault.