### PR TITLE
New integration to check alertmanager config

### DIFF
--- a/reconcile/alertmanager_config_validator.py
+++ b/reconcile/alertmanager_config_validator.py
@@ -1,0 +1,88 @@
+import sys
+import semver
+import base64
+import logging
+
+import reconcile.utils.gql as gql
+import reconcile.utils.threaded as threaded
+import reconcile.utils.amtool as amtool
+import reconcile.openshift_resources_base as orb
+
+from reconcile.status import ExitCodes
+
+QONTRACT_INTEGRATION = 'alertmanager_config_validator'
+QONTRACT_INTEGRATION_VERSION = semver.format_version(0, 1, 0)
+
+ALERTMANAGER_SECRET_PATH = '/observability/alertmanager/' \
+                           'alertmanager-instance.secret.yaml'
+ALERTMANAGER_SECRET_KEY = 'alertmanager.yaml'
+
+
+def check_config(config):
+    '''Helper function to run amtool check-config via threaded.run'''
+    config['check_result'] = amtool.check_config(config['data'])
+    return config
+
+
+def get_config_data(namespace_info):
+    '''Returns a dict with the alertmanager config from the cluster refered
+       in the namespace info'''
+
+    openshift_resources = namespace_info.get('openshiftResources')
+
+    if not openshift_resources:
+        return
+
+    for r in openshift_resources:
+        path = r['path']
+        if path != ALERTMANAGER_SECRET_PATH:
+            continue
+
+        openshift_resource = \
+            orb.fetch_openshift_resource(resource=r, parent=namespace_info)
+
+        try:
+            encoded = openshift_resource.body['data'][ALERTMANAGER_SECRET_KEY]
+            data = base64.b64decode(encoded).decode('utf-8')
+        except KeyError:
+            logging.warning('No data found in config secret for key '
+                            f'{ALERTMANAGER_SECRET_KEY}')
+            return
+
+        return {'cluster': namespace_info['cluster']['name'], 'data': data}
+
+
+def run(dry_run, thread_pool_size=20, cluster_name=None):
+    orb.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION
+    orb.QONTRACT_INTEGRATION_VERSION = QONTRACT_INTEGRATION_VERSION
+
+    gqlapi = gql.get_api()
+
+    configs = []
+    for namespace_info in gqlapi.query(orb.NAMESPACES_QUERY)['namespaces']:
+        if namespace_info['name'] != 'openshift-customer-monitoring':
+            continue
+
+        if cluster_name and namespace_info['cluster']['name'] != cluster_name:
+            continue
+
+        config_data = get_config_data(namespace_info)
+        if config_data:
+            configs.append(config_data)
+
+    if not configs:
+        logging.error(f'No configs found at {ALERTMANAGER_SECRET_PATH}')
+        sys.exit(ExitCodes.ERROR)
+
+    result = threaded.run(func=check_config,
+                          iterable=configs,
+                          thread_pool_size=thread_pool_size)
+
+    failed = [config for config in result if not config['check_result']]
+
+    if failed:
+        for f in failed:
+            logging.error(f'Error in alertmanager config from cluster '
+                          f"{f['cluster']}:  {f['check_result']}")
+
+        sys.exit(ExitCodes.ERROR)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -92,6 +92,7 @@ import reconcile.kafka_clusters
 import reconcile.terraform_aws_route53
 import reconcile.prometheus_rules_tester
 import reconcile.dashdotdb_dvo
+import reconcile.alertmanager_config_validator
 
 from reconcile.status import ExitCodes
 from reconcile.status import RunningState
@@ -1183,4 +1184,14 @@ def integrations_validator(ctx):
 @click.pass_context
 def prometheus_rules_tester(ctx, thread_pool_size, cluster_name):
     run_integration(reconcile.prometheus_rules_tester, ctx.obj,
+                    thread_pool_size, cluster_name)
+
+
+@integration.command()
+@threaded()
+@binary(['amtool'])
+@cluster_name
+@click.pass_context
+def alertmanager_config_validator(ctx, thread_pool_size, cluster_name):
+    run_integration(reconcile.alertmanager_config_validator, ctx.obj,
                     thread_pool_size, cluster_name)

--- a/reconcile/utils/amtool.py
+++ b/reconcile/utils/amtool.py
@@ -1,0 +1,43 @@
+import tempfile
+from subprocess import run, PIPE
+
+
+class AmtoolResult(object):
+    '''This class represents a amtool command execution result'''
+    def __init__(self, is_ok, message):
+        self.is_ok = is_ok
+        self.message = message
+
+    def __str__(self):
+        return str(self.message).replace('\n', '')
+
+    def __bool__(self):
+        return self.is_ok
+
+
+def check_config(yaml_str):
+    '''Run amtool check rules on the given yaml string'''
+    return _run_yaml_str_cmd(cmd=['amtool', 'check-config'],
+                             yaml_str=yaml_str)
+
+
+def _run_yaml_str_cmd(cmd, yaml_str):
+    try:
+        with tempfile.NamedTemporaryFile(mode='w+') as fp:
+            fp.write(yaml_str)
+            fp.flush()
+            cmd.append(fp.name)
+            status = run(cmd, stdout=PIPE, stderr=PIPE)
+    except Exception as e:
+        return AmtoolResult(False, f'Error running amtool: {e}')
+
+    if status.returncode != 0:
+        message = 'Error running amtool'
+        if status.stdout:
+            message += ' - ' + status.stdout.decode()
+        if status.stderr:
+            message += ' - ' + status.stderr.decode()
+
+        return AmtoolResult(False, message)
+
+    return AmtoolResult(True, status.stdout.decode())


### PR DESCRIPTION
The approach is not very satisfactory, as we need to know the file where
the config is located. The other approach would be to define a schema
for the alertmanager config in app-interface, but it looks like
duplicating the job as we're going to check the schema anyway. As we
only have one alertmanager config this looks enough for the moment but
we may want to define a very lax schema in app-interface in the future
to better identify these files.

Closes [APPSRE-2419](https://issues.redhat.com/browse/APPSRE-2419)
Needs https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/14174

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>