### PR TITLE
[openshift-saas-deploy] skip empty promotion

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -923,6 +923,8 @@ class SaasHerder():
         If there were promotion sections in the participating saas files
         validate that the conditions are met. """
         for item in self.promotions:
+            if item is None:
+                continue
             # validate that the commit sha being promoted
             # was succesfully published to the subscribed channel(s)
             commit_sha = item['commit_sha']


### PR DESCRIPTION
When an Image is not found, `promotion` returns as None, which we do not handle.

This PR changes the behavior to skip validating a `None` promotion. The integration will still exit with an error code and the promotion itself will be published as failed (unable to promote to it, as expected).