### PR TITLE
[qontract-cli] add aws-creds get subcommand

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -484,6 +484,25 @@ def bot_login(ctx, cluster_name):
 
 
 @get.command()
+@click.argument('account_name')
+@click.pass_context
+def aws_creds(ctx, account_name):
+    settings = queries.get_app_interface_settings()
+    secret_reader = SecretReader(settings=settings)
+    accounts = queries.get_aws_accounts()
+    accounts = [a for a in accounts if a['name'] == account_name]
+    if len(accounts) == 0:
+        print(f"{account_name} not found.")
+        sys.exit(1)
+
+    account = accounts[0]
+    secret = secret_reader.read_all(account['automationToken'])
+    print(f"export AWS_REGION={account['resourcesDefaultRegion']}")
+    print(f"export AWS_ACCESS_KEY_ID={secret['aws_access_key_id']}")
+    print(f"export AWS_SECRET_ACCESS_KEY={secret['aws_secret_access_key']}")
+
+
+@get.command()
 @click.argument('name', default='')
 @click.pass_context
 def namespaces(ctx, name):

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -483,15 +483,19 @@ def bot_login(ctx, cluster_name):
     print(f"oc login --server {server} --token {token}")
 
 
-@get.command()
+@get.command(
+    short_help="obtain automation credentials for "
+               "aws account by name. executing this "
+               "command will set up the environment:"
+               "$(aws get aws-creds --account-name foo)"
+)
 @click.argument('account_name')
 @click.pass_context
 def aws_creds(ctx, account_name):
     settings = queries.get_app_interface_settings()
     secret_reader = SecretReader(settings=settings)
-    accounts = queries.get_aws_accounts()
-    accounts = [a for a in accounts if a['name'] == account_name]
-    if len(accounts) == 0:
+    accounts = queries.get_aws_accounts(name=account_name)
+    if not accounts:
         print(f"{account_name} not found.")
         sys.exit(1)
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -486,7 +486,7 @@ def bot_login(ctx, cluster_name):
 @get.command(
     short_help="obtain automation credentials for "
                "aws account by name. executing this "
-               "command will set up the environment:"
+               "command will set up the environment: "
                "$(aws get aws-creds --account-name foo)"
 )
 @click.argument('account_name')


### PR DESCRIPTION
similar to `qontract-cli get bot-login`, but for AWS accounts. this will result in the credentials of the terraform user.
these creds should be used in case someone can't access their own creds or aws account and a swift action is required.