### PR TITLE
Refactor terraform_vpc_peerings.build_desired_*state

### DIFF
--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -244,7 +244,7 @@ def build_desired_state_vpc_mesh(clusters, ocm_map, settings):
             account_vpcs = \
                 aws_api.get_vpcs_details(
                     account,
-                    tags=json.loads(peer_connection.get('tags') or {}),
+                    tags=json.loads(peer_connection.get('tags') or '{}'),
                     route_tables=peer_connection.get('manageRoutes'),
                 )
             for vpc in account_vpcs:

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -182,8 +182,7 @@ def build_desired_state_all_clusters(clusters, ocm_map, settings):
             items = build_desired_state_single_cluster(
                 cluster_info, ocm_map, settings
             )
-            if items:
-                desired_state.extend(items)
+            desired_state.extend(items)
         except Exception:
             logging.exception(
                 f"Failed to get desired state for {cluster_info['name']}"

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -5,7 +5,7 @@ import json
 
 import reconcile.queries as queries
 
-from reconcile.utils.aws_api import AWSApi
+import reconcile.utils.aws_api as awsapi
 from reconcile.utils.defer import defer
 from reconcile.utils.ocm import OCMMap
 from reconcile.utils.terraform_client import TerraformClient as Terraform
@@ -111,7 +111,7 @@ def build_desired_state_cluster(clusters, ocm_map, settings):
                 continue
             accepter_manage_routes = peer_info.get('manageRoutes')
 
-            aws_api = AWSApi(1, [req_aws], settings=settings)
+            aws_api = awsapi.AWSApi(1, [req_aws], settings=settings)
             requester_vpc_id, requester_route_table_ids, _ = \
                 aws_api.get_cluster_vpc_details(
                     req_aws,
@@ -142,7 +142,7 @@ def build_desired_state_cluster(clusters, ocm_map, settings):
                 error = True
                 continue
 
-            aws_api = AWSApi(1, [acc_aws], settings=settings)
+            aws_api = awsapi.AWSApi(1, [acc_aws], settings=settings)
             accepter_vpc_id, accepter_route_table_ids, _ = \
                 aws_api.get_cluster_vpc_details(
                     acc_aws,
@@ -208,7 +208,7 @@ def build_desired_state_vpc_mesh(clusters, ocm_map, settings):
                 )
             account['assume_region'] = requester['region']
             account['assume_cidr'] = requester['cidr_block']
-            aws_api = AWSApi(1, [account], settings=settings)
+            aws_api = awsapi.AWSApi(1, [account], settings=settings)
             requester_vpc_id, requester_route_table_ids, _ = \
                 aws_api.get_cluster_vpc_details(
                     account,
@@ -295,7 +295,7 @@ def build_desired_state_vpc(clusters, ocm_map, settings):
                 )
             account['assume_region'] = requester['region']
             account['assume_cidr'] = requester['cidr_block']
-            aws_api = AWSApi(1, [account], settings=settings)
+            aws_api = awsapi.AWSApi(1, [account], settings=settings)
             requester_vpc_id, requester_route_table_ids, _ = \
                 aws_api.get_cluster_vpc_details(
                     account,

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -33,6 +33,17 @@ class TestBuildDesiredStateAllClusters(testslide.TestCase):
                 }
             }
         ]
+        self.settings = {}
+        self.aws_account = {
+            'name': 'accountname',
+            'uid': 'anuid',
+            'terraformUserName': 'aterraformusename',
+            'automationtoken': 'anautomationtoken',
+            'assume_role': 'arole:very:useful:indeed:it:is',
+            'assume_region': 'moon-tranquility-1',
+            'assume_cidr': '172.25.0.0/12',
+        }
+
         self.peer = {
             'vpc': '172.17.0.0/12',
             'service': '10.1.0.0/8',
@@ -59,73 +70,12 @@ class TestBuildDesiredStateAllClusters(testslide.TestCase):
             }
         self.clusters[0]['peering']['connections'][0]['cluster'] = \
             self.peer_cluster
-        self.aws_account = {
-            'name': 'accountname',
-            'uid': 'anuid',
-            'terraformUserName': 'aterraformusename',
-            'automationtoken': 'anautomationtoken',
-            'assume_role': 'arole:very:useful:indeed:it:is',
-            'assume_region': 'moon-tranquility-1',
-            'assume_cidr': '172.25.0.0/12',
-        }
-        self.peer_vpc = {
-            'cidr_block': '172.30.0.0/12',
-            'vpc_id': 'peervpcid',
-            'route_table_ids': ['peer_route_table_id']
-        }
-        self.settings = {}
-        self.awsapi = testslide.StrictMock(awsapi.AWSApi)
-        self.mock_constructor(
-            awsapi, 'AWSApi'
-        ).to_return_value(self.awsapi)
-        self.maxDiff = None
-        self.find_matching_peering = self.mock_callable(
-            sut, 'find_matching_peering'
+        self.build_single_cluster = self.mock_callable(
+            sut, 'build_desired_state_single_cluster'
         )
         self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
 
     def test_one_cluster(self):
-        self.mock_callable(
-            sut, 'aws_account_from_infrastructure_access'
-        ).for_call(
-            self.clusters[0], 'network-mgmt', {}
-        ).to_return_value(
-            self.aws_account
-        ).and_assert_called_once()
-        self.mock_callable(
-            sut, 'aws_account_from_infrastructure_access'
-        ).for_call(
-            self.peer_cluster, 'network-mgmt', {}
-        ).to_return_value(self.aws_account).and_assert_called_once()
-        self.find_matching_peering.for_call(
-            self.clusters[0], self.clusters[0]['peering']['connections'][0],
-            self.peer_cluster,
-            'cluster-vpc-accepter'
-        ).to_return_value(self.peer).and_assert_called_once()
-        aws_req = {
-            'assume_region': 'mars-plain-1',
-            'assume_cidr': '172.16.0.0/12',
-            **self.aws_account
-        }
-        self.mock_callable(
-            self.awsapi, 'get_cluster_vpc_details'
-        ).for_call(
-            aws_req, route_tables=True
-        ).to_return_value(
-            ('vpcid', ['route_table_id'], {})
-        ).and_assert_called_once()
-        aws_req = {
-            'assume_region': 'mars-olympus-2',
-            'assume_cidr': '172.17.0.0/12',
-            **self.aws_account
-        }
-        self.mock_callable(
-            self.awsapi, 'get_cluster_vpc_details'
-        ).for_call(
-            aws_req, route_tables=None
-        ).to_return_value(
-            ('acceptervpcid', ['accepterroutetableid'], {})
-        ).and_assert_called_once()
 
         expected = [
             {
@@ -157,52 +107,24 @@ class TestBuildDesiredStateAllClusters(testslide.TestCase):
                 'deleted': False
             }
         ]
+        self.build_single_cluster.for_call(
+            self.clusters[0], {}, self.settings
+        ).to_return_value(expected).and_assert_called_once()
+
         rs = sut.build_desired_state_all_clusters(
             self.clusters, {}, self.settings
         )
         self.assertEqual(rs, (expected, False))
 
-    def test_one_cluster_no_peers(self):
-        self.clusters[0]['peering']['connections'] = []
-        self.mock_callable(
-            sut, 'aws_account_from_infrastructure_access'
-        ).to_return_value(self.aws_account).and_assert_called_once()
+    def test_one_cluster_failing(self):
+        self.build_single_cluster.to_raise(
+            sut.BadTerraformPeeringState
+        ).and_assert_called_once()
         self.assertEqual(
             sut.build_desired_state_all_clusters(
                 self.clusters, {}, self.settings
                 ),
-            ([], False))
-
-    def test_one_cluster_no_matches(self):
-        self.mock_callable(
-            sut, 'aws_account_from_infrastructure_access'
-        ).to_return_value(self.aws_account)
-        self.find_matching_peering.to_return_value(
-            None
-        ).and_assert_called_once()
-        self.assertEqual(
-            sut.build_desired_state_all_clusters(
-                self.clusters, {}, self.settings
-            ),
-            ([], True)
-        )
-
-    def test_one_cluster_no_vpc_in_aws(self):
-        self.mock_callable(
-            sut, 'aws_account_from_infrastructure_access'
-        ).to_return_value(self.aws_account)
-        self.find_matching_peering.to_return_value(
-            self.peer
-        ).and_assert_called_once()
-        self.mock_callable(
-            self.awsapi, 'get_cluster_vpc_details'
-        ).to_return_value((None, None, {})).and_assert_called_once()
-        self.assertEqual(
-            sut.build_desired_state_all_clusters(
-                self.clusters, {}, self.settings
-            ),
-            ([], True)
-        )
+            ([], True))
 
 
 class TestBuildDesiredStateSingleCluster(testslide.TestCase):

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -4,7 +4,7 @@ import reconcile.utils.aws_api as awsapi
 import reconcile.terraform_vpc_peerings as sut
 
 
-class TestBuildDesiredStateCluster(testslide.TestCase):
+class TestBuildDesiredStateAllClusters(testslide.TestCase):
 
     def setUp(self):
         super().setUp()
@@ -157,7 +157,9 @@ class TestBuildDesiredStateCluster(testslide.TestCase):
                 'deleted': False
             }
         ]
-        rs = sut.build_desired_state_all_clusters(self.clusters, {}, self.settings)
+        rs = sut.build_desired_state_all_clusters(
+            self.clusters, {}, self.settings
+        )
         self.assertEqual(rs, (expected, False))
 
     def test_one_cluster_no_peers(self):
@@ -166,18 +168,22 @@ class TestBuildDesiredStateCluster(testslide.TestCase):
             sut, 'aws_account_from_infrastructure_access'
         ).to_return_value(self.aws_account).and_assert_called_once()
         self.assertEqual(
-            sut.build_desired_state_all_clusters(self.clusters, {}, self.settings),
+            sut.build_desired_state_all_clusters(
+                self.clusters, {}, self.settings
+                ),
             ([], False))
 
     def test_one_cluster_no_matches(self):
         self.mock_callable(
             sut, 'aws_account_from_infrastructure_access'
         ).to_return_value(self.aws_account)
-        self.mock_callable(sut, 'find_matching_peering').to_return_value(
+        self.find_matching_peering.to_return_value(
             None
         ).and_assert_called_once()
         self.assertEqual(
-            sut.build_desired_state_all_clusters(self.clusters, {}, self.settings),
+            sut.build_desired_state_all_clusters(
+                self.clusters, {}, self.settings
+            ),
             ([], True)
         )
 
@@ -185,13 +191,230 @@ class TestBuildDesiredStateCluster(testslide.TestCase):
         self.mock_callable(
             sut, 'aws_account_from_infrastructure_access'
         ).to_return_value(self.aws_account)
-        self.mock_callable(sut, 'find_matching_peering').to_return_value(
+        self.find_matching_peering.to_return_value(
             self.peer
         ).and_assert_called_once()
         self.mock_callable(
             self.awsapi, 'get_cluster_vpc_details'
         ).to_return_value((None, None, {})).and_assert_called_once()
         self.assertEqual(
-            sut.build_desired_state_all_clusters(self.clusters, {}, self.settings),
+            sut.build_desired_state_all_clusters(
+                self.clusters, {}, self.settings
+            ),
             ([], True)
         )
+
+
+class TestBuildDesiredStateSingleCluster(testslide.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.cluster = {
+            'name': 'clustername',
+            'spec': {
+                'region': 'mars-plain-1',
+            },
+            'network': {
+                'vpc': '172.16.0.0/12',
+                'service': '10.0.0.0/8',
+                'pod': '192.168.0.0/16',
+            },
+            'peering': {
+                'connections': [
+                    {
+                        'provider': 'cluster-vpc-requester',
+                        'name': 'peername',
+                        'vpc': {
+                            '$ref': '/aws/account/vpcs/mars-plain-1'
+                        },
+                        'manageRoutes': True,
+                    },
+                ]
+            }
+        }
+        self.peer = {
+            'vpc': '172.17.0.0/12',
+            'service': '10.1.0.0/8',
+            'pod': '192.168.1.0/16',
+        }
+        self.peer_cluster = {
+                'name': 'apeerclustername',
+                'spec': {
+                    'region': 'mars-olympus-2',
+                },
+                'network': self.peer,
+                'peering': {
+                    'connections': [
+                        {
+                            'provider': 'cluster-vpc-requester',
+                            'name': 'peername',
+                            'vpc': {
+                                '$ref': '/aws/account/vpcs/mars-plain-1'
+                            },
+                            'manageRoutes': True,
+                        },
+                    ]
+                }
+            }
+        self.cluster['peering']['connections'][0]['cluster'] = \
+            self.peer_cluster
+        self.aws_account = {
+            'name': 'accountname',
+            'uid': 'anuid',
+            'terraformUserName': 'aterraformusename',
+            'automationtoken': 'anautomationtoken',
+            'assume_role': 'arole:very:useful:indeed:it:is',
+            'assume_region': 'moon-tranquility-1',
+            'assume_cidr': '172.25.0.0/12',
+        }
+        self.peer_vpc = {
+            'cidr_block': '172.30.0.0/12',
+            'vpc_id': 'peervpcid',
+            'route_table_ids': ['peer_route_table_id']
+        }
+        self.settings = {}
+        self.awsapi = testslide.StrictMock(awsapi.AWSApi)
+        self.mock_constructor(
+            awsapi, 'AWSApi'
+        ).to_return_value(self.awsapi)
+        self.maxDiff = None
+        self.find_matching_peering = self.mock_callable(
+            sut, 'find_matching_peering'
+        )
+        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
+
+    def test_base(self):
+        self.mock_callable(
+            sut, 'aws_account_from_infrastructure_access'
+        ).for_call(
+            self.cluster, 'network-mgmt', {}
+        ).to_return_value(
+            self.aws_account
+        ).and_assert_called_once()
+        self.mock_callable(
+            sut, 'aws_account_from_infrastructure_access'
+        ).for_call(
+            self.peer_cluster, 'network-mgmt', {}
+        ).to_return_value(self.aws_account).and_assert_called_once()
+        self.find_matching_peering.for_call(
+            self.cluster, self.cluster['peering']['connections'][0],
+            self.peer_cluster,
+            'cluster-vpc-accepter'
+        ).to_return_value(self.peer).and_assert_called_once()
+        aws_req = {
+            'assume_region': 'mars-plain-1',
+            'assume_cidr': '172.16.0.0/12',
+            **self.aws_account
+        }
+        self.mock_callable(
+            self.awsapi, 'get_cluster_vpc_details'
+        ).for_call(
+            aws_req, route_tables=True
+        ).to_return_value(
+            ('vpcid', ['route_table_id'], {})
+        ).and_assert_called_once()
+        aws_req = {
+            'assume_region': 'mars-olympus-2',
+            'assume_cidr': '172.17.0.0/12',
+            **self.aws_account
+        }
+        self.mock_callable(
+            self.awsapi, 'get_cluster_vpc_details'
+        ).for_call(
+            aws_req, route_tables=None
+        ).to_return_value(
+            ('acceptervpcid', ['accepterroutetableid'], {})
+        ).and_assert_called_once()
+
+        expected = [
+            {
+                'connection_provider': 'cluster-vpc-requester',
+                'connection_name': 'peername',
+                'requester': {
+                    'vpc_id': 'vpcid',
+                    'route_table_ids': ['route_table_id'],
+                    'region': 'mars-plain-1',
+                    'cidr_block': '172.16.0.0/12',
+                    'peer_owner_id': 'it',
+                    'account': {
+                        'assume_region': 'mars-olympus-2',
+                        'assume_cidr': '172.17.0.0/12',
+                        **self.aws_account,
+                    }
+                },
+                'accepter': {
+                    'vpc_id': 'acceptervpcid',
+                    'route_table_ids': ['accepterroutetableid'],
+                    'region': 'mars-olympus-2',
+                    'cidr_block': '172.17.0.0/12',
+                    'account': {
+                        'assume_region': 'mars-olympus-2',
+                        'assume_cidr': '172.17.0.0/12',
+                        **self.aws_account,
+                    }
+                },
+                'deleted': False
+            }
+        ]
+        rs = sut.build_desired_state_single_cluster(
+            self.cluster, {}, self.settings
+        )
+        self.assertEqual(rs, expected)
+
+    def test_no_peerings(self):
+        self.cluster['peering']['connections'] = []
+        self.mock_callable(
+            sut, 'aws_account_from_infrastructure_access'
+        ).to_return_value(self.aws_account).and_assert_called_once()
+        rs = sut.build_desired_state_single_cluster(
+            self.cluster, {}, self.settings
+        )
+        self.assertEqual(rs, [])
+
+    def test_no_matches(self):
+        self.mock_callable(
+            sut, 'aws_account_from_infrastructure_access'
+        ).to_return_value(self.aws_account)
+        self.find_matching_peering.to_return_value(None)
+        with self.assertRaises(sut.BadTerraformPeeringState):
+            sut.build_desired_state_single_cluster(
+                self.cluster, {}, self.settings
+            )
+
+    def test_no_vpc_in_aws(self):
+        self.mock_callable(
+            sut, 'aws_account_from_infrastructure_access'
+        ).to_return_value(self.aws_account)
+        self.find_matching_peering.to_return_value(
+            self.peer
+        ).and_assert_called_once()
+        self.mock_callable(
+            self.awsapi, 'get_cluster_vpc_details'
+        ).to_return_value((None, None, {})).and_assert_called_once()
+
+        with self.assertRaises(sut.BadTerraformPeeringState):
+            sut.build_desired_state_single_cluster(
+                self.cluster, {}, self.settings
+            )
+
+    def test_no_peer_account(self):
+        self.mock_callable(
+            sut, 'aws_account_from_infrastructure_access'
+        ).for_call(
+            self.cluster, 'network-mgmt', {}
+        ).to_return_value(self.aws_account)
+        self.mock_callable(
+            sut, 'aws_account_from_infrastructure_access'
+        ).for_call(
+            self.peer_cluster, 'network-mgmt', {}
+        ).to_return_value(None).and_assert_called_once()
+        self.find_matching_peering.to_return_value(self.peer)
+        self.mock_callable(
+            self.awsapi, 'get_cluster_vpc_details'
+        ).to_return_value(
+            ('vpcid', ['route_table_id'], {})
+        ).and_assert_called_once()
+
+        with self.assertRaises(sut.BadTerraformPeeringState):
+            sut.build_desired_state_single_cluster(
+                self.cluster, {}, self.settings
+            )

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -1,0 +1,195 @@
+import testslide
+
+import reconcile.utils.aws_api as awsapi
+import reconcile.terraform_vpc_peerings as sut
+
+
+class TestBuildDesiredStateCluster(testslide.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.clusters = [
+            {
+                'name': 'clustername',
+                'spec': {
+                    'region': 'mars-plain-1',
+                },
+                'network': {
+                    'vpc': '172.16.0.0/12',
+                    'service': '10.0.0.0/8',
+                    'pod': '192.168.0.0/16',
+                },
+                'peering': {
+                    'connections': [
+                        {
+                            'provider': 'cluster-vpc-requester',
+                            'name': 'peername',
+                            'vpc': {
+                                '$ref': '/aws/account/vpcs/mars-plain-1'
+                            },
+                            'manageRoutes': True,
+                        },
+                    ]
+                }
+            }
+        ]
+        self.peer = {
+            'vpc': '172.17.0.0/12',
+            'service': '10.1.0.0/8',
+            'pod': '192.168.1.0/16',
+        }
+        self.peer_cluster = {
+                'name': 'apeerclustername',
+                'spec': {
+                    'region': 'mars-olympus-2',
+                },
+                'network': self.peer,
+                'peering': {
+                    'connections': [
+                        {
+                            'provider': 'cluster-vpc-requester',
+                            'name': 'peername',
+                            'vpc': {
+                                '$ref': '/aws/account/vpcs/mars-plain-1'
+                            },
+                            'manageRoutes': True,
+                        },
+                    ]
+                }
+            }
+        self.clusters[0]['peering']['connections'][0]['cluster'] = \
+            self.peer_cluster
+        self.aws_account = {
+            'name': 'accountname',
+            'uid': 'anuid',
+            'terraformUserName': 'aterraformusename',
+            'automationtoken': 'anautomationtoken',
+            'assume_role': 'arole:very:useful:indeed:it:is'
+        }
+        self.peer_vpc = {
+            'cidr_block': '172.30.0.0/12',
+            'vpc_id': 'peervpcid',
+            'route_table_ids': ['peer_route_table_id']
+        }
+        self.settings = {}
+        self.awsapi = testslide.StrictMock(awsapi.AWSApi)
+        self.mock_constructor(
+            awsapi, 'AWSApi'
+        ).to_return_value(self.awsapi)
+        self.maxDiff = None
+        self.find_matching_peering = self.mock_callable(
+            sut, 'find_matching_peering'
+        )
+        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
+
+    def test_one_cluster(self):
+        self.mock_callable(
+            sut, 'aws_account_from_infrastructure_access'
+        ).for_call(
+            self.clusters[0], 'network-mgmt', {}
+        ).to_return_value(
+            self.aws_account
+        ).and_assert_called_once()
+        self.mock_callable(
+            sut, 'aws_account_from_infrastructure_access'
+        ).for_call(
+            self.peer_cluster, 'network-mgmt', {}
+        ).to_return_value(self.aws_account).and_assert_called_once()
+        self.find_matching_peering.for_call(
+            self.clusters[0], self.clusters[0]['peering']['connections'][0],
+            self.peer_cluster,
+            'cluster-vpc-accepter'
+        ).to_return_value(self.peer).and_assert_called_once()
+        aws_req = {
+            'assume_region': 'mars-plain-1',
+            'assume_cidr': '172.16.0.0/12',
+            **self.aws_account
+        }
+        self.mock_callable(
+            self.awsapi, 'get_cluster_vpc_details'
+        ).for_call(
+            aws_req, route_tables=True
+        ).to_return_value(
+            ('vpcid', ['route_table_id'], False)
+        ).and_assert_called_once()
+        aws_req = {
+            'assume_region': 'mars-olympus-2',
+            'assume_cidr': '172.17.0.0/12',
+            **self.aws_account
+        }
+        self.mock_callable(
+            self.awsapi, 'get_cluster_vpc_details'
+        ).for_call(
+            aws_req, route_tables=None
+        ).to_return_value(
+            ('acceptervpcid', ['accepterroutetableid'], False)
+        ).and_assert_called_once()
+
+        expected = [
+            {
+                'connection_provider': 'cluster-vpc-requester',
+                'connection_name': 'peername',
+                'requester': {
+                    'vpc_id': 'vpcid',
+                    'route_table_ids': ['route_table_id'],
+                    'region': 'mars-plain-1',
+                    'cidr_block': '172.16.0.0/12',
+                    'peer_owner_id': 'it',
+                    'account': {
+                        'assume_region': 'mars-olympus-2',
+                        'assume_cidr': '172.17.0.0/12',
+                        **self.aws_account,
+                    }
+                },
+                'accepter': {
+                    'vpc_id': 'acceptervpcid',
+                    'route_table_ids': ['accepterroutetableid'],
+                    'region': 'mars-olympus-2',
+                    'cidr_block': '172.17.0.0/12',
+                    'account': {
+                        'assume_region': 'mars-olympus-2',
+                        'assume_cidr': '172.17.0.0/12',
+                        **self.aws_account,
+                    }
+                },
+                'deleted': False
+            }
+        ]
+        rs = sut.build_desired_state_cluster(self.clusters, {}, self.settings)
+        self.assertEqual(rs, (expected, False))
+
+    def test_one_cluster_no_peers(self):
+        self.clusters[0]['peering']['connections'] = []
+        self.mock_callable(
+            sut, 'aws_account_from_infrastructure_access'
+        ).to_return_value(self.aws_account).and_assert_called_once()
+        self.assertEqual(
+            sut.build_desired_state_cluster(self.clusters, {}, self.settings),
+            ([], False))
+
+    def test_one_cluster_no_matches(self):
+        self.mock_callable(
+            sut, 'aws_account_from_infrastructure_access'
+        ).to_return_value(self.aws_account)
+        self.mock_callable(sut, 'find_matching_peering').to_return_value(
+            None
+        ).and_assert_called_once()
+        self.assertEqual(
+            sut.build_desired_state_cluster(self.clusters, {}, self.settings),
+            ([], True)
+        )
+
+    def test_one_cluster_no_vpc_in_aws(self):
+        self.mock_callable(
+            sut, 'aws_account_from_infrastructure_access'
+        ).to_return_value(self.aws_account)
+        self.mock_callable(sut, 'find_matching_peering').to_return_value(
+            self.peer
+        ).and_assert_called_once()
+        self.mock_callable(
+            self.awsapi, 'get_cluster_vpc_details'
+        ).to_return_value((None, None, True)).and_assert_called_once()
+        self.assertEqual(
+            sut.build_desired_state_cluster(self.clusters, {}, self.settings),
+            ([], True)
+        )

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -2,6 +2,7 @@ import testslide
 
 import reconcile.utils.aws_api as awsapi
 import reconcile.terraform_vpc_peerings as sut
+import reconcile.utils.ocm as ocm
 
 
 class TestBuildDesiredStateAllClusters(testslide.TestCase):
@@ -340,3 +341,208 @@ class TestBuildDesiredStateSingleCluster(testslide.TestCase):
             sut.build_desired_state_single_cluster(
                 self.cluster, {}, self.settings
             )
+
+class TestBuildDesiredStateVpcMesh(testslide.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.clusters = [
+            {
+                'name': 'clustername',
+                'spec': {
+                    'region': 'mars-plain-1',
+                },
+                'network': {
+                    'vpc': '172.16.0.0/12',
+                    'service': '10.0.0.0/8',
+                    'pod': '192.168.0.0/16',
+                },
+                'peering': {
+                    'connections': [
+                        {
+                            'provider': 'account-vpc-mesh',
+                            'name': 'peername',
+                            'vpc': {
+                                '$ref': '/aws/account/vpcs/mars-plain-1'
+                            },
+                            'manageRoutes': True,
+                            'tags': '["tag1"]',
+                        },
+                    ]
+                }
+            }
+        ]
+        self.peer = {
+            'vpc': '172.17.0.0/12',
+            'service': '10.1.0.0/8',
+            'pod': '192.168.1.0/16',
+        }
+        self.peer_cluster = {
+            'name': 'apeerclustername',
+            'spec': {
+                'region': 'mars-olympus-2',
+            },
+            'network': self.peer,
+            'peering': {
+                'connections': [
+                    {
+                        'provider': 'cluster-vpc-requester',
+                        'name': 'peername',
+                        'vpc': {
+                            '$ref': '/aws/account/vpcs/mars-plain-1'
+                        },
+                        'manageRoutes': True,
+                        'tags': '["tag1"]',
+                    },
+                ]
+            }
+        }
+
+        self.aws_account = {
+            'name': 'accountname',
+            'uid': 'anuid',
+            'terraformUsername': 'aterraformusename',
+            'automationtoken': 'anautomationtoken',
+            'assume_role': 'arole:very:useful:indeed:it:is',
+            'assume_region': 'moon-tranquility-1',
+            'assume_cidr': '172.25.0.0/12',
+        }
+        self.peer_account = {
+            'name': 'peer_account',
+            'uid': 'peeruid',
+            'terraformUsername': 'peerterraformusename',
+            'automationtoken': 'peeranautomationtoken',
+            'assume_role': 'a:peer:role:indeed:it:is',
+            'assume_region': 'mars-hellas-1',
+            'assume_cidr': '172.25.0.0/12',
+        }
+        self.clusters[0]['peering']['connections'][0]['cluster'] = \
+            self.peer_cluster
+        self.clusters[0]['peering']['connections'][0]['account'] = \
+            self.peer_account
+        self.peer_vpc = {
+            'cidr_block': '172.30.0.0/12',
+            'vpc_id': 'peervpcid',
+            'route_table_ids': ['peer_route_table_id']
+        }
+        self.settings = {}
+        self.awsapi = testslide.StrictMock(awsapi.AWSApi)
+        self.mock_constructor(
+            awsapi, 'AWSApi'
+        ).to_return_value(self.awsapi)
+        self.maxDiff = None
+        self.find_matching_peering = self.mock_callable(
+            sut, 'find_matching_peering'
+        )
+        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
+        self.ocm = testslide.StrictMock(template=ocm.OCM)
+        self.ocm_map = {
+            'clustername': self.ocm
+        }
+        self.ocm.get_aws_infrastructure_access_terraform_assume_role = \
+            lambda cluster, uid, tfuser: self.peer_account['assume_role']
+        self.account_vpcs = [
+            {
+                'vpc_id': 'vpc1',
+                'region': 'moon-dark-1',
+                'cidr_block': '192.168.3.0/24',
+                'route_table_ids': ['vpc1_route_table'],
+            },
+            {
+                'vpc_id': 'vpc2',
+                'region': 'mars-utopia-2',
+                'cidr_block': '192.168.4.0/24',
+                'route_table_ids': ['vpc2_route_table'],
+            }
+        ]
+
+
+    def test_one_cluster(self):
+        req_account = {
+            **self.peer_account,
+            'assume_region': 'mars-plain-1',
+            'assume_cidr': '172.16.0.0/12',
+        }
+        self.mock_callable(
+            self.awsapi, 'get_cluster_vpc_details'
+        ).for_call(
+            req_account, route_tables=True
+        ).to_return_value(
+            ('vpc_id', ['route_table_id'], 'subnet_id')
+        ).and_assert_called_once()
+
+        self.mock_callable(
+            self.awsapi, 'get_vpcs_details'
+        ).for_call(
+            req_account, tags=['tag1'], route_tables=True
+        ).to_return_value(self.account_vpcs).and_assert_called_once()
+
+        expected = [
+            {
+                'connection_provider': 'account-vpc-mesh',
+                'connection_name': 'peername_peer_account-vpc1',
+                'requester': {
+                    'vpc_id': 'vpc_id',
+                    'route_table_ids': ['route_table_id'],
+                    'account': self.peer_account,
+                    'region': 'mars-plain-1',
+                    'cidr_block': '172.16.0.0/12',
+                },
+                'accepter': {
+                    'vpc_id': 'vpc1',
+                    'region': 'moon-dark-1',
+                    'cidr_block': '192.168.3.0/24',
+                    'route_table_ids': ['vpc1_route_table'],
+                    'account': self.peer_account,
+                },
+                'deleted': False,
+            },
+            {
+                'connection_provider': 'account-vpc-mesh',
+                'connection_name': 'peername_peer_account-vpc2',
+                'requester': {
+                    'vpc_id': 'vpc_id',
+                    'route_table_ids': ['route_table_id'],
+                    'account': self.peer_account,
+                    'region': 'mars-plain-1',
+                    'cidr_block': '172.16.0.0/12',
+                },
+                'accepter': {
+                    'vpc_id': 'vpc2',
+                    'region': 'mars-utopia-2',
+                    'cidr_block': '192.168.4.0/24',
+                    'route_table_ids': ['vpc2_route_table'],
+                    'account': self.peer_account,
+                },
+                'deleted': False,
+            }
+        ]
+        rs = sut.build_desired_state_vpc_mesh(self.clusters, self.ocm_map, {})
+        self.assertEqual(rs, (expected, False))
+
+    def test_no_peering_connections(self):
+        self.clusters[0]['peering']['connections'] = []
+        rs = sut.build_desired_state_vpc_mesh(self.clusters, self.ocm_map, {})
+        self.assertEqual(rs, ([], False))
+
+    def test_no_peer_vpc_id(self):
+        self.mock_callable(
+            self.awsapi, 'get_cluster_vpc_details'
+        ).to_return_value((None, [None], None)).and_assert_called_once()
+
+        rs = sut.build_desired_state_vpc_mesh(self.clusters, self.ocm_map, {})
+        self.assertEqual(rs, ([], True))
+
+    def test_no_vpcs_in_account(self):
+        self.mock_callable(
+            self.awsapi, 'get_cluster_vpc_details'
+        ).to_return_value(
+            ('vpc_id', ['route_table_id'], 'subnet_id')
+        ).and_assert_called_once()
+
+        self.mock_callable(
+            self.awsapi, 'get_vpcs_details'
+        ).to_return_value([]).and_assert_called_once()
+
+        rs = sut.build_desired_state_vpc_mesh(self.clusters, self.ocm_map, {})
+        self.assertEqual(rs, ([], False))

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -342,6 +342,7 @@ class TestBuildDesiredStateSingleCluster(testslide.TestCase):
                 self.cluster, {}, self.settings
             )
 
+
 class TestBuildDesiredStateVpcMesh(testslide.TestCase):
 
     def setUp(self):
@@ -426,15 +427,10 @@ class TestBuildDesiredStateVpcMesh(testslide.TestCase):
             'route_table_ids': ['peer_route_table_id']
         }
         self.settings = {}
-        self.awsapi = testslide.StrictMock(awsapi.AWSApi)
-        self.mock_constructor(
-            awsapi, 'AWSApi'
-        ).to_return_value(self.awsapi)
-        self.maxDiff = None
-        self.find_matching_peering = self.mock_callable(
-            sut, 'find_matching_peering'
+        self.vpc_mesh_single_cluster = self.mock_callable(
+            sut, 'build_desired_state_vpc_mesh_single_cluster'
         )
-        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
+        self.maxDiff = None
         self.ocm = testslide.StrictMock(template=ocm.OCM)
         self.ocm_map = {
             'clustername': self.ocm
@@ -455,9 +451,171 @@ class TestBuildDesiredStateVpcMesh(testslide.TestCase):
                 'route_table_ids': ['vpc2_route_table'],
             }
         ]
+        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
 
+    def test_all_fine(self):
+        expected = [
+            {
+                'connection_provider': 'account-vpc-mesh',
+                'connection_name': 'peername_peer_account-vpc1',
+                'requester': {
+                    'vpc_id': 'vpc_id',
+                    'route_table_ids': ['route_table_id'],
+                    'account': self.peer_account,
+                    'region': 'mars-plain-1',
+                    'cidr_block': '172.16.0.0/12',
+                },
+                'accepter': {
+                    'vpc_id': 'vpc1',
+                    'region': 'moon-dark-1',
+                    'cidr_block': '192.168.3.0/24',
+                    'route_table_ids': ['vpc1_route_table'],
+                    'account': self.peer_account,
+                },
+                'deleted': False,
+            },
+            {
+                'connection_provider': 'account-vpc-mesh',
+                'connection_name': 'peername_peer_account-vpc2',
+                'requester': {
+                    'vpc_id': 'vpc_id',
+                    'route_table_ids': ['route_table_id'],
+                    'account': self.peer_account,
+                    'region': 'mars-plain-1',
+                    'cidr_block': '172.16.0.0/12',
+                },
+                'accepter': {
+                    'vpc_id': 'vpc2',
+                    'region': 'mars-utopia-2',
+                    'cidr_block': '192.168.4.0/24',
+                    'route_table_ids': ['vpc2_route_table'],
+                    'account': self.peer_account,
+                },
+                'deleted': False,
+            }
+        ]
+        self.vpc_mesh_single_cluster.for_call(
+            self.clusters[0], self.ocm, {}
+        ).to_return_value(expected)
+
+        rs = sut.build_desired_state_vpc_mesh(self.clusters, self.ocm_map, {})
+        self.assertEqual(rs, (expected, False))
+
+    def test_cluster_raises(self):
+        self.vpc_mesh_single_cluster.to_raise(Exception("This is wrong"))
+        rs = sut.build_desired_state_vpc_mesh(self.clusters, self.ocm_map, {})
+        self.assertEqual(rs, ([], True))
+
+
+class TestBuildDesiredStateVpcMeshSingleCluster(testslide.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.cluster = {
+            'name': 'clustername',
+            'spec': {
+                'region': 'mars-plain-1',
+            },
+            'network': {
+                'vpc': '172.16.0.0/12',
+                'service': '10.0.0.0/8',
+                'pod': '192.168.0.0/16',
+            },
+            'peering': {
+                'connections': [
+                    {
+                        'provider': 'account-vpc-mesh',
+                        'name': 'peername',
+                        'vpc': {
+                            '$ref': '/aws/account/vpcs/mars-plain-1'
+                        },
+                        'manageRoutes': True,
+                        'tags': '["tag1"]',
+                    },
+                ]
+            }
+        }
+        self.peer = {
+            'vpc': '172.17.0.0/12',
+            'service': '10.1.0.0/8',
+            'pod': '192.168.1.0/16',
+        }
+        self.peer_cluster = {
+            'name': 'apeerclustername',
+            'spec': {
+                'region': 'mars-olympus-2',
+            },
+            'network': self.peer,
+            'peering': {
+                'connections': [
+                    {
+                        'provider': 'cluster-vpc-requester',
+                        'name': 'peername',
+                        'vpc': {
+                            '$ref': '/aws/account/vpcs/mars-plain-1'
+                        },
+                        'manageRoutes': True,
+                        'tags': '["tag1"]',
+                    },
+                ]
+            }
+        }
+        self.awsapi = testslide.StrictMock(awsapi.AWSApi)
+        self.mock_constructor(
+            awsapi, 'AWSApi'
+        ).to_return_value(self.awsapi)
+        self.find_matching_peering = self.mock_callable(
+            sut, 'find_matching_peering'
+        )
+        self.aws_account = {
+            'name': 'accountname',
+            'uid': 'anuid',
+            'terraformUsername': 'aterraformusename',
+            'automationtoken': 'anautomationtoken',
+            'assume_role': 'arole:very:useful:indeed:it:is',
+            'assume_region': 'moon-tranquility-1',
+            'assume_cidr': '172.25.0.0/12',
+        }
+        self.peer_account = {
+            'name': 'peer_account',
+            'uid': 'peeruid',
+            'terraformUsername': 'peerterraformusename',
+            'automationtoken': 'peeranautomationtoken',
+            'assume_role': 'a:peer:role:indeed:it:is',
+            'assume_region': 'mars-hellas-1',
+            'assume_cidr': '172.25.0.0/12',
+        }
+        self.cluster['peering']['connections'][0]['cluster'] = \
+            self.peer_cluster
+        self.cluster['peering']['connections'][0]['account'] = \
+            self.peer_account
+        self.peer_vpc = {
+            'cidr_block': '172.30.0.0/12',
+            'vpc_id': 'peervpcid',
+            'route_table_ids': ['peer_route_table_id']
+        }
+        self.settings = {}
+        self.maxDiff = None
+        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
+        self.ocm = testslide.StrictMock(template=ocm.OCM)
+        self.ocm.get_aws_infrastructure_access_terraform_assume_role = \
+            lambda cluster, uid, tfuser: self.peer_account['assume_role']
+        self.account_vpcs = [
+            {
+                'vpc_id': 'vpc1',
+                'region': 'moon-dark-1',
+                'cidr_block': '192.168.3.0/24',
+                'route_table_ids': ['vpc1_route_table'],
+            },
+            {
+                'vpc_id': 'vpc2',
+                'region': 'mars-utopia-2',
+                'cidr_block': '192.168.4.0/24',
+                'route_table_ids': ['vpc2_route_table'],
+            }
+        ]
 
     def test_one_cluster(self):
+
         req_account = {
             **self.peer_account,
             'assume_region': 'mars-plain-1',
@@ -517,32 +675,24 @@ class TestBuildDesiredStateVpcMesh(testslide.TestCase):
                 'deleted': False,
             }
         ]
-        rs = sut.build_desired_state_vpc_mesh(self.clusters, self.ocm_map, {})
-        self.assertEqual(rs, (expected, False))
+
+        rs = sut.build_desired_state_vpc_mesh_single_cluster(
+            self.cluster, self.ocm, {})
+        self.assertEqual(rs, expected)
 
     def test_no_peering_connections(self):
-        self.clusters[0]['peering']['connections'] = []
-        rs = sut.build_desired_state_vpc_mesh(self.clusters, self.ocm_map, {})
-        self.assertEqual(rs, ([], False))
+        self.cluster['peering']['connections'] = []
+        rs = sut.build_desired_state_vpc_mesh_single_cluster(
+            self.cluster, self.ocm, {}
+        )
+        self.assertEqual(rs, [])
 
     def test_no_peer_vpc_id(self):
         self.mock_callable(
             self.awsapi, 'get_cluster_vpc_details'
         ).to_return_value((None, [None], None)).and_assert_called_once()
 
-        rs = sut.build_desired_state_vpc_mesh(self.clusters, self.ocm_map, {})
-        self.assertEqual(rs, ([], True))
-
-    def test_no_vpcs_in_account(self):
-        self.mock_callable(
-            self.awsapi, 'get_cluster_vpc_details'
-        ).to_return_value(
-            ('vpc_id', ['route_table_id'], 'subnet_id')
-        ).and_assert_called_once()
-
-        self.mock_callable(
-            self.awsapi, 'get_vpcs_details'
-        ).to_return_value([]).and_assert_called_once()
-
-        rs = sut.build_desired_state_vpc_mesh(self.clusters, self.ocm_map, {})
-        self.assertEqual(rs, ([], False))
+        with self.assertRaises(sut.BadTerraformPeeringState):
+            sut.build_desired_state_vpc_mesh_single_cluster(
+                self.cluster, self.ocm, {}
+            )

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -64,7 +64,9 @@ class TestBuildDesiredStateCluster(testslide.TestCase):
             'uid': 'anuid',
             'terraformUserName': 'aterraformusename',
             'automationtoken': 'anautomationtoken',
-            'assume_role': 'arole:very:useful:indeed:it:is'
+            'assume_role': 'arole:very:useful:indeed:it:is',
+            'assume_region': 'moon-tranquility-1',
+            'assume_cidr': '172.25.0.0/12',
         }
         self.peer_vpc = {
             'cidr_block': '172.30.0.0/12',
@@ -110,7 +112,7 @@ class TestBuildDesiredStateCluster(testslide.TestCase):
         ).for_call(
             aws_req, route_tables=True
         ).to_return_value(
-            ('vpcid', ['route_table_id'], False)
+            ('vpcid', ['route_table_id'], {})
         ).and_assert_called_once()
         aws_req = {
             'assume_region': 'mars-olympus-2',
@@ -122,7 +124,7 @@ class TestBuildDesiredStateCluster(testslide.TestCase):
         ).for_call(
             aws_req, route_tables=None
         ).to_return_value(
-            ('acceptervpcid', ['accepterroutetableid'], False)
+            ('acceptervpcid', ['accepterroutetableid'], {})
         ).and_assert_called_once()
 
         expected = [
@@ -155,7 +157,7 @@ class TestBuildDesiredStateCluster(testslide.TestCase):
                 'deleted': False
             }
         ]
-        rs = sut.build_desired_state_cluster(self.clusters, {}, self.settings)
+        rs = sut.build_desired_state_all_clusters(self.clusters, {}, self.settings)
         self.assertEqual(rs, (expected, False))
 
     def test_one_cluster_no_peers(self):
@@ -164,7 +166,7 @@ class TestBuildDesiredStateCluster(testslide.TestCase):
             sut, 'aws_account_from_infrastructure_access'
         ).to_return_value(self.aws_account).and_assert_called_once()
         self.assertEqual(
-            sut.build_desired_state_cluster(self.clusters, {}, self.settings),
+            sut.build_desired_state_all_clusters(self.clusters, {}, self.settings),
             ([], False))
 
     def test_one_cluster_no_matches(self):
@@ -175,7 +177,7 @@ class TestBuildDesiredStateCluster(testslide.TestCase):
             None
         ).and_assert_called_once()
         self.assertEqual(
-            sut.build_desired_state_cluster(self.clusters, {}, self.settings),
+            sut.build_desired_state_all_clusters(self.clusters, {}, self.settings),
             ([], True)
         )
 
@@ -188,8 +190,8 @@ class TestBuildDesiredStateCluster(testslide.TestCase):
         ).and_assert_called_once()
         self.mock_callable(
             self.awsapi, 'get_cluster_vpc_details'
-        ).to_return_value((None, None, True)).and_assert_called_once()
+        ).to_return_value((None, None, {})).and_assert_called_once()
         self.assertEqual(
-            sut.build_desired_state_cluster(self.clusters, {}, self.settings),
+            sut.build_desired_state_all_clusters(self.clusters, {}, self.settings),
             ([], True)
         )

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -431,7 +431,7 @@ class TestBuildDesiredStateVpcMesh(testslide.TestCase):
             sut, 'build_desired_state_vpc_mesh_single_cluster'
         )
         self.maxDiff = None
-        self.ocm = testslide.StrictMock(template=ocm.OCM)
+        self.ocm = testslide.StrictMock(ocm.OCM)
         self.ocm_map = {
             'clustername': self.ocm
         }
@@ -696,3 +696,181 @@ class TestBuildDesiredStateVpcMeshSingleCluster(testslide.TestCase):
             sut.build_desired_state_vpc_mesh_single_cluster(
                 self.cluster, self.ocm, {}
             )
+
+
+class TestBuildDesiredStateVpc(testslide.TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.peer = {
+            'vpc': '172.17.0.0/12',
+            'service': '10.1.0.0/8',
+            'pod': '192.168.1.0/16',
+        }
+        self.aws_account = {
+            'name': 'accountname',
+            'uid': 'anuid',
+            'terraformUsername': 'aterraformusename',
+            'automationtoken': 'anautomationtoken',
+            'assume_role': 'arole:very:useful:indeed:it:is',
+            'assume_region': 'moon-tranquility-1',
+            'assume_cidr': '172.25.0.0/12',
+        }
+
+        self.clusters = [
+            {
+                'name': 'clustername',
+                'spec': {
+                    'region': 'mars-plain-1',
+                },
+                'network': {
+                    'vpc': '172.16.0.0/12',
+                    'service': '10.0.0.0/8',
+                    'pod': '192.168.0.0/16',
+                },
+                'peering': {
+                    'connections': [
+                        {
+                            'provider': 'account-vpc',
+                            'name': 'peername',
+                            'vpc': {
+                                '$ref': '/aws/account/vpcs/mars-plain-1',
+                                'cidr_block': '172.30.0.0/12',
+                                'vpc_id': 'avpcid',
+                                **self.peer,
+                                'region': 'mars-olympus-2',
+                                'account': self.aws_account,
+                            },
+                            'manageRoutes': True,
+                        },
+                    ]
+                }
+            }
+        ]
+        self.settings = {}
+
+        self.peer_cluster = {
+                'name': 'apeerclustername',
+                'spec': {
+                    'region': 'mars-olympus-2',
+                },
+                'network': self.peer,
+                'peering': {
+                    'connections': [
+                        {
+                            'provider': 'account-vpc',
+                            'name': 'peername',
+                            'vpc': {
+                                '$ref': '/aws/account/vpcs/mars-plain-1'
+                            },
+                            'manageRoutes': True,
+                        },
+                    ]
+                }
+            }
+        self.clusters[0]['peering']['connections'][0]['cluster'] = \
+            self.peer_cluster
+        self.build_single_cluster = self.mock_callable(
+            sut, 'build_desired_state_single_cluster'
+        )
+        self.ocm = testslide.StrictMock(template=ocm.OCM)
+        self.ocm_map = {
+            'clustername': self.ocm
+        }
+        self.awsapi = testslide.StrictMock(awsapi.AWSApi)
+        self.mock_constructor(
+            awsapi, 'AWSApi'
+        ).to_return_value(self.awsapi)
+        self.ocm.get_aws_infrastructure_access_terraform_assume_role = \
+            lambda cluster, uid, tfuser: self.aws_account['assume_role']
+        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
+        self.maxDiff = None
+
+    def test_all_fine(self):
+        expected = [
+            {
+                'accepter': {
+                    'account': {
+                        'assume_cidr': '172.16.0.0/12',
+                        'assume_region': 'mars-plain-1',
+                        'assume_role': 'this:wonderful:role:hell:yeah',
+                        'automationtoken': 'anautomationtoken',
+                        'name': 'accountname',
+                        'terraformUsername': 'aterraformusename',
+                        'uid': 'anuid'
+                    },
+                    'cidr_block': '172.30.0.0/12',
+                    'region': 'mars-olympus-2',
+                    'vpc_id': 'avpcid'
+                },
+                'connection_name': 'peername',
+                'connection_provider': 'account-vpc',
+                'deleted': False,
+                'requester': {
+                    'account': {
+                        'assume_cidr': '172.16.0.0/12',
+                        'assume_region': 'mars-plain-1',
+                        'assume_role': 'this:wonderful:role:hell:yeah',
+                        'automationtoken': 'anautomationtoken',
+                        'name': 'accountname',
+                        'terraformUsername': 'aterraformusename',
+                        'uid': 'anuid'
+                    },
+                    'cidr_block': '172.16.0.0/12',
+                    'region': 'mars-plain-1',
+                    'route_table_ids': ['routetableid'],
+                    'vpc_id': 'vpcid'
+                }
+            }
+        ]
+        self.mock_callable(
+            self.awsapi, 'get_cluster_vpc_details',
+        ).for_call(
+            self.aws_account,
+            route_tables=True
+        ).to_return_value(
+            ('vpcid', ['routetableid'], {})
+        ).and_assert_called_once()
+        self.mock_callable(
+            self.ocm, 'get_aws_infrastructure_access_terraform_assume_role'
+        ).for_call(
+            self.clusters[0]['name'],
+            self.aws_account['uid'],
+            self.aws_account['terraformUsername']
+        ).to_return_value(
+            'this:wonderful:role:hell:yeah'
+        ).and_assert_called_once()
+        rs = sut.build_desired_state_vpc(
+            self.clusters, self.ocm_map, self.settings
+        )
+        self.assertEqual(rs, (expected, False))
+
+    def test_different_provider(self):
+        self.clusters[0]['peering']['connections'][0]['provider'] = \
+            'something-else'
+        self.assertEqual(
+            sut.build_desired_state_vpc(
+                self.clusters, self.ocm_map, self.settings
+            ),
+            ([], False)
+        )
+
+    def test_no_vpc_id(self):
+        self.mock_callable(
+            self.awsapi, 'get_cluster_vpc_details'
+        ).to_return_value(
+            (None, None, None)
+        ).and_assert_called_once()
+
+        self.mock_callable(
+            self.ocm, 'get_aws_infrastructure_access_terraform_assume_role'
+        ).to_return_value(
+            'a:role:that:you:will:like'
+        ).and_assert_called_once()
+
+        self.assertEqual(
+            sut.build_desired_state_vpc(
+                self.clusters, self.ocm_map, self.settings
+            ),
+            ([], True)
+        )


### PR DESCRIPTION
This is the first step to prevent this integration from crashing when
some resource is not available. First I add tests, which has helped me
understand the code (which is complicated), next I can modify it and
refactor whatever's necessary.

It introduces a testing dependency on
[testslide](https://testslide.readthedocs.io).

Some of the mocked-out classes have lots of side effects in their
constructor, and mocking that out is a royal pain. Instead, I can rely
on `mock_constructor` to do the right thing, and I also gain far
better and stricter mocks.
