### PR TITLE
[terraform-vpc-peerings] set assume_region and assume_cidr only once

### DIFF
--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -55,7 +55,9 @@ def aws_account_from_infrastructure_access(cluster, access_level, ocm_map):
                         cluster['name'],
                         awsAccess['awsGroup']['account']['uid'],
                         awsAccess['awsGroup']['account']['terraformUsername'],
-                    )
+                    ),
+                'assume_region': cluster['spec']['region'],
+                'assume_cidr': cluster['network']['vpc']
             }
     return account
 
@@ -81,8 +83,6 @@ def build_desired_state_cluster(clusters, ocm_map, settings):
             logging.error(msg)
             error = True
             continue
-        req_aws['assume_region'] = cluster_info['spec']['region']
-        req_aws['assume_cidr'] = cluster_info['network']['vpc']
 
         peering_info = cluster_info['peering']
         peer_connections = peering_info['connections']
@@ -141,8 +141,6 @@ def build_desired_state_cluster(clusters, ocm_map, settings):
                 logging.error(msg)
                 error = True
                 continue
-            acc_aws['assume_region'] = peer_cluster['spec']['region']
-            acc_aws['assume_cidr'] = peer_cluster['network']['vpc']
 
             aws_api = AWSApi(1, [acc_aws], settings=settings)
             accepter_vpc_id, accepter_route_table_ids, _ = \

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -9,6 +9,7 @@ class MockOCM:
                                                             tf_user):
         return f"{cluster}/{tf_account_id}/{tf_user}"
 
+
 class TestAWSAccountFromInfrastructureAccess(TestCase):
     def test_aws_account_from_infrastructure_access(self):
         cluster = {

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -1,0 +1,80 @@
+from unittest import TestCase
+import reconcile.terraform_vpc_peerings as integ
+
+
+class MockOCM:
+    @staticmethod
+    def get_aws_infrastructure_access_terraform_assume_role(cluster,
+                                                            tf_account_id,
+                                                            tf_user):
+        return f"{cluster}/{tf_account_id}/{tf_user}"
+
+class TestAWSAccountFromInfrastructureAccess(TestCase):
+    def test_aws_account_from_infrastructure_access(self):
+        cluster = {
+            'name': 'cluster',
+            'spec': {
+                'region': 'region'
+            },
+            'network': {
+                'vpc': 'vpc'
+            },
+            'awsInfrastructureAccess': [
+                {
+                    'awsGroup': {
+                        'account': {
+                            'name': 'account',
+                            'uid': 'uid',
+                            'terraformUsername': 'terraform',
+                            'automationToken': 'token'
+                        }
+                    },
+                    'accessLevel': 'read-only'
+                }
+            ]
+        }
+        ocm_map = {
+            'cluster': MockOCM()
+        }
+        expected_result = {
+            'name': 'account',
+            'uid': 'uid',
+            'terraformUsername': 'terraform',
+            'automationToken': 'token',
+            'assume_role': 'cluster/uid/terraform',
+            'assume_region': 'region',
+            'assume_cidr': 'vpc'
+        }
+        account = integ.aws_account_from_infrastructure_access(
+            cluster, 'read-only', ocm_map)
+        self.assertEqual(account, expected_result)
+
+    def test_aws_account_from_infrastructure_access_none(self):
+        cluster = {
+            'name': 'cluster',
+            'spec': {
+                'region': 'region'
+            },
+            'network': {
+                'vpc': 'vpc'
+            },
+            'awsInfrastructureAccess': [
+                {
+                    'awsGroup': {
+                        'account': {
+                            'name': 'account',
+                            'uid': 'uid',
+                            'terraformUsername': 'terraform',
+                            'automationToken': 'token'
+                        }
+                    },
+                    'accessLevel': 'read-only'
+                }
+            ]
+        }
+        ocm_map = {
+            'cluster': MockOCM()
+        }
+        account = integ.aws_account_from_infrastructure_access(
+            cluster, 'not-read-only', ocm_map)
+        self.assertIsNone(account)

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -11,8 +11,8 @@ class MockOCM:
 
 
 class TestAWSAccountFromInfrastructureAccess(TestCase):
-    def test_aws_account_from_infrastructure_access(self):
-        cluster = {
+    def setUp(self):
+        self.cluster = {
             'name': 'cluster',
             'spec': {
                 'region': 'region'
@@ -34,9 +34,10 @@ class TestAWSAccountFromInfrastructureAccess(TestCase):
                 }
             ]
         }
-        ocm_map = {
+        self.ocm_map = {
             'cluster': MockOCM()
         }
+    def test_aws_account_from_infrastructure_access(self):
         expected_result = {
             'name': 'account',
             'uid': 'uid',
@@ -47,35 +48,10 @@ class TestAWSAccountFromInfrastructureAccess(TestCase):
             'assume_cidr': 'vpc'
         }
         account = integ.aws_account_from_infrastructure_access(
-            cluster, 'read-only', ocm_map)
+            self.cluster, 'read-only', self.ocm_map)
         self.assertEqual(account, expected_result)
 
     def test_aws_account_from_infrastructure_access_none(self):
-        cluster = {
-            'name': 'cluster',
-            'spec': {
-                'region': 'region'
-            },
-            'network': {
-                'vpc': 'vpc'
-            },
-            'awsInfrastructureAccess': [
-                {
-                    'awsGroup': {
-                        'account': {
-                            'name': 'account',
-                            'uid': 'uid',
-                            'terraformUsername': 'terraform',
-                            'automationToken': 'token'
-                        }
-                    },
-                    'accessLevel': 'read-only'
-                }
-            ]
-        }
-        ocm_map = {
-            'cluster': MockOCM()
-        }
         account = integ.aws_account_from_infrastructure_access(
-            cluster, 'not-read-only', ocm_map)
+            self.cluster, 'not-read-only', self.ocm_map)
         self.assertIsNone(account)


### PR DESCRIPTION
a minor refactor. also adds tests.