### PR TITLE
[smtp] lazy client init

### DIFF
--- a/reconcile/utils/smtp_client.py
+++ b/reconcile/utils/smtp_client.py
@@ -23,13 +23,17 @@ class SmtpClient:
         self.passwd = smtp_config['password']
         self.mail_address = config['smtp']['mail_address']
 
-        self.client = smtplib.SMTP(host=self.host,
-                                   port=self.port)
-        self.client.send
-        self.client.starttls()
-        self.client.login(self.user, self.passwd)
-
+        self._client = None
         self._server = None
+
+    @property
+    def client(self):
+        if self._client is None:
+            self._client = smtplib.SMTP(host=self.host, port=self.port)
+            self._client.send
+            self._client.starttls()
+            self._client.login(self.user, self.passwd)
+        return self._client
 
     @property
     def server(self):


### PR DESCRIPTION
we have been recently seeing errors with the SMTP client. any such issue is causing the following integrations to fail:
- email-sender
- requests-sender
- sql-query
- terraform-users
- sentry-helper

the integrations are failing to initiate the SMTP client, which is happening on every iteration, even if there are no changes to be made (most of the time). the client should only be initialized when it's needed (to send a mail).

this PR changes the smtp client to a property (also adding consistency to `server`) which means it will only initialize the client when it's needed and not as part of a class instantiation.