### PR TITLE
Fix storage updates performed by the ocm-clusters integration

### DIFF
--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -229,10 +229,10 @@ class OCM:
                 'compute_machine_type': {'id': instance_type}
             }
 
-        storage_quota = cluster_spec.get('storage_quota')
-        if storage_quota is not None:
+        storage = cluster_spec.get('storage')
+        if storage is not None:
             ocm_spec['storage_quota'] = {
-                'value': float(cluster_spec['storage'] * 1073741824)  # 1024^3
+                'value': float(storage * 1073741824)  # 1024^3
             }
 
         load_balancers = cluster_spec.get('load_balancers')


### PR DESCRIPTION
app-interface uses the 'storage' key and OCM uses the 'storage_quota'
key. Using the wrong key to parse the a-i spec was result in discarding
any storage changes. There are some other changes that can be made here
to ensure that an empty cluster spec patch doesn't occur silently, but
that will be handled in a separate PR.

For additional testing, I added some logging at the beginning/end of the `update_cluster` method.

```
# Before the change
## Input
{'storage': 4100} 
## Output (what we sent to patch)
{}

# After the change
## Input
{'storage': 4100}
## Output (what we sent to patch)
{'storage_quota': {'value': 4402341478400.0}}
```