### PR TITLE
[saas-file-owners] overall hold

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -309,6 +309,7 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None,
 
     comments = gl.get_merge_request_comments(gitlab_merge_request_id)
     comment_lines = {}
+    hold = False
     for diff in diffs:
         # check if this diff was actually changed in the current MR
         saas_file_path = diff['saas_file_path']
@@ -327,7 +328,8 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None,
         # check for a lgtm by an owner of this app
         saas_file_name = diff['saas_file_name']
         saas_file_owners = owners.get(saas_file_name)
-        valid_lgtm, hold = check_if_lgtm(saas_file_owners, comments)
+        valid_lgtm, current_hold = check_if_lgtm(saas_file_owners, comments)
+        hold = hold or current_hold
         if hold:
             gl.add_label_to_merge_request(
                 gitlab_merge_request_id, hold_label)


### PR DESCRIPTION
since `hold` is being calculated per diff, we need to keep a global hold variable if a previous diff indicated a hold.

fixes the madness in https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/18509