### PR TITLE
[terraform-resources] add support for a full run with account_name

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -254,11 +254,9 @@ def populate_oc_resources(spec, ri, account_name):
         logging.error(msg)
 
 
-def fetch_current_state(dry_run, namespaces, thread_pool_size,
+def fetch_current_state(namespaces, thread_pool_size,
                         internal, use_jump_host, account_name):
     ri = ResourceInventory()
-    if dry_run:
-        return ri, None
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces, integration=QONTRACT_INTEGRATION,
                     settings=settings, internal=internal,
@@ -301,7 +299,7 @@ def setup(dry_run, print_only, thread_pool_size, internal,
     settings = queries.get_app_interface_settings()
     namespaces = gqlapi.query(TF_NAMESPACES_QUERY)['namespaces']
     tf_namespaces = filter_tf_namespaces(namespaces, account_name)
-    ri, oc_map = fetch_current_state(dry_run, tf_namespaces, thread_pool_size,
+    ri, oc_map = fetch_current_state(tf_namespaces, thread_pool_size,
                                      internal, use_jump_host, account_name)
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size,
                                          oc_map=oc_map,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -400,7 +400,8 @@ def run(dry_run, print_only=False,
     actions = ob.realize_data(dry_run, oc_map, ri, caller=account_name)
 
     disable_keys(dry_run, thread_pool_size,
-                 disable_service_account_keys=True)
+                 disable_service_account_keys=True,
+                 account_name=account_name)
 
     if not dry_run and actions and vault_output_path:
         write_outputs_to_vault(vault_output_path, ri)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -233,9 +233,10 @@ def populate_oc_resources(spec, ri, account_name):
             openshift_resource = OR(item,
                                     QONTRACT_INTEGRATION,
                                     QONTRACT_INTEGRATION_VERSION)
-            caller = openshift_resource.caller
-            if account_name and caller and caller != account_name:
-                continue
+            if account_name:
+                caller = openshift_resource.caller
+                if caller and caller != account_name:
+                    continue
 
             ri.add_current(
                 spec.cluster,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -219,7 +219,7 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 5, 2)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 
-def populate_oc_resources(spec, ri):
+def populate_oc_resources(spec, ri, account_name):
     if spec.oc is None:
         return
 
@@ -233,6 +233,10 @@ def populate_oc_resources(spec, ri):
             openshift_resource = OR(item,
                                     QONTRACT_INTEGRATION,
                                     QONTRACT_INTEGRATION_VERSION)
+            caller = openshift_resource.caller
+            if account_name and caller and caller != account_name:
+                continue
+
             ri.add_current(
                 spec.cluster,
                 spec.namespace,
@@ -251,7 +255,7 @@ def populate_oc_resources(spec, ri):
 
 
 def fetch_current_state(dry_run, namespaces, thread_pool_size,
-                        internal, use_jump_host):
+                        internal, use_jump_host, account_name):
     ri = ResourceInventory()
     if dry_run:
         return ri, None
@@ -267,7 +271,8 @@ def fetch_current_state(dry_run, namespaces, thread_pool_size,
             namespaces=namespaces,
             override_managed_types=['Secret']
         )
-    threaded.run(populate_oc_resources, state_specs, thread_pool_size, ri=ri)
+    threaded.run(populate_oc_resources, state_specs, thread_pool_size, ri=ri,
+                 account_name=account_name)
 
     return ri, oc_map
 
@@ -297,7 +302,7 @@ def setup(dry_run, print_only, thread_pool_size, internal,
     namespaces = gqlapi.query(TF_NAMESPACES_QUERY)['namespaces']
     tf_namespaces = filter_tf_namespaces(namespaces, account_name)
     ri, oc_map = fetch_current_state(dry_run, tf_namespaces, thread_pool_size,
-                                     internal, use_jump_host)
+                                     internal, use_jump_host, account_name)
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size,
                                          oc_map=oc_map,
                                          settings=settings)
@@ -386,29 +391,19 @@ def run(dry_run, print_only=False,
         if disabled_deletions_detected:
             cleanup_and_exit(tf, disabled_deletions_detected)
 
-    if dry_run:
-        cleanup_and_exit(tf)
-
-    if not light:
+    if not dry_run and not light:
         err = tf.apply()
         if err:
             cleanup_and_exit(tf, err)
 
-    # Temporary skip apply secret for running tf-r per account locally.
-    # The integration running on the cluster will manage the secret
-    # after any manual running.
-    # Will refactor with caller for further operator implement.
-    if account_name:
-        cleanup_and_exit(tf)
+    tf.populate_desired_state(ri, oc_map, tf_namespaces, account_name)
 
-    tf.populate_desired_state(ri, oc_map, tf_namespaces)
-
-    actions = ob.realize_data(dry_run, oc_map, ri)
+    actions = ob.realize_data(dry_run, oc_map, ri, caller=account_name)
 
     disable_keys(dry_run, thread_pool_size,
                  disable_service_account_keys=True)
 
-    if actions and vault_output_path:
+    if not dry_run and actions and vault_output_path:
         write_outputs_to_vault(vault_output_path, ri)
 
     if ri.has_error_registered():

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -395,7 +395,7 @@ def run(dry_run, print_only=False,
     if dry_run:
         cleanup_and_exit(tf)
 
-    if not dry_run and not light:
+    if not light:
         err = tf.apply()
         if err:
             cleanup_and_exit(tf, err)
@@ -408,7 +408,7 @@ def run(dry_run, print_only=False,
                  disable_service_account_keys=True,
                  account_name=account_name)
 
-    if not dry_run and actions and vault_output_path:
+    if actions and vault_output_path:
         write_outputs_to_vault(vault_output_path, ri)
 
     if ri.has_error_registered():

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -255,9 +255,11 @@ def populate_oc_resources(spec, ri, account_name):
         logging.error(msg)
 
 
-def fetch_current_state(namespaces, thread_pool_size,
+def fetch_current_state(dry_run, namespaces, thread_pool_size,
                         internal, use_jump_host, account_name):
     ri = ResourceInventory()
+    if dry_run:
+        return ri, None
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces, integration=QONTRACT_INTEGRATION,
                     settings=settings, internal=internal,
@@ -300,7 +302,7 @@ def setup(dry_run, print_only, thread_pool_size, internal,
     settings = queries.get_app_interface_settings()
     namespaces = gqlapi.query(TF_NAMESPACES_QUERY)['namespaces']
     tf_namespaces = filter_tf_namespaces(namespaces, account_name)
-    ri, oc_map = fetch_current_state(tf_namespaces, thread_pool_size,
+    ri, oc_map = fetch_current_state(dry_run, tf_namespaces, thread_pool_size,
                                      internal, use_jump_host, account_name)
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size,
                                          oc_map=oc_map,
@@ -389,6 +391,9 @@ def run(dry_run, print_only=False,
         tf.dump_deleted_users(io_dir)
         if disabled_deletions_detected:
             cleanup_and_exit(tf, disabled_deletions_detected)
+
+    if dry_run:
+        cleanup_and_exit(tf)
 
     if not dry_run and not light:
         err = tf.apply()

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -1,0 +1,31 @@
+from unittest import TestCase
+import reconcile.terraform_resources as integ
+
+
+class TestSupportFunctions(TestCase):
+
+    def test_filter_no_managed_tf_resources(self):
+        ra = {'account': 'a'}
+        ns1 = {'managedTerraformResources': False, 'terraformResources': []}
+        ns2 = {'managedTerraformResources': True, 'terraformResources': [ra]}
+        namespaces = [ns1, ns2]
+        filtered = integ.filter_tf_namespaces(namespaces, None)
+        self.assertEqual(filtered, [ns2])
+
+    def test_filter_tf_namespaces_with_account_name(self):
+        ra = {'account': 'a'}
+        rb = {'account': 'b'}
+        ns1 = {'managedTerraformResources': True, 'terraformResources': [ra]}
+        ns2 = {'managedTerraformResources': True, 'terraformResources': [rb]}
+        namespaces = [ns1, ns2]
+        filtered = integ.filter_tf_namespaces(namespaces, 'a')
+        self.assertEqual(filtered, [ns1])
+
+    def test_filter_tf_namespaces_without_account_name(self):
+        ra = {'account': 'a'}
+        rb = {'account': 'b'}
+        ns1 = {'managedTerraformResources': True, 'terraformResources': [ra]}
+        ns2 = {'managedTerraformResources': True, 'terraformResources': [rb]}
+        namespaces = [ns1, ns2]
+        filtered = integ.filter_tf_namespaces(namespaces, None)
+        self.assertEqual(filtered, namespaces)

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -231,13 +231,16 @@ class TerraformClient:
 
         return data
 
-    def populate_desired_state(self, ri, oc_map, tf_namespaces):
+    def populate_desired_state(self, ri, oc_map, tf_namespaces, account_name):
         self.init_outputs()  # get updated output
 
         # Dealing with credentials for RDS replicas
         replicas_info = self.get_replicas_info(namespaces=tf_namespaces)
 
         for account, output in self.outputs.items():
+            if account_name and account != account_name:
+                continue
+
             formatted_output = self.format_output(
                 output, self.OUTPUT_TYPE_SECRETS)
 


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3399

depends on #1666

until now we couldn't run the integration fully with `--account-name` as it would have removed Secrets from other accounts.
with this PR, we now filter the Secrets based on their called (the name of the aws account), and it enables to run the integration per account.

future work:
1. create terraform-resources-wrapper, which will run the integration in parallel per account (makes tf init, tf plan, tf apply run per account and not wait for all accounts to finish each stage)
2. implement a sharded run per account (https://issues.redhat.com/browse/APPSRE-2963)