### PR TITLE
Re-add logging of skipped managedResourceTypes

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -61,7 +61,8 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
     elif namespaces:
         for namespace_info in namespaces:
             if override_managed_types is None:
-                managed_types = set(namespace_info.get(managed_types_key, []))
+                managed_types = set(namespace_info.get(managed_types_key)
+                                    or [])
             else:
                 managed_types = set(override_managed_types)
 
@@ -77,10 +78,11 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
                 continue
 
             namespace = namespace_info['name']
+            # These may exit but have a value of None
             managed_resource_names = \
-                namespace_info.get('managedResourceNames', [])
+                namespace_info.get('managedResourceNames') or []
             managed_resource_type_overrides = \
-                namespace_info.get('managedResourceTypeOverrides', [])
+                namespace_info.get('managedResourceTypeOverrides') or []
 
             # Initialize current state specs
             for resource_type in managed_types:

--- a/reconcile/openshift_limitranges.py
+++ b/reconcile/openshift_limitranges.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 
+from contextlib import suppress
 
 import reconcile.queries as queries
 import reconcile.openshift_base as ob
@@ -75,13 +76,14 @@ def add_desired_state(namespaces, ri, oc_map):
         if 'resources' not in namespace:
             continue
         for resource in namespace["resources"]:
-            ri.add_desired(
-                namespace['cluster']['name'],
-                namespace['name'],
-                resource.kind,
-                resource.name,
-                resource
-            )
+            with suppress(KeyError):
+                ri.add_desired(
+                    namespace['cluster']['name'],
+                    namespace['name'],
+                    resource.kind,
+                    resource.name,
+                    resource
+                )
 
 
 @defer

--- a/reconcile/openshift_network_policies.py
+++ b/reconcile/openshift_network_policies.py
@@ -1,6 +1,8 @@
 import sys
 import logging
 
+from contextlib import suppress
+
 import reconcile.utils.gql as gql
 import reconcile.openshift_base as ob
 
@@ -98,13 +100,14 @@ def fetch_desired_state(namespaces, ri, oc_map):
             resource_name = "allow-from-{}-namespace".format(source_namespace)
             oc_resource = \
                 construct_oc_resource(resource_name, source_namespace)
-            ri.add_desired(
-                cluster,
-                namespace,
-                'NetworkPolicy',
-                resource_name,
-                oc_resource
-            )
+            with suppress(KeyError):
+                ri.add_desired(
+                    cluster,
+                    namespace,
+                    'NetworkPolicy',
+                    resource_name,
+                    oc_resource
+                )
 
 
 @defer

--- a/reconcile/openshift_resourcequotas.py
+++ b/reconcile/openshift_resourcequotas.py
@@ -2,6 +2,7 @@ import collections
 import logging
 import sys
 
+from contextlib import suppress
 
 import reconcile.queries as queries
 import reconcile.openshift_base as ob
@@ -53,13 +54,14 @@ def fetch_desired_state(namespaces, ri, oc_map):
         for quota in quotas:
             quota_name = quota['name']
             quota_resource = construct_resource(quota)
-            ri.add_desired(
-                cluster,
-                namespace,
-                'ResourceQuota',
-                quota_name,
-                quota_resource
-            )
+            with suppress(KeyError):
+                ri.add_desired(
+                    cluster,
+                    namespace,
+                    'ResourceQuota',
+                    quota_name,
+                    quota_resource
+                )
 
 
 @defer

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -135,7 +135,7 @@ def fetch_desired_state(ri, oc_map):
                         resource_name,
                         oc_resource
                     )
-                except ResourceKeyExistsError:
+                except (KeyError, ResourceKeyExistsError):
                     # a user may have a Role assigned to them
                     # from multiple app-interface roles
                     pass

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -145,3 +145,37 @@ class TestInitSpecsToFetch(testslide.TestCase):
         )
 
         self.assert_specs_match(rs, expected)
+
+    def test_namespaces_no_managedresourcenames(self) -> None:
+        self.namespaces[0]['managedResourceNames'] = None
+        self.namespaces[0]['managedResourceTypeOverrides'] = None
+
+        expected = [
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+        self.assert_specs_match(rs, expected)
+
+    def test_namespaces_no_managedresourcetypes(self) -> None:
+        self.namespaces[0]['managedResourceTypes'] = None
+
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+        self.assertEqual(rs, [])

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -1,0 +1,147 @@
+from typing import List, cast
+
+import testslide
+import reconcile.openshift_base as sut
+import reconcile.utils.openshift_resource as resource
+import reconcile.utils.oc as oc
+
+
+class TestInitSpecsToFetch(testslide.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.resource_inventory = cast(
+            resource.ResourceInventory,
+            testslide.StrictMock(resource.ResourceInventory)
+        )
+
+        self.oc_map = cast(oc.OC_Map, testslide.StrictMock(oc.OC_Map))
+        self.mock_constructor(oc, 'OC_Map').to_return_value(self.oc_map)
+        self.namespaces = [
+            {
+                "name": "ns1",
+                "managedResourceTypes": ["Template"],
+                "cluster": {"name": "cs1"},
+                "managedResourceNames": [
+                    {"resource": "Template",
+                     "resourceNames": ["tp1", "tp2"],
+                     },
+                    {"resource": "Secret",
+                     "resourceNames": ["sc1"],
+                     }
+                ],
+                "openshiftResources": [
+                    {"provider": "resource",
+                     "path": "/some/path.yml"
+                     }
+                ]
+            }
+        ]
+
+        self.mock_callable(
+            self.resource_inventory, 'initialize_resource_type'
+        ).for_call(
+            'cs1', 'ns1', 'Template'
+        ).to_return_value(None)
+
+        self.mock_callable(
+            self.oc_map, 'get'
+        ).for_call("cs1").to_return_value("stuff")
+        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
+
+    def test_only_cluster_or_namespace(self) -> None:
+        with self.assertRaises(KeyError):
+            sut.init_specs_to_fetch(
+                self.resource_inventory,
+                self.oc_map,
+                [{"foo": "bar"}],
+                [{"name": 'cluster1'}],
+            )
+
+    def test_no_cluster_or_namespace(self) -> None:
+        with self.assertRaises(KeyError):
+            sut.init_specs_to_fetch(self.resource_inventory, self.oc_map)
+
+    def assert_specs_match(
+            self, result: List[sut.StateSpec], expected: List[sut.StateSpec]
+    ) -> None:
+        """Assert that two list of StateSpec are equal. Needed since StateSpec
+        doesn't implement __eq__ and it's not worth to add for we will convert
+        it to a dataclass when we move to Python 3.9"""
+        self.assertEqual(
+            [r.__dict__ for r in result],
+            [e.__dict__ for e in expected],
+        )
+
+    def test_namespaces_managed(self) -> None:
+        expected = [
+            sut.StateSpec(
+                type="current",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource="Template",
+                resource_names=["tp1", "tp2"],
+            ),
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+
+        rs = sut.init_specs_to_fetch(
+                self.resource_inventory,
+                self.oc_map,
+                namespaces=self.namespaces,
+            )
+
+        self.maxDiff = None
+        self.assert_specs_match(rs, expected)
+
+    def test_namespaces_managed_with_overrides(self) -> None:
+        self.namespaces[0]['managedResourceTypeOverrides'] = [
+            {
+                "resource": "Project",
+                "override": "something.project",
+            },
+            {
+                "resource": "Template",
+                "override": "something.template"
+            }
+        ]
+        expected = [
+            sut.StateSpec(
+                type="current",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource="Template",
+                resource_names=["tp1", "tp2"],
+                resource_type_override="something.template",
+            ),
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+
+        self.assert_specs_match(rs, expected)

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -93,6 +93,10 @@ class JobNotRunningError(Exception):
     pass
 
 
+class UnableToApplyError(Exception):
+    pass
+
+
 class OCDecorators:
     @classmethod
     def process_reconcile_time(cls, function):
@@ -730,6 +734,9 @@ class OCDeprecated:
                     if ': primary clusterIP can not be unset' in err:
                         raise PrimaryClusterIPCanNotBeUnsetError(
                             f"[{self.server}]: {err}")
+                    raise UnableToApplyError(
+                        f"[{self.server}: {err}"
+                    )
                 if 'metadata.annotations: Too long' in err:
                     raise MetaDataAnnotationsTooLongApplyError(
                         f"[{self.server}]: {err}")

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -448,12 +448,9 @@ class ResourceInventory:
 
     def add_desired(self, cluster, namespace, resource_type, name, value):
         with self._lock:
-            try:
-                desired = \
-                    (self._clusters[cluster][namespace][resource_type]
-                        ['desired'])
-            except KeyError:
-                return None
+            desired = (self._clusters[cluster][namespace][resource_type]
+                       ['desired'])
+
             if name in desired:
                 raise ResourceKeyExistsError(name)
             desired[name] = value

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -5,6 +5,7 @@ import os
 import shutil
 
 from collections import defaultdict
+from contextlib import suppress
 from threading import Lock
 
 from python_terraform import Terraform, IsFlagged, TerraformCommandError
@@ -273,13 +274,14 @@ class TerraformClient:
                 oc_resource = \
                     self.construct_oc_resource(output_resource_name, data,
                                                account, annotations)
-                ri.add_desired(
-                    cluster,
-                    namespace,
-                    resource,
-                    output_resource_name,
-                    oc_resource
-                )
+                with suppress(KeyError):
+                    ri.add_desired(
+                        cluster,
+                        namespace,
+                        resource,
+                        output_resource_name,
+                        oc_resource
+                    )
 
     @staticmethod
     def get_replicas_info(namespaces):


### PR DESCRIPTION
When managedResourceNames or managedResourceTypeOverride are empty,
the graphql query still returns the field, but its value is None.
    
We handle it correctly now. I have added a unit test as well.
