### PR TITLE
[terraform-resources] use correct elasticache endpoint depending on cluster_mode

### DIFF
--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -1545,7 +1545,14 @@ class TerrascriptClient:
         # with the following fields
         # db.endpoint
         output_name_0_13 = output_prefix + '__db_endpoint'
-        output_value = '${' + tf_resource.primary_endpoint_address + '}'
+        # https://docs.aws.amazon.com/AmazonElastiCache/
+        # latest/red-ug/Endpoints.html
+        if values.get('cluster_mode'):
+            output_value = \
+                '${' + tf_resource.configuration_endpoint_address + '}'
+        else:
+            output_value = \
+                '${' + tf_resource.primary_endpoint_address + '}'
         tf_resources.append(Output(output_name_0_13, value=output_value))
         # db.port
         output_name_0_13 = output_prefix + '__db_port'


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3531

It appears these files were never used to create an ElastiCache instance, which means this may fail: https://github.com/app-sre/qontract-reconcile/blob/c917dcfaebd58d02031440b8b4aced2ad546f312/reconcile/utils/terrascript_client.py#L1544-L1547

If it does, we will need to add this output only if cluster mode is disabled, and otherwise use `configuration_endpoint_address`, as explained here: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group#attributes-reference

The idea was that we only support HA setups, as can be inferred from the initial documentation: https://gitlab.cee.redhat.com/service/app-interface/-/blob/f3b3475e1858d02a7f775c98d28c413ef7833973/README.md#L1378

But it seems that it didn't come to be the reality.

Best practices around which endpoints to use: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/Endpoints.html