### PR TITLE
[service-dependencies] add kafka dependency

### DIFF
--- a/reconcile/service_dependencies.py
+++ b/reconcile/service_dependencies.py
@@ -94,6 +94,11 @@ def get_desired_dependency_names(app, dependency_map):
         if tf_namespaces:
             required_dep_names.update(
                 get_dependency_names(dependency_map, 'aws'))
+        kafka_namespaces = [n for n in namespaces
+                            if n.get('kafkaClusters')]
+        if kafka_namespaces:
+            required_dep_names.update(
+                get_dependency_names(dependency_map, 'kafka'))
 
     return required_dep_names
 

--- a/reconcile/service_dependencies.py
+++ b/reconcile/service_dependencies.py
@@ -32,6 +32,9 @@ APPS_QUERY = """
     }
     namespaces {
       managedTerraformResources
+      kafkaCluster {
+        name
+      }
     }
   }
 }
@@ -95,7 +98,7 @@ def get_desired_dependency_names(app, dependency_map):
             required_dep_names.update(
                 get_dependency_names(dependency_map, 'aws'))
         kafka_namespaces = [n for n in namespaces
-                            if n.get('kafkaClusters')]
+                            if n.get('kafkaCluster')]
         if kafka_namespaces:
             required_dep_names.update(
                 get_dependency_names(dependency_map, 'kafka'))


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2727
depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/12321

this will add a check that all apps that rely on kafka specify that in their dependencies.