### PR TITLE
[oc] create group if not exists

### DIFF
--- a/utils/oc.py
+++ b/utils/oc.py
@@ -209,6 +209,8 @@ class OC(object):
                 raise e
 
     def create_group(self, group):
+        if self.get_group_if_exists(group) is not None:
+            return
         cmd = ['adm', 'groups', 'new', group]
         self._run(cmd)
 


### PR DESCRIPTION
the openshift-groups integration thinks that an empty group does not exist.
instead of diving into it, adding a check if the group exists before creating it (which is good practice in any case).