### PR TITLE
[openshift-namespaces] do not fail if namespace exists

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -218,7 +218,11 @@ class OC:
 
     def new_project(self, namespace):
         cmd = ['new-project', namespace]
-        self._run(cmd)
+        try:
+            self._run(cmd)
+        except StatusCodeError as e:
+            if 'AlreadyExists' not in str(e):
+                raise e
 
     def delete_project(self, namespace):
         cmd = ['delete', 'project', namespace]


### PR DESCRIPTION
fixes:
```
[openshift-namespaces] Error running qontract-reconcile: [REDACTED]: Error from server (AlreadyExists): project.project.openshift.io "REDACTED" already exists
[openshift-namespaces] Traceback (most recent call last):
[openshift-namespaces]   File "/run-integration.py", line 69, in <module>
[openshift-namespaces]     integration.invoke(ctx)
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1259, in invoke
[openshift-namespaces]     return _process_result(sub_ctx.command.invoke(sub_ctx))
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1066, in invoke
[openshift-namespaces]     return ctx.invoke(self.callback, **ctx.params)
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 610, in invoke
[openshift-namespaces]     return callback(*args, **kwargs)
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/binary.py", line 17, in f_binary
[openshift-namespaces]     f(*args, **kwargs)
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/binary.py", line 57, in f_binary_version
[openshift-namespaces]     f(*args, **kwargs)
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/decorators.py", line 21, in new_func
[openshift-namespaces]     return f(get_current_context(), *args, **kwargs)
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 810, in openshift_namespaces
[openshift-namespaces]     use_jump_host)
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 370, in run_integration
[openshift-namespaces]     func_container.run(dry_run, *args, **kwargs)
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/defer.py", line 15, in func_wrapper
[openshift-namespaces]     return func(*args, defer=defer, **kwargs)
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_namespaces.py", line 127, in run
[openshift-namespaces]     create_new_project(spec, oc_map)
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_namespaces.py", line 110, in create_new_project
[openshift-namespaces]     oc.new_project(namespace)
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/oc.py", line 221, in new_project
[openshift-namespaces]     self._run(cmd)
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/sretoolbox-0.9.2-py3.6.egg/sretoolbox/utils/retry.py", line 28, in f_retry
[openshift-namespaces]     raise exception
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/sretoolbox-0.9.2-py3.6.egg/sretoolbox/utils/retry.py", line 23, in f_retry
[openshift-namespaces]     return function(*args, **kwargs)
[openshift-namespaces]   File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/oc.py", line 493, in _run
[openshift-namespaces]     raise StatusCodeError(f"[{self.server}]: {err}")
[openshift-namespaces] reconcile.utils.oc.StatusCodeError: [REDACTED]: Error from server (AlreadyExists): project.project.openshift.io "REDACTED" already exists
```