### PR TITLE
Fail when namespaces list resource names or overrides of unmanaged types

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1,7 +1,7 @@
 import logging
 import itertools
 
-from typing import Optional, List, Iterable, Mapping
+from typing import Optional, Iterable, Mapping
 
 import yaml
 
@@ -53,7 +53,7 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
                         clusters: Optional[Iterable[Mapping]] = None,
                         override_managed_types: Optional[Iterable[str]] = None,
                         managed_types_key: str = 'managedResourceTypes'
-                        ) -> List[StateSpec]:
+                        ) -> list[StateSpec]:
     state_specs = []
 
     if clusters and namespaces:
@@ -117,6 +117,21 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
                     resource_type_override=resource_type_overrides.get(kind),
                     resource_names=names)
                 state_specs.append(c_spec)
+                managed_types.remove(kind)
+
+            # Produce "empty" StateSpec's for any resource type that
+            # doesn't have an explicit managedResourceName listed in
+            # the namespace
+            state_specs.extend(
+                StateSpec(
+                    "current",
+                    oc,
+                    cluster,
+                    namespace,
+                    t,
+                    resource_type_override=resource_type_overrides.get(t),
+                    resource_names=None
+                ) for t in managed_types)
 
             # Initialize desired state specs
             openshift_resources = namespace_info.get('openshiftResources')

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1,5 +1,8 @@
 import logging
 import itertools
+
+from typing import Optional, List, Iterable, Mapping
+
 import yaml
 
 from sretoolbox.utils import retry
@@ -45,11 +48,12 @@ class StateSpec:
         self.resource_names = resource_names
 
 
-def init_specs_to_fetch(ri, oc_map,
-                        namespaces=None,
-                        clusters=None,
-                        override_managed_types=None,
-                        managed_types_key='managedResourceTypes'):
+def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
+                        namespaces: Optional[Iterable[Mapping]] = None,
+                        clusters: Optional[Iterable[Mapping]] = None,
+                        override_managed_types: Optional[Iterable[str]] = None,
+                        managed_types_key: str = 'managedResourceTypes'
+                        ) -> List[StateSpec]:
     state_specs = []
 
     if clusters and namespaces:
@@ -57,9 +61,10 @@ def init_specs_to_fetch(ri, oc_map,
     elif namespaces:
         for namespace_info in namespaces:
             if override_managed_types is None:
-                managed_types = namespace_info.get(managed_types_key)
+                managed_types = set(namespace_info.get(managed_types_key)
+                                    or [])
             else:
-                managed_types = override_managed_types
+                managed_types = set(override_managed_types)
 
             if not managed_types:
                 continue
@@ -73,35 +78,44 @@ def init_specs_to_fetch(ri, oc_map,
                 continue
 
             namespace = namespace_info['name']
+            # These may exit but have a value of None
             managed_resource_names = \
-                namespace_info.get('managedResourceNames')
+                namespace_info.get('managedResourceNames') or []
             managed_resource_type_overrides = \
-                namespace_info.get('managedResourceTypeOverrides')
+                namespace_info.get('managedResourceTypeOverrides') or []
 
             # Initialize current state specs
             for resource_type in managed_types:
                 ri.initialize_resource_type(cluster, namespace, resource_type)
-                # Handle case of specific managed resources
-                resource_names = \
-                    [mrn['resourceNames'] for mrn in managed_resource_names
-                     if mrn['resource'] == resource_type] \
-                    if managed_resource_names else None
-                # Handle case of resource type override
-                resource_type_override = \
-                    [mnto['override'] for mnto
-                     in managed_resource_type_overrides
-                     if mnto['resource'] == resource_type] \
-                    if managed_resource_type_overrides else None
-                # If not None, there is a single element in the list
-                if resource_names:
-                    [resource_names] = resource_names
-                if resource_type_override:
-                    [resource_type_override] = resource_type_override
+            resource_names = {}
+            resource_type_overrides = {}
+            for mrn in managed_resource_names:
+                # Current implementation guarantees only one
+                # managed_resource_name of each managed type
+                if mrn['resource'] in managed_types:
+                    resource_names[mrn['resource']] = mrn['resourceNames']
+                else:
+                    logging.info(
+                        f"Skipping non-managed resources {mrn} "
+                        f"on {cluster}/{namespace}"
+                    )
+
+            for o in managed_resource_type_overrides:
+                # Current implementation guarantees only one
+                # override of each managed type
+                if o['resource'] in managed_types:
+                    resource_type_overrides[o['resource']] = o['override']
+                else:
+                    logging.info(
+                        f"Skipping nom-managed override {o} "
+                        f"on {cluster}/{namespace}")
+
+            for kind, names in resource_names.items():
                 c_spec = StateSpec(
                     "current", oc, cluster, namespace,
-                    resource_type,
-                    resource_type_override=resource_type_override,
-                    resource_names=resource_names)
+                    kind,
+                    resource_type_override=resource_type_overrides.get(kind),
+                    resource_names=names)
                 state_specs.append(c_spec)
 
             # Initialize desired state specs
@@ -113,7 +127,7 @@ def init_specs_to_fetch(ri, oc_map,
     elif clusters:
         # set namespace to something indicative
         namespace = 'cluster'
-        for cluster_info in clusters or []:
+        for cluster_info in clusters:
             cluster = cluster_info['name']
             oc = oc_map.get(cluster)
             if not oc:

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -95,9 +95,9 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
                 if mrn['resource'] in managed_types:
                     resource_names[mrn['resource']] = mrn['resourceNames']
                 else:
-                    logging.info(
-                        f"Skipping non-managed resources {mrn} "
-                        f"on {cluster}/{namespace}"
+                    raise KeyError(
+                        f"Non-managed resource {mrn} listed on "
+                        f"{cluster}/{namespace}"
                     )
 
             for o in managed_resource_type_overrides:
@@ -106,9 +106,10 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
                 if o['resource'] in managed_types:
                     resource_type_overrides[o['resource']] = o['override']
                 else:
-                    logging.info(
-                        f"Skipping nom-managed override {o} "
-                        f"on {cluster}/{namespace}")
+                    raise KeyError(
+                        f"Non-managed override {o} listed "
+                        f"on {cluster}/{namespace}"
+                    )
 
             for kind, names in resource_names.items():
                 c_spec = StateSpec(

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -149,8 +149,19 @@ class TestInitSpecsToFetch(testslide.TestCase):
     def test_namespaces_no_managedresourcenames(self) -> None:
         self.namespaces[0]['managedResourceNames'] = None
         self.namespaces[0]['managedResourceTypeOverrides'] = None
-
+        self.maxDiff = None
         expected = [
+            sut.StateSpec(
+                type="current",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                parent=None,
+                resource="Template",
+                resource_names=None,
+                resource_type_override=None,
+
+            ),
             sut.StateSpec(
                 type="desired",
                 oc="stuff",

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -1,0 +1,181 @@
+from typing import List, cast
+
+import testslide
+import reconcile.openshift_base as sut
+import reconcile.utils.openshift_resource as resource
+import reconcile.utils.oc as oc
+
+
+class TestInitSpecsToFetch(testslide.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.resource_inventory = cast(
+            resource.ResourceInventory,
+            testslide.StrictMock(resource.ResourceInventory)
+        )
+
+        self.oc_map = cast(oc.OC_Map, testslide.StrictMock(oc.OC_Map))
+        self.mock_constructor(oc, 'OC_Map').to_return_value(self.oc_map)
+        self.namespaces = [
+            {
+                "name": "ns1",
+                "managedResourceTypes": ["Template"],
+                "cluster": {"name": "cs1"},
+                "managedResourceNames": [
+                    {"resource": "Template",
+                     "resourceNames": ["tp1", "tp2"],
+                     },
+                    {"resource": "Secret",
+                     "resourceNames": ["sc1"],
+                     }
+                ],
+                "openshiftResources": [
+                    {"provider": "resource",
+                     "path": "/some/path.yml"
+                     }
+                ]
+            }
+        ]
+
+        self.mock_callable(
+            self.resource_inventory, 'initialize_resource_type'
+        ).for_call(
+            'cs1', 'ns1', 'Template'
+        ).to_return_value(None)
+
+        self.mock_callable(
+            self.oc_map, 'get'
+        ).for_call("cs1").to_return_value("stuff")
+        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
+
+    def test_only_cluster_or_namespace(self) -> None:
+        with self.assertRaises(KeyError):
+            sut.init_specs_to_fetch(
+                self.resource_inventory,
+                self.oc_map,
+                [{"foo": "bar"}],
+                [{"name": 'cluster1'}],
+            )
+
+    def test_no_cluster_or_namespace(self) -> None:
+        with self.assertRaises(KeyError):
+            sut.init_specs_to_fetch(self.resource_inventory, self.oc_map)
+
+    def assert_specs_match(
+            self, result: List[sut.StateSpec], expected: List[sut.StateSpec]
+    ) -> None:
+        """Assert that two list of StateSpec are equal. Needed since StateSpec
+        doesn't implement __eq__ and it's not worth to add for we will convert
+        it to a dataclass when we move to Python 3.9"""
+        self.assertEqual(
+            [r.__dict__ for r in result],
+            [e.__dict__ for e in expected],
+        )
+
+    def test_namespaces_managed(self) -> None:
+        expected = [
+            sut.StateSpec(
+                type="current",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource="Template",
+                resource_names=["tp1", "tp2"],
+            ),
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+
+        rs = sut.init_specs_to_fetch(
+                self.resource_inventory,
+                self.oc_map,
+                namespaces=self.namespaces,
+            )
+
+        self.maxDiff = None
+        self.assert_specs_match(rs, expected)
+
+    def test_namespaces_managed_with_overrides(self) -> None:
+        self.namespaces[0]['managedResourceTypeOverrides'] = [
+            {
+                "resource": "Project",
+                "override": "something.project",
+            },
+            {
+                "resource": "Template",
+                "override": "something.template"
+            }
+        ]
+        expected = [
+            sut.StateSpec(
+                type="current",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource="Template",
+                resource_names=["tp1", "tp2"],
+                resource_type_override="something.template",
+            ),
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+
+        self.assert_specs_match(rs, expected)
+
+    def test_namespaces_no_managedresourcenames(self) -> None:
+        self.namespaces[0]['managedResourceNames'] = None
+        self.namespaces[0]['managedResourceTypeOverrides'] = None
+
+        expected = [
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+        self.assert_specs_match(rs, expected)
+
+    def test_namespaces_no_managedresourcetypes(self) -> None:
+        self.namespaces[0]['managedResourceTypes'] = None
+
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+        self.assertEqual(rs, [])


### PR DESCRIPTION
It is a configuration error for a namespace to list entries in
`managedResourceNames` or `managedResourceTypeOverrides` of kinds that
are not in `managedResourceTypes`.

The first step here is to re-add #1901 - it was doing most of the work
and had all the tests.

Then, we fix the bug that forced [its revert](#1911), together with
better tests.  In this case, when a namespace lists
`managedResourceTypes` that have no match in `managedResourceNames` we
still want to initialize an `StateSpec` - we may be adding resources
of this kind without modifying or overriding their names.

Finally, instead of logging stuff we raise `KeyError`, to let the
integration handle the error.

TODO: Adjust schemas to forbid the combination of empty/non-existing
`managedResourceTypes` with non-empty
`managedResourceNames`/`managedResourceTypeOverrides`.

To test this, I removed the `Template` entry from
`managedResourceTypes` in the openshift-config namespace of one of our
clusters, which has `Template` among its `managedResourceNames` - got
the expected exception:

    KeyError: "Non-managed resource {'resource': 'Template', 'resourceNames': ['project-request']} listed on app-sre-prod-01/openshift-config"

and the integration crashes. Do we want the integration to crash on
this? Do we want to capture the exception somewhere?

Fixes APPSRE-3890.
