### PR TITLE
[ocm] get_addon by id instead of by name

### DIFF
--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -637,10 +637,10 @@ class OCM:
         api = '/api/clusters_mgmt/v1/addons'
         self.addons = self._get_json(api).get('items')
 
-    def get_addon(self, name):
+    def get_addon(self, id):
         for addon in self.addons:
-            resource_name = addon['resource_name']
-            if name == resource_name:
+            addon_id = addon['id']
+            if id == addon_id:
                 return addon
         return None
 


### PR DESCRIPTION
the `name` is prefixed with `addon-`, and i think we'd prefer to use the `id`.

related to:
- https://issues.redhat.com/browse/APPSRE-2865
- https://issues.redhat.com/browse/APPSRE-2697