### PR TITLE
[jjb] retry lock cache

### DIFF
--- a/utils/jjb_client.py
+++ b/utils/jjb_client.py
@@ -17,6 +17,8 @@ from contextlib import contextmanager
 from jenkins_jobs.builder import JenkinsManager
 from jenkins_jobs.parser import YamlParser
 from jenkins_jobs.registry import ModuleRegistry
+from jenkins_jobs.errors import JenkinsJobsException
+from sretoolbox.utils import retry
 
 from reconcile.exceptions import FetchResourceError
 
@@ -243,6 +245,7 @@ class JJB(object):
         for wd in self.working_dirs.values():
             shutil.rmtree(wd)
 
+    @retry(exceptions=(JenkinsJobsException))
     def get_jobs(self, wd, name):
         ini_path = '{}/{}.ini'.format(wd, name)
         config_path = '{}/config.yaml'.format(wd)


### PR DESCRIPTION
this PR will retry failures we have been seeing recently:
```
Traceback (most recent call last):
  File "/usr/local/bin/qontract-reconcile", line 33, in <module>
    sys.exit(load_entry_point('reconcile==0.2.2', 'console_scripts', 'qontract-reconcile')())
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 533, in jenkins_webhooks
    run_integration(reconcile.jenkins_webhooks, ctx.obj)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 341, in run_integration
    func_container.run(dry_run, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/jenkins_webhooks.py", line 43, in run
    desired_state = jjb.get_job_webhooks_data()
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/utils/jjb_client.py", line 263, in get_job_webhooks_data
    jobs = self.get_jobs(wd, name)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/utils/jjb_client.py", line 252, in get_jobs
    builder = JenkinsManager(jjb.jjb_config)
  File "/usr/local/lib/python3.6/site-packages/jenkins_job_builder-2.10.1-py3.6.egg/jenkins_jobs/builder.py", line 60, in __init__
    flush=jjb_config.builder['flush_cache'])
  File "/usr/local/lib/python3.6/site-packages/jenkins_job_builder-2.10.1-py3.6.egg/jenkins_jobs/cache.py", line 54, in __init__
    "Unable to lock cache for '%s'" % jenkins_url)
jenkins_jobs.errors.JenkinsJobsException: Unable to lock cache for 'https://ci.int.devshift.net'
```

example: https://ci.int.devshift.net/job/service-app-interface-gl-pr-check/28472/app-interface_20JSON_20validation/