### PR TITLE
[terraform-resources] support openshift service for alb

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -247,6 +247,7 @@ AWS_ACCOUNTS_QUERY = """
     path
     name
     uid
+    terraformUsername
     consoleUrl
     resourcesDefaultRegion
     supportedDeploymentRegions

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -231,6 +231,7 @@ provider
       write
     }
     ips
+    openshift_service
   }
   paths {
     read

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -272,6 +272,9 @@ TF_NAMESPACES_QUERY = """
         version
         format
       }
+      spec {
+        region
+      }
       internal
     }
   }

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from threading import Lock
 from typing import TYPE_CHECKING
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
-from typing_extensions import Literal
 
 from boto3 import Session
 from sretoolbox.utils import threaded

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from threading import Lock
 from typing import TYPE_CHECKING
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+from typing_extensions import Literal
 
 from boto3 import Session
 from sretoolbox.utils import threaded
@@ -716,7 +717,7 @@ class AWSApi:
     # pylint: disable=method-hidden
     def _get_assumed_role_client(self, account_name: str, assume_role: str,
                                  assume_region: str,
-                                 client_type: str = 'ec2') -> EC2Client:
+                                 client_type='ec2') -> EC2Client:
         assumed_session = self._get_assume_role_session(account_name,
                                                         assume_role,
                                                         assume_region)

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -848,7 +848,7 @@ class AWSApi:
         lbs = elb_client.describe_load_balancers()['LoadBalancerDescriptions']
         result_ips = set()
         for lb in lbs:
-            lb_name = lb['LoadBalancerArn']
+            lb_name = lb['LoadBalancerName']
             tag_descriptions = elb_client.describe_tags(
                 LoadBalancerNames=[lb_name]
             )['TagDescriptions']

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -837,6 +837,9 @@ class AWSApi:
 
         return results
 
+    def get_alb_network_interface_ips(self, account, service_name):
+        raise NotImplemented('get_alb_network_interface_ips')
+
     @staticmethod
     # pylint: disable=method-hidden
     def get_vpc_default_sg_id(vpc_id: str, ec2: EC2Client) -> Optional[str]:

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -715,11 +715,12 @@ class AWSApi:
 
     # pylint: disable=method-hidden
     def _get_assumed_role_client(self, account_name: str, assume_role: str,
-                                 assume_region: str) -> EC2Client:
+                                 assume_region: str,
+                                 client_type: str = 'ec2') -> EC2Client:
         assumed_session = self._get_assume_role_session(account_name,
                                                         assume_role,
                                                         assume_region)
-        return assumed_session.client('ec2')
+        return assumed_session.client(client_type)
 
     @staticmethod
     # pylint: disable=method-hidden

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3394,7 +3394,7 @@ class TerrascriptClient:
                 cluster['name'],
                 account['uid'],
                 account['terraformUsername'],
-            ),
+            )
         account['assume_region'] = cluster['spec']['region']
         service_name = \
             f"{namespace_info['name']}/{openshift_service}"

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3527,7 +3527,7 @@ class TerrascriptClient:
             }
             write_weighted_target_groups.append(write_weighted_item)
 
-            for ip in t['ips']:
+            for ip in target_ips:
                 # https://www.terraform.io/docs/providers/aws/r/
                 # lb_target_group_attachment.html
                 values = {

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3464,7 +3464,14 @@ class TerrascriptClient:
         write_weighted_target_groups = []
         for t in resource['targets']:
             target_name = t['name']
-            target_ips = t['ips']
+            t_openshift_service = t.get('openshift_service')
+            t_ips = t.get('ips')
+            if t_openshift_service:
+                raise NotImplemented('alb target openshift_service')
+            elif t_ips:
+                target_ips = t_ips
+            else:
+                raise KeyError('expected one of openshift_service or ips.')
 
             # https://www.terraform.io/docs/providers/random/r/id
             # The random ID will regenerate based on the 'keepers' values


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4107

depends on https://github.com/app-sre/qontract-schemas/pull/20

This allows for setting an OpenShift Service name as the target for an ALB.
With `openshift_service` defined, the integration will search the cluster's AWS account for a load balancer matching the OpenShift service, find its network interfaces and get their private IP (instead of manually doing it and hard coding the IP).

it is strongly recommended to review commit by commit.