### PR TITLE
[terraform-resources] lambda permission fix

### DIFF
--- a/utils/terrascript_client.py
+++ b/utils/terrascript_client.py
@@ -1971,7 +1971,7 @@ class TerrascriptClient(object):
                 'action': 'lambda:InvokeFunction',
                 'function_name': "${" + lambds_tf_resource.arn + "}",
                 'principal': 'logs.amazonaws.com',
-                'source_arn': "${" + log_group_tf_resource.arn + "}"
+                'source_arn': "${" + log_group_tf_resource.arn + "}:*"
             }
 
             if provider:


### PR DESCRIPTION
would this fix the following error?
```
Error: Error creating Cloudwatch log subscription filter: InvalidParameterException: Could not execute the lambda function. Make sure you have given CloudWatch Logs permission to execute your function.
```
based on https://forums.aws.amazon.com/thread.jspa?threadID=310484