### PR TITLE
[SQSGateway] only initiate submitter queue account

### DIFF
--- a/reconcile/utils/sqs_gateway.py
+++ b/reconcile/utils/sqs_gateway.py
@@ -14,6 +14,7 @@ class SQSGateway(object):
     def __init__(self, accounts, settings=None):
         queue_url = os.environ['gitlab_pr_submitter_queue_url']
         account = self.get_queue_account(accounts, queue_url)
+        accounts = [a for a in accounts if a['name'] == account]
         aws_api = AWSApi(1, accounts, settings=settings)
         session = aws_api.get_session(account)
 


### PR DESCRIPTION
fixes #1327

this will avoid deployment jobs from initiating tokens for all AWS accounts, and only do it for the AWS account with the MR submitter queue.

fixes https://ci.ext.devshift.net/view/github-mirror/job/openshift-saas-deploy-saas-github-mirror-test-App-SRE-stage/25/console