### PR TITLE
[terraform-vpc/tgw] avoid init users in aws api

### DIFF
--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -61,7 +61,8 @@ def build_desired_state_tgw_attachments(clusters, ocm_map, settings):
                     )
             account['assume_region'] = accepter['region']
             account['assume_cidr'] = accepter['cidr_block']
-            aws_api = AWSApi(1, [account], settings=settings)
+            aws_api = AWSApi(1, [account], settings=settings,
+                             init_users=False)
             accepter_vpc_id, accepter_route_table_ids, \
                 accepter_subnets_id_az = \
                 aws_api.get_cluster_vpc_details(

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -105,7 +105,8 @@ def build_desired_state_single_cluster(cluster_info, ocm_map, settings):
 
         accepter_manage_routes = peer_info.get('manageRoutes')
 
-        aws_api = awsapi.AWSApi(1, [req_aws], settings=settings)
+        aws_api = awsapi.AWSApi(1, [req_aws], settings=settings,
+                                init_users=False)
         requester_vpc_id, requester_route_table_ids, _ = \
             aws_api.get_cluster_vpc_details(
                 req_aws,
@@ -137,7 +138,8 @@ def build_desired_state_single_cluster(cluster_info, ocm_map, settings):
                 f"peering {peer_connection_name}"
             )
 
-        aws_api = awsapi.AWSApi(1, [acc_aws], settings=settings)
+        aws_api = awsapi.AWSApi(1, [acc_aws], settings=settings,
+                                init_users=False)
         accepter_vpc_id, accepter_route_table_ids, _ = \
             aws_api.get_cluster_vpc_details(
                 acc_aws,
@@ -219,7 +221,8 @@ def build_desired_state_vpc_mesh_single_cluster(cluster_info, ocm, settings):
             )
         account['assume_region'] = requester['region']
         account['assume_cidr'] = requester['cidr_block']
-        aws_api = awsapi.AWSApi(1, [account], settings=settings)
+        aws_api = awsapi.AWSApi(1, [account], settings=settings,
+                                init_users=False)
         requester_vpc_id, requester_route_table_ids, _ = \
             aws_api.get_cluster_vpc_details(
                 account,
@@ -326,7 +329,8 @@ def build_desired_state_vpc_single_cluster(cluster_info, ocm, settings):
         )
         account['assume_region'] = requester['region']
         account['assume_cidr'] = requester['cidr_block']
-        aws_api = awsapi.AWSApi(1, [account], settings=settings)
+        aws_api = awsapi.AWSApi(1, [account], settings=settings,
+                                init_users=False)
         requester_vpc_id, requester_route_table_ids, _ = \
             aws_api.get_cluster_vpc_details(
                 account,

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -23,13 +23,14 @@ class AWSApi:
     """Wrapper around AWS SDK"""
 
     def __init__(self, thread_pool_size, accounts, settings=None,
-                 init_ecr_auth_tokens=False):
+                 init_ecr_auth_tokens=False, init_users=True):
         self.thread_pool_size = thread_pool_size
         self.secret_reader = SecretReader(settings=settings)
         self.init_sessions_and_resources(accounts)
         if init_ecr_auth_tokens:
             self.init_ecr_auth_tokens(accounts)
-        self.init_users()
+        if init_users:
+            self.init_users()
         self._lock = Lock()
         self.resource_types = \
             ['s3', 'sqs', 'dynamodb', 'rds', 'rds_snapshots']


### PR DESCRIPTION
there is no use to initiate users in these integrations, and we'll avoid some precious rate limit:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/terraform_vpc_peerings.py", line 182, in build_desired_state_all_clusters
    cluster_info, ocm_map, settings
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/terraform_vpc_peerings.py", line 108, in build_desired_state_single_cluster
    aws_api = awsapi.AWSApi(1, [req_aws], settings=settings)
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/utils/aws_api.py", line 32, in __init__
    self.init_users()
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/utils/aws_api.py", line 70, in init_users
    users = self.paginate(iam, 'list_users', 'Users')
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/utils/aws_api.py", line 211, in paginate
    for page in paginator.paginate(**params)
  File "/usr/local/lib/python3.6/site-packages/qontract_reconcile-0.3.0-py3.6.egg/reconcile/utils/aws_api.py", line 210, in <listcomp>
    return [values
  File "/usr/local/lib/python3.6/site-packages/botocore-1.21.0-py3.6.egg/botocore/paginate.py", line 255, in __iter__
    response = self._make_request(current_kwargs)
  File "/usr/local/lib/python3.6/site-packages/botocore-1.21.0-py3.6.egg/botocore/paginate.py", line 332, in _make_request
    return self._method(**current_kwargs)
  File "/usr/local/lib/python3.6/site-packages/botocore-1.21.0-py3.6.egg/botocore/client.py", line 386, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.6/site-packages/botocore-1.21.0-py3.6.egg/botocore/client.py", line 705, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (Throttling) when calling the ListUsers operation (reached max retries: 4): Rate exceeded
```