### PR TITLE
[jira-watcher] don't act on empty jira boards

### DIFF
--- a/reconcile/jira_watcher.py
+++ b/reconcile/jira_watcher.py
@@ -113,6 +113,12 @@ def run(dry_run):
         if not is_in_shard_round_robin(jira_board['name'], index):
             continue
         jira, current_state = fetch_current_state(jira_board, settings)
+        if not current_state:
+            logging.warning(
+                'not acting on empty Jira boards. ' +
+                'please create a ticket to get started.'
+            )
+            continue
         previous_state = fetch_previous_state(state, jira.project)
         if previous_state:
             diffs = calculate_diff(jira.server, current_state, previous_state)


### PR DESCRIPTION
related to https://issues.redhat.com/browse/ASIC-16

we sometimes get empty responses from Jira but without an error, which causes the integration to think all tickets were deleted.
similarly to what we did with unleash-watcher in #1047, let's not act on empty jira boards.