### PR TITLE
Improve reporting of GPG errors in requests-sender

### DIFF
--- a/reconcile/requests_sender.py
+++ b/reconcile/requests_sender.py
@@ -97,7 +97,7 @@ def run(dry_run):
         except CalledProcessError as e:
             logging.exception(
                 f"Failed to handle GPG key for {org_username} "
-                f"({credentials_name}): {e.stderr}"
+                f"({credentials_name}): {e.stdout}"
             )
             error = True
 


### PR DESCRIPTION
We are merging stdout and stderr, and in this case it actually
simplifies code.
