### PR TITLE
[slack-usergroups] handle empty pagerduty targets

### DIFF
--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -156,6 +156,8 @@ def get_slack_usernames_from_pagerduty(pagerduties, users, usergroup):
         pd = PagerDutyApi(pd_token, settings=settings)
         pagerduty_names = pd.get_pagerduty_users(pd_resource_type,
                                                  pd_resource_id)
+        if not pagerduty_names:
+            continue
         pagerduty_names = [name.split('+', 1)[0] for name in pagerduty_names]
         if not pagerduty_names:
             continue


### PR DESCRIPTION
now that it seems that slack supports empty usergroups via the API, we can allow for empty PagerDuty targets to be defined (an escalation policy or a schedule with no one in it). this _should_ lead to an empty slack usergroup.

related to https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/13802