### PR TITLE
[kafka-clusters] add support for multi_az and service accounts

### DIFF
--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -473,6 +473,7 @@ integrations:
     limits:
       memory: 400Mi
       cpu: 200m
+  extraArgs: --vault-throughput-path app-sre/integrations-throughput
   logs:
     cloudwatch: true
     slack: true

--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -465,6 +465,17 @@ integrations:
   logs:
     cloudwatch: true
     slack: true
+- name: kafka-clusters
+  resources:
+    requests:
+      memory: 200Mi
+      cpu: 100m
+    limits:
+      memory: 400Mi
+      cpu: 200m
+  logs:
+    cloudwatch: true
+    slack: true
 - name: email-sender
   resources:
     requests:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -14589,7 +14589,7 @@ objects:
           - name: INTEGRATION_NAME
             value: kafka-clusters
           - name: INTEGRATION_EXTRA_ARGS
-            value: ""
+            value: "--vault-throughput-path app-sre/integrations-throughput"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -14473,6 +14473,206 @@ objects:
   kind: Deployment
   metadata:
     labels:
+      app: qontract-reconcile-kafka-clusters
+    name: qontract-reconcile-kafka-clusters
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile-kafka-clusters
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile-kafka-clusters
+          component: qontract-reconcile
+      spec:
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                key: slack.webhook_url
+                name: app-interface
+          - name: SLACK_CHANNEL
+            value: ${SLACK_CHANNEL}
+          - name: SLACK_ICON_EMOJI
+            value: ${SLACK_ICON_EMOJI}
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type slack
+                webhook_url ${SLACK_WEBHOOK_URL}
+                channel ${SLACK_CHANNEL}
+                icon_emoji ${SLACK_ICON_EMOJI}
+                username sd-app-sre-bot
+                flush_interval 10s
+                message "\`\`\`[kafka-clusters] %s\`\`\`"
+              </store>
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name kafka-clusters
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          ports:
+            - name: http
+              containerPort: 9090
+          env:
+          - name: SHARDS
+            value: "1"
+          - name: SHARD_ID
+            value: "0"
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: kafka-clusters
+          - name: INTEGRATION_EXTRA_ARGS
+            value: ""
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: GITHUB_API
+          - name: SENTRY_DSN
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
+          - name: UNLEASH_API_URL
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: API_URL
+          - name: UNLEASH_CLIENT_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: CLIENT_ACCESS_TOKEN
+          - name: SLOW_OC_RECONCILE_THRESHOLD
+            value: "${SLOW_OC_RECONCILE_THRESHOLD}"
+          - name: LOG_SLOW_OC_RECONCILE
+            value: "${LOG_SLOW_OC_RECONCILE}"
+          resources:
+            limits:
+              cpu: 200m
+              memory: 400Mi
+            requests:
+              cpu: 100m
+              memory: 200Mi
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
       app: qontract-reconcile-email-sender
     name: qontract-reconcile-email-sender
   spec:

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -303,6 +303,15 @@ def vault_output_path(function):
     return function
 
 
+def vault_throughput_path(function):
+    function = click.option('--vault-throughput-path',
+                            help='path in Vault to find input resources '
+                                 'and store output resources.',
+                            default='')(function)
+
+    return function
+
+
 def cluster_name(function):
     function = click.option('--cluster-name',
                             help='cluster name to act on.',
@@ -1262,10 +1271,12 @@ def ecr_mirror(ctx, thread_pool_size):
 @binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
+@vault_throughput_path
 @click.pass_context
-def kafka_clusters(ctx, thread_pool_size, internal, use_jump_host):
+def kafka_clusters(ctx, thread_pool_size, internal, use_jump_host,
+                   vault_throughput_path):
     run_integration(reconcile.kafka_clusters, ctx.obj, thread_pool_size,
-                    internal, use_jump_host)
+                    internal, use_jump_host, vault_throughput_path)
 
 
 @integration.command()

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -83,6 +83,19 @@ def run(dry_run, thread_pool_size=10,
     error = False
     for kafka_cluster in kafka_clusters:
         kafka_cluster_name = kafka_cluster['name']
+        # get a service account for the cluster
+        # we match cluster to service account by name
+        service_accounts = [sa for sa in kafka_service_accounts
+                            if sa['name'] == kafka_cluster_name]
+        if service_accounts:
+            service_account = service_accounts[0]
+        else:
+            service_account = {}
+            logging.info(['create_service_account', kafka_cluster_name])
+            if not dry_run:
+                ocm = ocm_map.get(kafka_cluster_name)
+                service_account = \
+                    ocm.create_kafka_service_account(kafka_cluster_name)
         desired_cluster = [c for c in desired_state
                            if kafka_cluster_name == c['name']][0]
         current_cluster = [c for c in current_state
@@ -109,20 +122,6 @@ def run(dry_run, thread_pool_size=10,
         if current_cluster['status'] != 'ready':
             continue
         # we have a ready cluster!
-        # let's get/create a service account for it
-        # we match cluster to service account by name
-        service_accounts = [sa for sa in kafka_service_accounts
-                            if sa['name'] == kafka_cluster_name]
-        if service_accounts:
-            service_account = service_accounts[0]
-        else:
-            service_account = {}
-            logging.info(['create_service_account', kafka_cluster_name])
-            if not dry_run:
-                ocm = ocm_map.get(kafka_cluster_name)
-                service_account = \
-                    ocm.create_kafka_service_account(kafka_cluster_name)
-        
         # let's create a Secret in all referencing namespaces
         kafka_namespaces = kafka_cluster['namespaces']
         secret_fields = ['bootstrapServerHost']

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -126,10 +126,6 @@ def run(dry_run, thread_pool_size=10,
                 result_sa = \
                     ocm.create_kafka_service_account(
                         kafka_cluster_name, fields=sa_fields)
-                # this is the only time we will get the clientSecret
-                # so we write it to vault to be able to get it again
-                write_output_to_vault(
-                    vault_throughput_path, kafka_cluster_name, result_sa)
         
         desired_cluster = [c for c in desired_state
                            if kafka_cluster_name == c['name']][0]
@@ -172,6 +168,10 @@ def run(dry_run, thread_pool_size=10,
                 resource.name,
                 resource
             )
+        if not dry_run:
+            write_output_to_vault(vault_throughput_path,
+                                  kafka_cluster_name,
+                                  resource.body['data'])
 
     ob.realize_data(dry_run, oc_map, ri)
 

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -74,15 +74,17 @@ def run(dry_run, thread_pool_size=10,
         use_jump_host=use_jump_host)
     defer(lambda: oc_map.cleanup())
 
-    current_state = ocm_map.kafka_cluster_specs()
-    desired_state = fetch_desired_state(kafka_clusters)
+    current_state = {}
+    desired_state = {}
+    current_state['clusters'] = ocm_map.kafka_cluster_specs()
+    desired_state['clusters'] = fetch_desired_state(kafka_clusters)
 
     error = False
     for kafka_cluster in kafka_clusters:
         kafka_cluster_name = kafka_cluster['name']
-        desired_cluster = [c for c in desired_state
+        desired_cluster = [c for c in desired_state['clusters']
                            if kafka_cluster_name == c['name']][0]
-        current_cluster = [c for c in current_state
+        current_cluster = [c for c in current_state['clusters']
                            if kafka_cluster_name == c['name']]
         # check if cluster exists. if not - create it
         if not current_cluster:

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -106,8 +106,10 @@ def run(dry_run, thread_pool_size=10,
             logging.info(['create_service_account', kafka_cluster_name])
             if not dry_run:
                 ocm = ocm_map.get(kafka_cluster_name)
+                sa_fields = ['clientId', 'clientSecret']
                 result_sa = \
-                    ocm.create_kafka_service_account(kafka_cluster_name)
+                    ocm.create_kafka_service_account(
+                        kafka_cluster_name, fields=sa_fields)
                 # this is the only time we will get the clientSecret
                 # so we write it to vault to be able to get it again
                 write_output_to_vault(

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -42,7 +42,8 @@ def fetch_desired_state(clusters):
         item = {
             'name': cluster_info['name'],
             'cloud_provider': cluster_info['spec']['provider'],
-            'region': cluster_info['spec']['region']
+            'region': cluster_info['spec']['region'],
+            'multi_az': cluster_info['spec']['multi_az'],
         }
         desired_state.append(item)
     return desired_state

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -76,15 +76,15 @@ def run(dry_run, thread_pool_size=10,
 
     current_state = {}
     desired_state = {}
-    current_state['clusters'] = ocm_map.kafka_cluster_specs()
-    desired_state['clusters'] = fetch_desired_state(kafka_clusters)
+    current_state = ocm_map.kafka_cluster_specs()
+    desired_state = fetch_desired_state(kafka_clusters)
 
     error = False
     for kafka_cluster in kafka_clusters:
         kafka_cluster_name = kafka_cluster['name']
-        desired_cluster = [c for c in desired_state['clusters']
+        desired_cluster = [c for c in desired_state
                            if kafka_cluster_name == c['name']][0]
-        current_cluster = [c for c in current_state['clusters']
+        current_cluster = [c for c in current_state
                            if kafka_cluster_name == c['name']]
         # check if cluster exists. if not - create it
         if not current_cluster:

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -122,7 +122,7 @@ def run(dry_run, thread_pool_size=10,
             logging.info(['create_service_account', kafka_cluster_name])
             if not dry_run:
                 ocm = ocm_map.get(kafka_cluster_name)
-                sa_fields = ['clientId', 'clientSecret']
+                sa_fields = ['clientID', 'clientSecret']
                 result_sa = \
                     ocm.create_kafka_service_account(
                         kafka_cluster_name, fields=sa_fields)

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -86,16 +86,16 @@ def run(dry_run, thread_pool_size=10,
         service_accounts = [sa for sa in kafka_service_accounts
                             if sa['name'] == kafka_cluster_name]
         if service_accounts:
-            service_account = service_accounts[0]
+            result_sa = service_accounts[0]
         else:
-            service_account = {}
+            result_sa = {}
             logging.info(['create_service_account', kafka_cluster_name])
             if not dry_run:
                 ocm = ocm_map.get(kafka_cluster_name)
-                service_account = \
+                result_sa = \
                     ocm.create_kafka_service_account(kafka_cluster_name)
         # the name was only needed for matching
-        service_account.pop('name', None)
+        result_sa.pop('name', None)
         desired_cluster = [c for c in desired_state
                            if kafka_cluster_name == c['name']][0]
         current_cluster = [c for c in current_state
@@ -127,7 +127,7 @@ def run(dry_run, thread_pool_size=10,
         secret_fields = ['bootstrapServerHost']
         data = {k: v for k, v in current_cluster.items()
                 if k in secret_fields}
-        data.update(service_account)
+        data.update(result_sa)
         resource = construct_oc_resource(data)
         for namespace_info in kafka_namespaces:
             ri.add_desired(

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -74,8 +74,6 @@ def run(dry_run, thread_pool_size=10,
         use_jump_host=use_jump_host)
     defer(lambda: oc_map.cleanup())
 
-    current_state = {}
-    desired_state = {}
     current_state = ocm_map.kafka_cluster_specs()
     desired_state = fetch_desired_state(kafka_clusters)
     kafka_service_accounts = ocm_map.kafka_service_account_specs()
@@ -96,6 +94,8 @@ def run(dry_run, thread_pool_size=10,
                 ocm = ocm_map.get(kafka_cluster_name)
                 service_account = \
                     ocm.create_kafka_service_account(kafka_cluster_name)
+        # the name was only needed for matching
+        service_account.pop('name', None)
         desired_cluster = [c for c in desired_state
                            if kafka_cluster_name == c['name']][0]
         current_cluster = [c for c in current_state

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -126,7 +126,7 @@ def run(dry_run, thread_pool_size=10,
                 result_sa = \
                     ocm.create_kafka_service_account(
                         kafka_cluster_name, fields=sa_fields)
-        
+
         desired_cluster = [c for c in desired_state
                            if kafka_cluster_name == c['name']][0]
         current_cluster = [c for c in current_state

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -103,7 +103,7 @@ def run(dry_run, thread_pool_size=10,
             error = True
             continue
         # check if cluster is ready. if not - wait
-        if current_cluster['status'] != 'complete':
+        if current_cluster['status'] != 'ready':
             continue
         # we have a ready cluster!
         # let's create a Secret in all referencing namespaces

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -8,7 +8,7 @@ import reconcile.queries as queries
 
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.defer import defer
-from reconcile.utils.ocm import OCMMap
+from reconcile.utils.ocm import OCMMap, STATUS_READY
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.status import ExitCodes
 
@@ -119,7 +119,7 @@ def run(dry_run, thread_pool_size=10,
             error = True
             continue
         # check if cluster is ready. if not - wait
-        if current_cluster['status'] != 'ready':
+        if current_cluster['status'] != STATUS_READY:
             continue
         # we have a ready cluster!
         # let's create a Secret in all referencing namespaces

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -51,7 +51,12 @@ def fetch_desired_state(clusters):
 
 @defer
 def run(dry_run, thread_pool_size=10,
-        internal=None, use_jump_host=True, defer=None):
+        internal=None, use_jump_host=True,
+        vault_throughput_path=None, defer=None):
+    if not vault_throughput_path:
+        logging.error('must supply vault throughput path')
+        sys.exit(ExitCodes.ERROR)
+
     kafka_clusters = queries.get_kafka_clusters()
     if not kafka_clusters:
         logging.debug("No Kafka clusters found in app-interface")

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -543,6 +543,7 @@ KAFKA_CLUSTERS_QUERY = """
     spec {
       provider
       region
+      multi_az
     }
     namespaces {
       name

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -7,6 +7,9 @@ from sretoolbox.utils import retry
 from reconcile.utils.secret_reader import SecretReader
 
 
+STATUS_READY = 'ready'
+
+
 class OCM:
     """
     OCM is an instance of OpenShift Cluster Manager.
@@ -56,10 +59,10 @@ class OCM:
         self.clusters = {
             c['name']: self._get_cluster_ocm_spec(c, skip_provision_shards)
             for c in clusters if c['managed']
-            and c['state'] == 'ready'
+            and c['state'] == STATUS_READY
         }
         self.not_ready_clusters = [c['name'] for c in clusters
-                                   if c['managed'] and c['state'] != 'ready']
+                                   if c['managed'] and c['state'] != STATUS_READY]
 
     def _get_cluster_ocm_spec(self, cluster, skip_provision_shards):
         ocm_spec = {

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -662,15 +662,13 @@ class OCM:
         params = {'async': 'true'}
         self._post(api, data, params)
 
-    def create_kafka_service_account(self, name):
+    def create_kafka_service_account(self, name, fields=None):
         """ Creates a Kafka service account """
         api = f'{KAS_API_BASE}/v1/serviceaccounts'
         result = self._post(api, {'name': name})
-        return {
-            'name': result['name'],
-            'client_id': result['clientID'],
-            'client_secret': result['clientSecret'],
-        }
+        if fields:
+            result = {k: v for k, v in result.items() if k in fields}
+        return result
 
     def _init_addons(self):
         """Returns a list of Addons """

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -645,8 +645,10 @@ class OCM:
             sa_id = sa['id']
             id_api = f'{api}/{sa_id}'
             sa_details = self._get_json(id_api)
-            item = {k: v for k, v in sa_details.items() if k in fields}
-            results.append(item)
+            if fields:
+                sa_details = {k: v for k, v in sa_details.items()
+                              if k in fields}
+            results.append(sa_details)
         return results
 
     def create_kafka_cluster(self, data):

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -9,6 +9,8 @@ from reconcile.utils.secret_reader import SecretReader
 
 STATUS_READY = 'ready'
 
+CS_API_BASE = '/api/clusters_mgmt'
+
 
 class OCM:
     """
@@ -53,7 +55,7 @@ class OCM:
         }
 
     def _init_clusters(self, skip_provision_shards):
-        api = '/api/clusters_mgmt/v1/clusters'
+        api = f'{CS_API_BASE}/v1/clusters'
         clusters = self._get_json(api)['items']
         self.cluster_ids = {c['name']: c['id'] for c in clusters}
         self.clusters = {
@@ -112,7 +114,7 @@ class OCM:
         :type cluster: dict
         :type dry_run: bool
         """
-        api = '/api/clusters_mgmt/v1/clusters'
+        api = f'{CS_API_BASE}/v1/clusters'
         cluster_spec = cluster['spec']
         cluster_network = cluster['network']
         ocm_spec = {
@@ -179,7 +181,7 @@ class OCM:
         :type dry_run: bool
         """
         cluster_id = self.cluster_ids.get(name)
-        api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}'
+        api = f'{CS_API_BASE}/v1/clusters/{cluster_id}'
         cluster_spec = cluster['spec']
         ocm_spec = {
             'nodes': {
@@ -226,12 +228,12 @@ class OCM:
         cluster_id = self.cluster_ids.get(cluster)
         if not cluster_id:
             return None
-        api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/groups'
+        api = f'{CS_API_BASE}/v1/clusters/{cluster_id}/groups'
         groups = self._get_json(api)['items']
         if group_id not in [g['id'] for g in groups]:
             return None
 
-        api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
+        api = f'{CS_API_BASE}/v1/clusters/{cluster_id}/' + \
               f'groups/{group_id}/users'
         users = self._get_json(api)['items']
         return {'users': [u['id'] for u in users]}
@@ -249,7 +251,7 @@ class OCM:
         :type user: string
         """
         cluster_id = self.cluster_ids[cluster]
-        api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
+        api = f'{CS_API_BASE}/v1/clusters/{cluster_id}/' + \
               f'groups/{group_id}/users'
         self._post(api, {'id': user})
 
@@ -265,7 +267,7 @@ class OCM:
         :type user: string
         """
         cluster_id = self.cluster_ids[cluster]
-        api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
+        api = f'{CS_API_BASE}/v1/clusters/{cluster_id}/' + \
               f'groups/{group_id}/users/{user_id}'
         self._delete(api)
 
@@ -280,7 +282,7 @@ class OCM:
         cluster_id = self.cluster_ids.get(cluster)
         if not cluster_id:
             return []
-        api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
+        api = f'{CS_API_BASE}/v1/clusters/{cluster_id}/' + \
               'aws_infrastructure_access_role_grants'
         role_grants = self._get_json(api)['items']
         return [(r['user_arn'], r['role']['id'], r['state'], r['console_url'])
@@ -290,7 +292,7 @@ class OCM:
                                                             tf_account_id,
                                                             tf_user):
         cluster_id = self.cluster_ids[cluster]
-        api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
+        api = f'{CS_API_BASE}/v1/clusters/{cluster_id}/' + \
               'aws_infrastructure_access_role_grants'
         role_grants = self._get_json(api)['items']
         user_arn = f"arn:aws:iam::{tf_account_id}:user/{tf_user}"
@@ -322,7 +324,7 @@ class OCM:
         :type access_level: string
         """
         cluster_id = self.cluster_ids[cluster]
-        api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
+        api = f'{CS_API_BASE}/v1/clusters/{cluster_id}/' + \
               'aws_infrastructure_access_role_grants'
         self._post(api, {'user_arn': user_arn, 'role': {'id': access_level}})
 
@@ -341,7 +343,7 @@ class OCM:
         :type access_level: string
         """
         cluster_id = self.cluster_ids[cluster]
-        api = f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
+        api = f'{CS_API_BASE}/v1/clusters/{cluster_id}/' + \
               'aws_infrastructure_access_role_grants'
         role_grants = self._get_json(api)['items']
         for rg in role_grants:
@@ -364,7 +366,7 @@ class OCM:
         if not cluster_id:
             return result_idps
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/identity_providers'
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}/identity_providers'
         idps = self._get_json(api).get('items')
         if not idps:
             return result_idps
@@ -398,7 +400,7 @@ class OCM:
         cluster = spec['cluster']
         cluster_id = self.cluster_ids[cluster]
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/identity_providers'
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}/identity_providers'
         payload = {
             'type': 'GithubIdentityProvider',
             'mapping_method': 'claim',
@@ -423,7 +425,7 @@ class OCM:
         if not cluster_id:
             return results
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}' + \
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}' + \
             '/external_configuration/labels'
         items = self._get_json(api).get('items')
         if not items:
@@ -447,7 +449,7 @@ class OCM:
         """
         cluster_id = self.cluster_ids[cluster]
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}' + \
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}' + \
             '/external_configuration/labels'
         self._post(api, label)
 
@@ -462,7 +464,7 @@ class OCM:
         """
         cluster_id = self.cluster_ids[cluster]
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}' + \
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}' + \
             '/external_configuration/labels'
         items = self._get_json(api).get('items')
         item = [item for item in items if label.items() <= item.items()]
@@ -470,7 +472,7 @@ class OCM:
             return
         label_id = item[0]['id']
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}' + \
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}' + \
             f'/external_configuration/labels/{label_id}'
         self._delete(api)
 
@@ -486,7 +488,7 @@ class OCM:
         if not cluster_id:
             return results
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/machine_pools'
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}/machine_pools'
         items = self._get_json(api).get('items')
         if not items:
             return results
@@ -510,7 +512,7 @@ class OCM:
         """
         cluster_id = self.cluster_ids[cluster]
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/machine_pools'
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}/machine_pools'
         self._post(api, spec)
 
     def update_machine_pool(self, cluster, spec):
@@ -527,7 +529,7 @@ class OCM:
         labels = spec.get('labels', {})
         spec['labels'] = labels
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/machine_pools/' + \
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}/machine_pools/' + \
             f'{machine_pool_id}'
         self._patch(api, spec)
 
@@ -543,7 +545,7 @@ class OCM:
         cluster_id = self.cluster_ids[cluster]
         machine_pool_id = spec['id']
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/machine_pools/' + \
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}/machine_pools/' + \
             f'{machine_pool_id}'
         self._delete(api)
 
@@ -559,7 +561,7 @@ class OCM:
         if not cluster_id:
             return results
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/upgrade_policies'
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}/upgrade_policies'
         items = self._get_json(api).get('items')
         if not items:
             return results
@@ -584,7 +586,7 @@ class OCM:
         """
         cluster_id = self.cluster_ids[cluster]
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/upgrade_policies'
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}/upgrade_policies'
         self._post(api, spec)
 
     def delete_upgrade_policy(self, cluster, spec):
@@ -599,7 +601,7 @@ class OCM:
         cluster_id = self.cluster_ids[cluster]
         upgrade_policy_id = spec['id']
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/' + \
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}/' + \
             f'upgrade_policies/{upgrade_policy_id}'
         self._delete(api)
 
@@ -611,7 +613,7 @@ class OCM:
         :type cluster: string
         """
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/provision_shard'
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}/provision_shard'
         return self._get_json(api)
 
     @staticmethod
@@ -669,7 +671,7 @@ class OCM:
 
     def _init_addons(self):
         """Returns a list of Addons """
-        api = '/api/clusters_mgmt/v1/addons'
+        api = '{CS_API_BASE}/v1/addons'
         self.addons = self._get_json(api).get('items')
 
     def get_addon(self, id):
@@ -691,7 +693,7 @@ class OCM:
         if not cluster_id:
             return results
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/addons'
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}/addons'
         items = self._get_json(api).get('items')
         if not items:
             return results
@@ -717,7 +719,7 @@ class OCM:
         """
         cluster_id = self.cluster_ids[cluster]
         api = \
-            f'/api/clusters_mgmt/v1/clusters/{cluster_id}/addons'
+            f'{CS_API_BASE}/v1/clusters/{cluster_id}/addons'
         parameters = spec.pop('parameters', None)
         data = {'addon': spec}
         if parameters is not None:

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -672,7 +672,7 @@ class OCM:
 
     def _init_addons(self):
         """Returns a list of Addons """
-        api = '{CS_API_BASE}/v1/addons'
+        api = f'{CS_API_BASE}/v1/addons'
         self.addons = self._get_json(api).get('items')
 
     def get_addon(self, id):

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -900,7 +900,7 @@ class OCMMap:
 
     def kafka_service_account_specs(self):
         """ Get dictionary of Kafka service account specs in the OCM map. """
-        fields = ['name', 'clientID', 'clientSecret']
+        fields = ['name', 'clientID']
         service_account_specs = []
         for ocm in self.ocm_map.values():
             service_accounts = ocm.get_kafka_service_accounts(fields=fields)

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -857,7 +857,7 @@ class OCMMap:
 
     def kafka_cluster_specs(self):
         """Get dictionary of Kafka cluster names and specs in the OCM map."""
-        fields = ['id', 'status', 'cloud_provider', 'region',
+        fields = ['id', 'status', 'cloud_provider', 'region', 'multi_az',
                   'name', 'bootstrapServerHost']
         cluster_specs = []
         for ocm in self.ocm_map.values():

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -66,7 +66,8 @@ class OCM:
             and c['state'] == STATUS_READY
         }
         self.not_ready_clusters = [c['name'] for c in clusters
-                                   if c['managed'] and c['state'] != STATUS_READY]
+                                   if c['managed']
+                                   and c['state'] != STATUS_READY]
 
     def _get_cluster_ocm_spec(self, cluster, skip_provision_shards):
         ocm_spec = {

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -9,6 +9,7 @@ from reconcile.utils.secret_reader import SecretReader
 
 STATUS_READY = 'ready'
 
+AMS_API_BASE = '/api/accounts_mgmt'
 CS_API_BASE = '/api/clusters_mgmt'
 
 
@@ -625,7 +626,7 @@ class OCM:
         return {k: v for k, v in autoscale.items() if k in desired_keys}
 
     def get_pull_secrets(self,):
-        api = '/api/accounts_mgmt/v1/access_token'
+        api = f'{AMS_API_BASE}/v1/access_token'
         return self._post(api)
 
     def get_kafka_clusters(self, fields=None):

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -11,6 +11,7 @@ STATUS_READY = 'ready'
 
 AMS_API_BASE = '/api/accounts_mgmt'
 CS_API_BASE = '/api/clusters_mgmt'
+KAS_API_BASE = '/api/managed-services-api'
 
 
 class OCM:
@@ -631,7 +632,7 @@ class OCM:
 
     def get_kafka_clusters(self, fields=None):
         """Returns details of the Kafka clusters """
-        api = '/api/managed-services-api/v1/kafkas'
+        api = f'{KAS_API_BASE}/v1/kafkas'
         clusters = self._get_json(api)['items']
         if fields:
             clusters = [{k: v for k, v in cluster.items()
@@ -642,7 +643,7 @@ class OCM:
     def get_kafka_service_accounts(self, fields=None):
         """Returns details of the Kafka service accounts """
         results = []
-        api = '/api/managed-services-api/v1/serviceaccounts'
+        api = f'{KAS_API_BASE}/v1/serviceaccounts'
         service_accounts = self._get_json(api)['items']
         for sa in service_accounts:
             sa_id = sa['id']
@@ -656,13 +657,13 @@ class OCM:
 
     def create_kafka_cluster(self, data):
         """Creates (async) a Kafka cluster """
-        api = '/api/managed-services-api/v1/kafkas'
+        api = f'{KAS_API_BASE}/v1/kafkas'
         params = {'async': 'true'}
         self._post(api, data, params)
 
     def create_kafka_service_account(self, name):
         """ Creates a Kafka service account """
-        api = '/api/managed-services-api/v1/serviceaccounts'
+        api = f'{KAS_API_BASE}/v1/serviceaccounts'
         result = self._post(api, {'name': name})
         return {
             'name': result['name'],


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2728

for a consumer to use a cluster, they need a service account. this PR adds support for creating a service account per cluster (with the cluster name being the service account name) and returns the credentials for that service account in the output Secret to be consumed by applications.