### PR TITLE
[saas-file-owners] remove hold label when hold is cancelled

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -211,9 +211,10 @@ def check_if_lgtm(owners, comments):
             if line == '/hold':
                 hold = True
                 approved = False
-            if line == '/hold cancel' and lgtm_comment:
+            if line == '/hold cancel':
                 hold = False
-                approved = True
+                if lgtm_comment:
+                    approved = True
 
     return approved, hold
 


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3072

the current behavior will not remove the hold label if there isn't a valid lgtm. this isn't the right behavior, and the hold label should be removed if it's cancelled.