### PR TITLE
retry lookup_vault_secret

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -5,6 +5,7 @@ import sys
 
 from threading import Lock
 from textwrap import indent
+from sretoolbox.utils import retry
 
 import anymarkup
 import jinja2
@@ -172,6 +173,7 @@ class UnknownTemplateTypeError(Exception):
         super().__init__("unknown template type error: " + str(msg))
 
 
+@retry()
 def lookup_vault_secret(path, key, version=None, tvars=None):
     if tvars is not None:
         path = process_jinja2_template(path, vars=tvars)


### PR DESCRIPTION
this PR adds a retry around a method to fetch a secret from vault which often fails. this is probably a problem with vault, but as consumers we just want to retry.

```
error processing jinja2 template: error fetching vault secret: local node not active but active cluster node not found

Original Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 187, in lookup_vault_secret
    vault_client = VaultClient()
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/vault.py", line 251, in __new__
    is_authenticated = cls._instance._client.is_authenticated()
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/v1/__init__.py", line 529, in is_authenticated
    self.lookup_token()
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/v1/__init__.py", line 377, in lookup_token
    return self._adapter.get(path, wrap_ttl=wrap_ttl).json()
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/adapters.py", line 93, in get
    return self.request('get', url, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/adapters.py", line 276, in request
    utils.raise_for_error(response.status_code, text, errors=errors)
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/utils.py", line 39, in raise_for_error
    raise exceptions.InternalServerError(message, errors=errors)
hvac.exceptions.InternalServerError: local node not active but active cluster node not found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 203, in process_jinja2_template
    r = template.render(vars)
  File "/usr/local/lib/python3.6/site-packages/Jinja2-2.10.3-py3.6.egg/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/Jinja2-2.10.3-py3.6.egg/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/local/lib/python3.6/site-packages/Jinja2-2.10.3-py3.6.egg/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/site-packages/Jinja2-2.10.3-py3.6.egg/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 15, in top-level template code
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/jinja2_ext.py", line 21, in _b64encode
    content = caller()
  File "/usr/local/lib/python3.6/site-packages/Jinja2-2.10.3-py3.6.egg/jinja2/runtime.py", line 574, in _invoke
    rv = self._func(*arguments)
  File "<template>", line 15, in template
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 195, in <lambda>
    lookup_vault_secret(p, k, v, vars)})
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 190, in lookup_vault_secret
    raise FetchVaultSecretError(e)
reconcile.openshift_resources_base.FetchVaultSecretError: error fetching vault secret: local node not active but active cluster node not found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 454, in fetch_openshift_resource
    add_path_to_prom_rules=add_path_to_prom_rules)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 254, in fetch_provider_resource
    content = tfunc(content, tvars)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 218, in process_extracurlyjinja2_template
    return process_jinja2_template(body, vars=vars, env=env)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 205, in process_jinja2_template
    raise Jinja2TemplateError(e)
reconcile.openshift_resources_base.Jinja2TemplateError: error processing jinja2 template: error fetching vault secret: local node not active but active cluster node not found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/threaded.py", line 10, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 594, in fetch_states
    spec.parent)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 536, in fetch_desired_state
    openshift_resource = fetch_openshift_resource(resource, parent)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 457, in fetch_openshift_resource
    raise ResourceTemplateRenderError(msg)
reconcile.openshift_resources_base.ResourceTemplateRenderError: could not render template at path /hive-stage/osd-ldap-secret.selectorsyncset.yaml
error processing jinja2 template: error fetching vault secret: local node not active but active cluster node not found
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 187, in lookup_vault_secret
    vault_client = VaultClient()
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/vault.py", line 251, in __new__
    is_authenticated = cls._instance._client.is_authenticated()
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/v1/__init__.py", line 529, in is_authenticated
    self.lookup_token()
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/v1/__init__.py", line 377, in lookup_token
    return self._adapter.get(path, wrap_ttl=wrap_ttl).json()
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/adapters.py", line 93, in get
    return self.request('get', url, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/adapters.py", line 276, in request
    utils.raise_for_error(response.status_code, text, errors=errors)
  File "/usr/local/lib/python3.6/site-packages/hvac-0.7.2-py3.6.egg/hvac/utils.py", line 39, in raise_for_error
    raise exceptions.InternalServerError(message, errors=errors)
hvac.exceptions.InternalServerError: local node not active but active cluster node not found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 203, in process_jinja2_template
    r = template.render(vars)
  File "/usr/local/lib/python3.6/site-packages/Jinja2-2.10.3-py3.6.egg/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/Jinja2-2.10.3-py3.6.egg/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/usr/local/lib/python3.6/site-packages/Jinja2-2.10.3-py3.6.egg/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/site-packages/Jinja2-2.10.3-py3.6.egg/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 15, in top-level template code
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/jinja2_ext.py", line 21, in _b64encode
    content = caller()
  File "/usr/local/lib/python3.6/site-packages/Jinja2-2.10.3-py3.6.egg/jinja2/runtime.py", line 574, in _invoke
    rv = self._func(*arguments)
  File "<template>", line 15, in template
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 195, in <lambda>
    lookup_vault_secret(p, k, v, vars)})
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 190, in lookup_vault_secret
    raise FetchVaultSecretError(e)
reconcile.openshift_resources_base.FetchVaultSecretError: error fetching vault secret: local node not active but active cluster node not found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 454, in fetch_openshift_resource
    add_path_to_prom_rules=add_path_to_prom_rules)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 254, in fetch_provider_resource
    content = tfunc(content, tvars)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 218, in process_extracurlyjinja2_template
    return process_jinja2_template(body, vars=vars, env=env)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 205, in process_jinja2_template
    raise Jinja2TemplateError(e)
reconcile.openshift_resources_base.Jinja2TemplateError: error processing jinja2 template: error fetching vault secret: local node not active but active cluster node not found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/threaded.py", line 10, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 594, in fetch_states
    spec.parent)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 536, in fetch_desired_state
    openshift_resource = fetch_openshift_resource(resource, parent)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/openshift_resources_base.py", line 457, in fetch_openshift_resource
    raise ResourceTemplateRenderError(msg)
reconcile.openshift_resources_base.ResourceTemplateRenderError: could not render template at path /hive-stage/osd-ldap-secret.selectorsyncset.yaml
error processing jinja2 template: error fetching vault secret: local node not active but active cluster node not found

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/run-integration.py", line 70, in <module>
    integration.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/utils/binary.py", line 18, in f_binary
    f(*args, **kwargs)
```