### PR TITLE
[terraform-users] enable deletion by default

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -956,7 +956,7 @@ def terraform_resources(ctx, print_only, enable_deletion,
 @throughput
 @threaded(default=20)
 @binary(['terraform', 'gpg'])
-@enable_deletion(default=False)
+@enable_deletion(default=True)
 @send_mails(default=True)
 @click.pass_context
 def terraform_users(ctx, print_only, enable_deletion, io_dir,


### PR DESCRIPTION
following #1275, this PR is enabling terraform-users to delete resources.