### PR TITLE
[gitlab-owners] handle empty or malformed approvers/reviewers

### DIFF
--- a/utils/repo_owners.py
+++ b/utils/repo_owners.py
@@ -138,7 +138,7 @@ class RepoOwners:
                 # Non-parsable OWNERS file
                 continue
 
-            approvers = owners.get('approvers', set())
+            approvers = owners.get('approvers') or set()
 
             # Approver might be an alias. Let's resolve them.
             resolved_approvers = set()
@@ -148,7 +148,7 @@ class RepoOwners:
                 else:
                     resolved_approvers.add(approver)
 
-            reviewers = owners.get('reviewers', set())
+            reviewers = owners.get('reviewers') or set()
 
             # Reviewer might be an alias. Let's resolve them.
             resolved_reviewers = set()


### PR DESCRIPTION
handle cases such as https://gitlab.cee.redhat.com/service/managed-services-api/-/blob/1bfbc4ebee12b7834c5074bd1d8d9a1d9378a36a/OWNERS#L16

```
approvers:
- a
- b
reviewers:
```

manifests in: https://ci.int.devshift.net/job/qontract-reconcile-timed-gitlab-owners/4068/console