### PR TITLE
[saas-file-owners] consider use_channel_in_image_tag as a diff

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -61,7 +61,8 @@ def collect_state():
         saas_file_parameters = json.loads(saas_file.get('parameters') or '{}')
         saas_file_definitions = {
             'managed_resource_types': saas_file['managedResourceTypes'],
-            'image_patterns': saas_file['imagePatterns']
+            'image_patterns': saas_file['imagePatterns'],
+            'use_channel_in_image_tag': saas_file['use_channel_in_image_tag'],
         }
         resource_templates = saas_file['resourceTemplates']
         for resource_template in resource_templates:


### PR DESCRIPTION
since `use_channel_in_image_tag` was introduced as a new top-level section of a saas file, we need to explicitly add it to the logic of comparing if there were changes to a saas file. this is done so we do a dry-run of a deployment in the MR adding usage of `use_channel_in_image_tag`.

the dry-run deployment did not run for MRs such as https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/17951, which causes the tests to pass, despite having issues (now fixed).