### PR TITLE
Improve error handling in quay-permissions

### DIFF
--- a/reconcile/quay_permissions.py
+++ b/reconcile/quay_permissions.py
@@ -86,39 +86,38 @@ def run(dry_run):
                             continue
 
                         perm_org_key = (
-                          permission['quayOrg']['instance']['name'],
-                          permission['quayOrg']['name']
+                            permission['quayOrg']['instance']['name'],
+                            permission['quayOrg']['name']
                         )
 
                         if perm_org_key != org_key:
-                            logging.warning('wrong org, should be %s', org_key)
+                            logging.warning(
+                                f'wrong org, should be {org_key}'
+                            )
                             continue
 
                         team_name = permission['team']
 
                         # processing team section
                         logging.debug(['team', team_name])
-
-                        current_role = \
-                            quay_api.get_repo_team_permissions(
-                                repo_name, team_name)
-                        if current_role != role:
-                            logging.info(
-                                ['update_role', org_key, repo_name,
-                                 team_name, role])
-                            if not dry_run:
-                                try:
+                        try:
+                            current_role = \
+                                quay_api.get_repo_team_permissions(
+                                    repo_name, team_name)
+                            if current_role != role:
+                                logging.info(
+                                    ['update_role', org_key, repo_name,
+                                     team_name, role])
+                                if not dry_run:
                                     quay_api.set_repo_team_permissions(
                                         repo_name, team_name, role)
-                                except Exception as e:
-                                    error = True
-                                    logging.error(
-                                        'could not set repo permissions: '
-                                        'repo name: %s, '
-                                        'team name: %s. '
-                                        'details: {%s}',
-                                        repo_name, team_name, e
-                                    )
+                        except Exception:
+                            error = True
+                            logging.exception(
+                                'could not manage repo permissions: '
+                                f'repo name: {repo_name}, '
+                                f'team name: {team_name}'
+                            )
 
     if error:
         sys.exit(ExitCodes.ERROR)

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -12,7 +12,7 @@ DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
 class TestGitLabHousekeeping:
     @staticmethod
     def test_clean_pipelines_happy_path():
-        now = datetime.now()
+        now = datetime.utcnow()
 
         ten_minutes_ago = now - timedelta(minutes=10)
         two_hours_ago = now - timedelta(minutes=120)

--- a/reconcile/test/test_utils_quay_api.py
+++ b/reconcile/test/test_utils_quay_api.py
@@ -1,9 +1,9 @@
 import json
-
+from requests import HTTPError
 import pytest
 import responses
 
-from reconcile.utils.quay_api import QuayApi, RequestsException, \
+from reconcile.utils.quay_api import QuayApi, \
     QuayTeamNotFoundException
 
 ORG = 'some-org'
@@ -51,7 +51,7 @@ def test_create_or_update_team_raises(quay_api):
         status=400
     )
 
-    with pytest.raises(RequestsException):
+    with pytest.raises(HTTPError):
         quay_api.create_or_update_team(TEAM_NAME)
 
 
@@ -77,5 +77,5 @@ def test_list_team_members_raises_other_status_codes(quay_api):
         status=401
     )
 
-    with pytest.raises(RequestsException):
+    with pytest.raises(HTTPError):
         quay_api.list_team_members(TEAM_NAME)

--- a/reconcile/utils/quay_api.py
+++ b/reconcile/utils/quay_api.py
@@ -59,6 +59,10 @@ class QuayApi:
         return True
 
     def remove_user_from_team(self, user, team):
+        """Deletes an user from a team.
+
+        :raises HTTPError if there are any problems with the request
+        """
         url_team = "{}/organization/{}/team/{}/members/{}".format(
             self.api_url, self.organization,
             team, user
@@ -83,6 +87,10 @@ class QuayApi:
         return True
 
     def add_user_to_team(self, user, team):
+        """Adds an user to a team.
+
+        :raises HTTPError if there are any errors with the request
+        """
         if user in self.list_team_members(team, cache=True):
             return True
 
@@ -120,6 +128,8 @@ class QuayApi:
     def list_images(self, images=None, page=None, count=0):
         """
         https://docs.quay.io/api/swagger/#!/repository/listRepos
+
+        :raises HTTPError: failure when listing the images in the repository
         """
 
         if count > self.LIMIT_FOLLOWS:
@@ -153,6 +163,11 @@ class QuayApi:
             return images
 
     def repo_create(self, repo_name, description, public):
+        """Creates a repository called repo_name with the given description
+        and public flag.
+
+        :raise HTTPError: the operation fails
+        """
         visibility = "public" if public else "private"
 
         url = "{}/repository".format(self.api_url)

--- a/reconcile/utils/quay_api.py
+++ b/reconcile/utils/quay_api.py
@@ -1,12 +1,6 @@
 import requests
 
 
-class RequestsException(Exception):
-    def __init__(self, r):
-        message = "\nCode: %s\n%s" % (r.status_code, r.text)
-        super(Exception, self).__init__(message)
-
-
 class QuayTeamNotFoundException(Exception):
     pass
 
@@ -44,7 +38,7 @@ class QuayApi:
                 f"contact org owner to create the "
                 f"team manually.")
         elif not r.ok:
-            raise RequestsException(r)
+            raise requests.HTTPError(response=r)
 
         body = r.json()
 
@@ -79,14 +73,14 @@ class QuayApi:
                 user, team)
 
             if message != expected_message:
-                raise RequestsException(r)
+                raise requests.HTTPError(response=r)
 
         url_org = "{}/organization/{}/members/{}".format(
             self.api_url, self.organization, user)
 
         r = requests.delete(url_org, headers=self.auth_header)
         if not r.ok:
-            raise RequestsException(r)
+            raise requests.HTTPError(response=r)
 
         return True
 
@@ -98,7 +92,7 @@ class QuayApi:
             self.api_url, self.organization, team, user)
         r = requests.put(url, headers=self.auth_header)
         if not r.ok:
-            raise RequestsException(r)
+            raise requests.HTTPError(response=r)
         return True
 
     def create_or_update_team(self, team: str, role="member",
@@ -126,7 +120,7 @@ class QuayApi:
         r = requests.put(url, headers=self.auth_header, json=payload)
 
         if not r.ok:
-            raise RequestsException(r)
+            raise requests.HTTPError(response=r)
 
     def list_images(self, images=None, page=None, count=0):
         """
@@ -146,7 +140,7 @@ class QuayApi:
         # perform request
         r = requests.get(url, params=params, headers=self.auth_header)
         if not r.ok:
-            raise RequestsException(r)
+            raise requests.HTTPError(response=r)
 
         # read body
         body = r.json()
@@ -180,7 +174,7 @@ class QuayApi:
         # perform request
         r = requests.post(url, json=params, headers=self.auth_header)
         if not r.ok:
-            raise RequestsException(r)
+            raise requests.HTTPError(response=r)
 
     def repo_delete(self, repo_name):
         url = "{}/repository/{}/{}".format(
@@ -190,7 +184,7 @@ class QuayApi:
         # perform request
         r = requests.delete(url, headers=self.auth_header)
         if not r.ok:
-            raise RequestsException(r)
+            raise requests.HTTPError(response=r)
 
     def repo_update_description(self, repo_name, description):
         url = "{}/repository/{}/{}".format(
@@ -206,7 +200,7 @@ class QuayApi:
         # perform request
         r = requests.put(url, json=params, headers=self.auth_header)
         if not r.ok:
-            raise RequestsException(r)
+            raise requests.HTTPError(response=r)
 
     def repo_make_public(self, repo_name):
         self._repo_change_visibility(repo_name, "public")
@@ -226,7 +220,7 @@ class QuayApi:
         # perform request
         r = requests.post(url, json=params, headers=self.auth_header)
         if not r.ok:
-            raise RequestsException(r)
+            raise requests.HTTPError(response=r)
 
     def get_repo_team_permissions(self, repo_name, team):
         url = f"{self.api_url}/repository/{self.organization}/" +\
@@ -238,7 +232,7 @@ class QuayApi:
             if message == expected_message:
                 return None
 
-            raise RequestsException(r)
+            raise requests.HTTPError(response=r)
 
         return r.json().get('role') or None
 
@@ -248,4 +242,4 @@ class QuayApi:
         body = {'role': role}
         r = requests.put(url, json=body, headers=self.auth_header)
         if not r.ok:
-            raise RequestsException(r)
+            raise requests.HTTPError(response=r)


### PR DESCRIPTION
There are more methods that can raise exceptions, so we cover each
iteration (i.e, each reviewed repository) in a try-except block.

Also, we replace the old `RequestsException` with the `HTTPError`
class supplied by `requests`. This gives us more information,
including access to the failed response and request.

This way, we can get complete error messages, such as:

```[2021-09-06 22:12:54] [ERROR] [quay_permissions.py:run:116] - Could not manage repo permissions on repo $REPO_NAME,team $TEAM_NAME - status code: 403 - resource URL: https://quay.io/api/v1/repository/$REPOSITORY_SHA/$REPOSITORY_NAME/permissions/team/$TEAM_NAME
Traceback (most recent call last):
[...]
requests.exceptions.HTTPError: 403 Client Error: FORBIDDEN for url: ...
```

