### PR TITLE
[saasherder] change parameters not reused log from warning to error

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -133,7 +133,8 @@ class SaasHerder():
                                     f'target: \"{t_key}: {t_value}\". ' + \
                                     f'env: \"{e_key}: {e_value}\". ' + \
                                     f'consider \"{t_key}: {replacement}\"'
-                            logging.warning(f'{msg}: {details}')
+                            logging.error(f'{msg}: {details}')
+                            self.valid = False
 
         # saas file name duplicates
         duplicates = {saas_file_name: saas_file_paths


### PR DESCRIPTION
openshift-saas-deploy collects parameters for deployment from 2 places:
1. saas file parameters (top level, resource template level, target level)
2. environment parameters

if a parameter is defined with values that can be reused from the environment level, we currently log a warning message.

this PR changes the behavior so that we log an error message and exit with error instead, which means we will enforce reusing parameters.

this is an alternative for #1557

output example: https://ci.int.devshift.net/job/service-app-interface-gl-pr-check/61084/artifact/temp/reports/reconcile_reports_success/reconcile-saas-file-validator.txt