### PR TITLE
[openshift] add support for recycling StatefulSet

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -246,7 +246,7 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
 
             oc.delete(namespace=namespace, kind=resource_type,
                       name=resource.name, cascade=cascade)
-            oc.apply(namespace=namespace, resource=annotated
+            oc.apply(namespace=namespace, resource=annotated)
 
             if not cascade:
                 oc.recycle_orphan_pods(dry_run, namespace, resource)

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -12,6 +12,7 @@ from reconcile.utils.oc import MayNotChangeOnceSetError
 from reconcile.utils.oc import PrimaryClusterIPCanNotBeUnsetError
 from reconcile.utils.oc import InvalidValueApplyError
 from reconcile.utils.oc import MetaDataAnnotationsTooLongApplyError
+from reconcile.utils.oc import StatefulSetUpdateForbidden
 from reconcile.utils.oc import OC_Map
 from reconcile.utils.oc import StatusCodeError
 from reconcile.utils.oc import UnsupportedMediaTypeError

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -254,7 +254,7 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
                       name=resource.name)
             oc.apply(namespace=namespace, resource=annotated)
         except StatefulSetUpdateForbidden:
-            if resource_type not in ['StatefulSet']:
+            if resource_type != 'StatefulSet':
                 raise
 
             logging.info(['delete_sts_and_apply', cluster, namespace,

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -260,7 +260,7 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
             oc.apply(namespace=namespace, resource=annotated)
 
             if not cascade:
-                oc.recycle_orphan_pods(dry_run, namespace, resource)
+                oc.recycle_sts_orphan_pods(dry_run, namespace, resource)
         except (MayNotChangeOnceSetError, PrimaryClusterIPCanNotBeUnsetError):
             if resource_type not in ['Service']:
                 raise

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -257,13 +257,13 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
             if resource_type not in ['StatefulSet']:
                 raise
 
-            logging.info(['delete_and_apply', cluster, namespace,
+            logging.info(['delete_sts_and_apply', cluster, namespace,
                           resource_type, resource.name])
             owned_pods = oc.get_owned_pods(namespace, resource)
             oc.delete(namespace=namespace, kind=resource_type,
                       name=resource.name, cascade=False)
             oc.apply(namespace=namespace, resource=annotated)
-            logging.info(['recycle_pods', cluster, namespace,
+            logging.info(['recycle_sts_pods', cluster, namespace,
                           resource_type, resource.name])
             # the resource was applied without cascading, we proceed
             # to recycle the pods belonging to the old resource.

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -239,10 +239,21 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
         except FieldIsImmutableError:
             # Add more resources types to the list when you're
             # sure they're safe.
-            if resource_type not in ['Route', 'Service', 'StatefulSet']:
+            supported_resource_types = {
+                'Route': {
+                    'cascade': True
+                },
+                'Service': {
+                    'cascade': True
+                },
+                'StatefulSet': {
+                    'cascade': False
+                },
+            }
+            if resource_type not in supported_resource_types:
                 raise
 
-            cascade = resource_type not in ['StatefulSet']
+            cascade = supported_resource_types[resource_type]['cascade']
 
             oc.delete(namespace=namespace, kind=resource_type,
                       name=resource.name, cascade=cascade)

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -239,12 +239,17 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
         except FieldIsImmutableError:
             # Add more resources types to the list when you're
             # sure they're safe.
-            if resource_type not in ['Route', 'Service']:
+            if resource_type not in ['Route', 'Service', 'StatefulSet']:
                 raise
 
+            cascade = resource_type not in ['StatefulSet']
+
             oc.delete(namespace=namespace, kind=resource_type,
-                      name=resource.name)
-            oc.apply(namespace=namespace, resource=annotated)
+                      name=resource.name, cascade=cascade)
+            oc.apply(namespace=namespace, resource=annotated
+
+            if not cascade:
+                oc.recycle_orphan_pods(dry_run, namespace, resource)
         except (MayNotChangeOnceSetError, PrimaryClusterIPCanNotBeUnsetError):
             if resource_type not in ['Service']:
                 raise

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -255,12 +255,14 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
 
             cascade = supported_resource_types[resource_type]['cascade']
 
+            logging.info(['delete_and_apply', cluster, namespace,
+                          resource_type, resource.name])
             oc.delete(namespace=namespace, kind=resource_type,
                       name=resource.name, cascade=cascade)
             oc.apply(namespace=namespace, resource=annotated)
 
             if not cascade:
-                logging.info(['recycling', cluster, namespace,
+                logging.info(['recycle_sts_orphan_pods', cluster, namespace,
                               resource_type, resource.name])
                 oc.recycle_sts_orphan_pods(dry_run, namespace, resource)
         except (MayNotChangeOnceSetError, PrimaryClusterIPCanNotBeUnsetError):

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -262,6 +262,8 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
 
             logging.info(['delete_and_apply', cluster, namespace,
                           resource_type, resource.name])
+            owned_pods = \
+                None if cascade else oc.get_owned_pods(namespace, resource)
             oc.delete(namespace=namespace, kind=resource_type,
                       name=resource.name, cascade=cascade)
             oc.apply(namespace=namespace, resource=annotated)
@@ -272,9 +274,9 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
                 # note: we really just delete pods and let the new resource
                 # recreate them. we delete one by one and wait for a new
                 # pod to become ready before proceeding to the next one.
-                logging.info(['recycle_sts_orphan_pods', cluster, namespace,
+                logging.info(['recycle_pods', cluster, namespace,
                               resource_type, resource.name])
-                oc.recycle_sts_orphan_pods(dry_run, namespace, resource)
+                oc.recycle_orphan_pods(namespace, owned_pods)
         except (MayNotChangeOnceSetError, PrimaryClusterIPCanNotBeUnsetError):
             if resource_type not in ['Service']:
                 raise

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -260,6 +260,8 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
             oc.apply(namespace=namespace, resource=annotated)
 
             if not cascade:
+                logging.info(['recycling', cluster, namespace,
+                              resource_type, resource.name])
                 oc.recycle_sts_orphan_pods(dry_run, namespace, resource)
         except (MayNotChangeOnceSetError, PrimaryClusterIPCanNotBeUnsetError):
             if resource_type not in ['Service']:

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -1,0 +1,48 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from reconcile.utils.oc import OC, PodNotReadyError
+
+
+class TestValidatePodReady(TestCase):
+    @staticmethod
+    @patch.object(OC, 'get')
+    def test_validate_pod_ready_all_good(oc_get):
+        oc_get.return_value = {
+            'status': {
+                'containerStatuses': [
+                    {
+                        'name': 'container1',
+                        'ready': True,
+                    },
+                    {
+                        'name': 'container2',
+                        'ready': True
+                    }
+                ]
+            }
+        }
+        oc = OC('server', 'token', local=True)
+        oc.validate_pod_ready('namespace', 'podname')
+
+    @patch.object(OC, 'get')
+    def test_validate_pod_ready_one_missing(self, oc_get):
+        oc_get.return_value = {
+            'status': {
+                'containerStatuses': [
+                    {
+                        'name': 'container1',
+                        'ready': True,
+                    },
+                    {
+                        'name': 'container2',
+                        'ready': False
+                    }
+                ]
+            }
+        }
+
+        oc = OC('server', 'token', local=True)
+        with self.assertRaises(PodNotReadyError):
+            # Bypass the retry stuff
+            oc.validate_pod_ready.__wrapped__(oc, 'namespace', 'podname')

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -67,7 +67,6 @@ class TestGetOwnedPods(TestCase):
             }
         ]
 
-
         oc = OC('server', 'token', local=True)
         pods = oc.get_owned_pods('namespace', owner_resource)
         self.assertEqual(len(pods), 1)

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -47,6 +47,10 @@ class UnsupportedMediaTypeError(Exception):
     pass
 
 
+class StatefulSetUpdateForbidden(Exception):
+    pass
+
+
 class NoOutputError(Exception):
     pass
 
@@ -644,7 +648,7 @@ class OC:
                 if 'UnsupportedMediaType' in err:
                     raise UnsupportedMediaTypeError(f"[{self.server}]: {err}")
                 if 'updates to statefulset spec for fields other than' in err:
-                    raise FieldIsImmutableError(f"[{self.server}]: {err}")
+                    raise StatefulSetUpdateForbidden(f"[{self.server}]: {err}")
             if not (allow_not_found and 'NotFound' in err):
                 raise StatusCodeError(f"[{self.server}]: {err}")
 

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -459,6 +459,7 @@ class OC:
 
     @retry(max_attempts=20)
     def validate_pod_ready(self, namespace, name):
+        logging.info(['validate_pod_ready', namespace, name])
         pod = self.get(namespace, 'Pod', name)
         for status in pod['status']['containerStatuses']:
             if not status['ready']:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -463,7 +463,7 @@ class OC:
 
     @retry(max_attempts=20)
     def validate_pod_ready(self, namespace, name):
-        logging.info(['validate_pod_ready', namespace, name])
+        logging.info([validate_pod_ready.__name__, namespace, name])
         pod = self.get(namespace, 'Pod', name)
         for status in pod['status']['containerStatuses']:
             if not status['ready']:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -440,7 +440,11 @@ class OC:
         name = user.split('/')[1]
         return "system:serviceaccount:{}:{}".format(namespace, name)
 
-    def recycle_orphan_pods(self, dry_run, namespace, resource):
+    def recycle_sts_orphan_pods(
+            self, dry_run, namespace, resource):
+        if resource.kind != 'StatefulSet':
+            raise RecyclePodsUnsupportedKindError(resource.kind)
+
         pods = self.get(namespace, 'Pod')['items']
         for p in pods:
             owner = self.get_obj_root_owner(namespace, p)

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -463,7 +463,7 @@ class OC:
 
     @retry(max_attempts=20)
     def validate_pod_ready(self, namespace, name):
-        logging.info([validate_pod_ready.__name__, namespace, name])
+        logging.info([self.validate_pod_ready.__name__, namespace, name])
         pod = self.get(namespace, 'Pod', name)
         for status in pod['status']['containerStatuses']:
             if not status['ready']:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -449,12 +449,9 @@ class OC:
         owned_pods = []
         for p in pods:
             owner = self.get_obj_root_owner(namespace, p)
-            if resource.kind != owner['kind']:
-                continue
-            if resource.name != owner['metadata']['name']:
-                continue
-            # we found an owned pod
-            owned_pods.append(p)
+            if (resource.kind, resource.name) == \
+                    (owner['kind'], owner['metadata']['name']):
+                owned_pods.append(p)
 
         return owned_pods
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3351

```
Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', and 'updateStrategy' are forbidden
```

this PR adds support to apply every additional changes to StatefulSets without incurring any downtime.

When we detect a fields immutable error for a StatefulSet:
1. delete statefulset with cascade false to prevent the pods from being deleted
2. apply the updated statefulset
3. delete one pod at a time and wait for the new statefulset to bring it up