### PR TITLE
add slack to saas file v2 query

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1335,6 +1335,26 @@ SAAS_FILES_QUERY_V2 = """
         }
       }
     }
+    slack {
+      output
+      workspace {
+        name
+        integrations {
+          name
+          token {
+            path
+            field
+          }
+          channel
+          icon_emoji
+          username
+        }
+      }
+      channel
+      notifications {
+        start
+      }
+    }
     managedResourceTypes
     takeover
     compare


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3187

this will re-enable slack events output notifications for v2 saas files.