### PR TITLE
add integration for status page component management

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -107,6 +107,7 @@ import reconcile.dashdotdb_slo
 import reconcile.jenkins_job_builds_cleaner
 import reconcile.cluster_deployment_mapper
 import reconcile.gabi_authorized_users
+import reconcile.status_page_components
 
 from reconcile.status import ExitCodes
 from reconcile.status import RunningState
@@ -1441,3 +1442,9 @@ def gabi_authorized_users(ctx, thread_pool_size, internal, use_jump_host):
 @click.pass_context
 def dyn_traffic_director(ctx, enable_deletion):
     run_integration(reconcile.dyn_traffic_director, ctx.obj, enable_deletion)
+
+
+@integration.command()
+@click.pass_context
+def status_page_components(ctx):
+    run_integration(reconcile.status_page_components, ctx.obj)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2346,3 +2346,36 @@ DYN_TRAFFIC_DIRECTORS_QUERY = """
 def get_dyn_traffic_directors():
     gqlapi = gql.get_api()
     return gqlapi.query(DYN_TRAFFIC_DIRECTORS_QUERY)['dyn_traffic_directors']
+
+
+STATUS_PAGE_QUERY = """
+{
+  status_pages: status_page_v1 {
+    name
+    pageId
+    apiUrl
+    provider
+    credentials {
+      path
+      field
+      version
+      format
+    }
+    components {
+      name
+      displayName
+      description
+      path
+      groupName
+      apps {
+        name
+      }
+    }
+  }
+}
+"""
+
+
+def get_status_pages():
+    gqlapi = gql.get_api()
+    return gqlapi.query(STATUS_PAGE_QUERY)['status_pages']

--- a/reconcile/status_page_components.py
+++ b/reconcile/status_page_components.py
@@ -4,7 +4,7 @@ from typing import Optional, Any
 from collections.abc import Iterable
 import sys
 
-from pydantic import BaseModel, Field, validate_arguments
+from pydantic import BaseModel, Field
 from pydantic.networks import HttpUrl
 import statuspageio  # type: ignore
 

--- a/reconcile/status_page_components.py
+++ b/reconcile/status_page_components.py
@@ -1,0 +1,261 @@
+from abc import abstractmethod
+import logging
+from typing import Optional, Any
+from collections.abc import Iterable
+import sys
+
+from pydantic import BaseModel, Field, validate_arguments
+from pydantic.networks import HttpUrl
+import statuspageio  # type: ignore
+
+from reconcile import queries
+from reconcile.utils.semver_helper import make_semver
+from reconcile.utils.state import State
+from reconcile.utils.vaultsecretref import VaultSecretRef
+
+
+QONTRACT_INTEGRATION = "status-page-components"
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
+
+
+LOG = logging.getLogger(__name__)
+
+
+class AtlassianComponent(BaseModel):
+    """
+    atlassian status page REST schema for component
+    """
+
+    id: str
+    name: str
+    description: Optional[str]
+    position: int
+    status: str
+    automation_email: Optional[str]
+    group_id: Optional[str]
+    group: Optional[bool]
+    group_name: Optional[str]
+
+
+class StatusComponent(BaseModel):
+    """
+    app-interface schema dependencies/status-page-component-1
+    """
+
+    name: str
+    display_name: str = Field(..., alias="displayName")
+    description: Optional[str]
+    group_name: Optional[str] = Field(..., alias="groupName")
+    component_id: Optional[str]
+
+
+class StatusPageProvider(BaseModel):
+    """
+    Provider specific status page reconcile implementation is implemented
+    as a subclass of `StatusPageProvider`
+    """
+
+    @abstractmethod
+    def component_ids(self) -> Iterable[str]:
+        return []
+
+    @abstractmethod
+    def apply_component(self, dry_run: bool,
+                        desired: StatusComponent) -> Optional[str]:
+        return None
+
+    @abstractmethod
+    def delete_component(self, dry_run: bool, id: str):
+        return None
+
+
+class StatusPage(BaseModel):
+    """
+    app-interface schema dependencies/status-page-1
+    """
+
+    name: str
+    page_id: str = Field(..., alias="pageId")
+    api_url: HttpUrl = Field(..., alias="apiUrl")
+    credentials: VaultSecretRef
+    components: list[StatusComponent]
+    provider: str
+
+    def get_page_provider(self) -> StatusPageProvider:
+        if self.provider == "atlassian":
+            return AtlassianStatusPage(page_id=self.page_id,
+                                       api_url=self.api_url,
+                                       token=self.credentials.get("token"))
+        else:
+            raise ValueError(f"provider {self.provider} is not supported")
+
+    def reconcile(self, dry_run: bool, state: State):
+        name_to_id_state = state.get_all("")
+        page_provider = self.get_page_provider()
+
+        # restore component ids from state
+        for desired in self.components:
+            desired.component_id = name_to_id_state.get(desired.name)
+
+        # delete
+        id_to_name_state = {v: k for k, v in name_to_id_state.items()}
+        desired_component_names = [c.name for c in self.components]
+        for current_id in page_provider.component_ids():
+            # if the component is known to the state management and if it is
+            # not known to the desired state, it was once managed by this
+            # integration but was delete from app-interface -> delete from page
+            name_for_current_component = id_to_name_state.get(current_id)
+            if (name_for_current_component and
+               name_for_current_component not in desired_component_names):
+                LOG.info(f"delete component {name_for_current_component} "
+                         f"from page {self.name}")
+                page_provider.delete_component(dry_run, current_id)
+                state.rm(name_for_current_component)
+
+        # create and update
+        for desired in self.components:
+            component_id = page_provider.apply_component(dry_run, desired)
+            if component_id and desired.component_id != component_id:
+                self._bind_component(dry_run, desired, component_id, state)
+
+    def _bind_component(self, dry_run: bool,
+                        component: StatusComponent, component_id: str,
+                        state: State) -> None:
+        LOG.info(f"bind component {component.name} to ID {component_id} "
+                 f"on page {self.name}")
+        if not dry_run:
+            state.add(component.name, component_id, force=True)
+            component.component_id = component_id
+
+
+class AtlassianStatusPage(StatusPageProvider):
+
+    page_id: str
+    api_url: str
+    token: str
+
+    components_by_id: dict[str, AtlassianComponent] = {}
+    components_by_displayname: dict[str, AtlassianComponent] = {}
+    group_name_to_id: dict[str, str] = {}
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self._rebuild_state()
+
+    def _rebuild_state(self):
+        components = self._fetch_components()
+        self.components_by_id = {c.id: c for c in components}
+        self.components_by_displayname = {c.name: c for c in components}
+        self.group_name_to_id = {g.name: g.id for g in components if g.group}
+
+    def component_ids(self) -> Iterable[str]:
+        return self.components_by_id.keys()
+
+    def _find_component(self,
+                        component: StatusComponent
+                        ) -> Optional[AtlassianComponent]:
+        if component.component_id \
+           and component.component_id in self.components_by_id:
+            return self.components_by_id.get(component.component_id)
+        else:
+            return self.components_by_displayname.get(component.display_name)
+
+    def apply_component(self, dry_run: bool,
+                        desired: StatusComponent) -> Optional[str]:
+        current = self._find_component(desired)
+        if current \
+           and desired.display_name == current.name \
+           and desired.description == current.description \
+           and desired.group_name == current.group_name:
+            # todo logging
+            return current.id
+
+        # precheck - does the desired group exists?
+        group_id = None
+        if desired.group_name:
+            group_id = self.group_name_to_id.get(desired.group_name, None)
+            if not group_id:
+                raise ValueError(f"Group {desired.group_name} referenced "
+                                 f"by {desired.name} does not exist")
+
+        # Special handling if a component needs to be moved out of any grouping
+        # We would need to use the component_group endpoint but for now let's
+        # just raise this as an error because of lazyness へ‿(ツ)‿ㄏ
+        if current and current.group_name and not desired.group_name:
+            raise ValueError(f"Remove grouping from the component "
+                             f"{desired.group_name} is currently unsupported")
+
+        component_update = dict(
+            name=desired.display_name,
+            description=desired.description
+        )
+        if group_id:
+            component_update["group_id"] = group_id
+
+        if current:
+            LOG.info(f"update component {desired.name}: {component_update}")
+            if not dry_run:
+                self._update_component(current.id, component_update)
+            return current.id
+        else:
+            LOG.info(f"create component {desired.name}: {component_update}")
+            if not dry_run:
+                return self._create_component(component_update)
+            else:
+                return None
+
+    def _update_component(self, id: str, data: dict[str, Any]) -> None:
+        self._client().components.update(id, **data)
+
+    def _create_component(self, data: dict[str, Any]) -> Optional[str]:
+        result = self._client().components.create(**data)
+        return result.get("id")
+
+    def delete_component(self, dry_run: bool, id: str) -> None:
+        if not dry_run:
+            self._client().components.delete(id)
+            self._rebuild_state()
+
+    def _fetch_components(self) -> list[AtlassianComponent]:
+        raw_components = self._client().components.list()
+        group_ids_to_name = {g.id: g.name for g in raw_components if g.group}
+        return [
+            AtlassianComponent(
+                **c.toDict(),
+                group_name=group_ids_to_name.get(c.group_id, None)
+            )
+            for c in raw_components
+        ]
+
+    def _client(self):
+        return statuspageio.Client(api_key=self.token,
+                                   page_id=self.page_id,
+                                   organization_id="unset")
+
+
+def fetch_pages() -> list[StatusPage]:
+    return [StatusPage(**p) for p in queries.get_status_pages()]
+
+
+def get_state() -> State:
+    settings = queries.get_app_interface_settings()
+    accounts = queries.get_aws_accounts()
+    return State(integration=QONTRACT_INTEGRATION,
+                 accounts=accounts,
+                 settings=settings)
+
+
+def run(dry_run: bool = False):
+    state = get_state()
+    status_pages = fetch_pages()
+
+    page_reconcile_error_occured = False
+    for page in status_pages:
+        try:
+            page.reconcile(dry_run, state)
+        except Exception:
+            LOG.exception(f"failed to reconcile statuspage {page.name}")
+            page_reconcile_error_occured = True
+
+    if page_reconcile_error_occured:
+        sys.exit(1)

--- a/reconcile/status_page_components.py
+++ b/reconcile/status_page_components.py
@@ -110,7 +110,8 @@ class StatusPage(BaseModel):
                 LOG.info(f"delete component {name_for_current_component} "
                          f"from page {self.name}")
                 page_provider.delete_component(dry_run, current_id)
-                state.rm(name_for_current_component)
+                if not dry_run:
+                    state.rm(name_for_current_component)
 
         # create and update
         for desired in self.components:

--- a/reconcile/status_page_components.py
+++ b/reconcile/status_page_components.py
@@ -65,7 +65,7 @@ class StatusPageProvider(BaseModel):
         return None
 
     @abstractmethod
-    def delete_component(self, dry_run: bool, id: str):
+    def delete_component(self, dry_run: bool, id: str) -> None:
         return None
 
 

--- a/reconcile/status_page_components.py
+++ b/reconcile/status_page_components.py
@@ -248,13 +248,13 @@ def run(dry_run: bool = False):
     state = get_state()
     status_pages = fetch_pages()
 
-    page_reconcile_error_occured = False
+    error = False
     for page in status_pages:
         try:
             page.reconcile(dry_run, state)
         except Exception:
             LOG.exception(f"failed to reconcile statuspage {page.name}")
-            page_reconcile_error_occured = True
+            error = True
 
-    if page_reconcile_error_occured:
+    if error:
         sys.exit(1)

--- a/reconcile/test/fixtures/statuspage/test_bind_component.yaml
+++ b/reconcile/test/fixtures/statuspage/test_bind_component.yaml
@@ -1,0 +1,37 @@
+appInterface:
+  pages:
+  - name: page_1
+    pageId: page_1
+    apiUrl: 'https://api.statuspage.io'
+    credentials:
+      path: app-sre/creds/status.redhat.com
+      field: all
+    provider: atlassian
+    components:
+    - name: comp_1
+      displayName: Component 1
+      description: null
+      path: /dependencies/statuspage/test-component.yml
+      groupName: group_1
+      apps: []
+
+atlassianApi:
+  components:
+    page_1:
+    - id: comp_id_1
+      name: Component 1
+      descripton: null
+      position: 1
+      status: Ok
+      automation_email: automate-me@please.com
+      group_id: group_id_1
+      group: false
+      group_name: group_1
+    - id: group_id_1
+      name:  group_1
+      descripton: null
+      position: 1
+      status: Ok
+      automation_email: null
+      group_id: null
+      group: true

--- a/reconcile/test/fixtures/statuspage/test_create_component.yaml
+++ b/reconcile/test/fixtures/statuspage/test_create_component.yaml
@@ -1,0 +1,28 @@
+appInterface:
+  pages:
+  - name: page_1
+    pageId: page_1
+    apiUrl: 'https://api.statuspage.io'
+    credentials:
+      path: app-sre/creds/status.redhat.com
+      field: all
+    provider: atlassian
+    components:
+    - name: comp_1
+      displayName: Component 1
+      description: null
+      path: /dependencies/statuspage/test-component.yml
+      groupName: group_1
+      apps: []
+
+atlassianApi:
+  components:
+    page_1:
+    - id: group_id_1
+      name:  group_1
+      descripton: null
+      position: 1
+      status: Ok
+      automation_email: null
+      group_id: null
+      group: true

--- a/reconcile/test/fixtures/statuspage/test_delete_component.yaml
+++ b/reconcile/test/fixtures/statuspage/test_delete_component.yaml
@@ -1,0 +1,53 @@
+appInterface:
+  state:
+    comp_1: comp_id_1
+    comp_3: comp_id_3
+  pages:
+  - name: page_1
+    pageId: page_1
+    apiUrl: 'https://api.statuspage.io'
+    credentials:
+      path: app-sre/creds/status.redhat.com
+      field: all
+    provider: atlassian
+    components:
+    - name: comp_3
+      displayName: Component 3
+      description: null
+      path: /dependencies/statuspage/test-component.yml
+      groupName: group_1
+      apps: []
+
+atlassianApi:
+  components:
+    page_1:
+    # this one was previously managed by app-interface -> delete
+    - id: comp_id_1
+      name: Component 1
+      descripton: null
+      position: 1
+      status: Ok
+      automation_email: automate-me@please.com
+      group_id: group_id_1
+      group: false
+      group_name: group_1
+    # this one is not managed by app-interface -> ignore
+    - id: comp_id_2
+      name: Component 2
+      descripton: null
+      position: 1
+      status: Ok
+      automation_email: automate-me@please.com
+      group_id: group_id_1
+      group: false
+      group_name: group_1
+    # this one is still managed by app-interface -> keep
+    - id: comp_id_3
+      name: Component 3
+      descripton: null
+      position: 1
+      status: Ok
+      automation_email: automate-me@please.com
+      group_id: group_id_1
+      group: false
+      group_name: group_1

--- a/reconcile/test/fixtures/statuspage/test_group_does_not_exist.yaml
+++ b/reconcile/test/fixtures/statuspage/test_group_does_not_exist.yaml
@@ -1,0 +1,20 @@
+appInterface:
+  pages:
+  - name: page_1
+    pageId: page_1
+    apiUrl: 'https://api.statuspage.io'
+    credentials:
+      path: app-sre/creds/status.redhat.com
+      field: all
+    provider: atlassian
+    components:
+    - name: comp_1
+      displayName: Component 1
+      description: null
+      path: /dependencies/statuspage/test-component.yml
+      groupName: group_1
+      apps: []
+
+atlassianApi:
+  components:
+    page_1: []

--- a/reconcile/test/fixtures/statuspage/test_state_management_on_bind.yaml
+++ b/reconcile/test/fixtures/statuspage/test_state_management_on_bind.yaml
@@ -1,0 +1,30 @@
+appInterface:
+  pages:
+  - name: page_1
+    pageId: page_1
+    apiUrl: 'https://api.statuspage.io'
+    credentials:
+      path: app-sre/creds/status.redhat.com
+      field: all
+    provider: atlassian
+    components:
+    - name: comp_1
+      displayName: Component 1
+      description: null
+      path: /dependencies/statuspage/test-component.yml
+      groupName: group_1
+      apps: []
+
+atlassianApi:
+  components:
+    page_1:
+    - id: comp_id_1
+      name: Component 1
+      descripton: null
+      position: 1
+      status: Ok
+      automation_email: automate-me@please.com
+      group_id: group_id_1
+      group: false
+      group_name: group_1
+

--- a/reconcile/test/fixtures/statuspage/test_state_management_on_fetch.yaml
+++ b/reconcile/test/fixtures/statuspage/test_state_management_on_fetch.yaml
@@ -1,0 +1,24 @@
+appInterface:
+  state:
+    comp_1: comp_id_1
+  pages:
+  - name: page_1
+    pageId: page_1
+    apiUrl: 'https://api.statuspage.io'
+    credentials:
+      path: app-sre/creds/status.redhat.com
+      field: all
+    provider: atlassian
+    components:
+    - name: comp_1
+      displayName: Component 1
+      description: null
+      path: /dependencies/statuspage/test-component.yml
+      groupName: group_1
+      apps: []
+    - name: comp_2
+      displayName: Component 2
+      description: null
+      path: /dependencies/statuspage/test-component.yml
+      groupName: group_1
+      apps: []

--- a/reconcile/test/fixtures/statuspage/test_update_component.yaml
+++ b/reconcile/test/fixtures/statuspage/test_update_component.yaml
@@ -1,0 +1,97 @@
+appInterface:
+  state:
+    comp_1: comp_id_1
+    comp_2: comp_id_2
+    comp_3: comp_id_3
+    comp_4: comp_id_4
+  pages:
+  - name: page_1
+    pageId: page_1
+    apiUrl: 'https://api.statuspage.io'
+    credentials:
+      path: app-sre/creds/status.redhat.com
+      field: all
+    provider: atlassian
+    components:
+    - name: comp_1
+      displayName: Component 1
+      description: null
+      path: /dependencies/statuspage/test-component.yml
+      groupName: group_1
+      apps: []
+    - name: comp_2
+      displayName: Component 2
+      description: new description
+      path: /dependencies/statuspage/test-component.yml
+      groupName: group_1
+      apps: []
+    - name: comp_3
+      displayName: Component 3
+      description: null
+      path: /dependencies/statuspage/test-component.yml
+      groupName: group_1
+      apps: []
+    - name: comp_4
+      displayName: Component 4
+      description: null
+      path: /dependencies/statuspage/test-component.yml
+      groupName: group_1
+      apps: []
+
+atlassianApi:
+  components:
+    page_1:
+    # actual components
+    - id: comp_id_1
+      name: Component 1 Old
+      descripton: null
+      position: 1
+      status: Ok
+      automation_email: automate-me@please.com
+      group_id: group_id_1
+      group: false
+      group_name: group_1
+    - id: comp_id_2
+      name: Component 2
+      descripton: null
+      position: 2
+      status: Ok
+      automation_email: automate-me@please.com
+      group_id: group_id_1
+      group: false
+      group_name: group_1
+    - id: comp_id_3
+      name: Component 3
+      descripton: null
+      position: 3
+      status: Ok
+      automation_email: automate-me@please.com
+      group_id: group_id_2
+      group: false
+      group_name: group_2
+    - id: comp_id_4
+      name: Component 4
+      descripton: null
+      position: 1
+      status: Ok
+      automation_email: automate-me@please.com
+      group_id: group_id_1
+      group: false
+      group_name: group_1
+    # groups
+    - id: group_id_1
+      name:  group_1
+      descripton: null
+      position: 1
+      status: Ok
+      automation_email: null
+      group_id: null
+      group: true
+    - id: group_id_2
+      name:  group_2
+      descripton: null
+      position: 2
+      status: Ok
+      automation_email: null
+      group_id: null
+      group: true

--- a/reconcile/test/test_status_page_components.py
+++ b/reconcile/test/test_status_page_components.py
@@ -1,0 +1,291 @@
+from unittest import TestCase
+from unittest.mock import patch
+from typing import Optional
+
+from reconcile.status_page_components import (
+  AtlassianComponent, AtlassianStatusPage, StatusComponent, StatusPage)
+from reconcile.utils.vaultsecretref import VaultSecretRef
+from .fixtures import Fixtures
+
+
+fxt = Fixtures('statuspage')
+
+
+def get_page_fixtures(path: str) -> list[StatusPage]:
+    pages = fxt.get_anymarkup(path)["appInterface"]["pages"]
+    return [StatusPage(**p) for p in pages]
+
+
+def get_atlassian_component_fixtures(path: str, page_id: str) \
+        -> list[AtlassianComponent]:
+    components = fxt.get_anymarkup(path)["atlassianApi"]["components"][page_id]
+    return [AtlassianComponent(**p) for p in components]
+
+
+class StateStub:
+    """
+    dict based mock for reconcile.utils.state
+    """
+
+    def __init__(self, state=None):
+        if state is not None:
+            self.state = state
+        else:
+            self.state = {}
+
+    def get_all(self, _):
+        return self.state
+
+    def add(self, key, value, force=False):
+        self.state[key] = value
+
+    def rm(self, key):
+        del self.state[key]
+
+
+def get_state_fixture(path: str) -> StateStub:
+    return StateStub(fxt.get_anymarkup(path)["appInterface"]["state"])
+
+
+def component_to_dict(component: StatusComponent,
+                      group_id: Optional[str]) -> dict[str, Optional[str]]:
+    data = dict(
+        name=component.display_name,
+        description=component.description,
+    )
+    if group_id:
+        data["group_id"] = group_id
+    return data
+
+
+def stub_resolve_secret():
+    def f(self):
+        return {"token": "token"}
+    return f
+
+
+@patch.object(VaultSecretRef, '_resolve_secret',
+              new_callable=stub_resolve_secret)
+class TestReconcileLogic(TestCase):
+
+    @patch.object(AtlassianStatusPage, '_create_component')
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    def test_create_component(self, fetch_mock, create_mock, vault_mock):
+        """
+        Test if the creation logic is called for a component missing on the
+        status page.
+        """
+        fixture_name = "test_create_component.yaml"
+        fetch_mock.return_value = \
+            get_atlassian_component_fixtures(fixture_name, "page_1")
+        create_mock.return_value = None
+        page = get_page_fixtures(fixture_name)[0]
+
+        page.reconcile(False, StateStub())
+
+        create_mock.assert_called_with(
+            component_to_dict(page.components[0], "group_id_1")
+        )
+
+    @patch.object(StatusPage, '_bind_component')
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    def test_bind_component(self, fetch_mock, bind_mock, vault_mock):
+        """
+        Test if bind logic is called for a component that already exists on
+        the status page but is not bound to the one in desired state.
+        """
+        fixture_name = "test_bind_component.yaml"
+        fetch_mock.return_value = \
+            get_atlassian_component_fixtures(fixture_name, "page_1")
+        page = get_page_fixtures(fixture_name)[0]
+        state = StateStub()
+
+        # execute bind logic through reconciling
+        page.reconcile(False, state)
+
+        # check if binding was called
+        bind_mock.assert_called_with(False, page.components[0],
+                                     "comp_id_1", state)
+
+    @patch.object(AtlassianStatusPage, '_update_component')
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    def test_update_component(self, fetch_mock, update_mock, vault_mock):
+        """
+        Test if updates are triggered for components when their name, group
+        or description changes. The fixture for this test includes three
+        components, that need update for different reasons, and one component
+        that is up to date.
+        """
+        fixture_name = "test_update_component.yaml"
+        fetch_mock.return_value = \
+            get_atlassian_component_fixtures(fixture_name, "page_1")
+        update_mock.return_value = None
+        page = get_page_fixtures(fixture_name)[0]
+        self.assertEqual(len(page.components), 4)
+
+        page.reconcile(False, get_state_fixture(fixture_name))
+
+        update_mock.assert_any_call(
+            page.components[0].component_id,
+            component_to_dict(page.components[0], "group_id_1"))
+        update_mock.assert_any_call(
+            page.components[1].component_id,
+            component_to_dict(page.components[1], "group_id_1"))
+        update_mock.assert_any_call(
+            page.components[2].component_id,
+            component_to_dict(page.components[2], "group_id_1"))
+        self.assertEqual(update_mock.call_count, 3)
+
+    @patch.object(AtlassianStatusPage, 'delete_component')
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    def test_delete_component(self, fetch_mock, delete_mock, vault_mock):
+        """
+        Test if deletion is triggerd for a component that does not exist
+        anymore in app-interface, but is still known to the State and to
+        the status page.
+        """
+        fixture_name = "test_delete_component.yaml"
+        fetch_mock.return_value = \
+            get_atlassian_component_fixtures(fixture_name, "page_1")
+        delete_mock.return_value = None
+        page = get_page_fixtures(fixture_name)[0]
+        state = get_state_fixture(fixture_name)
+
+        page.reconcile(False, state)
+
+        delete_mock.assert_called_with(False, "comp_id_1")
+        self.assertEqual(delete_mock.call_count, 1)
+
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    def test_group_exists(self, fetch_mock, vault_mock):
+        """
+        Test if the creation logic is yielding an exception when a group is
+        referenced, that does not exist.
+        """
+        fixture_name = "test_group_does_not_exist.yaml"
+        fetch_mock.return_value = \
+            get_atlassian_component_fixtures(fixture_name, "page_1")
+        vault_mock.return_value = {"token": "token"}
+        page = get_page_fixtures(fixture_name)[0]
+        dry_run = True
+
+        with self.assertRaises(ValueError) as cm:
+            page.reconcile(dry_run, StateStub())
+        self.assertRegexpMatches(str(cm.exception), r"^Group.*does not exist$")
+
+
+class TestComponentOrdering(TestCase):
+
+    def test_place_component_in_empty_group(self):
+        pass
+
+    def test_place_component_in_group(self):
+        pass
+
+    def test_place_component_top_level(self):
+        pass
+
+
+@patch.object(VaultSecretRef, '_resolve_secret',
+              new_callable=stub_resolve_secret)
+class TestStateManagement(TestCase):
+
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    @patch.object(AtlassianStatusPage, 'apply_component')
+    def test_state_management_on_fetch(self, apply_mock, fetch_mock,
+                                       vault_mock):
+        """
+        Test if state management correctly relates component ids with
+        components declared in desired state.
+        """
+        fixture_name = "test_state_management_on_fetch.yaml"
+        apply_mock.return_value = None
+        fetch_mock.return_value = []
+        page = get_page_fixtures(fixture_name)[0]
+
+        page.reconcile(True, get_state_fixture(fixture_name))
+
+        for c in page.components:
+            if c.name == "comp_1":
+                self.assertEqual(c.component_id, "comp_id_1")
+            elif c.name == "comp_2":
+                self.assertIsNone(c.component_id)
+
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    def test_state_management_on_bind(self, fetch_mock, vault_mock):
+        """
+        Test if state management correctly binds components with their
+        corresponding id on the status page.
+        """
+        fixture_name = "test_state_management_on_bind.yaml"
+        fetch_mock.return_value = \
+            get_atlassian_component_fixtures(fixture_name, "page_1")
+        state = StateStub()
+        page = get_page_fixtures(fixture_name)[0]
+
+        page.reconcile(False, state)
+
+        self.assertEqual(page.components[0].component_id, "comp_id_1")
+        self.assertEqual(state.get_all("")["comp_1"], "comp_id_1")
+
+
+class TestDryRunBehaviour(TestCase):
+
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    @patch.object(AtlassianStatusPage, "_create_component")
+    def test_dry_run_on_create(self, create_mock, fetch_mock):
+        self._exec_dry_run_test_on_create(True, create_mock, fetch_mock)
+
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    @patch.object(AtlassianStatusPage, "_create_component")
+    def test_no_dry_run_on_create(self, create_mock, fetch_mock):
+        self._exec_dry_run_test_on_create(False, create_mock, fetch_mock)
+
+    def _exec_dry_run_test_on_create(self, dry_run, create_mock, fetch_mock):
+        create_mock.create.return_value = "id"
+        fetch_mock.return_value = []
+        provider = AtlassianStatusPage(page_id="page_id",
+                                       api_url="https://a.com",
+                                       token="token")
+
+        component = StatusComponent(name="comp_1", displayName="comp_1",
+                                    groupName=None)
+        provider.apply_component(dry_run, component)
+
+        if dry_run:
+            create_mock.assert_not_called()
+        else:
+            create_mock.assert_called()
+
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    @patch.object(AtlassianStatusPage, "_update_component")
+    def test_dry_run_on_update(self, update_mock, fetch_mock):
+        self._exec_dry_run_test_on_update(True, update_mock, fetch_mock)
+
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    @patch.object(AtlassianStatusPage, "_update_component")
+    def test_no_dry_run_on_update(self, update_mock, fetch_mock):
+        self._exec_dry_run_test_on_update(False, update_mock, fetch_mock)
+
+    def _exec_dry_run_test_on_update(self, dry_run, update_mock, fetch_mock):
+        fetch_mock.return_value = [
+            AtlassianComponent(
+                id="comp_id_1",
+                name="comp_1",
+                description="old description",
+                position=1,
+                status="ok"
+            )
+        ]
+        provider = AtlassianStatusPage(page_id="page_id",
+                                       api_url="https://a.com",
+                                       token="token")
+
+        component = StatusComponent(name="comp_1", displayName="comp_1",
+                                    groupName=None)
+        provider.apply_component(dry_run, component)
+
+        if dry_run:
+            update_mock.assert_not_called()
+        else:
+            update_mock.assert_called()

--- a/reconcile/test/test_status_page_components.py
+++ b/reconcile/test/test_status_page_components.py
@@ -300,6 +300,7 @@ class TestDryRunBehaviour(TestCase):
         provider = AtlassianStatusPage(page_id="page_id",
                                        api_url="https://a.com",
                                        token="token")
+        provider.rebuild_state()
 
         component = StatusComponent(name="comp_1", displayName="comp_1",
                                     groupName=None)

--- a/reconcile/test/test_status_page_components.py
+++ b/reconcile/test/test_status_page_components.py
@@ -64,13 +64,14 @@ def stub_resolve_secret():
     return f
 
 
-@patch.object(VaultSecretRef, '_resolve_secret',
-              new_callable=stub_resolve_secret)
 class TestReconcileLogic(TestCase):
 
+    @staticmethod
+    @patch.object(VaultSecretRef, '_resolve_secret',
+                  new_callable=stub_resolve_secret)
     @patch.object(AtlassianStatusPage, '_create_component')
     @patch.object(AtlassianStatusPage, '_fetch_components')
-    def test_create_component(self, fetch_mock, create_mock, vault_mock):
+    def test_create_component(fetch_mock, create_mock, vault_mock):
         """
         Test if the creation logic is called for a component missing on the
         status page.
@@ -87,9 +88,12 @@ class TestReconcileLogic(TestCase):
             component_to_dict(page.components[0], "group_id_1")
         )
 
+    @staticmethod
+    @patch.object(VaultSecretRef, '_resolve_secret',
+                  new_callable=stub_resolve_secret)
     @patch.object(StatusPage, '_bind_component')
     @patch.object(AtlassianStatusPage, '_fetch_components')
-    def test_bind_component(self, fetch_mock, bind_mock, vault_mock):
+    def test_bind_component(fetch_mock, bind_mock, vault_mock):
         """
         Test if bind logic is called for a component that already exists on
         the status page but is not bound to the one in desired state.
@@ -107,6 +111,8 @@ class TestReconcileLogic(TestCase):
         bind_mock.assert_called_with(False, page.components[0],
                                      "comp_id_1", state)
 
+    @patch.object(VaultSecretRef, '_resolve_secret',
+                  new_callable=stub_resolve_secret)
     @patch.object(AtlassianStatusPage, '_update_component')
     @patch.object(AtlassianStatusPage, '_fetch_components')
     def test_update_component(self, fetch_mock, update_mock, vault_mock):
@@ -136,6 +142,8 @@ class TestReconcileLogic(TestCase):
             component_to_dict(page.components[2], "group_id_1"))
         self.assertEqual(update_mock.call_count, 3)
 
+    @patch.object(VaultSecretRef, '_resolve_secret',
+                  new_callable=stub_resolve_secret)
     @patch.object(AtlassianStatusPage, 'delete_component')
     @patch.object(AtlassianStatusPage, '_fetch_components')
     def test_delete_component(self, fetch_mock, delete_mock, vault_mock):
@@ -156,6 +164,8 @@ class TestReconcileLogic(TestCase):
         delete_mock.assert_called_with(False, "comp_id_1")
         self.assertEqual(delete_mock.call_count, 1)
 
+    @patch.object(VaultSecretRef, '_resolve_secret',
+                  new_callable=stub_resolve_secret)
     @patch.object(AtlassianStatusPage, '_fetch_components')
     def test_group_exists(self, fetch_mock, vault_mock):
         """
@@ -171,7 +181,7 @@ class TestReconcileLogic(TestCase):
 
         with self.assertRaises(ValueError) as cm:
             page.reconcile(dry_run, StateStub())
-        self.assertRegexpMatches(str(cm.exception), r"^Group.*does not exist$")
+        self.assertRegex(str(cm.exception), r"^Group.*does not exist$")
 
 
 class TestComponentOrdering(TestCase):
@@ -231,17 +241,22 @@ class TestStateManagement(TestCase):
 
 class TestDryRunBehaviour(TestCase):
 
+    @staticmethod
     @patch.object(AtlassianStatusPage, '_fetch_components')
     @patch.object(AtlassianStatusPage, "_create_component")
-    def test_dry_run_on_create(self, create_mock, fetch_mock):
-        self._exec_dry_run_test_on_create(True, create_mock, fetch_mock)
+    def test_dry_run_on_create(create_mock, fetch_mock):
+        TestDryRunBehaviour._exec_dry_run_test_on_create(True, create_mock,
+                                                         fetch_mock)
 
+    @staticmethod
     @patch.object(AtlassianStatusPage, '_fetch_components')
     @patch.object(AtlassianStatusPage, "_create_component")
-    def test_no_dry_run_on_create(self, create_mock, fetch_mock):
-        self._exec_dry_run_test_on_create(False, create_mock, fetch_mock)
+    def test_no_dry_run_on_create(create_mock, fetch_mock):
+        TestDryRunBehaviour._exec_dry_run_test_on_create(False, create_mock,
+                                                         fetch_mock)
 
-    def _exec_dry_run_test_on_create(self, dry_run, create_mock, fetch_mock):
+    @staticmethod
+    def _exec_dry_run_test_on_create(dry_run, create_mock, fetch_mock):
         create_mock.create.return_value = "id"
         fetch_mock.return_value = []
         provider = AtlassianStatusPage(page_id="page_id",
@@ -257,17 +272,22 @@ class TestDryRunBehaviour(TestCase):
         else:
             create_mock.assert_called()
 
+    @staticmethod
     @patch.object(AtlassianStatusPage, '_fetch_components')
     @patch.object(AtlassianStatusPage, "_update_component")
-    def test_dry_run_on_update(self, update_mock, fetch_mock):
-        self._exec_dry_run_test_on_update(True, update_mock, fetch_mock)
+    def test_dry_run_on_update(update_mock, fetch_mock):
+        TestDryRunBehaviour._exec_dry_run_test_on_update(True, update_mock,
+                                                         fetch_mock)
 
+    @staticmethod
     @patch.object(AtlassianStatusPage, '_fetch_components')
     @patch.object(AtlassianStatusPage, "_update_component")
-    def test_no_dry_run_on_update(self, update_mock, fetch_mock):
-        self._exec_dry_run_test_on_update(False, update_mock, fetch_mock)
+    def test_no_dry_run_on_update(update_mock, fetch_mock):
+        TestDryRunBehaviour._exec_dry_run_test_on_update(False, update_mock,
+                                                         fetch_mock)
 
-    def _exec_dry_run_test_on_update(self, dry_run, update_mock, fetch_mock):
+    @staticmethod
+    def _exec_dry_run_test_on_update(dry_run, update_mock, fetch_mock):
         fetch_mock.return_value = [
             AtlassianComponent(
                 id="comp_id_1",

--- a/reconcile/utils/state.py
+++ b/reconcile/utils/state.py
@@ -148,7 +148,7 @@ class State:
         """
         Gets all keys and values from the state in the specified path.
         """
-        return {k.replace(f'/{path}/', ''): self.get(k.lstrip('/'))
+        return {k.replace(f'{path}/', '').strip('/'): self.get(k.lstrip('/'))
                 for k in self.ls() if k.startswith(f'/{path}')}
 
     def __getitem__(self, item):

--- a/reconcile/utils/vaultsecretref.py
+++ b/reconcile/utils/vaultsecretref.py
@@ -1,0 +1,33 @@
+from typing import Optional, cast
+
+from dataclasses import dataclass
+
+from reconcile.utils.vault import VaultClient, _VaultClient
+
+
+@dataclass
+class VaultSecretRef:
+
+    _ALL_FIELDS = "all"
+
+    path: str
+    field: str
+    format: Optional[str] = None
+    version: Optional[int] = None
+
+    def get(self, field=None, default=None):
+        secret_content = self._resolve_secret()
+        if field:
+            return secret_content.get(field, default)
+        elif self.field == VaultSecretRef._ALL_FIELDS:
+            return secret_content
+        else:
+            return secret_content.get(self.field, default)
+
+    def _resolve_secret(self) -> dict[str, str]:
+        vault_client = cast(_VaultClient, VaultClient())
+        if self.field == VaultSecretRef._ALL_FIELDS:
+            return vault_client.read_all(self.__dict__)
+        else:
+            field_value = vault_client.read(self.__dict__)
+            return {self.field: field_value}

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,8 @@ setup(
         "sshtunnel>=0.4.0",
         "croniter>=1.0.15,<1.1.0",
         "dyn~=1.8.1",
+        "transity-statuspageio>=0.0.3,<0.1",
+        "pydantic>=1.8.2,<1.9.0",
     ],
 
     test_suite="tests",

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps = -r{toxinidir}/requirements-test.txt
 [testenv:lint]
 commands =
     flake8 reconcile tools e2e_tests
-    pylint -j0 reconcile tools e2e_tests
+    pylint -j0 --extension-pkg-whitelist='pydantic' reconcile tools e2e_tests
 
 [testenv:type]
 commands = mypy {posargs}


### PR DESCRIPTION
### Overview
the new integration can create, update and delete status page components based on the qontract-schemas `dependencies/status-page-1.yml` and `dependencies/status-page-component-1.yml``

### atlassian page provider
The integration is currently implementing page management for Atlassian status pages (statuspage.io). Other status page provided can be added as necessary. The provider of a page is defined in the `provider` field of `dependencies/status-page-1.yml`

### pydantic
I wanted to point out the use of pydantic and dataclasses since this integration is also a POC for that approach. Please note the following:
* Field aliases are used to bridge the camelCase world of schemas with the snake_case world of python

Please also note that VaultSecretRef is not using pydantic but plain python dataclasses. I've chosen this approach to isolate the experiment with pydantic to the status_page_components.py file. 

### VaultSecretRef
I was playing a bit with consuming vault secrets a bit more conveniently directly from a declaration in a schema. So have a look at vaultsecretref.py and how it is used in status_page_component.py#StatusPage

