### PR TITLE
add support to mirror multiple ocp release channels

### DIFF
--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -161,6 +161,9 @@ class OcpReleaseMirror:
 
             self.registry_creds['auths'].update(quay_target_org['auths'])
 
+        # Initiate channel groups
+        self.channel_groups = instance['mirrorChannels']
+
     def run(self):
         ocp_releases = self._get_ocp_releases()
         if not ocp_releases:
@@ -255,9 +258,8 @@ class OcpReleaseMirror:
             if enabled == 'false':
                 continue
             # ClusterImageSets may be in different channels.
-            # Let's only mirror stable
             channel_group = labels['api.openshift.com/channel-group']
-            if channel_group != 'stable':
+            if channel_group not in self.channel_groups:
                 continue
             ocp_releases.append(OcpReleaseInfo(release_image, name))
         return ocp_releases

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1873,6 +1873,7 @@ OCP_RELEASE_ECR_MIRROR_QUERY = """
     }
     ocpReleaseEcrIdentifier
     ocpArtDevEcrIdentifier
+    mirrorChannels
   }
 }
 """


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3880

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/26503

back when we created this integration, it was a choice to only mirror stable (due to ECR limitations?).
as ocm-quay has turned into our fallback, we want to mirror more release channels into it (no space/other limitations).