### PR TITLE
Fix linters on Python 3.9

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -139,7 +139,7 @@ def before_breadcrumb(crumb, hint):
 
 # Enable Sentry
 if os.getenv('SENTRY_DSN'):
-    sentry_sdk.init(
+    sentry_sdk.init(  # pylint: disable=abstract-class-instantiated
         os.environ['SENTRY_DSN'],
         before_breadcrumb=before_breadcrumb
     )

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -115,7 +115,7 @@ def handle_stale_items(dry_run, gl, days_interval, enable_closing, item_type):
 
 def is_good_to_merge(merge_label, labels):
     return merge_label in labels and \
-        not any(l in HOLD_LABELS for l in labels)
+        not any(b in HOLD_LABELS for b in labels)
 
 
 def rebase_merge_requests(dry_run, gl, rebase_limit, pipeline_timeout=None,

--- a/reconcile/gitlab_labeler.py
+++ b/reconcile/gitlab_labeler.py
@@ -44,7 +44,7 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None):
     changed_paths = \
         gl.get_merge_request_changed_paths(gitlab_merge_request_id)
     guessed_labels = guess_labels(project_labels, changed_paths)
-    labels_to_add = [l for l in guessed_labels if l not in labels]
+    labels_to_add = [b for b in guessed_labels if b not in labels]
     if labels_to_add:
         logging.info(['add_labels', labels_to_add])
         gl.add_labels_to_merge_request(gitlab_merge_request_id, labels_to_add)

--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -24,7 +24,7 @@ def delete_builds(jenkins, builds_todel, dry_run=True):
         if not dry_run:
             try:
                 jenkins.delete_build(build['job_name'], build['build_id'])
-            except Exception as e:
+            except Exception:
                 msg = f"failed to delete {job_name}/{build_id}"
                 logging.exception(msg)
 

--- a/reconcile/openshift_limitranges.py
+++ b/reconcile/openshift_limitranges.py
@@ -47,11 +47,11 @@ def construct_resources(namespaces):
         }
 
         # Build each limit item ignoring null ones
-        for l in limitranges['limits']:
+        for lr in limitranges['limits']:
             speclimit = {}
             for ltype in SUPPORTED_LIMITRANGE_TYPES:
-                if ltype in l and l[ltype] is not None:
-                    speclimit[ltype] = l[ltype]
+                if ltype in lr and lr[ltype] is not None:
+                    speclimit[ltype] = lr[ltype]
             body['spec']['limits'].append(speclimit)
 
         resource = OR(body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION)

--- a/reconcile/sentry_helper.py
+++ b/reconcile/sentry_helper.py
@@ -23,8 +23,8 @@ def get_sentry_users_from_mails(mails):
     user_names = set()
     for mail in mails:
         msg = mail['msg']
-        user_line = [l for l in msg.split('\n')
-                     if 'is requesting access to' in l]
+        user_line = [ln for ln in msg.split('\n')
+                     if 'is requesting access to' in ln]
         if not user_line:
             continue
         user_line = user_line[0]

--- a/reconcile/test/test_aggregated_list.py
+++ b/reconcile/test/test_aggregated_list.py
@@ -179,8 +179,8 @@ class TestAggregatedDiffRunner:
         on_update_insert = []
         on_update_delete = []
 
-        def recorder(l):
-            return lambda p, i: l.append([p, i])
+        def recorder(ls):
+            return lambda p, i: ls.append([p, i])
 
         runner = AggregatedDiffRunner(left.diff(right))
 

--- a/reconcile/test/test_openshift_namespace_labels.py
+++ b/reconcile/test/test_openshift_namespace_labels.py
@@ -19,7 +19,7 @@ class NS():
     def __init__(self, cluster: str, name: str,
                  current: Optional[Dict[str, str]],
                  managed: Optional[List[str]],
-                 desired: Dict[str, str], exists: bool=True):
+                 desired: Dict[str, str], exists: bool = True):
         self.cluster = cluster
         self.name = name
         self.current = current

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -314,7 +314,7 @@ class GitLabApi:
         merge_request.notes.create({'body': comment})
 
     def get_project_labels(self):
-        return [l.name for l in self.project.labels.list(all=True)]
+        return [ln.name for ln in self.project.labels.list(all=True)]
 
     def get_merge_request_labels(self, mr_id):
         merge_request = self.project.mergerequests.get(mr_id)

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -159,7 +159,7 @@ class GqlApi:
             # resources is not complete.
             resources = self.query(query, {'path': path},
                                    skip_validation=True)['resources']
-        except GqlApiError as e:
+        except GqlApiError:
             raise GqlGetResourceError(
                 path,
                 'Resource not found.')

--- a/reconcile/utils/jenkins_api.py
+++ b/reconcile/utils/jenkins_api.py
@@ -149,12 +149,9 @@ class JenkinsApi:
     def safe_restart(self, force_restart=False):
         url = "{}/safeRestart".format(self.url)
         if self.should_restart or force_restart:
-            logging.debug(
-                'performing safe restart. should_restart=%s, '
-                'force_restart=%s.',
-                self.should_restart,
-                force_restart
-            )
+            logging.debug('performing safe restart. '
+                          f'should_restart={self.should_restart}, '
+                          f'force_restart={force_restart}.')
             res = requests.post(
                 url,
                 verify=self.ssl_verify,

--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -197,8 +197,8 @@ class JJB:
                     dlines = d.readlines()
 
                     differ = difflib.Differ()
-                    diff = [l for l in differ.compare(clines, dlines)
-                            if l.startswith(('-', '+'))]
+                    diff = [ln for ln in differ.compare(clines, dlines)
+                            if ln.startswith(('-', '+'))]
                     logging.debug("DIFF:\n" + "".join(diff))
 
     def compare_files(self, from_files, subtract_files, in_op=False):

--- a/reconcile/utils/quay_api.py
+++ b/reconcile/utils/quay_api.py
@@ -43,8 +43,8 @@ class QuayApi:
 
         # Using a set because members may be repeated
         members = set()
-        for member in body[u'members']:
-            members.add(member[u'name'])
+        for member in body['members']:
+            members.add(member['name'])
 
         members_list = list(members)
         self.team_members[team] = members_list

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -456,7 +456,7 @@ class TerraformClient:
         split_outputs = []
         try:
             for output in outputs:
-                output_lines = [l for l in output.split('\n') if len(l) != 0]
+                output_lines = [ln for ln in output.split('\n') if ln]
                 split_outputs.append(output_lines)
         except Exception:
             logging.warning("failed to split outputs to lines.")

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 anymarkup==0.7.0
-flake8==3.5.0
+flake8~=3.9
 kubernetes~=12.0
 pylint~=2.6
 pytest~=6.2


### PR DESCRIPTION
Use a version of flake8 that doesn't crash, fix any new errors, and
make pylint ignore an instantiation that has always worked.
