### PR TITLE
[openshift-saas-deploy-triggers] threaded run + refactor

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -119,8 +119,8 @@ def construct_tekton_trigger_resource(saas_file_name,
               error_details=name), long_name
 
 
-def trigger(dry_run,
-            spec,
+def trigger(spec,
+            dry_run,
             jenkins_map,
             oc_map,
             already_triggered,
@@ -131,8 +131,8 @@ def trigger(dry_run,
     """Trigger a deployment according to the specified pipelines provider
 
     Args:
-            dry_run (bool): Is this a dry run
             spec (dict): A trigger spec as created by saasherder
+            dry_run (bool): Is this a dry run
             jenkins_map (dict): Instance names with JenkinsApi instances
             oc_map (OC_Map): a dictionary of OC clients per cluster
             already_triggered (list): A list of already triggered deployments.

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -46,11 +46,13 @@ def setup(saas_files,
     pipelines_providers = queries.get_pipelines_providers()
     tkn_provider_namespaces = [pp['namespace'] for pp in pipelines_providers
                                if pp['provider'] == 'tekton']
-    oc_map = OC_Map(namespaces=tkn_provider_namespaces,
-                    integration=integration,
-                    settings=settings, internal=internal,
-                    use_jump_host=use_jump_host,
-                    thread_pool_size=thread_pool_size)
+
+    oc_map = OC_Map(
+        namespaces=tkn_provider_namespaces,
+        integration=integration,
+        settings=settings, internal=internal,
+        use_jump_host=use_jump_host,
+        thread_pool_size=thread_pool_size)
 
     saasherder = SaasHerder(
         saas_files,

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -15,6 +15,7 @@ from reconcile.utils.saasherder import SaasHerder
 
 _trigger_lock = Lock()
 
+
 def setup(saas_files,
           thread_pool_size,
           internal,
@@ -94,6 +95,7 @@ def trigger(spec,
     """
 
     # TODO: Convert these into a dataclass.
+    saas_file_name = spec['saas_file_name']
     provider_name = spec['pipelines_provider']['provider']
 
     error = False
@@ -209,6 +211,7 @@ def _trigger_tekton(spec,
             )
 
     return error
+
 
 def _construct_tekton_trigger_resource(saas_file_name,
                                        env_name,

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -138,7 +138,7 @@ def trigger(spec,
             dry_run (bool): Is this a dry run
             jenkins_map (dict): Instance names with JenkinsApi instances
             oc_map (OC_Map): a dictionary of OC clients per cluster
-            already_triggered (list): A list of already triggered deployments.
+            already_triggered (set): A set of already triggered deployments.
                                       It will get populated by this function.
             settings (dict): App-interface settings
             state_update_method (function): A method to call to update state
@@ -167,7 +167,7 @@ def trigger(spec,
             if job_name not in already_triggered:
                 logging.info(['trigger_job', instance_name, job_name])
                 if dry_run:
-                    already_triggered.append(job_name)
+                    already_triggered.add(job_name)
 
         if not dry_run:
             jenkins = jenkins_map[instance_name]
@@ -175,7 +175,7 @@ def trigger(spec,
                 with _trigger_lock:
                     if job_name not in already_triggered:
                         jenkins.trigger_job(job_name)
-                        already_triggered.append(job_name)
+                        already_triggered.add(job_name)
                     state_update_method(spec)
             except Exception as e:
                 error = True
@@ -205,7 +205,7 @@ def trigger(spec,
                             resource_type=tkn_trigger_resource.kind,
                             resource=tkn_trigger_resource,
                             wait_for_namespace=False)
-                    already_triggered.append(tkn_name)
+                    already_triggered.add(tkn_name)
                 if not dry_run:
                     state_update_method(spec)
         except Exception as e:

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -15,17 +15,21 @@ from reconcile.utils.saasherder import SaasHerder
 
 _trigger_lock = Lock()
 
-def setup(options):
+def setup(saas_files,
+          thread_pool_size,
+          internal,
+          use_jump_host,
+          integration,
+          integration_version):
     """Setup required resources for triggering integrations
 
     Args:
-        options (dict): A dictionary containing:
-            saas_files (list): SaaS files graphql query results
-            thread_pool_size (int): Thread pool size to use
-            internal (bool): Should run for internal/extrenal/all clusters
-            use_jump_host (bool): Should use jump host to reach clusters
-            integration (string): Name of calling integration
-            integration_version (string): Version of calling integration
+        saas_files (list): SaaS files graphql query results
+        thread_pool_size (int): Thread pool size to use
+        internal (bool): Should run for internal/extrenal/all clusters
+        use_jump_host (bool): Should use jump host to reach clusters
+        integration (string): Name of calling integration
+        integration_version (string): Version of calling integration
 
     Returns:
         saasherder (SaasHerder): a SaasHerder instance
@@ -33,12 +37,6 @@ def setup(options):
         oc_map (OC_Map): a dictionary of OC clients per cluster
         settings (dict): App-interface settings
     """
-    saas_files = options['saas_files']
-    thread_pool_size = options['thread_pool_size']
-    internal = options['internal']
-    use_jump_host = options['use_jump_host']
-    integration = options['integration']
-    integration_version = options['integration_version']
 
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -11,7 +11,7 @@ from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.jenkins_job_builder import get_openshift_saas_deploy_job_name
 from reconcile.utils.oc import OC_Map
 from reconcile.utils.gitlab_api import GitLabApi
-from reconcile.utils.saasherder import SaasHerder
+from reconcile.utils.saasherder import SaasHerder, Providers
 
 _trigger_lock = Lock()
 
@@ -99,7 +99,7 @@ def trigger(spec,
     provider_name = spec['pipelines_provider']['provider']
 
     error = False
-    if provider_name == 'jenkins':
+    if provider_name == Providers.JENKINS:
         error = _trigger_jenkins(
             spec,
             dry_run,
@@ -108,7 +108,7 @@ def trigger(spec,
             settings,
             state_update_method)
 
-    elif provider_name == 'tekton':
+    elif provider_name == Providers.TEKTON:
         error = _trigger_tekton(
             spec,
             dry_run,

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -133,20 +133,6 @@ def _trigger_jenkins(spec,
                      already_triggered,
                      settings,
                      state_update_method):
-    """Trigger a deployment via Jenkins job
-
-    Args:
-        spec (dict): A trigger spec as created by saasherder
-        dry_run (bool): Is this a dry run
-        jenkins_map (dict): Instance names with JenkinsApi instances
-        already_triggered (set): A set of already triggered deployments.
-                                    It will get populated by this function.
-        settings (dict): App-interface settings
-        state_update_method (function): A method to call to update state
-
-    Returns:
-        bool: True if there was an error, False otherwise
-    """
     # TODO: Convert these into a dataclass.
     saas_file_name = spec['saas_file_name']
     env_name = spec['env_name']
@@ -183,23 +169,6 @@ def _trigger_tekton(spec,
                     state_update_method,
                     integration,
                     integration_version):
-    """Trigger a deployment according to the specified pipelines provider
-
-    Args:
-        spec (dict): A trigger spec as created by saasherder
-        dry_run (bool): Is this a dry run
-        oc_map (OC_Map): a dictionary of OC clients per cluster
-        already_triggered (set): A set of already triggered deployments.
-                                 It will get populated by this function.
-        settings (dict): App-interface settings
-        state_update_method (function): A method to call to update state
-        integration (string): Name of calling integration
-        integration_version (string): Version of calling integration
-
-    Returns:
-        bool: True if there was an error, False otherwise
-    """
-
     # TODO: Convert these into a dataclass.
     saas_file_name = spec['saas_file_name']
     env_name = spec['env_name']

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -38,7 +38,7 @@ def run(dry_run, thread_pool_size=10, internal=None,
     trigger_specs = saasherder.get_configs_diff()
     # This will be populated by osdt_base.trigger in the below loop and
     # we need it to be consistent across all iterations
-    already_triggered = []
+    already_triggered = set()
 
     trigger_errors = \
         threaded.run(

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -40,7 +40,7 @@ def run(dry_run, thread_pool_size=10, internal=None,
     # we need it to be consistent across all iterations
     already_triggered = set()
 
-    trigger_errors = \
+    errors = \
         threaded.run(
             osdt_base.trigger,
             trigger_specs,
@@ -54,7 +54,6 @@ def run(dry_run, thread_pool_size=10, internal=None,
             integration=QONTRACT_INTEGRATION,
             integration_version=QONTRACT_INTEGRATION_VERSION
         )
-    error = True in trigger_errors
 
-    if error:
+    if any(errors):
         sys.exit(ExitCodes.ERROR)

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -42,8 +42,8 @@ def run(dry_run, thread_pool_size=10, internal=None,
     error = False
     for job_spec in trigger_specs:
         trigger_error = osdt_base.trigger(
-            dry_run=dry_run,
             spec=job_spec,
+            dry_run=dry_run,
             jenkins_map=jenkins_map,
             oc_map=oc_map,
             already_triggered=already_triggered,

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -1,8 +1,9 @@
-import logging
 import sys
+import logging
 
 import reconcile.queries as queries
 import reconcile.openshift_saas_deploy_trigger_base as osdt_base
+import reconcile.utils.threaded as threaded
 
 from reconcile.status import ExitCodes
 from reconcile.utils.defer import defer
@@ -39,10 +40,11 @@ def run(dry_run, thread_pool_size=10, internal=None,
     # we need it to be consistent across all iterations
     already_triggered = []
 
-    error = False
-    for job_spec in trigger_specs:
-        trigger_error = osdt_base.trigger(
-            spec=job_spec,
+    trigger_errors = \
+        threaded.run(
+            osdt_base.trigger,
+            trigger_specs,
+            thread_pool_size,
             dry_run=dry_run,
             jenkins_map=jenkins_map,
             oc_map=oc_map,
@@ -52,8 +54,7 @@ def run(dry_run, thread_pool_size=10, internal=None,
             integration=QONTRACT_INTEGRATION,
             integration_version=QONTRACT_INTEGRATION_VERSION
         )
-        if trigger_error:
-            error = True
+    error = True in trigger_errors
 
     if error:
         sys.exit(ExitCodes.ERROR)

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -24,15 +24,15 @@ def run(dry_run, thread_pool_size=10, internal=None,
         sys.exit(ExitCodes.ERROR)
     saas_files = [sf for sf in saas_files if is_in_shard(sf['name'])]
 
-    setup_options = {
-        'saas_files': saas_files,
-        'thread_pool_size': thread_pool_size,
-        'internal': internal,
-        'use_jump_host': use_jump_host,
-        'integration': QONTRACT_INTEGRATION,
-        'integration_version': QONTRACT_INTEGRATION_VERSION,
-    }
-    saasherder, jenkins_map, oc_map, settings = osdt_base.setup(setup_options)
+    saasherder, jenkins_map, oc_map, settings = \
+        osdt_base.setup(
+            saas_files=saas_files,
+            thread_pool_size=thread_pool_size,
+            internal=internal,
+            use_jump_host=use_jump_host,
+            integration=QONTRACT_INTEGRATION,
+            integration_version=QONTRACT_INTEGRATION_VERSION
+        )
     defer(lambda: oc_map.cleanup())
 
     trigger_specs = saasherder.get_configs_diff()

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -49,7 +49,7 @@ def run(dry_run, thread_pool_size=10, internal=None,
     # we need it to be consistent across all iterations
     already_triggered = set()
 
-    trigger_errors = \
+    errors = \
         threaded.run(
             osdt_base.trigger,
             trigger_specs,
@@ -63,7 +63,6 @@ def run(dry_run, thread_pool_size=10, internal=None,
             integration=QONTRACT_INTEGRATION,
             integration_version=QONTRACT_INTEGRATION_VERSION
         )
-    error = True in trigger_errors
 
-    if error:
+    if any(errors):
         sys.exit(ExitCodes.ERROR)

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -48,8 +48,8 @@ def run(dry_run, thread_pool_size=10, internal=None,
     error = False
     for job_spec in trigger_specs:
         trigger_error = osdt_base.trigger(
-            dry_run=dry_run,
             spec=job_spec,
+            dry_run=dry_run,
             jenkins_map=jenkins_map,
             oc_map=oc_map,
             already_triggered=already_triggered,

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -33,15 +33,15 @@ def run(dry_run, thread_pool_size=10, internal=None,
                 if target['disable']:
                     targets.remove(target)
 
-    setup_options = {
-        'saas_files': saas_files,
-        'thread_pool_size': thread_pool_size,
-        'internal': internal,
-        'use_jump_host': use_jump_host,
-        'integration': QONTRACT_INTEGRATION,
-        'integration_version': QONTRACT_INTEGRATION_VERSION,
-    }
-    saasherder, jenkins_map, oc_map, settings = osdt_base.setup(setup_options)
+    saasherder, jenkins_map, oc_map, settings = \
+        osdt_base.setup(
+            saas_files=saas_files,
+            thread_pool_size=thread_pool_size,
+            internal=internal,
+            use_jump_host=use_jump_host,
+            integration=QONTRACT_INTEGRATION,
+            integration_version=QONTRACT_INTEGRATION_VERSION
+        )
     defer(lambda: oc_map.cleanup())
 
     trigger_specs = saasherder.get_moving_commits_diff(dry_run)

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -45,7 +45,9 @@ def run(dry_run, thread_pool_size=10, internal=None,
     defer(lambda: oc_map.cleanup())
 
     trigger_specs = saasherder.get_moving_commits_diff(dry_run)
-    already_triggered = []
+    # This will be populated by osdt_base.trigger in the below loop and
+    # we need it to be consistent across all iterations
+    already_triggered = set()
 
     trigger_errors = \
         threaded.run(

--- a/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
+++ b/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
@@ -46,7 +46,7 @@ def run(dry_run, thread_pool_size=10, internal=None,
     # we need it to be consistent across all iterations
     already_triggered = set()
 
-    trigger_errors = \
+    errors = \
         threaded.run(
             osdt_base.trigger,
             trigger_specs,
@@ -60,7 +60,6 @@ def run(dry_run, thread_pool_size=10, internal=None,
             integration=QONTRACT_INTEGRATION,
             integration_version=QONTRACT_INTEGRATION_VERSION
         )
-    error = True in trigger_errors
 
-    if error:
+    if any(errors):
         sys.exit(ExitCodes.ERROR)

--- a/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
+++ b/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
@@ -1,8 +1,9 @@
 import sys
 import logging
 
-import reconcile.openshift_saas_deploy_trigger_base as osdt_base
 import reconcile.queries as queries
+import reconcile.openshift_saas_deploy_trigger_base as osdt_base
+import reconcile.utils.threaded as threaded
 
 from reconcile.status import ExitCodes
 from reconcile.utils.defer import defer
@@ -42,10 +43,12 @@ def run(dry_run, thread_pool_size=10, internal=None,
     current_state = fetch_current_state(jenkins_map)
     trigger_specs = saasherder.get_upstream_jobs_diff(dry_run, current_state)
     already_triggered = []
-    error = False
-    for job_spec in trigger_specs:
-        trigger_error = osdt_base.trigger(
-            spec=job_spec,
+
+    trigger_errors = \
+        threaded.run(
+            osdt_base.trigger,
+            trigger_specs,
+            thread_pool_size,
             dry_run=dry_run,
             jenkins_map=jenkins_map,
             oc_map=oc_map,
@@ -55,8 +58,7 @@ def run(dry_run, thread_pool_size=10, internal=None,
             integration=QONTRACT_INTEGRATION,
             integration_version=QONTRACT_INTEGRATION_VERSION
         )
-        if trigger_error:
-            error = True
+    error = True in trigger_errors
 
     if error:
         sys.exit(ExitCodes.ERROR)

--- a/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
+++ b/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
@@ -42,7 +42,9 @@ def run(dry_run, thread_pool_size=10, internal=None,
 
     current_state = fetch_current_state(jenkins_map)
     trigger_specs = saasherder.get_upstream_jobs_diff(dry_run, current_state)
-    already_triggered = []
+    # This will be populated by osdt_base.trigger in the below loop and
+    # we need it to be consistent across all iterations
+    already_triggered = set()
 
     trigger_errors = \
         threaded.run(

--- a/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
+++ b/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
@@ -45,8 +45,8 @@ def run(dry_run, thread_pool_size=10, internal=None,
     error = False
     for job_spec in trigger_specs:
         trigger_error = osdt_base.trigger(
-            dry_run=dry_run,
             spec=job_spec,
+            dry_run=dry_run,
             jenkins_map=jenkins_map,
             oc_map=oc_map,
             already_triggered=already_triggered,

--- a/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
+++ b/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
@@ -29,15 +29,15 @@ def run(dry_run, thread_pool_size=10, internal=None,
         sys.exit(ExitCodes.ERROR)
     saas_files = [sf for sf in saas_files if is_in_shard(sf['name'])]
 
-    setup_options = {
-        'saas_files': saas_files,
-        'thread_pool_size': thread_pool_size,
-        'internal': internal,
-        'use_jump_host': use_jump_host,
-        'integration': QONTRACT_INTEGRATION,
-        'integration_version': QONTRACT_INTEGRATION_VERSION,
-    }
-    saasherder, jenkins_map, oc_map, settings = osdt_base.setup(setup_options)
+    saasherder, jenkins_map, oc_map, settings = \
+        osdt_base.setup(
+            saas_files=saas_files,
+            thread_pool_size=thread_pool_size,
+            internal=internal,
+            use_jump_host=use_jump_host,
+            integration=QONTRACT_INTEGRATION,
+            integration_version=QONTRACT_INTEGRATION_VERSION
+        )
     defer(lambda: oc_map.cleanup())
 
     current_state = fetch_current_state(jenkins_map)

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -582,8 +582,7 @@ class SaasHerder():
                               image_patterns=image_patterns,
                               image_auth=image_auth,
                               error_prefix=error_prefix)
-        error = True in errors
-        return error
+        return any(errors)
 
     def _initiate_github(self, saas_file):
         auth = saas_file.get('authentication') or {}

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -20,6 +20,11 @@ from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.state import State
 
 
+class Providers:
+    JENKINS = 'jenkins'
+    TEKTON = 'tekton'
+
+
 class SaasHerder():
     """Wrapper around SaaS deployment actions."""
 
@@ -1013,7 +1018,7 @@ class SaasHerder():
             # wrapping the instance in a pipelines provider structure
             # for backwards compatibility
             pipelines_provider = {
-                'provider': 'jenkins',
+                'provider': Providers.JENKINS,
                 'instance': saas_file['instance'],
             }
         if saas_file_api_version == 'v2':


### PR DESCRIPTION
this PR started out as adding usage of multi threading.
from there, it was difficult not to refactor the trigger function to lock for as little time as possible.
from there, it was difficult not to make the different trigger provider sections look as similar as possible.
from there, it was difficult not to change `already_triggered` to a set (also was a debt to @Piojo).
from there, it was difficult not to extract them to functions (also was a debt to @rporres).
from there, it was difficult not to update `setup` from options to **options (also was a debt to @Piojo).
from there, it was difficult not to drop one line in the `oc_map` initiation (also was a debt to my OCD).

note to the wise reviewers: commit by commit.
note to future selves: this is likely not a complete refactor (thoughts of more OOP come to mind), but it makes things much simpler to understand and discuss.
