### PR TITLE
APPSRE-3648: Update semver.parse method to VersionInfo.parse

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -10,6 +10,7 @@ from github import Github, GithubException
 from requests import exceptions as rqexc
 from sretoolbox.container import Image
 from sretoolbox.utils import retry
+from typing import List
 
 import reconcile.utils.threaded as threaded
 

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -10,7 +10,6 @@ from github import Github, GithubException
 from requests import exceptions as rqexc
 from sretoolbox.container import Image
 from sretoolbox.utils import retry
-from typing import List
 
 import reconcile.utils.threaded as threaded
 

--- a/reconcile/utils/semver_helper.py
+++ b/reconcile/utils/semver_helper.py
@@ -6,7 +6,7 @@ def make_semver(major, minor, patch):
 
 
 def parse_semver(version):
-    return semver.VersionInfo(**semver.parse(version))
+    return semver.VersionInfo.parse(version)
 
 
 def sort_versions(versions):

--- a/reconcile/utils/semver_helper.py
+++ b/reconcile/utils/semver_helper.py
@@ -1,5 +1,6 @@
-import semver
 from typing import List, Iterable
+import semver
+
 
 def make_semver(major: int, minor: int, patch: int) -> str:
     return str(semver.VersionInfo(major=major, minor=minor, patch=patch))

--- a/reconcile/utils/semver_helper.py
+++ b/reconcile/utils/semver_helper.py
@@ -1,15 +1,15 @@
 import semver
+from typing import List, Iterable
 
-
-def make_semver(major, minor, patch):
+def make_semver(major: int, minor: int, patch: int) -> str:
     return str(semver.VersionInfo(major=major, minor=minor, patch=patch))
 
 
-def parse_semver(version):
+def parse_semver(version: str) -> semver.VersionInfo:
     return semver.VersionInfo.parse(version)
 
 
-def sort_versions(versions):
+def sort_versions(versions: Iterable[str]) -> List[str]:
     """sort versions by semver
 
     Args:


### PR DESCRIPTION
* Update the semver parse method (deprecated) to VersionInfo.parse
* Add type hints to semver helper methods. 

https://issues.redhat.com/browse/APPSRE-3648
