### PR TITLE
[terraform-resources] fail on delete of RDS with deletion_protection

### DIFF
--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -211,7 +211,19 @@ class TerraformClient:
                             'account': name,
                             'user': resource_name
                         })
-
+                    if resource_type == 'aws_db_instance':
+                        deletion_protected = \
+                            resource_change['before'].get(
+                                'deletion_protection')
+                        if deletion_protected:
+                            disabled_deletion_detected = True
+                            logging.error(
+                                '\'delete\' action is not enabled for '
+                                'deletion protected RDS instance: '
+                                f'{resource_name}. Please set '
+                                'deletion_protection to false in a new MR. '
+                                'The new MR must be merged first.'
+                            )
         return disabled_deletion_detected, deleted_users
 
     @staticmethod


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3997

this PR will cause terraform-resources to fail when attempting to delete an RDS with deletion_protection.