### PR TITLE
[terraform] add handle to apply updated outputs

### DIFF
--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -177,6 +177,7 @@ class TerraformClient:
             before = self.outputs[name].get(output_name, {}).get('value')
             after = output_change['after']
             if before != after:
+                logging.info(['update', name, 'output', output_name])
                 self.should_apply = True
 
         resource_changes = output.get('resource_changes')

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -166,6 +166,19 @@ class TerraformClient:
             raise NotImplementedError(
                 'terraform show untested format version')
 
+        # https://www.terraform.io/docs/internals/json-format.html
+        # Terraform is not yet fully able to
+        # track changes to output values, so the actions indicated may not be
+        # fully accurate, but the "after" value will always be correct.
+        # to overcome the "before" value not being accurate,
+        # we find it in the previously initiated outputs.
+        output_changes = output.get('output_changes', {})
+        for output_name, output_change in output_changes.items():
+            before = self.outputs[name].get(output_name, {}).get('value')
+            after = output_change['after']
+            if before != after:
+                self.should_apply = True
+
         resource_changes = output.get('resource_changes')
         if resource_changes is None:
             return disabled_deletion_detected, deleted_users


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3867

following #1840, we currently skip `terraform apply` unless there is a change to an actual resource. there are cases that only outputs are updated, and we currently skip it.

with this PR, we compare the predicted outputs (produced by `terraform plan` + `terraform show`) with the current outputs (produced by `terraform output`). if we find a mismatch - we set `should_apply` to `True`.

this will cause the integration to perform `terraform apply` for output changes only (such as adding a ca_cert to a DB).