### PR TITLE
[ocm-upgrade-scheduler] properly sort versions

### DIFF
--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -11,6 +11,7 @@ import reconcile.queries as queries
 from reconcile.utils.ocm import OCMMap
 from reconcile.utils.state import State
 from reconcile.utils.data_structures import get_or_init
+from reconcile.utils.semver_helper import sort_versions
 
 QONTRACT_INTEGRATION = 'ocm-upgrade-scheduler'
 
@@ -226,7 +227,7 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
         # choose version that meets the conditions and add it to the diffs
         available_upgrades = \
             ocm.get_available_upgrades(d['current_version'], d['channel'])
-        for version in reversed(sorted(available_upgrades)):
+        for version in reversed(sort_versions(available_upgrades)):
             logging.debug(
                 f'[{cluster}] checking conditions for version {version}')
             if ocm.version_blocked(version):

--- a/reconcile/test/test_utils_semver_helper.py
+++ b/reconcile/test/test_utils_semver_helper.py
@@ -1,0 +1,12 @@
+from unittest import TestCase
+
+import reconcile.utils.semver_helper as svh
+
+
+class TestSortVersions(TestCase):
+    def test_sort_versions(self):
+        versions = \
+            ['4.8.0', '4.8.0-rc.0', '4.8.0-fc.1', '4.8.1', '4.8.0-rc.2']
+        expected = \
+            ['4.8.0-fc.1', '4.8.0-rc.0', '4.8.0-rc.2', '4.8.0', '4.8.1']
+        self.assertEqual(expected, svh.sort_versions(versions))

--- a/reconcile/utils/semver_helper.py
+++ b/reconcile/utils/semver_helper.py
@@ -3,3 +3,19 @@ import semver
 
 def make_semver(major, minor, patch):
     return str(semver.VersionInfo(major=major, minor=minor, patch=patch))
+
+
+def sort_versions(versions):
+    """sort versions by semver
+
+    Args:
+        versions (list): string versions to sort
+
+    Returns:
+        list: string versions sorted by semver
+    """
+    semver_versions = sorted([
+        semver.VersionInfo(**semver.parse(v))
+        for v in versions
+    ])
+    return [str(v) for v in semver_versions]


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3647

We are currently using python's builtin `sorted` function, which incorrectly sorts versions when there are feature/release candidates involved. We want release candidates to be considered earlier from a release. In this example, we want a sorting function that sorts `4.8.0-rc.2` to be before `4.8.0`.