### PR TITLE
[slack-usergroups] handle usergroup without users

### DIFF
--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -37,7 +37,7 @@ class SlackApi(object):
         usergroup = self.get_usergroup(handle)
         description = usergroup['description']
 
-        user_ids = usergroup['users']
+        user_ids = usergroup.get('users', [])
         users = self.get_users_by_ids(user_ids)
 
         channel_ids = usergroup['prefs']['channels']


### PR DESCRIPTION
fixes:
```
16:25:40 Traceback (most recent call last):
16:25:40   File "/usr/local/bin/qontract-reconcile", line 33, in <module>
16:25:40     sys.exit(load_entry_point('reconcile==0.2.2', 'console_scripts', 'qontract-reconcile')())
16:25:40   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 829, in __call__
16:25:40     return self.main(*args, **kwargs)
16:25:40   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 782, in main
16:25:40     rv = self.invoke(ctx)
16:25:40   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1259, in invoke
16:25:40     return _process_result(sub_ctx.command.invoke(sub_ctx))
16:25:40   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1066, in invoke
16:25:40     return ctx.invoke(self.callback, **ctx.params)
16:25:40   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 610, in invoke
16:25:40     return callback(*args, **kwargs)
16:25:40   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/decorators.py", line 21, in new_func
16:25:40     return f(get_current_context(), *args, **kwargs)
16:25:40   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 595, in slack_usergroups
16:25:40     run_integration(reconcile.slack_usergroups, ctx.obj)
16:25:40   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 359, in run_integration
16:25:40     func_container.run(dry_run, *args, **kwargs)
16:25:40   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/slack_usergroups.py", line 346, in run
16:25:40     current_state = get_current_state(slack_map)
16:25:40   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/slack_usergroups.py", line 121, in get_current_state
16:25:40     users, channels, description = slack.describe_usergroup(ug)
16:25:40   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/slack_api.py", line 40, in describe_usergroup
16:25:40     user_ids = usergroup['users']
16:25:40 KeyError: 'users'
```