### PR TITLE
bump helm version, rename binary from helm3 to helm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,9 +24,9 @@ rc:
 	@docker --config=$(DOCKER_CONF) push $(IMAGE_NAME):$(IMAGE_TAG)-rc
 
 generate:
-	@helm3 lint helm/qontract-reconcile
-	@helm3 template helm/qontract-reconcile -n qontract-reconcile -f helm/qontract-reconcile/values-external.yaml > openshift/qontract-reconcile.yaml
-	@helm3 template helm/qontract-reconcile -n qontract-reconcile -f helm/qontract-reconcile/values-internal.yaml > openshift/qontract-reconcile-internal.yaml
+	@helm lint helm/qontract-reconcile
+	@helm template helm/qontract-reconcile -n qontract-reconcile -f helm/qontract-reconcile/values-external.yaml > openshift/qontract-reconcile.yaml
+	@helm template helm/qontract-reconcile -n qontract-reconcile -f helm/qontract-reconcile/values-internal.yaml > openshift/qontract-reconcile-internal.yaml
 
 build-test:
 	@docker build -t $(IMAGE_TEST) -f dockerfiles/Dockerfile.test .

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -8,9 +8,9 @@ RUN yum install -y epel-release && \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install tox
 
-RUN curl -L https://get.helm.sh/helm-v3.0.3-linux-amd64.tar.gz |tar xvz && \
-    mv linux-amd64/helm /usr/bin/helm3 && \
-    chmod +x /usr/bin/helm3 && \
+RUN curl -L https://get.helm.sh/helm-v3.6.2-linux-amd64.tar.gz |tar xvz && \
+    mv linux-amd64/helm /usr/local/bin/helm && \
+    chmod +x /usr/local/bin/helm && \
     rm -rf linux-amd64
 
 COPY . /package


### PR DESCRIPTION
The main reason for this change is to fix a personal annoyance. This also bumps the Helm version in the test image.

Helm v3 has been out for a while and the default binary name is `helm`. As far as I can tell distributions are packaging the binary as such and not `helm3`. This has been an annoyance for me personally as the Makefile wants a `helm3` binary