### PR TITLE
qontract-cli command to set status page component status

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -755,8 +755,6 @@ def aws_support_cases_sos(ctx, gitlab_project_id, thread_pool_size):
 
 @integration.command()
 @threaded(default=20)
-@binary(['oc', 'ssh', 'amtool'])
-@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @cluster_name

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -755,6 +755,8 @@ def aws_support_cases_sos(ctx, gitlab_project_id, thread_pool_size):
 
 @integration.command()
 @threaded(default=20)
+@binary(['oc', 'ssh', 'amtool'])
+@binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @cluster_name

--- a/reconcile/status_page_components.py
+++ b/reconcile/status_page_components.py
@@ -69,7 +69,7 @@ class StatusPageProvider(BaseModel):
         return None
 
     @abstractmethod
-    def update_component_status(self, dry_run:bool,
+    def update_component_status(self, dry_run: bool,
                                 id: str, status: str) -> None:
         return None
 
@@ -98,7 +98,7 @@ class StatusPage(BaseModel):
 
     def get_component_by_name(self, name) -> Optional[StatusComponent]:
         return next(
-            filter(lambda c: c.name == name, self.components), # type: ignore
+            filter(lambda c: c.name == name, self.components),  # type: ignore
             None
         )
 
@@ -153,10 +153,12 @@ class StatusPage(BaseModel):
             state.add(component.name, component_id, force=True)
             component.component_id = component_id
 
+
 ATLASSIAN_COMPONENT_STATES = [
     "operational", "under_maintenance", "degraded_performance",
     "partial_outage", "major_outage"
 ]
+
 
 class AtlassianStatusPage(StatusPageProvider):
 

--- a/reconcile/status_page_components.py
+++ b/reconcile/status_page_components.py
@@ -153,6 +153,10 @@ class StatusPage(BaseModel):
             state.add(component.name, component_id, force=True)
             component.component_id = component_id
 
+ATLASSIAN_COMPONENT_STATES = [
+    "operational", "under_maintenance", "degraded_performance",
+    "partial_outage", "major_outage"
+]
 
 class AtlassianStatusPage(StatusPageProvider):
 
@@ -249,21 +253,15 @@ class AtlassianStatusPage(StatusPageProvider):
             for c in raw_components
         ]
 
-    def supported_component_states(_):
-        return [
-            "operational", "under_maintenance", "degraded_performance",
-            "partial_outage", "major_outage"
-        ]
-
     def update_component_status(self, dry_run: bool,
                                 id: str, status: str) -> None:
-        if status in self.supported_component_states():
+        if status in ATLASSIAN_COMPONENT_STATES:
             if not dry_run:
                 self._update_component(id, {"status": status})
         else:
             raise ValueError(
                 f"unsupported state {status} - "
-                f"must be one of {self.supported_component_states()}"
+                f"must be one of {ATLASSIAN_COMPONENT_STATES}"
             )
 
     def _client(self):

--- a/reconcile/test/fixtures/statuspage/test_component_status_update.yaml
+++ b/reconcile/test/fixtures/statuspage/test_component_status_update.yaml
@@ -1,0 +1,31 @@
+appInterface:
+  state:
+    comp_1: comp_id_1
+  pages:
+  - name: page_1
+    pageId: page_1
+    apiUrl: 'https://api.statuspage.io'
+    credentials:
+      path: app-sre/creds/status.redhat.com
+      field: all
+    provider: atlassian
+    components:
+    - name: comp_1
+      displayName: Component 1
+      description: null
+      path: /dependencies/statuspage/test-component.yml
+      groupName: group_1
+      apps: []
+
+atlassianApi:
+  components:
+    page_1:
+    - id: comp_id_1
+      name: Component 1
+      descripton: null
+      position: 1
+      status: Ok
+      automation_email: automate-me@please.com
+      group_id: group_id_1
+      group: false
+      group_name: group_1

--- a/reconcile/test/test_status_page_components.py
+++ b/reconcile/test/test_status_page_components.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from typing import Optional
 
 from reconcile.status_page_components import (
-  AtlassianComponent, AtlassianStatusPage, StatusComponent, StatusPage, fetch_pages, get_state, update_component_status)
+  AtlassianComponent, AtlassianStatusPage, StatusComponent, StatusPage)
 from reconcile.utils.vaultsecretref import VaultSecretRef
 from .fixtures import Fixtures
 
@@ -330,12 +330,12 @@ class TestComponentStatusUpdate(TestCase):
         with self.assertRaises(ValueError):
             page.update_component_status(True, "comp_x", "operational", state)
 
-
+    @staticmethod
     @patch.object(VaultSecretRef, '_resolve_secret',
                   new_callable=stub_resolve_secret)
     @patch.object(AtlassianStatusPage, '_fetch_components')
     @patch.object(AtlassianStatusPage, 'update_component_status')
-    def test_update(self, update_mock, fetch_mock, vault_mock):
+    def test_update(update_mock, fetch_mock, vault_mock):
         fixture_name = "test_component_status_update.yaml"
 
         page = get_page_fixtures(fixture_name)[0]
@@ -346,7 +346,6 @@ class TestComponentStatusUpdate(TestCase):
         page.update_component_status(True, "comp_1", "operational", state)
 
         update_mock.assert_called_with(True, "comp_id_1", "operational")
-
 
     @patch.object(VaultSecretRef, '_resolve_secret',
                   new_callable=stub_resolve_secret)

--- a/reconcile/test/test_status_page_components.py
+++ b/reconcile/test/test_status_page_components.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from typing import Optional
 
 from reconcile.status_page_components import (
-  AtlassianComponent, AtlassianStatusPage, StatusComponent, StatusPage)
+  AtlassianComponent, AtlassianStatusPage, StatusComponent, StatusPage, fetch_pages, get_state, update_component_status)
 from reconcile.utils.vaultsecretref import VaultSecretRef
 from .fixtures import Fixtures
 
@@ -32,6 +32,9 @@ class StateStub:
             self.state = state
         else:
             self.state = {}
+
+    def get(self, key):
+        return self.state.get(key)
 
     def get_all(self, _):
         return self.state
@@ -310,3 +313,51 @@ class TestDryRunBehaviour(TestCase):
             update_mock.assert_not_called()
         else:
             update_mock.assert_called()
+
+
+class TestComponentStatusUpdate(TestCase):
+
+    @patch.object(VaultSecretRef, '_resolve_secret',
+                  new_callable=stub_resolve_secret)
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    def test_update_missing_component(self, fetch_mock, vault_mock):
+        fixture_name = "test_component_status_update.yaml"
+
+        page = get_page_fixtures(fixture_name)[0]
+        fetch_mock.return_value = []
+        state = get_state_fixture(fixture_name)
+
+        with self.assertRaises(ValueError):
+            page.update_component_status(True, "comp_x", "operational", state)
+
+
+    @patch.object(VaultSecretRef, '_resolve_secret',
+                  new_callable=stub_resolve_secret)
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    @patch.object(AtlassianStatusPage, 'update_component_status')
+    def test_update(self, update_mock, fetch_mock, vault_mock):
+        fixture_name = "test_component_status_update.yaml"
+
+        page = get_page_fixtures(fixture_name)[0]
+        fetch_mock.return_value = \
+            get_atlassian_component_fixtures(fixture_name, page.name)
+        state = get_state_fixture(fixture_name)
+
+        page.update_component_status(True, "comp_1", "operational", state)
+
+        update_mock.assert_called_with(True, "comp_id_1", "operational")
+
+
+    @patch.object(VaultSecretRef, '_resolve_secret',
+                  new_callable=stub_resolve_secret)
+    @patch.object(AtlassianStatusPage, '_fetch_components')
+    def test_wrong_status(self, fetch_mock, vault_mock):
+        fixture_name = "test_component_status_update.yaml"
+
+        page = get_page_fixtures(fixture_name)[0]
+        fetch_mock.return_value = \
+            get_atlassian_component_fixtures(fixture_name, page.name)
+        state = get_state_fixture(fixture_name)
+
+        with self.assertRaises(ValueError):
+            page.update_component_status(True, "comp_1", "invalid", state)

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -8,8 +8,8 @@ import requests
 import yaml
 
 from tabulate import tabulate
-from reconcile.status_page_components import (update_component_status,
-                                             fetch_pages)
+from reconcile.status_page_components import (
+    update_component_status, fetch_pages)
 
 from reconcile.utils import dnsutils
 from reconcile.utils import gql

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -8,7 +8,8 @@ import requests
 import yaml
 
 from tabulate import tabulate
-from reconcile.status_page_components import update_component_status, fetch_pages
+from reconcile.status_page_components import (update_component_status,
+                                             fetch_pages)
 
 from reconcile.utils import dnsutils
 from reconcile.utils import gql

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -8,6 +8,7 @@ import requests
 import yaml
 
 from tabulate import tabulate
+from reconcile.status_page_components import update_component_status, fetch_pages
 
 from reconcile.utils import dnsutils
 from reconcile.utils import gql
@@ -860,6 +861,40 @@ def slack_usergroup(ctx, workspace, usergroup, username):
     else:
         users = [slack.get_random_deleted_user()]
     slack.update_usergroup_users(ugid, users)
+
+
+@get.command()
+@click.pass_context
+def statuspage_components(ctx):
+    data = []
+    for page in fetch_pages():
+        for component in page.components:
+            data.append({
+                "component_name": component.name,
+                "component_display_name": component.display_name,
+                "page": page.name
+            })
+    columns = ['component_name', 'component_display_name', 'page']
+    print_output(ctx.obj['options'], data, columns)
+
+
+@set.command()
+@click.argument('component_name')
+@click.argument('component_status')
+@environ(['APP_INTERFACE_STATE_BUCKET', 'APP_INTERFACE_STATE_BUCKET_ACCOUNT'])
+def statuspage_component_status(component_name, component_status):
+    """Set the status of a status page component.
+
+    COMPONENT_NAME is the name of a component; get a list with
+        'qontract-cli get statuspage-components'
+
+    COMPONENT_STATUS one of: operational, under_maintenance,
+        degraded_performance, partial_outage, major_outage
+    """
+    try:
+        update_component_status(False, component_name, component_status)
+    except Exception as e:
+        print(f"failed - {e}")
 
 
 @root.group()


### PR DESCRIPTION
qontract-cli get statuspage-components
  this command lists all available status page components

qontract-cli set statuspage-component-status <component-name> <status>
  this command sets the status for a status page component

Ref: https://issues.redhat.com/browse/APPSRE-4206

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>