### PR TITLE
[openshift-saas-deploy-trigger] update state even if not triggered

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -295,8 +295,6 @@ def _trigger_tekton(spec,
                       resource_type=tkn_trigger_resource.kind,
                       resource=tkn_trigger_resource,
                       wait_for_namespace=False)
-            if not dry_run:
-                saasherder.update_state(trigger_type, spec)
         except Exception as e:
             error = True
             logging.error(
@@ -304,6 +302,9 @@ def _trigger_tekton(spec,
                 f"in {tkn_cluster_name}/{tkn_namespace_name}. " +
                 f"details: {str(e)}"
             )
+
+    if not error and not dry_run:
+        saasherder.update_state(trigger_type, spec)
 
     return error
 

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -245,13 +245,15 @@ def _trigger_jenkins(spec,
             jenkins = jenkins_map[instance_name]
             try:
                 jenkins.trigger_job(job_name)
-                saasherder.update_state(trigger_type, spec)
             except Exception as e:
                 error = True
                 logging.error(
                     f"could not trigger job {job_name} " +
                     f"in {instance_name}. details: {str(e)}"
                 )
+
+    if not error and not dry_run:
+        saasherder.update_state(trigger_type, spec)
 
     return error
 


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3375

in all openshift-saas-deploy-trigger integrations, we update a state based on the last triggered spec.
sometimes, there will be multiple specs that would trigger the same deployment. in such cases, we only want to trigger the deployment once. however, we still need to persist the spec to the state so this deployment is not triggered again in the next iteration.

this is actually a regression. here is the a previous working version: https://github.com/app-sre/qontract-reconcile/blob/864a5d500da0300177004d1ef411013297a8e6d3/reconcile/openshift_saas_deploy_trigger_configs.py#L60-L63

summary: even if a deployment is skipped because it was already triggered, we still need to persist the spec to the state.