### PR TITLE
[App-interface-reporter] Remove production promotions, add saas-deploy

### DIFF
--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -79,10 +79,10 @@ class Report:
         self.date = date
         self.report_sections = {}
 
-        # saas deploy jobs
+        # promotions
         self.add_report_section(
-            'saas_deploy_jobs',
-            self.app.get('saas_deploy_jobs')
+            'promotions',
+            self.app.get('promotions')
         )
         # merges to master
         self.add_report_section(
@@ -303,13 +303,13 @@ def get_apps_data(date, month_delta=1):
 
         app['post_deploy_jobs'] = post_deploy_jobs
 
-        logging.info(f"collecting saas deploy jobs for {app_name}")
-        app["saas_deploy_jobs"] = {}
+        logging.info(f"collecting promotion history for {app_name}")
+        app["promotions"] = {}
         if app_name in saas_deploy_history:
             for env, history in saas_deploy_history[app_name].items():
                 if history:
                     successes = [h for h in history if h == 'SUCCESS']
-                    app["saas_deploy_jobs"][env] = {
+                    app["promotions"][env] = {
                         "total": len(history),
                         "success": len(successes),
                     }

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -238,6 +238,7 @@ def get_apps_data(date, month_delta=1):
             for target in template["targets"]:
                 env_name = target["namespace"]["environment"]["name"]
                 job_name = get_openshift_saas_deploy_job_name(saas_file_name, env_name, settings)
+                logging.info(f"getting build history for {job_name}")
                 build_history = jenkins_map[instance_name].get_build_history(job_name, timestamp_limit)
                 if app_name not in saas_deploy_history:
                     saas_deploy_history[app_name] = {env_name: build_history}

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -20,6 +20,7 @@ import reconcile.jenkins_plugins as jenkins_base
 from reconcile.utils.mr import CreateAppInterfaceReporter
 from reconcile import mr_client_gateway
 from reconcile.jenkins_job_builder import init_jjb
+from reconcile.jenkins_job_builder import get_openshift_saas_deploy_job_name
 from reconcile.cli import (
     config_file,
     log_level,
@@ -81,9 +82,13 @@ class Report:
         # promotions
         self.add_report_section(
             'production_promotions',
-            self.get_activity_content(self.app.get('promotions'))
+            self.app.get('promotions')
         )
-
+        # saas deploy jobs
+        self.add_report_section(
+            'saas_deploy_jobs',
+            self.app.get('saas_deploy_jobs')
+        )
         # merges to master
         self.add_report_section(
             'merges_to_master',
@@ -202,14 +207,14 @@ def get_apps_data(date, month_delta=1):
     apps = queries.get_apps()
     saas_files = queries.get_saas_files()
     jjb, _ = init_jjb()
-    saas_jobs = jjb.get_all_jobs(job_types=['saas-deploy', 'promote-to-prod'])
+    promotion_jobs = jjb.get_all_jobs(job_types=['promote-to-prod'])
     build_master_jobs = jjb.get_all_jobs(job_types=['build-master'])
     jenkins_map = jenkins_base.get_jenkins_map()
     time_limit = date - relativedelta(months=month_delta)
     timestamp_limit = \
         int(time_limit.replace(tzinfo=timezone.utc).timestamp())
-    saas_build_history = \
-        get_build_history(jenkins_map, saas_jobs, timestamp_limit)
+    promotion_build_history = \
+        get_build_history(jenkins_map, promotion_jobs, timestamp_limit)
     build_master_build_history = \
         get_build_history(jenkins_map, build_master_jobs, timestamp_limit)
 
@@ -222,6 +227,22 @@ def get_apps_data(date, month_delta=1):
     metrics = requests.get(f'{dashdotdb_url}/api/v1/metrics',
                            auth=(dashdotdb_user, dashdotdb_pass)).text
     namespaces = queries.get_namespaces()
+
+    saas_deploy_history = {} 
+    for saas_file in saas_files:
+        saas_file_name = saas_file['name']
+        app_name = saas_file["app"]["name"]
+        instance_url = saas_file["instance"]["serverUrl"]
+        instance_name = saas_file["instance"]["name"]
+        for template in saas_file["resourceTemplates"]:
+            for target in template["targets"]:
+                env_name = target["namespace"]["environment"]["name"]
+                job_name = get_openshift_saas_deploy_job_name(saas_file_name, env_name, settings)
+                build_history = jenkins_map[instance_name].get_build_history(job_name, timestamp_limit)
+                if app_name not in saas_deploy_history:
+                    saas_deploy_history[app_name] = {env_name: build_history}
+                else:
+                    saas_deploy_history[app_name].update({env_name: build_history})
 
     for app in apps:
         if not app['codeComponents']:
@@ -283,11 +304,22 @@ def get_apps_data(date, month_delta=1):
         saas_repos = [c['url'] for c in app['codeComponents']
                       if c['resource'] == 'saasrepo']
         for sr in saas_repos:
-            sr_history = saas_build_history.get(sr)
-            if not sr_history:
-                continue
-            successes = [h for h in sr_history if h == 'SUCCESS']
-            app['promotions'][sr] = (len(sr_history), len(successes))
+            promotion_history = promotion_build_history.get(sr)
+            if promotion_history:
+                for env, history in promotion_history.items():
+                    successes = [h for h in history if h == 'SUCCESS']
+                    if sr not in app["promotions"]:
+                        app["promotions"][sr] = {env: {"total": len(history), "success" : len(successes)}}
+                    else:
+                        app["promotions"][sr].update({env: {"total": len(history), "success" : len(successes)}})
+
+        logging.info(f"collecting saas deploy jobs for {app_name}")
+        app["saas_deploy_jobs"] = {}
+        if app_name in saas_deploy_history:
+            for env, history in saas_deploy_history[app_name].items():
+                if history:
+                    successes = [h for h in history if h == 'SUCCESS']
+                    app["saas_deploy_jobs"][env] = {"total": len(history), "success" : len(successes)}
 
         logging.info(f"collecting merge activity for {app_name}")
         app['merge_activity'] = {}

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -37,8 +37,10 @@ DASHDOTDB_SECRET = os.environ.get('DASHDOTDB_SECRET',
 def promql(url, query, auth=None):
     """
     Run an instant-query on the prometheus instance.
+
     The returned structure is documented here:
     https://prometheus.io/docs/prometheus/latest/querying/api/#instant-queries
+
     :param url: base prometheus url (not the API endpoint).
     :type url: string
     :param query: this is a second value
@@ -492,12 +494,19 @@ def main(configfile, dry_run, log_level, gitlab_project_id, reports_path):
     if not dry_run:
         email_body = """\
             Hello,
+
             A new report by the App SRE team is now available at:
             https://visual-app-interface.devshift.net/reports
+
             You can use the Search bar to search by App.
+
             You can also view reports per service here:
             https://visual-app-interface.devshift.net/services
+
+
             Having problems? Ping us on #sd-app-sre on Slack!
+
+
             You are receiving this message because you are a member
             of app-interface or subscribed to a mailing list specified
             as owning a service being run by the App SRE team:


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/APPSRE-2954
Issue: Although we are trying to collect[ both saas_deploy and promote-to-prod](https://github.com/app-sre/qontract-reconcile/blob/master/tools/app_interface_reporter.py#L421), saas-deploy jobs are [ignored](https://github.com/app-sre/qontract-reconcile/blob/11dd2f09566a430a6bba0b3d62312a493c631c61/reconcile/utils/jjb_client.py#L347) in jjb_client. saas_deploy and promote-to-prod have different ways to fetch jenkins history. Also, each saas file/ promotion job might have multiple environments and thus multiple job names {saas_file_name}-{env_name}. However, the key is [repo url of a job](https://github.com/app-sre/qontract-reconcile/blob/86753c4f5bb545e1c2a4053278a76e105775ca08/tools/app_interface_reporter.py#L582) and multiple job names map to the same repo url. 
Example: [saas-openshiftio-promote-to-prod](https://ci.centos.org/job/devtools-saas-openshiftio-promote-to-prod/api/json?tree=builds[timestamp,result]) is overwritten by [saas-openshiftio-promote-to-prod-v4](https://ci.centos.org/job/devtools-saas-openshiftio-promote-to-prod-v4/api/json?tree=builds[timestamp,result]) and [saas-analytics-promote-to-prod](https://ci.centos.org/job/devtools-saas-analytics-promote-to-prod/api/json?tree=builds[timestamp,result]) is overwritten by [saas-analytics--promote-to-prod-v4](https://ci.centos.org/job/devtools-saas-analytics-promote-to-prod-v4/api/json?tree=builds[timestamp,result]). 
Proposed Solution: Collect saas deploy and production promotion separately, keep env information. 