### PR TITLE
[saasherder] set default value for state promotion to empty dict

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -980,7 +980,7 @@ class SaasHerder():
             if subscribe:
                 for channel in subscribe:
                     state_key = f"promotions/{channel}/{commit_sha}"
-                    value = self.state.get(state_key, None)
+                    value = self.state.get(state_key, {})
                     success = value.get('success')
                     if not success:
                         logging.error(


### PR DESCRIPTION
when adding an automated promotion in a single step (both `publish` and `subscribe`) - there isn't a first success published yet, which causes app-interface pr-check jobs to fail.

this PR is meant to relax that a bit and allow for smoother migrations as part of https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/19968.

since the structure of the data we store in the state is a dict, this PR also makes things more correct.