### PR TITLE
[App-interface-reporter] Get all builds 

### DIFF
--- a/reconcile/utils/jenkins_api.py
+++ b/reconcile/utils/jenkins_api.py
@@ -134,7 +134,7 @@ class JenkinsApi:
 
     def get_build_history(self, job_name, time_limit):
         url = f"{self.url}/job/{job_name}/api/json" + \
-            "?tree=builds[timestamp,result]"
+            "?tree=allBuilds[timestamp,result]"
         res = requests.get(
             url,
             verify=self.ssl_verify,


### PR DESCRIPTION
Jira link: https://issues.redhat.com/browse/APPSRE-2954
Issue: Visual-qontract is displaying only the last 100 build histories in a month, instead of all. 
Report example: https://visual-app-interface.devshift.net/reports#/reports/app-interface/2021-02-01.yml 
Proposed solution: According to the [jenkens api doc](https://ci.ext.devshift.net/job/openshift-assisted-service-gh-build-master/api/), we should change the url pattern from `url = f"{self.url}/job/{job_name}/api/json?tree=builds[timestamp,result]` to `url = f"{self.url}/job/{job_name}/api/json?tree=allBuilds[timestamp,result]"` in order to get all builds. 
Jenkins example:
https://ci.ext.devshift.net/job/openshift-assisted-service-gh-build-master/api/json?tree=builds[timestamp,result]
https://ci.ext.devshift.net/job/openshift-assisted-service-gh-build-master/api/json?tree=allBuilds[timestamp,result] 

