### PR TITLE
introduce new integration: dyn-traffic-director

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 - `aws-support-cases-sos`: Scan AWS support cases for reports of leaked keys and remove them (only submits PR)
 - `dashdotdb-cso`: Collects the ImageManifestVuln CRs from all the clusters and posts them to Dashdotdb.
 - `dashdotdb-dvo`: Collects the DeploymentValidations from all the clusters and posts them to Dashdotdb.
+- `dyn-traffic-director`: Manage Traffic Director services in Dyn DNS
 - `ecr-mirror`: Mirrors external images into AWS ECR.
 - `gcr-mirror`: Mirrors external images into Google Container Registry.
 - `github-repo-invites`: Accept GitHub repository invitations for known repositories.

--- a/config.toml.example
+++ b/config.toml.example
@@ -30,3 +30,9 @@ base_dn = "ou=users,dc=example,dc=com"
 secret_path = 'secrets/path/to/smtp/creds'
 # (mandatory) mail address to send mails to
 mail_address = 'example.com'
+
+[dyn]
+# This section is required by `qontract-reconcile dyn-traffic-director`
+
+# (mandatory) path to dyn credentials in vault
+secrets_path = 'secrets/path/to/dyn/creds'

--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -20,6 +20,16 @@ integrations:
   logs:
     slack: true
   state: true
+- name: dyn-traffic-director
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 100m
+    limits:
+      memory: 150Mi
+      cpu: 200m
+  logs:
+    slack: true
 - name: github
   resources:
     requests:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -406,6 +406,201 @@ objects:
   kind: Deployment
   metadata:
     labels:
+      app: qontract-reconcile-dyn-traffic-director
+    name: qontract-reconcile-dyn-traffic-director
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile-dyn-traffic-director
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile-dyn-traffic-director
+          component: qontract-reconcile
+      spec:
+        serviceAccountName: qontract-reconcile
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                key: slack.webhook_url
+                name: app-interface
+          - name: SLACK_CHANNEL
+            value: ${SLACK_CHANNEL}
+          - name: SLACK_ICON_EMOJI
+            value: ${SLACK_ICON_EMOJI}
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type slack
+                webhook_url ${SLACK_WEBHOOK_URL}
+                channel ${SLACK_CHANNEL}
+                icon_emoji ${SLACK_ICON_EMOJI}
+                username sd-app-sre-bot
+                flush_interval 10s
+                message "\`\`\`[dyn-traffic-director] %s\`\`\`"
+              </store>
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name dyn-traffic-director
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          ports:
+            - name: http
+              containerPort: 9090
+          env:
+          - name: SHARDS
+            value: "1"
+          - name: SHARD_ID
+            value: "0"
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: dyn-traffic-director
+          - name: INTEGRATION_EXTRA_ARGS
+            value: ""
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: GITHUB_API
+          - name: SENTRY_DSN
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
+          - name: UNLEASH_API_URL
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: API_URL
+          - name: UNLEASH_CLIENT_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: CLIENT_ACCESS_TOKEN
+          - name: SLOW_OC_RECONCILE_THRESHOLD
+            value: "${SLOW_OC_RECONCILE_THRESHOLD}"
+          - name: LOG_SLOW_OC_RECONCILE
+            value: "${LOG_SLOW_OC_RECONCILE}"
+          - name: USE_NATIVE_CLIENT
+            value: "${USE_NATIVE_CLIENT}"
+          resources:
+            limits:
+              cpu: ${DYN_TRAFFIC_DIRECTOR_CPU_LIMIT}
+              memory: ${DYN_TRAFFIC_DIRECTOR_MEMORY_LIMIT}
+            requests:
+              cpu: ${DYN_TRAFFIC_DIRECTOR_CPU_REQUEST}
+              memory: ${DYN_TRAFFIC_DIRECTOR_MEMORY_REQUEST}
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
       app: qontract-reconcile-github
     name: qontract-reconcile-github
   spec:
@@ -24583,6 +24778,14 @@ parameters:
 - name: AWS_IAM_PASSWORD_RESET_CPU_REQUEST
   value: 100m
 - name: AWS_IAM_PASSWORD_RESET_MEMORY_REQUEST
+  value: 100Mi
+- name: DYN_TRAFFIC_DIRECTOR_CPU_LIMIT
+  value: 200m
+- name: DYN_TRAFFIC_DIRECTOR_MEMORY_LIMIT
+  value: 150Mi
+- name: DYN_TRAFFIC_DIRECTOR_CPU_REQUEST
+  value: 100m
+- name: DYN_TRAFFIC_DIRECTOR_MEMORY_REQUEST
   value: 100Mi
 - name: GITHUB_CPU_LIMIT
   value: 200m

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -9,6 +9,7 @@ import sentry_sdk
 
 from reconcile.utils import config
 from reconcile.utils import gql
+import reconcile.dyn_traffic_director
 import reconcile.github_org
 import reconcile.github_owners
 import reconcile.github_users
@@ -1433,3 +1434,10 @@ def gabi_authorized_users(ctx, thread_pool_size, internal, use_jump_host):
     run_integration(reconcile.gabi_authorized_users,
                     ctx.obj, thread_pool_size, internal,
                     use_jump_host)
+
+
+@integration.command()
+@enable_deletion(default=False)
+@click.pass_context
+def dyn_traffic_director(ctx, enable_deletion):
+    run_integration(reconcile.dyn_traffic_director, ctx.obj, enable_deletion)

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -198,6 +198,10 @@ def process_tds(current: dict, desired: dict,
         rpool = DSFResponsePool(label=td_name, rs_chains=[failover_chain])
         ruleset = DSFRuleset(label=td_name, criteria_type='always',
                              response_pools=[rpool])
+
+        # Constructor does the actual resource creation and checking for
+        # creation completion.
+        # It returns returns a resource ID which we don't need
         TrafficDirector(td_name, ttl=td_ttl, rulesets=[ruleset],
                         nodes=[attach_node])
 

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -78,7 +78,7 @@ def fetch_current_state() -> Dict[str, Dict]:
                             })
 
         # need to be sorted for comparison later
-        records = sorted(records, key=lambda d: d['hostname'])
+        records.sort(key=lambda d: d['hostname'])
 
         state['tds'][td_name] = {
             'name': td_name,
@@ -117,7 +117,7 @@ def fetch_desired_state() -> Dict[str, Dict]:
             })
 
         # need to be sorted for comparison later
-        records = sorted(records, key=lambda d: d['hostname'])
+        records.sort(key=lambda d: d['hostname'])
 
         state['tds'][td_name] = {
             'name': td_name,

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -36,7 +36,7 @@ class UnsupportedRecordType(Exception):
     pass
 
 
-def fetch_current_state() -> Dict[str, Dict]:
+def fetch_current_state() -> Dict[str, Dict]:  # pragma: no cover
     state: dict = {
         'tds': {},
     }
@@ -90,7 +90,7 @@ def fetch_current_state() -> Dict[str, Dict]:
     return state
 
 
-def fetch_desired_state() -> Dict[str, Dict]:
+def fetch_desired_state() -> Dict[str, Dict]:  # pragma: no cover
     dyn_tds = queries.get_dyn_traffic_directors()
 
     state: dict = {
@@ -147,7 +147,8 @@ def get_traffic_director_service(name: str):
 
 def process_tds(current: Mapping[str, Mapping[str, Any]],
                 desired: Mapping[str, Mapping[str, Any]],
-                dry_run: bool = True, enable_deletion: bool = False) -> bool:
+                dry_run: bool = True,
+                enable_deletion: bool = False) -> bool:  # pragma: no cover
     errors = False
 
     added = list(desired.keys() - current.keys())

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -145,8 +145,7 @@ def process_tds(current: Dict[str, Dict], desired: Dict[str, Dict],
     # Process removed TD services
     for name in removed:
         td_name = current[name]['name']
-        msg = ['delete_td', td_name]
-        logging.info(msg)
+        logging.info(['delete_td', td_name])
 
         if not enable_deletion:
             logging.info('deletion action is disabled. '
@@ -166,8 +165,7 @@ def process_tds(current: Dict[str, Dict], desired: Dict[str, Dict],
         td_ttl = desired[name]['ttl']
         td_records = desired[name]['records']
 
-        msg = ['create_td', name]
-        logging.info(msg)
+        logging.info(['create_td', name])
 
         records = [
             DSFCNAMERecord(r['hostname'], label='',
@@ -215,16 +213,14 @@ def process_tds(current: Dict[str, Dict], desired: Dict[str, Dict],
 
         # Check if ttl need to be updated
         if current[name]['ttl'] != desired[name]['ttl']:
-            msg = ['update_td_ttl', name, desired[name]['ttl']]
-            logging.info(msg)
+            logging.info(['update_td_ttl', name, desired[name]['ttl']])
 
             if not dry_run:
                 update_td.ttl = desired[name]['ttl']
 
         # Check if records need to be updated
         if current[name]['records'] != desired[name]['records']:
-            msg = ['update_td_records', name, desired[name]['records']]
-            logging.info(msg)
+            logging.info(['update_td_records', name, desired[name]['records']])
 
             if not dry_run:
                 # Generate a new list of CNAME records
@@ -250,8 +246,9 @@ def process_tds(current: Dict[str, Dict], desired: Dict[str, Dict],
 
         # Check if node attachment need to be updated
         if current[name]['nodes'] != desired[name]['nodes']:
-            msg = ['update_td_node', name, desired[name]['nodes']]
-            logging.info(msg)
+            logging.info(
+                ['update_td_node', name, desired[name]['nodes']]
+            )
 
             if not dry_run:
                 # Find the DNS node to attach the TD service to

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -133,9 +133,9 @@ def process_tds(current: dict, desired: dict,
                 dry_run: bool = True, enable_deletion: bool = False) -> bool:
     errors = False
 
-    added: List[str] = [name for name in desired if name not in current]
-    removed: List[str] = [name for name in current if name not in desired]
-    changed: List[str] = [
+    added = list(desired.keys() - current.keys())
+    removed = list(current.keys() - desired.keys())
+    changed = [
         dname
         for dname, d in desired.items()
         for cname, c in current.items()

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -110,7 +110,7 @@ def fetch_desired_state() -> dict:
                 hostname = record['hostname']
             else:
                 raise InvalidRecord('either cluster or hostname must '
-                                    'be defined on a record')
+                                    f'be defined on a record. Got: {record}')
             records.append({
                 'hostname': hostname.rstrip('.'),
                 'weight': record['weight'],

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -177,8 +177,8 @@ def process_tds(current: dict, desired: dict,
 
         attach_node = None
         zones = dyn_zones.get_all_zones()
-        for zone in zones:
-            for node in zone.get_all_nodes():
+        for z in zones:
+            for node in z.get_all_nodes():
                 if node.fqdn == td_name:
                     attach_node = node
 

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Mapping, Union
 import warnings
 
 from reconcile import queries
@@ -145,7 +145,8 @@ def get_traffic_director_service(name: str):
     return None
 
 
-def process_tds(current: Dict[str, Dict], desired: Dict[str, Dict],
+def process_tds(current: Mapping[str, Mapping[str, Any]],
+                desired: Mapping[str, Mapping[str, Any]],
                 dry_run: bool = True, enable_deletion: bool = False) -> bool:
     errors = False
 

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -169,12 +169,11 @@ def process_tds(current: dict, desired: dict,
         msg = ['create_td', name]
         logging.info(msg)
 
-        records = []
-        for record in td_records:
-            records.append(
-                DSFCNAMERecord(record['hostname'], label='',
-                               automation='manual', weight=record['weight'])
-            )
+        records = [
+            DSFCNAMERecord(record['hostname'], label='',
+                           automation='manual', weight=record['weight'])
+            for record in td_records
+        ]
 
         attach_node = None
         zones = dyn_zones.get_all_zones()

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -36,7 +36,7 @@ class UnsupportedRecordType(Exception):
     pass
 
 
-def fetch_current_state() -> dict:
+def fetch_current_state() -> Dict[str, Dict]:
     state: dict = {
         'tds': {},
     }
@@ -90,7 +90,7 @@ def fetch_current_state() -> dict:
     return state
 
 
-def fetch_desired_state() -> dict:
+def fetch_desired_state() -> Dict[str, Dict]:
     dyn_tds = queries.get_dyn_traffic_directors()
 
     state: dict = {

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -170,9 +170,9 @@ def process_tds(current: dict, desired: dict,
         logging.info(msg)
 
         records = [
-            DSFCNAMERecord(record['hostname'], label='',
-                           automation='manual', weight=record['weight'])
-            for record in td_records
+            DSFCNAMERecord(r['hostname'], label='',
+                           automation='manual', weight=r['weight'])
+            for r in td_records
         ]
 
         attach_node = None
@@ -228,13 +228,11 @@ def process_tds(current: dict, desired: dict,
 
             if not dry_run:
                 # Generate a new list of CNAME records
-                records = []
-                for record in desired[name]['records']:
-                    records.append(
-                        DSFCNAMERecord(record['hostname'], label='',
-                                       automation='manual',
-                                       weight=record['weight'])
-                    )
+                records = [
+                    DSFCNAMERecord(r['hostname'], label='',
+                                   automation='manual', weight=r['weight'])
+                    for r in desired[name]['records']
+                ]
 
                 # Generate a new recordset
                 new_rset = DSFRecordSet('CNAME', label=desired[name]['name'],

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -151,11 +151,9 @@ def process_tds(current: dict, desired: dict,
         if not enable_deletion:
             logging.info('deletion action is disabled. '
                          'Delete manually or enable deletion.')
-
-        if dry_run:
             continue
 
-        if not enable_deletion:
+        if dry_run:
             continue
 
         for curtd in dyn_services.get_all_dsf_services():

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -1,0 +1,303 @@
+import logging
+from typing import Dict, List, Union
+import warnings
+
+from reconcile import queries
+from reconcile.utils.config import ConfigNotFound, get_config
+from reconcile.utils.secret_reader import SecretReader
+
+# Dirty hack to silence annoying SyntaxWarnings present as of dyn==1.8.1
+# which will pollute our CLI output
+# PR for fix upstream: https://github.com/dyninc/dyn-python/pull/140
+# This is unlikely to be ever fixed as this repo has not been updated in 4 yrs
+with warnings.catch_warnings():
+    warnings.simplefilter('ignore')
+    from dyn.tm import session as dyn_session  # type: ignore
+    from dyn.tm import services as dyn_services  # type: ignore
+    from dyn.tm import zones as dyn_zones  # type: ignore
+    from dyn.tm.services.dsf import DSFCNAMERecord  # type: ignore
+    from dyn.tm.services.dsf import DSFFailoverChain  # type: ignore
+    from dyn.tm.services.dsf import DSFRecordSet  # type: ignore
+    from dyn.tm.services.dsf import DSFResponsePool  # type: ignore
+    from dyn.tm.services.dsf import DSFRuleset  # type: ignore
+    from dyn.tm.services.dsf import TrafficDirector  # type: ignore
+
+QONTRACT_INTEGRATION = 'dyn-traffic-director'
+
+DEFAULT_TD_TTL = 30
+DEFAULT_WEIGHT = 100
+
+
+class InvalidRecord(Exception):
+    pass
+
+
+class UnsupportedRecordType(Exception):
+    pass
+
+
+def fetch_current_state() -> dict:
+    state: dict = {
+        'tds': {},
+    }
+
+    for td in dyn_services.get_all_dsf_services():
+        td_name: str = td.label
+        td_nodes: List[str] = [node['fqdn'] for node in td.nodes
+                               if 'fqdn' in node]
+        td_ttl: int = td.ttl
+
+        records: List[Dict[str, Union[str, int]]] = []
+        # Need to follow the hierarchy, even though the one we create/manage
+        # is flat (only one of each)
+        # TD <- Ruleset -> ResponsePool <- FailoverChain <- RecordSet <- Record
+        for ruleset in td.rulesets:
+            for pool in ruleset.response_pools:
+                for chain in pool.rs_chains:
+                    for recordset in chain.record_sets:
+                        for record in recordset.records:
+                            rdata = record.rdata()
+                            if 'cname_rdata' not in rdata:
+                                raise UnsupportedRecordType(
+                                    f'record type {type(record)} is not '
+                                    f'supported: {record}'
+                                )
+
+                            cname_rdata = record.rdata()['cname_rdata']
+                            if 'cname' not in cname_rdata:
+                                raise UnsupportedRecordType(
+                                    f'record missing a cname field: {record}'
+                                )
+
+                            records.append({
+                                'hostname':
+                                # strip trailing dot added by Dyn
+                                cname_rdata['cname'].rstrip('.'),
+                                'weight':
+                                int(cname_rdata.get('weight', DEFAULT_WEIGHT)),
+                            })
+
+        # need to be sorted for comparison later
+        records = sorted(records, key=lambda d: d['hostname'])
+
+        state['tds'][td_name] = {
+            'name': td_name,
+            'nodes': td_nodes,
+            'ttl': td_ttl,
+            'records': records,
+        }
+
+    return state
+
+
+def fetch_desired_state() -> dict:
+    dyn_tds = queries.get_dyn_traffic_directors()
+
+    state: dict = {
+        'tds': {},
+    }
+
+    for td in dyn_tds:
+        td_name: str = td['name']
+        td_records: List[Dict] = td.get('records', [])
+        td_ttl: int = td.get('ttl', DEFAULT_TD_TTL)
+
+        records: List[Dict[str, Union[str, int]]] = []
+        for record in td_records:
+            if record['cluster']:
+                hostname = record['cluster']['elbFQDN']
+            elif record['hostname']:
+                hostname = record['hostname']
+            else:
+                raise InvalidRecord('either cluster or hostname must '
+                                    'be defined on a record')
+            records.append({
+                'hostname': hostname.rstrip('.'),
+                'weight': record['weight'],
+            })
+
+        # need to be sorted for comparison later
+        records = sorted(records, key=lambda d: d['hostname'])
+
+        state['tds'][td_name] = {
+            'name': td_name,
+            'nodes': [td_name],
+            'ttl': td_ttl,
+            'records': records,
+        }
+
+    return state
+
+
+def process_tds(current: dict, desired: dict,
+                dry_run: bool = True, enable_deletion: bool = False) -> bool:
+    errors = False
+
+    added: List[str] = [name for name in desired if name not in current]
+    removed: List[str] = [name for name in current if name not in desired]
+    changed: List[str] = [
+        dname
+        for dname, d in desired.items()
+        for cname, c in current.items()
+        if dname == cname if d != c
+    ]
+
+    # Process removed TD services
+    for name in removed:
+        td_name = current[name]['name']
+        msg = ['delete_td']
+        msg.append(name)
+        logging.info(msg)
+
+        if not enable_deletion:
+            logging.info('deletion action is disabled. '
+                         'Delete manually or enable deletion.')
+
+        if dry_run:
+            continue
+
+        if not enable_deletion:
+            continue
+
+        for curtd in dyn_services.get_all_dsf_services():
+            if curtd.label == td_name:
+                curtd.delete()
+
+    # Process added TD services
+    for name in added:
+        td_name = desired[name]['name']
+        td_ttl = desired[name]['ttl']
+        td_records = desired[name]['records']
+
+        msg = ['create_td']
+        msg.append(name)
+        logging.info(msg)
+
+        records = []
+        for record in td_records:
+            records.append(
+                DSFCNAMERecord(record['hostname'], label='',
+                               automation='manual', weight=record['weight'])
+            )
+
+        attach_node = None
+        zones = dyn_zones.get_all_zones()
+        for zone in zones:
+            for node in zone.get_all_nodes():
+                if node.fqdn == td_name:
+                    attach_node = node
+
+        if not attach_node:
+            logging.error(
+                f"Could not find a DNS node named '{name}' to attach to"
+            )
+            errors = True
+
+        if dry_run:
+            continue
+
+        record_set = DSFRecordSet('CNAME', label=td_name,
+                                  automation='manual', records=records)
+        failover_chain = DSFFailoverChain(label=td_name,
+                                          record_sets=[record_set])
+        rpool = DSFResponsePool(label=td_name, rs_chains=[failover_chain])
+        ruleset = DSFRuleset(label=td_name, criteria_type='always',
+                             response_pools=[rpool])
+        TrafficDirector(td_name, ttl=td_ttl, rulesets=[ruleset],
+                        nodes=[attach_node])
+
+    # Process updated TD services
+    for name in changed:
+        # Find TD service to update
+        update_td: TrafficDirector = None
+        for td in dyn_services.get_all_dsf_services():
+            if td.label == name:
+                update_td = td
+
+        # Check if ttl need to be updated
+        if current[name]['ttl'] != desired[name]['ttl']:
+            msg = ['update_td_ttl']
+            msg.append(name)
+            msg.append(desired[name]['ttl'])
+            logging.info(msg)
+
+            if not dry_run:
+                update_td.ttl = desired[name]['ttl']
+
+        # Check if records need to be updated
+        if current[name]['records'] != desired[name]['records']:
+            msg = ['update_td_records']
+            msg.append(name)
+            msg.append(desired[name]['records'])
+            logging.info(msg)
+
+            if not dry_run:
+                # Generate a new list of CNAME records
+                records = []
+                for record in desired[name]['records']:
+                    records.append(
+                        DSFCNAMERecord(record['hostname'], label='',
+                                       automation='manual',
+                                       weight=record['weight'])
+                    )
+
+                # Generate a new recordset
+                new_rset = DSFRecordSet('CNAME', label=desired[name]['name'],
+                                        automation='manual',
+                                        records=records)
+                # ... must follow the hierarchy
+                # TD <- Ruleset -> ResponsePool <- FailoverChain <- RecordSet
+                for ruleset in update_td.rulesets:
+                    for pool in ruleset.response_pools:
+                        for chain in pool.rs_chains:
+                            for rset in chain.record_sets:
+                                if rset.label == desired[name]['name']:
+                                    new_rset.add_to_failover_chain(chain)
+                                    rset.delete()
+
+        # Check if node attachment need to be updated
+        if current[name]['nodes'] != desired[name]['nodes']:
+            msg = ['update_td_node']
+            msg.append(name)
+            msg.append(desired[name]['nodes'])
+            logging.info(msg)
+
+            if not dry_run:
+                # Find the DNS node to attach the TD service to
+                attach_node = None
+                zones = dyn_zones.get_all_zones()
+                for zone in zones:
+                    for node in zone.get_all_nodes():
+                        if node.fqdn == desired[name]['name']:
+                            attach_node = node
+
+                if not attach_node:
+                    logging.error(
+                        f"Could not find a node named '{name}' to attach to"
+                    )
+                    errors = True
+
+                update_td.nodes = [attach_node]
+
+    return errors
+
+
+def run(dry_run: bool, enable_deletion: bool):
+    settings = queries.get_app_interface_settings()
+    secret_reader = SecretReader(settings=settings)
+
+    creds_path = get_config().get('dyn', {}).get('secrets_path', None)
+    if not creds_path:
+        raise ConfigNotFound("Dyn config missing from config file")
+
+    creds = secret_reader.read_all({'path': creds_path})
+    dyn_session.DynectSession(creds['customer'],
+                              creds['dyn_id'],
+                              creds['password'])
+
+    desired = fetch_desired_state()
+    current = fetch_current_state()
+
+    process_tds(current['tds'], desired['tds'],
+                dry_run=dry_run,
+                enable_deletion=enable_deletion)

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -439,7 +439,7 @@ def update_td(name: str, current: Mapping[str, Any],
 def process_tds(current: Mapping[str, Mapping[str, Any]],
                 desired: Mapping[str, Mapping[str, Any]],
                 dry_run: bool = True,
-                enable_deletion: bool = False):
+                enable_deletion: bool = False) -> None:
     added = list(desired.keys() - current.keys())
     removed = list(current.keys() - desired.keys())
     changed = [

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -145,8 +145,7 @@ def process_tds(current: dict, desired: dict,
     # Process removed TD services
     for name in removed:
         td_name = current[name]['name']
-        msg = ['delete_td']
-        msg.append(name)
+        msg = ['delete_td', td_name]
         logging.info(msg)
 
         if not enable_deletion:
@@ -169,8 +168,7 @@ def process_tds(current: dict, desired: dict,
         td_ttl = desired[name]['ttl']
         td_records = desired[name]['records']
 
-        msg = ['create_td']
-        msg.append(name)
+        msg = ['create_td', name]
         logging.info(msg)
 
         records = []
@@ -216,9 +214,7 @@ def process_tds(current: dict, desired: dict,
 
         # Check if ttl need to be updated
         if current[name]['ttl'] != desired[name]['ttl']:
-            msg = ['update_td_ttl']
-            msg.append(name)
-            msg.append(desired[name]['ttl'])
+            msg = ['update_td_ttl', name, desired[name]['ttl']]
             logging.info(msg)
 
             if not dry_run:
@@ -226,9 +222,7 @@ def process_tds(current: dict, desired: dict,
 
         # Check if records need to be updated
         if current[name]['records'] != desired[name]['records']:
-            msg = ['update_td_records']
-            msg.append(name)
-            msg.append(desired[name]['records'])
+            msg = ['update_td_records', name, desired[name]['records']]
             logging.info(msg)
 
             if not dry_run:
@@ -257,9 +251,7 @@ def process_tds(current: dict, desired: dict,
 
         # Check if node attachment need to be updated
         if current[name]['nodes'] != desired[name]['nodes']:
-            msg = ['update_td_node']
-            msg.append(name)
-            msg.append(desired[name]['nodes'])
+            msg = ['update_td_node', name, desired[name]['nodes']]
             logging.info(msg)
 
             if not dry_run:

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -129,7 +129,7 @@ def fetch_desired_state() -> Dict[str, Dict]:
     return state
 
 
-def process_tds(current: dict, desired: dict,
+def process_tds(current: Dict[str, Dict], desired: Dict[str, Dict],
                 dry_run: bool = True, enable_deletion: bool = False) -> bool:
     errors = False
 

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -216,18 +216,10 @@ def _get_dyn_traffic_director_records(td: TrafficDirector, ruleset_label: str,
     """
     # Need to follow the hierarchy
     # TD <- Ruleset -> ResponsePool <- FailoverChain <- RecordSet <- Record
-    try:
-        ruleset = _get_dyn_traffic_director_ruleset(td, ruleset_label)
-        rpool = _get_dyn_traffic_director_response_pool(ruleset, rpool_label)
-        chain = _get_dyn_traffic_director_chain(rpool, chain_label)
-        recordset = _get_dyn_traffic_director_recordset(chain, rset_label)
-    except DynResourceNotFound as e:
-        raise DynResourceNotFound(
-            f'could not retrieve records for traffic director: {td.label}, '
-            f'ruleset: {ruleset_label}, resourcepool: {rpool_label}, '
-            f'failoverchain: {chain_label}, recordset: {rset_label}. '
-            f'The specific error was: {e}'
-        )
+    ruleset = _get_dyn_traffic_director_ruleset(td, ruleset_label)
+    rpool = _get_dyn_traffic_director_response_pool(ruleset, rpool_label)
+    chain = _get_dyn_traffic_director_chain(rpool, chain_label)
+    recordset = _get_dyn_traffic_director_recordset(chain, rset_label)
     return recordset.records
 
 
@@ -244,21 +236,13 @@ def _update_dyn_traffic_director_records(td: TrafficDirector, records: List,
 
     # Need to follow the hierarchy
     # TD <- Ruleset -> ResponsePool <- FailoverChain <- RecordSet <- Record
-    try:
-        ruleset = _get_dyn_traffic_director_ruleset(td, ruleset_label)
-        rpool = _get_dyn_traffic_director_response_pool(ruleset, rpool_label)
-        chain = _get_dyn_traffic_director_chain(rpool, chain_label)
-        current_recordset = _get_dyn_traffic_director_recordset(chain,
-                                                                rset_label)
-    except DynResourceNotFound as e:
-        raise DynResourceNotFound(
-            f'could not retrieve records for traffic director: {td.label}, '
-            f'ruleset: {ruleset_label}, resourcepool: {rpool_label}, '
-            f'failoverchain: {chain_label}, recordset: {rset_label}. '
-            f'The specific error was: {e}'
-        )
+    ruleset = _get_dyn_traffic_director_ruleset(td, ruleset_label)
+    rpool = _get_dyn_traffic_director_response_pool(ruleset, rpool_label)
+    chain = _get_dyn_traffic_director_chain(rpool, chain_label)
+    current_recordset = _get_dyn_traffic_director_recordset(chain, rset_label)
 
     new_rset.add_to_failover_chain(chain)
+
     current_recordset.delete()
 
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2323,3 +2323,26 @@ def get_permissions_for_slack_usergroup():
     gqlapi = gql.get_api()
     permissions = gqlapi.query(PERMISSIONS_QUERY)['permissions']
     return [p for p in permissions if p['service'] == 'slack-usergroup']
+
+
+DYN_TRAFFIC_DIRECTORS_QUERY = """
+{
+  dyn_traffic_directors: dyn_traffic_directors_v1 {
+    name
+    ttl
+    records {
+      cluster {
+        name
+        elbFQDN
+      }
+      hostname
+      weight
+    }
+  }
+}
+"""
+
+
+def get_dyn_traffic_directors():
+    gqlapi = gql.get_api()
+    return gqlapi.query(DYN_TRAFFIC_DIRECTORS_QUERY)['dyn_traffic_directors']

--- a/reconcile/test/test_dyn_traffic_director.py
+++ b/reconcile/test/test_dyn_traffic_director.py
@@ -59,7 +59,6 @@ def get_all_dsf_services_fixture(mocker):
     ]
 
 
-@httpretty.activate(allow_net_connect=False)
 def test_get_traffic_director_service(get_all_dsf_services_fixture):
     res = integ.get_traffic_director_service('bar')
     assert isinstance(res, integ.dyn_services.TrafficDirector)

--- a/reconcile/test/test_dyn_traffic_director.py
+++ b/reconcile/test/test_dyn_traffic_director.py
@@ -6,7 +6,7 @@ import reconcile.dyn_traffic_director as integ
 
 
 @pytest.fixture
-def zones_nodes_fixture(mocker):
+def get_all_zones_fixture(mocker):
     mock_get_all_zones = mocker.patch.object(
         integ.dyn_zones, 'get_all_zones', autospec=True)
 
@@ -25,12 +25,42 @@ def zones_nodes_fixture(mocker):
     mock_get_all_zones.return_value = [zone_a, zone_b]
 
 
-def test_get_node(zones_nodes_fixture):
+def test_get_node(get_all_zones_fixture):
     res = integ.get_node('zoneA-nodeA.')
     assert isinstance(res, integ.dyn_zones.Node)
     assert res.fqdn == 'zoneA-nodeA.'
 
 
-def test_get_node_not_found(zones_nodes_fixture):
+def test_get_node_not_found(get_all_zones_fixture):
     res = integ.get_node('non-existing-node')
     assert res is None
+
+
+# Mock Class for TrafficDirector
+# The Dyn module's TrafficDirector class calls the Dyn API multiple times as
+# part of it's constructor. This Mock class purpose is to avoid this and allow
+# us to test our code without having to construct a fully valid TrafficDirector
+class MockTrafficDirector(integ.dyn_services.TrafficDirector):
+    def __init__(self, label):
+        self._label = label
+        self._service_id = label
+
+
+@pytest.fixture
+def get_all_dsf_services_fixture(mocker):
+    mock_get_all_dsf_Services = mocker.patch.object(
+        integ.dyn_services, 'get_all_dsf_services', autospec=True
+    )
+
+    mock_get_all_dsf_Services.return_value = [
+        MockTrafficDirector('foo'),
+        MockTrafficDirector('bar'),
+        MockTrafficDirector('baz'),
+    ]
+
+
+@httpretty.activate(allow_net_connect=False)
+def test_get_traffic_director_service(get_all_dsf_services_fixture):
+    res = integ.get_traffic_director_service('bar')
+    assert isinstance(res, integ.dyn_services.TrafficDirector)
+    assert res.label == 'bar'

--- a/reconcile/test/test_dyn_traffic_director.py
+++ b/reconcile/test/test_dyn_traffic_director.py
@@ -67,6 +67,23 @@ def generate_state(td_count: int, node_count: int, records_count: int,
     }
 
 
+def test_process_tds_empty_state(mocker):
+    """Tests that nothing happens given empty states"""
+    current = generate_state(0, 0, 0, 0)
+    desired = generate_state(0, 0, 0, 0)
+
+    mock_create_td = mocker.patch.object(integ, 'create_td', autospec=True)
+    mock_delete_td = mocker.patch.object(integ, 'delete_td', autospec=True)
+    mock_update_td = mocker.patch.object(integ, 'update_td', autospec=True)
+
+    integ.process_tds(current, desired, dry_run=True,
+                      enable_deletion=False)
+
+    mock_create_td.assert_not_called()
+    mock_delete_td.assert_not_called()
+    mock_update_td.assert_not_called()
+
+
 def test_process_tds_noop(mocker):
     """Tests that nothing happens given identical current & desired inputs"""
     current = generate_state(1, 1, 3, 30)

--- a/reconcile/test/test_dyn_traffic_director.py
+++ b/reconcile/test/test_dyn_traffic_director.py
@@ -79,9 +79,9 @@ def test_process_tds_noop(mocker):
     integ.process_tds(current, desired, dry_run=True,
                       enable_deletion=False)
 
-    assert not mock_create_td.called
-    assert not mock_delete_td.called
-    assert not mock_update_td.called
+    mock_create_td.assert_not_called()
+    mock_delete_td.assert_not_called()
+    mock_update_td.assert_not_called()
 
 
 def test_process_tds_added_td(mocker):
@@ -96,9 +96,9 @@ def test_process_tds_added_td(mocker):
     integ.process_tds(current, desired, dry_run=True,
                       enable_deletion=False)
 
-    assert mock_create_td.called
-    assert not mock_delete_td.called
-    assert not mock_update_td.called
+    mock_create_td.assert_called_once()
+    mock_delete_td.assert_not_called()
+    mock_update_td.assert_not_called()
 
 
 def test_process_tds_deleted_td(mocker):
@@ -113,9 +113,9 @@ def test_process_tds_deleted_td(mocker):
     integ.process_tds(current, desired, dry_run=True,
                       enable_deletion=False)
 
-    assert not mock_create_td.called
-    assert mock_delete_td.called
-    assert not mock_update_td.called
+    mock_create_td.assert_not_called()
+    mock_delete_td.assert_called_once()
+    mock_update_td.assert_not_called()
 
 
 def test_process_tds_updated_td_nodes(mocker):
@@ -131,9 +131,9 @@ def test_process_tds_updated_td_nodes(mocker):
     integ.process_tds(current, desired, dry_run=True,
                       enable_deletion=False)
 
-    assert not mock_create_td.called
-    assert not mock_delete_td.called
-    assert mock_update_td.called
+    mock_create_td.assert_not_called()
+    mock_delete_td.assert_not_called()
+    mock_update_td.assert_called_once()
 
 
 def test_process_tds_updated_td_ttl(mocker):
@@ -148,9 +148,9 @@ def test_process_tds_updated_td_ttl(mocker):
     integ.process_tds(current, desired, dry_run=True,
                       enable_deletion=False)
 
-    assert not mock_create_td.called
-    assert not mock_delete_td.called
-    assert mock_update_td.called
+    mock_create_td.assert_not_called()
+    mock_delete_td.assert_not_called()
+    mock_update_td.assert_called_once()
 
 
 def test_process_tds_updated_td_records(mocker):
@@ -166,6 +166,6 @@ def test_process_tds_updated_td_records(mocker):
     integ.process_tds(current, desired, dry_run=True,
                       enable_deletion=False)
 
-    assert not mock_create_td.called
-    assert not mock_delete_td.called
-    assert mock_update_td.called
+    mock_create_td.assert_not_called()
+    mock_delete_td.assert_not_called()
+    mock_update_td.assert_called_once()

--- a/reconcile/test/test_dyn_traffic_director.py
+++ b/reconcile/test/test_dyn_traffic_director.py
@@ -1,0 +1,36 @@
+from unittest.mock import create_autospec
+
+import pytest
+
+import reconcile.dyn_traffic_director as integ
+
+
+@pytest.fixture
+def zones_nodes_fixture(mocker):
+    mock_get_all_zones = mocker.patch.object(
+        integ.dyn_zones, 'get_all_zones', autospec=True)
+
+    zone_a = create_autospec(integ.dyn_zones.Zone)
+    zone_a.get_all_nodes.return_value = [
+        integ.dyn_zones.Node('zoneA-nodeA'),
+        integ.dyn_zones.Node('zoneA-nodeB'),
+    ]
+
+    zone_b = create_autospec(integ.dyn_zones.Zone)
+    zone_b.get_all_nodes.return_value = [
+        integ.dyn_zones.Node('zoneB-nodeA'),
+        integ.dyn_zones.Node('zoneB-nodeB'),
+    ]
+
+    mock_get_all_zones.return_value = [zone_a, zone_b]
+
+
+def test_get_node(zones_nodes_fixture):
+    res = integ.get_node('zoneA-nodeA.')
+    assert isinstance(res, integ.dyn_zones.Node)
+    assert res.fqdn == 'zoneA-nodeA.'
+
+
+def test_get_node_not_found(zones_nodes_fixture):
+    res = integ.get_node('non-existing-node')
+    assert res is None

--- a/reconcile/utils/config.py
+++ b/reconcile/utils/config.py
@@ -3,6 +3,10 @@ import toml
 _config = None
 
 
+class ConfigNotFound(Exception):
+    pass
+
+
 class SecretNotFound(Exception):
     pass
 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "websocket-client<0.55.0,>=0.35",
         "sshtunnel>=0.4.0",
         "croniter>=1.0.15,<1.1.0",
+        "dyn~=1.8.1",
     ],
 
     test_suite="tests",


### PR DESCRIPTION
Ref.: https://issues.redhat.com/browse/APPSRE-3884

Depends on schema changes: https://github.com/app-sre/qontract-schemas/pull/7

Notes for reviewers:
- The Dyn module is old and has not been updated in almost 4 years. It works well for our purpose and avoids having to re-implement their REST API. The Dyn service is being retired so we should not expect changes in their APIs or the module: https://www.oracle.com/corporate/acquisitions/dyn/technologies/enterprise-customer-faq.html
- I've used type hints where it made sense
- Unfortunately no tests. I think it may be acceptable to not have tests considering this is a service that is being retired and not being updated. I'm happy to add tests if deemed absolutely necessary