### PR TITLE
APPSRE-3784: Use permissions instead of roles

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2132,3 +2132,68 @@ GABI_INSTANCES_QUERY = """
 def get_gabi_instances():
     gqlapi = gql.get_api()
     return gqlapi.query(GABI_INSTANCES_QUERY)['gabi_instances']
+
+
+PERMISSIONS_QUERY = """
+{
+  permissions: permissions_v1 {
+    service
+    ...on PermissionSlackUsergroup_v1 {
+      channels
+      description
+      handle
+      ownersFromRepos
+      pagerduty {
+          name
+          instance {
+            name
+          }
+          scheduleID
+          escalationPolicyID
+        }
+      roles {
+        users {
+            name
+            org_username
+            slack_username
+            pagerduty_username
+        }
+    }
+      schedule {
+          schedule {
+            start
+            end
+            users {
+              org_username
+              slack_username
+            }
+          }
+        }
+      workspace {
+        name
+        token {
+          path
+          field
+        }
+        api_client {
+          global {
+            max_retries
+            timeout
+          }
+          methods {
+            name
+            args
+          }
+        }
+        managedUsergroups
+      }
+    }
+  }
+}
+"""
+
+
+def get_permissions_for_slack_usergroup():
+    gqlapi = gql.get_api()
+    permissions = gqlapi.query(PERMISSIONS_QUERY)['permissions']
+    return [p for p in permissions if p['service'] == 'slack-usergroup']

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -4,7 +4,6 @@ from datetime import datetime
 from urllib.parse import urlparse
 from sretoolbox.utils import retry
 
-from reconcile.utils import gql
 from reconcile.utils.github_api import GithubApi
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.pagerduty_api import PagerDutyMap
@@ -12,80 +11,6 @@ from reconcile.utils.repo_owners import RepoOwners
 from reconcile.utils.slack_api import SlackApi, SlackApiError, SlackApiConfig
 from reconcile import queries
 
-
-PERMISSIONS_QUERY = """
-{
-  permissions: permissions_v1 {
-    service
-    ...on PermissionSlackUsergroup_v1 {
-      handle
-      workspace {
-        name
-        token {
-          path
-          field
-        }
-        api_client {
-          global {
-            max_retries
-            timeout
-          }
-          methods {
-            name
-            args
-          }
-        }
-        managedUsergroups
-      }
-    }
-  }
-}
-"""
-
-ROLES_QUERY = """
-{
-  roles: roles_v1 {
-    name
-    users {
-      name
-      org_username
-      slack_username
-      pagerduty_username
-    }
-    permissions {
-      service
-      ...on PermissionSlackUsergroup_v1 {
-        handle
-        workspace {
-          name
-          managedUsergroups
-        }
-        pagerduty {
-          name
-          instance {
-            name
-          }
-          scheduleID
-          escalationPolicyID
-        }
-        channels
-        description
-        ownersFromRepos
-        schedule {
-          schedule {
-            start
-            end
-            users {
-              org_username
-              slack_username
-            }
-          }
-        }
-      }
-    }
-  }
-}
-"""
 
 DATE_FORMAT = '%Y-%m-%d %H:%M'
 QONTRACT_INTEGRATION = 'slack-usergroups'
@@ -107,22 +32,15 @@ class GitApi:
         raise ValueError(f"Unable to handle URL: {url}")
 
 
-def get_permissions():
-    gqlapi = gql.get_api()
-    permissions = gqlapi.query(PERMISSIONS_QUERY)['permissions']
-    return [p for p in permissions if p['service'] == 'slack-usergroup']
-
-
 def get_slack_map():
     settings = queries.get_app_interface_settings()
-    permissions = get_permissions()
+    permissions = queries.get_permissions_for_slack_usergroup()
     slack_map = {}
     for sp in permissions:
         workspace = sp['workspace']
         workspace_name = workspace['name']
         if workspace_name in slack_map:
             continue
-
         slack_api_kwargs = {
             'settings': settings,
         }
@@ -141,7 +59,6 @@ def get_slack_map():
             "managed_usergroups": workspace['managedUsergroups']
         }
         slack_map[workspace_name] = workspace_spec
-
     return slack_map
 
 
@@ -311,69 +228,63 @@ def get_desired_state(slack_map, pagerduty_map):
                 (ex. state['coreos']['app-sre-ic']
     :rtype: dict
     """
-    gqlapi = gql.get_api()
-    roles = gqlapi.query(ROLES_QUERY)['roles']
+    permissions = queries.get_permissions()
     all_users = queries.get_users()
 
     desired_state = {}
-    for r in roles:
-        for p in r['permissions']:
-            if p['service'] != 'slack-usergroup':
-                continue
+    for p in permissions:
+        if p['service'] != 'slack-usergroup':
+            continue
+        workspace = p['workspace']
+        managed_usergroups = workspace['managedUsergroups']
+        if managed_usergroups is None:
+            continue
 
-            workspace = p['workspace']
-            managed_usergroups = workspace['managedUsergroups']
-            if managed_usergroups is None:
-                continue
+        workspace_name = workspace['name']
+        usergroup = p['handle']
+        description = p['description']
+        if usergroup not in managed_usergroups:
+            raise KeyError(
+                f'[{workspace_name}] usergroup {usergroup} \
+                    not in managed usergroups {managed_usergroups}'
+                )
 
-            workspace_name = workspace['name']
-            usergroup = p['handle']
-            description = p['description']
-            if usergroup not in managed_usergroups:
-                logging.warning(
-                    '[{}] usergroup {} not in managed usergroups {}'.format(
-                        workspace_name,
-                        usergroup,
-                        managed_usergroups
-                    ))
-                continue
+        slack = slack_map[workspace_name]['slack']
+        ugid = slack.get_usergroup_id(usergroup)
 
-            slack = slack_map[workspace_name]['slack']
-            ugid = slack.get_usergroup_id(usergroup)
-            user_names = [get_slack_username(u) for u in r['users']]
+        all_user_names = \
+            [get_slack_username(u) for r in p['roles'] for u in r['users']]
+        slack_usernames_pagerduty = \
+            get_slack_usernames_from_pagerduty(
+                p['pagerduty'], all_users, usergroup, pagerduty_map)
+        all_user_names.extend(slack_usernames_pagerduty)
 
-            slack_usernames_pagerduty = \
-                get_slack_usernames_from_pagerduty(p['pagerduty'],
-                                                   all_users, usergroup,
-                                                   pagerduty_map)
-            user_names.extend(slack_usernames_pagerduty)
+        slack_usernames_repo = get_slack_usernames_from_owners(
+                p['ownersFromRepos'], all_users, usergroup)
+        all_user_names.extend(slack_usernames_repo)
 
-            slack_usernames_repo = get_slack_usernames_from_owners(
-                    p['ownersFromRepos'], all_users, usergroup)
-            user_names.extend(slack_usernames_repo)
+        slack_usernames_schedule = get_slack_usernames_from_schedule(
+            p['schedule']
+        )
+        all_user_names.extend(slack_usernames_schedule)
 
-            slack_usernames_schedule = get_slack_usernames_from_schedule(
-                p['schedule']
-            )
-            user_names.extend(slack_usernames_schedule)
+        user_names = list(set(all_user_names))
+        users = slack.get_users_by_names(user_names)
 
-            users = slack.get_users_by_names(user_names)
+        channel_names = [] if p['channels'] is None else p['channels']
+        channels = slack.get_channels_by_names(channel_names)
 
-            channel_names = [] if p['channels'] is None else p['channels']
-            channels = slack.get_channels_by_names(channel_names)
-
-            try:
-                desired_state[workspace_name][usergroup]['users'].update(users)
-            except KeyError:
-                desired_state.setdefault(workspace_name, {})[usergroup] = {
-                    "workspace": workspace_name,
-                    "usergroup": usergroup,
-                    "usergroup_id": ugid,
-                    "users": users,
-                    "channels": channels,
-                    "description": description,
-                }
-
+        try:
+            desired_state[workspace_name][usergroup]['users'].update(users)
+        except KeyError:
+            desired_state.setdefault(workspace_name, {})[usergroup] = {
+                "workspace": workspace_name,
+                "usergroup": usergroup,
+                "usergroup_id": ugid,
+                "users": users,
+                "channels": channels,
+                "description": description,
+            }
     return desired_state
 
 

--- a/reconcile/test/fixtures/slack_usergroups/permissions.yml
+++ b/reconcile/test/fixtures/slack_usergroups/permissions.yml
@@ -1,0 +1,63 @@
+permissions:
+  - service: github-org-team
+  - service: slack-usergroup
+    channels:
+      - sd-sre-platform
+      - sd-ims-backplane
+    description: backplane service owners (managed via app-interface)
+    handle: backplane-team
+    ownersFromRepos:
+      - someurl
+    pagerduty: null
+    roles:
+      - users: []
+    schedule: null
+    workspace:
+      name: coreos
+      token:
+        path: app-sre/creds/slack-app-sre-groups
+        field: bot_token
+        api_client:
+          global:
+            max_retries: 5
+            timeout: 30
+          methods:
+            - name: userslist
+              args: limit
+            - name:  conversationslist
+              args: limit
+      managedUsergroups:
+        - app-sre-team
+        - app-sre-ic
+  - service: slack-usergroup
+    channels:
+      - sd-sre-platform
+      - sre-operators
+    description: SREP managed-cluster-config owners (managed via app-interface)
+    handle: saas-osd-operators
+    ownersFromRepos:
+      - null 
+    pagerduty: null
+    roles:
+      - name: Rafael
+        org_username: razevedo
+        slack_username: null
+        pagerduty_username: null
+    schedule: null
+    workspace:
+      name: coreos
+      token:
+        path: app-sre/creds/slack-app-sre-groups
+        field: bot_token
+        api_client:
+          global:
+            max_retries: 5
+            timeout: 30
+          methods:
+            - name: userslist
+              args: limit
+            - name:  conversationslist
+              args: limit
+      managedUsergroups:
+        - app-sre-team
+        - app-sre-ic

--- a/reconcile/test/test_queries.py
+++ b/reconcile/test/test_queries.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+from unittest.mock import create_autospec, patch
+
+from reconcile import queries
+from reconcile.utils import gql
+
+from .fixtures import Fixtures
+
+
+class TestQueries(TestCase):
+    @patch.object(gql, "get_api", autospec=True)
+    def test_get_permissions_return_all_slack_usergroup(self, mock_get_api):
+        gqlapi_mock = create_autospec(gql.GqlApi)
+        gqlapi_mock.query.side_effect = \
+            self.get_permissions_query_side_effect
+        mock_get_api.return_value = gqlapi_mock
+        result = queries.get_permissions_for_slack_usergroup()
+        self.assertEqual({x['service'] for x in result}, {'slack-usergroup'})
+
+    @staticmethod
+    def get_permissions_query_side_effect(query):
+        if query == queries.PERMISSIONS_QUERY:
+            fxt = Fixtures('slack_usergroups')
+            permission = fxt.get_anymarkup('permissions.yml')
+            return permission


### PR DESCRIPTION
### Why:
Originally slack-usergroups integration query the roles and loop through it to update permission, which means when there is no role for a permission, it will be skipped. And we want to avoid that. So the proposal was to query permissions and iterate those instead, with the schema change to include the information about roles there.
### What:
- Update the query of permissions with the updated schema; 
- Use permissions instead of roles to generate desired state so no permission update will be skipped due to role not exist; 
- Fail integration instead of log warning when the user group is not in managedUsergroup.
- pull permission query to queries module
- Add tests
### Validation:
Dry-run success before adding the failing mechanism, which result in a failing for crc-bop-team. Asking what to do there right now.
Added tests and all tests passed.