### PR TITLE
Add decorator for ensuring specific binary versions are available

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -100,9 +100,16 @@ from reconcile.status import RunningState
 from reconcile.utils.gql import (GqlApiError, GqlApiErrorForbiddenSchema,
                                  GqlApiIntegrationNotFound)
 from reconcile.utils.aggregated_list import RunnerException
-from reconcile.utils.binary import binary
+from reconcile.utils.binary import binary, binary_version
 from reconcile.utils.environ import environ
 from reconcile.utils.unleash import get_feature_toggle_state
+
+
+TERRAFORM_VERSION = '0.13.5'
+TERRAFORM_VERSION_REGEX = r'^Terraform\sv([\d]+\.[\d]+\.[\d]+)$'
+
+OC_VERSION = '4.6.1'
+OC_VERSION_REGEX = r'^Client\sVersion:\s([\d]+\.[\d]+\.[\d]+)$'
 
 
 def before_breadcrumb(crumb, hint):
@@ -414,6 +421,8 @@ def integration(ctx, configfile, dry_run, validate_schemas, dump_schemas_file,
 @terraform
 @threaded()
 @binary(['terraform'])
+@binary_version('terraform', ['version'],
+                TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @enable_deletion(default=False)
 @click.pass_context
 def terraform_aws_route53(ctx, print_only, enable_deletion,
@@ -942,6 +951,9 @@ def user_validator(ctx):
 @vault_output_path
 @threaded(default=20)
 @binary(['terraform', 'oc'])
+@binary_version('terraform', ['version'],
+                TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @enable_deletion(default=False)
@@ -965,6 +977,8 @@ def terraform_resources(ctx, print_only, enable_deletion,
 @throughput
 @threaded(default=20)
 @binary(['terraform', 'gpg'])
+@binary_version('terraform', ['version'],
+                TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @enable_deletion(default=True)
 @send_mails(default=True)
 @click.pass_context
@@ -980,6 +994,8 @@ def terraform_users(ctx, print_only, enable_deletion, io_dir,
 @terraform
 @threaded()
 @binary(['terraform'])
+@binary_version('terraform', ['version'],
+                TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @enable_deletion(default=False)
 @click.pass_context
 def terraform_vpc_peerings(ctx, print_only, enable_deletion,

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -477,6 +477,7 @@ def github_validator(ctx):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @click.pass_context
@@ -490,6 +491,7 @@ def openshift_clusterrolebindings(ctx, thread_pool_size, internal,
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @click.pass_context
@@ -501,6 +503,7 @@ def openshift_rolebindings(ctx, thread_pool_size, internal, use_jump_host):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @click.pass_context
@@ -512,6 +515,7 @@ def openshift_groups(ctx, thread_pool_size, internal, use_jump_host):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @click.pass_context
@@ -523,6 +527,7 @@ def openshift_users(ctx, thread_pool_size, internal, use_jump_host):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @vault_output_path
@@ -589,6 +594,7 @@ def unleash_watcher(ctx):
 @integration.command()
 @environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @threaded()
 @internal()
 @use_jump_host()
@@ -681,6 +687,7 @@ def aws_support_cases_sos(ctx, gitlab_project_id, thread_pool_size):
 @integration.command()
 @threaded(default=20)
 @binary(['oc', 'ssh', 'amtool'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @cluster_name
@@ -702,6 +709,7 @@ def openshift_resources(ctx, thread_pool_size, internal, use_jump_host,
 @threaded(default=20)
 @throughput
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @click.option('--saas-file-name',
               default=None,
               help='saas-file to act on.')
@@ -722,6 +730,7 @@ def openshift_saas_deploy(ctx, thread_pool_size, io_dir,
 @gitlab_project_id
 @threaded()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @throughput
 @click.pass_context
 def openshift_saas_deploy_wrapper(ctx, thread_pool_size, io_dir,
@@ -792,6 +801,7 @@ def gitlab_labeler(ctx, gitlab_project_id, gitlab_merge_request_id):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @click.pass_context
@@ -804,6 +814,7 @@ def openshift_namespaces(ctx, thread_pool_size, internal, use_jump_host):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @click.pass_context
@@ -816,6 +827,7 @@ def openshift_network_policies(ctx, thread_pool_size, internal, use_jump_host):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @click.pass_context
@@ -829,6 +841,7 @@ def openshift_acme(ctx, thread_pool_size, internal, use_jump_host):
 @threaded()
 @take_over()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @click.pass_context
@@ -843,6 +856,7 @@ def openshift_limitranges(ctx, thread_pool_size, internal,
 @threaded()
 @take_over()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @click.pass_context
@@ -856,6 +870,7 @@ def openshift_resourcequotas(ctx, thread_pool_size, internal,
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @cluster_name
@@ -872,6 +887,7 @@ def openshift_vault_secrets(ctx, thread_pool_size, internal, use_jump_host,
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @cluster_name
@@ -888,6 +904,7 @@ def openshift_routes(ctx, thread_pool_size, internal, use_jump_host,
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh', 'jsonnet'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @click.pass_context
@@ -1178,6 +1195,7 @@ def ocp_release_ecr_mirror(ctx):
 @integration.command()
 @threaded()
 @binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @click.pass_context

--- a/reconcile/utils/binary.py
+++ b/reconcile/utils/binary.py
@@ -1,5 +1,8 @@
+import re
+
 from functools import wraps
 from distutils.spawn import find_executable
+from subprocess import run, PIPE
 
 
 def binary(binaries=[]):
@@ -14,3 +17,43 @@ def binary(binaries=[]):
             f(*args, **kwargs)
         return f_binary
     return deco_binary
+
+
+def binary_version(binary, version_args, search_regex, expected_version):
+    """Check that a binary exists and is a desired version"""
+    def deco_binary_version(f):
+        @wraps(f)
+        def f_binary_version(*args, **kwargs):
+            regex = re.compile(search_regex)
+
+            cmd = [binary]
+            cmd.extend(version_args)
+            res = run(cmd, stdout=PIPE, stderr=PIPE)
+            if res.returncode != 0:
+                raise Exception(
+                    f"Could not execute binary '{binary}' for binary version "
+                    f"check: return code {res.returncode}")
+
+            found = False
+            match = None
+            for line in res.stdout.splitlines():
+                match = regex.search(line.decode("utf-8"))
+                if match is not None:
+                    found = True
+                    break
+
+            if not found:
+                raise Exception(
+                    f"Could not find version for binary '{binary}' via regex "
+                    f"for binary version check: "
+                    f"regex did not match: '{search_regex}'")
+
+            version = match.group(1)
+            if version != expected_version:
+                raise Exception(
+                    f"Binary version check for binary {binary} failed! "
+                    f"Expected: {expected_version}, found: {version}")
+
+            f(*args, **kwargs)
+        return f_binary_version
+    return deco_binary_version


### PR DESCRIPTION
- Add `binary_version` decorator
- Add `binary_version` decorator to all `cli.py` commands that uses `terraform` or `oc`

Solves APPSRE-2932 and should help with APPSRE-2724