### PR TITLE
[ocm] add option to not init addons, rename skip to init

### DIFF
--- a/reconcile/ocm_addons.py
+++ b/reconcile/ocm_addons.py
@@ -14,7 +14,7 @@ QONTRACT_INTEGRATION = 'ocm-addons'
 def fetch_current_state(clusters):
     settings = queries.get_app_interface_settings()
     ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
-                     settings=settings)
+                     settings=settings, init_addons=True)
 
     current_state = []
     for cluster in clusters:

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -65,7 +65,7 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
     clusters = queries.get_clusters()
     clusters = [c for c in clusters if c.get('ocm') is not None]
     ocm_map = OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
-                     settings=settings, skip_provision_shards=False)
+                     settings=settings, init_provision_shards=True)
     current_state, pending_state = ocm_map.cluster_specs()
     desired_state = fetch_desired_state(clusters)
 

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -29,10 +29,14 @@ class OCM:
     :param access_token_client_id: client-id to get access token
     :param access_token_url: URL to get access token from
     :param offline_token: Long lived offline token used to get access token
+    :param init_provision_shards: should initiate provision shards
+    :param init_addons: should initiate addons
     :type url: string
     :type access_token_client_id: string
     :type access_token_url: string
     :type offline_token: string
+    :type init_provision_shards: bool
+    :type init_addons: bool
     """
     def __init__(self, url, access_token_client_id, access_token_url,
                  offline_token, init_provision_shards=False,
@@ -863,14 +867,19 @@ class OCMMap:
     :param integration: Name of calling integration.
                         Used to disable integrations.
     :param settings: App Interface settings
+    :param init_provision_shards: should initiate provision shards
+    :param init_addons: should initiate addons
     :type clusters: list
     :type namespaces: list
     :type integration: string
     :type settings: dict
+    :type init_provision_shards: bool
+    :type init_addons: bool
     """
     def __init__(self, clusters=None, namespaces=None,
                  integration='', settings=None,
-                 init_provision_shards=False):
+                 init_provision_shards=False,
+                 init_addons=False):
         """Initiates OCM instances for each OCM referenced in a cluster."""
         self.clusters_map = {}
         self.ocm_map = {}
@@ -881,15 +890,18 @@ class OCMMap:
             raise KeyError('expected only one of clusters or namespaces.')
         elif clusters:
             for cluster_info in clusters:
-                self.init_ocm_client(cluster_info, init_provision_shards)
+                self.init_ocm_client(cluster_info, init_provision_shards,
+                                     init_addons)
         elif namespaces:
             for namespace_info in namespaces:
                 cluster_info = namespace_info['cluster']
-                self.init_ocm_client(cluster_info, init_provision_shards)
+                self.init_ocm_client(cluster_info, init_provision_shards,
+                                     init_addons)
         else:
             raise KeyError('expected one of clusters or namespaces.')
 
-    def init_ocm_client(self, cluster_info, init_provision_shards):
+    def init_ocm_client(self, cluster_info, init_provision_shards,
+                        init_addons):
         """
         Initiate OCM client.
         Gets the OCM information and initiates an OCM client.
@@ -897,6 +909,8 @@ class OCMMap:
         the current integration is disabled on it.
 
         :param cluster_info: Graphql cluster query result
+        :param init_provision_shards: should initiate provision shards
+        :param init_addons: should initiate addons
 
         :type cluster_info: dict
         """
@@ -921,7 +935,8 @@ class OCMMap:
             token = secret_reader.read(ocm_offline_token)
             self.ocm_map[ocm_name] = \
                 OCM(url, access_token_client_id, access_token_url, token,
-                    init_provision_shards=init_provision_shards)
+                    init_provision_shards=init_provision_shards,
+                    init_addons=init_addons)
 
     def cluster_disabled(self, cluster_info):
         """

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -35,7 +35,8 @@ class OCM:
     :type offline_token: string
     """
     def __init__(self, url, access_token_client_id, access_token_url,
-                 offline_token, init_provision_shards=False):
+                 offline_token, init_provision_shards=False,
+                 init_addons=False):
         """Initiates access token and gets clusters information."""
         self.url = url
         self.access_token_client_id = access_token_client_id
@@ -44,7 +45,8 @@ class OCM:
         self._init_access_token()
         self._init_request_headers()
         self._init_clusters(init_provision_shards=init_provision_shards)
-        self._init_addons()
+        if init_addons:
+            self._init_addons()
 
     @retry()
     def _init_access_token(self):


### PR DESCRIPTION
we do not need to initiate addons in every integration that uses OCM, so changing that to be opt-in.
also changing the skip to init for a positive declaration which is less confusing.