### PR TITLE
Fail again when resource names or overrides have unexpected kinds

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -93,10 +93,15 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
                 # managed_resource_name of each managed type
                 if mrn['resource'] in managed_types:
                     resource_names[mrn['resource']] = mrn['resourceNames']
+                elif override_managed_types:
+                    logging.debug(
+                        f"Skipping resource {mrn['resource']} in {cluster}/"
+                        f"{namespace} because the integration explicitly "
+                        "dismisses it")
                 else:
                     raise KeyError(
-                        f"Non-managed resource {mrn} listed on "
-                        f"{cluster}/{namespace}"
+                        f"Non-managed resource name {mrn} listed on "
+                        f"{cluster}/{namespace} (valid kinds: {managed_types})"
                     )
 
             for o in managed_resource_type_overrides:
@@ -104,10 +109,16 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
                 # override of each managed type
                 if o['resource'] in managed_types:
                     resource_type_overrides[o['resource']] = o['override']
+                elif override_managed_types:
+                    logging.debug(
+                        f"Skipping resource type override {o} listed on"
+                        f"{cluster}/{namespace} because the integration "
+                        "dismisses it explicitly"
+                    )
                 else:
                     raise KeyError(
-                        f"Non-managed override {o} listed "
-                        f"on {cluster}/{namespace}"
+                        f"Non-managed override {o} listed on "
+                        f"{cluster}/{namespace} (valid kinds: {managed_types})"
                     )
 
             for kind, names in resource_names.items():

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1,5 +1,8 @@
 import logging
 import itertools
+
+from typing import Optional, Iterable, Mapping
+
 import yaml
 
 from sretoolbox.utils import retry
@@ -44,11 +47,12 @@ class StateSpec:
         self.resource_names = resource_names
 
 
-def init_specs_to_fetch(ri, oc_map,
-                        namespaces=None,
-                        clusters=None,
-                        override_managed_types=None,
-                        managed_types_key='managedResourceTypes'):
+def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
+                        namespaces: Optional[Iterable[Mapping]] = None,
+                        clusters: Optional[Iterable[Mapping]] = None,
+                        override_managed_types: Optional[Iterable[str]] = None,
+                        managed_types_key: str = 'managedResourceTypes'
+                        ) -> list[StateSpec]:
     state_specs = []
 
     if clusters and namespaces:
@@ -56,9 +60,10 @@ def init_specs_to_fetch(ri, oc_map,
     elif namespaces:
         for namespace_info in namespaces:
             if override_managed_types is None:
-                managed_types = namespace_info.get(managed_types_key)
+                managed_types = set(namespace_info.get(managed_types_key)
+                                    or [])
             else:
-                managed_types = override_managed_types
+                managed_types = set(override_managed_types)
 
             if not managed_types:
                 continue
@@ -72,36 +77,61 @@ def init_specs_to_fetch(ri, oc_map,
                 continue
 
             namespace = namespace_info['name']
+            # These may exit but have a value of None
             managed_resource_names = \
-                namespace_info.get('managedResourceNames')
+                namespace_info.get('managedResourceNames') or []
             managed_resource_type_overrides = \
-                namespace_info.get('managedResourceTypeOverrides')
+                namespace_info.get('managedResourceTypeOverrides') or []
 
             # Initialize current state specs
             for resource_type in managed_types:
                 ri.initialize_resource_type(cluster, namespace, resource_type)
-                # Handle case of specific managed resources
-                resource_names = \
-                    [mrn['resourceNames'] for mrn in managed_resource_names
-                     if mrn['resource'] == resource_type] \
-                    if managed_resource_names else None
-                # Handle case of resource type override
-                resource_type_override = \
-                    [mnto['override'] for mnto
-                     in managed_resource_type_overrides
-                     if mnto['resource'] == resource_type] \
-                    if managed_resource_type_overrides else None
-                # If not None, there is a single element in the list
-                if resource_names:
-                    [resource_names] = resource_names
-                if resource_type_override:
-                    [resource_type_override] = resource_type_override
+            resource_names = {}
+            resource_type_overrides = {}
+            for mrn in managed_resource_names:
+                # Current implementation guarantees only one
+                # managed_resource_name of each managed type
+                if mrn['resource'] in managed_types:
+                    resource_names[mrn['resource']] = mrn['resourceNames']
+                else:
+                    raise KeyError(
+                        f"Non-managed resource {mrn} listed on "
+                        f"{cluster}/{namespace}"
+                    )
+
+            for o in managed_resource_type_overrides:
+                # Current implementation guarantees only one
+                # override of each managed type
+                if o['resource'] in managed_types:
+                    resource_type_overrides[o['resource']] = o['override']
+                else:
+                    raise KeyError(
+                        f"Non-managed override {o} listed "
+                        f"on {cluster}/{namespace}"
+                    )
+
+            for kind, names in resource_names.items():
                 c_spec = StateSpec(
                     "current", oc, cluster, namespace,
-                    resource_type,
-                    resource_type_override=resource_type_override,
-                    resource_names=resource_names)
+                    kind,
+                    resource_type_override=resource_type_overrides.get(kind),
+                    resource_names=names)
                 state_specs.append(c_spec)
+                managed_types.remove(kind)
+
+            # Produce "empty" StateSpec's for any resource type that
+            # doesn't have an explicit managedResourceName listed in
+            # the namespace
+            state_specs.extend(
+                StateSpec(
+                    "current",
+                    oc,
+                    cluster,
+                    namespace,
+                    t,
+                    resource_type_override=resource_type_overrides.get(t),
+                    resource_names=None
+                ) for t in managed_types)
 
             # Initialize desired state specs
             openshift_resources = namespace_info.get('openshiftResources')
@@ -112,7 +142,7 @@ def init_specs_to_fetch(ri, oc_map,
     elif clusters:
         # set namespace to something indicative
         namespace = 'cluster'
-        for cluster_info in clusters or []:
+        for cluster_info in clusters:
             cluster = cluster_info['name']
             oc = oc_map.get(cluster)
             if not oc:

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -3,6 +3,8 @@ import json
 import logging
 import sys
 
+from typing import Iterable, Tuple, Optional, Any
+
 from threading import Lock
 from textwrap import indent
 from sretoolbox.utils import retry
@@ -614,15 +616,17 @@ def fetch_states(spec, ri):
 
 
 def fetch_data(namespaces, thread_pool_size, internal, use_jump_host,
-               init_api_resources=False):
+               init_api_resources=False, overrides=None):
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
+    logging.debug(f"Overriding keys {overrides}")
     oc_map = OC_Map(namespaces=namespaces, integration=QONTRACT_INTEGRATION,
                     settings=settings, internal=internal,
                     use_jump_host=use_jump_host,
                     thread_pool_size=thread_pool_size,
                     init_api_resources=init_api_resources)
-    state_specs = ob.init_specs_to_fetch(ri, oc_map, namespaces=namespaces)
+    state_specs = ob.init_specs_to_fetch(ri, oc_map, namespaces=namespaces,
+                                         override_managed_types=overrides)
     threaded.run(fetch_states, state_specs, thread_pool_size, ri=ri)
 
     return oc_map, ri
@@ -640,24 +644,29 @@ def filter_namespaces_by_cluster_and_namespace(namespaces,
     return namespaces
 
 
-def canonicalize_namespaces(namespaces, providers):
+def canonicalize_namespaces(
+        namespaces: Iterable[dict[str, Any]], providers: list[str]
+) -> Tuple[list[dict[str, Any]], Optional[list[str]]]:
     canonicalized_namespaces = []
+    override = None
+    logging.debug(f"Received providers {providers}")
     for namespace_info in namespaces:
         ob.aggregate_shared_resources(namespace_info, 'openshiftResources')
-        openshift_resources = namespace_info.get('openshiftResources')
-        if openshift_resources:
-            for resource in openshift_resources[:]:
-                if resource['provider'] not in providers:
-                    openshift_resources.remove(resource)
-        if openshift_resources:
-            if len(providers) == 1:
-                if providers[0] == 'vault-secret':
-                    namespace_info['managedResourceTypes'] = ['Secret']
-                elif providers[0] == 'route':
-                    namespace_info['managedResourceTypes'] = ['Route']
+        openshift_resources: list = \
+            namespace_info.get('openshiftResources') or []
+        ors = [r for r in openshift_resources if r['provider'] in providers]
+        if ors and providers:
+            # For the time being we only care about the first item in
+            # providers
+            # TODO: confvert it to a scalar?
+            if providers[0] == 'vault-secret':
+                override = ['Secret']
+            elif providers[0] == 'route':
+                override = ['Route']
+            namespace_info['openshiftResources'] = ors
             canonicalized_namespaces.append(namespace_info)
-
-    return canonicalized_namespaces
+    logging.info(f"Overriding {override}")
+    return canonicalized_namespaces, override
 
 
 @defer
@@ -678,10 +687,10 @@ def run(dry_run, thread_pool_size=10, internal=None,
             cluster_name,
             namespace_name
         )
-    namespaces = canonicalize_namespaces(namespaces, providers)
+    namespaces, overrides = canonicalize_namespaces(namespaces, providers)
     oc_map, ri = \
         fetch_data(namespaces, thread_pool_size, internal, use_jump_host,
-                   init_api_resources=init_api_resources)
+                   init_api_resources=init_api_resources, overrides=overrides)
     defer(oc_map.cleanup)
 
     ob.realize_data(dry_run, oc_map, ri, thread_pool_size)

--- a/reconcile/test/fixtures/namespaces/openshift-resources-only.yml
+++ b/reconcile/test/fixtures/namespaces/openshift-resources-only.yml
@@ -1,0 +1,13 @@
+---
+name: ns1
+cluster:
+  name: cs1
+managedResourceTypes:
+  - Template
+openshiftResources:
+  - provider: resource
+    path: /some/path.yml
+  - provider: vault-secret
+    path: /secret/place.yml
+  - provider: route
+    path: /route/network.yml

--- a/reconcile/test/fixtures/namespaces/valid-ns.yml
+++ b/reconcile/test/fixtures/namespaces/valid-ns.yml
@@ -1,0 +1,14 @@
+---
+name: ns1
+cluster:
+  name: cs1
+managedResourceTypes:
+  - Template
+managedResourceNames:
+  - resource: Template
+    resourceNames:
+      - tp1
+      - tp2
+openshiftResources:
+  - provider: resource
+    path: /some/path.yml

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -1,0 +1,214 @@
+from typing import List, cast
+
+import testslide
+import reconcile.openshift_base as sut
+import reconcile.utils.openshift_resource as resource
+from reconcile.utils import oc
+
+
+class TestInitSpecsToFetch(testslide.TestCase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.resource_inventory = cast(
+            resource.ResourceInventory,
+            testslide.StrictMock(resource.ResourceInventory)
+        )
+
+        self.oc_map = cast(oc.OC_Map, testslide.StrictMock(oc.OC_Map))
+        self.mock_constructor(oc, 'OC_Map').to_return_value(self.oc_map)
+        self.namespaces = [
+            {
+                "name": "ns1",
+                "managedResourceTypes": ["Template"],
+                "cluster": {"name": "cs1"},
+                "managedResourceNames": [
+                    {"resource": "Template",
+                     "resourceNames": ["tp1", "tp2"],
+                     },
+                ],
+                "openshiftResources": [
+                    {"provider": "resource",
+                     "path": "/some/path.yml"
+                     }
+                ]
+            }
+        ]
+
+        self.mock_callable(
+            self.resource_inventory, 'initialize_resource_type'
+        ).for_call(
+            'cs1', 'ns1', 'Template'
+        ).to_return_value(None)
+
+        self.mock_callable(
+            self.oc_map, 'get'
+        ).for_call("cs1").to_return_value("stuff")
+        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
+
+    def test_only_cluster_or_namespace(self) -> None:
+        with self.assertRaises(KeyError):
+            sut.init_specs_to_fetch(
+                self.resource_inventory,
+                self.oc_map,
+                [{"foo": "bar"}],
+                [{"name": 'cluster1'}],
+            )
+
+    def test_no_cluster_or_namespace(self) -> None:
+        with self.assertRaises(KeyError):
+            sut.init_specs_to_fetch(self.resource_inventory, self.oc_map)
+
+    def assert_specs_match(
+            self, result: List[sut.StateSpec], expected: List[sut.StateSpec]
+    ) -> None:
+        """Assert that two list of StateSpec are equal. Needed since StateSpec
+        doesn't implement __eq__ and it's not worth to add for we will convert
+        it to a dataclass when we move to Python 3.9"""
+        self.assertEqual(
+            [r.__dict__ for r in result],
+            [e.__dict__ for e in expected],
+        )
+
+    def test_namespaces_managed(self) -> None:
+        expected = [
+            sut.StateSpec(
+                type="current",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource="Template",
+                resource_names=["tp1", "tp2"],
+            ),
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+        self.assert_specs_match(rs, expected)
+
+    def test_namespaces_managed_with_overrides(self) -> None:
+        self.namespaces[0]['managedResourceTypeOverrides'] = [
+            {
+                "resource": "Template",
+                "override": "something.template"
+            }
+        ]
+        expected = [
+            sut.StateSpec(
+                type="current",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource="Template",
+                resource_names=["tp1", "tp2"],
+                resource_type_override="something.template",
+            ),
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+
+        self.assert_specs_match(rs, expected)
+
+    def test_namespaces_no_managedresourcenames(self) -> None:
+        self.namespaces[0]['managedResourceNames'] = None
+        self.namespaces[0]['managedResourceTypeOverrides'] = None
+        self.maxDiff = None
+        expected = [
+            sut.StateSpec(
+                type="current",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                parent=None,
+                resource="Template",
+                resource_names=None,
+                resource_type_override=None,
+
+            ),
+            sut.StateSpec(
+                type="desired",
+                oc="stuff",
+                cluster="cs1",
+                namespace="ns1",
+                resource={
+                    "provider": "resource",
+                    "path": "/some/path.yml"
+                },
+                parent=self.namespaces[0]
+            )
+        ]
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+        self.assert_specs_match(rs, expected)
+
+    def test_namespaces_no_managedresourcetypes(self) -> None:
+        self.namespaces[0]['managedResourceTypes'] = None
+        rs = sut.init_specs_to_fetch(
+            self.resource_inventory,
+            self.oc_map,
+            namespaces=self.namespaces,
+        )
+
+        self.assertEqual(rs, [])
+
+    def test_namespaces_extra_managed_resource_name(self) -> None:
+        # mypy doesn't recognize that this is a list
+        self.namespaces[0]['managedResourceNames'].append(  # type: ignore
+            {
+                "resource": "Secret",
+                "resourceNames": ["s1", "s2"],
+            },
+        )
+
+        with self.assertRaises(KeyError):
+            sut.init_specs_to_fetch(
+                self.resource_inventory,
+                self.oc_map,
+                namespaces=self.namespaces,
+            )
+
+    def test_namespaces_extra_override(self) -> None:
+        self.namespaces[0]['managedResourceTypeOverrides'] = [
+            {
+                "resource": "Project",
+                "override": "something.project",
+            }
+        ]
+
+        with self.assertRaises(KeyError):
+            sut.init_specs_to_fetch(
+                self.resource_inventory,
+                self.oc_map,
+                namespaces=self.namespaces
+            )

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -1,0 +1,78 @@
+from unittest import TestCase
+from unittest.mock import patch
+from reconcile.test.fixtures import Fixtures
+
+from reconcile.openshift_resources_base import canonicalize_namespaces, ob
+
+
+@patch.object(ob, 'aggregate_shared_resources', autospec=True)
+class TestCanonicalizeNamespaces(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.fixture = Fixtures('namespaces')
+
+    def setUp(self):
+        self.namespaces = [
+            self.fixture.get_anymarkup('openshift-resources-only.yml')
+        ]
+
+    def test_secret(self, ob):
+        ns, override = canonicalize_namespaces(
+            self.namespaces, ['vault-secret'])
+        self.assertEqual(
+            (ns, override),
+            ([
+                {'name': 'ns1',
+                 'cluster': {'name': 'cs1'},
+                 'managedResourceTypes': ['Template'],
+                 'openshiftResources': [
+                     {
+                         'provider': 'vault-secret',
+                         'path': '/secret/place.yml',
+                     }
+                 ]
+                 }
+            ],
+                ['Secret']
+            ))
+
+    def test_route(self, ob):
+        ns, override = canonicalize_namespaces(
+            self.namespaces, ['route']
+        )
+        self.assertEqual(
+            (ns, override),
+            ([
+                {
+                    'name': 'ns1',
+                    'cluster': {'name': 'cs1'},
+                    'managedResourceTypes': ['Template'],
+                    'openshiftResources': [
+                        {
+                            'provider': 'route',
+                            'path': '/route/network.yml'
+                        }
+                    ]
+                }
+            ],
+                ['Route']
+            ))
+
+    def test_no_overrides(self, ob):
+        ns, override = canonicalize_namespaces(self.namespaces, ['resource'])
+        self.assertEqual(
+            (ns, override),
+            ([
+                {'name': 'ns1',
+                 'cluster': {'name': 'cs1'},
+                 'managedResourceTypes': ['Template'],
+                 'openshiftResources': [
+                     {
+                         'provider': 'resource',
+                         'path': '/some/path.yml'
+                     }
+                 ]
+                 }
+            ],
+                None
+            ))


### PR DESCRIPTION
See the description of #1986

We fix the bug that made it crash with integrations that wanted to
override managed resource types, such as openshift-limitranges or
openshift-vault-resources.

To achieve that, we rework how `openshift_resources_base` filters
`openshiftResources` in `canonicalize_namespaces`. We add type hints
to assist the refactoring and change its return type to make overrides
explicit.

Note to reviewers: the types for `canonicalize_namespaces` are
correct. We use features specific of `dict` and `list` that can't be
matched with `Mapping` or `Iterable` or any other abstraction.
