### PR TITLE
[metrics] Change run_status from Counter to Gauge

### DIFF
--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -87,9 +87,6 @@ if __name__ == "__main__":
         run_status.labels(integration=INTEGRATION_NAME,
                           shards=SHARDS, shard_id=SHARD_ID).set(return_code)
 
-        if return_code == ExitCodes.DATA_CHANGED:
-            continue
-
         if RUN_ONCE:
             sys.exit(return_code)
 

--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -84,8 +84,8 @@ if __name__ == "__main__":
 
         run_time.labels(integration=INTEGRATION_NAME,
                         shards=SHARDS, shard_id=SHARD_ID).set(time_spent)
-        run_status.labels(integration=INTEGRATION_NAME, status=return_code,
-                          shards=SHARDS, shard_id=SHARD_ID).inc()
+        run_status.labels(integration=INTEGRATION_NAME,
+                          shards=SHARDS, shard_id=SHARD_ID).set(return_code)
 
         if return_code == ExitCodes.DATA_CHANGED:
             continue

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -109,14 +109,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -68,14 +68,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -274,14 +266,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -494,14 +478,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -699,14 +675,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -895,14 +863,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -1106,14 +1066,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -1326,14 +1278,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -1541,14 +1485,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -1742,14 +1678,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -1953,14 +1881,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -2153,14 +2073,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -2366,14 +2278,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -2569,14 +2473,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -2782,14 +2678,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -2985,14 +2873,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -3198,14 +3078,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -3401,14 +3273,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -3614,14 +3478,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -3817,14 +3673,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -4030,14 +3878,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -4233,14 +4073,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -4446,14 +4278,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -4648,14 +4472,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -4839,14 +4655,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -5045,14 +4853,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -5241,14 +5041,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -5447,14 +5239,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -5639,14 +5423,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -5817,14 +5593,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -6018,14 +5786,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -6233,14 +5993,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -6443,14 +6195,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -6641,14 +6385,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -6847,14 +6583,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -7034,14 +6762,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -68,14 +68,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -264,14 +256,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -470,14 +454,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -666,14 +642,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -872,14 +840,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -1064,14 +1024,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -1242,14 +1194,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -1430,14 +1374,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -1608,14 +1544,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -1800,14 +1728,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -2006,14 +1926,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -2193,14 +2105,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -2388,14 +2292,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -2578,14 +2474,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -2761,14 +2649,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -2963,14 +2843,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -3150,14 +3022,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -3349,14 +3213,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -3555,14 +3411,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -3751,14 +3599,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -3957,14 +3797,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -4153,14 +3985,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -4359,14 +4183,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -4555,14 +4371,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -4761,14 +4569,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -4957,14 +4757,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -5163,14 +4955,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -5359,14 +5143,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -5565,14 +5341,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -5761,14 +5529,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -5967,14 +5727,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -6163,14 +5915,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -6369,14 +6113,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -6565,14 +6301,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -6771,14 +6499,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -6967,14 +6687,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -7173,14 +6885,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -7369,14 +7073,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -7575,14 +7271,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -7771,14 +7459,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -7977,14 +7657,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -8169,14 +7841,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -8356,14 +8020,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -8562,14 +8218,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -8758,14 +8406,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -8964,14 +8604,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -9160,14 +8792,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -9366,14 +8990,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -9562,14 +9178,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -9768,14 +9376,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -9964,14 +9564,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -10170,14 +9762,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -10362,14 +9946,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -10540,14 +10116,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -10728,14 +10296,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -10906,14 +10466,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -11094,14 +10646,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -11272,14 +10816,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -11460,14 +10996,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -11638,14 +11166,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -11826,14 +11346,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -12004,14 +11516,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -12192,14 +11696,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -12370,14 +11866,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -12562,14 +12050,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -12768,14 +12248,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -12964,14 +12436,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -13170,14 +12634,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -13366,14 +12822,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -13572,14 +13020,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -13764,14 +13204,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -13951,14 +13383,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -14162,14 +13586,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -14354,14 +13770,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -14541,14 +13949,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -14747,14 +14147,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -14943,14 +14335,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -15149,14 +14533,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -15345,14 +14721,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -15558,14 +14926,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -15757,14 +15117,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -15935,14 +15287,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -16139,14 +15483,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -16338,14 +15674,6 @@ objects:
               @type grep
               <exclude>
                 key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
                 pattern /using gql endpoint/
               </exclude>
             </filter>
@@ -16516,14 +15844,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep
@@ -16708,14 +16028,6 @@ objects:
                 @type none
               </parse>
             </source>
-
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /HTTP Error 409: Conflict/
-              </exclude>
-            </filter>
 
             <filter integration>
               @type grep

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -103,7 +103,7 @@ import reconcile.jenkins_job_builds_cleaner
 from reconcile.status import ExitCodes
 from reconcile.status import RunningState
 
-from reconcile.utils.gql import (GqlApiError, GqlApiErrorForbiddenSchema,
+from reconcile.utils.gql import (GqlApiErrorForbiddenSchema,
                                  GqlApiIntegrationNotFound)
 from reconcile.utils.aggregated_list import RunnerException
 from reconcile.utils.binary import binary, binary_version
@@ -414,14 +414,6 @@ def run_integration(func_container, ctx, *args, **kwargs):
     except GqlApiErrorForbiddenSchema as e:
         sys.stderr.write(str(e) + "\n")
         sys.exit(ExitCodes.FORBIDDEN_SCHEMA)
-    except GqlApiError as e:
-        if '409' in str(e):
-            logging.info('Data changed during execution. This is fine.')
-            # exit code to relect conflict
-            # TODO: document this better
-            sys.exit(ExitCodes.DATA_CHANGED)
-        else:
-            raise e
     finally:
         if ctx.get('dump_schemas_file'):
             gqlapi = gql.get_api()

--- a/reconcile/status.py
+++ b/reconcile/status.py
@@ -1,7 +1,6 @@
 class ExitCodes:
     SUCCESS = 0
     ERROR = 1
-    DATA_CHANGED = 3
     INTEGRATION_NOT_FOUND = 4
     FORBIDDEN_SCHEMA = 5
 

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -159,8 +159,6 @@ class GqlApi:
             resources = self.query(query, {'path': path},
                                    skip_validation=True)['resources']
         except GqlApiError as e:
-            if '409' in str(e):
-                raise e
             raise GqlGetResourceError(
                 path,
                 'Resource not found.')

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -7,10 +7,9 @@ run_time = Gauge(name='qontract_reconcile_last_run_seconds',
                  documentation='Last run duration in seconds',
                  labelnames=['integration', 'shards', 'shard_id'])
 
-run_status = Counter(name='qontract_reconcile_run_status',
-                     documentation='Status of the runs',
-                     labelnames=['integration', 'status',
-                                 'shards', 'shard_id'])
+run_status = Gauge(name='qontract_reconcile_last_run_status',
+                   documentation='Last run status',
+                   labelnames=['integration', 'shards', 'shard_id'])
 
 reconcile_time = Histogram(name='qontract_reconcile_function_'
                                 'elapsed_seconds_since_bundle_commit',

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -1,5 +1,4 @@
 from prometheus_client import Gauge
-from prometheus_client import Counter
 from prometheus_client import Histogram
 
 


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3368

we are often not getting alerted for failing integrations. this PR changes the run_status metrics from Counter to Gauge, with the value being the exit code.

this will allow us to replace our existing alert:
```
sum(increase(qontract_reconcile_run_status_total{status!~"0|3|-9"}[5m])) by (integration, shards, shard_id, status) > 0
```
with a much simpler one:
```
qontract_reconcile_run_status_total > 0
```

this PR also removes the 409 conflict handling which was removed in https://github.com/app-sre/qontract-server/pull/88. with this, we can just check that the run_status is `> 0`.