### PR TITLE
register error on ResourceKeyExistsError

### DIFF
--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -10,6 +10,9 @@ import semver
 
 
 class ResourceKeyExistsError(Exception):
+    """ Exception to indicate an attempt to add a desired resource
+    with the same name and the same type as was already added previously
+    """
     pass
 
 
@@ -452,6 +455,7 @@ class ResourceInventory:
             except KeyError:
                 return None
             if name in desired:
+                self.register_error()
                 raise ResourceKeyExistsError(name)
             desired[name] = value
 

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -13,7 +13,6 @@ class ResourceKeyExistsError(Exception):
     """ Exception to indicate an attempt to add a desired resource
     with the same name and the same type as was already added previously
     """
-    pass
 
 
 class ConstructResourceError(Exception):


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3331

as some consumers of the ResourceInventory class rely on it's error registering, we need to start registering more.
in [today's example](https://console-openshift-console.apps.appsrep05ue1.zqxk.p1.openshiftapps.com/k8s/ns/app-sre-pipelines/tekton.dev~v1beta1~PipelineRun/saas-grafana-app-sre-stage-202106070212/logs/openshift-saas-deploy), a deployment reported success while it actually failed due to this exception being raised.