### PR TITLE
target_promotion init to dict if None

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -306,7 +306,7 @@ class SaasHerder():
         target = options['target']
         github = options['github']
         target_ref = target['ref']
-        target_promotion = target.get('promotion')
+        target_promotion = target.get('promotion') or {}
 
         resources = None
         html_url = None


### PR DESCRIPTION
fixes #1323
```
Original Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/threaded.py", line 10, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/saasherder.py", line 611, in populate_desired_state_saas_file
    self._process_template(process_template_options)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/saasherder.py", line 393, in _process_template
    target_promotion['commit_sha'] = commit_sha
TypeError: 'NoneType' object does not support item assignment
```