### PR TITLE
Give trigger(...) named arguments

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -119,11 +119,18 @@ def construct_tekton_trigger_resource(saas_file_name,
               error_details=name), long_name
 
 
-def trigger(options):
+def trigger(dry_run,
+            spec,
+            jenkins_map,
+            oc_map,
+            already_triggered,
+            settings,
+            state_update_method,
+            integration,
+            integration_version):
     """Trigger a deployment according to the specified pipelines provider
 
     Args:
-        options (dict): A dictionary containing:
             dry_run (bool): Is this a dry run
             spec (dict): A trigger spec as created by saasherder
             jenkins_map (dict): Instance names with JenkinsApi instances
@@ -138,16 +145,8 @@ def trigger(options):
     Returns:
         bool: True if there was an error, False otherwise
     """
-    dry_run = options['dry_run']
-    spec = options['spec']
-    jenkins_map = options['jenkins_map']
-    oc_map = options['oc_map']
-    already_triggered = options['already_triggered']
-    settings = options['settings']
-    state_update_method = options['state_update_method']
-    integration = options['integration']
-    integration_version = options['integration_version']
 
+    # TODO: Convert these into a dataclass.
     saas_file_name = spec['saas_file_name']
     env_name = spec['env_name']
     timeout = spec['timeout']

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -39,18 +39,17 @@ def run(dry_run, thread_pool_size=10, internal=None,
 
     error = False
     for job_spec in trigger_specs:
-        trigger_options = {
-            'dry_run': dry_run,
-            'spec': job_spec,
-            'jenkins_map': jenkins_map,
-            'oc_map': oc_map,
-            'already_triggered': already_triggered,
-            'settings': settings,
-            'state_update_method': saasherder.update_config,
-            'integration': QONTRACT_INTEGRATION,
-            'integration_version': QONTRACT_INTEGRATION_VERSION,
-        }
-        trigger_error = osdt_base.trigger(trigger_options)
+        trigger_error = osdt_base.trigger(
+            dry_run=dry_run,
+            spec=job_spec,
+            jenkins_map=jenkins_map,
+            oc_map=oc_map,
+            already_triggered=already_triggered,
+            settings=settings,
+            state_update_method=saasherder.update_config,
+            integration=QONTRACT_INTEGRATION,
+            integration_version=QONTRACT_INTEGRATION_VERSION
+        )
         if trigger_error:
             error = True
 

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -45,18 +45,17 @@ def run(dry_run, thread_pool_size=10, internal=None,
     already_triggered = []
     error = False
     for job_spec in trigger_specs:
-        trigger_options = {
-            'dry_run': dry_run,
-            'spec': job_spec,
-            'jenkins_map': jenkins_map,
-            'oc_map': oc_map,
-            'already_triggered': already_triggered,
-            'settings': settings,
-            'state_update_method': saasherder.update_moving_commit,
-            'integration': QONTRACT_INTEGRATION,
-            'integration_version': QONTRACT_INTEGRATION_VERSION,
-        }
-        trigger_error = osdt_base.trigger(trigger_options)
+        trigger_error = osdt_base.trigger(
+            dry_run=dry_run,
+            spec=job_spec,
+            jenkins_map=jenkins_map,
+            oc_map=oc_map,
+            already_triggered=already_triggered,
+            settings=settings,
+            state_update_method=saasherder.update_moving_commit,
+            integration=QONTRACT_INTEGRATION,
+            integration_version=QONTRACT_INTEGRATION_VERSION,
+        )
         if trigger_error:
             error = True
 


### PR DESCRIPTION
Even this is too lenient - the spec and settings dictionaries can
probably be flattened or converted into something friendly static analyzer.

Using named arguments instead of passing a dictionary and unpacking it
makes the code less surprising, and allows linters to detect typos
instead of having crashes at runtime.

If I screw up during my development, pylint is now able to say things
like:

```
reconcile/openshift_saas_deploy_trigger_configs.py:53:24: E1120: No value for argument 'spec' in function call (no-value-for-parameter)
reconcile/openshift_saas_deploy_trigger_configs.py:53:24: E1120: No value for argument 'jenkins_map' in function call (no-value-for-parameter)
reconcile/openshift_saas_deploy_trigger_configs.py:53:24: E1120: No value for argument 'oc_map' in function call (no-value-for-parameter)
reconcile/openshift_saas_deploy_trigger_configs.py:53:24: E1120: No value for argument 'already_triggered' in function call (no-value-for-parameter)
reconcile/openshift_saas_deploy_trigger_configs.py:53:24: E1120: No value for argument 'settings' in function call (no-value-for-parameter)
reconcile/openshift_saas_deploy_trigger_configs.py:53:24: E1120: No value for argument 'state_update_method' in function call (no-value-for-parameter)
reconcile/openshift_saas_deploy_trigger_configs.py:53:24: E1120: No value for argument 'integration' in function call (no-value-for-parameter)
reconcile/openshift_saas_deploy_trigger_configs.py:53:24: E1120: No value for argument 'integration_version' in function call (no-value-for-parameter)
```
