### PR TITLE
APPSRE-3225: support multiple quays

### DIFF
--- a/reconcile/quay_base.py
+++ b/reconcile/quay_base.py
@@ -1,8 +1,11 @@
+from collections import namedtuple
+
 from reconcile.utils.secret_reader import SecretReader
 import reconcile.queries as queries
 
 from reconcile.utils.quay_api import QuayApi
 
+OrgKey = namedtuple('OrgKey', ['instance', 'org_name'])
 
 def get_quay_api_store():
     """
@@ -17,10 +20,10 @@ def get_quay_api_store():
     for org_data in quay_orgs:
         instance_name = org_data['instance']['name']
         org_name = org_data['name']
-        key = (instance_name, org_name)
+        org_key = OrgKey(instance_name, org_name)
         base_url = org_data['instance']['url']
         token = secret_reader.read(org_data['automationToken'])
-        store[key] = {
+        store[org_key] = {
             'api': QuayApi(token, org_name, base_url=base_url),
             'teams': org_data.get('managedTeams')
         }

--- a/reconcile/quay_base.py
+++ b/reconcile/quay_base.py
@@ -16,10 +16,10 @@ def get_quay_api_store():
     store = {}
     for org_data in quay_orgs:
         name = org_data['name']
-        server_url = org_data.get('serverUrl')
+        api_url = org_data['instance']['url']
         token = secret_reader.read(org_data['automationToken'])
         store[name] = {
-            'api': QuayApi(token, name, base_url=server_url),
+            'api': QuayApi(token, name, api_url=api_url),
             'teams': org_data.get('managedTeams')
         }
 

--- a/reconcile/quay_base.py
+++ b/reconcile/quay_base.py
@@ -15,11 +15,13 @@ def get_quay_api_store():
     secret_reader = SecretReader(settings=settings)
     store = {}
     for org_data in quay_orgs:
-        name = org_data['name']
+        instance_name = org_data['instance']['name']
+        org_name = org_data['name']
+        key = (instance_name, org_name)
         api_url = org_data['instance']['url']
         token = secret_reader.read(org_data['automationToken'])
-        store[name] = {
-            'api': QuayApi(token, name, api_url=api_url),
+        store[key] = {
+            'api': QuayApi(token, org_name, api_url=api_url),
             'teams': org_data.get('managedTeams')
         }
 

--- a/reconcile/quay_base.py
+++ b/reconcile/quay_base.py
@@ -7,6 +7,7 @@ from reconcile.utils.quay_api import QuayApi
 
 OrgKey = namedtuple('OrgKey', ['instance', 'org_name'])
 
+
 def get_quay_api_store():
     """
     Returns a dictionary with a key for each Quay organization

--- a/reconcile/quay_base.py
+++ b/reconcile/quay_base.py
@@ -18,10 +18,10 @@ def get_quay_api_store():
         instance_name = org_data['instance']['name']
         org_name = org_data['name']
         key = (instance_name, org_name)
-        api_url = org_data['instance']['url']
+        base_url = org_data['instance']['url']
         token = secret_reader.read(org_data['automationToken'])
         store[key] = {
-            'api': QuayApi(token, org_name, api_url=api_url),
+            'api': QuayApi(token, org_name, base_url=base_url),
             'teams': org_data.get('managedTeams')
         }
 

--- a/reconcile/quay_membership.py
+++ b/reconcile/quay_membership.py
@@ -23,7 +23,12 @@ QUAY_ORG_QUERY = """
     permissions {
       service
       ...on PermissionQuayOrgTeam_v1 {
-        org
+        quayOrg {
+          name
+          instance {
+            name
+          }
+        }
         team
       }
     }
@@ -34,10 +39,27 @@ QUAY_ORG_QUERY = """
 QONTRACT_INTEGRATION = 'quay-membership'
 
 
+def process_permission(permission):
+    """Returns a new permission object with the right keys
+
+    State needs these fields: service, org, team.
+
+    But the input (coming from QUAY_ORG_QUERY) will have:
+    service, quayOrg, team
+    """
+
+    return {
+        'service': permission['service'],
+        'team': permission['team'],
+        'org': (permission['quayOrg']['instance']['name'],
+                permission['quayOrg']['name'])
+    }
+
+
 def fetch_current_state(quay_api_store):
     state = AggregatedList()
 
-    for name, org_data in quay_api_store.items():
+    for org_key, org_data in quay_api_store.items():
         quay_api = org_data['api']
         teams = org_data['teams']
         if not teams:
@@ -46,7 +68,7 @@ def fetch_current_state(quay_api_store):
             members = quay_api.list_team_members(team)
             state.add({
                 'service': 'quay-membership',
-                'org': name,
+                'org': org_key,
                 'team': team
             }, members)
     return state
@@ -59,10 +81,11 @@ def fetch_desired_state():
     state = AggregatedList()
 
     for role in result['roles']:
-        permissions = list(filter(
-            lambda p: p.get('service') == 'quay-membership',
-            role['permissions']
-        ))
+        permissions = [
+            process_permission(p)
+            for p in role['permissions']
+            if p.get('service') == 'quay-membership'
+        ]
 
         if permissions:
             members = []
@@ -78,7 +101,8 @@ def fetch_desired_state():
             for bot in role['bots']:
                 append_quay_username_members(bot)
 
-            list(map(lambda p: state.add(p, members), permissions))
+            for permission in permissions:
+                state.add(permission, members)
 
     return state
 

--- a/reconcile/quay_membership.py
+++ b/reconcile/quay_membership.py
@@ -101,8 +101,8 @@ def fetch_desired_state():
             for bot in role['bots']:
                 append_quay_username_members(bot)
 
-            for permission in permissions:
-                state.add(permission, members)
+            for p in permissions:
+                state.add(p, members)
 
     return state
 

--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -24,6 +24,7 @@ QONTRACT_INTEGRATION = 'quay-mirror'
 
 OrgKey = namedtuple('OrgKey', ['instance', 'org_name'])
 
+
 class QuayMirror:
 
     QUAY_ORG_CATALOG_QUERY = """
@@ -93,8 +94,8 @@ class QuayMirror:
 
                     org_key = OrgKey(instance, org)
                     summary[org_key].append({'name': item["name"],
-                                                     'mirror': item['mirror'],
-                                                     'server_url': server_url})
+                                             'mirror': item['mirror'],
+                                             'server_url': server_url})
 
         return summary
 

--- a/reconcile/quay_permissions.py
+++ b/reconcile/quay_permissions.py
@@ -81,7 +81,7 @@ def run(dry_run):
                     role = team['role']
                     for permission in permissions:
                         if permission['service'] != 'quay-membership':
-                            logging.warning('wrong service kind, ' +
+                            logging.warning('wrong service kind, '
                                             'should be quay-membership')
                             continue
 
@@ -91,8 +91,7 @@ def run(dry_run):
                         )
 
                         if perm_org_key != org_key:
-                            logging.warning('wrong org, ' +
-                                            f'should be {org_key}')
+                            logging.warning('wrong org, should be %s', org_key)
                             continue
 
                         team_name = permission['team']
@@ -114,10 +113,11 @@ def run(dry_run):
                                 except Exception as e:
                                     error = True
                                     logging.error(
-                                        'could not set repo permissions: ' +
-                                        f'repo name: {repo_name}, ' +
-                                        f'team name: {team_name}. ' +
-                                        f'details: {str(e)}'
+                                        'could not set repo permissions: '
+                                        'repo name: %s, '
+                                        'team name: %s. '
+                                        'details: {%s}',
+                                        repo_name, team_name, e
                                     )
 
     if error:

--- a/reconcile/quay_repos.py
+++ b/reconcile/quay_repos.py
@@ -16,6 +16,9 @@ QUAY_REPOS_QUERY = """
     quayRepos {
       org {
         name
+        instance {
+          name
+        }
       }
       items {
         name
@@ -33,11 +36,11 @@ QONTRACT_INTEGRATION = 'quay-repos'
 def fetch_current_state(quay_api_store):
     state = AggregatedList()
 
-    for name, data in quay_api_store.items():
+    for key, data in quay_api_store.items():
         quay_api = data['api']
         for repo in quay_api.list_images():
             params = {
-                'org': name,
+                'org': key,
                 'repo': repo['name']
             }
 
@@ -70,10 +73,12 @@ def fetch_desired_state():
             continue
 
         for quay_repo in quay_repos:
-            name = quay_repo['org']['name']
+            instance_name = quay_repo['org']['instance']['name']
+            org_name = quay_repo['org']['name']
+            org_key = (instance_name, org_name)
             for repo in quay_repo['items']:
                 params = {
-                    'org': name,
+                    'org': org_key,
                     'repo': repo['name']
                 }
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1587,7 +1587,10 @@ QUAY_REPOS_QUERY = """
     quayRepos {
       org {
         name
-        serverUrl
+        instance {
+          name
+          url
+        }
       }
       items {
         name

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -936,6 +936,7 @@ QUAY_ORGS_QUERY = """
   quay_orgs: quay_orgs_v1 {
     name
     instance {
+      name
       url
     }
     managedTeams

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -993,7 +993,13 @@ ROLES_QUERY = """
           team
         }
         ... on PermissionQuayOrgTeam_v1 {
-          org
+          quayOrg {
+            name
+            instance {
+              name
+              url
+            }
+          }
           team
         }
       }

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -935,7 +935,9 @@ QUAY_ORGS_QUERY = """
 {
   quay_orgs: quay_orgs_v1 {
     name
-    serverUrl
+    instance {
+      url
+    }
     managedTeams
     automationToken {
       path

--- a/reconcile/service_dependencies.py
+++ b/reconcile/service_dependencies.py
@@ -28,6 +28,9 @@ APPS_QUERY = """
     quayRepos {
       org {
         name
+        instance {
+          name
+        }
       }
     }
     namespaces {

--- a/reconcile/test/fixtures/quay_membership/desired_state_simple.yml
+++ b/reconcile/test/fixtures/quay_membership/desired_state_simple.yml
@@ -7,7 +7,10 @@ gql_response:
     name: role1
     permissions:
     - service: quay-membership
-      org: my_org
+      quayOrg:
+        name: my_org
+        instance:
+          name: my_instance
       team: my_team
 
 state:
@@ -16,6 +19,6 @@ state:
   - user2
   params:
     service: quay-membership
-    org: my_org
+    org: [my_instance, my_org]
     team: my_team
 

--- a/reconcile/test/fixtures/quay_repos/current_state_simple.yml
+++ b/reconcile/test/fixtures/quay_repos/current_state_simple.yml
@@ -1,5 +1,8 @@
 quay_org_catalog:
   - name: org1
+    instance:
+      name: quay.io
+      url: quay.io
     repos:
     - name: repo1
       is_public: true

--- a/reconcile/test/fixtures/quay_repos/desired_state_simple.yml
+++ b/reconcile/test/fixtures/quay_repos/desired_state_simple.yml
@@ -3,6 +3,8 @@ gql_response:
   - quayRepos:
     - org:
         name: org1
+        instance:
+          name: my_instance
       items:
       - name: repo1
         description: desc1
@@ -12,13 +14,13 @@ gql_response:
         public: false
 state:
 - params:
-    org: org1
+    org: [my_instance, org1]
     repo: repo1
   items:
   - description: desc1
     public: true
 - params:
-    org: org1
+    org: [my_instance, org1]
     repo: repo2
   items:
   - description: desc2

--- a/reconcile/utils/quay_api.py
+++ b/reconcile/utils/quay_api.py
@@ -8,16 +8,14 @@ class RequestsException(Exception):
 
 
 class QuayApi:
-    API_URL = 'https://quay.io/api/v1'
     LIMIT_FOLLOWS = 15
 
-    def __init__(self, token, organization, base_url=None):
+    def __init__(self, token, organization, api_url='https://quay.io/api/v1'):
         self.token = token
         self.organization = organization
         self.auth_header = {"Authorization": "Bearer %s" % (token,)}
         self.team_members = {}
-        if base_url:
-            self.API_URL = f"https://{base_url}/api/v1"
+        self.api_url = api_url
 
     def list_team_members(self, team, **kwargs):
         if kwargs.get("cache"):
@@ -26,7 +24,7 @@ class QuayApi:
                 return cache_members
 
         url = "{}/organization/{}/team/{}/members?includePending=true".format(
-            self.API_URL, self.organization, team)
+            self.api_url, self.organization, team)
 
         r = requests.get(url, headers=self.auth_header)
         if r.status_code == 404:
@@ -50,7 +48,7 @@ class QuayApi:
         return members_list
 
     def user_exists(self, user):
-        url = "{}/users/{}".format(self.API_URL, user)
+        url = "{}/users/{}".format(self.api_url, user)
         r = requests.get(url, headers=self.auth_header)
         if not r.ok:
             return False
@@ -58,7 +56,7 @@ class QuayApi:
 
     def remove_user_from_team(self, user, team):
         url_team = "{}/organization/{}/team/{}/members/{}".format(
-            self.API_URL, self.organization,
+            self.api_url, self.organization,
             team, user
         )
 
@@ -73,7 +71,7 @@ class QuayApi:
                 raise RequestsException(r)
 
         url_org = "{}/organization/{}/members/{}".format(
-            self.API_URL, self.organization, user)
+            self.api_url, self.organization, user)
 
         r = requests.delete(url_org, headers=self.auth_header)
         if not r.ok:
@@ -86,7 +84,7 @@ class QuayApi:
             return True
 
         url = "{}/organization/{}/team/{}/members/{}".format(
-            self.API_URL, self.organization, team, user)
+            self.api_url, self.organization, team, user)
         r = requests.put(url, headers=self.auth_header)
         if not r.ok:
             raise RequestsException(r)
@@ -100,7 +98,7 @@ class QuayApi:
         if count > self.LIMIT_FOLLOWS:
             raise("Too many page follows")
 
-        url = "{}/repository".format(self.API_URL)
+        url = "{}/repository".format(self.api_url)
 
         # params
         params = {'namespace': self.organization}
@@ -131,7 +129,7 @@ class QuayApi:
     def repo_create(self, repo_name, description, public):
         visibility = "public" if public else "private"
 
-        url = "{}/repository".format(self.API_URL)
+        url = "{}/repository".format(self.api_url)
 
         params = {
             "repo_kind": "image",
@@ -148,7 +146,7 @@ class QuayApi:
 
     def repo_delete(self, repo_name):
         url = "{}/repository/{}/{}".format(
-            self.API_URL, self.organization, repo_name
+            self.api_url, self.organization, repo_name
         )
 
         # perform request
@@ -158,7 +156,7 @@ class QuayApi:
 
     def repo_update_description(self, repo_name, description):
         url = "{}/repository/{}/{}".format(
-            self.API_URL,
+            self.api_url,
             self.organization,
             repo_name
         )
@@ -180,7 +178,7 @@ class QuayApi:
 
     def _repo_change_visibility(self, repo_name, visibility):
         url = "{}/repository/{}/{}/changevisibility".format(
-            self.API_URL, self.organization, repo_name
+            self.api_url, self.organization, repo_name
         )
 
         params = {
@@ -193,7 +191,7 @@ class QuayApi:
             raise RequestsException(r)
 
     def get_repo_team_permissions(self, repo_name, team):
-        url = f"{self.API_URL}/repository/{self.organization}/" +\
+        url = f"{self.api_url}/repository/{self.organization}/" +\
               f"{repo_name}/permissions/team/{team}"
         r = requests.get(url, headers=self.auth_header)
         if not r.ok:
@@ -207,7 +205,7 @@ class QuayApi:
         return r.json().get('role') or None
 
     def set_repo_team_permissions(self, repo_name, team, role):
-        url = f"{self.API_URL}/repository/{self.organization}/" +\
+        url = f"{self.api_url}/repository/{self.organization}/" +\
               f"{repo_name}/permissions/team/{team}"
         body = {'role': role}
         r = requests.put(url, json=body, headers=self.auth_header)

--- a/reconcile/utils/quay_api.py
+++ b/reconcile/utils/quay_api.py
@@ -10,12 +10,12 @@ class RequestsException(Exception):
 class QuayApi:
     LIMIT_FOLLOWS = 15
 
-    def __init__(self, token, organization, api_url='https://quay.io/api/v1'):
+    def __init__(self, token, organization, base_url='quay.io'):
         self.token = token
         self.organization = organization
         self.auth_header = {"Authorization": "Bearer %s" % (token,)}
         self.team_members = {}
-        self.api_url = api_url
+        self.api_url = f"https://{base_url}/api/v1"
 
     def list_team_members(self, team, **kwargs):
         if kwargs.get("cache"):


### PR DESCRIPTION
Depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/17290

The `instance { url }` section is now mandatory for all quay_orgs (and `serverUrl` was never used). We will always pass the full api_url to the contructor.