### PR TITLE
Add --skip-tf-provider-list flag

### DIFF
--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -61,7 +61,8 @@ def run(dry_run, thread_pool_size=10,
     settings = queries.get_app_interface_settings()
     aws = AWSApi(thread_pool_size, accounts, settings=settings)
     keys_to_delete = get_keys_to_delete(accounts)
-    working_dirs = init_tf_working_dirs(accounts, thread_pool_size, skip_tf_providers_list, settings)
+    working_dirs = init_tf_working_dirs(accounts, thread_pool_size,
+                                        skip_tf_providers_list, settings)
     defer(lambda: cleanup(working_dirs))
     error = aws.delete_keys(dry_run, keys_to_delete, working_dirs,
                             disable_service_account_keys)

--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -24,7 +24,7 @@ def get_keys_to_delete(accounts):
 
 
 def init_tf_working_dirs(accounts, thread_pool_size,
-                         skip_tf_providers_list,
+                         skip_tf_provider_list,
                          settings):
     # copied here to avoid circular dependency
     QONTRACT_INTEGRATION = 'terraform_resources'
@@ -40,7 +40,7 @@ def init_tf_working_dirs(accounts, thread_pool_size,
                      QONTRACT_TF_PREFIX,
                      thread_pool_size,
                      accounts,
-                     skip_tf_providers_list=skip_tf_providers_list,
+                     skip_tf_provider_list=skip_tf_provider_list,
                      settings=settings)
     return ts.dump()
 
@@ -53,7 +53,7 @@ def cleanup(working_dirs):
 @defer
 def run(dry_run, thread_pool_size=10,
         disable_service_account_keys=False, account_name=None, defer=None,
-        skip_tf_providers_list=None):
+        skip_tf_provider_list=None):
     accounts = filter_accounts(queries.get_aws_accounts(), account_name)
     if not accounts:
         raise ValueError(f"aws account {account_name} not found")
@@ -62,7 +62,7 @@ def run(dry_run, thread_pool_size=10,
     aws = AWSApi(thread_pool_size, accounts, settings=settings)
     keys_to_delete = get_keys_to_delete(accounts)
     working_dirs = init_tf_working_dirs(accounts, thread_pool_size,
-                                        skip_tf_providers_list, settings)
+                                        skip_tf_provider_list, settings)
     defer(lambda: cleanup(working_dirs))
     error = aws.delete_keys(dry_run, keys_to_delete, working_dirs,
                             disable_service_account_keys)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -363,6 +363,14 @@ def enable_deletion(**kwargs):
     return f
 
 
+def skip_tf_provider_list(function):
+    function = click.option('--skip-tf-provider-list',
+                            help='comma-separated list of terraform providers to skip applying.',
+                            default=None)(function)
+
+    return function
+
+
 def send_mails(**kwargs):
     def f(function):
         opt = '--send-mails/--no-send-mails'
@@ -708,10 +716,12 @@ def aws_garbage_collector(ctx, thread_pool_size, io_dir):
 @integration.command()
 @threaded()
 @account_name
+@skip_tf_provider_list
 @click.pass_context
-def aws_iam_keys(ctx, thread_pool_size, account_name):
+def aws_iam_keys(ctx, thread_pool_size, account_name, skip_tf_provider_list):
     run_integration(reconcile.aws_iam_keys, ctx.obj,
-                    thread_pool_size, account_name=account_name)
+                    thread_pool_size, account_name=account_name,
+                    skip_tf_provider_list=skip_tf_provider_list)
 
 
 @integration.command()
@@ -1053,6 +1063,7 @@ def user_validator(ctx):
 @internal()
 @use_jump_host()
 @enable_deletion(default=False)
+@skip_tf_provider_list
 @account_name
 @click.option('--light/--full',
               default=False,
@@ -1060,12 +1071,14 @@ def user_validator(ctx):
 @click.pass_context
 def terraform_resources(ctx, print_only, enable_deletion,
                         io_dir, thread_pool_size, internal, use_jump_host,
-                        light, vault_output_path, account_name):
+                        light, vault_output_path, account_name,
+                        skip_tf_provider_list):
     run_integration(reconcile.terraform_resources,
                     ctx.obj, print_only,
                     enable_deletion, io_dir, thread_pool_size,
                     internal, use_jump_host, light, vault_output_path,
                     account_name=account_name,
+                    skip_tf_provider_list=skip_tf_provider_list,
                     extra_labels=ctx.obj.get('extra_labels', {}))
 
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -366,7 +366,10 @@ def enable_deletion(**kwargs):
 def skip_tf_provider_list(function):
     function = click.option('--skip-tf-provider-list',
                             help='comma-separated list of terraform \
-                                providers to skip applying.',
+                                providers to skip creating or modifying \
+                                resources for. \
+                                (this will not stop terraform from \
+                                DESTROYING resources from any provider!)',
                             default=None)(function)
 
     return function

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -365,7 +365,8 @@ def enable_deletion(**kwargs):
 
 def skip_tf_provider_list(function):
     function = click.option('--skip-tf-provider-list',
-                            help='comma-separated list of terraform providers to skip applying.',
+                            help='comma-separated list of terraform \
+                                providers to skip applying.',
                             default=None)(function)
 
     return function

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -368,8 +368,9 @@ def skip_tf_provider_list(function):
                             help='comma-separated list of terraform \
                                 providers to skip creating or modifying \
                                 resources for. \
-                                (this will not stop terraform from \
-                                DESTROYING resources from any provider!)',
+                                (this will consequently cause terraform to \
+                                DESTROY existing resources from providers \
+                                in this list!)',
                             default=None)(function)
 
     return function

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -133,7 +133,7 @@ def run(dry_run=False, print_only=False,
                      "",
                      thread_pool_size,
                      participating_accounts,
-                     skip_tf_providers_list='',
+                     skip_tf_providers_list=None,
                      settings=settings)
 
     desired_state = build_desired_state(zones)

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -133,7 +133,7 @@ def run(dry_run=False, print_only=False,
                      "",
                      thread_pool_size,
                      participating_accounts,
-                     skip_tf_providers_list=None,
+                     skip_tf_provider_list=None,
                      settings=settings)
 
     desired_state = build_desired_state(zones)

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -133,6 +133,7 @@ def run(dry_run=False, print_only=False,
                      "",
                      thread_pool_size,
                      participating_accounts,
+                     skip_tf_providers_list='',
                      settings=settings)
 
     desired_state = build_desired_state(zones)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -402,7 +402,7 @@ def run(dry_run, print_only=False,
         thread_pool_size=10, internal=None, use_jump_host=True,
         light=False, vault_output_path='',
         account_name=None, extra_labels=None, defer=None,
-        skip_tf_provider_list=''):
+        skip_tf_provider_list=None):
 
     ri, oc_map, tf, tf_namespaces = \
         setup(dry_run, print_only, thread_pool_size, internal,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -302,12 +302,12 @@ def fetch_current_state(dry_run, namespaces, thread_pool_size,
 
 
 def init_working_dirs(accounts, thread_pool_size,
-                      skip_tf_providers_list, oc_map=None, settings=None):
+                      skip_tf_provider_list, oc_map=None, settings=None):
     ts = Terrascript(QONTRACT_INTEGRATION,
                      QONTRACT_TF_PREFIX,
                      thread_pool_size,
                      accounts,
-                     skip_tf_providers_list,
+                     skip_tf_provider_list,
                      oc_map,
                      settings=settings)
     working_dirs = ts.dump()
@@ -315,7 +315,7 @@ def init_working_dirs(accounts, thread_pool_size,
 
 
 def setup(dry_run, print_only, thread_pool_size, internal,
-          use_jump_host, account_name, extra_labels, skip_tf_providers_list):
+          use_jump_host, account_name, extra_labels, skip_tf_provider_list):
     gqlapi = gql.get_api()
     accounts = queries.get_aws_accounts()
     if account_name:
@@ -332,7 +332,7 @@ def setup(dry_run, print_only, thread_pool_size, internal,
     ts, working_dirs = \
         init_working_dirs(accounts,
                           thread_pool_size,
-                          skip_tf_providers_list=skip_tf_providers_list,
+                          skip_tf_provider_list=skip_tf_provider_list,
                           oc_map=oc_map,
                           settings=settings)
     tf = Terraform(QONTRACT_INTEGRATION,
@@ -406,7 +406,8 @@ def run(dry_run, print_only=False,
 
     ri, oc_map, tf, tf_namespaces = \
         setup(dry_run, print_only, thread_pool_size, internal,
-              use_jump_host, account_name, extra_labels, skip_tf_provider_list)
+              use_jump_host, account_name, skip_tf_provider_list,
+              extra_labels)
 
     if not dry_run:
         defer(lambda: oc_map.cleanup())

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -307,15 +307,15 @@ def init_working_dirs(accounts, thread_pool_size,
                      QONTRACT_TF_PREFIX,
                      thread_pool_size,
                      accounts,
-                     skip_tf_provider_list,
-                     oc_map,
+                     skip_tf_provider_list=skip_tf_provider_list,
+                     oc_map=oc_map,
                      settings=settings)
     working_dirs = ts.dump()
     return ts, working_dirs
 
 
 def setup(dry_run, print_only, thread_pool_size, internal,
-          use_jump_host, account_name, extra_labels, skip_tf_provider_list):
+          use_jump_host, account_name, skip_tf_provider_list, extra_labels):
     gqlapi = gql.get_api()
     accounts = queries.get_aws_accounts()
     if account_name:

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -302,14 +302,14 @@ def fetch_current_state(dry_run, namespaces, thread_pool_size,
 
 
 def init_working_dirs(accounts, thread_pool_size,
-                      oc_map=None, settings=None, skip_tf_providers_list):
+                      skip_tf_providers_list, oc_map=None, settings=None):
     ts = Terrascript(QONTRACT_INTEGRATION,
                      QONTRACT_TF_PREFIX,
                      thread_pool_size,
                      accounts,
+                     skip_tf_providers_list,
                      oc_map,
-                     settings=settings,
-                     skip_tf_providers_list)
+                     settings=settings)
     working_dirs = ts.dump()
     return ts, working_dirs
 
@@ -329,10 +329,12 @@ def setup(dry_run, print_only, thread_pool_size, internal,
     tf_namespaces = filter_tf_namespaces(namespaces, account_name)
     ri, oc_map = fetch_current_state(dry_run, tf_namespaces, thread_pool_size,
                                      internal, use_jump_host, account_name)
-    ts, working_dirs = init_working_dirs(accounts, thread_pool_size,
-                                         oc_map=oc_map,
-                                         settings=settings,
-                                         skip_tf_providers_list)
+    ts, working_dirs = \
+        init_working_dirs(accounts,
+                          thread_pool_size,
+                          skip_tf_providers_list=skip_tf_providers_list,
+                          oc_map=oc_map,
+                          settings=settings)
     tf = Terraform(QONTRACT_INTEGRATION,
                    QONTRACT_INTEGRATION_VERSION,
                    QONTRACT_TF_PREFIX,
@@ -347,6 +349,7 @@ def setup(dry_run, print_only, thread_pool_size, internal,
                          settings=settings)
     else:
         ocm_map = None
+
     ts.populate_resources(tf_namespaces, existing_secrets, account_name,
                           ocm_map=ocm_map)
     ts.dump(print_only, existing_dirs=working_dirs)
@@ -403,7 +406,7 @@ def run(dry_run, print_only=False,
 
     ri, oc_map, tf, tf_namespaces = \
         setup(dry_run, print_only, thread_pool_size, internal,
-              use_jump_host, account_name, extra_labels)
+              use_jump_host, account_name, extra_labels, skip_tf_provider_list)
 
     if not dry_run:
         defer(lambda: oc_map.cleanup())

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -440,7 +440,8 @@ def run(dry_run, print_only=False,
 
     disable_keys(dry_run, thread_pool_size,
                  disable_service_account_keys=True,
-                 account_name=account_name)
+                 account_name=account_name,
+                 skip_tf_provider_list=skip_tf_provider_list)
 
     if actions and vault_output_path:
         write_outputs_to_vault(vault_output_path, ri)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -302,19 +302,20 @@ def fetch_current_state(dry_run, namespaces, thread_pool_size,
 
 
 def init_working_dirs(accounts, thread_pool_size,
-                      oc_map=None, settings=None):
+                      oc_map=None, settings=None, skip_tf_providers_list):
     ts = Terrascript(QONTRACT_INTEGRATION,
                      QONTRACT_TF_PREFIX,
                      thread_pool_size,
                      accounts,
                      oc_map,
-                     settings=settings)
+                     settings=settings,
+                     skip_tf_providers_list)
     working_dirs = ts.dump()
     return ts, working_dirs
 
 
 def setup(dry_run, print_only, thread_pool_size, internal,
-          use_jump_host, account_name, extra_labels):
+          use_jump_host, account_name, extra_labels, skip_tf_providers_list):
     gqlapi = gql.get_api()
     accounts = queries.get_aws_accounts()
     if account_name:
@@ -330,7 +331,8 @@ def setup(dry_run, print_only, thread_pool_size, internal,
                                      internal, use_jump_host, account_name)
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size,
                                          oc_map=oc_map,
-                                         settings=settings)
+                                         settings=settings,
+                                         skip_tf_providers_list)
     tf = Terraform(QONTRACT_INTEGRATION,
                    QONTRACT_INTEGRATION_VERSION,
                    QONTRACT_TF_PREFIX,
@@ -396,7 +398,8 @@ def run(dry_run, print_only=False,
         enable_deletion=False, io_dir='throughput/',
         thread_pool_size=10, internal=None, use_jump_host=True,
         light=False, vault_output_path='',
-        account_name=None, extra_labels=None, defer=None):
+        account_name=None, extra_labels=None, defer=None,
+        skip_tf_provider_list=''):
 
     ri, oc_map, tf, tf_namespaces = \
         setup(dry_run, print_only, thread_pool_size, internal,

--- a/reconcile/terraform_resources_wrapper.py
+++ b/reconcile/terraform_resources_wrapper.py
@@ -37,8 +37,8 @@ def tfr_run_wrapper(account_name,
                     use_jump_host,
                     light,
                     vault_output_path,
-                    extra_labels,
-                    skip_tf_provider_list):
+                    skip_tf_provider_list,
+                    extra_labels):
     exit_code = 0
     try:
         tfr.run(dry_run=dry_run,
@@ -51,8 +51,8 @@ def tfr_run_wrapper(account_name,
                 light=light,
                 vault_output_path=vault_output_path,
                 account_name=account_name,
-                extra_labels=extra_labels,
-                skip_tf_provider_list=skip_tf_provider_list)
+                skip_tf_provider_list=skip_tf_provider_list,
+                extra_labels=extra_labels)
     except SystemExit as e:
         exit_code = e.code
     return exit_code
@@ -61,8 +61,9 @@ def tfr_run_wrapper(account_name,
 def run(dry_run, print_only=False,
         enable_deletion=False, io_dir='throughput/',
         thread_pool_size=10, internal=None, use_jump_host=True,
-        light=False, vault_output_path='', extra_labels=None,
-        skip_tf_provider_list=''):
+        light=False, vault_output_path='',
+        skip_tf_provider_list=None,
+        extra_labels=None):
     account_names = [
         name for index, name in enumerate(sorted(get_accounts_names()))
         if is_in_shard_round_robin(name, index)
@@ -83,8 +84,8 @@ def run(dry_run, print_only=False,
         use_jump_host=use_jump_host,
         light=light,
         vault_output_path=vault_output_path,
-        extra_labels=extra_labels,
-        skip_tf_provider_list=skip_tf_provider_list
+        skip_tf_provider_list=skip_tf_provider_list,
+        extra_labels=extra_labels
     )
 
     if any(exit_codes):

--- a/reconcile/terraform_resources_wrapper.py
+++ b/reconcile/terraform_resources_wrapper.py
@@ -22,7 +22,7 @@ def get_accounts_names():
                      tfr.QONTRACT_INTEGRATION_VERSION,
                      1,
                      accounts,
-                     skip_tf_providers_list=None,
+                     skip_tf_provider_list=None,
                      settings=settings)
     return ts.uids.keys()
 

--- a/reconcile/terraform_resources_wrapper.py
+++ b/reconcile/terraform_resources_wrapper.py
@@ -22,7 +22,7 @@ def get_accounts_names():
                      tfr.QONTRACT_INTEGRATION_VERSION,
                      1,
                      accounts,
-                     skip_tf_providers_list='',
+                     skip_tf_providers_list=None,
                      settings=settings)
     return ts.uids.keys()
 

--- a/reconcile/terraform_resources_wrapper.py
+++ b/reconcile/terraform_resources_wrapper.py
@@ -22,6 +22,7 @@ def get_accounts_names():
                      tfr.QONTRACT_INTEGRATION_VERSION,
                      1,
                      accounts,
+                     skip_tf_providers_list='',
                      settings=settings)
     return ts.uids.keys()
 

--- a/reconcile/terraform_resources_wrapper.py
+++ b/reconcile/terraform_resources_wrapper.py
@@ -36,7 +36,8 @@ def tfr_run_wrapper(account_name,
                     use_jump_host,
                     light,
                     vault_output_path,
-                    extra_labels):
+                    extra_labels,
+                    skip_tf_provider_list):
     exit_code = 0
     try:
         tfr.run(dry_run=dry_run,
@@ -49,7 +50,8 @@ def tfr_run_wrapper(account_name,
                 light=light,
                 vault_output_path=vault_output_path,
                 account_name=account_name,
-                extra_labels=extra_labels)
+                extra_labels=extra_labels,
+                skip_tf_provider_list=skip_tf_provider_list)
     except SystemExit as e:
         exit_code = e.code
     return exit_code
@@ -58,7 +60,8 @@ def tfr_run_wrapper(account_name,
 def run(dry_run, print_only=False,
         enable_deletion=False, io_dir='throughput/',
         thread_pool_size=10, internal=None, use_jump_host=True,
-        light=False, vault_output_path='', extra_labels=None):
+        light=False, vault_output_path='', extra_labels=None,
+        skip_tf_provider_list=''):
     account_names = [
         name for index, name in enumerate(sorted(get_accounts_names()))
         if is_in_shard_round_robin(name, index)
@@ -80,6 +83,7 @@ def run(dry_run, print_only=False,
         light=light,
         vault_output_path=vault_output_path,
         extra_labels=extra_labels,
+        skip_tf_provider_list=skip_tf_provider_list
     )
 
     if any(exit_codes):

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -54,7 +54,7 @@ def setup(print_only, thread_pool_size):
                      QONTRACT_TF_PREFIX,
                      thread_pool_size,
                      accounts,
-                     skip_tf_providers_list=None,
+                     skip_tf_provider_list=None,
                      settings=settings)
     err = ts.populate_users(tf_roles)
     if err:

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -49,11 +49,12 @@ def setup(print_only, thread_pool_size):
     tf_roles = [r for r in roles
                 if r['aws_groups'] is not None
                 or r['user_policies'] is not None]
+
     ts = Terrascript(QONTRACT_INTEGRATION,
                      QONTRACT_TF_PREFIX,
                      thread_pool_size,
                      accounts,
-                     skip_tf_providers_list='',
+                     skip_tf_providers_list=None,
                      settings=settings)
     err = ts.populate_users(tf_roles)
     if err:

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -53,6 +53,7 @@ def setup(print_only, thread_pool_size):
                      QONTRACT_TF_PREFIX,
                      thread_pool_size,
                      accounts,
+                     skip_tf_providers_list='',
                      settings=settings)
     err = ts.populate_users(tf_roles)
     if err:

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -430,7 +430,7 @@ def run(dry_run, print_only=False,
         "",
         thread_pool_size,
         accounts,
-        skip_tf_providers_list=None,
+        skip_tf_provider_list=None,
         settings=settings)
     ts.populate_additional_providers(participating_accounts)
     ts.populate_vpc_peerings(desired_state)

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -430,7 +430,7 @@ def run(dry_run, print_only=False,
         "",
         thread_pool_size,
         accounts,
-        skip_tf_providers_list='',
+        skip_tf_providers_list=None,
         settings=settings)
     ts.populate_additional_providers(participating_accounts)
     ts.populate_vpc_peerings(desired_state)

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -430,6 +430,7 @@ def run(dry_run, print_only=False,
         "",
         thread_pool_size,
         accounts,
+        skip_tf_providers_list='',
         settings=settings)
     ts.populate_additional_providers(participating_accounts)
     ts.populate_vpc_peerings(desired_state)

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -105,7 +105,8 @@ class aws_ecrpublic_repository(Resource):
 
 class TerrascriptClient:
     def __init__(self, integration, integration_prefix,
-                 thread_pool_size, accounts, oc_map=None, settings=None, skip_tf_providers_list):
+                 thread_pool_size, accounts, skip_tf_providers_list=None,
+                 oc_map=None, settings=None):
         self.integration = integration
         self.integration_prefix = integration_prefix
         self.oc_map = oc_map

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -155,8 +155,10 @@ class TerrascriptClient:
         self.default_regions = {a['name']: a['resourcesDefaultRegion']
                                 for a in filtered_accounts}
         github_config = get_config()['github']
-        if 'cloudwatch' not in self.skip_tf_providers_list:
-            self.token = github_config['app-sre']['token']
+        # if 'cloudwatch' not in self.skip_tf_providers_list:
+        self.token = github_config['app-sre']['token']
+        print('here is token')
+        print(self.token)
         self.logtoes_zip = ''
 
     def get_logtoes_zip(self, release_url):

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -116,6 +116,8 @@ class TerrascriptClient:
         self.skip_tf_provider_list = []
         if skip_tf_provider_list:
             self.skip_tf_provider_list = skip_tf_provider_list.split(',')
+        logging.debug('skipping the following terraform providers:')
+        logging.debug(self.skip_tf_provider_list)
 
         self.secret_reader = SecretReader(settings=settings)
         self.populate_configs(filtered_accounts)
@@ -159,8 +161,6 @@ class TerrascriptClient:
         self.default_regions = {a['name']: a['resourcesDefaultRegion']
                                 for a in filtered_accounts}
 
-        print('here is skip_tf_provider_list')
-        print(self.skip_tf_provider_list)
         if 'cloudwatch' not in self.skip_tf_provider_list:
             github_config = get_config()['github']
             self.token = github_config['app-sre']['token']

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -105,7 +105,7 @@ class aws_ecrpublic_repository(Resource):
 
 class TerrascriptClient:
     def __init__(self, integration, integration_prefix,
-                 thread_pool_size, accounts, skip_tf_providers_list=None,
+                 thread_pool_size, accounts, skip_tf_provider_list=None,
                  oc_map=None, settings=None):
         self.integration = integration
         self.integration_prefix = integration_prefix
@@ -113,9 +113,9 @@ class TerrascriptClient:
         self.thread_pool_size = thread_pool_size
         filtered_accounts = self.filter_disabled_accounts(accounts)
 
-        self.skip_tf_providers_list = []
-        if skip_tf_providers_list:
-            self.skip_tf_providers_list = skip_tf_providers_list.split(',')
+        self.skip_tf_provider_list = []
+        if skip_tf_provider_list:
+            self.skip_tf_provider_list = skip_tf_provider_list.split(',')
 
         self.secret_reader = SecretReader(settings=settings)
         self.populate_configs(filtered_accounts)
@@ -159,9 +159,9 @@ class TerrascriptClient:
         self.default_regions = {a['name']: a['resourcesDefaultRegion']
                                 for a in filtered_accounts}
 
-        print('here is skip_tf_providers_list')
-        print(skip_tf_providers_list)
-        if 'cloudwatch' not in self.skip_tf_providers_list:
+        print('here is skip_tf_provider_list')
+        print(skip_tf_provider_list)
+        if 'cloudwatch' not in self.skip_tf_provider_list:
             github_config = get_config()['github']
             self.token = github_config['app-sre']['token']
             self.logtoes_zip = ''
@@ -803,9 +803,9 @@ class TerrascriptClient:
         resource = populate_spec['resource']
         namespace_info = populate_spec['namespace_info']
         provider = resource['provider']
-        if provider in self.skip_tf_providers_list:
+        if provider in self.skip_tf_provider_list:
             logging.warning(f'skipped populating tf resource {resource} \
-             because its provider {provider} is in skip_tf_providers_list')
+             because its provider {provider} is in skip_tf_provider_list')
         elif provider == 'rds':
             self.populate_tf_resource_rds(resource, namespace_info,
                                           existing_secrets)

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -112,7 +112,11 @@ class TerrascriptClient:
         self.oc_map = oc_map
         self.thread_pool_size = thread_pool_size
         filtered_accounts = self.filter_disabled_accounts(accounts)
-        self.skip_tf_providers_list = skip_tf_providers_list.split(',')
+
+        self.skip_tf_providers_list = []
+        if skip_tf_providers_list:
+            self.skip_tf_providers_list = skip_tf_providers_list.split(',')
+
         self.secret_reader = SecretReader(settings=settings)
         self.populate_configs(filtered_accounts)
         self.versions = {a['name']: a['providerVersion']
@@ -154,12 +158,13 @@ class TerrascriptClient:
         self.uids = {a['name']: a['uid'] for a in filtered_accounts}
         self.default_regions = {a['name']: a['resourcesDefaultRegion']
                                 for a in filtered_accounts}
-        github_config = get_config()['github']
-        # if 'cloudwatch' not in self.skip_tf_providers_list:
-        self.token = github_config['app-sre']['token']
-        print('here is token')
-        print(self.token)
-        self.logtoes_zip = ''
+
+        print('here is skip_tf_providers_list')
+        print(skip_tf_providers_list)
+        if 'cloudwatch' not in self.skip_tf_providers_list:
+            github_config = get_config()['github']
+            self.token = github_config['app-sre']['token']
+            self.logtoes_zip = ''
 
     def get_logtoes_zip(self, release_url):
         if not self.logtoes_zip:

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -160,7 +160,7 @@ class TerrascriptClient:
                                 for a in filtered_accounts}
 
         print('here is skip_tf_provider_list')
-        print(skip_tf_provider_list)
+        print(self.skip_tf_provider_list)
         if 'cloudwatch' not in self.skip_tf_provider_list:
             github_config = get_config()['github']
             self.token = github_config['app-sre']['token']


### PR DESCRIPTION
Adds flag `--skip-tf-provider-list` which accepts a comma-seperated list of terraform providers that qontract-reconcile should skip doing anything with.

Currently supports only the `terraform_resources` and `aws_iam_keys` integrations.

The primary motivation for this is to provide a more convenient way of dealing with [this line of code](https://github.com/app-sre/qontract-reconcile/blob/b3366922af4231074c748a832a0243e096eeeac2/reconcile/utils/terrascript_client.py#L156). A 'GitHub config' from graphQL is only involved with managing cloudwatch tf-resources. Previously, I had been commenting out that line of code when testing non-cloudwatch tf-resource integrations. It got annoying making sure I didn't accidentally commit that.

With this PR, I can locally run non-cloudwatch tf-resources integrations like this:

` qontract-reconcile --config $QR_DEV_CONFIG terraform-resources --skip-tf-provider-list=cloudwatch`