### PR TITLE
[openshift-saas-deploy] add support for cluster-admin automation token

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -171,7 +171,8 @@ def fetch_current_state(namespaces=None,
                         override_managed_types=None,
                         internal=None,
                         use_jump_host=True,
-                        init_api_resources=False):
+                        init_api_resources=False,
+                        cluster_admin=False):
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(namespaces=namespaces,
@@ -181,7 +182,8 @@ def fetch_current_state(namespaces=None,
                     internal=internal,
                     use_jump_host=use_jump_host,
                     thread_pool_size=thread_pool_size,
-                    init_api_resources=init_api_resources)
+                    init_api_resources=init_api_resources,
+                    cluster_admin=cluster_admin)
     state_specs = \
         init_specs_to_fetch(
             ri,

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -121,7 +121,8 @@ def run(dry_run, thread_pool_size=10, io_dir='throughput/',
         thread_pool_size=thread_pool_size,
         integration=QONTRACT_INTEGRATION,
         integration_version=QONTRACT_INTEGRATION_VERSION,
-        init_api_resources=True)
+        init_api_resources=True,
+        cluster_admin=saasherder.cluster_admin)
     defer(lambda: oc_map.cleanup())
     saasherder.populate_desired_state(ri)
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1271,6 +1271,11 @@ SAAS_FILES_QUERY_V1 = """
               field
               format
             }
+            clusterAdminAutomationToken {
+              path
+              field
+              format
+            }
             internal
             disable {
               integrations
@@ -1411,6 +1416,11 @@ SAAS_FILES_QUERY_V2 = """
                 }
             }
             automationToken {
+              path
+              field
+              format
+            }
+            clusterAdminAutomationToken {
               path
               field
               format

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1222,6 +1222,7 @@ SAAS_FILES_QUERY_V1 = """
     compare
     timeout
     publishJobLogs
+    clusterAdmin
     imagePatterns
     use_channel_in_image_tag
     authentication {
@@ -1365,6 +1366,7 @@ SAAS_FILES_QUERY_V2 = """
     takeover
     compare
     publishJobLogs
+    clusterAdmin
     imagePatterns
     use_channel_in_image_tag
     authentication {

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -73,6 +73,7 @@ class SaasHerder():
         self.take_over = self._get_saas_file_attribute('takeover')
         self.compare = self._get_saas_file_attribute('compare')
         self.publish_job_logs = self._get_saas_file_attribute('publishJobLogs')
+        self.cluster_admin = self._get_saas_file_attribute('clusterAdmin')
         if accounts:
             self._initiate_state(accounts)
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3457

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/22078

in order to be able to apply resources to facilitate this ticket, we need to apply them as cluster admins. with this PR, we can add `clusterAdmin: true` to a saas file and the credentials will be used from the `clusterAdminAutomationToken` key instead of the `automationToken` key of a cluster.