### PR TITLE
[openshift-saas-deploy] validate StatefulSet after deployment

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -455,6 +455,7 @@ def validate_data(oc_map, actions):
     supported_kinds = [
         'Deployment',
         'DeploymentConfig',
+        'StatefulSet',
         'Subscription',
         'Job',
         'ClowdApp'
@@ -478,7 +479,7 @@ def validate_data(oc_map, actions):
             if not status:
                 raise ValidationError('status')
             # add elif to validate additional resource kinds
-            if kind in ['Deployment', 'DeploymentConfig']:
+            if kind in ['Deployment', 'DeploymentConfig', 'StatefulSet']:
                 desired_replicas = resource['spec']['replicas']
                 if desired_replicas == 0:
                     continue


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3351

this PR adds validation that a deployment on a StatefulSet was successful.

follow up on #1627

about keeping a state in case the deployment stops mid-run -
in such case, it is expected that the next deployment realizes that the StatefulSet is not in a healthy state and fail.
with this PR - this will now be the reality.