### PR TITLE
More immutable-type errors

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -8,6 +8,8 @@ import reconcile.queries as queries
 import reconcile.utils.threaded as threaded
 
 from reconcile.utils.oc import FieldIsImmutableError
+from reconcile.utils.oc import MayNotChangeOnceSetError
+from reconcile.utils.oc import PrimaryClusterIPCanNotBeUnsetError
 from reconcile.utils.oc import InvalidValueApplyError
 from reconcile.utils.oc import MetaDataAnnotationsTooLongApplyError
 from reconcile.utils.oc import OC_Map
@@ -238,6 +240,9 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
             # Add more resources types to the list when you're
             # sure they're safe.
             if resource_type not in ['Route', 'Service']:
+                raise
+        except (MayNotChangeOnceSetError, PrimaryClusterIPCanNotBeUnsetError):
+            if resource_type not in ['Service']:
                 raise
 
             oc.delete(namespace=namespace, kind=resource_type,

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -31,6 +31,14 @@ class FieldIsImmutableError(Exception):
     pass
 
 
+class MayNotChangeOnceSetError(Exception):
+    pass
+
+
+class PrimaryClusterIPCanNotBeUnsetError(Exception):
+    pass
+
+
 class MetaDataAnnotationsTooLongApplyError(Exception):
     pass
 
@@ -591,8 +599,15 @@ class OC:
             if kwargs.get('apply'):
                 if 'Invalid value: 0x0' in err:
                     raise InvalidValueApplyError(f"[{self.server}]: {err}")
-                if 'Invalid value: ' in err and ': field is immutable' in err:
-                    raise FieldIsImmutableError(f"[{self.server}]: {err}")
+                if 'Invalid value: ' in err:
+                    if ': field is immutable' in err:
+                        raise FieldIsImmutableError(f"[{self.server}]: {err}")
+                    if ': may not change once set' in err:
+                        raise MayNotChangeOnceSetError(
+                            f"[{self.server}]: {err}")
+                    if ': primary clusterIP can not be unset' in err:
+                        raise PrimaryClusterIPCanNotBeUnsetError(
+                            f"[{self.server}]: {err}")
                 if 'metadata.annotations: Too long' in err:
                     raise MetaDataAnnotationsTooLongApplyError(
                         f"[{self.server}]: {err}")


### PR DESCRIPTION
The case we're specifically addressing here is making a Service
headless. We need to set the clusterIP to either None or "" (empty).
Kubernetes doesn't allow for clusterIP to be unset or modified, hence we
need to delete the Service and recreate it again.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>