### PR TITLE
[terraform-resources] support aws partition (in sqs)

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -267,6 +267,7 @@ AWS_ACCOUNTS_QUERY = """
     ecrs {
       region
     }
+    partition
   }
 }
 """

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -160,7 +160,7 @@ class TerrascriptClient:
                 access_key=config['aws_access_key_id'],
                 secret_key=config['aws_secret_access_key'],
                 version=self.versions.get(name),
-                region=config['region'])
+                region=config['resourcesDefaultRegion'])
 
             # the time provider can be removed if all AWS accounts
             # upgrade to a provider version with this bug fix

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -183,6 +183,8 @@ class TerrascriptClient:
         self.uids = {a['name']: a['uid'] for a in filtered_accounts}
         self.default_regions = {a['name']: a['resourcesDefaultRegion']
                                 for a in filtered_accounts}
+        self.partitions = {a['name']: a.get('partition') or 'aws'
+                           for a in filtered_accounts}
         github_config = get_config()['github']
         self.token = github_config['app-sre']['token']
         self.logtoes_zip = ''
@@ -235,6 +237,9 @@ class TerrascriptClient:
         secret['resourcesDefaultRegion'] = \
             account['resourcesDefaultRegion']
         return (account_name, secret)
+
+    def _get_partition(self, account):
+        return self.partitions[account]
 
     @staticmethod
     def get_tf_iam_group(group_name):

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -2265,7 +2265,8 @@ class TerrascriptClient:
                 "Effect": "Allow",
                 "Principal": "*",
                 "Action": "sqs:SendMessage",
-                "Resource": "arn:aws:sqs:*:*:" + sqs_identifier,
+                "Resource": f"arn:{self._get_partition(account)}:" +
+                            f"sqs:*:*:{sqs_identifier}",
                 "Condition": {
                     "ArnEquals": {
                         "aws:SourceArn":
@@ -2296,7 +2297,8 @@ class TerrascriptClient:
                     {
                         "Effect": "Allow",
                         "Principal": {
-                            "AWS": "arn:aws:iam::" + uid + ":root"
+                            "AWS": f"arn:{self._get_partition(account)}:" +
+                                   f"iam::{uid}:root"
                         },
                         "Action": "kms:*",
                         "Resource": "*"
@@ -2398,7 +2400,8 @@ class TerrascriptClient:
                     "Effect": "Allow",
                     "Action": ["sqs:*"],
                     "Resource": [
-                        "arn:aws:sqs:*:{}:{}".format(uid, sqs_identifier)
+                        f"arn:{self._get_partition(account)}:" +
+                        f"sqs:*:{uid}:{sqs_identifier}"
                     ]
                 },
                 {

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -160,7 +160,7 @@ class TerrascriptClient:
                 access_key=config['aws_access_key_id'],
                 secret_key=config['aws_secret_access_key'],
                 version=self.versions.get(name),
-                region=config['resourcesDefaultRegion'])
+                region=config['region'])
 
             # the time provider can be removed if all AWS accounts
             # upgrade to a provider version with this bug fix
@@ -1913,7 +1913,8 @@ class TerrascriptClient:
                         "Effect": "Allow",
                         "Action": ["sqs:*"],
                         "Resource": [
-                            "arn:aws:sqs:*:{}:{}".format(uid, q)
+                            f"arn:{self._get_partition(account)}:" +
+                            f"sqs:*:{uid}:{q}"
                             for q in all_queues
                         ]
                     },


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4008

depends on https://github.com/app-sre/qontract-schemas/pull/8

this PR adds an option to define a `partition` on an aws account file. this is required for policies and other aws resources to be compliant with the aws account type (regular (`aws`) vs GovCloud (`aws-us-gov`)).