### PR TITLE
[openshift-users] allow users without identities

### DIFF
--- a/reconcile/openshift_users.py
+++ b/reconcile/openshift_users.py
@@ -18,7 +18,8 @@ def get_cluster_users(cluster, oc_map):
         logging.log(level=oc.log_level, msg=oc.message)
         return []
     users = [u['metadata']['name'] for u in oc.get_users()
-             if len(u['identities']) == 1
+             if u.get('identities', None) is not None
+             and len(u['identities']) == 1
              and u['identities'][0].startswith('github')
              and not u['metadata'].get('labels', {}).get('admin', '')]
 


### PR DESCRIPTION
fixes:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/threaded.py", line 10, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_users.py", line 20, in get_cluster_users
    users = [u['metadata']['name'] for u in oc.get_users()
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_users.py", line 21, in <listcomp>
    if len(u['identities']) == 1
TypeError: object of type 'NoneType' has no len()

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/qontract-reconcile", line 33, in <module>
    sys.exit(load_entry_point('reconcile==0.2.2', 'console_scripts', 'qontract-reconcile')())
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/binary.py", line 18, in f_binary
    f(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/binary.py", line 60, in f_binary_version
    f(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 547, in openshift_users
    thread_pool_size, internal, use_jump_host)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 394, in run_integration
    func_container.run(dry_run, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/defer.py", line 15, in func_wrapper
    return func(*args, defer=defer, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_users.py", line 101, in run
    fetch_current_state(thread_pool_size, internal, use_jump_host)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_users.py", line 36, in fetch_current_state
    thread_pool_size, oc_map=oc_map)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/threaded.py", line 25, in run
    return pool.map(func_partial, iterable)
  File "/usr/lib64/python3.6/multiprocessing/pool.py", line 266, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib64/python3.6/multiprocessing/pool.py", line 644, in get
    raise self._value
  File "/usr/lib64/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib64/python3.6/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/threaded.py", line 13, in wrapper
    raise type(e)(msg)
TypeError: object of type 'NoneType' has no len()

Original Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/threaded.py", line 10, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_users.py", line 20, in get_cluster_users
    users = [u['metadata']['name'] for u in oc.get_users()
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_users.py", line 21, in <listcomp>
    if len(u['identities']) == 1
TypeError: object of type 'NoneType' has no len()
```