### PR TITLE
[aws-garbage-collector] don't keep failed history

### DIFF
--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -519,6 +519,7 @@ cronjobs:
   cron: '0 */2 * * *'
   extraArgs: --vault-output-path app-sre/integrations-output
 - name: aws-garbage-collector
+  failedJobHistoryLimit: "0"
   resources:
     requests:
         memory: 200Mi

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -11804,7 +11804,7 @@ objects:
     schedule: "0 0 * * 0"
     concurrencyPolicy: Allow
     successfulJobHistoryLimit: 3
-    failedJobHistoryLimit: 1
+    failedJobHistoryLimit: 0
     jobTemplate:
       spec:
         template:


### PR DESCRIPTION
even if it fails, it succeeds on the next run (been that way for over a year).