### PR TITLE
Support generating IMAGE_DIGEST

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -435,8 +435,11 @@ class SaasHerder():
                 consolidated_parameters['IMAGE_TAG'] = image_tag
 
             # This relies on IMAGE_TAG already being calculated.
-            if self._parameter_value_needed(
-                    "REPO_DIGEST", consolidated_parameters, template):
+            need_repo_digest = self._parameter_value_needed(
+                "REPO_DIGEST", consolidated_parameters, template)
+            need_image_digest = self._parameter_value_needed(
+                "IMAGE_DIGEST", consolidated_parameters, template)
+            if need_repo_digest or need_image_digest:
                 try:
                     logging.debug("Generating REPO_DIGEST.")
                     registry_image = consolidated_parameters["REGISTRY_IMG"]
@@ -450,8 +453,11 @@ class SaasHerder():
                 try:
                     image_uri = f"{registry_image}:{image_tag}"
                     img = Image(image_uri, **image_auth)
-                    consolidated_parameters[
-                        "REPO_DIGEST"] = f"{img.url_digest}"
+                    if need_repo_digest:
+                        consolidated_parameters[
+                            "REPO_DIGEST"] = img.url_digest
+                    if need_image_digest:
+                        consolidated_parameters["IMAGE_DIGEST"] = img.digest
                 except (rqexc.ConnectionError, rqexc.HTTPError) as e:
                     logging.error(
                         f"[{saas_file_name}/{resource_template_name}] "


### PR DESCRIPTION
Today referencing an image with:

`  image: ${REPO_DIGEST}`

requires designating `REGISTRY_IMG` as a required parameter even if it is not explicitly used anywhere in the template. To make things more scrutable, this commit adds support for generating a new `IMAGE_DIGEST` value, which comprises just the digest (`sha256:xxxx...`) whereas `REPO_DIGEST` comprises the full by-digest URL. With this change, the template file can include:

```
parameters:
- name: REGISTRY_IMG
  required: true
- name: IMAGE_DIGEST
  required: true

...

    image: ${REGISTRY_IMG}@${IMAGE_DIGEST}
```

To wit, you're explicitly using all the parameters you require.

APPSRE-3265