### PR TITLE
introduce integration jenkins-job-builds-cleaner

### DIFF
--- a/helm/qontract-reconcile/values-internal.yaml
+++ b/helm/qontract-reconcile/values-internal.yaml
@@ -225,6 +225,16 @@ integrations:
     slack: true
   state: true
   cache: true
+- name: jenkins-job-builds-cleaner
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 100m
+    limits:
+      memory: 200Mi
+      cpu: 200m
+  logs:
+    slack: false
 - name: jenkins-roles
   resources:
     requests:

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -5772,6 +5772,189 @@ objects:
   kind: Deployment
   metadata:
     labels:
+      app: qontract-reconcile-jenkins-job-builds-cleaner
+    name: qontract-reconcile-jenkins-job-builds-cleaner
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile-jenkins-job-builds-cleaner
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile-jenkins-job-builds-cleaner
+          component: qontract-reconcile
+      spec:
+        serviceAccountName: qontract-reconcile
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name jenkins-job-builds-cleaner
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          ports:
+            - name: http
+              containerPort: 9090
+          env:
+          - name: SHARDS
+            value: "1"
+          - name: SHARD_ID
+            value: "0"
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: jenkins-job-builds-cleaner
+          - name: INTEGRATION_EXTRA_ARGS
+            value: ""
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: GITHUB_API
+          - name: SENTRY_DSN
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
+          - name: UNLEASH_API_URL
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: API_URL
+          - name: UNLEASH_CLIENT_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: CLIENT_ACCESS_TOKEN
+          - name: SLOW_OC_RECONCILE_THRESHOLD
+            value: "${SLOW_OC_RECONCILE_THRESHOLD}"
+          - name: LOG_SLOW_OC_RECONCILE
+            value: "${LOG_SLOW_OC_RECONCILE}"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
       app: qontract-reconcile-jenkins-roles
     name: qontract-reconcile-jenkins-roles
   spec:

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -98,6 +98,7 @@ import reconcile.dashdotdb_dvo
 import reconcile.sendgrid_teammates
 import reconcile.osd_mirrors_data_updater
 import reconcile.dashdotdb_slo
+import reconcile.jenkins_job_builds_cleaner
 
 from reconcile.status import ExitCodes
 from reconcile.status import RunningState
@@ -601,6 +602,12 @@ def jenkins_job_builder(ctx, io_dir, print_only,
                         config_name, job_name, instance_name):
     run_integration(reconcile.jenkins_job_builder, ctx.obj, io_dir,
                     print_only, config_name, job_name, instance_name)
+
+
+@integration.command()
+@click.pass_context
+def jenkins_job_builds_cleaner(ctx):
+    run_integration(reconcile.jenkins_job_builds_cleaner, ctx.obj)
 
 
 @integration.command()

--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -1,0 +1,83 @@
+import logging
+import re
+import time
+
+import reconcile.queries as queries
+
+from reconcile.utils.jenkins_api import JenkinsApi
+
+QONTRACT_INTEGRATION = 'jenkins-job-builds-cleaner'
+
+
+def hours_to_ms(hours):
+    return hours * 60 * 60 * 1000
+
+
+def delete_builds(jenkins, builds_todel, dry_run=True):
+    delete_builds_count = len(builds_todel)
+    for idx, build in enumerate(builds_todel, start=1):
+        job_name = build['job_name']
+        build_id = build['build_id']
+        progress_str = f"{idx}/{delete_builds_count}"
+        logging.debug([progress_str, job_name, build['rule_name'],
+                       build['rule_keep_hours'], build_id])
+        if not dry_run:
+            try:
+                jenkins.delete_build(build['job_name'], build['build_id'])
+            except Exception as e:
+                msg = f"failed to delete {job_name}/{build_id}"
+                logging.exception(msg)
+
+
+def find_builds(jenkins, job_names, rules):
+    # Current time in ms
+    time_ms = time.time() * 1000
+
+    builds_found = []
+    for job_name in job_names:
+        builds = None
+        for rule in rules:
+            if rule['name_re'].search(job_name):
+                # Fetch list of builds if we dont have it already
+                if not builds:
+                    builds = jenkins.get_builds(job_name)
+                for build in builds:
+                    if time_ms - rule['keep_ms'] > build['timestamp']:
+                        builds_found.append({
+                            'job_name': job_name,
+                            'rule_name': rule['name'],
+                            'rule_keep_hours': rule['keep_hours'],
+                            'build_id': build['id'],
+                        })
+    return builds_found
+
+
+def run(dry_run):
+    jenkins_instances = queries.get_jenkins_instances()
+    settings = queries.get_app_interface_settings()
+
+    for instance in jenkins_instances:
+        instance_cleanup_rules = instance.get('buildsCleanupRules', [])
+        if not instance_cleanup_rules:
+            # Skip instance if no cleanup rules defined
+            continue
+
+        # Process cleanup rules, pre-compile as regexes
+        cleanup_rules = []
+        for rule in instance_cleanup_rules:
+            cleanup_rules.append({
+                'name': rule['name'],
+                'name_re': re.compile(rule['name']),
+                'keep_hours': rule['keep_hours'],
+                'keep_ms': hours_to_ms(rule['keep_hours'])
+            })
+
+        token = instance['token']
+        jenkins = JenkinsApi(token, ssl_verify=False, settings=settings)
+        all_job_names = jenkins.get_job_names()
+
+        builds_todel = find_builds(jenkins, all_job_names, cleanup_rules)
+
+        logging.info(f'{len(builds_todel)} builds will be deleted')
+        delete_builds(jenkins, builds_todel, dry_run)
+        logging.info('deletion completed')

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -136,6 +136,10 @@ JENKINS_INSTANCES_QUERY = """
     plugins
     deleteMethod
     managedProjects
+    buildsCleanupRules {
+      name
+      keep_hours
+    }
   }
 }
 """


### PR DESCRIPTION
We currently have a cronjob running on jenkins master that looks at the builds folders creation time and deletes them according to timestamps. The behavior is similar in this new integration but while the cronjob is deleting the build folders from the filesystem this integration will do it via the jenkins REST API

The problem with deleting the build folders from the filesystem is that jenkins still keeps all the builds loaded in memory until there is a safe or full restart of jenkins. This causes increased memory and overhead when jobs and build history are queried. Listing build history happens frequently from many places: the web UI, monitoring/prometheus and upon every webhook among others.

This integration is meant to replace the cronjob that we have on the server so that builds are deleted properly via the API.

One alternative to this integration was to use the builds discarder functionality in jenkins but as many have pointed out this has caused issues in the past, thus the reason for wanting to do it via an integration.