### PR TITLE
[terraform-resources] add support for kinesis streams

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -145,6 +145,13 @@ provider
   }
   output_resource_name
 }
+... on NamespaceTerraformResourceKinesis_v1 {
+  account
+  region
+  identifier
+  defaults
+  output_resource_name
+}
 """
 
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2755
depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/12410

this PR adds terraform-resources support for kinesis streams based on:
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kinesis_stream

it also creates a new function `get_tf_iam_service_user` which can be reused by other populate functions.