### PR TITLE
add support for group association by org username

### DIFF
--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -13,11 +13,13 @@ ROLES_QUERY = """
   roles: roles_v1 {
     name
     users {
+      org_username
       github_username
     }
     access {
       cluster {
         name
+        internal
       }
       group
     }
@@ -108,13 +110,19 @@ def fetch_desired_state(oc_map):
                 continue
 
             for u in r['users']:
-                if u['github_username'] is None:
-                    continue
+                if a['cluster']['internal']:
+                    username = u.get('org_username')
+                    if username is None:
+                        continue
+                else:
+                    username = u.get('github_username')
+                    if username is None:
+                        continue
 
                 desired_state.append({
                     "cluster": a['cluster']['name'],
                     "group": a['group'],
-                    "user": u['github_username']
+                    "user": username
                 })
 
     return desired_state


### PR DESCRIPTION
this change affects the following integrations:
- openshift-groups
- ocm-groups
- openshift-users

if a cluster is defined as `internal`, instead of using the github username, we use the org username.

this PR is done in the context of https://issues.redhat.com/browse/APPSRE-3261, where we create an internal OSD cluster.