### PR TITLE
Skip construct desired_state for app-sre-escalation-undefined usergroup

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2143,6 +2143,7 @@ PERMISSIONS_QUERY = """
       description
       handle
       ownersFromRepos
+      skip
       pagerduty {
           name
           instance {

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -235,6 +235,9 @@ def get_desired_state(slack_map, pagerduty_map):
     for p in permissions:
         if p['service'] != 'slack-usergroup':
             continue
+        skip_flag = p['skip']
+        if skip_flag:
+            continue
         workspace = p['workspace']
         managed_usergroups = workspace['managedUsergroups']
         if managed_usergroups is None:


### PR DESCRIPTION
### Why
There is a [permission](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/data/teams/placeholder-escalation-permission.yml) defined as placeholder for app-sre-escalation-undefined usergroup. Now that we loop through permissions, the integration breaks when it run to it because the usergroup has no actual usergroup etc
### What:
Skipping it.