### PR TITLE
Validate container names against DNS-1123 in OpenshiftResource

### DIFF
--- a/reconcile/test/fixtures/openshift_resource/invalid_resource_container_name_format.yml
+++ b/reconcile/test/fixtures/openshift_resource/invalid_resource_container_name_format.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo
+  labels:
+    app: foo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: foo
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: this_is_invalid # underscores are not allowed
+        image: foo:0.1.2

--- a/reconcile/test/fixtures/openshift_resource/invalid_resource_container_name_too_long.yml
+++ b/reconcile/test/fixtures/openshift_resource/invalid_resource_container_name_too_long.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo
+  labels:
+    app: foo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: foo
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      # name is too long (> 63 char)
+      - name: this-is-invalid-because-im-way-too-longggggggggggggggggggggggggg
+        image: foo:0.1.2
+
+

--- a/reconcile/test/fixtures/openshift_resource/invalid_resource_name_format.yml
+++ b/reconcile/test/fixtures/openshift_resource/invalid_resource_name_format.yml
@@ -1,0 +1,20 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: this_is_invalid # underscores are not allowed
+  labels:
+    app: foo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: foo
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foo
+        image: foo:0.1.2

--- a/reconcile/test/fixtures/openshift_resource/invalid_resource_name_too_long.yml
+++ b/reconcile/test/fixtures/openshift_resource/invalid_resource_name_too_long.yml
@@ -1,0 +1,23 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  # name is too long (> 253 char)
+  name: this-is-invalid-because-im-way-too-longggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggggg
+  labels:
+    app: foo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: foo
+  template:
+    metadata:
+      labels:
+        app: foo
+    spec:
+      containers:
+      - name: foo
+        image: foo:0.1.2
+
+

--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -26,6 +26,36 @@ class TestOpenshiftResource(object):
             openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
             assert openshift_resource.verify_valid_k8s_object() is None
 
+    def test_invalid_name_format(self):
+        resource = fxt.get_anymarkup('invalid_resource_name_format.yml')
+
+        with pytest.raises(ConstructResourceError):
+            openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
+            assert openshift_resource.verify_valid_k8s_object() is None
+
+    def test_invalid_name_too_long(self):
+        resource = fxt.get_anymarkup('invalid_resource_name_too_long.yml')
+
+        with pytest.raises(ConstructResourceError):
+            openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
+            assert openshift_resource.verify_valid_k8s_object() is None
+
+    def test_invalid_container_name_format(self):
+        resource = fxt.get_anymarkup(
+            'invalid_resource_container_name_format.yml')
+
+        with pytest.raises(ConstructResourceError):
+            openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
+            assert openshift_resource.verify_valid_k8s_object() is None
+
+    def test_invalid_container_name_too_long(self):
+        resource = fxt.get_anymarkup(
+            'invalid_resource_container_name_too_long.yml')
+
+        with pytest.raises(ConstructResourceError):
+            openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
+            assert openshift_resource.verify_valid_k8s_object() is None
+
     def test_annotates_resource(self):
         resource = fxt.get_anymarkup('annotates_resource.yml')
         openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -19,6 +19,13 @@ class ConstructResourceError(Exception):
         )
 
 
+# Regexes for kubernetes objects fields which have to adhere to DNS-1123
+DNS_SUBDOMAIN_RE = re.compile(
+    r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$')
+DNS_LABEL_RE = re.compile(r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
+DNS_NAMES_URL = \
+    'https://kubernetes.io/docs/concepts/overview/working-with-objects/names/'
+
 IGNORABLE_DATA_FIELDS = ['service-ca.crt']
 
 
@@ -163,17 +170,37 @@ class OpenshiftResource(object):
                 e.__class__.__name__, self.error_details)
             raise ConstructResourceError(msg)
 
-        r = '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*'
         if self.kind not in \
                 ['Role', 'RoleBinding', 'ClusterRole', 'ClusterRoleBinding'] \
-                and not re.search(r'^{}$'.format(r), self.name):
+                and not DNS_SUBDOMAIN_RE.match(self.name):
             msg = f"The {self.kind} \"{self.name}\" is invalid: " + \
-                f"metadata.name: Invalid value: \"{self.name}\": " + \
-                f"a DNS-1123 subdomain must consist of lower case " + \
-                f"alphanumeric characters, '-' or '.', and must start " + \
-                f"and end with an alphanumeric character (e.g. " + \
-                f"'example.com', regex used for validation is '{r}')"
+                f"metadata.name: Invalid value: \"{self.name}\". " + \
+                f"This field must adhere to DNS-1123 subdomain names spec." + \
+                f"More info can be found at {DNS_NAMES_URL}."
             raise ConstructResourceError(msg)
+
+        # All objects that have a spec.template.spec.containers[]
+        try:
+            containers = self.body['spec']['template']['spec']['containers']
+            if not isinstance(containers, list):
+                msg = f"The {self.kind} \"{self.name}\" is invalid: " + \
+                      f"spec.template.spec.containers is not a list"
+                raise ConstructResourceError(msg)
+            for c in containers:
+                cname = c.get('name', None)
+                if cname is None:
+                    msg = f"The {self.kind} \"{self.name}\" is invalid: " + \
+                        f"an item in spec.template.spec.containers was " + \
+                        f"found without a required name field"
+                    raise ConstructResourceError(msg)
+                if not DNS_LABEL_RE.match(cname):
+                    msg = f"The {self.kind} \"{self.name}\" is invalid: " + \
+                        f"an container in spec.template.spec.containers " + \
+                        f"was found with an invalid name ({cname}). More " + \
+                        f"info at {DNS_NAMES_URL}."
+                    raise ConstructResourceError(msg)
+        except KeyError:
+            pass
 
     def has_qontract_annotations(self):
         try:

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -20,8 +20,10 @@ class ConstructResourceError(Exception):
 
 
 # Regexes for kubernetes objects fields which have to adhere to DNS-1123
+DNS_SUBDOMAIN_MAX_LENGTH = 253
 DNS_SUBDOMAIN_RE = re.compile(
     r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$')
+DNS_LABEL_MAX_LENGTH = 63
 DNS_LABEL_RE = re.compile(r'^[a-z0-9]([-a-z0-9]*[a-z0-9])?$')
 DNS_NAMES_URL = \
     'https://kubernetes.io/docs/concepts/overview/working-with-objects/names/'
@@ -172,7 +174,8 @@ class OpenshiftResource(object):
 
         if self.kind not in \
                 ['Role', 'RoleBinding', 'ClusterRole', 'ClusterRoleBinding'] \
-                and not DNS_SUBDOMAIN_RE.match(self.name):
+                and (not DNS_SUBDOMAIN_RE.match(self.name) or
+                     not len(self.name) <= DNS_SUBDOMAIN_MAX_LENGTH):
             msg = f"The {self.kind} \"{self.name}\" is invalid: " + \
                 f"metadata.name: Invalid value: \"{self.name}\". " + \
                 f"This field must adhere to DNS-1123 subdomain names spec." + \
@@ -193,7 +196,8 @@ class OpenshiftResource(object):
                         f"an item in spec.template.spec.containers was " + \
                         f"found without a required name field"
                     raise ConstructResourceError(msg)
-                if not DNS_LABEL_RE.match(cname):
+                if (not DNS_LABEL_RE.match(cname) or
+                        not len(cname) <= DNS_LABEL_MAX_LENGTH):
                     msg = f"The {self.kind} \"{self.name}\" is invalid: " + \
                         f"an container in spec.template.spec.containers " + \
                         f"was found with an invalid name ({cname}). More " + \


### PR DESCRIPTION
This PR adds validation for container names in OpenshiftResource. Corresponding tests have also been added.

This also extracts the DNS-1123 based regexes as global variables so they can be reused elsewhere in the future.

I have also changed the error messages slightly for clarity and added a link to the kubernetes docs on object naming