### PR TITLE
[ocm-upgrade-scheduler] keep track of workload types and days of usage per version

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1188,6 +1188,7 @@ def ocm_machine_pools(ctx, thread_pool_size):
 
 
 @integration.command()
+@environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
 @threaded()
 @click.pass_context
 def ocm_upgrade_scheduler(ctx, thread_pool_size):

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -52,19 +52,23 @@ def update_history(history, upgrade_policies):
         history (dict): history in the following format:
         {
           "check_in": "2021-08-29 18:01:27.730441",
-          "version1": {
-            "workload1": {
-              "soak_days": 21,
-              "reporting": [
-                "cluster1",
-                "cluster2"
-              ]
-            },
-            "workload2": {
-              "soak_days": 6,
-              "reporting": [
-                "cluster3"
-              ]
+          "versions": {
+            "version1": {
+                "workloads": {
+                    "workload1": {
+                        "soak_days": 21,
+                        "reporting": [
+                            "cluster1",
+                            "cluster2"
+                        ]
+                    },
+                        "workload2": {
+                        "soak_days": 6,
+                        "reporting": [
+                            "cluster3"
+                        ]
+                    }
+                }
             }
           }
         }
@@ -77,17 +81,19 @@ def update_history(history, upgrade_policies):
 
     now = datetime.utcnow()
     check_in = parser.parse(get_or_init(history, 'check_in', str(now)))
+    versions = get_or_init(history, 'versions', {})
 
     # we iterate over clusters upgrade policies and update the version history
     for item in upgrade_policies:
         current_version = item['current_version']
-        version_history = get_or_init(history, current_version, {})
+        version_history = get_or_init(versions, current_version, {})
+        version_workloads = get_or_init(version_history, 'workloads', {})
         cluster = item['cluster']
         workloads = item['workloads']
         # we keep the version history per workload
         for w in workloads:
             workload_history = get_or_init(
-                version_history, w,
+                version_workloads, w,
                 copy.deepcopy(default_workload_history))
 
             reporting = workload_history['reporting']

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -1,9 +1,15 @@
 import sys
 import logging
+import copy
+
+from datetime import datetime
+from dateutil import parser
 
 import reconcile.queries as queries
 
 from reconcile.utils.ocm import OCMMap
+from reconcile.utils.state import State
+from reconcile.utils.data_structures import get_or_init
 
 QONTRACT_INTEGRATION = 'ocm-upgrade-scheduler'
 
@@ -36,6 +42,94 @@ def fetch_desired_state(clusters):
         desired_state.append(upgrade_policy)
 
     return desired_state
+
+
+def update_history(history, upgrade_policies):
+    """Update history with information from clusters
+    with upgrade policies.
+
+    Args:
+        history (dict): history in the following format:
+        {
+          "check_in": "2021-08-29 18:01:27.730441",
+          "version1": {
+            "workload1": {
+              "soak_days": 21,
+              "reporting": [
+                "cluster1",
+                "cluster2"
+              ]
+            },
+            "workload2": {
+              "soak_days": 6,
+              "reporting": [
+                "cluster3"
+              ]
+            }
+          }
+        }
+        upgrade_policies (list): query results of clusters upgrade policies
+    """
+    default_workload_history = {
+        'soak_days': 0.0,
+        'reporting': [],
+    }
+
+    now = datetime.utcnow()
+    check_in = parser.parse(get_or_init(history, 'check_in', str(now)))
+
+    # we iterate over clusters upgrade policies and update the version history
+    for item in upgrade_policies:
+        current_version = item['current_version']
+        version_history = get_or_init(history, current_version, {})
+        cluster = item['cluster']
+        workloads = item['workloads']
+        # we keep the version history per workload
+        for w in workloads:
+            workload_history = get_or_init(
+                version_history, w,
+                copy.deepcopy(default_workload_history))
+
+            reporting = workload_history['reporting']
+            # if the cluster is already reporting - accumulate it.
+            # if not - add it to the reporting list (first report)
+            if cluster in reporting:
+                workload_history['soak_days'] += \
+                    (now - check_in).total_seconds() / 86400  # seconds in day
+            else:
+                workload_history['reporting'].append(cluster)
+
+    history['check_in'] = str(now)
+
+
+def get_version_history(dry_run, upgrade_policies, ocm_map):
+    """Get a summary of versions history per OCM instance
+
+    Args:
+        dry_run (bool): save updated history to remote state
+        upgrade_policies (list): query results of clusters upgrade policies
+        ocm_map (OCMMap): OCM clients per OCM instance
+
+    Returns:
+        dict: version history per OCM instance
+    """
+    settings = queries.get_app_interface_settings()
+    accounts = queries.get_aws_accounts()
+    state = State(
+        integration=QONTRACT_INTEGRATION,
+        accounts=accounts,
+        settings=settings
+    )
+    results = {}
+    # we keep a remote state per OCM instance
+    for ocm_name in ocm_map.instances():
+        history = state.get(ocm_name, {})
+        update_history(history, upgrade_policies)
+        results[ocm_name] = history
+        if not dry_run:
+            state.add(ocm_name, history, force=True)
+
+    return results
 
 
 def calculate_diff(current_state, desired_state):
@@ -88,6 +182,7 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
 
     ocm_map, current_state = fetch_current_state(clusters)
     desired_state = fetch_desired_state(clusters)
+    # versions_history = get_version_history(dry_run, desired_state, ocm_map)
     diffs, err = calculate_diff(current_state, desired_state)
     act(dry_run, diffs, ocm_map)
 

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -32,6 +32,7 @@ def fetch_desired_state(clusters):
         cluster_name = cluster['name']
         upgrade_policy = cluster['upgradePolicy']
         upgrade_policy['cluster'] = cluster_name
+        upgrade_policy['current_version'] = cluster['spec']['version']
         desired_state.append(upgrade_policy)
 
     return desired_state

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -351,8 +351,11 @@ CLUSTERS_QUERY = """
       labels
     }
     upgradePolicy {
-      schedule_type
+      workloads
       schedule
+      conditions {
+        soakDays
+      }
     }
     additionalRouters {
       private

--- a/reconcile/test/test_ocm_upgrade_scheduler.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler.py
@@ -65,5 +65,4 @@ class TestUpdateHistory(TestCase):
                 }
             }
         }
-        self.maxDiff = None
         self.assertEqual(expected, history)

--- a/reconcile/test/test_ocm_upgrade_scheduler.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler.py
@@ -11,19 +11,23 @@ class TestUpdateHistory(TestCase):
     def test_update_history(self):
         history = {
             "check_in": "2021-08-29 18:00:00",
-            "version1": {
-                "workload1": {
-                    "soak_days": 21.0,
-                    "reporting": [
-                        "cluster1",
-                        "cluster2"
-                    ]
-                },
-                "workload2": {
-                    "soak_days": 6.0,
-                    "reporting": [
-                        "cluster3"
-                    ]
+            "versions": {
+                "version1": {
+                    "workloads": {
+                        "workload1": {
+                            "soak_days": 21.0,
+                            "reporting": [
+                                "cluster1",
+                                "cluster2"
+                            ]
+                        },
+                        "workload2": {
+                            "soak_days": 6.0,
+                            "reporting": [
+                                "cluster3"
+                            ]
+                        }
+                    }
                 }
             }
         }
@@ -49,19 +53,23 @@ class TestUpdateHistory(TestCase):
         ous.update_history(history, upgrade_policies)
         expected = {
             "check_in": "2021-08-30 18:00:00",
-            "version1": {
-                "workload1": {
-                    "soak_days": 23.0,
-                    "reporting": [
-                        "cluster1",
-                        "cluster2"
-                    ]
-                },
-                "workload2": {
-                    "soak_days": 7.0,
-                    "reporting": [
-                        "cluster3"
-                    ]
+            "versions": {
+                "version1": {
+                    "workloads": {
+                        "workload1": {
+                            "soak_days": 23.0,
+                            "reporting": [
+                                "cluster1",
+                                "cluster2"
+                            ]
+                        },
+                        "workload2": {
+                            "soak_days": 7.0,
+                            "reporting": [
+                                "cluster3"
+                            ]
+                        }
+                    }
                 }
             }
         }

--- a/reconcile/test/test_ocm_upgrade_scheduler.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler.py
@@ -1,0 +1,69 @@
+from unittest import TestCase
+from unittest.mock import patch, Mock
+from datetime import datetime
+from dateutil import parser
+
+import reconcile.ocm_upgrade_scheduler as ous
+
+
+class TestUpdateHistory(TestCase):
+    @patch.object(ous, 'datetime', Mock(wraps=datetime))
+    def test_update_history(self):
+        history = {
+            "check_in": "2021-08-29 18:00:00",
+            "version1": {
+                "workload1": {
+                    "soak_days": 21.0,
+                    "reporting": [
+                        "cluster1",
+                        "cluster2"
+                    ]
+                },
+                "workload2": {
+                    "soak_days": 6.0,
+                    "reporting": [
+                        "cluster3"
+                    ]
+                }
+            }
+        }
+        ous.datetime.utcnow.return_value = \
+            parser.parse("2021-08-30 18:00:00.00000")
+        upgrade_policies = [
+            {
+                'workloads': ['workload1'],
+                'cluster': 'cluster1',
+                'current_version': 'version1'
+            },
+            {
+                'workloads': ['workload1'],
+                'cluster': 'cluster2',
+                'current_version': 'version1'
+            },
+            {
+                'workloads': ['workload2'],
+                'cluster': 'cluster3',
+                'current_version': 'version1'
+            },
+        ]
+        ous.update_history(history, upgrade_policies)
+        expected = {
+            "check_in": "2021-08-30 18:00:00",
+            "version1": {
+                "workload1": {
+                    "soak_days": 23.0,
+                    "reporting": [
+                        "cluster1",
+                        "cluster2"
+                    ]
+                },
+                "workload2": {
+                    "soak_days": 7.0,
+                    "reporting": [
+                        "cluster3"
+                    ]
+                }
+            }
+        }
+        self.maxDiff = None
+        self.assertEqual(expected, history)

--- a/reconcile/test/test_utils_data_structures.py
+++ b/reconcile/test/test_utils_data_structures.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+
+import reconcile.utils.data_structures as ds
+
+
+class TestGetOrInit(TestCase):
+    def test_get_or_init_get(self):
+        d = {'k': 'v'}
+        self.assertEqual(ds.get_or_init(d, 'k', 'notv'), 'v')
+
+    def test_get_or_init_init(self):
+        d = {}
+        self.assertEqual(ds.get_or_init(d, 'k', 'v'), 'v')

--- a/reconcile/utils/data_structures.py
+++ b/reconcile/utils/data_structures.py
@@ -1,0 +1,13 @@
+def get_or_init(d, k, v):
+    """Gets (or initiates) a value in a dictionary key
+
+    Args:
+        d (dict): dictionary to work
+        k (hashable): key to use
+        v (value): value to initiate if key doesn't exist
+
+    Returns:
+        [type]: [description]
+    """
+    d.setdefault(k, v)
+    return d[k]

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -938,6 +938,10 @@ class OCMMap:
                     init_provision_shards=init_provision_shards,
                     init_addons=init_addons)
 
+    def instances(self):
+        """Get list of OCM instance names initiated in the OCM map."""
+        return self.ocm_map.keys()
+
     def cluster_disabled(self, cluster_info):
         """
         Checks if the calling integration is disabled in this cluster.


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3638

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/24369

In order to be able to upgrade based on our first condition (soak days of a version), we need to keep track of versions running on our clusters, what workloads each cluster is running.

With this information, we can start building our logic of "to upgrade or not to upgrade" based on the conditions described in the Epic's design document.