### PR TITLE
raise error while init

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -684,6 +684,8 @@ class OCDeprecated:
 
         if code != 0:
             err = err.decode('utf-8')
+            if 'Unable to connect to the server' in err:
+                raise StatusCodeError(f"[{self.server}]: {err}")
             if kwargs.get('apply'):
                 if 'Invalid value: 0x0' in err:
                     raise InvalidValueApplyError(f"[{self.server}]: {err}")


### PR DESCRIPTION
Catch error when running `oc version` during `init_oc_client`. 

If failed 10 times, registered the cluster unreachable.

Signed-off-by: Feng Huang <fehuang@redhat.com>