### PR TITLE
[openshift-saas-deploy] add github large file handler

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -199,8 +199,35 @@ class SaasHerder():
 
     @staticmethod
     def _get_file_contents_github(repo, path, commit_sha):
-        f = repo.get_contents(path, commit_sha)
-        return f.decoded_content
+        try:
+            f = repo.get_contents(path, commit_sha)
+            return f.decoded_content
+        except GithubException as e:
+            # slightly copied with love from
+            # https://github.com/PyGithub/PyGithub/issues/661
+            errors = e.data['errors']
+            # example errors dict that we are looking for
+            # {
+            #    'message': '<text>',
+            #    'errors': [{
+            #                  'resource': 'Blob',
+            #                  'field': 'data',
+            #                  'code': 'too_large'
+            #               }],
+            #    'documentation_url': '<url>'
+            # }
+            for error in errors:
+                if error['code'] == 'too_large':
+                    # get large files
+                    tree = repo.get_git_tree(
+                        commit_sha, recursive='/' in path).tree
+                    for x in tree:
+                        if x.path != path.lstrip('/'):
+                            continue
+                        blob = repo.get_git_blob(x.sha)
+                        return base64.b64decode(blob.content).decode("utf8")
+
+            raise e
 
     @retry()
     def _get_file_contents(self, options):


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-2959

upstream issue: https://github.com/PyGithub/PyGithub/issues/661

this PR adds a handle to errors caused by files with a size of over 1MB. the new code can handle files up to 100MB, which i doubt we'll ever reach in text files.