### PR TITLE
upgrade openssl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         "pypd>=1.1.0,<1.2.0",
         "Jinja2>=2.10.1,<2.11.0",
         "jira~=3.1",
-        "pyOpenSSL>=19.0.0,<20.0.0",
+        "pyOpenSSL~=21.0",
         "ruamel.yaml>=0.16.5,<0.17.0",
         "terrascript==0.9.0",
         "tabulate>=0.8.6,<0.9.0",


### PR DESCRIPTION
```
/usr/local/lib64/python3.9/site-packages/cryptography/hazmat/backends/openssl/x509.py:14: CryptographyDeprecationWarning: This version of cryptography contains a temporary pyOpenSSL fallback path. Upgrade pyOpenSSL now.
```

https://ci.int.devshift.net/job/service-app-interface-gl-pr-check/102727/console