### PR TITLE
[ocm-upgrade-scheduler] add support to reject versions based on regex expressions

### DIFF
--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -36,3 +36,8 @@ class TestVersionBlocked(TestCase):
         self.ocm.blocked_versions = [r'^.*-fc\..*$']
         result = self.ocm.version_blocked('1.2.3-fc.1')
         self.assertTrue(result)
+
+    def test_version_not_blocked_regex(self):
+        self.ocm.blocked_versions = [r'^.*-fc\..*$']
+        result = self.ocm.version_blocked('1.2.3-rc.1')
+        self.assertFalse(result)

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -31,3 +31,8 @@ class TestVersionBlocked(TestCase):
         self.ocm.blocked_versions = ['1.2.3', '1.2.4']
         result = self.ocm.version_blocked('1.2.3')
         self.assertTrue(result)
+
+    def test_version_blocked_regex(self):
+        self.ocm.blocked_versions = [r'^.*-fc\..*$']
+        result = self.ocm.version_blocked('1.2.3-fc.1')
+        self.assertTrue(result)

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1,5 +1,5 @@
 import logging
-
+import re
 import requests
 
 from sretoolbox.utils import retry
@@ -596,7 +596,7 @@ class OCM:
         Returns:
             bool: is version blocked
         """
-        return version in self.blocked_versions
+        return any(re.search(b, version) for b in self.blocked_versions)
 
     def get_available_upgrades(self, version, channel):
         """Get available versions to upgrade from specified version


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3646

follows up on #1796

this PR adds support to define a regex expression in `blockedVersions` in addition to a specific version.
this will allow us to avoid upgrades to feature candidate versions (for example).