### PR TITLE
terraform enable deletion per account

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -244,6 +244,7 @@ AWS_ACCOUNTS_QUERY = """
       field
     }
     garbageCollection
+    enableDeletion
     disable {
       integrations
     }

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -115,6 +115,7 @@ def run(dry_run=False, print_only=False,
     tf = Terraform(QONTRACT_INTEGRATION,
                    QONTRACT_INTEGRATION_VERSION,
                    "",
+                   participating_accounts,
                    working_dirs,
                    thread_pool_size)
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -332,14 +332,14 @@ def run(dry_run, print_only=False,
         cleanup_and_exit(tf, err)
 
     if not light:
-        deletions_detected, err = tf.plan(enable_deletion)
+        disabled_deletions_detected, err = tf.plan(enable_deletion)
         if err:
             cleanup_and_exit(tf, err)
-        if deletions_detected:
+        if disabled_deletions_detected:
             if enable_deletion:
                 tf.dump_deleted_users(io_dir)
             else:
-                cleanup_and_exit(tf, deletions_detected)
+                cleanup_and_exit(tf, disabled_deletions_detected)
 
     if dry_run:
         cleanup_and_exit(tf)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -281,6 +281,7 @@ def setup(dry_run, print_only, thread_pool_size, internal,
     tf = Terraform(QONTRACT_INTEGRATION,
                    QONTRACT_INTEGRATION_VERSION,
                    QONTRACT_TF_PREFIX,
+                   accounts,
                    working_dirs,
                    thread_pool_size)
     existing_secrets = tf.get_terraform_output_secrets()

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -336,7 +336,7 @@ def run(dry_run, print_only=False,
         if err:
             cleanup_and_exit(tf, err)
         tf.dump_deleted_users(io_dir)
-        if disabled_deletions_detected and not enable_deletion:
+        if disabled_deletions_detected:
             cleanup_and_exit(tf, disabled_deletions_detected)
 
     if dry_run:

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -335,11 +335,9 @@ def run(dry_run, print_only=False,
         disabled_deletions_detected, err = tf.plan(enable_deletion)
         if err:
             cleanup_and_exit(tf, err)
-        if disabled_deletions_detected:
-            if enable_deletion:
-                tf.dump_deleted_users(io_dir)
-            else:
-                cleanup_and_exit(tf, disabled_deletions_detected)
+        tf.dump_deleted_users(io_dir)
+        if disabled_deletions_detected and not enable_deletion:
+            cleanup_and_exit(tf, disabled_deletions_detected)
 
     if dry_run:
         cleanup_and_exit(tf)

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -122,11 +122,9 @@ def run(dry_run, print_only=False,
     disabled_deletions_detected, err = tf.plan(enable_deletion)
     if err:
         cleanup_and_exit(tf, err)
-    if disabled_deletions_detected:
-        if enable_deletion:
-            tf.dump_deleted_users(io_dir)
-        else:
-            cleanup_and_exit(tf, disabled_deletions_detected)
+    tf.dump_deleted_users(io_dir)
+    if disabled_deletions_detected and not enable_deletion:
+        cleanup_and_exit(tf, disabled_deletions_detected)
 
     if dry_run:
         cleanup_and_exit(tf)

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -119,14 +119,14 @@ def run(dry_run, print_only=False,
         err = True
         cleanup_and_exit(tf, err)
 
-    deletions_detected, err = tf.plan(enable_deletion)
+    disabled_deletions_detected, err = tf.plan(enable_deletion)
     if err:
         cleanup_and_exit(tf, err)
-    if deletions_detected:
+    if disabled_deletions_detected:
         if enable_deletion:
             tf.dump_deleted_users(io_dir)
         else:
-            cleanup_and_exit(tf, deletions_detected)
+            cleanup_and_exit(tf, disabled_deletions_detected)
 
     if dry_run:
         cleanup_and_exit(tf)

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -123,7 +123,7 @@ def run(dry_run, print_only=False,
     if err:
         cleanup_and_exit(tf, err)
     tf.dump_deleted_users(io_dir)
-    if disabled_deletions_detected and not enable_deletion:
+    if disabled_deletions_detected:
         cleanup_and_exit(tf, disabled_deletions_detected)
 
     if dry_run:

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -60,7 +60,7 @@ def setup(print_only, thread_pool_size):
 
     working_dirs = ts.dump(print_only)
 
-    return working_dirs
+    return accounts, working_dirs
 
 
 def send_email_invites(new_users, settings):
@@ -101,7 +101,7 @@ def cleanup_and_exit(tf=None, status=False):
 def run(dry_run, print_only=False,
         enable_deletion=False, io_dir='throughput/',
         thread_pool_size=10, send_mails=True):
-    working_dirs = setup(print_only, thread_pool_size)
+    accounts, working_dirs = setup(print_only, thread_pool_size)
     if print_only:
         cleanup_and_exit()
     if working_dirs is None:
@@ -111,6 +111,7 @@ def run(dry_run, print_only=False,
     tf = Terraform(QONTRACT_INTEGRATION,
                    QONTRACT_INTEGRATION_VERSION,
                    QONTRACT_TF_PREFIX,
+                   accounts,
                    working_dirs,
                    thread_pool_size,
                    init_users=True)

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -305,10 +305,10 @@ def run(dry_run, print_only=False,
 
     defer(lambda: tf.cleanup())
 
-    deletions_detected, err = tf.plan(enable_deletion)
+    disabled_deletions_detected, err = tf.plan(enable_deletion)
     if err:
         sys.exit(1)
-    if deletions_detected and not enable_deletion:
+    if disabled_deletions_detected and not enable_deletion:
         sys.exit(1)
 
     if dry_run:

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -296,6 +296,7 @@ def run(dry_run, print_only=False,
     tf = Terraform(QONTRACT_INTEGRATION,
                    QONTRACT_INTEGRATION_VERSION,
                    "",
+                   accounts,
                    working_dirs,
                    thread_pool_size)
 

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -308,7 +308,7 @@ def run(dry_run, print_only=False,
     disabled_deletions_detected, err = tf.plan(enable_deletion)
     if err:
         sys.exit(1)
-    if disabled_deletions_detected and not enable_deletion:
+    if disabled_deletions_detected:
         sys.exit(1)
 
     if dry_run:

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -26,7 +26,7 @@ class TerraformClient:
         self.integration_version = integration_version
         self.integration_prefix = integration_prefix
         self.working_dirs = working_dirs
-        self.accounts = accounts
+        self.accounts = {a['name']: a for a in accounts}
         self.parallelism = thread_pool_size
         self.thread_pool_size = thread_pool_size
         self._log_lock = Lock()

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -150,6 +150,12 @@ class TerraformClient:
 
     def log_plan_diff(self, name, tf, enable_deletion):
         disabled_deletion_detected = False
+        account_enable_deletion = \
+            self.accounts[name].get('enableDeletion') or False
+        # deletions are alowed
+        # if enableDeletion is true for an account
+        # or if the integration's enable_deletion is true
+        deletions_allowed = enable_deletion or account_enable_deletion
         deleted_users = []
 
         output = self.terraform_show(name, tf.working_dir)
@@ -176,8 +182,8 @@ class TerraformClient:
                 with self._log_lock:
                     logging.info([action, name, resource_type, resource_name])
                 if action == 'delete':
-                    disabled_deletion_detected = True
-                    if not enable_deletion:
+                    if not deletions_allowed:
+                        disabled_deletion_detected = True
                         logging.error(
                             '\'delete\' action is not enabled. ' +
                             'Please run the integration manually ' +

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -20,12 +20,13 @@ ALLOWED_TF_SHOW_FORMAT_VERSION = "0.1"
 
 class TerraformClient:
     def __init__(self, integration, integration_version,
-                 integration_prefix, working_dirs, thread_pool_size,
+                 integration_prefix, accounts, working_dirs, thread_pool_size,
                  init_users=False):
         self.integration = integration
         self.integration_version = integration_version
         self.integration_prefix = integration_prefix
         self.working_dirs = working_dirs
+        self.accounts = accounts
         self.parallelism = thread_pool_size
         self.thread_pool_size = thread_pool_size
         self._log_lock = Lock()

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -149,7 +149,7 @@ class TerraformClient:
         return disabled_deletion_detected, deleted_users, error
 
     def log_plan_diff(self, name, tf, enable_deletion):
-        deletions_detected = False
+        disabled_deletion_detected = False
         deleted_users = []
 
         output = self.terraform_show(name, tf.working_dir)
@@ -160,7 +160,7 @@ class TerraformClient:
 
         resource_changes = output.get('resource_changes')
         if resource_changes is None:
-            return deletions_detected, deleted_users
+            return disabled_deletion_detected, deleted_users
 
         # https://www.terraform.io/docs/internals/json-format.html
         for resource_change in resource_changes:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2936

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/15710

this PR will allow deleting resources in terraform integrations from aws accountss where `enableDeletion` is true.
there is a cli argument that can be passed to terraform integrations called `--enable-deletion`. this PR will enable deleting resources even if the default for enable deletion for the entire integration is false.

tl;dr - what we define on an aws account file is stronger.