### PR TITLE
Ignore expected invalid_users errors

### DIFF
--- a/reconcile/test/test_utils_slack_api.py
+++ b/reconcile/test/test_utils_slack_api.py
@@ -154,6 +154,33 @@ def test_get_user_id_by_name_reraise(get_config_mock, slack_api):
     with pytest.raises(SlackApiError):
         slack_api.client.get_user_id_by_name('someuser')
 
+
+def test_update_usergroups_users_empty_no_raise(mocker, slack_api):
+    """
+    invalid_users errors shouldn't be raised because providing an empty
+    list is actually removing users from the usergroup.
+    """
+    mocker.patch.object(SlackApi, 'get_random_deleted_user', autospec=True)
+
+    slack_api.mock_slack_client.return_value.usergroups_users_update\
+        .side_effect = SlackApiError('Some error message',
+                                     {'error': 'invalid_users'})
+
+    slack_api.client.update_usergroup_users('ABCD', [])
+
+
+def test_update_usergroups_users_raise(slack_api):
+    """
+    Any errors other than invalid_users should result in an exception being
+    raised.
+    """
+    slack_api.mock_slack_client.return_value.usergroups_users_update \
+        .side_effect = SlackApiError('Some error message',
+                                     {'error': 'internal_error'})
+
+    with pytest.raises(SlackApiError):
+        slack_api.client.update_usergroup_users('ABCD', ['USERA'])
+
 #
 # Slack WebClient retry tests
 #

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -164,7 +164,13 @@ class SlackApi:
         if len(users_list) == 0:
             users_list = [self.get_random_deleted_user()]
 
-        self._sc.usergroups_users_update(usergroup=id, users=users_list)
+        try:
+            self._sc.usergroups_users_update(usergroup=id, users=users_list)
+        except SlackApiError as e:
+            # Slack can throw an invalid_users error when emptying groups, but
+            # it will still empty the group (so this can be ignored).
+            if e.response['error'] != 'invalid_users':
+                raise
 
     def get_random_deleted_user(self):
         for user_id, user_data in self._get('users').items():


### PR DESCRIPTION
This fixes a regression from #1824 that was missed due to refactoring
of tests. The current impact is only that a single error message is
displayed each time we empty a group.