### PR TITLE
[slack-usergroups] Add retry for throttled usergroups.update calls

### DIFF
--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -363,7 +363,10 @@ def act(desired_state, slack_map):
             # sensitive updates.
             logging.error(error)
 
-        slack.update_usergroup(ugid, channels, description)
+        try:
+            slack.update_usergroup(ugid, channels, description)
+        except SlackAPICallException as error:
+            logging.error(error)
 
 
 def run(dry_run):

--- a/reconcile/test/test_utils_slack_api.py
+++ b/reconcile/test/test_utils_slack_api.py
@@ -152,3 +152,64 @@ def test_slack_api_update_usergroup_users_invalid_users(slack_api):
 
     with patch('time.sleep'):
         slack_api.client.update_usergroup_users('ABCD', ['USERA', 'USERB'])
+
+
+def test_slack_api_update_usergroup_rate_limit_raise(slack_api):
+    """Raise an exception when the retry count has been exhausted."""
+    # Reset the mock to clear any calls during __init__
+    slack_api.mock_slack_client.return_value.api_call.reset_mock()
+
+    slack_api.mock_slack_client.return_value.api_call.return_value = {
+        'error': 'ratelimited',
+        'headers': {
+            'retry-after': '5'
+        }
+    }
+
+    with pytest.raises(SlackAPIRateLimitedException):
+        with patch('time.sleep'):
+            slack_api.client.update_usergroup('ABCD', ['CHANA', 'CHANB'],
+                                              'Some description')
+
+    assert slack_api.mock_slack_client.return_value.api_call.call_count == 5
+
+
+def test_slack_api_update_usergroup_rate_limit_retry(slack_api):
+    """
+    Retry without raising an exception when rate-limited fewer than the max
+    number of retries.
+    """
+    # Reset the mock to clear any calls during __init__
+    slack_api.mock_slack_client.return_value.api_call.reset_mock()
+
+    rate_limit_response = {
+        'error': 'ratelimited',
+        'headers': {
+            'retry-after': '5'
+        }
+    }
+
+    # Returns 3 rate-limited responses, and one OK response
+    slack_api.mock_slack_client.return_value.api_call.side_effect = [
+        rate_limit_response,
+        rate_limit_response,
+        rate_limit_response,
+        {'ok': 'true'}
+    ]
+
+    with patch('time.sleep'):
+        slack_api.client.update_usergroup('ABCD', ['CHANA', 'CHANB'],
+                                          'Some description')
+
+    assert slack_api.mock_slack_client.return_value.api_call.call_count == 4
+
+
+def test_slack_api_update_usergroup_raise_for_errors(slack_api):
+    slack_api.mock_slack_client.return_value.api_call.return_value = {
+        'error': 'some_unknown_error',
+    }
+
+    with pytest.raises(SlackAPICallException):
+        with patch('time.sleep'):
+            slack_api.client.update_usergroup('ABCD', ['CHANA', 'CHANB'],
+                                              'Some description')


### PR DESCRIPTION
This was tested successfully in the app-sre environment on usergroups that were failing to create due to throttling, as well as catching errors associated with a usergroup that had a description that was too long.

Note that there is some code duplication here in the error handling.  Normally I'd generalize this, but I plan to upgrade for the Slack SDK v1 to v3 in the next couple of weeks, which has retry capability built into it.