### PR TITLE
[saas-file-owners] allow to self-service use_channel_in_image_tag

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -195,11 +195,13 @@ def valid_diff(current_state, desired_state):
     for c in current_state_copy:
         c.pop('ref')
         c.pop('parameters')
+        c['saas_file_definitions'].pop('use_channel_in_image_tag')
         c.pop('disable', None)
     desired_state_copy = copy.deepcopy(desired_state)
     for d in desired_state_copy:
         d.pop('ref')
         d.pop('parameters')
+        d['saas_file_definitions'].pop('use_channel_in_image_tag')
         d.pop('disable', None)
     return current_state_copy == desired_state_copy
 


### PR DESCRIPTION
our integrations are covering our bases very well. if `use_channel_in_image_tag` is used, our integrations are checking all cases for all different targets.

the merge strategy for `use_channel_in_image_tag` is (by @2uasimojo):

The use_channel_in_image_tag attribute needs to be rolled out in
stages. This is because it causes the generated IMAGE_TAG to change
from $hash to $channel-$hash. This is incompatible with older
versions of the in-repo OLM bundle, which specify the image with tag
${CHANNEL}-${IMAGE_TAG}: this would become e.g.
staging-staging-abc1234 if we just landed use_channel_in_image_tag
by itself, resulting in broken builds.
The stages are as follows:

Freeze staging/integration to the hash of the current master (prod is
already frozen). Supply the IMAGE_TAG parameter explicitly,
corresponding to the frozen hash.
Land the in-repo change to cut over to $REPO_DIGEST

Revert the staging/integration parts of step #1. This
should unfreeze staging/integration and cause them to start using
$REPO_DIGEST properly.
During the prod promotion that gets us to/past the commit from #2
above, remove the IMAGE_TAG parameter from the prod envs. This should
cause prod to start using $REPO_DIGEST properly.