### PR TITLE
fix base64 secret keep reconcile when contains newline

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -296,6 +296,7 @@ def fetch_provider_vault_secret(
             continue
         if k.lower().endswith(QONTRACT_BASE64_SUFFIX):
             k = k[:-len(QONTRACT_BASE64_SUFFIX)]
+            v = v.replace('\n', '')
         elif v is not None:
             v = base64.b64encode(v.encode()).decode('utf-8')
         body['data'][k] = v


### PR DESCRIPTION
e.g. https://vault.devshift.net/ui/vault/secrets/insights/show/secrets/insights-stage/platform-docs-stage/service-credentials

Signed-off-by: Feng Huang <fehuang@redhat.com>