### PR TITLE
[sentry-config] iterate over keys implicitly

### DIFF
--- a/reconcile/sentry_config.py
+++ b/reconcile/sentry_config.py
@@ -479,7 +479,7 @@ def fetch_desired_state(gqlapi, sentry_instance, ghapi):
             # Only add users if the team they are a part of is in the same
             # sentry instance we are querying for information
             if team['instance']['consoleUrl'] == sentryUrl:
-                if team['name'] not in team_members.keys():
+                if team['name'] not in team_members:
                     team_members[team['name']] = members
                 else:
                     team_members[team['name']].extend(members)


### PR DESCRIPTION
```
12:15:02 lint run-test: commands[1] | pylint -j0 --extension-pkg-whitelist=pydantic reconcile tools e2e_tests
12:15:16 ************* Module reconcile.sentry_config
12:16:32 reconcile/sentry_config.py:482:39: C0201: Consider iterating the dictionary directly instead of calling .keys() (consider-iterating-dictionary)
```