### PR TITLE
Move the managedRepos processing to where we need it

### DIFF
--- a/reconcile/quay_base.py
+++ b/reconcile/quay_base.py
@@ -8,7 +8,7 @@ from reconcile.utils.quay_api import QuayApi
 OrgKey = namedtuple('OrgKey', ['instance', 'org_name'])
 
 
-def get_quay_api_store(managed_repos=False):
+def get_quay_api_store():
     """
     Returns a dictionary with a key for each Quay organization
     managed in app-interface.
@@ -19,8 +19,6 @@ def get_quay_api_store(managed_repos=False):
     secret_reader = SecretReader(settings=settings)
     store = {}
     for org_data in quay_orgs:
-        if managed_repos and not org_data['managedRepos']:
-            continue
         instance_name = org_data['instance']['name']
         org_name = org_data['name']
         org_key = OrgKey(instance_name, org_name)
@@ -36,7 +34,8 @@ def get_quay_api_store(managed_repos=False):
             'url': base_url,
             'api': QuayApi(token, org_name, base_url=base_url),
             'push_token': push_token,
-            'teams': org_data.get('managedTeams')
+            'teams': org_data.get('managedTeams'),
+            'managedRepos': org_data.get('managedRepos'),
         }
 
     return store

--- a/reconcile/quay_repos.py
+++ b/reconcile/quay_repos.py
@@ -38,6 +38,9 @@ def fetch_current_state(quay_api_store):
     state = AggregatedList()
 
     for key, data in quay_api_store.items():
+        if not data['managedRepos']:
+            continue
+
         quay_api = data['api']
         for repo in quay_api.list_images():
             params = {
@@ -187,7 +190,7 @@ class RunnerAction:
 
 
 def run(dry_run):
-    quay_api_store = get_quay_api_store(managed_repos=True)
+    quay_api_store = get_quay_api_store()
 
     current_state = fetch_current_state(quay_api_store)
     desired_state = fetch_desired_state()

--- a/reconcile/test/fixtures/quay_repos/current_state_simple.yml
+++ b/reconcile/test/fixtures/quay_repos/current_state_simple.yml
@@ -1,5 +1,6 @@
 quay_org_catalog:
   - name: org1
+    managedRepos: true
     instance:
       name: quay.io
       url: quay.io

--- a/reconcile/test/test_quay_repos.py
+++ b/reconcile/test/test_quay_repos.py
@@ -45,7 +45,8 @@ class TestQuayRepos:
         store = {}
         for org_data in quay_org_catalog:
             name = org_data['name']
-            store[name] = {'api': QuayApiMock(org_data['repos'])}
+            store[name] = {'api': QuayApiMock(org_data['repos']),
+                           'managedRepos': org_data['managedRepos']}
 
         current_state = quay_repos.fetch_current_state(store)
         current_state = current_state.dump()


### PR DESCRIPTION
The `managedRepos` is an option of interest for the quay-repos
integration.

Instead of changing the behaviour of the `get_quay_api_store()` acording
to the integration using it, let' s just make sure it ships enough
information so the quay-repos integration knows what to do.

Then, in the quay-repos intregration, we test the `managedRepos` in the
`fetch_current_state()`, the same way we do for the `fetch_desired_state()`.