### PR TITLE
add imagePullSecrets for sha256sum

### DIFF
--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -334,7 +334,12 @@ class OpenshiftResource:
 
         if body['kind'] == 'ServiceAccount':
             if 'imagePullSecrets' in body:
-                body.pop('imagePullSecrets')
+                # remove default pull secrets added by k8s
+                imagePullSecrets = \
+                    [s for s in body.pop('imagePullSecrets')
+                     if '-dockercfg-' not in s['name']]
+                if imagePullSecrets:
+                    body['imagePullSecrets'] = imagePullSecrets
             if 'secrets' in body:
                 body.pop('secrets')
 


### PR DESCRIPTION
same as https://github.com/app-sre/qontract-reconcile/blob/master/reconcile/utils/openshift_resource.py#L77-L79

```
[2021-03-09 19:26:19] [INFO] [openshift_base.py:apply:206] - ['apply', 'telemeter-prod-01', 'telemeter-production', 'ServiceAccount', 'prometheus-telemeter']
[2021-03-09 19:26:19] [INFO] [openshift_base.py:apply:206] - ['apply', 'app-sre-prod-04', 'uhc-production', 'ServiceAccount', 'clusters-service']
[2021-03-09 19:26:19] [INFO] [openshift_base.py:apply:206] - ['apply', 'app-sre-prod-04', 'uhc-production', 'ServiceAccount', 'account-manager']
[2021-03-09 19:26:19] [INFO] [openshift_base.py:apply:206] - ['apply', 'app-sre-prod-04', 'uhc-production', 'ServiceAccount', 'ocm-service-log']
[2021-03-09 19:26:20] [INFO] [openshift_base.py:apply:206] - ['apply', 'app-sre-stage-01', 'uhc-stage', 'ServiceAccount', 'clusters-service']
[2021-03-09 19:26:20] [INFO] [openshift_base.py:apply:206] - ['apply', 'app-sre-stage-01', 'uhc-stage', 'ServiceAccount', 'account-manager']
[2021-03-09 19:26:20] [INFO] [openshift_base.py:apply:206] - ['apply', 'app-sre-stage-01', 'uhc-stage', 'ServiceAccount', 'ocm-service-log']
[2021-03-09 19:26:20] [INFO] [openshift_base.py:apply:206] - ['apply', 'app-sre-stage-01', 'telemeter-stage', 'ServiceAccount', 'prometheus-telemeter']
[2021-03-09 19:26:20] [INFO] [openshift_base.py:apply:206] - ['apply', 'crcs01ue1', 'platform-mq-stage', 'ServiceAccount', 'private-image-puller']
[2021-03-09 19:26:20] [INFO] [openshift_base.py:apply:206] - ['apply', 'crcs01ue1', 'xjoin-stage', 'ServiceAccount', 'private-image-puller']
[2021-03-09 19:26:20] [INFO] [openshift_base.py:apply:206] - ['apply', 'crcs01ue1', 'rbac-stage', 'ServiceAccount', 'private-image-puller']
[2021-03-09 19:26:20] [INFO] [openshift_base.py:apply:206] - ['apply', 'ssotest01ue1', 'uhc-stage', 'ServiceAccount', 'clusters-service']
[2021-03-09 19:26:20] [INFO] [openshift_base.py:apply:206] - ['apply', 'ssotest01ue1', 'uhc-stage', 'ServiceAccount', 'account-manager']
[2021-03-09 19:26:20] [INFO] [openshift_base.py:apply:206] - ['apply', 'hive-integration', 'sandbox', 'ServiceAccount', 'sandbox']
[2021-03-09 19:26:20] [INFO] [openshift_base.py:apply:206] - ['apply', 'hive-integration', 'uhc-integration', 'ServiceAccount', 'account-manager']
[2021-03-09 19:26:20] [INFO] [openshift_base.py:apply:206] - ['apply', 'hive-integration', 'uhc-integration', 'ServiceAccount', 'ocm-service-log']
[2021-03-09 19:26:20] [INFO] [openshift_base.py:apply:206] - ['apply', 'hive-integration', 'uhc-integration', 'ServiceAccount', 'clusters-service']
```
add imagePullSecrets for prometheus-telemeter https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/15970/diffs
add imagePullSecrets for uhc-* sa https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/resources/services/ocm/serviceaccount.yaml#L7
delete imagePullSecrets `quay-rhcloudperfscale-pull` (secrets already removed from cluster) for crcs01ue1 sa


Signed-off-by: Feng Huang <fehuang@redhat.com>