### PR TITLE
[openshift-upgrade-watcher] fix missing upgrades due to resource name

### DIFF
--- a/reconcile/openshift_upgrade_watcher.py
+++ b/reconcile/openshift_upgrade_watcher.py
@@ -42,12 +42,12 @@ def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True,
         upgrade_config = oc.get(
             namespace='openshift-managed-upgrade-operator',
             kind='UpgradeConfig',
-            name='osd-upgrade-config',
             allow_not_found=True
-        )
+        )['items']
         if not upgrade_config:
             logging.debug(f'[{cluster}] UpgradeConfig not found.')
             continue
+        [upgrade_config] = upgrade_config
 
         upgrade_spec = upgrade_config['spec']
         upgrade_at = upgrade_spec['upgradeAt']


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3376

due to the UpgradeConfig resource changing it's name in https://github.com/openshift/managed-upgrade-operator/pull/224, we are no longer getting notifications for upgrades.
we also added internal OSD clusters, which means this integration needs to run internally.