### PR TITLE
[APPSRE-2772] Fix logging configuration

### DIFF
--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -31,15 +31,15 @@ LOG = logging.getLogger(__name__)
 # Messages to stdout
 STREAM_HANDLER = logging.StreamHandler(sys.stdout)
 STREAM_HANDLER.setFormatter(logging.Formatter(fmt='%(message)s'))
-LOG.addHandler(STREAM_HANDLER)
 
 # Messages to the log file
 if LOG_FILE is not None:
     FILE_HANDLER = logging.FileHandler(LOG_FILE)
     FILE_HANDLER.setFormatter(logging.Formatter(fmt='%(message)s'))
-    LOG.addHandler(FILE_HANDLER)
 
-LOG.setLevel(logging.INFO)
+# Setting up the root logger
+logging.basicConfig(level=logging.INFO,
+                    handlers=(STREAM_HANDLER, FILE_HANDLER))
 
 
 def build_args():


### PR DESCRIPTION
Before, when we were using subprocess, we would collect the subprocess
messages to STDOUT and log them using this module's logger.

Now, running integrations in the same session, the strategy is
different: we setup the root logger handlers and they will tackle
any messages generated.

Signed-off-by: Amador Pahim <apahim@redhat.com>