### PR TITLE
Add instrumented classes for common usage

### DIFF
--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -7,7 +7,6 @@ import time
 
 from collections import defaultdict, namedtuple
 
-from sretoolbox.container import Image
 from sretoolbox.container.image import ImageComparisonError
 from sretoolbox.container import Skopeo
 from sretoolbox.container.skopeo import SkopeoCmdError
@@ -16,7 +15,7 @@ from reconcile import queries
 from reconcile.status import ExitCodes
 from reconcile.utils import gql
 from reconcile.utils.secret_reader import SecretReader
-
+from reconcile.utils.instrumented_wrappers import InstrumentedImage as Image
 
 _LOG = logging.getLogger(__name__)
 

--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -8,14 +8,16 @@ import time
 from collections import defaultdict, namedtuple
 
 from sretoolbox.container.image import ImageComparisonError
-from sretoolbox.container import Skopeo
 from sretoolbox.container.skopeo import SkopeoCmdError
 
 from reconcile import queries
 from reconcile.status import ExitCodes
 from reconcile.utils import gql
 from reconcile.utils.secret_reader import SecretReader
-from reconcile.utils.instrumented_wrappers import InstrumentedImage as Image
+from reconcile.utils.instrumented_wrappers import (
+    InstrumentedImage as Image,
+    InstrumentedSkopeo as Skopeo
+)
 
 _LOG = logging.getLogger(__name__)
 

--- a/reconcile/test/test_instrumented_wrappers.py
+++ b/reconcile/test/test_instrumented_wrappers.py
@@ -1,12 +1,14 @@
 from unittest import TestCase
 from unittest.mock import patch
 
+from prometheus_client import Counter
+
 from sretoolbox.container import Image
 import reconcile.utils.instrumented_wrappers as instrumented
 
 
 class TestInstrumentedImage(TestCase):
-    @patch.object(instrumented.InstrumentedImage._registry_reachouts, 'labels')
+    @patch.object(Counter, 'labels')
     @patch.object(Image, '_get_manifest')
     def test_instrumented_reachout(self, getter, counter):
         # pylint: disable=no-self-use

--- a/reconcile/test/test_instrumented_wrappers.py
+++ b/reconcile/test/test_instrumented_wrappers.py
@@ -1,0 +1,15 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from sretoolbox.container import Image
+import reconcile.utils.instrumented_wrappers as instrumented
+
+
+class TestInstrumentedImage(TestCase):
+    @patch.object(instrumented.InstrumentedImage._registry_reachouts, 'inc')
+    @patch.object(Image, '_request_get')
+    def test_instrumented_reachout(self, getter, counter):
+        i = instrumented.InstrumentedImage('aregistry/animage:atag')
+        i._request_get("http://localhost")
+        getter.assert_called_once_with("http://localhost")
+        counter.assert_called_once()

--- a/reconcile/test/test_instrumented_wrappers.py
+++ b/reconcile/test/test_instrumented_wrappers.py
@@ -15,3 +15,22 @@ class TestInstrumentedImage(TestCase):
         counter.assert_called_once()
         counter.return_value.inc.assert_called_once()
 
+
+class TestInstrumentedCache(TestCase):
+    def test_get_set(self):
+        c = instrumented.InstrumentedCache('aninteg', 2, 0)
+        c['lifeuniverseandeverything'] = 42
+        self.assertEqual(c['lifeuniverseandeverything'], 42)
+
+    def test_get_not_exists(self):
+        c = instrumented.InstrumentedCache('aninteg', 2, 0)
+        with self.assertRaises(KeyError):
+            c['akeythatdoesnotexist']
+
+    def test_del(self):
+        c = instrumented.InstrumentedCache('aninteg', 2, 0)
+        c['todelete'] = 42
+        self.assertEqual(c['todelete'], 42)
+        del c['todelete']
+        with self.assertRaises(KeyError):
+            c['todelete']

--- a/reconcile/test/test_instrumented_wrappers.py
+++ b/reconcile/test/test_instrumented_wrappers.py
@@ -9,6 +9,7 @@ class TestInstrumentedImage(TestCase):
     @patch.object(instrumented.InstrumentedImage._registry_reachouts, 'labels')
     @patch.object(Image, '_get_manifest')
     def test_instrumented_reachout(self, getter, counter):
+        # pylint: disable=no-self-use
         i = instrumented.InstrumentedImage('aregistry/animage:atag')
         i._get_manifest()
         getter.assert_called_once_with()

--- a/reconcile/test/test_instrumented_wrappers.py
+++ b/reconcile/test/test_instrumented_wrappers.py
@@ -6,10 +6,12 @@ import reconcile.utils.instrumented_wrappers as instrumented
 
 
 class TestInstrumentedImage(TestCase):
-    @patch.object(instrumented.InstrumentedImage._registry_reachouts, 'inc')
-    @patch.object(Image, '_request_get')
+    @patch.object(instrumented.InstrumentedImage._registry_reachouts, 'labels')
+    @patch.object(Image, '_get_manifest')
     def test_instrumented_reachout(self, getter, counter):
         i = instrumented.InstrumentedImage('aregistry/animage:atag')
-        i._request_get("http://localhost")
-        getter.assert_called_once_with("http://localhost")
+        i._get_manifest()
+        getter.assert_called_once_with()
         counter.assert_called_once()
+        counter.return_value.inc.assert_called_once()
+

--- a/reconcile/utils/instrumented_wrappers.py
+++ b/reconcile/utils/instrumented_wrappers.py
@@ -1,0 +1,81 @@
+from prometheus_client import Counter, Gauge
+
+from sretoolbox.container import Image
+
+
+class InstrumentedImage(Image):
+    """Normal Image that exposes the count of reachouts to external
+    registries.
+
+    It helps us understand the performance of our caches and predict
+    our mirroring-related costs.
+
+    """
+    _registry_reachouts = Counter(
+        name='qontract_reconcile_registry_reachouts',
+        documentation='Number GET requests on public image registries',
+    )
+    #    labelnames=['integrations', 'shards', 'shard_id'])
+
+    def _request_get(self, url):
+        # TODO: Do I need to raise by labels? I don't think so
+        self._registry_reachouts.inc()
+        super()._request_get(url)
+
+
+class InstrumentedCache:
+    _cache_hits = Counter(
+        name='qontract_reconcile_cache_hits',
+        documentation='Number of hits to this cache',
+        labelnames=['integrations', 'shards', 'shard_id']
+    )
+
+    _cache_misses = Counter(
+        name='qontract_reconcile_cache_misses',
+        documentation='Number of misses on this cache',
+        labelnames=['integrations', 'shards', 'shard_id']
+    )
+
+    _cache_size = Gauge(
+        name='qontract_reconcile_cache_size',
+        documentation='Size of the cache',
+        labelnames=['integration', 'shards', 'shard_id']
+    )
+
+    def __init__(self, integration_name, shards, shard_id):
+        self.integraton_name = integration_name
+        self.shards = shards
+        self.shard_id = shard_id
+
+        self._hits = self._cache_hits.labels(
+            integration=integration_name,
+            shards=shards,
+            shard_id=shard_id
+        )
+        self._misses = self._cache_misses.labels(
+            integration=integration_name,
+            shards=shards,
+            shard_id=shard_id
+        )
+        self._size = self._cache_size.labels(
+            integration=integration_name,
+            shards=shards,
+            shard_id=shard_id
+        )
+
+        self._cache = {}
+
+    def __getitem__(self, item):
+        if item in self._cache:
+            self._hits.inc()
+        else:
+            self._misses.inc()
+        return self._cache[item]
+
+    def __setitem__(self, key, value):
+        self._cache[key] = value
+        self._size.inc()
+
+    def __delitem__(self, key):
+        del self._cache[key]
+        self._size.dec(1)

--- a/reconcile/utils/instrumented_wrappers.py
+++ b/reconcile/utils/instrumented_wrappers.py
@@ -42,7 +42,7 @@ class InstrumentedCache:
     )
 
     _cache_misses = Counter(
-        name='qontract_reconcile_cache_misses',
+        name='qontract_reconcile_cache_misses_total',
         documentation='Number of misses on this cache',
         labelnames=['integration', 'shards', 'shard_id']
     )

--- a/reconcile/utils/instrumented_wrappers.py
+++ b/reconcile/utils/instrumented_wrappers.py
@@ -23,13 +23,14 @@ class InstrumentedImage(Image):
     _registry_reachouts = Counter(
         name='qontract_reconcile_registry_get_manifest_total',
         documentation='Number of GET requests on public image registries',
-        labelnames=['integration', 'shard', 'shard_id'])
+        labelnames=['integration', 'shard', 'shard_id', 'registry'])
 
     def _get_manifest(self):
         self._registry_reachouts.labels(
             integration=INTEGRATION_NAME,
             shard=SHARDS,
-            shard_id=SHARD_ID
+            shard_id=SHARD_ID,
+            registry=self.registry,
         ).inc()
         super()._get_manifest()
 

--- a/reconcile/utils/instrumented_wrappers.py
+++ b/reconcile/utils/instrumented_wrappers.py
@@ -22,7 +22,7 @@ class InstrumentedImage(Image):
     """
     _registry_reachouts = Counter(
         name='qontract_reconcile_registry_get_manifest_total',
-        documentation='Number of GET requests on public image registries',
+        documentation='Number of GET requests on image registries',
         labelnames=['integration', 'shard', 'shard_id', 'registry'])
 
     def _get_manifest(self):
@@ -37,7 +37,7 @@ class InstrumentedImage(Image):
 
 class InstrumentedCache:
     _cache_hits = Counter(
-        name='qontract_reconcile_cache_hits',
+        name='qontract_reconcile_cache_hits_tocal',
         documentation='Number of hits to this cache',
         labelnames=['integration', 'shards', 'shard_id']
     )
@@ -49,8 +49,8 @@ class InstrumentedCache:
     )
 
     _cache_size = Gauge(
-        name='qontract_reconcile_cache_size',
-        documentation='Size of the cache',
+        name='qontract_reconcile_cache_cardinality',
+        documentation='Number of keys in the cache',
         labelnames=['integration', 'shards', 'shard_id']
     )
 

--- a/reconcile/utils/instrumented_wrappers.py
+++ b/reconcile/utils/instrumented_wrappers.py
@@ -94,7 +94,7 @@ class InstrumentedCache:
 
 class InstrumentedSkopeo(Skopeo):
     _copy_count = Counter(
-        name='qontract_reconcile_skopeo_copy',
+        name='qontract_reconcile_skopeo_copy_total',
         documentation='Number of copy commands issued by Skopeo',
         labelnames=['integration', 'shard', 'shard_id'],
     )

--- a/reconcile/utils/instrumented_wrappers.py
+++ b/reconcile/utils/instrumented_wrappers.py
@@ -21,7 +21,7 @@ class InstrumentedImage(Image):
 
     """
     _registry_reachouts = Counter(
-        name='qontract_reconcile_registry_reachouts',
+        name='qontract_reconcile_registry_get_manifest_total',
         documentation='Number of GET requests on public image registries',
         labelnames=['integration', 'shard', 'shard_id'])
 

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -1,5 +1,4 @@
-from prometheus_client import Gauge
-from prometheus_client import Histogram
+from prometheus_client import Gauge, Counter, Histogram
 
 
 run_time = Gauge(name='qontract_reconcile_last_run_seconds',
@@ -17,3 +16,32 @@ reconcile_time = Histogram(name='qontract_reconcile_function_'
                            labelnames=['name', 'integration'],
                            buckets=(60.0, 150.0, 300.0, 600.0, 1200.0, 1800.0,
                                     2400.0, 3000.0, float("inf")))
+
+registry_reachouts = Counter(
+    name='qontract_reconcile_registry_get_manifest_total',
+    documentation='Number of GET requests on image registries',
+    labelnames=['integration', 'shard', 'shard_id', 'registry'])
+
+cache_hits = Counter(
+    name='qontract_reconcile_cache_hits_tocal',
+    documentation='Number of hits to this cache',
+    labelnames=['integration', 'shards', 'shard_id']
+)
+
+cache_misses = Counter(
+    name='qontract_reconcile_cache_misses_total',
+    documentation='Number of misses on this cache',
+    labelnames=['integration', 'shards', 'shard_id']
+)
+
+cache_size = Gauge(
+    name='qontract_reconcile_cache_cardinality',
+    documentation='Number of keys in the cache',
+    labelnames=['integration', 'shards', 'shard_id']
+)
+
+copy_count = Counter(
+    name='qontract_reconcile_skopeo_copy_total',
+    documentation='Number of copy commands issued by Skopeo',
+    labelnames=['integration', 'shard', 'shard_id'],
+)

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -23,7 +23,7 @@ registry_reachouts = Counter(
     labelnames=['integration', 'shard', 'shard_id', 'registry'])
 
 cache_hits = Counter(
-    name='qontract_reconcile_cache_hits_tocal',
+    name='qontract_reconcile_cache_hits_total',
     documentation='Number of hits to this cache',
     labelnames=['integration', 'shards', 'shard_id']
 )


### PR DESCRIPTION
As part of APPSRE-3385 we need to review measure how often we reach
to the external registry, and how effective our cache is.

For the first part, we keep `sretools.container.Image` decoupled from
Prometheus by subclassing it inside this repository, and instrumenting
the method that matters in this context: `_get_requests`. We make
`quay_mirror` use this instrumented version.

Then, we add a simple dictionary-like class that reports on hits,
misses and size. This will become our cache. We don't subclass `dict`
here since we may need to use a more sophisticated, persistent cache
with the same look and feel.

TODO:

* Is this the right way to use Prometheus metrics?
