### PR TITLE
Log updates to clusters only if there are updated specs

### DIFF
--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -153,23 +153,24 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
                 current_spec['spec'].pop(k, None)
                 desired_spec['spec'].pop(k, None)
 
-            if current_spec != desired_spec:
-                # check if cluster update is valid
-                update_spec, err = get_cluster_update_spec(
-                    cluster_name,
-                    current_spec,
-                    desired_spec,
-                )
-                if err:
-                    error = True
-                    continue
-                # update cluster
+            # check if cluster update, if any, is valid
+            update_spec, err = get_cluster_update_spec(
+                cluster_name,
+                current_spec,
+                desired_spec,
+            )
+            if err:
+                logging.warning(f"Invalid changes to spec: {update_spec}")
+                error = True
+                continue
+            # update cluster
+            # TODO(mafriedm): check dry_run in OCM API patch
+            if update_spec:
+                logging.info(['update_cluster', cluster_name])
                 logging.debug(
                     '[%s] desired spec %s is different ' +
                     'from current spec %s',
                     cluster_name, desired_spec, current_spec)
-                logging.info(['update_cluster', cluster_name])
-                # TODO(mafriedm): check dry_run in OCM API patch
                 if not dry_run:
                     ocm = ocm_map.get(cluster_name)
                     ocm.update_cluster(cluster_name, update_spec, dry_run)

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -136,7 +136,7 @@ class TestRun(TestCase):
         ).for_call().to_return_value((current, {})).and_assert_called_once()
         self.mock_callable(occ, 'get_cluster_update_spec').to_return_value(
             ({},  False)
-        ).and_assert_not_called()
+        ).and_assert_called_once()
         with self.assertRaises(ValueError) as e:
             occ.run(True)
             self.assertEqual(e.args, (0, ))
@@ -171,7 +171,7 @@ class TestRun(TestCase):
         ).and_assert_called_once()
         self.mock_callable(occ, 'get_cluster_update_spec').to_return_value(
             ({},  False)
-        ).and_assert_not_called()
+        ).and_assert_called_once()
         with self.assertRaises(ValueError) as e:
             occ.run(False)
             self.assertEqual(e.args, (0, ))


### PR DESCRIPTION
Now, the desired and current specs contain different fields, such as
consoleUrl on one or domain on the other. The previous difference
doesn't work anymore. However, the results to
`get_cluster_update_spec` remain the same and are the true measure of
whether any changes need to be applied to the cluster itself.

Adjusted unit tests and ran locally. Clusters with all fields correct
are not logged, but clusters with changes in their spec still display
this message.
