### PR TITLE
[ocp-release-ecr-mirror] only mirror stable+enabled ClusterImageSets

### DIFF
--- a/reconcile/ocp_release_ecr_mirror.py
+++ b/reconcile/ocp_release_ecr_mirror.py
@@ -201,6 +201,11 @@ class OcpReleaseEcrMirror:
             enabled = labels['api.openshift.com/enabled']
             if enabled == 'false':
                 continue
+            # ClusterImageSets may be in different channels.
+            # Let's only mirror stable
+            channel_group = labels['api.openshift.com/channel-group']
+            if channel_group != 'stable':
+                continue
             ocp_releases.append(release_image)
         return ocp_releases
 

--- a/reconcile/ocp_release_ecr_mirror.py
+++ b/reconcile/ocp_release_ecr_mirror.py
@@ -195,6 +195,12 @@ class OcpReleaseEcrMirror:
             # Let's filter out everything not from quay.io
             if not release_image.startswith('quay.io'):
                 continue
+            # ClusterImagesSets may be enabled or disabled.
+            # Let's only mirror enabled ones
+            enabled_label = 'api.openshift.com/enabled'
+            enabled = clusterimageset['metadata']['labels'][enabled_label]
+            if enabled == 'false':
+                continue
             ocp_releases.append(release_image)
         return ocp_releases
 

--- a/reconcile/ocp_release_ecr_mirror.py
+++ b/reconcile/ocp_release_ecr_mirror.py
@@ -195,10 +195,10 @@ class OcpReleaseEcrMirror:
             # Let's filter out everything not from quay.io
             if not release_image.startswith('quay.io'):
                 continue
+            labels = clusterimageset['metadata']['labels']
             # ClusterImagesSets may be enabled or disabled.
             # Let's only mirror enabled ones
-            enabled_label = 'api.openshift.com/enabled'
-            enabled = clusterimageset['metadata']['labels'][enabled_label]
+            enabled = labels['api.openshift.com/enabled']
             if enabled == 'false':
                 continue
             ocp_releases.append(release_image)


### PR DESCRIPTION
we are currently mirroring all images.
Let's avoid some mirroring:
- if a CIS is disabled
- if a CIS is not in the stable channel

future work should include actually performing a reconciliation and not just mirroring, but this is an easy start.
Just with these changes we reduce the number of unique mirrored releases from 141 to 17.