### PR TITLE
Fix template inclusion during packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import find_packages
 from setuptools import setup
-from glob import glob
 
 
 setup(
@@ -17,8 +16,7 @@ setup(
     url='https://github.com/app-sre/qontract-reconcile',
 
     packages=find_packages(exclude=('tests',)),
-
-    data_files=[('reconcile/templates', glob('reconcile/templates/*.j2'))],
+    package_data={'reconcile': ['templates/*.j2']},
 
     install_requires=[
         "sretoolbox==0.15.0",


### PR DESCRIPTION
This issue was discovered after the move to installing with pip
install instead of setup.py install. It was discovered that the
template files were missing. The templates were never included in
the correct location in the wheel distribution, only when q-r was
installed locally via setup.py install. This fix will ensure that
they are included in the expected directory for both local installs
and wheel distributions.

As per the setuptools docs, package_data is more appropriate because
these template files are closely related to the package implementation
and they are expected to be in the package directory.

To prove this only made the expected changes I generated a wheel with `python3 setup.py bdist_wheel` and got a checksum and list of all the files in the wheels. The diff produced is below:

```
$ diff -u data_files.txt package_data.txt 
--- data_files.txt	2021-10-04 10:57:10.839214739 -0400
+++ package_data.txt	2021-10-04 10:38:20.906529843 -0400
@@ -7,8 +7,6 @@
 81e025c0c921784d971adcd765953c25  ./e2e_tests/default_project_labels.py
 4520de4e5822f1d7c5a7d0a1b685839b  ./e2e_tests/network_policy_test_base.py
 d3555885ce7b5e6da7ae986ebc86a593  ./e2e_tests/test_base.py
-522eb9fc45b2fbd967ec2f91714b2408  ./qontract_reconcile-0.3.0.data/data/reconcile/templates/aws_access_key_email.j2
-5b8e7c067f87fdaf3bf73136717af69e  ./qontract_reconcile-0.3.0.data/data/reconcile/templates/email.yml.j2
 d41d8cd98f00b204e9800998ecf8427e  ./reconcile/__init__.py
 18826021389c3874d70c2f57ad87a9b7  ./reconcile/aws_ecr_image_pull_secrets.py
 f0d42691646f1381ee40614702a9477b  ./reconcile/aws_garbage_collector.py
@@ -117,6 +115,8 @@
 b9c87f462842eab359c2284788d1c5f5  ./reconcile/unleash_watcher.py
 28c1281ab387558597e5960eba0b7e0d  ./reconcile/user_validator.py
 d41d8cd98f00b204e9800998ecf8427e  ./reconcile/templates/__init__.py
+522eb9fc45b2fbd967ec2f91714b2408  ./reconcile/templates/aws_access_key_email.j2
+5b8e7c067f87fdaf3bf73136717af69e  ./reconcile/templates/email.yml.j2
 d41d8cd98f00b204e9800998ecf8427e  ./reconcile/test/__init__.py
 2768d7d94baefab0397c916538042f6b  ./reconcile/test/fixtures.py
 8746187539a6754f41605ed7bbb0aed1  ./reconcile/test/test_aggregated_list.py
@@ -224,4 +224,4 @@
 40c30724e4d957d3b27cb3926dbb72fa  ./qontract_reconcile-0.3.0.dist-info/WHEEL
 cac27e63c84eed7f3a81c36e34df5d7e  ./qontract_reconcile-0.3.0.dist-info/entry_points.txt
 8061b66147fb72c563abb8e6e4b0436c  ./qontract_reconcile-0.3.0.dist-info/top_level.txt
-6d9c93bb711678287deefd2341356209  ./qontract_reconcile-0.3.0.dist-info/RECORD
+d4b0f58f498644d0af7e8dd4cca49164  ./qontract_reconcile-0.3.0.dist-info/RECORD
```

This puts the template files in `reconcile/templates` as expected. Also, before this change, building a container with `make build` resulted in:

```
# ls /usr/local/lib/python3.6/site-packages/reconcile/templates/
__init__.py  __pycache__
```

After the change:

```
# ls /usr/local/lib/python3.6/site-packages/reconcile/templates/
aws_access_key_email.j2  email.yml.j2  __init__.py  __pycache__

```