### PR TITLE
[openshift-base] statefulset pvc resize

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -307,7 +307,7 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
                           resource_type, resource.name])
             current_resource = oc.get(namespace, resource_type, resource.name)
             current_storage = oc.get_storage(current_resource)
-            desired_storage = oc.get_storage(resource)
+            desired_storage = oc.get_storage(resource.body)
             resize_required = current_storage != desired_storage
             if resize_required:
                 owned_pods = oc.get_owned_pods(namespace, resource)

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -305,9 +305,24 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
 
             logging.info(['delete_sts_and_apply', cluster, namespace,
                           resource_type, resource.name])
+            current_resource = oc.get(namespace, resource_type, resource.name)
+            current_storage = oc.get_storage(current_resource)
+            desired_storage = oc.get_storage(resource)
+            resize_required = current_storage != desired_storage
+            if resize_required:
+                owned_pods = oc.get_owned_pods(namespace, resource)
+                owned_pvc_names = oc.get_pod_owned_pvc_names(owned_pods)
             oc.delete(namespace=namespace, kind=resource_type,
                       name=resource.name, cascade=False)
             oc.apply(namespace=namespace, resource=annotated)
+            # the resource was applied without cascading.
+            # if the change was in the storage, we need to
+            # take care of the resize ourselves.
+            # ref: https://github.com/kubernetes/enhancements/pull/2842
+            if resize_required:
+                logging.info(['resizing_pvcs', cluster, namespace,
+                              owned_pvc_names])
+                oc.resize_pvcs(namespace, owned_pvc_names, desired_storage)
 
     if recycle_pods:
         oc.recycle_pods(dry_run, namespace, resource_type, resource)

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -305,18 +305,9 @@ def apply(dry_run, oc_map, cluster, namespace, resource_type, resource,
 
             logging.info(['delete_sts_and_apply', cluster, namespace,
                           resource_type, resource.name])
-            owned_pods = oc.get_owned_pods(namespace, resource)
             oc.delete(namespace=namespace, kind=resource_type,
                       name=resource.name, cascade=False)
             oc.apply(namespace=namespace, resource=annotated)
-            logging.info(['recycle_sts_pods', cluster, namespace,
-                          resource_type, resource.name])
-            # the resource was applied without cascading, we proceed
-            # to recycle the pods belonging to the old resource.
-            # note: we really just delete pods and let the new resource
-            # recreate them. we delete one by one and wait for a new
-            # pod to become ready before proceeding to the next one.
-            oc.recycle_orphan_pods(namespace, owned_pods)
 
     if recycle_pods:
         oc.recycle_pods(dry_run, namespace, resource_type, resource)

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -267,6 +267,7 @@ class TestGetObjRootOwner(TestCase):
             oc.get_obj_root_owner('namespace', obj, allow_not_found=False)
 
 
+@patch.dict(os.environ, {"USE_NATIVE_CLIENT": "False"}, clear=True)
 class TestPodOwnedPVCNames(TestCase):
     def setUp(self):
         self.oc = OC('cluster', 'server', 'token', local=True)
@@ -288,6 +289,7 @@ class TestPodOwnedPVCNames(TestCase):
         self.assertEqual(owned_pvc_names[0], 'cm')
 
 
+@patch.dict(os.environ, {"USE_NATIVE_CLIENT": "False"}, clear=True)
 class TestGetStorage(TestCase):
     def setUp(self):
         self.oc = OC('cluster', 'server', 'token', local=True)

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -286,13 +286,13 @@ class TestPodOwnedPVCNames(TestCase):
         oc = OC('cluster', 'server', 'token', local=True)
         owned_pvc_names = oc.get_pod_owned_pvc_names(pods)
         self.assertEqual(len(owned_pvc_names), 1)
-        self.assertEqual(owned_pvc_names[0], 'cm')
+        self.assertEqual(list(owned_pvc_names)[0], 'cm')
 
 
 @patch.dict(os.environ, {"USE_NATIVE_CLIENT": "False"}, clear=True)
 class TestGetStorage(TestCase):
     def test_none(self):
-        resource = {'spec': 'whatever'}
+        resource = {'spec': {'what': 'ever'}}
         oc = OC('cluster', 'server', 'token', local=True)
         storage = oc.get_storage(resource)
         self.assertIsNone(storage)

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -282,8 +282,13 @@ class TestPodOwnedPVCNames(TestCase):
         self.assertEqual(len(owned_pvc_names), 0)
 
     def test_ok(self):
-        pods = [{'spec': {'volumes':
-            [{'persistentVolumeClaim': {'claimName': 'cm'}}]}}]
+        pods = [{
+            'spec': {
+                'volumes': [{
+                    'persistentVolumeClaim': {'claimName': 'cm'}
+                }]
+            }
+        }]
         oc = OC('cluster', 'server', 'token', local=True)
         owned_pvc_names = oc.get_pod_owned_pvc_names(pods)
         self.assertEqual(len(owned_pvc_names), 1)

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -270,19 +270,20 @@ class TestGetObjRootOwner(TestCase):
 @patch.dict(os.environ, {"USE_NATIVE_CLIENT": "False"}, clear=True)
 class TestPodOwnedPVCNames(TestCase):
     def test_no_volumes(self):
-        pods = [{'volumes': []}]
+        pods = [{'spec': {'volumes': []}}]
         oc = OC('cluster', 'server', 'token', local=True)
         owned_pvc_names = oc.get_pod_owned_pvc_names(pods)
         self.assertEqual(len(owned_pvc_names), 0)
 
     def test_other_volumes(self):
-        pods = [{'volumes': [{'configMap': {'name': 'cm'}}]}]
+        pods = [{'spec': {'volumes': [{'configMap': {'name': 'cm'}}]}}]
         oc = OC('cluster', 'server', 'token', local=True)
         owned_pvc_names = oc.get_pod_owned_pvc_names(pods)
         self.assertEqual(len(owned_pvc_names), 0)
 
     def test_ok(self):
-        pods = [{'volumes': [{'persistentVolumeClaim': {'claimName': 'cm'}}]}]
+        pods = [{'spec': {'volumes':
+            [{'persistentVolumeClaim': {'claimName': 'cm'}}]}}]
         oc = OC('cluster', 'server', 'token', local=True)
         owned_pvc_names = oc.get_pod_owned_pvc_names(pods)
         self.assertEqual(len(owned_pvc_names), 1)

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -269,34 +269,32 @@ class TestGetObjRootOwner(TestCase):
 
 @patch.dict(os.environ, {"USE_NATIVE_CLIENT": "False"}, clear=True)
 class TestPodOwnedPVCNames(TestCase):
-    def setUp(self):
-        self.oc = OC('cluster', 'server', 'token', local=True)
-
     def test_no_volumes(self):
         pods = [{'volumes': []}]
-        owned_pvc_names = self.oc.get_pod_owned_pvc_names(pods)
+        oc = OC('cluster', 'server', 'token', local=True)
+        owned_pvc_names = oc.get_pod_owned_pvc_names(pods)
         self.assertEqual(len(owned_pvc_names), 0)
 
     def test_other_volumes(self):
         pods = [{'volumes': [{'configMap': {'name': 'cm'}}]}]
-        owned_pvc_names = self.oc.get_pod_owned_pvc_names(pods)
+        oc = OC('cluster', 'server', 'token', local=True)
+        owned_pvc_names = oc.get_pod_owned_pvc_names(pods)
         self.assertEqual(len(owned_pvc_names), 0)
 
     def test_ok(self):
         pods = [{'volumes': [{'persistentVolumeClaim': {'claimName': 'cm'}}]}]
-        owned_pvc_names = self.oc.get_pod_owned_pvc_names(pods)
+        oc = OC('cluster', 'server', 'token', local=True)
+        owned_pvc_names = oc.get_pod_owned_pvc_names(pods)
         self.assertEqual(len(owned_pvc_names), 1)
         self.assertEqual(owned_pvc_names[0], 'cm')
 
 
 @patch.dict(os.environ, {"USE_NATIVE_CLIENT": "False"}, clear=True)
 class TestGetStorage(TestCase):
-    def setUp(self):
-        self.oc = OC('cluster', 'server', 'token', local=True)
-
     def test_none(self):
         resource = {'spec': 'whatever'}
-        storage = self.oc.get_storage(resource)
+        oc = OC('cluster', 'server', 'token', local=True)
+        storage = oc.get_storage(resource)
         self.assertIsNone(storage)
 
     def test_ok(self):
@@ -316,7 +314,8 @@ class TestGetStorage(TestCase):
                 ]
             }
         }
-        result = self.oc.get_storage(resource)
+        oc = OC('cluster', 'server', 'token', local=True)
+        result = oc.get_storage(resource)
         self.assertEqual(result, size)
 
 

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -526,7 +526,7 @@ class OCDeprecated:
     def get_pod_owned_pvc_names(pods: Iterable[dict[str, dict]]) -> set[str]:
         owned_pvc_names = set()
         for p in pods:
-            vols = p.get('volumes')
+            vols = p['spec'].get('volumes')
             if not vols:
                 continue
             for v in vols:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from functools import wraps
 from subprocess import Popen, PIPE
 from threading import Lock
-from typing import Dict, Iterable, List, Optional
+from typing import Dict, Iterable, List
 
 import urllib3
 

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -537,7 +537,7 @@ class OCDeprecated:
         return owned_pvc_names
 
     @staticmethod
-    def get_storage(resource: dict) -> Optional[str]:
+    def get_storage(resource):
         # resources with volumeClaimTemplates
         with suppress(KeyError, IndexError):
             vct = resource['spec']['volumeClaimTemplates'][0]

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from functools import wraps
 from subprocess import Popen, PIPE
 from threading import Lock
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 
 import urllib3
 
@@ -523,7 +523,7 @@ class OCDeprecated:
         return owned_pods
 
     @staticmethod
-    def get_pod_owned_pvc_names(pods):
+    def get_pod_owned_pvc_names(pods: Iterable[dict[str, dict]]) -> set[str]:
         owned_pvc_names = set()
         for p in pods:
             vols = p.get('volumes')
@@ -537,7 +537,7 @@ class OCDeprecated:
         return owned_pvc_names
 
     @staticmethod
-    def get_storage(resource):
+    def get_storage(resource: dict) -> Optional[str]:
         # resources with volumeClaimTemplates
         with suppress(KeyError, IndexError):
             vct = resource['spec']['volumeClaimTemplates'][0]

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -5,6 +5,7 @@ import os
 import re
 import tempfile
 import time
+from contextlib import suppress
 from datetime import datetime
 from functools import wraps
 from subprocess import Popen, PIPE
@@ -348,6 +349,13 @@ class OCDeprecated:
         return self._msg_to_process_reconcile_time(namespace, resource.body)
 
     @OCDecorators.process_reconcile_time
+    def patch(self, namespace, kind, name, patch):
+        cmd = ['patch', '-n', namespace, kind, name, '-p', json.dumps(patch)]
+        self._run(cmd)
+        resource = {'kind': kind, 'metadata': {'name': name}}
+        return self._msg_to_process_reconcile_time(namespace, resource)
+
+    @OCDecorators.process_reconcile_time
     def delete(self, namespace, kind, name, cascade=True):
         cmd = ['delete', '-n', namespace, kind, name,
                f'--cascade={str(cascade).lower()}']
@@ -513,6 +521,32 @@ class OCDeprecated:
                 owned_pods.append(p)
 
         return owned_pods
+
+    @staticmethod
+    def get_pod_owned_pvc_names(pods):
+        owned_pvc_names = set()
+        for p in pods:
+            vols = p.get('volumes')
+            if not vols:
+                continue
+            for v in vols:
+                with suppress(KeyError):
+                    cn = v['persistentVolumeClaim']['claimName']
+                    owned_pvc_names.add(cn)
+
+        return owned_pvc_names
+
+    @staticmethod
+    def get_storage(resource):
+        # resources with volumeClaimTemplates
+        with suppress(KeyError, IndexError):
+            vct = resource['spec']['volumeClaimTemplates'][0]
+            return vct['spec']['resources']['requests']['storage']
+
+    def resize_pvcs(self, namespace, pvc_names, size):
+        patch = {'spec': {'resources': {'requests': {'storage': size}}}}
+        for p in pvc_names:
+            self.patch(namespace, 'PersistentVolumeClaim', p, patch)
 
     def recycle_orphan_pods(self, namespace, pods):
         for p in pods:


### PR DESCRIPTION
related to https://issues.redhat.com/browse/ASIC-145

during the incident, we noticed that pods were being picked up by the newly applied statefulset without being restarted, including picking up an updated storage size.

this needs to be validated through docs or an experiment.