### PR TITLE
terrascript_client: alb security group egress rules

### DIFF
--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3330,6 +3330,25 @@ class TerrascriptClient:
                     **empty_required_sg_values,
                 }
             ],
+
+            'egress': [
+                {
+                    'description': 'allow http',
+                    'from_port': 80,
+                    'to_port': 80,
+                    'protocol': 'tcp',
+                    'cidr_blocks': ['0.0.0.0/0'],
+                    **empty_required_sg_values,
+                },
+                {
+                    'description': 'allow https',
+                    'from_port': 443,
+                    'to_port': 443,
+                    'protocol': 'tcp',
+                    'cidr_blocks': ['0.0.0.0/0'],
+                    **empty_required_sg_values,
+                }
+            ]
         }
         sg_tf_resource = aws_security_group(identifier, **values)
         tf_resources.append(sg_tf_resource)


### PR DESCRIPTION
The ALB security group should allow egress to the ports of the backing instances (target groups)