### PR TITLE
[terraform-resources] LB target group should be HTTP2

### DIFF
--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3357,6 +3357,7 @@ class TerrascriptClient:
                 'name': target_name,
                 'port': 443,
                 'protocol': 'HTTPS',
+                'protocol_version': 'HTTP2',
                 'target_type': 'ip',
                 'vpc_id': vpc_id,
                 'health_check': {


### PR DESCRIPTION
For the current use case, the target ELB/App is expecting HTTP2 traffic