### PR TITLE
support pod count resource quotas

### DIFF
--- a/reconcile/openshift_resourcequotas.py
+++ b/reconcile/openshift_resourcequotas.py
@@ -19,11 +19,13 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 def flatten(d, parent_key='', sep='.'):
     items = []
     for k, v in d.items():
+        if v is None:
+            continue
         new_key = parent_key + sep + k if parent_key else k
         if isinstance(v, collections.MutableMapping):
             items.extend(flatten(v, new_key, sep=sep).items())
         else:
-            items.append((new_key, v))
+            items.append((new_key, str(v)))
     return dict(items)
 
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -713,6 +713,7 @@ NAMESPACES_QUERY = """
             cpu
             memory
           }
+          pods
         }
         scopes
       }


### PR DESCRIPTION
app-interface allows pod quotas since https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/27123/diffs but the q-r does not currently.

Openshift-resourcequota integrations are failing with `The ResourceQuota "pod-count" is invalid` due to `limits` and `requests` being `None`... and `pods` inexistant