### PR TITLE
[openshift-saas-deploy-trigger-cleaner] introduce new integration

### DIFF
--- a/helm/qontract-reconcile/values-internal.yaml
+++ b/helm/qontract-reconcile/values-internal.yaml
@@ -130,6 +130,15 @@ integrations:
     slack: true
   state: true
   shards: 3
+- name: openshift-saas-deploy-trigger-cleaner
+  resources:
+    requests:
+      memory: 800Mi
+      cpu: 400m
+    limits:
+      memory: 1000Mi
+      cpu: 600m
+  extraArgs: --no-use-jump-host
 - name: terraform-resources
   resources:
     requests:

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -3569,6 +3569,189 @@ objects:
   kind: Deployment
   metadata:
     labels:
+      app: qontract-reconcile-openshift-saas-deploy-trigger-cleaner
+    name: qontract-reconcile-openshift-saas-deploy-trigger-cleaner
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile-openshift-saas-deploy-trigger-cleaner
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile-openshift-saas-deploy-trigger-cleaner
+          component: qontract-reconcile
+      spec:
+        serviceAccountName: qontract-reconcile
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /HTTP Error 409: Conflict/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name openshift-saas-deploy-trigger-cleaner
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          ports:
+            - name: http
+              containerPort: 9090
+          env:
+          - name: SHARDS
+            value: "1"
+          - name: SHARD_ID
+            value: "0"
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: openshift-saas-deploy-trigger-cleaner
+          - name: INTEGRATION_EXTRA_ARGS
+            value: "--no-use-jump-host"
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: GITHUB_API
+          - name: SENTRY_DSN
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
+          - name: UNLEASH_API_URL
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: API_URL
+          - name: UNLEASH_CLIENT_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: CLIENT_ACCESS_TOKEN
+          - name: SLOW_OC_RECONCILE_THRESHOLD
+            value: "${SLOW_OC_RECONCILE_THRESHOLD}"
+          - name: LOG_SLOW_OC_RECONCILE
+            value: "${LOG_SLOW_OC_RECONCILE}"
+          resources:
+            limits:
+              cpu: 600m
+              memory: 1000Mi
+            requests:
+              cpu: 400m
+              memory: 800Mi
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
       app: qontract-reconcile-terraform-resources
     name: qontract-reconcile-terraform-resources
   spec:

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -32,6 +32,7 @@ import reconcile.openshift_saas_deploy_wrapper
 import reconcile.openshift_saas_deploy_trigger_moving_commits
 import reconcile.openshift_saas_deploy_trigger_upstream_jobs
 import reconcile.openshift_saas_deploy_trigger_configs
+import reconcile.openshift_saas_deploy_trigger_cleaner
 import reconcile.saas_file_owners
 import reconcile.gitlab_ci_skipper
 import reconcile.gitlab_labeler
@@ -831,6 +832,20 @@ def openshift_saas_deploy_trigger_configs(ctx, thread_pool_size,
                                           internal, use_jump_host):
     run_integration(
         reconcile.openshift_saas_deploy_trigger_configs,
+        ctx.obj, thread_pool_size, internal, use_jump_host)
+
+
+@integration.command()
+@threaded()
+@binary(['oc', 'ssh'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
+@internal()
+@use_jump_host()
+@click.pass_context
+def openshift_saas_deploy_trigger_cleaner(ctx, thread_pool_size,
+                                          internal, use_jump_host):
+    run_integration(
+        reconcile.openshift_saas_deploy_trigger_cleaner,
         ctx.obj, thread_pool_size, internal, use_jump_host)
 
 

--- a/reconcile/openshift_saas_deploy_trigger_cleaner.py
+++ b/reconcile/openshift_saas_deploy_trigger_cleaner.py
@@ -1,0 +1,71 @@
+import logging
+
+from datetime import datetime, timedelta
+from dateutil import parser
+
+import reconcile.queries as queries
+
+from reconcile.utils.oc import OC_Map
+from reconcile.utils.defer import defer
+from reconcile.utils.semver_helper import make_semver
+from reconcile.utils.saasherder import Providers
+
+
+QONTRACT_INTEGRATION = 'openshift-saas-deploy-trigger-cleaner'
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
+
+
+def within_retention_days(resource, days):
+    metadata = resource['metadata']
+    creation_date = parser.parse(metadata['creationTimestamp'])
+    interval = datetime.utcnow().date() - creation_date.date()
+
+    return interval < timedelta(days=days)
+
+
+@defer
+def run(dry_run, thread_pool_size=10, internal=None,
+        use_jump_host=True, defer=None):
+    settings = queries.get_app_interface_settings()
+    pipelines_providers = queries.get_pipelines_providers()
+    tkn_namespaces = [pp['namespace'] for pp in pipelines_providers
+                      if pp['provider'] == Providers.TEKTON]
+
+    oc_map = OC_Map(
+        namespaces=tkn_namespaces,
+        integration=QONTRACT_INTEGRATION,
+        settings=settings, internal=internal,
+        use_jump_host=use_jump_host,
+        thread_pool_size=thread_pool_size)
+    defer(lambda: oc_map.cleanup())
+
+    for pp in pipelines_providers:
+        retention = pp.get('retention')
+        if not retention:
+            continue
+
+        if pp['provider'] == Providers.TEKTON:
+            ns_info = pp['namespace']
+            namespace = ns_info['name']
+            cluster = ns_info['cluster']['name']
+            oc = oc_map.get(cluster)
+            pipeline_runs = sorted(
+                oc.get(namespace, 'PipelineRun')['items'],
+                key=lambda k: k['metadata']['creationTimestamp']
+            )
+
+            retention_min = retention.get('min')
+            if retention_min:
+                pipeline_runs = pipeline_runs[retention_min:]
+
+            retention_days = retention.get('days')
+            for pr in pipeline_runs:
+                name = pr['metadata']['name']
+                if retention_days and \
+                        within_retention_days(pr, retention_days):
+                    continue
+
+                logging.info(['delete_trigger',
+                              cluster, namespace, 'PipelineRun', name])
+                if not dry_run:
+                    oc.delete(cluster, namespace, 'PipelineRun', name)

--- a/reconcile/openshift_saas_deploy_trigger_cleaner.py
+++ b/reconcile/openshift_saas_deploy_trigger_cleaner.py
@@ -68,4 +68,4 @@ def run(dry_run, thread_pool_size=10, internal=None,
                 logging.info(['delete_trigger',
                               cluster, namespace, 'PipelineRun', name])
                 if not dry_run:
-                    oc.delete(cluster, namespace, 'PipelineRun', name)
+                    oc.delete(namespace, 'PipelineRun', name)

--- a/reconcile/openshift_saas_deploy_trigger_cleaner.py
+++ b/reconcile/openshift_saas_deploy_trigger_cleaner.py
@@ -54,7 +54,7 @@ def run(dry_run, thread_pool_size=10, internal=None,
                 key=lambda k: k['metadata']['creationTimestamp']
             )
 
-            retention_min = retention.get('min')
+            retention_min = retention.get('minimum')
             if retention_min:
                 pipeline_runs = pipeline_runs[retention_min:]
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1532,6 +1532,10 @@ PIPELINES_PROVIDERS_QUERY = """
   pipelines_providers: pipelines_providers_v1 {
     name
     provider
+    retention {
+      days
+      min
+    }
     ...on PipelinesProviderTekton_v1 {
       namespace {
         name

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1534,7 +1534,7 @@ PIPELINES_PROVIDERS_QUERY = """
     provider
     retention {
       days
-      min
+      minimum
     }
     ...on PipelinesProviderTekton_v1 {
       namespace {


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3340

this PR introduces a new integration called `openshift-saas-deploy-trigger-cleaner`.
this integration goes over all pipelines providers, and for each one of type `tekton` it performs a cleanup according to an optinal `retention` section.

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/20431