### PR TITLE
[WiP] Don't mirror any docker.io images to public repos

### DIFF
--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -103,7 +103,6 @@ class QuayMirror:
 
                     mirror_image = Image(item['mirror']['url'])
                     if (mirror_image.registry == 'docker.io'
-                            and mirror_image.repository == 'library'
                             and item['public']):
                         _LOG.error("Image %s can't be mirrored to a public "
                                    "quay repository.", mirror_image)


### PR DESCRIPTION
Aparently the issue is not only with official docker images, but with
any images hosted in docker.io.

Signed-off-by: Amador Pahim <apahim@redhat.com>