### PR TITLE
[dashdotdb-slo] integration includes SLODoc name in POST request bodies to dashdotDB

### DIFF
--- a/reconcile/dashdotdb_slo.py
+++ b/reconcile/dashdotdb_slo.py
@@ -18,12 +18,8 @@ class DashdotdbSLO(DashdotdbBase):
         if service_slo is None:
             return None
 
-        LOG.debug('Here are SLO JSON items that this integration \
-                  is about to POST to dashdotdb \
-                  (if NOT in dry-run mode):\n')
         for item in service_slo:
-            LOG.debug(f'\n{item}\n')
-        LOG.debug('* End of SLO JSON items. *')
+            LOG.debug(f'About to POST SLO JSON item to dashdotDB:\n{item}\n')
 
         response = None
 

--- a/reconcile/dashdotdb_slo.py
+++ b/reconcile/dashdotdb_slo.py
@@ -84,6 +84,7 @@ class DashdotdbSLO(DashdotdbBase):
                     "service": ns['app'],
                     "value": slo_value,
                     "target": slo_target,
+                    "SLODoc": {"name": slo_document['name']},
                 })
         return result
 

--- a/reconcile/dashdotdb_slo.py
+++ b/reconcile/dashdotdb_slo.py
@@ -18,6 +18,13 @@ class DashdotdbSLO(DashdotdbBase):
         if service_slo is None:
             return None
 
+        LOG.debug('Here are SLO JSON items that this integration \
+                  is about to POST to dashdotdb \
+                  (if NOT in dry-run mode):\n')
+        for item in service_slo:
+            LOG.debug(f'\n{item}\n')
+        LOG.debug('* End of SLO JSON items. *')
+
         response = None
 
         if self.dry_run:


### PR DESCRIPTION
This implements the 'Implementation - Storing SLO Metric Data' portion of [this design doc](https://github.com/app-sre/qontract-reconcile/blob/master/docs/design/slo_doc_tracking_for_slo_metric_data.md) and relates to [this internal Jira issue](https://issues.redhat.com/browse/APPSRE-3570).

---

This updates the dashdotdb-slo integration to include the SLODoc name in POST request bodies to dashdotDB.

I also added some additional debug logging to make it easier to validate this new functionality.

---

There is [an open PR for dashdotDB](https://github.com/app-sre/dashdotdb/pull/62) to enable dashdotDB to store and return slodoc-names. 

Even without that dashdotDB PR, I validated that dashdotdb's APIs do not break when this Q-R integration POSTs data with the `SLODoc` property (in other words: it is safe to merge this Q-R PR at any time).

---

Here is local dry-run Q-R output proving that SLODOc data is to be POST'ed as expected: 

```
$ qr --dry-run --config ~/W/cnf/qontract-reconcile/config.prod.toml --log-level DEBUG dashdotdb-slo
...
[2021-10-15 15:20:05] [DEBUG] [dashdotdb_slo.py:_post:22] - About to POST SLO JSON item to dashdotDB:
{'name': 'policy-engine errors', 'SLIType': 'availability', 'namespace': {'name': 'cincinnati-production', 'app': {'name': 'Cincinnati'}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}, 'service': {'name': 'Cincinnati'}, 'value': 99.78173791187716, 'target': 95.0, 'SLODoc': {'name': 'cincinnati'}}

[2021-10-15 15:20:05] [DEBUG] [dashdotdb_slo.py:_post:22] - About to POST SLO JSON item to dashdotDB:
{'name': 'image-builder compose success', 'SLIType': 'latency', 'namespace': {'name': 'image-builder-prod', 'app': {'name': 'image-builder-crc'}, 'cluster': {'name': 'crcp01ue1', 'automationToken': {'path': 'app-sre/creds/kube-configs/crcp01ue1', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.crcp01ue1.devshift.net', 'spec': {'private': False}}}, 'cluster': {'name': 'crcp01ue1', 'automationToken': {'path': 'app-sre/creds/kube-configs/crcp01ue1', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.crcp01ue1.devshift.net', 'spec': {'private': False}}, 'service': {'name': 'image-builder-crc'}, 'value': 0.0, 'target': 95.0, 'SLODoc': {'name': 'image-builder'}}

[2021-10-15 15:20:05] [DEBUG] [dashdotdb_slo.py:_post:22] - About to POST SLO JSON item to dashdotDB:
{'name': 'policy-engine availability', 'SLIType': 'availability', 'namespace': {'name': 'cincinnati-production', 'app': {'name': 'Cincinnati'}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}, 'service': {'name': 'Cincinnati'}, 'value': 96.83668507519755, 'target': 95.0, 'SLODoc': {'name': 'cincinnati'}}

[2021-10-15 15:20:05] [DEBUG] [dashdotdb_slo.py:_post:22] - About to POST SLO JSON item to dashdotDB:
{'name': 'SSO API Latency', 'SLIType': 'latency', 'namespace': {'name': 'mas-sso-production', 'app': {'name': 'mas-sso'}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}, 'service': {'name': 'mas-sso'}, 'value': 99.99955143964621, 'target': 99.0, 'SLODoc': {'name': 'mas-sso'}}

[2021-10-15 15:20:05] [DEBUG] [dashdotdb_slo.py:_post:22] - About to POST SLO JSON item to dashdotDB:
{'name': 'API availability', 'SLIType': 'availability', 'namespace': {'name': 'managed-services-production', 'app': {'name': 'managed-services'}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}, 'service': {'name': 'managed-services'}, 'value': 99.99715108808174, 'target': 95.0, 'SLODoc': {'name': 'kas-fleet-manager'}}

[2021-10-15 15:20:05] [DEBUG] [dashdotdb_slo.py:_post:22] - About to POST SLO JSON item to dashdotDB:
{'name': 'SSO API Availability', 'SLIType': 'availability', 'namespace': {'name': 'mas-sso-production', 'app': {'name': 'mas-sso'}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}, 'service': {'name': 'mas-sso'}, 'value': 99.9992076351754, 'target': 99.0, 'SLODoc': {'name': 'mas-sso'}}

[2021-10-15 15:20:05] [DEBUG] [dashdotdb_slo.py:_post:22] - About to POST SLO JSON item to dashdotDB:
{'name': 'API Latency 90%', 'SLIType': 'latency', 'namespace': {'name': 'managed-services-production', 'app': {'name': 'managed-services'}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}, 'service': {'name': 'managed-services'}, 'value': 98.69386600564086, 'target': 90.0, 'SLODoc': {'name': 'kas-fleet-manager'}}

[2021-10-15 15:20:05] [DEBUG] [dashdotdb_slo.py:_post:22] - About to POST SLO JSON item to dashdotDB:
{'name': 'latency', 'SLIType': 'latency', 'namespace': {'name': 'uhc-production', 'app': {'name': 'ocm'}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}, 'service': {'name': 'ocm'}, 'value': 99.80033979438677, 'target': 95.0, 'SLODoc': {'name': 'clusters-service'}}

[2021-10-15 15:20:05] [DEBUG] [dashdotdb_slo.py:_post:22] - About to POST SLO JSON item to dashdotDB:
{'name': 'API Latency 99%', 'SLIType': 'latency', 'namespace': {'name': 'managed-services-production', 'app': {'name': 'managed-services'}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}, 'service': {'name': 'managed-services'}, 'value': 99.9663008174747, 'target': 99.0, 'SLODoc': {'name': 'kas-fleet-manager'}}

[2021-10-15 15:20:05] [DEBUG] [dashdotdb_slo.py:_post:22] - About to POST SLO JSON item to dashdotDB:
{'name': 'errors', 'SLIType': 'availability', 'namespace': {'name': 'uhc-production', 'app': {'name': 'ocm'}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}}, 'cluster': {'name': 'app-sre-prod-04', 'automationToken': {'path': 'app-sre/creds/kube-configs/app-sre-prod-04', 'field': 'token', 'format': None}, 'prometheusUrl': 'https://prometheus.app-sre-prod-04.devshift.net', 'spec': {'private': False}}, 'service': {'name': 'ocm'}, 'value': 99.85490531641751, 'target': 95.0, 'SLODoc': {'name': 'clusters-service'}}
...
```



