### PR TITLE
[slack-usergroups] allow usergroup permission to be defined from multiple roles

### DIFF
--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -277,14 +277,20 @@ def get_desired_state(slack_map):
             channel_names = [] if p['channels'] is None else p['channels']
             channels = slack.get_channels_by_names(channel_names)
 
-            desired_state.append({
-                "workspace": workspace_name,
-                "usergroup": usergroup,
-                "usergroup_id": ugid,
-                "users": users,
-                "channels": channels,
-                "description": description,
-            })
+            existing_items = [i for i in desired_state
+                              if i['workspace'] == workspace_name
+                              and i['usergroup'] == usergroup]
+            if len(existing_items) == 1:
+                existing_items[0]['users'].update(users)
+            else:
+                desired_state.append({
+                    "workspace": workspace_name,
+                    "usergroup": usergroup,
+                    "usergroup_id": ugid,
+                    "users": users,
+                    "channels": channels,
+                    "description": description,
+                })
 
     return desired_state
 


### PR DESCRIPTION
due to the way we collect slack user groups (per role, per user) we are not taking into account that the same slack usergroup can be referenced from multiple roles. this leads to people being added and removed from such defined groups.

this PR takes into account that a previous item referencing the same slack usergroup was already added to the desired state. if such item is found, we append the additional users into it instead of adding a new item to the desired state.