### PR TITLE
[kafka-clusters] disable deletion

### DIFF
--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -192,7 +192,8 @@ def run(dry_run, thread_pool_size=10,
                                   kafka_cluster_name,
                                   resource.body['data'])
 
-    ob.realize_data(dry_run, oc_map, ri)
+    ob.realize_data(dry_run, oc_map, ri,
+                    override_enable_deletion=False)
 
     if error:
         sys.exit(ExitCodes.ERROR)


### PR DESCRIPTION
we've observed cases where output Secrets were deleted. this PR denies that.
until we can further investigate - let's add this safety net.