### PR TITLE
[openshift-saas-deploy] add support for automated promotions

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -687,6 +687,8 @@ def openshift_resources(ctx, thread_pool_size, internal, use_jump_host,
 
 @integration.command()
 @environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
+@environ(['gitlab_pr_submitter_queue_url'])
+@gitlab_project_id
 @threaded(default=20)
 @throughput
 @binary(['oc', 'ssh'])
@@ -698,21 +700,24 @@ def openshift_resources(ctx, thread_pool_size, internal, use_jump_host,
               help='environment to deploy to.')
 @click.pass_context
 def openshift_saas_deploy(ctx, thread_pool_size, io_dir,
-                          saas_file_name, env_name):
+                          saas_file_name, env_name, gitlab_project_id):
     run_integration(reconcile.openshift_saas_deploy,
                     ctx.obj, thread_pool_size, io_dir,
-                    saas_file_name, env_name)
+                    saas_file_name, env_name, gitlab_project_id)
 
 
 @integration.command()
 @environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
+@environ(['gitlab_pr_submitter_queue_url'])
+@gitlab_project_id
 @threaded()
 @binary(['oc', 'ssh'])
 @throughput
 @click.pass_context
-def openshift_saas_deploy_wrapper(ctx, thread_pool_size, io_dir):
+def openshift_saas_deploy_wrapper(ctx, thread_pool_size, io_dir,
+                                  gitlab_project_id):
     run_integration(reconcile.openshift_saas_deploy_wrapper,
-                    ctx.obj, thread_pool_size, io_dir)
+                    ctx.obj, thread_pool_size, io_dir, gitlab_project_id)
 
 
 @integration.command()

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -95,7 +95,8 @@ def run(dry_run, thread_pool_size=10, io_dir='throughput/',
     # publish results of this deployment
     # based on promotion information in targets
     success = not ri.has_error_registered()
-    if not dry_run:
+    # only publish promotions for deployment jobs (a single saas file)
+    if not dry_run and len(saasherder.saas_files) == 1:
         mr_cli = mr_client_gateway.init(gitlab_project_id=gitlab_project_id)
         saasherder.publish_promotions(success, all_saas_files, mr_cli)
 

--- a/reconcile/openshift_saas_deploy_wrapper.py
+++ b/reconcile/openshift_saas_deploy_wrapper.py
@@ -27,7 +27,8 @@ def osd_run_wrapper(diff, dry_run, available_thread_pool_size,
     return exit_code
 
 
-def run(dry_run, thread_pool_size=10, io_dir='throughput/', gitlab_project_id=None):
+def run(dry_run, thread_pool_size=10, io_dir='throughput/',
+        gitlab_project_id=None):
     saas_file_owners_diffs = read_saas_file_owners_diffs(io_dir)
     if len(saas_file_owners_diffs) == 0:
         return

--- a/reconcile/openshift_saas_deploy_wrapper.py
+++ b/reconcile/openshift_saas_deploy_wrapper.py
@@ -11,7 +11,8 @@ QONTRACT_INTEGRATION = 'openshift-saas-deploy-wrapper'
 QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
 
 
-def osd_run_wrapper(diff, dry_run, available_thread_pool_size):
+def osd_run_wrapper(diff, dry_run, available_thread_pool_size,
+                    gitlab_project_id):
     saas_file_name = diff['saas_file_name']
     env_name = diff['environment']
     exit_code = 0
@@ -19,13 +20,14 @@ def osd_run_wrapper(diff, dry_run, available_thread_pool_size):
         osd.run(dry_run=dry_run,
                 thread_pool_size=available_thread_pool_size,
                 saas_file_name=saas_file_name,
-                env_name=env_name)
+                env_name=env_name,
+                gitlab_project_id=gitlab_project_id)
     except SystemExit as e:
         exit_code = e.code
     return exit_code
 
 
-def run(dry_run, thread_pool_size=10, io_dir='throughput/'):
+def run(dry_run, thread_pool_size=10, io_dir='throughput/', gitlab_project_id=None):
     saas_file_owners_diffs = read_saas_file_owners_diffs(io_dir)
     if len(saas_file_owners_diffs) == 0:
         return
@@ -38,7 +40,8 @@ def run(dry_run, thread_pool_size=10, io_dir='throughput/'):
     exit_codes = threaded.run(
         osd_run_wrapper, saas_file_owners_diffs, thread_pool_size,
         dry_run=dry_run,
-        available_thread_pool_size=available_thread_pool_size
+        available_thread_pool_size=available_thread_pool_size,
+        gitlab_project_id=gitlab_project_id,
     )
 
     if [ec for ec in exit_codes if ec]:

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1168,6 +1168,7 @@ SAAS_FILES_QUERY = """
         }
         ref
         promotion {
+          auto
           publish
           subscribe
         }

--- a/reconcile/utils/mr/auto_promoter.py
+++ b/reconcile/utils/mr/auto_promoter.py
@@ -13,11 +13,13 @@ class AutoPromoter(MergeRequestBase):
 
         super().__init__()
 
-        self.labels = [] # TODO(mafriedm): add AUTO_MERGE
+        # TODO(mafriedm): add AUTO_MERGE
+        self.labels = []
 
     @property
     def title(self):
-        return (f'[{self.name}] clusters updates')
+        # TODO(mafriedm): update this to be more descriptive and unique
+        return (f'[{self.name}] openshift-saas-deploy automated promotion')
 
     def process(self, gitlab_cli):
         changes = False

--- a/reconcile/utils/mr/auto_promoter.py
+++ b/reconcile/utils/mr/auto_promoter.py
@@ -22,7 +22,6 @@ class AutoPromoter(MergeRequestBase):
         return (f'[{self.name}] openshift-saas-deploy automated promotion')
 
     def process(self, gitlab_cli):
-        changes = False
         for item in self.promotions:
             saas_file_paths = item.get('saas_file_paths')
             if not saas_file_paths:
@@ -53,7 +52,6 @@ class AutoPromoter(MergeRequestBase):
                             continue
                         if any(c in subscribe for c in publish):
                             target['ref'] = commit_sha
-                            changes = True
 
                 new_content = '---\n'
                 new_content += yaml.dump(content, Dumper=yaml.RoundTripDumper)
@@ -62,6 +60,3 @@ class AutoPromoter(MergeRequestBase):
                                        file_path=saas_file_path,
                                        commit_message=msg,
                                        content=new_content)
-
-        if not changes:
-            self.cancel('Saas files are up to date. Nothing to do.')

--- a/reconcile/utils/mr/auto_promoter.py
+++ b/reconcile/utils/mr/auto_promoter.py
@@ -38,7 +38,8 @@ class AutoPromoter(MergeRequestBase):
                     file_path=saas_file_path,
                     ref=self.main_branch
                 )
-                content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+                content = yaml.load(raw_file.decode(),
+                                    Loader=yaml.RoundTripLoader)
                 for rt in content['resourceTemplates']:
                     for target in rt['targets']:
                         target_promotion = target.get('promotion')

--- a/reconcile/utils/mr/auto_promoter.py
+++ b/reconcile/utils/mr/auto_promoter.py
@@ -1,0 +1,64 @@
+import ruamel.yaml as yaml
+
+from reconcile.utils.mr.base import MergeRequestBase
+# from reconcile.utils.mr.labels import AUTO_MERGE
+
+
+class AutoPromoter(MergeRequestBase):
+
+    name = 'auto_promoter'
+
+    def __init__(self, promotions):
+        self.promotions = promotions
+
+        super().__init__()
+
+        self.labels = [] # TODO(mafriedm): add AUTO_MERGE
+
+    @property
+    def title(self):
+        return (f'[{self.name}] clusters updates')
+
+    def process(self, gitlab_cli):
+        changes = False
+        for item in self.promotions:
+            saas_file_paths = item.get('saas_file_paths')
+            if not saas_file_paths:
+                continue
+            publish = item.get('publish')
+            if not publish:
+                continue
+            commit_sha = item.get('commit_sha')
+            if not commit_sha:
+                continue
+            for saas_file_path in saas_file_paths:
+                raw_file = gitlab_cli.project.files.get(
+                    file_path=saas_file_path,
+                    ref=self.main_branch
+                )
+                content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+                for rt in content['resourceTemplates']:
+                    for target in rt['targets']:
+                        target_promotion = target.get('promotion')
+                        if not target_promotion:
+                            continue
+                        target_auto = target_promotion.get('auto')
+                        if not target_auto:
+                            continue
+                        subscribe = target_promotion.get('subscribe')
+                        if not subscribe:
+                            continue
+                        if any(c in subscribe for c in publish):
+                            target['ref'] = commit_sha
+                            changes = True
+
+                new_content = '---\n'
+                new_content += yaml.dump(content, Dumper=yaml.RoundTripDumper)
+                msg = f'auto promote {commit_sha} in {saas_file_path}'
+                gitlab_cli.update_file(branch_name=self.branch,
+                                       file_path=saas_file_path,
+                                       commit_message=msg,
+                                       content=new_content)
+
+        if not changes:
+            self.cancel('Saas files are up to date. Nothing to do.')

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -883,7 +883,7 @@ class SaasHerder():
         """
         subscribe_saas_file_path_map = {}
         for saas_file in saas_files:
-            saas_file_path = saas_file['path']
+            saas_file_path = 'data' + saas_file['path']
             for rt in saas_file['resourceTemplates']:
                 for target in rt['targets']:
                     target_promotion = target.get('promotion')

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -14,6 +14,7 @@ from reconcile.utils.oc import OC, StatusCodeError
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.state import State
 from reconcile.github_org import get_config
+from reconcile.utils.mr.auto_promoter import AutoPromoter
 
 
 class SaasHerder():
@@ -837,15 +838,20 @@ class SaasHerder():
 
         return True
 
-    def publish_promotions(self, success):
+    def publish_promotions(self, success, saas_files, mr_cli):
         """
         If there were promotion sections in the participating saas files
         publish the results for future promotion validations. """
+        subscribe_saas_file_path_map = \
+            self._get_subscribe_saas_file_path_map(saas_files, auto_only=True)
+        trigger_promotion = False
         for item in self.promotions:
             commit_sha = item['commit_sha']
             publish = item.get('publish')
             if publish:
+                all_subscribed_saas_file_paths = set()
                 for channel in publish:
+                    # publish to state to pass promotion gate
                     state_key = f"promotions/{channel}/{commit_sha}"
                     value = {
                         'success': success
@@ -855,3 +861,44 @@ class SaasHerder():
                         f'Commit {commit_sha} was published ' +
                         f'with success {success} to channel {channel}'
                     )
+                    # collect data to trigger promotion
+                    subscribed_saas_file_paths = \
+                        subscribe_saas_file_path_map.get(channel)
+                    if subscribed_saas_file_paths:
+                        all_subscribed_saas_file_paths.update(
+                            subscribed_saas_file_paths)
+                item['saas_file_paths'] = all_subscribed_saas_file_paths
+                if all_subscribed_saas_file_paths:
+                    trigger_promotion = True
+
+        if trigger_promotion:
+            mr = AutoPromoter(self.promotions)
+            mr.submit(cli=mr_cli)
+
+    @staticmethod
+    def _get_subscribe_saas_file_path_map(saas_files, auto_only=False):
+        """
+        Returns a dict with subscribe channels as keys and a
+        list of paths of saas files containing these channels.
+        """
+        subscribe_saas_file_path_map = {}
+        for saas_file in saas_files:
+            saas_file_path = saas_file['path']
+            for rt in saas_file['resourceTemplates']:
+                for target in rt['targets']:
+                    target_promotion = target.get('promotion')
+                    if not target_promotion:
+                        continue
+                    target_auto = target_promotion.get('auto')
+                    if auto_only and not target_auto:
+                        continue
+                    subscribe = target_promotion.get('subscribe')
+                    if not subscribe:
+                        continue
+                    for channel in subscribe:
+                        subscribe_saas_file_path_map.setdefault(
+                            channel, set())
+                        subscribe_saas_file_path_map[channel].add(
+                            saas_file_path)
+
+        return subscribe_saas_file_path_map


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2244

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/13902

this PR adds support for automated promotions for saas file targets defining `auto: true` in the `promotion` section.
this works by sending messages to the SQS gateway to promote a change and consumed by the MR consumer integration.