### PR TITLE
[github] retry be more specific

### DIFF
--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -95,6 +95,13 @@ def get_config(desired_org_name=None):
 
 
 @retry()
+def get_org_and_teams(github, org_name):
+    org = github.get_organization(org_name)
+    teams = org.get_teams()
+    return org, teams
+
+
+@retry()
 def get_members(unit):
     return [member.login for member in unit.get_members()]
 
@@ -111,7 +118,7 @@ def fetch_current_state(gh_api_store):
         # we manage all teams
         is_managed = managed_teams is None or len(managed_teams) == 0
 
-        org = g.get_organization(org_name)
+        org, teams = get_org_and_teams(g, org_name)
 
         org_members = None
         if is_managed:
@@ -120,7 +127,7 @@ def fetch_current_state(gh_api_store):
             org_members = [m.lower() for m in org_members]
 
         all_team_members = []
-        for team in org.get_teams():
+        for team in teams:
             if not is_managed and team.name not in managed_teams:
                 continue
 

--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -95,6 +95,11 @@ def get_config(desired_org_name=None):
 
 
 @retry()
+def get_members(unit):
+    return [member.login for member in unit.get_members()]
+
+
+@retry()
 def fetch_current_state(gh_api_store):
     state = AggregatedList()
 
@@ -110,7 +115,7 @@ def fetch_current_state(gh_api_store):
 
         org_members = None
         if is_managed:
-            org_members = [member.login for member in org.get_members()]
+            org_members = get_members(org)
             org_members.extend(raw_gh_api.org_invitations(org_name))
             org_members = [m.lower() for m in org_members]
 
@@ -119,7 +124,7 @@ def fetch_current_state(gh_api_store):
             if not is_managed and team.name not in managed_teams:
                 continue
 
-            members = [member.login for member in team.get_members()]
+            members = get_members(team)
             members.extend(raw_gh_api.team_invitations(org.id, team.id))
             members = [m.lower() for m in members]
             all_team_members.extend(members)

--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -106,7 +106,6 @@ def get_members(unit):
     return [member.login for member in unit.get_members()]
 
 
-@retry()
 def fetch_current_state(gh_api_store):
     state = AggregatedList()
 

--- a/reconcile/test/test_github_org.py
+++ b/reconcile/test/test_github_org.py
@@ -152,7 +152,7 @@ class TestGithubOrg:
         class SimpleOrgMock:
             @staticmethod
             def get_teams():
-                return 'teams'
+                return ['teams']
 
         class SimpleGithubMock():
             @staticmethod
@@ -161,4 +161,4 @@ class TestGithubOrg:
 
         g = SimpleGithubMock()
         _, teams = github_org.get_org_and_teams(g, 'org')
-        assert teams == 'teams'
+        assert teams == ['teams']

--- a/reconcile/test/test_github_org.py
+++ b/reconcile/test/test_github_org.py
@@ -147,3 +147,19 @@ class TestGithubOrg:
 
         org = SimpleOrgMock()
         assert github_org.get_members(org) == ['a', 'b']
+
+    def test_get_org_teams(self):
+        class SimpleOrgMock:
+            @staticmethod
+            def get_teams():
+                return 'teams'
+
+        class SimpleGithubMock():
+            @staticmethod
+            def get_organization(org_name):
+                return SimpleOrgMock()
+
+        g = SimpleGithubMock()
+        expected_org = SimpleOrgMock()
+        _, teams = github_org.get_org_and_teams(g, 'org')
+        assert teams == 'teams'

--- a/reconcile/test/test_github_org.py
+++ b/reconcile/test/test_github_org.py
@@ -160,6 +160,5 @@ class TestGithubOrg:
                 return SimpleOrgMock()
 
         g = SimpleGithubMock()
-        expected_org = SimpleOrgMock()
         _, teams = github_org.get_org_and_teams(g, 'org')
         assert teams == 'teams'

--- a/reconcile/test/test_github_org.py
+++ b/reconcile/test/test_github_org.py
@@ -134,3 +134,16 @@ class TestGithubOrg:
 
     def test_desired_state_simple(self):
         self.do_desired_state_test('desired_state_simple.yml')
+
+    def test_get_members(self):
+        class SimpleMemberMock:
+            def __init__(self, login):
+                self.login = login
+
+        class SimpleOrgMock:
+            @staticmethod
+            def get_members():
+                return [SimpleMemberMock('a'), SimpleMemberMock('b')]
+
+        org = SimpleOrgMock()
+        assert github_org.get_members(org) == ['a', 'b']


### PR DESCRIPTION
before this MR, we had a giant `retry` over `fetch_current_state`. if anything failed, the entire function was retried.
with this PR, we are retrying more specific things and avoiding repeating previously successful operations.

example failure: https://coreos.slack.com/archives/CS0E65QCV/p1628183673223500
```
Error running qontract-reconcile: 502 {"message": "Error reaching https://api.github.com: ReadTimeout"}
Traceback (most recent call last):
  File "/run-integration.py", line 73, in <module>
    integration.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 471, in github
    run_integration(reconcile.github_org, ctx.obj)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/cli.py", line 413, in run_integration
    func_container.run(dry_run, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/github_org.py", line 369, in run
    current_state = fetch_current_state(gh_api_store)
  File "/usr/local/lib/python3.6/site-packages/sretoolbox-0.13.0-py3.6.egg/sretoolbox/utils/retry.py", line 47, in f_retry
    raise exception
  File "/usr/local/lib/python3.6/site-packages/sretoolbox-0.13.0-py3.6.egg/sretoolbox/utils/retry.py", line 42, in f_retry
    return function(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/github_org.py", line 122, in fetch_current_state
    members = [member.login for member in team.get_members()]
  File "/usr/local/lib/python3.6/site-packages/reconcile-0.2.2-py3.6.egg/reconcile/github_org.py", line 122, in <listcomp>
    members = [member.login for member in team.get_members()]
  File "/usr/local/lib/python3.6/site-packages/PyGithub-1.55-py3.6.egg/github/PaginatedList.py", line 56, in __iter__
    newElements = self._grow()
  File "/usr/local/lib/python3.6/site-packages/PyGithub-1.55-py3.6.egg/github/PaginatedList.py", line 67, in _grow
    newElements = self._fetchNextPage()
  File "/usr/local/lib/python3.6/site-packages/PyGithub-1.55-py3.6.egg/github/PaginatedList.py", line 200, in _fetchNextPage
    "GET", self.__nextUrl, parameters=self.__nextParams, headers=self.__headers
  File "/usr/local/lib/python3.6/site-packages/PyGithub-1.55-py3.6.egg/github/Requester.py", line 355, in requestJsonAndCheck
    verb, url, parameters, headers, input, self.__customConnection(url)
  File "/usr/local/lib/python3.6/site-packages/PyGithub-1.55-py3.6.egg/github/Requester.py", line 378, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.GithubException: 502 {"message": "Error reaching https://api.github.com: ReadTimeout"}
```

while this ReadTimeout is being separately investigated in github-mirror (https://issues.redhat.com/browse/APPSRE-2746), there is no reason we can't be smarter.