### PR TITLE
[ocm-upgrade-scheduler] add support to reject specific versions

### DIFF
--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -227,7 +227,16 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
     return diffs
 
 
+def sort_diffs(diff):
+    if diff['action'] == 'delete':
+        return 1
+    else:
+        return 2
+    return diffs
+
+
 def act(dry_run, diffs, ocm_map):
+    diffs.sort(key=sort_diffs)
     for diff in diffs:
         action = diff.pop('action')
         cluster = diff.pop('cluster')
@@ -236,6 +245,8 @@ def act(dry_run, diffs, ocm_map):
             ocm = ocm_map.get(cluster)
             if action == 'create':
                 ocm.create_upgrade_policy(cluster, diff)
+            elif action == 'delete':
+                ocm.delete_upgrade_policy(cluster, diff)
 
 
 def run(dry_run, gitlab_project_id=None, thread_pool_size=10):

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -190,7 +190,11 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
         ocm = ocm_map.get(cluster)
         c = [c for c in current_state if c['cluster'] == cluster]
         if c:
-            [c] = c  # there can only be one upgrade policy per cluster
+            # there can only be one upgrade policy per cluster
+            if len(c) != 1:
+                raise ValueError(
+                    f'[{cluster}] expected only one upgrade policy')
+            [c] = c
             version = c.get('version')  # may not exist in automatic upgrades
             if version and ocm.version_blocked(version):
                 logging.debug(

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -251,7 +251,6 @@ def sort_diffs(diff):
         return 1
     else:
         return 2
-    return diffs
 
 
 def act(dry_run, diffs, ocm_map):

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -259,12 +259,14 @@ def act(dry_run, diffs, ocm_map):
     for diff in diffs:
         action = diff.pop('action')
         cluster = diff.pop('cluster')
-        logging.info([action, cluster, diff['version'], diff['next_run']])
-        if not dry_run:
-            ocm = ocm_map.get(cluster)
-            if action == 'create':
+        ocm = ocm_map.get(cluster)
+        if action == 'create':
+            logging.info([action, cluster, diff['version'], diff['next_run']])
+            if not dry_run:
                 ocm.create_upgrade_policy(cluster, diff)
-            elif action == 'delete':
+        elif action == 'delete':
+            logging.info([action, cluster, diff['version']])
+            if not dry_run:
                 ocm.delete_upgrade_policy(cluster, diff)
 
 

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -195,12 +195,12 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
                 logging.debug(
                     f'[{cluster}] found existing upgrade policy ' +
                     f'with blocked version {version}')
-                    item = {
-                        'action': 'delete',
-                        'cluster': cluster,
-                        'id': c['id'],
-                    }
-                    diffs.append(item)
+                item = {
+                    'action': 'delete',
+                    'cluster': cluster,
+                    'id': c['id'],
+                }
+                diffs.append(item)
             else:
                 logging.debug(
                     f'[{cluster}] skipping cluster with ' +

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -190,6 +190,7 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
         ocm = ocm_map.get(cluster)
         c = [c for c in current_state if c['cluster'] == cluster]
         if c:
+            [c] = c  # there can only be one upgrade policy per cluster
             version = c.get('version')  # may not exist in automatic upgrades
             if version and ocm.version_blocked(version):
                 logging.debug(
@@ -198,6 +199,7 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
                 item = {
                     'action': 'delete',
                     'cluster': cluster,
+                    'version': version,
                     'id': c['id'],
                 }
                 diffs.append(item)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -307,6 +307,7 @@ CLUSTERS_QUERY = """
         format
         version
       }
+      blockedVersions
     }
     awsInfrastructureAccess {
       awsGroup {

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -27,3 +27,8 @@ class TestVersionBlocked(TestCase):
         self.ocm.blocked_versions = ['1.2.3']
         result = self.ocm.version_blocked('1.2.4')
         self.assertFalse(result)
+
+    def test_version_blocked_multiple(self):
+        self.ocm.blocked_versions = ['1.2.3', '1.2.4']
+        result = self.ocm.version_blocked('1.2.3')
+        self.assertTrue(result)

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -1,0 +1,29 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from reconcile.utils.ocm import OCM
+
+
+class TestVersionBlocked(TestCase):
+    @patch.object(OCM, '_init_access_token')
+    @patch.object(OCM, '_init_request_headers')
+    @patch.object(OCM, '_init_clusters')
+    # pylint: disable=arguments-differ
+    def setUp(self, ocm_init_access_token,
+              ocm_init_request_headers, ocm_init_clusters):
+        self.ocm = OCM('name', 'url', 'tid', 'turl', 'ot')
+
+    def test_no_blocked_versions(self):
+        self.ocm.blocked_versions = None
+        result = self.ocm.version_blocked('1.2.3')
+        self.assertFalse(result)
+
+    def test_version_blocked(self):
+        self.ocm.blocked_versions = ['1.2.3']
+        result = self.ocm.version_blocked('1.2.3')
+        self.assertTrue(result)
+
+    def test_version_not_blocked(self):
+        self.ocm.blocked_versions = ['1.2.3']
+        result = self.ocm.version_blocked('1.2.4')
+        self.assertFalse(result)

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -855,10 +855,10 @@ class OCM:
         self._post(api, data)
 
     def _init_blocked_versions(self, blocked_versions):
-        if blocked_versions is None:
-            self.blocked_versions = set()
-        else:
+        try:
             self.blocked_versions = set(blocked_versions)
+        except TypeError:
+            self.blocked_versions = set()
 
     @retry(max_attempts=10)
     def _get_json(self, api):

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -16,7 +16,8 @@ KAS_API_BASE = '/api/kafkas_mgmt'
 MACHINE_POOL_DESIRED_KEYS = {'id', 'instance_type',
                              'replicas', 'labels', 'taints'}
 UPGRADE_CHANNELS = {'stable', 'fast', 'candidate'}
-UPGRADE_POLICY_DESIRED_KEYS = {'id', 'schedule_type', 'schedule', 'next_run'}
+UPGRADE_POLICY_DESIRED_KEYS = \
+    {'id', 'schedule_type', 'schedule', 'next_run', 'version'}
 ROUTER_DESIRED_KEYS = {'id', 'listening', 'dns_name', 'route_selectors'}
 AUTOSCALE_DESIRED_KEYS = {'min_replicas', 'max_replicas'}
 CLUSTER_ADDON_DESIRED_KEYS = {'id', 'parameters'}

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -33,16 +33,18 @@ class OCM:
     :param offline_token: Long lived offline token used to get access token
     :param init_provision_shards: should initiate provision shards
     :param init_addons: should initiate addons
+    :param blocked_versions: versions to block upgrades for
     :type url: string
     :type access_token_client_id: string
     :type access_token_url: string
     :type offline_token: string
     :type init_provision_shards: bool
     :type init_addons: bool
+    :type blocked_version: list
     """
     def __init__(self, name, url, access_token_client_id, access_token_url,
                  offline_token, init_provision_shards=False,
-                 init_addons=False):
+                 init_addons=False, blocked_versions=None):
         """Initiates access token and gets clusters information."""
         self.name = name
         self.url = url
@@ -54,6 +56,7 @@ class OCM:
         self._init_clusters(init_provision_shards=init_provision_shards)
         if init_addons:
             self._init_addons()
+        self.blocked_versions = blocked_versions
 
     @retry()
     def _init_access_token(self):
@@ -963,7 +966,8 @@ class OCMMap:
                 OCM(name, url,
                     access_token_client_id, access_token_url, token,
                     init_provision_shards=init_provision_shards,
-                    init_addons=init_addons)
+                    init_addons=init_addons,
+                    blocked_versions=ocm_info.get('blockedVersions'))
 
     def instances(self):
         """Get list of OCM instance names initiated in the OCM map."""

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -57,7 +57,7 @@ class OCM:
         self._init_clusters(init_provision_shards=init_provision_shards)
         if init_addons:
             self._init_addons()
-        self.blocked_versions = blocked_versions
+        self._init_blocked_versions(blocked_versions)
 
     @retry()
     def _init_access_token(self):
@@ -853,6 +853,12 @@ class OCM:
             data['parameters'] = {}
             data['parameters']['items'] = parameters
         self._post(api, data)
+
+    def _init_blocked_versions(self, blocked_versions):
+        if blocked_versions is None:
+            self.blocked_versions = set()
+        else:
+            self.blocked_versions = set(blocked_versions)
 
     @retry(max_attempts=10)
     def _get_json(self, api):

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -585,6 +585,19 @@ class OCM:
             f'{machine_pool_id}'
         self._delete(api)
 
+    def version_blocked(self, version):
+        """Check if a version is blocked
+
+        Args:
+            version (string): version to check
+            blocked_versions (list): versions to block upgrade for
+
+        Returns:
+            bool: is version blocked
+        """
+        return self.blocked_versions is not None and \
+            version in self.blocked_versions
+
     def get_available_upgrades(self, version, channel):
         """Get available versions to upgrade from specified version
         in the specified channel


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3641

schema: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/24403

as we discover versions which are not working well for us, we need to have a way to define a list of versions we shouldn't upgrade to.