### PR TITLE
[terraform-resources] only apply if apply is needed

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -422,7 +422,7 @@ def run(dry_run, print_only=False,
     if dry_run:
         cleanup_and_exit(tf)
 
-    if not light:
+    if not light and tf.should_apply:
         err = tf.apply()
         if err:
             cleanup_and_exit(tf, err)

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -31,6 +31,7 @@ class TerraformClient:
         self.parallelism = thread_pool_size
         self.thread_pool_size = thread_pool_size
         self._log_lock = Lock()
+        self.should_apply = False
 
         self.init_specs()
         self.init_outputs()
@@ -182,6 +183,7 @@ class TerraformClient:
                     continue
                 with self._log_lock:
                     logging.info([action, name, resource_type, resource_name])
+                    self.should_apply = True
                 if action == 'delete':
                     if not deletions_allowed:
                         disabled_deletion_detected = True


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3702

We are seeing this issue multiple times in pr-checks:
```
Error: Saved plan is stale

The given plan file can no longer be applied because the state was changed by
another operation after the plan was created.
```
This is probably because the actual terraform integration(s) are running continuously and performing `terraform apply` even without anything to change.
Let's try to avoid `terraform apply` if no changes are going to be made. This should alleviate this error and cause it to appear much less (and indirectly, speeding up app-interface pr-check time)
 