### PR TITLE
Fix missing error key in GH exception

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -271,7 +271,7 @@ class SaasHerder():
         except GithubException as e:
             # slightly copied with love from
             # https://github.com/PyGithub/PyGithub/issues/661
-            errors = e.data['errors']
+            errors = e.data.get('errors', [])
             # example errors dict that we are looking for
             # {
             #    'message': '<text>',


### PR DESCRIPTION
We cannot assume errors is always going to appear. It is not there when
the GH error is a 404.

Related to https://issues.redhat.com/browse/APPSRE-3838

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>