### PR TITLE
[openshift-saas-deploy] register error on invalid promotions

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -129,6 +129,7 @@ def run(dry_run, thread_pool_size=10, io_dir='throughput/',
     # based on promotion information in targets
     if not saasherder.validate_promotions():
         logging.error('invalid promotions')
+        ri.register_error()
         sys.exit(ExitCodes.ERROR)
 
     # if saas_file_name is defined, the integration


### PR DESCRIPTION
since we use `ri` to check for errors and decide the result based on that - let's register an error when we encounter an invalid promotion.

part of https://issues.redhat.com/browse/APPSRE-3187