### PR TITLE
add safety nets to terraform integrations

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -935,7 +935,7 @@ def terraform_resources(ctx, print_only, enable_deletion,
 @throughput
 @threaded(default=20)
 @binary(['terraform', 'gpg'])
-@enable_deletion(default=True)
+@enable_deletion(default=False)
 @send_mails(default=True)
 @click.pass_context
 def terraform_users(ctx, print_only, enable_deletion, io_dir,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -357,7 +357,13 @@ def run(dry_run, print_only=False,
 
     tf.populate_desired_state(ri, oc_map)
 
-    ob.realize_data(dry_run, oc_map, ri)
+    # temporarily not allowing resources to be deleted
+    # or for pods to be recycled
+    # this should be removed after we gained confidence
+    # following the terraform 0.13 upgrade
+    ob.realize_data(dry_run, oc_map, ri,
+                    override_enable_deletion=enable_deletion,
+                    recycle_pods=enable_deletion)
 
     disable_keys(dry_run, thread_pool_size,
                  disable_service_account_keys=True)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2269

this PR will prevent terraform integrations from deleting resources. this is a safety net for the duration of the terraform 0.13 upgrade and this PR should be reverted once we gained confidence.