### PR TITLE
add support for additional labels in metrics (+implement for terraform-resources)

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1051,7 +1051,8 @@ def terraform_resources(ctx, print_only, enable_deletion,
                     ctx.obj, print_only,
                     enable_deletion, io_dir, thread_pool_size,
                     internal, use_jump_host, light, vault_output_path,
-                    account_name=account_name)
+                    account_name=account_name,
+                    extra_labels=ctx.obj['extra_labels'])
 
 
 @integration.command()

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1052,7 +1052,7 @@ def terraform_resources(ctx, print_only, enable_deletion,
                     enable_deletion, io_dir, thread_pool_size,
                     internal, use_jump_host, light, vault_output_path,
                     account_name=account_name,
-                    extra_labels=ctx.obj['extra_labels'])
+                    extra_labels=ctx.obj.get('extra_labels', {}))
 
 
 @integration.command()

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -299,7 +299,7 @@ def setup(dry_run, print_only, thread_pool_size, internal,
                     if n['name'] == account_name]
         if not accounts:
             raise ValueError(f"aws account {account_name} is not found")
-        extra_labels['key'] = account_name
+        extra_labels['shard_key'] = account_name
     settings = queries.get_app_interface_settings()
     namespaces = gqlapi.query(TF_NAMESPACES_QUERY)['namespaces']
     tf_namespaces = filter_tf_namespaces(namespaces, account_name)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -291,7 +291,7 @@ def init_working_dirs(accounts, thread_pool_size,
 
 
 def setup(dry_run, print_only, thread_pool_size, internal,
-          use_jump_host, account_name):
+          use_jump_host, account_name, extra_labels):
     gqlapi = gql.get_api()
     accounts = queries.get_aws_accounts()
     if account_name:
@@ -299,6 +299,7 @@ def setup(dry_run, print_only, thread_pool_size, internal,
                     if n['name'] == account_name]
         if not accounts:
             raise ValueError(f"aws account {account_name} is not found")
+        extra_labels['key'] = account_name
     settings = queries.get_app_interface_settings()
     namespaces = gqlapi.query(TF_NAMESPACES_QUERY)['namespaces']
     tf_namespaces = filter_tf_namespaces(namespaces, account_name)
@@ -369,11 +370,11 @@ def run(dry_run, print_only=False,
         enable_deletion=False, io_dir='throughput/',
         thread_pool_size=10, internal=None, use_jump_host=True,
         light=False, vault_output_path='',
-        account_name=None, defer=None):
+        account_name=None, extra_labels=None, defer=None):
 
     ri, oc_map, tf, tf_namespaces = \
         setup(dry_run, print_only, thread_pool_size, internal,
-              use_jump_host, account_name)
+              use_jump_host, account_name, extra_labels)
 
     if not dry_run:
         defer(lambda: oc_map.cleanup())

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -2,7 +2,7 @@ from prometheus_client import Gauge
 from prometheus_client import Histogram
 
 
-extra_labels = {'key': None}
+extra_labels = {'shard_key': None}
 label_keys = list(extra_labels.keys())
 
 run_time = Gauge(

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -3,16 +3,17 @@ from prometheus_client import Histogram
 
 
 extra_labels = {'key': None}
+label_keys = list(extra_labels.keys())
 
-run_time = Gauge(name='qontract_reconcile_last_run_seconds',
-                 documentation='Last run duration in seconds',
-                 labelnames=['integration', 'shards', 'shard_id'] + \
-                      list(extra_labels.keys()))
+run_time = Gauge(
+     name='qontract_reconcile_last_run_seconds',
+     documentation='Last run duration in seconds',
+     labelnames=['integration', 'shards', 'shard_id'] + label_keys)
 
-run_status = Gauge(name='qontract_reconcile_last_run_status',
-                   documentation='Last run status',
-                   labelnames=['integration', 'shards', 'shard_id'] + \
-                      list(extra_labels.keys()))
+run_status = Gauge(
+     name='qontract_reconcile_last_run_status',
+     documentation='Last run status',
+     labelnames=['integration', 'shards', 'shard_id'] + label_keys)
 
 reconcile_time = Histogram(name='qontract_reconcile_function_'
                                 'elapsed_seconds_since_bundle_commit',

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -2,13 +2,17 @@ from prometheus_client import Gauge
 from prometheus_client import Histogram
 
 
+extra_labels = {'key': None}
+
 run_time = Gauge(name='qontract_reconcile_last_run_seconds',
                  documentation='Last run duration in seconds',
-                 labelnames=['integration', 'shards', 'shard_id'])
+                 labelnames=['integration', 'shards', 'shard_id'] + \
+                      list(extra_labels.keys()))
 
 run_status = Gauge(name='qontract_reconcile_last_run_status',
                    documentation='Last run status',
-                   labelnames=['integration', 'shards', 'shard_id'])
+                   labelnames=['integration', 'shards', 'shard_id'] + \
+                      list(extra_labels.keys()))
 
 reconcile_time = Histogram(name='qontract_reconcile_function_'
                                 'elapsed_seconds_since_bundle_commit',


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3424

It will be useful to be able to expose additional labels on metrics based on the data that is being processed.
One use case would be - if terraform-resources is running per account and is running slowly, we would want to know which is the problematic account.

this is just an implementation proposal that works. feel free to review it and suggest improvements to things i'm obviously missing.

note: this works.