### PR TITLE
[openshift-saas-deploy-trigger-configs] remove trigger loop

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -1,7 +1,5 @@
 import logging
 import sys
-import time
-
 
 import reconcile.queries as queries
 import reconcile.openshift_saas_deploy_trigger_base as osdt_base

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -6,6 +6,7 @@ import time
 import reconcile.queries as queries
 import reconcile.openshift_saas_deploy_trigger_base as osdt_base
 
+from reconcile.status import ExitCodes
 from reconcile.utils.defer import defer
 from reconcile.utils.semver_helper import make_semver
 
@@ -20,7 +21,7 @@ def run(dry_run, thread_pool_size=10, internal=None,
     saas_files = queries.get_saas_files(v1=True, v2=True)
     if not saas_files:
         logging.error('no saas files found')
-        sys.exit(1)
+        sys.exit(ExitCodes.ERROR)
 
     setup_options = {
         'saas_files': saas_files,
@@ -38,24 +39,22 @@ def run(dry_run, thread_pool_size=10, internal=None,
     # we need it to be consistent across all iterations
     already_triggered = []
 
-    error = True  # enter loop
-    while error:
-        error = False
-        for job_spec in trigger_specs:
-            trigger_options = {
-                'dry_run': dry_run,
-                'spec': job_spec,
-                'jenkins_map': jenkins_map,
-                'oc_map': oc_map,
-                'already_triggered': already_triggered,
-                'settings': settings,
-                'state_update_method': saasherder.update_config,
-                'integration': QONTRACT_INTEGRATION,
-                'integration_version': QONTRACT_INTEGRATION_VERSION,
-            }
-            trigger_error = osdt_base.trigger(trigger_options)
-            if trigger_error:
-                error = True
+    error = False
+    for job_spec in trigger_specs:
+        trigger_options = {
+            'dry_run': dry_run,
+            'spec': job_spec,
+            'jenkins_map': jenkins_map,
+            'oc_map': oc_map,
+            'already_triggered': already_triggered,
+            'settings': settings,
+            'state_update_method': saasherder.update_config,
+            'integration': QONTRACT_INTEGRATION,
+            'integration_version': QONTRACT_INTEGRATION_VERSION,
+        }
+        trigger_error = osdt_base.trigger(trigger_options)
+        if trigger_error:
+            error = True
 
-        if error:
-            time.sleep(10)  # add to contants module once created
+    if error:
+        sys.exit(ExitCodes.ERROR)

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -4,6 +4,7 @@ import logging
 import reconcile.openshift_saas_deploy_trigger_base as osdt_base
 import reconcile.queries as queries
 
+from reconcile.status import ExitCodes
 from reconcile.utils.defer import defer
 from reconcile.utils.semver_helper import make_semver
 
@@ -18,7 +19,7 @@ def run(dry_run, thread_pool_size=10, internal=None,
     saas_files = queries.get_saas_files(v1=True, v2=True)
     if not saas_files:
         logging.error('no saas files found')
-        sys.exit(1)
+        sys.exit(ExitCodes.ERROR)
 
     # Remove saas-file targets that are disabled
     for saas_file in saas_files[:]:
@@ -60,4 +61,4 @@ def run(dry_run, thread_pool_size=10, internal=None,
             error = True
 
     if error:
-        sys.exit(1)
+        sys.exit(ExitCodes.ERROR)


### PR DESCRIPTION
now that this integration runs as a pod, we don't need to enter a loop and trigger at any cost. if an error occurs, it may be fixed in the next iteration. this way we will not be blocked on our problematic trigger and will still trigger other jobs.