### PR TITLE
[sentry-config] add pagination

### DIFF
--- a/reconcile/utils/sentry_client.py
+++ b/reconcile/utils/sentry_client.py
@@ -52,7 +52,7 @@ class SentryClient:
             response = \
                 call(f"{url}?&cursor={cursor}", headers=headers, json=payload)
             response.raise_for_status()
-            # if there are pages, each response is a list to append
+            # if there are pages, each response is a list to extend
             all_results += response.json()
 
         return all_results

--- a/reconcile/utils/sentry_client.py
+++ b/reconcile/utils/sentry_client.py
@@ -43,6 +43,9 @@ class SentryClient:
                 break
             # 2nd item is the next page
             next_item = link.split(', ')[1]
+            # copied with love from
+            # https://stackoverflow.com/questions/10663093/
+            # use-python-format-string-in-reverse-for-parsing
             _, rel, results, cursor = parse.parse(item_format, next_item)
             if rel != 'next' or results != 'true':
                 break

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
         "sentry-sdk~=0.14",
         "jenkins-job-builder==2.10.1",
         "tzlocal==2.1",
+        "parse==1.18.0",
     ],
 
     test_suite="tests",


### PR DESCRIPTION
as we grew larger in numbers, some calls now do not return all results and include a `link` header in the response indicating of more pages.
this PR adds usage of these pages to return the complete response (if pages exist, the response is a list of items).