### PR TITLE
[ocm-clusters] update update channel_group api endpoint

### DIFF
--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -190,7 +190,9 @@ class OCM:
                     'internal' if cluster_spec['private']
                     else 'external'
             },
-            'upgrade_channel_group': cluster_spec['channel'],
+            'version': {
+                'channel_group': cluster_spec['channel'],
+            }
         }
 
         autoscale = cluster_spec.get('autoscale')

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -192,7 +192,7 @@ class OCM:
             },
             'version': {
                 'channel_group': cluster_spec['channel'],
-            }
+            },
         }
 
         autoscale = cluster_spec.get('autoscale')


### PR DESCRIPTION
follows up on #1372, based on https://source.redhat.com/groups/public/service-delivery/service_delivery_blog/switching_clusters_channel_group