### PR TITLE
Increase memory allocation for quay-mirror

### DIFF
--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -55,10 +55,10 @@ integrations:
   sleepDurationSecs: 300
   resources:
     requests:
-      memory: 150Mi
+      memory: 970Mi
       cpu: 200m
     limits:
-      memory: 200Mi
+      memory: 1Gi
       cpu: 300m
 - name: quay-mirror-org
   resources:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -24014,11 +24014,11 @@ parameters:
 - name: QUAY_MIRROR_CPU_LIMIT
   value: 300m
 - name: QUAY_MIRROR_MEMORY_LIMIT
-  value: 200Mi
+  value: 1Gi
 - name: QUAY_MIRROR_CPU_REQUEST
   value: 200m
 - name: QUAY_MIRROR_MEMORY_REQUEST
-  value: 150Mi
+  value: 970Mi
 - name: QUAY_MIRROR_ORG_CPU_LIMIT
   value: 300m
 - name: QUAY_MIRROR_ORG_MEMORY_LIMIT


### PR DESCRIPTION
To store the in-memory cache we introduce as part of
https://issues.redhat.com/browse/APPSRE-3385 . The initial estimate is
50,000 failed requests at 20KB each - manifests are usually around
10KB, so this should give us plenty of room.
