### PR TITLE
[sqs-gateway] do not init aws users

### DIFF
--- a/reconcile/utils/sqs_gateway.py
+++ b/reconcile/utils/sqs_gateway.py
@@ -15,7 +15,7 @@ class SQSGateway:
         queue_url = os.environ['gitlab_pr_submitter_queue_url']
         account = self.get_queue_account(accounts, queue_url)
         accounts = [a for a in accounts if a['name'] == account]
-        aws_api = AWSApi(1, accounts, settings=settings)
+        aws_api = AWSApi(1, accounts, settings=settings, init_users=False)
         session = aws_api.get_session(account)
 
         self.sqs = session.client('sqs')


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-4141

sqs-gateway is used by openshift-saas-deploy to publish promotions. without init_users, we are actually initiating all users, which takes a lot of memory.

example: saas-app-sre-observability-per-cluster -
with `init_users=True`:
![image](https://user-images.githubusercontent.com/28562329/146007012-305b2dec-be4c-4688-b0bc-e8eee7324e98.png)

with `init_users=False`:
![image](https://user-images.githubusercontent.com/28562329/146007197-4bf47674-619d-4faf-a1d3-7a775df1fc40.png)
