### PR TITLE
[vault] retry write

### DIFF
--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -225,7 +225,6 @@ class _VaultClient:
                 self._refresh_client_auth()
                 raise SecretNotFound
 
-
     def _write_v2(self, path, data):
         # do not forget to run `self._read_all_v2.cache_clear()`
         # if this ever get's implemented


### PR DESCRIPTION
this PR adds a retry to vault's write function like we did for the read function. it also adds a handle in case the token needs to be refreshed (otherwise we will never be able to write output secrets)