### PR TITLE
add tekton rbac example

### DIFF
--- a/tekton/rbac.yaml
+++ b/tekton/rbac.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: tekton-trigger-access
+rules:
+- apiGroups:
+  - tekton.dev
+  resources:
+  - pipelineruns
+  verbs:
+  - create
+  - delete


### PR DESCRIPTION
to show how we manage permissions inside a pipelines namespace