### PR TITLE
Improved detection of Vault KV version and better handling of Forbidden errors

### DIFF
--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -80,10 +80,16 @@ class _VaultClient:
         """
         secret_path = secret['path']
         secret_version = secret.get('version')
-        try:
+
+        data = None
+        if secret_version is not None:
             data = self._read_all_v2(secret_path, secret_version)
-        except Exception:
+        else:
             data = self._read_all_v1(secret_path)
+
+        if data is None:
+            raise SecretNotFound(secret_path, secret_version)
+
         return data
 
     def _read_all_v2(self, path, version):


### PR DESCRIPTION
- Properly raise vault access forbidden errors (with useful message)
- Refactor the naive try/except for falling back to KV_1 if KV_2 failed into a proper detection of the KV version 

This will hopefuully solve most of the very lengthy stack traces we've been getting in the logs which were caused by bad secrets and/or permission denied. With this we should be able to spot and fit these more easily