### PR TITLE
Disable some linter checks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -58,4 +58,9 @@ disable = attribute-defined-outside-init,
           unused-variable,
           use-a-generator,
           use-dict-literal,
-          use-list-literal
+          use-list-literal,
+          consider-using-f-string,
+          consider-iterating-dictionary,
+          raising-bad-type,
+          global-variable-not-assigned,
+          unsupported-membership-test


### PR DESCRIPTION
They are new in pylint 2.11, and fixing them belongs in a different
PR.
