### PR TITLE
[github-repo-permissions-validator] consider invitations

### DIFF
--- a/reconcile/github_repo_invites.py
+++ b/reconcile/github_repo_invites.py
@@ -48,6 +48,7 @@ def run(dry_run):
             org = url[:url.rindex('/')]
             known_orgs.add(org)
 
+    invitations = set()
     for i in g.repo_invitations():
         invitation_id = i['id']
         invitation_url = i['html_url']
@@ -57,8 +58,11 @@ def run(dry_run):
         accept = url in urls or any(url.startswith(org) for org in known_orgs)
         if accept:
             logging.info(['accept', url])
+            invitations.add(url)
 
             if not dry_run:
                 g.accept_repo_invitation(invitation_id)
         else:
             logging.debug(['skipping', url])
+
+    return invitations

--- a/reconcile/github_repo_permissions_validator.py
+++ b/reconcile/github_repo_permissions_validator.py
@@ -5,6 +5,7 @@ import sys
 
 from github import Github
 
+from reconcile.github_repo_invites import run as get_invitations
 from reconcile.jenkins_job_builder import init_jjb
 from reconcile.github_org import get_config
 from reconcile.utils.semver_helper import make_semver
@@ -40,13 +41,15 @@ def run(dry_run, instance_name, bot_token_org_name):
 
     gh = init_github(bot_token_org_name)
 
+    invitations = get_invitations(dry_run=True)
+
     error = False
     for job in pr_check_jobs:
         repo_url = jjb.get_repo_url(job)
         repo_name = repo_url.rstrip("/").replace('https://github.com/', '')
         repo = gh.get_repo(repo_name)
         permissions = repo.permissions
-        if not permissions.push:
+        if not permissions.push and repo_url not in invitations:
             logging.error(
                 f'missing write permissions for bot in repo {repo_url}')
             error = True


### PR DESCRIPTION
for the bot user to be able to post test results to a commit, it needs to have write permissions in the github repository.
we currently validate that the user has that write permission when a pr-check job is added for that repository.

when adding both the pr-check job and the repository to a `codeComponents` section, there is a chicken and egg situtation -
assuming an invitation is pending, we will only automatically accept it (with `github-repo-invites`) after the MR was merged. so the invitation is pending, but the MR will keep failing because the bot doesn't have write permissions for the repo. but the invitation in pending...

this PR adds a check if there is a pending invitation.