### PR TITLE
[qontract-cli] add get version-history command

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -170,7 +170,7 @@ def version_history(ctx):
                     'version': version,
                     'workload': workload,
                     'soak_days': round(workload_data['soak_days'], 2),
-                    'clusters': workload_data['reporting'],
+                    'clusters': ', '.join(workload_data['reporting']),
                 }
                 results.append(item)
     columns = ['ocm', 'version', 'workload', 'soak_days', 'clusters']


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3639

depends on #1793 (so only review the last 2 commits)

as version history changes, we want to be able to see information about versions that we are using or have used. based on this information, we will be able to understand why an upgrade is scheduled or not.

the intention is to invoke this command as part of the app-interface-output repository.