### PR TITLE
add logging of cluster name from within oc

### DIFF
--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -201,8 +201,9 @@ class OcpReleaseMirror:
         # Creating a new, bare, OC client since we don't
         # want to run this against any cluster or via
         # a jump host
-        oc_cli = OC(name='', server='', token='', jh=None, settings=None,
-                    init_projects=False, init_api_resources=False)
+        oc_cli = OC(cluster_name='', server='', token='', jh=None,
+                    settings=None, init_projects=False,
+                    init_api_resources=False)
         oc_cli.release_mirror(from_release=ocp_release,
                               to=dest_ocp_art_dev,
                               to_release=dest_ocp_release,

--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -201,7 +201,7 @@ class OcpReleaseMirror:
         # Creating a new, bare, OC client since we don't
         # want to run this against any cluster or via
         # a jump host
-        oc_cli = OC(server='', token='', jh=None, settings=None,
+        oc_cli = OC(name='', server='', token='', jh=None, settings=None,
                     init_projects=False, init_api_resources=False)
         oc_cli.release_mirror(from_release=ocp_release,
                               to=dest_ocp_art_dev,

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -67,7 +67,7 @@ class TestGetOwnedPods(TestCase):
             }
         ]
 
-        oc = OC('server', 'token', local=True)
+        oc = OC('cluster', 'server', 'token', local=True)
         pods = oc.get_owned_pods('namespace', owner_resource)
         self.assertEqual(len(pods), 1)
         self.assertEqual(pods[0]['metadata']['name'], 'pod1')
@@ -91,7 +91,7 @@ class TestValidatePodReady(TestCase):
                 ]
             }
         }
-        oc = OC('server', 'token', local=True)
+        oc = OC('cluster', 'server', 'token', local=True)
         oc.validate_pod_ready('namespace', 'podname')
 
     @patch.object(OC, 'get')
@@ -111,7 +111,7 @@ class TestValidatePodReady(TestCase):
             }
         }
 
-        oc = OC('server', 'token', local=True)
+        oc = OC('cluster', 'server', 'token', local=True)
         with self.assertRaises(PodNotReadyError):
             # Bypass the retry stuff
             oc.validate_pod_ready.__wrapped__(oc, 'namespace', 'podname')
@@ -141,7 +141,7 @@ class TestGetObjRootOwner(TestCase):
             owner_obj
         ]
 
-        oc = OC('server', 'token', local=True)
+        oc = OC('cluster', 'server', 'token', local=True)
         result_owner_obj = oc.get_obj_root_owner('namespace', obj)
         self.assertEqual(result_owner_obj, owner_obj)
 
@@ -152,6 +152,6 @@ class TestGetObjRootOwner(TestCase):
             }
         }
 
-        oc = OC('server', 'token', local=True)
+        oc = OC('cluster', 'server', 'token', local=True)
         result_obj = oc.get_obj_root_owner('namespace', obj)
         self.assertEqual(result_obj, obj)

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -503,7 +503,7 @@ class OC:
             raise RecyclePodsInvalidAnnotationValue('should be "true"')
         if qontract_recycle != 'true':
             logging.debug(['skipping_pod_recycle_no_annotation',
-                           self.name, namespace, dep_kind])
+                           self.cluster_name, namespace, dep_kind])
             return
 
         dep_name = dep_resource.name
@@ -544,7 +544,7 @@ class OC:
             for obj in objs:
                 name = obj['metadata']['name']
                 logging.info([f'recycle_{kind.lower()}',
-                              self.name, namespace, name])
+                              self.cluster_name, namespace, name])
                 if not dry_run:
                     now = datetime.now()
                     recycle_time = now.strftime("%d/%m/%Y %H:%M:%S")

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -160,10 +160,10 @@ class OCProcessReconcileTimeDecoratorMsg:
 
 
 class OC:
-    def __init__(self, name, server, token, jh=None, settings=None,
+    def __init__(self, cluster_name, server, token, jh=None, settings=None,
                  init_projects=False, init_api_resources=False,
                  local=False):
-        self.name = name
+        self.cluster_name = cluster_name
         self.server = server
         oc_base_cmd = [
             'oc',
@@ -465,7 +465,7 @@ class OC:
     @retry(max_attempts=20)
     def validate_pod_ready(self, namespace, name):
         logging.info([self.validate_pod_ready.__name__,
-                      self.name, namespace, name])
+                      self.cluster_name, namespace, name])
         pod = self.get(namespace, 'Pod', name)
         for status in pod['status']['containerStatuses']:
             if not status['ready']:
@@ -482,7 +482,7 @@ class OC:
         supported_kinds = ['Secret', 'ConfigMap']
         if dep_kind not in supported_kinds:
             logging.debug(['skipping_pod_recycle_unsupported',
-                           self.name, namespace, dep_kind])
+                           self.cluster_name, namespace, dep_kind])
             return
 
         dep_annotations = dep_resource.body['metadata'].get('annotations', {})

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -163,6 +163,18 @@ class OC:
     def __init__(self, cluster_name, server, token, jh=None, settings=None,
                  init_projects=False, init_api_resources=False,
                  local=False):
+        """Initiates an OC client
+
+        Args:
+            cluster_name (string): Name of cluster
+            server (string): Server URL of the cluster
+            token (string): Token to use for authentication
+            jh (dict, optional): Info to initiate JumpHostSSH
+            settings (dict, optional): App-interface settings
+            init_projects (bool, optional): Initiate projects
+            init_api_resources (bool, optional): Initiate api-resources
+            local (bool, optional): Use oc locally
+        """
         self.cluster_name = cluster_name
         self.server = server
         oc_base_cmd = [

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -464,7 +464,8 @@ class OC:
 
     @retry(max_attempts=20)
     def validate_pod_ready(self, namespace, name):
-        logging.info([self.validate_pod_ready.__name__, namespace, name])
+        logging.info([self.validate_pod_ready.__name__,
+                      self.name, namespace, name])
         pod = self.get(namespace, 'Pod', name)
         for status in pod['status']['containerStatuses']:
             if not status['ready']:
@@ -481,7 +482,7 @@ class OC:
         supported_kinds = ['Secret', 'ConfigMap']
         if dep_kind not in supported_kinds:
             logging.debug(['skipping_pod_recycle_unsupported',
-                           namespace, dep_kind])
+                           self.name, namespace, dep_kind])
             return
 
         dep_annotations = dep_resource.body['metadata'].get('annotations', {})
@@ -490,7 +491,7 @@ class OC:
             raise RecyclePodsInvalidAnnotationValue('should be "true"')
         if qontract_recycle != 'true':
             logging.debug(['skipping_pod_recycle_no_annotation',
-                           namespace, dep_kind])
+                           self.name, namespace, dep_kind])
             return
 
         dep_name = dep_resource.name
@@ -530,7 +531,8 @@ class OC:
         for kind, objs in recyclables.items():
             for obj in objs:
                 name = obj['metadata']['name']
-                logging.info([f'recycle_{kind.lower()}', namespace, name])
+                logging.info([f'recycle_{kind.lower()}',
+                              self.name, namespace, name])
                 if not dry_run:
                     now = datetime.now()
                     recycle_time = now.strftime("%d/%m/%Y %H:%M:%S")

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -160,9 +160,10 @@ class OCProcessReconcileTimeDecoratorMsg:
 
 
 class OC:
-    def __init__(self, server, token, jh=None, settings=None,
+    def __init__(self, name, server, token, jh=None, settings=None,
                  init_projects=False, init_api_resources=False,
                  local=False):
+        self.name = name
         self.server = server
         oc_base_cmd = [
             'oc',
@@ -738,7 +739,7 @@ class OC_Map:
             else:
                 jump_host = None
             try:
-                oc_client = OC(server_url, token, jump_host,
+                oc_client = OC(cluster, server_url, token, jump_host,
                                settings=self.settings,
                                init_projects=self.init_projects,
                                init_api_resources=self.init_api_resources)

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -517,7 +517,7 @@ class SaasHerder():
                         + f"{image_uri}: {str(e)}")
                     return None, None, None
 
-            oc = OC('server', 'token', local=True)
+            oc = OC('cluster', 'server', 'token', local=True)
             try:
                 resources = oc.process(template, consolidated_parameters)
             except StatusCodeError as e:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3326

some actions are logged from within `oc.py`, which is unaware of the name of the cluster. this PR adds the name of the cluster to the OC initiation and adds it to logging messages.