### PR TITLE
[RunningState] Default value for attributes not explicetly created is None

### DIFF
--- a/reconcile/status.py
+++ b/reconcile/status.py
@@ -22,5 +22,5 @@ class RunningState(_RunningState):
     """
     def __getattr__(self, item):
         """
-        Default value for attributes not explicetly created is None.
+        Default value for attributes not explicitly created is None.
         """

--- a/reconcile/status.py
+++ b/reconcile/status.py
@@ -20,3 +20,7 @@ class RunningState(_RunningState):
     the running state. Attributes will be populated
     by the callers.
     """
+    def __getattr__(self, item):
+        """
+        Default value for attributes not explicetly created is None.
+        """


### PR DESCRIPTION
one of our e2e tests is `create_namespace` which creates a namespace on each cluster that we manage and verifies that it is created according to a predefined template.

this test has been failing:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/threaded.py", line 10, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/e2e_tests/create_namespace.py", line 29, in test_cluster
    oc.delete_project(ns_under_test)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/oc.py", line 116, in wrapper
    integration=running_state.integration
AttributeError: 'RunningState' object has no attribute 'integration'
```

e2e tests should not be publishing metrics (they also do not run in the cluster, so it doesn't make sense at the moment). perhaps they should be running on the cluster just like any other integration? :thinking: 

in any case, this PR will fix this failure: https://ci.int.devshift.net/job/service-app-interface-gl-periodic-job-e2e-tests/256/artifact/reports/e2e_tests_reports_fail/e2e-test-create-namespace.txt