### PR TITLE
APPSRE-3559: Recorded SLO values in Dash.DB don't have enough precision

### DIFF
--- a/reconcile/dashdotdb_slo.py
+++ b/reconcile/dashdotdb_slo.py
@@ -109,15 +109,19 @@ class DashdotdbSLO:
                 prom_result = prom_response['data']['result']
                 if not prom_result:
                     continue
+
                 slo_value = prom_result[0]['value']
                 if not slo_value:
                     continue
+
+                slo_value = float(slo_value[1])
+                slo_target = float(slo['SLOTarget'])
+
+                # In Dash.DB we want to always store SLOs in percentages
                 if unit == "percent_0_1":
-                    slo_value = int(float(slo_value[1]) * 100)
-                    slo_target = int(slo['SLOTarget'] * 100)
-                elif unit == "percent_0_100":
-                    slo_value = int(slo_value[1])
-                    slo_target = slo['SLOTarget']
+                    slo_value *= 100
+                    slo_target *= 100
+
                 result.append({
                     "name": slo['name'],
                     "SLIType": slo['SLIType'],


### PR DESCRIPTION
Currently the data in Dash.DB doesn't have enough precision:

```
serviceslometrics{cluster="...",name="Tenant Manager API availability",namespace="...",service="...",slitype="availability",type="slo_target"} 95.0
```

This is because we are doing an `int()` on the SLO values. This PR changes that to a float.