### PR TITLE
add build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![](https://img.shields.io/github/license/app-sre/qontract-reconcile.svg?style=flat)
+![build](https://ci.ext.devshift.net/buildStatus/icon?job=app-sre-qontract-reconcile-gh-build-master)
+![license](https://img.shields.io/github/license/app-sre/qontract-reconcile.svg?style=flat)
 
 # qontract-reconcile
 


### PR DESCRIPTION
we were requested to enable this for our tenants in https://issues.redhat.com/browse/APPSRE-3945.

let's use it as well.

see what this looks like: https://github.com/maorfr/qontract-reconcile/tree/badge#readme