### PR TITLE
[gql] retry init from config

### DIFF
--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -176,7 +176,7 @@ def get_sha(server, token=None):
     return sha
 
 
-@retry(exceptions=GqlApiError, max_attempts=5)
+@retry(exceptions=requests.exceptions.HTTPError, max_attempts=5)
 def get_git_commit_info(sha, server, token=None):
     git_commit_info_endpoint = server._replace(path=f'/git-commit-info/{sha}')
     headers = {'Authorization': token} if token else None

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -176,6 +176,7 @@ def get_sha(server, token=None):
     return sha
 
 
+@retry(exceptions=GqlApiError)
 def get_git_commit_info(sha, server, token=None):
     git_commit_info_endpoint = server._replace(path=f'/git-commit-info/{sha}')
     headers = {'Authorization': token} if token else None
@@ -186,7 +187,6 @@ def get_git_commit_info(sha, server, token=None):
     return git_commit_info
 
 
-@retry(exceptions=GqlApiError)
 def init_from_config(sha_url=True, integration=None, validate_schemas=False,
                      print_url=True):
     config = get_config()

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -91,7 +91,7 @@ class GqlApi:
             if not self._valid_schemas:
                 raise GqlApiIntegrationNotFound(int_name)
 
-    @retry(exceptions=GqlApiError)
+    @retry(exceptions=GqlApiError, max_attempts=5)
     def query(self, query, variables=None, skip_validation=False):
         try:
             # supress print on HTTP error
@@ -176,7 +176,7 @@ def get_sha(server, token=None):
     return sha
 
 
-@retry(exceptions=GqlApiError)
+@retry(exceptions=GqlApiError, max_attempts=5)
 def get_git_commit_info(sha, server, token=None):
     git_commit_info_endpoint = server._replace(path=f'/git-commit-info/{sha}')
     headers = {'Authorization': token} if token else None

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -186,6 +186,7 @@ def get_git_commit_info(sha, server, token=None):
     return git_commit_info
 
 
+@retry(exceptions=GqlApiError)
 def init_from_config(sha_url=True, integration=None, validate_schemas=False,
                      print_url=True):
     config = get_config()


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3084

there may be cases where the active sha in one pod is different from another pod, which may lead to inconsistencies in data fetched. adding a retry to this function eventually makes sure that we are using a matching sha and git commit info (even if those were queried between different qontract-server pods).

we also add a `max_attempts` of 5 to allow time for s3-reload to reload data. the default is: https://github.com/app-sre/csnotify/blob/a3522611b4d05c63525529b2a522977fc5aa3478/s3-watcher.go#L105