### PR TITLE
Dockerfile temp updated to fix skopeo install

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -35,7 +35,10 @@ ENV JSONNET_VENDOR_DIR=/opt/jsonnet-bundler/vendor
 
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_8/devel:kubic:libcontainers:stable.repo && \
-    dnf install -y skopeo && \
+    # temp fix for mirror issues for container-commons and skopeo
+    # the original line: dnf install -y skopeo && \
+    dnf install -y https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_8/x86_64/containers-common-1.2.0-12.el8.x86_64.rpm && \
+    dnf install -y https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_8/x86_64/skopeo-1.2.0-12.el8.x86_64.rpm && \
     dnf install -y python3 python3-pip python3-devel git unzip gcc gcc-c++ openssh-clients openssl glibc-langpack-en && \
     python3 -m pip install --upgrade pip setuptools && \
     dnf clean all


### PR DESCRIPTION
Installing skopeo has some mirror issues:
```
11:18:03 Downloading Packages:
11:18:04 [MIRROR] skopeo-1.2.0-12.el8.x86_64.rpm: Interrupted by header callback: Server reports Content-Length: 12764780 but expected size is: 12746092
11:18:04 [MIRROR] containers-common-1.2.0-12.el8.x86_64.rpm: Interrupted by header callback: Server reports Content-Length: 93400 but expected size is: 93392
11:18:05 [MIRROR] skopeo-1.2.0-12.el8.x86_64.rpm: Interrupted by header callback: Server reports Content-Length: 12764780 but expected size is: 12746092
11:18:05 [MIRROR] containers-common-1.2.0-12.el8.x86_64.rpm: Interrupted by header callback: Server reports Content-Length: 93400 but expected size is: 93392
11:18:05 [FAILED] containers-common-1.2.0-12.el8.x86_64.rpm: No more mirrors to try - All mirrors were already tried without success
```

This temp change should fix it while we look for a more comprehensive fix