### PR TITLE
[kafka-clusters] improve failure mode

### DIFF
--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -9,7 +9,7 @@ import reconcile.queries as queries
 
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.defer import defer
-from reconcile.utils.ocm import OCMMap, STATUS_READY
+from reconcile.utils.ocm import OCMMap, STATUS_READY, STATUS_FAILED
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.status import ExitCodes
 from reconcile.utils.vault import VaultClient
@@ -163,8 +163,16 @@ def run(dry_run, thread_pool_size=10,
         # check if cluster is ready. if not - wait
         cluster_status = current_cluster['status']
         if cluster_status != STATUS_READY:
-            logging.warning(
-                f'[{kafka_cluster_name}] cluster status is {cluster_status}')
+            # check if cluster is failed
+            if cluster_status == STATUS_FAILED:
+                failed_reason = current_cluster['failed_reason']
+                logging.error(
+                    f'[{kafka_cluster_name}] cluster status is {cluster_status}. '
+                    f'reason: {failed_reason}'    
+                )
+            else:
+                logging.warning(
+                    f'[{kafka_cluster_name}] cluster status is {cluster_status}')
             continue
         # we have a ready cluster!
         # get a service account for the cluster

--- a/reconcile/kafka_clusters.py
+++ b/reconcile/kafka_clusters.py
@@ -161,18 +161,18 @@ def run(dry_run, thread_pool_size=10,
             error = True
             continue
         # check if cluster is ready. if not - wait
-        cluster_status = current_cluster['status']
-        if cluster_status != STATUS_READY:
+        status = current_cluster['status']
+        if status != STATUS_READY:
             # check if cluster is failed
-            if cluster_status == STATUS_FAILED:
+            if status == STATUS_FAILED:
                 failed_reason = current_cluster['failed_reason']
                 logging.error(
-                    f'[{kafka_cluster_name}] cluster status is {cluster_status}. '
+                    f'[{kafka_cluster_name}] cluster status is {status}. '
                     f'reason: {failed_reason}'    
                 )
             else:
                 logging.warning(
-                    f'[{kafka_cluster_name}] cluster status is {cluster_status}')
+                    f'[{kafka_cluster_name}] cluster status is {status}')
             continue
         # we have a ready cluster!
         # get a service account for the cluster

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -325,6 +325,7 @@ def _realize_resource_data(unpacked_ri_item,
                            caller,
                            wait_for_namespace,
                            no_dry_run_skip_compare,
+                           override_enable_deletion,
                            recycle_pods):
     cluster, namespace, resource_type, data = unpacked_ri_item
     actions = []
@@ -337,6 +338,9 @@ def _realize_resource_data(unpacked_ri_item,
         return actions
 
     enable_deletion = False if ri.has_error_registered() else True
+    # only allow to override enable_deletion if no errors were found
+    if enable_deletion is True and override_enable_deletion is False:
+        enable_deletion = False
 
     # desired items
     for name, d_item in data['desired'].items():
@@ -459,6 +463,7 @@ def realize_data(dry_run, oc_map, ri, thread_pool_size,
                  caller=None,
                  wait_for_namespace=False,
                  no_dry_run_skip_compare=False,
+                 override_enable_deletion=None,
                  recycle_pods=True):
     """
     Realize the current state to the desired state.
@@ -473,6 +478,7 @@ def realize_data(dry_run, oc_map, ri, thread_pool_size,
                    to deploy to the same namespace
     :param wait_for_namespace: wait for namespace to exist before applying
     :param no_dry_run_skip_compare: when running without dry-run, skip compare
+    :param override_enable_deletion: override calculated enable_deletion value
     :param recycle_pods: should pods be recycled if a dependency changed
     """
     args = locals()

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -325,7 +325,6 @@ def _realize_resource_data(unpacked_ri_item,
                            caller,
                            wait_for_namespace,
                            no_dry_run_skip_compare,
-                           override_enable_deletion,
                            recycle_pods):
     cluster, namespace, resource_type, data = unpacked_ri_item
     actions = []
@@ -338,9 +337,6 @@ def _realize_resource_data(unpacked_ri_item,
         return actions
 
     enable_deletion = False if ri.has_error_registered() else True
-    # only allow to override enable_deletion if no errors were found
-    if enable_deletion is True and override_enable_deletion is False:
-        enable_deletion = False
 
     # desired items
     for name, d_item in data['desired'].items():
@@ -463,7 +459,6 @@ def realize_data(dry_run, oc_map, ri, thread_pool_size,
                  caller=None,
                  wait_for_namespace=False,
                  no_dry_run_skip_compare=False,
-                 override_enable_deletion=None,
                  recycle_pods=True):
     """
     Realize the current state to the desired state.
@@ -478,7 +473,6 @@ def realize_data(dry_run, oc_map, ri, thread_pool_size,
                    to deploy to the same namespace
     :param wait_for_namespace: wait for namespace to exist before applying
     :param no_dry_run_skip_compare: when running without dry-run, skip compare
-    :param override_enable_deletion: override calculated enable_deletion value
     :param recycle_pods: should pods be recycled if a dependency changed
     """
     args = locals()

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -8,6 +8,7 @@ from reconcile.utils.secret_reader import SecretReader
 
 
 STATUS_READY = 'ready'
+STATUS_FAILED = 'failed'
 
 AMS_API_BASE = '/api/accounts_mgmt'
 CS_API_BASE = '/api/clusters_mgmt'
@@ -1044,7 +1045,7 @@ class OCMMap:
     def kafka_cluster_specs(self):
         """Get dictionary of Kafka cluster names and specs in the OCM map."""
         fields = ['id', 'status', 'cloud_provider', 'region', 'multi_az',
-                  'name', 'bootstrapServerHost']
+                  'name', 'bootstrapServerHost', 'failed_reason']
         cluster_specs = []
         for ocm in self.ocm_map.values():
             clusters = ocm.get_kafka_clusters(fields=fields)


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3901

while working around the integration, figured it could use better error handling.
instead of using `override_enable_deletion` which is usually kept for sensitive operations such as migrations (#1279), we switch to using `ri.register_error`, which is a common pattern across the repository.

we also add better handling for a `failed` status of a cluster, which we are inspecting as part of the mentioned ticket.