### PR TITLE
Add validation logic for ClowdJobInvocation

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -607,7 +607,8 @@ def follow_logs(oc_map, actions, io_dir):
     """
 
     supported_kinds = [
-        'Job'
+        'Job',
+        'ClowdJobInvocation'
     ]
     for action in actions:
         if action['action'] == ACTION_APPLIED:
@@ -623,7 +624,15 @@ def follow_logs(oc_map, actions, io_dir):
             if not oc:
                 logging.log(level=oc.log_level, msg=oc.message)
                 continue
-            oc.job_logs(namespace, name, follow=True, output=io_dir)
+
+            if kind == 'Job':
+                oc.job_logs(namespace, name, follow=True, output=io_dir)
+            if kind == 'ClowdJobInvocation':
+                resource = oc.get(namespace, kind, name=name)
+                jobs = resource.get('status', {}).get('jobs', {})
+                for jn in jobs:
+                    logging.info(['collecting', cluster, namespace, kind, jn])
+                    oc.job_logs(namespace, jn, follow=True, output=io_dir)
 
 
 def aggregate_shared_resources(namespace_info, shared_resources_type):

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -577,7 +577,6 @@ def validate_data(oc_map, actions):
             elif kind == 'ClowdJobInvocation':
                 completed = status.get('completed')
                 jobs = status.get('jobs', {})
-                conditions = status.get('conditions')
                 if jobs:
                     logging.info(f'CJI {name} jobs are: {jobs}')
                     logging.info(yaml.safe_dump(jobs))
@@ -591,6 +590,7 @@ def validate_data(oc_map, actions):
                             f'CJI {name} failed jobs: {failed_jobs}')
                 else:
                     logging.info(f'CJI {name} has not completed')
+                    conditions = status.get('conditions')
                     if conditions:
                         logging.info(f'CJI conditions are: {conditions}')
                         logging.info(yaml.safe_dump(conditions))

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -576,23 +576,24 @@ def validate_data(oc_map, actions):
                     raise ValidationError(name)
             elif kind == 'ClowdJobInvocation':
                 completed = status.get('completed')
-                if not completed:
+                jobs = status.get('jobs', {})
+                conditions = status.get('conditions')
+                if jobs:
+                    logging.info(f'CJI {name} jobs are: {jobs}')
+                    logging.info(yaml.safe_dump(jobs))
+                if completed:
+                    failed_jobs = []
+                    for job_name, job_state in jobs.items():
+                        if job_state == 'Failed':
+                            failed_jobs.append(job_name)
+                    if failed_jobs:
+                        raise ValidationErrorJobFailed(
+                            f'CJI {name} failed jobs: {failed_jobs}')
+                else:
                     logging.info(f'CJI {name} has not completed')
-                    conditions = status.get('conditions')
                     if conditions:
                         logging.info(f'CJI conditions are: {conditions}')
                         logging.info(yaml.safe_dump(conditions))
-                    jobs = status.get('jobs')
-                    if jobs:
-                        logging.info(f'CJI jobs are: {jobs}')
-                        logging.info(yaml.safe_dump(jobs))
-                        failed_jobs = []
-                        for job_name, job_state in jobs.items():
-                            if job_state == 'Failed':
-                                failed_jobs.append(job_name)
-                        if failed_jobs:
-                            raise ValidationErrorJobFailed(
-                                f'CJI {name} failed jobs: {failed_jobs}')
                     raise ValidationError(name)
 
 


### PR DESCRIPTION
Depends on https://github.com/RedHatInsights/clowder/pull/430

Adds validation logic for checking whether a Clowder ClowdJobInvocation has completed, and if it is 'completed', checks to see if any of its invoked child Jobs have failed.

Also follows logs of all jobs invoked by a ClowdJobInvocation