### PR TITLE
[terrascript] init log to ES zip only lazy and once

### DIFF
--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -190,12 +190,12 @@ class TerrascriptClient:
                                 for a in filtered_accounts}
         self.partitions = {a['name']: a.get('partition') or 'aws'
                            for a in filtered_accounts}
-        github_config = get_config()['github']
-        self.token = github_config['app-sre']['token']
         self.logtoes_zip = ''
 
     def get_logtoes_zip(self, release_url):
         if not self.logtoes_zip:
+            github_config = get_config()['github']
+            self.token = github_config['app-sre']['token']
             self.logtoes_zip = self.download_logtoes_zip(LOGTOES_RELEASE)
         if release_url == LOGTOES_RELEASE:
             return self.logtoes_zip

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -194,9 +194,13 @@ class TerrascriptClient:
 
     def get_logtoes_zip(self, release_url):
         if not self.logtoes_zip:
-            github_config = get_config()['github']
-            self.token = github_config['app-sre']['token']
-            self.logtoes_zip = self.download_logtoes_zip(LOGTOES_RELEASE)
+            with Lock():
+                # this may have already happened, so we check again
+                if not self.logtoes_zip:
+                    github_config = get_config()['github']
+                    self.token = github_config['app-sre']['token']
+                    self.logtoes_zip = \
+                        self.download_logtoes_zip(LOGTOES_RELEASE)
         if release_url == LOGTOES_RELEASE:
             return self.logtoes_zip
         else:

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -191,10 +191,11 @@ class TerrascriptClient:
         self.partitions = {a['name']: a.get('partition') or 'aws'
                            for a in filtered_accounts}
         self.logtoes_zip = ''
+        self.logtoes_zip_lock = Lock()
 
     def get_logtoes_zip(self, release_url):
         if not self.logtoes_zip:
-            with Lock():
+            with self.logtoes_zip_lock:
                 # this may have already happened, so we check again
                 if not self.logtoes_zip:
                     github_config = get_config()['github']


### PR DESCRIPTION
this PR changes the initiation of the lambda zip to only be initiated when needed and to only be initiated once.
we use a lock because there is concurrency.

the implementation of hard coding `app-sre` is wrong, but this is not what this change is about.