### PR TITLE
Ignore invalid_users errors from Slack API

### DIFF
--- a/reconcile/test/test_utils_slack_api.py
+++ b/reconcile/test/test_utils_slack_api.py
@@ -139,3 +139,16 @@ def test_slack_api_update_usergroup_users_raise_for_errors(slack_api):
     with pytest.raises(SlackAPICallException):
         with patch('time.sleep'):
             slack_api.client.update_usergroup_users('ABCD', ['USERA', 'USERB'])
+
+
+def test_slack_api_update_usergroup_users_invalid_users(slack_api):
+    """
+    Don't raise an exception when Slack returns an 'invalid_users' error
+    because it will still empty groups as expected.
+    """
+    slack_api.mock_slack_client.return_value.api_call.return_value = {
+        'error': 'invalid_users',
+    }
+
+    with patch('time.sleep'):
+        slack_api.client.update_usergroup_users('ABCD', ['USERA', 'USERB'])

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -111,7 +111,9 @@ class SlackApi:
             raise SlackAPIRateLimitedException(
                 f"Slack API throttled after max retry attempts - "
                 f"method=usergroups.users.update usergroup={id} users={users}")
-        elif error:
+        # Slack can throw an invalid_users error when emptying groups, but it
+        # will still empty the group (so this can be ignored).
+        elif error and error != 'invalid_users':
             raise SlackAPICallException(
                 f"Slack returned error: {error} - "
                 f"method=usergroups.users.update usergroup={id} users={users}")


### PR DESCRIPTION
When emptying a Slack user group, the API will return an invalid_users
errors, but the change still takes effect. As such, we can ignore
these errors.