### PR TITLE
[gitlab-housekeeping] handle error in merge

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -188,10 +188,13 @@ def merge_merge_requests(dry_run, gl, merge_limit, rebase, insist=False,
 
             logging.info(['merge', gl.project.name, mr.iid])
             if not dry_run and merges < merge_limit:
-                mr.merge()
-                if rebase:
-                    return
-                merges += 1
+                try:
+                    mr.merge()
+                    if rebase:
+                        return
+                    merges += 1
+                except gitlab.exceptions.GitlabMRClosedError as e:
+                    logging.error('unable to merge {}: {}'.format(mr.iid, e))
 
 
 def run(dry_run, wait_for_pipeline):


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2768

```
09:52:01 [2020-12-02 07:52:01] [INFO] [gitlab_housekeeping.py:merge_merge_requests:189] - ['merge', 'managed-services-api', 145]
09:52:01 Traceback (most recent call last):
09:52:02   File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/exceptions.py", line 259, in wrapped_f
09:52:02     return f(*args, **kwargs)
09:52:02   File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/v4/objects.py", line 2834, in merge
09:52:03     server_data = self.manager.gitlab.http_put(path, post_data=data, **kwargs)
09:52:03   File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/__init__.py", line 711, in http_put
09:52:03     **kwargs
09:52:04   File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/__init__.py", line 564, in http_request
09:52:04     response_body=result.content,
09:52:04 gitlab.exceptions.GitlabHttpError: 406: Branch cannot be merged
09:52:04 
09:52:05 During handling of the above exception, another exception occurred:
09:52:05 
09:52:05 Traceback (most recent call last):
09:52:06   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/gitlab_housekeeping.py", line 219, in run
09:52:06     wait_for_pipeline=wait_for_pipeline)
09:52:06   File "/usr/local/lib/python3.6/site-packages/sretoolbox-0.9.1-py3.6.egg/sretoolbox/utils/retry.py", line 28, in f_retry
09:52:06     raise exception
09:52:07   File "/usr/local/lib/python3.6/site-packages/sretoolbox-0.9.1-py3.6.egg/sretoolbox/utils/retry.py", line 23, in f_retry
09:52:07     return function(*args, **kwargs)
09:52:07   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/gitlab_housekeeping.py", line 191, in merge_merge_requests
09:52:07     mr.merge()
09:52:08   File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/cli.py", line 43, in wrapped_f
09:52:08     return f(*args, **kwargs)
09:52:08   File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/exceptions.py", line 261, in wrapped_f
09:52:09     raise error(e.error_message, e.response_code, e.response_body)
09:52:09 gitlab.exceptions.GitlabMRClosedError: 406: Branch cannot be merged
09:52:09 
09:52:09 During handling of the above exception, another exception occurred:
09:52:10 
09:52:10 Traceback (most recent call last):
09:52:10   File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/exceptions.py", line 259, in wrapped_f
09:52:10     return f(*args, **kwargs)
09:52:10   File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/v4/objects.py", line 2834, in merge
09:52:11     server_data = self.manager.gitlab.http_put(path, post_data=data, **kwargs)
09:52:11   File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/__init__.py", line 711, in http_put
09:52:11     **kwargs
09:52:11   File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/__init__.py", line 564, in http_request
09:52:12     response_body=result.content,
09:52:12 gitlab.exceptions.GitlabHttpError: 406: Branch cannot be merged
09:52:12 
09:52:12 During handling of the above exception, another exception occurred:
09:52:13 
09:52:13 Traceback (most recent call last):
09:52:13   File "/usr/local/bin/qontract-reconcile", line 33, in <module>
09:52:13     sys.exit(load_entry_point('reconcile==0.2.2', 'console_scripts', 'qontract-reconcile')())
09:52:14   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 829, in __call__
09:52:14     return self.main(*args, **kwargs)
09:52:14   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 782, in main
09:52:14     rv = self.invoke(ctx)
09:52:14   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1259, in invoke
09:52:15     return _process_result(sub_ctx.command.invoke(sub_ctx))
09:52:15   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1066, in invoke
09:52:15     return ctx.invoke(self.callback, **ctx.params)
09:52:15   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 610, in invoke
09:52:16     return callback(*args, **kwargs)
09:52:16   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/decorators.py", line 21, in new_func
09:52:16     return f(get_current_context(), *args, **kwargs)
09:52:16   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 596, in gitlab_housekeeping
09:52:16     wait_for_pipeline)
09:52:17   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 336, in run_integration
09:52:17     func_container.run(dry_run, *args, **kwargs)
09:52:17   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/gitlab_housekeeping.py", line 222, in run
09:52:17     wait_for_pipeline=wait_for_pipeline)
09:52:18   File "/usr/local/lib/python3.6/site-packages/sretoolbox-0.9.1-py3.6.egg/sretoolbox/utils/retry.py", line 28, in f_retry
09:52:18     raise exception
09:52:18   File "/usr/local/lib/python3.6/site-packages/sretoolbox-0.9.1-py3.6.egg/sretoolbox/utils/retry.py", line 23, in f_retry
09:52:18     return function(*args, **kwargs)
09:52:19   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/gitlab_housekeeping.py", line 191, in merge_merge_requests
09:52:19     mr.merge()
09:52:19   File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/cli.py", line 43, in wrapped_f
09:52:19     return f(*args, **kwargs)
09:52:19   File "/usr/local/lib/python3.6/site-packages/python_gitlab-1.11.0-py3.6.egg/gitlab/exceptions.py", line 261, in wrapped_f
09:52:20     raise error(e.error_message, e.response_code, e.response_body)
09:52:20 gitlab.exceptions.GitlabMRClosedError: 406: Branch cannot be merged
```