### PR TITLE
Fix handling of managedResourceTypes

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -118,8 +118,8 @@ from reconcile.utils.unleash import get_feature_toggle_state
 TERRAFORM_VERSION = '0.13.7'
 TERRAFORM_VERSION_REGEX = r'^Terraform\sv([\d]+\.[\d]+\.[\d]+)$'
 
-OC_VERSION = '4.6.1'
-OC_VERSION_REGEX = r'^Client\sVersion:\s([\d]+\.[\d]+\.[\d]+)$'
+OC_VERSION = '4.8.0'
+OC_VERSION_REGEX = r'^Client\sVersion:\s([\d]+\.[\d]+\.[\d]+)-.*$'
 
 LOG_FMT = '[%(asctime)s] [%(levelname)s] ' \
     '[%(filename)s:%(funcName)s:%(lineno)d] - %(message)s'

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1,5 +1,8 @@
 import logging
 import itertools
+
+from typing import Optional, List, Iterable, Mapping
+
 import yaml
 
 from sretoolbox.utils import retry
@@ -45,11 +48,12 @@ class StateSpec:
         self.resource_names = resource_names
 
 
-def init_specs_to_fetch(ri, oc_map,
-                        namespaces=None,
-                        clusters=None,
-                        override_managed_types=None,
-                        managed_types_key='managedResourceTypes'):
+def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
+                        namespaces: Optional[Iterable[Mapping]] = None,
+                        clusters: Optional[Iterable[Mapping]] = None,
+                        override_managed_types: Optional[Iterable[str]] = None,
+                        managed_types_key: str = 'managedResourceTypes'
+                        ) -> List[StateSpec]:
     state_specs = []
 
     if clusters and namespaces:

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -61,9 +61,9 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
     elif namespaces:
         for namespace_info in namespaces:
             if override_managed_types is None:
-                managed_types = namespace_info.get(managed_types_key)
+                managed_types = set(namespace_info.get(managed_types_key, []))
             else:
-                managed_types = override_managed_types
+                managed_types = set(override_managed_types)
 
             if not managed_types:
                 continue
@@ -78,34 +78,42 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
 
             namespace = namespace_info['name']
             managed_resource_names = \
-                namespace_info.get('managedResourceNames')
+                namespace_info.get('managedResourceNames', [])
             managed_resource_type_overrides = \
-                namespace_info.get('managedResourceTypeOverrides')
+                namespace_info.get('managedResourceTypeOverrides', [])
 
             # Initialize current state specs
             for resource_type in managed_types:
                 ri.initialize_resource_type(cluster, namespace, resource_type)
-                # Handle case of specific managed resources
-                resource_names = \
-                    [mrn['resourceNames'] for mrn in managed_resource_names
-                     if mrn['resource'] == resource_type] \
-                    if managed_resource_names else None
-                # Handle case of resource type override
-                resource_type_override = \
-                    [mnto['override'] for mnto
-                     in managed_resource_type_overrides
-                     if mnto['resource'] == resource_type] \
-                    if managed_resource_type_overrides else None
-                # If not None, there is a single element in the list
-                if resource_names:
-                    [resource_names] = resource_names
-                if resource_type_override:
-                    [resource_type_override] = resource_type_override
+            resource_names = {}
+            resource_type_overrides = {}
+            for mrn in managed_resource_names:
+                # Current implementation guarantees only one
+                # managed_resource_name of each managed type
+                if mrn['resource'] in managed_types:
+                    resource_names[mrn['resource']] = mrn['resourceNames']
+                else:
+                    logging.info(
+                        f"Skipping non-managed resources {mrn} "
+                        f"on {cluster}/{namespace}"
+                    )
+
+            for o in managed_resource_type_overrides:
+                # Current implementation guarantees only one
+                # override of each managed type
+                if o['resource'] in managed_types:
+                    resource_type_overrides[o['resource']] = o['override']
+                else:
+                    logging.info(
+                        f"Skipping nom-managed override {o} "
+                        f"on {cluster}/{namespace}")
+
+            for kind, names in resource_names.items():
                 c_spec = StateSpec(
                     "current", oc, cluster, namespace,
-                    resource_type,
-                    resource_type_override=resource_type_override,
-                    resource_names=resource_names)
+                    kind,
+                    resource_type_override=resource_type_overrides.get(kind),
+                    resource_names=names)
                 state_specs.append(c_spec)
 
             # Initialize desired state specs
@@ -117,7 +125,7 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
     elif clusters:
         # set namespace to something indicative
         namespace = 'cluster'
-        for cluster_info in clusters or []:
+        for cluster_info in clusters:
             cluster = cluster_info['name']
             oc = oc_map.get(cluster)
             if not oc:

--- a/reconcile/openshift_limitranges.py
+++ b/reconcile/openshift_limitranges.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 
+from contextlib import suppress
 
 import reconcile.queries as queries
 import reconcile.openshift_base as ob
@@ -75,13 +76,14 @@ def add_desired_state(namespaces, ri, oc_map):
         if 'resources' not in namespace:
             continue
         for resource in namespace["resources"]:
-            ri.add_desired(
-                namespace['cluster']['name'],
-                namespace['name'],
-                resource.kind,
-                resource.name,
-                resource
-            )
+            with suppress(KeyError):
+                ri.add_desired(
+                    namespace['cluster']['name'],
+                    namespace['name'],
+                    resource.kind,
+                    resource.name,
+                    resource
+                )
 
 
 @defer

--- a/reconcile/openshift_network_policies.py
+++ b/reconcile/openshift_network_policies.py
@@ -1,6 +1,8 @@
 import sys
 import logging
 
+from contextlib import suppress
+
 import reconcile.utils.gql as gql
 import reconcile.openshift_base as ob
 
@@ -98,13 +100,14 @@ def fetch_desired_state(namespaces, ri, oc_map):
             resource_name = "allow-from-{}-namespace".format(source_namespace)
             oc_resource = \
                 construct_oc_resource(resource_name, source_namespace)
-            ri.add_desired(
-                cluster,
-                namespace,
-                'NetworkPolicy',
-                resource_name,
-                oc_resource
-            )
+            with suppress(KeyError):
+                ri.add_desired(
+                    cluster,
+                    namespace,
+                    'NetworkPolicy',
+                    resource_name,
+                    oc_resource
+                )
 
 
 @defer

--- a/reconcile/openshift_resourcequotas.py
+++ b/reconcile/openshift_resourcequotas.py
@@ -2,6 +2,7 @@ import collections
 import logging
 import sys
 
+from contextlib import suppress
 
 import reconcile.queries as queries
 import reconcile.openshift_base as ob
@@ -53,13 +54,14 @@ def fetch_desired_state(namespaces, ri, oc_map):
         for quota in quotas:
             quota_name = quota['name']
             quota_resource = construct_resource(quota)
-            ri.add_desired(
-                cluster,
-                namespace,
-                'ResourceQuota',
-                quota_name,
-                quota_resource
-            )
+            with suppress(KeyError):
+                ri.add_desired(
+                    cluster,
+                    namespace,
+                    'ResourceQuota',
+                    quota_name,
+                    quota_resource
+                )
 
 
 @defer

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -135,7 +135,7 @@ def fetch_desired_state(ri, oc_map):
                         resource_name,
                         oc_resource
                     )
-                except ResourceKeyExistsError:
+                except (KeyError, ResourceKeyExistsError):
                     # a user may have a Role assigned to them
                     # from multiple app-interface roles
                     pass

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -1,0 +1,147 @@
+from typing import List, cast
+
+import testslide
+import reconcile.openshift_base as sut
+import reconcile.utils.openshift_resource as resource
+import reconcile.utils.oc as oc
+
+
+class TestInitSpecsToFetch(testslide.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.resource_inventory = cast(
+            resource.ResourceInventory,
+            testslide.StrictMock(resource.ResourceInventory)
+        )
+
+        self.oc_map = cast(oc.OC_Map, testslide.StrictMock(oc.OC_Map))
+        self.mock_constructor(oc, 'OC_Map').to_return_value(self.oc_map)
+        self.namespaces = [
+            {
+                "name": "ns1",
+                "managedResourceTypes": ["Template"],
+                "cluster": {"name": "cs1"},
+                "managedResourceNames": [
+                    {"resource": "Template",
+                     "resourceNames": ["tp1", "tp2"],
+                     },
+                    {"resource": "Secret",
+                     "resourceNames": ["sc1"],
+                     }
+                ],
+                "openshiftResources": [
+                    {"provider": "resource",
+                     "path": "/some/path.yml"
+                     }
+                ]
+            }
+        ]
+
+        self.mock_callable(
+            self.resource_inventory, 'initialize_resource_type'
+        ).for_call(
+            'cs1', 'ns1', 'Template'
+        ).to_return_value(None)
+
+        self.mock_callable(
+            self.oc_map, 'get'
+        ).for_call("cs1").to_return_value("stuff")
+        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
+
+    def test_only_cluster_or_namespace(self) -> None:
+        with self.assertRaises(KeyError):
+            sut.init_specs_to_fetch(
+                self.resource_inventory,
+                self.oc_map,
+                [{"foo": "bar"}],
+                [{"name": 'cluster1'}],
+            )
+
+    def test_no_cluster_or_namespace(self) -> None:
+        with self.assertRaises(KeyError):
+            sut.init_specs_to_fetch(self.resource_inventory, self.oc_map)
+
+    def assert_specs_match(
+            self, result: List[sut.StateSpec], expected: List[sut.StateSpec]
+    ) -> None:
+        """Assert that two list of StateSpec are equal. Needed since StateSpec
+        doesn't implement __eq__ and it's not worth to add for we will convert
+        it to a dataclass when we move to Python 3.9"""
+        self.assertEqual(
+            [r.__dict__ for r in result],
+            [e.__dict__ for e in expected],
+        )
+
+    def test_namespaces_managed(self) -> None:
+        expected = [
+            sut.StateSpec(
+                type="current",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource="Template",
+                resource_names=["tp1", "tp2"],
+            ),
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+
+        rs = sut.init_specs_to_fetch(
+                self.resource_inventory,
+                self.oc_map,
+                namespaces=self.namespaces,
+            )
+
+        self.maxDiff = None
+        self.assert_specs_match(rs, expected)
+
+    def test_namespaces_managed_with_overrides(self) -> None:
+        self.namespaces[0]['managedResourceTypeOverrides'] = [
+            {
+                "resource": "Project",
+                "override": "something.project",
+            },
+            {
+                "resource": "Template",
+                "override": "something.template"
+            }
+        ]
+        expected = [
+            sut.StateSpec(
+                type="current",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource="Template",
+                resource_names=["tp1", "tp2"],
+                resource_type_override="something.template",
+            ),
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+
+        self.assert_specs_match(rs, expected)

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -89,6 +89,10 @@ class JobNotRunningError(Exception):
     pass
 
 
+class UnableToApplyError(Exception):
+    pass
+
+
 class OCDecorators:
     @classmethod
     def process_reconcile_time(cls, function):
@@ -713,6 +717,9 @@ class OCDeprecated:
                     if ': primary clusterIP can not be unset' in err:
                         raise PrimaryClusterIPCanNotBeUnsetError(
                             f"[{self.server}]: {err}")
+                    raise UnableToApplyError(
+                        f"[{self.server}: {err}"
+                    )
                 if 'metadata.annotations: Too long' in err:
                     raise MetaDataAnnotationsTooLongApplyError(
                         f"[{self.server}]: {err}")

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -448,12 +448,9 @@ class ResourceInventory:
 
     def add_desired(self, cluster, namespace, resource_type, name, value):
         with self._lock:
-            try:
-                desired = \
-                    (self._clusters[cluster][namespace][resource_type]
-                        ['desired'])
-            except KeyError:
-                return None
+            desired = (self._clusters[cluster][namespace][resource_type]
+                       ['desired'])
+
             if name in desired:
                 raise ResourceKeyExistsError(name)
             desired[name] = value

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -838,13 +838,20 @@ class SaasHerder():
                 )
             except ResourceKeyExistsError:
                 ri.register_error()
-                msg = \
-                    f"[{cluster}/{namespace}] desired item " + \
-                    f"already exists: {resource_kind}/{resource_name}. " + \
-                    f"saas file name: {saas_file_name}, " + \
-                    "resource template name: " + \
-                    f"{process_template_options['resource_template_name']}."
-                logging.error(msg)
+                logging.error(
+                    f"[{cluster}/{namespace}] desired item "
+                    f"already exists: {resource_kind}/{resource_name}. "
+                    f"saas file name: {saas_file_name}, "
+                    "resource template name: "
+                    f"{process_template_options['resource_template_name']}.")
+            except KeyError:
+                ri.register_error()
+                logging.error(
+                    f"[{cluster}/{namespace}] desired item of unexpected "
+                    f"scope: {resource_kind}/{resource_name}. "
+                    f"saas file name: {saas_file_name} "
+                    "resource template name: "
+                    f"{process_template_options['resource_template_name']}.")
 
         return promotion
 

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -783,7 +783,7 @@ class SaasHerder():
         saas_file_name = spec['saas_file_name']
         cluster = spec['cluster']
         namespace = spec['namespace']
-        managed_resource_types = spec['managed_resource_types']
+        managed_resource_types = set(spec['managed_resource_types'])
         process_template_options = spec['process_template_options']
         check_images_options_base = spec['check_images_options_base']
         instance_name = spec['instance_name']
@@ -795,10 +795,22 @@ class SaasHerder():
             ri.register_error()
             return
         # filter resources
-        resources = [resource for resource in resources
-                     if isinstance(resource, dict)
-                     and resource.get('kind') in managed_resource_types]
+        rs = []
+        for r in resources:
+            if isinstance(r, dict):
+                kind = r.get('kind')
+                if kind in managed_resource_types:
+                    resources.append(r)
+                else:
+                    logging.info(
+                        f"Skipping resource of kind {kind} on "
+                        f"{cluster}/{namespace} - {instance_name}"
+                    )
+            else:
+                logging.info("Skipping non-dictionary resource on "
+                             f"{cluster}/{namespace} - {instance_name}")
         # additional processing of resources
+        resources = rs
         self._additional_resource_process(resources, html_url)
         # check images
         skip_check_images = upstream and self.jenkins_map and instance_name \

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -5,6 +5,7 @@ import os
 import shutil
 
 from collections import defaultdict
+from contextlib import suppress
 from threading import Lock
 
 from python_terraform import Terraform, IsFlagged, TerraformCommandError
@@ -273,13 +274,14 @@ class TerraformClient:
                 oc_resource = \
                     self.construct_oc_resource(output_resource_name, data,
                                                account, annotations)
-                ri.add_desired(
-                    cluster,
-                    namespace,
-                    resource,
-                    output_resource_name,
-                    oc_resource
-                )
+                with suppress(KeyError):
+                    ri.add_desired(
+                        cluster,
+                        namespace,
+                        resource,
+                        output_resource_name,
+                        oc_resource
+                    )
 
     @staticmethod
     def get_replicas_info(namespaces):


### PR DESCRIPTION
We were silently skipping resource types we weren't managing, making
troubleshooting misconfigurations very hard.

First, we add type hints to `openshift_base.init_specs_to_fetch`, to
make it easier to understand and to refactor. 

Then, we can log skipped managedResourceNames in this method. This PR
refactors the namespace handling path to achieve that. There are unit
tests to confirm the behaviour is the same as it used to be, but
please have a look and feel free to suggest relevant configurations
that need extra tests.

Next, we raise an exception if `oc.apply`. There is a failure mode in
which an invalid input can be discarded and not raise any exceptions,
we now have a fall-back exception if that happens. I am not sure
unmanaged types can reach the `apply` phase - probably not - but I
found this bug in my investigation and it's trivial to sort out.

Afterwards, `openshift_resources` expects
`ResourceInventory.add_desired` to raise a `KeyError` if it tries to
add for application a resource of a kind that shouldn't be
managed. However, `add_desired` was silently dropping that exception
on the floor, a behaviour all remaining callers expected. So, I have
restored the exception and handled or suppressed it where appropriate.

Finally, saasherder also does its own filtering when processing SaaS
files - until now we've only handled namespaces. So we refactor a loop
in there to have more verbose logging. Writing unit tests for this one
is extremely hard, and the expansion of this list comprehension to a
loop should be easy-ish for a human reviewer to critique.

Fixes https://issues.redhat.com/browse/APPSRE-3668
