### PR TITLE
[aws-iam-keys] add support to run per account

### DIFF
--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -43,8 +43,13 @@ def cleanup(working_dirs):
 
 @defer
 def run(dry_run, thread_pool_size=10,
-        disable_service_account_keys=False, defer=None):
+        disable_service_account_keys=False, account_name=None, defer=None):
     accounts = queries.get_aws_accounts()
+    if account_name:
+        accounts = [a for a in accounts if a['name'] == account_name]
+        if not accounts:
+            raise ValueError(f"aws account {account_name} not found")
+
     settings = queries.get_app_interface_settings()
     aws = AWSApi(thread_pool_size, accounts, settings=settings)
     keys_to_delete = get_keys_to_delete(accounts)

--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -11,6 +11,12 @@ from reconcile.utils.terrascript_client \
 QONTRACT_INTEGRATION = 'aws-iam-keys'
 
 
+def filter_accounts(accounts, account_name):
+    if account_name:
+        accounts = [a for a in accounts if a['name'] == account_name]
+    return accounts
+
+
 def get_keys_to_delete(accounts):
     return {account['name']: account['deleteKeys']
             for account in accounts
@@ -44,11 +50,9 @@ def cleanup(working_dirs):
 @defer
 def run(dry_run, thread_pool_size=10,
         disable_service_account_keys=False, account_name=None, defer=None):
-    accounts = queries.get_aws_accounts()
-    if account_name:
-        accounts = [a for a in accounts if a['name'] == account_name]
-        if not accounts:
-            raise ValueError(f"aws account {account_name} not found")
+    accounts = filter_accounts(queries.get_aws_accounts(), account_name)
+    if not accounts:
+        raise ValueError(f"aws account {account_name} not found")
 
     settings = queries.get_app_interface_settings()
     aws = AWSApi(thread_pool_size, accounts, settings=settings)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -704,10 +704,11 @@ def aws_garbage_collector(ctx, thread_pool_size, io_dir):
 
 @integration.command()
 @threaded()
+@account_name
 @click.pass_context
-def aws_iam_keys(ctx, thread_pool_size):
+def aws_iam_keys(ctx, thread_pool_size, account_name):
     run_integration(reconcile.aws_iam_keys, ctx.obj,
-                    thread_pool_size)
+                    thread_pool_size, account_name=account_name)
 
 
 @integration.command()

--- a/reconcile/test/test_aws_iam_keys.py
+++ b/reconcile/test/test_aws_iam_keys.py
@@ -1,0 +1,28 @@
+from unittest import TestCase
+import reconcile.aws_iam_keys as integ
+
+
+class TestSupportFunctions(TestCase):
+
+    def test_filter_accounts_with_account_name(self):
+        a = {'name': 'a'}
+        b = {'name': 'b'}
+        accounts = [a, b]
+        filtered = integ.filter_accounts(accounts, a['name'])
+        self.assertEqual(filtered, [a])
+
+    def test_filter_accounts_without_account_name(self):
+        a = {'name': 'a'}
+        b = {'name': 'b'}
+        accounts = [a, b]
+        filtered = integ.filter_accounts(accounts, None)
+        self.assertEqual(filtered, accounts)
+
+    def test_get_keys_to_delete(self):
+        a = {'name': 'a', 'deleteKeys': ['k1', 'k2']}
+        b = {'name': 'b', 'deleteKeys': None}
+        c = {'name': 'c', 'deleteKeys': []}
+        accounts = [a, b, c]
+        expected_result = {a['name']: a['deleteKeys']}
+        keys_to_delete = integ.get_keys_to_delete(accounts)
+        self.assertEqual(keys_to_delete, expected_result)


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3399

required for #1664

this PR enables running the `aws-iam-keys` integration for a specific AWS account. since this integration is called from within `terraform-resources`, which can be run for a specific account, this will be beneficial.