### PR TITLE
openshift_groups: catch exceptions and log error for context before re-throwing exception

### DIFF
--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -50,7 +50,14 @@ def get_cluster_state(group_items, oc_map):
         logging.log(level=oc.log_level, msg=oc.message)
         return results
     group_name = group_items["group_name"]
-    group = oc.get_group_if_exists(group_name)
+    try:
+        group = oc.get_group_if_exists(group_name)
+    except Exception as e:
+        msg = (
+            'could not get group state for cluster/group combination: {}/{}'
+        ).format(cluster, group_name)
+        logging.error(msg)
+        raise e
     if group is None:
         return results
     for user in group['users'] or []:


### PR DESCRIPTION
The integration is crashing on timeout issues and the exception does not have any context.

This is not ideal but this should be safe and will help find out what cluster/group is causing issues