### PR TITLE
avoid sha256sum mismatch when setting resourcequota scopes to []

### DIFF
--- a/reconcile/openshift_resourcequotas.py
+++ b/reconcile/openshift_resourcequotas.py
@@ -38,9 +38,10 @@ def construct_resource(quota):
         },
         "spec": {
             "hard": flatten(quota['resources']),
-            "scopes": quota['scopes'] or []
         }
     }
+    if quota['scopes']:
+        body['spec']['scopes'] = quota['scopes']
     return OR(body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION,
               error_details=quota['name'])
 


### PR DESCRIPTION
when setting `scopes: []` in desired, the `sha256sum()` calculation will mismatch because kubernetes will drop that field when retrieving the quota:

```
spec:
  hard:
    pods: "200"
```
