### PR TITLE
openshift compare logic for OperatorGroup

### DIFF
--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -358,6 +358,9 @@ class OpenshiftResource:
             if body['apiVersion'] == 'authorization.openshift.io/v1':
                 body['apiVersion'] = 'rbac.authorization.k8s.io/v1'
 
+        if body['kind'] == 'OperatorGroup':
+            annotations.pop('olm.providedAPIs', None)
+
         if body['kind'] == 'RoleBinding':
             if 'groupNames' in body:
                 body.pop('groupNames')


### PR DESCRIPTION
since this annotation is added automatically, our integrations think that they need to reconcile OperatorGroup.