### PR TITLE
Raise exception on unexpected failure modes in oc.apply

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -93,6 +93,10 @@ class JobNotRunningError(Exception):
     pass
 
 
+class UnableToApplyError(Exception):
+    pass
+
+
 class OCDecorators:
     @classmethod
     def process_reconcile_time(cls, function):
@@ -733,6 +737,9 @@ class OCDeprecated:
                     if ': primary clusterIP can not be unset' in err:
                         raise PrimaryClusterIPCanNotBeUnsetError(
                             f"[{self.server}]: {err}")
+                    raise UnableToApplyError(
+                        f"[{self.server}: {err}"
+                    )
                 if 'metadata.annotations: Too long' in err:
                     raise MetaDataAnnotationsTooLongApplyError(
                         f"[{self.server}]: {err}")


### PR DESCRIPTION
If there is a new kind `Invalid value:` error when running `oc.apply`
the current code ignores it silently.

We add a fallback exception to discover such situations.

Refs APPSRE-3668
