### PR TITLE
[terraform-resources] add support for public repositories

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -96,6 +96,7 @@ provider
   identifier
   region
   output_resource_name
+  public
 }
 ... on NamespaceTerraformResourceS3CloudFront_v1 {
   account

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -2524,6 +2524,7 @@ class TerrascriptClient:
         identifier = resource['identifier']
         defaults_path = resource.get('defaults', None)
         overrides = resource.get('overrides', None)
+
         values = self.get_values(defaults_path) if defaults_path else {}
         self.aggregate_values(values)
         self.override_values(values, overrides)

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -29,7 +29,6 @@ from terrascript.resource import (aws_db_instance, aws_db_parameter_group,
                                   aws_iam_user_policy_attachment,
                                   aws_sqs_queue, aws_dynamodb_table,
                                   aws_ecr_repository, aws_s3_bucket_policy,
-                                  aws_ecrpublic_repository,
                                   aws_cloudfront_origin_access_identity,
                                   aws_cloudfront_distribution,
                                   aws_vpc_peering_connection,
@@ -50,6 +49,8 @@ from terrascript.resource import (aws_db_instance, aws_db_parameter_group,
                                   aws_route53_zone,
                                   aws_route53_record,
                                   aws_route53_health_check)
+# temporary to create aws_ecrpublic_repository
+from terrascript import Resource
 
 import reconcile.utils.gql as gql
 import reconcile.utils.threaded as threaded
@@ -86,6 +87,11 @@ class UnknownProviderError(Exception):
 def safe_resource_id(s):
     """Sanitize a string into a valid terraform resource id"""
     return s.translate({ord(c): "_" for c in "."})
+
+
+# temporary pending https://github.com/mjuenema/python-terrascript/issues/160
+class aws_ecrpublic_repository(Resource):
+    pass
 
 
 class TerrascriptClient:
@@ -1693,6 +1699,8 @@ class TerrascriptClient:
         tf_resources.append(ecr_tf_resource)
         output_name_0_13 = output_prefix + '__url'
         output_value = '${' + ecr_tf_resource.repository_url + '}'
+        if public:
+            output_value = '${' + ecr_tf_resource.repository_uri + '}'
         tf_resources.append(Output(output_name_0_13, value=output_value))
         output_name_0_13 = output_prefix + '__aws_region'
         tf_resources.append(Output(output_name_0_13, value=region))

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "jira>=2.0.0,<2.1.0",
         "pyOpenSSL>=19.0.0,<20.0.0",
         "ruamel.yaml>=0.16.5,<0.17.0",
-        "terrascript==0.9.0",
+        "terrascript==0.9.0", # TODO: update after https://github.com/mjuenema/python-terrascript/issues/160
         "tabulate>=0.8.6,<0.9.0",
         "UnleashClient>=3.4.2,<3.5.0",
         "prometheus-client~=0.8",

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "jira>=2.0.0,<2.1.0",
         "pyOpenSSL>=19.0.0,<20.0.0",
         "ruamel.yaml>=0.16.5,<0.17.0",
-        "terrascript==0.9.0", # TODO: update after https://github.com/mjuenema/python-terrascript/issues/160
+        "terrascript==0.9.0",
         "tabulate>=0.8.6,<0.9.0",
         "UnleashClient>=3.4.2,<3.5.0",
         "prometheus-client~=0.8",


### PR DESCRIPTION
since public ecr repositories are now available in terraform, we can provision them.

the dependency is implementation in terrascript, which should be followed up  in https://github.com/mjuenema/python-terrascript/issues/160.
EDIT: i believe i found a hack that allows us to create aws_ecrpublic_repository resources without upgrading terrascript (added comments in the code).

terraform docs: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecrpublic_repository
schema changes: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/16919