### PR TITLE
[saas-file-owners] only add comments when MR is rebased

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -253,8 +253,9 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None,
     desired_state = collect_state()
     diffs = [s for s in desired_state if s not in current_state]
 
+    rebased = gl.is_merge_request_rebased(gitlab_merge_request_id)
     compare_diffs = collect_compare_diffs(current_state, desired_state)
-    if compare_diffs:
+    if compare_diffs and rebased:
         compare_diffs_comment_body = 'Diffs:\n' + \
             '\n'.join([f'- {d}' for d in compare_diffs])
         gl.add_comment_to_merge_request(
@@ -314,7 +315,7 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None,
                          if not c.endswith(saas_file_path)]
 
     comment_body = '\n'.join(comment_lines.values())
-    if comment_body:
+    if comment_body and rebased:
         # if there are still entries in this list - they are not approved
         if not valid_saas_file_changes_only:
             comment_body = comment_body + \

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -296,6 +296,15 @@ class GitLabApi(object):
                              'id': note.id})
         return comments
 
+    def is_merge_request_rebased(self, mr_id):
+        merge_request = self.project.mergerequests.get(mr_id)
+        target_branch = merge_request.target_branch
+        head = self.project.commits.list(ref_name=target_branch)[0].id
+        result = self.project.repository_compare(merge_request.sha, head)
+        if len(result['commits']) == 0:  # rebased
+            return True
+        return False
+
     def delete_gitlab_comment(self, mr_id, comment_id):
         merge_request = self.project.mergerequests.get(mr_id)
         note = merge_request.notes.get(comment_id)


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3029

we are seeing issues of non-rebased MRs thinking they change a saas file that was recently merged.
to avoid that, we can just not comment on the MR if it is not rebased (while keeping all other behaviors).