### PR TITLE
do not use jump host in internal openshift integrations

### DIFF
--- a/helm/qontract-reconcile/values-internal.yaml
+++ b/helm/qontract-reconcile/values-internal.yaml
@@ -17,7 +17,7 @@ integrations:
     limits:
       memory: 720Mi
       cpu: 200m
-  extraArgs: --internal
+  extraArgs: --internal --no-use-jump-host
   logs:
     slack: true
   internalCertificates: true
@@ -29,7 +29,7 @@ integrations:
     limits:
       memory: 500Mi
       cpu: 200m
-  extraArgs: --internal
+  extraArgs: --internal --no-use-jump-host
   logs:
     slack: true
   internalCertificates: true
@@ -43,7 +43,7 @@ integrations:
       # Limits 30% above requests
       memory: 1040Mi
       cpu: 500m
-  extraArgs: --internal
+  extraArgs: --internal --no-use-jump-host
   logs:
     slack: true
 - name: openshift-upgrade-watcher
@@ -66,7 +66,7 @@ integrations:
       # Limits 30% above requests
       memory: 780Mi
       cpu: 300m
-  extraArgs: --internal
+  extraArgs: --internal --no-use-jump-host
   logs:
     slack: true
 - name: openshift-namespaces
@@ -77,7 +77,7 @@ integrations:
     limits:
       memory: 800Mi
       cpu: 200m
-  extraArgs: --internal
+  extraArgs: --internal --no-use-jump-host
   logs:
     slack: true
   internalCertificates: true
@@ -89,7 +89,7 @@ integrations:
     limits:
       memory: 700Mi
       cpu: 250m
-  extraArgs: --internal
+  extraArgs: --internal --no-use-jump-host
   logs:
     slack: true
   internalCertificates: true
@@ -101,7 +101,7 @@ integrations:
     limits:
       memory: 1040Mi
       cpu: 300m
-  extraArgs: --internal
+  extraArgs: --internal --no-use-jump-host
   logs:
     slack: true
 - name: openshift-resources
@@ -112,7 +112,7 @@ integrations:
     limits:
       memory: 1200Mi
       cpu: 400m
-  extraArgs: --internal
+  extraArgs: --internal --no-use-jump-host
   logs:
     slack: true
   internalCertificates: true
@@ -124,7 +124,7 @@ integrations:
     limits:
       memory: 800Mi
       cpu: 400m
-  extraArgs: --internal
+  extraArgs: --internal --no-use-jump-host
   internalCertificates: true
 - name: openshift-routes
   resources:
@@ -136,7 +136,7 @@ integrations:
       # Limits 30% above requests
       memory: 1040Mi
       cpu: 300m
-  extraArgs: --internal
+  extraArgs: --internal --no-use-jump-host
 - name: openshift-serviceaccount-tokens
   resources:
     requests:
@@ -145,7 +145,7 @@ integrations:
     limits:
       memory: 1000Mi
       cpu: 400m
-  extraArgs: --vault-output-path app-sre/integrations-output
+  extraArgs: --no-use-jump-host --vault-output-path app-sre/integrations-output
   logs:
     slack: true
   internalCertificates: true

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -321,7 +321,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-rolebindings
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--internal"
+            value: "--internal --no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -528,7 +528,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-clusterrolebindings
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--internal"
+            value: "--internal --no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -725,7 +725,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-users
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--internal"
+            value: "--internal --no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1100,7 +1100,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-groups
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--internal"
+            value: "--internal --no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1303,7 +1303,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-namespaces
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--internal"
+            value: "--internal --no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1510,7 +1510,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-network-policies
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--internal"
+            value: "--internal --no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1707,7 +1707,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-limitranges
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--internal"
+            value: "--internal --no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -1910,7 +1910,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-resources
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--internal"
+            value: "--internal --no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -2099,7 +2099,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-vault-secrets
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--internal"
+            value: "--internal --no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -2278,7 +2278,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-routes
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--internal"
+            value: "--internal --no-use-jump-host"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API
@@ -2481,7 +2481,7 @@ objects:
           - name: INTEGRATION_NAME
             value: openshift-serviceaccount-tokens
           - name: INTEGRATION_EXTRA_ARGS
-            value: "--vault-output-path app-sre/integrations-output"
+            value: "--no-use-jump-host --vault-output-path app-sre/integrations-output"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API


### PR DESCRIPTION
we use VPC peerings when running integrations inside our clusters instead of a jump host.