### PR TITLE
[openshift-saas-deploy-triggers] add tekton support

### DIFF
--- a/helm/qontract-reconcile/values-internal.yaml
+++ b/helm/qontract-reconcile/values-internal.yaml
@@ -99,6 +99,7 @@ integrations:
     limits:
       memory: 400Mi
       cpu: 400m
+  extraArgs: --no-use-jump-host
   logs:
     slack: true
   state: true
@@ -110,6 +111,7 @@ integrations:
     limits:
       memory: 400Mi
       cpu: 400m
+  extraArgs: --no-use-jump-host
   logs:
     slack: true
   state: true

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -1814,7 +1814,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-saas-deploy-trigger-configs
           - name: INTEGRATION_EXTRA_ARGS
-            value: ""
+            value: "--no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -2022,7 +2022,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-saas-deploy-trigger-moving-commits
           - name: INTEGRATION_EXTRA_ARGS
-            value: ""
+            value: "--no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -791,21 +791,31 @@ def saas_file_validator(ctx):
 @integration.command()
 @environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
 @threaded()
+@binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
+@internal()
+@use_jump_host()
 @click.pass_context
-def openshift_saas_deploy_trigger_moving_commits(ctx, thread_pool_size):
+def openshift_saas_deploy_trigger_moving_commits(ctx, thread_pool_size,
+                                                 internal, use_jump_host):
     run_integration(
         reconcile.openshift_saas_deploy_trigger_moving_commits,
-        ctx.obj, thread_pool_size)
+        ctx.obj, thread_pool_size, internal, use_jump_host)
 
 
 @integration.command()
 @environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
 @threaded()
+@binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
+@internal()
+@use_jump_host()
 @click.pass_context
-def openshift_saas_deploy_trigger_configs(ctx, thread_pool_size):
+def openshift_saas_deploy_trigger_configs(ctx, thread_pool_size,
+                                          internal, use_jump_host):
     run_integration(
         reconcile.openshift_saas_deploy_trigger_configs,
-        ctx.obj, thread_pool_size)
+        ctx.obj, thread_pool_size, internal, use_jump_host)
 
 
 @integration.command()

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -193,7 +193,7 @@ def trigger(options):
             error = True
             logging.error(
                 f"could not trigger pipeline {tkn_name} " +
-                f"in {tkn_cluster_name}\{tkn_namespace_name}. " +
+                f"in {tkn_cluster_name}/{tkn_namespace_name}. " +
                 f"details: {str(e)}"
             )
     else:

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -1,6 +1,66 @@
 import logging
+import datetime
 
+import reconcile.openshift_base as osb
+import reconcile.queries as queries
+import reconcile.jenkins_plugins as jenkins_base
+
+from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.jenkins_job_builder import get_openshift_saas_deploy_job_name
+from reconcile.utils.oc import OC_Map
+from reconcile.utils.gitlab_api import GitLabApi
+from reconcile.utils.saasherder import SaasHerder
+
+
+def setup(options):
+    """Setup required resources for triggering integrations
+
+    Args:
+        options (dict): A dictionary containing:
+            saas_files (list): SaaS files graphql query results
+            thread_pool_size (int): Thread pool size to use
+            internal (bool): Should run for internal/extrenal/all clusters
+            use_jump_host (bool): Should use jump host to reach clusters
+            integration (string): Name of calling integration
+            integration_version (string): Version of calling integration
+
+    Returns:
+        saasherder (SaasHerder): a SaasHerder instance
+        jenkins_map (dict): Instance names with JenkinsApi instances
+        oc_map (OC_Map): a dictionary of OC clients per cluster
+        settings (dict): App-interface settings
+    """
+    saas_files = options['saas_files']
+    thread_pool_size = options['thread_pool_size']
+    internal = options['internal']
+    use_jump_host = options['use_jump_host']
+    integration = options['integration']
+    integration_version = options['integration_version']
+
+    instance = queries.get_gitlab_instance()
+    settings = queries.get_app_interface_settings()
+    accounts = queries.get_aws_accounts()
+    gl = GitLabApi(instance, settings=settings)
+    jenkins_map = jenkins_base.get_jenkins_map()
+    pipelines_providers = queries.get_pipelines_providers()
+    tkn_provider_namespaces = [pp['namespace'] for pp in pipelines_providers
+                               if pp['provider'] == 'tekton']
+    oc_map = OC_Map(namespaces=tkn_provider_namespaces,
+                    integration=integration,
+                    settings=settings, internal=internal,
+                    use_jump_host=use_jump_host,
+                    thread_pool_size=thread_pool_size)
+
+    saasherder = SaasHerder(
+        saas_files,
+        thread_pool_size=thread_pool_size,
+        gitlab=gl,
+        integration=integration,
+        integration_version=integration_version,
+        settings=settings,
+        accounts=accounts)
+
+    return saasherder, jenkins_map, oc_map, settings
 
 
 def trigger(options):
@@ -11,9 +71,12 @@ def trigger(options):
             dry_run (bool): Is this a dry run
             spec (dict): A trigger spec as created by saasherder
             jenkins_map (dict): Instance names with JenkinsApi instances
+            oc_map (OC_Map): a dictionary of OC clients per cluster
             already_triggered (list): A list of already triggered deployments
             settings (dict): App-interface settings
             state_update_method (function): A method to call to update state
+            integration (string): Name of calling integration
+            integration_version (string): Version of calling integration
 
     Returns:
         bool: True if there was an error, False otherwise
@@ -21,9 +84,12 @@ def trigger(options):
     dry_run = options['dry_run']
     spec = options['spec']
     jenkins_map = options['jenkins_map']
+    oc_map = options['oc_map']
     already_triggered = options['already_triggered']
     settings = options['settings']
     state_update_method = options['state_update_method']
+    integration = options['integration']
+    integration_version = options['integration_version']
 
     saas_file_name = spec['saas_file_name']
     env_name = spec['env_name']

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -17,7 +17,7 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 @defer
 def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, defer=None):
-    saas_files = queries.get_saas_files(v1=False, v2=True)
+    saas_files = queries.get_saas_files(v1=True, v2=True)
     if not saas_files:
         logging.error('no saas files found')
         sys.exit(1)

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -4,38 +4,34 @@ import time
 
 
 import reconcile.queries as queries
-import reconcile.jenkins_plugins as jenkins_base
 import reconcile.openshift_saas_deploy_trigger_base as osdt_base
 
+from reconcile.utils.defer import defer
 from reconcile.utils.semver_helper import make_semver
-from reconcile.utils.gitlab_api import GitLabApi
-from reconcile.utils.saasherder import SaasHerder
 
 
 QONTRACT_INTEGRATION = 'openshift-saas-deploy-trigger-configs'
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
-def run(dry_run, thread_pool_size=10):
-    saas_files = queries.get_saas_files()
+@defer
+def run(dry_run, thread_pool_size=10, internal=None,
+        use_jump_host=True, defer=None):
+    saas_files = queries.get_saas_files(v1=False, v2=True)
     if not saas_files:
         logging.error('no saas files found')
         sys.exit(1)
 
-    instance = queries.get_gitlab_instance()
-    settings = queries.get_app_interface_settings()
-    accounts = queries.get_aws_accounts()
-    gl = GitLabApi(instance, settings=settings)
-    jenkins_map = jenkins_base.get_jenkins_map()
-
-    saasherder = SaasHerder(
-        saas_files,
-        thread_pool_size=thread_pool_size,
-        gitlab=gl,
-        integration=QONTRACT_INTEGRATION,
-        integration_version=QONTRACT_INTEGRATION_VERSION,
-        settings=settings,
-        accounts=accounts)
+    setup_options = {
+        'saas_files': saas_files,
+        'thread_pool_size': thread_pool_size,
+        'internal': internal,
+        'use_jump_host': use_jump_host,
+        'integration': QONTRACT_INTEGRATION,
+        'integration_version': QONTRACT_INTEGRATION_VERSION,
+    }
+    saasherder, jenkins_map, oc_map, settings = osdt_base.setup(setup_options)
+    defer(lambda: oc_map.cleanup())
 
     trigger_specs = saasherder.get_configs_diff()
     already_triggered = []
@@ -48,9 +44,12 @@ def run(dry_run, thread_pool_size=10):
                 'dry_run': dry_run,
                 'spec': job_spec,
                 'jenkins_map': jenkins_map,
+                'oc_map': oc_map,
                 'already_triggered': already_triggered,
                 'settings': settings,
                 'state_update_method': saasherder.update_config,
+                'integration': QONTRACT_INTEGRATION,
+                'integration_version': QONTRACT_INTEGRATION_VERSION,
             }
             trigger_error = osdt_base.trigger(trigger_options)
             if trigger_error:

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -1,22 +1,21 @@
 import sys
 import logging
 
-
-import reconcile.jenkins_plugins as jenkins_base
 import reconcile.openshift_saas_deploy_trigger_base as osdt_base
 import reconcile.queries as queries
 
+from reconcile.utils.defer import defer
 from reconcile.utils.semver_helper import make_semver
-from reconcile.utils.gitlab_api import GitLabApi
-from reconcile.utils.saasherder import SaasHerder
 
 
 QONTRACT_INTEGRATION = 'openshift-saas-deploy-trigger-moving-commits'
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
-def run(dry_run, thread_pool_size=10):
-    saas_files = queries.get_saas_files()
+@defer
+def run(dry_run, thread_pool_size=10, internal=None,
+        use_jump_host=True, defer=None):
+    saas_files = queries.get_saas_files(v1=False, v2=True)
     if not saas_files:
         logging.error('no saas files found')
         sys.exit(1)
@@ -30,20 +29,16 @@ def run(dry_run, thread_pool_size=10):
                 if target['disable']:
                     targets.remove(target)
 
-    instance = queries.get_gitlab_instance()
-    settings = queries.get_app_interface_settings()
-    accounts = queries.get_aws_accounts()
-    gl = GitLabApi(instance, settings=settings)
-    jenkins_map = jenkins_base.get_jenkins_map()
-
-    saasherder = SaasHerder(
-        saas_files,
-        thread_pool_size=thread_pool_size,
-        gitlab=gl,
-        integration=QONTRACT_INTEGRATION,
-        integration_version=QONTRACT_INTEGRATION_VERSION,
-        settings=settings,
-        accounts=accounts)
+    setup_options = {
+        'saas_files': saas_files,
+        'thread_pool_size': thread_pool_size,
+        'internal': internal,
+        'use_jump_host': use_jump_host,
+        'integration': QONTRACT_INTEGRATION,
+        'integration_version': QONTRACT_INTEGRATION_VERSION,
+    }
+    saasherder, jenkins_map, oc_map, settings = osdt_base.setup(setup_options)
+    defer(lambda: oc_map.cleanup())
 
     trigger_specs = saasherder.get_moving_commits_diff(dry_run)
     already_triggered = []
@@ -53,9 +48,12 @@ def run(dry_run, thread_pool_size=10):
             'dry_run': dry_run,
             'spec': job_spec,
             'jenkins_map': jenkins_map,
+            'oc_map': oc_map,
             'already_triggered': already_triggered,
             'settings': settings,
             'state_update_method': saasherder.update_moving_commit,
+            'integration': QONTRACT_INTEGRATION,
+            'integration_version': QONTRACT_INTEGRATION_VERSION,
         }
         trigger_error = osdt_base.trigger(trigger_options)
         if trigger_error:

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -15,7 +15,7 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 @defer
 def run(dry_run, thread_pool_size=10, internal=None,
         use_jump_host=True, defer=None):
-    saas_files = queries.get_saas_files(v1=False, v2=True)
+    saas_files = queries.get_saas_files(v1=True, v2=True)
     if not saas_files:
         logging.error('no saas files found')
         sys.exit(1)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1500,6 +1500,51 @@ def get_saas_files_minimal(v1=True, v2=False):
     return saas_files
 
 
+PIPELINES_PROVIDERS_QUERY = """
+{
+  pipelines_providers: pipelines_providers_v1 {
+    name
+    provider
+    ...on PipelinesProviderTekton_v1 {
+      namespace {
+        name
+        cluster {
+          name
+          serverUrl
+          jumpHost {
+            hostname
+            knownHosts
+            user
+            port
+            identity {
+              path
+              field
+              format
+            }
+          }
+          automationToken {
+            path
+            field
+            format
+          }
+          internal
+          disable {
+            integrations
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def get_pipelines_providers():
+    """ Returns PipelinesProvider resources defined in app-interface."""
+    gqlapi = gql.get_api()
+    return gqlapi.query(PIPELINES_PROVIDERS_QUERY)['pipelines_providers']
+
+
 JIRA_BOARDS_QUERY = """
 {
   jira_boards: jira_boards_v1 {


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3187

follows up on #1577

this PR adds Tekton trigger implementation (applying `PipelineRun`s). it also adds any required cli args for `oc` usage and does a small refactor of the setup phase of the triggering integrations.
