### PR TITLE
[ocm] skip provision shards mapping

### DIFF
--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -30,7 +30,7 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
     clusters = queries.get_clusters()
     clusters = [c for c in clusters if c.get('ocm') is not None]
     ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
-                     settings=settings)
+                     settings=settings, skip_provision_shards=False)
     current_state, pending_state = ocm_map.cluster_specs()
     desired_state = fetch_desired_state(clusters)
 


### PR DESCRIPTION
querying for each cluster's provision shard is time consuming and only required for the ocm-clusters integration.