### PR TITLE
Replace easy_install usage with the pip equivalents

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,16 +126,17 @@ python3 -m venv venv
 source venv/bin/activate
 
 # make sure you are running the latest setuptools
-python3 -m pip install --upgrade pip setuptools
+pip install --upgrade pip setuptools
 ```
 
 Install the package:
 
 ```sh
-python3 setup.py install
+pip install .
 
-# or alternatively use this for a devel environment
-python3 setup.py develop
+# or use this for development mode so rebuild/reinstall isn't necessary after 
+# each change that is made during development
+pip install -e .
 
 # optionally install all test/type dependencies - useful when writing tests,
 # auto-completion in your IDE, etc.

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -7,7 +7,9 @@ COPY reconcile reconcile
 COPY tools tools
 COPY setup.py .
 
-RUN python3 setup.py install
+# setup.py install is not used because it will install pre-releases:
+# https://github.com/pypa/setuptools/issues/855
+RUN python3 -m pip install .
 
 COPY dockerfiles/hack/run-integration.py /run-integration.py
 CMD [ "/run-integration.py" ]


### PR DESCRIPTION
easy_install (used with `setup.py install`) will install pre-releases
which is unexpected and undesirable behavior.

More information:

https://github.com/pypa/setuptools/issues/855

I tested this by creating a venv with `python setup.py install` and another with `pip install .`  The diff of the `pip freeze` output was:

```
$ diff easy_install.txt pip.txt 
29c29
< jira==2.0.1.0rc1
---
> jira==2.0.0
56c56
< python-jenkins==1.8.0.0a0
---
> python-jenkins==1.7.0
86c86
< wrapt==1.13.0rc3
---
> wrapt==1.12.1

```

This is exactly what I expect.  The `pip` install ignored alpha and release candidates while easy_install was happy to install versions that we don't want to rely on in production.