### PR TITLE
move self-implemented caches to functools.lru_cache

### DIFF
--- a/reconcile/utils/sentry_client.py
+++ b/reconcile/utils/sentry_client.py
@@ -1,6 +1,7 @@
-import requests
+import functools
 import json
 import parse
+import requests
 
 from sretoolbox.utils import retry
 
@@ -11,7 +12,6 @@ class SentryClient:
     def __init__(self, host, token):
         self.host = host
         self.auth_token = token
-        self._cache = {}
 
     @retry()
     def _do_sentry_api_call_(self, method, path, slugs, payload=None):
@@ -59,12 +59,9 @@ class SentryClient:
         return all_results
 
     # Organization functions
+    @functools.lru_cache()
     def get_organizations(self):
-        organizations = self._cache.get('organizations')
-        if organizations:
-            return organizations
         response = self._do_sentry_api_call_("get", "organizations", [])
-        self._cache['organizations'] = response
         return response
 
     def get_organization(self, slug):
@@ -72,12 +69,9 @@ class SentryClient:
         return response
 
     # Project functions
+    @functools.lru_cache()
     def get_projects(self):
-        projects = self._cache.get('projects')
-        if projects:
-            return projects
         response = self._do_sentry_api_call_("get", "projects", [])
-        self._cache['projects'] = response
         return response
 
     def get_project(self, slug):
@@ -228,13 +222,10 @@ class SentryClient:
         return response
 
     # User/Member functions
+    @functools.lru_cache()
     def get_users(self):
-        users = self._cache.get('users')
-        if users:
-            return users
         response = self._do_sentry_api_call_("get", "organizations",
                                              [self.ORGANIZATION, "members"])
-        self._cache['users'] = response
         return response
 
     def get_user(self, email):


### PR DESCRIPTION
This issue implements the changes from: https://issues.redhat.com/browse/APPSRE-2866
We figured, that this pattern:

```python
class Foo:
  __init__(self):
    self._cache = {}

  get_something(self):
    cache_key = 'something'
    cached = self._cache.get(cache_key)
    if cached is not None:
      return cached
    fresh = do_expensive_operation_to_get_something()
    self._cache[cache_key] = fresh
```

can be expressed in a simpler way using [@functools.lru_cache](https://docs.python.org/3/library/functools.html#functools.lru_cache):

```python
import functools

class Foo:
  @functools.lru_cache()
  get_something(self):
    return do_expensive_operation_to_get_something()

  # added to explain further usage:

  @functools.lru_cache()
  get_something_by_id(self, id):
    # results are even cached based on function argument values
    return do_expensive_operation_to_get_something_by_id(id)

  update_something(self):
    do_something_that_makes_cached_data_from_get_something_stale()
    # remove all data from `get_something`'s cache
    self.get_something.cache_clear()
```

cc @apahim 