### PR TITLE
[App Interface Reporter] Add Service SLO Metrics

### DIFF
--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -441,13 +441,13 @@ def get_apps_data(date, month_delta=1, thread_pool_size=10):
                         if namespace not in slo_mx[cluster]:
                             slo_mx[cluster][namespace] = {}
                         if slo_name not in slo_mx[cluster][namespace]:
-                            slo_value = int(sample.labels['value'])
-                            slo_target = int(sample.labels['target'])
                             slo_mx[cluster][namespace][slo_name] = {
-                                'target': slo_target,
-                                'value': slo_value
+                                sample.labels['type']: sample.value
                             }
-
+                        else:
+                            slo_mx[cluster][namespace][slo_name].update({
+                                sample.labels['type']: sample.value
+                            })
         app['container_vulnerabilities'] = vuln_mx
         app['deployment_validations'] = validt_mx
         app['service_slo'] = slo_mx


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/APPSRE-2955

Example usage:
```
app-interface-reporter --config config.reporter.toml --log-level INFO --reports-path throughput --dry-run 
```

Dashdotdb pr: https://github.com/app-sre/dashdotdb/pull/39
If running dashdotdb locally =>
```
    dashdotdb_url = "http://localhost:8080/"
    dashdotdb_user = "postgres"
    dashdotdb_pass = "postgres"
```

Report Example (`service_slo` not null):
```
$schema: /app-sre/report-1.yml
labels:
  app: Cincinnati
name: Cincinnati-2021-03-26
app:
  $ref: /services/cincinnati/app.yml
date: '2021-03-26'
contentFormatVersion: 1.0.0
content: |
  promotions:
    saas-cincinnati:
    - env: osd-stage
      cluster: app-sre-stage-01
      namespace: cincinnati-stage
      total: 7
      success: 5
    - env: osd-production
      cluster: app-sre-prod-04
      namespace: cincinnati-production
      total: 1
      success: 1
  merge_activities:
    https://github.com/openshift/cincinnati:
    - branch: master
      total: 5
      success: 5
    - branch: master
      total: 5
      success: 0
  container_vulnerabilities: null
  post_deploy_jobs: null
  deployment_validations: null
  service_slo:
  - cluster: app-sre-prod-04
    namespace: cincinnati-production
    slo_name: policy-engine latency
    target: 95
    value: 99
  - cluster: app-sre-prod-04
    namespace: cincinnati-production
    slo_name: policy-engine errors
    target: 95
    value: 100
  - cluster: app-sre-prod-04
    namespace: cincinnati-production
    slo_name: policy-engine availability
    target: 95
    value: 99
```
Note: `deployment_validations` and `container_vulnerabilities` are null here because I didn't populate my local dashdotdb for those two fields. 
Report Example (`service_slo` null):
```
$schema: /app-sre/report-1.yml
labels:
  app: che-dev
name: che-dev-2021-03-26
app:
  $ref: /services/che-dev/app.yml
date: '2021-03-26'
contentFormatVersion: 1.0.0
content: |
  promotions: null
  merge_activities: null
  container_vulnerabilities: null
  post_deploy_jobs: null
  deployment_validations: null
  service_slo: null
```
