### PR TITLE
ocm-addon: catch addon install exception and log error

### DIFF
--- a/reconcile/ocm_addons.py
+++ b/reconcile/ocm_addons.py
@@ -76,7 +76,12 @@ def act(dry_run, diffs, ocm_map):
             continue
         if not dry_run:
             if action == 'install':
-                ocm.install_addon(cluster, diff)
+                try:
+                    ocm.install_addon(cluster, diff)
+                except Exception as e:
+                    logging.error(f'could not install addon {addon_id}: {e}')
+                    err = True
+                    continue
             # uninstall is not supported
 
     return err


### PR DESCRIPTION
the ocm error is already logged in addition to the exception

this catches the exception and logs an error message instead