### PR TITLE
[qontract-cli] add get clusters egress IPs command

### DIFF
--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -34,9 +34,11 @@ class TestAWSAccountFromInfrastructureAccess(TestCase):
                 }
             ]
         }
-        ocm_map = {
+        self.ocm_map = {
             'cluster': MockOCM()
         }
+
+    def test_aws_account_from_infrastructure_access(self):
         expected_result = {
             'name': 'account',
             'uid': 'uid',

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -34,10 +34,9 @@ class TestAWSAccountFromInfrastructureAccess(TestCase):
                 }
             ]
         }
-        self.ocm_map = {
+        ocm_map = {
             'cluster': MockOCM()
         }
-    def test_aws_account_from_infrastructure_access(self):
         expected_result = {
             'name': 'account',
             'uid': 'uid',

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -701,6 +701,17 @@ class AWSApi:
 
         return vpc_id, route_table_ids, subnets_id_az
 
+    def get_cluster_nat_gateways_egress_ips(self, account):
+        assumed_session = self._get_assume_role_session(account)
+        assumed_ec2 = assumed_session.client('ec2')
+        nat_gateways = assumed_ec2.describe_nat_gateways()
+        egress_ips = set()
+        for nat in nat_gateways.get('NatGateways'):
+            for address in nat['NatGatewayAddresses']:
+                egress_ips.add(address['PublicIp'])
+
+        return egress_ips
+
     def get_vpcs_details(self, account, tags=None, route_tables=False):
         results = []
         session = self.get_session(account['name'])


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3383

we want to make it easier to get the clusters' Egress IPs in case:
- we migrate a service between clusters and there is a matter of whitelisting IPs
- we onboard a new hive cluster (required for cloud-ingress-operator / managed-cluster-config): https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/sop/hive-shard-provisioning.md#cloud-ingress-operator

with this PR, we can add this command to app-interface-output and get the required information automatically.

depends on #1729, #1730 (both currently merged into this one)

note to the reviewer: review only last 2 commits.