### PR TITLE
[terraform-vpc-peerings] add support to provide role to assume for account-vpc

### DIFF
--- a/helm/qontract-reconcile/values-fedramp.yaml
+++ b/helm/qontract-reconcile/values-fedramp.yaml
@@ -107,6 +107,17 @@ integrations:
   logs:
     slack: true
   disableUnleash: true
+- name: terraform-vpc-peerings
+  resources:
+    requests:
+      memory: 2600Mi
+      cpu: 500m
+    limits:
+      memory: 3200Mi
+      cpu: 1400m
+  logs:
+    slack: true
+  disableUnleash: true
 - name: jenkins-job-builder
   resources:
     requests:

--- a/openshift/qontract-reconcile-fedramp.yaml
+++ b/openshift/qontract-reconcile-fedramp.yaml
@@ -1678,6 +1678,191 @@ objects:
         - name: fluentd-config
           emptyDir: {}
 - apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: qontract-reconcile-terraform-vpc-peerings
+    name: qontract-reconcile-terraform-vpc-peerings
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile-terraform-vpc-peerings
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile-terraform-vpc-peerings
+          component: qontract-reconcile
+      spec:
+        serviceAccountName: qontract-reconcile
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                key: slack.webhook_url
+                name: app-interface
+          - name: SLACK_CHANNEL
+            value: ${SLACK_CHANNEL}
+          - name: SLACK_ICON_EMOJI
+            value: ${SLACK_ICON_EMOJI}
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type slack
+                webhook_url ${SLACK_WEBHOOK_URL}
+                channel ${SLACK_CHANNEL}
+                icon_emoji ${SLACK_ICON_EMOJI}
+                username sd-app-sre-bot
+                flush_interval 10s
+                message "\`\`\`[terraform-vpc-peerings] %s\`\`\`"
+              </store>
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name terraform-vpc-peerings
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          ports:
+            - name: http
+              containerPort: 9090
+          env:
+          - name: SHARDS
+            value: "1"
+          - name: SHARD_ID
+            value: "0"
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: terraform-vpc-peerings
+          - name: INTEGRATION_EXTRA_ARGS
+            value: ""
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: GITHUB_API
+          - name: SENTRY_DSN
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
+          - name: SLOW_OC_RECONCILE_THRESHOLD
+            value: "${SLOW_OC_RECONCILE_THRESHOLD}"
+          - name: LOG_SLOW_OC_RECONCILE
+            value: "${LOG_SLOW_OC_RECONCILE}"
+          - name: USE_NATIVE_CLIENT
+            value: "${USE_NATIVE_CLIENT}"
+          resources:
+            limits:
+              cpu: ${TERRAFORM_VPC_PEERINGS_CPU_LIMIT}
+              memory: ${TERRAFORM_VPC_PEERINGS_MEMORY_LIMIT}
+            requests:
+              cpu: ${TERRAFORM_VPC_PEERINGS_CPU_REQUEST}
+              memory: ${TERRAFORM_VPC_PEERINGS_MEMORY_REQUEST}
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
+- apiVersion: apps/v1
   kind: StatefulSet
   metadata:
     labels:
@@ -3330,6 +3515,14 @@ parameters:
   value: 400m
 - name: TERRAFORM_TGW_ATTACHMENTS_MEMORY_REQUEST
   value: 2300Mi
+- name: TERRAFORM_VPC_PEERINGS_CPU_LIMIT
+  value: 1400m
+- name: TERRAFORM_VPC_PEERINGS_MEMORY_LIMIT
+  value: 3200Mi
+- name: TERRAFORM_VPC_PEERINGS_CPU_REQUEST
+  value: 500m
+- name: TERRAFORM_VPC_PEERINGS_MEMORY_REQUEST
+  value: 2600Mi
 - name: JENKINS_JOB_BUILDER_CPU_LIMIT
   value: 200m
 - name: JENKINS_JOB_BUILDER_MEMORY_LIMIT

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -467,6 +467,7 @@ CLUSTERS_QUERY = """
             cidr_block
             region
           }
+          assumeRole
         }
         ... on ClusterPeeringConnectionAccountVPCMesh_v1 {
           account {

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -369,7 +369,8 @@ def build_desired_state_vpc_single_cluster(cluster_info, ocm: Optional[OCM],
     return desired_state
 
 
-def build_desired_state_vpc(clusters, ocm_map: Optional[OCMMap], awsapi: AWSApi):
+def build_desired_state_vpc(clusters, ocm_map: Optional[OCMMap],
+                            awsapi: AWSApi):
     """
     Fetch state for VPC peerings between a cluster and a VPC (account)
     """

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -398,7 +398,8 @@ def run(dry_run, print_to_file=None,
                 if c.get('peering') is not None]
     with_ocm = any(c.get('ocm') for c in clusters)
     if with_ocm:
-        ocm_map = ocm.OCMMap(clusters=clusters, integration=QONTRACT_INTEGRATION,
+        ocm_map = ocm.OCMMap(clusters=clusters,
+                             integration=QONTRACT_INTEGRATION,
                              settings=settings)
     else:
         # this is a case for an OCP cluster which is not provisioned

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -176,7 +176,7 @@ def build_desired_state_all_clusters(clusters, ocm_map: OCMMap,
     """
     Fetch state for VPC peerings between two OCM clusters
     """
-    desired_state = []
+    desired_state: list[dict] = []
     error = False
     if not ocm_map:
         logging.debug('cluster-vpc is not yet supported without OCM')
@@ -276,7 +276,7 @@ def build_desired_state_vpc_mesh(clusters, ocm_map: OCMMap, awsapi: AWSApi):
     """
     Fetch state for VPC peerings between a cluster and all VPCs in an account
     """
-    desired_state = []
+    desired_state: list[dict] = []
     error = False
     if not ocm_map:
         logging.debug('account-vpc-mesh is not yet supported without OCM')

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -116,7 +116,7 @@ def build_desired_state_single_cluster(cluster_info, ocm_map: OCMMap,
             )
         if requester_vpc_id is None:
             raise BadTerraformPeeringState(
-                f'[{cluster_name} could not find VPC ID for cluster'
+                f'[{cluster_name}] could not find VPC ID for cluster'
             )
 
         requester = {
@@ -351,7 +351,7 @@ def build_desired_state_vpc_single_cluster(cluster_info, ocm: OCM,
 
         if requester_vpc_id is None:
             raise BadTerraformPeeringState(
-                f'[{cluster} could not find VPC ID for cluster'
+                f'[{cluster}] could not find VPC ID for cluster'
             )
         requester['vpc_id'] = requester_vpc_id
         requester['route_table_ids'] = requester_route_table_ids

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import json
+from typing import Union
 
 from reconcile import queries
 from reconcile.utils import aws_api
@@ -171,7 +172,7 @@ def build_desired_state_single_cluster(cluster_info, ocm_map: OCMMap,
     return peerings
 
 
-def build_desired_state_all_clusters(clusters, ocm_map: OCMMap,
+def build_desired_state_all_clusters(clusters, ocm_map: Union[OCMMap, dict],
                                      awsapi: AWSApi):
     """
     Fetch state for VPC peerings between two OCM clusters
@@ -272,7 +273,8 @@ def build_desired_state_vpc_mesh_single_cluster(cluster_info, ocm: OCM,
     return desired_state
 
 
-def build_desired_state_vpc_mesh(clusters, ocm_map: OCMMap, awsapi: AWSApi):
+def build_desired_state_vpc_mesh(clusters, ocm_map: Union[OCMMap, dict],
+                                 awsapi: AWSApi):
     """
     Fetch state for VPC peerings between a cluster and all VPCs in an account
     """
@@ -368,7 +370,8 @@ def build_desired_state_vpc_single_cluster(cluster_info, ocm: OCM,
     return desired_state
 
 
-def build_desired_state_vpc(clusters, ocm_map: OCMMap, awsapi: AWSApi):
+def build_desired_state_vpc(clusters, ocm_map: Union[OCMMap, dict],
+                            awsapi: AWSApi):
     """
     Fetch state for VPC peerings between a cluster and a VPC (account)
     """

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -196,7 +196,8 @@ def build_desired_state_all_clusters(clusters, ocm_map: OCMMap,
     return desired_state, error
 
 
-def build_desired_state_vpc_mesh_single_cluster(cluster_info, ocm: OCM, awsapi: AWSApi):
+def build_desired_state_vpc_mesh_single_cluster(cluster_info, ocm: OCM,
+                                                awsapi: AWSApi):
     desired_state = []
 
     cluster = cluster_info['name']
@@ -270,8 +271,7 @@ def build_desired_state_vpc_mesh_single_cluster(cluster_info, ocm: OCM, awsapi: 
     return desired_state
 
 
-def build_desired_state_vpc_mesh(clusters, ocm_map: OCMMap,
-                                 awsapi: AWSApi):
+def build_desired_state_vpc_mesh(clusters, ocm_map: OCMMap, awsapi: AWSApi):
     """
     Fetch state for VPC peerings between a cluster and all VPCs in an account
     """

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -330,13 +330,18 @@ def build_desired_state_vpc_single_cluster(cluster_info, ocm: Optional[OCM],
         # there is no OCM at all.
         if provided_assume_role:
             account['assume_role'] = provided_assume_role
-        else:
+        elif ocm is not None:
             account['assume_role'] = \
                 ocm.get_aws_infrastructure_access_terraform_assume_role(
                 cluster,
                 peer_vpc['account']['uid'],
                 peer_vpc['account']['terraformUsername']
             )
+        else:
+            raise KeyError(
+                f'[{cluster}] peering connection '
+                f'{connection_name} must either specify assumeRole '
+                'or ocm should be defined to obtain role to assume')
         account['assume_region'] = requester['region']
         account['assume_cidr'] = requester['cidr_block']
         requester_vpc_id, requester_route_table_ids, _ = \

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -179,7 +179,7 @@ def build_desired_state_all_clusters(clusters, ocm_map: OCMMap,
     desired_state = []
     error = False
     if not ocm_map:
-        logging.warning('cluster-vpc is not yet supported without OCM')
+        logging.debug('cluster-vpc is not yet supported without OCM')
         return desired_state, error
 
     for cluster_info in clusters:
@@ -279,7 +279,7 @@ def build_desired_state_vpc_mesh(clusters, ocm_map: OCMMap, awsapi: AWSApi):
     desired_state = []
     error = False
     if not ocm_map:
-        logging.warning('account-vpc-mesh is not yet supported without OCM')
+        logging.debug('account-vpc-mesh is not yet supported without OCM')
         return desired_state, error
 
     for cluster_info in clusters:

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -196,8 +196,7 @@ def build_desired_state_all_clusters(clusters, ocm_map: OCMMap,
     return desired_state, error
 
 
-def build_desired_state_vpc_mesh_single_cluster(cluster_info, ocm: OCM,
-                                                awsapi: AWSApi):
+def build_desired_state_vpc_mesh_single_cluster(cluster_info, ocm: OCM, awsapi: AWSApi):
     desired_state = []
 
     cluster = cluster_info['name']
@@ -365,8 +364,7 @@ def build_desired_state_vpc_single_cluster(cluster_info, ocm: Optional[OCM],
     return desired_state
 
 
-def build_desired_state_vpc(clusters, ocm_map: Optional[OCMMap],
-                            awsapi: AWSApi):
+def build_desired_state_vpc(clusters, ocm_map: Optional[OCMMap], awsapi: AWSApi):
     """
     Fetch state for VPC peerings between a cluster and a VPC (account)
     """

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -89,7 +89,7 @@ class TestRun(testslide.TestCase):
         }])
         self.clusters = self.mock_callable(
             queries, 'get_clusters').to_return_value([
-                {"name": "aname", "peering": {"apeering"}}
+                {"name": "aname", "ocm": "aocm", "peering": {"apeering"}}
             ]).and_assert_called_once()
         self.settings = self.mock_callable(
             queries, 'get_app_interface_settings').to_return_value(

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -41,9 +41,7 @@ class TestAWSAccountFromInfrastructureAccess(testslide.TestCase):
                 }
             ]
         }
-        self.ocm_map = {
-            'cluster': MockOCM()
-        }
+        self.ocm = MockOCM()
 
     def test_aws_account_from_infrastructure_access(self):
         expected_result = {
@@ -56,12 +54,12 @@ class TestAWSAccountFromInfrastructureAccess(testslide.TestCase):
             'assume_cidr': 'vpc'
         }
         account = integ.aws_account_from_infrastructure_access(
-            self.cluster, 'read-only', self.ocm_map)
+            self.cluster, 'read-only', self.ocm)
         self.assertEqual(account, expected_result)
 
     def test_aws_account_from_infrastructure_access_none(self):
         account = integ.aws_account_from_infrastructure_access(
-            self.cluster, 'not-read-only', self.ocm_map)
+            self.cluster, 'not-read-only', self.ocm)
         self.assertIsNone(account)
 
 

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -112,7 +112,7 @@ class TestBuildDesiredStateAllClusters(testslide.TestCase):
             }
         ]
         self.build_single_cluster.for_call(
-            self.clusters[0], self.ocm_map, self.awsapi
+            self.clusters[0], self.ocm, self.awsapi
         ).to_return_value(expected).and_assert_called_once()
 
         rs = sut.build_desired_state_all_clusters(
@@ -223,14 +223,14 @@ class TestBuildDesiredStateSingleCluster(testslide.TestCase):
         self.mock_callable(
             sut, 'aws_account_from_infrastructure_access'
         ).for_call(
-            self.cluster, 'network-mgmt', self.ocm_map
+            self.cluster, 'network-mgmt', self.ocm
         ).to_return_value(
             self.aws_account
         ).and_assert_called_once()
         self.mock_callable(
             sut, 'aws_account_from_infrastructure_access'
         ).for_call(
-            self.peer_cluster, 'network-mgmt', self.ocm_map
+            self.peer_cluster, 'network-mgmt', self.ocm
         ).to_return_value(self.aws_account).and_assert_called_once()
         self.find_matching_peering.for_call(
             self.cluster, self.cluster['peering']['connections'][0],
@@ -293,7 +293,7 @@ class TestBuildDesiredStateSingleCluster(testslide.TestCase):
             }
         ]
         rs = sut.build_desired_state_single_cluster(
-            self.cluster, self.ocm_map, self.awsapi
+            self.cluster, self.ocm, self.awsapi
         )
         self.assertEqual(rs, expected)
 
@@ -303,7 +303,7 @@ class TestBuildDesiredStateSingleCluster(testslide.TestCase):
             sut, 'aws_account_from_infrastructure_access'
         ).to_return_value(self.aws_account).and_assert_called_once()
         rs = sut.build_desired_state_single_cluster(
-            self.cluster, self.ocm_map, self.awsapi
+            self.cluster, self.ocm, self.awsapi
         )
         self.assertEqual(rs, [])
 
@@ -314,7 +314,7 @@ class TestBuildDesiredStateSingleCluster(testslide.TestCase):
         self.find_matching_peering.to_return_value(None)
         with self.assertRaises(sut.BadTerraformPeeringState):
             sut.build_desired_state_single_cluster(
-                self.cluster, self.ocm_map, self.awsapi
+                self.cluster, self.ocm, self.awsapi
             )
 
     def test_no_vpc_in_aws(self):
@@ -330,19 +330,19 @@ class TestBuildDesiredStateSingleCluster(testslide.TestCase):
 
         with self.assertRaises(sut.BadTerraformPeeringState):
             sut.build_desired_state_single_cluster(
-                self.cluster, self.ocm_map, self.awsapi
+                self.cluster, self.ocm, self.awsapi
             )
 
     def test_no_peer_account(self):
         self.mock_callable(
             sut, 'aws_account_from_infrastructure_access'
         ).for_call(
-            self.cluster, 'network-mgmt', self.ocm_map
+            self.cluster, 'network-mgmt', self.ocm
         ).to_return_value(self.aws_account)
         self.mock_callable(
             sut, 'aws_account_from_infrastructure_access'
         ).for_call(
-            self.peer_cluster, 'network-mgmt', self.ocm_map
+            self.peer_cluster, 'network-mgmt', self.ocm
         ).to_return_value(None).and_assert_called_once()
         self.find_matching_peering.to_return_value(self.peer)
         self.mock_callable(
@@ -353,7 +353,7 @@ class TestBuildDesiredStateSingleCluster(testslide.TestCase):
 
         with self.assertRaises(sut.BadTerraformPeeringState):
             sut.build_desired_state_single_cluster(
-                self.cluster, self.ocm_map, self.awsapi
+                self.cluster, self.ocm, self.awsapi
             )
 
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4092

depends on https://github.com/app-sre/qontract-schemas/pull/13

to be able to create vpc peerings without OCM using the account-vpc provider.
