### PR TITLE
[openshift-saas-deploy] always generate IMAGE_TAG

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -411,9 +411,9 @@ class SaasHerder():
                     f"error fetching template: {str(e)}")
                 return None, None, None
 
-            # add IMAGE_TAG only if it is required and unspecified
-            if self._parameter_value_needed(
-                    "IMAGE_TAG", consolidated_parameters, template):
+            # add IMAGE_TAG only if it is unspecified
+            image_tag = consolidated_parameters.get('IMAGE_TAG')
+            if not image_tag:
                 sha_substring = commit_sha[:hash_length]
                 # IMAGE_TAG takes one of two forms:
                 # - If saas file attribute 'use_channel_in_image_tag' is true,
@@ -441,12 +441,11 @@ class SaasHerder():
                 try:
                     logging.debug("Generating REPO_DIGEST.")
                     registry_image = consolidated_parameters["REGISTRY_IMG"]
-                    image_tag = consolidated_parameters["IMAGE_TAG"]
                 except KeyError as e:
                     logging.error(
                         f"[{saas_file_name}/{resource_template_name}] "
                         + f"{html_url}: error generating REPO_DIGEST. "
-                        + "Is REGISTRY_IMG or IMAGE_TAG missing? "
+                        + "Is REGISTRY_IMG missing? "
                         + f"{str(e)}")
                     return None, None, None
                 try:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -434,8 +434,7 @@ class SaasHerder():
                     image_tag = sha_substring
                 consolidated_parameters['IMAGE_TAG'] = image_tag
 
-            # Do this in a separate loop, since it relies on IMAGE_TAG already
-            # being calculated.
+            # This relies on IMAGE_TAG already being calculated.
             if self._parameter_value_needed(
                     "REPO_DIGEST", consolidated_parameters, template):
                 try:


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3265

we currently only generate IMAGE_TAG if it is a parameter in the openshift template and it is not explicitly specified in the saas file parameters. there are cases where we need to use the image tag to generate other parameters, such as REPO_DIGEST.

generally, since there are no real operations to generate the image tag, we can just always do it.