### PR TITLE
tekton saas file v2 support #1

### DIFF
--- a/reconcile/gitlab_mr_sqs_consumer.py
+++ b/reconcile/gitlab_mr_sqs_consumer.py
@@ -22,7 +22,7 @@ def run(dry_run, gitlab_project_id):
     sqs_cli = SQSGateway(accounts, settings=settings)
 
     instance = queries.get_gitlab_instance()
-    saas_files = queries.get_saas_files_minimal()
+    saas_files = queries.get_saas_files_minimal(v1=True, v2=True)
     gitlab_cli = GitLabApi(instance, project_id=gitlab_project_id,
                            settings=settings, saas_files=saas_files)
 

--- a/reconcile/mr_client_gateway.py
+++ b/reconcile/mr_client_gateway.py
@@ -30,7 +30,7 @@ def init(gitlab_project_id=None, sqs_or_gitlab=None):
 
         instance = queries.get_gitlab_instance()
         settings = queries.get_app_interface_settings()
-        saas_files = queries.get_saas_files_minimal()
+        saas_files = queries.get_saas_files_minimal(v1=True, v2=True)
 
         return GitLabApi(instance, project_id=gitlab_project_id,
                          settings=settings, saas_files=saas_files)

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -23,14 +23,17 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 def run(dry_run, thread_pool_size=10, io_dir='throughput/',
         saas_file_name=None, env_name=None,
         gitlab_project_id=None, defer=None):
-    all_saas_files = queries.get_saas_files()
-    saas_files = queries.get_saas_files(saas_file_name, env_name)
+    all_saas_files = queries.get_saas_files(v1=True, v2=True)
+    saas_files = queries.get_saas_files(saas_file_name, env_name,
+                                        v1=True, v2=True)
     if not saas_files:
         logging.error('no saas files found')
         sys.exit(ExitCodes.ERROR)
 
     instance = queries.get_gitlab_instance()
-    desired_jenkins_instances = [s['instance']['name'] for s in saas_files]
+    # intsance exists in v1 saas files only
+    desired_jenkins_instances = [s['instance']['name'] for s in saas_files
+                                 if s.get('instance')]
     jenkins_map = jenkins_base.get_jenkins_map(
         desired_instances=desired_jenkins_instances)
     settings = queries.get_app_interface_settings()

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -31,7 +31,7 @@ def run(dry_run, thread_pool_size=10, io_dir='throughput/',
         sys.exit(ExitCodes.ERROR)
 
     instance = queries.get_gitlab_instance()
-    # intsance exists in v1 saas files only
+    # instance exists in v1 saas files only
     desired_jenkins_instances = [s['instance']['name'] for s in saas_files
                                  if s.get('instance')]
     jenkins_map = jenkins_base.get_jenkins_map(

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1176,95 +1176,14 @@ def get_app_interface_sql_queries():
     return gqlapi.query(APP_INTERFACE_SQL_QUERIES_QUERY)['sql_queries']
 
 
-SAAS_FILE_QUERY_COMMON = """
-path
-name
-app {
-  name
-}
-managedResourceTypes
-takeover
-compare
-timeout
-publishJobLogs
-imagePatterns
-use_channel_in_image_tag
-authentication {
-  code {
-    path
-    field
-  }
-  image {
-    path
-  }
-}
-parameters
-resourceTemplates {
-  name
-  url
-  path
-  provider
-  hash_length
-  parameters
-  targets {
-    namespace {
-      name
-      environment {
-        name
-        parameters
-      }
-      app {
-        name
-      }
-      cluster {
-        name
-        serverUrl
-        jumpHost {
-          hostname
-          knownHosts
-          user
-          port
-          identity {
-              path
-              field
-              format
-          }
-        }
-        automationToken {
-          path
-          field
-          format
-        }
-        internal
-        disable {
-          integrations
-        }
-      }
-    }
-    ref
-    promotion {
-      auto
-      publish
-      subscribe
-    }
-    parameters
-    upstream
-    disable
-  }
-}
-roles {
-  users {
-    org_username
-    tag_on_merge_requests
-  }
-}
-"""
-
-
 SAAS_FILES_QUERY_V1 = """
 {
   saas_files: saas_files_v1 {
-    %s
+    path
+    name
+    app {
+      name
+    }
     instance {
       name
       serverUrl
@@ -1294,15 +1213,95 @@ SAAS_FILES_QUERY_V1 = """
         start
       }
     }
+    managedResourceTypes
+    takeover
+    compare
+    timeout
+    publishJobLogs
+    imagePatterns
+    use_channel_in_image_tag
+    authentication {
+      code {
+        path
+        field
+      }
+      image {
+        path
+      }
+    }
+    parameters
+    resourceTemplates {
+      name
+      url
+      path
+      provider
+      hash_length
+      parameters
+      targets {
+        namespace {
+          name
+          environment {
+            name
+            parameters
+          }
+          app {
+            name
+          }
+          cluster {
+            name
+            serverUrl
+            jumpHost {
+                hostname
+                knownHosts
+                user
+                port
+                identity {
+                    path
+                    field
+                    format
+                }
+            }
+            automationToken {
+              path
+              field
+              format
+            }
+            internal
+            disable {
+              integrations
+            }
+          }
+        }
+        ref
+        promotion {
+          auto
+          publish
+          subscribe
+        }
+        parameters
+        upstream
+        disable
+      }
+    }
+    roles {
+      users {
+        org_username
+        tag_on_merge_requests
+      }
+    }
   }
 }
-""" % (indent(SAAS_FILE_QUERY_COMMON, 4*' '))
+"""
 
 
 SAAS_FILES_QUERY_V2 = """
 {
-  saas_files: saas_files_v2 {
-    %s
+  saas_files: saas_files_v1 {
+    path
+    name
+    app {
+      name
+    }
     pipelinesNamespace {
       name
       cluster {
@@ -1330,9 +1329,85 @@ SAAS_FILES_QUERY_V2 = """
         }
       }
     }
+    managedResourceTypes
+    takeover
+    compare
+    timeout
+    publishJobLogs
+    imagePatterns
+    use_channel_in_image_tag
+    authentication {
+      code {
+        path
+        field
+      }
+      image {
+        path
+      }
+    }
+    parameters
+    resourceTemplates {
+      name
+      url
+      path
+      provider
+      hash_length
+      parameters
+      targets {
+        namespace {
+          name
+          environment {
+            name
+            parameters
+          }
+          app {
+            name
+          }
+          cluster {
+            name
+            serverUrl
+            jumpHost {
+                hostname
+                knownHosts
+                user
+                port
+                identity {
+                    path
+                    field
+                    format
+                }
+            }
+            automationToken {
+              path
+              field
+              format
+            }
+            internal
+            disable {
+              integrations
+            }
+          }
+        }
+        ref
+        promotion {
+          auto
+          publish
+          subscribe
+        }
+        parameters
+        upstream
+        disable
+      }
+    }
+    roles {
+      users {
+        org_username
+        tag_on_merge_requests
+      }
+    }
   }
 }
-""" % (indent(SAAS_FILE_QUERY_COMMON, 4*' '))
+"""
 
 
 def get_saas_files(saas_file_name=None, env_name=None, app_name=None,

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1294,6 +1294,122 @@ SAAS_FILES_QUERY_V1 = """
 """
 
 
+SAAS_FILES_QUERY_V2 = """
+{
+  saas_files: saas_files_v1 {
+    path
+    name
+    app {
+      name
+    }
+    pipelinesNamespace {
+      name
+      cluster {
+        name
+        serverUrl
+        jumpHost {
+          hostname
+          knownHosts
+          user
+          port
+          identity {
+              path
+              field
+              format
+          }
+        }
+        automationToken {
+          path
+          field
+          format
+        }
+        internal
+        disable {
+          integrations
+        }
+      }
+    }
+    managedResourceTypes
+    takeover
+    compare
+    timeout
+    publishJobLogs
+    imagePatterns
+    use_channel_in_image_tag
+    authentication {
+      code {
+        path
+        field
+      }
+      image {
+        path
+      }
+    }
+    parameters
+    resourceTemplates {
+      name
+      url
+      path
+      provider
+      hash_length
+      parameters
+      targets {
+        namespace {
+          name
+          environment {
+            name
+            parameters
+          }
+          app {
+            name
+          }
+          cluster {
+            name
+            serverUrl
+            jumpHost {
+                hostname
+                knownHosts
+                user
+                port
+                identity {
+                    path
+                    field
+                    format
+                }
+            }
+            automationToken {
+              path
+              field
+              format
+            }
+            internal
+            disable {
+              integrations
+            }
+          }
+        }
+        ref
+        promotion {
+          auto
+          publish
+          subscribe
+        }
+        parameters
+        upstream
+        disable
+      }
+    }
+    roles {
+      users {
+        org_username
+        tag_on_merge_requests
+      }
+    }
+  }
+}
+"""
+
+
 def get_saas_files(saas_file_name=None, env_name=None, app_name=None):
     """ Returns SaasFile resources defined in app-interface """
     gqlapi = gql.get_api()

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1296,7 +1296,7 @@ SAAS_FILES_QUERY_V1 = """
 
 SAAS_FILES_QUERY_V2 = """
 {
-  saas_files: saas_files_v1 {
+  saas_files: saas_files_v2 {
     path
     name
     app {

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1455,7 +1455,7 @@ def get_saas_files(saas_file_name=None, env_name=None, app_name=None,
     return saas_files
 
 
-SAAS_FILES_MINIMAL_QUERY = """
+SAAS_FILES_MINIMAL_QUERY_V1 = """
 {
   saas_files: saas_files_v1 {
     path
@@ -1465,10 +1465,29 @@ SAAS_FILES_MINIMAL_QUERY = """
 """
 
 
-def get_saas_files_minimal():
-    """ Returns SaasFile resources defined in app-interface """
+SAAS_FILES_MINIMAL_QUERY_V2 = """
+{
+  saas_files: saas_files_v2 {
+    path
+    name
+  }
+}
+"""
+
+
+def get_saas_files_minimal(v1=True, v2=False):
+    """ Returns SaasFile resources defined in app-interface.
+    Returns v1 saas files by default. """
     gqlapi = gql.get_api()
-    return gqlapi.query(SAAS_FILES_MINIMAL_QUERY)['saas_files']
+    saas_files = []
+    if v1:
+        saas_files_v1 = gqlapi.query(SAAS_FILES_MINIMAL_QUERY_V1)['saas_files']
+        saas_files.extend(saas_files_v1)
+    if v2:
+        saas_files_v2 = gqlapi.query(SAAS_FILES_MINIMAL_QUERY_V2)['saas_files']
+        saas_files.extend(saas_files_v1)
+
+    return saas_files
 
 
 JIRA_BOARDS_QUERY = """

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1417,11 +1417,11 @@ def get_saas_files(saas_file_name=None, env_name=None, app_name=None,
     gqlapi = gql.get_api()
     saas_files = []
     if v1:
-      saas_files_v1 = gqlapi.query(SAAS_FILES_QUERY_V1)['saas_files']
-      saas_files.extend(saas_files_v1)
+        saas_files_v1 = gqlapi.query(SAAS_FILES_QUERY_V1)['saas_files']
+        saas_files.extend(saas_files_v1)
     if v2:
-      saas_files_v2 = gqlapi.query(SAAS_FILES_QUERY_V2)['saas_files']
-      saas_files.extend(saas_files_v2)
+        saas_files_v2 = gqlapi.query(SAAS_FILES_QUERY_V2)['saas_files']
+        saas_files.extend(saas_files_v2)
 
     if saas_file_name is None and env_name is None and app_name is None:
         return saas_files
@@ -1485,7 +1485,7 @@ def get_saas_files_minimal(v1=True, v2=False):
         saas_files.extend(saas_files_v1)
     if v2:
         saas_files_v2 = gqlapi.query(SAAS_FILES_MINIMAL_QUERY_V2)['saas_files']
-        saas_files.extend(saas_files_v1)
+        saas_files.extend(saas_files_v2)
 
     return saas_files
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1302,30 +1302,34 @@ SAAS_FILES_QUERY_V2 = """
     app {
       name
     }
-    pipelinesNamespace {
+    pipelinesProvider {
       name
-      cluster {
+      provider
+      namespace {
         name
-        serverUrl
-        jumpHost {
-          hostname
-          knownHosts
-          user
-          port
-          identity {
+        cluster {
+          name
+          serverUrl
+          jumpHost {
+            hostname
+            knownHosts
+            user
+            port
+            identity {
               path
               field
               format
+            }
           }
-        }
-        automationToken {
-          path
-          field
-          format
-        }
-        internal
-        disable {
-          integrations
+          automationToken {
+            path
+            field
+            format
+          }
+          internal
+          disable {
+            integrations
+          }
         }
       }
     }

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1176,14 +1176,95 @@ def get_app_interface_sql_queries():
     return gqlapi.query(APP_INTERFACE_SQL_QUERIES_QUERY)['sql_queries']
 
 
+SAAS_FILE_QUERY_COMMON = """
+path
+name
+app {
+  name
+}
+managedResourceTypes
+takeover
+compare
+timeout
+publishJobLogs
+imagePatterns
+use_channel_in_image_tag
+authentication {
+  code {
+    path
+    field
+  }
+  image {
+    path
+  }
+}
+parameters
+resourceTemplates {
+  name
+  url
+  path
+  provider
+  hash_length
+  parameters
+  targets {
+    namespace {
+      name
+      environment {
+        name
+        parameters
+      }
+      app {
+        name
+      }
+      cluster {
+        name
+        serverUrl
+        jumpHost {
+          hostname
+          knownHosts
+          user
+          port
+          identity {
+              path
+              field
+              format
+          }
+        }
+        automationToken {
+          path
+          field
+          format
+        }
+        internal
+        disable {
+          integrations
+        }
+      }
+    }
+    ref
+    promotion {
+      auto
+      publish
+      subscribe
+    }
+    parameters
+    upstream
+    disable
+  }
+}
+roles {
+  users {
+    org_username
+    tag_on_merge_requests
+  }
+}
+"""
+
+
 SAAS_FILES_QUERY_V1 = """
 {
   saas_files: saas_files_v1 {
-    path
-    name
-    app {
-      name
-    }
+    %s
     instance {
       name
       serverUrl
@@ -1213,95 +1294,15 @@ SAAS_FILES_QUERY_V1 = """
         start
       }
     }
-    managedResourceTypes
-    takeover
-    compare
-    timeout
-    publishJobLogs
-    imagePatterns
-    use_channel_in_image_tag
-    authentication {
-      code {
-        path
-        field
-      }
-      image {
-        path
-      }
-    }
-    parameters
-    resourceTemplates {
-      name
-      url
-      path
-      provider
-      hash_length
-      parameters
-      targets {
-        namespace {
-          name
-          environment {
-            name
-            parameters
-          }
-          app {
-            name
-          }
-          cluster {
-            name
-            serverUrl
-            jumpHost {
-                hostname
-                knownHosts
-                user
-                port
-                identity {
-                    path
-                    field
-                    format
-                }
-            }
-            automationToken {
-              path
-              field
-              format
-            }
-            internal
-            disable {
-              integrations
-            }
-          }
-        }
-        ref
-        promotion {
-          auto
-          publish
-          subscribe
-        }
-        parameters
-        upstream
-        disable
-      }
-    }
-    roles {
-      users {
-        org_username
-        tag_on_merge_requests
-      }
-    }
   }
 }
-"""
+""" % (indent(SAAS_FILE_QUERY_COMMON, 4*' '))
 
 
 SAAS_FILES_QUERY_V2 = """
 {
-  saas_files: saas_files_v1 {
-    path
-    name
-    app {
-      name
-    }
+  saas_files: saas_files_v2 {
+    %s
     pipelinesNamespace {
       name
       cluster {
@@ -1329,85 +1330,9 @@ SAAS_FILES_QUERY_V2 = """
         }
       }
     }
-    managedResourceTypes
-    takeover
-    compare
-    timeout
-    publishJobLogs
-    imagePatterns
-    use_channel_in_image_tag
-    authentication {
-      code {
-        path
-        field
-      }
-      image {
-        path
-      }
-    }
-    parameters
-    resourceTemplates {
-      name
-      url
-      path
-      provider
-      hash_length
-      parameters
-      targets {
-        namespace {
-          name
-          environment {
-            name
-            parameters
-          }
-          app {
-            name
-          }
-          cluster {
-            name
-            serverUrl
-            jumpHost {
-                hostname
-                knownHosts
-                user
-                port
-                identity {
-                    path
-                    field
-                    format
-                }
-            }
-            automationToken {
-              path
-              field
-              format
-            }
-            internal
-            disable {
-              integrations
-            }
-          }
-        }
-        ref
-        promotion {
-          auto
-          publish
-          subscribe
-        }
-        parameters
-        upstream
-        disable
-      }
-    }
-    roles {
-      users {
-        org_username
-        tag_on_merge_requests
-      }
-    }
   }
 }
-"""
+""" % (indent(SAAS_FILE_QUERY_COMMON, 4*' '))
 
 
 def get_saas_files(saas_file_name=None, env_name=None, app_name=None):

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1305,30 +1305,32 @@ SAAS_FILES_QUERY_V2 = """
     pipelinesProvider {
       name
       provider
-      namespace {
-        name
-        cluster {
+      ...on PipelinesProviderTekton_v1 {
+        namespace {
           name
-          serverUrl
-          jumpHost {
-            hostname
-            knownHosts
-            user
-            port
-            identity {
+          cluster {
+            name
+            serverUrl
+            jumpHost {
+              hostname
+              knownHosts
+              user
+              port
+              identity {
+                path
+                field
+                format
+              }
+            }
+            automationToken {
               path
               field
               format
             }
-          }
-          automationToken {
-            path
-            field
-            format
-          }
-          internal
-          disable {
-            integrations
+            internal
+            disable {
+              integrations
+            }
           }
         }
       }

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1395,7 +1395,6 @@ SAAS_FILES_QUERY_V2 = """
           subscribe
         }
         parameters
-        upstream
         disable
       }
     }

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1335,10 +1335,19 @@ SAAS_FILES_QUERY_V2 = """
 """ % (indent(SAAS_FILE_QUERY_COMMON, 4*' '))
 
 
-def get_saas_files(saas_file_name=None, env_name=None, app_name=None):
-    """ Returns SaasFile resources defined in app-interface """
+def get_saas_files(saas_file_name=None, env_name=None, app_name=None,
+                   v1=True,
+                   v2=False):
+    """ Returns SaasFile resources defined in app-interface.
+    Returns v1 saas files by default. """
     gqlapi = gql.get_api()
-    saas_files = gqlapi.query(SAAS_FILES_QUERY_V1)['saas_files']
+    saas_files = []
+    if v1:
+      saas_files_v1 = gqlapi.query(SAAS_FILES_QUERY_V1)['saas_files']
+      saas_files.extend(saas_files_v1)
+    if v2:
+      saas_files_v2 = gqlapi.query(SAAS_FILES_QUERY_V2)['saas_files']
+      saas_files.extend(saas_files_v2)
 
     if saas_file_name is None and env_name is None and app_name is None:
         return saas_files

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1176,7 +1176,7 @@ def get_app_interface_sql_queries():
     return gqlapi.query(APP_INTERFACE_SQL_QUERIES_QUERY)['sql_queries']
 
 
-SAAS_FILES_QUERY = """
+SAAS_FILES_QUERY_V1 = """
 {
   saas_files: saas_files_v1 {
     path
@@ -1297,7 +1297,7 @@ SAAS_FILES_QUERY = """
 def get_saas_files(saas_file_name=None, env_name=None, app_name=None):
     """ Returns SaasFile resources defined in app-interface """
     gqlapi = gql.get_api()
-    saas_files = gqlapi.query(SAAS_FILES_QUERY)['saas_files']
+    saas_files = gqlapi.query(SAAS_FILES_QUERY_V1)['saas_files']
 
     if saas_file_name is None and env_name is None and app_name is None:
         return saas_files

--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -28,7 +28,7 @@ def get_diffs_file_path(io_dir):
 
 def collect_owners():
     owners = {}
-    saas_files = queries.get_saas_files()
+    saas_files = queries.get_saas_files(v1=True, v2=True)
     for saas_file in saas_files:
         saas_file_name = saas_file['name']
         owners[saas_file_name] = set()
@@ -54,7 +54,7 @@ def collect_owners():
 
 def collect_state():
     state = []
-    saas_files = queries.get_saas_files()
+    saas_files = queries.get_saas_files(v1=True, v2=True)
     for saas_file in saas_files:
         saas_file_path = saas_file['path']
         saas_file_name = saas_file['name']

--- a/reconcile/saas_file_validator.py
+++ b/reconcile/saas_file_validator.py
@@ -10,7 +10,7 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
 def run(dry_run):
-    saas_files = queries.get_saas_files()
+    saas_files = queries.get_saas_files(v1=True, v2=True)
     settings = queries.get_app_interface_settings()
     saasherder = SaasHerder(
         saas_files,

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -653,7 +653,9 @@ class SaasHerder():
         saas_file_name = saas_file['name']
         github = self._initiate_github(saas_file)
         image_auth = self._initiate_image_auth(saas_file)
-        instance_name = saas_file['instance']['name']
+        instance = saas_file.get('instance')
+        # instance exists in v1 saas files only
+        instance_name = instance['name'] if instance else None
         managed_resource_types = saas_file['managedResourceTypes']
         image_patterns = saas_file['imagePatterns']
         resource_templates = saas_file['resourceTemplates']

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -662,7 +662,8 @@ def saas_dev(ctx, app_name=None, saas_file_name=None, env_name=None):
     if env_name in [None, '']:
         print('env-name must be defined')
         return
-    saas_files = queries.get_saas_files(saas_file_name, env_name, app_name)
+    saas_files = queries.get_saas_files(saas_file_name, env_name, app_name
+                                        v1=True, v2=True)
     if not saas_files:
         print('no saas files found')
         sys.exit(1)

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -662,7 +662,7 @@ def saas_dev(ctx, app_name=None, saas_file_name=None, env_name=None):
     if env_name in [None, '']:
         print('env-name must be defined')
         return
-    saas_files = queries.get_saas_files(saas_file_name, env_name, app_name
+    saas_files = queries.get_saas_files(saas_file_name, env_name, app_name,
                                         v1=True, v2=True)
     if not saas_files:
         print('no saas files found')


### PR DESCRIPTION
this is the first PR to add support for saas files v2 (implemented with Tekton under the hood). we try to make the logic for v1 and v2 as similar as possible, with only the underlying implementation different (trigger job in jenkins vs do something in tekton).

related to https://issues.redhat.com/browse/APPSRE-3187
depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/19569

this PR changes logic in the following way:
1. add v2 queries
2. treat (jenkins) instance as optional (as tekton things will be running inside a cluster)

essentially, this PR does not add any new functionality and only influences integrations to make them work as they did until today.
