### PR TITLE
Improve logs returned when validating desired state

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -433,17 +433,23 @@ def validate_data(oc_map, actions):
                 ready_replicas = status.get('readyReplicas')
                 if not desired_replicas == replicas == \
                         ready_replicas == updated_replicas:
-                    logging.info('new replicas not ready, status is invalid')
+                    logging.info(
+                        f'{kind} {name} has replicas that are not ready '
+                        f'({ready_replicas} ready / {desired_replicas} total)')
                     raise ValidationError(name)
             elif kind == 'Subscription':
                 state = status.get('state')
                 if state != 'AtLatestKnown':
-                    logging.info('Subscription status.state is invalid')
+                    logging.info(
+                        f'Subscription {name} state is invalid. '
+                        f'Current state: {state}')
                     raise ValidationError(name)
             elif kind == 'Job':
                 succeeded = status.get('succeeded')
+                conditions = status.get('conditions')
                 if not succeeded:
-                    logging.info('Job has not succeeded, status is invalid')
+                    logging.info(f'Job {name} has not succeeded')
+                    logging.info(f'Job conditions are: {conditions}')
                     raise ValidationError(name)
             elif kind == 'ClowdApp':
                 deployments = status.get('deployments')
@@ -455,8 +461,9 @@ def validate_data(oc_map, actions):
                 ready_deployments = deployments.get('readyDeployments')
                 if managed_deployments != ready_deployments:
                     logging.info(
-                        'ClowdApp has not ready deployments, ' +
-                        'status is invalid')
+                        f'ClowdApp has deployments that are not ready '
+                        f'({ready_deployments} ready / '
+                        f'{managed_deployments} total)')
                     raise ValidationError(name)
 
 

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1,4 +1,5 @@
 import logging
+import yaml
 
 import utils.threaded as threaded
 import reconcile.queries as queries
@@ -446,10 +447,12 @@ def validate_data(oc_map, actions):
                     raise ValidationError(name)
             elif kind == 'Job':
                 succeeded = status.get('succeeded')
-                conditions = status.get('conditions')
                 if not succeeded:
                     logging.info(f'Job {name} has not succeeded')
-                    logging.info(f'Job conditions are: {conditions}')
+                    conditions = status.get('conditions')
+                    if conditions:
+                        logging.info(f'Job conditions are: {conditions}')
+                        logging.info(yaml.safe_dump(conditions))
                     raise ValidationError(name)
             elif kind == 'ClowdApp':
                 deployments = status.get('deployments')


### PR DESCRIPTION
This improves the log messages when we're validating desired state to give more info to the end users:
* Deployment/DeploymentConfig: tell the user how many replicas are ready vs total desired
* Subscription: tell the user what the actual state is
* Job: tell the user what the conditions are (currently dumped as-is to simplify code)
* ClowApp: tell the user how many deployments are ready vs. total managed