### PR TITLE
Getting credentials from the replica_source for the replica Secret

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -537,6 +537,18 @@ NAMESPACES_QUERY = """
     app {
       name
     }
+    terraformResources
+      {
+        provider
+        ... on NamespaceTerraformResourceRDS_v1
+        {
+          account
+          identifier
+          output_resource_name
+          defaults
+          replica_source
+        }
+      }
     cluster {
       name
       serverUrl

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -287,7 +287,7 @@ def setup(dry_run, print_only, thread_pool_size, internal,
     ts.populate_resources(tf_namespaces, existing_secrets, account_name)
     ts.dump(print_only, existing_dirs=working_dirs)
 
-    return ri, oc_map, tf
+    return ri, oc_map, tf, tf_namespaces
 
 
 def cleanup_and_exit(tf=None, status=False, working_dirs={}):
@@ -317,7 +317,7 @@ def run(dry_run, print_only=False,
         light=False, vault_output_path='',
         account_name=None, defer=None):
 
-    ri, oc_map, tf = \
+    ri, oc_map, tf, tf_namespaces = \
         setup(dry_run, print_only, thread_pool_size, internal,
               use_jump_host, account_name)
 
@@ -355,7 +355,7 @@ def run(dry_run, print_only=False,
     if account_name:
         cleanup_and_exit(tf)
 
-    tf.populate_desired_state(ri, oc_map)
+    tf.populate_desired_state(ri, oc_map, tf_namespaces)
 
     # temporarily not allowing resources to be deleted
     # or for pods to be recycled


### PR DESCRIPTION
We can't set the username/password for a RDS replica in terraform, but
we still want them in the OpenShift Secret. For that, we find the
username/password from the replica_source in the terraform output and
copy them to the replica Secret data.