### PR TITLE
Drop all references to prometheusUrl and alertmanagerUrl

### DIFF
--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -22,8 +22,7 @@ ALLOWED_SPEC_UPDATE_FIELDS = {
 }
 
 OCM_GENERATED_FIELDS = ['network', 'consoleUrl', 'serverUrl', 'elbFQDN']
-PREDICTABLE_FIELDS = ['prometheusUrl', 'alertmanagerUrl', ]
-MANAGED_FIELDS = ['spec'] + OCM_GENERATED_FIELDS + PREDICTABLE_FIELDS
+MANAGED_FIELDS = ['spec'] + OCM_GENERATED_FIELDS
 
 
 def fetch_desired_state(clusters):

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -34,8 +34,6 @@ class TestFetchDesiredState(TestCase):
                     'consoleUrl': '',
                     'serverUrl': '',
                     'elbFQDN': '',
-                    'prometheusUrl': '',
-                    'alertmanagerUrl': ''
                 }
             }
         )
@@ -126,8 +124,6 @@ class TestRun(TestCase):
                 'consoleUrl': 'aconsoleurl',
                 'serverUrl': 'aserverurl',
                 'elbFQDN': 'anelbfqdn',
-                'prometheusUrl': 'aprometheusurl',
-                'alertmanagerUrl': 'analertmanagerurl',
             }
         }
         desired = deepcopy(current)


### PR DESCRIPTION
Since we are going to handle them in a different place.
