### PR TITLE
[saas-file-owners] add support to delete target

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -77,6 +77,7 @@ def collect_state():
                 cluster = namespace_info['cluster']['name']
                 environment = namespace_info['environment']['name']
                 target_ref = target['ref']
+                target_delete = target.get('delete')
                 target_parameters = \
                     json.loads(target.get('parameters') or '{}')
                 parameters = {}
@@ -94,7 +95,8 @@ def collect_state():
                     'ref': target_ref,
                     'parameters': parameters,
                     'saas_file_definitions':
-                        copy.deepcopy(saas_file_definitions)
+                        copy.deepcopy(saas_file_definitions),
+                    'delete': target_delete,
                 })
     return state
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3425

follow up on #1680

this PR will make `saas-file-owners` realize there was a change in a target, thus causing the `openshift-saas-deploy-wrapper` to show proper results in pr-checks.