### PR TITLE
[oc] retry recycle

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -585,11 +585,10 @@ class OCDeprecated:
     def recycle(self, dry_run, namespace, kind, obj):
         """Recycles an object by adding a recycle.time annotation
 
-        Args:
-            dry_run (bool): Is this a dry run
-            namespace (string): Namespace to work in
-            kind (string): Object kind
-            obj (dict): Object to recycle
+        :param dry_run: Is this a dry run
+        :param namespace: Namespace to work in
+        :param kind: Object kind
+        :param obj: Object to recycle
         """
         name = obj['metadata']['name']
         logging.info([f'recycle_{kind.lower()}',

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -593,7 +593,7 @@ class OCDeprecated:
         """
         name = obj['metadata']['name']
         logging.info([f'recycle_{kind.lower()}',
-                        self.cluster_name, namespace, name])
+                      self.cluster_name, namespace, name])
         if not dry_run:
             now = datetime.now()
             recycle_time = now.strftime("%d/%m/%Y %H:%M:%S")

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -598,6 +598,8 @@ class OCDeprecated:
             now = datetime.now()
             recycle_time = now.strftime("%d/%m/%Y %H:%M:%S")
 
+            # get the object in case it was modified
+            obj = self.get(namespace, kind, name)
             # honor update strategy by setting annotations to force
             # a new rollout
             a = obj['spec']['template']['metadata'].get(

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -575,10 +575,10 @@ class OCDeprecated:
 
         for kind, objs in recyclables.items():
             for obj in objs:
-                self.recycle_root_owner(dry_run, namespace, kind, obj)
+                self.recycle(dry_run, namespace, kind, obj)
 
-    def recycle_root_owner(self, dry_run, namespace, kind, obj):
-        """Recycles a root owner object by adding a recycle.time annotation
+    def recycle(self, dry_run, namespace, kind, obj):
+        """Recycles an object by adding a recycle.time annotation
 
         Args:
             dry_run (bool): Is this a dry run

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -65,6 +65,10 @@ class StatefulSetUpdateForbidden(Exception):
     pass
 
 
+class ObjectHasBeenModifiedError(Exception):
+    pass
+
+
 class NoOutputError(Exception):
     pass
 
@@ -577,6 +581,7 @@ class OCDeprecated:
             for obj in objs:
                 self.recycle(dry_run, namespace, kind, obj)
 
+    @retry(exceptions=ObjectHasBeenModifiedError)
     def recycle(self, dry_run, namespace, kind, obj):
         """Recycles an object by adding a recycle.time annotation
 
@@ -731,6 +736,8 @@ class OCDeprecated:
                     raise UnsupportedMediaTypeError(f"[{self.server}]: {err}")
                 if 'updates to statefulset spec for fields other than' in err:
                     raise StatefulSetUpdateForbidden(f"[{self.server}]: {err}")
+                if 'the object has been modified' in err:
+                    raise ObjectHasBeenModifiedError(f"[{self.server}]: {err}")
             if not (allow_not_found and 'NotFound' in err):
                 raise StatusCodeError(f"[{self.server}]: {err}")
 


### PR DESCRIPTION
related to https://issues.redhat.com/browse/ASIC-86

in some cases, a `Deployment` was applied along (and before) a `ConfigMap`. we may be trying to apply an outdated `Deployment`, so let's get it before we act on it and retry for this particular case:
```
Operation cannot be fulfilled on deployments.apps "<deployment_name>": the object has been modified; please apply your changes to the latest version and try again
```