### PR TITLE
openshift_resources_base: avoid mutating default arguments in process_jinja2_template

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -192,7 +192,11 @@ def lookup_vault_secret(path, key, version=None, tvars=None):
         raise FetchVaultSecretError(e)
 
 
-def process_jinja2_template(body, vars={}, env={}):
+def process_jinja2_template(body, vars=None, env=None):
+    if vars is None:
+        vars = {}
+    if env is None:
+        env = {}
     vars.update({'vault': lambda p, k, v=None:
                  lookup_vault_secret(p, k, v, vars)})
     try:


### PR DESCRIPTION
This fix will avoid the possible consequences of mutating the default arguments if none are passed. Instead if no such arguments are passed, an empty dict is created.

> severity:error rule:python.lang.correctness.common-mistakes.default-mutable-dict.default-mutable-dict: Function process_jinja2_template mutates default dict vars. Python only instantiates default function arguments once and shares the instance across the function calls. If the default function argument is mutated, that will modify the instance used by all future function calls. This can cause unexpected results, or lead to security vulnerabilities whereby one function consumer can view or modify the data of another function consumer. Instead, use a default argument (like None) to indicate that no argument was provided and instantiate a new dictionary at that time. For example: `if vars is None: vars = {}`.