### PR TITLE
Don't set the availability zone for an RDS instance if that instance

### DIFF
--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -765,7 +765,12 @@ class TerrascriptClient:
                 "letter. Subsequent characters can be letters, " +
                 f"underscores, or digits (0-9): {values['name']}")
 
-        az = values.get('availability_zone')
+        # we can't specify the availability_zone for an multi_az
+        # rds instance
+        if values.get('multi_az'):
+            az = values.pop('availability_zone')
+        else:
+            az = values.get('availability_zone')
         provider = ''
         if az is not None and self._multiregion_account_(account):
             values['availability_zone'] = az


### PR DESCRIPTION
is multi_az