### PR TITLE
re-create target groups instead of updating them

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -12,7 +12,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
     python3 -m pip wheel . --wheel-dir /work/wheels
 
 
-FROM quay.io/app-sre/qontract-reconcile-base:0.6.2
+FROM quay.io/app-sre/qontract-reconcile-base:0.7.0
 
 # Cache mount. We don't need te wheel files in the final image.
 # This COPY will create a layer with all the wheel files to install the app.


### PR DESCRIPTION
This PR solves an issue where it is not possible to update a target group while it is attached to a rule/listener

The issue was described upstream in https://github.com/hashicorp/terraform-provider-aws/issues/636 which was closed without a fix

The approach to the fix takes inspiration from a workaround found on the upstream issue
- Use the random provider to generate an ID based on some values
- As long as the values (keepers) do not change across plan execution, the ID will remain the same
- Use the ID as part of the ALB target group name
- Set the target groups lifecycle policy `create_before_destroy` to `true` such that whenever a target group has to be re-created it is done so before the old resource is destroyed

This PR has been tested in staging and the existing ALB configurations will migrate transparently
