### PR TITLE
[qontract-cli] add aws-route53-zones command

### DIFF
--- a/reconcile/utils/dnsutils.py
+++ b/reconcile/utils/dnsutils.py
@@ -1,0 +1,9 @@
+from dns import resolver
+
+
+def get_nameservers(domain):
+    records = []
+    answers = resolver.query(domain, 'NS')
+    for rdata in answers:
+        records.append(rdata.to_text())
+    return records

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "tzlocal==2.1",
         "parse==1.18.0",
         "sendgrid>=6.4.8,<6.5.0",
+        "dnspython~=2.1",
     ],
 
     test_suite="tests",

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -488,6 +488,11 @@ def print_table(content, columns, table_format='simple'):
                 cell = cell.get(token) or {}
             if cell == {}:
                 cell = ''
+            if isinstance(cell, list):
+                if table_format == 'github':
+                    cell = '<br />'.join(cell)
+                else:
+                    cell = '\n'.join(cell)
             row_data.append(cell)
         table_data.append(row_data)
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -7,6 +7,7 @@ import yaml
 
 from tabulate import tabulate
 
+import reconcile.utils.dnsutils as dnsutils
 import reconcile.utils.gql as gql
 import reconcile.utils.config as config
 from reconcile.utils.secret_reader import SecretReader
@@ -175,6 +176,27 @@ def ocm_aws_infrastructure_access_switch_role_links(ctx):
             results.append(item)
 
     columns = ['cluster', 'user_arn', 'access_level', 'switch_role_link']
+    print_output(ctx.obj['output'], results, columns)
+
+
+@get.command()
+@click.pass_context
+def aws_route53_zones(ctx):
+    zones = queries.get_dns_zones()
+
+    results = []
+    for zone in zones:
+        zone_name = zone['name']
+        zone_records = zone['records']
+        zone_nameservers = dnsutils.get_nameservers(zone_name)
+        item = {
+            'domain': zone_name,
+            'records': len(zone_records),
+            'nameservers': zone_nameservers
+        }
+        results.append(item)
+
+    columns = ['domain', 'records', 'nameservers']
     print_output(ctx.obj['output'], results, columns)
 
 


### PR DESCRIPTION
The `aws-route53-zones` command is used to list information about DNS zones that are managed in app-interface.

Other than listing the zone name and number of records, it also uses the `dnspython` package to query the nameservers (NS) and return them. This is useful for tenants who are looking for their nameservers to use after adding a new zone to app-interface.

I went with a simple DNS query rather than somehow looking at the terraform state or doing AWS API calls. DNS queries should work just fine and don't require extra privileges

I also added a small change to handle lists in table cells. tabular supports multiline cells natively for some table formats but does not have support for github-flavored markdown multiline cells, hence the addition of `<br>` tags when that format is used

The first use of this will be to output the information in the app-interface-output repo