### PR TITLE
[terraform-resources] add support to provision aws load balancer

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ branch = True
 omit = reconcile/test/*
 
 [report]
-fail_under = 23.1
+fail_under = 23.0

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -201,11 +201,22 @@ provider
   output_resource_name
   annotations
 }
-... on NamespaceTerraformResourceLB_v1 {
+... on NamespaceTerraformResourceALB_v1 {
   account
   region
   identifier
-  defaults
+  vpc {
+    id
+    subnets {
+      id
+    }
+  }
+  certificate_arn
+  targets {
+    name
+    weight
+    ips
+  }
   output_resource_name
   annotations
 }

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -206,7 +206,7 @@ provider
   region
   identifier
   vpc {
-    id
+    vpc_id
     subnets {
       id
     }

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -201,6 +201,14 @@ provider
   output_resource_name
   annotations
 }
+... on NamespaceTerraformResourceLB_v1 {
+  account
+  region
+  identifier
+  defaults
+  output_resource_name
+  annotations
+}
 """
 
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -214,6 +214,7 @@ provider
   certificate_arn
   targets {
     name
+    default
     weight
     ips
   }

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -56,7 +56,8 @@ from terrascript.resource import (
     aws_route53_zone,
     aws_route53_record,
     aws_route53_health_check,
-    aws_cloudfront_public_key
+    aws_cloudfront_public_key,
+    aws_lb,
 )
 # temporary to create aws_ecrpublic_repository
 from terrascript import Resource
@@ -830,6 +831,8 @@ class TerrascriptClient:
         elif provider == 's3-cloudfront-public-key':
             self.populate_tf_resource_s3_cloudfront_public_key(resource,
                                                                namespace_info)
+        elif provider == 'lb':
+            self.populate_tf_resource_lb(resource, namespace_info)
         else:
             raise UnknownProviderError(provider)
 
@@ -3264,3 +3267,27 @@ class TerrascriptClient:
 
         for tf_resource in tf_resources:
             self.add_resource(account, tf_resource)
+
+    def populate_tf_resource_lb(self, resource, namespace_info):
+        account, identifier, values, output_prefix, \
+            output_resource_name, annotations = \
+            self.init_values(resource, namespace_info)
+
+        self.init_common_outputs(tf_resources, namespace_info, output_prefix,
+                                 output_resource_name, annotations)
+
+        # https://www.terraform.io/docs/providers/aws/r/lb.html
+        tf_resource = aws_lb(identifier, **values)
+        self.add_resource(account, tf_resource)
+
+        # outputs
+        ## dns name
+        output_name_0_13 = output_prefix + '__dns_name'
+        output_value = tf_resources.dns_name
+        self.add_resource(
+            account, Output(output_name_0_13, value=output_value))
+        ## zone id
+        output_name_0_13 = output_prefix + '__zone_id'
+        output_value = tf_resources.zone_id
+        self.add_resource(
+            account, Output(output_name_0_13, value=output_value))

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -59,6 +59,7 @@ from terrascript.resource import (
     aws_route53_health_check,
     aws_cloudfront_public_key,
     aws_lb,
+    aws_lb_target_group,
 )
 # temporary to create aws_ecrpublic_repository
 from terrascript import Resource
@@ -3331,6 +3332,27 @@ class TerrascriptClient:
         }
         lb_tf_resource = aws_lb(identifier, **values)
         tf_resources.append(lb_tf_resource)
+
+        for t in resource['targets']:
+            target_name = t['name']
+            # https://www.terraform.io/docs/providers/aws/r/
+            # lb_target_group.html
+            values = {
+                'name': target_name,
+                'port': 443,
+                'protocol': 'HTTPS',
+                'target_type': 'ip',
+                'vpc_id': vpc_id,
+                'health_check': {
+                    'interval': 10,
+                    'path': '/',
+                    'protocol': 'HTTPS',
+                    'port': 443,
+                }
+            }
+            lbt_identifier = f'{identifier}-{target_name}'
+            lbt_tf_resource = aws_lb_target_group(lbt_identifier, **values)
+            tf_resources.append(lbt_tf_resource)
 
         # outputs
         # dns name

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3281,11 +3281,11 @@ class TerrascriptClient:
         tf_resources.append(lb_tf_resource)
 
         # outputs
-        ## dns name
+        # dns name
         output_name_0_13 = output_prefix + '__dns_name'
         output_value = lb_tf_resource.dns_name
         tf_resources.append(Output(output_name_0_13, value=output_value))
-        ## zone id
+        # zone id
         output_name_0_13 = output_prefix + '__zone_id'
         output_value = lb_tf_resource.zone_id
         tf_resources.append(Output(output_name_0_13, value=output_value))

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -831,8 +831,8 @@ class TerrascriptClient:
         elif provider == 's3-cloudfront-public-key':
             self.populate_tf_resource_s3_cloudfront_public_key(resource,
                                                                namespace_info)
-        elif provider == 'lb':
-            self.populate_tf_resource_lb(resource, namespace_info)
+        elif provider == 'alb':
+            self.populate_tf_resource_alb(resource, namespace_info)
         else:
             raise UnknownProviderError(provider)
 
@@ -3268,7 +3268,7 @@ class TerrascriptClient:
         for tf_resource in tf_resources:
             self.add_resource(account, tf_resource)
 
-    def populate_tf_resource_lb(self, resource, namespace_info):
+    def populate_tf_resource_alb(self, resource, namespace_info):
         account, identifier, values, output_prefix, \
             output_resource_name, annotations = \
             self.init_values(resource, namespace_info)

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3325,7 +3325,7 @@ class TerrascriptClient:
             'internal': False,
             'load_balancer_type': 'application',
             'security_groups': [f'${{{sg_tf_resource.id}}}'],
-            'subnets': [],
+            'subnets': [s['id'] for s in vpc['subnets']],
             'tags': common_values['tags'],
             'depends_on': [deps],
         }

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3269,7 +3269,7 @@ class TerrascriptClient:
             self.add_resource(account, tf_resource)
 
     def populate_tf_resource_alb(self, resource, namespace_info):
-        account, identifier, values, output_prefix, \
+        account, identifier, common_values, output_prefix, \
             output_resource_name, annotations = \
             self.init_values(resource, namespace_info)
         tf_resources = []
@@ -3277,6 +3277,14 @@ class TerrascriptClient:
                                  output_resource_name, annotations)
 
         # https://www.terraform.io/docs/providers/aws/r/lb.html
+        values = {
+            'name': identifier,
+            'internal': False,
+            'load_balancer_type': 'application',
+            'security_groups': [],
+            'subnets': [],
+            'tags': common_values['tags'],
+        }
         lb_tf_resource = aws_lb(identifier, **values)
         tf_resources.append(lb_tf_resource)
 
@@ -3284,10 +3292,6 @@ class TerrascriptClient:
         # dns name
         output_name_0_13 = output_prefix + '__dns_name'
         output_value = lb_tf_resource.dns_name
-        tf_resources.append(Output(output_name_0_13, value=output_value))
-        # zone id
-        output_name_0_13 = output_prefix + '__zone_id'
-        output_value = lb_tf_resource.zone_id
         tf_resources.append(Output(output_name_0_13, value=output_value))
 
         for tf_resource in tf_resources:

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3272,22 +3272,23 @@ class TerrascriptClient:
         account, identifier, values, output_prefix, \
             output_resource_name, annotations = \
             self.init_values(resource, namespace_info)
-
+        tf_resources = []
         self.init_common_outputs(tf_resources, namespace_info, output_prefix,
                                  output_resource_name, annotations)
 
         # https://www.terraform.io/docs/providers/aws/r/lb.html
-        tf_resource = aws_lb(identifier, **values)
-        self.add_resource(account, tf_resource)
+        lb_tf_resource = aws_lb(identifier, **values)
+        tf_resources.append(lb_tf_resource)
 
         # outputs
         ## dns name
         output_name_0_13 = output_prefix + '__dns_name'
-        output_value = tf_resources.dns_name
-        self.add_resource(
-            account, Output(output_name_0_13, value=output_value))
+        output_value = lb_tf_resource.dns_name
+        tf_resources.append(Output(output_name_0_13, value=output_value))
         ## zone id
         output_name_0_13 = output_prefix + '__zone_id'
-        output_value = tf_resources.zone_id
-        self.add_resource(
-            account, Output(output_name_0_13, value=output_value))
+        output_value = lb_tf_resource.zone_id
+        tf_resources.append(Output(output_name_0_13, value=output_value))
+
+        for tf_resource in tf_resources:
+            self.add_resource(account, tf_resource)

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3353,10 +3353,13 @@ class TerrascriptClient:
             tf_resources.append(lbt_tf_resource)
 
             for ip in t['ips']:
+                # https://www.terraform.io/docs/providers/aws/r/
+                # lb_target_group_attachment.html
                 values = {
                     'target_group_arn': f'${{{lbt_tf_resource.arn}}}',
                     'target_id': ip,
                     'port': 443,
+                    'depends_on': self.get_dependencies([lbt_tf_resource]),
                 }
                 ip_slug = ip.replace('.', '_')
                 lbta_identifier = f'{lbt_identifier}-{ip_slug}'

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -60,6 +60,7 @@ from terrascript.resource import (
     aws_cloudfront_public_key,
     aws_lb,
     aws_lb_target_group,
+    aws_lb_target_group_attachment,
 )
 # temporary to create aws_ecrpublic_repository
 from terrascript import Resource
@@ -3353,6 +3354,18 @@ class TerrascriptClient:
             lbt_identifier = f'{identifier}-{target_name}'
             lbt_tf_resource = aws_lb_target_group(lbt_identifier, **values)
             tf_resources.append(lbt_tf_resource)
+
+            for ip in t['ips']:
+                values = {
+                    'target_group_arn': f'${{{lbt_tf_resource.arn}}}',
+                    'target_id': ip,
+                    'port': 443,
+                }
+                ip_slug = ip.replace('.', '_')
+                lbta_identifier = f'{lbt_identifier}-{ip_slug}'
+                lbta_tf_resource = \
+                    aws_lb_target_group_attachment(lbta_identifier, **values)
+                tf_resources.append(lbta_tf_resource)
 
         # outputs
         # dns name

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3400,7 +3400,8 @@ class TerrascriptClient:
             'depends_on': self.get_dependencies([lb_tf_resource]),
         }
         redirect_identifier = f'{identifier}-redirect'
-        redirect_lbl_tf_resource = aws_lb_listener(redirect_identifier, **values)
+        redirect_lbl_tf_resource = \
+            aws_lb_listener(redirect_identifier, **values)
         tf_resources.append(redirect_lbl_tf_resource)
         # forward
         if not default_target:

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3319,9 +3319,6 @@ class TerrascriptClient:
         tf_resources.append(sg_tf_resource)
 
         # https://www.terraform.io/docs/providers/aws/r/lb.html
-        deps = self.get_dependencies([
-            sg_tf_resource,
-        ])
         values = {
             'name': identifier,
             'internal': False,
@@ -3329,7 +3326,7 @@ class TerrascriptClient:
             'security_groups': [f'${{{sg_tf_resource.id}}}'],
             'subnets': [s['id'] for s in vpc['subnets']],
             'tags': common_values['tags'],
-            'depends_on': [deps],
+            'depends_on': self.get_dependencies([sg_tf_resource]),
         }
         lb_tf_resource = aws_lb(identifier, **values)
         tf_resources.append(lb_tf_resource)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3695

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/25145

this PR adds support to provision LBs using terraform: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb

this PR initially adds support for Application LB only, and only for HTTPS (with an HTTP redirection). we can refactor when future use cases come along.