### PR TITLE
[terraform-vpc-peerings] add support for VPC mesh (PrivateLink)

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -383,6 +383,18 @@ CLUSTERS_QUERY = """
             region
           }
         }
+        ... on ClusterPeeringConnectionAccountVPCMesh_v1 {
+          account {
+            name
+            uid
+            terraformUsername
+            automationToken {
+              path
+              field
+            }
+          }
+          tags
+        }
         ... on ClusterPeeringConnectionClusterRequester_v1 {
           cluster {
             name

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+import json
 
 import semver
 
@@ -227,7 +228,7 @@ def build_desired_state_vpc_mesh(clusters, ocm_map, settings):
             account_vpcs = \
                 aws_api.get_vpcs_details(
                     account,
-                    tags=peer_connection.get('tags'),
+                    tags=json.loads(peer_connection.get('tags') or {}),
                     route_tables=peer_connection.get('manageRoutes'),
                 )
             for vpc in account_vpcs:

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -204,8 +204,8 @@ def build_desired_state_vpc_mesh(clusters, ocm_map, settings):
             account['assume_role'] = \
                 ocm.get_aws_infrastructure_access_terraform_assume_role(
                     cluster,
-                    peer_vpc['account']['uid'],
-                    peer_vpc['account']['terraformUsername']
+                    account['uid'],
+                    account['terraformUsername']
                 )
             account['assume_region'] = requester['region']
             account['assume_cidr'] = requester['cidr_block']
@@ -249,7 +249,6 @@ def build_desired_state_vpc_mesh(clusters, ocm_map, settings):
                 desired_state.append(item)
 
     return desired_state, error
-
 
 
 def build_desired_state_vpc(clusters, ocm_map, settings):

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -233,7 +233,9 @@ def build_desired_state_vpc_mesh(clusters, ocm_map, settings):
                 )
             for vpc in account_vpcs:
                 vpc_id = vpc['vpc_id']
-                connection_name = f"{peer_connection['name']}_{vpc_id}"
+                connection_name = \
+                    f"{peer_connection['name']}_" + \
+                    f"{account['name']}-{vpc_id}"
                 accepter = {
                     'vpc_id': vpc_id,
                     'region': vpc['region'],

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -227,6 +227,7 @@ def build_desired_state_vpc_mesh(clusters, ocm_map, settings):
             account_vpcs = \
                 aws_api.get_vpcs_details(
                     account,
+                    tags=peer_connection.get('tags'),
                     route_tables=peer_connection.get('manageRoutes'),
                 )
             for vpc in account_vpcs:

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -175,6 +175,83 @@ def build_desired_state_cluster(clusters, ocm_map, settings):
     return desired_state, error
 
 
+def build_desired_state_vpc_mesh(clusters, ocm_map, settings):
+    """
+    Fetch state for VPC peerings between a cluster and all VPCs in an account
+    """
+    desired_state = []
+    error = False
+
+    for cluster_info in clusters:
+        cluster = cluster_info['name']
+        ocm = ocm_map.get(cluster)
+        peering_info = cluster_info['peering']
+        peer_connections = peering_info['connections']
+        for peer_connection in peer_connections:
+            # We only care about account-vpc-mesh peering providers
+            peer_connection_provider = peer_connection['provider']
+            if not peer_connection_provider == 'account-vpc-mesh':
+                continue
+            # requester is the cluster's AWS account
+            requester = {
+                'cidr_block': cluster_info['network']['vpc'],
+                'region': cluster_info['spec']['region']
+            }
+
+            account = peer_connection['account']
+            # assume_role is the role to assume to provision the
+            # peering connection request, through the accepter AWS account.
+            account['assume_role'] = \
+                ocm.get_aws_infrastructure_access_terraform_assume_role(
+                    cluster,
+                    peer_vpc['account']['uid'],
+                    peer_vpc['account']['terraformUsername']
+                )
+            account['assume_region'] = requester['region']
+            account['assume_cidr'] = requester['cidr_block']
+            aws_api = AWSApi(1, [account], settings=settings)
+            requester_vpc_id, requester_route_table_ids = \
+                aws_api.get_cluster_vpc_id(
+                    account,
+                    route_tables=peer_connection.get('manageRoutes')
+                )
+
+            if requester_vpc_id is None:
+                logging.error(f'[{cluster} could not find VPC ID for cluster')
+                error = True
+                continue
+            requester['vpc_id'] = requester_vpc_id
+            requester['route_table_ids'] = requester_route_table_ids
+            requester['account'] = account
+
+            account_vpcs = \
+                aws_api.get_vpcs_details(
+                    account,
+                    route_tables=peer_connection.get('manageRoutes'),
+                )
+            for vpc in account_vpcs:
+                vpc_id = vpc['vpc_id']
+                connection_name = f"{peer_connection['name']}_{vpc_id}"
+                accepter = {
+                    'vpc_id': vpc_id,
+                    'region': vpc['region'],
+                    'cidr_block': vpc['cidr_block'],
+                    'route_table_ids': vpc['route_table_ids'],
+                    'account': account,
+                }
+                item = {
+                    'connection_provider': peer_connection_provider,
+                    'connection_name': connection_name,
+                    'requester': requester,
+                    'accepter': accepter,
+                    'deleted': peer_connection.get('delete', False)
+                }
+                desired_state.append(item)
+
+    return desired_state, error
+
+
+
 def build_desired_state_vpc(clusters, ocm_map, settings):
     """
     Fetch state for VPC peerings between a cluster and a VPC (account)
@@ -258,13 +335,22 @@ def run(dry_run, print_only=False,
     if err:
         sys.exit(1)
 
+    # Fetch desired state for cluster-to-account (vpc mesh) VPCs
+    desired_state_vpc_mesh, err = \
+        build_desired_state_vpc_mesh(clusters, ocm_map, settings)
+    if err:
+        sys.exit(1)
+
     # Fetch desired state for cluster-to-cluster VPCs
     desired_state_cluster, err = \
         build_desired_state_cluster(clusters, ocm_map, settings)
     if err:
         sys.exit(1)
 
-    desired_state = desired_state_vpc + desired_state_cluster
+    desired_state = \
+        desired_state_vpc + \
+        desired_state_vpc_mesh + \
+        desired_state_cluster
 
     # check there are no repeated vpc connection names
     connection_names = [c['connection_name'] for c in desired_state]

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -678,7 +678,8 @@ class AWSApi:
             vpcs = ec2.describe_vpcs()
             for vpc in vpcs.get('Vpcs'):
                 if tags:
-                    vpc_tags = {t['Key']: t['Value'] for t in vpc['Tags']}
+                    vpc_tags = \
+                        {t['Key']: t['Value'] for t in vpc.get('Tags', [])}
                     if tags not in vpc_tags:
                         continue
                 vpc_id = vpc['VpcId']

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -660,11 +660,11 @@ class AWSApi:
 
         route_table_ids = None
         if route_tables and vpc_id:
-            route_tables = assumed_ec2.describe_route_tables(
+            vpc_route_tables = assumed_ec2.describe_route_tables(
                 Filters=[{'Name': 'vpc-id', 'Values': [vpc_id]}]
             )
             route_table_ids = [rt['RouteTableId']
-                               for rt in route_tables['RouteTables']]
+                               for rt in vpc_route_tables['RouteTables']]
 
         return vpc_id, route_table_ids
 
@@ -686,11 +686,12 @@ class AWSApi:
                 cidr_block = vpc['CidrBlock']
                 route_table_ids = None
                 if route_tables:
-                    ec2.describe_route_tables(
+                    vpc_route_tables = ec2.describe_route_tables(
                         Filters=[{'Name': 'vpc-id', 'Values': [vpc_id]}]
                     )
                     route_table_ids = [rt['RouteTableId']
-                                       for rt in route_tables['RouteTables']]
+                                       for rt
+                                       in vpc_route_tables['RouteTables']]
                 item = {
                     'vpc_id': vpc_id,
                     'region': region_name,

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -683,7 +683,7 @@ class AWSApi:
                     if not tags.items() <= vpc_tags.items():
                         continue
                 vpc_id = vpc['VpcId']
-                cidr_block = vpc['cidrBlock']
+                cidr_block = vpc['CidrBlock']
                 route_table_ids = None
                 if route_tables:
                     ec2.describe_route_tables(

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -668,7 +668,7 @@ class AWSApi:
 
         return vpc_id, route_table_ids
 
-    def get_vpcs_details(self, account, route_tables=False):
+    def get_vpcs_details(self, account, tags=None, route_tables=False):
         results = []
         session = self.get_session(account['name'])
         ec2 = session.client('ec2')
@@ -677,6 +677,10 @@ class AWSApi:
             ec2 = session.client('ec2', region_name=region_name)
             vpcs = ec2.describe_vpcs()
             for vpc in vpcs.get('Vpcs'):
+                if tags:
+                    vpc_tags = {t['Key']: t['Value'] for t in vpc['Tags']}
+                    if tags not in vpc_tags:
+                        continue
                 vpc_id = vpc['VpcId']
                 cidr_block = vpc['cidrBlock']
                 route_table_ids = None

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -680,7 +680,7 @@ class AWSApi:
                 if tags:
                     vpc_tags = \
                         {t['Key']: t['Value'] for t in vpc.get('Tags', [])}
-                    if tags not in vpc_tags:
+                    if not tags.items() <= vpc_tags.items():
                         continue
                 vpc_id = vpc['VpcId']
                 cidr_block = vpc['cidrBlock']

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -685,7 +685,7 @@ class AWSApi:
                         Filters=[{'Name': 'vpc-id', 'Values': [vpc_id]}]
                     )
                     route_table_ids = [rt['RouteTableId']
-                                    for rt in route_tables['RouteTables']]
+                                       for rt in route_tables['RouteTables']]
                 item = {
                     'vpc_id': vpc_id,
                     'region': region_name,
@@ -695,7 +695,6 @@ class AWSApi:
                 results.append(item)
 
         return results
-
 
     def get_route53_zones(self):
         """

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -675,13 +675,13 @@ class AWSApi:
         regions = [r['RegionName'] for r in ec2.describe_regions()['Regions']]
         for region_name in regions:
             ec2 = session.client('ec2', region_name=region_name)
-            vpcs = ec2.describe_vpcs()
+            vpcs = ec2.describe_vpcs(
+                Filters=[
+                    {'Name': f'tag:{k}', 'Values': [v]}
+                    for k, v in tags.items()
+                ]
+            )
             for vpc in vpcs.get('Vpcs'):
-                if tags:
-                    vpc_tags = \
-                        {t['Key']: t['Value'] for t in vpc.get('Tags', [])}
-                    if not tags.items() <= vpc_tags.items():
-                        continue
                 vpc_id = vpc['VpcId']
                 cidr_block = vpc['CidrBlock']
                 route_table_ids = None

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -491,7 +491,7 @@ class TerrascriptClient:
                     'Name': connection_name
                 }
             }
-            if connection_provider == 'account-vpc':
+            if connection_provider in ['account-vpc', 'account-vpc-mesh']:
                 if self._multiregion_account_(acc_account_name):
                     values['provider'] = 'aws.' + accepter['region']
             else:
@@ -511,7 +511,8 @@ class TerrascriptClient:
                             '${aws_vpc_peering_connection_accepter.' +
                             identifier + '.id}'
                     }
-                    if connection_provider == 'account-vpc':
+                    if connection_provider in \
+                            ['account-vpc', 'account-vpc-mesh']:
                         if self._multiregion_account_(acc_account_name):
                             values['provider'] = 'aws.' + accepter['region']
                     else:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3133

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/15769

this PR adds logic to create VPC peerings between a cluster and all VPCs (or tagged VPCs) in an AWS account - VPC mesh.

the PR does not change the logic of how we create VPC peerings, but only adds logic to the collection phase - where we now take into consideration a new provider - `account-vpc-mesh`.