### PR TITLE
[APPSRE-3325]Introduce code coverage in tox configs

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+branch = True
+omit = reconcile/tests/*
+[report]
+fail_under = 19

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 .tox
 .pytest_cache
 .eggs
-
+.coverage
 build
 dist
 venv

--- a/reconcile/test/test_make.py
+++ b/reconcile/test/test_make.py
@@ -1,5 +1,7 @@
 import subprocess
 
+import pytest
+
 
 def run_make(sub_command):
     cmd = ['make', sub_command]
@@ -17,6 +19,9 @@ def has_uncommited_changes():
 
 class TestMake:
     @staticmethod
+    @pytest.mark.skip(
+        "Broken - uncommitted changes are normal during development"
+        )
     def test_make_generate():
         assert not has_uncommited_changes(), ('No uncommited changes must '
                                               'exists')

--- a/reconcile/test/test_make.py
+++ b/reconcile/test/test_make.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 
 import pytest
@@ -19,9 +20,10 @@ def has_uncommited_changes():
 
 class TestMake:
     @staticmethod
-    @pytest.mark.skip(
-        "Broken - uncommitted changes are normal during development"
-        )
+    @pytest.mark.skipif(
+        not os.environ.get("HUDSON_HOME"),
+        reason="This test is only for CI environments",
+    )
     def test_make_generate():
         assert not has_uncommited_changes(), ('No uncommited changes must '
                                               'exists')

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,23 @@ envlist = py36
 commands =
     flake8 reconcile tools e2e_tests
     pylint -j0 reconcile tools e2e_tests
-    pytest
+    pytest --cov=reconcile
 deps =
-    pytest==3.9.2
+    pytest==6.2.4
+    pytest-cov==2.12.1
     mock==2.0.0
     anymarkup==0.7.0
     flake8==3.5.0
     pylint==2.6.0
+
+[testenv:report]
+deps = coverage
+skip_install = true
+commands =
+    coverage report
+    coverage html
+
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = py36
 commands =
     flake8 reconcile tools e2e_tests
     pylint -j0 reconcile tools e2e_tests
-    pytest --cov=reconcile
+    pytest --cov=reconcile --cov-report=term-missing
 deps =
     pytest==6.2.4
     pytest-cov==2.12.1


### PR DESCRIPTION
To get the tests ball rolling. We seem to be using tox for testing, so
I adapt its configuration to generate reports.

The minimum required coverage is 19%. We currently have 19.07%
coverage.

I also disable the `test_make` file, which doesn't work at all on my
system, even without any local changes to my git repository.
