### PR TITLE
allow config file to be defined through environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ qontract-reconcile --config config.toml --dry-run <subcommand>
 qontract-reconcile --config config.toml <subcommand>
 ```
 
+> Note: you can use the `QONTRACT_CONFIG` environment variable instead of using `--config`.
+
 ## OpenShift usage
 
 OpenShift templates can be found [here](/openshift/qontract-reconcile.yaml). In order to add integrations there please use the [helm](/helm/README.md) chart provided.

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -151,6 +151,7 @@ def config_file(function):
     help_msg = 'Path to configuration file in toml format.'
     function = click.option('--config', 'configfile',
                             required=True,
+                            default=os.environ.get('QONTRACT_CONFIG'),
                             help=help_msg)(function)
     return function
 


### PR DESCRIPTION
i never want to type `--config` again.