### PR TITLE
[slack-usergroups] add support for empty usergroups

### DIFF
--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -80,7 +80,7 @@ class SlackApi(object):
         # since Slack API does not support empty usergroups
         # we can trick it by passing a deleted user
         if len(users_list) == 0:
-            users = [self.get_random_deleted_user()]
+            users_list = [self.get_random_deleted_user()]
         users = ','.join(users_list)
         self.sc.api_call(
             "usergroups.users.update",

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -77,12 +77,19 @@ class SlackApi(object):
         )
 
     def update_usergroup_users(self, id, users_list):
+        # since Slack API does not support empty usergroups
+        # we can trick it by passing a deleted user
+        if len(users) == 0:
+            users = [self.get_random_deleted_user()]
         users = ','.join(users_list)
         self.sc.api_call(
             "usergroups.users.update",
             usergroup=id,
             users=users,
         )
+
+    def get_random_deleted_user(self):
+        return ''
 
     def get_channels_by_names(self, channels_names):
         return {k: v for k, v in self.get('channels').items()

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -89,7 +89,9 @@ class SlackApi(object):
         )
 
     def get_random_deleted_user(self):
-        return ''
+        for user_id, user_data in self._get('users').items():
+            if user_data['deleted'] is True:
+                return user_id
 
     def get_channels_by_names(self, channels_names):
         return {k: v['name'] for k, v in self._get('channels').items()

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -93,6 +93,10 @@ class SlackApi(object):
             if user_data['deleted'] is True:
                 return user_id
 
+        logging.error('could not find a deleted user, ' +
+                      'empty usergroup will not work')
+        return ''
+
     def get_channels_by_names(self, channels_names):
         return {k: v['name'] for k, v in self._get('channels').items()
                 if v in channels_names}

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -1,4 +1,5 @@
 import time
+import logging
 
 from slackclient import SlackClient
 from sretoolbox.utils import retry

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -92,23 +92,23 @@ class SlackApi(object):
         return ''
 
     def get_channels_by_names(self, channels_names):
-        return {k: v for k, v in self.get('channels').items()
+        return {k: v['name'] for k, v in self._get('channels').items()
                 if v in channels_names}
 
     def get_channels_by_ids(self, channels_ids):
-        return {k: v for k, v in self.get('channels').items()
+        return {k: v['name'] for k, v in self._get('channels').items()
                 if k in channels_ids}
 
     def get_users_by_names(self, user_names):
-        return {k: v for k, v in self.get('users').items()
+        return {k: v['name'] for k, v in self._get('users').items()
                 if v in user_names}
 
     def get_users_by_ids(self, users_ids):
-        return {k: v for k, v in self.get('users').items()
+        return {k: v['name'] for k, v in self._get('users').items()
                 if k in users_ids}
 
     @retry()
-    def get(self, type):
+    def _get(self, type):
         result_key = 'members' if type == 'users' else type
         results = {}
         cursor = ''
@@ -125,7 +125,7 @@ class SlackApi(object):
                 time.sleep(1)
                 continue
             for r in result[result_key]:
-                results[r['id']] = r['name']
+                results[r['id']] = r
             cursor = result['response_metadata']['next_cursor']
             if cursor == '':
                 break


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2949

we found out that if you pass a deleted user to a usergroup, it can be emptied out.
this will allow us to support usergroups which are not active 24/7.