### PR TITLE
Fix various auto-promotion issues

### DIFF
--- a/reconcile/utils/mr/auto_promoter.py
+++ b/reconcile/utils/mr/auto_promoter.py
@@ -34,7 +34,7 @@ class AutoPromoter(MergeRequestBase):
             for saas_file_path in saas_file_paths:
                 raw_file = gitlab_cli.project.files.get(
                     file_path=saas_file_path,
-                    ref=self.main_branch
+                    ref=self.branch
                 )
                 content = yaml.load(raw_file.decode(),
                                     Loader=yaml.RoundTripLoader)

--- a/reconcile/utils/mr/auto_promoter.py
+++ b/reconcile/utils/mr/auto_promoter.py
@@ -1,5 +1,7 @@
 import logging
 from ruamel import yaml
+import json
+import hashlib
 
 from reconcile.utils.mr.base import MergeRequestBase
 from reconcile.utils.mr.labels import AUTO_MERGE
@@ -21,8 +23,14 @@ class AutoPromoter(MergeRequestBase):
 
     @property
     def title(self):
-        # TODO(mafriedm): update this to be more descriptive and unique
-        return (f'[{self.name}] openshift-saas-deploy automated promotion')
+        """
+        to make the MR title unique, add a sha256sum of the promotions to it
+        TODO: while adding a digest ensures uniqueness, this title is still not very descriptive
+        """
+        m = hashlib.sha256()
+        m.update(json.dumps(self.promotions, sort_keys=True).encode("utf-8"))
+        digest = m.hexdigest()[:6]
+        return (f'[{self.name}] openshift-saas-deploy automated promotion {digest}')
 
     def process(self, gitlab_cli):
         for item in self.promotions:

--- a/reconcile/utils/mr/auto_promoter.py
+++ b/reconcile/utils/mr/auto_promoter.py
@@ -1,7 +1,7 @@
 import logging
-from ruamel import yaml
 import json
 import hashlib
+from ruamel import yaml
 
 from reconcile.utils.mr.base import MergeRequestBase
 from reconcile.utils.mr.labels import AUTO_MERGE
@@ -25,12 +25,14 @@ class AutoPromoter(MergeRequestBase):
     def title(self):
         """
         to make the MR title unique, add a sha256sum of the promotions to it
-        TODO: while adding a digest ensures uniqueness, this title is still not very descriptive
+        TODO: while adding a digest ensures uniqueness, this title is
+              still not very descriptive
         """
         m = hashlib.sha256()
         m.update(json.dumps(self.promotions, sort_keys=True).encode("utf-8"))
         digest = m.hexdigest()[:6]
-        return (f'[{self.name}] openshift-saas-deploy automated promotion {digest}')
+        return (f'[{self.name}] openshift-saas-deploy automated '
+                f'promotion {digest}')
 
     def process(self, gitlab_cli):
         for item in self.promotions:
@@ -69,13 +71,14 @@ class AutoPromoter(MergeRequestBase):
 
                 if saas_file_updated:
                     new_content = '---\n'
-                    new_content += yaml.dump(content, Dumper=yaml.RoundTripDumper)
+                    new_content += yaml.dump(content,
+                                             Dumper=yaml.RoundTripDumper)
                     msg = f'auto promote {commit_sha} in {saas_file_path}'
                     gitlab_cli.update_file(branch_name=self.branch,
                                            file_path=saas_file_path,
                                            commit_message=msg,
                                            content=new_content)
                 else:
-                    LOG.info(f"commit sha {commit_sha} has already been promoted to all"
-                             f"targets in {content['name']} subscribing to"
-                             f"{','.join(item['publish'])}")
+                    LOG.info(f"commit sha {commit_sha} has already been "
+                             f"promoted to all targets in {content['name']} "
+                             f"subscribing to {','.join(item['publish'])}")


### PR DESCRIPTION
This MR addresses multiple issues in the qontract-reconcile auto-promotion feature

## Prevent auto promoter from reverting changes when processing multiple promotions per saas file

When the auto-promote processes more than one target-promotion in a saas file
at the same time, the second promotion reverts the first one.

walkthrough:
* while processing the first promotion, the saas file from the master branch
  is loaded, the target ref is updated, and a commit to the temporary branch
  is created
* when another promotion for the same saas file is processed, the saas file
  is loaded again from the master branch, which does not contain the change
  from the first promotion. then the change from the promotion is applied and
  a commit is added to the temporary branch. this commit effectively reverts
  the change from previous commits in the temporary branch to the saas file.

the behaviour can be prevented by reading the saas file from the temporary
branch. for the first promotion to process, this does not make a difference,
because the temporary branch has just been created from master. for all
consecutive commits, it is the right thing to do, to prevent the revert and
build upon the previous changes.

This has been part of the problem in APPSRE-4001 where the customer
observed such a ref revert.

## Prevent empty commits for auto promoter

This code change prevents empty commits in situations where a commit sha
has already been promoted to all subscribed targets in a saas file. Those
empty commits are noisy and confusing in the MRs and could also be the
reason for certain unmergable auto-promote MRs (unconfirmed).

## Ensure unique auto promoter MR title
The title of auto promoter MRs have been static, which resulted in dropped
promotions because MergeRequestBase prevents the creation of MRs with
duplicate names.

This has been part of the problem for APPSRE-4001 where the logs of
gitlab-mr-sqs-consumer showed multiple promotions close after one another
for different saas files, and one being dropped because of the
duplicate title.