### PR TITLE
[openshift-saas-deploy-triggers] split to separate slack channel

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -75,8 +75,13 @@ objects:
               secretKeyRef:
                 key: slack.webhook_url
                 name: app-interface
+          {{- if $integration.trigger }}
+          - name: SLACK_CHANNEL
+            value: ${SLACK_CHANNEL_TRIGGER}
+          {{- else }}
           - name: SLACK_CHANNEL
             value: ${SLACK_CHANNEL}
+          {{- end }}
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           {{- end }}
@@ -388,6 +393,8 @@ parameters:
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL
   value: "sd-app-sre-reconcile-stage"
+- name: SLACK_CHANNEL_TRIGGER
+  value: "sd-app-sre-triggers-stage"
 - name: SLACK_ICON_EMOJI
   value: ":bust_in_silhouette:"
 - name: GITHUB_API

--- a/helm/qontract-reconcile/values-internal.yaml
+++ b/helm/qontract-reconcile/values-internal.yaml
@@ -104,6 +104,7 @@ integrations:
     slack: true
   state: true
   shards: 3
+  trigger: true
 - name: openshift-saas-deploy-trigger-moving-commits
   resources:
     requests:
@@ -117,6 +118,7 @@ integrations:
     slack: true
   state: true
   shards: 5
+  trigger: true
 - name: openshift-saas-deploy-trigger-upstream-jobs
   resources:
     requests:
@@ -130,6 +132,7 @@ integrations:
     slack: true
   state: true
   shards: 3
+  trigger: true
 - name: openshift-saas-deploy-trigger-cleaner
   resources:
     requests:
@@ -139,6 +142,9 @@ integrations:
       memory: 1000Mi
       cpu: 600m
   extraArgs: --no-use-jump-host
+  logs:
+    slack: true
+  trigger: true
 - name: terraform-resources
   resources:
     requests:

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -1729,7 +1729,7 @@ objects:
                 key: slack.webhook_url
                 name: app-interface
           - name: SLACK_CHANNEL
-            value: ${SLACK_CHANNEL}
+            value: ${SLACK_CHANNEL_TRIGGER}
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           - name: LOG_GROUP_NAME
@@ -1937,7 +1937,7 @@ objects:
                 key: slack.webhook_url
                 name: app-interface
           - name: SLACK_CHANNEL
-            value: ${SLACK_CHANNEL}
+            value: ${SLACK_CHANNEL_TRIGGER}
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           - name: LOG_GROUP_NAME
@@ -2145,7 +2145,7 @@ objects:
                 key: slack.webhook_url
                 name: app-interface
           - name: SLACK_CHANNEL
-            value: ${SLACK_CHANNEL}
+            value: ${SLACK_CHANNEL_TRIGGER}
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           - name: LOG_GROUP_NAME
@@ -2353,7 +2353,7 @@ objects:
                 key: slack.webhook_url
                 name: app-interface
           - name: SLACK_CHANNEL
-            value: ${SLACK_CHANNEL}
+            value: ${SLACK_CHANNEL_TRIGGER}
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           - name: LOG_GROUP_NAME
@@ -2561,7 +2561,7 @@ objects:
                 key: slack.webhook_url
                 name: app-interface
           - name: SLACK_CHANNEL
-            value: ${SLACK_CHANNEL}
+            value: ${SLACK_CHANNEL_TRIGGER}
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           - name: LOG_GROUP_NAME
@@ -2769,7 +2769,7 @@ objects:
                 key: slack.webhook_url
                 name: app-interface
           - name: SLACK_CHANNEL
-            value: ${SLACK_CHANNEL}
+            value: ${SLACK_CHANNEL_TRIGGER}
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           - name: LOG_GROUP_NAME
@@ -2977,7 +2977,7 @@ objects:
                 key: slack.webhook_url
                 name: app-interface
           - name: SLACK_CHANNEL
-            value: ${SLACK_CHANNEL}
+            value: ${SLACK_CHANNEL_TRIGGER}
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           - name: LOG_GROUP_NAME
@@ -3185,7 +3185,7 @@ objects:
                 key: slack.webhook_url
                 name: app-interface
           - name: SLACK_CHANNEL
-            value: ${SLACK_CHANNEL}
+            value: ${SLACK_CHANNEL_TRIGGER}
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           - name: LOG_GROUP_NAME
@@ -3393,7 +3393,7 @@ objects:
                 key: slack.webhook_url
                 name: app-interface
           - name: SLACK_CHANNEL
-            value: ${SLACK_CHANNEL}
+            value: ${SLACK_CHANNEL_TRIGGER}
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           - name: LOG_GROUP_NAME
@@ -3601,7 +3601,7 @@ objects:
                 key: slack.webhook_url
                 name: app-interface
           - name: SLACK_CHANNEL
-            value: ${SLACK_CHANNEL}
+            value: ${SLACK_CHANNEL_TRIGGER}
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           - name: LOG_GROUP_NAME
@@ -3809,7 +3809,7 @@ objects:
                 key: slack.webhook_url
                 name: app-interface
           - name: SLACK_CHANNEL
-            value: ${SLACK_CHANNEL}
+            value: ${SLACK_CHANNEL_TRIGGER}
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           - name: LOG_GROUP_NAME
@@ -4011,6 +4011,15 @@ objects:
               memory: 20Mi
               cpu: 25m
           env:
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                key: slack.webhook_url
+                name: app-interface
+          - name: SLACK_CHANNEL
+            value: ${SLACK_CHANNEL_TRIGGER}
+          - name: SLACK_ICON_EMOJI
+            value: ${SLACK_ICON_EMOJI}
           - name: LOG_GROUP_NAME
             valueFrom:
               secretKeyRef:
@@ -4057,6 +4066,15 @@ objects:
 
             <match integration>
               @type copy
+              <store>
+                @type slack
+                webhook_url ${SLACK_WEBHOOK_URL}
+                channel ${SLACK_CHANNEL}
+                icon_emoji ${SLACK_ICON_EMOJI}
+                username sd-app-sre-bot
+                flush_interval 10s
+                message "\`\`\`[openshift-saas-deploy-trigger-cleaner] %s\`\`\`"
+              </store>
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
@@ -6807,6 +6825,8 @@ parameters:
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL
   value: "sd-app-sre-reconcile-stage"
+- name: SLACK_CHANNEL_TRIGGER
+  value: "sd-app-sre-triggers-stage"
 - name: SLACK_ICON_EMOJI
   value: ":bust_in_silhouette:"
 - name: GITHUB_API

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -17260,6 +17260,8 @@ parameters:
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL
   value: "sd-app-sre-reconcile-stage"
+- name: SLACK_CHANNEL_TRIGGER
+  value: "sd-app-sre-triggers-stage"
 - name: SLACK_ICON_EMOJI
   value: ":bust_in_silhouette:"
 - name: GITHUB_API


### PR DESCRIPTION
the reconcile channel is too busy to be usable with the amount of deployments we are triggering.

this PR will allow to split the slack output of trigger integrations to their own slack channel.