### PR TITLE
allow OC init to skip version

### DIFF
--- a/utils/oc.py
+++ b/utils/oc.py
@@ -58,7 +58,8 @@ class JobNotRunningError(Exception):
 
 class OC(object):
     def __init__(self, server, token, jh=None, settings=None,
-                 init_projects=False, init_api_resources=False):
+                 init_projects=False, init_api_resources=False,
+                 local=False):
         self.server = server
         oc_base_cmd = [
             'oc',
@@ -73,7 +74,8 @@ class OC(object):
 
         self.oc_base_cmd = oc_base_cmd
         # calling get_version to check if cluster is reachable
-        self.get_version()
+        if not local:
+            self.get_version()
         self.init_projects = init_projects
         if self.init_projects:
             self.projects = [p['metadata']['name']

--- a/utils/saasherder.py
+++ b/utils/saasherder.py
@@ -325,7 +325,7 @@ class SaasHerder():
                                 get_commit_sha_options)
                             consolidated_parameters['IMAGE_TAG'] = image_tag
 
-            oc = OC('server', 'token')
+            oc = OC('server', 'token', local=True)
             try:
                 resources = oc.process(template, consolidated_parameters)
             except StatusCodeError as e:


### PR DESCRIPTION
fixes #1214 

since we use OC in saasherder process_template to do `oc process`, we are initializing a "local" oc client (without an actual server). this PR will skip `get_version` if OC is initialized with `local=True`.