### PR TITLE
[aws-iam-password-reset] also reset MFA device

### DIFF
--- a/reconcile/aws_iam_password_reset.py
+++ b/reconcile/aws_iam_password_reset.py
@@ -38,4 +38,5 @@ def run(dry_run):
                 aws_api = AWSApi(1, [a], settings=settings)
 
             aws_api.reset_password(account_name, user_name)
+            aws_api.reset_mfa(account_name, user_name)
             state.add(state_key)

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -606,6 +606,18 @@ class AWSApi:
         iam = s.client('iam')
         iam.delete_login_profile(UserName=user_name)
 
+    def reset_mfa(self, account, user_name):
+        s = self.sessions[account]
+        iam = s.client('iam')
+        mfa_devices = iam.list_mfa_devices(UserName=user_name)['MFADevices']
+        for d in mfa_devices:
+            serial_number = d['SerialNumber']
+            iam.deactivate_mfa_device(
+                UserName=user_name,
+                SerialNumber=serial_number
+            )
+            iam.delete_virtual_mfa_device(SerialNumber=serial_number)
+
     @staticmethod
     def get_user_keys(iam, user):
         key_list = iam.list_access_keys(UserName=user)['AccessKeyMetadata']


### PR DESCRIPTION
though these actions are not always required to happen together, it is simpler to add the MFA reset in the same functionality as reset password.

slack thread: https://coreos.slack.com/archives/CCRND57FW/p1639393370415200