### PR TITLE
[qontract-cli] add set slack-usergroup command

### DIFF
--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -8,6 +8,10 @@ from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.config import get_config
 
 
+class UserNotFoundException(Exception):
+    pass
+
+
 class UsergroupNotFoundException(Exception):
     pass
 
@@ -107,7 +111,7 @@ class SlackApi:
             email=f"{user_name}@{mail_address}"
         )
         if not result['ok']:
-            raise Exception(result['error'])
+            raise UserNotFoundException(result['error'])
         return result['user']['id']
 
     def get_channels_by_names(self, channels_names):

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -5,6 +5,7 @@ from slackclient import SlackClient
 from sretoolbox.utils import retry
 
 from reconcile.utils.secret_reader import SecretReader
+from reconcile.utils.config import get_config
 
 
 class UsergroupNotFoundException(Exception):
@@ -97,6 +98,17 @@ class SlackApi:
         logging.error('could not find a deleted user, ' +
                       'empty usergroup will not work')
         return ''
+
+    def get_user_id_by_name(self, user_name):
+        config = get_config()
+        mail_address = config['smtp']['mail_address']
+        result = self.sc.api_call(
+            "users.lookupByEmail",
+            email=f"{user_name}@{mail_address}"
+        )
+        if not result['ok']:
+            raise Exception(result['error'])
+        return result['user']['id']
 
     def get_channels_by_names(self, channels_names):
         return {k: v['name'] for k, v in self._get('channels').items()

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -593,7 +593,6 @@ def print_table(content, columns, table_format='simple'):
     print(tabulate(table_data, headers=headers, tablefmt=table_format))
 
 
-
 @root.group()
 @output
 @click.pass_context

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -10,12 +10,13 @@ from tabulate import tabulate
 import reconcile.utils.dnsutils as dnsutils
 import reconcile.utils.gql as gql
 import reconcile.utils.config as config
-from reconcile.utils.secret_reader import SecretReader
 import reconcile.queries as queries
 import reconcile.openshift_resources_base as orb
 import reconcile.terraform_users as tfu
 import reconcile.terraform_vpc_peerings as tfvpc
 
+from reconcile.slack_base import init_slack_workspace
+from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.terraform_client import TerraformClient as Terraform
 from reconcile.utils.state import State
@@ -590,6 +591,33 @@ def print_table(content, columns, table_format='simple'):
         table_data.append(row_data)
 
     print(tabulate(table_data, headers=headers, tablefmt=table_format))
+
+
+
+@root.group()
+@output
+@click.pass_context
+def set(ctx, output):
+    ctx.obj['output'] = output
+
+
+@set.command()
+@click.argument('workspace')
+@click.argument('usergroup')
+@click.argument('username')
+@click.pass_context
+def slack_usergroup(ctx, workspace, usergroup, username):
+    """Update users in a slack usergroup.
+    Use an org_username as the username.
+    To empty a slack usergroup, pass '' (empty string) as the username.
+    """
+    slack = init_slack_workspace('qontract-cli')
+    ugid = slack.get_usergroup_id(usergroup)
+    if username:
+        users = [slack.get_user_id_by_name(username)]
+    else:
+        users = [slack.get_random_deleted_user()]
+    slack.update_usergroup_users(ugid, users)
 
 
 @root.group()


### PR DESCRIPTION
with this command, we can add users to a usergroup:
```
qontract-cli --config config.debug.toml set slack-usergroup <workspace> <usergroup> <username>
```
adding someone to a usergroup is easier through the slack UI, but this command is mostly useful to empty a slack usergroup:
```
qontract-cli --config config.debug.toml set slack-usergroup <workspace> <usergroup> ''
```

this will help us with adding/removing ourselves from usergroups, such as the upcoming @app-sre-onboarding-ic.