### PR TITLE
Run app-interface-reporter in an Openshift cronjob

### DIFF
--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -52,8 +52,8 @@ logging.basicConfig(level=logging.INFO,
 
 
 def build_entry_point_args(command: click.Command, config: str,
-                           dry_run: str, integration_name: str,
-                           extra_args: str) -> list[str]:
+                           dry_run: Optional[str], integration_name: str,
+                           extra_args: Optional[str]) -> list[str]:
     args = ['--config', config]
     if dry_run is not None:
         args.append(dry_run)
@@ -138,9 +138,9 @@ def main():
             return_code = int(exc_obj.code)
         # We have to be generic since we don't know what can happen
         # in the integrations, but we want to continue the loop anyway
-        except Exception as exc_obj:
+        except Exception:
             sleep = SLEEP_ON_ERROR
-            LOG.exception(f"Error running {COMMAND_NAME}: %s", exc_obj)
+            LOG.exception(f"Error running {COMMAND_NAME}")
             return_code = ExitCodes.ERROR
 
         time_spent = time.monotonic() - start_time

--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -86,7 +86,37 @@ def build_entry_point_func(command_name: str) -> click.Command:
             f"Have a look at setup.py for valid entry points.")
 
 
-if __name__ == "__main__":
+def main():
+    """
+    This entry point script expects certain env variables
+    * COMMAND_NAME (optional, defaults to qontract-reconcile)
+      an entry point as defined in setup.py must be a click.Command
+    * INTEGRATION_NAME
+      used as name for the subcommand for command if present as a subcommand
+      on the click command
+    * INTEGRATION_EXTRA_ARGS (optional)
+      space separated list of arguments that will be passed to the command
+      or subcommand
+    * CONFIG
+      path to the config toml file
+    * LOG_FILE
+      path for the logfile to write to
+    * DRY_RUN (optional)
+      this is not a boolean but must contain the actual dry-run flag value,
+      so --dry-run or --no-dry-run
+    * RUN_ONCE (optional)
+      if 'true', execute the integration once and exit
+      otherwise run the integration in a loop controlled by SLEEP_DURATION_SECS
+      and SLEEP_ON_ERROR
+    * SLEEP_DURATION_SECS (default 600)
+      amount of seconds to sleep between successful integration runs
+    * SLEEP_ON_ERROR (default 10)
+      amount of seconds to sleep before another integration run is started
+
+    Based on those variables, the following command will be executed
+      $COMMAND --config $CONFIG $DRY_RUN $INTEGRATION_NAME $INTEGRATION_EXTRA_ARGS
+    """
+
     start_http_server(9090)
 
     command = build_entry_point_func(COMMAND_NAME)
@@ -126,3 +156,7 @@ if __name__ == "__main__":
             sys.exit(return_code)
 
         time.sleep(int(sleep))
+
+
+if __name__ == "__main__":
+    main()

--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -4,11 +4,14 @@ import logging
 import os
 import sys
 import time
+from typing import Optional
 
 from prometheus_client import start_http_server
+from importlib import metadata
+import click
 
 from reconcile.status import ExitCodes
-from reconcile.cli import integration, LOG_FMT, LOG_DATEFMT
+from reconcile.cli import LOG_FMT, LOG_DATEFMT
 from reconcile.utils.metrics import run_time
 from reconcile.utils.metrics import run_status
 from reconcile.utils.metrics import extra_labels
@@ -18,6 +21,7 @@ SHARDS = int(os.environ.get('SHARDS', 1))
 SHARD_ID = int(os.environ.get('SHARD_ID', 0))
 
 INTEGRATION_NAME = os.environ['INTEGRATION_NAME']
+COMMAND_NAME = os.environ.get('COMMAND_NAME', 'qontract-reconcile')
 
 RUN_ONCE = os.environ.get('RUN_ONCE')
 DRY_RUN = os.environ.get('DRY_RUN')
@@ -47,30 +51,56 @@ logging.basicConfig(level=logging.INFO,
                     handlers=HANDLERS)
 
 
-def build_args():
-    args = ['--config', CONFIG]
-    if DRY_RUN is not None:
-        args.append(DRY_RUN)
-    args.append(INTEGRATION_NAME)
-    if INTEGRATION_EXTRA_ARGS is not None:
-        args.extend(INTEGRATION_EXTRA_ARGS.split())
+def build_entry_point_args(command: click.Command, config: str,
+                           dry_run: str, integration_name: str,
+                           extra_args: str) -> list[str]:
+    args = ['--config', config]
+    if dry_run is not None:
+        args.append(dry_run)
+
+    # if the integration_name is a known sub command, we add it right before the extra_args
+    if integration_name and isinstance(command, click.MultiCommand) and \
+            command.get_command(None, integration_name):
+        args.append(integration_name)
+
+    if extra_args is not None:
+        args.extend(extra_args.split())
     return args
+
+
+def build_entry_point_func(command_name: str) -> click.Command:
+    """
+    Use the entry point information from setup.py to
+    find the function to invoke for a command.
+    """
+    console_script_entry_points = {
+        ep.name: ep
+        for ep in metadata.entry_points()["console_scripts"]
+    }
+    entry_point: Optional[metadata.EntryPoint] = console_script_entry_points.get(command_name, None)
+    if entry_point:
+        return entry_point.load()
+    else:
+        raise ValueError(
+            f"Command {command_name} unknown."
+            f"Have a look at setup.py for valid entry points.")
 
 
 if __name__ == "__main__":
     start_http_server(9090)
 
+    command = build_entry_point_func(COMMAND_NAME)
+    args = build_entry_point_args(command, CONFIG, DRY_RUN, INTEGRATION_NAME, INTEGRATION_EXTRA_ARGS)
     while True:
         sleep = SLEEP_DURATION_SECS
         start_time = time.monotonic()
         # Running the integration via Click, so we don't have to replicate
         # the CLI logic here
         try:
-            with integration.make_context(info_name='qontract-reconcile',
-                                          args=build_args()) as ctx:
+            with command.make_context(info_name=COMMAND_NAME, args=args) as ctx:
                 ctx.ensure_object(dict)
                 ctx.obj['extra_labels'] = extra_labels
-                integration.invoke(ctx)
+                command.invoke(ctx)
                 return_code = 0
         # This is for when the integration explicitly
         # calls sys.exit(N)
@@ -80,7 +110,7 @@ if __name__ == "__main__":
         # in the integrations, but we want to continue the loop anyway
         except Exception as exc_obj:
             sleep = SLEEP_ON_ERROR
-            LOG.exception('Error running qontract-reconcile: %s', exc_obj)
+            LOG.exception(f"Error running {COMMAND_NAME}: %s", exc_obj)
             return_code = ExitCodes.ERROR
 
         time_spent = time.monotonic() - start_time

--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -60,7 +60,7 @@ def build_entry_point_args(command: click.Command, config: str,
 
     # if the integration_name is a known sub command, we add it right before the extra_args
     if integration_name and isinstance(command, click.MultiCommand) and \
-            command.get_command(None, integration_name):
+            command.get_command(None, integration_name): # type: ignore
         args.append(integration_name)
 
     if extra_args is not None:

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -321,6 +321,10 @@ objects:
                 value: 'true'
               - name: DRY_RUN
                 value: ${DRY_RUN}
+              {{- if $integration.command }}
+              - name: COMMAND_NAME
+                value: {{ $integration.command }}
+              {{- end }}
               - name: INTEGRATION_NAME
                 value: {{ $integration.name }}
               - name: INTEGRATION_EXTRA_ARGS

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -211,11 +211,17 @@ objects:
             value: "${USE_NATIVE_CLIENT}"
           {{- with $integration.extraEnv }}
           {{- range $i, $env := . }}
+          {{- if $env.secretKey }}
           - name: {{ $env.secretKey }}
             valueFrom:
               secretKeyRef:
                 name: {{ $env.secretName }}
                 key: {{ $env.secretKey }}
+          {{- end }}
+          {{- if $env.name }}
+          - name: {{ $env.name }}
+            value: {{ $env.value }}
+          {{- end }}
           {{- end }}
           {{- end }}
           {{- if $integration.resources }}
@@ -346,11 +352,17 @@ objects:
                     key: CLIENT_ACCESS_TOKEN
               {{- with $integration.extraEnv }}
               {{- range $i, $env := . }}
+              {{- if $env.secretKey}}
               - name: {{ $env.secretKey }}
                 valueFrom:
                   secretKeyRef:
                     name: {{ $env.secretName }}
                     key: {{ $env.secretKey }}
+              {{- end }}
+              {{- if $env.name }}
+              - name: {{ $env.name }}
+                value: {{ $env.value }}
+              {{- end }}
               {{- end }}
               {{- end }}
               {{- if $integration.dashdotdb }}

--- a/helm/qontract-reconcile/values-internal.yaml
+++ b/helm/qontract-reconcile/values-internal.yaml
@@ -437,6 +437,6 @@ cronjobs:
   # first day of month
   cron: '0 1 1 * *'
   extraEnv:
-    - name: XDG_CACHE_HOME
-      value: /tmp/.cache
+  - name: XDG_CACHE_HOME
+    value: /tmp/.cache
   extraArgs: --gitlab-project-id=${APP_INTERFACE_PROJECT_ID} --reports-path=/tmp/report

--- a/helm/qontract-reconcile/values-internal.yaml
+++ b/helm/qontract-reconcile/values-internal.yaml
@@ -423,3 +423,20 @@ cronjobs:
   # once a day
   cron: '0 5 * * *'
   dashdotdb: true
+- name: app-interface-reporter
+  command: app-interface-reporter
+  concurrencyPolicy: Replace
+  restartPolicy: Never
+  resources:
+    requests:
+      memory: 400Mi
+      cpu: 100m
+    limits:
+      memory: 600Mi
+      cpu: 200m
+  # first day of month
+  cron: '0 1 1 * *'
+  extraEnv:
+    - name: XDG_CACHE_HOME
+      value: /tmp/.cache
+  extraArgs: --gitlab-project-id=${APP_INTERFACE_PROJECT_ID} --reports-path=/tmp/report

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -8092,6 +8092,67 @@ objects:
             - name: qontract-reconcile-toml
               secret:
                 secretName: qontract-reconcile-toml
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  metadata:
+    labels:
+      app: qontract-reconcile-app-interface-reporter
+    name: qontract-reconcile-app-interface-reporter
+  spec:
+    schedule: "0 1 1 * *"
+    concurrencyPolicy: Replace
+    successfulJobHistoryLimit: 3
+    failedJobHistoryLimit: 1
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: int
+              image: ${IMAGE}:${IMAGE_TAG}
+              env:
+              - name: RUN_ONCE
+                value: 'true'
+              - name: DRY_RUN
+                value: ${DRY_RUN}
+              - name: COMMAND_NAME
+                value: app-interface-reporter
+              - name: INTEGRATION_NAME
+                value: app-interface-reporter
+              - name: INTEGRATION_EXTRA_ARGS
+                value: "--gitlab-project-id=${APP_INTERFACE_PROJECT_ID} --reports-path=/tmp/report"
+              - name: GITHUB_API
+                valueFrom:
+                  configMapKeyRef:
+                    name: app-interface
+                    key: GITHUB_API
+              - name: UNLEASH_API_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: API_URL
+              - name: UNLEASH_CLIENT_ACCESS_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: CLIENT_ACCESS_TOKEN
+              - name: XDG_CACHE_HOME
+                value: /tmp/.cache
+              volumeMounts:
+              - name: qontract-reconcile-toml
+                mountPath: /config
+              resources:
+                limits:
+                  cpu: ${APP_INTERFACE_REPORTER_CPU_LIMIT}
+                  memory: ${APP_INTERFACE_REPORTER_MEMORY_LIMIT}
+                requests:
+                  cpu: ${APP_INTERFACE_REPORTER_CPU_REQUEST}
+                  memory: ${APP_INTERFACE_REPORTER_MEMORY_REQUEST}
+            restartPolicy: Never
+            volumes:
+            - name: qontract-reconcile-toml
+              secret:
+                secretName: qontract-reconcile-toml
 - apiVersion: v1
   kind: Service
   metadata:
@@ -8458,4 +8519,12 @@ parameters:
 - name: DASHDOTDB_SLO_CPU_REQUEST
   value: 100m
 - name: DASHDOTDB_SLO_MEMORY_REQUEST
+  value: 400Mi
+- name: APP_INTERFACE_REPORTER_CPU_LIMIT
+  value: 200m
+- name: APP_INTERFACE_REPORTER_MEMORY_LIMIT
+  value: 600Mi
+- name: APP_INTERFACE_REPORTER_CPU_REQUEST
+  value: 100m
+- name: APP_INTERFACE_REPORTER_MEMORY_REQUEST
   value: 400Mi


### PR DESCRIPTION
These changes adapt the cronjob helm chart template and qontract-reconcile container CMD script run-integration.py to allow the execution of arbitrary click based entry point commands. This will enable us to run tools like app-interface-reporter or e2etests.

The additional ENV variable `COMMAND_NAME` can be used to specify an entry point command made available through setup.py. If not specified, `COMMAND_NAME` will default to `qontract-reconcile` for backward compatibility. The `INTEGRATION_NAME` env var is used as subcommand when `COMMAND_NAME` references a click group.

An example of how to specify a command can be found in the `values-internal.yaml` file changed with this PR.

Ref APPSRE-3535