### PR TITLE
quay-mirror: increase default sleep duration

### DIFF
--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -52,6 +52,7 @@ integrations:
   logs:
     slack: true
 - name: quay-mirror
+  sleepDurationSecs: 300
   resources:
     requests:
       memory: 150Mi

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -1115,7 +1115,7 @@ objects:
           - name: INTEGRATION_EXTRA_ARGS
             value: ""
           - name: SLEEP_DURATION_SECS
-            value: ${SLEEP_DURATION_SECS}
+            value: ${QUAY_MIRROR_SLEEP_DURATION_SECS}
           - name: GITHUB_API
             valueFrom:
               configMapKeyRef:
@@ -17320,6 +17320,8 @@ parameters:
   value: 100m
 - name: QUAY_MEMBERSHIP_MEMORY_REQUEST
   value: 50Mi
+- name: QUAY_MIRROR_SLEEP_DURATION_SECS
+  value: "300"
 - name: QUAY_MIRROR_CPU_LIMIT
   value: 300m
 - name: QUAY_MIRROR_MEMORY_LIMIT


### PR DESCRIPTION
Increase the default sync interval from 30 seconds to 300 (5 minutes)