### PR TITLE
terraform_aws_route53: safe_resource_id should sanitize * characters

### DIFF
--- a/reconcile/test/test_terrascript_client_utils.py
+++ b/reconcile/test/test_terrascript_client_utils.py
@@ -1,0 +1,17 @@
+from unittest import TestCase
+import reconcile.utils.terrascript_client as tsclient
+
+
+class TestSupportFunctions(TestCase):
+
+    def test_sanitize_resource_with_dots(self):
+        self.assertEqual(
+            tsclient.safe_resource_id("foo.example.com"),
+            "foo_example_com"
+        )
+
+    def test_sanitize_resource_with_wildcard(self):
+        self.assertEqual(
+            tsclient.safe_resource_id("*.foo.example.com"),
+            "_star_foo_example_com"
+        )

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -103,7 +103,9 @@ class UnknownProviderError(Exception):
 
 def safe_resource_id(s):
     """Sanitize a string into a valid terraform resource id"""
-    return s.translate({ord(c): "_" for c in "."})
+    res = s.translate({ord(c): "_" for c in "."})
+    res = res.replace("*", "_star")
+    return res
 
 
 class aws_ecrpublic_repository(Resource):


### PR DESCRIPTION
Because the integration uses the record name to build the terraform resource ID we need to sanitize * characters such that the resulting resource ID is valid

Ref APPSRE-3776