### PR TITLE
[terraform-resources] Allow AWS IAM service accounts access to cluster's AWS infrastructure via OCM

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -14,6 +14,7 @@ from reconcile.aws_iam_keys import run as disable_keys
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.defer import defer
 from reconcile.utils.oc import OC_Map
+from reconcile.utils.ocm import OCMMap
 from reconcile.utils.oc import StatusCodeError
 from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.terrascript_client import TerrascriptClient as Terrascript
@@ -296,7 +297,12 @@ def setup(dry_run, print_only, thread_pool_size, internal,
                    working_dirs,
                    thread_pool_size)
     existing_secrets = tf.get_terraform_output_secrets()
-    ts.populate_resources(tf_namespaces, existing_secrets, account_name)
+    clusters = [c for c in queries.get_clusters()
+                if c.get('ocm') is not None]
+    ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
+                     settings=settings)
+    ts.populate_resources(tf_namespaces, existing_secrets, account_name,
+                          ocm_map=ocm_map)
     ts.dump(print_only, existing_dirs=working_dirs)
 
     return ri, oc_map, tf, tf_namespaces

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -64,6 +64,12 @@ provider
   policies
   user_policy
   output_resource_name
+  aws_infrastructure_access {
+    cluster {
+      name
+    }
+    access_level
+  }
 }
 ... on NamespaceTerraformResourceSQS_v1 {
   account


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3234

this PR adds the option to define `aws_infrastructure_access` for an IAM service account created with terraform-resources.
this is to allow such users the network-mgmt role via the AWS infrastructure access feature of OCM.

this is done to enable Hive to access it's own cluster's AWS account to perform PrivateLink related operations (https://github.com/openshift/aws-account-operator/pull/539).

the final result of all this is that the IAM user created by terraform-resources will be granted AWS infrastructure access through ocm-aws-infrastructure-access. once that access is granted, a `role_arn` key will be added to the output Secret created by terraform-resources, as required for section (3) of https://github.com/openshift/hive/blob/master/docs/awsprivatelink.md#permissions-required-for-aws-private-link.