### PR TITLE
Create Quay teams that don't already exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .eggs
 .coverage
 build
+coverage.xml
 dist
 venv
 throughput

--- a/reconcile/quay_membership.py
+++ b/reconcile/quay_membership.py
@@ -70,8 +70,9 @@ def fetch_current_state(quay_api_store):
             try:
                 members = quay_api.list_team_members(team)
             except QuayTeamNotFoundException:
-                logging.warning("Attempted to list members for team %s/%s, "
-                                "but it doesn't exist", org_key.org_name, team)
+                logging.warning("Attempted to list members for team %s in "
+                                "org %s/%s, but it doesn't exist", team,
+                                org_key.instance, org_key.org_name)
             else:
                 # Teams are only added to the state if they exist so that
                 # there is a proper diff between the desired and current state.

--- a/reconcile/quay_membership.py
+++ b/reconcile/quay_membership.py
@@ -8,7 +8,7 @@ from reconcile.utils.aggregated_list import (AggregatedList,
                                              RunnerException)
 from reconcile.quay_base import get_quay_api_store
 from reconcile.status import ExitCodes
-
+from reconcile.utils.quay_api import QuayTeamNotFoundException
 
 QUAY_ORG_QUERY = """
 {
@@ -67,12 +67,19 @@ def fetch_current_state(quay_api_store):
         if not teams:
             continue
         for team in teams:
-            members = quay_api.list_team_members(team)
-            state.add({
-                'service': 'quay-membership',
-                'org': org_key,
-                'team': team
-            }, members)
+            try:
+                members = quay_api.list_team_members(team)
+            except QuayTeamNotFoundException:
+                logging.warning("Attempted to list members for team %s/%s, "
+                                "but it doesn't exist", org_key.org_name, team)
+            else:
+                # Teams are only added to the state if they exist so that
+                # there is a proper diff between the desired and current state.
+                state.add({
+                    'service': 'quay-membership',
+                    'org': org_key,
+                    'team': team
+                }, members)
     return state
 
 
@@ -139,6 +146,34 @@ class RunnerAction:
 
         return action
 
+    def create_team(self):
+        """
+        Create an empty team in Quay. This method avoids adding users to the
+        new team. add_to_team() will handle updating the member list the
+        next time run() is executed, while keeping this action very simple.
+        """
+        label = "create_team"
+
+        def action(params, items):
+            org = params["org"]
+            team = params["team"]
+
+            # Ensure all quay org/teams are declared as dependencies in a
+            # `/dependencies/quay-org-1.yml` datafile.
+            if team not in self.quay_api_store[org]["teams"]:
+                raise RunnerException(f"Quay team {team} is not defined as a "
+                                      f"managedTeam in the {org} org.")
+
+            logging.info([label, org, team])
+
+            if not self.dry_run:
+                quay_api = self.quay_api_store[org]['api']
+                quay_api.create_or_update_team(team)
+
+            return True
+
+        return action
+
     def del_from_team(self):
         label = "del_from_team"
 
@@ -168,29 +203,13 @@ def run(dry_run):
 
     # calculate diff
     diff = current_state.diff(desired_state)
-
-    # Ensure all quay org/teams are declared as dependencies:
-    # any item that appears in `diff['insert']` means that it's not listed
-    # in a `/dependencies/quay-org-1.yml` datafile.
-    if len(diff['insert']) > 0:
-        unknown_teams = [
-            "- {}/{}".format(
-                item["params"]["org"],
-                item["params"]["team"],
-            )
-            for item in diff['insert']
-        ]
-
-        raise RunnerException((
-            "Unknown quay/org/team found:\n"
-            "{}"
-        ).format("\n".join(unknown_teams))
-        )
+    logging.debug("State diff: %s", diff)
 
     # Run actions
     runner_action = RunnerAction(dry_run, quay_api_store)
     runner = AggregatedDiffRunner(diff)
 
+    runner.register("insert", runner_action.create_team())
     runner.register("update-insert", runner_action.add_to_team())
     runner.register("update-delete", runner_action.del_from_team())
     runner.register("delete", runner_action.del_from_team())

--- a/reconcile/test/test_utils_quay_api.py
+++ b/reconcile/test/test_utils_quay_api.py
@@ -1,0 +1,81 @@
+import json
+
+import pytest
+import responses
+
+from reconcile.utils.quay_api import QuayApi, RequestsException, \
+    QuayTeamNotFoundException
+
+ORG = 'some-org'
+BASE_URL = 'some.quay.io'
+TEAM_NAME = 'some-team'
+
+
+@pytest.fixture
+def quay_api():
+    return QuayApi('some-token', ORG, base_url=BASE_URL)
+
+
+@responses.activate
+def test_create_or_update_team_default_payload(quay_api):
+    responses.add(
+        responses.PUT,
+        f'https://{BASE_URL}/api/v1/organization/{ORG}/team/{TEAM_NAME}',
+        status=200
+    )
+
+    quay_api.create_or_update_team(TEAM_NAME)
+
+    assert json.loads(responses.calls[0].request.body) == {'role': 'member'}
+
+
+@responses.activate
+def test_create_or_update_team_with_description(quay_api):
+    responses.add(
+        responses.PUT,
+        f'https://{BASE_URL}/api/v1/organization/{ORG}/team/{TEAM_NAME}',
+        status=200
+    )
+
+    quay_api.create_or_update_team(TEAM_NAME, description="This is a team")
+
+    assert json.loads(responses.calls[0].request.body) == \
+        {'role': 'member', 'description': 'This is a team'}
+
+
+@responses.activate
+def test_create_or_update_team_raises(quay_api):
+    responses.add(
+        responses.PUT,
+        f'https://{BASE_URL}/api/v1/organization/{ORG}/team/{TEAM_NAME}',
+        status=400
+    )
+
+    with pytest.raises(RequestsException):
+        quay_api.create_or_update_team(TEAM_NAME)
+
+
+@responses.activate
+def test_list_team_members_raises_team_doesnt_exist(quay_api):
+    responses.add(
+        responses.GET,
+        f'https://{BASE_URL}/api/v1/organization/{ORG}/team/{TEAM_NAME}/'
+        f'members?includePending=true',
+        status=404
+    )
+
+    with pytest.raises(QuayTeamNotFoundException):
+        quay_api.list_team_members(TEAM_NAME)
+
+
+@responses.activate
+def test_list_team_members_raises_other_status_codes(quay_api):
+    responses.add(
+        responses.GET,
+        f'https://{BASE_URL}/api/v1/organization/{ORG}/team/{TEAM_NAME}/'
+        f'members?includePending=true',
+        status=401
+    )
+
+    with pytest.raises(RequestsException):
+        quay_api.list_team_members(TEAM_NAME)

--- a/tox-devel.ini
+++ b/tox-devel.ini
@@ -7,6 +7,7 @@ commands =
 deps =
     pytest==6.2.4
     mock==2.0.0
+    responses
     anymarkup==0.7.0
     flake8==3.5.0
     pylint==2.6.0

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,12 @@ envlist = py36
 commands =
     flake8 reconcile tools e2e_tests
     pylint -j0 reconcile tools e2e_tests
-    pytest --cov=reconcile --cov-report=term-missing
+    pytest --cov=reconcile --cov-report=term-missing --cov-report xml
 deps =
     pytest==6.2.4
     pytest-cov==2.12.1
     mock==2.0.0
+    responses
     anymarkup==0.7.0
     flake8==3.5.0
     pylint==2.6.0
@@ -22,6 +23,7 @@ skip_install = true
 commands =
     coverage report
     coverage html
+    coverage xml
 
 [testenv:clean]
 deps = coverage


### PR DESCRIPTION
This change creates a Quay team when it doesn't exist and a member needs to be added to the team.  A default role of `member` is assigned to the team as a sane default.  Prior to this change an exception would be thrown and the team would need to be created manually.