### PR TITLE
Add prometheus-rules-validator integration

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -32,6 +32,7 @@ ENV OC_VERSION=4.6.1
 ENV TF_VERSION=0.11.14
 ENV GIT_SECRETS_VERSION=1.3.0
 ENV JSONNET_VENDOR_DIR=/opt/jsonnet-bundler/vendor
+ENV PROMETHEUS_VERSION=2.23.0
 
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_8/devel:kubic:libcontainers:stable.repo && \
@@ -54,6 +55,8 @@ RUN curl https://github.com/awslabs/git-secrets/archive/${GIT_SECRETS_VERSION}.t
     tar -zvxf git-secrets.tar.gz git-secrets-${GIT_SECRETS_VERSION}/git-secrets && \
     mv git-secrets-${GIT_SECRETS_VERSION}/git-secrets /usr/local/bin/git-secrets && \
     rm -rf git-secrets*
+
+RUN curl -sfL https://github.com/prometheus/prometheus/releases/download/v${PROMETHEUS_VERSION}/prometheus-${PROMETHEUS_VERSION}.linux-amd64.tar.gz | tar -zxf - -C /usr/local/bin --strip-components=1 prometheus-${PROMETHEUS_VERSION}.linux-amd64/promtool
 
 COPY --from=jsonnet-builder /jsonnet/jsonnet /usr/local/bin/jsonnet
 COPY --from=jsonnet-builder /jsonnet-bundler/vendor ${JSONNET_VENDOR_DIR}

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -89,6 +89,7 @@ import reconcile.integrations_validator
 import reconcile.dashdotdb_cso
 import reconcile.ocp_release_ecr_mirror
 import reconcile.kafka_clusters
+import reconcile.prometheus_rules_validator
 
 from reconcile.status import ExitCodes
 from reconcile.status import RunningState
@@ -1135,3 +1136,13 @@ def kafka_clusters(ctx, thread_pool_size, internal, use_jump_host):
 def integrations_validator(ctx):
     run_integration(reconcile.integrations_validator, ctx.obj,
                     reconcile.cli.integration.commands.keys())
+
+
+@integration.command()
+@threaded()
+@binary(['promtool'])
+@cluster_name
+@click.pass_context
+def prometheus_rules_validator(ctx, thread_pool_size, cluster_name):
+    run_integration(reconcile.prometheus_rules_validator, ctx.obj,
+                    thread_pool_size, cluster_name)

--- a/reconcile/prometheus_rules_validator.py
+++ b/reconcile/prometheus_rules_validator.py
@@ -34,6 +34,10 @@ def run(dry_run, thread_pool_size=10, cluster_name=None):
             continue
 
         openshift_resources = n.get('openshiftResources')
+        if not openshift_resources:
+            logging.warning("No openshiftResources defined for namespace"
+                            f"{n['name']} in cluster {n['cluster']['name']}")
+            continue
 
         for r in openshift_resources:
             if r['path'] not in rules_paths:

--- a/reconcile/prometheus_rules_validator.py
+++ b/reconcile/prometheus_rules_validator.py
@@ -1,0 +1,54 @@
+import sys
+import semver
+import logging
+
+import utils.gql as gql
+import utils.threaded as threaded
+import utils.promtool as promtool
+import reconcile.openshift_resources_base as orb
+import reconcile.queries as queries
+
+QONTRACT_INTEGRATION = 'prometheus_rules_validator'
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
+
+
+def check_rule(rule):
+    try:
+        promtool.check_rule(rule['spec'])
+    except Exception as e:
+        return {'path': rule['path'], 'message': str(e).replace('\n', '')}
+
+
+def run(dry_run, thread_pool_size=10, cluster_name=None):
+    orb.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION
+    orb.QONTRACT_INTEGRATION_VERSION = QONTRACT_INTEGRATION_VERSION
+
+    gqlapi = gql.get_api()
+    rules_paths = queries.get_prometheus_rules_paths()
+
+    rules = []
+    for n in gqlapi.query(orb.NAMESPACES_QUERY)['namespaces']:
+        if n['name'] != 'openshift-customer-monitoring':
+            continue
+
+        if cluster_name and n['cluster']['name'] != cluster_name:
+            continue
+
+        openshift_resources = n.get('openshiftResources')
+
+        for r in openshift_resources:
+            if r['path'] not in rules_paths:
+                continue
+
+            openshift_resource = orb.fetch_openshift_resource(r, n)
+            rules.append({'path': r['path'],
+                          'spec': openshift_resource.body['spec']})
+
+    failed = [f for f in threaded.run(check_rule, rules, thread_pool_size)
+              if f]
+
+    if failed:
+        for f in failed:
+            logging.warning(f"Error in rule {f['path']}: {f['message']}")
+
+        sys.exit(1)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1529,3 +1529,21 @@ OCP_RELEASE_ECR_MIRROR_QUERY = """
 def get_ocp_release_ecr_mirror():
     gqlapi = gql.get_api()
     return gqlapi.query(OCP_RELEASE_ECR_MIRROR_QUERY)['ocp_release_ecr_mirror']
+
+
+PROMETHEUS_RULES_PATHS_QUERY = """
+{
+  resources: resources_v1(schema: "/openshift/prometheus-rule-1.yml") {
+    path
+  }
+}
+"""
+
+
+def get_prometheus_rules_paths():
+    gqlapi = gql.get_api()
+    paths = set()
+    for r in gqlapi.query(PROMETHEUS_RULES_PATHS_QUERY)['resources']:
+        paths.add(r['path'])
+
+    return paths

--- a/utils/promtool.py
+++ b/utils/promtool.py
@@ -3,8 +3,16 @@ import tempfile
 from subprocess import run, PIPE
 
 
-class PromtoolError(Exception):
-    pass
+class PromtoolResult(object):
+    def __init__(self, is_ok, message):
+        self.is_ok = is_ok
+        self.message = message
+
+    def __str__(self):
+        return str(self.message).replace('\n', '')
+
+    def __bool__(self):
+        return self.is_ok
 
 
 def check_rule(yaml_spec):
@@ -15,13 +23,13 @@ def check_rule(yaml_spec):
             cmd = ['promtool', 'check', 'rules', fp.name]
             status = run(cmd, stdout=PIPE, stderr=PIPE)
     except Exception as e:
-        raise PromtoolError(f'Error building promtool file: {e}')
+        return PromtoolResult(False, f'Error building promtool file: {e}')
 
     if status.returncode != 0:
         message = 'Error running promtool'
         if status.stderr:
             message += ": " + status.stderr.decode()
 
-        raise PromtoolError(message)
+        return PromtoolResult(False, message)
 
-    return status.stdout
+    return PromtoolResult(True, status.stdout.decode())

--- a/utils/promtool.py
+++ b/utils/promtool.py
@@ -11,7 +11,7 @@ def check_rule(yaml_spec):
     try:
         with tempfile.NamedTemporaryFile() as fp:
             fp.write(yaml.dump(yaml_spec).encode())
-            fp.seek(0)
+            fp.flush()
             cmd = ['promtool', 'check', 'rules', fp.name]
             status = run(cmd, stdout=PIPE, stderr=PIPE)
     except Exception as e:

--- a/utils/promtool.py
+++ b/utils/promtool.py
@@ -1,0 +1,27 @@
+import yaml
+import tempfile
+from subprocess import run, PIPE
+
+
+class PromtoolError(Exception):
+    pass
+
+
+def check_rule(yaml_spec):
+    try:
+        with tempfile.NamedTemporaryFile() as fp:
+            fp.write(yaml.dump(yaml_spec).encode())
+            fp.seek(0)
+            cmd = ['promtool', 'check', 'rules', fp.name]
+            status = run(cmd, stdout=PIPE, stderr=PIPE)
+    except Exception as e:
+        raise PromtoolError(f'Error building promtool file: {e}')
+
+    if status.returncode != 0:
+        message = 'Error running promtool'
+        if status.stderr:
+            message += ": " + status.stderr.decode()
+
+        raise PromtoolError(message)
+
+    return status.stdout


### PR DESCRIPTION
Part of https://issues.redhat.com/browse/APPSRE-1146

It is debatable that this is actually an integration, as it will only
run on pr-check. But the code made sense here, as all the utils are here
and I would have needed to copy too much code elsewhere.

The complication here has been to be able to query qontract-server for
PrometheusRules. This has been done to just resolve the templates we
needed, reducing the run time (in my laptop) from 1m20 to 10s. Since
this is an integration that will run with every namespace change (see
app-interface related PR) and we're committed to reduce the PR check
time, this is important.

Related PRs:

* App-interface schema
  * https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/13366

* Add schema to resource in app-interface bundle
  * https://github.com/app-sre/qontract-validator/pull/25
  * https://github.com/app-sre/qontract-validator/pull/29

* Support schema in resources in qontract-server
  * https://github.com/app-sre/qontract-server/pull/100

* Avoid checking schema in resource graphql queries:
  * https://github.com/app-sre/qontract-reconcile/pull/1260

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>