### PR TITLE
[terraform-tgw-attachments] add support for routes

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -410,6 +410,7 @@ CLUSTERS_QUERY = """
             }
           }
           tags
+          cidrBlock
         }
         ... on ClusterPeeringConnectionClusterRequester_v1 {
           cluster {

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -87,6 +87,7 @@ def build_desired_state_tgw_attachments(clusters, ocm_map, settings):
                     'tgw_id': tgw_id,
                     'tgw_arn': tgw['tgw_arn'],
                     'region': tgw['region'],
+                    'cidr_block': peer_connection.get('cidrBlock'),
                     'account': account,
                 }
                 item = {

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -656,6 +656,21 @@ class TerrascriptClient:
             self.add_resource(
                 req_account_name, tf_resource_attachment_accepter)
 
+            # add routes to existing route tables
+            route_table_ids = accepter.get('route_table_ids')
+            req_cidr_block = requester.get('cidr_block')
+            if route_table_ids and req_cidr_block:
+                for route_table_id in route_table_ids:
+                    values = {
+                        'provider': 'aws.' + acc_alias,
+                        'route_table_id': route_table_id,
+                        'destination_cidr_block': req_cidr_block,
+                        'transit_gateway_id': requester['tgw_id']
+                    }
+                    route_identifier = f'{identifier}-{route_table_id}'
+                    tf_resource = aws_route(route_identifier, **values)
+                    self.add_resource(acc_account_name, tf_resource)
+
     @staticmethod
     def get_az_unique_subnet_ids(subnets_id_az):
         """ returns a list of subnet ids which are unique per az """


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3150

this PR adds support for managing routes in the VPC's route tables (in the cluster's aws account).
the cidr block comes from app-interface and is not known at run time.