### PR TITLE
option to disable management of quay repos

### DIFF
--- a/reconcile/quay_base.py
+++ b/reconcile/quay_base.py
@@ -8,7 +8,7 @@ from reconcile.utils.quay_api import QuayApi
 OrgKey = namedtuple('OrgKey', ['instance', 'org_name'])
 
 
-def get_quay_api_store():
+def get_quay_api_store(managed_repos=False):
     """
     Returns a dictionary with a key for each Quay organization
     managed in app-interface.
@@ -19,6 +19,8 @@ def get_quay_api_store():
     secret_reader = SecretReader(settings=settings)
     store = {}
     for org_data in quay_orgs:
+        if managed_repos and not org_data['managedRepos']:
+            continue
         instance_name = org_data['instance']['name']
         org_name = org_data['name']
         org_key = OrgKey(instance_name, org_name)

--- a/reconcile/quay_repos.py
+++ b/reconcile/quay_repos.py
@@ -16,6 +16,7 @@ QUAY_REPOS_QUERY = """
     quayRepos {
       org {
         name
+        managedRepos
         instance {
           name
         }
@@ -73,6 +74,9 @@ def fetch_desired_state():
             continue
 
         for quay_repo in quay_repos:
+            if not quay_repo['org']['managedRepos']:
+                continue
+
             instance_name = quay_repo['org']['instance']['name']
             org_name = quay_repo['org']['name']
             org_key = (instance_name, org_name)
@@ -183,7 +187,7 @@ class RunnerAction:
 
 
 def run(dry_run):
-    quay_api_store = get_quay_api_store()
+    quay_api_store = get_quay_api_store(managed_repos=True)
 
     current_state = fetch_current_state(quay_api_store)
     desired_state = fetch_desired_state()

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -935,6 +935,7 @@ QUAY_ORGS_QUERY = """
 {
   quay_orgs: quay_orgs_v1 {
     name
+    managedRepos
     instance {
       name
       url


### PR DESCRIPTION
This is to add the `managedRepos` option to allow to enable or disable management of quay.io repos