### PR TITLE
[qontract-cli] add get command for aws infrastructure access switch role links

### DIFF
--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -19,7 +19,7 @@ def fetch_current_state():
         cluster = cluster_info['name']
         ocm = ocm_map.get(cluster)
         role_grants = ocm.get_aws_infrastructure_access_role_grants(cluster)
-        for user_arn, access_level in role_grants:
+        for user_arn, access_level, _ in role_grants:
             item = {
                 'cluster': cluster,
                 'user_arn': user_arn,

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -278,7 +278,7 @@ class OCM:
               'aws_infrastructure_access_role_grants'
         role_grants = self._get_json(api)['items']
         return [(r['user_arn'], r['role']['id'], r['console_url'])
-                 for r in role_grants]
+                for r in role_grants]
 
     def get_aws_infrastructure_access_terraform_assume_role(self, cluster,
                                                             tf_account_id,

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -277,7 +277,8 @@ class OCM:
         api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
               'aws_infrastructure_access_role_grants'
         role_grants = self._get_json(api)['items']
-        return [(r['user_arn'], r['role']['id']) for r in role_grants]
+        return [(r['user_arn'], r['role']['id'], r['console_url'])
+                 for r in role_grants]
 
     def get_aws_infrastructure_access_terraform_assume_role(self, cluster,
                                                             tf_account_id,

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -151,6 +151,33 @@ def clusters_network(ctx, name):
 
 
 @get.command()
+@click.pass_context
+def ocm_aws_infrastructure_access_switch_role_links(ctx):
+    settings = queries.get_app_interface_settings()
+    clusters = queries.get_clusters()
+    clusters = [c for c in clusters if c.get('ocm') is not None]
+    ocm_map = OCMMap(clusters=clusters, settings=settings)
+
+    results = []
+    for cluster in clusters:
+        cluster_name = cluster['name']
+        ocm = ocm_map.get(cluster_name)
+        role_grants = \
+            ocm.get_aws_infrastructure_access_role_grants(cluster_name)
+        for user_arn, access_level, switch_role_link in role_grants:
+            item = {
+                'cluster': cluster_name,
+                'user_arn': user_arn,
+                'access_level': access_level,
+                'switch_role_link': switch_role_link,
+            }
+            results.append(item)
+
+    columns = ['cluster', 'user_arn', 'access_level', 'switch_role_link']
+    print_output(ctx.obj['output'], results, columns)
+
+
+@get.command()
 @click.argument('cluster_name')
 @click.pass_context
 def bot_login(ctx, cluster_name):


### PR DESCRIPTION
a utility function to get a list of all the switch role links from the OCM console for all our clusters.

related to https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/FAQ.md#get-access-to-cluster-logs-via-log-forwarding