### PR TITLE
[terraform-resources] only add ready network interfaces to ALB private IPs

### DIFF
--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -861,6 +861,8 @@ class AWSApi:
                 for ni in nis:
                     if ni['Description'] != f"ELB {lb_name}":
                         continue
+                    if ni['Status'] != 'in-use':
+                        continue
                     # found a network interface!
                     ip = ni['PrivateIpAddress']
                     result_ips.add(ip)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4117

this PR adds logic to skip "unready" network interfaces from being added to an ALB's IP list.