### PR TITLE
desolve vpc peerings dependency on awsInfrastructureAccess

### DIFF
--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -55,13 +55,17 @@ def build_desired_state_tgw_attachments(clusters, ocm_map, settings):
             account['assume_region'] = accepter['region']
             account['assume_cidr'] = accepter['cidr_block']
             aws_api = AWSApi(1, [account], settings=settings)
-            accepter_vpc_id, accepter_route_table_ids, \
-                accepter_subnets_id_az = \
-                aws_api.get_cluster_vpc_details(
-                    account,
-                    route_tables=peer_connection.get('manageRoutes'),
-                    subnets=True,
-                )
+            try:
+                accepter_vpc_id, accepter_route_table_ids, \
+                    accepter_subnets_id_az = \
+                    aws_api.get_cluster_vpc_details(
+                        account,
+                        route_tables=peer_connection.get('manageRoutes'),
+                        subnets=True,
+                    )
+            except aws_api.MissingRoleARNError as e:
+                logging.error(str(e))
+                continue
 
             if accepter_vpc_id is None:
                 logging.error(f'[{cluster} could not find VPC ID for cluster')

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -112,11 +112,16 @@ def build_desired_state_cluster(clusters, ocm_map, settings):
             accepter_manage_routes = peer_info.get('manageRoutes')
 
             aws_api = AWSApi(1, [req_aws], settings=settings)
-            requester_vpc_id, requester_route_table_ids, _ = \
-                aws_api.get_cluster_vpc_details(
-                    req_aws,
-                    route_tables=requester_manage_routes
-                )
+            try:
+                requester_vpc_id, requester_route_table_ids, _ = \
+                    aws_api.get_cluster_vpc_details(
+                        req_aws,
+                        route_tables=requester_manage_routes
+                    )
+            except aws_api.MissingRoleARNError as e:
+                logging.error(str(e))
+                continue
+
             if requester_vpc_id is None:
                 msg = f'[{cluster_name} could not find VPC ID for cluster'
                 logging.error(msg)
@@ -145,11 +150,16 @@ def build_desired_state_cluster(clusters, ocm_map, settings):
             acc_aws['assume_cidr'] = peer_cluster['network']['vpc']
 
             aws_api = AWSApi(1, [acc_aws], settings=settings)
-            accepter_vpc_id, accepter_route_table_ids, _ = \
-                aws_api.get_cluster_vpc_details(
-                    acc_aws,
-                    route_tables=accepter_manage_routes
-                )
+            try:
+                accepter_vpc_id, accepter_route_table_ids, _ = \
+                    aws_api.get_cluster_vpc_details(
+                        acc_aws,
+                        route_tables=accepter_manage_routes
+                    )
+            except aws_api.MissingRoleARNError as e:
+                logging.error(str(e))
+                continue
+
             if accepter_vpc_id is None:
                 msg = f'[{peer_cluster_name} could not find VPC ID for cluster'
                 logging.error(msg)
@@ -211,11 +221,15 @@ def build_desired_state_vpc_mesh(clusters, ocm_map, settings):
             account['assume_region'] = requester['region']
             account['assume_cidr'] = requester['cidr_block']
             aws_api = AWSApi(1, [account], settings=settings)
-            requester_vpc_id, requester_route_table_ids, _ = \
-                aws_api.get_cluster_vpc_details(
-                    account,
-                    route_tables=peer_connection.get('manageRoutes')
-                )
+            try:
+                requester_vpc_id, requester_route_table_ids, _ = \
+                    aws_api.get_cluster_vpc_details(
+                        account,
+                        route_tables=peer_connection.get('manageRoutes')
+                    )
+            except aws_api.MissingRoleARNError as e:
+                logging.error(str(e))
+                continue
 
             if requester_vpc_id is None:
                 logging.error(f'[{cluster} could not find VPC ID for cluster')
@@ -298,11 +312,15 @@ def build_desired_state_vpc(clusters, ocm_map, settings):
             account['assume_region'] = requester['region']
             account['assume_cidr'] = requester['cidr_block']
             aws_api = AWSApi(1, [account], settings=settings)
-            requester_vpc_id, requester_route_table_ids, _ = \
-                aws_api.get_cluster_vpc_details(
-                    account,
-                    route_tables=peer_connection.get('manageRoutes')
-                )
+            try:
+                requester_vpc_id, requester_route_table_ids, _ = \
+                    aws_api.get_cluster_vpc_details(
+                        account,
+                        route_tables=peer_connection.get('manageRoutes')
+                    )
+            except aws_api.MissingRoleARNError as e:
+                logging.error(str(e))
+                continue
 
             if requester_vpc_id is None:
                 logging.error(f'[{cluster} could not find VPC ID for cluster')

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -19,6 +19,10 @@ class InvalidResourceTypeError(Exception):
     pass
 
 
+class MissingRoleARNError(Exception):
+    pass
+
+
 class AWSApi:
     """Wrapper around AWS SDK"""
 
@@ -636,7 +640,7 @@ class AWSApi:
         sts = session.client('sts')
         role_arn = account['assume_role']
         if not role_arn:
-            raise KeyError(
+            raise MissingRoleARNError(
                 'Could not find Role ARN. This is likely caused '
                 'due to a missing awsInfrastructureAccess section.'
             )


### PR DESCRIPTION
in order to create a VPC peering through app-interface, the `awsInfrastructureAccess` section has to be merged in advance for terraform to get access to the cluster's aws account.

with this PR, the peering section and the access section can be submitted in the same MR, and the vpc peerings integration will log warnings until the access is granted.