### PR TITLE
[ocm-upgrade-scheduler] add support to schedule upgrades based on conditions

### DIFF
--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -39,6 +39,7 @@ def fetch_desired_state(clusters):
         upgrade_policy = cluster['upgradePolicy']
         upgrade_policy['cluster'] = cluster_name
         upgrade_policy['current_version'] = cluster['spec']['version']
+        upgrade_policy['channel'] = cluster['spec']['channel']
         desired_state.append(upgrade_policy)
 
     return desired_state

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -204,7 +204,7 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
             ocm.get_available_upgrades(d['current_version'], d['channel'])
         for version in reversed(available_upgrades):
             if version_conditions_met(version, version_history, ocm.name,
-                                       d['workloads'], d['conditions']):
+                                      d['workloads'], d['conditions']):
                 item = {
                     'action': 'create',
                     'cluster': cluster,

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -223,9 +223,6 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
                 }
                 diffs.append(item)
                 break
-            else:
-                logging.debug(
-                    f'[{cluster}] conditions not met for version {version}')
 
     return diffs
 

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -202,7 +202,7 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
         ocm = ocm_map.get(cluster)
         available_upgrades = \
             ocm.get_available_upgrades(d['current_version'], d['channel'])
-        for version in reversed(available_upgrades):
+        for version in reversed(sorted(available_upgrades)):
             if version_conditions_met(version, version_history, ocm.name,
                                       d['workloads'], d['conditions']):
                 item = {

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -203,6 +203,7 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
                 f'[{cluster}] skipping cluster with no upcoming upgrade')
             continue
 
+        # choose version that meets the conditions and add it to the diffs
         ocm = ocm_map.get(cluster)
         available_upgrades = \
             ocm.get_available_upgrades(d['current_version'], d['channel'])

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -24,7 +24,7 @@ def fetch_current_state(clusters):
         cluster_name = cluster['name']
         ocm = ocm_map.get(cluster_name)
         upgrade_policies = \
-            ocm.get_upgrade_policies(cluster_name, schedule_type='automatic')
+            ocm.get_upgrade_policies(cluster_name)
         for upgrade_policy in upgrade_policies:
             upgrade_policy['cluster'] = cluster_name
             current_state.append(upgrade_policy)

--- a/reconcile/test/test_ocm_upgrade_scheduler.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler.py
@@ -75,6 +75,7 @@ class TestUpdateHistory(TestCase):
         }
         self.assertEqual(expected, history)
 
+
 class TestVersionConditionsMet(TestCase):
     def setUp(self):
         self.version = '1.2.3'

--- a/reconcile/test/test_ocm_upgrade_scheduler.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler.py
@@ -95,9 +95,23 @@ class TestVersionConditionsMet(TestCase):
             }
         }
 
-    def test_conditions_met(self):
+    def test_conditions_met_larger(self):
         upgrade_conditions = {
             'soakDays': 1.0
+        }
+
+        conditions_met = ous.version_conditions_met(
+            self.version,
+            self.history,
+            self.ocm_name,
+            [self.workload],
+            upgrade_conditions,
+        )
+        self.assertTrue(conditions_met)
+
+    def test_conditions_met_equal(self):
+        upgrade_conditions = {
+            'soakDays': 2.0
         }
 
         conditions_met = ous.version_conditions_met(

--- a/reconcile/test/test_ocm_upgrade_scheduler.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler.py
@@ -74,3 +74,64 @@ class TestUpdateHistory(TestCase):
             }
         }
         self.assertEqual(expected, history)
+
+class TestVersionConditionsMet(TestCase):
+    def setUp(self):
+        self.version = '1.2.3'
+        self.ocm_name = 'ocm'
+        self.workload = 'workload1'
+        self.history = {
+            self.ocm_name: {
+                'versions': {
+                    self.version: {
+                        'workloads': {
+                            self.workload: {
+                                'soak_days': 2.0
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    def test_conditions_met(self):
+        upgrade_conditions = {
+            'soakDays': 1.0
+        }
+
+        conditions_met = ous.version_conditions_met(
+            self.version,
+            self.history,
+            self.ocm_name,
+            [self.workload],
+            upgrade_conditions,
+        )
+        self.assertTrue(conditions_met)
+
+    def test_conditions_not_met(self):
+        upgrade_conditions = {
+            'soakDays': 3.0
+        }
+
+        conditions_met = ous.version_conditions_met(
+            self.version,
+            self.history,
+            self.ocm_name,
+            [self.workload],
+            upgrade_conditions,
+        )
+        self.assertFalse(conditions_met)
+
+    def test_soak_zero_for_new_version(self):
+        upgrade_conditions = {
+            'soakDays': 0.0
+        }
+
+        conditions_met = ous.version_conditions_met(
+            '0.0.0',
+            self.history,
+            self.ocm_name,
+            [self.workload],
+            upgrade_conditions,
+        )
+        self.assertTrue(conditions_met)

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -25,6 +25,7 @@ class OCM:
     """
     OCM is an instance of OpenShift Cluster Manager.
 
+    :param name: OCM instance name
     :param url: OCM instance URL
     :param access_token_client_id: client-id to get access token
     :param access_token_url: URL to get access token from
@@ -38,10 +39,11 @@ class OCM:
     :type init_provision_shards: bool
     :type init_addons: bool
     """
-    def __init__(self, url, access_token_client_id, access_token_url,
+    def __init__(self, name, url, access_token_client_id, access_token_url,
                  offline_token, init_provision_shards=False,
                  init_addons=False):
         """Initiates access token and gets clusters information."""
+        self.name = name
         self.url = url
         self.access_token_client_id = access_token_client_id
         self.access_token_url = access_token_url
@@ -931,10 +933,12 @@ class OCMMap:
             self.ocm_map[ocm_name] = False
         else:
             url = ocm_info['url']
+            name = ocm_info['name']
             secret_reader = SecretReader(settings=self.settings)
             token = secret_reader.read(ocm_offline_token)
             self.ocm_map[ocm_name] = \
-                OCM(url, access_token_client_id, access_token_url, token,
+                OCM(name, url,
+                    access_token_client_id, access_token_url, token,
                     init_provision_shards=init_provision_shards,
                     init_addons=init_addons)
 

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -15,6 +15,7 @@ KAS_API_BASE = '/api/kafkas_mgmt'
 
 MACHINE_POOL_DESIRED_KEYS = {'id', 'instance_type',
                              'replicas', 'labels', 'taints'}
+UPGRADE_CHANNELS = {'stable', 'fast', 'candidate'}
 UPGRADE_POLICY_DESIRED_KEYS = {'id', 'schedule_type', 'schedule', 'next_run'}
 ROUTER_DESIRED_KEYS = {'id', 'listening', 'dns_name', 'route_selectors'}
 AUTOSCALE_DESIRED_KEYS = {'min_replicas', 'max_replicas'}
@@ -580,6 +581,28 @@ class OCM:
             f'{CS_API_BASE}/v1/clusters/{cluster_id}/machine_pools/' + \
             f'{machine_pool_id}'
         self._delete(api)
+
+    def get_available_upgrades(self, version, channel):
+        """Get available versions to upgrade from specified version
+        in the specified channel
+
+        Args:
+            version (string): OpenShift version ID
+            channel (string): Upgrade channel
+
+        Raises:
+            KeyError: if specified channel is not valid
+
+        Returns:
+            list: available versions to upgrade to
+        """
+        if channel not in UPGRADE_CHANNELS:
+            raise KeyError(f'channel should be one of {UPGRADE_CHANNELS}')
+        version_id = f'openshift-v{version}'
+        if channel != 'stable':
+            version_id = f'{version_id}-{channel}'
+        api = f'{CS_API_BASE}/v1/versions/{version_id}'
+        return self._get_json(api).get('available_upgrades', [])
 
     def get_upgrade_policies(self, cluster, schedule_type=None):
         """Returns a list of details of Upgrade Policies

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
         "openshift>=0.11.2",
         "websocket-client<0.55.0,>=0.35",
         "sshtunnel>=0.4.0",
+        "croniter>=1.0.15,<1.1.0",
     ],
 
     test_suite="tests",


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3640

depends on #1793

Conditions are defined in an `upgradePolicy` of a cluster. in this ticket, we will switch from using automatic upgrades to manual upgrades that will be set by the ocm-upgrade-scheduler integration if conditions are met for a specific version that is available for upgrade.