### PR TITLE
[gitlab-housekeeping] remove lgtm label if saas-file-update label exists

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -166,7 +166,7 @@ def merge_merge_requests(dry_run, gl, merge_limit, rebase, insist=False,
             if SAAS_FILE_LABEL in labels and LGTM_LABEL in labels:
                 logging.warning(
                     f"[{gl.project.name}/{mr.iid}] 'lgtm' label not " +
-                    f"suitable for saas file update. removing 'lgtm' label"
+                    "suitable for saas file update. removing 'lgtm' label"
                 )
                 gl.remove_label_from_merge_request(mr.iid, LGTM_LABEL)
                 continue

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -168,7 +168,8 @@ def merge_merge_requests(dry_run, gl, merge_limit, rebase, insist=False,
                     f"[{gl.project.name}/{mr.iid}] 'lgtm' label not " +
                     "suitable for saas file update. removing 'lgtm' label"
                 )
-                gl.remove_label_from_merge_request(mr.iid, LGTM_LABEL)
+                if not dry_run:
+                    gl.remove_label_from_merge_request(mr.iid, LGTM_LABEL)
                 continue
 
             target_branch = mr.target_branch


### PR DESCRIPTION
`saas-file-update` label is added when the changes on a MR are valid saas file changes only. in these cases, it is expected that the saas file owners add a `/lgtm` comment, which will add the `bot/approved` label which will lead make gitlab-housekeeping merge the MR.

this PR will cause gitlab-housekeeping to remove a `lgtm` label when this is a valid saas file change.

this effectively means that our team loses our powers to add the lgtm label to saas file update MRs (but we can always force merge in case of emergency)

example MR: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/19002
slack thread: https://coreos.slack.com/archives/CCRND57FW/p1620312615431000