### PR TITLE
[terraform-aws-route53] do not set ttl on alias

### DIFF
--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -490,8 +490,9 @@ class TerrascriptClient:
                     record_id = f"{record_id}_{counts[record_id]}"
 
                 # Use default TTL if none is specified
+                # or if this record is an alias
                 # None/zero is accepted but not a good default
-                if record.get('ttl') is None:
+                if not record.get('alias') and record.get('ttl') is None:
                     record['ttl'] = default_ttl
 
                 # Define healthcheck if needed


### PR DESCRIPTION
`alias` conflicts with `ttl` and `records`: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record#alias