### PR TITLE
[ocm-clusters] improve cluster update and add validation

### DIFF
--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -24,6 +24,42 @@ def fetch_desired_state(clusters):
     return desired_state
 
 
+def get_cluster_update_spec(cluster_name, current_spec, desired_spec):
+    """ Get a cluster spec to update. Returns an error if diff is invalid """
+    allowed_spec_update_fields = [
+        'instance_type',
+        'storage',
+        'load_balancers',
+        'private',
+        'channel',
+        'autoscale',
+        'nodes'
+    ]
+    error = False
+    if current_spec['network'] != desired_spec['network']:
+        error = True
+        logging.error(f'[{cluster_name}] invalid update: network')
+    current_spec_spec = current_spec['spec']
+    desired_spec_spec = desired_spec['spec']
+    updated = {k: desired_spec_spec[k] for k in desired_spec_spec
+               if current_spec_spec[k] != desired_spec_spec[k]}
+
+    # we only need deleted to check if a field removal is valid
+    # we really want to check updated + deleted, and since
+    # we have no further use for deleted -
+    deleted = {k: current_spec_spec[k] for k in current_spec_spec
+               if k not in desired_spec_spec}
+    diffs = deleted
+    diffs.update(updated)
+
+    for k in diffs:
+        if k not in allowed_spec_update_fields:
+            error = True
+            logging.error(f'[{cluster_name}] invalid update: {k}')
+
+    return updated, error
+
+
 def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
     settings = queries.get_app_interface_settings()
     clusters = queries.get_clusters()
@@ -95,6 +131,15 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
                 desired_spec['spec'].pop(k, None)
 
             if current_spec != desired_spec:
+                # check if cluster update is valid
+                update_spec, err = get_cluster_update_spec(
+                    cluster_name,
+                    current_spec,
+                    desired_spec,
+                )
+                if err:
+                    error = True
+                    continue
                 # update cluster
                 logging.debug(
                     '[%s] desired spec %s is different ' +
@@ -104,7 +149,7 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
                 # TODO(mafriedm): check dry_run in OCM API patch
                 if not dry_run:
                     ocm = ocm_map.get(cluster_name)
-                    ocm.update_cluster(cluster_name, desired_spec, dry_run)
+                    ocm.update_cluster(cluster_name, update_spec, dry_run)
         else:
             # create cluster
             if cluster_name in pending_state:

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -26,7 +26,7 @@ def fetch_desired_state(clusters):
 
 def get_cluster_update_spec(cluster_name, current_spec, desired_spec):
     """ Get a cluster spec to update. Returns an error if diff is invalid """
-    allowed_spec_update_fields = [
+    allowed_spec_update_fields = {
         'instance_type',
         'storage',
         'load_balancers',
@@ -34,7 +34,7 @@ def get_cluster_update_spec(cluster_name, current_spec, desired_spec):
         'channel',
         'autoscale',
         'nodes'
-    ]
+    }
     error = False
     if current_spec['network'] != desired_spec['network']:
         error = True
@@ -52,10 +52,10 @@ def get_cluster_update_spec(cluster_name, current_spec, desired_spec):
     diffs = deleted
     diffs.update(updated)
 
-    for k in diffs:
-        if k not in allowed_spec_update_fields:
-            error = True
-            logging.error(f'[{cluster_name}] invalid update: {k}')
+    invalid_fields = set(diffs.keys()) - allowed_spec_update_fields
+    if invalid_fields:
+        error = True
+        logging.error(f'[{cluster_name}] invalid updates: {invalid_fields}')
 
     return updated, error
 


### PR DESCRIPTION
this PR changes the way we update a cluster via OCM.
first, we validate that any updated fields are able to be updated in OCM. second, we only pass the updated fields to the clusters PATCH endpoint instead of passing all fields that can be updated, even if they were not updated.

this really solves 2 problems:
1. the integration will return an error when trying to update an invalid field.
2. assuming we want to update cluster storage quota (for example) during an upgrade. in the current situation, since we are passing the `channel` field as well, the cluster update will be rejected. with this change, only updated fields will be passed.