### PR TITLE
periodic vault refresh

### DIFF
--- a/reconcile/test/test_vault_utils.py
+++ b/reconcile/test/test_vault_utils.py
@@ -1,0 +1,45 @@
+import importlib
+import os
+import time
+
+import pytest
+
+from mock import patch, MagicMock
+
+import reconcile.utils.vault as vault
+
+
+class SleepCalled(Exception):
+    pass
+
+
+class testVaultClient(vault._VaultClient):  # pylint: disable=W0223
+    def __init__(self):  # pylint: disable=W0231
+        pass
+
+
+class TestVaultUtils:
+    @staticmethod
+    def test_vault_auto_refresh_env():
+        os.environ['VAULT_AUTO_REFRESH_INTERVAL'] = '1'
+        importlib.reload(vault)
+        assert vault.VAULT_AUTO_REFRESH_INTERVAL == 1
+
+    @staticmethod
+    def test_vault_auto_refresh_no_env():
+        del os.environ['VAULT_AUTO_REFRESH_INTERVAL']
+        assert os.getenv('VAULT_AUTO_REFRESH_INTERVAL') is None
+        importlib.reload(vault)
+        assert vault.VAULT_AUTO_REFRESH_INTERVAL == 600
+
+    @staticmethod
+    @patch.object(time, 'sleep')
+    def test_sleep_is_called(sleep):
+        sleep.side_effect = SleepCalled
+
+        testVaultClient._refresh_client_auth = MagicMock()
+
+        client = testVaultClient()
+
+        with pytest.raises(SleepCalled):
+            client._auto_refresh_client_auth()

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -111,17 +111,9 @@ class _VaultClient:
         if kv_version == 2:
             data = self._read_all_v2(secret_path, secret_version)
         else:
-            try:
-                data = self._read_all_v1(secret_path)
-            except SecretAccessForbidden:
-                # setting data to None to be caught in the next
-                # section and to lead to a client auth refresh.
-                # even if this is a real problem of access forbidden,
-                # we just retry, and there is no harm in retrying.
-                data = None
+            data = self._read_all_v1(secret_path)
 
         if data is None:
-            self._refresh_client_auth()
             raise SecretNotFound
 
         return data
@@ -200,17 +192,9 @@ class _VaultClient:
         if kv_version == 2:
             data = self._read_v2(secret_path, secret_field, secret_version)
         else:
-            try:
-                data = self._read_v1(secret_path, secret_field)
-            except SecretAccessForbidden:
-                # setting data to None to be caught in the next
-                # section and to lead to a client auth refresh.
-                # even if this is a real problem of access forbidden,
-                # we just retry, and there is no harm in retrying.
-                data = None
+            data = self._read_v1(secret_path, secret_field)
 
         if data is None:
-            self._refresh_client_auth()
             raise SecretNotFound
 
         return base64.b64decode(data) if secret_format == 'base64' else data
@@ -248,11 +232,7 @@ class _VaultClient:
         if kv_version == 2:
             self._write_v2(secret_path, data)
         else:
-            try:
-                self._write_v1(secret_path, data)
-            except SecretAccessForbidden:
-                self._refresh_client_auth()
-                raise SecretNotFound
+            self._write_v1(secret_path, data)
 
     def _write_v2(self, path, data):
         # do not forget to run `self._read_all_v2.cache_clear()`

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -1,6 +1,9 @@
+import os
 import base64
 import time
 import functools
+import threading
+import logging
 
 import hvac
 import requests
@@ -10,6 +13,10 @@ from requests.adapters import HTTPAdapter
 from sretoolbox.utils import retry
 
 from reconcile.utils.config import get_config
+
+LOG = logging.getLogger(__name__)
+VAULT_AUTO_REFRESH_INTERVAL = int(
+    os.getenv('VAULT_AUTO_REFRESH_INTERVAL') or 600)
 
 
 class SecretNotFound(Exception):
@@ -39,7 +46,8 @@ class _VaultClient:
     to a versioned KV engine (v2), since that includes both a path
     and a version (no invalidation required).
     """
-    def __init__(self):
+
+    def __init__(self, auto_refresh=True):
         config = get_config()
 
         server = config['vault']['server']
@@ -67,6 +75,20 @@ class _VaultClient:
 
         if not authenticated:
             raise VaultConnectionError()
+
+        if auto_refresh:
+            t = threading.Thread(target=self._auto_refresh_client_auth,
+                                 daemon=True)
+            t.start()
+
+    def _auto_refresh_client_auth(self):
+        """
+        Thread that periodically refreshes the vault token
+        """
+        while True:
+            time.sleep(VAULT_AUTO_REFRESH_INTERVAL)
+            LOG.debug('auto refresh client auth')
+            self._refresh_client_auth()
 
     def _refresh_client_auth(self):
         self._client.auth_approle(self.role_id, self.secret_id)


### PR DESCRIPTION
The vault token has a TTL. Once that TTL has expired, when trying to
access vault secrets it will return a permission error, as the token is
no longer valid.

Our code is currently reactive, we watch when that happens, we refresh
the vault token, and try again.

That approach is not optimal as it requires handling the same error in
multiple places. We want to proactively refresh the token before it
expires in order to avoid the problem altogether.

Note that this is required because our integrations are long running and
our goal is to exceed the TTL.

We were previously assuming SecretAccessForbidden was a symptom of token
expiration. Therefore we were catching that exception, refreshing the
token, and raising a SecretNotFound to get the code to retry the
operation.

With the proactive token refresh we don't need to handle this. If the
vault client raises SecretAccessForbidden it's now likely a problem with
the RBAC of the client, so we don't want to hide it.

Related MRs:
#1414
#1480