### PR TITLE
[threaded] try to raise with original message

### DIFF
--- a/reconcile/utils/threaded.py
+++ b/reconcile/utils/threaded.py
@@ -10,7 +10,10 @@ def full_traceback(func):
             return func(*args, **kwargs)
         except Exception as e:
             msg = "{}\n\nOriginal {}".format(e, traceback.format_exc())
-            raise type(e)(msg)
+            try:
+                raise type(e)(msg)
+            except Exception:
+                raise e
     return wrapper
 
 


### PR DESCRIPTION
we sometimes try to raise an exception that attempts to initiate based on properties that do not exist.
we can default to at least making sure the exception is raised instead.

this case is related to all openshift integrations:
```
During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/run-integration.py", line 73, in <module>
    integration.invoke(ctx)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile/utils/binary.py", line 18, in f_binary
    f(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile/utils/binary.py", line 60, in f_binary_version
    f(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile/cli.py", line 536, in openshift_rolebindings
    thread_pool_size, internal, use_jump_host)
  File "/usr/local/lib/python3.6/site-packages/reconcile/cli.py", line 415, in run_integration
    func_container.run(dry_run, *args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile/utils/defer.py", line 15, in func_wrapper
    return func(*args, defer=defer, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/reconcile/openshift_rolebindings.py", line 181, in run
    use_jump_host=use_jump_host)
  File "/usr/local/lib/python3.6/site-packages/reconcile/openshift_base.py", line 190, in fetch_current_state
    cluster_admin=cluster_admin)
  File "/usr/local/lib/python3.6/site-packages/reconcile/utils/oc.py", line 1083, in __init__
    cluster_admin=cluster_admin)
  File "/usr/local/lib/python3.6/site-packages/reconcile/utils/threaded.py", line 45, in run
    return pool.map(func_partial, iterable)
  File "/usr/lib64/python3.6/multiprocessing/pool.py", line 266, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib64/python3.6/multiprocessing/pool.py", line 644, in get
    raise self._value
  File "/usr/lib64/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib64/python3.6/multiprocessing/pool.py", line 44, in mapstar
    return list(map(*args))
  File "/usr/local/lib/python3.6/site-packages/reconcile/utils/threaded.py", line 13, in wrapper
    raise type(e)(msg)
  File "/usr/local/lib/python3.6/site-packages/openshift/dynamic/exceptions.py", line 34, in __init__
    self.status = e.status
AttributeError: 'str' object has no attribute 'status'
```