### PR TITLE
retry terraform plan

### DIFF
--- a/utils/lean_terraform_client.py
+++ b/utils/lean_terraform_client.py
@@ -23,6 +23,6 @@ def show_json(working_dir, out_file):
                  cwd=working_dir, stdout=PIPE, stderr=PIPE)
     out, err = proc.communicate()
     if proc.returncode:
-        logging.error(err)
-        raise Exception('terraform show failed')
+        logging.warning(err)
+        raise Exception('terraform show failed: ' + str(err))
     return json.loads(out)

--- a/utils/terraform_client.py
+++ b/utils/terraform_client.py
@@ -134,6 +134,7 @@ class TerraformClient(object):
         with open(file_path, 'w') as f:
             f.write(json.dumps(self.deleted_users))
 
+    @retry()
     def terraform_plan(self, plan_spec, enable_deletion):
         name = plan_spec['name']
         tf = plan_spec['tf']


### PR DESCRIPTION
there are cases where `terraform show` claims that:
```
Saved plan is stale
The given plan file can no longer be applied because the state was changed by
another operation after the plan was created.
```
let's retry the plan phase to see if it helps.