### PR TITLE
Bump coverage thresholds

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ branch = True
 omit = reconcile/test/*
 
 [report]
-fail_under = 26.3
+fail_under = 27.35


### PR DESCRIPTION
Python 3.9 counts these differently (and I don't know why). We are now
at almost 27.4%.
