### PR TITLE
Reduce the memory allocations for quay mirror

### DIFF
--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -55,10 +55,10 @@ integrations:
   sleepDurationSecs: 300
   resources:
     requests:
-      memory: 970Mi
+      memory: 550Mi
       cpu: 200m
     limits:
-      memory: 1Gi
+      memory: 550Mi
       cpu: 300m
 - name: quay-mirror-org
   resources:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -24216,11 +24216,11 @@ parameters:
 - name: QUAY_MIRROR_CPU_LIMIT
   value: 300m
 - name: QUAY_MIRROR_MEMORY_LIMIT
-  value: 1Gi
+  value: 550Mi
 - name: QUAY_MIRROR_CPU_REQUEST
   value: 200m
 - name: QUAY_MIRROR_MEMORY_REQUEST
-  value: 970Mi
+  value: 550Mi
 - name: QUAY_MIRROR_ORG_CPU_LIMIT
   value: 300m
 - name: QUAY_MIRROR_ORG_MEMORY_LIMIT


### PR DESCRIPTION
This pod is using about 420MB, let's give it 550 for good measure.
