### PR TITLE
adds next run to qontract-cli get cluster-upgrades

### DIFF
--- a/utils/ocm.py
+++ b/utils/ocm.py
@@ -496,7 +496,7 @@ class OCM(object):
         for item in items:
             if schedule_type and item['schedule_type'] != schedule_type:
                 continue
-            desired_keys = ['id', 'schedule_type', 'schedule']
+            desired_keys = ['id', 'schedule_type', 'schedule', 'next_run']
             result = {k: v for k, v in item.items() if k in desired_keys}
             results.append(result)
 


### PR DESCRIPTION
Example output:

```
NAME               UPGRADE    UPGRADEPOLICY    SCHEDULE    NEXT_RUN
-----------------  ---------  ---------------  ----------  --------------------
REDACTED           batch0     automatic        0 7 * * *   2020-12-12T07:00:00Z
REDACTED           batch0     automatic        0 10 * * *  2020-12-12T10:00:00Z
REDACTED           batch0     automatic        0 8 * * *   2020-12-12T08:00:00Z
REDACTED           batch1     manual
REDACTED           batch1     manual
REDACTED           batch1     manual
REDACTED           batch1     manual
REDACTED           batch1     automatic        0 11 * * *  2020-12-12T11:00:00Z
REDACTED           batch1     manual
REDACTED           batch1     automatic        0 13 * * *  2020-12-12T13:00:00Z
REDACTED           batch1     manual
REDACTED           batch1     manual
REDACTED           batch2     manual
REDACTED           batch2     manual
REDACTED           batch2     manual
REDACTED           batch2     manual
REDACTED           batch2     manual
REDACTED           batch2     manual
REDACTED           batch2     manual
REDACTED           batch2     manual
REDACTED           batch2     manual
REDACTED           batch2     automatic        0 14 * * *  2020-12-12T14:00:00Z
```