### PR TITLE
[gql] get_sha raise and retry

### DIFF
--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -180,10 +180,12 @@ def init(url, token=None, integration=None, validate_schemas=False):
     return _gqlapi
 
 
+@retry(exceptions=requests.exceptions.HTTPError, max_attempts=5)
 def get_sha(server, token=None):
     sha_endpoint = server._replace(path='/sha256')
     headers = {'Authorization': token} if token else None
     response = requests.get(sha_endpoint.geturl(), headers=headers)
+    response.raise_for_status()
     sha = response.content.decode('utf-8')
     return sha
 


### PR DESCRIPTION
in a case where the call to get the current sha failed, we are currently silently proceeding to get git commit info of that sha.
instead, we need to make sure we got a valid response for the sha request and retry otherwise.

reported in https://coreos.slack.com/archives/CCRND57FW/p1631524355358800

error details:
```
Traceback (most recent call last):
  File "/usr/local/bin/qontract-reconcile", line 33, in <module>
    sys.exit(load_entry_point('qontract-reconcile==0.3.0', 'console_scripts', 'qontract-reconcile')())
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/utils/environ.py", line 15, in f_environ
    f(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/utils/environ.py", line 15, in f_environ
    f(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/utils/binary.py", line 18, in f_binary
    f(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/utils/binary.py", line 60, in f_binary_version
    f(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click-7.1.2-py3.6.egg/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/cli.py", line 771, in openshift_saas_deploy
    saas_file_name, env_name, gitlab_project_id)
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/cli.py", line 400, in run_integration
    print_url=ctx['gql_url_print'])
  File "/usr/local/lib/python3.6/site-packages/sretoolbox-0.15.0-py3.6.egg/sretoolbox/utils/retry.py", line 73, in f_retry
    return function(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/utils/gql.py", line 216, in init_from_config
    git_commit_info = get_git_commit_info(sha, server_url, token)
  File "/usr/local/lib/python3.6/site-packages/sretoolbox-0.15.0-py3.6.egg/sretoolbox/utils/retry.py", line 78, in f_retry
    raise exception
  File "/usr/local/lib/python3.6/site-packages/sretoolbox-0.15.0-py3.6.egg/sretoolbox/utils/retry.py", line 73, in f_retry
    return function(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/utils/gql.py", line 197, in get_git_commit_info
    response.raise_for_status()
  File "/usr/local/lib/python3.6/site-packages/requests-2.22.0-py3.6.egg/requests/models.py", line 940, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 404 Client Error: Not Found for url: https://app-interface.devshift.net/git-commit-info/%3Chtml%3E%0D%0A%3Chead%3E%3Ctitle%3E502%20Bad%20Gateway%3C/title%3E%3C/head%3E%0D%0A%3Cbody%3E%0D%0A%3Ccenter%3E%3Ch1%3E502%20Bad%20Gateway%3C/h1%3E%3C/center%3E%0D%0A%3Chr%3E%3Ccenter%3Enginx/1.16.1%3C/center%3E%0D%0A%3C/body%3E%0D%0A%3C/html%3E%0D%0A
```