### PR TITLE
[vault] read v2 version should not be none

### DIFF
--- a/e2e_tests/test_base.py
+++ b/e2e_tests/test_base.py
@@ -25,6 +25,7 @@ CLUSTERS_QUERY = """
     automationToken {
       path
       field
+      version
       format
     }
     disable {

--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -70,6 +70,7 @@ CLUSTERS_QUERY = """
     automationToken {
       path
       field
+      version
       format
     }
   }

--- a/reconcile/openshift_network_policies.py
+++ b/reconcile/openshift_network_policies.py
@@ -30,6 +30,7 @@ NAMESPACES_QUERY = """
       automationToken {
         path
         field
+        version
         format
       }
       internal

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -126,6 +126,7 @@ NAMESPACES_QUERY = """
       automationToken {
         path
         field
+        version
         format
       }
       internal

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -29,7 +29,7 @@ from reconcile.utils.openshift_resource import (OpenshiftResource as OR,
                                                 ConstructResourceError,
                                                 ResourceInventory,
                                                 ResourceKeyExistsError)
-from reconcile.utils.vault import SecretVersionNotFound
+from reconcile.utils.vault import SecretVersionNotFound, SecretVersionIsNone
 from reconcile.utils.vault import VaultClient
 
 
@@ -485,7 +485,7 @@ def fetch_openshift_resource(resource, parent):
                 integration_version=QONTRACT_INTEGRATION_VERSION,
                 validate_alertmanager_config=validate_alertmanager_config,
                 alertmanager_config_key=alertmanager_config_key)
-        except SecretVersionNotFound as e:
+        except (SecretVersionNotFound, SecretVersionIsNone) as e:
             raise FetchVaultSecretError(e)
     elif provider == 'route':
         tls_path = resource['vault_tls_secret_path']

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -492,6 +492,7 @@ CLUSTERS_QUERY = """
     automationToken {
       path
       field
+      version
       format
     }
     internal
@@ -532,6 +533,7 @@ CLUSTERS_MINIMAL_QUERY = """
     automationToken {
       path
       field
+      version
       format
     }
     internal
@@ -593,6 +595,7 @@ KAFKA_CLUSTERS_QUERY = """
         automationToken {
           path
           field
+          version
           format
         }
       }
@@ -667,6 +670,7 @@ NAMESPACES_QUERY = """
       automationToken {
         path
         field
+        version
         format
       }
       internal
@@ -748,6 +752,7 @@ NAMESPACES_MINIMAL_QUERY = """
       automationToken {
         path
         field
+        version
         format
       }
       internal
@@ -789,6 +794,7 @@ namespace {
     automationToken {
       path
       field
+      version
       format
     }
     internal
@@ -822,6 +828,7 @@ SERVICEACCOUNT_TOKENS_QUERY = """
       automationToken {
         path
         field
+        version
         format
       }
       internal
@@ -1341,11 +1348,13 @@ SAAS_FILES_QUERY_V1 = """
             automationToken {
               path
               field
+              version
               format
             }
             clusterAdminAutomationToken {
               path
               field
+              version
               format
             }
             internal
@@ -1409,6 +1418,7 @@ SAAS_FILES_QUERY_V2 = """
             automationToken {
               path
               field
+              version
               format
             }
             internal
@@ -1490,11 +1500,13 @@ SAAS_FILES_QUERY_V2 = """
             automationToken {
               path
               field
+              version
               format
             }
             clusterAdminAutomationToken {
               path
               field
+              version
               format
             }
             internal
@@ -1645,6 +1657,7 @@ PIPELINES_PROVIDERS_QUERY = """
           automationToken {
             path
             field
+            version
             format
           }
           internal
@@ -1885,6 +1898,7 @@ OCP_RELEASE_ECR_MIRROR_QUERY = """
       automationToken {
         path
         field
+        version
         format
       }
       internal
@@ -2010,6 +2024,7 @@ SLO_DOCUMENTS_QUERY = """
         automationToken {
           path
           field
+          version
           format
         }
         prometheusUrl
@@ -2117,6 +2132,7 @@ GABI_INSTANCES_QUERY = """
           automationToken {
             path
             field
+            version
             format
           }
           internal

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -263,6 +263,7 @@ TF_NAMESPACES_QUERY = """
       automationToken {
         path
         field
+        version
         format
       }
       internal

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -27,6 +27,10 @@ class SecretAccessForbidden(Exception):
     pass
 
 
+class SecretVersionIsNone(Exception):
+    pass
+
+
 class SecretVersionNotFound(Exception):
     pass
 
@@ -138,6 +142,10 @@ class _VaultClient:
         path_split = path.split('/')
         mount_point = path_split[0]
         read_path = '/'.join(path_split[1:])
+        if version is None:
+            msg = ('version can not be null '
+                   f'for secret with path \'{path}\'.')
+            raise SecretVersionIsNone(msg)
         try:
             secret = self._client.secrets.kv.v2.read_secret_version(
                 mount_point=mount_point,


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4068

since read operations are cached, we can not allow for secrets in a kv v2 secret engine to be referenced without a version, since that prevents us from getting an expected result (i.e. we would get the latest version, which doesn't happen).

with this change, secrets in kv v2 secret engines can only be referenced together with a version.