### PR TITLE
Guaranteed default QoS for deploy resources

### DIFF
--- a/reconcile/openshift_tekton_resources.py
+++ b/reconcile/openshift_tekton_resources.py
@@ -25,8 +25,8 @@ RESOURCE_MAX_LENGTH = 63
 
 # Defaults
 DEFAULT_DEPLOY_RESOURCES_STEP_NAME = 'qontract-reconcile'
-DEFAULT_DEPLOY_RESOURCES = {'requests': {'cpu': '50m',
-                                         'memory': '200Mi'},
+DEFAULT_DEPLOY_RESOURCES = {'requests': {'cpu': '200m',
+                                         'memory': '300Mi'},
                             'limits': {'cpu': '200m',
                                        'memory': '300Mi'}}
 # Queries


### PR DESCRIPTION
We don't want to have any overcommit issues with deployments which are a
critical part of our infra. We want to make sure that every taskrun
scheduled will have enough node resources and potential problems will
only come from the limits being too strict.

Part of APPSRE-3389

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>