### PR TITLE
APPSRE-3868: Remove keys with None value 

### DIFF
--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -141,7 +141,20 @@ class GqlApi:
                 "`data` field missing from GraphQL"
                 "server response."))
 
+        if result['data'] is not None:
+            self.filter_null(result['data'])
+
         return result['data']
+
+    def filter_null(self, data):
+        if not isinstance(data, (str, int)):
+            for k, v in data.copy().items():
+                if isinstance(v, dict):
+                    self.filter_null(v)
+                elif isinstance(v, list):
+                    [self.filter_null(x) for x in v]
+                elif v is None:
+                    del data[k]
 
     def get_resource(self, path):
         query = """


### PR DESCRIPTION
### What
Remove keys with None value from graphql results to avoid integration failure.
### Why
Integrations expect the field to have valid value when it's in the data, otherwise the integration will failed. 
Note that GraphQL has all types by default nullable, so they will be null unless we declare it as not-nullable. But we are not declare any type that way as far as I can tell. Therefore in order to overcome this without changing all integration code, we filter all the keys that has a null value once we got the result.
### Validation
I ran a few queries including 
```
{
  namespaces_v1 {
    managedResourceTypes
    path
  }
}
```
and
```
{
  saas_files_v2(name: "saas-github-mirror") {
    name
    takeover
    path
  }
}
```
The null valued keys has been removed in the result of this code change.