### PR TITLE
[oc] recycle pods allow controller object to not be found

### DIFF
--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -199,7 +199,7 @@ class TestGetObjRootOwner(TestCase):
 
         oc = OC('cluster', 'server', 'token', local=True)
         result_obj = oc.get_obj_root_owner('namespace', obj,
-                                                 allow_not_found=True)
+                                           allow_not_found=True)
         self.assertEqual(result_obj, obj)
 
     @patch.object(OC, 'get')

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -1,7 +1,7 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-from reconcile.utils.oc import OC, PodNotReadyError
+from reconcile.utils.oc import OC, PodNotReadyError, StatusCodeError
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 
 
@@ -155,3 +155,72 @@ class TestGetObjRootOwner(TestCase):
         oc = OC('cluster', 'server', 'token', local=True)
         result_obj = oc.get_obj_root_owner('namespace', obj)
         self.assertEqual(result_obj, obj)
+
+    def test_controller_false_return_obj(self):
+        """Returns obj if all ownerReferences have controller set to false
+        """
+        obj = {
+            'metadata': {
+                'name': 'pod1',
+                'ownerReferences': [
+                    {
+                        'controller': False
+                    }
+                ]
+            }
+        }
+
+        oc = OC('cluster', 'server', 'token', local=True)
+        result_obj = oc.get_obj_root_owner('namespace', obj)
+        self.assertEqual(result_obj, obj)
+
+    @patch.object(OC, 'get')
+    def test_controller_true_allow_true_ref_not_found_return_obj(self):
+        """Returns obj if controller is true, allow_not_found is true,
+        but referenced object does not exist '{}'
+        """
+        obj = {
+            'metadata': {
+                'name': 'pod1',
+                'ownerReferences': [
+                    {
+                        'controller': True,
+                        'kind': 'ownerkind',
+                        'name': 'ownername'
+                    }
+                ]
+            }
+        }
+        owner_obj = '{}'
+
+        oc_get.side_effect = [
+            owner_obj
+        ]
+
+        oc = OC('cluster', 'server', 'token', local=True)
+        result_owner_obj = oc.get_obj_root_owner('namespace', obj,
+                                                 allow_not_found=True)
+        self.assertEqual(result_owner_obj, owner_obj)
+
+    def test_controller_true_allow_false_ref_not_found_raise(self):
+        """Throws an exception if controller is true, allow_not_found false,
+        but referenced object does not exist
+        """
+        obj = {
+            'metadata': {
+                'name': 'pod1',
+                'ownerReferences': [
+                    {
+                        'controller': True,
+                        'kind': 'ownerkind',
+                        'name': 'ownername'
+                    }
+                ]
+            }
+        }
+
+        oc_get.side_effect = StatusCodeError
+
+        oc = OC('cluster', 'server', 'token', local=True)
+        with self.assertRaises(StatusCodeError):
+            oc.get_obj_root_owner('namespace', obj, allow_not_found=False)

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -175,7 +175,7 @@ class TestGetObjRootOwner(TestCase):
         self.assertEqual(result_obj, obj)
 
     @patch.object(OC, 'get')
-    def test_controller_true_allow_true_ref_not_found_return_obj(self):
+    def test_cont_true_allow_true_ref_not_found_return_obj(self, oc_get):
         """Returns obj if controller is true, allow_not_found is true,
         but referenced object does not exist '{}'
         """
@@ -202,7 +202,8 @@ class TestGetObjRootOwner(TestCase):
                                                  allow_not_found=True)
         self.assertEqual(result_owner_obj, owner_obj)
 
-    def test_controller_true_allow_false_ref_not_found_raise(self):
+    @patch.object(OC, 'get')
+    def test_controller_true_allow_false_ref_not_found_raise(self, oc_get):
         """Throws an exception if controller is true, allow_not_found false,
         but referenced object does not exist
         """

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -198,9 +198,9 @@ class TestGetObjRootOwner(TestCase):
         ]
 
         oc = OC('cluster', 'server', 'token', local=True)
-        result_owner_obj = oc.get_obj_root_owner('namespace', obj,
+        result_obj = oc.get_obj_root_owner('namespace', obj,
                                                  allow_not_found=True)
-        self.assertEqual(result_owner_obj, owner_obj)
+        self.assertEqual(result_obj, obj)
 
     @patch.object(OC, 'get')
     def test_controller_true_allow_false_ref_not_found_raise(self, oc_get):

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -191,7 +191,7 @@ class TestGetObjRootOwner(TestCase):
                 ]
             }
         }
-        owner_obj = '{}'
+        owner_obj = {}
 
         oc_get.side_effect = [
             owner_obj

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -561,6 +561,23 @@ class OC:
                     self._run(cmd, stdin=stdin, apply=True)
 
     def get_obj_root_owner(self, ns, obj, allow_not_found=False):
+        """Get object root owner (recursively find the top level owner).
+        - Returns obj if it has no ownerReferences
+        - Returns obj if all ownerReferences have controller set to false
+        - Returns obj if controller is true, allow_not_found is true,
+          but referenced object does not exist
+        - Throws an exception if controller is true, allow_not_found false,
+          but referenced object does not exist
+        - Recurses if controller is true and referenced object exists
+
+        Args:
+            ns (string): namespace of the object
+            obj (dict): representation of the object
+            allow_not_found (bool, optional): allow owner to be not found
+
+        Returns:
+            dict: representation of the object's owner
+        """
         refs = obj['metadata'].get('ownerReferences', [])
         for r in refs:
             if r.get('controller'):


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3326

from the time we collect pods and until we look for their owner some time may pass. during that time, the pod may be deleted or its owner can be deleted (like we are seeing here: https://coreos.slack.com/archives/CS0E65QCV/p1626791826140700).

to handle that we allow the owner to not be found, which will allow us to move on to the next object and successfully recycle pods.