### PR TITLE
[terraform-users] add support to define alternate aws username

### DIFF
--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -13,6 +13,7 @@ TF_QUERY = """
   roles: roles_v1 {
     users {
       org_username
+      aws_username
       public_gpg_key
     }
     aws_groups {

--- a/reconcile/test/test_terrascript_client_utils.py
+++ b/reconcile/test/test_terrascript_client_utils.py
@@ -15,3 +15,18 @@ class TestSupportFunctions(TestCase):
             tsclient.safe_resource_id("*.foo.example.com"),
             "_star_foo_example_com"
         )
+
+    def test_aws_username_org(self):
+        result = 'org'
+        user = {
+            'org_username': result
+        }
+        self.assertEqual(tsclient._get_aws_username(user), result)
+
+    def test_aws_username_aws(self):
+        result = 'aws'
+        user = {
+            'org_username': 'org',
+            'aws_username': result
+        }
+        self.assertEqual(tsclient._get_aws_username(user), result)

--- a/reconcile/test/test_terrascript_client_utils.py
+++ b/reconcile/test/test_terrascript_client_utils.py
@@ -17,16 +17,18 @@ class TestSupportFunctions(TestCase):
         )
 
     def test_aws_username_org(self):
+        ts = tsclient.TerrascriptClient('', '', 1, [])
         result = 'org'
         user = {
             'org_username': result
         }
-        self.assertEqual(tsclient._get_aws_username(user), result)
+        self.assertEqual(ts._get_aws_username(user), result)
 
     def test_aws_username_aws(self):
+        ts = tsclient.TerrascriptClient('', '', 1, [])
         result = 'aws'
         user = {
             'org_username': 'org',
             'aws_username': result
         }
-        self.assertEqual(tsclient._get_aws_username(user), result)
+        self.assertEqual(ts._get_aws_username(user), result)

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -308,6 +308,10 @@ class TerrascriptClient:
                     groups[account_name][group_name] = 'Done'
         return groups
 
+    @staticmethod
+    def _get_aws_username(user):
+        return user.get('aws_username') or user['org_username']
+
     def populate_iam_users(self, roles):
         for role in roles:
             users = role['users']
@@ -330,7 +334,7 @@ class TerrascriptClient:
                 self.add_resource(account_name, tf_output)
 
                 for user in users:
-                    user_name = user['org_username']
+                    user_name = self._get_aws_username(user)
 
                     # Ref: terraform aws iam_user
                     tf_iam_user = self.get_tf_iam_user(user_name)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4122

depends on https://github.com/app-sre/qontract-schemas/pull/21

this PR adds support to define `aws_username` in a user file to create aws IAM users with user name different from `org_username`.