### PR TITLE
[terraform-resources] add support for read/write path split in alb

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -221,7 +221,10 @@ provider
   targets {
     name
     default
-    weight
+    weights {
+      read
+      write
+    }
     ips
   }
   output_resource_name

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3492,7 +3492,7 @@ class TerrascriptClient:
                 },
             },
             'condition': {
-                'http_request_method': {'values': ['GET']},
+                'http_request_method': {'values': ['GET', 'HEAD']},
             },
             'depends_on': self.get_dependencies([forward_lbl_tf_resource]),
         }
@@ -3517,7 +3517,7 @@ class TerrascriptClient:
                 },
             },
             'condition': {
-                'http_request_method': {'values': ['POST']},
+                'http_request_method': {'values': ['POST', 'PUT', 'DELETE']},
             },
             'depends_on': self.get_dependencies([forward_lbl_tf_resource]),
         }

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3374,7 +3374,7 @@ class TerrascriptClient:
         tf_resources.append(lb_tf_resource)
 
         default_target = None
-        weighted_target_groups = []
+        write_weighted_target_groups = []
         for t in resource['targets']:
             target_name = t['name']
             # https://www.terraform.io/docs/providers/aws/r/
@@ -3403,11 +3403,12 @@ class TerrascriptClient:
                 default_target = lbt_tf_resource
 
             # initiate weighted target groups to use for listener rule
-            weighted_item = {
+            # write
+            write_weighted_item = {
                 'arn': f'${{{lbt_tf_resource.arn}}}',
-                'weight': t['weight'],
+                'weight': t['weights']['write'],
             }
-            weighted_target_groups.append(weighted_item)
+            write_weighted_target_groups.append(write_weighted_item)
 
             for ip in t['ips']:
                 # https://www.terraform.io/docs/providers/aws/r/
@@ -3467,15 +3468,16 @@ class TerrascriptClient:
         tf_resources.append(forward_lbl_tf_resource)
 
         # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
-        weights = [t['weight'] for t in weighted_target_groups]
-        if sum(weights) != 100:
+        # write
+        write_weights = [t['weight'] for t in write_weighted_target_groups]
+        if sum(write_weights) != 100:
             raise ValueError('sum of weights of targets should be 100')
         values = {
             'listener_arn': f'${{{forward_lbl_tf_resource.arn}}}',
             'action': {
                 'type': 'forward',
                 'forward': {
-                    'target_group': weighted_target_groups,
+                    'target_group': write_weighted_target_groups,
                     'stickiness': {
                         'enabled': False,
                         'duration': 1,  # required

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3374,6 +3374,7 @@ class TerrascriptClient:
         tf_resources.append(lb_tf_resource)
 
         default_target = None
+        read_weighted_target_groups = []
         write_weighted_target_groups = []
         for t in resource['targets']:
             target_name = t['name']
@@ -3403,6 +3404,12 @@ class TerrascriptClient:
                 default_target = lbt_tf_resource
 
             # initiate weighted target groups to use for listener rule
+            # read
+            read_weighted_item = {
+                'arn': f'${{{lbt_tf_resource.arn}}}',
+                'weight': t['weights']['read'],
+            }
+            read_weighted_target_groups.append(read_weighted_item)
             # write
             write_weighted_item = {
                 'arn': f'${{{lbt_tf_resource.arn}}}',
@@ -3468,6 +3475,31 @@ class TerrascriptClient:
         tf_resources.append(forward_lbl_tf_resource)
 
         # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
+        # read
+        read_weights = [t['weight'] for t in read_weighted_target_groups]
+        if sum(read_weights) != 100:
+            raise ValueError('sum of weights of targets should be 100')
+        values = {
+            'listener_arn': f'${{{forward_lbl_tf_resource.arn}}}',
+            'action': {
+                'type': 'forward',
+                'forward': {
+                    'target_group': read_weighted_target_groups,
+                    'stickiness': {
+                        'enabled': False,
+                        'duration': 1,  # required
+                    },
+                },
+            },
+            'condition': {
+                'http_request_method': {'values': ['GET']},
+            },
+            'depends_on': self.get_dependencies([forward_lbl_tf_resource]),
+        }
+        lblr_read_identifier = f'{identifier}-read'
+        lblr_read_tf_resource = \
+            aws_lb_listener_rule(lblr_read_identifier, **values)
+        tf_resources.append(lblr_read_tf_resource)
         # write
         write_weights = [t['weight'] for t in write_weighted_target_groups]
         if sum(write_weights) != 100:
@@ -3489,8 +3521,10 @@ class TerrascriptClient:
             },
             'depends_on': self.get_dependencies([forward_lbl_tf_resource]),
         }
-        lblr_tf_resource = aws_lb_listener_rule(identifier, **values)
-        tf_resources.append(lblr_tf_resource)
+        lblr_write_identifier = f'{identifier}-write'
+        lblr_write_tf_resource = \
+            aws_lb_listener_rule(lblr_write_identifier, **values)
+        tf_resources.append(lblr_write_tf_resource)
 
         # outputs
         # dns name


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3695

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/26162

this PR adds support to control the weights of traffic split between read and write paths (as opposed to only write path currently).

@jfchevrette PTAL