### PR TITLE
Add missing dependencies to tox.ini

### DIFF
--- a/tox-devel.ini
+++ b/tox-devel.ini
@@ -11,3 +11,4 @@ deps =
     flake8==3.5.0
     pylint==2.6.0
     testslide==2.6.3
+    kubernetes~=12.0

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ deps =
     anymarkup==0.7.0
     flake8==3.5.0
     pylint==2.6.0
+    testslide==2.6.3
+    kubernetes~=12.0
 
 [testenv:report]
 deps = coverage


### PR DESCRIPTION
The move to native oc introduced a dependency on kubernetes that
breaks some tests. And then, I'm introducing testslide on some other
work.
