### PR TITLE
Revert "register error on ResourceKeyExistsError (#1610)"

### DIFF
--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -10,9 +10,7 @@ import semver
 
 
 class ResourceKeyExistsError(Exception):
-    """ Exception to indicate an attempt to add a desired resource
-    with the same name and the same type as was already added previously
-    """
+    pass
 
 
 class ConstructResourceError(Exception):
@@ -454,7 +452,6 @@ class ResourceInventory:
             except KeyError:
                 return None
             if name in desired:
-                self.register_error()
                 raise ResourceKeyExistsError(name)
             desired[name] = value
 


### PR DESCRIPTION
This reverts commit d9c7d2ab8e9f9ad21d27e72c1e6af2356e9aec17.

This is making openshift-rolebindings and openshift-clusterrolebindings silently fail