### PR TITLE
[terraform-resources] add crendentials file like secret

### DIFF
--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -2682,11 +2682,19 @@ class TerrascriptClient:
         # outputs
         # aws_access_key_id
         output_name_0_13 = output_prefix + '__aws_access_key_id'
-        output_value = '${' + tf_resource.id + '}'
-        tf_resources.append(Output(output_name_0_13, value=output_value))
+        output_value_id = '${' + tf_resource.id + '}'
+        tf_resources.append(Output(output_name_0_13, value=output_value_id))
         # aws_secret_access_key
         output_name_0_13 = output_prefix + '__aws_secret_access_key'
-        output_value = '${' + tf_resource.secret + '}'
+        output_value_secret = '${' + tf_resource.secret + '}'
+        tf_resources.append(
+            Output(output_name_0_13, value=output_value_secret))
+        # aws credentials file
+        output_name_0_13 = output_prefix + '__credentials'
+        output_value = \
+            '[default]\n' + \
+            f'aws_access_key_id = {output_value_id}\n' + \
+            f'aws_secret_access_key = {output_value_secret}'
         tf_resources.append(Output(output_name_0_13, value=output_value))
 
         return tf_resources


### PR DESCRIPTION
this will allow using this file-like secret as a mounted volume in pods. this is another option to use the aws credentials chain.

in our case, this key is added to the `instance` secret in openshift-logging namespaces where we use log forwarding and we want to override it to enable https://issues.redhat.com/browse/APPSRE-3284