### PR TITLE
[terraform-resources] add support for ca_cert output in RDS secret

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -36,6 +36,11 @@ provider
   replica_source
   output_resource_db_name
   reset_password
+  ca_cert {
+    path
+    field
+    version
+  }
   annotations
 }
 ... on NamespaceTerraformResourceS3_v1 {

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -270,6 +270,17 @@ class TerraformClient:
                     self.integration_prefix)]
                 annotations = data.get('{}_annotations'.format(
                     self.integration_prefix))
+                # add special handling for ca_cert
+                # which is saved base64 encoded in terrafor state.
+                # we decode it because construct_oc_resource
+                # will encode it again.
+                # if we find more examples that require this treatment
+                # we will need to hanle it in a more generic way
+                ca_cert_key = f'{self.integration_prefix}__ca_cert'
+                ca_cert = data.get(ca_cert_key)
+                if ca_cert:
+                    data[ca_cert_key] = base64.b64decode(ca_cert)
+
                 oc_resource = \
                     self.construct_oc_resource(output_resource_name, data,
                                                account, annotations)

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -271,7 +271,7 @@ class TerraformClient:
                 annotations = data.get('{}_annotations'.format(
                     self.integration_prefix))
                 # add special handling for ca_cert
-                # which is saved base64 encoded in terrafor state.
+                # which is saved base64 encoded in terraform state.
                 # we decode it because construct_oc_resource
                 # will encode it again.
                 # if we find more examples that require this treatment

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -87,7 +87,7 @@ GH_BASE_URL = os.environ.get('GITHUB_API', 'https://api.github.com')
 LOGTOES_RELEASE = 'repos/app-sre/logs-to-elasticsearch-lambda/releases/latest'
 VARIABLE_KEYS = ['region', 'availability_zone', 'parameter_group',
                  'enhanced_monitoring', 'replica_source',
-                 'output_resource_db_name', 'reset_password',
+                 'output_resource_db_name', 'reset_password', 'ca_cert',
                  'sqs_identifier', 's3_events', 'bucket_policy',
                  'storage_class', 'kms_encryption',
                  'variables', 'policies', 'user_policy',
@@ -979,6 +979,14 @@ class TerrascriptClient:
         else:
             password = ""
         values['password'] = password
+
+        ca_cert = values.pop('ca_cert', None)
+        if ca_cert:
+            # db.ca_cert
+            output_name_0_13 = output_prefix + '__ca_cert'
+            certificate = self.secret_reader.read(ca_cert)
+            output_value = base64.b64encode(certificate.encode()).decode()
+            tf_resources.append(Output(output_name_0_13, value=output_value))
 
         region = self._region_from_availability_zone_(
             az) or self.default_regions.get(account)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3785

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/25874

this PR adds support to define a `ca_cert` in an RDS definition. this will lead to an additional key in the output Secret containing the content of the specified key in a vault secret.

this is a generic way to provide the global CA certificate for usage with AWS RDS databases.