### PR TITLE
find skopeo package and install with rpm

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -37,7 +37,7 @@ ENV PROMETHEUS_VERSION=2.23.0
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_8/devel:kubic:libcontainers:stable.repo && \
     SKOPEO_PKG=$(dnf list -q skopeo.x86_64 | tail -1 | awk '{print $1"-"$2}' | sed 's/\(.*\).x86_64-[0-9]:\(.*\)\(.el8\)$/\1-\2\3.x86_64.rpm/') && \
-    rpm -vi https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_8/x86_64/$SKOPEO_PKG && \
+    rpm -vi https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_8/x86_64/${SKOPEO_PKG} && \
     dnf install -y python3 python3-pip python3-devel git unzip gcc gcc-c++ openssh-clients openssl glibc-langpack-en && \
     python3 -m pip install --upgrade pip setuptools && \
     dnf clean all

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -36,7 +36,8 @@ ENV PROMETHEUS_VERSION=2.23.0
 
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
     curl -L -o /etc/yum.repos.d/devel:kubic:libcontainers:stable.repo https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_8/devel:kubic:libcontainers:stable.repo && \
-    dnf install -y skopeo && \
+    SKOPEO_PKG=$(dnf list -q skopeo.x86_64 | tail -1 | awk '{print $1"-"$2}' | sed 's/\(.*\).x86_64-[0-9]:\(.*\)\(.el8\)$/\1-\2\3.x86_64.rpm/') && \
+    rpm -vi https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/CentOS_8/x86_64/$SKOPEO_PKG && \
     dnf install -y python3 python3-pip python3-devel git unzip gcc gcc-c++ openssh-clients openssl glibc-langpack-en && \
     python3 -m pip install --upgrade pip setuptools && \
     dnf clean all


### PR DESCRIPTION
There seems to be checksum issues coming from the header when using DNF.  
This will check for the package nvr and then we can install with `rpm -vi` instead