### PR TITLE
[terraform] add 0.13 compliant outputs

### DIFF
--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -265,11 +265,10 @@ class TerraformClient(object):
             # of the integration.
             if '[' not in k or ']' not in k:
                 continue
-            # this currently has no effect
-            # it will replace the above condition when we
+            # this will replace the above condition when we
             # upgrade to terraform 0.13
-            if '__' not in k:
-                continue
+            # if '__' not in k:
+            #     continue
 
             # if the output is of the form 'qrtf.enc-passwords[user_name]'
             # this is a user output and should not be formed to a Secret

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -256,13 +256,19 @@ class TerraformClient(object):
             self.integration_prefix, self.OUTPUT_TYPE_CONSOLEURLS)
         for k, v in output.items():
             # the integration creates outputs of the form
-            # output_secret_name[secret_key] = secret_value
+            # 0.11: output_secret_name[secret_key] = secret_value
+            # 0.13: output_secret_name__secret_key = secret_value
             # in case of manual debugging, additional outputs
             # may be added, and may (should) not conform to this
             # naming convention. as outputs are persisted to remote
             # state, we would not want them to affect any runs
             # of the integration.
             if '[' not in k or ']' not in k:
+                continue
+            # this currently has no effect
+            # it will replace the above condition when we
+            # upgrade to terraform 0.13
+            if '__' not in k:
                 continue
 
             # if the output is of the form 'qrtf.enc-passwords[user_name]'
@@ -289,6 +295,16 @@ class TerraformClient(object):
             k_split = k.split('[')
             resource_name = k_split[0]
             field_key = k_split[1][:-1]
+            # the following section will replace
+            # the above section with terraform 0.13
+            # k_split = k.split('__')
+            # resource_name = k_split[0]
+            # field_key = k_split[1]
+            # if field_key.startswith('db'):
+            #     # since we can't use '.' in output keys
+            #     # and we want to maintain compatability
+            #     # replace '_' with '.' when this is a db secret
+            #     field_key = field_key.replace('_', '.')
             field_value = v['value']
             if resource_name not in data:
                 data[resource_name] = {}

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -229,7 +229,7 @@ class TerrascriptClient(object):
                 output_name = '{}.console-urls[{}]'.format(
                     self.integration_prefix, account_name
                 )
-                output_name_0_13 = '{}.console-urls__{}'.format(
+                output_name_0_13 = '{}_console-urls__{}'.format(
                     self.integration_prefix, account_name
                 )
                 output_value = account_console_url
@@ -297,7 +297,7 @@ class TerrascriptClient(object):
                     # 'qrtf.enc-passwords[user_name] = <encrypted password>
                     output_name = '{}.enc-passwords[{}]'.format(
                         self.integration_prefix, user_name)
-                    output_name_0_13 = '{}.enc-passwords__{}'.format(
+                    output_name_0_13 = '{}_enc-passwords__{}'.format(
                         self.integration_prefix, user_name)
                     output_value = '${' + tf_iam_user_login_profile.fullname \
                         + '.encrypted_password}'
@@ -1237,7 +1237,7 @@ class TerrascriptClient(object):
         # with the following fields
         # db.endpoint
         output_name = output_prefix + '[db.endpoint]'
-        output_name_0_13 = output_prefix + '__db.endpoint'
+        output_name_0_13 = output_prefix + '__db_endpoint'
         output_value = '${' + tf_resource.fullname + \
                        '.primary_endpoint_address}'
         tf_resources.append(output(output_name, value=output_value))
@@ -1709,7 +1709,7 @@ class TerrascriptClient(object):
         output_name = output_prefix + \
             '[cloud_front_origin_access_identity_id]'
         output_name_0_13 = output_prefix + \
-            '[cloud_front_origin_access_identity_id]'
+            '__cloud_front_origin_access_identity_id'
         output_value = '${' + cf_oai_tf_resource.fullname + \
             '.id}'
         tf_resources.append(output(output_name, value=output_value))

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -229,8 +229,13 @@ class TerrascriptClient(object):
                 output_name = '{}.console-urls[{}]'.format(
                     self.integration_prefix, account_name
                 )
+                output_name_0_13 = '{}.console-urls__{}'.format(
+                    self.integration_prefix, account_name
+                )
                 output_value = account_console_url
                 tf_output = output(output_name, value=output_value)
+                self.add_resource(account_name, tf_output)
+                tf_output = output(output_name_0_13, value=output_value)
                 self.add_resource(account_name, tf_output)
 
                 for iu in range(len(users)):
@@ -292,9 +297,13 @@ class TerrascriptClient(object):
                     # 'qrtf.enc-passwords[user_name] = <encrypted password>
                     output_name = '{}.enc-passwords[{}]'.format(
                         self.integration_prefix, user_name)
+                    output_name_0_13 = '{}.enc-passwords__{}'.format(
+                        self.integration_prefix, user_name)
                     output_value = '${' + tf_iam_user_login_profile.fullname \
                         + '.encrypted_password}'
                     tf_output = output(output_name, value=output_value)
+                    self.add_resource(account_name, tf_output)
+                    tf_output = output(output_name_0_13, value=output_value)
                     self.add_resource(account_name, tf_output)
 
             user_policies = role['user_policies'] or []
@@ -722,26 +731,36 @@ class TerrascriptClient(object):
         # with the following fields
         # db.host
         output_name = output_prefix + '[db.host]'
+        output_name_0_13 = output_prefix + '__db_host'
         output_value = '${' + tf_resource.fullname + '.address}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
         # db.port
         output_name = output_prefix + '[db.port]'
+        output_name_0_13 = output_prefix + '__db_port'
         output_value = '${' + tf_resource.fullname + '.port}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
         # db.name
         output_name = output_prefix + '[db.name]'
+        output_name_0_13 = output_prefix + '__db_name'
         output_value = output_resource_db_name or values.get('name', '')
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
         # only set db user/password if not a replica or creation from snapshot
         if self._db_needs_auth_(values):
             # db.user
             output_name = output_prefix + '[db.user]'
+            output_name_0_13 = output_prefix + '__db_user'
             output_value = values['username']
             tf_resources.append(output(output_name, value=output_value))
+            tf_resources.append(output(output_name_0_13, value=output_value))
             # db.password
             output_name = output_prefix + '[db.password]'
+            output_name_0_13 = output_prefix + '__db_password'
             output_value = values['password']
             tf_resources.append(output(output_name, value=output_value))
+            tf_resources.append(output(output_name_0_13, value=output_value))
             # only add reset_password key to the terraform state
             # if reset_password_current_value is defined.
             # this means that if the reset_password field is removed
@@ -750,8 +769,11 @@ class TerrascriptClient(object):
             # leading to a recycle of the pods using this resource.
             if reset_password_current_value:
                 output_name = output_prefix + '[reset_password]'
+                output_name_0_13 = output_prefix + '__reset_password'
                 output_value = reset_password_current_value
                 tf_resources.append(output(output_name, value=output_value))
+                tf_resources.append(
+                    output(output_name_0_13, value=output_value))
 
         for tf_resource in tf_resources:
             self.add_resource(account, tf_resource)
@@ -1050,13 +1072,19 @@ class TerrascriptClient(object):
         bucket_tf_resource = aws_s3_bucket(identifier, **values)
         tf_resources.append(bucket_tf_resource)
         output_name = output_prefix + '[bucket]'
+        output_name_0_13 = output_prefix + '__bucket'
         output_value = '${' + bucket_tf_resource.fullname + '.bucket}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
         output_name = output_prefix + '[aws_region]'
+        output_name_0_13 = output_prefix + '__aws_region'
         tf_resources.append(output(output_name, value=region))
+        tf_resources.append(output(output_name_0_13, value=region))
         endpoint = 's3.{}.amazonaws.com'.format(region)
         output_name = output_prefix + '[endpoint]'
+        output_name_0_13 = output_prefix + '__endpoint'
         tf_resources.append(output(output_name, value=endpoint))
+        tf_resources.append(output(output_name_0_13, value=endpoint))
 
         sqs_identifier = common_values.get('sqs_identifier', None)
         if sqs_identifier is not None:
@@ -1209,18 +1237,24 @@ class TerrascriptClient(object):
         # with the following fields
         # db.endpoint
         output_name = output_prefix + '[db.endpoint]'
+        output_name_0_13 = output_prefix + '__db.endpoint'
         output_value = '${' + tf_resource.fullname + \
                        '.primary_endpoint_address}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
         # db.port
         output_name = output_prefix + '[db.port]'
+        output_name_0_13 = output_prefix + '__db_port'
         output_value = '${' + tf_resource.fullname + '.port}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
         # db.auth_token
         if values.get('transit_encryption_enabled', False):
             output_name = output_prefix + '[db.auth_token]'
+            output_name_0_13 = output_prefix + '_db_auth_token'
             output_value = values['auth_token']
             tf_resources.append(output(output_name, value=output_value))
+            tf_resources.append(output(output_name_0_13, value=output_value))
 
         for tf_resource in tf_resources:
             self.add_resource(account, tf_resource)
@@ -1268,7 +1302,9 @@ class TerrascriptClient(object):
                     to_replace = '${' + k + '}'
                     user_policy = user_policy.replace(to_replace, v)
                     output_name = output_prefix + '[{}]'.format(k)
+                    output_name_0_13 = output_prefix + '__{}'.format(k)
                     tf_resources.append(output(output_name, value=v))
+                    tf_resources.append(output(output_name_0_13, value=v))
             tf_aws_iam_user_policy = aws_iam_user_policy(
                 identifier,
                 name=identifier,
@@ -1330,12 +1366,17 @@ class TerrascriptClient(object):
                 queue_tf_resource = aws_sqs_queue(queue, **values)
                 tf_resources.append(queue_tf_resource)
                 output_name = output_prefix + '[aws_region]'
+                output_name_0_13 = output_prefix + '__aws_region'
                 tf_resources.append(output(output_name, value=region))
+                tf_resources.append(output(output_name_0_13, value=region))
                 output_name = '{}[{}]'.format(output_prefix, queue_key)
+                output_name_0_13 = '{}__{}'.format(output_prefix, queue_key)
                 output_value = \
                     'https://sqs.{}.amazonaws.com/{}/{}'.format(
                         region, uid, queue)
                 tf_resources.append(output(output_name, value=output_value))
+                tf_resources.append(
+                    output(output_name_0_13, value=output_value))
             all_queues_per_spec.append(all_queues)
 
         # iam resources
@@ -1440,13 +1481,19 @@ class TerrascriptClient(object):
                 table_tf_resource = aws_dynamodb_table(table, **values)
                 tf_resources.append(table_tf_resource)
                 output_name = '{}[{}]'.format(output_prefix, table_key)
+                output_name_0_13 = '{}__{}'.format(output_prefix, table_key)
                 tf_resources.append(output(output_name, value=table))
+                tf_resources.append(output(output_name_0_13, value=table))
 
         output_name = output_prefix + '[aws_region]'
+        output_name_0_13 = output_prefix + '__aws_region'
         tf_resources.append(output(output_name, value=region))
+        tf_resources.append(output(output_name_0_13, value=region))
         output_name = output_prefix + '[endpoint]'
+        output_name_0_13 = output_prefix + '__endpoint'
         output_value = f"https://dynamodb.{region}.amazonaws.com"
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
 
         # iam resources
         # Terraform resource reference:
@@ -1512,10 +1559,14 @@ class TerrascriptClient(object):
         ecr_tf_resource = aws_ecr_repository(identifier, **values)
         tf_resources.append(ecr_tf_resource)
         output_name = output_prefix + '[url]'
+        output_name_0_13 = output_prefix + '__url'
         output_value = '${' + ecr_tf_resource.fullname + '.repository_url}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
         output_name = output_prefix + '[aws_region]'
+        output_name_0_13 = output_prefix + '__aws_region'
         tf_resources.append(output(output_name, value=region))
+        tf_resources.append(output(output_name_0_13, value=region))
 
         # iam resources
         # Terraform resource reference:
@@ -1654,26 +1705,42 @@ class TerrascriptClient(object):
         tf_resources.append(cf_distribution_tf_resource)
 
         # outputs
+        ## cloud_front_origin_access_identity_id
         output_name = output_prefix + \
+            '[cloud_front_origin_access_identity_id]'
+        output_name_0_13 = output_prefix + \
             '[cloud_front_origin_access_identity_id]'
         output_value = '${' + cf_oai_tf_resource.fullname + \
             '.id}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        ## s3_canonical_user_id
         output_name = output_prefix + \
             '[s3_canonical_user_id]'
+        output_name_0_13 = output_prefix + \
+            '__s3_canonical_user_id'
         output_value = '${' + cf_oai_tf_resource.fullname + \
             '.s3_canonical_user_id}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        ## distribution_domain
         output_name = output_prefix + \
             '[distribution_domain]'
+        output_name_0_13 = output_prefix + \
+            '__distribution_domain'
         output_value = '${' + cf_distribution_tf_resource.fullname + \
             '.domain_name}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        ## origin_access_identity
         output_name = output_prefix + \
             '[origin_access_identity]'
+        output_name_0_13 = output_prefix + \
+            '__origin_access_identity'
         output_value = 'origin-access-identity/cloudfront/' + \
             '${' + cf_oai_tf_resource.fullname + '.id}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
 
         for tf_resource in tf_resources:
             self.add_resource(account, tf_resource)
@@ -1755,12 +1822,19 @@ class TerrascriptClient(object):
         values['depends_on'] = [user_tf_resource]
         access_key_tf_resource = aws_iam_access_key(sqs_identifier, **values)
         tf_resources.append(access_key_tf_resource)
+        # outputs
+        ## sqs_aws_access_key_id
         output_name = output_prefix + '[sqs_aws_access_key_id]'
+        output_name_0_13 = output_prefix + '__sqs_aws_access_key_id'
         output_value = '${' + access_key_tf_resource.fullname + '.id}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        ## sqs_aws_secret_access_key
         output_name = output_prefix + '[sqs_aws_secret_access_key]'
+        output_name_0_13 = output_prefix + '__sqs_aws_secret_access_key'
         output_value = '${' + access_key_tf_resource.fullname + '.secret}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
 
         # iam policy for queue
         values = {}
@@ -1798,10 +1872,12 @@ class TerrascriptClient(object):
 
         # outputs
         output_name = '{}[{}]'.format(output_prefix, sqs_identifier)
+        output_name_0_13 = '{}__{}'.format(output_prefix, sqs_identifier)
         output_value = \
             'https://sqs.{}.amazonaws.com/{}/{}'.format(
                 region, uid, sqs_identifier)
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
 
         for tf_resource in tf_resources:
             self.add_resource(account, tf_resource)
@@ -1984,10 +2060,14 @@ class TerrascriptClient(object):
             tf_resources.append(subscription_tf_resource)
 
         output_name = output_prefix + '[log_group_name]'
+        output_name_0_13 = output_prefix + '__log_group_name'
         output_value = '${' + log_group_tf_resource.fullname + '.name}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
         output_name = output_prefix + '[aws_region]'
+        output_name_0_13 = output_prefix + '__aws_region'
         tf_resources.append(output(output_name, value=region))
+        tf_resources.append(output(output_name_0_13, value=region))
 
         # iam resources
         # Terraform resource reference:
@@ -2072,8 +2152,10 @@ class TerrascriptClient(object):
 
         # key_id
         output_name = output_prefix + '[key_id]'
+        output_name_0_13 = output_prefix + '__key_id'
         output_value = '${' + tf_resource.fullname + '.key_id}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
 
         alias_values = {}
         alias_values['name'] = "alias/" + identifier
@@ -2109,10 +2191,17 @@ class TerrascriptClient(object):
         # https://www.terraform.io/docs/providers/aws/r/kinesis_stream.html
         kinesis_tf_resource = aws_kinesis_stream(identifier, **values)
         tf_resources.append(kinesis_tf_resource)
+        # outputs
+        ## stream_name
         output_name = output_prefix + '[stream_name]'
+        output_name_0_13 = output_prefix + '__stream_name'
         tf_resources.append(output(output_name, value=identifier))
+        tf_resources.append(output(output_name_0_13, value=identifier))
+        ## aws_region
         output_name = output_prefix + '[aws_region]'
+        output_name_0_13 = output_prefix + '__aws_region'
         tf_resources.append(output(output_name, value=region))
+        tf_resources.append(output(output_name_0_13, value=region))
 
         # iam resources
         policy = {
@@ -2210,12 +2299,19 @@ class TerrascriptClient(object):
         values['depends_on'] = [user_tf_resource]
         tf_resource = aws_iam_access_key(identifier, **values)
         tf_resources.append(tf_resource)
+        # outputs
+        ## aws_access_key_id
         output_name = output_prefix + '[aws_access_key_id]'
+        output_name_0_13 = output_prefix + '__aws_access_key_id'
         output_value = '${' + tf_resource.fullname + '.id}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        ## aws_secret_access_key
         output_name = output_prefix + '[aws_secret_access_key]'
+        output_name_0_13 = output_prefix + '__aws_secret_access_key'
         output_value = '${' + tf_resource.fullname + '.secret}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
 
         return tf_resources
 
@@ -2351,23 +2447,40 @@ class TerrascriptClient(object):
     def init_common_outputs(self, tf_resources, namespace_info,
                             output_prefix, output_resource_name):
         output_format = '{}[{}.{}]'
+        output_format_0_13 = '{}__{}_{}'
         cluster, namespace = self.unpack_namespace_info(namespace_info)
+        # cluster
         output_name = output_format.format(
+            output_prefix, self.integration_prefix, 'cluster')
+        output_name_0_13 = output_format_0_13.format(
             output_prefix, self.integration_prefix, 'cluster')
         output_value = cluster
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        # namespace
         output_name = output_format.format(
+            output_prefix, self.integration_prefix, 'namespace')
+        output_name_0_13 = output_format_0_13.format(
             output_prefix, self.integration_prefix, 'namespace')
         output_value = namespace
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        # resource
         output_name = output_format.format(
+            output_prefix, self.integration_prefix, 'resource')
+        output_name_0_13 = output_format_0_13.format(
             output_prefix, self.integration_prefix, 'resource')
         output_value = 'Secret'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        # output_resource_name
         output_name = output_format.format(
+            output_prefix, self.integration_prefix, 'output_resource_name')
+        output_name_0_13 = output_format_0_13.format(
             output_prefix, self.integration_prefix, 'output_resource_name')
         output_value = output_resource_name
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
 
     def get_values(self, path):
         gqlapi = gql.get_api()
@@ -2588,32 +2701,45 @@ class TerrascriptClient(object):
         tf_resources.append(es_tf_resource)
 
         # Setup outputs
+        ## arn
         output_name = output_prefix + '[arn]'
+        output_name_0_13 = output_prefix + '__arn'
         output_value = '${' + es_tf_resource.fullname + '.arn}'
         tf_resources.append(output(output_name, value=output_value))
-
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        ## domain_id
         output_name = output_prefix + '[domain_id]'
+        output_name_0_13 = output_prefix + '__domain_id'
         output_value = '${' + es_tf_resource.fullname + '.domain_id}'
         tf_resources.append(output(output_name, value=output_value))
-
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        ## domain_name
         output_name = output_prefix + '[domain_name]'
+        output_name_0_13 = output_prefix + '__domain_name'
         output_value = '${' + es_tf_resource.fullname + '.domain_name}'
         tf_resources.append(output(output_name, value=output_value))
-
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        ## endpoint
         output_name = output_prefix + '[endpoint]'
+        output_name_0_13 = output_prefix + '__endpoint'
         output_value = 'https://' + \
             '${' + es_tf_resource.fullname + '.endpoint}'
         tf_resources.append(output(output_name, value=output_value))
-
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        ## kibana_endpoint
         output_name = output_prefix + '[kibana_endpoint]'
+        output_name_0_13 = output_prefix + '__kibana_endpoint'
         output_value = 'https://' + \
             '${' + es_tf_resource.fullname + '.kibana_endpoint}'
         tf_resources.append(output(output_name, value=output_value))
-
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        ## vpc_id
         output_name = output_prefix + '[vpc_id]'
+        output_name_0_13 = output_prefix + '__vpc_id'
         output_value = '${' + es_tf_resource.fullname + \
             '.vpc_options.0.vpc_id}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
 
         for tf_resource in tf_resources:
             self.add_resource(account, tf_resource)
@@ -2660,19 +2786,31 @@ class TerrascriptClient(object):
         acm_tf_resource = aws_acm_certificate(identifier, **values)
         tf_resources.append(acm_tf_resource)
 
+        # outputs
+        ## arn
         output_name = output_prefix + '[arn]'
+        output_name_0_13 = output_prefix + '__arn'
         output_value = '${' + acm_tf_resource.fullname + '.arn}'
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        ## key
         output_name = output_prefix + '[key]'
+        output_name_0_13 = output_prefix + '__key'
         output_value = key
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
+        ## certificate
         output_name = output_prefix + '[certificate]'
+        output_name_0_13 = output_prefix + '__certificate'
         output_value = certificate
         tf_resources.append(output(output_name, value=output_value))
+        tf_resources.append(output(output_name_0_13, value=output_value))
         if caCertificate is not None:
             output_name = output_prefix + '[caCertificate]'
+            output_name_0_13 = output_prefix + '__caCertificate'
             output_value = caCertificate
             tf_resources.append(output(output_name, value=output_value))
+            tf_resources.append(output(output_name_0_13, value=output_value))
 
         for tf_resource in tf_resources:
             self.add_resource(account, tf_resource)

--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -1705,7 +1705,7 @@ class TerrascriptClient(object):
         tf_resources.append(cf_distribution_tf_resource)
 
         # outputs
-        ## cloud_front_origin_access_identity_id
+        # cloud_front_origin_access_identity_id
         output_name = output_prefix + \
             '[cloud_front_origin_access_identity_id]'
         output_name_0_13 = output_prefix + \
@@ -1714,7 +1714,7 @@ class TerrascriptClient(object):
             '.id}'
         tf_resources.append(output(output_name, value=output_value))
         tf_resources.append(output(output_name_0_13, value=output_value))
-        ## s3_canonical_user_id
+        # s3_canonical_user_id
         output_name = output_prefix + \
             '[s3_canonical_user_id]'
         output_name_0_13 = output_prefix + \
@@ -1723,7 +1723,7 @@ class TerrascriptClient(object):
             '.s3_canonical_user_id}'
         tf_resources.append(output(output_name, value=output_value))
         tf_resources.append(output(output_name_0_13, value=output_value))
-        ## distribution_domain
+        # distribution_domain
         output_name = output_prefix + \
             '[distribution_domain]'
         output_name_0_13 = output_prefix + \
@@ -1732,7 +1732,7 @@ class TerrascriptClient(object):
             '.domain_name}'
         tf_resources.append(output(output_name, value=output_value))
         tf_resources.append(output(output_name_0_13, value=output_value))
-        ## origin_access_identity
+        # origin_access_identity
         output_name = output_prefix + \
             '[origin_access_identity]'
         output_name_0_13 = output_prefix + \
@@ -1823,13 +1823,13 @@ class TerrascriptClient(object):
         access_key_tf_resource = aws_iam_access_key(sqs_identifier, **values)
         tf_resources.append(access_key_tf_resource)
         # outputs
-        ## sqs_aws_access_key_id
+        # sqs_aws_access_key_id
         output_name = output_prefix + '[sqs_aws_access_key_id]'
         output_name_0_13 = output_prefix + '__sqs_aws_access_key_id'
         output_value = '${' + access_key_tf_resource.fullname + '.id}'
         tf_resources.append(output(output_name, value=output_value))
         tf_resources.append(output(output_name_0_13, value=output_value))
-        ## sqs_aws_secret_access_key
+        # sqs_aws_secret_access_key
         output_name = output_prefix + '[sqs_aws_secret_access_key]'
         output_name_0_13 = output_prefix + '__sqs_aws_secret_access_key'
         output_value = '${' + access_key_tf_resource.fullname + '.secret}'
@@ -2192,12 +2192,12 @@ class TerrascriptClient(object):
         kinesis_tf_resource = aws_kinesis_stream(identifier, **values)
         tf_resources.append(kinesis_tf_resource)
         # outputs
-        ## stream_name
+        # stream_name
         output_name = output_prefix + '[stream_name]'
         output_name_0_13 = output_prefix + '__stream_name'
         tf_resources.append(output(output_name, value=identifier))
         tf_resources.append(output(output_name_0_13, value=identifier))
-        ## aws_region
+        # aws_region
         output_name = output_prefix + '[aws_region]'
         output_name_0_13 = output_prefix + '__aws_region'
         tf_resources.append(output(output_name, value=region))
@@ -2300,13 +2300,13 @@ class TerrascriptClient(object):
         tf_resource = aws_iam_access_key(identifier, **values)
         tf_resources.append(tf_resource)
         # outputs
-        ## aws_access_key_id
+        # aws_access_key_id
         output_name = output_prefix + '[aws_access_key_id]'
         output_name_0_13 = output_prefix + '__aws_access_key_id'
         output_value = '${' + tf_resource.fullname + '.id}'
         tf_resources.append(output(output_name, value=output_value))
         tf_resources.append(output(output_name_0_13, value=output_value))
-        ## aws_secret_access_key
+        # aws_secret_access_key
         output_name = output_prefix + '[aws_secret_access_key]'
         output_name_0_13 = output_prefix + '__aws_secret_access_key'
         output_value = '${' + tf_resource.fullname + '.secret}'
@@ -2331,7 +2331,7 @@ class TerrascriptClient(object):
             working_dirs = existing_dirs
         for name, ts in self.tss.items():
             if print_only:
-                print('##### {} #####'.format(name))
+                print('#### {} #####'.format(name))
                 print(ts.dump())
             if existing_dirs is None:
                 wd = tempfile.mkdtemp()
@@ -2701,39 +2701,39 @@ class TerrascriptClient(object):
         tf_resources.append(es_tf_resource)
 
         # Setup outputs
-        ## arn
+        # arn
         output_name = output_prefix + '[arn]'
         output_name_0_13 = output_prefix + '__arn'
         output_value = '${' + es_tf_resource.fullname + '.arn}'
         tf_resources.append(output(output_name, value=output_value))
         tf_resources.append(output(output_name_0_13, value=output_value))
-        ## domain_id
+        # domain_id
         output_name = output_prefix + '[domain_id]'
         output_name_0_13 = output_prefix + '__domain_id'
         output_value = '${' + es_tf_resource.fullname + '.domain_id}'
         tf_resources.append(output(output_name, value=output_value))
         tf_resources.append(output(output_name_0_13, value=output_value))
-        ## domain_name
+        # domain_name
         output_name = output_prefix + '[domain_name]'
         output_name_0_13 = output_prefix + '__domain_name'
         output_value = '${' + es_tf_resource.fullname + '.domain_name}'
         tf_resources.append(output(output_name, value=output_value))
         tf_resources.append(output(output_name_0_13, value=output_value))
-        ## endpoint
+        # endpoint
         output_name = output_prefix + '[endpoint]'
         output_name_0_13 = output_prefix + '__endpoint'
         output_value = 'https://' + \
             '${' + es_tf_resource.fullname + '.endpoint}'
         tf_resources.append(output(output_name, value=output_value))
         tf_resources.append(output(output_name_0_13, value=output_value))
-        ## kibana_endpoint
+        # kibana_endpoint
         output_name = output_prefix + '[kibana_endpoint]'
         output_name_0_13 = output_prefix + '__kibana_endpoint'
         output_value = 'https://' + \
             '${' + es_tf_resource.fullname + '.kibana_endpoint}'
         tf_resources.append(output(output_name, value=output_value))
         tf_resources.append(output(output_name_0_13, value=output_value))
-        ## vpc_id
+        # vpc_id
         output_name = output_prefix + '[vpc_id]'
         output_name_0_13 = output_prefix + '__vpc_id'
         output_value = '${' + es_tf_resource.fullname + \
@@ -2787,19 +2787,19 @@ class TerrascriptClient(object):
         tf_resources.append(acm_tf_resource)
 
         # outputs
-        ## arn
+        # arn
         output_name = output_prefix + '[arn]'
         output_name_0_13 = output_prefix + '__arn'
         output_value = '${' + acm_tf_resource.fullname + '.arn}'
         tf_resources.append(output(output_name, value=output_value))
         tf_resources.append(output(output_name_0_13, value=output_value))
-        ## key
+        # key
         output_name = output_prefix + '[key]'
         output_name_0_13 = output_prefix + '__key'
         output_value = key
         tf_resources.append(output(output_name, value=output_value))
         tf_resources.append(output(output_name_0_13, value=output_value))
-        ## certificate
+        # certificate
         output_name = output_prefix + '[certificate]'
         output_name_0_13 = output_prefix + '__certificate'
         output_value = certificate


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2269

this PR adds terrraform 0.13 compliant outputs (no `.`, `[`, `]`) which will eventually replace the current outputs.
we need the outputs to exist in parallel to be able to start using the new outputs and only remove the old ones before migrating to terraform 0.13.