### PR TITLE
[openshift-serviceaccount-tokens] add support to define resource output name

### DIFF
--- a/reconcile/openshift_serviceaccount_tokens.py
+++ b/reconcile/openshift_serviceaccount_tokens.py
@@ -54,7 +54,7 @@ def fetch_desired_state(namespaces, ri, oc_map):
                 logging.log(level=oc.log_level, msg=oc.message)
                 continue
             sa_token = oc.sa_get_token(sa_namespace_name, sa_name)
-            oc_resource_name = \
+            oc_resource_name = sat.get('name') or \
                 f"{sa_cluster_name}-{sa_namespace_name}-{sa_name}"
             oc_resource = construct_sa_token_oc_resource(
                 oc_resource_name, sa_name, sa_token)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -810,6 +810,7 @@ def get_namespaces(minimal=False):
 
 
 SA_TOKEN = """
+name
 namespace {
   name
   cluster {


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/39

this will allow an ability to define the name of the output Secret (both in OpenShift and in Vault).