### PR TITLE
[App Interface Reporter] Collect info for multi env merge activities 

### DIFF
--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -84,10 +84,10 @@ class Report:
             'promotions',
             self.app.get('promotions')
         )
-        # merges to master
+        # merge activities
         self.add_report_section(
-            'merges_to_master',
-            self.get_activity_content(self.app.get('merge_activity'))
+            'merge_activities',
+            self.app.get('merge_activity')
         )
         # Container Vulnerabilities
         self.add_report_section(
@@ -202,13 +202,13 @@ def get_apps_data(date, month_delta=1):
     apps = queries.get_apps()
     saas_files = queries.get_saas_files()
     jjb, _ = init_jjb()
-    build_master_jobs = jjb.get_all_jobs(job_types=['build-master'])
+    build_jobs = jjb.get_all_jobs(job_types=['build'])
     jenkins_map = jenkins_base.get_jenkins_map()
     time_limit = date - relativedelta(months=month_delta)
     timestamp_limit = \
         int(time_limit.replace(tzinfo=timezone.utc).timestamp())
-    build_master_build_history = \
-        get_build_history(jenkins_map, build_master_jobs, timestamp_limit)
+    build_jobs_history = \
+        get_build_history(jenkins_map, build_jobs, timestamp_limit)
 
     settings = queries.get_app_interface_settings()
     secret_reader = SecretReader(settings=settings)
@@ -319,11 +319,27 @@ def get_apps_data(date, month_delta=1):
         code_repos = [c['url'] for c in app['codeComponents']
                       if c['resource'] == 'upstream']
         for cr in code_repos:
-            cr_history = build_master_build_history.get(cr)
+            cr_history = build_jobs_history.get(cr)
             if not cr_history:
                 continue
-            successes = [h for h in cr_history if h == 'SUCCESS']
-            app['merge_activity'][cr] = (len(cr_history), len(successes))
+            for env, history in cr_history.items():
+                if not history:
+                    continue
+                successes = [h for h in history if h == 'SUCCESS']
+                if cr not in app["merge_activity"]:
+                    app["merge_activity"][cr] = {
+                        env: {
+                            "total": len(history),
+                            "success": len(successes)
+                        }
+                    }
+                else:
+                    app["merge_activity"][cr].update({
+                        env: {
+                            "total": len(history),
+                            "success": len(successes)
+                        }
+                    })
 
         logging.info(f"collecting dashdotdb information for {app_name}")
         app_namespaces = []
@@ -387,10 +403,30 @@ def get_build_history(jenkins_map, jobs, timestamp_limit):
         jenkins = jenkins_map[instance]
         for job in jobs:
             logging.info(f"getting build history for {job['name']}")
-            build_history = \
-                jenkins.get_build_history(job['name'], timestamp_limit)
-            repo_url = get_repo_url(job)
-            history[repo_url] = build_history
+            # continue if no repo_url
+            if 'properties' not in job:
+                continue
+            if 'github' not in job['properties'][0]:
+                continue
+
+            if 'build_branch' in job:
+                job_env = job['build_branch']
+            elif 'id' in job:
+                job_env = job['id']
+            else:
+                continue
+
+            try:
+                build_history = \
+                    jenkins.get_build_history(job['name'], timestamp_limit)
+                repo_url = get_repo_url(job)
+                if repo_url not in history:
+                    history[repo_url] = {job_env: build_history}
+                else:
+                    history[repo_url].update({job_env: build_history})
+            except requests.exceptions.HTTPError:
+                logging.info(f"getting build history failed \
+                    for {job['name']}")
 
     return history
 

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -413,7 +413,6 @@ def get_build_history(jenkins_map, jobs, timestamp_limit):
             try:
                 build_history = \
                     jenkins.get_build_history(job['name'], timestamp_limit)
-                repo_url = get_repo_url(job)
                 if repo_url not in history:
                     history[repo_url] = {job_env: build_history}
                 else:

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -322,23 +322,21 @@ def get_apps_data(date, month_delta=1):
             cr_history = build_jobs_history.get(cr)
             if not cr_history:
                 continue
-            for env, history in cr_history.items():
+            for branch, history in cr_history.items():
                 if not history:
                     continue
                 successes = [h for h in history if h == 'SUCCESS']
                 if cr not in app["merge_activity"]:
-                    app["merge_activity"][cr] = {
-                        env: {
-                            "total": len(history),
-                            "success": len(successes)
-                        }
-                    }
+                    app["merge_activity"][cr] = [{
+                        "branch": branch,
+                        "total": len(history),
+                        "success": len(successes)
+                        }]
                 else:
-                    app["merge_activity"][cr].update({
-                        env: {
-                            "total": len(history),
-                            "success": len(successes)
-                        }
+                    app["merge_activity"][cr].append({
+                        "branch": branch,
+                        "total": len(history),
+                        "success": len(successes)
                     })
 
         logging.info(f"collecting dashdotdb information for {app_name}")
@@ -406,20 +404,17 @@ def get_build_history(jenkins_map, jobs, timestamp_limit):
             try:
                 repo_url = get_repo_url(job)
             except KeyError:
-                logging.info(f"getting build history failed \
-                    for {job['name']}")
+                logging.debug(f"{job['name']}: no repo_url found")
                 continue
-            job_env = job['branch']
             try:
                 build_history = \
                     jenkins.get_build_history(job['name'], timestamp_limit)
                 if repo_url not in history:
-                    history[repo_url] = {job_env: build_history}
+                    history[repo_url] = {job['branch']: build_history}
                 else:
-                    history[repo_url].update({job_env: build_history})
+                    history[repo_url].update({job['branch']: build_history})
             except requests.exceptions.HTTPError:
-                logging.info(f"getting build history failed \
-                    for {job['name']}")
+                logging.debug(f"{job['name']}: get build history failed")
                 continue
 
     return history

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -403,19 +403,13 @@ def get_build_history(jenkins_map, jobs, timestamp_limit):
         jenkins = jenkins_map[instance]
         for job in jobs:
             logging.info(f"getting build history for {job['name']}")
-            # continue if no repo_url
-            if 'properties' not in job:
+            try:
+                repo_url = get_repo_url(job)
+            except KeyError:
+                logging.info(f"getting build history failed \
+                    for {job['name']}")
                 continue
-            if 'github' not in job['properties'][0]:
-                continue
-
-            if 'build_branch' in job:
-                job_env = job['build_branch']
-            elif 'id' in job:
-                job_env = job['id']
-            else:
-                continue
-
+            job_env = job['branch']
             try:
                 build_history = \
                     jenkins.get_build_history(job['name'], timestamp_limit)
@@ -427,6 +421,7 @@ def get_build_history(jenkins_map, jobs, timestamp_limit):
             except requests.exceptions.HTTPError:
                 logging.info(f"getting build history failed \
                     for {job['name']}")
+                continue
 
     return history
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/APPSRE-2954
Issue: Currently merges_to_master only collects activities in master branch, while it is also possible to have activities in main, tag, etc. 
Example (`merge_activities` is not null):
```
$schema: /app-sre/report-1.yml
labels:
  app: quayio
name: quayio-2021-03-12
app:
  $ref: /services/quayio/app.yml
date: '2021-03-12'
contentFormatVersion: 1.0.0
content: |
  promotions:
    quay-production-standby:
      total: 1
      success: 1
  merge_activities:
    https://github.com/quay/quay:
    - branch: master
      total: 1
      success: 0
    https://github.com/app-sre/syslog-cloudwatch-bridge:
    - branch: master
      total: 1
      success: 1
    https://github.com/quay/clair:
    - branch: master
      total: 10
      success: 10
    https://github.com/coreos-inc/apostille:
    - branch: master
      total: 1
      success: 0
    https://github.com/quay/update-banner-job:
    - branch: master
      total: 10
      success: 7
  container_vulnerabilities: null
  post_deploy_jobs:
  - cluster: quays02ue1
    namespace: apostille
    post_deploy_job: false
  - cluster: quayp05ue1
    namespace: quay
    post_deploy_job: false
  - cluster: quayp03ue1
    namespace: quay-mysql-diag-prod
    post_deploy_job: false
  - cluster: quayp04ue2
    namespace: quay
    post_deploy_job: false
  deployment_validations: null
```

Example (`merge_activities` is null):
```
$schema: /app-sre/report-1.yml
labels:
  app: che-dev
name: che-dev-2021-03-12
app:
  $ref: /services/che-dev/app.yml
date: '2021-03-12'
contentFormatVersion: 1.0.0
content: |
  promotions: null
  merge_activities: null
  container_vulnerabilities: null
  post_deploy_jobs: null
  deployment_validations: null

```