### PR TITLE
add support to recycle DaemonSet

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -479,6 +479,7 @@ class OC:
             'Deployment',
             'DeploymentConfig',
             'StatefulSet',
+            'DaemonSet',
         ]
         for pod in pods_to_recycle:
             owner = self.get_obj_root_owner(namespace, pod)


### PR DESCRIPTION
part of APPSRE-3284

this is required to recycle fluentd pods in openshift-logging after a new instance secret was created.
or in general - recycle DaemonSet pods.