### PR TITLE
prevent openshift integrations from reconciling errored clusters

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -154,7 +154,7 @@ def populate_current_state(spec, ri, integration, integration_version):
                 openshift_resource.name,
                 openshift_resource
             )
-    except StatusCodeError as e:
+    except StatusCodeError:
         ri.register_error(cluster=spec.cluster)
 
 

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -140,19 +140,22 @@ def populate_current_state(spec, ri, integration, integration_version):
         msg = f"[{spec.cluster}] cluster has no API resource {spec.resource}."
         logging.warning(msg)
         return
-    for item in oc.get_items(spec.resource,
-                             namespace=spec.namespace,
-                             resource_names=spec.resource_names):
-        openshift_resource = OR(item,
-                                integration,
-                                integration_version)
-        ri.add_current(
-            spec.cluster,
-            spec.namespace,
-            spec.resource,
-            openshift_resource.name,
-            openshift_resource
-        )
+    try:
+        for item in oc.get_items(spec.resource,
+                                 namespace=spec.namespace,
+                                 resource_names=spec.resource_names):
+            openshift_resource = OR(item,
+                                    integration,
+                                    integration_version)
+            ri.add_current(
+                spec.cluster,
+                spec.namespace,
+                spec.resource,
+                openshift_resource.name,
+                openshift_resource
+            )
+    except StatusCodeError as e:
+        ri.register_error(cluster=spec.cluster)
 
 
 def fetch_current_state(namespaces=None,

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -297,6 +297,14 @@ def realize_data(dry_run, oc_map, ri,
         enable_deletion = False
 
     for cluster, namespace, resource_type, data in ri:
+        if ri.has_error_registered(cluster=cluster):
+            msg = (
+                "[{}] skipping realize_data for "
+                "cluster with errors"
+            ).format(cluster)
+            logging.error(msg)
+            continue
+
         # desired items
         for name, d_item in data['desired'].items():
             c_item = data['current'].get(name)

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -603,7 +603,7 @@ def fetch_states(spec, ri):
                                 spec.parent)
 
     except StatusCodeError as e:
-        ri.register_error()
+        ri.register_error(cluster=spec.cluster)
         msg = 'cluster: {},'
         msg += 'namespace: {},'
         msg += 'resource_names: {},'

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -216,7 +216,7 @@ def populate_oc_resources(spec, ri):
                 openshift_resource
             )
     except StatusCodeError as e:
-        ri.register_error()
+        ri.register_error(cluster=spec.cluster)
         msg = 'cluster: {},'
         msg += 'namespace: {},'
         msg += 'resource: {},'

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -425,6 +425,7 @@ class ResourceInventory(object):
     def __init__(self):
         self._clusters = {}
         self._error_registered = False
+        self._error_registered_clusters = {}
         self._lock = Lock()
 
     def initialize_resource_type(self, cluster, namespace, resource_type):
@@ -464,8 +465,12 @@ class ResourceInventory(object):
                     data = self._clusters[cluster][namespace][resource_type]
                     yield (cluster, namespace, resource_type, data)
 
-    def register_error(self):
+    def register_error(self, cluster=None):
         self._error_registered = True
+        if cluster is not None:
+            self._error_registered_clusters[cluster] = True
 
-    def has_error_registered(self):
+    def has_error_registered(self, cluster=None):
+        if cluster is not None:
+            return self._error_registered_clusters.get(cluster) or False
         return self._error_registered

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -472,5 +472,5 @@ class ResourceInventory(object):
 
     def has_error_registered(self, cluster=None):
         if cluster is not None:
-            return self._error_registered_clusters.get(cluster) or False
+            return self._error_registered_clusters.get(cluster, False)
         return self._error_registered


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-2942

we have recently added an ability to check if a cluster is reachable and skip it if it isn't: #1214

one scenario that is not covered by this PR is a cluster starting to be unreachable during an integration (and not in the beginning like covered by #1214). In this scenario as things stand, we will try to reconcile all resources that failed to be fetched:
```
(venv) (master) $ git diff
diff --git a/reconcile/openshift_resources_base.py b/reconcile/openshift_resources_base.py
index 9600245..f8295ee 100644
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -593,6 +593,7 @@ def fetch_desired_state(oc, ri, cluster, namespace, resource, parent):
 def fetch_states(spec, ri):
     try:
         if spec.type == "current":
+            raise StatusCodeError('test')
             fetch_current_state(spec.oc, ri, spec.cluster,
                                 spec.namespace, spec.resource,
                                 spec.resource_type_override,
(venv) (master) $ qontract-reconcile --config config.debug.toml --dry-run openshift-resources --cluster-name test-cluster --namespace-name test-namespace
[2021-02-07 12:23:44] [INFO] [gql.py:init_from_config:205] - using gql endpoint http://localhost:4000/graphqlsha/xxxx
[2021-02-07 12:23:49] [ERROR] [openshift_resources_base.py:fetch_states:616] - cluster: test-cluster,namespace: test-namespace,resource_names: None,exception: test
[2021-02-07 12:23:49] [INFO] [openshift_base.py:apply:201] - ['apply', 'test-cluster', 'test-namespace', 'ConfigMap', 'test-cm']
(venv) (master) $ echo $?
1
```

the integration exits with `1` indicating that it understands that something went wrong, but it still wants to apply the resource (assumes it doesn't exist).

this PR adds the ability to register an error (via `ResourceInventory`) to a specific cluster. with this, we can now skip clusters with errors in `realize_data` and avoid applying resources that already exist.

this is good for several reasons:
1. any applied resource with `qontract.recycle: true` will cause pods to be recycled, and now we will not apply resources.
2. our SLOs are calculated based on apply/delete, and now we will skip the cluster and by that we will pass on storing the metric.

with the changes of this PR in place, this is the new behavior of an integration:
```
(venv) (realize-cluster-error) $ qontract-reconcile --config config.debug.toml --dry-run openshift-resources --cluster-name test-cluster --namespace-name test-namespace
[2021-02-07 12:43:21] [INFO] [gql.py:init_from_config:205] - using gql endpoint http://localhost:4000/graphqlsha/xxxx
[2021-02-07 12:43:25] [ERROR] [openshift_resources_base.py:fetch_states:616] - cluster: test-cluster,namespace: test-namespace,resource_names: None,exception: test
[2021-02-07 12:43:25] [ERROR] [openshift_base.py:realize_data:305] - [test-cluster] skipping realize_data for cluster with errors
(venv) (realize-cluster-error) $ echo $?
1
```

notes to the reviewer:
there are things about this PR which I don't particularly like, such as wrapping a few calls under the same `try` block. this is currently the way it is in many places and I'd like to change that in a future PR for all occurrences.