### PR TITLE
[saasherder] handle None promotions

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -1174,6 +1174,8 @@ class SaasHerder():
             self._get_subscribe_saas_file_path_map(saas_files, auto_only=True)
         trigger_promotion = False
         for item in self.promotions:
+            if item is None:
+                continue
             commit_sha = item['commit_sha']
             publish = item.get('publish')
             if publish:


### PR DESCRIPTION
when publishing promotions, some of them may be set to None (no deployment happened). let's handle it.