### PR TITLE
add support for _target_cluster for A records

### DIFF
--- a/reconcile/utils/dnsutils.py
+++ b/reconcile/utils/dnsutils.py
@@ -7,3 +7,11 @@ def get_nameservers(domain):
     for rdata in answers:
         records.append(rdata.to_text())
     return records
+
+
+def get_a_records(host):
+    records = []
+    answers = resolver.query(host, 'A')
+    for rdata in answers:
+        records.append(rdata.to_text())
+    return records


### PR DESCRIPTION
Currently if someone uses `_target_cluster` on a `A` record the integration will happily take it but terraform will fail to apply because a hostname is not valid for an `A` record.

Furthermore, we have users that desire pointing the apex of their zone to a cluster. Since `CNAME` is not permitted at the zone apex, an `A` record have to be used.

This change handles using `_target_cluster` for `A` records by resolving the `_target_cluster`'s `elbFQDN` host and then it uses the IPs as targets for the `A` record. If the ELB IPs were to change, the integration would pick up the changes and update the zone accordingly.

This also add a safeguard for when no values are set or discovered so we don't and up configuring a record with no values 