### PR TITLE
Add validation to alertmanager config

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/qontract-reconcile-base:0.1.2
+FROM quay.io/app-sre/qontract-reconcile-base:0.2.0
 
 WORKDIR /reconcile
 

--- a/reconcile/utils/amtool.py
+++ b/reconcile/utils/amtool.py
@@ -1,0 +1,43 @@
+import tempfile
+from subprocess import run, PIPE
+
+
+class AmtoolResult(object):
+    '''This class represents a amtool command execution result'''
+    def __init__(self, is_ok, message):
+        self.is_ok = is_ok
+        self.message = message
+
+    def __str__(self):
+        return str(self.message).replace('\n', '')
+
+    def __bool__(self):
+        return self.is_ok
+
+
+def check_config(yaml_str):
+    '''Run amtool check rules on the given yaml string'''
+    return _run_yaml_str_cmd(cmd=['amtool', 'check-config'],
+                             yaml_str=yaml_str)
+
+
+def _run_yaml_str_cmd(cmd, yaml_str):
+    try:
+        with tempfile.NamedTemporaryFile(mode='w+') as fp:
+            fp.write(yaml_str)
+            fp.flush()
+            cmd.append(fp.name)
+            status = run(cmd, stdout=PIPE, stderr=PIPE)
+    except Exception as e:
+        return AmtoolResult(False, f'Error running amtool: {e}')
+
+    if status.returncode != 0:
+        message = 'Error running amtool'
+        if status.stdout:
+            message += ' - ' + status.stdout.decode()
+        if status.stderr:
+            message += ' - ' + status.stderr.decode()
+
+        return AmtoolResult(False, message)
+
+    return AmtoolResult(True, status.stdout.decode())


### PR DESCRIPTION
This is done via a `validate_alertmanager_config` option in openshift
resources. In this way we don't have to write a new integration that
resolves templates we are already resolving.

Closes [APPSRE-2419](https://issues.redhat.com/browse/APPSRE-2419)
Needs https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/14174

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>