### PR TITLE
[MTSRE-117] MRs to managed tenants must be merged with "/lgtm" even after rebase

### DIFF
--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -317,9 +317,9 @@ class MRApproval:
 
 def act(repos, dry_run, state, instance, settings):
     for r in repos:
-        repo = r[0]  # List with single URL
-        persist_lgtm = r[1]  # Boolean
-        gitlab_cli = GitLabApi(instance, project_url=repo, settings=settings)
+        repo = r['repo']
+        persist_lgtm = r['persist_lgtm']
+        gitlab_cli = GitLabApi(instance, project_url=[repo], settings=settings)
         project_owners = RepoOwners(git_cli=gitlab_cli,
                                     ref=gitlab_cli.project.default_branch)
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -914,7 +914,7 @@ def get_repos_gitlab_owner(server=''):
     code_components = get_code_components()
 
     return [{'repo': c['url'],
-             'persist_lgtm': c['gitlabRepoOwners']['persistLgtm']}
+             'persist_lgtm': c['gitlabRepoOwners']['keepApprovalAfterRebase']}
             for c in code_components
             if c['url'].startswith(server) and
             c['gitlabRepoOwners'] and

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -913,7 +913,8 @@ def get_repos_gitlab_owner(server=''):
     """
     code_components = get_code_components()
 
-    return [([c['url']], c['gitlabRepoOwners']['persistLgtm'])
+    return [{'repo': c['url'],
+             'persist_lgtm': c['gitlabRepoOwners']['persistLgtm']}
             for c in code_components
             if c['url'].startswith(server) and
             c['gitlabRepoOwners'] and

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -856,6 +856,7 @@ APPS_QUERY = """
       resource
       gitlabRepoOwners {
         enabled
+        persistLgtm
       }
       gitlabHousekeeping {
         enabled
@@ -911,7 +912,9 @@ def get_repos_gitlab_owner(server=''):
     server: url of the server to return. for example: https://github.com
     """
     code_components = get_code_components()
-    return [c['url'] for c in code_components
+
+    return [([c['url']], c['gitlabRepoOwners']['persistLgtm'])
+            for c in code_components
             if c['url'].startswith(server) and
             c['gitlabRepoOwners'] and
             c['gitlabRepoOwners']['enabled']]

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -1,6 +1,8 @@
 import logging
 
 from urllib.parse import urlparse
+from dateutil import parser as dateparser
+
 from sretoolbox.utils import retry
 
 import gitlab
@@ -277,6 +279,23 @@ class GitLabApi:
 
     def get_merge_requests(self, state):
         return self.get_items(self.project.mergerequests.list, state=state)
+
+    def get_merge_request_diffs(self, mr_id):
+        diffs = []
+        merge_request = self.project.mergerequests.get(mr_id)
+        changes = merge_request.changes()['changes']
+        for change in changes:
+            diffs.append(change['diff'])
+        return diffs
+
+    @staticmethod
+    def get_merge_request_top_commit_timestamp(mr):
+        commits = mr.commits()
+        if commits:
+            top_commit = next(commits)
+            return dateparser.parse(top_commit.created_at)
+        else:
+            return None
 
     def get_merge_request_changed_paths(self, mr_id):
         merge_request = self.project.mergerequests.get(mr_id)


### PR DESCRIPTION
Depends on - https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/23349

### Problem 

Currently, an ‘/lgtm’ comment from an approver is not honored after the bot performs a rebase on a MR. As a result, approvers are required to manually issue additional ‘/lgtm’s until the MR is automatically merged.

Why does this happen? The bot takes into consideration only those ‘/lgtm’ which were commented after the top commit was pushed. A rebase causes the timestamp on the commits to change to when the MR was rebased.

### Solution

Each time an ‘/lgtm’ comment is added, the changes (or the diff) that it is approving should be stored on AWS S3. When the integration collects valid ‘/lgtm’ comments, it must check if the diff corresponding to that ‘/lgtm’ matches the diff at the time of merging. This way, the bot can differentiate between a rebase and an actual change being pushed.

Signed-off-by: Mayank Shah <m.shah@redhat.com>