### PR TITLE
sentry-config: prevent a user from being in the same team twice

### DIFF
--- a/reconcile/sentry_config.py
+++ b/reconcile/sentry_config.py
@@ -136,7 +136,8 @@ class SentryState:
                 if user not in self.users.keys():
                     self.users[user] = [team]
                 else:
-                    self.users[user].append(team)
+                    if team not in self.users[user]:
+                        self.users[user].append(team)
 
     def init_projects_from_current_state(self, client, projects):
         # Input is in the form of project:teams[]


### PR DESCRIPTION
When a user belong to more than one role that grants access to the same sentry team, the integration will keep trying to reconcile the state while showing the following log

```
[sentry-config] ['team_membership', 'example@redhat.com', 'my-sentry-project,my-sentry-project', 'https://sentry.example.com']
```

Upon investigation, the above user was in fact member of multiple roles that granted access to the `my-sentry-project` sentry project.

While this may seem odd, I believe it is a very valid case when two different roles might grants different permission and access to one common sentry project. The alternative to this fix would be to ask the users to split out the roles into more roles, but I think this may lead to a more cumbersome experience to users.

This change ensures that a team is only added to a user's desired state if it's not already there.