### PR TITLE
Add tooling binaries to Dockerfile.test

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/qontract-reconcile-builder:0.1.1 as build-image
+FROM quay.io/app-sre/qontract-reconcile-builder:0.2.0 as build-image
 
 WORKDIR /work
 

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -1,16 +1,10 @@
-FROM quay.io/app-sre/qontract-reconcile-builder:0.1.1
+FROM quay.io/app-sre/qontract-reconcile-builder:0.2.0
 
 WORKDIR /package
 COPY . /package
 
-RUN curl -L https://get.helm.sh/helm-v3.6.2-linux-amd64.tar.gz | tar xvz && \
-    mv linux-amd64/helm /usr/local/bin/helm && \
-    chmod +x /usr/local/bin/helm && \
-    rm -rf linux-amd64 && mkdir ~/.gnupg && \
-    echo no-user-agent > ~/.gnupg/gpg.conf && \
-    dnf upgrade -y
-
-RUN python3 -m pip install --upgrade pip && \
+RUN microdnf upgrade -y && \
+    python3 -m pip install --upgrade pip && \
     python3 -m pip install tox
 
 CMD [ "tox" ]


### PR DESCRIPTION
* Helm installation moved to qontract-reconcile-builder image. 
* Now the dockerfile.test image extends from qontract-reconcile-base. Now all tooling binaries are available for testing purposes. 