### PR TITLE
Revert "monthly validation report metrics for visual-app-interface (#…

### DIFF
--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -102,13 +102,6 @@ class Report(object):
                 self.app.get('container_vulnerabilities')
             )
         )
-        # Deployment Validations
-        self.add_report_section(
-            'deployment_validations',
-            self.get_validations_content(
-                self.app_get('deployment_validations')
-            )
-        )
 
     @property
     def path(self):
@@ -182,19 +175,6 @@ class Report(object):
                 parsed_metrics.append({'cluster': cluster,
                                        'namespace': namespace,
                                        'vulnerabilities': severities})
-        return parsed_metrics
-
-    @staticmethod
-    def get_validations_content(deployment_validations):
-        parsed_metrics = []
-        if not deployment_validations:
-            return parsed_metrics
-
-        for cluster, namespaces in deployment_validations.items():
-            for namespace, validations in namespaces.items():
-                parsed_metrics.append({'cluster': cluster,
-                                       'namespace': namespace,
-                                       'validations': validations})
         return parsed_metrics
 
     def get_performance_metrics(self, performance_parameters, method, field):
@@ -444,57 +424,33 @@ def get_apps_data(date, month_delta=1):
             successes = [h for h in cr_history if h == 'SUCCESS']
             app['merge_activity'][cr] = (len(cr_history), len(successes))
 
-        logging.info(f"collecting dashdotdb information for {app_name}")
+        logging.info(f"collecting vulnerabilities information for {app_name}")
         app_namespaces = []
         for namespace in namespaces:
             if namespace['app']['name'] != app['name']:
                 continue
             app_namespaces.append(namespace)
-        vuln_mx = {}
-        validt_mx = {}
+        app_metrics = {}
         for family in text_string_to_metric_families(metrics):
             for sample in family.samples:
-                if sample.name == 'imagemanifestvuln_total':
-                    for app_namespace in app_namespaces:
-                        cluster = sample.labels['cluster']
-                        if app_namespace['cluster']['name'] != cluster:
-                            continue
-                        namespace = sample.labels['namespace']
-                        if app_namespace['name'] != namespace:
-                            continue
-                        severity = sample.labels['severity']
-                        if cluster not in vuln_mx:
-                            vuln_mx[cluster] = {}
-                        if namespace not in vuln_mx[cluster]:
-                            vuln_mx[cluster][namespace] = {}
-                        if severity not in vuln_mx[cluster][namespace]:
-                            value = int(sample.value)
-                            vuln_mx[cluster][namespace][severity] = value
-                if sample.name == 'deploymentvalidation_total':
-                    for app_namespace in app_namespaces:
-                        cluster = sample.labels['cluster']
-                        if app_namespace['cluster']['name'] != cluster:
-                            continue
-                        namespace = sample.labels['namespace']
-                        if app_namespace['name'] != namespace:
-                            continue
-                        validation = sample.labels['validation']
-                        # dvo: fail == 1, pass == 0, py: true == 1, false == 0
-                        # so: ({false|pass}, {true|fail})
-                        status = ('Passed', 'Failed')[sample.labels['status']]
-                        if cluster not in validt_mx:
-                            validt_mx[cluster] = {}
-                        if namespace not in validt_mx[cluster]:
-                            validt_mx[cluster][namespace] = {}
-                        if validation not in validt_mx[cluster][namespace]:
-                            validt_mx[cluster][namespace][validation] = {}
-                        if status not in validt_mx[cluster][namespace][validation]:  # noqa: E501
-                            validt_mx[cluster][namespace][validation][status] = {}  # noqa: E501
+                if sample.name != 'imagemanifestvuln_total':
+                    continue
+                for app_namespace in app_namespaces:
+                    cluster = sample.labels['cluster']
+                    if app_namespace['cluster']['name'] != cluster:
+                        continue
+                    namespace = sample.labels['namespace']
+                    if app_namespace['name'] != namespace:
+                        continue
+                    severity = sample.labels['severity']
+                    if cluster not in app_metrics:
+                        app_metrics[cluster] = {}
+                    if namespace not in app_metrics[cluster]:
+                        app_metrics[cluster][namespace] = {}
+                    if severity not in app_metrics[cluster][namespace]:
                         value = int(sample.value)
-                        validt_mx[cluster][namespace][validation][status] = value  # noqa: E501
-
-        app['container_vulnerabilities'] = vuln_mx
-        app['deployment_validations'] = validt_mx
+                        app_metrics[cluster][namespace][severity] = value
+        app['container_vulnerabilities'] = app_metrics
 
     return apps
 


### PR DESCRIPTION
…1330)"

This reverts commit 721c5c70d3c5ab0a3c64c4894c7a2250d3087b6d.

@mmclanerh the reporter is broken in different ways... first one being:
```python
INFO: collecting dashdotdb information for quayio
Traceback (most recent call last):
  File "/home/apahim/git/qontract-reconcile/venv/bin/app-interface-reporter", line 33, in <module>
    sys.exit(load_entry_point('reconcile', 'console_scripts', 'app-interface-reporter')())
  File "/home/apahim/git/qontract-reconcile/venv/lib64/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/apahim/git/qontract-reconcile/venv/lib64/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/apahim/git/qontract-reconcile/venv/lib64/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/apahim/git/qontract-reconcile/venv/lib64/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/apahim/git/qontract-reconcile/tools/app_interface_reporter.py", line 535, in main
    apps = get_apps_data(now)
  File "/home/apahim/git/qontract-reconcile/tools/app_interface_reporter.py", line 484, in get_apps_data
    status = ('Passed', 'Failed')[sample.labels['status']]
TypeError: tuple indices must be integers or slices, not str
```

Unfortunatelly I'm on a tight schedule here, so I'm going to revert this hoping that you can check it out?