### PR TITLE
[openshift-saas-deploy] add support to delete target

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1285,6 +1285,7 @@ SAAS_FILES_QUERY_V1 = """
         parameters
         upstream
         disable
+        delete
       }
     }
     roles {
@@ -1432,6 +1433,7 @@ SAAS_FILES_QUERY_V2 = """
           name
         }
         disable
+        delete
       }
     }
     roles {

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -261,3 +261,19 @@ class TestGetMovingCommitsDiffSaasFile(TestCase):
             ),
             []
         )
+
+
+class TestPopulateDesiredState(TestCase):
+    def test_populate_desired_state_saas_file_delete(self):
+        spec = {'delete': True}
+        saasherder = SaasHerder(
+            [],
+            thread_pool_size=1,
+            gitlab=None,
+            integration='',
+            integration_version='',
+            settings={}
+        )
+        desired_state = \
+            saasherder.populate_desired_state_saas_file(spec, None)
+        self.assertEqual(None, desired_state)

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -276,4 +276,4 @@ class TestPopulateDesiredState(TestCase):
         )
         desired_state = \
             saasherder.populate_desired_state_saas_file(spec, None)
-        self.assertEqual(None, desired_state)
+        self.assertIsNone(desired_state)

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -763,6 +763,10 @@ class SaasHerder():
         return specs
 
     def populate_desired_state_saas_file(self, spec, ri):
+        if spec['delete']:
+            # to delete resources, we avoid adding them to the desired state
+            return
+
         saas_file_name = spec['saas_file_name']
         cluster = spec['cluster']
         namespace = spec['namespace']
@@ -771,7 +775,6 @@ class SaasHerder():
         check_images_options_base = spec['check_images_options_base']
         instance_name = spec['instance_name']
         upstream = spec['upstream']
-        delete = spec['delete']
 
         resources, html_url, promotion = \
             self._process_template(process_template_options)
@@ -813,14 +816,13 @@ class SaasHerder():
                 caller_name=saas_file_name,
                 error_details=html_url)
             try:
-                if not delete:
-                    ri.add_desired(
-                        cluster,
-                        namespace,
-                        resource_kind,
-                        resource_name,
-                        oc_resource
-                    )
+                ri.add_desired(
+                    cluster,
+                    namespace,
+                    resource_kind,
+                    resource_name,
+                    oc_resource
+                )
             except ResourceKeyExistsError:
                 ri.register_error()
                 msg = \

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -755,7 +755,8 @@ class SaasHerder():
                     'process_template_options': process_template_options,
                     'check_images_options_base': check_images_options_base,
                     'instance_name': instance_name,
-                    'upstream': target.get('upstream')
+                    'upstream': target.get('upstream'),
+                    'delete': target.get('delete'),
                 }
                 specs.append(spec)
 
@@ -770,6 +771,7 @@ class SaasHerder():
         check_images_options_base = spec['check_images_options_base']
         instance_name = spec['instance_name']
         upstream = spec['upstream']
+        delete = spec['delete']
 
         resources, html_url, promotion = \
             self._process_template(process_template_options)
@@ -811,13 +813,14 @@ class SaasHerder():
                 caller_name=saas_file_name,
                 error_details=html_url)
             try:
-                ri.add_desired(
-                    cluster,
-                    namespace,
-                    resource_kind,
-                    resource_name,
-                    oc_resource
-                )
+                if not delete:
+                    ri.add_desired(
+                        cluster,
+                        namespace,
+                        resource_kind,
+                        resource_name,
+                        oc_resource
+                    )
             except ResourceKeyExistsError:
                 ri.register_error()
                 msg = \


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3425

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/21589

this PR adds support for a `delete` boolean in a saas file target to indicate that resources associated to that target should be removed.

the implementation is quite simple: if the target has `delete: true`, we don't add it's resources to the desired state. since they will be found in the current state and not in the desired state, they will be removed.