### PR TITLE
reduce code coverage to allow a buffer

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ branch = True
 omit = reconcile/test/*
 
 [report]
-fail_under = 26.49
+fail_under = 26.45


### PR DESCRIPTION
required to allow us to merge any urgent fixes or new code that is not (yet) testable.

unblocks #1962
follows up on #1958, which left a 0.1% buffer for python 3.6.8
```
Required test coverage of 26.49% reached. Total coverage: 26.50%
```