### PR TITLE
[openshift] redact error when applying secrets

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -402,8 +402,8 @@ def _realize_resource_data(unpacked_ri_item,
             ri.register_error()
             err = str(e) if resource_type != 'Secret' \
                 else f'error applying Secret {d_item.name}: REDACTED'
-            msg = "[{}/{}] {} (error details: {})".format(
-                cluster, namespace, err, d_item.error_details)
+            msg = f"[{cluster}/{namespace}] {err} " + \
+                f"(error details: {d_item.error_details})"
             logging.error(msg)
 
     # current items

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -400,8 +400,10 @@ def _realize_resource_data(unpacked_ri_item,
             actions.append(action)
         except StatusCodeError as e:
             ri.register_error()
+            err = str(e) if resource_type != 'Secret' \
+                else f'error applying Secret {d_item.name}: REDACTED'
             msg = "[{}/{}] {} (error details: {})".format(
-                cluster, namespace, str(e), d_item.error_details)
+                cluster, namespace, err, d_item.error_details)
             logging.error(msg)
 
     # current items


### PR DESCRIPTION
with this PR, when there is an error applying a Secret (when there is a possibility the error contains the Secret itself), we will not print the error.

this will allow us to add slack output for other integrations, such as openshift-secrets.