### PR TITLE
Add a tox config friendlier to development

### DIFF
--- a/tox-devel.ini
+++ b/tox-devel.ini
@@ -1,0 +1,13 @@
+[tox]
+envlist = py36
+
+[testenv]
+commands =
+    pytest {posargs}
+deps =
+    pytest==6.2.4
+    mock==2.0.0
+    anymarkup==0.7.0
+    flake8==3.5.0
+    pylint==2.6.0
+    testslide==2.6.3


### PR DESCRIPTION
To speed up development, it only runs pytest, and we can pass
positional arguments to narrow down the tests we want executed, like:

```
tox -c tox-devel.ini -- reconcile/test/test_utils_gpg.py
tox -c tox-devel.ini -- reconcile/test/test_utils_gpg.py::TestGpgKeyValid
tox -c tox-devel.ini
```
