### PR TITLE
saasherder: Adding GenericTemplateExecutor provider + populate desired state test

### DIFF
--- a/reconcile/test/fixtures/saasfiles/rendered_resources.yaml
+++ b/reconcile/test/fixtures/saasfiles/rendered_resources.yaml
@@ -1,0 +1,194 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/component: api
+    app.kubernetes.io/instance: observatorium
+    app.kubernetes.io/name: observatorium-api
+    app.kubernetes.io/part-of: observatorium
+    app.kubernetes.io/version: main-2021-09-10-v0.1.2-52-ga24d7d2
+  name: observatorium-observatorium-mst-api
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: api
+      app.kubernetes.io/instance: observatorium
+      app.kubernetes.io/name: observatorium-api
+      app.kubernetes.io/part-of: observatorium
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-api
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/tracing: jaeger-agent
+        app.kubernetes.io/version: main-2021-09-10-v0.1.2-52-ga24d7d2
+    spec:
+      containers:
+        - args:
+            - '--web.listen=0.0.0.0:8080'
+            - '--web.internal.listen=0.0.0.0:8081'
+            - >-
+              --metrics.read.endpoint=http://observatorium-thanos-query-frontend.observatorium-mst-stage.svc.cluster.local:9090
+            - >-
+              --metrics.write.endpoint=http://observatorium-thanos-receive.observatorium-mst-stage.svc.cluster.local:19291
+            - '--log.level=warn'
+            - >-
+              --logs.read.endpoint=http://observatorium-loki-query-frontend-http.observatorium-logs-stage.svc.cluster.local:3100
+            - >-
+              --logs.tail.endpoint=http://observatorium-loki-querier-http.observatorium-logs-stage.svc.cluster.local:3100
+            - >-
+              --logs.write.endpoint=http://observatorium-loki-distributor-http.observatorium-logs-stage.svc.cluster.local:3100
+            - '--rbac.config=/etc/observatorium/rbac.yaml'
+            - '--tenants.config=/etc/observatorium/tenants.yaml'
+            - >-
+              --middleware.rate-limiter.grpc-address=observatorium-gubernator.observatorium-mst-stage.svc.cluster.local:8081
+            - '--internal.tracing.endpoint=localhost:6831'
+          image: 'quay.io/observatorium/api:main-2021-09-10-v0.1.2-52-ga24d7d2'
+          livenessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /live
+              port: 8081
+              scheme: HTTP
+            periodSeconds: 30
+          name: observatorium-api
+          ports:
+            - containerPort: 8081
+              name: internal
+            - containerPort: 8080
+              name: public
+          readinessProbe:
+            failureThreshold: 12
+            httpGet:
+              path: /ready
+              port: 8081
+              scheme: HTTP
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: '1'
+              memory: 1Gi
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          volumeMounts:
+            - mountPath: /etc/observatorium/rbac.yaml
+              name: rbac
+              readOnly: true
+              subPath: rbac.yaml
+            - mountPath: /etc/observatorium/tenants.yaml
+              name: tenants
+              readOnly: true
+              subPath: tenants.yaml
+        - args:
+            - '--web.listen=127.0.0.1:8082'
+            - '--web.internal.listen=0.0.0.0:8083'
+            - '--web.healthchecks.url=http://127.0.0.1:8082'
+            - '--log.level=warn'
+            - '--ams.url=https://api.stage.openshift.com'
+            - '--resource-type-prefix=observatorium'
+            - '--oidc.client-id=$(CLIENT_ID)'
+            - '--oidc.client-secret=$(CLIENT_SECRET)'
+            - '--oidc.issuer-url=$(ISSUER_URL)'
+            - '--opa.package=observatorium'
+            - >-
+              --memcached=observatorium-api-cache-memcached.observatorium-mst-stage.svc.cluster.local:11211
+            - '--memcached.expire=300'
+            - '--ams.mappings=dptp=1oZtjZXK3EP4kJSaYXwMmorAqnS'
+            - '--ams.mappings=managedkafka=1h0UApMaFwzvGLGlfuzUpITFFQ0'
+            - '--ams.mappings=osd=1lneg5EWJaGAK3d7RZpAJM9WujU'
+          env:
+            - name: ISSUER_URL
+              valueFrom:
+                secretKeyRef:
+                  key: issuer-url
+                  name: observatorium-observatorium-mst-api
+            - name: CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: client-id
+                  name: observatorium-observatorium-mst-api
+            - name: CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: client-secret
+                  name: observatorium-observatorium-mst-api
+          image: 'quay.io/observatorium/opa-ams:master-2021-07-14-d517f70'
+          livenessProbe:
+            failureThreshold: 10
+            httpGet:
+              path: /live
+              port: 8083
+              scheme: HTTP
+            periodSeconds: 30
+          name: opa-ams
+          ports:
+            - containerPort: 8082
+              name: opa-ams-api
+            - containerPort: 8083
+              name: opa-ams-metrics
+          readinessProbe:
+            failureThreshold: 12
+            httpGet:
+              path: /ready
+              port: 8083
+              scheme: HTTP
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: 200m
+              memory: 200Mi
+            requests:
+              cpu: 100m
+              memory: 100Mi
+        - args:
+            - >-
+              --reporter.grpc.host-port=dns:///jaeger-collector-headless.observatorium-stage.svc:14250
+            - '--reporter.type=grpc'
+            - '--agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)'
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          image: 'quay.io/app-sre/jaegertracing-jaeger-agent:1.22.0'
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 14271
+              scheme: HTTP
+          name: jaeger-agent
+          ports:
+            - containerPort: 5778
+              name: configs
+            - containerPort: 6831
+              name: jaeger-thrift
+            - containerPort: 14271
+              name: metrics
+          resources:
+            limits:
+              cpu: 128m
+              memory: 128Mi
+            requests:
+              cpu: 32m
+              memory: 64Mi
+      serviceAccountName: observatorium-mst
+      volumes:
+        - configMap:
+            name: observatorium-observatorium-mst-api
+          name: rbac
+        - name: tenants
+          secret:
+            secretName: observatorium-observatorium-mst-api

--- a/reconcile/test/fixtures/saasfiles/saas_remote_openshift_template.yaml
+++ b/reconcile/test/fixtures/saasfiles/saas_remote_openshift_template.yaml
@@ -1,0 +1,287 @@
+---
+$schema: /app-sre/saas-file-2.yml
+
+labels:
+  service: observatorium
+
+name: saas-realistic-openshift-template-remote
+description: Test
+
+app:
+  $ref: /services/rhobs/observatorium-mst/app.yml
+
+pipelinesProvider:
+  $ref: /services/rhobs/observatorium/pipelines/observatorium-pipeline.app-sre-prod-01.yaml
+
+slack:
+  workspace:
+    $ref: /dependencies/slack/coreos.yml
+  channel: team-monitoring-info
+
+authentication:
+  image:
+    path: app-sre/ci-int/redhat-registry-io-pull
+    field: all
+
+managedResourceTypes:
+- Deployment
+- Service
+- StatefulSet
+- ConfigMap
+- Role
+- RoleBinding
+- ServiceAccount
+- PodDisruptionBudget
+- PersistentVolumeClaim
+- PrometheusRule
+
+imagePatterns:
+- quay.io/conprof/conprof
+- quay.io/thanos/thanos
+- quay.io/observatorium
+- quay.io/app-sre
+- quay.io/openshift/origin-oauth-proxy
+- quay.io/prometheus/memcached-exporter
+- registry.redhat.io/rhel8/memcached
+- quay.io/jpkroehling/all-in-one
+- quay.io/app-sre/gubernator
+- quay.io/openshift/origin-configmap-reloader
+
+parameters:
+  OAUTH_PROXY_IMAGE: quay.io/openshift/origin-oauth-proxy
+  OAUTH_PROXY_IMAGE_TAG: 4.8.0 # Pinning version before 4.9.0 due to https://github.com/openshift/oauth-proxy/issues/229.
+
+resourceTemplates:
+- name: observatorium-mst-common
+  path: /resources/services/observatorium-template.yaml
+  url: https://github.com/rhobs/configuration
+  parameters:
+    # NOTICE: Please specify image tags for each environment separately.
+    # And sort them alphabetically.
+    AMS_URL: ${OCM_BASE_URL}
+    JAEGER_AGENT_IMAGE: quay.io/app-sre/jaegertracing-jaeger-agent
+    MEMCACHED_EXPORTER_IMAGE: quay.io/prometheus/memcached-exporter
+    MEMCACHED_IMAGE: registry.redhat.io/rhel8/memcached
+    OPA_AMS_IMAGE: quay.io/observatorium/opa-ams
+  targets:
+  - namespace:
+      $ref: /services/rhobs/observatorium-mst/namespaces/observatorium-mst-stage.yml
+    ref: a513f3676c8430265208111048dec36ea86fcd56
+    parameters:
+      NAMESPACE: observatorium-mst-stage
+      OBSERVATORIUM_METRICS_NAMESPACE: observatorium-mst-stage
+      OBSERVATORIUM_LOGS_NAMESPACE: observatorium-logs-stage
+      DPTP_ORGANIZATION_ID: 1oZtjZXK3EP4kJSaYXwMmorAqnS
+      GUBERNATOR_REPLICAS: 3
+      JAEGER_AGENT_IMAGE_TAG: 1.22.0
+      JAEGER_COLLECTOR_NAMESPACE: observatorium-stage
+      MANAGEDKAFKA_ORGANIZATION_ID: 1h0UApMaFwzvGLGlfuzUpITFFQ0
+      MEMCACHED_CONNECTION_LIMIT: 3072Mi
+      MEMCACHED_CPU_LIMIT: 3
+      MEMCACHED_CPU_REQUEST: 500m
+      MEMCACHED_EXPORTER_CPU_LIMIT: 200m
+      MEMCACHED_EXPORTER_CPU_REQUEST: 50m
+      MEMCACHED_EXPORTER_IMAGE_TAG: v0.6.0
+      MEMCACHED_EXPORTER_MEMORY_LIMIT: 200Mi
+      MEMCACHED_EXPORTER_MEMORY_REQUEST: 50Mi
+      MEMCACHED_IMAGE_TAG: 1.5
+      MEMCACHED_MEMORY_LIMIT_MB: 2048Mi
+      MEMCACHED_MEMORY_LIMIT:  1844Mi
+      MEMCACHED_MEMORY_REQUEST: 1329Mi
+      OBSERVATORIUM_API_CPU_LIMIT: 1
+      OBSERVATORIUM_API_CPU_REQUEST: 100m
+      OBSERVATORIUM_API_IDENTIFIER: observatorium-observatorium-mst-api
+      OBSERVATORIUM_API_IMAGE_TAG: main-2021-09-10-v0.1.2-52-ga24d7d2
+      OBSERVATORIUM_API_MEMORY_LIMIT: 1Gi
+      OBSERVATORIUM_API_MEMORY_REQUEST: 256Mi
+      OBSERVATORIUM_API_REPLICAS: 3
+      OPA_AMS_CPU_LIMIT: 200m
+      OPA_AMS_CPU_REQUEST: 100m
+      OPA_AMS_IMAGE_TAG: master-2021-07-14-d517f70
+      OPA_AMS_MEMCACHED_EXPIRE: "300"
+      OPA_AMS_MEMORY_LIMIT: 200Mi
+      OPA_AMS_MEMORY_REQUEST: 100Mi
+      OSD_ORGANIZATION_ID: 1lneg5EWJaGAK3d7RZpAJM9WujU
+      PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET: 'observatorium-thanos-receive'
+      SERVICE_ACCOUNT_NAME: observatorium-mst
+  - namespace:
+      $ref: /services/rhobs/observatorium-mst/namespaces/observatorium-mst-production.yml
+    # Commit for github.com/rhobs/configuration repo. Keep it pinned, so we know what we can promote to production.
+    ref: 4ba049635dd62d57605ea74890c08caef067ed13
+    parameters:
+      NAMESPACE: observatorium-mst-production
+      OBSERVATORIUM_METRICS_NAMESPACE: observatorium-mst-production
+      OBSERVATORIUM_LOGS_NAMESPACE: observatorium-logs-production
+      PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET: 'observatorium-thanos-receive'
+      GUBERNATOR_REPLICAS: 3
+      JAEGER_AGENT_IMAGE_TAG: 1.22.0
+      JAEGER_COLLECTOR_NAMESPACE: observatorium-production
+      OBSERVATORIUM_API_REPLICAS: 5
+      OBSERVATORIUM_API_CPU_REQUEST: 100m
+      OBSERVATORIUM_API_CPU_LIMIT: 1
+      OBSERVATORIUM_API_MEMORY_REQUEST: 256Mi
+      OBSERVATORIUM_API_MEMORY_LIMIT: 1Gi
+      OPA_AMS_MEMCACHED_EXPIRE: "300"
+      OPA_AMS_CPU_REQUEST: 100m
+      OPA_AMS_CPU_LIMIT: 200m
+      OPA_AMS_MEMORY_REQUEST: 100Mi
+      OPA_AMS_MEMORY_LIMIT: 200Mi
+      OSD_ORGANIZATION_ID: 1ln3QD58ag2A5fqq5Dh1wa2lX5P
+      MANAGEDKAFKA_ORGANIZATION_ID: 1h0TWioN3nZDs6oUI7eT5SowRjo
+      MEMCACHED_IMAGE_TAG: 1.5
+      MEMCACHED_MEMORY_LIMIT_MB: 2048Mi
+      MEMCACHED_CONNECTION_LIMIT: 3072Mi
+      MEMCACHED_CPU_REQUEST: 500m
+      MEMCACHED_CPU_LIMIT: 3
+      MEMCACHED_MEMORY_REQUEST: 1329Mi
+      MEMCACHED_MEMORY_LIMIT:  1844Mi
+      MEMCACHED_EXPORTER_CPU_REQUEST: 50m
+      MEMCACHED_EXPORTER_CPU_LIMIT: 200m
+      MEMCACHED_EXPORTER_MEMORY_REQUEST: 50Mi
+      MEMCACHED_EXPORTER_MEMORY_LIMIT: 200Mi
+      SERVICE_ACCOUNT_NAME: observatorium-mst
+      OBSERVATORIUM_API_IDENTIFIER: observatorium-observatorium-mst-api
+      OBSERVATORIUM_API_IMAGE: quay.io/observatorium/api
+      OBSERVATORIUM_API_IMAGE_TAG: main-2021-09-10-v0.1.2-52-ga24d7d2
+      OPA_AMS_IMAGE_TAG: master-2021-02-24-fc0d722
+      MEMCACHED_EXPORTER_IMAGE_TAG: v0.6.0
+- name: observatorium-mst-metrics
+  path: /resources/services/observatorium-metrics-template.yaml
+  url: https://github.com/rhobs/configuration
+  parameters:
+    # NOTICE: Please specify image tags for each environment separately.
+    # And sort them alphabetically.
+    JAEGER_AGENT_IMAGE: quay.io/app-sre/jaegertracing-jaeger-agent
+    MEMCACHED_EXPORTER_IMAGE: quay.io/prometheus/memcached-exporter
+    MEMCACHED_IMAGE: registry.redhat.io/rhel8/memcached
+    STORAGE_CLASS: "gp2"
+    THANOS_IMAGE: quay.io/thanos/thanos
+  targets:
+  - namespace:
+      $ref: /services/rhobs/observatorium-mst/namespaces/observatorium-mst-stage.yml
+    ref: 17358120d2019d171f93a0c92e059b6b9acc7a03
+    parameters:
+      NAMESPACE: observatorium-mst-stage
+      OBSERVATORIUM_METRICS_NAMESPACE: observatorium-mst-stage
+      OBSERVATORIUM_LOGS_NAMESPACE: observatorium-logs-stage
+      JAEGER_AGENT_IMAGE_TAG: 1.22.0
+      JAEGER_COLLECTOR_NAMESPACE: observatorium-stage
+      MEMCACHED_CONNECTION_LIMIT: 3072Mi
+      MEMCACHED_CPU_LIMIT: 3
+      MEMCACHED_CPU_REQUEST: 500m
+      MEMCACHED_EXPORTER_CPU_LIMIT: 200m
+      MEMCACHED_EXPORTER_CPU_REQUEST: 50m
+      MEMCACHED_EXPORTER_IMAGE_TAG: v0.6.0
+      MEMCACHED_EXPORTER_MEMORY_LIMIT: 200Mi
+      MEMCACHED_EXPORTER_MEMORY_REQUEST: 50Mi
+      MEMCACHED_IMAGE_TAG: 1.5
+      MEMCACHED_MEMORY_LIMIT_MB: 2048Mi
+      MEMCACHED_MEMORY_LIMIT:  1844Mi
+      MEMCACHED_MEMORY_REQUEST: 1329Mi
+      SERVICE_ACCOUNT_NAME: observatorium-mst
+      THANOS_COMPACTOR_LOG_LEVEL: 'debug'
+      THANOS_COMPACTOR_PVC_REQUEST: '50Gi'
+      THANOS_COMPACTOR_REPLICAS: 1
+      THANOS_COMPACTOR_RETENTION_RESOULTION_RAW: '30d'
+      THANOS_COMPACTOR_RETENTION_RESOULTION_FIVE_MINUTES: '30d'
+      THANOS_COMPACTOR_RETENTION_RESOULTION_ONE_HOUR: '30d'
+      THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING: '--no-downsampling.disable'
+      THANOS_CONFIG_SECRET: observatorium-mst-thanos-objectstorage
+      THANOS_IMAGE_TAG: v0.23.0-rc.0
+      THANOS_QUERIER_CPU_LIMIT: '3'
+      THANOS_QUERIER_CPU_REQUEST: '2'
+      THANOS_QUERIER_MEMORY_LIMIT: '12Gi'
+      THANOS_QUERIER_MEMORY_REQUEST: '8Gi'
+      THANOS_QUERIER_REPLICAS: 4
+      THANOS_QUERY_FRONTEND_CPU_LIMIT: '2'
+      THANOS_QUERY_FRONTEND_CPU_REQUEST: '500m'
+      THANOS_QUERY_FRONTEND_MEMORY_LIMIT: '2Gi'
+      THANOS_QUERY_FRONTEND_MEMORY_REQUEST: '1Gi'
+      THANOS_QUERY_FRONTEND_REPLICAS: 3
+      THANOS_RECEIVE_CONTROLLER_IMAGE_TAG: master-2020-02-06-b66e0c8
+      THANOS_RECEIVE_CPU_LIMIT: '2'
+      THANOS_RECEIVE_CPU_REQUEST: '2'
+      THANOS_RECEIVE_DEBUG_ENV: '1'
+      THANOS_RECEIVE_LOG_LEVEL: 'debug'
+      THANOS_RECEIVE_MEMORY_LIMIT: '12Gi'
+      THANOS_RECEIVE_MEMORY_REQUEST: '12Gi'
+      THANOS_RECEIVE_REPLICAS: 4
+      THANOS_RULER_CPU_LIMIT: '1'
+      THANOS_RULER_CPU_REQUEST: '500m'
+      THANOS_RULER_LOG_LEVEL: 'info'
+      THANOS_RULER_MEMORY_LIMIT: '2Gi'
+      THANOS_RULER_MEMORY_REQUEST: '2Gi'
+      THANOS_RULER_PVC_REQUEST: '50Gi'
+      THANOS_RULER_REPLICAS: 2
+      THANOS_S3_SECRET: observatorium-mst-thanos-stage-s3
+      THANOS_STORE_CACHE_MEMORY_LIMIT_MB: 2048
+      THANOS_STORE_CPU_LIMIT: '250m'
+      THANOS_STORE_CPU_REQUEST: '50m'
+      THANOS_STORE_LOG_LEVEL: 'debug'
+      THANOS_STORE_MEMORY_LIMIT: '8Gi'
+      THANOS_STORE_MEMORY_REQUEST: '4Gi'
+      THANOS_STORE_REPLICAS: 1
+  - namespace:
+      $ref: /services/rhobs/observatorium-mst/namespaces/observatorium-mst-production.yml
+    # Commit for github.com/rhobs/configuration repo. Keep it pinned, so we know what we can promote to production.
+    ref: 17358120d2019d171f93a0c92e059b6b9acc7a03
+    parameters:
+      NAMESPACE: observatorium-mst-production
+      OBSERVATORIUM_METRICS_NAMESPACE: observatorium-mst-production
+      OBSERVATORIUM_LOGS_NAMESPACE: observatorium-logs-production
+      JAEGER_AGENT_IMAGE_TAG: 1.22.0
+      JAEGER_COLLECTOR_NAMESPACE: observatorium-production
+      THANOS_CONFIG_SECRET: observatorium-mst-thanos-objectstorage
+      THANOS_S3_SECRET: observatorium-mst-thanos-production-s3
+      THANOS_IMAGE_TAG: v0.23.0-rc.0
+      THANOS_RECEIVE_CONTROLLER_IMAGE_TAG: master-2020-02-06-b66e0c8
+      THANOS_QUERIER_REPLICAS: 4
+      THANOS_QUERIER_CPU_REQUEST: '1'
+      THANOS_QUERIER_CPU_LIMIT: '1'
+      THANOS_QUERIER_MEMORY_REQUEST: '16Gi'
+      THANOS_QUERIER_MEMORY_LIMIT: '16Gi'
+      THANOS_QUERY_FRONTEND_REPLICAS: 3
+      THANOS_QUERY_FRONTEND_CPU_REQUEST: '100m'
+      THANOS_QUERY_FRONTEND_CPU_LIMIT: '1'
+      THANOS_QUERY_FRONTEND_MEMORY_REQUEST: '256Mi'
+      THANOS_QUERY_FRONTEND_MEMORY_LIMIT: '1Gi'
+      THANOS_STORE_LOG_LEVEL: 'debug'
+      THANOS_STORE_REPLICAS: 1
+      THANOS_STORE_CPU_REQUEST: '1'
+      THANOS_STORE_CPU_LIMIT: '1'
+      THANOS_STORE_MEMORY_REQUEST: '5Gi'
+      THANOS_STORE_MEMORY_LIMIT: '20Gi'
+      THANOS_RECEIVE_REPLICAS: 5
+      THANOS_RECEIVE_CPU_REQUEST: '700m'
+      THANOS_RECEIVE_CPU_LIMIT: '700m'
+      THANOS_RECEIVE_MEMORY_REQUEST: '5Gi'
+      THANOS_RECEIVE_MEMORY_LIMIT: '5Gi'
+      THANOS_RECEIVE_LOG_LEVEL: 'debug'
+      THANOS_RECEIVE_DEBUG_ENV: '1'
+      THANOS_COMPACTOR_REPLICAS: 1
+      THANOS_COMPACTOR_RETENTION_RESOULTION_RAW: '365d'
+      THANOS_COMPACTOR_RETENTION_RESOULTION_FIVE_MINUTES: '365d'
+      THANOS_COMPACTOR_RETENTION_RESOULTION_ONE_HOUR: '365d'
+      THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING: '--no-downsampling.disable'
+      THANOS_COMPACTOR_PVC_REQUEST: '50Gi'
+      THANOS_RULER_LOG_LEVEL: 'info'
+      THANOS_RULER_REPLICAS: 2
+      THANOS_RULER_CPU_REQUEST: '500m'
+      THANOS_RULER_CPU_LIMIT: '1'
+      THANOS_RULER_MEMORY_REQUEST: '2Gi'
+      THANOS_RULER_MEMORY_LIMIT: '2Gi'
+      THANOS_RULER_PVC_REQUEST: '50Gi'
+      THANOS_COMPACTOR_LOG_LEVEL: 'debug'
+      THANOS_STORE_CACHE_MEMORY_LIMIT_MB: 2048
+      MEMCACHED_IMAGE_TAG: 1.5
+      MEMCACHED_MEMORY_LIMIT_MB: 2048Mi
+      MEMCACHED_CONNECTION_LIMIT: 3072Mi
+      MEMCACHED_CPU_REQUEST: 500m
+      MEMCACHED_CPU_LIMIT: 3
+      MEMCACHED_MEMORY_REQUEST: 1329Mi
+      MEMCACHED_MEMORY_LIMIT:  1844Mi
+      MEMCACHED_EXPORTER_CPU_REQUEST: 50m
+      MEMCACHED_EXPORTER_CPU_LIMIT: 200m
+      MEMCACHED_EXPORTER_MEMORY_REQUEST: 50Mi
+      MEMCACHED_EXPORTER_MEMORY_LIMIT: 200Mi
+      SERVICE_ACCOUNT_NAME: observatorium-mst

--- a/reconcile/test/fixtures/saasfiles/saas_remote_openshift_template.yaml
+++ b/reconcile/test/fixtures/saasfiles/saas_remote_openshift_template.yaml
@@ -7,21 +7,44 @@ labels:
 name: saas-realistic-openshift-template-remote
 description: Test
 
-app:
-  $ref: /services/rhobs/observatorium-mst/app.yml
+#app:
+#  $ref: /services/rhobs/observatorium-mst/app.yml
+#
+#pipelinesProvider:
+#  $ref: /services/rhobs/observatorium/pipelines/observatorium-pipeline.app-sre-prod-01.yaml
+#
+#slack:
+#  workspace:
+#    $ref: /dependencies/slack/coreos.yml
+#  channel: team-monitoring-info
 
-pipelinesProvider:
-  $ref: /services/rhobs/observatorium/pipelines/observatorium-pipeline.app-sre-prod-01.yaml
-
-slack:
-  workspace:
-    $ref: /dependencies/slack/coreos.yml
-  channel: team-monitoring-info
-
-authentication:
-  image:
-    path: app-sre/ci-int/redhat-registry-io-pull
-    field: all
+_placeholders:
+  - &STAGING_NAMESPACE
+    name: "observatorium-mst-stage"
+    environment:
+      name: "stage"
+      parameters:
+        CHANNEL: staging
+        OCM_BASE_URL: https://api.stage.openshift.com
+        SSO_BASE_URL: https://sso.redhat.com/auth/realms/redhat-external
+      labels:
+        service: openshift-dedicated
+        type: stage
+    cluster:
+      name: "stage-1"
+  - &PRODUCTION_NAMESPACE
+    name: "observatorium-mst-production"
+    environment:
+      name: "production"
+      parameters:
+        CHANNEL: production
+        OCM_BASE_URL: https://api.openshift.com
+        SSO_BASE_URL: https://sso.redhat.com/auth/realms/redhat-external
+      labels:
+        service: openshift-dedicated
+        type: production
+    cluster:
+      name: "prod-1"
 
 managedResourceTypes:
 - Deployment
@@ -56,16 +79,13 @@ resourceTemplates:
   path: /resources/services/observatorium-template.yaml
   url: https://github.com/rhobs/configuration
   parameters:
-    # NOTICE: Please specify image tags for each environment separately.
-    # And sort them alphabetically.
     AMS_URL: ${OCM_BASE_URL}
     JAEGER_AGENT_IMAGE: quay.io/app-sre/jaegertracing-jaeger-agent
     MEMCACHED_EXPORTER_IMAGE: quay.io/prometheus/memcached-exporter
     MEMCACHED_IMAGE: registry.redhat.io/rhel8/memcached
     OPA_AMS_IMAGE: quay.io/observatorium/opa-ams
   targets:
-  - namespace:
-      $ref: /services/rhobs/observatorium-mst/namespaces/observatorium-mst-stage.yml
+  - namespace: *STAGING_NAMESPACE
     ref: a513f3676c8430265208111048dec36ea86fcd56
     parameters:
       NAMESPACE: observatorium-mst-stage
@@ -104,8 +124,7 @@ resourceTemplates:
       OSD_ORGANIZATION_ID: 1lneg5EWJaGAK3d7RZpAJM9WujU
       PROMETHEUS_AMS_REMOTE_WRITE_PROXY_TARGET: 'observatorium-thanos-receive'
       SERVICE_ACCOUNT_NAME: observatorium-mst
-  - namespace:
-      $ref: /services/rhobs/observatorium-mst/namespaces/observatorium-mst-production.yml
+  - namespace: *PRODUCTION_NAMESPACE
     # Commit for github.com/rhobs/configuration repo. Keep it pinned, so we know what we can promote to production.
     ref: 4ba049635dd62d57605ea74890c08caef067ed13
     parameters:
@@ -157,8 +176,7 @@ resourceTemplates:
     STORAGE_CLASS: "gp2"
     THANOS_IMAGE: quay.io/thanos/thanos
   targets:
-  - namespace:
-      $ref: /services/rhobs/observatorium-mst/namespaces/observatorium-mst-stage.yml
+  - namespace: *STAGING_NAMESPACE
     ref: 17358120d2019d171f93a0c92e059b6b9acc7a03
     parameters:
       NAMESPACE: observatorium-mst-stage
@@ -221,8 +239,7 @@ resourceTemplates:
       THANOS_STORE_MEMORY_LIMIT: '8Gi'
       THANOS_STORE_MEMORY_REQUEST: '4Gi'
       THANOS_STORE_REPLICAS: 1
-  - namespace:
-      $ref: /services/rhobs/observatorium-mst/namespaces/observatorium-mst-production.yml
+  - namespace: *PRODUCTION_NAMESPACE
     # Commit for github.com/rhobs/configuration repo. Keep it pinned, so we know what we can promote to production.
     ref: 17358120d2019d171f93a0c92e059b6b9acc7a03
     parameters:

--- a/reconcile/test/fixtures/saasfiles_remote_repo/17358120d2019d171f93a0c92e059b6b9acc7a03_resources_services_observatorium-metrics-template.yaml
+++ b/reconcile/test/fixtures/saasfiles_remote_repo/17358120d2019d171f93a0c92e059b6b9acc7a03_resources_services_observatorium-metrics-template.yaml
@@ -1,0 +1,2767 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: observatorium-metrics
+objects:
+  - apiVersion: v1
+    data:
+      session_secret: ""
+    kind: Secret
+    metadata:
+      labels:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-compact
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: compact-proxy
+    type: Opaque
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        service.alpha.openshift.io/serving-cert-secret-name: compact-tls
+      labels:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-compact
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-compact
+    spec:
+      ports:
+        - name: http
+          port: 10902
+          targetPort: 10902
+        - name: https
+          port: 8443
+          targetPort: 8443
+      selector:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-compact
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-compact
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-compact
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-compact
+        app.kubernetes.io/part-of: observatorium
+        prometheus: app-sre
+      name: observatorium-thanos-compact
+    spec:
+      endpoints:
+        - port: http
+          relabelings:
+            - separator: /
+              sourceLabels:
+                - namespace
+                - pod
+              targetLabel: instance
+      namespaceSelector:
+        matchNames: ${{NAMESPACES}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: database-compactor
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-compact
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      labels:
+        app.kubernetes.io/component: database-compactor
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-compact
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-compact
+    spec:
+      replicas: ${{THANOS_COMPACTOR_REPLICAS}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: database-compactor
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-compact
+          app.kubernetes.io/part-of: observatorium
+      serviceName: observatorium-thanos-compact
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: database-compactor
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: thanos-compact
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+        spec:
+          containers:
+            - args:
+                - compact
+                - --wait
+                - --log.level=${THANOS_COMPACTOR_LOG_LEVEL}
+                - --log.format=logfmt
+                - --objstore.config=$(OBJSTORE_CONFIG)
+                - --data-dir=/var/thanos/compact
+                - --debug.accept-malformed-index
+                - --retention.resolution-raw=${THANOS_COMPACTOR_RETENTION_RESOULTION_RAW}
+                - --retention.resolution-5m=${THANOS_COMPACTOR_RETENTION_RESOULTION_FIVE_MINUTES}
+                - --retention.resolution-1h=${THANOS_COMPACTOR_RETENTION_RESOULTION_ONE_HOUR}
+                - --delete-delay=48h
+                - --deduplication.replica-label=replica
+                - --debug.max-compaction-level=3
+                - ${THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING}
+              env:
+                - name: OBJSTORE_CONFIG
+                  valueFrom:
+                    secretKeyRef:
+                      key: thanos.yaml
+                      name: ${THANOS_CONFIG_SECRET}
+                - name: HOST_IP_ADDRESS
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_access_key_id
+                      name: ${THANOS_S3_SECRET}
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_secret_access_key
+                      name: ${THANOS_S3_SECRET}
+              image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 4
+                httpGet:
+                  path: /-/healthy
+                  port: 10902
+                  scheme: HTTP
+                periodSeconds: 30
+              name: thanos-compact
+              ports:
+                - containerPort: 10902
+                  name: http
+              readinessProbe:
+                failureThreshold: 20
+                httpGet:
+                  path: /-/ready
+                  port: 10902
+                  scheme: HTTP
+                periodSeconds: 5
+              resources:
+                limits:
+                  cpu: ${THANOS_COMPACTOR_CPU_LIMIT}
+                  memory: ${THANOS_COMPACTOR_MEMORY_LIMIT}
+                requests:
+                  cpu: ${THANOS_COMPACTOR_CPU_REQUEST}
+                  memory: ${THANOS_COMPACTOR_MEMORY_REQUEST}
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+                - mountPath: /var/thanos/compact
+                  name: data
+                  readOnly: false
+            - args:
+                - -provider=openshift
+                - -https-address=:8443
+                - -http-address=
+                - -email-domain=*
+                - -upstream=http://localhost:10902
+                - -openshift-service-account=${SERVICE_ACCOUNT_NAME}
+                - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}'
+                - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
+                - -tls-cert=/etc/tls/private/tls.crt
+                - -tls-key=/etc/tls/private/tls.key
+                - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+                - -cookie-secret-file=/etc/proxy/secrets/session_secret
+                - -openshift-ca=/etc/pki/tls/cert.pem
+                - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              image: ${OAUTH_PROXY_IMAGE}:${OAUTH_PROXY_IMAGE_TAG}
+              name: oauth-proxy
+              ports:
+                - containerPort: 8443
+                  name: https
+              resources:
+                limits:
+                  cpu: ${OAUTH_PROXY_CPU_LIMITS}
+                  memory: ${OAUTH_PROXY_MEMORY_LIMITS}
+                requests:
+                  cpu: ${OAUTH_PROXY_CPU_REQUEST}
+                  memory: ${OAUTH_PROXY_MEMORY_REQUEST}
+              volumeMounts:
+                - mountPath: /etc/tls/private
+                  name: compact-tls
+                  readOnly: false
+                - mountPath: /etc/proxy/secrets
+                  name: compact-proxy
+                  readOnly: false
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          securityContext: {}
+          serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+          terminationGracePeriodSeconds: 120
+          volumes:
+            - name: compact-tls
+              secret:
+                secretName: compact-tls
+            - name: compact-proxy
+              secret:
+                secretName: compact-proxy
+      volumeClaimTemplates:
+        - metadata:
+            labels:
+              app.kubernetes.io/component: database-compactor
+              app.kubernetes.io/instance: observatorium
+              app.kubernetes.io/name: thanos-compact
+              app.kubernetes.io/part-of: observatorium
+            name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: ${THANOS_COMPACTOR_PVC_REQUEST}
+            storageClassName: ${STORAGE_CLASS}
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-layer
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-query
+    spec:
+      replicas: ${{THANOS_QUERIER_REPLICAS}}
+      securityContext: {}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: query-layer
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-query
+          app.kubernetes.io/part-of: observatorium
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: query-layer
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: thanos-query
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/tracing: jaeger-agent
+            app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+        spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app.kubernetes.io/name
+                          operator: In
+                          values:
+                            - thanos-query
+                    namespaces:
+                      - ${NAMESPACE}
+                    topologyKey: kubernetes.io/hostname
+                  weight: 100
+          containers:
+            - args:
+                - query
+                - --grpc-address=0.0.0.0:10901
+                - --http-address=0.0.0.0:9090
+                - --log.level=${THANOS_QUERIER_LOG_LEVEL}
+                - --log.format=logfmt
+                - --query.replica-label=replica
+                - --query.replica-label=rule_replica
+                - --query.replica-label=prometheus_replica
+                - --store=dnssrv+_grpc._tcp.observatorium-thanos-rule.${NAMESPACE}.svc.cluster.local
+                - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-0.${NAMESPACE}.svc.cluster.local
+                - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-1.${NAMESPACE}.svc.cluster.local
+                - --store=dnssrv+_grpc._tcp.observatorium-thanos-store-shard-2.${NAMESPACE}.svc.cluster.local
+                - --store=dnssrv+_grpc._tcp.observatorium-thanos-receive-default.${NAMESPACE}.svc.cluster.local
+                - --web.prefix-header=X-Forwarded-Prefix
+                - --query.timeout=15m
+                - --query.lookback-delta=15m
+                - |-
+                  --tracing.config="config":
+                    "sampler_param": 2
+                    "sampler_type": "ratelimiting"
+                    "service_name": "thanos-query"
+                  "type": "JAEGER"
+                - --query.auto-downsampling
+              env:
+                - name: HOST_IP_ADDRESS
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+              image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 4
+                httpGet:
+                  path: /-/healthy
+                  port: 9090
+                  scheme: HTTP
+                periodSeconds: 30
+              name: thanos-query
+              ports:
+                - containerPort: 10901
+                  name: grpc
+                - containerPort: 9090
+                  name: http
+                - containerPort: 9091
+                  name: https
+              readinessProbe:
+                failureThreshold: 20
+                httpGet:
+                  path: /-/ready
+                  port: 9090
+                  scheme: HTTP
+                periodSeconds: 5
+              resources:
+                limits:
+                  cpu: ${THANOS_QUERIER_CPU_LIMIT}
+                  memory: ${THANOS_QUERIER_MEMORY_LIMIT}
+                requests:
+                  cpu: ${THANOS_QUERIER_CPU_REQUEST}
+                  memory: ${THANOS_QUERIER_MEMORY_REQUEST}
+              terminationMessagePolicy: FallbackToLogsOnError
+            - args:
+                - -provider=openshift
+                - -https-address=:9091
+                - -http-address=
+                - -email-domain=*
+                - -upstream=http://localhost:9090
+                - -openshift-service-account=${SERVICE_ACCOUNT_NAME}
+                - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}'
+                - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
+                - -tls-cert=/etc/tls/private/tls.crt
+                - -tls-key=/etc/tls/private/tls.key
+                - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+                - -cookie-secret-file=/etc/proxy/secrets/session_secret
+                - -openshift-ca=/etc/pki/tls/cert.pem
+                - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              image: ${OAUTH_PROXY_IMAGE}:${OAUTH_PROXY_IMAGE_TAG}
+              name: oauth-proxy
+              ports:
+                - containerPort: 9091
+                  name: https
+              resources:
+                limits:
+                  cpu: ${OAUTH_PROXY_CPU_LIMITS}
+                  memory: ${OAUTH_PROXY_MEMORY_LIMITS}
+                requests:
+                  cpu: ${OAUTH_PROXY_CPU_REQUEST}
+                  memory: ${OAUTH_PROXY_MEMORY_REQUEST}
+              volumeMounts:
+                - mountPath: /etc/tls/private
+                  name: query-tls
+                  readOnly: false
+                - mountPath: /etc/proxy/secrets
+                  name: query-proxy
+                  readOnly: false
+            - args:
+                - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+                - --reporter.type=grpc
+                - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+              env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /
+                  port: 14271
+                  scheme: HTTP
+              name: jaeger-agent
+              ports:
+                - containerPort: 5778
+                  name: configs
+                - containerPort: 6831
+                  name: jaeger-thrift
+                - containerPort: 14271
+                  name: metrics
+              resources:
+                limits:
+                  cpu: 128m
+                  memory: 128Mi
+                requests:
+                  cpu: 32m
+                  memory: 64Mi
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          securityContext: {}
+          serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+          terminationGracePeriodSeconds: 120
+          volumes:
+            - name: query-tls
+              secret:
+                secretName: query-tls
+            - name: query-proxy
+              secret:
+                secretName: query-proxy
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query-frontend
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-query-frontend
+    spec:
+      replicas: ${{THANOS_QUERY_FRONTEND_REPLICAS}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: query-cache
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-query-frontend
+          app.kubernetes.io/part-of: observatorium
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: query-cache
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: thanos-query-frontend
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/tracing: jaeger-agent
+            app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+        spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app.kubernetes.io/name
+                          operator: In
+                          values:
+                            - thanos-query-frontend
+                    namespaces:
+                      - ${NAMESPACE}
+                    topologyKey: kubernetes.io/hostname
+                  weight: 100
+          containers:
+            - args:
+                - query-frontend
+                - --log.level=info
+                - --log.format=logfmt
+                - --query-frontend.compress-responses
+                - --http-address=0.0.0.0:9090
+                - --query-frontend.downstream-url=http://observatorium-thanos-query.${NAMESPACE}.svc.cluster.local.:9090
+                - --query-frontend.log-queries-longer-than=${THANOS_QUERY_FRONTEND_LOG_QUERIES_LONGER_THAN}
+                - |-
+                  --query-range.response-cache-config="config":
+                    "max_size": "0"
+                    "max_size_items": 2048
+                    "validity": "6h"
+                  "type": "in-memory"
+                - |-
+                  --tracing.config="config":
+                    "sampler_param": 2
+                    "sampler_type": "ratelimiting"
+                    "service_name": "thanos-query-frontend"
+                  "type": "JAEGER"
+                - --query-range.split-interval=${THANOS_QUERY_FRONTEND_SPLIT_INTERVAL}
+                - --labels.split-interval=${THANOS_QUERY_FRONTEND_SPLIT_INTERVAL}
+                - --query-range.max-retries-per-request=${THANOS_QUERY_FRONTEND_MAX_RETRIES}
+                - --labels.max-retries-per-request=${THANOS_QUERY_FRONTEND_MAX_RETRIES}
+                - --labels.default-time-range=336h
+                - |-
+                  --labels.response-cache-config="config":
+                    "max_size": "0"
+                    "max_size_items": 2048
+                    "validity": "6h"
+                  "type": "in-memory"
+                - --cache-compression-type=snappy
+              env:
+                - name: HOST_IP_ADDRESS
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+              image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 4
+                httpGet:
+                  path: /-/healthy
+                  port: 9090
+                  scheme: HTTP
+                periodSeconds: 30
+              name: thanos-query-frontend
+              ports:
+                - containerPort: 9090
+                  name: http
+              readinessProbe:
+                failureThreshold: 20
+                httpGet:
+                  path: /-/ready
+                  port: 9090
+                  scheme: HTTP
+                periodSeconds: 5
+              resources:
+                limits:
+                  cpu: ${THANOS_QUERY_FRONTEND_CPU_LIMIT}
+                  memory: ${THANOS_QUERY_FRONTEND_MEMORY_LIMIT}
+                requests:
+                  cpu: ${THANOS_QUERY_FRONTEND_CPU_REQUEST}
+                  memory: ${THANOS_QUERY_FRONTEND_MEMORY_REQUEST}
+              terminationMessagePolicy: FallbackToLogsOnError
+            - args:
+                - -provider=openshift
+                - -https-address=:9091
+                - -http-address=
+                - -email-domain=*
+                - -upstream=http://localhost:9090
+                - -openshift-service-account=${SERVICE_ACCOUNT_NAME}
+                - '-openshift-sar={"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}'
+                - '-openshift-delegate-urls={"/": {"resource": "namespaces", "verb": "get", "name": "${NAMESPACE}", "namespace": "${NAMESPACE}"}}'
+                - -tls-cert=/etc/tls/private/tls.crt
+                - -tls-key=/etc/tls/private/tls.key
+                - -client-secret-file=/var/run/secrets/kubernetes.io/serviceaccount/token
+                - -cookie-secret-file=/etc/proxy/secrets/session_secret
+                - -openshift-ca=/etc/pki/tls/cert.pem
+                - -openshift-ca=/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              image: ${OAUTH_PROXY_IMAGE}:${OAUTH_PROXY_IMAGE_TAG}
+              name: oauth-proxy
+              ports:
+                - containerPort: 9091
+                  name: https
+              resources:
+                limits:
+                  cpu: ${OAUTH_PROXY_CPU_LIMITS}
+                  memory: ${OAUTH_PROXY_MEMORY_LIMITS}
+                requests:
+                  cpu: ${OAUTH_PROXY_CPU_REQUEST}
+                  memory: ${OAUTH_PROXY_MEMORY_REQUEST}
+              volumeMounts:
+                - mountPath: /etc/tls/private
+                  name: query-frontend-tls
+                  readOnly: false
+                - mountPath: /etc/proxy/secrets
+                  name: query-frontend-proxy
+                  readOnly: false
+            - args:
+                - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+                - --reporter.type=grpc
+                - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+              env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /
+                  port: 14271
+                  scheme: HTTP
+              name: jaeger-agent
+              ports:
+                - containerPort: 5778
+                  name: configs
+                - containerPort: 6831
+                  name: jaeger-thrift
+                - containerPort: 14271
+                  name: metrics
+              resources:
+                limits:
+                  cpu: 128m
+                  memory: 128Mi
+                requests:
+                  cpu: 32m
+                  memory: 64Mi
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          securityContext: {}
+          serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+          terminationGracePeriodSeconds: 120
+          volumes:
+            - name: query-frontend-tls
+              secret:
+                secretName: query-frontend-tls
+            - name: query-frontend-proxy
+              secret:
+                secretName: query-frontend-proxy
+  - apiVersion: v1
+    data:
+      session_secret: ""
+    kind: Secret
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query-frontend
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: query-frontend-proxy
+    type: Opaque
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        service.alpha.openshift.io/serving-cert-secret-name: query-frontend-tls
+      labels:
+        app.kubernetes.io/component: query-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query-frontend
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-query-frontend
+    spec:
+      ports:
+        - name: http
+          port: 9090
+          targetPort: 9090
+        - name: https
+          port: 9091
+          targetPort: 9091
+      selector:
+        app.kubernetes.io/component: query-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query-frontend
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query-frontend
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-query-frontend
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query-frontend
+        app.kubernetes.io/part-of: observatorium
+        prometheus: app-sre
+      name: observatorium-thanos-query-frontend
+    spec:
+      endpoints:
+        - port: http
+          relabelings:
+            - separator: /
+              sourceLabels:
+                - namespace
+                - pod
+              targetLabel: instance
+      namespaceSelector:
+        matchNames: ${{NAMESPACES}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: query-cache
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-query-frontend
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    data:
+      session_secret: ""
+    kind: Secret
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-layer
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: query-proxy
+    type: Opaque
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      annotations:
+        service.alpha.openshift.io/serving-cert-secret-name: query-tls
+      labels:
+        app.kubernetes.io/component: query-layer
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-query
+    spec:
+      ports:
+        - name: grpc
+          port: 10901
+          targetPort: 10901
+        - name: http
+          port: 9090
+          targetPort: 9090
+        - name: https
+          port: 9091
+          targetPort: 9091
+      selector:
+        app.kubernetes.io/component: query-layer
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-layer
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-query
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        app.kubernetes.io/component: query-layer
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-query
+        app.kubernetes.io/part-of: observatorium
+        prometheus: app-sre
+      name: observatorium-thanos-query
+    spec:
+      endpoints:
+        - port: http
+          relabelings:
+            - separator: /
+              sourceLabels:
+                - namespace
+                - pod
+              targetLabel: instance
+      namespaceSelector:
+        matchNames: ${{NAMESPACES}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: query-layer
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-query
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    data:
+      hashrings.json: |-
+        [
+          {
+            "hashring": "default",
+            "tenants": [
+
+            ]
+          }
+        ]
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/component: kubernetes-controller
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-receive-controller
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_RECEIVE_CONTROLLER_IMAGE_TAG}
+      name: observatorium-thanos-receive-controller-tenants
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: kubernetes-controller
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-receive-controller
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_RECEIVE_CONTROLLER_IMAGE_TAG}
+      name: observatorium-thanos-receive-controller
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: kubernetes-controller
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-receive-controller
+          app.kubernetes.io/part-of: observatorium
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: kubernetes-controller
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: thanos-receive-controller
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/version: ${THANOS_RECEIVE_CONTROLLER_IMAGE_TAG}
+        spec:
+          containers:
+            - args:
+                - --configmap-name=observatorium-thanos-receive-controller-tenants
+                - --configmap-generated-name=observatorium-thanos-receive-controller-tenants-generated
+                - --file-name=hashrings.json
+                - --namespace=$(NAMESPACE)
+              env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+              image: ${THANOS_RECEIVE_CONTROLLER_IMAGE}:${THANOS_RECEIVE_CONTROLLER_IMAGE_TAG}
+              name: thanos-receive-controller
+              ports:
+                - containerPort: 8080
+                  name: http
+              resources:
+                limits:
+                  cpu: 64m
+                  memory: 128Mi
+                requests:
+                  cpu: 10m
+                  memory: 24Mi
+              securityContext: {}
+          securityContext: {}
+          serviceAccount: observatorium-thanos-receive-controller
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/component: kubernetes-controller
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-receive-controller
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_RECEIVE_CONTROLLER_IMAGE_TAG}
+      name: observatorium-thanos-receive-controller
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - configmaps
+        verbs:
+          - list
+          - watch
+          - get
+          - create
+          - update
+      - apiGroups:
+          - apps
+        resources:
+          - statefulsets
+        verbs:
+          - list
+          - watch
+          - get
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: kubernetes-controller
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-receive-controller
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_RECEIVE_CONTROLLER_IMAGE_TAG}
+      name: observatorium-thanos-receive-controller
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: observatorium-thanos-receive-controller
+    subjects:
+      - kind: ServiceAccount
+        name: observatorium-thanos-receive-controller
+        namespace: ${NAMESPACE}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: kubernetes-controller
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-receive-controller
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_RECEIVE_CONTROLLER_IMAGE_TAG}
+      name: observatorium-thanos-receive-controller
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          targetPort: 8080
+      selector:
+        app.kubernetes.io/component: kubernetes-controller
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-receive-controller
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: kubernetes-controller
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-receive-controller
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_RECEIVE_CONTROLLER_IMAGE_TAG}
+      name: observatorium-thanos-receive-controller
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        prometheus: app-sre
+      name: observatorium-thanos-receive-controller
+    spec:
+      endpoints:
+        - port: http
+      namespaceSelector:
+        matchNames: ${{NAMESPACES}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: kubernetes-controller
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-receive-controller
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: policy/v1beta1
+    kind: PodDisruptionBudget
+    metadata:
+      name: observatorium-thanos-receive-default
+    spec:
+      maxUnavailable: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: database-write-hashring
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-receive
+          app.kubernetes.io/part-of: observatorium
+          controller.receive.thanos.io/hashring: default
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: database-write-hashring
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-receive
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+        controller.receive.thanos.io/hashring: default
+      name: observatorium-thanos-receive-default
+    spec:
+      clusterIP: None
+      ports:
+        - name: grpc
+          port: 10901
+          targetPort: 10901
+        - name: http
+          port: 10902
+          targetPort: 10902
+        - name: remote-write
+          port: 19291
+          targetPort: 19291
+      selector:
+        app.kubernetes.io/component: database-write-hashring
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-receive
+        app.kubernetes.io/part-of: observatorium
+        controller.receive.thanos.io/hashring: default
+  - apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      labels:
+        app.kubernetes.io/component: database-write-hashring
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-receive
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+        controller.receive.thanos.io: thanos-receive-controller
+        controller.receive.thanos.io/hashring: default
+      name: observatorium-thanos-receive-default
+    spec:
+      replicas: ${{THANOS_RECEIVE_REPLICAS}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: database-write-hashring
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-receive
+          app.kubernetes.io/part-of: observatorium
+          controller.receive.thanos.io/hashring: default
+      serviceName: observatorium-thanos-receive-default
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: database-write-hashring
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: thanos-receive
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/tracing: jaeger-agent
+            app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+            controller.receive.thanos.io/hashring: default
+        spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app.kubernetes.io/name
+                          operator: In
+                          values:
+                            - thanos-receive
+                        - key: app.kubernetes.io/instance
+                          operator: In
+                          values:
+                            - observatorium
+                    namespaces:
+                      - ${NAMESPACE}
+                    topologyKey: kubernetes.io/hostname
+                  weight: 100
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app.kubernetes.io/name
+                          operator: In
+                          values:
+                            - thanos-receive
+                        - key: app.kubernetes.io/instance
+                          operator: In
+                          values:
+                            - observatorium
+                    namespaces:
+                      - ${NAMESPACE}
+                    topologyKey: topology.kubernetes.io/zone
+                  weight: 100
+          containers:
+            - args:
+                - receive
+                - --log.level=${THANOS_RECEIVE_LOG_LEVEL}
+                - --log.format=logfmt
+                - --grpc-address=0.0.0.0:10901
+                - --http-address=0.0.0.0:10902
+                - --remote-write.address=0.0.0.0:19291
+                - --receive.replication-factor=3
+                - --objstore.config=$(OBJSTORE_CONFIG)
+                - --tsdb.path=${THANOS_RECEIVE_TSDB_PATH}
+                - --tsdb.retention=4d
+                - --receive.local-endpoint=$(NAME).observatorium-thanos-receive-default.$(NAMESPACE).svc.cluster.local:10901
+                - --label=replica="$(NAME)"
+                - --label=receive="true"
+                - --receive.hashrings-file=/var/lib/thanos-receive/hashrings.json
+                - |-
+                  --tracing.config="config":
+                    "sampler_param": 2
+                    "sampler_type": "ratelimiting"
+                    "service_name": "thanos-receive"
+                  "type": "JAEGER"
+                - --receive.default-tenant-id=FB870BF3-9F3A-44FF-9BF7-D7A047A52F43
+              env:
+                - name: NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: OBJSTORE_CONFIG
+                  valueFrom:
+                    secretKeyRef:
+                      key: thanos.yaml
+                      name: ${THANOS_CONFIG_SECRET}
+                - name: HOST_IP_ADDRESS
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: DEBUG
+                  value: ${THANOS_RECEIVE_DEBUG_ENV}
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_access_key_id
+                      name: ${THANOS_S3_SECRET}
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_secret_access_key
+                      name: ${THANOS_S3_SECRET}
+                - name: DEBUG
+                  value: ${THANOS_RECEIVE_DEBUG_ENV}
+              image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 8
+                httpGet:
+                  path: /-/healthy
+                  port: 10902
+                  scheme: HTTP
+                periodSeconds: 30
+              name: thanos-receive
+              ports:
+                - containerPort: 10901
+                  name: grpc
+                - containerPort: 10902
+                  name: http
+                - containerPort: 19291
+                  name: remote-write
+              readinessProbe:
+                failureThreshold: 20
+                httpGet:
+                  path: /-/ready
+                  port: 10902
+                  scheme: HTTP
+                periodSeconds: 5
+              resources:
+                limits:
+                  cpu: ${THANOS_RECEIVE_CPU_LIMIT}
+                  memory: ${THANOS_RECEIVE_MEMORY_LIMIT}
+                requests:
+                  cpu: ${THANOS_RECEIVE_CPU_REQUEST}
+                  memory: ${THANOS_RECEIVE_MEMORY_REQUEST}
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+                - mountPath: /var/thanos/receive
+                  name: data
+                  readOnly: false
+                - mountPath: /var/lib/thanos-receive
+                  name: hashring-config
+            - args:
+                - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+                - --reporter.type=grpc
+                - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+              env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /
+                  port: 14271
+                  scheme: HTTP
+              name: jaeger-agent
+              ports:
+                - containerPort: 5778
+                  name: configs
+                - containerPort: 6831
+                  name: jaeger-thrift
+                - containerPort: 14271
+                  name: metrics
+              resources:
+                limits:
+                  cpu: 128m
+                  memory: 128Mi
+                requests:
+                  cpu: 32m
+                  memory: 64Mi
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          securityContext: {}
+          serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+          terminationGracePeriodSeconds: 900
+          volumes:
+            - configMap:
+                name: observatorium-thanos-receive-controller-tenants-generated
+              name: hashring-config
+      volumeClaimTemplates:
+        - metadata:
+            labels:
+              app.kubernetes.io/component: database-write-hashring
+              app.kubernetes.io/instance: observatorium
+              app.kubernetes.io/name: thanos-receive
+              app.kubernetes.io/part-of: observatorium
+              controller.receive.thanos.io/hashring: default
+            name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 50Gi
+            storageClassName: ${STORAGE_CLASS}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-receive
+        app.kubernetes.io/part-of: observatorium
+      name: observatorium-thanos-receive
+    spec:
+      ports:
+        - name: grpc
+          port: 10901
+          targetPort: 10901
+        - name: http
+          port: 10902
+          targetPort: 10902
+        - name: remote-write
+          port: 19291
+          targetPort: 19291
+      selector:
+        app.kubernetes.io/name: thanos-receive
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: database-write-hashring
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-receive
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-receive
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        app.kubernetes.io/component: database-write-hashring
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-receive
+        app.kubernetes.io/part-of: observatorium
+        prometheus: app-sre
+      name: observatorium-thanos-receive
+    spec:
+      endpoints:
+        - port: http
+          relabelings:
+            - separator: /
+              sourceLabels:
+                - namespace
+                - pod
+              targetLabel: instance
+      namespaceSelector:
+        matchNames: ${{NAMESPACES}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: database-write-hashring
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-receive
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    data:
+      observatorium.yaml: |-
+        "groups":
+        - "interval": "1m"
+          "name": "telemeter-telemeter.rules"
+          "rules":
+          - "expr": |
+              count by (name,reason) (cluster_operator_conditions{condition="Degraded"} == 1)
+            "labels":
+              "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+            "record": "name_reason:cluster_operator_degraded:count"
+          - "expr": |
+              count by (name,reason) (cluster_operator_conditions{condition="Available"} == 0)
+            "labels":
+              "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+            "record": "name_reason:cluster_operator_unavailable:count"
+          - "expr": |
+              sort_desc(max by (_id,code) (code:apiserver_request_count:rate:sum{code=~"(4|5)\\d\\d"}) > 0.5)
+            "labels":
+              "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+            "record": "id_code:apiserver_request_error_rate_sum:max"
+          - "expr": |
+              bottomk by (_id) (1, max by (_id, version) (0 * cluster_version{type="failure"}) or max by (_id, version) (1 + 0 * cluster_version{type="current"}))
+            "labels":
+              "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+            "record": "id_version:cluster_available"
+          - "expr": |
+              topk by (_id) (1, max by (_id, managed, ebs_account, internal) (label_replace(label_replace((subscription_labels{support=~"Standard|Premium|Layered"} * 0 + 1) or subscription_labels * 0, "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com"), "managed", "", "managed", "false")) + on(_id) group_left(version) (topk by (_id) (1, id_version*0)) + on(_id) group_left(install_type) (topk by (_id) (1, id_install_type*0)) + on(_id) group_left(host_type) (topk by (_id) (1, id_primary_host_type*0)) + on(_id) group_left(provider) (topk by (_id) (1, id_provider*0)))
+            "labels":
+              "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+            "record": "id_version_ebs_account_internal:cluster_subscribed"
+          - "expr": |
+              0 * (max by (_id,host_type) (topk by (_id) (1, label_replace(label_replace(label_replace(label_replace(label_replace(label_replace(cluster:virt_platform_nodes:sum, "host_type", "$1", "type", "(aws|ibm_.*|ovirt|none|rhev|gcp|openstack|hyperv|vmware)"), "host_type", "virt-unknown", "host_type", ""), "host_type", "kvm-unknown", "type", "kvm"), "host_type", "xen-unknown", "type", "xen.*"), "host_type", "metal", "host_type", "none"), "host_type", "ibm-$1", "host_type", "ibm[_-](power|systemz).*"))) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}), "host_type", "", "host_type", ""))
+            "labels":
+              "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+            "record": "id_primary_host_type"
+          - "expr": |
+              0 * topk by (_id) (1, count by (_id, provider) (label_replace(cluster_infrastructure_provider * 0 + 2, "provider", "$1", "type", "(.*)")) or on(_id) label_replace(max by (_id) (cluster_version{type="current"}*0+1), "provider", "", "provider", "") or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "provider", "hypershift-unknown", "provider", ""))
+            "labels":
+              "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+            "record": "id_provider"
+          - "expr": |
+              0 * (max by (_id,version) (topk by (_id) (1, cluster_version{type="current"})) or on(_id) label_replace(max by (_id) (cluster:node_instance_type_count:sum*0), "version", "", "unknown", ""))
+            "labels":
+              "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+            "record": "id_version"
+          - "expr": |
+              0 * (count by (_id, install_type) (label_replace(label_replace(label_replace(label_replace(topk by (_id) (1, cluster_installer), "install_type", "upi", "type", "other"), "install_type", "ipi", "type", "openshift-install"), "install_type", "hive", "invoker", "hive"), "install_type", "assisted-installer", "invoker", "assisted-installer")) or on(_id) (label_replace(count by (_id) (cluster:virt_platform_nodes:sum), "install_type", "hypershift-unknown", "install_type", ""))*0)
+            "labels":
+              "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+            "record": "id_install_type"
+          - "expr": |
+              0 * (max by (_id,cloudpak_type) (topk by (_id) (1, count by (_id,cloudpak_type) (label_replace(subscription_sync_total{installed=~"ibm-((licensing|common-service)-operator).*"}, "cloudpak_type", "unknown", "", ".*")))))
+            "labels":
+              "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+            "record": "id_cloudpak_type"
+          - "expr": |
+              topk by(_id) (1,
+                (label_replace(7+0*count by (_id) (cluster:usage:resources:sum{resource="netnamespaces.network.openshift.io"}), "network_type", "OpenshiftSDN", "", "") > 0) or
+                (label_replace(6+0*count by (_id) (cluster:usage:resources:sum{resource="clusterinformations.crd.projectcalico.org"}), "network_type", "Calico", "", "") > 0) or
+                (label_replace(5+0*count by (_id) (cluster:usage:resources:sum{resource="acicontainersoperators.aci.ctrl"}), "network_type", "ACI", "", "") > 0) or
+                (label_replace(4+0*count by (_id) (cluster:usage:resources:sum{resource="kuryrnetworks.openstack.org"}), "network_type", "Kuryr", "", "") > 0) or
+                (label_replace(3+0*count by (_id) (cluster:usage:resources:sum{resource="ciliumendpoints.cilium.io"}), "network_type", "Cilium", "", "") > 0) or
+                (label_replace(2+0*count by (_id) (cluster:usage:resources:sum{resource="ncpconfigs.nsx.vmware.com"}), "network_type", "VMWareNSX", "", "") > 0) or
+                (label_replace(1+0*count by (_id) (cluster:usage:resources:sum{resource="egressips.k8s.ovn.org"}), "network_type", "OVNKube", "", "")) or
+                (label_replace(0+0*max by (_id) (cluster:node_instance_type_count:sum*0), "network_type", "unknown", "", ""))
+              )
+            "labels":
+              "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+            "record": "id_network_type"
+          - "expr": |
+              0 * topk by (ebs_account) (1, max by (ebs_account,account_type,internal,email_domain) (label_replace(label_replace(label_replace(subscription_labels{email_domain="redhat.com"}*0+5, "class", "Internal", "class", ".*") or label_replace(subscription_labels{class!="Customer",email_domain=~"(.*\\.|^)ibm.com"}*0+4, "class", "Internal", "class", ".*") or (subscription_labels{class="Customer"}*0+3) or (subscription_labels{class="Partner"}*0+2) or (subscription_labels{class="Evaluation"}*0+1) or label_replace(subscription_labels{class!~"Evaluation|Customer|Partner"}*0+0, "class", "", "class", ".*"), "account_type", "$1", "class", "(.+)"), "internal", "true", "email_domain", "redhat.com|(.*\\.|^)ibm.com") ))
+            "labels":
+              "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+            "record": "ebs_account_account_type_email_domain_internal"
+          - "expr": |
+              topk(500, sum (acm_managed_cluster_info) by (managed_cluster_id, cloud, created_via, endpoint, instance, job, namespace, pod, service, vendor, version))
+            "labels":
+              "tenant_id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+            "record": "acm_top500_mcs:acm_managed_cluster_info"
+    kind: ConfigMap
+    metadata:
+      annotations:
+        qontract.recycle: "true"
+      labels:
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/part-of: observatorium
+      name: observatorium-rules
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-rule
+    spec:
+      clusterIP: None
+      ports:
+        - name: grpc
+          port: 10901
+          targetPort: 10901
+        - name: http
+          port: 10902
+          targetPort: 10902
+      selector:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-rule
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+        prometheus: app-sre
+      name: observatorium-thanos-rule
+    spec:
+      endpoints:
+        - port: http
+          relabelings:
+            - separator: /
+              sourceLabels:
+                - namespace
+                - pod
+              targetLabel: instance
+      namespaceSelector:
+        matchNames: ${{NAMESPACES}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: rule-evaluation-engine
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-rule
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      labels:
+        app.kubernetes.io/component: rule-evaluation-engine
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-rule
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-rule
+    spec:
+      replicas: ${{THANOS_RULER_REPLICAS}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: rule-evaluation-engine
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-rule
+          app.kubernetes.io/part-of: observatorium
+      serviceName: observatorium-thanos-rule
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: rule-evaluation-engine
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: thanos-rule
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/tracing: jaeger-agent
+            app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+        spec:
+          containers:
+            - args:
+                - rule
+                - --log.level=${THANOS_RULER_LOG_LEVEL}
+                - --log.format=logfmt
+                - --grpc-address=0.0.0.0:10901
+                - --http-address=0.0.0.0:10902
+                - --objstore.config=$(OBJSTORE_CONFIG)
+                - --data-dir=/var/thanos/rule
+                - --label=rule_replica="$(NAME)"
+                - --alert.label-drop=rule_replica
+                - --tsdb.retention=48h
+                - --tsdb.block-duration=2h
+                - --query=dnssrv+_http._tcp.observatorium-thanos-query.${NAMESPACE}.svc.cluster.local
+                - --rule-file=/etc/thanos/rules/observatorium-rules/observatorium.yaml
+                - |-
+                  --tracing.config="config":
+                    "sampler_param": 2
+                    "sampler_type": "ratelimiting"
+                    "service_name": "thanos-rule"
+                  "type": "JAEGER"
+              env:
+                - name: NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OBJSTORE_CONFIG
+                  valueFrom:
+                    secretKeyRef:
+                      key: thanos.yaml
+                      name: ${THANOS_CONFIG_SECRET}
+                - name: HOST_IP_ADDRESS
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_access_key_id
+                      name: ${THANOS_S3_SECRET}
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_secret_access_key
+                      name: ${THANOS_S3_SECRET}
+              image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 24
+                httpGet:
+                  path: /-/healthy
+                  port: 10902
+                  scheme: HTTP
+                periodSeconds: 5
+              name: thanos-rule
+              ports:
+                - containerPort: 10901
+                  name: grpc
+                - containerPort: 10902
+                  name: http
+              readinessProbe:
+                failureThreshold: 18
+                httpGet:
+                  path: /-/ready
+                  port: 10902
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 5
+              resources:
+                limits:
+                  cpu: ${THANOS_RULER_CPU_LIMIT}
+                  memory: ${THANOS_RULER_MEMORY_LIMIT}
+                requests:
+                  cpu: ${THANOS_RULER_CPU_REQUEST}
+                  memory: ${THANOS_RULER_MEMORY_REQUEST}
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+                - mountPath: /var/thanos/rule
+                  name: data
+                  readOnly: false
+                - mountPath: /etc/thanos/rules/observatorium-rules
+                  name: observatorium-rules
+            - args:
+                - -webhook-url=http://localhost:10902/-/reload
+                - -volume-dir=/etc/thanos/rules/observatorium-rules
+              image: ${CONFIGMAP_RELOADER_IMAGE}:${CONFIGMAP_RELOADER_IMAGE_TAG}
+              name: configmap-reloader
+              volumeMounts:
+                - mountPath: /etc/thanos/rules/observatorium-rules
+                  name: observatorium-rules
+            - args:
+                - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+                - --reporter.type=grpc
+                - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+              env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /
+                  port: 14271
+                  scheme: HTTP
+              name: jaeger-agent
+              ports:
+                - containerPort: 5778
+                  name: configs
+                - containerPort: 6831
+                  name: jaeger-thrift
+                - containerPort: 14271
+                  name: metrics
+              resources:
+                limits:
+                  cpu: 128m
+                  memory: 128Mi
+                requests:
+                  cpu: 32m
+                  memory: 64Mi
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          securityContext: {}
+          serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+          volumes:
+            - configMap:
+                name: observatorium-rules
+              name: observatorium-rules
+      volumeClaimTemplates:
+        - metadata:
+            labels:
+              app.kubernetes.io/component: rule-evaluation-engine
+              app.kubernetes.io/instance: observatorium
+              app.kubernetes.io/name: thanos-rule
+              app.kubernetes.io/part-of: observatorium
+            name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: ${THANOS_RULER_PVC_REQUEST}
+            storageClassName: ${STORAGE_CLASS}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: store-bucket-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+      name: observatorium-thanos-store-bucket-cache-memcached
+    spec:
+      clusterIP: None
+      ports:
+        - name: client
+          port: 11211
+          targetPort: 11211
+        - name: metrics
+          port: 9150
+          targetPort: 9150
+      selector:
+        app.kubernetes.io/component: store-bucket-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: store-bucket-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+      name: observatorium-thanos-store-bucket-cache-memcached
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        prometheus: app-sre
+      name: observatorium-thanos-store-bucket-cache-memcached
+    spec:
+      endpoints:
+        - port: metrics
+      namespaceSelector:
+        matchNames: ${{NAMESPACES}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: store-bucket-cache
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: memcached
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      labels:
+        app.kubernetes.io/component: store-bucket-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+      name: observatorium-thanos-store-bucket-cache-memcached
+    spec:
+      replicas: ${{THANOS_STORE_BUCKET_CACHE_REPLICAS}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: store-bucket-cache
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: memcached
+          app.kubernetes.io/part-of: observatorium
+      serviceName: observatorium-thanos-store-bucket-cache-memcached
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: store-bucket-cache
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: memcached
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+        spec:
+          containers:
+            - args:
+                - -m ${THANOS_STORE_BUCKET_CACHE_MEMORY_LIMIT_MB}
+                - -I 1m
+                - -c ${THANOS_STORE_BUCKET_CACHE_CONNECTION_LIMIT}
+                - -v
+              image: ${MEMCACHED_IMAGE}:${MEMCACHED_IMAGE_TAG}
+              name: memcached
+              ports:
+                - containerPort: 11211
+                  name: client
+              resources:
+                limits:
+                  cpu: ${THANOS_STORE_BUCKET_CACHE_MEMCACHED_CPU_LIMIT}
+                  memory: ${THANOS_STORE_BUCKET_CACHE_MEMCACHED_MEMORY_LIMIT}
+                requests:
+                  cpu: ${THANOS_STORE_BUCKET_CACHE_MEMCACHED_CPU_REQUEST}
+                  memory: ${THANOS_STORE_BUCKET_CACHE_MEMCACHED_MEMORY_REQUEST}
+              terminationMessagePolicy: FallbackToLogsOnError
+            - args:
+                - --memcached.address=localhost:11211
+                - --web.listen-address=0.0.0.0:9150
+              image: ${MEMCACHED_EXPORTER_IMAGE}:${MEMCACHED_EXPORTER_IMAGE_TAG}
+              name: exporter
+              ports:
+                - containerPort: 9150
+                  name: metrics
+              resources:
+                limits:
+                  cpu: ${MEMCACHED_EXPORTER_CPU_LIMIT}
+                  memory: ${MEMCACHED_EXPORTER_MEMORY_LIMIT}
+                requests:
+                  cpu: ${MEMCACHED_EXPORTER_CPU_REQUEST}
+                  memory: ${MEMCACHED_EXPORTER_MEMORY_REQUEST}
+          securityContext: {}
+          serviceAccountName: observatorium-thanos-store-bucket-cache-memcached
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: store-index-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+      name: observatorium-thanos-store-index-cache-memcached
+    spec:
+      clusterIP: None
+      ports:
+        - name: client
+          port: 11211
+          targetPort: 11211
+        - name: metrics
+          port: 9150
+          targetPort: 9150
+      selector:
+        app.kubernetes.io/component: store-index-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: store-index-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+      name: observatorium-thanos-store-index-cache-memcached
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        prometheus: app-sre
+      name: observatorium-thanos-store-index-cache-memcached
+    spec:
+      endpoints:
+        - port: metrics
+      namespaceSelector:
+        matchNames: ${{NAMESPACES}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: store-index-cache
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: memcached
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      labels:
+        app.kubernetes.io/component: store-index-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+      name: observatorium-thanos-store-index-cache-memcached
+    spec:
+      replicas: ${{THANOS_STORE_INDEX_CACHE_REPLICAS}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: store-index-cache
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: memcached
+          app.kubernetes.io/part-of: observatorium
+      serviceName: observatorium-thanos-store-index-cache-memcached
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: store-index-cache
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: memcached
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+        spec:
+          containers:
+            - args:
+                - -m ${THANOS_STORE_INDEX_CACHE_MEMORY_LIMIT_MB}
+                - -I 5m
+                - -c ${THANOS_STORE_INDEX_CACHE_CONNECTION_LIMIT}
+                - -v
+              image: ${MEMCACHED_IMAGE}:${MEMCACHED_IMAGE_TAG}
+              name: memcached
+              ports:
+                - containerPort: 11211
+                  name: client
+              resources:
+                limits:
+                  cpu: ${THANOS_STORE_INDEX_CACHE_MEMCACHED_CPU_LIMIT}
+                  memory: ${THANOS_STORE_INDEX_CACHE_MEMCACHED_MEMORY_LIMIT}
+                requests:
+                  cpu: ${THANOS_STORE_INDEX_CACHE_MEMCACHED_CPU_REQUEST}
+                  memory: ${THANOS_STORE_INDEX_CACHE_MEMCACHED_MEMORY_REQUEST}
+              terminationMessagePolicy: FallbackToLogsOnError
+            - args:
+                - --memcached.address=localhost:11211
+                - --web.listen-address=0.0.0.0:9150
+              image: ${MEMCACHED_EXPORTER_IMAGE}:${MEMCACHED_EXPORTER_IMAGE_TAG}
+              name: exporter
+              ports:
+                - containerPort: 9150
+                  name: metrics
+              resources:
+                limits:
+                  cpu: ${MEMCACHED_EXPORTER_CPU_LIMIT}
+                  memory: ${MEMCACHED_EXPORTER_MEMORY_LIMIT}
+                requests:
+                  cpu: ${MEMCACHED_EXPORTER_CPU_REQUEST}
+                  memory: ${MEMCACHED_EXPORTER_MEMORY_REQUEST}
+          securityContext: {}
+          serviceAccountName: observatorium-thanos-store-index-cache-memcached
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-store
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+      name: observatorium-thanos-store-shard
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-store
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+        store.thanos.io/shard: shard-0
+      name: observatorium-thanos-store-shard-0
+    spec:
+      clusterIP: None
+      ports:
+        - name: grpc
+          port: 10901
+          targetPort: 10901
+        - name: http
+          port: 10902
+          targetPort: 10902
+      selector:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-store
+        app.kubernetes.io/part-of: observatorium
+        store.thanos.io/shard: shard-0
+  - apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      labels:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-store
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+        store.thanos.io/shard: shard-0
+      name: observatorium-thanos-store-shard-0
+    spec:
+      replicas: ${{THANOS_STORE_REPLICAS}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: object-store-gateway
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-store
+          app.kubernetes.io/part-of: observatorium
+          store.thanos.io/shard: shard-0
+      serviceName: observatorium-thanos-store-shard-0
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: object-store-gateway
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: thanos-store
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/tracing: jaeger-agent
+            app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+            store.thanos.io/shard: shard-0
+        spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app.kubernetes.io/name
+                          operator: In
+                          values:
+                            - thanos-store
+                        - key: app.kubernetes.io/instance
+                          operator: In
+                          values:
+                            - observatorium
+                    namespaces:
+                      - ${NAMESPACE}
+                    topologyKey: kubernetes.io/hostname
+                  weight: 100
+          containers:
+            - args:
+                - store
+                - --log.level=${THANOS_STORE_LOG_LEVEL}
+                - --log.format=logfmt
+                - --data-dir=/var/thanos/store
+                - --grpc-address=0.0.0.0:10901
+                - --http-address=0.0.0.0:10902
+                - --objstore.config=$(OBJSTORE_CONFIG)
+                - --ignore-deletion-marks-delay=24h
+                - |-
+                  --index-cache.config="config":
+                    "addresses":
+                    - "dnssrv+_client._tcp.observatorium-thanos-store-index-cache-memcached.${NAMESPACE}.svc"
+                    "dns_provider_update_interval": "10s"
+                    "max_async_buffer_size": 200000
+                    "max_async_concurrency": 200
+                    "max_get_multi_batch_size": 100
+                    "max_get_multi_concurrency": 1000
+                    "max_idle_connections": 1300
+                    "max_item_size": "5MiB"
+                    "timeout": "2s"
+                  "type": "memcached"
+                - |-
+                  --store.caching-bucket.config="blocks_iter_ttl": "5m"
+                  "chunk_object_attrs_ttl": "24h"
+                  "chunk_subrange_size": 16000
+                  "chunk_subrange_ttl": "24h"
+                  "config":
+                    "addresses":
+                    - "dnssrv+_client._tcp.observatorium-thanos-store-bucket-cache-memcached.${NAMESPACE}.svc"
+                    "dns_provider_update_interval": "10s"
+                    "max_async_buffer_size": 25000
+                    "max_async_concurrency": 50
+                    "max_get_multi_batch_size": 100
+                    "max_get_multi_concurrency": 1000
+                    "max_idle_connections": 1100
+                    "max_item_size": "1MiB"
+                    "timeout": "2s"
+                  "max_chunks_get_range_requests": 3
+                  "metafile_content_ttl": "24h"
+                  "metafile_doesnt_exist_ttl": "15m"
+                  "metafile_exists_ttl": "2h"
+                  "metafile_max_size": "1MiB"
+                  "type": "memcached"
+                - |-
+                  --tracing.config="config":
+                    "sampler_param": 2
+                    "sampler_type": "ratelimiting"
+                    "service_name": "thanos-store"
+                  "type": "JAEGER"
+                - |
+                  --selector.relabel-config=
+                    - action: hashmod
+                      source_labels: ["__block_id"]
+                      target_label: shard
+                      modulus: 3
+                    - action: keep
+                      source_labels: ["shard"]
+                      regex: 0
+              env:
+                - name: OBJSTORE_CONFIG
+                  valueFrom:
+                    secretKeyRef:
+                      key: thanos.yaml
+                      name: ${THANOS_CONFIG_SECRET}
+                - name: HOST_IP_ADDRESS
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_access_key_id
+                      name: ${THANOS_S3_SECRET}
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_secret_access_key
+                      name: ${THANOS_S3_SECRET}
+              image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 8
+                httpGet:
+                  path: /-/healthy
+                  port: 10902
+                  scheme: HTTP
+                periodSeconds: 30
+              name: thanos-store
+              ports:
+                - containerPort: 10901
+                  name: grpc
+                - containerPort: 10902
+                  name: http
+              readinessProbe:
+                failureThreshold: 20
+                httpGet:
+                  path: /-/ready
+                  port: 10902
+                  scheme: HTTP
+                periodSeconds: 5
+              resources:
+                limits:
+                  cpu: ${THANOS_STORE_CPU_LIMIT}
+                  memory: ${THANOS_STORE_MEMORY_LIMIT}
+                requests:
+                  cpu: ${THANOS_STORE_CPU_REQUEST}
+                  memory: ${THANOS_STORE_MEMORY_REQUEST}
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+                - mountPath: /var/thanos/store
+                  name: data
+                  readOnly: false
+            - args:
+                - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+                - --reporter.type=grpc
+                - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+              env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /
+                  port: 14271
+                  scheme: HTTP
+              name: jaeger-agent
+              ports:
+                - containerPort: 5778
+                  name: configs
+                - containerPort: 6831
+                  name: jaeger-thrift
+                - containerPort: 14271
+                  name: metrics
+              resources:
+                limits:
+                  cpu: 128m
+                  memory: 128Mi
+                requests:
+                  cpu: 32m
+                  memory: 64Mi
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          securityContext: {}
+          serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+          terminationGracePeriodSeconds: 120
+          volumes: []
+      volumeClaimTemplates:
+        - metadata:
+            labels:
+              app.kubernetes.io/component: object-store-gateway
+              app.kubernetes.io/instance: observatorium
+              app.kubernetes.io/name: thanos-store
+              app.kubernetes.io/part-of: observatorium
+              store.thanos.io/shard: shard-0
+            name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 50Gi
+            storageClassName: ${STORAGE_CLASS}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-store
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+        store.thanos.io/shard: shard-1
+      name: observatorium-thanos-store-shard-1
+    spec:
+      clusterIP: None
+      ports:
+        - name: grpc
+          port: 10901
+          targetPort: 10901
+        - name: http
+          port: 10902
+          targetPort: 10902
+      selector:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-store
+        app.kubernetes.io/part-of: observatorium
+        store.thanos.io/shard: shard-1
+  - apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      labels:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-store
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+        store.thanos.io/shard: shard-1
+      name: observatorium-thanos-store-shard-1
+    spec:
+      replicas: ${{THANOS_STORE_REPLICAS}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: object-store-gateway
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-store
+          app.kubernetes.io/part-of: observatorium
+          store.thanos.io/shard: shard-1
+      serviceName: observatorium-thanos-store-shard-1
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: object-store-gateway
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: thanos-store
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/tracing: jaeger-agent
+            app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+            store.thanos.io/shard: shard-1
+        spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app.kubernetes.io/name
+                          operator: In
+                          values:
+                            - thanos-store
+                        - key: app.kubernetes.io/instance
+                          operator: In
+                          values:
+                            - observatorium
+                    namespaces:
+                      - ${NAMESPACE}
+                    topologyKey: kubernetes.io/hostname
+                  weight: 100
+          containers:
+            - args:
+                - store
+                - --log.level=${THANOS_STORE_LOG_LEVEL}
+                - --log.format=logfmt
+                - --data-dir=/var/thanos/store
+                - --grpc-address=0.0.0.0:10901
+                - --http-address=0.0.0.0:10902
+                - --objstore.config=$(OBJSTORE_CONFIG)
+                - --ignore-deletion-marks-delay=24h
+                - |-
+                  --index-cache.config="config":
+                    "addresses":
+                    - "dnssrv+_client._tcp.observatorium-thanos-store-index-cache-memcached.${NAMESPACE}.svc"
+                    "dns_provider_update_interval": "10s"
+                    "max_async_buffer_size": 200000
+                    "max_async_concurrency": 200
+                    "max_get_multi_batch_size": 100
+                    "max_get_multi_concurrency": 1000
+                    "max_idle_connections": 1300
+                    "max_item_size": "5MiB"
+                    "timeout": "2s"
+                  "type": "memcached"
+                - |-
+                  --store.caching-bucket.config="blocks_iter_ttl": "5m"
+                  "chunk_object_attrs_ttl": "24h"
+                  "chunk_subrange_size": 16000
+                  "chunk_subrange_ttl": "24h"
+                  "config":
+                    "addresses":
+                    - "dnssrv+_client._tcp.observatorium-thanos-store-bucket-cache-memcached.${NAMESPACE}.svc"
+                    "dns_provider_update_interval": "10s"
+                    "max_async_buffer_size": 25000
+                    "max_async_concurrency": 50
+                    "max_get_multi_batch_size": 100
+                    "max_get_multi_concurrency": 1000
+                    "max_idle_connections": 1100
+                    "max_item_size": "1MiB"
+                    "timeout": "2s"
+                  "max_chunks_get_range_requests": 3
+                  "metafile_content_ttl": "24h"
+                  "metafile_doesnt_exist_ttl": "15m"
+                  "metafile_exists_ttl": "2h"
+                  "metafile_max_size": "1MiB"
+                  "type": "memcached"
+                - |-
+                  --tracing.config="config":
+                    "sampler_param": 2
+                    "sampler_type": "ratelimiting"
+                    "service_name": "thanos-store"
+                  "type": "JAEGER"
+                - |
+                  --selector.relabel-config=
+                    - action: hashmod
+                      source_labels: ["__block_id"]
+                      target_label: shard
+                      modulus: 3
+                    - action: keep
+                      source_labels: ["shard"]
+                      regex: 1
+              env:
+                - name: OBJSTORE_CONFIG
+                  valueFrom:
+                    secretKeyRef:
+                      key: thanos.yaml
+                      name: ${THANOS_CONFIG_SECRET}
+                - name: HOST_IP_ADDRESS
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_access_key_id
+                      name: ${THANOS_S3_SECRET}
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_secret_access_key
+                      name: ${THANOS_S3_SECRET}
+              image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 8
+                httpGet:
+                  path: /-/healthy
+                  port: 10902
+                  scheme: HTTP
+                periodSeconds: 30
+              name: thanos-store
+              ports:
+                - containerPort: 10901
+                  name: grpc
+                - containerPort: 10902
+                  name: http
+              readinessProbe:
+                failureThreshold: 20
+                httpGet:
+                  path: /-/ready
+                  port: 10902
+                  scheme: HTTP
+                periodSeconds: 5
+              resources:
+                limits:
+                  cpu: ${THANOS_STORE_CPU_LIMIT}
+                  memory: ${THANOS_STORE_MEMORY_LIMIT}
+                requests:
+                  cpu: ${THANOS_STORE_CPU_REQUEST}
+                  memory: ${THANOS_STORE_MEMORY_REQUEST}
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+                - mountPath: /var/thanos/store
+                  name: data
+                  readOnly: false
+            - args:
+                - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+                - --reporter.type=grpc
+                - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+              env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /
+                  port: 14271
+                  scheme: HTTP
+              name: jaeger-agent
+              ports:
+                - containerPort: 5778
+                  name: configs
+                - containerPort: 6831
+                  name: jaeger-thrift
+                - containerPort: 14271
+                  name: metrics
+              resources:
+                limits:
+                  cpu: 128m
+                  memory: 128Mi
+                requests:
+                  cpu: 32m
+                  memory: 64Mi
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          securityContext: {}
+          serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+          terminationGracePeriodSeconds: 120
+          volumes: []
+      volumeClaimTemplates:
+        - metadata:
+            labels:
+              app.kubernetes.io/component: object-store-gateway
+              app.kubernetes.io/instance: observatorium
+              app.kubernetes.io/name: thanos-store
+              app.kubernetes.io/part-of: observatorium
+              store.thanos.io/shard: shard-1
+            name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 50Gi
+            storageClassName: ${STORAGE_CLASS}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-store
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+        store.thanos.io/shard: shard-2
+      name: observatorium-thanos-store-shard-2
+    spec:
+      clusterIP: None
+      ports:
+        - name: grpc
+          port: 10901
+          targetPort: 10901
+        - name: http
+          port: 10902
+          targetPort: 10902
+      selector:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-store
+        app.kubernetes.io/part-of: observatorium
+        store.thanos.io/shard: shard-2
+  - apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      labels:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-store
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+        store.thanos.io/shard: shard-2
+      name: observatorium-thanos-store-shard-2
+    spec:
+      replicas: ${{THANOS_STORE_REPLICAS}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: object-store-gateway
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-store
+          app.kubernetes.io/part-of: observatorium
+          store.thanos.io/shard: shard-2
+      serviceName: observatorium-thanos-store-shard-2
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: object-store-gateway
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: thanos-store
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/tracing: jaeger-agent
+            app.kubernetes.io/version: ${THANOS_IMAGE_TAG}
+            store.thanos.io/shard: shard-2
+        spec:
+          affinity:
+            podAntiAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - podAffinityTerm:
+                    labelSelector:
+                      matchExpressions:
+                        - key: app.kubernetes.io/name
+                          operator: In
+                          values:
+                            - thanos-store
+                        - key: app.kubernetes.io/instance
+                          operator: In
+                          values:
+                            - observatorium
+                    namespaces:
+                      - ${NAMESPACE}
+                    topologyKey: kubernetes.io/hostname
+                  weight: 100
+          containers:
+            - args:
+                - store
+                - --log.level=${THANOS_STORE_LOG_LEVEL}
+                - --log.format=logfmt
+                - --data-dir=/var/thanos/store
+                - --grpc-address=0.0.0.0:10901
+                - --http-address=0.0.0.0:10902
+                - --objstore.config=$(OBJSTORE_CONFIG)
+                - --ignore-deletion-marks-delay=24h
+                - |-
+                  --index-cache.config="config":
+                    "addresses":
+                    - "dnssrv+_client._tcp.observatorium-thanos-store-index-cache-memcached.${NAMESPACE}.svc"
+                    "dns_provider_update_interval": "10s"
+                    "max_async_buffer_size": 200000
+                    "max_async_concurrency": 200
+                    "max_get_multi_batch_size": 100
+                    "max_get_multi_concurrency": 1000
+                    "max_idle_connections": 1300
+                    "max_item_size": "5MiB"
+                    "timeout": "2s"
+                  "type": "memcached"
+                - |-
+                  --store.caching-bucket.config="blocks_iter_ttl": "5m"
+                  "chunk_object_attrs_ttl": "24h"
+                  "chunk_subrange_size": 16000
+                  "chunk_subrange_ttl": "24h"
+                  "config":
+                    "addresses":
+                    - "dnssrv+_client._tcp.observatorium-thanos-store-bucket-cache-memcached.${NAMESPACE}.svc"
+                    "dns_provider_update_interval": "10s"
+                    "max_async_buffer_size": 25000
+                    "max_async_concurrency": 50
+                    "max_get_multi_batch_size": 100
+                    "max_get_multi_concurrency": 1000
+                    "max_idle_connections": 1100
+                    "max_item_size": "1MiB"
+                    "timeout": "2s"
+                  "max_chunks_get_range_requests": 3
+                  "metafile_content_ttl": "24h"
+                  "metafile_doesnt_exist_ttl": "15m"
+                  "metafile_exists_ttl": "2h"
+                  "metafile_max_size": "1MiB"
+                  "type": "memcached"
+                - |-
+                  --tracing.config="config":
+                    "sampler_param": 2
+                    "sampler_type": "ratelimiting"
+                    "service_name": "thanos-store"
+                  "type": "JAEGER"
+                - |
+                  --selector.relabel-config=
+                    - action: hashmod
+                      source_labels: ["__block_id"]
+                      target_label: shard
+                      modulus: 3
+                    - action: keep
+                      source_labels: ["shard"]
+                      regex: 2
+              env:
+                - name: OBJSTORE_CONFIG
+                  valueFrom:
+                    secretKeyRef:
+                      key: thanos.yaml
+                      name: ${THANOS_CONFIG_SECRET}
+                - name: HOST_IP_ADDRESS
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.hostIP
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_access_key_id
+                      name: ${THANOS_S3_SECRET}
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: aws_secret_access_key
+                      name: ${THANOS_S3_SECRET}
+              image: ${THANOS_IMAGE}:${THANOS_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 8
+                httpGet:
+                  path: /-/healthy
+                  port: 10902
+                  scheme: HTTP
+                periodSeconds: 30
+              name: thanos-store
+              ports:
+                - containerPort: 10901
+                  name: grpc
+                - containerPort: 10902
+                  name: http
+              readinessProbe:
+                failureThreshold: 20
+                httpGet:
+                  path: /-/ready
+                  port: 10902
+                  scheme: HTTP
+                periodSeconds: 5
+              resources:
+                limits:
+                  cpu: ${THANOS_STORE_CPU_LIMIT}
+                  memory: ${THANOS_STORE_MEMORY_LIMIT}
+                requests:
+                  cpu: ${THANOS_STORE_CPU_REQUEST}
+                  memory: ${THANOS_STORE_MEMORY_REQUEST}
+              terminationMessagePolicy: FallbackToLogsOnError
+              volumeMounts:
+                - mountPath: /var/thanos/store
+                  name: data
+                  readOnly: false
+            - args:
+                - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+                - --reporter.type=grpc
+                - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+              env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /
+                  port: 14271
+                  scheme: HTTP
+              name: jaeger-agent
+              ports:
+                - containerPort: 5778
+                  name: configs
+                - containerPort: 6831
+                  name: jaeger-thrift
+                - containerPort: 14271
+                  name: metrics
+              resources:
+                limits:
+                  cpu: 128m
+                  memory: 128Mi
+                requests:
+                  cpu: 32m
+                  memory: 64Mi
+          nodeSelector:
+            beta.kubernetes.io/os: linux
+          securityContext: {}
+          serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+          terminationGracePeriodSeconds: 120
+          volumes: []
+      volumeClaimTemplates:
+        - metadata:
+            labels:
+              app.kubernetes.io/component: object-store-gateway
+              app.kubernetes.io/instance: observatorium
+              app.kubernetes.io/name: thanos-store
+              app.kubernetes.io/part-of: observatorium
+              store.thanos.io/shard: shard-2
+            name: data
+          spec:
+            accessModes:
+              - ReadWriteOnce
+            resources:
+              requests:
+                storage: 50Gi
+            storageClassName: ${STORAGE_CLASS}
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        app.kubernetes.io/component: object-store-gateway
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: thanos-store
+        app.kubernetes.io/part-of: observatorium
+        prometheus: app-sre
+      name: observatorium-thanos-store-shard
+    spec:
+      endpoints:
+        - port: http
+          relabelings:
+            - separator: /
+              sourceLabels:
+                - namespace
+                - pod
+              targetLabel: instance
+      namespaceSelector:
+        matchNames: ${{NAMESPACES}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: object-store-gateway
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: thanos-store
+          app.kubernetes.io/part-of: observatorium
+parameters:
+  - name: NAMESPACE
+    value: observatorium-metrics
+  - name: NAMESPACES
+    value: '["telemeter", "observatorium-metrics", "observatorium-mst-production"]'
+  - name: JAEGER_AGENT_IMAGE_TAG
+    value: 1.15.0
+  - name: JAEGER_AGENT_IMAGE
+    value: quay.io/app-sre/jaegertracing-jaeger-agent
+  - name: JAEGER_COLLECTOR_NAMESPACE
+    value: $(NAMESPACE)
+  - name: MEMCACHED_CPU_LIMIT
+    value: "3"
+  - name: MEMCACHED_CPU_REQUEST
+    value: 500m
+  - name: MEMCACHED_EXPORTER_CPU_LIMIT
+    value: 200m
+  - name: MEMCACHED_EXPORTER_CPU_REQUEST
+    value: 50m
+  - name: MEMCACHED_EXPORTER_IMAGE_TAG
+    value: v0.6.0
+  - name: MEMCACHED_EXPORTER_IMAGE
+    value: docker.io/prom/memcached-exporter
+  - name: MEMCACHED_EXPORTER_MEMORY_LIMIT
+    value: 200Mi
+  - name: MEMCACHED_EXPORTER_MEMORY_REQUEST
+    value: 50Mi
+  - name: MEMCACHED_IMAGE_TAG
+    value: 1.5.20-alpine
+  - name: MEMCACHED_IMAGE
+    value: docker.io/memcached
+  - name: MEMCACHED_MEMORY_LIMIT
+    value: 1844Mi
+  - name: MEMCACHED_MEMORY_REQUEST
+    value: 1329Mi
+  - name: OAUTH_PROXY_CPU_LIMITS
+    value: 200m
+  - name: OAUTH_PROXY_CPU_REQUEST
+    value: 100m
+  - name: OAUTH_PROXY_IMAGE_TAG
+    value: 4.7.0
+  - name: OAUTH_PROXY_IMAGE
+    value: quay.io/openshift/origin-oauth-proxy
+  - name: OAUTH_PROXY_MEMORY_LIMITS
+    value: 200Mi
+  - name: OAUTH_PROXY_MEMORY_REQUEST
+    value: 100Mi
+  - name: SERVICE_ACCOUNT_NAME
+    value: prometheus-telemeter
+  - name: STORAGE_CLASS
+    value: gp2
+  - name: THANOS_COMPACTOR_CPU_LIMIT
+    value: "1"
+  - name: THANOS_COMPACTOR_CPU_REQUEST
+    value: 100m
+  - name: THANOS_COMPACTOR_LOG_LEVEL
+    value: info
+  - name: THANOS_COMPACTOR_RETENTION_RESOULTION_RAW
+    value: 14d
+  - name: THANOS_COMPACTOR_RETENTION_RESOULTION_FIVE_MINUTES
+    value: 1s
+  - name: THANOS_COMPACTOR_RETENTION_RESOULTION_ONE_HOUR
+    value: 1s
+  - name: THANOS_COMPACTOR_RETENTION_DISABLE_DOWNSAMPLING
+    value: --downsampling.disable
+  - name: THANOS_COMPACTOR_MEMORY_LIMIT
+    value: 5Gi
+  - name: THANOS_COMPACTOR_MEMORY_REQUEST
+    value: 1Gi
+  - name: THANOS_COMPACTOR_PVC_REQUEST
+    value: 50Gi
+  - name: THANOS_COMPACTOR_REPLICAS
+    value: "1"
+  - name: THANOS_CONFIG_SECRET
+    value: thanos-objectstorage
+  - name: THANOS_IMAGE_TAG
+    value: master-2020-08-12-70f89d83
+  - name: THANOS_IMAGE
+    value: quay.io/thanos/thanos
+  - name: THANOS_QUERIER_CPU_LIMIT
+    value: "1"
+  - name: THANOS_QUERIER_CPU_REQUEST
+    value: 100m
+  - name: THANOS_QUERIER_LOG_LEVEL
+    value: info
+  - name: THANOS_QUERIER_MEMORY_LIMIT
+    value: 1Gi
+  - name: THANOS_QUERIER_MEMORY_REQUEST
+    value: 256Mi
+  - name: THANOS_QUERIER_REPLICAS
+    value: "3"
+  - name: THANOS_QUERIER_SVC_URL
+    value: http://thanos-querier.observatorium.svc:9090
+  - name: THANOS_QUERY_FRONTEND_CPU_LIMIT
+    value: "1"
+  - name: THANOS_QUERY_FRONTEND_CPU_REQUEST
+    value: 100m
+  - name: THANOS_QUERY_FRONTEND_LOG_QUERIES_LONGER_THAN
+    value: 5s
+  - name: THANOS_QUERY_FRONTEND_MAX_RETRIES
+    value: "0"
+  - name: THANOS_QUERY_FRONTEND_MEMORY_LIMIT
+    value: 1Gi
+  - name: THANOS_QUERY_FRONTEND_MEMORY_REQUEST
+    value: 256Mi
+  - name: THANOS_QUERY_FRONTEND_REPLICAS
+    value: "3"
+  - name: THANOS_QUERY_FRONTEND_SPLIT_INTERVAL
+    value: 24h
+  - name: THANOS_RECEIVE_CONTROLLER_IMAGE_TAG
+    value: master-2019-10-18-d55fee2
+  - name: THANOS_RECEIVE_CONTROLLER_IMAGE
+    value: quay.io/observatorium/thanos-receive-controller
+  - name: THANOS_RECEIVE_CPU_LIMIT
+    value: "1"
+  - name: THANOS_RECEIVE_CPU_REQUEST
+    value: "1"
+  - name: THANOS_RECEIVE_DEBUG_ENV
+    value: ""
+  - name: THANOS_RECEIVE_LOG_LEVEL
+    value: info
+  - name: THANOS_RECEIVE_MEMORY_LIMIT
+    value: 1Gi
+  - name: THANOS_RECEIVE_MEMORY_REQUEST
+    value: 1Gi
+  - name: THANOS_RECEIVE_REPLICAS
+    value: "5"
+  - name: THANOS_RECEIVE_TSDB_PATH
+    value: /var/thanos/receive
+  - name: THANOS_RULER_CPU_LIMIT
+    value: "1"
+  - name: THANOS_RULER_CPU_REQUEST
+    value: 500m
+  - name: THANOS_RULER_LOG_LEVEL
+    value: info
+  - name: THANOS_RULER_MEMORY_LIMIT
+    value: 2Gi
+  - name: THANOS_RULER_MEMORY_REQUEST
+    value: 2Gi
+  - name: THANOS_RULER_PVC_REQUEST
+    value: 50Gi
+  - name: THANOS_RULER_REPLICAS
+    value: "2"
+  - name: THANOS_S3_SECRET
+    value: telemeter-thanos-stage-s3
+  - name: THANOS_STORE_BUCKET_CACHE_CONNECTION_LIMIT
+    value: "3072"
+  - name: THANOS_STORE_BUCKET_CACHE_MEMCACHED_CPU_LIMIT
+    value: "3"
+  - name: THANOS_STORE_BUCKET_CACHE_MEMCACHED_CPU_REQUEST
+    value: 500m
+  - name: THANOS_STORE_BUCKET_CACHE_MEMCACHED_MEMORY_LIMIT
+    value: 3Gi
+  - name: THANOS_STORE_BUCKET_CACHE_MEMCACHED_MEMORY_REQUEST
+    value: 2558Mi
+  - name: THANOS_STORE_BUCKET_CACHE_MEMORY_LIMIT_MB
+    value: "2048"
+  - name: THANOS_STORE_BUCKET_CACHE_REPLICAS
+    value: "3"
+  - name: THANOS_STORE_CPU_LIMIT
+    value: "2"
+  - name: THANOS_STORE_CPU_REQUEST
+    value: 500m
+  - name: THANOS_STORE_INDEX_CACHE_CONNECTION_LIMIT
+    value: "3072"
+  - name: THANOS_STORE_INDEX_CACHE_MEMCACHED_CPU_LIMIT
+    value: "3"
+  - name: THANOS_STORE_INDEX_CACHE_MEMCACHED_CPU_REQUEST
+    value: 500m
+  - name: THANOS_STORE_INDEX_CACHE_MEMCACHED_MEMORY_LIMIT
+    value: 3Gi
+  - name: THANOS_STORE_INDEX_CACHE_MEMCACHED_MEMORY_REQUEST
+    value: 2558Mi
+  - name: THANOS_STORE_INDEX_CACHE_MEMORY_LIMIT_MB
+    value: "2048"
+  - name: THANOS_STORE_INDEX_CACHE_REPLICAS
+    value: "3"
+  - name: THANOS_STORE_LOG_LEVEL
+    value: info
+  - name: THANOS_STORE_MEMORY_LIMIT
+    value: 8Gi
+  - name: THANOS_STORE_MEMORY_REQUEST
+    value: 1Gi
+  - name: THANOS_STORE_REPLICAS
+    value: "5"
+  - name: CONFIGMAP_RELOADER_IMAGE
+    value: quay.io/openshift/origin-configmap-reloader
+  - name: CONFIGMAP_RELOADER_IMAGE_TAG
+    value: 4.5.0

--- a/reconcile/test/fixtures/saasfiles_remote_repo/4ba049635dd62d57605ea74890c08caef067ed13_resources_services_observatorium-template.yaml
+++ b/reconcile/test/fixtures/saasfiles_remote_repo/4ba049635dd62d57605ea74890c08caef067ed13_resources_services_observatorium-template.yaml
@@ -1,0 +1,876 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: observatorium
+objects:
+  - apiVersion: v1
+    data:
+      rbac.yaml: |-
+        "roleBindings":
+        - "name": "rhobs"
+          "roles":
+          - "rhobs"
+          "subjects":
+          - "kind": "group"
+            "name": "rhobs"
+        - "name": "telemeter-server"
+          "roles":
+          - "telemeter-write"
+          "subjects":
+          - "kind": "user"
+            "name": "service-account-telemeter-service-staging"
+          - "kind": "user"
+            "name": "service-account-telemeter-service"
+        - "name": "subwatch"
+          "roles":
+          - "telemeter-read"
+          "subjects":
+          - "kind": "user"
+            "name": "service-account-observatorium-subwatch-staging"
+          - "kind": "user"
+            "name": "service-account-observatorium-subwatch"
+        "roles":
+        - "name": "rhobs"
+          "permissions":
+          - "read"
+          - "write"
+          "resources":
+          - "metrics"
+          - "logs"
+          "tenants":
+          - "rhobs"
+        - "name": "telemeter-write"
+          "permissions":
+          - "write"
+          "resources":
+          - "metrics"
+          "tenants":
+          - "telemeter"
+        - "name": "telemeter-read"
+          "permissions":
+          - "read"
+          "resources":
+          - "metrics"
+          "tenants":
+          - "telemeter"
+    kind: ConfigMap
+    metadata:
+      annotations:
+        qontract.recycle: "true"
+      labels:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-api
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${OBSERVATORIUM_API_IMAGE_TAG}
+      name: ${OBSERVATORIUM_API_IDENTIFIER}
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-api
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${OBSERVATORIUM_API_IMAGE_TAG}
+      name: ${OBSERVATORIUM_API_IDENTIFIER}
+    spec:
+      replicas: ${{OBSERVATORIUM_API_REPLICAS}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: api
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: observatorium-api
+          app.kubernetes.io/part-of: observatorium
+      strategy:
+        rollingUpdate:
+          maxSurge: 0
+          maxUnavailable: 1
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: api
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: observatorium-api
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/tracing: jaeger-agent
+            app.kubernetes.io/version: ${OBSERVATORIUM_API_IMAGE_TAG}
+        spec:
+          containers:
+            - args:
+                - --web.listen=0.0.0.0:8080
+                - --web.internal.listen=0.0.0.0:8081
+                - --metrics.read.endpoint=http://observatorium-thanos-query-frontend.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:9090
+                - --metrics.write.endpoint=http://observatorium-thanos-receive.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:19291
+                - --log.level=warn
+                - --logs.read.endpoint=http://observatorium-loki-query-frontend-http.${OBSERVATORIUM_LOGS_NAMESPACE}.svc.cluster.local:3100
+                - --logs.tail.endpoint=http://observatorium-loki-querier-http.${OBSERVATORIUM_LOGS_NAMESPACE}.svc.cluster.local:3100
+                - --logs.write.endpoint=http://observatorium-loki-distributor-http.${OBSERVATORIUM_LOGS_NAMESPACE}.svc.cluster.local:3100
+                - --rbac.config=/etc/observatorium/rbac.yaml
+                - --tenants.config=/etc/observatorium/tenants.yaml
+                - --middleware.rate-limiter.grpc-address=observatorium-gubernator.${NAMESPACE}.svc.cluster.local:8081
+                - --internal.tracing.endpoint=localhost:6831
+                - --middleware.concurrent-request-limit=${OBSERVATORIUM_API_PER_POD_CONCURRENT_REQUETST_LIMIT}
+              image: ${OBSERVATORIUM_API_IMAGE}:${OBSERVATORIUM_API_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 10
+                httpGet:
+                  path: /live
+                  port: 8081
+                  scheme: HTTP
+                periodSeconds: 30
+              name: observatorium-api
+              ports:
+                - containerPort: 8081
+                  name: internal
+                - containerPort: 8080
+                  name: public
+              readinessProbe:
+                failureThreshold: 12
+                httpGet:
+                  path: /ready
+                  port: 8081
+                  scheme: HTTP
+                periodSeconds: 5
+              resources:
+                limits:
+                  cpu: ${OBSERVATORIUM_API_CPU_LIMIT}
+                  memory: ${OBSERVATORIUM_API_MEMORY_LIMIT}
+                requests:
+                  cpu: ${OBSERVATORIUM_API_CPU_REQUEST}
+                  memory: ${OBSERVATORIUM_API_MEMORY_REQUEST}
+              volumeMounts:
+                - mountPath: /etc/observatorium/rbac.yaml
+                  name: rbac
+                  readOnly: true
+                  subPath: rbac.yaml
+                - mountPath: /etc/observatorium/tenants.yaml
+                  name: tenants
+                  readOnly: true
+                  subPath: tenants.yaml
+            - args:
+                - --web.listen=127.0.0.1:8082
+                - --web.internal.listen=0.0.0.0:8083
+                - --web.healthchecks.url=http://127.0.0.1:8082
+                - --log.level=warn
+                - --ams.url=${AMS_URL}
+                - --resource-type-prefix=observatorium
+                - --oidc.client-id=$(CLIENT_ID)
+                - --oidc.client-secret=$(CLIENT_SECRET)
+                - --oidc.issuer-url=$(ISSUER_URL)
+                - --opa.package=observatorium
+                - --memcached=observatorium-api-cache-memcached.${NAMESPACE}.svc.cluster.local:11211
+                - --memcached.expire=${OPA_AMS_MEMCACHED_EXPIRE}
+                - --ams.mappings=dptp=${DPTP_ORGANIZATION_ID}
+                - --ams.mappings=managedkafka=${MANAGEDKAFKA_ORGANIZATION_ID}
+                - --ams.mappings=osd=${OSD_ORGANIZATION_ID}
+              env:
+                - name: ISSUER_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: issuer-url
+                      name: ${OBSERVATORIUM_API_IDENTIFIER}
+                - name: CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: client-id
+                      name: ${OBSERVATORIUM_API_IDENTIFIER}
+                - name: CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      key: client-secret
+                      name: ${OBSERVATORIUM_API_IDENTIFIER}
+              image: ${OPA_AMS_IMAGE}:${OPA_AMS_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 10
+                httpGet:
+                  path: /live
+                  port: 8083
+                  scheme: HTTP
+                periodSeconds: 30
+              name: opa-ams
+              ports:
+                - containerPort: 8082
+                  name: opa-ams-api
+                - containerPort: 8083
+                  name: opa-ams-metrics
+              readinessProbe:
+                failureThreshold: 12
+                httpGet:
+                  path: /ready
+                  port: 8083
+                  scheme: HTTP
+                periodSeconds: 5
+              resources:
+                limits:
+                  cpu: ${OPA_AMS_CPU_LIMIT}
+                  memory: ${OPA_AMS_MEMORY_LIMIT}
+                requests:
+                  cpu: ${OPA_AMS_CPU_REQUEST}
+                  memory: ${OPA_AMS_MEMORY_REQUEST}
+            - args:
+                - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+                - --reporter.type=grpc
+                - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+              env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /
+                  port: 14271
+                  scheme: HTTP
+              name: jaeger-agent
+              ports:
+                - containerPort: 5778
+                  name: configs
+                - containerPort: 6831
+                  name: jaeger-thrift
+                - containerPort: 14271
+                  name: metrics
+              resources:
+                limits:
+                  cpu: 128m
+                  memory: 128Mi
+                requests:
+                  cpu: 32m
+                  memory: 64Mi
+          serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+          volumes:
+            - configMap:
+                name: ${OBSERVATORIUM_API_IDENTIFIER}
+              name: rbac
+            - name: tenants
+              secret:
+                secretName: ${OBSERVATORIUM_API_IDENTIFIER}
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-api
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${OBSERVATORIUM_API_IMAGE_TAG}
+      name: ${OBSERVATORIUM_API_IDENTIFIER}
+    stringData:
+      tenants.yaml: |-
+        "tenants":
+        - "id": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+          "name": "rhobs"
+          "oidc":
+            "clientID": "id"
+            "clientSecret": "secret"
+            "groupClaim": "groups"
+            "issuerURL": "https://rhobs.tenants.observatorium.io"
+            "usernameClaim": "preferred_username"
+        - "id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "name": "telemeter"
+          "oidc":
+            "clientID": "id"
+            "clientSecret": "secret"
+            "issuerURL": "https://sso.redhat.com/auth/realms/redhat-external"
+            "usernameClaim": "preferred_username"
+        - "id": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
+          "name": "dptp"
+          "oidc":
+            "clientID": "id"
+            "clientSecret": "secret"
+            "issuerURL": "https://sso.redhat.com/auth/realms/redhat-external"
+            "usernameClaim": "preferred_username"
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-api
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${OBSERVATORIUM_API_IMAGE_TAG}
+      name: ${OBSERVATORIUM_API_IDENTIFIER}
+    spec:
+      ports:
+        - name: internal
+          port: 8081
+          targetPort: 8081
+        - name: public
+          port: 8080
+          targetPort: 8080
+        - name: opa-ams-api
+          port: 8082
+          targetPort: 8082
+        - name: opa-ams-metrics
+          port: 8083
+          targetPort: 8083
+      selector:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-api
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-api
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${OBSERVATORIUM_API_IMAGE_TAG}
+      name: ${OBSERVATORIUM_API_IDENTIFIER}
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        prometheus: app-sre
+      name: observatorium-api
+    spec:
+      endpoints:
+        - port: internal
+        - port: opa-ams-metrics
+      namespaceSelector:
+        matchNames:
+          - ${NAMESPACE}
+          - ${MST_NAMESPACE}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: api
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: observatorium-api
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: rate-limiter
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: gubernator
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${GUBERNATOR_IMAGE_TAG}
+      name: observatorium-gubernator
+    spec:
+      replicas: ${{GUBERNATOR_REPLICAS}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: rate-limiter
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: gubernator
+          app.kubernetes.io/part-of: observatorium
+      strategy:
+        rollingUpdate:
+          maxSurge: 0
+          maxUnavailable: 1
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: rate-limiter
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: gubernator
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/version: ${GUBERNATOR_IMAGE_TAG}
+        spec:
+          containers:
+            - env:
+                - name: GUBER_K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: GUBER_K8S_POD_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.podIP
+                - name: GUBER_HTTP_ADDRESS
+                  value: 0.0.0.0:8080
+                - name: GUBER_GRPC_ADDRESS
+                  value: 0.0.0.0:8081
+                - name: GUBER_K8S_POD_PORT
+                  value: "8081"
+                - name: GUBER_K8S_ENDPOINTS_SELECTOR
+                  value: app.kubernetes.io/name=gubernator
+              image: ${GUBERNATOR_IMAGE}:${GUBERNATOR_IMAGE_TAG}
+              name: gubernator
+              ports:
+                - containerPort: 8081
+                  name: grpc
+                - containerPort: 8080
+                  name: http
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /v1/HealthCheck
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 30
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  cpu: ${GUBERNATOR_CPU_LIMIT}
+                  memory: ${GUBERNATOR_MEMORY_LIMIT}
+                requests:
+                  cpu: ${GUBERNATOR_CPU_REQUEST}
+                  memory: ${GUBERNATOR_MEMORY_REQUEST}
+          restartPolicy: Always
+          serviceAccountName: observatorium-gubernator
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/component: rate-limiter
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: gubernator
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${GUBERNATOR_IMAGE_TAG}
+      name: observatorium-gubernator
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+        verbs:
+          - list
+          - watch
+          - get
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: rate-limiter
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: gubernator
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${GUBERNATOR_IMAGE_TAG}
+      name: observatorium-gubernator
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: observatorium-gubernator
+    subjects:
+      - kind: ServiceAccount
+        name: observatorium-gubernator
+        namespace: ${NAMESPACE}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: rate-limiter
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: gubernator
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${GUBERNATOR_IMAGE_TAG}
+      name: observatorium-gubernator
+    spec:
+      ports:
+        - name: grpc
+          port: 8081
+          targetPort: 8081
+        - name: http
+          port: 8080
+          targetPort: 8080
+      selector:
+        app.kubernetes.io/component: rate-limiter
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: gubernator
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    imagePullSecrets:
+      - name: quay.io
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: rate-limiter
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: gubernator
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${GUBERNATOR_IMAGE_TAG}
+      name: observatorium-gubernator
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        prometheus: app-sre
+      name: observatorium-gubernator
+    spec:
+      endpoints:
+        - port: http
+      namespaceSelector:
+        matchNames:
+          - ${NAMESPACE}
+          - ${MST_NAMESPACE}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: rate-limiter
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: gubernator
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: api-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+      name: observatorium-api-cache-memcached
+    spec:
+      clusterIP: None
+      ports:
+        - name: client
+          port: 11211
+          targetPort: 11211
+        - name: metrics
+          port: 9150
+          targetPort: 9150
+      selector:
+        app.kubernetes.io/component: api-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      name: observatorium-api-cache-memcached
+    spec:
+      endpoints:
+        - port: metrics
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: api-cache
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: memcached
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      labels:
+        app.kubernetes.io/component: api-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+      name: observatorium-api-cache-memcached
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: api-cache
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: memcached
+          app.kubernetes.io/part-of: observatorium
+      serviceName: observatorium-api-cache-memcached
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: api-cache
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: memcached
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+        spec:
+          containers:
+            - args:
+                - -m ${MEMCACHED_MEMORY_LIMIT_MB}
+                - -I 5m
+                - -c ${MEMCACHED_CONNECTION_LIMIT}
+                - -v
+              image: ${MEMCACHED_IMAGE}:${MEMCACHED_IMAGE_TAG}
+              name: memcached
+              ports:
+                - containerPort: 11211
+                  name: client
+              resources:
+                limits:
+                  cpu: ${MEMCACHED_CPU_LIMIT}
+                  memory: ${MEMCACHED_MEMORY_LIMIT}
+                requests:
+                  cpu: ${MEMCACHED_CPU_REQUEST}
+                  memory: ${MEMCACHED_MEMORY_REQUEST}
+              terminationMessagePolicy: FallbackToLogsOnError
+            - args:
+                - --memcached.address=localhost:11211
+                - --web.listen-address=0.0.0.0:9150
+              image: ${MEMCACHED_EXPORTER_IMAGE}:${MEMCACHED_EXPORTER_IMAGE_TAG}
+              name: exporter
+              ports:
+                - containerPort: 9150
+                  name: metrics
+              resources:
+                limits:
+                  cpu: ${MEMCACHED_EXPORTER_CPU_LIMIT}
+                  memory: ${MEMCACHED_EXPORTER_MEMORY_LIMIT}
+                requests:
+                  cpu: ${MEMCACHED_EXPORTER_CPU_REQUEST}
+                  memory: ${MEMCACHED_EXPORTER_MEMORY_REQUEST}
+  - apiVersion: v1
+    data:
+      queries.yaml: |-
+        "queries":
+        - "name": "Clusters"
+          "query": "avg_over_time(sum(count by (_id) (max without (prometheus,receive,instance) ( cluster_version{type=\"current\"} )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h])"
+        - "name": "Clusters aged 1w"
+          "query": "avg_over_time(sum(count by (_id) (max without (prometheus,receive,instance) ( (time() - cluster_version{type=\"initial\"}) > (7 * 24 * 60 * 60) )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h])"
+        - "name": "Nodes"
+          "query": "avg_over_time(sum(sum by (_id) (max without (prometheus,receive,instance) ( cluster:node_instance_type_count:sum)) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h])"
+        - "name": "Cores"
+          "query": "avg_over_time(sum(sum by (_id) (max without (prometheus,receive,instance) ( cluster:capacity_cpu_cores:sum)) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h])"
+        - "name": "Workload CPU"
+          "query": "avg_over_time(sum(max by (_id) (max without (prometheus,receive,instance) ( workload:cpu_usage_cores:sum )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h])"
+        - "name": "Etcd Objects"
+          "query": "avg_over_time(sum(sum by (_id) (max without (prometheus,receive,instance) ( instance:etcd_object_counts:sum )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h])"
+        - "name": "Weekly Active Users"
+          "query": "count(count by (account) (count_over_time(subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"}[7d])))"
+        - "name": "Unique customers"
+          "query": "count(count by (email_domain) (count_over_time(subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com|gmail.com\"}[7d])))"
+        - "name": "Hybrid customers"
+          "query": "count(count by (email_domain) (count by (email_domain,type) (count by (_id,type,email_domain) (cluster_infrastructure_provider{} + on (_id) group_left(email_domain) (topk by (_id) (1, 0 * subscription_labels{}))))) and on (email_domain) (count by (email_domain) (count by (email_domain,type) (count by (_id,type,email_domain) (cluster_infrastructure_provider{} + on (_id) group_left(email_domain) (topk by (_id) (1, 0 * subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com|gmail.com\"}))))) > 1))"
+        - "name": "Subscribed clusters"
+          "query": "avg_over_time(sum(count by (_id) (max without (prometheus,receive,instance) ( cluster_version{type=\"current\"} )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{support=~\"Standard|Premium|Layered\"})))[7d:12h])"
+        - "name": "Subscribed nodes"
+          "query": "avg_over_time(sum(sum by (_id) (max without (prometheus,receive,instance) ( cluster:node_instance_type_count:sum)) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{support=~\"Standard|Premium\"})))[7d:12h])"
+        - "name": "Subscribed cores"
+          "query": "avg_over_time(sum(sum by (_id) (max without (prometheus,receive,instance) ( cluster:capacity_cpu_cores:sum)) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{support=~\"Standard|Premium|Layered\"})))[7d:12h])"
+        - "name": "Hours failing per week"
+          "query": "sum((max by (_id) (count_over_time((cluster_version{type=\"failure\"} * 0 + 1)[7d:15m]) > 1) + on (_id) group_left(email_domain) topk by (_id) (1, 0 * max_over_time(subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"}[7d]))) / 4)"
+        - "name": "Average code age (days)"
+          "query": "avg_over_time(avg(max by (_id) (max without (prometheus,receive,instance) ( (time() - cluster_version{type=\"current\"}))) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h]) / 60 / 60 / 24"
+        - "name": "Average subscribed code age (days)"
+          "query": "avg_over_time(avg(max by (_id) (max without (prometheus,receive,instance) ( (time() - cluster_version{type=\"current\"}))) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{support=~\"Standard|Premium|Layered\"})))[7d:12h]) / 60 / 60 / 24"
+        - "name": "Clusters upgrading to 4.2"
+          "query": "count(((count by (_id) (count_over_time(cluster_version{from_version=~\"4\\\\.1\\\\.\\\\d+\",version=~\"4\\\\.2\\\\.\\\\d+\",type=\"updating\"}[7d])))*0+1) + on(_id) group_left(_blah) (topk by (_id) (1, 0*subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"})))"
+        - "name": "Failed 4.2 upgrades"
+          "query": "count(((max by (_id) (sum_over_time((1+0*cluster_version{from_version=~\"4\\\\.1\\\\.\\\\d+\",version=~\"4\\\\.2\\\\.\\\\d+\",type=\"failure\"})[7d:15m]))) > 2) + on(_id) group_left(_blah) (topk by (_id) (1, 0*subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"})))"
+        - "name": "Clusters upgrading to 4.3"
+          "query": "count(((count by (_id) (count_over_time(cluster_version{from_version=~\"4\\\\.2\\\\.\\\\d+\",version=~\"4\\\\.3\\\\.\\\\d+\",type=\"updating\"}[7d])))*0+1) + on(_id) group_left(_blah) (topk by (_id) (1, 0*subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"})))"
+        - "name": "Clusters upgrading to 4.4"
+          "query": "count(((count by (_id) (count_over_time(cluster_version{from_version=~\"4\\\\.2\\\\.\\\\d+\",version=~\"4\\\\.4\\\\.\\\\d+\",type=\"updating\"}[7d])))*0+1) + on(_id) group_left(_blah) (topk by (_id) (1, 0*subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"})))"
+        - "name": "Failed 4.3 upgrades"
+          "query": "count(((max by (_id) (sum_over_time((1+0*cluster_version{from_version=~\"4\\\\.2\\\\.\\\\d+\",version=~\"4\\\\.3\\\\.\\\\d+\",type=\"failure\"})[7d:15m]))) > 2) + on(_id) group_left(_blah) (topk by (_id) (1, 0*subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"})))"
+        - "name": "Failed 4.4 upgrades"
+          "query": "count(((max by (_id) (sum_over_time((1+0*cluster_version{from_version=~\"4\\\\.2\\\\.\\\\d+\",version=~\"4\\\\.4\\\\.\\\\d+\",type=\"failure\"})[7d:15m]))) > 2) + on(_id) group_left(_blah) (topk by (_id) (1, 0*subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"})))"
+        - "name": "4.4 clusters"
+          "query": "avg_over_time(count(count by (_id) (max without (prometheus,receive,instance) ( cluster_version{type=\"current\",version=~\"4\\\\.4\\\\.\\\\d+\"} )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[1d:12h])"
+        - "name": "4.3 clusters"
+          "query": "avg_over_time(count(count by (_id) (max without (prometheus,receive,instance) ( cluster_version{type=\"current\",version=~\"4\\\\.3\\\\.\\\\d+\"} )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[1d:12h])"
+        - "name": "4.2 clusters"
+          "query": "avg_over_time(count(count by (_id) (max without (prometheus,receive,instance) ( cluster_version{type=\"current\",version=~\"4\\\\.2\\\\.\\\\d+\"} )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[1d:12h])"
+        - "name": "4.1 clusters"
+          "query": "avg_over_time(count(count by (_id) (max without (prometheus,receive,instance) ( cluster_version{type=\"current\",version=~\"4\\\\.1\\\\.\\\\d+\"} )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[1d:12h])"
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/component: blackbox-prober
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-up
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: master-2020-06-15-d763595
+      name: observatorium-observatorium-up
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: blackbox-prober
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-up
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: master-2020-06-15-d763595
+      name: observatorium-observatorium-up
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: blackbox-prober
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: observatorium-up
+          app.kubernetes.io/part-of: observatorium
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: blackbox-prober
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: observatorium-up
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/version: master-2020-06-15-d763595
+        spec:
+          containers:
+            - args:
+                - --duration=0
+                - --log.level=debug
+                - --endpoint-type=metrics
+                - --queries-file=/etc/up/queries.yaml
+                - --endpoint-read=http://observatorium-thanos-query-frontend.${NAMESPACE}.svc:9090/api/v1/query
+              image: quay.io/observatorium/up:master-2020-06-15-d763595
+              name: observatorium-up
+              ports:
+                - containerPort: 8080
+                  name: http
+              resources:
+                limits:
+                  cpu: 20m
+                  memory: 50Mi
+                requests:
+                  cpu: 5m
+                  memory: 10Mi
+              volumeMounts:
+                - mountPath: /etc/up/
+                  name: query-config
+                  readOnly: false
+          volumes:
+            - configMap:
+                name: observatorium-observatorium-up
+              name: query-config
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: blackbox-prober
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-up
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: master-2020-06-15-d763595
+      name: observatorium-observatorium-up
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          targetPort: 8080
+      selector:
+        app.kubernetes.io/component: blackbox-prober
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-up
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        prometheus: app-sre
+      name: observatorium-up
+    spec:
+      endpoints:
+        - port: http
+      namespaceSelector:
+        matchNames:
+          - ${NAMESPACE}
+          - ${MST_NAMESPACE}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: blackbox-prober
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: observatorium-up
+          app.kubernetes.io/part-of: observatorium
+parameters:
+  - name: NAMESPACE
+    value: observatorium
+  - name: OBSERVATORIUM_METRICS_NAMESPACE
+    value: observatorium-metrics
+  - name: OBSERVATORIUM_LOGS_NAMESPACE
+    value: observatorium-logs
+  - name: AMS_URL
+    value: https://api.openshift.com
+  - name: DPTP_ORGANIZATION_ID
+    value: ""
+  - name: GUBERNATOR_CPU_LIMIT
+    value: 200m
+  - name: GUBERNATOR_CPU_REQUEST
+    value: 100m
+  - name: GUBERNATOR_IMAGE_TAG
+    value: 1.0.0-rc.1
+  - name: GUBERNATOR_IMAGE
+    value: quay.io/app-sre/gubernator
+  - name: GUBERNATOR_MEMORY_LIMIT
+    value: 200Mi
+  - name: GUBERNATOR_MEMORY_REQUEST
+    value: 100Mi
+  - name: GUBERNATOR_REPLICAS
+    value: "2"
+  - name: JAEGER_AGENT_IMAGE_TAG
+    value: 1.22.0
+  - name: JAEGER_AGENT_IMAGE
+    value: jaegertracing/jaeger-agent
+  - name: JAEGER_COLLECTOR_NAMESPACE
+    value: $(NAMESPACE)
+  - name: MANAGEDKAFKA_ORGANIZATION_ID
+    value: ""
+  - name: MEMCACHED_CONNECTION_LIMIT
+    value: "3072"
+  - name: MEMCACHED_CPU_LIMIT
+    value: "3"
+  - name: MEMCACHED_CPU_REQUEST
+    value: 500m
+  - name: MEMCACHED_EXPORTER_CPU_LIMIT
+    value: 200m
+  - name: MEMCACHED_EXPORTER_CPU_REQUEST
+    value: 50m
+  - name: MEMCACHED_EXPORTER_IMAGE_TAG
+    value: v0.6.0
+  - name: MEMCACHED_EXPORTER_IMAGE
+    value: docker.io/prom/memcached-exporter
+  - name: MEMCACHED_EXPORTER_MEMORY_LIMIT
+    value: 200Mi
+  - name: MEMCACHED_EXPORTER_MEMORY_REQUEST
+    value: 50Mi
+  - name: MEMCACHED_IMAGE_TAG
+    value: 1.5.20-alpine
+  - name: MEMCACHED_IMAGE
+    value: docker.io/memcached
+  - name: MEMCACHED_MEMORY_LIMIT_MB
+    value: "2048"
+  - name: MEMCACHED_MEMORY_LIMIT
+    value: 1844Mi
+  - name: MEMCACHED_MEMORY_REQUEST
+    value: 1329Mi
+  - name: OAUTH_PROXY_CPU_LIMITS
+    value: 200m
+  - name: OAUTH_PROXY_CPU_REQUEST
+    value: 100m
+  - name: OAUTH_PROXY_IMAGE_TAG
+    value: 4.7.0
+  - name: OAUTH_PROXY_IMAGE
+    value: quay.io/openshift/origin-oauth-proxy
+  - name: OAUTH_PROXY_MEMORY_LIMITS
+    value: 200Mi
+  - name: OAUTH_PROXY_MEMORY_REQUEST
+    value: 100Mi
+  - name: OBSERVATORIUM_API_CPU_LIMIT
+    value: "1"
+  - name: OBSERVATORIUM_API_CPU_REQUEST
+    value: 100m
+  - name: OBSERVATORIUM_API_IDENTIFIER
+    value: observatorium-observatorium-api
+  - name: OBSERVATORIUM_API_IMAGE_TAG
+    value: master-2021-03-26-v0.1.1-200-gea0242a
+  - name: OBSERVATORIUM_API_IMAGE
+    value: quay.io/observatorium/api
+  - name: OBSERVATORIUM_API_MEMORY_LIMIT
+    value: 1Gi
+  - name: OBSERVATORIUM_API_MEMORY_REQUEST
+    value: 256Mi
+  - name: OBSERVATORIUM_API_REPLICAS
+    value: "3"
+  - name: OBSERVATORIUM_API_PER_POD_CONCURRENT_REQUETST_LIMIT
+    value: "50"
+  - name: OPA_AMS_CPU_LIMIT
+    value: 200m
+  - name: OPA_AMS_CPU_REQUEST
+    value: 100m
+  - name: OPA_AMS_IMAGE_TAG
+    value: master-2021-02-17-ed50046
+  - name: OPA_AMS_IMAGE
+    value: quay.io/observatorium/opa-ams
+  - name: OPA_AMS_MEMCACHED_EXPIRE
+    value: "300"
+  - name: OPA_AMS_MEMORY_LIMIT
+    value: 200Mi
+  - name: OPA_AMS_MEMORY_REQUEST
+    value: 100Mi
+  - name: OSD_ORGANIZATION_ID
+    value: ""
+  - name: SERVICE_ACCOUNT_NAME
+    value: prometheus-telemeter

--- a/reconcile/test/fixtures/saasfiles_remote_repo/a513f3676c8430265208111048dec36ea86fcd56_resources_services_observatorium-template.yaml
+++ b/reconcile/test/fixtures/saasfiles_remote_repo/a513f3676c8430265208111048dec36ea86fcd56_resources_services_observatorium-template.yaml
@@ -1,0 +1,885 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: observatorium
+objects:
+  - apiVersion: v1
+    data:
+      rbac.yaml: |-
+        "roleBindings":
+        - "name": "rhobs"
+          "roles":
+          - "rhobs"
+          "subjects":
+          - "kind": "group"
+            "name": "rhobs"
+        - "name": "telemeter-server"
+          "roles":
+          - "telemeter-write"
+          "subjects":
+          - "kind": "user"
+            "name": "service-account-telemeter-service-staging"
+          - "kind": "user"
+            "name": "service-account-telemeter-service"
+        - "name": "subwatch"
+          "roles":
+          - "telemeter-read"
+          "subjects":
+          - "kind": "user"
+            "name": "service-account-observatorium-subwatch-staging"
+          - "kind": "user"
+            "name": "service-account-observatorium-subwatch"
+        "roles":
+        - "name": "rhobs"
+          "permissions":
+          - "read"
+          - "write"
+          "resources":
+          - "metrics"
+          - "logs"
+          "tenants":
+          - "rhobs"
+        - "name": "telemeter-write"
+          "permissions":
+          - "write"
+          "resources":
+          - "metrics"
+          "tenants":
+          - "telemeter"
+        - "name": "telemeter-read"
+          "permissions":
+          - "read"
+          "resources":
+          - "metrics"
+          "tenants":
+          - "telemeter"
+    kind: ConfigMap
+    metadata:
+      annotations:
+        qontract.recycle: "true"
+      labels:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-api
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${OBSERVATORIUM_API_IMAGE_TAG}
+      name: ${OBSERVATORIUM_API_IDENTIFIER}
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-api
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${OBSERVATORIUM_API_IMAGE_TAG}
+      name: ${OBSERVATORIUM_API_IDENTIFIER}
+    spec:
+      replicas: ${{OBSERVATORIUM_API_REPLICAS}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: api
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: observatorium-api
+          app.kubernetes.io/part-of: observatorium
+      strategy:
+        rollingUpdate:
+          maxSurge: 0
+          maxUnavailable: 1
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: api
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: observatorium-api
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/tracing: jaeger-agent
+            app.kubernetes.io/version: ${OBSERVATORIUM_API_IMAGE_TAG}
+        spec:
+          containers:
+            - args:
+                - --web.listen=0.0.0.0:8080
+                - --web.internal.listen=0.0.0.0:8081
+                - --metrics.read.endpoint=http://observatorium-thanos-query-frontend.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:9090
+                - --metrics.write.endpoint=http://observatorium-thanos-receive.${OBSERVATORIUM_METRICS_NAMESPACE}.svc.cluster.local:19291
+                - --log.level=warn
+                - --logs.read.endpoint=http://observatorium-loki-query-frontend-http.${OBSERVATORIUM_LOGS_NAMESPACE}.svc.cluster.local:3100
+                - --logs.tail.endpoint=http://observatorium-loki-querier-http.${OBSERVATORIUM_LOGS_NAMESPACE}.svc.cluster.local:3100
+                - --logs.write.endpoint=http://observatorium-loki-distributor-http.${OBSERVATORIUM_LOGS_NAMESPACE}.svc.cluster.local:3100
+                - --rbac.config=/etc/observatorium/rbac.yaml
+                - --tenants.config=/etc/observatorium/tenants.yaml
+                - --middleware.rate-limiter.grpc-address=observatorium-gubernator.${NAMESPACE}.svc.cluster.local:8081
+                - --internal.tracing.endpoint=localhost:6831
+              image: ${OBSERVATORIUM_API_IMAGE}:${OBSERVATORIUM_API_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 10
+                httpGet:
+                  path: /live
+                  port: 8081
+                  scheme: HTTP
+                periodSeconds: 30
+              name: observatorium-api
+              ports:
+                - containerPort: 8081
+                  name: internal
+                - containerPort: 8080
+                  name: public
+              readinessProbe:
+                failureThreshold: 12
+                httpGet:
+                  path: /ready
+                  port: 8081
+                  scheme: HTTP
+                periodSeconds: 5
+              resources:
+                limits:
+                  cpu: ${OBSERVATORIUM_API_CPU_LIMIT}
+                  memory: ${OBSERVATORIUM_API_MEMORY_LIMIT}
+                requests:
+                  cpu: ${OBSERVATORIUM_API_CPU_REQUEST}
+                  memory: ${OBSERVATORIUM_API_MEMORY_REQUEST}
+              volumeMounts:
+                - mountPath: /etc/observatorium/rbac.yaml
+                  name: rbac
+                  readOnly: true
+                  subPath: rbac.yaml
+                - mountPath: /etc/observatorium/tenants.yaml
+                  name: tenants
+                  readOnly: true
+                  subPath: tenants.yaml
+            - args:
+                - --web.listen=127.0.0.1:8082
+                - --web.internal.listen=0.0.0.0:8083
+                - --web.healthchecks.url=http://127.0.0.1:8082
+                - --log.level=warn
+                - --ams.url=${AMS_URL}
+                - --resource-type-prefix=observatorium
+                - --oidc.client-id=$(CLIENT_ID)
+                - --oidc.client-secret=$(CLIENT_SECRET)
+                - --oidc.issuer-url=$(ISSUER_URL)
+                - --opa.package=observatorium
+                - --memcached=observatorium-api-cache-memcached.${NAMESPACE}.svc.cluster.local:11211
+                - --memcached.expire=${OPA_AMS_MEMCACHED_EXPIRE}
+                - --ams.mappings=dptp=${DPTP_ORGANIZATION_ID}
+                - --ams.mappings=managedkafka=${MANAGEDKAFKA_ORGANIZATION_ID}
+                - --ams.mappings=osd=${OSD_ORGANIZATION_ID}
+              env:
+                - name: ISSUER_URL
+                  valueFrom:
+                    secretKeyRef:
+                      key: issuer-url
+                      name: ${OBSERVATORIUM_API_IDENTIFIER}
+                - name: CLIENT_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: client-id
+                      name: ${OBSERVATORIUM_API_IDENTIFIER}
+                - name: CLIENT_SECRET
+                  valueFrom:
+                    secretKeyRef:
+                      key: client-secret
+                      name: ${OBSERVATORIUM_API_IDENTIFIER}
+              image: ${OPA_AMS_IMAGE}:${OPA_AMS_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 10
+                httpGet:
+                  path: /live
+                  port: 8083
+                  scheme: HTTP
+                periodSeconds: 30
+              name: opa-ams
+              ports:
+                - containerPort: 8082
+                  name: opa-ams-api
+                - containerPort: 8083
+                  name: opa-ams-metrics
+              readinessProbe:
+                failureThreshold: 12
+                httpGet:
+                  path: /ready
+                  port: 8083
+                  scheme: HTTP
+                periodSeconds: 5
+              resources:
+                limits:
+                  cpu: ${OPA_AMS_CPU_LIMIT}
+                  memory: ${OPA_AMS_MEMORY_LIMIT}
+                requests:
+                  cpu: ${OPA_AMS_CPU_REQUEST}
+                  memory: ${OPA_AMS_MEMORY_REQUEST}
+            - args:
+                - --reporter.grpc.host-port=dns:///jaeger-collector-headless.${JAEGER_COLLECTOR_NAMESPACE}.svc:14250
+                - --reporter.type=grpc
+                - --agent.tags=pod.namespace=$(NAMESPACE),pod.name=$(POD)
+              env:
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+              image: ${JAEGER_AGENT_IMAGE}:${JAEGER_AGENT_IMAGE_TAG}
+              livenessProbe:
+                failureThreshold: 5
+                httpGet:
+                  path: /
+                  port: 14271
+                  scheme: HTTP
+              name: jaeger-agent
+              ports:
+                - containerPort: 5778
+                  name: configs
+                - containerPort: 6831
+                  name: jaeger-thrift
+                - containerPort: 14271
+                  name: metrics
+              resources:
+                limits:
+                  cpu: 128m
+                  memory: 128Mi
+                requests:
+                  cpu: 32m
+                  memory: 64Mi
+          serviceAccountName: ${SERVICE_ACCOUNT_NAME}
+          volumes:
+            - configMap:
+                name: ${OBSERVATORIUM_API_IDENTIFIER}
+              name: rbac
+            - name: tenants
+              secret:
+                secretName: ${OBSERVATORIUM_API_IDENTIFIER}
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      labels:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-api
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${OBSERVATORIUM_API_IMAGE_TAG}
+      name: ${OBSERVATORIUM_API_IDENTIFIER}
+    stringData:
+      tenants.yaml: |-
+        "tenants":
+        - "id": "770c1124-6ae8-4324-a9d4-9ce08590094b"
+          "name": "rhobs"
+          "oidc":
+            "clientID": "id"
+            "clientSecret": "secret"
+            "groupClaim": "groups"
+            "issuerURL": "https://rhobs.tenants.observatorium.io"
+            "usernameClaim": "preferred_username"
+        - "id": "FB870BF3-9F3A-44FF-9BF7-D7A047A52F43"
+          "name": "telemeter"
+          "oidc":
+            "clientID": "id"
+            "clientSecret": "secret"
+            "issuerURL": "https://sso.redhat.com/auth/realms/redhat-external"
+            "usernameClaim": "preferred_username"
+        - "id": "AC879303-C60F-4D0D-A6D5-A485CFD638B8"
+          "name": "dptp"
+          "oidc":
+            "clientID": "id"
+            "clientSecret": "secret"
+            "issuerURL": "https://sso.redhat.com/auth/realms/redhat-external"
+            "usernameClaim": "preferred_username"
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-api
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${OBSERVATORIUM_API_IMAGE_TAG}
+      name: ${OBSERVATORIUM_API_IDENTIFIER}
+    spec:
+      ports:
+        - name: internal
+          port: 8081
+          targetPort: 8081
+        - name: public
+          port: 8080
+          targetPort: 8080
+        - name: opa-ams-api
+          port: 8082
+          targetPort: 8082
+        - name: opa-ams-metrics
+          port: 8083
+          targetPort: 8083
+      selector:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-api
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: api
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-api
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${OBSERVATORIUM_API_IMAGE_TAG}
+      name: ${OBSERVATORIUM_API_IDENTIFIER}
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        prometheus: app-sre
+      name: observatorium-api
+    spec:
+      endpoints:
+        - port: internal
+        - port: opa-ams-metrics
+      namespaceSelector:
+        matchNames: ${{NAMESPACES}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: api
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: observatorium-api
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: rate-limiter
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: gubernator
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${GUBERNATOR_IMAGE_TAG}
+      name: observatorium-gubernator
+    spec:
+      replicas: ${{GUBERNATOR_REPLICAS}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: rate-limiter
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: gubernator
+          app.kubernetes.io/part-of: observatorium
+      strategy:
+        rollingUpdate:
+          maxSurge: 0
+          maxUnavailable: 1
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: rate-limiter
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: gubernator
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/version: ${GUBERNATOR_IMAGE_TAG}
+        spec:
+          containers:
+            - env:
+                - name: GUBER_K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: GUBER_K8S_POD_IP
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: status.podIP
+                - name: GUBER_HTTP_ADDRESS
+                  value: 0.0.0.0:8080
+                - name: GUBER_GRPC_ADDRESS
+                  value: 0.0.0.0:8081
+                - name: GUBER_K8S_POD_PORT
+                  value: "8081"
+                - name: GUBER_K8S_ENDPOINTS_SELECTOR
+                  value: app.kubernetes.io/name=gubernator
+              image: ${GUBERNATOR_IMAGE}:${GUBERNATOR_IMAGE_TAG}
+              name: gubernator
+              ports:
+                - containerPort: 8081
+                  name: grpc
+                - containerPort: 8080
+                  name: http
+              readinessProbe:
+                failureThreshold: 3
+                httpGet:
+                  path: /v1/HealthCheck
+                  port: 8080
+                  scheme: HTTP
+                initialDelaySeconds: 10
+                periodSeconds: 30
+                timeoutSeconds: 1
+              resources:
+                limits:
+                  cpu: ${GUBERNATOR_CPU_LIMIT}
+                  memory: ${GUBERNATOR_MEMORY_LIMIT}
+                requests:
+                  cpu: ${GUBERNATOR_CPU_REQUEST}
+                  memory: ${GUBERNATOR_MEMORY_REQUEST}
+          restartPolicy: Always
+          serviceAccountName: observatorium-gubernator
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: Role
+    metadata:
+      labels:
+        app.kubernetes.io/component: rate-limiter
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: gubernator
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${GUBERNATOR_IMAGE_TAG}
+      name: observatorium-gubernator
+    rules:
+      - apiGroups:
+          - ""
+        resources:
+          - endpoints
+        verbs:
+          - list
+          - watch
+          - get
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      labels:
+        app.kubernetes.io/component: rate-limiter
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: gubernator
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${GUBERNATOR_IMAGE_TAG}
+      name: observatorium-gubernator
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: observatorium-gubernator
+    subjects:
+      - kind: ServiceAccount
+        name: observatorium-gubernator
+        namespace: ${NAMESPACE}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: rate-limiter
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: gubernator
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${GUBERNATOR_IMAGE_TAG}
+      name: observatorium-gubernator
+    spec:
+      ports:
+        - name: grpc
+          port: 8081
+          targetPort: 8081
+        - name: http
+          port: 8080
+          targetPort: 8080
+      selector:
+        app.kubernetes.io/component: rate-limiter
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: gubernator
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    imagePullSecrets:
+      - name: quay.io
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: rate-limiter
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: gubernator
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${GUBERNATOR_IMAGE_TAG}
+      name: observatorium-gubernator
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        prometheus: app-sre
+      name: observatorium-gubernator
+    spec:
+      endpoints:
+        - port: http
+      namespaceSelector:
+        matchNames: ${{NAMESPACES}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: rate-limiter
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: gubernator
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: api-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+      name: observatorium-api-cache-memcached
+    spec:
+      clusterIP: None
+      ports:
+        - name: client
+          port: 11211
+          targetPort: 11211
+        - name: metrics
+          port: 9150
+          targetPort: 9150
+      selector:
+        app.kubernetes.io/component: api-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      labels:
+        app.kubernetes.io/component: api-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+      name: observatorium-api-cache-memcached
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      name: observatorium-api-cache-memcached
+    spec:
+      endpoints:
+        - port: metrics
+      namespaceSelector:
+        matchNames: ${{NAMESPACES}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: api-cache
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: memcached
+          app.kubernetes.io/part-of: observatorium
+  - apiVersion: apps/v1
+    kind: StatefulSet
+    metadata:
+      labels:
+        app.kubernetes.io/component: api-cache
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: memcached
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+      name: observatorium-api-cache-memcached
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: api-cache
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: memcached
+          app.kubernetes.io/part-of: observatorium
+      serviceName: observatorium-api-cache-memcached
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: api-cache
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: memcached
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/version: ${MEMCACHED_IMAGE_TAG}
+        spec:
+          containers:
+            - args:
+                - -m ${MEMCACHED_MEMORY_LIMIT_MB}
+                - -I 5m
+                - -c ${MEMCACHED_CONNECTION_LIMIT}
+                - -v
+              image: ${MEMCACHED_IMAGE}:${MEMCACHED_IMAGE_TAG}
+              name: memcached
+              ports:
+                - containerPort: 11211
+                  name: client
+              resources:
+                limits:
+                  cpu: ${MEMCACHED_CPU_LIMIT}
+                  memory: ${MEMCACHED_MEMORY_LIMIT}
+                requests:
+                  cpu: ${MEMCACHED_CPU_REQUEST}
+                  memory: ${MEMCACHED_MEMORY_REQUEST}
+              terminationMessagePolicy: FallbackToLogsOnError
+            - args:
+                - --memcached.address=localhost:11211
+                - --web.listen-address=0.0.0.0:9150
+              image: ${MEMCACHED_EXPORTER_IMAGE}:${MEMCACHED_EXPORTER_IMAGE_TAG}
+              name: exporter
+              ports:
+                - containerPort: 9150
+                  name: metrics
+              resources:
+                limits:
+                  cpu: ${MEMCACHED_EXPORTER_CPU_LIMIT}
+                  memory: ${MEMCACHED_EXPORTER_MEMORY_LIMIT}
+                requests:
+                  cpu: ${MEMCACHED_EXPORTER_CPU_REQUEST}
+                  memory: ${MEMCACHED_EXPORTER_MEMORY_REQUEST}
+          securityContext: {}
+          serviceAccountName: observatorium-api-cache-memcached
+  - apiVersion: v1
+    data:
+      queries.yaml: |-
+        "queries":
+        - "name": "Clusters"
+          "query": "avg_over_time(sum(count by (_id) (max without (prometheus,receive,instance) ( cluster_version{type=\"current\"} )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h])"
+        - "name": "Clusters aged 1w"
+          "query": "avg_over_time(sum(count by (_id) (max without (prometheus,receive,instance) ( (time() - cluster_version{type=\"initial\"}) > (7 * 24 * 60 * 60) )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h])"
+        - "name": "Nodes"
+          "query": "avg_over_time(sum(sum by (_id) (max without (prometheus,receive,instance) ( cluster:node_instance_type_count:sum)) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h])"
+        - "name": "Cores"
+          "query": "avg_over_time(sum(sum by (_id) (max without (prometheus,receive,instance) ( cluster:capacity_cpu_cores:sum)) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h])"
+        - "name": "Workload CPU"
+          "query": "avg_over_time(sum(max by (_id) (max without (prometheus,receive,instance) ( workload:cpu_usage_cores:sum )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h])"
+        - "name": "Etcd Objects"
+          "query": "avg_over_time(sum(sum by (_id) (max without (prometheus,receive,instance) ( instance:etcd_object_counts:sum )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h])"
+        - "name": "Weekly Active Users"
+          "query": "count(count by (account) (count_over_time(subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"}[7d])))"
+        - "name": "Unique customers"
+          "query": "count(count by (email_domain) (count_over_time(subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com|gmail.com\"}[7d])))"
+        - "name": "Hybrid customers"
+          "query": "count(count by (email_domain) (count by (email_domain,type) (count by (_id,type,email_domain) (cluster_infrastructure_provider{} + on (_id) group_left(email_domain) (topk by (_id) (1, 0 * subscription_labels{}))))) and on (email_domain) (count by (email_domain) (count by (email_domain,type) (count by (_id,type,email_domain) (cluster_infrastructure_provider{} + on (_id) group_left(email_domain) (topk by (_id) (1, 0 * subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com|gmail.com\"}))))) > 1))"
+        - "name": "Subscribed clusters"
+          "query": "avg_over_time(sum(count by (_id) (max without (prometheus,receive,instance) ( cluster_version{type=\"current\"} )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{support=~\"Standard|Premium|Layered\"})))[7d:12h])"
+        - "name": "Subscribed nodes"
+          "query": "avg_over_time(sum(sum by (_id) (max without (prometheus,receive,instance) ( cluster:node_instance_type_count:sum)) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{support=~\"Standard|Premium\"})))[7d:12h])"
+        - "name": "Subscribed cores"
+          "query": "avg_over_time(sum(sum by (_id) (max without (prometheus,receive,instance) ( cluster:capacity_cpu_cores:sum)) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{support=~\"Standard|Premium|Layered\"})))[7d:12h])"
+        - "name": "Hours failing per week"
+          "query": "sum((max by (_id) (count_over_time((cluster_version{type=\"failure\"} * 0 + 1)[7d:15m]) > 1) + on (_id) group_left(email_domain) topk by (_id) (1, 0 * max_over_time(subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"}[7d]))) / 4)"
+        - "name": "Average code age (days)"
+          "query": "avg_over_time(avg(max by (_id) (max without (prometheus,receive,instance) ( (time() - cluster_version{type=\"current\"}))) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[7d:12h]) / 60 / 60 / 24"
+        - "name": "Average subscribed code age (days)"
+          "query": "avg_over_time(avg(max by (_id) (max without (prometheus,receive,instance) ( (time() - cluster_version{type=\"current\"}))) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{support=~\"Standard|Premium|Layered\"})))[7d:12h]) / 60 / 60 / 24"
+        - "name": "Clusters upgrading to 4.2"
+          "query": "count(((count by (_id) (count_over_time(cluster_version{from_version=~\"4\\\\.1\\\\.\\\\d+\",version=~\"4\\\\.2\\\\.\\\\d+\",type=\"updating\"}[7d])))*0+1) + on(_id) group_left(_blah) (topk by (_id) (1, 0*subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"})))"
+        - "name": "Failed 4.2 upgrades"
+          "query": "count(((max by (_id) (sum_over_time((1+0*cluster_version{from_version=~\"4\\\\.1\\\\.\\\\d+\",version=~\"4\\\\.2\\\\.\\\\d+\",type=\"failure\"})[7d:15m]))) > 2) + on(_id) group_left(_blah) (topk by (_id) (1, 0*subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"})))"
+        - "name": "Clusters upgrading to 4.3"
+          "query": "count(((count by (_id) (count_over_time(cluster_version{from_version=~\"4\\\\.2\\\\.\\\\d+\",version=~\"4\\\\.3\\\\.\\\\d+\",type=\"updating\"}[7d])))*0+1) + on(_id) group_left(_blah) (topk by (_id) (1, 0*subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"})))"
+        - "name": "Clusters upgrading to 4.4"
+          "query": "count(((count by (_id) (count_over_time(cluster_version{from_version=~\"4\\\\.2\\\\.\\\\d+\",version=~\"4\\\\.4\\\\.\\\\d+\",type=\"updating\"}[7d])))*0+1) + on(_id) group_left(_blah) (topk by (_id) (1, 0*subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"})))"
+        - "name": "Failed 4.3 upgrades"
+          "query": "count(((max by (_id) (sum_over_time((1+0*cluster_version{from_version=~\"4\\\\.2\\\\.\\\\d+\",version=~\"4\\\\.3\\\\.\\\\d+\",type=\"failure\"})[7d:15m]))) > 2) + on(_id) group_left(_blah) (topk by (_id) (1, 0*subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"})))"
+        - "name": "Failed 4.4 upgrades"
+          "query": "count(((max by (_id) (sum_over_time((1+0*cluster_version{from_version=~\"4\\\\.2\\\\.\\\\d+\",version=~\"4\\\\.4\\\\.\\\\d+\",type=\"failure\"})[7d:15m]))) > 2) + on(_id) group_left(_blah) (topk by (_id) (1, 0*subscription_labels{email_domain!~\"redhat.com|(.*\\\\.|^)ibm.com\"})))"
+        - "name": "4.4 clusters"
+          "query": "avg_over_time(count(count by (_id) (max without (prometheus,receive,instance) ( cluster_version{type=\"current\",version=~\"4\\\\.4\\\\.\\\\d+\"} )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[1d:12h])"
+        - "name": "4.3 clusters"
+          "query": "avg_over_time(count(count by (_id) (max without (prometheus,receive,instance) ( cluster_version{type=\"current\",version=~\"4\\\\.3\\\\.\\\\d+\"} )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[1d:12h])"
+        - "name": "4.2 clusters"
+          "query": "avg_over_time(count(count by (_id) (max without (prometheus,receive,instance) ( cluster_version{type=\"current\",version=~\"4\\\\.2\\\\.\\\\d+\"} )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[1d:12h])"
+        - "name": "4.1 clusters"
+          "query": "avg_over_time(count(count by (_id) (max without (prometheus,receive,instance) ( cluster_version{type=\"current\",version=~\"4\\\\.1\\\\.\\\\d+\"} )) + on (_id) group_left(_blah) (topk by (_id) (1, 0 *subscription_labels{email_domain!~\"redhat.com|(^|.*\\\\.)ibm.com\"})))[1d:12h])"
+    kind: ConfigMap
+    metadata:
+      labels:
+        app.kubernetes.io/component: blackbox-prober
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-up
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: master-2020-06-15-d763595
+      name: observatorium-observatorium-up
+  - apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      labels:
+        app.kubernetes.io/component: blackbox-prober
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-up
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: master-2020-06-15-d763595
+      name: observatorium-observatorium-up
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: blackbox-prober
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: observatorium-up
+          app.kubernetes.io/part-of: observatorium
+      template:
+        metadata:
+          labels:
+            app.kubernetes.io/component: blackbox-prober
+            app.kubernetes.io/instance: observatorium
+            app.kubernetes.io/name: observatorium-up
+            app.kubernetes.io/part-of: observatorium
+            app.kubernetes.io/version: master-2020-06-15-d763595
+        spec:
+          containers:
+            - args:
+                - --duration=0
+                - --log.level=debug
+                - --endpoint-type=metrics
+                - --queries-file=/etc/up/queries.yaml
+                - --endpoint-read=http://observatorium-thanos-query-frontend.${NAMESPACE}.svc:9090/api/v1/query
+              image: quay.io/observatorium/up:master-2020-06-15-d763595
+              name: observatorium-up
+              ports:
+                - containerPort: 8080
+                  name: http
+              resources:
+                limits:
+                  cpu: 20m
+                  memory: 50Mi
+                requests:
+                  cpu: 5m
+                  memory: 10Mi
+              volumeMounts:
+                - mountPath: /etc/up/
+                  name: query-config
+                  readOnly: false
+          volumes:
+            - configMap:
+                name: observatorium-observatorium-up
+              name: query-config
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      labels:
+        app.kubernetes.io/component: blackbox-prober
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-up
+        app.kubernetes.io/part-of: observatorium
+        app.kubernetes.io/version: master-2020-06-15-d763595
+      name: observatorium-observatorium-up
+    spec:
+      ports:
+        - name: http
+          port: 8080
+          targetPort: 8080
+      selector:
+        app.kubernetes.io/component: blackbox-prober
+        app.kubernetes.io/instance: observatorium
+        app.kubernetes.io/name: observatorium-up
+        app.kubernetes.io/part-of: observatorium
+  - apiVersion: monitoring.coreos.com/v1
+    kind: ServiceMonitor
+    metadata:
+      labels:
+        prometheus: app-sre
+      name: observatorium-up
+    spec:
+      endpoints:
+        - port: http
+      namespaceSelector:
+        matchNames: ${{NAMESPACES}}
+      selector:
+        matchLabels:
+          app.kubernetes.io/component: blackbox-prober
+          app.kubernetes.io/instance: observatorium
+          app.kubernetes.io/name: observatorium-up
+          app.kubernetes.io/part-of: observatorium
+parameters:
+  - name: NAMESPACE
+    value: observatorium
+  - name: NAMESPACES
+    value: '["telemeter", "observatorium-metrics", "observatorium-mst-production"]'
+  - name: OBSERVATORIUM_METRICS_NAMESPACE
+    value: observatorium-metrics
+  - name: OBSERVATORIUM_LOGS_NAMESPACE
+    value: observatorium-logs
+  - name: AMS_URL
+    value: https://api.openshift.com
+  - name: DPTP_ORGANIZATION_ID
+    value: ""
+  - name: GUBERNATOR_CPU_LIMIT
+    value: 200m
+  - name: GUBERNATOR_CPU_REQUEST
+    value: 100m
+  - name: GUBERNATOR_IMAGE_TAG
+    value: 1.0.0-rc.1
+  - name: GUBERNATOR_IMAGE
+    value: quay.io/app-sre/gubernator
+  - name: GUBERNATOR_MEMORY_LIMIT
+    value: 200Mi
+  - name: GUBERNATOR_MEMORY_REQUEST
+    value: 100Mi
+  - name: GUBERNATOR_REPLICAS
+    value: "2"
+  - name: JAEGER_AGENT_IMAGE_TAG
+    value: 1.22.0
+  - name: JAEGER_AGENT_IMAGE
+    value: jaegertracing/jaeger-agent
+  - name: JAEGER_COLLECTOR_NAMESPACE
+    value: $(NAMESPACE)
+  - name: MANAGEDKAFKA_ORGANIZATION_ID
+    value: ""
+  - name: MEMCACHED_CONNECTION_LIMIT
+    value: "3072"
+  - name: MEMCACHED_CPU_LIMIT
+    value: "3"
+  - name: MEMCACHED_CPU_REQUEST
+    value: 500m
+  - name: MEMCACHED_EXPORTER_CPU_LIMIT
+    value: 200m
+  - name: MEMCACHED_EXPORTER_CPU_REQUEST
+    value: 50m
+  - name: MEMCACHED_EXPORTER_IMAGE_TAG
+    value: v0.6.0
+  - name: MEMCACHED_EXPORTER_IMAGE
+    value: docker.io/prom/memcached-exporter
+  - name: MEMCACHED_EXPORTER_MEMORY_LIMIT
+    value: 200Mi
+  - name: MEMCACHED_EXPORTER_MEMORY_REQUEST
+    value: 50Mi
+  - name: MEMCACHED_IMAGE_TAG
+    value: 1.5.20-alpine
+  - name: MEMCACHED_IMAGE
+    value: docker.io/memcached
+  - name: MEMCACHED_MEMORY_LIMIT_MB
+    value: "2048"
+  - name: MEMCACHED_MEMORY_LIMIT
+    value: 1844Mi
+  - name: MEMCACHED_MEMORY_REQUEST
+    value: 1329Mi
+  - name: OAUTH_PROXY_CPU_LIMITS
+    value: 200m
+  - name: OAUTH_PROXY_CPU_REQUEST
+    value: 100m
+  - name: OAUTH_PROXY_IMAGE_TAG
+    value: 4.7.0
+  - name: OAUTH_PROXY_IMAGE
+    value: quay.io/openshift/origin-oauth-proxy
+  - name: OAUTH_PROXY_MEMORY_LIMITS
+    value: 200Mi
+  - name: OAUTH_PROXY_MEMORY_REQUEST
+    value: 100Mi
+  - name: OBSERVATORIUM_API_CPU_LIMIT
+    value: "1"
+  - name: OBSERVATORIUM_API_CPU_REQUEST
+    value: 100m
+  - name: OBSERVATORIUM_API_IDENTIFIER
+    value: observatorium-observatorium-api
+  - name: OBSERVATORIUM_API_IMAGE_TAG
+    value: master-2021-03-26-v0.1.1-200-gea0242a
+  - name: OBSERVATORIUM_API_IMAGE
+    value: quay.io/observatorium/api
+  - name: OBSERVATORIUM_API_MEMORY_LIMIT
+    value: 1Gi
+  - name: OBSERVATORIUM_API_MEMORY_REQUEST
+    value: 256Mi
+  - name: OBSERVATORIUM_API_REPLICAS
+    value: "3"
+  - name: OBSERVATORIUM_API_PER_POD_CONCURRENT_REQUETST_LIMIT
+    value: "50"
+  - name: OPA_AMS_CPU_LIMIT
+    value: 200m
+  - name: OPA_AMS_CPU_REQUEST
+    value: 100m
+  - name: OPA_AMS_IMAGE_TAG
+    value: master-2021-02-17-ed50046
+  - name: OPA_AMS_IMAGE
+    value: quay.io/observatorium/opa-ams
+  - name: OPA_AMS_MEMCACHED_EXPIRE
+    value: "300"
+  - name: OPA_AMS_MEMORY_LIMIT
+    value: 200Mi
+  - name: OPA_AMS_MEMORY_REQUEST
+    value: 100Mi
+  - name: OSD_ORGANIZATION_ID
+    value: ""
+  - name: SERVICE_ACCOUNT_NAME
+    value: prometheus-telemeter

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -286,6 +286,7 @@ class TestPopulateDesiredState(TestCase):
         )
 
         # Mock GitHub.
+        # TODO(bwplotka): Mock getting stuff from repo.
         self.initiate_gh_patcher = patch.object(
             SaasHerder, '_initiate_github', autospec=True, return_value=None,
         )
@@ -306,6 +307,8 @@ class TestPopulateDesiredState(TestCase):
     def test_populate_desired_state_cases(self):
         ir = ResourceInventory()
         self.saasherder.populate_desired_state(ir)
+
+        # TODO(bwplotka): Assert correct resources.
         self.assertEqual({"yolo": "yolo"}, ir._clusters)
 
 

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -264,19 +264,25 @@ class TestGetMovingCommitsDiffSaasFile(TestCase):
 
 
 class TestPopulateDesiredState(TestCase):
-    def test_populate_desired_state_saas_file_delete(self):
-        spec = {'delete': True}
-        saasherder = SaasHerder(
-            [],
+    def setUp(self):
+        saas_files = []
+        self.saasherder = SaasHerder(
+            saas_files,
             thread_pool_size=1,
             gitlab=None,
             integration='',
             integration_version='',
             settings={}
         )
-        desired_state = \
-            saasherder.populate_desired_state_saas_file(spec, None)
+
+    def test_populate_desired_state_saas_file_delete(self):
+        spec = {'delete': True}
+
+        desired_state = self.saasherder.populate_desired_state_saas_file(spec, None)
         self.assertIsNone(desired_state)
+
+    def test_populate_desired_state_cases(self):
+        print("yolo")
 
 
 class TestGetSaasFileAttribute(TestCase):

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -9,8 +9,7 @@ from github import GithubException
 
 from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.saasherder import SaasHerder
-import reconcile.utils.config as config
-import reconcile.utils.gql as gql
+
 
 class TestCheckSaasFileEnvComboUnique(TestCase):
     def test_check_saas_file_env_combo_unique(self):
@@ -285,8 +284,18 @@ class TestPopulateDesiredState(TestCase):
             integration_version='',
             settings={}
         )
-        config.init_from_toml(Fixtures('github_org').path('config.toml'))
-        gql.init_from_config(sha_url=False)
+
+        # Mock GitHub.
+        self.initiate_gh_patcher = patch.object(
+            SaasHerder, '_initiate_github', autospec=True, return_value=None,
+        )
+        self.initiate_gh_patcher.start()
+
+    def tearDown(self):
+        for p in (
+                self.initiate_gh_patcher,
+        ):
+            p.stop()
 
     def test_populate_desired_state_saas_file_delete(self):
         spec = {'delete': True}

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -282,7 +282,7 @@ class TestPopulateDesiredState(TestCase):
             gitlab=None,
             integration='',
             integration_version='',
-            settings={}
+            settings={'hashLength':  7}
         )
 
         # Mock GitHub.

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -704,6 +704,7 @@ class SaasHerder():
                                self.saas_files,
                                self.thread_pool_size)
         desired_state_specs = list(itertools.chain.from_iterable(results))
+        logging.warning(desired_state_specs)
         promotions = threaded.run(self.populate_desired_state_saas_file,
                                   desired_state_specs,
                                   self.thread_pool_size,
@@ -711,18 +712,22 @@ class SaasHerder():
         self.promotions = promotions
 
     def init_populate_desired_state_specs(self, saas_file):
+        logging.warning(saas_file)
         specs = []
         saas_file_name = saas_file['name']
         github = self._initiate_github(saas_file)
         image_auth = self._initiate_image_auth(saas_file)
+
+        # Instance exists in v1 saas files only.
         instance = saas_file.get('instance')
-        # instance exists in v1 saas files only
         instance_name = instance['name'] if instance else None
+
         managed_resource_types = saas_file['managedResourceTypes']
         image_patterns = saas_file['imagePatterns']
         resource_templates = saas_file['resourceTemplates']
         saas_file_parameters = self._collect_parameters(saas_file)
-        # iterate over resource templates (multiple per saas_file)
+
+        # Iterate over resource templates (multiple per saas_file).
         for rt in resource_templates:
             rt_name = rt['name']
             url = rt['url']
@@ -735,11 +740,12 @@ class SaasHerder():
             consolidated_parameters.update(saas_file_parameters)
             consolidated_parameters.update(parameters)
 
-            # iterate over targets (each target is a namespace)
+            # Iterate over targets (each target is a namespace).
             for target in rt['targets']:
                 if target.get('disable'):
-                    # a warning is logged during SaasHerder initiation
+                    # Warning is logged during SaasHerder initiation.
                     continue
+
                 cluster, namespace = \
                     self._get_cluster_and_namespace(target)
                 process_template_options = {

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -660,7 +660,7 @@ class SaasHerder():
     def _initiate_image_auth(self, saas_file):
         """
         This function initiates a dict required for image authentication.
-        This dict will be used as kwargs for sertoolbox's Image.
+        This dict will be used as kwargs for sretoolbox's Image.
         The image authentication secret specified in the saas file must
         contain the 'user' and 'token' keys, and may optionally contain
         a 'url' key specifying the image registry url to be passed to check
@@ -674,6 +674,7 @@ class SaasHerder():
         auth = saas_file.get('authentication')
         if not auth:
             return {}
+
         auth_image_secret = auth.get('image')
         if not auth_image_secret:
             return {}
@@ -704,7 +705,6 @@ class SaasHerder():
                                self.saas_files,
                                self.thread_pool_size)
         desired_state_specs = list(itertools.chain.from_iterable(results))
-        logging.warning(desired_state_specs)
         promotions = threaded.run(self.populate_desired_state_saas_file,
                                   desired_state_specs,
                                   self.thread_pool_size,
@@ -712,7 +712,6 @@ class SaasHerder():
         self.promotions = promotions
 
     def init_populate_desired_state_specs(self, saas_file):
-        logging.warning(saas_file)
         specs = []
         saas_file_name = saas_file['name']
         github = self._initiate_github(saas_file)
@@ -745,7 +744,7 @@ class SaasHerder():
                 if target.get('disable'):
                     # Warning is logged during SaasHerder initiation.
                     continue
-
+                logging.warning(target)
                 cluster, namespace = \
                     self._get_cluster_and_namespace(target)
                 process_template_options = {

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -436,6 +436,7 @@ class SaasHerder():
         html_url = None
         commit_sha = None
 
+        # TODO(bwplotka): Add docker executor.
         if provider == 'openshift-template':
             hash_length = options['hash_length']
             parameters = options['parameters']

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -745,7 +745,6 @@ class SaasHerder():
                 if target.get('disable'):
                     # Warning is logged during SaasHerder initiation.
                     continue
-                logging.warning(target)
                 cluster, namespace = \
                     self._get_cluster_and_namespace(target)
                 process_template_options = {


### PR DESCRIPTION
Motivation and task: https://issues.redhat.com/browse/MON-1699

Idea: Add docker template executor that takes you can configure in Saas file:
* image with something that takes input Yaml + templates and produces YAML resources 
* where to take templates from
* input YAML with all parameters 

Currently adding tests for basic openshift template first, then extending with docker executor. Let me know if this idea makes sense (: cc @maorfr @jmelis @rporres 