### PR TITLE
Report failed repo in saasherder.get_sha

### DIFF
--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -1,4 +1,7 @@
 from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from github import GithubException
 
 from reconcile.utils.saasherder import SaasHerder
 
@@ -115,3 +118,144 @@ class TestCheckSaasFileEnvComboUnique(TestCase):
         )
 
         self.assertFalse(saasherder.valid)
+
+
+class TestGetMovingCommitsDiffSaasFile(TestCase):
+    def setUp(self):
+        self.saas_files = [
+            {
+                'path': 'path1',
+                'name': 'a1',
+                'managedResourceTypes': [],
+                'resourceTemplates':
+                [
+                    {
+                        'name': 'rt',
+                        'url': 'http://github.com/user/repo',
+                        'targets':
+                        [
+                            {
+                                'namespace': {
+                                    'name': 'ns',
+                                    'environment': {
+                                        'name': 'env1'
+                                    },
+                                    'cluster': {
+                                        'name': 'cluster1'
+                                    }
+                                },
+                                'parameters': {},
+                                'ref': 'main',
+                            },
+                            {
+                                'namespace': {
+                                    'name': 'ns',
+                                    'environment': {
+                                        'name': 'env2'
+                                    },
+                                    'cluster': {
+                                        'name': 'cluster2'
+                                    }
+                                },
+                                'parameters': {},
+                                'ref': 'secondary'
+                            }
+                        ]
+                    }
+                ],
+                'roles': [
+                    {'users': [{'org_username': 'myname'}]}
+                ]
+            }
+        ]
+        self.initiate_gh_patcher = patch.object(
+            SaasHerder, '_initiate_github', autospec=True
+        )
+        self.get_pipelines_provider_patcher = patch.object(
+            SaasHerder, '_get_pipelines_provider'
+        )
+        self.get_commit_sha_patcher = patch.object(
+            SaasHerder, '_get_commit_sha', autospec=True
+        )
+        self.initiate_gh = self.initiate_gh_patcher.start()
+        self.get_pipelines_provider = self.get_pipelines_provider_patcher.start()
+        self.get_commit_sha = self.get_commit_sha_patcher.start()
+        self.maxDiff = None
+
+    def tearDown(self):
+        for p in (
+                self.initiate_gh_patcher,
+                self.get_pipelines_provider_patcher,
+                self.get_commit_sha_patcher
+        ):
+            p.stop()
+
+    def test_get_moving_commits_diff_saas_file_all_fine(self):
+        saasherder = SaasHerder(
+            self.saas_files,
+            thread_pool_size=1,
+            gitlab=None,
+            integration='',
+            integration_version='',
+            settings={},
+            validate=False
+        )
+        saasherder.state = MagicMock()
+        saasherder.state.get.return_value = 'asha'
+        self.get_commit_sha.side_effect = ('abcd4242', '4242efg')
+        self.get_pipelines_provider.return_value = 'apipelineprovider'
+        expected = [
+            {
+                'saas_file_name': self.saas_files[0]['name'],
+                'env_name': 'env1',
+                'timeout': None,
+                'ref': 'main',
+                'commit_sha': 'abcd4242',
+                'cluster_name': 'cluster1',
+                'pipelines_provider': 'apipelineprovider',
+                'namespace_name': 'ns',
+                'rt_name': 'rt',
+            },
+            {
+                'saas_file_name': self.saas_files[0]['name'],
+                'env_name': 'env2',
+                'timeout': None,
+                'ref': 'secondary',
+                'commit_sha': '4242efg',
+                'cluster_name': 'cluster2',
+                'pipelines_provider': 'apipelineprovider',
+                'namespace_name': 'ns',
+                'rt_name': 'rt',
+            }
+        ]
+
+        self.assertEqual(
+            saasherder.get_moving_commits_diff_saas_file(
+                self.saas_files[0], True
+            ),
+            expected
+        )
+
+    def test_get_moving_commits_diff_saas_file_bad_sha1(self):
+        saasherder = SaasHerder(
+            self.saas_files,
+            thread_pool_size=1,
+            gitlab=None,
+            integration='',
+            integration_version='',
+            settings={},
+            validate=False
+        )
+        saasherder.state = MagicMock()
+        saasherder.state.get.return_value = 'asha'
+        self.get_pipelines_provider.return_value = 'apipelineprovider'
+        self.get_commit_sha.side_effect = GithubException(
+            401, 'somedata', {'aheader': 'avalue'}
+        )
+        # At least we don't crash!
+        self.assertEqual(
+                        saasherder.get_moving_commits_diff_saas_file(
+                self.saas_files[0], True
+            ),
+            []
+        )

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -67,7 +67,8 @@ class TestCheckSaasFileEnvComboUnique(TestCase):
         saas_files = [
             {
                 'path': 'path1',
-                'name': 'long-name-which-is-too-long-to-produce-unique-combo',
+                'name':
+                'long-name-which-is-too-long-to-produce-unique-combo',
                 'managedResourceTypes': [],
                 'resourceTemplates':
                 [
@@ -178,7 +179,8 @@ class TestGetMovingCommitsDiffSaasFile(TestCase):
             SaasHerder, '_get_commit_sha', autospec=True
         )
         self.initiate_gh = self.initiate_gh_patcher.start()
-        self.get_pipelines_provider = self.get_pipelines_provider_patcher.start()
+        self.get_pipelines_provider = \
+            self.get_pipelines_provider_patcher.start()
         self.get_commit_sha = self.get_commit_sha_patcher.start()
         self.maxDiff = None
 
@@ -254,7 +256,7 @@ class TestGetMovingCommitsDiffSaasFile(TestCase):
         )
         # At least we don't crash!
         self.assertEqual(
-                        saasherder.get_moving_commits_diff_saas_file(
+            saasherder.get_moving_commits_diff_saas_file(
                 self.saas_files[0], True
             ),
             []

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -5,6 +5,7 @@ import os
 
 import yaml
 
+from gitlab.exceptions import GitlabError
 from github import Github, GithubException
 from requests import exceptions as rqexc
 from sretoolbox.container import Image
@@ -915,7 +916,7 @@ class SaasHerder():
                         'commit_sha': desired_commit_sha
                     }
                     trigger_specs.append(job_spec)
-                except GithubException:
+                except (GithubException, GitlabError):
                     logging.exception(
                         f"Skipping target {saas_file_name}:{rt_name}"
                         f" - repo: {url} - ref: {ref}"

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -865,10 +865,10 @@ class SaasHerder():
         github = self._initiate_github(saas_file)
         trigger_specs = []
         for rt in saas_file['resourceTemplates']:
-            try:
-                rt_name = rt['name']
-                url = rt['url']
-                for target in rt['targets']:
+            rt_name = rt['name']
+            url = rt['url']
+            for target in rt['targets']:
+                try:
                     # don't trigger if there is a linked upstream job
                     if target.get('upstream'):
                         continue
@@ -915,11 +915,11 @@ class SaasHerder():
                         'commit_sha': desired_commit_sha
                     }
                     trigger_specs.append(job_spec)
-            except GithubException:
-                logging.exception(
-                    f"Skipping all remaining targets in {saas_file_name}:{rt_name}"
-                    f" - repo: {url} - ref: {ref}"
-                )
+                except GithubException:
+                    logging.exception(
+                        f"Skipping target {saas_file_name}:{rt_name}"
+                        f" - repo: {url} - ref: {ref}"
+                    )
 
         return trigger_specs
 

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -865,55 +865,61 @@ class SaasHerder():
         github = self._initiate_github(saas_file)
         trigger_specs = []
         for rt in saas_file['resourceTemplates']:
-            rt_name = rt['name']
-            url = rt['url']
-            for target in rt['targets']:
-                # don't trigger if there is a linked upstream job
-                if target.get('upstream'):
-                    continue
-                ref = target['ref']
-                get_commit_sha_options = {
-                    'url': url,
-                    'ref': ref,
-                    'github': github
-                }
-                desired_commit_sha = \
-                    self._get_commit_sha(get_commit_sha_options)
-                # don't trigger on refs which are commit shas
-                if ref == desired_commit_sha:
-                    continue
-                namespace = target['namespace']
-                cluster_name = namespace['cluster']['name']
-                namespace_name = namespace['name']
-                env_name = namespace['environment']['name']
-                key = f"{saas_file_name}/{rt_name}/{cluster_name}/" + \
-                    f"{namespace_name}/{env_name}/{ref}"
-                current_commit_sha = self.state.get(key, None)
-                # skip if there is no change in commit sha
-                if current_commit_sha == desired_commit_sha:
-                    continue
-                # don't trigger if this is the first time
-                # this target is being deployed.
-                # that will be taken care of by
-                # openshift-saas-deploy-trigger-configs
-                if current_commit_sha is None:
-                    # store the value to take over from now on
-                    if not dry_run:
-                        self.state.add(key, value=desired_commit_sha)
-                    continue
-                # we finally found something we want to trigger on!
-                job_spec = {
-                    'saas_file_name': saas_file_name,
-                    'env_name': env_name,
-                    'timeout': timeout,
-                    'pipelines_provider': pipelines_provider,
-                    'rt_name': rt_name,
-                    'cluster_name': cluster_name,
-                    'namespace_name': namespace_name,
-                    'ref': ref,
-                    'commit_sha': desired_commit_sha
-                }
-                trigger_specs.append(job_spec)
+            try:
+                rt_name = rt['name']
+                url = rt['url']
+                for target in rt['targets']:
+                    # don't trigger if there is a linked upstream job
+                    if target.get('upstream'):
+                        continue
+                    ref = target['ref']
+                    get_commit_sha_options = {
+                        'url': url,
+                        'ref': ref,
+                        'github': github
+                    }
+                    desired_commit_sha = \
+                        self._get_commit_sha(get_commit_sha_options)
+                    # don't trigger on refs which are commit shas
+                    if ref == desired_commit_sha:
+                        continue
+                    namespace = target['namespace']
+                    cluster_name = namespace['cluster']['name']
+                    namespace_name = namespace['name']
+                    env_name = namespace['environment']['name']
+                    key = f"{saas_file_name}/{rt_name}/{cluster_name}/" + \
+                        f"{namespace_name}/{env_name}/{ref}"
+                    current_commit_sha = self.state.get(key, None)
+                    # skip if there is no change in commit sha
+                    if current_commit_sha == desired_commit_sha:
+                        continue
+                    # don't trigger if this is the first time
+                    # this target is being deployed.
+                    # that will be taken care of by
+                    # openshift-saas-deploy-trigger-configs
+                    if current_commit_sha is None:
+                        # store the value to take over from now on
+                        if not dry_run:
+                            self.state.add(key, value=desired_commit_sha)
+                        continue
+                    # we finally found something we want to trigger on!
+                    job_spec = {
+                        'saas_file_name': saas_file_name,
+                        'env_name': env_name,
+                        'timeout': timeout,
+                        'pipelines_provider': pipelines_provider,
+                        'rt_name': rt_name,
+                        'cluster_name': cluster_name,
+                        'namespace_name': namespace_name,
+                        'ref': ref,
+                        'commit_sha': desired_commit_sha
+                    }
+                    trigger_specs.append(job_spec)
+            except GithubException:
+                logging.exception(
+                    f"Skipping all remaining targets in {saas_file_name}:{rt_name}"
+                    f" - repo: {url} - ref: {ref}"
+                )
 
         return trigger_specs
 


### PR DESCRIPTION
When we try to fetch a non-existing commit from the Github API, we get
an exception that prints the offending commit but not the
repository.

In the context of integrations, when we are processing many different
repositories, we don't know which of them is actually giving problems.
