### PR TITLE
[MTSRE-36] gitlabRepoOwners now has the branch name

### DIFF
--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -299,8 +299,8 @@ class MRApproval:
 
 
 def act(repo, dry_run, instance, settings):
-    gitlab_cli = GitLabApi(instance, project_url=repo, settings=settings)
-    project_owners = RepoOwners(git_cli=gitlab_cli)
+    gitlab_cli = GitLabApi(instance, project_url=repo.url, settings=settings)
+    project_owners = RepoOwners(git_cli=gitlab_cli, ref=repo.branch)
 
     for mr in gitlab_cli.get_merge_requests(state=MRState.OPENED):
         mr_approval = MRApproval(gitlab_client=gitlab_cli,
@@ -356,8 +356,8 @@ def act(repo, dry_run, instance, settings):
 def run(dry_run, thread_pool_size=10):
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()
-    repos = queries.get_repos_gitlab_owner(server=instance['url'])
-    threaded.run(act, repos, thread_pool_size,
+    gl_repo_owners = queries.get_repos_gitlab_owner(server=instance['url'])
+    threaded.run(act, gl_repo_owners, thread_pool_size,
                  dry_run=dry_run,
                  instance=instance,
                  settings=settings)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1,4 +1,5 @@
 import logging
+from collections import namedtuple
 
 from textwrap import indent
 
@@ -897,13 +898,15 @@ def get_repos(server=''):
 
 
 def get_repos_gitlab_owner(server=''):
-    """ Returns all repos defined under codeComponents that have gitlabOwner
-    enabled.
+    """ Returns all repos defined under codeComponents that have
+    gitlabRepoOwners defined.
     Optional arguments:
-    server: url of the server to return. for example: https://github.com
+    server: url of the server to return.
     """
     code_components = get_code_components()
-    return [c['url'] for c in code_components
+    GitlabRepoOwners = namedtuple('GitlabRepoOwners', ['url', 'branch'])
+    return [GitlabRepoOwners(c['url'], c['gitlabRepoOwners'])
+            for c in code_components
             if c['url'].startswith(server) and
             c['gitlabRepoOwners']]
 


### PR DESCRIPTION
gitlabRepoOwners used to be a boolean, but now it brings the branch name
to compare the MR against, as some repos are migrating from "master" to
"main".

app-interface counterpart: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/17914