### PR TITLE
Revert "bug fix: Q-R cannot create RDS replicas w/ enhanced-monitoring"

### DIFF
--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -15,7 +15,7 @@ from ipaddress import ip_network, ip_address
 import anymarkup
 import requests
 
-from terrascript import (Terrascript, provider, Provider, Terraform,
+from terrascript import (Terrascript, provider, Terraform,
                          Backend, Output, data)
 from terrascript.resource import (
     aws_db_instance, aws_db_parameter_group,
@@ -112,20 +112,6 @@ class aws_ecrpublic_repository(Resource):
     pass
 
 
-# temporary until we upgrade to a terrascript release
-# that supports this provider
-# https://github.com/mjuenema/python-terrascript/pull/166
-class time(Provider):
-    pass
-
-
-# temporary until we upgrade to a terrascript release
-# that supports this resource
-# https://github.com/mjuenema/python-terrascript/pull/166
-class time_sleep(Resource):
-    pass
-
-
 class TerrascriptClient:
     def __init__(self, integration, integration_prefix,
                  thread_pool_size, accounts, oc_map=None, settings=None):
@@ -161,14 +147,6 @@ class TerrascriptClient:
                 secret_key=config['aws_secret_access_key'],
                 version=self.versions.get(name),
                 region=config['region'])
-
-            # the time provider can be removed if all AWS accounts
-            # upgrade to a provider version with this bug fix
-            # https://github.com/hashicorp/terraform-provider-aws/pull/20926
-            ts += time(
-                version="0.7.2"
-            )
-
             b = Backend("s3",
                         access_key=config['aws_access_key_id'],
                         secret_key=config['aws_secret_access_key'],
@@ -1072,31 +1050,6 @@ class TerrascriptClient:
                 raise FetchResourceError(
                     f"source {replica_source} for read replica " +
                     f"{identifier} not found")
-
-        # There seems to be a bug in tf-provider-aws when making replicas
-        # w/ ehanced-monitoring, causing tf to not wait long enough
-        # between the actions of creating an enhanced-monitoring IAM role
-        # and checking the permissions of that role on a RDS replica
-        # if the source-db already exists.
-        # Therefore we wait 30s between these actions.
-        # This sleep can be removed if all AWS accounts upgrade
-        # to a provider version with this bug fix.
-        # https://github.com/hashicorp/terraform-provider-aws/pull/20926
-        if enhanced_monitoring and replica_source:
-            sleep_vals = {}
-            sleep_vals['depends_on'] = [attachment_res_name]
-            sleep_vals['create_duration'] = "30s"
-
-            # time_sleep
-            # Terraform resource reference:
-            # https://registry.terraform.io
-            # /providers/hashicorp/time/latest/docs/resources/sleep
-            time_sleep_resource = time_sleep(identifier, **sleep_vals)
-
-            tf_resources.append(time_sleep_resource)
-            time_sleep_res_name = \
-                self.get_dependencies([time_sleep_resource])[0]
-            deps.append(time_sleep_res_name)
 
         kms_key_id = values.pop('kms_key_id', None)
         if kms_key_id is not None:


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#1845

reverted due to errors in all terraform integration when promoting: https://ci.int.devshift.net/job/service-app-interface-gl-pr-check/89334/app-interface_20JSON_20validation/

cc @bkez322 