### PR TITLE
All integrations ship to cloudwatch always

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -5,6 +5,7 @@ metadata:
   name: qontract-reconcile
 objects:
 {{- range $i, $integration := .Values.integrations }}
+{{- $logs := $integration.logs | default dict -}}
 {{- $shards := int $integration.shards | default 1 }}
 {{- range $shard_id := until $shards }}
 - apiVersion: apps/v1
@@ -43,7 +44,6 @@ objects:
           app: qontract-reconcile-{{ $integration.name }}
           component: qontract-reconcile
       spec:
-        {{- if $integration.logs }}
         initContainers:
         - name: config
           image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
@@ -56,7 +56,7 @@ objects:
               memory: 20Mi
               cpu: 25m
           env:
-          {{- if $integration.logs.slack }}
+          {{- if $logs.slack }}
           - name: SLACK_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
@@ -67,13 +67,11 @@ objects:
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           {{- end }}
-          {{- if $integration.logs.cloudwatch }}
           - name: LOG_GROUP_NAME
             valueFrom:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: log_group_name
-          {{- end }}
           command: ["/bin/sh", "-c"]
           args:
           - |
@@ -115,7 +113,7 @@ objects:
 
             <match integration>
               @type copy
-              {{- if $integration.logs.slack }}
+              {{- if $logs.slack }}
               <store>
                 @type slack
                 webhook_url ${SLACK_WEBHOOK_URL}
@@ -126,20 +124,17 @@ objects:
                 message "\`\`\`[{{ $integration.name }}] %s\`\`\`"
               </store>
               {{- end }}
-              {{- if $integration.logs.cloudwatch }}
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
                 log_stream_name {{ $integration.name }}
                 auto_create_stream true
               </store>
-              {{- end }}
             </match>
             EOF
           volumeMounts:
           - name: fluentd-config
             mountPath: /fluentd/etc/
-        {{- end }}
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -169,10 +164,8 @@ objects:
               configMapKeyRef:
                 name: app-interface
                 key: SENTRY_DSN
-          {{- if $integration.logs }}
           - name: LOG_FILE
             value: "${LOG_FILE}"
-          {{- end }}
           {{- if $integration.state }}
           - name: APP_INTERFACE_STATE_BUCKET
             valueFrom:
@@ -214,13 +207,11 @@ objects:
           - name: cache
             mountPath: /.cache
           {{- end }}
-        {{- if $integration.logs }}
           - name: logs
             mountPath: /fluentd/log/
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
-          {{- if $integration.logs.cloudwatch }}
           env:
           - name: AWS_REGION
             valueFrom:
@@ -237,7 +228,6 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: aws_secret_access_key
-          {{- end }}
           resources:
             requests:
               memory: 30Mi
@@ -250,17 +240,14 @@ objects:
             mountPath: /fluentd/log/
           - name: fluentd-config
             mountPath: /fluentd/etc/
-        {{- end }}
         volumes:
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
-        {{- if $integration.logs }}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
-        {{- end }}
 {{- end }}
 {{- end }}
 {{- range $i, $integration := .Values.cronjobs }}

--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -9,7 +9,6 @@ integrations:
       cpu: 200m
   logs:
     slack: true
-    cloudwatch: true
 - name: github
   resources:
     requests:
@@ -22,7 +21,6 @@ integrations:
       cpu: 200m
   logs:
     slack: true
-    cloudwatch: true
 - name: github-owners
   resources:
     requests:
@@ -33,7 +31,6 @@ integrations:
       cpu: 200m
   logs:
     slack: true
-    cloudwatch: true
 - name: github-repo-invites
   resources:
     requests:
@@ -44,7 +41,6 @@ integrations:
       cpu: 200m
   logs:
     slack: true
-    cloudwatch: true
 - name: quay-membership
   resources:
     requests:
@@ -55,7 +51,6 @@ integrations:
       cpu: 200m
   logs:
     slack: true
-    cloudwatch: true
 - name: quay-mirror
   resources:
     requests:
@@ -64,8 +59,6 @@ integrations:
     limits:
       memory: 200Mi
       cpu: 300m
-  logs:
-    cloudwatch: true
 - name: quay-mirror-org
   resources:
     requests:
@@ -74,8 +67,6 @@ integrations:
     limits:
       memory: 200Mi
       cpu: 300m
-  logs:
-    cloudwatch: true
 - name: gcr-mirror
   resources:
     requests:
@@ -84,8 +75,6 @@ integrations:
     limits:
       memory: 200Mi
       cpu: 300m
-  logs:
-    cloudwatch: true
 - name: ecr-mirror
   resources:
     requests:
@@ -94,8 +83,6 @@ integrations:
     limits:
       memory: 500Mi
       cpu: 600m
-  logs:
-    cloudwatch: true
 - name: quay-repos
   resources:
     requests:
@@ -106,7 +93,6 @@ integrations:
       cpu: 200m
   logs:
     slack: true
-    cloudwatch: true
 - name: quay-permissions
   resources:
     requests:
@@ -117,7 +103,6 @@ integrations:
       cpu: 200m
   logs:
     slack: true
-    cloudwatch: true
 - name: jira-watcher
   resources:
     requests:
@@ -161,7 +146,6 @@ integrations:
     secretKey: gitlab_pr_submitter_queue_url
   logs:
     slack: false
-    cloudwatch: true
 - name: openshift-users
   resources:
     requests:
@@ -175,7 +159,6 @@ integrations:
   extraArgs: --no-use-jump-host
   logs:
     slack: true
-    cloudwatch: true
 - name: openshift-upgrade-watcher
   resources:
     requests:
@@ -199,7 +182,6 @@ integrations:
   extraArgs: --no-use-jump-host
   logs:
     slack: true
-    cloudwatch: true
 - name: openshift-namespaces
   resources:
     requests:
@@ -213,7 +195,6 @@ integrations:
   extraArgs: --external --no-use-jump-host
   logs:
     slack: true
-    cloudwatch: true
 - name: openshift-clusterrolebindings
   resources:
     requests:
@@ -227,7 +208,6 @@ integrations:
   extraArgs: --external --no-use-jump-host
   logs:
     slack: true
-    cloudwatch: true
 - name: openshift-rolebindings
   resources:
     requests:
@@ -242,7 +222,6 @@ integrations:
   shards: 10
   logs:
     slack: true
-    cloudwatch: true
 - name: openshift-network-policies
   resources:
     requests:
@@ -257,7 +236,6 @@ integrations:
   shards: 10
   logs:
     slack: true
-    cloudwatch: true
 - name: openshift-limitranges
   resources:
     requests:
@@ -269,7 +247,6 @@ integrations:
   extraArgs: --no-use-jump-host
   logs:
     slack: true
-    cloudwatch: true
 - name: openshift-resourcequotas
   resources:
     requests:
@@ -289,7 +266,6 @@ integrations:
       cpu: 1200m
   extraArgs: --external --no-use-jump-host
   logs:
-    cloudwatch: true
     slack: true
   shards: 10
 - name: openshift-vault-secrets
@@ -301,8 +277,6 @@ integrations:
       memory: 800Mi
       cpu: 1200m
   extraArgs: --external --no-use-jump-host
-  logs:
-    cloudwatch: true
   shards: 10
 - name: openshift-routes
   resources:
@@ -315,8 +289,6 @@ integrations:
       memory: 1040Mi
       cpu: 300m
   extraArgs: --no-use-jump-host
-  logs:
-    cloudwatch: true
   shards: 2
 - name: terraform-aws-route53
   resources:
@@ -328,7 +300,6 @@ integrations:
       cpu: 500m
   logs:
     slack: true
-    cloudwatch: true
 - name: terraform-resources
   resources:
     requests:
@@ -340,7 +311,6 @@ integrations:
   extraArgs: --external --no-use-jump-host --vault-output-path app-sre/integrations-output
   logs:
     slack: true
-    cloudwatch: true
 - name: terraform-users
   resources:
     requests:
@@ -352,7 +322,6 @@ integrations:
   extraArgs: --io-dir /tmp/throughput/
   logs:
     slack: true
-    cloudwatch: true
 - name: terraform-vpc-peerings
   resources:
     requests:
@@ -363,7 +332,6 @@ integrations:
       cpu: 500m
   logs:
     slack: true
-    cloudwatch: true
 - name: terraform-tgw-attachments
   resources:
     requests:
@@ -374,7 +342,6 @@ integrations:
       cpu: 400m
   logs:
     slack: true
-    cloudwatch: true
 - name: ocm-addons
   resources:
     requests:
@@ -385,7 +352,6 @@ integrations:
       cpu: 200m
   logs:
     slack: true
-    cloudwatch: true
 - name: ocm-groups
   resources:
     requests:
@@ -394,8 +360,6 @@ integrations:
     limits:
       memory: 200Mi
       cpu: 200m
-  logs:
-    cloudwatch: true
 - name: ocm-clusters
   resources:
     requests:
@@ -406,7 +370,6 @@ integrations:
       cpu: 200m
   logs:
     slack: true
-    cloudwatch: true
   extraEnv:
   - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
     secretKey: gitlab_pr_submitter_queue_url
@@ -420,7 +383,6 @@ integrations:
       cpu: 100m
   logs:
     slack: true
-    cloudwatch: true
 - name: ocm-github-idp
   resources:
     requests:
@@ -430,8 +392,6 @@ integrations:
       memory: 200Mi
       cpu: 200m
   extraArgs: --vault-input-path app-sre/integrations-input
-  logs:
-    cloudwatch: true
 - name: ocm-machine-pools
   resources:
     requests:
@@ -441,7 +401,6 @@ integrations:
       memory: 200Mi
       cpu: 200m
   logs:
-    cloudwatch: true
     slack: true
 - name: ocm-upgrade-scheduler
   resources:
@@ -452,7 +411,6 @@ integrations:
       memory: 200Mi
       cpu: 200m
   logs:
-    cloudwatch: true
     slack: true
 - name: ocm-external-configuration-labels
   resources:
@@ -463,7 +421,6 @@ integrations:
       memory: 200Mi
       cpu: 200m
   logs:
-    cloudwatch: true
     slack: true
 - name: kafka-clusters
   resources:
@@ -475,7 +432,6 @@ integrations:
       cpu: 200m
   extraArgs: --vault-throughput-path app-sre/integrations-throughput
   logs:
-    cloudwatch: true
     slack: true
 - name: email-sender
   resources:
@@ -487,7 +443,6 @@ integrations:
       cpu: 50m
   logs:
     slack: true
-    cloudwatch: true
   state: true
 - name: requests-sender
   resources:
@@ -499,7 +454,6 @@ integrations:
       cpu: 50m
   logs:
     slack: true
-    cloudwatch: true
   state: true
 - name: sentry-config
   resources:
@@ -509,8 +463,6 @@ integrations:
     limits:
       memory: 200Mi
       cpu: 200m
-  logs:
-    cloudwatch: true
 - name: sentry-helper
   resources:
     requests:
@@ -530,7 +482,6 @@ integrations:
       cpu: 300m
   logs:
     slack: true
-    cloudwatch: true
   state: true
   extraArgs: --enable-deletion
 - name: slack-cluster-usergroups
@@ -559,7 +510,6 @@ integrations:
       cpu: 200m
   logs:
     slack: true
-    cloudwatch: true
 cronjobs:
 - name: aws-ecr-image-pull-secrets
   resources:

--- a/helm/qontract-reconcile/values-internal.yaml
+++ b/helm/qontract-reconcile/values-internal.yaml
@@ -9,7 +9,6 @@ integrations:
       cpu: 200m
   logs:
     slack: true
-    cloudwatch: true
 - name: openshift-rolebindings
   resources:
     requests:
@@ -21,7 +20,6 @@ integrations:
   extraArgs: --internal
   logs:
     slack: true
-    cloudwatch: true
 - name: openshift-clusterrolebindings
   resources:
     requests:
@@ -33,7 +31,6 @@ integrations:
   extraArgs: --internal
   logs:
     slack: true
-    cloudwatch: true
 - name: openshift-namespaces
   resources:
     requests:
@@ -45,7 +42,6 @@ integrations:
   extraArgs: --internal
   logs:
     slack: true
-    cloudwatch: true
 - name: openshift-network-policies
   resources:
     requests:
@@ -57,7 +53,6 @@ integrations:
   extraArgs: --internal
   logs:
     slack: true
-    cloudwatch: true
 - name: openshift-resources
   resources:
     requests:
@@ -68,7 +63,6 @@ integrations:
       cpu: 400m
   extraArgs: --internal
   logs:
-    cloudwatch: true
     slack: true
 - name: openshift-vault-secrets
   resources:
@@ -79,8 +73,6 @@ integrations:
       memory: 400Mi
       cpu: 400m
   extraArgs: --internal
-  logs:
-    cloudwatch: true
 - name: openshift-serviceaccount-tokens
   resources:
     requests:
@@ -91,7 +83,6 @@ integrations:
       cpu: 400m
   extraArgs: --vault-output-path app-sre/integrations-output
   logs:
-    cloudwatch: true
     slack: true
 - name: openshift-saas-deploy-trigger-configs
   resources:
@@ -102,7 +93,6 @@ integrations:
       memory: 400Mi
       cpu: 400m
   logs:
-    cloudwatch: true
     slack: true
   state: true
 - name: openshift-saas-deploy-trigger-moving-commits
@@ -114,7 +104,6 @@ integrations:
       memory: 400Mi
       cpu: 400m
   logs:
-    cloudwatch: true
     slack: true
   state: true
 - name: terraform-resources
@@ -128,7 +117,6 @@ integrations:
   extraArgs: --internal --light --vault-output-path app-sre/integrations-output
   logs:
     slack: true
-    cloudwatch: true
 - name: gitlab-projects
   resources:
     requests:
@@ -138,7 +126,6 @@ integrations:
       memory: 200Mi
       cpu: 200m
   logs:
-    cloudwatch: true
     slack: true
 - name: gitlab-members
   resources:
@@ -149,7 +136,6 @@ integrations:
       memory: 200Mi
       cpu: 200m
   logs:
-    cloudwatch: true
     slack: true
 - name: gitlab-permissions
   resources:
@@ -160,7 +146,6 @@ integrations:
       memory: 200Mi
       cpu: 200m
   logs:
-    cloudwatch: true
     slack: true
 - name: gitlab-integrations
   resources:
@@ -171,7 +156,6 @@ integrations:
       memory: 200Mi
       cpu: 200m
   logs:
-    cloudwatch: true
     slack: true
 - name: gitlab-owners
   resources:
@@ -182,7 +166,7 @@ integrations:
       memory: 200Mi
       cpu: 200m
   logs:
-    cloudwatch: true
+    slack: true
 - name: gitlab-housekeeping
   resources:
     requests:
@@ -192,8 +176,6 @@ integrations:
       memory: 200Mi
       cpu: 200m
   extraArgs: --wait-for-pipeline
-  logs:
-    cloudwatch: true
 - name: jenkins-job-builder
   resources:
     requests:
@@ -216,7 +198,6 @@ integrations:
       memory: 200Mi
       cpu: 200m
   logs:
-    cloudwatch: true
     slack: true
 - name: jenkins-webhooks
   resources:
@@ -227,7 +208,6 @@ integrations:
       memory: 200Mi
       cpu: 200m
   logs:
-    cloudwatch: true
     slack: true
   cache: true
 - name: jenkins-webhooks-cleaner
@@ -239,7 +219,6 @@ integrations:
       memory: 200Mi
       cpu: 200m
   logs:
-    cloudwatch: true
     slack: true
 - name: ldap-users
   resources:
@@ -251,7 +230,6 @@ integrations:
       cpu: 200m
   extraArgs: ${APP_INTERFACE_PROJECT_ID}
   logs:
-    cloudwatch: true
     slack: true
 - name: gitlab-mr-sqs-consumer
   resources:
@@ -265,6 +243,4 @@ integrations:
   - secretName: ${APP_INTERFACE_SQS_SECRET_NAME}
     secretKey: gitlab_pr_submitter_queue_url
   extraArgs: ${APP_INTERFACE_PROJECT_ID}
-  logs:
-    cloudwatch: true
   state: true

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -3030,6 +3030,15 @@ objects:
               memory: 20Mi
               cpu: 25m
           env:
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                key: slack.webhook_url
+                name: app-interface
+          - name: SLACK_CHANNEL
+            value: ${SLACK_CHANNEL}
+          - name: SLACK_ICON_EMOJI
+            value: ${SLACK_ICON_EMOJI}
           - name: LOG_GROUP_NAME
             valueFrom:
               secretKeyRef:
@@ -3076,6 +3085,15 @@ objects:
 
             <match integration>
               @type copy
+              <store>
+                @type slack
+                webhook_url ${SLACK_WEBHOOK_URL}
+                channel ${SLACK_CHANNEL}
+                icon_emoji ${SLACK_ICON_EMOJI}
+                username sd-app-sre-bot
+                flush_interval 10s
+                message "\`\`\`[gitlab-owners] %s\`\`\`"
+              </store>
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -2150,6 +2150,75 @@ objects:
           app: qontract-reconcile-jira-watcher
           component: qontract-reconcile
       spec:
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name jira-watcher
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -2179,6 +2248,8 @@ objects:
               configMapKeyRef:
                 name: app-interface
                 key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
           - name: APP_INTERFACE_STATE_BUCKET
             valueFrom:
               secretKeyRef:
@@ -2210,10 +2281,47 @@ objects:
           volumeMounts:
           - name: qontract-reconcile-toml
             mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         volumes:
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -2231,6 +2339,75 @@ objects:
           app: qontract-reconcile-unleash-watcher
           component: qontract-reconcile
       spec:
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name unleash-watcher
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -2260,6 +2437,8 @@ objects:
               configMapKeyRef:
                 name: app-interface
                 key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
           - name: APP_INTERFACE_STATE_BUCKET
             valueFrom:
               secretKeyRef:
@@ -2291,10 +2470,47 @@ objects:
           volumeMounts:
           - name: qontract-reconcile-toml
             mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         volumes:
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -2312,6 +2528,75 @@ objects:
           app: qontract-reconcile-github-scanner
           component: qontract-reconcile
       spec:
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name github-scanner
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -2341,6 +2626,8 @@ objects:
               configMapKeyRef:
                 name: app-interface
                 key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
           - name: UNLEASH_API_URL
             valueFrom:
               secretKeyRef:
@@ -2370,10 +2657,47 @@ objects:
           volumeMounts:
           - name: qontract-reconcile-toml
             mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         volumes:
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -2778,6 +3102,75 @@ objects:
           app: qontract-reconcile-openshift-upgrade-watcher
           component: qontract-reconcile
       spec:
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name openshift-upgrade-watcher
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -2807,6 +3200,8 @@ objects:
               configMapKeyRef:
                 name: app-interface
                 key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
           - name: APP_INTERFACE_STATE_BUCKET
             valueFrom:
               secretKeyRef:
@@ -2838,10 +3233,47 @@ objects:
           volumeMounts:
           - name: qontract-reconcile-toml
             mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         volumes:
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -7659,6 +8091,75 @@ objects:
           app: qontract-reconcile-openshift-resourcequotas
           component: qontract-reconcile
       spec:
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name openshift-resourcequotas
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -7688,6 +8189,8 @@ objects:
               configMapKeyRef:
                 name: app-interface
                 key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
           - name: UNLEASH_API_URL
             valueFrom:
               secretKeyRef:
@@ -7712,10 +8215,47 @@ objects:
           volumeMounts:
           - name: qontract-reconcile-toml
             mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         volumes:
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -15282,6 +15822,75 @@ objects:
           app: qontract-reconcile-sentry-helper
           component: qontract-reconcile
       spec:
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name sentry-helper
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -15311,6 +15920,8 @@ objects:
               configMapKeyRef:
                 name: app-interface
                 key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
           - name: APP_INTERFACE_STATE_BUCKET
             valueFrom:
               secretKeyRef:
@@ -15342,10 +15953,47 @@ objects:
           volumeMounts:
           - name: qontract-reconcile-toml
             mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         volumes:
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -15570,6 +16218,75 @@ objects:
           app: qontract-reconcile-slack-cluster-usergroups
           component: qontract-reconcile
       spec:
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name slack-cluster-usergroups
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -15599,6 +16316,8 @@ objects:
               configMapKeyRef:
                 name: app-interface
                 key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
           - name: UNLEASH_API_URL
             valueFrom:
               secretKeyRef:
@@ -15623,10 +16342,47 @@ objects:
           volumeMounts:
           - name: qontract-reconcile-toml
             mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         volumes:
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -15644,6 +16400,75 @@ objects:
           app: qontract-reconcile-ocp-release-mirror
           component: qontract-reconcile
       spec:
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name ocp-release-mirror
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         containers:
         - name: int
           image: ${IMAGE}:${IMAGE_TAG}
@@ -15673,6 +16498,8 @@ objects:
               configMapKeyRef:
                 name: app-interface
                 key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
           - name: UNLEASH_API_URL
             valueFrom:
               secretKeyRef:
@@ -15697,10 +16524,47 @@ objects:
           volumeMounts:
           - name: qontract-reconcile-toml
             mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
         volumes:
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:


### PR DESCRIPTION
Currently some integrations do not ship logs to cloudwatch:
- jira-watcher
- unleash-watcher
- github-scanner
- openshift-upgrade-watcher
- openshift-resourcequotas
- sentry-helper
- slack-cluster-usergroups
- ocp-release-mirror

We want to always ship logs to cloudwatch. This PR will make it part of the
template. It is recommended to review this PR commit by commit.