### PR TITLE
oc int bug fix for openshift-saas-deploy-wrapper integration

### DIFF
--- a/utils/oc.py
+++ b/utils/oc.py
@@ -73,7 +73,8 @@ class OC(object):
 
         self.oc_base_cmd = oc_base_cmd
         # calling get_version to check if cluster is reachable
-        self.get_version()
+        if server != 'server':
+            self.get_version()
         self.init_projects = init_projects
         if self.init_projects:
             self.projects = [p['metadata']['name']


### PR DESCRIPTION
We were failing with the error below when running the openshift-saas-deploy-wrapper integration.
`utils.oc.StatusCodeError: [server]: Unable to connect to the server: dial tcp: lookup server on 10.5.30.160:53: no such host`


