### PR TITLE
[wip] read github config in terraform only if needed

### DIFF
--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -110,7 +110,6 @@ class TerrascriptClient(object):
         self.uids = {a['name']: a['uid'] for a in filtered_accounts}
         self.default_regions = {a['name']: a['resourcesDefaultRegion']
                                 for a in filtered_accounts}
-        github_config = get_config()['github']
         self.logtoes_zip = ''
 
     def get_logtoes_zip(self, release_url):

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -111,7 +111,6 @@ class TerrascriptClient(object):
         self.default_regions = {a['name']: a['resourcesDefaultRegion']
                                 for a in filtered_accounts}
         github_config = get_config()['github']
-        self.token = github_config['app-sre']['token']
         self.logtoes_zip = ''
 
     def get_logtoes_zip(self, release_url):
@@ -123,7 +122,8 @@ class TerrascriptClient(object):
             return self.download_logtoes_zip(release_url)
 
     def download_logtoes_zip(self, release_url):
-        headers = {'Authorization': 'token ' + self.token}
+        token = get_config()['github']['app-sre']['token']
+        headers = {'Authorization': 'token ' + token}
         r = requests.get(GH_BASE_URL + '/' + release_url, headers=headers)
         r.raise_for_status()
         data = r.json()


### PR DESCRIPTION
required to be able to run https://github.com/app-sre/app-interface/pull/5

this should be solved better (there are multiple places where we assume the existence of the `app-sre` github org).