### PR TITLE
[terraform-users] improve new users detection

### DIFF
--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -65,7 +65,6 @@ class TerraformClient:
         new_users = []
         self.init_outputs()  # get updated output
         for account, output in self.outputs.items():
-            existing_users = self.users[account]
             user_passwords = self.format_output(
                 output, self.OUTPUT_TYPE_PASSWORDS)
             console_urls = self.format_output(

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -6,11 +6,11 @@ import shutil
 
 from collections import defaultdict
 from threading import Lock
+from dataclasses import dataclass
 from python_terraform import Terraform, IsFlagged, TerraformCommandError
 from ruamel import yaml
 from sretoolbox.utils import retry
 from sretoolbox.utils import threaded
-from dataclasses import dataclass
 
 import reconcile.utils.lean_terraform_client as lean_tf
 

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -10,6 +10,7 @@ from python_terraform import Terraform, IsFlagged, TerraformCommandError
 from ruamel import yaml
 from sretoolbox.utils import retry
 from sretoolbox.utils import threaded
+from dataclasses import dataclass
 
 import reconcile.utils.lean_terraform_client as lean_tf
 
@@ -19,10 +20,10 @@ from reconcile.utils.openshift_resource import OpenshiftResource as OR
 ALLOWED_TF_SHOW_FORMAT_VERSION = "0.1"
 
 
+@dataclass
 class AccountUser:
-    def __init__(self, account, user):
-        self.account = account
-        self.user = user
+    account: str
+    user: str
 
 
 class TerraformClient:


### PR DESCRIPTION
we currently rely on the terraform state to understand if a new user was created.
in #1897 we introduced a way to reset user passwords by deleting the login profile.

this PR detects when a new login profile is created and sends an email as a result.