### PR TITLE
Useful stdout logging in run-integration

### DIFF
--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -8,7 +8,7 @@ import time
 from prometheus_client import start_http_server
 
 from reconcile.status import ExitCodes
-from reconcile.cli import integration
+from reconcile.cli import integration, LOG_FMT, LOG_DATEFMT
 from reconcile.utils.metrics import run_time
 from reconcile.utils.metrics import run_status
 
@@ -30,7 +30,8 @@ LOG = logging.getLogger(__name__)
 
 # Messages to stdout
 STREAM_HANDLER = logging.StreamHandler(sys.stdout)
-STREAM_HANDLER.setFormatter(logging.Formatter(fmt='%(message)s'))
+STREAM_HANDLER.setFormatter(logging.Formatter(fmt=LOG_FMT,
+                                              datefmt=LOG_DATEFMT))
 HANDLERS = [STREAM_HANDLER]
 
 # Messages to the log file

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -111,6 +111,10 @@ TERRAFORM_VERSION_REGEX = r'^Terraform\sv([\d]+\.[\d]+\.[\d]+)$'
 OC_VERSION = '4.6.1'
 OC_VERSION_REGEX = r'^Client\sVersion:\s([\d]+\.[\d]+\.[\d]+)$'
 
+LOG_FMT = '[%(asctime)s] [%(levelname)s] ' \
+    '[%(filename)s:%(funcName)s:%(lineno)d] - %(message)s'
+LOG_DATEFMT = '%Y-%m-%d %H:%M:%S'
+
 
 def before_breadcrumb(crumb, hint):
     # https://docs.sentry.io/platforms/python/configuration/filtering/
@@ -387,12 +391,7 @@ def run_integration(func_container, ctx, *args, **kwargs):
 
 def init_log_level(log_level):
     level = getattr(logging, log_level) if log_level else logging.INFO
-    format = '[%(asctime)s] [%(levelname)s] '
-    format += '[%(filename)s:%(funcName)s:%(lineno)d] '
-    format += '- %(message)s'
-    logging.basicConfig(format=format,
-                        datefmt='%Y-%m-%d %H:%M:%S',
-                        level=level)
+    logging.basicConfig(format=LOG_FMT, datefmt=LOG_DATEFMT, level=level)
 
 
 @click.group()


### PR DESCRIPTION
Using the same format we have in the cli. Current format without dates makes difficult to debug stuff in pods stdout.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>