### PR TITLE
Skip clusters with empty serverUrl in openshift-(users|groups) [APPSR…

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1,5 +1,7 @@
 import logging
 import itertools
+from typing import Mapping, MutableSequence
+
 import yaml
 
 from sretoolbox.utils import retry
@@ -661,3 +663,16 @@ def aggregate_shared_resources(namespace_info, shared_resources_type):
         else:
             namespace_type_resources = shared_type_resources_items
             namespace_info[shared_resources_type] = namespace_type_resources
+
+
+def remove_clusters_empty_server_url(
+        clusters: MutableSequence[Mapping]) -> None:
+    """
+    Remove any clusters where serverUrl is empty. This can happen when a new
+    cluster is created and the serverUrl hasn't been added yet.
+    """
+    for c in list(clusters):
+        if not c['serverUrl']:
+            logging.warning('Skipping cluster %s because serverUrl is '
+                            'empty', c['name'])
+            clusters.remove(c)

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -5,6 +5,7 @@ import itertools
 import reconcile.utils.gql as gql
 import reconcile.utils.threaded as threaded
 import reconcile.queries as queries
+from reconcile.openshift_base import remove_clusters_empty_server_url
 
 from reconcile.utils.oc import OC_Map
 from reconcile.utils.defer import defer
@@ -81,6 +82,9 @@ def create_groups_list(clusters, oc_map):
 
 def fetch_current_state(thread_pool_size, internal, use_jump_host):
     clusters = [c for c in queries.get_clusters() if is_in_shard(c['name'])]
+    # New clusters can cause failures in this integration without this.
+    remove_clusters_empty_server_url(clusters)
+
     ocm_clusters = [c['name'] for c in clusters if c.get('ocm') is not None]
     current_state = []
     settings = queries.get_app_interface_settings()

--- a/reconcile/openshift_users.py
+++ b/reconcile/openshift_users.py
@@ -5,6 +5,7 @@ import reconcile.utils.threaded as threaded
 import reconcile.openshift_groups as openshift_groups
 import reconcile.openshift_rolebindings as openshift_rolebindings
 import reconcile.queries as queries
+from reconcile.openshift_base import remove_clusters_empty_server_url
 
 from reconcile.utils.oc import OC_Map
 from reconcile.utils.defer import defer
@@ -29,6 +30,9 @@ def get_cluster_users(cluster, oc_map):
 
 def fetch_current_state(thread_pool_size, internal, use_jump_host):
     clusters = queries.get_clusters(minimal=True)
+    # New clusters can cause failures in this integration without this.
+    remove_clusters_empty_server_url(clusters)
+
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(clusters=clusters, integration=QONTRACT_INTEGRATION,
                     settings=settings, internal=internal,

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -1,0 +1,29 @@
+import copy
+
+from reconcile.openshift_base import remove_clusters_empty_server_url
+
+
+def test_remove_clusters_empty_server_url_no_removal():
+    initial_clusters = [
+        {'name': 'cluster-1', 'serverUrl': 'http://localhost'},
+        {'name': 'cluster-2', 'serverUrl': 'http://localhost'}
+    ]
+
+    clusters = copy.deepcopy(initial_clusters)
+
+    remove_clusters_empty_server_url(clusters)
+
+    assert clusters == initial_clusters
+
+
+def test_remove_cluster_empty_server_url_removal():
+    clusters = [
+        {'name': 'cluster-1', 'serverUrl': 'http://localhost'},
+        {'name': 'cluster-2', 'serverUrl': ''}
+    ]
+
+    remove_clusters_empty_server_url(clusters)
+
+    assert clusters == [
+        {'name': 'cluster-1', 'serverUrl': 'http://localhost'}
+    ]

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -778,6 +778,13 @@ class OCNative(OCDeprecated):
         super().__init__(cluster_name, server, token, jh, settings,
                          init_projects=False, init_api_resources=False,
                          local=local)
+
+        # server is empty for certain use cases like saasherder where process()
+        # is being used. A refactor to provide that functionality outside of
+        # this class would allow an exception to be thrown here instead.
+        # This would be advantageous because AttributeErrors when
+        # client/api_kind_version aren't set is less obvious than failing
+        # early.
         if server:
             self.client = self._get_client(server, token)
             self.api_kind_version = self.get_api_resources()


### PR DESCRIPTION
…E-3866]

When a new cluster is added, it has an empty serverUrl for some period
of time, which causes openshift-(users|groups) to crash.

A longer-term solution is discussed briefly in APPSRE-3866. This fix
would require raising an exception when server is empty in OCNative.
That will be handled separately as this only appears to be an issue
for two integrations at the moment. A comment was added to OCNative
to make the situation clear for the next person who comes across this
in case the refactor isn't prioritized.