### PR TITLE
[openshift] reconcile away deleted annotations

### DIFF
--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -59,7 +59,7 @@ class OpenshiftResource:
                     pass
                 elif self.ignorable_key_value_pair(obj1_k, obj1_v):
                     pass
-                elif obj1_k in ['data', 'labels']:
+                elif obj1_k in ['data', 'labels', 'annotations']:
                     diff = [k for k in obj2_v
                             if k not in obj1_v
                             and k not in IGNORABLE_DATA_FIELDS]


### PR DESCRIPTION
our compare logic mostly checks if all desired keys exist and ignores existing keys (which usually come from k8s defaults).
this PR adds a special behavior for annotations - to compare them and delete redundant keys.