### PR TITLE
[APPSRE-3917] pylint assignment-from-no-return

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,6 +1,5 @@
 [MESSAGES CONTROL]
-disable = assignment-from-no-return,
-          attribute-defined-outside-init,
+disable = attribute-defined-outside-init,
           bad-super-call,
           broad-except,
           cell-var-from-loop,

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -106,9 +106,7 @@ def run(dry_run=False, print_only=False,
 
     desired_state = build_desired_state(zones)
 
-    error = ts.populate_route53(desired_state)
-    if error:
-        sys.exit(ExitCodes.ERROR)
+    ts.populate_route53(desired_state)
     working_dirs = ts.dump(print_only=print_only)
 
     if print_only:


### PR DESCRIPTION
[`ts.populate_route53`](https://github.com/app-sre/qontract-reconcile/blob/master/reconcile/utils/terrascript_client.py#L370-L421) has no explicit return, so no need to check for it.


Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>