### PR TITLE
Re-add response caches to quay-mirror images

### DIFF
--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -12,11 +12,12 @@ from sretoolbox.container.skopeo import SkopeoCmdError
 
 from reconcile import queries
 from reconcile.status import ExitCodes
-from reconcile.utils import gql
+from reconcile.utils import gql, sharding
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.instrumented_wrappers import (
     InstrumentedImage as Image,
-    InstrumentedSkopeo as Skopeo
+    InstrumentedSkopeo as Skopeo,
+    InstrumentedCache
 )
 
 _LOG = logging.getLogger(__name__)
@@ -44,6 +45,12 @@ class QuayMirror:
     }
     """
 
+    response_cache = InstrumentedCache(
+        integration_name=QONTRACT_INTEGRATION,
+        shards=sharding.SHARDS,
+        shard_id=sharding.SHARD_ID
+    )
+
     def __init__(self, dry_run=False):
         self.dry_run = dry_run
         self.gqlapi = gql.get_api()
@@ -64,8 +71,8 @@ class QuayMirror:
                 except SkopeoCmdError as details:
                     _LOG.error('[%s]', details)
 
-    @staticmethod
-    def process_repos_query():
+    @classmethod
+    def process_repos_query(cls):
         apps = queries.get_quay_repos()
 
         summary = defaultdict(list)
@@ -85,7 +92,10 @@ class QuayMirror:
                     if item['mirror'] is None:
                         continue
 
-                    mirror_image = Image(item['mirror']['url'])
+                    mirror_image = Image(
+                        item['mirror']['url'],
+                        response_cache=cls.response_cache
+                    )
                     if (mirror_image.registry == 'docker.io'
                             and mirror_image.repository == 'library'
                             and item['public']):
@@ -130,8 +140,10 @@ class QuayMirror:
             org = org_key.org_name
             for item in data:
                 push_creds = self.push_creds[org_key].split(':')
-                image = Image(f'{item["server_url"]}/{org}/{item["name"]}',
-                              username=push_creds[0], password=push_creds[1])
+                image = Image(
+                    f'{item["server_url"]}/{org}/{item["name"]}',
+                    username=push_creds[0], password=push_creds[1],
+                    response_cache=self.response_cache)
 
                 mirror_url = item['mirror']['url']
 
@@ -146,7 +158,8 @@ class QuayMirror:
                     mirror_creds = f'{username}:{password}'
 
                 image_mirror = Image(mirror_url, username=username,
-                                     password=password)
+                                     password=password,
+                                     response_cache=self.response_cache)
 
                 tags = item['mirror'].get('tags')
                 tags_exclude = item['mirror'].get('tagsExclude')

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     data_files=[('reconcile/templates', glob('reconcile/templates/*.j2'))],
 
     install_requires=[
-        "sretoolbox==0.13.2",
+        "sretoolbox==0.14.1",
         "Click>=7.0,<8.0",
         "graphqlclient>=0.2.4,<0.3.0",
         "toml>=0.10.0,<0.11.0",

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     data_files=[('reconcile/templates', glob('reconcile/templates/*.j2'))],
 
     install_requires=[
-        "sretoolbox==0.13.0",
+        "sretoolbox==0.13.2",
         "Click>=7.0,<8.0",
         "graphqlclient>=0.2.4,<0.3.0",
         "toml>=0.10.0,<0.11.0",


### PR DESCRIPTION
Re-add caching of manifests to alleviate pressure on the docker APIs.

Using now a better version of sretoolbox.

TODO: How do I test this without downloading everything under the sun
to my laptop?
