### PR TITLE
[APPSRE-2765] gitlab-owners approval comment improvements

### DIFF
--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -142,6 +142,13 @@ class MRApproval:
             # creation time
             comment_created_at = dateparser.parse(comment['created_at'])
             if comment_created_at < self.top_commit_created_at:
+                if body.startswith('[OWNERS]'):
+                    if not self.dry_run:
+                        _LOG.info([f'Project:{self.gitlab.project.id} '
+                                   f'Merge Request:{self.mr.iid} '
+                                   f'- removing stale comment'])
+                        self.gitlab.delete_gitlab_comment(self.mr.iid,
+                                                          comment['id'])
                 continue
 
             # If we find a comment equals to the report,

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -292,7 +292,8 @@ class GitLabApi(object):
             created_at = note.created_at
             comments.append({'username': username,
                              'body': body,
-                             'created_at': created_at})
+                             'created_at': created_at,
+                             'id': note.id})
         return comments
 
     def add_merge_request_comment(self, mr_id, comment):

--- a/utils/gitlab_api.py
+++ b/utils/gitlab_api.py
@@ -296,6 +296,11 @@ class GitLabApi(object):
                              'id': note.id})
         return comments
 
+    def delete_gitlab_comment(self, mr_id, comment_id):
+        merge_request = self.project.mergerequests.get(mr_id)
+        note = merge_request.notes.get(comment_id)
+        note.delete()
+
     def add_merge_request_comment(self, mr_id, comment):
         merge_request = self.project.mergerequests.get(mr_id)
         merge_request.notes.create({'body': comment})


### PR DESCRIPTION
This Pull Requests introduces two main changes:

- Stale approval comments, created before the last update, are removed.
- Comments are now less verbose and in Markdown (instead of JSON). Example:

Then
```
{
    "README.md": {
        "approvers": [
            "asegundo",
            "jeder",
            "jmelisba",
            "kasingh"
        ],
        "reviewers": [
            "amoran",
            "asegundo",
            "jeder",
            "jmelisba",
            "kasingh",
            "mafriedm"
        ]
    },
    "docs/addons_has_external_resources.md": {
        "approvers": [
            "asegundo",
            "jeder",
            "jmelisba",
            "kasingh"
        ],
        "reviewers": [
            "amoran",
            "asegundo",
            "jeder",
            "jmelisba",
            "kasingh",
            "mafriedm"
        ]
    },
    "addons/managed-api-service/metadata/stage/sku-limits.yaml.j2": {
        "approvers": [
            "cbrookes",
            "dffrench",
            "gryan",
            "jcoleman",
            "pamccart",
            "pbrookes",
            "ppaszki",
            "sfrancog",
            "trepel",
            "weil"
        ],
        "reviewers": [
            "cbrookes",
            "dffrench",
            "gryan",
            "jcoleman",
            "pamccart",
            "pbrookes",
            "ppaszki",
            "sfrancog",
            "trepel",
            "weil"
        ]
    }
}
```

Now:

```
[OWNERS] You will need a "/lgtm" from one person from each of these groups:

* asegundo, jeder, jmelisba, kasingh
* cbrookes, dffrench, gryan, jcoleman, pamccart, pbrookes, ppaszki, sfrancog, trepel, weil

Additional relevant reviewers are: amoran, mafriedm
```

In action:

https://gitlab.cee.redhat.com/service/managed-tenants/-/merge_requests/469

Pro-tip: review this PR per-commit basis ;)