### PR TITLE
add support to delete specific aws resources

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -264,6 +264,11 @@ AWS_ACCOUNTS_QUERY = """
     }
     garbageCollection
     enableDeletion
+    deletionApprovals {
+      type
+      name
+      expiration
+    }
     disable {
       integrations
     }

--- a/reconcile/test/test_utils_terraform_client.py
+++ b/reconcile/test/test_utils_terraform_client.py
@@ -1,0 +1,87 @@
+from unittest import TestCase
+import reconcile.utils.terraform_client as tfclient
+
+
+class TestDeletionApproved(TestCase):
+
+    def test_no_deletion_approvals(self):
+        account = {
+            'name': 'a1',
+            'deletionApprovals': []
+        }
+        tf = tfclient.TerraformClient(
+            'integ',
+            'v1',
+            'integ_pfx',
+            [account],
+            {},
+            1
+        )
+        result = tf.deletion_approved('a1', 't1', 'n1')
+        self.assertFalse(result)
+
+    def test_deletion_not_approved(self):
+        account = {
+            'name': 'a1',
+            'deletionApprovals': [
+                {
+                    'type': 't1',
+                    'name': 'n1',
+                    'expiration': '2000-01-01'
+                }
+            ]
+        }
+        tf = tfclient.TerraformClient(
+            'integ',
+            'v1',
+            'integ_pfx',
+            [account],
+            {},
+            1
+        )
+        result = tf.deletion_approved('a1', 't2', 'n2')
+        self.assertFalse(result)
+
+    def test_deletion_approved_expired(self):
+        account = {
+            'name': 'a1',
+            'deletionApprovals': [
+                {
+                    'type': 't1',
+                    'name': 'n1',
+                    'expiration': '2000-01-01'
+                }
+            ]
+        }
+        tf = tfclient.TerraformClient(
+            'integ',
+            'v1',
+            'integ_pfx',
+            [account],
+            {},
+            1
+        )
+        result = tf.deletion_approved('a1', 't1', 'n1')
+        self.assertFalse(result)
+
+    def test_deletion_approved(self):
+        account = {
+            'name': 'a1',
+            'deletionApprovals': [
+                {
+                    'type': 't1',
+                    'name': 'n1',
+                    'expiration': '2500-01-01'
+                }
+            ]
+        }
+        tf = tfclient.TerraformClient(
+            'integ',
+            'v1',
+            'integ_pfx',
+            [account],
+            {},
+            1
+        )
+        result = tf.deletion_approved('a1', 't1', 'n1')
+        self.assertTrue(result)

--- a/reconcile/test/test_utils_terraform_client.py
+++ b/reconcile/test/test_utils_terraform_client.py
@@ -85,3 +85,25 @@ class TestDeletionApproved(TestCase):
         )
         result = tf.deletion_approved('a1', 't1', 'n1')
         self.assertTrue(result)
+
+    def test_expiration_value_error(self):
+        account = {
+            'name': 'a1',
+            'deletionApprovals': [
+                {
+                    'type': 't1',
+                    'name': 'n1',
+                    'expiration': '2000'
+                }
+            ]
+        }
+        tf = tfclient.TerraformClient(
+            'integ',
+            'v1',
+            'integ_pfx',
+            [account],
+            {},
+            1
+        )
+        with self.assertRaises(tfclient.DeletionApprovalExpirationValueError):
+            tf.deletion_approved('a1', 't1', 'n1')

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -28,6 +28,10 @@ class AccountUser:
     user: str
 
 
+class DeletionApprovalExpirationValueError(Exception):
+    pass
+
+
 class TerraformClient:
     def __init__(self, integration, integration_version,
                  integration_prefix, accounts, working_dirs, thread_pool_size,
@@ -258,7 +262,14 @@ class TerraformClient:
             return False
         now = datetime.utcnow()
         for da in deletion_approvals:
-            expiration = datetime.strptime(da['expiration'], DATE_FORMAT)
+            try:
+                expiration = datetime.strptime(da['expiration'], DATE_FORMAT)
+            except ValueError:
+                raise DeletionApprovalExpirationValueError(
+                    f"[{account_name}] expiration not does not match "
+                    f"date format {DATE_FORMAT}. details: "
+                    f"type: {da['type']}, name: {da['name']}"
+                )
             if resource_type == da['type'] \
                     and resource_name == da['name'] \
                     and now <= expiration:

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -261,7 +261,7 @@ class TerraformClient:
             expiration = datetime.strptime(da['expiration'], DATE_FORMAT)
             if resource_type == da['type'] \
                     and resource_name == da['name'] \
-                    and expiration <= now:
+                    and now <= expiration:
                 return True
 
         return False

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -219,7 +219,10 @@ class TerraformClient:
                 if action == 'delete':
                     if resource_type in always_enabled_deletions:
                         continue
-                    if not deletions_allowed:
+
+                    if not deletions_allowed and not \
+                            self.deletion_approved(
+                                name, resource_type, resource_name):
                         disabled_deletion_detected = True
                         logging.error(
                             '\'delete\' action is not enabled. ' +
@@ -245,6 +248,9 @@ class TerraformClient:
                                 'The new MR must be merged first.'
                             )
         return disabled_deletion_detected, deleted_users, created_users
+
+    def deletion_approved(self, account_name, resource_type, resource_name):
+        return False
 
     @staticmethod
     def terraform_show(name, working_dir):


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4186

depends on https://github.com/app-sre/qontract-schemas/pull/38

this PR adds an ability to define resources that are approved for deletion, even for an account that does not have deletions enabled.