### PR TITLE
[slack-usergroups] only initiate pagerduty users once

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1960,3 +1960,21 @@ SRE_CHECKPOINTS_QUERY = """
 def get_sre_checkpoints():
     gqlapi = gql.get_api()
     return gqlapi.query(SRE_CHECKPOINTS_QUERY)['sre_checkpoints']
+
+
+PAGERDUTY_INSTANCES_QUERY = """
+{
+  pagerduty_instances: pagerduty_instances_v1 {
+    name
+    token {
+      path
+      field
+    }
+  }
+}
+"""
+
+
+def get_pagerduty_instances():
+    gqlapi = gql.get_api()
+    return gqlapi.query(PAGERDUTY_INSTANCES_QUERY)['pagerduty_instances']

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -116,6 +116,7 @@ def get_pagerduty_map():
     settings = queries.get_app_interface_settings()
     return PagerDutyMap(instances, settings)
 
+
 def get_current_state(slack_map):
     current_state = []
 

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -6,7 +6,7 @@ from sretoolbox.utils import retry
 from reconcile.utils import gql
 from reconcile.utils.github_api import GithubApi
 from reconcile.utils.gitlab_api import GitLabApi
-from reconcile.utils.pagerduty_api import PagerDutyApi
+from reconcile.utils.pagerduty_api import PagerDutyMap
 from reconcile.utils.repo_owners import RepoOwners
 from reconcile.utils.slack_api import SlackApi
 from reconcile import queries
@@ -51,9 +51,8 @@ ROLES_QUERY = """
         }
         pagerduty {
           name
-          token {
-            path
-            field
+          instance {
+            name
           }
           scheduleID
           escalationPolicyID
@@ -112,6 +111,11 @@ def get_slack_map():
     return slack_map
 
 
+def get_pagerduty_map():
+    instances = queries.get_pagerduty_instances()
+    settings = queries.get_app_interface_settings()
+    return PagerDutyMap(instances, settings)
+
 def get_current_state(slack_map):
     current_state = []
 
@@ -140,12 +144,11 @@ def get_pagerduty_name(user):
 
 
 @retry()
-def get_slack_usernames_from_pagerduty(pagerduties, users, usergroup):
-    settings = queries.get_app_interface_settings()
+def get_slack_usernames_from_pagerduty(pagerduties, users, usergroup,
+                                       pagerduty_map):
     all_slack_usernames = []
     all_pagerduty_names = [get_pagerduty_name(u) for u in users]
     for pagerduty in pagerduties or []:
-        pd_token = pagerduty['token']
         pd_schedule_id = pagerduty['scheduleID']
         if pd_schedule_id is not None:
             pd_resource_type = 'schedule'
@@ -155,7 +158,7 @@ def get_slack_usernames_from_pagerduty(pagerduties, users, usergroup):
             pd_resource_type = 'escalationPolicy'
             pd_resource_id = pd_escalation_policy_id
 
-        pd = PagerDutyApi(pd_token, settings=settings)
+        pd = pagerduty_map.get(pagerduty['instance']['name'])
         pagerduty_names = pd.get_pagerduty_users(pd_resource_type,
                                                  pd_resource_id)
         if not pagerduty_names:
@@ -234,7 +237,7 @@ def get_slack_usernames_from_owners(owners_from_repo, users, usergroup):
     return all_slack_usernames
 
 
-def get_desired_state(slack_map):
+def get_desired_state(slack_map, pagerduty_map):
     gqlapi = gql.get_api()
     roles = gqlapi.query(ROLES_QUERY)['roles']
     all_users = queries.get_users()
@@ -268,7 +271,8 @@ def get_desired_state(slack_map):
 
             slack_usernames_pagerduty = \
                 get_slack_usernames_from_pagerduty(p['pagerduty'],
-                                                   all_users, usergroup)
+                                                   all_users, usergroup,
+                                                   pagerduty_map)
             user_names.extend(slack_usernames_pagerduty)
 
             slack_usernames_repo = get_slack_usernames_from_owners(
@@ -354,8 +358,9 @@ def act(desired_state, slack_map):
 
 def run(dry_run):
     slack_map = get_slack_map()
+    pagerduty_map = get_pagerduty_map()
+    desired_state = get_desired_state(slack_map, pagerduty_map)
     current_state = get_current_state(slack_map)
-    desired_state = get_desired_state(slack_map)
 
     print_diff(current_state, desired_state)
 

--- a/reconcile/utils/pagerduty_api.py
+++ b/reconcile/utils/pagerduty_api.py
@@ -76,3 +76,27 @@ class PagerDutyApi:
                 # and next escalation is not 0 minutes from now
                 break
         return users
+
+
+class PagerDutyMap:
+    """A collection of PagerDutyApi instances per PagerDuty instance
+    """
+
+    def __init__(self, instances, settings=None):
+        self.pd_apis = {}
+        for i in instances:
+            name = i['name']
+            token = i['token']
+            pd_api = PagerDutyApi(token, settings=settings)
+            self.pd_apis[name] = pd_api
+
+    def get(name):
+        """Get PagerDutyApi by instance name
+
+        Args:
+            name (string): instance name
+
+        Returns:
+            PagerDutyApi: PagerDutyApi instance
+        """
+        return self.pd_apis.get(name)

--- a/reconcile/utils/pagerduty_api.py
+++ b/reconcile/utils/pagerduty_api.py
@@ -90,7 +90,7 @@ class PagerDutyMap:
             pd_api = PagerDutyApi(token, settings=settings)
             self.pd_apis[name] = pd_api
 
-    def get(name):
+    def get(self, name):
         """Get PagerDutyApi by instance name
 
         Args:


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3566

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/23544

this PR will make slack-usergroups initiate PagerDuty users only once, instead of once per pagerduty target.