### PR TITLE
Build production image during tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ generate:
 build-test:
 	@docker build -t $(IMAGE_TEST) -f dockerfiles/Dockerfile.test .
 
-test: build-test
+test: build-test build
 	@docker run --rm $(IMAGE_TEST)
 
 clean:


### PR DESCRIPTION
After the mess with #1917 - we confirm we can build and release every
PR.

Since docker caches layers locally, the overhead on our tests is
fairly small:

    # With this dependency
    $ time make test
    [...]
    real	3m54,172s
    user	0m0,619s
    sys 	0m0,342s
    # Without this dependency
    $ time make test
    real	3m53,636s
    user	0m0,337s
    sys 	0m0,200s
