### PR TITLE
Generate click arguments on each integration run

### DIFF
--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -120,8 +120,8 @@ def main():
     start_http_server(9090)
 
     command = build_entry_point_func(COMMAND_NAME)
-    args = build_entry_point_args(command, CONFIG, DRY_RUN, INTEGRATION_NAME, INTEGRATION_EXTRA_ARGS)
     while True:
+        args = build_entry_point_args(command, CONFIG, DRY_RUN, INTEGRATION_NAME, INTEGRATION_EXTRA_ARGS)
         sleep = SLEEP_DURATION_SECS
         start_time = time.monotonic()
         # Running the integration via Click, so we don't have to replicate


### PR DESCRIPTION
Click consumes and removes elements from the argument list past along
to the execution of a command. Therefore the argument list can not be
reused accross integration runs, and a new one needs to be created
each time.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>