### PR TITLE
[openshift-saas-deploy-triggers] prepare for v2 pipelines provider

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -34,7 +34,7 @@ def trigger(options):
 
     error = False
     if provider_name == 'jenkins':
-        instance_name = spec['instance_name']
+        instance_name = pipelines_provider['instance']['name']
         job_name = get_openshift_saas_deploy_job_name(
             saas_file_name, env_name, settings)
         if job_name not in already_triggered:

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -9,7 +9,6 @@ def trigger(options):
     Args:
         options (dict): A dictionary containing:
             dry_run (bool): Is this a dry run
-            saasherder (SaasHerder): a SaasHerder class instance
             spec (dict): A trigger spec as created by saasherder
             jenkins_map (dict): Instance names with JenkinsApi instances
             already_triggered (list): A list of already triggered deployments
@@ -20,7 +19,6 @@ def trigger(options):
         bool: True if there was an error, False otherwise
     """
     dry_run = options['dry_run']
-    saasherder = options['saasherder']
     spec = options['spec']
     jenkins_map = options['jenkins_map']
     already_triggered = options['already_triggered']

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -1,0 +1,66 @@
+import logging
+
+from reconcile.jenkins_job_builder import get_openshift_saas_deploy_job_name
+
+
+def trigger(options):
+    """Trigger a deployment according to the specified pipelines provider
+
+    Args:
+        options (dict): A dictionary containing:
+            dry_run (bool): Is this a dry run
+            saasherder (SaasHerder): a SaasHerder class instance
+            spec (dict): A trigger spec as created by saasherder
+            jenkins_map (dict): Instance names with JenkinsApi instances
+            already_triggered (list): A list of already triggered deployments
+            settings (dict): App-interface settings
+            state_update_method (function): A method to call to update state
+
+    Returns:
+        bool: True if there was an error, False otherwise
+    """
+    dry_run = options['dry_run']
+    saasherder = options['saasherder']
+    spec = options['spec']
+    jenkins_map = options['jenkins_map']
+    already_triggered = options['already_triggered']
+    settings = options['settings']
+    state_update_method = options['state_update_method']
+
+    saas_file_name = spec['saas_file_name']
+    env_name = spec['env_name']
+    pipelines_provider = spec['pipelines_provider']
+    provider_name = pipelines_provider['provider']
+
+    error = False
+    if provider_name == 'jenkins':
+        instance_name = spec['instance_name']
+        job_name = get_openshift_saas_deploy_job_name(
+            saas_file_name, env_name, settings)
+        if job_name not in already_triggered:
+            logging.info(['trigger_job', instance_name, job_name])
+            if dry_run:
+                already_triggered.append(job_name)
+
+        if not dry_run:
+            jenkins = jenkins_map[instance_name]
+            try:
+                if job_name not in already_triggered:
+                    jenkins.trigger_job(job_name)
+                    already_triggered.append(job_name)
+                state_update_method(spec)
+            except Exception as e:
+                error = True
+                logging.error(
+                    f"could not trigger job {job_name} " +
+                    f"in {instance_name}. details: {str(e)}"
+                )
+    elif provider_name == 'tekton':
+        raise NotImplementedError('trigger base tekton provider')
+    else:
+        logging.error(
+            f'[{saas_file_name}] unsupported provider: ' +
+            f'{provider_name}'
+        )
+
+    return error

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -46,7 +46,6 @@ def run(dry_run, thread_pool_size=10):
         for job_spec in trigger_specs:
             trigger_options = {
                 'dry_run': dry_run,
-                'saasherder': saasherder,
                 'spec': job_spec,
                 'jenkins_map': jenkins_map,
                 'already_triggered': already_triggered,

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -5,11 +5,11 @@ import time
 
 import reconcile.queries as queries
 import reconcile.jenkins_plugins as jenkins_base
+import reconcile.openshift_saas_deploy_trigger_base as osdt_base
 
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.saasherder import SaasHerder
-from reconcile.jenkins_job_builder import get_openshift_saas_deploy_job_name
 
 
 QONTRACT_INTEGRATION = 'openshift-saas-deploy-trigger-configs'
@@ -44,29 +44,18 @@ def run(dry_run, thread_pool_size=10):
     while error:
         error = False
         for job_spec in trigger_specs:
-            saas_file_name = job_spec['saas_file_name']
-            env_name = job_spec['env_name']
-            instance_name = job_spec['instance_name']
-            job_name = get_openshift_saas_deploy_job_name(
-                saas_file_name, env_name, settings)
-            if job_name not in already_triggered:
-                logging.info(['trigger_job', instance_name, job_name])
-                if dry_run:
-                    already_triggered.append(job_name)
-
-            if not dry_run:
-                jenkins = jenkins_map[instance_name]
-                try:
-                    if job_name not in already_triggered:
-                        jenkins.trigger_job(job_name)
-                        already_triggered.append(job_name)
-                    saasherder.update_config(job_spec)
-                except Exception as e:
-                    error = True
-                    logging.error(
-                        f"could not trigger job {job_name} " +
-                        f"in {instance_name}. details: {str(e)}"
-                    )
+            trigger_options = {
+                'dry_run': dry_run,
+                'saasherder': saasherder,
+                'spec': job_spec,
+                'jenkins_map': jenkins_map,
+                'already_triggered': already_triggered,
+                'settings': settings,
+                'state_update_method': saasherder.update_config,
+            }
+            trigger_error = osdt_base.trigger(trigger_options)
+            if trigger_error:
+                error = True
 
         if error:
             time.sleep(10)  # add to contants module once created

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -3,9 +3,9 @@ import logging
 
 
 import reconcile.jenkins_plugins as jenkins_base
+import reconcile.openshift_saas_deploy_trigger_base as osdt_base
 import reconcile.queries as queries
 
-from reconcile.jenkins_job_builder import get_openshift_saas_deploy_job_name
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.saasherder import SaasHerder
@@ -49,27 +49,18 @@ def run(dry_run, thread_pool_size=10):
     already_triggered = []
     error = False
     for job_spec in trigger_specs:
-        saas_file_name = job_spec['saas_file_name']
-        env_name = job_spec['env_name']
-        instance_name = job_spec['instance_name']
-        job_name = get_openshift_saas_deploy_job_name(
-            saas_file_name, env_name, settings)
-        if job_name not in already_triggered:
-            logging.info(['trigger_job', instance_name, job_name])
-            if dry_run:
-                already_triggered.append(job_name)
-
-        if not dry_run:
-            jenkins = jenkins_map[instance_name]
-            try:
-                if job_name not in already_triggered:
-                    jenkins.trigger_job(job_name)
-                    already_triggered.append(job_name)
-                saasherder.update_moving_commit(job_spec)
-            except Exception:
-                error = True
-                logging.error(
-                    f"could not trigger job {job_name} in {instance_name}.")
+        trigger_options = {
+            'dry_run': dry_run,
+            'saasherder': saasherder,
+            'spec': job_spec,
+            'jenkins_map': jenkins_map,
+            'already_triggered': already_triggered,
+            'settings': settings,
+            'state_update_method': saasherder.update_moving_commit,
+        }
+        trigger_error = osdt_base.trigger(trigger_options)
+        if trigger_error:
+            error = True
 
     if error:
         sys.exit(1)

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -51,7 +51,6 @@ def run(dry_run, thread_pool_size=10):
     for job_spec in trigger_specs:
         trigger_options = {
             'dry_run': dry_run,
-            'saasherder': saasherder,
             'spec': job_spec,
             'jenkins_map': jenkins_map,
             'already_triggered': already_triggered,

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1424,9 +1424,13 @@ def get_saas_files(saas_file_name=None, env_name=None, app_name=None,
     saas_files = []
     if v1:
         saas_files_v1 = gqlapi.query(SAAS_FILES_QUERY_V1)['saas_files']
+        for sf in saas_files_v1:
+            sf['apiVersion'] = 'v1'
         saas_files.extend(saas_files_v1)
     if v2:
         saas_files_v2 = gqlapi.query(SAAS_FILES_QUERY_V2)['saas_files']
+        for sf in saas_files_v2:
+            sf['apiVersion'] = 'v2'
         saas_files.extend(saas_files_v2)
 
     if saas_file_name is None and env_name is None and app_name is None:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -781,6 +781,7 @@ class SaasHerder():
     def get_moving_commits_diff_saas_file(self, saas_file, dry_run):
         saas_file_name = saas_file['name']
         instace_name = saas_file['instance']['name']
+        pipelines_provider = self._get_pipelines_provider(saas_file)
         github = self._initiate_github(saas_file)
         trigger_specs = []
         for rt in saas_file['resourceTemplates']:
@@ -825,6 +826,7 @@ class SaasHerder():
                     'saas_file_name': saas_file_name,
                     'env_name': env_name,
                     'instance_name': instace_name,
+                    'pipelines_provider': pipelines_provider,
                     'rt_name': rt_name,
                     'cluster_name': cluster_name,
                     'namespace_name': namespace_name,
@@ -858,6 +860,7 @@ class SaasHerder():
         saas_file_parameters = saas_file.get('parameters')
         saas_file_managed_resource_types = saas_file['managedResourceTypes']
         instace_name = saas_file['instance']['name']
+        pipelines_provider = self._get_pipelines_provider(saas_file)
         trigger_specs = []
         for rt in saas_file['resourceTemplates']:
             rt_name = rt['name']
@@ -891,6 +894,7 @@ class SaasHerder():
                     'saas_file_name': saas_file_name,
                     'env_name': env_name,
                     'instance_name': instace_name,
+                    'pipelines_provider': pipelines_provider,
                     'rt_name': rt_name,
                     'cluster_name': cluster_name,
                     'namespace_name': namespace_name,
@@ -899,6 +903,29 @@ class SaasHerder():
                 trigger_specs.append(job_spec)
 
         return trigger_specs
+
+    @staticmethod
+    def _get_pipelines_provider(saas_file):
+        """Returns the Pipelines Provider for a SaaS file.
+
+        Args:
+            saas_file (dict): SaaS file GQL query result with apiVersion key
+
+        Returns:
+            dict: Pipelines Provider details
+        """
+        saas_file_api_version = saas_file['apiVersion']
+        if saas_file_api_version == 'v1':
+            # wrapping the instance in a pipelines provider structure
+            # for backwards compatibility
+            pipelines_provider = {
+                'provider': 'jenkins',
+                'instance': saas_file['instance'],
+            }
+        if saas_file_api_version == 'v2':
+            pipelines_provider = saas_file['pipelinesProvider']
+
+        return pipelines_provider
 
     @staticmethod
     def sanitize_namespace(namespace):

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -780,7 +780,6 @@ class SaasHerder():
 
     def get_moving_commits_diff_saas_file(self, saas_file, dry_run):
         saas_file_name = saas_file['name']
-        instace_name = saas_file['instance']['name']
         pipelines_provider = self._get_pipelines_provider(saas_file)
         github = self._initiate_github(saas_file)
         trigger_specs = []
@@ -825,7 +824,6 @@ class SaasHerder():
                 job_spec = {
                     'saas_file_name': saas_file_name,
                     'env_name': env_name,
-                    'instance_name': instace_name,
                     'pipelines_provider': pipelines_provider,
                     'rt_name': rt_name,
                     'cluster_name': cluster_name,
@@ -859,7 +857,6 @@ class SaasHerder():
         saas_file_name = saas_file['name']
         saas_file_parameters = saas_file.get('parameters')
         saas_file_managed_resource_types = saas_file['managedResourceTypes']
-        instace_name = saas_file['instance']['name']
         pipelines_provider = self._get_pipelines_provider(saas_file)
         trigger_specs = []
         for rt in saas_file['resourceTemplates']:
@@ -893,7 +890,6 @@ class SaasHerder():
                 job_spec = {
                     'saas_file_name': saas_file_name,
                     'env_name': env_name,
-                    'instance_name': instace_name,
                     'pipelines_provider': pipelines_provider,
                     'rt_name': rt_name,
                     'cluster_name': cluster_name,


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3187

this PR refactors the openshift-saas-deploy trigger integrations to be aware of api version and trigger a new deployment in the appropriate provider (v1 - jenkins, v2 - tekton (not yet implemented)).