### PR TITLE
[APPSRE-3369]Improve error handling and reporting in requests_sender

### DIFF
--- a/reconcile/requests_sender.py
+++ b/reconcile/requests_sender.py
@@ -77,13 +77,13 @@ def run(dry_run):
             org_username = user['org_username']
             logging.info(['send_credentials', org_username, credentials_name])
 
+            request_name = credentials_request_to_send['name']
+            names = [org_username]
+            subject = request_name
+            encrypted_credentials = get_encrypted_credentials(
+                credentials_name, user, settings, smtp_client
+            )
             if not dry_run:
-                request_name = credentials_request_to_send['name']
-                names = [org_username]
-                subject = request_name
-                encrypted_credentials = get_encrypted_credentials(
-                    credentials_name, user, settings, smtp_client
-                )
                 body = MESSAGE_TEMPLATE.format(
                     request_name, credentials_name, encrypted_credentials
                 )

--- a/reconcile/requests_sender.py
+++ b/reconcile/requests_sender.py
@@ -30,7 +30,7 @@ Encrypted credentials:
 """
 
 
-def get_ecrypted_credentials(credentials_name, user, settings, smtp_client):
+def get_encrypted_credentials(credentials_name, user, settings, smtp_client):
     credentials_map = settings['credentials']
     credentials_map_item = \
         [c for c in credentials_map if c['name'] == credentials_name]
@@ -84,16 +84,16 @@ def run(dry_run):
             request_name = credentials_request_to_send['name']
             names = [org_username]
             subject = request_name
-            ecrypted_credentials = get_ecrypted_credentials(credentials_name,
+            encrypted_credentials = get_encrypted_credentials(credentials_name,
                                                             user, settings,
                                                             smtp_client)
-            if not ecrypted_credentials:
+            if not encrypted_credentials:
                 error = True
                 logging.error(
                     f"could not get encrypted credentials {credentials_name}")
                 continue
             body = MESSAGE_TEMPLATE.format(
-                request_name, credentials_name, ecrypted_credentials)
+                request_name, credentials_name, encrypted_credentials)
             smtp_client.send_mail(names, subject, body)
             state.add(request_name)
 

--- a/reconcile/test/test_requests_sender.py
+++ b/reconcile/test/test_requests_sender.py
@@ -23,20 +23,22 @@ class TestRunInteg(TestCase):
             }
         ]
 
-        self.exit_patcher = patch.object(sys, 'exit')
+        self.exit_patcher = patch.object(sys, 'exit', autospec=True)
         self.get_encrypted_creds_patcher = patch.object(
             integ, 'get_encrypted_credentials'
         )
-        self.smtpclient_patcher = patch.object(integ, 'SmtpClient')
+        self.smtpclient_patcher = patch.object(
+            integ, 'SmtpClient', autospec=True
+        )
         self.get_settings_patcher = patch.object(
-            queries, 'get_app_interface_settings'
+            queries, 'get_app_interface_settings', autospec=True
         )
         self.get_aws_accounts_patcher = patch.object(
-            queries, 'get_aws_accounts'
+            queries, 'get_aws_accounts', autospec=True
         )
         self.get_credentials_requests_patcher = patch.object(
-            queries, 'get_credentials_requests')
-        self.state_patcher = patch.object(integ, 'State')
+            queries, 'get_credentials_requests', autospec=True)
+        self.state_patcher = patch.object(integ, 'State', autospec=True)
 
         self.do_exit = self.exit_patcher.start()
         self.get_encrypted_credentials = \

--- a/reconcile/test/test_requests_sender.py
+++ b/reconcile/test/test_requests_sender.py
@@ -115,3 +115,12 @@ class TestRunInteg(TestCase):
         self.do_exit.assert_called_once()
         self.get_encrypted_credentials.assert_called_once()
         self.smtpclient.return_value.send_mail.assert_not_called()
+
+    def test_dry_run_honored(self):
+        self.state.return_value.exists.return_value = False
+        integ.run(True)
+
+        self.get_encrypted_credentials.assert_called_once()
+        self.do_exit.assert_not_called()
+        self.smtpclient.return_value.send_mail.assert_not_called()
+        self.state.return_value.add.assert_not_called()

--- a/reconcile/test/test_requests_sender.py
+++ b/reconcile/test/test_requests_sender.py
@@ -1,0 +1,107 @@
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+import reconcile.queries as queries
+import reconcile.requests_sender as integ
+import sys
+
+
+class TestRunInteg(TestCase):
+
+    def setUp(self):
+        self.user = {
+            'org_username': 'myorg',
+            'public_gpg_key': 'mykey',
+        }
+
+        self.requests = [
+            {
+                'user': self.user,
+                'credentials': 'credentials_name',
+                'name': 'aname',
+            }
+        ]
+
+        self.exit_patcher = patch.object(sys, 'exit')
+        self.get_encrypted_creds_patcher = patch.object(
+            integ, 'get_encrypted_credentials'
+        )
+        self.smtpclient_patcher = patch.object(integ, 'SmtpClient')
+        self.get_settings_patcher = patch.object(
+            queries, 'get_app_interface_settings'
+        )
+        self.get_aws_accounts_patcher = patch.object(
+            queries, 'get_aws_accounts'
+        )
+        self.get_credentials_requests_patcher = patch.object(
+            queries, 'get_credentials_requests')
+        self.state_patcher = patch.object(integ, 'State')
+
+        self.do_exit = self.exit_patcher.start()
+        self.get_encrypted_credentials = self.get_encrypted_creds_patcher.start()
+        self.smtpclient = self.smtpclient_patcher.start()
+        self.get_app_interface_settings = self.get_settings_patcher.start()
+        self.get_aws_accounts = self.get_aws_accounts_patcher.start()
+        self.get_credentials_requests = self.get_credentials_requests_patcher.start()
+        self.get_credentials_requests.return_value = self.requests
+        self.get_encrypted_credentials.return_value = 'anencryptedcred'
+        self.state = self.state_patcher.start()
+        self.settings = {
+            'smtp': {
+                'secret_path': 'asecretpath',
+                'server': 'aserver',
+                'password': 'apassword',
+                'port': 993,
+                'require_tls': True,
+                'username': 'asmtpuser',
+
+            }
+        }
+        self.get_app_interface_settings.return_value = self.settings
+        self.get_aws_accounts.return_value = ['anaccount']
+
+    def tearDown(self):
+        for p in (
+                self.exit_patcher,
+                self.get_encrypted_creds_patcher,
+                self.smtpclient_patcher,
+                self.get_settings_patcher,
+                self.get_credentials_requests_patcher,
+                self.get_aws_accounts_patcher,
+                self.state_patcher,
+        ):
+            p.stop()
+
+    def test_valid_credentials(self):
+        # Yeah, yeah, whatever
+        self.state.return_value.exists.return_value = False
+        #import pdb; pdb.set_trace()
+        integ.run(False)
+        # This has succeeded
+        self.do_exit.assert_not_called()
+        self.get_encrypted_credentials.assert_called_once_with(
+            'credentials_name', self.user, self.settings, self.smtpclient.return_value
+        )
+        calls = self.smtpclient.return_value.send_mail.call_args_list
+        self.assertEqual(len(calls), 1)
+        # I don't care too much about the body of the email, TBH
+        self.assertEqual(calls[0][0][:-1], (['myorg'], 'aname'))
+        # Just check that we're still sending the encrypted credential
+        # in the body. This assertion is backwards with regards to all
+        # other assertions :(
+        self.assertIn('anencryptedcred', calls[0][0][-1])
+
+    def test_existing_credentials(self):
+        self.state.return_value.exists.return_value = True
+        integ.run(False)
+        self.do_exit.assert_not_called()
+        self.get_encrypted_credentials.assert_not_called()
+        self.smtpclient.return_value.send_mail.assert_not_called()
+
+    def test_invalid_credentials(self):
+        self.get_encrypted_credentials.return_value = ''
+        self.state.return_value.exists.return_value = False
+        integ.run(False)
+        self.do_exit.assert_called_once()
+        self.get_encrypted_credentials.assert_called_once()
+        self.smtpclient.return_value.send_mail.assert_not_called()

--- a/reconcile/test/test_utils_gpg.py
+++ b/reconcile/test/test_utils_gpg.py
@@ -1,4 +1,7 @@
 from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+import subprocess
 
 import reconcile.utils.gpg as gpg
 
@@ -23,3 +26,32 @@ class TestGpgKeyValid(TestCase):
         valid, msg = gpg.gpg_key_valid(key)
         self.assertFalse(valid)
         self.assertEqual(msg, gpg.ERR_BASE64)
+
+
+# We have to mangle the namespace of the gpg module, since it imports
+# Popen. Had that module chosen "import subprocess;
+# subprocess.Popen(...)" we'd be patching subprocess instead.
+@patch.object(gpg, 'Popen')
+class TestGpgEncrypt(TestCase):
+    def test_gpg_encrypt_all_ok(self, popen):
+        popen.return_value.communicate.return_value = (b"stdout", b"stderr")
+        popen.return_value.returncode = 0
+
+        self.assertEqual(gpg.gpg_encrypt('acontent', 'arecipient', 'akey'),
+                         'stdout')
+
+    def test_gpg_encrypt_import_fail(self, popen):
+        popen.return_value.communicate.return_value = (b"stdout", b"stderr")
+        popen.return_value.returncode = 1
+
+        self.assertEqual(gpg.gpg_encrypt('acontent', 'arecipient', 'akey'),
+                         None)
+        popen.assert_called_once()
+
+    def test_gpg_encrypt_encrypt_fail(self, popen):
+        popen.return_value.communicate.return_value = (b"stdout", b"stderr")
+        popen.side_effect = (MagicMock(returncode=0), MagicMock(returncode=1))
+
+        self.assertEqual(gpg.gpg_encrypt('acontent', 'arecipient', 'akey'), None)
+        print(popen.call_args_list)
+        self.assertEqual(popen.call_count, 2)

--- a/reconcile/test/test_utils_gpg.py
+++ b/reconcile/test/test_utils_gpg.py
@@ -1,7 +1,5 @@
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
-
-import subprocess
+from unittest.mock import patch
 
 import reconcile.utils.gpg as gpg
 
@@ -31,27 +29,10 @@ class TestGpgKeyValid(TestCase):
 # We have to mangle the namespace of the gpg module, since it imports
 # Popen. Had that module chosen "import subprocess;
 # subprocess.Popen(...)" we'd be patching subprocess instead.
-@patch.object(gpg, 'Popen')
+@patch.object(gpg, 'run')
 class TestGpgEncrypt(TestCase):
     def test_gpg_encrypt_all_ok(self, popen):
         popen.return_value.communicate.return_value = (b"stdout", b"stderr")
-        popen.return_value.returncode = 0
 
         self.assertEqual(gpg.gpg_encrypt('acontent', 'arecipient', 'akey'),
                          'stdout')
-
-    def test_gpg_encrypt_import_fail(self, popen):
-        popen.return_value.communicate.return_value = (b"stdout", b"stderr")
-        popen.return_value.returncode = 1
-
-        self.assertEqual(gpg.gpg_encrypt('acontent', 'arecipient', 'akey'),
-                         None)
-        popen.assert_called_once()
-
-    def test_gpg_encrypt_encrypt_fail(self, popen):
-        popen.return_value.communicate.return_value = (b"stdout", b"stderr")
-        popen.side_effect = (MagicMock(returncode=0), MagicMock(returncode=1))
-
-        self.assertEqual(gpg.gpg_encrypt('acontent', 'arecipient', 'akey'), None)
-        print(popen.call_args_list)
-        self.assertEqual(popen.call_count, 2)

--- a/reconcile/utils/gpg.py
+++ b/reconcile/utils/gpg.py
@@ -1,10 +1,7 @@
 import base64
 import tempfile
-import shutil
 
-from subprocess import PIPE, Popen, STDOUT
-
-from reconcile.utils.defer import defer
+from subprocess import PIPE, Popen, STDOUT, run
 
 ERR_SPACES = 'key has spaces in it'
 ERR_EQUAL_SIGNS = 'equal signs should only appear at the end of the key'
@@ -53,23 +50,21 @@ def gpg_encrypt(content, recepient, public_gpg_key):
 
     with tempfile.TemporaryDirectory() as gnupg_home_dir:
         # import public gpg key
-        proc = Popen(['gpg', '--homedir', gnupg_home_dir,
-                      '--import'],
-                     stdin=PIPE,
-                     stdout=PIPE,
-                     stderr=STDOUT)
+        proc = run(['gpg', '--homedir', gnupg_home_dir,
+                    '--import'],
+                   stdin=PIPE,
+                   stdout=PIPE,
+                   stderr=STDOUT,
+                   check=True)
         out = proc.communicate(public_gpg_key_dec)
-        if proc.returncode != 0:
-            return None
         # encrypt content
-        proc = Popen(['gpg', '--homedir', gnupg_home_dir,
-                      '--trust-model', 'always',
-                      '--encrypt', '--armor', '-r', recepient],
-                     stdin=PIPE,
-                     stdout=PIPE,
-                     stderr=STDOUT)
+        proc = run(['gpg', '--homedir', gnupg_home_dir,
+                    '--trust-model', 'always',
+                    '--encrypt', '--armor', '-r', recepient],
+                   stdin=PIPE,
+                   stdout=PIPE,
+                   stderr=STDOUT,
+                   check=True)
         out = proc.communicate(content.encode())
-        if proc.returncode != 0:
-            return None
 
     return out[0].decode('utf-8')

--- a/reconcile/utils/gpg.py
+++ b/reconcile/utils/gpg.py
@@ -11,8 +11,7 @@ ERR_EQUAL_SIGNS = 'equal signs should only appear at the end of the key'
 ERR_BASE64 = 'could not perform base64 decode of key'
 
 
-@defer
-def gpg_key_valid(public_gpg_key, defer=None):
+def gpg_key_valid(public_gpg_key):
     stripped_public_gpg_key = public_gpg_key.rstrip()
     if ' ' in stripped_public_gpg_key:
         msg = ERR_SPACES
@@ -29,18 +28,18 @@ def gpg_key_valid(public_gpg_key, defer=None):
         msg = ERR_BASE64
         return False, msg
 
-    gnupg_home_dir = tempfile.mkdtemp()
-    defer(lambda: shutil.rmtree(gnupg_home_dir))
-    proc = Popen(['gpg', '--homedir', gnupg_home_dir],
-                 stdin=PIPE,
-                 stdout=PIPE,
-                 stderr=STDOUT)
-    out = proc.communicate(public_gpg_key_dec)
-    if proc.returncode != 0:
-        return False, out
+    with tempfile.TemporaryDirectory() as gnupg_home_dir:
+        proc = Popen(['gpg', '--homedir', gnupg_home_dir],
+                     stdin=PIPE,
+                     stdout=PIPE,
+                     stderr=STDOUT)
+        out = proc.communicate(public_gpg_key_dec)
+        if proc.returncode != 0:
+            return False, out
 
-    keys = out[0].decode('utf-8').split('\n')
-    key_types = [k.split(' ')[0] for k in keys if k]
+        keys = out[0].decode('utf-8').split('\n')
+        key_types = [k.split(' ')[0] for k in keys if k]
+
     ok = all(elem in key_types for elem in ['pub', 'sub'])
     if not ok:
         msg = 'key must contain both pub and sub entries'
@@ -49,30 +48,28 @@ def gpg_key_valid(public_gpg_key, defer=None):
     return True, ''
 
 
-@defer
-def gpg_encrypt(content, recepient, public_gpg_key, defer=None):
+def gpg_encrypt(content, recepient, public_gpg_key):
     public_gpg_key_dec = base64.b64decode(public_gpg_key)
 
-    gnupg_home_dir = tempfile.mkdtemp()
-    defer(lambda: shutil.rmtree(gnupg_home_dir))
-    # import public gpg key
-    proc = Popen(['gpg', '--homedir', gnupg_home_dir,
-                  '--import'],
-                 stdin=PIPE,
-                 stdout=PIPE,
-                 stderr=STDOUT)
-    out = proc.communicate(public_gpg_key_dec)
-    if proc.returncode != 0:
-        return None
-    # encrypt content
-    proc = Popen(['gpg', '--homedir', gnupg_home_dir,
-                  '--trust-model', 'always',
-                  '--encrypt', '--armor', '-r', recepient],
-                 stdin=PIPE,
-                 stdout=PIPE,
-                 stderr=STDOUT)
-    out = proc.communicate(content.encode())
-    if proc.returncode != 0:
-        return None
+    with tempfile.TemporaryDirectory() as gnupg_home_dir:
+        # import public gpg key
+        proc = Popen(['gpg', '--homedir', gnupg_home_dir,
+                      '--import'],
+                     stdin=PIPE,
+                     stdout=PIPE,
+                     stderr=STDOUT)
+        out = proc.communicate(public_gpg_key_dec)
+        if proc.returncode != 0:
+            return None
+        # encrypt content
+        proc = Popen(['gpg', '--homedir', gnupg_home_dir,
+                      '--trust-model', 'always',
+                      '--encrypt', '--armor', '-r', recepient],
+                     stdin=PIPE,
+                     stdout=PIPE,
+                     stderr=STDOUT)
+        out = proc.communicate(content.encode())
+        if proc.returncode != 0:
+            return None
 
     return out[0].decode('utf-8')


### PR DESCRIPTION
If, instead of relying on return values we use exceptions, we can
pass a lot of context to the part of the stack best suited to handle
it or to produce the most useful reporting.

So, I have replaced `Popen` with `run` in `gpg_encrypt`, so that I can
get such an exception while removing code.  I have not updated
`gpg_key_valid` since I'd need to update its callers and they are out
of the scope of this task.

I have also replaced some calls to `defer` with a more Pythonic
context manager.  In this case I have adapted `gpg_key_valid`, for
consistency and because it doesn't change its behaviour or API.  This
removes some code, more notably two imports.

Finally, I have tweaked the integration's `run` to keep the happy path
uninterrupted - that's the beauty of exceptions.  We also guarantee
that we perform as much work as possible, reporting failures but
continuing processing.
