### PR TITLE
add some typehints to terrascript_client.py

### DIFF
--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -2909,13 +2909,9 @@ class TerrascriptClient:
     # todo: rename to: 'get_names_from_tf_resource()'
     @staticmethod
     def get_dependencies(tf_resources: Iterable[Resource]
-                                    ) -> List[str]:
+                         ) -> List[str]:
         return [f"{tf_resource.__class__.__name__}.{tf_resource._name}"
                 for tf_resource in tf_resources]
-
-    @staticmethod
-    def get_name_from_tf_resource(tf_resource: Resource) -> str:
-        return f"{tf_resource.__class__.__name__}.{tf_resource._name}"
 
     @staticmethod
     def validate_elasticsearch_version(version):

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -2906,7 +2906,6 @@ class TerrascriptClient:
         namespace = namespace_info['name']
         return cluster, namespace
 
-    # todo: rename to: 'get_names_from_tf_resource()'
     @staticmethod
     def get_dependencies(tf_resources: Iterable[Resource]
                          ) -> List[str]:

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -9,6 +9,8 @@ import tempfile
 
 from threading import Lock
 
+from typing import Dict, List, Iterable, Optional
+
 import anymarkup
 import requests
 
@@ -97,7 +99,6 @@ def safe_resource_id(s):
     return s.translate({ord(c): "_" for c in "."})
 
 
-# temporary pending https://github.com/mjuenema/python-terrascript/issues/160
 class aws_ecrpublic_repository(Resource):
     pass
 
@@ -1115,7 +1116,11 @@ class TerrascriptClient:
 
         return False
 
-    def _find_resource_(self, account, source, provider):
+    def _find_resource_(self,
+                        account: str,
+                        source: str,
+                        provider: str
+                        ) -> Optional[Dict[str, Dict[str, Optional[str]]]]:
         if account not in self.account_resources:
             return None
 
@@ -2901,10 +2906,16 @@ class TerrascriptClient:
         namespace = namespace_info['name']
         return cluster, namespace
 
+    # todo: rename to: 'get_names_from_tf_resource()'
     @staticmethod
-    def get_dependencies(tf_resources):
+    def get_dependencies(tf_resources: Iterable[Resource]
+                                    ) -> List[str]:
         return [f"{tf_resource.__class__.__name__}.{tf_resource._name}"
                 for tf_resource in tf_resources]
+
+    @staticmethod
+    def get_name_from_tf_resource(tf_resource: Resource) -> str:
+        return f"{tf_resource.__class__.__name__}.{tf_resource._name}"
 
     @staticmethod
     def validate_elasticsearch_version(version):


### PR DESCRIPTION
For reasons currently unknown to me, [my PR](https://github.com/app-sre/qontract-reconcile/pull/1825) that attempted to refactor a few things seems to have still caused [some issues](https://ci.int.devshift.net/job/service-app-interface-gl-pr-check/85469/artifact/temp/reports/reconcile_reports_fail/reconcile-terraform-users.txt) in our staging environment. So now I am breaking that PR up into even smaller PRs. Starting with this. 

This just adds some type-hints.

MyPy seems happy when ran on this file.
```
$ mypy --ignore-missing-imports --install-types --non-interactive --no-implicit-optional reconcile/utils/terrascript_client.py
Success: no issues found in 1 source file
```