### PR TITLE
[kafka-clusters] fix SA creation

### DIFF
--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -138,14 +138,6 @@ def run(dry_run, thread_pool_size=10,
     error = False
     for kafka_cluster in kafka_clusters:
         kafka_cluster_name = kafka_cluster['name']
-        kafka_service_account = get_kafa_service_account(
-            kafka_service_accounts,
-            kafka_cluster_name,
-            vault_throughput_path,
-            dry_run,
-            ocm_map,
-        )
-
         desired_cluster = [c for c in desired_state
                            if kafka_cluster_name == c['name']][0]
         current_cluster = [c for c in current_state
@@ -172,6 +164,14 @@ def run(dry_run, thread_pool_size=10,
         if current_cluster['status'] != STATUS_READY:
             continue
         # we have a ready cluster!
+        # get a service account for the cluster
+        kafka_service_account = get_kafa_service_account(
+            kafka_service_accounts,
+            kafka_cluster_name,
+            vault_throughput_path,
+            dry_run,
+            ocm_map,
+        )
         # let's create a Secret in all referencing namespaces
         kafka_namespaces = kafka_cluster['namespaces']
         secret_fields = ['bootstrapServerHost']

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -54,6 +54,7 @@ def fetch_desired_state(clusters):
 def get_kafa_service_account(kafka_service_accounts,
                              kafka_cluster_name,
                              vault_throughput_path,
+                             dry_run,
                              ocm_map):
     """
     get a service account for the cluster
@@ -141,6 +142,7 @@ def run(dry_run, thread_pool_size=10,
             kafka_service_accounts,
             kafka_cluster_name,
             vault_throughput_path,
+            dry_run,
             ocm_map,
         )
 

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -137,7 +137,7 @@ def run(dry_run, thread_pool_size=10,
     error = False
     for kafka_cluster in kafka_clusters:
         kafka_cluster_name = kafka_cluster['name']
-        result_sa = get_kafa_service_account(
+        kafka_service_account = get_kafa_service_account(
             kafka_service_accounts,
             kafka_cluster_name,
             vault_throughput_path,
@@ -175,7 +175,7 @@ def run(dry_run, thread_pool_size=10,
         secret_fields = ['bootstrapServerHost']
         data = {k: v for k, v in current_cluster.items()
                 if k in secret_fields}
-        data.update(result_sa)
+        data.update(kafka_service_account)
         resource = construct_oc_resource(data)
         for namespace_info in kafka_namespaces:
             ri.add_desired(


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2728

when we create a SA, we write it to vault only when the cluster is ready. this creates a situation where an SA was created (sync) and the cluster was not (async) and we lose the SA clientSecret. the workaround is to delete the SA through the API and everything falls back into place.

this PR fixes it so we only create the SA when the cluster is ready, thus avoiding the situation.