### PR TITLE
Revert "add support for group association by org username"

### DIFF
--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -13,13 +13,11 @@ ROLES_QUERY = """
   roles: roles_v1 {
     name
     users {
-      org_username
       github_username
     }
     access {
       cluster {
         name
-        internal
       }
       group
     }
@@ -110,19 +108,13 @@ def fetch_desired_state(oc_map):
                 continue
 
             for u in r['users']:
-                if a['cluster']['internal']:
-                    username = u.get('org_username')
-                    if username is None:
-                        continue
-                else:
-                    username = u.get('github_username')
-                    if username is None:
-                        continue
+                if u['github_username'] is None:
+                    continue
 
                 desired_state.append({
                     "cluster": a['cluster']['name'],
                     "group": a['group'],
-                    "user": username
+                    "user": u['github_username']
                 })
 
     return desired_state


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#1550

reverting this and going to use github auth for internal clusters as well

cc @rporres 