### PR TITLE
[terraform-aws-route53] add support for private zones

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1878,6 +1878,10 @@ DNS_ZONES_QUERY = """
         format
       }
     }
+    vpc {
+      vpc_id
+      region
+    }
     unmanaged_record_names
     records {
       name

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -39,6 +39,14 @@ def build_desired_state(zones):
             'records': []
         }
 
+        # a vpc will be referenced for a zone to be considered private
+        vpc = zone.get('vpc')
+        if vpc:
+            zone_values['vpc'] = {
+                'vpc_id': vpc['vpc_id'],
+                'vpc_region': vpc['region']
+            }
+
         # Check if we have unmanaged_record_names (urn) and compile them
         # all as regular expressions
         urn_compiled = []

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -483,6 +483,7 @@ class TerrascriptClient:
             zone_id = safe_resource_id(f"{zone['name']}")
             zone_values = {
                 'name': zone['name'],
+                'vpc': zone.get('vpc'),
                 'comment': 'Managed by Terraform'
             }
             zone_resource = aws_route53_zone(zone_id, **zone_values)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4179

depends on https://github.com/app-sre/qontract-schemas/pull/32

by referencing a VPC, we are making the zone "private".