### PR TITLE
make vault read_all_v2 cache unbound to restore previous caching beha…

### DIFF
--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -108,7 +108,7 @@ class _VaultClient:
 
         return version
 
-    @functools.lru_cache()
+    @functools.lru_cache(maxsize=None)
     def _read_all_v2(self, path, version):
         path_split = path.split('/')
         mount_point = path_split[0]


### PR DESCRIPTION
…vior

this is a follow up to https://github.com/app-sre/qontract-reconcile/pull/1373/files#discussion_r573650034
and restores previous unbound caching behavior on the _read_all_v2 function