### PR TITLE
Log skipped managedResources on openshift_resource_base

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1,5 +1,8 @@
 import logging
 import itertools
+
+from typing import Optional, List, Iterable, Mapping
+
 import yaml
 
 from sretoolbox.utils import retry
@@ -45,11 +48,12 @@ class StateSpec:
         self.resource_names = resource_names
 
 
-def init_specs_to_fetch(ri, oc_map,
-                        namespaces=None,
-                        clusters=None,
-                        override_managed_types=None,
-                        managed_types_key='managedResourceTypes'):
+def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
+                        namespaces: Optional[Iterable[Mapping]] = None,
+                        clusters: Optional[Iterable[Mapping]] = None,
+                        override_managed_types: Optional[Iterable[str]] = None,
+                        managed_types_key: str = 'managedResourceTypes'
+                        ) -> List[StateSpec]:
     state_specs = []
 
     if clusters and namespaces:

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -61,7 +61,8 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
     elif namespaces:
         for namespace_info in namespaces:
             if override_managed_types is None:
-                managed_types = set(namespace_info.get(managed_types_key, []))
+                managed_types = set(namespace_info.get(managed_types_key)
+                                    or [])
             else:
                 managed_types = set(override_managed_types)
 
@@ -77,10 +78,11 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
                 continue
 
             namespace = namespace_info['name']
+            # These may exit but have a value of None
             managed_resource_names = \
-                namespace_info.get('managedResourceNames', [])
+                namespace_info.get('managedResourceNames') or []
             managed_resource_type_overrides = \
-                namespace_info.get('managedResourceTypeOverrides', [])
+                namespace_info.get('managedResourceTypeOverrides') or []
 
             # Initialize current state specs
             for resource_type in managed_types:

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -61,9 +61,9 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
     elif namespaces:
         for namespace_info in namespaces:
             if override_managed_types is None:
-                managed_types = namespace_info.get(managed_types_key)
+                managed_types = set(namespace_info.get(managed_types_key, []))
             else:
-                managed_types = override_managed_types
+                managed_types = set(override_managed_types)
 
             if not managed_types:
                 continue
@@ -78,34 +78,42 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
 
             namespace = namespace_info['name']
             managed_resource_names = \
-                namespace_info.get('managedResourceNames')
+                namespace_info.get('managedResourceNames', [])
             managed_resource_type_overrides = \
-                namespace_info.get('managedResourceTypeOverrides')
+                namespace_info.get('managedResourceTypeOverrides', [])
 
             # Initialize current state specs
             for resource_type in managed_types:
                 ri.initialize_resource_type(cluster, namespace, resource_type)
-                # Handle case of specific managed resources
-                resource_names = \
-                    [mrn['resourceNames'] for mrn in managed_resource_names
-                     if mrn['resource'] == resource_type] \
-                    if managed_resource_names else None
-                # Handle case of resource type override
-                resource_type_override = \
-                    [mnto['override'] for mnto
-                     in managed_resource_type_overrides
-                     if mnto['resource'] == resource_type] \
-                    if managed_resource_type_overrides else None
-                # If not None, there is a single element in the list
-                if resource_names:
-                    [resource_names] = resource_names
-                if resource_type_override:
-                    [resource_type_override] = resource_type_override
+            resource_names = {}
+            resource_type_overrides = {}
+            for mrn in managed_resource_names:
+                # Current implementation guarantees only one
+                # managed_resource_name of each managed type
+                if mrn['resource'] in managed_types:
+                    resource_names[mrn['resource']] = mrn['resourceNames']
+                else:
+                    logging.info(
+                        f"Skipping non-managed resources {mrn} "
+                        f"on {cluster}/{namespace}"
+                    )
+
+            for o in managed_resource_type_overrides:
+                # Current implementation guarantees only one
+                # override of each managed type
+                if o['resource'] in managed_types:
+                    resource_type_overrides[o['resource']] = o['override']
+                else:
+                    logging.info(
+                        f"Skipping nom-managed override {o} "
+                        f"on {cluster}/{namespace}")
+
+            for kind, names in resource_names.items():
                 c_spec = StateSpec(
                     "current", oc, cluster, namespace,
-                    resource_type,
-                    resource_type_override=resource_type_override,
-                    resource_names=resource_names)
+                    kind,
+                    resource_type_override=resource_type_overrides.get(kind),
+                    resource_names=names)
                 state_specs.append(c_spec)
 
             # Initialize desired state specs
@@ -117,7 +125,7 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
     elif clusters:
         # set namespace to something indicative
         namespace = 'cluster'
-        for cluster_info in clusters or []:
+        for cluster_info in clusters:
             cluster = cluster_info['name']
             oc = oc_map.get(cluster)
             if not oc:

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -145,3 +145,37 @@ class TestInitSpecsToFetch(testslide.TestCase):
         )
 
         self.assert_specs_match(rs, expected)
+
+    def test_namespaces_no_managedresourcenames(self) -> None:
+        self.namespaces[0]['managedResourceNames'] = None
+        self.namespaces[0]['managedResourceTypeOverrides'] = None
+
+        expected = [
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+        self.assert_specs_match(rs, expected)
+
+    def test_namespaces_no_managedresourcetypes(self) -> None:
+        self.namespaces[0]['managedResourceTypes'] = None
+
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+        self.assertEqual(rs, [])

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -1,0 +1,147 @@
+from typing import List, cast
+
+import testslide
+import reconcile.openshift_base as sut
+import reconcile.utils.openshift_resource as resource
+import reconcile.utils.oc as oc
+
+
+class TestInitSpecsToFetch(testslide.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.resource_inventory = cast(
+            resource.ResourceInventory,
+            testslide.StrictMock(resource.ResourceInventory)
+        )
+
+        self.oc_map = cast(oc.OC_Map, testslide.StrictMock(oc.OC_Map))
+        self.mock_constructor(oc, 'OC_Map').to_return_value(self.oc_map)
+        self.namespaces = [
+            {
+                "name": "ns1",
+                "managedResourceTypes": ["Template"],
+                "cluster": {"name": "cs1"},
+                "managedResourceNames": [
+                    {"resource": "Template",
+                     "resourceNames": ["tp1", "tp2"],
+                     },
+                    {"resource": "Secret",
+                     "resourceNames": ["sc1"],
+                     }
+                ],
+                "openshiftResources": [
+                    {"provider": "resource",
+                     "path": "/some/path.yml"
+                     }
+                ]
+            }
+        ]
+
+        self.mock_callable(
+            self.resource_inventory, 'initialize_resource_type'
+        ).for_call(
+            'cs1', 'ns1', 'Template'
+        ).to_return_value(None)
+
+        self.mock_callable(
+            self.oc_map, 'get'
+        ).for_call("cs1").to_return_value("stuff")
+        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
+
+    def test_only_cluster_or_namespace(self) -> None:
+        with self.assertRaises(KeyError):
+            sut.init_specs_to_fetch(
+                self.resource_inventory,
+                self.oc_map,
+                [{"foo": "bar"}],
+                [{"name": 'cluster1'}],
+            )
+
+    def test_no_cluster_or_namespace(self) -> None:
+        with self.assertRaises(KeyError):
+            sut.init_specs_to_fetch(self.resource_inventory, self.oc_map)
+
+    def assert_specs_match(
+            self, result: List[sut.StateSpec], expected: List[sut.StateSpec]
+    ) -> None:
+        """Assert that two list of StateSpec are equal. Needed since StateSpec
+        doesn't implement __eq__ and it's not worth to add for we will convert
+        it to a dataclass when we move to Python 3.9"""
+        self.assertEqual(
+            [r.__dict__ for r in result],
+            [e.__dict__ for e in expected],
+        )
+
+    def test_namespaces_managed(self) -> None:
+        expected = [
+            sut.StateSpec(
+                type="current",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource="Template",
+                resource_names=["tp1", "tp2"],
+            ),
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+
+        rs = sut.init_specs_to_fetch(
+                self.resource_inventory,
+                self.oc_map,
+                namespaces=self.namespaces,
+            )
+
+        self.maxDiff = None
+        self.assert_specs_match(rs, expected)
+
+    def test_namespaces_managed_with_overrides(self) -> None:
+        self.namespaces[0]['managedResourceTypeOverrides'] = [
+            {
+                "resource": "Project",
+                "override": "something.project",
+            },
+            {
+                "resource": "Template",
+                "override": "something.template"
+            }
+        ]
+        expected = [
+            sut.StateSpec(
+                type="current",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource="Template",
+                resource_names=["tp1", "tp2"],
+                resource_type_override="something.template",
+            ),
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+
+        self.assert_specs_match(rs, expected)


### PR DESCRIPTION
Log in `init_specs_to_fetch` any `managedResourceNames` or
`managedResourceTypeOverrides` not processed because they are not of a
kind listed in `managedResourceTypes`.

These configurations are currently dropped on the floor, making bad
configurations extremely hard to detect.

Continuation of APPSRE-3668

