### PR TITLE
[saas-file-owners] show commit diff in ascending order

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -120,7 +120,7 @@ def collect_compare_diffs(current_state, desired_state):
             if d['ref'] == c['ref']:
                 continue
             compare_diffs.add(
-                f"{d['url']}/compare/{c['ref']}...{d['ref']}")
+                f"{d['url']}/compare/{d['ref']}...{c['ref']}")
 
     return compare_diffs
 


### PR DESCRIPTION
for example, instead of https://github.com/app-sre/qontract-reconcile/compare/0e8b21cccf5b1d569d83e21c2d74bcb6c91917d3...5946738377f292fecd14611d0a11e41d52a1368e, we will now print https://github.com/app-sre/qontract-reconcile/compare/5946738377f292fecd14611d0a11e41d52a1368e...0e8b21cccf5b1d569d83e21c2d74bcb6c91917d3 in MRs' comments