### PR TITLE
[ocm] validate blocked versions regex expressions

### DIFF
--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -1,3 +1,5 @@
+import pytest
+
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -41,3 +43,14 @@ class TestVersionBlocked(TestCase):
         self.ocm.blocked_versions = [r'^.*-fc\..*$']
         result = self.ocm.version_blocked('1.2.3-rc.1')
         self.assertFalse(result)
+
+class TestVersionRegex(TestCase):
+    @patch.object(OCM, '_init_access_token')
+    @patch.object(OCM, '_init_request_headers')
+    @patch.object(OCM, '_init_clusters')
+    # pylint: disable=arguments-differ
+    def test_invalid_regex(self, ocm_init_access_token,
+              ocm_init_request_headers, ocm_init_clusters):
+        with pytest.raises(TypeError):
+            ocm = OCM('name', 'url', 'tid', 'turl', 'ot',
+                      blocked_versions=['['])

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -44,13 +44,14 @@ class TestVersionBlocked(TestCase):
         result = self.ocm.version_blocked('1.2.3-rc.1')
         self.assertFalse(result)
 
+
 class TestVersionRegex(TestCase):
     @patch.object(OCM, '_init_access_token')
     @patch.object(OCM, '_init_request_headers')
     @patch.object(OCM, '_init_clusters')
     # pylint: disable=arguments-differ
     def test_invalid_regex(self, ocm_init_access_token,
-              ocm_init_request_headers, ocm_init_clusters):
+                           ocm_init_request_headers, ocm_init_clusters):
         with pytest.raises(TypeError):
-            ocm = OCM('name', 'url', 'tid', 'turl', 'ot',
-                      blocked_versions=['['])
+            OCM('name', 'url', 'tid', 'turl', 'ot',
+                blocked_versions=['['])

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -1,7 +1,7 @@
-import pytest
-
 from unittest import TestCase
 from unittest.mock import patch
+
+import pytest
 
 from reconcile.utils.ocm import OCM
 

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -50,6 +50,7 @@ class TestVersionRegex(TestCase):
     @patch.object(OCM, '_init_request_headers')
     @patch.object(OCM, '_init_clusters')
     # pylint: disable=arguments-differ
+    # pylint: disable=no-self-use
     def test_invalid_regex(self, ocm_init_access_token,
                            ocm_init_request_headers, ocm_init_clusters):
         with pytest.raises(TypeError):

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -1,8 +1,6 @@
 from unittest import TestCase
 from unittest.mock import patch
 
-import pytest
-
 from reconcile.utils.ocm import OCM
 
 
@@ -50,9 +48,8 @@ class TestVersionRegex(TestCase):
     @patch.object(OCM, '_init_request_headers')
     @patch.object(OCM, '_init_clusters')
     # pylint: disable=arguments-differ
-    # pylint: disable=no-self-use
     def test_invalid_regex(self, ocm_init_access_token,
                            ocm_init_request_headers, ocm_init_clusters):
-        with pytest.raises(TypeError):
+        with self.assertRaises(TypeError):
             OCM('name', 'url', 'tid', 'turl', 'ot',
                 blocked_versions=['['])

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -858,6 +858,13 @@ class OCM:
         except TypeError:
             self.blocked_versions = set()
 
+        for b in self.blocked_versions:
+            try:
+                re.compile(b)
+            except re.error:
+                raise TypeError(
+                    f'blocked version is not a valid regex expression: {b}')
+
     @retry(max_attempts=10)
     def _get_json(self, api):
         r = requests.get(f"{self.url}{api}", headers=self.headers)

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -591,7 +591,6 @@ class OCM:
 
         Args:
             version (string): version to check
-            blocked_versions (list): versions to block upgrade for
 
         Returns:
             bool: is version blocked


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3646

follows up in #1799

this PR adds validation that all blocked versions are valid regex expressions.