### PR TITLE
[email-sender] remove faulty sections

### DIFF
--- a/reconcile/email_sender.py
+++ b/reconcile/email_sender.py
@@ -45,15 +45,7 @@ def collect_to(to):
             for service_owner in service_owners:
                 audience.add(service_owner['email'])
 
-    clusters = to.get('clusters', [])
-    # TODO: implement this
-    for _c in clusters:
-        pass
-
-    namespaces = to.get('namespaces', [])
-    # TODO: implement this
-    for _n in namespaces:
-        pass
+    # TODO: implement clusters and namespaces
 
     aws_accounts = to.get('aws_accounts')
     if aws_accounts:


### PR DESCRIPTION
bug introduced in #1853

```
Traceback (most recent call last):
  File "/run-integration.py", line 73, in <module>
    integration.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile/utils/environ.py", line 15, in f_environ
    f(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile/cli.py", line 1245, in email_sender
    run_integration(reconcile.email_sender, ctx.obj)
  File "/usr/local/lib/python3.6/site-packages/reconcile/cli.py", line 414, in run_integration
    func_container.run(dry_run, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile/email_sender.py", line 107, in run
    names = collect_to(email['to'])
  File "/usr/local/lib/python3.6/site-packages/reconcile/email_sender.py", line 50, in collect_to
    for _c in clusters:
TypeError: 'NoneType' object is not iterable
```