### PR TITLE
Sticky sessions

### DIFF
--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -200,7 +200,7 @@ def init(url, token=None, sha_url=True, integration=None,
     """
     global _gqlapi
     _gqlapi = GqlApi(url, token, integration, validate_schemas,
-                     sha_url=sha_url, use_sessions=True)
+                     sha_url=sha_url, use_sessions=use_sessions)
 
     if print_url:
         url = _gqlapi.client.query_url

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -64,7 +64,8 @@ class GqlApi:
         self.integration = int_name
         self.validate_schemas = validate_schemas
         self.client = QontractServerClient(
-            self.url, token=token, sticky_session=sticky_session, sha_url=sha_url)
+            self.url, token=token, sticky_session=sticky_session,
+            sha_url=sha_url)
 
         if validate_schemas and not int_name:
             raise Exception('Cannot validate schemas if integration name '

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -1,8 +1,6 @@
 import logging
 import textwrap
 
-from sretoolbox.utils import retry
-
 from reconcile.utils.qontract_server_client import QontractServerClient
 from reconcile.utils.config import get_config
 from reconcile.status import RunningState

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -58,13 +58,13 @@ class GqlApi:
     _queried_schemas = set()
 
     def __init__(self, url, token=None, int_name=None, validate_schemas=False,
-                 use_sessions=False, sha_url=False):
+                 sticky_session=False, sha_url=False):
         self.url = url
         self.token = token
         self.integration = int_name
         self.validate_schemas = validate_schemas
         self.client = QontractServerClient(
-            self.url, token=token, use_sessions=use_sessions, sha_url=sha_url)
+            self.url, token=token, sticky_session=sticky_session, sha_url=sha_url)
 
         if validate_schemas and not int_name:
             raise Exception('Cannot validate schemas if integration name '
@@ -146,7 +146,7 @@ class GqlApi:
 
 
 def init_from_config(sha_url=True, integration=None, validate_schemas=False,
-                     print_url=True, use_sessions=True):
+                     print_url=True, sticky_session=True):
     """Inits the GraphQL client based on the server url and token defined in the
     config. This method is a wrapper around `init`.
 
@@ -161,9 +161,9 @@ def init_from_config(sha_url=True, integration=None, validate_schemas=False,
     :param print_url: when a new sha is acquired, it will be printed,
         defaults to True
     :type print_url: bool, optional
-    :param use_sessions: reuse session for all the requests performed.
+    :param sticky_session: reuse session for all the requests performed.
         defaults to True
-    :type use_sessions: bool, optional
+    :type sticky_session: bool, optional
     """
 
     config = get_config()
@@ -171,11 +171,11 @@ def init_from_config(sha_url=True, integration=None, validate_schemas=False,
     token = config['graphql'].get('token')
     return init(server, token=token, sha_url=sha_url, integration=integration,
                 validate_schemas=validate_schemas, print_url=print_url,
-                use_sessions=use_sessions)
+                sticky_session=sticky_session)
 
 
 def init(url, token=None, sha_url=True, integration=None,
-         validate_schemas=False, print_url=True, use_sessions=True):
+         validate_schemas=False, print_url=True, sticky_session=True):
     """Inits the GraphQL client
 
 
@@ -193,14 +193,14 @@ def init(url, token=None, sha_url=True, integration=None,
     :param print_url: when a new sha is acquired, it will be printed,
         defaults to True
     :type print_url: bool, optional
-    :param use_sessions: reuse session for all the requests performed.
+    :param sticky_session: reuse session for all the requests performed.
         defaults to True
-    :type use_sessions: bool, optional
+    :type sticky_session: bool, optional
 
     """
     global _gqlapi
     _gqlapi = GqlApi(url, token, integration, validate_schemas,
-                     sha_url=sha_url, use_sessions=use_sessions)
+                     sha_url=sha_url, sticky_session=sticky_session)
 
     if print_url:
         url = _gqlapi.client.query_url

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -83,7 +83,6 @@ class GqlApi:
             if not self._valid_schemas:
                 raise GqlApiIntegrationNotFound(int_name)
 
-    @retry(exceptions=GqlApiError, max_attempts=5)
     def query(self, query, variables=None, skip_validation=False):
         try:
             result = self.client.query(query, variables)

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -1,16 +1,9 @@
-import contextlib
-import json
 import logging
-import os
 import textwrap
 
-from urllib.parse import urlparse
-
-import requests
-
 from sretoolbox.utils import retry
-from graphqlclient import GraphQLClient
 
+from reconcile.utils.qontract_server_client import QontractServerClient
 from reconcile.utils.config import get_config
 from reconcile.status import RunningState
 
@@ -66,19 +59,18 @@ class GqlApi:
     _valid_schemas = None
     _queried_schemas = set()
 
-    def __init__(self, url, token=None, int_name=None, validate_schemas=False):
+    def __init__(self, url, token=None, int_name=None, validate_schemas=False,
+                 use_sessions=False, sha_url=False):
         self.url = url
         self.token = token
         self.integration = int_name
         self.validate_schemas = validate_schemas
-        self.client = GraphQLClient(self.url)
+        self.client = QontractServerClient(
+            self.url, token=token, use_sessions=use_sessions, sha_url=sha_url)
 
         if validate_schemas and not int_name:
             raise Exception('Cannot validate schemas if integration name '
                             'is not supplied')
-
-        if token:
-            self.client.inject_token(token)
 
         if int_name:
             integrations = self.query(INTEGRATIONS_QUERY, skip_validation=True)
@@ -94,16 +86,10 @@ class GqlApi:
     @retry(exceptions=GqlApiError, max_attempts=5)
     def query(self, query, variables=None, skip_validation=False):
         try:
-            # supress print on HTTP error
-            # https://github.com/prisma-labs/python-graphql-client
-            # /blob/master/graphqlclient/client.py#L32-L33
-            with open(os.devnull, 'w') as f, contextlib.redirect_stdout(f):
-                result_json = self.client.execute(query, variables)
+            result = self.client.query(query, variables)
         except Exception as e:
             raise GqlApiError(
                 'Could not connect to GraphQL server ({})'.format(e))
-
-        result = json.loads(result_json)
 
         # show schemas if log level is debug
         query_schemas = result.get('extensions', {}).get('schemas', [])
@@ -162,51 +148,74 @@ class GqlApi:
         return list(self._queried_schemas)
 
 
-def init(url, token=None, integration=None, validate_schemas=False):
-    global _gqlapi
-    _gqlapi = GqlApi(url, token, integration, validate_schemas)
-    return _gqlapi
-
-
-def get_sha(server, token=None):
-    sha_endpoint = server._replace(path='/sha256')
-    headers = {'Authorization': token} if token else None
-    response = requests.get(sha_endpoint.geturl(), headers=headers)
-    sha = response.content.decode('utf-8')
-    return sha
-
-
-@retry(exceptions=requests.exceptions.HTTPError, max_attempts=5)
-def get_git_commit_info(sha, server, token=None):
-    git_commit_info_endpoint = server._replace(path=f'/git-commit-info/{sha}')
-    headers = {'Authorization': token} if token else None
-    response = requests.get(git_commit_info_endpoint.geturl(),
-                            headers=headers)
-    response.raise_for_status()
-    git_commit_info = response.json()
-    return git_commit_info
-
-
 def init_from_config(sha_url=True, integration=None, validate_schemas=False,
-                     print_url=True):
+                     print_url=True, use_sessions=True):
+    """Inits the GraphQL client based on the server url and token defined in the
+    config. This method is a wrapper around `init`.
+
+
+    :param sha_url: use the /graphqlsha/<sha> endpoint, defaults to True
+    :type sha_url: bool, optional
+    :param integration: name of the integration, required if validate_schemas
+    :type integration: [description], defaults to None
+    :param validate_schemas: raise error if non defined schemas are queried,
+        defaults to False
+    :type validate_schemas: bool, optional
+    :param print_url: when a new sha is acquired, it will be printed,
+        defaults to True
+    :type print_url: bool, optional
+    :param use_sessions: reuse session for all the requests performed.
+        defaults to True
+    :type use_sessions: bool, optional
+    """
+
     config = get_config()
-
-    server_url = urlparse(config['graphql']['server'])
-    server = server_url.geturl()
-
+    server = config['graphql']['server']
     token = config['graphql'].get('token')
-    if sha_url:
-        sha = get_sha(server_url, token)
-        server = server_url._replace(path=f'/graphqlsha/{sha}').geturl()
+    return init(server, token=token, sha_url=sha_url, integration=integration,
+                validate_schemas=validate_schemas, print_url=print_url,
+                use_sessions=use_sessions)
 
+
+def init(url, token=None, sha_url=True, integration=None,
+         validate_schemas=False, print_url=True, use_sessions=True):
+    """Inits the GraphQL client
+
+
+    :param url: Qontract Server url
+    :type url: str
+    :param token: authorization header, typically: `Bearer <user:pass|base64>`
+    :type token: str, optional
+    :param sha_url: use the /graphqlsha/<sha> endpoint, defaults to True
+    :type sha_url: bool, optional
+    :param integration: name of the integration, required if validate_schemas
+    :type integration: [description], defaults to None
+    :param validate_schemas: raise error if non defined schemas are queried,
+        defaults to False
+    :type validate_schemas: bool, optional
+    :param print_url: when a new sha is acquired, it will be printed,
+        defaults to True
+    :type print_url: bool, optional
+    :param use_sessions: reuse session for all the requests performed.
+        defaults to True
+    :type use_sessions: bool, optional
+
+    """
+    global _gqlapi
+    _gqlapi = GqlApi(url, token, integration, validate_schemas,
+                     sha_url=sha_url, use_sessions=True)
+
+    if print_url:
+        url = _gqlapi.client.query_url
+        logging.info(f'using gql endpoint {url}')
+
+    if sha_url:
         runing_state = RunningState()
-        git_commit_info = get_git_commit_info(sha, server_url, token)
+        git_commit_info = _gqlapi.client.get_git_commit_info()
         runing_state.timestamp = git_commit_info.get('timestamp')
         runing_state.commit = git_commit_info.get('commit')
 
-    if print_url:
-        logging.info(f'using gql endpoint {server}')
-    return init(server, token, integration, validate_schemas)
+    return _gqlapi
 
 
 def get_api():

--- a/reconcile/utils/qontract_server_client.py
+++ b/reconcile/utils/qontract_server_client.py
@@ -11,16 +11,17 @@ class QontractServerClient:
                  sha_url=False):
         self.base_url = url
         self.token = token
-        self.use_sessions = use_sessions
         self.sha = None
+
+        if use_sessions:
+            self.session = requests.Session()
+        else:
+            self.session = None
 
         if sha_url:
             self.set_graphqlsha_url()
         else:
             self.query_url = url
-
-        if self.use_sessions:
-            self.session = requests.Session()
 
     def set_graphqlsha_url(self):
         """Fetches the latest sha and sets the query url to use it.
@@ -74,7 +75,7 @@ class QontractServerClient:
         if self.token:
             headers['Authorization'] = self.token
 
-        if self.use_sessions:
+        if self.session:
             post_method = self.session.post
         else:
             post_method = requests.post

--- a/reconcile/utils/qontract_server_client.py
+++ b/reconcile/utils/qontract_server_client.py
@@ -1,0 +1,94 @@
+from urllib.parse import urlparse
+
+import requests
+
+
+class QontractServerClient:
+    """REST API for Qontract Server """
+
+    def __init__(self, url, token=None,
+                 use_sessions=False,
+                 sha_url=False):
+        self.base_url = url
+        self.token = token
+        self.use_sessions = use_sessions
+        self.sha = None
+
+        if sha_url:
+            self.set_graphqlsha_url()
+        else:
+            self.query_url = url
+
+        if self.use_sessions:
+            self.session = requests.Session()
+
+    def set_graphqlsha_url(self):
+        """Fetches the latest sha and sets the query url to use it.
+        """
+        self.sha = self.get_sha()
+        self.query_url = self._base_url_path(path=f'/graphqlsha/{self.sha}')
+
+    def get_sha(self):
+        """Get the sha of the last bundle.
+
+        :return: sha of the last bundle
+        :rtype: str
+        """
+        response = self._get(path='/sha256')
+        return response.content.decode('utf-8')
+
+    def get_git_commit_info(self, sha=None):
+        """Get the commit information
+
+        :param sha: sha, defaults to the active one
+        :type sha: str
+        :raises Exception: This method cannot be called if sha is not provided
+            and sha_url is not enabled.
+        :return: {'timestamp': '<ts>', 'commit': '<commit>'}
+        :rtype: dict
+        """
+        if sha is None:
+            sha = self.sha
+
+        if sha is None:
+            raise Exception('cannot get info if sha is None')
+
+        response = self._get(path=f'/git-commit-info/{sha}')
+        response.raise_for_status()
+        return response.json()
+
+    def query(self, query, variables=None):
+        """Performs a GraphQL query
+
+        :param query: the graphql query
+        :type query: str
+        :param variables: dictionary of variables, defaults to None
+        :type variables: dict, optional
+        :return: graphql response payload. keys: 'data' and '
+        :rtype: dict
+        """
+        data = {'query': query, 'variables': variables}
+
+        headers = {'Accept': 'application/json',
+                   'Content-Type': 'application/json'}
+        if self.token:
+            headers['Authorization'] = self.token
+
+        if self.use_sessions:
+            post_method = self.session.post
+        else:
+            post_method = requests.post
+
+        r = post_method(self.query_url, json=data, headers=headers)
+        r.raise_for_status()
+        return r.json()
+
+    def _base_url_path(self, path):
+        return urlparse(self.base_url)._replace(path=path).geturl()
+
+    def _get(self, path):
+        headers = {'Authorization': self.token} if self.token else None
+        url = self._base_url_path(path)
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        return response

--- a/reconcile/utils/qontract_server_client.py
+++ b/reconcile/utils/qontract_server_client.py
@@ -7,13 +7,13 @@ class QontractServerClient:
     """REST API for Qontract Server """
 
     def __init__(self, url, token=None,
-                 use_sessions=False,
+                 sticky_session=False,
                  sha_url=False):
         self.base_url = url
         self.token = token
         self.sha = None
 
-        if use_sessions:
+        if sticky_session:
             self.session = requests.Session()
         else:
             self.session = None

--- a/reconcile/utils/test/test_qontract_server_client.py
+++ b/reconcile/utils/test/test_qontract_server_client.py
@@ -6,29 +6,29 @@ import requests
 from reconcile.utils.qontract_server_client import QontractServerClient
 
 
-def mocked_requests_get(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, content):
+class MockResponse:
+    content = ''
+
+    def __init__(self, content=None):
+        if content:
             self.content = content.encode('utf-8')
 
-        def raise_for_status(self):
-            pass
+    def raise_for_status(self):
+        # pylint: disable=no-self-use
+        pass
 
+    def json(self):
+        # pylint: disable=no-self-use
+        return '{}'
+
+
+def mocked_requests_get(*args, **kwargs):
     if args[0] == 'https://example.com/sha256':
         return MockResponse("abcdef")
-
     return MockResponse('')
 
 
 def mocked_requests_post(*args, **kwargs):
-    class MockResponse:
-        def raise_for_status(self):
-            pass
-
-        def json(self):
-            # pylint: disable=no-self-use
-            return '{}'
-
     return MockResponse()
 
 

--- a/reconcile/utils/test/test_qontract_server_client.py
+++ b/reconcile/utils/test/test_qontract_server_client.py
@@ -26,6 +26,7 @@ def mocked_requests_post(*args, **kwargs):
             pass
 
         def json(self):
+            # pylint: disable=no-self-use
             return '{}'
 
     return MockResponse()

--- a/reconcile/utils/test/test_qontract_server_client.py
+++ b/reconcile/utils/test/test_qontract_server_client.py
@@ -1,0 +1,82 @@
+from unittest import mock
+
+from pytest import raises
+import requests
+
+from reconcile.utils.qontract_server_client import QontractServerClient
+
+
+def mocked_requests_get(*args, **kwargs):
+    class MockResponse:
+        def __init__(self, content):
+            self.content = content.encode('utf-8')
+
+        def raise_for_status(self):
+            pass
+
+    if args[0] == 'https://example.com/sha256':
+        return MockResponse("abcdef")
+
+    return MockResponse('')
+
+
+def mocked_requests_post(*args, **kwargs):
+    class MockResponse:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return '{}'
+
+    return MockResponse()
+
+
+class TestQontractServerClient:
+    @staticmethod
+    @mock.patch('requests.get', side_effect=mocked_requests_get)
+    def test_get_sha(mock_get):
+        client = QontractServerClient('https://example.com/graphql')
+        assert client.get_sha() == 'abcdef'
+
+    @staticmethod
+    @mock.patch('requests.post', side_effect=mocked_requests_post)
+    def test_query(mock_post):
+        client = QontractServerClient('https://example.com/graphql')
+        client.query('TESTQUERY')
+        first_call = mock_post.call_args_list[0]
+        assert first_call.args[0] == 'https://example.com/graphql'
+
+    @staticmethod
+    @mock.patch('requests.post', side_effect=mocked_requests_post)
+    def test_query_token(mock_post):
+        client = QontractServerClient(
+            'https://example.com/graphql', token="mytoken")
+        client.query('TESTQUERY')
+        first_call = mock_post.call_args_list[0]
+        assert first_call.kwargs['headers']['Authorization'] == 'mytoken'
+
+    @staticmethod
+    @mock.patch('requests.sessions.Session.post',
+                side_effect=mocked_requests_post)
+    def test_query_session(mock_post):
+        client = QontractServerClient('https://example.com/graphql',
+                                      use_sessions=True)
+        client.query('TESTQUERY')
+        first_call = mock_post.call_args_list[0]
+        assert first_call.args[0] == 'https://example.com/graphql'
+
+    @staticmethod
+    @mock.patch('requests.get', side_effect=mocked_requests_get)
+    @mock.patch('requests.post', side_effect=mocked_requests_post)
+    def test_query_sha(mock_post, mock_get):
+        client = QontractServerClient('https://example.com/graphql',
+                                      sha_url=True)
+        client.query('TESTQUERY')
+        first_call = mock_post.call_args_list[0]
+        assert first_call.args[0] == 'https://example.com/graphqlsha/abcdef'
+
+    @staticmethod
+    def test_query_raises():
+        client = QontractServerClient('https://example.com/graphql')
+        with raises(requests.exceptions.RequestException):
+            client.query('TESTQUERY')

--- a/reconcile/utils/test/test_qontract_server_client.py
+++ b/reconcile/utils/test/test_qontract_server_client.py
@@ -61,7 +61,7 @@ class TestQontractServerClient:
                 side_effect=mocked_requests_post)
     def test_query_session(mock_post):
         client = QontractServerClient('https://example.com/graphql',
-                                      use_sessions=True)
+                                      sticky_session=True)
         client.query('TESTQUERY')
         first_call = mock_post.call_args_list[0]
         assert first_call.args[0] == 'https://example.com/graphql'

--- a/reconcile/utils/test/test_qontract_server_client.py
+++ b/reconcile/utils/test/test_qontract_server_client.py
@@ -1,4 +1,4 @@
-from unittest import mock
+import mock
 
 from pytest import raises
 import requests

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     install_requires=[
         "sretoolbox==0.9.2",
         "Click>=7.0,<8.0",
-        "graphqlclient>=0.2.4,<0.3.0",
         "toml>=0.10.0,<0.11.0",
         "jsonpath-rw>=1.4.0,<1.5.0",
         "PyGithub>=1.47,<1.48",

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands =
     pytest
 deps =
     pytest==3.9.2
-    mock==2.0.0
+    mock==4.0.3
     anymarkup==0.7.0
     flake8==3.5.0
     pylint==2.6.0


### PR DESCRIPTION
The goal of this PR is to enable session reusage in the graphql queries.

We were using the [GraphQLClient](https://pypi.org/project/graphqlclient/), but the codebase seems abandoned, and it doesn't support reusing sessions, so this PR has replaced the external `GraphQLClient` with an internal `QontractServerClient`.

It's important to note that the session will be regenerated every time we `init` again, which is good, because the [run-integration.py](https://github.com/jmelis/qontract-reconcile/blob/sticky-sessions/dockerfiles/hack/run-integration.py#L69) script will reinitialize every time. This has been tested (although manually, no automated tests for this).