### PR TITLE
get_repo_team_permissions message may not exist

### DIFF
--- a/reconcile/utils/quay_api.py
+++ b/reconcile/utils/quay_api.py
@@ -233,7 +233,7 @@ class QuayApi:
               f"{repo_name}/permissions/team/{team}"
         r = requests.get(url, headers=self.auth_header)
         if not r.ok:
-            message = r.json()['message']
+            message = r.json().get('message')
             expected_message = "Team does not have permission for repo."
             if message == expected_message:
                 return None


### PR DESCRIPTION
in the quay_api, when we get a 403, the `message` key may not exist, causing us to raise the wrong exception.