### PR TITLE
[saas-file-validator] add validation for unique saas file and env combination

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -12,7 +12,8 @@ from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.jenkins_job_builder import get_openshift_saas_deploy_job_name
 from reconcile.utils.oc import OC_Map
 from reconcile.utils.gitlab_api import GitLabApi
-from reconcile.utils.saasherder import SaasHerder, Providers
+from reconcile.utils.saasherder import SaasHerder, Providers, \
+    UNIQUE_SAAS_FILE_ENV_COMBO_LEN
 from reconcile.utils.sharding import is_in_shard
 from reconcile.utils.defer import defer
 
@@ -339,7 +340,7 @@ def _construct_tekton_trigger_resource(saas_file_name,
     # with what we currently have in Jenkins.
     ts = datetime.datetime.utcnow().strftime('%Y%m%d%H%M')  # len 12
     # max name length can be 63. leaving 12 for the timestamp - 51
-    name = f"{long_name[:50]}-{ts}"
+    name = f"{long_name[:UNIQUE_SAAS_FILE_ENV_COMBO_LEN]}-{ts}"
     body = {
         "apiVersion": "tekton.dev/v1beta1",
         "kind": "PipelineRun",

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -1,0 +1,117 @@
+from unittest import TestCase
+
+from reconcile.utils.saasherder import SaasHerder
+
+
+class TestCheckSaasFileEnvComboUnique(TestCase):
+    def test_check_saas_file_env_combo_unique(self):
+        saas_files = [
+            {
+                'path': 'path1',
+                'name': 'a1',
+                'managedResourceTypes': [],
+                'resourceTemplates':
+                [
+                    {
+                        'name': 'rt',
+                        'targets':
+                        [
+                            {
+                                'namespace': {
+                                    'name': 'ns',
+                                    'environment': {
+                                        'name': 'env1'
+                                    },
+                                    'cluster': {
+                                        'name': 'cluster'
+                                    }
+                                },
+                                'parameters': {}
+                            },
+                            {
+                                'namespace': {
+                                    'name': 'ns',
+                                    'environment': {
+                                        'name': 'env2'
+                                    },
+                                    'cluster': {
+                                        'name': 'cluster'
+                                    }
+                                },
+                                'parameters': {}
+                            }
+                        ]
+                    }
+                ],
+                'roles': [
+                    {'users': [{'org_username': 'myname'}]}
+                ]
+            }
+        ]
+        saasherder = SaasHerder(
+            saas_files,
+            thread_pool_size=1,
+            gitlab=None,
+            integration='',
+            integration_version='',
+            settings={},
+            validate=True
+        )
+
+        self.assertTrue(saasherder.valid)
+
+    def test_check_saas_file_env_combo_not_unique(self):
+        saas_files = [
+            {
+                'path': 'path1',
+                'name': 'long-name-which-is-too-long-to-produce-unique-combo',
+                'managedResourceTypes': [],
+                'resourceTemplates':
+                [
+                    {
+                        'name': 'rt',
+                        'targets':
+                        [
+                            {
+                                'namespace': {
+                                    'name': 'ns',
+                                    'environment': {
+                                        'name': 'env1'
+                                    },
+                                    'cluster': {
+                                        'name': 'cluster'
+                                    }
+                                },
+                                'parameters': {}
+                            },
+                            {
+                                'namespace': {
+                                    'name': 'ns',
+                                    'environment': {
+                                        'name': 'env2'
+                                    },
+                                    'cluster': {
+                                        'name': 'cluster'
+                                    }
+                                },
+                                'parameters': {}
+                            }
+                        ]
+                    }
+                ],
+                'roles': [
+                    {'users': [{'org_username': 'myname'}]}
+                ]
+            }
+        ]
+        saasherder = SaasHerder(
+            saas_files,
+            thread_pool_size=1,
+            gitlab=None,
+            integration='',
+            integration_version='',
+            settings={},
+            validate=True
+        )
+
+        self.assertFalse(saasherder.valid)

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -32,6 +32,9 @@ class TriggerTypes:
     UPSTREAM_JOBS = 2
 
 
+UNIQUE_SAAS_FILE_ENV_COMBO_LEN = 50
+
+
 class SaasHerder():
     """Wrapper around SaaS deployment actions."""
 
@@ -189,13 +192,13 @@ class SaasHerder():
         # leaving 12 for the timestamp leaves us with 51
         # to create a unique pipelinerun name
         tkn_long_name = f"{saas_file_name}-{env_name}"
-        tkn_name = tkn_long_name[:50]
+        tkn_name = tkn_long_name[:UNIQUE_SAAS_FILE_ENV_COMBO_LEN]
         if tkn_name in self.tkn_unique_pipelineruns.keys() and \
                 self.tkn_unique_pipelineruns[tkn_name] != tkn_long_name:
             logging.error(
                 f'[{saas_file_name}/{env_name}] '
                 'saas file and env name combination must be '
-                'unique in the first 50 chars. '
+                f'unique in first {UNIQUE_SAAS_FILE_ENV_COMBO_LEN} chars. '
                 f'found not unique value: {tkn_name} '
                 f'from this long name: {tkn_long_name}')
             self.valid = False


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3342

we are deploying using Tekton PipelineRuns, which need to have a name of 63 chars or less (kubernetes limitation).
since we add a timestamp, we need to generate a unique combination in 51 chars to avoid conflicts between deployments.