### PR TITLE
fix quay-mirror lack of credentials for downstream repo

### DIFF
--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -140,7 +140,9 @@ class QuayMirror:
         sync_tasks = defaultdict(list)
         for org, data in summary.items():
             for item in data:
-                image = Image(f'{item["server_url"]}/{org}/{item["name"]}')
+                push_creds = self.push_creds[org].split(':')
+                image = Image(f'{item["server_url"]}/{org}/{item["name"]}',
+                              username=push_creds[0], password=push_creds[1])
 
                 mirror_url = item['mirror']['url']
 


### PR DESCRIPTION
quay-mirror can not get downstream repo's tag and keeping copying.

Signed-off-by: Feng Huang <fehuang@redhat.com>