### PR TITLE
[app-interface-reporter] report slo-doc-names with service-slo data

### DIFF
--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -460,7 +460,7 @@ def get_apps_data(date, month_delta=1, thread_pool_size=10):
                                 sample.labels['type']: sample.value
                             }
                         else:
-                            slo_mx[cluster][namespace][slo_doc_name][slo_name].update({
+                            slo_mx[cluster][namespace][slo_doc_name][slo_name].update({  # pylint: disable=line-too-long # noqa: E501
                                 sample.labels['type']: sample.value
                             })
         app['container_vulnerabilities'] = vuln_mx


### PR DESCRIPTION
This implements the 'Implementation - Producing Service Reports' portion of [this design doc](https://github.com/app-sre/qontract-reconcile/blob/master/docs/design/slo_doc_tracking_for_slo_metric_data.md) and relates to [this internal Jira issue](https://issues.redhat.com/browse/APPSRE-3570).

---

This makes app-interface-reporter grab the `slodoc` label from dashdotDB's SLO metrics, and include it as property `slo_doc_name` on monthly YAML reports.

---

This PR will break app-interface-reporter if merged before [this](https://github.com/app-sre/dashdotdb/pull/62) and [this](https://github.com/app-sre/qontract-reconcile/pull/1931), and before letting the dashdotdb-slo Q-R integration run at least once.