### PR TITLE
fix ocp-release-mirror keeps mirroring to ocm-quay

### DIFF
--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -188,8 +188,8 @@ class OcpReleaseMirror:
     def _run_mirror(self, ocp_release, dest_ocp_release, dest_ocp_art_dev):
         # Checking if the image is already there
         if self._is_image_there(dest_ocp_release):
-            LOG.info(f'Image {ocp_release} already in '
-                     f'the mirror. Skipping.')
+            LOG.debug(f'Image {ocp_release} already in '
+                      f'the mirror. Skipping.')
             return
 
         LOG.info(f'Mirroring {ocp_release} to {dest_ocp_art_dev} '
@@ -214,6 +214,8 @@ class OcpReleaseMirror:
 
         for registry, creds in self.registry_creds['auths'].items():
             # Getting the credentials for the image_obj
+            if '//' not in registry:
+                registry = '//' + registry
             registry_obj = urlparse(registry)
             if registry_obj.netloc != image_obj.registry:
                 continue
@@ -312,7 +314,14 @@ class OcpReleaseMirror:
     def _build_quay_auths(url, user, token):
         auth_bytes = bytes(f"{user}:{token}", 'utf-8')
         auth = base64.b64encode(auth_bytes).decode('utf-8')
-        return {url: {"auth": auth, "email": ""}}
+        return {
+            url: {
+                'username': user,
+                'password': token,
+                'email': '',
+                'auth': auth
+            }
+        }
 
 
 def run(dry_run):


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-3526

This pr fix 2 problems in ocp-release-mirror which results in it keeps pushing images to ocm-quay.

1. urlparse('quay.io').netloc return empty

According to https://docs.python.org/3/library/urllib.parse.html

> Following the syntax specifications in RFC 1808, urlparse recognizes a net2. 
loc only if it is properly introduced by ‘//’. Otherwise the input is presumed to be a relative URL and thus to start with a path component.

2. _build_quay_auths() does not include username and password

Signed-off-by: Feng Huang <fehuang@redhat.com>