### PR TITLE
[openshift-saas-deploy-triggers] add support for timeout

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -74,7 +74,7 @@ def construct_tekton_trigger_resource(saas_file_name,
     Args:
         saas_file_name (string): SaaS file name
         env_name (string): Environment name
-        timeout (Duration): Specifies the timeout before the PipelineRun fails
+        timeout (int): Timeout in minutes before the PipelineRun fails
         settings (dict): App-interface settings
         integration (string): Name of calling integration
         integration_version (string): Version of calling integration

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -63,13 +63,18 @@ def setup(options):
     return saasherder, jenkins_map, oc_map, settings
 
 
-def construct_tekton_trigger_resource(saas_file_name, env_name, settings,
-                                      integration, integration_version):
+def construct_tekton_trigger_resource(saas_file_name,
+                                      env_name,
+                                      timeout,
+                                      settings,
+                                      integration,
+                                      integration_version):
     """Construct a resource (PipelineRun) to trigger a deployment via Tekton.
 
     Args:
         saas_file_name (string): SaaS file name
         env_name (string): Environment name
+        timeout (Duration): Specifies the timeout before the PipelineRun fails
         settings (dict): App-interface settings
         integration (string): Name of calling integration
         integration_version (string): Version of calling integration
@@ -106,6 +111,10 @@ def construct_tekton_trigger_resource(saas_file_name, env_name, settings,
             ]
         }
     }
+    if timeout:
+        # conforming to Go’s ParseDuration format
+        body['spec']['timeout'] = f"{timeout}m"
+
     return OR(body, integration, integration_version,
               error_details=name), long_name
 
@@ -141,6 +150,7 @@ def trigger(options):
 
     saas_file_name = spec['saas_file_name']
     env_name = spec['env_name']
+    timeout = spec['timeout']
     pipelines_provider = spec['pipelines_provider']
     provider_name = pipelines_provider['provider']
 
@@ -174,6 +184,7 @@ def trigger(options):
         tkn_trigger_resource, tkn_name = construct_tekton_trigger_resource(
             saas_file_name,
             env_name,
+            timeout,
             settings,
             integration,
             integration_version

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -790,6 +790,7 @@ class SaasHerder():
 
     def get_moving_commits_diff_saas_file(self, saas_file, dry_run):
         saas_file_name = saas_file['name']
+        timeout = saas_file.get('timeout') or None
         pipelines_provider = self._get_pipelines_provider(saas_file)
         github = self._initiate_github(saas_file)
         trigger_specs = []
@@ -834,6 +835,7 @@ class SaasHerder():
                 job_spec = {
                     'saas_file_name': saas_file_name,
                     'env_name': env_name,
+                    'timeout': timeout,
                     'pipelines_provider': pipelines_provider,
                     'rt_name': rt_name,
                     'cluster_name': cluster_name,
@@ -867,6 +869,7 @@ class SaasHerder():
         saas_file_name = saas_file['name']
         saas_file_parameters = saas_file.get('parameters')
         saas_file_managed_resource_types = saas_file['managedResourceTypes']
+        timeout = saas_file.get('timeout') or None
         pipelines_provider = self._get_pipelines_provider(saas_file)
         trigger_specs = []
         for rt in saas_file['resourceTemplates']:
@@ -900,6 +903,7 @@ class SaasHerder():
                 job_spec = {
                     'saas_file_name': saas_file_name,
                     'env_name': env_name,
+                    'timeout': timeout,
                     'pipelines_provider': pipelines_provider,
                     'rt_name': rt_name,
                     'cluster_name': cluster_name,


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3187

this PR adds the ability to set a timeout for a deployment (for saas-file-1 - supported through the Jenkins timeout wrapper).

docs: https://tekton.dev/docs/pipelines/pipelineruns/#configuring-a-failure-timeout
