### PR TITLE
[ocm-upgrade-scheduler] natural sort of available upgrade versions

### DIFF
--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -5,6 +5,7 @@ import copy
 from datetime import datetime
 from dateutil import parser
 from croniter import croniter
+from natsort import natsorted
 
 import reconcile.queries as queries
 
@@ -226,7 +227,7 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
         # choose version that meets the conditions and add it to the diffs
         available_upgrades = \
             ocm.get_available_upgrades(d['current_version'], d['channel'])
-        for version in reversed(sorted(available_upgrades)):
+        for version in reversed(natsorted(available_upgrades)):
             logging.debug(
                 f'[{cluster}] checking conditions for version {version}')
             if ocm.version_blocked(version):

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(
         "websocket-client<0.55.0,>=0.35",
         "sshtunnel>=0.4.0",
         "croniter>=1.0.15,<1.1.0",
+        "natsort>=7.1.1,<7.2.0",
     ],
 
     test_suite="tests",


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3640

follows up on #1795

using `sorted(available_upgrades)` returns the wrong order when taking into account release and feature candidates:
```

```