### PR TITLE
Slow down Quay mirror variable even more

### DIFF
--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -17321,7 +17321,7 @@ parameters:
 - name: QUAY_MEMBERSHIP_MEMORY_REQUEST
   value: 50Mi
 - name: QUAY_MIRROR_SLEEP_DURATION_SECS
-  value: "300"
+  value: "1200"
 - name: QUAY_MIRROR_CPU_LIMIT
   value: 300m
 - name: QUAY_MIRROR_MEMORY_LIMIT


### PR DESCRIPTION
Because 300 seconds may not be enough.
