### PR TITLE
[qontract-cli] properly sort version history

### DIFF
--- a/reconcile/utils/semver_helper.py
+++ b/reconcile/utils/semver_helper.py
@@ -5,6 +5,10 @@ def make_semver(major, minor, patch):
     return str(semver.VersionInfo(major=major, minor=minor, patch=patch))
 
 
+def parse_semver(version):
+    return semver.VersionInfo(**semver.parse(version))
+
+
 def sort_versions(versions):
     """sort versions by semver
 
@@ -14,8 +18,5 @@ def sort_versions(versions):
     Returns:
         list: string versions sorted by semver
     """
-    semver_versions = sorted([
-        semver.VersionInfo(**semver.parse(v))
-        for v in versions
-    ])
+    semver_versions = sorted([parse_semver(v) for v in versions])
     return [str(v) for v in semver_versions]


### PR DESCRIPTION
to properly sort the version, we need the sorting to happen according to semver.
in this PR, we change the `version` field to be semver sortable. to properly print, we need to stringify the values beforehand.