### PR TITLE
[vault] retry reading secret when access is forbidden

### DIFF
--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -171,7 +171,14 @@ class _VaultClient:
         if kv_version == 2:
             data = self._read_v2(secret_path, secret_field, secret_version)
         else:
-            data = self._read_v1(secret_path, secret_field)
+            try:
+                data = self._read_v1(secret_path, secret_field)
+            except SecretAccessForbidden:
+                # setting data to None to be caught in the next
+                # section and to lead to a client auth refresh.
+                # even if this is a real problem of access forbidden,
+                # we just retry, and there is no harm in retrying.
+                data = None
 
         if data is None:
             self._refresh_client_auth()


### PR DESCRIPTION
following #1414, we saw a major decrease in authentication errors. we do see them from time to time still, but they have reduced a lot.

in this PR, we add a retry in case where we get access forbidden for a v1 secret, which is most of what we are currently seeing. this should reduce the noise completely!