### PR TITLE
[gitlab-housekeeping] do not rebase saas-file-update MRs

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -13,7 +13,7 @@ from reconcile.utils.gitlab_api import GitLabApi
 LGTM_LABEL = 'lgtm'
 MERGE_LABELS_PRIORITY = ['bot/approved', LGTM_LABEL, 'bot/automerge']
 SAAS_FILE_LABEL = 'saas-file-update'
-REBASE_LABELS_PRIORITY = MERGE_LABELS_PRIORITY + [SAAS_FILE_LABEL]
+REBASE_LABELS_PRIORITY = MERGE_LABELS_PRIORITY
 HOLD_LABELS = ['awaiting-approval', 'blocked/bot-access', 'hold', 'bot/hold',
                'do-not-merge/hold', 'do-not-merge/pending-review']
 


### PR DESCRIPTION
we currently rebase MRs with a `saas-file-update` label to achieve a faster merge when someone `/lgtm`s.
this is not proving itself and is causing a (sometimes) painful review experience (a MR waiting for a few days becomes a problem).

this will also reduce pressure from ci-int, leading to these very same MRs to become faster indirectly.