### PR TITLE
Depend on a newer sretoolbox

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     data_files=[('reconcile/templates', glob('reconcile/templates/*.j2'))],
 
     install_requires=[
-        "sretoolbox==0.14.1",
+        "sretoolbox==0.15.0",
         "Click>=7.0,<8.0",
         "graphqlclient>=0.2.4,<0.3.0",
         "toml>=0.10.0,<0.11.0",


### PR DESCRIPTION
The previous version didn't handle image caches properly. Also, the
new version is almost twice as fast at handling image metadata.

Refs APPSRE-3385
