### PR TITLE
[VaultClient] try-except is_authenticated

### DIFF
--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -6,6 +6,7 @@ import logging
 
 from hvac.exceptions import InvalidPath
 from requests.adapters import HTTPAdapter
+from requests.exceptions import ConnectionError
 
 from sretoolbox.utils import retry
 
@@ -186,7 +187,12 @@ class VaultClient:
             cls._instance = _VaultClient(*args, **kwargs)
             return cls._instance
 
-        if not cls._instance._client.is_authenticated():
+        try:
+            is_authenticated = cls._instance._client.is_authenticated()
+        except requests.exceptions.ConnectionError:
+            is_authenticated = False
+
+        if not is_authenticated:
             cls._instance = _VaultClient(*args, **kwargs)
             return cls._instance
 

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -6,7 +6,6 @@ import logging
 
 from hvac.exceptions import InvalidPath
 from requests.adapters import HTTPAdapter
-from requests.exceptions import ConnectionError
 
 from sretoolbox.utils import retry
 


### PR DESCRIPTION
should fix the following errors:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 189, in lookup_vault_secret
    vault_client = VaultClient()
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/vault.py", line 189, in __new__
    if not cls._instance._client.is_authenticated():
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/v1/__init__.py", line 529, in is_authenticated
    self.lookup_token()
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/v1/__init__.py", line 377, in lookup_token
    return self._adapter.get(path, wrap_ttl=wrap_ttl).json()
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/adapters.py", line 93, in get
    return self.request('get', url, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/adapters.py", line 267, in request
    **_kwargs
  File "/usr/local/lib/python3.6/site-packages/requests-2.22.0-py3.6.egg/requests/sessions.py", line 533, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.6/site-packages/requests-2.22.0-py3.6.egg/requests/sessions.py", line 646, in send
    r = adapter.send(request, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/requests-2.22.0-py3.6.egg/requests/adapters.py", line 498, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response',))
```