### PR TITLE
Use base image based on Python 3.9 for production

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/qontract-reconcile-base:0.3.6
+FROM quay.io/app-sre/qontract-reconcile-base:0.5.0
 
 WORKDIR /reconcile
 


### PR DESCRIPTION
It shifts us to Python 3.9

Refs APPSRE-3634
