### PR TITLE
[ocm-clusters] allow field to be replaced

### DIFF
--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -42,7 +42,7 @@ def get_cluster_update_spec(cluster_name, current_spec, desired_spec):
     current_spec_spec = current_spec['spec']
     desired_spec_spec = desired_spec['spec']
     updated = {k: desired_spec_spec[k] for k in desired_spec_spec
-               if current_spec_spec[k] != desired_spec_spec[k]}
+               if current_spec_spec.get(k) != desired_spec_spec[k]}
 
     # we only need deleted to check if a field removal is valid
     # we really want to check updated + deleted, and since


### PR DESCRIPTION
to update a cluster to have autoscaling (for example), we remove the `nodes` section and add an `autoscaling` section. with this PR, this change will not lead to a KeyError.

example: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/20298