### PR TITLE
Revert "Use base image based on Python 3.9 for production (#1917)"

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/qontract-reconcile-base:0.5.0
+FROM quay.io/app-sre/qontract-reconcile-base:0.3.6
 
 WORKDIR /reconcile
 


### PR DESCRIPTION
This reverts commit ef6b7f1d2a35bc458d5288784e1177b0e0dd0e04.

The base image is missing python39-devel
