### PR TITLE
[slack-usergroups] ignore nobody users from pagerduty

### DIFF
--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -208,7 +208,8 @@ def get_slack_usernames_from_pagerduty(pagerduties, users, usergroup,
                                                  pd_resource_id)
         if not pagerduty_names:
             continue
-        pagerduty_names = [name.split('+', 1)[0] for name in pagerduty_names]
+        pagerduty_names = [name.split('+', 1)[0] for name in pagerduty_names
+                           if 'nobody' not in name]
         if not pagerduty_names:
             continue
         slack_usernames = [get_slack_username(u)
@@ -217,8 +218,7 @@ def get_slack_usernames_from_pagerduty(pagerduties, users, usergroup,
                            in pagerduty_names]
         not_found_pagerduty_names = \
             [pagerduty_name for pagerduty_name in pagerduty_names
-             if pagerduty_name not in all_pagerduty_names
-             and 'nobody' not in pagerduty_name]
+             if pagerduty_name not in all_pagerduty_names]
         if not_found_pagerduty_names:
             msg = (
                 '[{}] PagerDuty username not found in app-interface: {} '


### PR DESCRIPTION
there are occasions where teams want to have no one on call in PagerDuty. to accomplish that, they often use a "nobody" user.
this PR will cause the slack-usergroups integration to ignore these users.

users in our own PagerDuty who follow this rule: https://redhat.pagerduty.com/users#?query=nobody

note:
this change can be very simple like this PR, or it can be "smarter", such as adding a list of users to ignore in the PagerDuty instance file in app-interface.
since this is only for warning purposes and does not influence the outcome of the integration, i believe the simple approach will work for now. we can always iterate if needed.