### PR TITLE
update qontract-reconcile-base

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/qontract-reconcile-base:0.3.2
+FROM quay.io/app-sre/qontract-reconcile-base:0.3.6
 
 WORKDIR /reconcile
 


### PR DESCRIPTION
$HOME is /root in podman and is / in openshift.
So we use /usr/local/share/terraform/plugins for Local Mirror Directories 
https://www.terraform.io/docs/cli/config/config-file.html#implied-local-mirror-directories

https://github.com/app-sre/container-images/compare/08b4b0586fe21deb95e7204301fdce06b7f85e16...f12eff5f49c497ceb8ba0387bf32044c34bc8e86

Signed-off-by: Feng Huang <fehuang@redhat.com>