### PR TITLE
[terraform-resources] remove spacial handling for ca_cert

### DIFF
--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -270,16 +270,6 @@ class TerraformClient:
                     self.integration_prefix)]
                 annotations = data.get('{}_annotations'.format(
                     self.integration_prefix))
-                # add special handling for ca_cert
-                # which is saved base64 encoded in terraform state.
-                # we decode it because construct_oc_resource
-                # will encode it again.
-                # if we find more examples that require this treatment
-                # we will need to hanle it in a more generic way
-                ca_cert_key = f'{self.integration_prefix}__ca_cert'
-                ca_cert = data.get(ca_cert_key)
-                if ca_cert:
-                    data[ca_cert_key] = base64.b64decode(ca_cert)
 
                 oc_resource = \
                     self.construct_oc_resource(output_resource_name, data,

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -984,8 +984,7 @@ class TerrascriptClient:
         if ca_cert:
             # db.ca_cert
             output_name_0_13 = output_prefix + '__ca_cert'
-            certificate = self.secret_reader.read(ca_cert)
-            output_value = base64.b64encode(certificate.encode()).decode()
+            output_value = self.secret_reader.read(ca_cert)
             tf_resources.append(Output(output_name_0_13, value=output_value))
 
         region = self._region_from_availability_zone_(


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3785

fixes #1872

terraform outputs can handle multi-line strings just fine, no need to work around anything.