### PR TITLE
Show stdout and stderr in amtool error messages

### DIFF
--- a/reconcile/utils/amtool.py
+++ b/reconcile/utils/amtool.py
@@ -29,7 +29,12 @@ def _run_yaml_str_cmd(cmd, yaml_str):
             cmd.append(fp.name)
             result = run(cmd, stdout=PIPE, stderr=PIPE, check=True)
     except Exception as e:
-        msg = f'Error running amtool: {e}'
+        msg = f'Error running amtool command [{" ".join(cmd)}]'
+        if e.stdout:
+            msg += f' {e.stdout.decode()}'
+        if e.stderr:
+            msg += f' {e.stderr.decode()}'
+
         return AmtoolResult(False, msg)
 
     return AmtoolResult(True, result.stdout.decode())


### PR DESCRIPTION
amtool has the strange behaviour of throwing important data on stdout
when it fails to validate

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>