### PR TITLE
[ocm-clusters] allow to change cluster channel group

### DIFF
--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -187,7 +187,8 @@ class OCM(object):
                 'listening':
                     'internal' if cluster_spec['private']
                     else 'external'
-            }
+            },
+            'upgrade_channel_group': cluster_spec['channel'],
         }
 
         autoscale = cluster_spec.get('autoscale')


### PR DESCRIPTION
following https://issues.redhat.com/browse/SDA-3297, we can now update cluster channel through the API.

the API will soon change to PATCH `version.channel_group` instead of `upgrade_channel_group`, but that's WIP