### PR TITLE
[APPSRE-3481] Change teams invitations endpoint on github integration

### DIFF
--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -120,7 +120,7 @@ def fetch_current_state(gh_api_store):
                 continue
 
             members = [member.login for member in team.get_members()]
-            members.extend(raw_gh_api.team_invitations(team.id))
+            members.extend(raw_gh_api.team_invitations(org.id, team.id))
             members = [m.lower() for m in members]
             all_team_members.extend(members)
 

--- a/reconcile/test/fixtures/github_org/current_state_simple.yml
+++ b/reconcile/test/fixtures/github_org/current_state_simple.yml
@@ -1,5 +1,7 @@
 gh_api:
   org_a:
+    id:
+    - id: 1234
     members:
     - login: user1
     - login: user2

--- a/reconcile/test/test_github_org.py
+++ b/reconcile/test/test_github_org.py
@@ -18,7 +18,7 @@ class RawGithubApiMock:
         return []
 
     @staticmethod
-    def team_invitations(team_id):
+    def team_invitations(org_id, team_id):
         return []
 
 
@@ -35,6 +35,10 @@ class GithubMock:
     class GithubOrgMock:
         def __init__(self, spec_org):
             self.spec_org = spec_org
+
+        @property
+        def id(self):
+            return self.spec_org["id"]
 
         class GithubTeamMock:
             def __init__(self, spec_team):

--- a/reconcile/utils/raw_github_api.py
+++ b/reconcile/utils/raw_github_api.py
@@ -76,8 +76,9 @@ class RawGithubApi:
             ) if login is not None
         ]
 
-    def team_invitations(self, team_id):
-        invitations = self.query('/teams/{}/invitations'.format(team_id))
+    def team_invitations(self, org_id, team_id):
+        invitations = self.query('/organizations/{}/team/{}/invitations'
+                                 .format(org_id, team_id))
 
         return [
             login for login in (


### PR DESCRIPTION
The Github_org integration is using an old endpoint to check the teams invitations that is deprecated by github 
https://docs.github.com/en/rest/reference/teams#list-pending-team-invitations-legacy

We found a problem with the endpoint and the github-mirror that seems that do not return information about the next pages of the request. 

This PR changes the endpoint to use the new endpoint 

https://docs.github.com/en/rest/reference/teams#list-pending-team-invitations