### PR TITLE
get providerVersion from account schema and not vault

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -232,6 +232,7 @@ AWS_ACCOUNTS_QUERY = """
     consoleUrl
     resourcesDefaultRegion
     supportedDeploymentRegions
+    providerVersion
     accountOwners {
       name
       email

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -85,6 +85,8 @@ class TerrascriptClient(object):
         filtered_accounts = self.filter_disabled_accounts(accounts)
         self.secret_reader = SecretReader(settings=settings)
         self.populate_configs(filtered_accounts)
+        self.versions = {a['name']: a['providerVersion']
+                         for a in filtered_accounts}
         tss = {}
         locks = {}
         for name, config in self.configs.items():
@@ -96,7 +98,7 @@ class TerrascriptClient(object):
                     ts += provider.aws(
                         access_key=config['aws_access_key_id'],
                         secret_key=config['aws_secret_access_key'],
-                        version=config['providerVersion'],
+                        version=self.versions.get(name),
                         region=region,
                         alias=region)
 
@@ -104,7 +106,7 @@ class TerrascriptClient(object):
             ts += provider.aws(
                 access_key=config['aws_access_key_id'],
                 secret_key=config['aws_secret_access_key'],
-                version=config['providerVersion'],
+                version=self.versions.get(name),
                 region=config['region'])
             b = Backend("s3",
                         access_key=config['aws_access_key_id'],
@@ -359,7 +361,7 @@ class TerrascriptClient(object):
                 ts += provider.aws(
                     access_key=config['aws_access_key_id'],
                     secret_key=config['aws_secret_access_key'],
-                    version=config['providerVersion'],
+                    version=self.versions.get(account_name),
                     region=account['assume_region'],
                     alias=alias,
                     assume_role={'role_arn': assume_role})

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -96,6 +96,7 @@ class TerrascriptClient(object):
                     ts += provider.aws(
                         access_key=config['aws_access_key_id'],
                         secret_key=config['aws_secret_access_key'],
+                        version=config['providerVersion'],
                         region=region,
                         alias=region)
 
@@ -103,6 +104,7 @@ class TerrascriptClient(object):
             ts += provider.aws(
                 access_key=config['aws_access_key_id'],
                 secret_key=config['aws_secret_access_key'],
+                version=config['providerVersion'],
                 region=config['region'])
             b = Backend("s3",
                         access_key=config['aws_access_key_id'],
@@ -116,8 +118,6 @@ class TerrascriptClient(object):
         self.tss = tss
         self.locks = locks
         self.uids = {a['name']: a['uid'] for a in filtered_accounts}
-        self.versions = {a['name']: a['providerVersion']
-                         for a in filtered_accounts}
         self.default_regions = {a['name']: a['resourcesDefaultRegion']
                                 for a in filtered_accounts}
         github_config = get_config()['github']
@@ -359,6 +359,7 @@ class TerrascriptClient(object):
                 ts += provider.aws(
                     access_key=config['aws_access_key_id'],
                     secret_key=config['aws_secret_access_key'],
+                    version=config['providerVersion'],
                     region=account['assume_region'],
                     alias=alias,
                     assume_role={'role_arn': assume_role})

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -96,7 +96,6 @@ class TerrascriptClient(object):
                     ts += provider.aws(
                         access_key=config['aws_access_key_id'],
                         secret_key=config['aws_secret_access_key'],
-                        version=config['aws_provider_version'],
                         region=region,
                         alias=region)
 
@@ -104,7 +103,6 @@ class TerrascriptClient(object):
             ts += provider.aws(
                 access_key=config['aws_access_key_id'],
                 secret_key=config['aws_secret_access_key'],
-                version=config['aws_provider_version'],
                 region=config['region'])
             b = Backend("s3",
                         access_key=config['aws_access_key_id'],
@@ -118,6 +116,8 @@ class TerrascriptClient(object):
         self.tss = tss
         self.locks = locks
         self.uids = {a['name']: a['uid'] for a in filtered_accounts}
+        self.versions = {a['name']: a['providerVersion']
+                         for a in filtered_accounts}
         self.default_regions = {a['name']: a['resourcesDefaultRegion']
                                 for a in filtered_accounts}
         github_config = get_config()['github']
@@ -359,7 +359,6 @@ class TerrascriptClient(object):
                 ts += provider.aws(
                     access_key=config['aws_access_key_id'],
                     secret_key=config['aws_secret_access_key'],
-                    version=config['aws_provider_version'],
                     region=account['assume_region'],
                     alias=alias,
                     assume_role={'role_arn': assume_role})


### PR DESCRIPTION
Removed references to vault secret for the `aws_provider_version` to `providerVersion` in the account config. 
Updates for `providerVersion` have already been made on the app-interface side and merged.