### PR TITLE
[terraform-client] print only to file that is not in a git repository

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -477,7 +477,7 @@ def integration(ctx, configfile, dry_run, validate_schemas, dump_schemas_file,
 @integration.command()
 @print_to_file
 @threaded()
-@binary(['terraform'])
+@binary(['terraform', 'git'])
 @binary_version('terraform', ['version'],
                 TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @enable_deletion(default=True)
@@ -1091,7 +1091,7 @@ def user_validator(ctx):
 @throughput
 @vault_output_path
 @threaded(default=20)
-@binary(['terraform', 'oc'])
+@binary(['terraform', 'oc', 'git'])
 @binary_version('terraform', ['version'],
                 TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
@@ -1119,7 +1119,7 @@ def terraform_resources(ctx, print_to_file, enable_deletion,
 @throughput
 @vault_output_path
 @threaded(default=20)
-@binary(['terraform', 'oc'])
+@binary(['terraform', 'oc', 'git'])
 @binary_version('terraform', ['version'],
                 TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
@@ -1144,7 +1144,7 @@ def terraform_resources_wrapper(ctx, print_to_file, enable_deletion,
 @print_to_file
 @throughput
 @threaded(default=20)
-@binary(['terraform', 'gpg'])
+@binary(['terraform', 'gpg', 'git'])
 @binary_version('terraform', ['version'],
                 TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @enable_deletion(default=True)
@@ -1161,7 +1161,7 @@ def terraform_users(ctx, print_to_file, enable_deletion, io_dir,
 @integration.command()
 @print_to_file
 @threaded()
-@binary(['terraform'])
+@binary(['terraform', 'git'])
 @binary_version('terraform', ['version'],
                 TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @enable_deletion(default=False)
@@ -1176,7 +1176,7 @@ def terraform_vpc_peerings(ctx, print_to_file, enable_deletion,
 @integration.command()
 @print_to_file
 @threaded()
-@binary(['terraform'])
+@binary(['terraform', 'git'])
 @binary_version('terraform', ['version'],
                 TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @enable_deletion(default=False)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -266,6 +266,14 @@ def print_only(function):
     return function
 
 
+def print_to_file(function):
+    function = click.option('--print-to-file',
+                            help='print the config to file.',
+                            default=None)(function)
+
+    return function
+
+
 def config_name(function):
     function = click.option('--config-name',
                             help='jenkins config name to print out.'
@@ -467,17 +475,17 @@ def integration(ctx, configfile, dry_run, validate_schemas, dump_schemas_file,
 
 
 @integration.command()
-@print_only
+@print_to_file
 @threaded()
 @binary(['terraform'])
 @binary_version('terraform', ['version'],
                 TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @enable_deletion(default=True)
 @click.pass_context
-def terraform_aws_route53(ctx, print_only, enable_deletion,
+def terraform_aws_route53(ctx, print_to_file, enable_deletion,
                           thread_pool_size):
     run_integration(reconcile.terraform_aws_route53, ctx.obj,
-                    print_only, enable_deletion, thread_pool_size)
+                    print_to_file, enable_deletion, thread_pool_size)
 
 
 @integration.command()
@@ -510,7 +518,7 @@ def github_users(ctx, gitlab_project_id, thread_pool_size,
 @environ(['gitlab_pr_submitter_queue_url'])
 @gitlab_project_id
 @threaded()
-@binary(['git', 'git-secrets'])
+# @binary(['git', 'git-secrets'])
 @click.pass_context
 def github_scanner(ctx, gitlab_project_id, thread_pool_size):
     run_integration(reconcile.github_scanner, ctx.obj,
@@ -1079,7 +1087,7 @@ def user_validator(ctx):
 
 
 @integration.command()
-@print_only
+@print_to_file
 @throughput
 @vault_output_path
 @threaded(default=20)
@@ -1095,11 +1103,11 @@ def user_validator(ctx):
               default=False,
               help='run without executing terraform plan and apply.')
 @click.pass_context
-def terraform_resources(ctx, print_only, enable_deletion,
+def terraform_resources(ctx, print_to_file, enable_deletion,
                         io_dir, thread_pool_size, internal, use_jump_host,
                         light, vault_output_path, account_name):
     run_integration(reconcile.terraform_resources,
-                    ctx.obj, print_only,
+                    ctx.obj, print_to_file,
                     enable_deletion, io_dir, thread_pool_size,
                     internal, use_jump_host, light, vault_output_path,
                     account_name=account_name,
@@ -1107,7 +1115,7 @@ def terraform_resources(ctx, print_only, enable_deletion,
 
 
 @integration.command()
-@print_only
+@print_to_file
 @throughput
 @vault_output_path
 @threaded(default=20)
@@ -1122,18 +1130,18 @@ def terraform_resources(ctx, print_only, enable_deletion,
               default=False,
               help='run without executing terraform plan and apply.')
 @click.pass_context
-def terraform_resources_wrapper(ctx, print_only, enable_deletion,
+def terraform_resources_wrapper(ctx, print_to_file, enable_deletion,
                                 io_dir, thread_pool_size, internal,
                                 use_jump_host, light, vault_output_path):
     run_integration(reconcile.terraform_resources_wrapper,
-                    ctx.obj, print_only,
+                    ctx.obj, print_to_file,
                     enable_deletion, io_dir, thread_pool_size,
                     internal, use_jump_host, light, vault_output_path,
                     extra_labels=ctx.obj.get('extra_labels', {}))
 
 
 @integration.command()
-@print_only
+@print_to_file
 @throughput
 @threaded(default=20)
 @binary(['terraform', 'gpg'])
@@ -1142,41 +1150,41 @@ def terraform_resources_wrapper(ctx, print_only, enable_deletion,
 @enable_deletion(default=True)
 @send_mails(default=True)
 @click.pass_context
-def terraform_users(ctx, print_only, enable_deletion, io_dir,
+def terraform_users(ctx, print_to_file, enable_deletion, io_dir,
                     thread_pool_size, send_mails):
     run_integration(reconcile.terraform_users,
-                    ctx.obj, print_only,
+                    ctx.obj, print_to_file,
                     enable_deletion, io_dir,
                     thread_pool_size, send_mails)
 
 
 @integration.command()
-@print_only
+@print_to_file
 @threaded()
 @binary(['terraform'])
 @binary_version('terraform', ['version'],
                 TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @enable_deletion(default=False)
 @click.pass_context
-def terraform_vpc_peerings(ctx, print_only, enable_deletion,
+def terraform_vpc_peerings(ctx, print_to_file, enable_deletion,
                            thread_pool_size):
     run_integration(reconcile.terraform_vpc_peerings,
-                    ctx.obj, print_only,
+                    ctx.obj, print_to_file,
                     enable_deletion, thread_pool_size)
 
 
 @integration.command()
-@print_only
+@print_to_file
 @threaded()
 @binary(['terraform'])
 @binary_version('terraform', ['version'],
                 TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @enable_deletion(default=False)
 @click.pass_context
-def terraform_tgw_attachments(ctx, print_only, enable_deletion,
+def terraform_tgw_attachments(ctx, print_to_file, enable_deletion,
                               thread_pool_size):
     run_integration(reconcile.terraform_tgw_attachments,
-                    ctx.obj, print_only,
+                    ctx.obj, print_to_file,
                     enable_deletion, thread_pool_size)
 
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -518,7 +518,7 @@ def github_users(ctx, gitlab_project_id, thread_pool_size,
 @environ(['gitlab_pr_submitter_queue_url'])
 @gitlab_project_id
 @threaded()
-# @binary(['git', 'git-secrets'])
+@binary(['git', 'git-secrets'])
 @click.pass_context
 def github_scanner(ctx, gitlab_project_id, thread_pool_size):
     run_integration(reconcile.github_scanner, ctx.obj,

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -128,7 +128,7 @@ def build_desired_state(zones):
 
 
 @defer
-def run(dry_run=False, print_only=False,
+def run(dry_run=False, print_to_file=None,
         enable_deletion=True, thread_pool_size=10, defer=None):
     settings = queries.get_app_interface_settings()
     zones = queries.get_dns_zones()
@@ -146,9 +146,9 @@ def run(dry_run=False, print_only=False,
     desired_state = build_desired_state(zones)
 
     ts.populate_route53(desired_state)
-    working_dirs = ts.dump(print_only=print_only)
+    working_dirs = ts.dump(print_to_file=print_to_file)
 
-    if print_only:
+    if print_to_file:
         sys.exit(ExitCodes.SUCCESS)
 
     tf = Terraform(QONTRACT_INTEGRATION,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -389,7 +389,7 @@ def init_working_dirs(accounts, thread_pool_size,
     return ts, working_dirs
 
 
-def setup(dry_run, print_only, thread_pool_size, internal,
+def setup(dry_run, print_to_file, thread_pool_size, internal,
           use_jump_host, account_name, extra_labels):
     gqlapi = gql.get_api()
     accounts = queries.get_aws_accounts()
@@ -423,7 +423,7 @@ def setup(dry_run, print_only, thread_pool_size, internal,
         ocm_map = None
     ts.populate_resources(tf_namespaces, existing_secrets, account_name,
                           ocm_map=ocm_map)
-    ts.dump(print_only, existing_dirs=working_dirs)
+    ts.dump(print_to_file, existing_dirs=working_dirs)
 
     return ri, oc_map, tf, tf_namespaces
 
@@ -468,20 +468,20 @@ def write_outputs_to_vault(vault_path, ri):
 
 
 @defer
-def run(dry_run, print_only=False,
+def run(dry_run, print_to_file=None,
         enable_deletion=False, io_dir='throughput/',
         thread_pool_size=10, internal=None, use_jump_host=True,
         light=False, vault_output_path='',
         account_name=None, extra_labels=None, defer=None):
 
     ri, oc_map, tf, tf_namespaces = \
-        setup(dry_run, print_only, thread_pool_size, internal,
+        setup(dry_run, print_to_file, thread_pool_size, internal,
               use_jump_host, account_name, extra_labels)
 
     if not dry_run:
         defer(oc_map.cleanup)
 
-    if print_only:
+    if print_to_file:
         cleanup_and_exit()
     if tf is None:
         err = True

--- a/reconcile/terraform_resources_wrapper.py
+++ b/reconcile/terraform_resources_wrapper.py
@@ -29,7 +29,7 @@ def get_accounts_names():
 
 def tfr_run_wrapper(account_name,
                     dry_run,
-                    print_only,
+                    print_to_file,
                     enable_deletion,
                     io_dir,
                     internal_thread_pool_size,
@@ -41,7 +41,7 @@ def tfr_run_wrapper(account_name,
     exit_code = 0
     try:
         tfr.run(dry_run=dry_run,
-                print_only=print_only,
+                print_to_file=print_to_file,
                 enable_deletion=enable_deletion,
                 io_dir=io_dir,
                 thread_pool_size=internal_thread_pool_size,
@@ -56,7 +56,7 @@ def tfr_run_wrapper(account_name,
     return exit_code
 
 
-def run(dry_run, print_only=False,
+def run(dry_run, print_to_file=None,
         enable_deletion=False, io_dir='throughput/',
         thread_pool_size=10, internal=None, use_jump_host=True,
         light=False, vault_output_path='', extra_labels=None):
@@ -72,7 +72,7 @@ def run(dry_run, print_only=False,
     exit_codes = threaded.run(
         tfr_run_wrapper, account_names, thread_pool_size,
         dry_run=dry_run,
-        print_only=print_only,
+        print_to_file=print_to_file,
         enable_deletion=enable_deletion,
         io_dir=io_dir,
         internal_thread_pool_size=thread_pool_size,

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -116,7 +116,7 @@ def build_desired_state_tgw_attachments(clusters, ocm_map: OCMMap,
 
 
 @defer
-def run(dry_run, print_only=False,
+def run(dry_run, print_to_file=None,
         enable_deletion=False, thread_pool_size=10, defer=None):
     settings = queries.get_app_interface_settings()
     clusters = [c for c in queries.get_clusters()
@@ -162,9 +162,9 @@ def run(dry_run, print_only=False,
                      settings=settings)
     ts.populate_additional_providers(participating_accounts)
     ts.populate_tgw_attachments(desired_state)
-    working_dirs = ts.dump(print_only=print_only)
+    working_dirs = ts.dump(print_to_file=print_to_file)
 
-    if print_only:
+    if print_to_file:
         sys.exit()
 
     tf = Terraform(QONTRACT_INTEGRATION,

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -42,7 +42,7 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 4, 2)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 
-def setup(print_only, thread_pool_size):
+def setup(print_to_file, thread_pool_size):
     gqlapi = gql.get_api()
     accounts = queries.get_aws_accounts()
     settings = queries.get_app_interface_settings()
@@ -59,7 +59,7 @@ def setup(print_only, thread_pool_size):
     if err:
         return None
 
-    working_dirs = ts.dump(print_only)
+    working_dirs = ts.dump(print_to_file)
 
     return accounts, working_dirs
 
@@ -99,11 +99,11 @@ def cleanup_and_exit(tf=None, status=False):
     sys.exit(status)
 
 
-def run(dry_run, print_only=False,
+def run(dry_run, print_to_file=None,
         enable_deletion=False, io_dir='throughput/',
         thread_pool_size=10, send_mails=True):
-    accounts, working_dirs = setup(print_only, thread_pool_size)
-    if print_only:
+    accounts, working_dirs = setup(print_to_file, thread_pool_size)
+    if print_to_file:
         cleanup_and_exit()
     if working_dirs is None:
         err = True

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -378,7 +378,7 @@ def build_desired_state_vpc(clusters, ocm_map: OCMMap, awsapi: AWSApi):
 
 
 @defer
-def run(dry_run, print_only=False,
+def run(dry_run, print_to_file=None,
         enable_deletion=False, thread_pool_size=10, defer=None):
     settings = queries.get_app_interface_settings()
     clusters = [c for c in queries.get_clusters()
@@ -433,9 +433,9 @@ def run(dry_run, print_only=False,
         settings=settings)
     ts.populate_additional_providers(participating_accounts)
     ts.populate_vpc_peerings(desired_state)
-    working_dirs = ts.dump(print_only=print_only)
+    working_dirs = ts.dump(print_to_file=print_to_file)
 
-    if print_only:
+    if print_to_file:
         sys.exit(0 if dry_run else int(any(errors)))
 
     tf = terraform.TerraformClient(

--- a/reconcile/utils/git.py
+++ b/reconcile/utils/git.py
@@ -32,6 +32,6 @@ def is_file_in_git_repo(file_path):
     dir_path = os.path.dirname(real_path)
     with open(os.devnull, 'w') as dev_null:
         proc = Popen(['git', 'git rev-parse', '--is-inside-work-tree'],
-                    cwd=dir_path, stdout=dev_null, stderr=dev_null)
+                     cwd=dir_path, stdout=dev_null, stderr=dev_null)
         proc.communicate()
     return proc.returncode == 0

--- a/reconcile/utils/git.py
+++ b/reconcile/utils/git.py
@@ -30,5 +30,8 @@ def checkout(commit, wd):
 def is_file_in_git_repo(file_path):
     real_path = os.path.realpath(file_path)
     dir_path = os.path.dirname(real_path)
-    git_path = os.path.join(dir_path, '.git')
-    return os.path.exists(git_path)
+    with open(os.devnull, 'w') as dev_null:
+        proc = Popen(['git', 'git rev-parse', '--is-inside-work-tree'],
+                    cwd=dir_path, stdout=dev_null, stderr=dev_null)
+        proc.communicate()
+    return proc.returncode == 0

--- a/reconcile/utils/git.py
+++ b/reconcile/utils/git.py
@@ -8,19 +8,21 @@ class GitError(Exception):
 
 
 def clone(repo_url, wd):
-    with open(os.devnull, 'w') as dev_null:
-        proc = Popen(['git', 'clone', repo_url, wd],
-                     stdout=dev_null, stderr=dev_null)
-        proc.communicate()
+    # pylint: disable=consider-using-with
+    DEVNULL = open(os.devnull, 'w')
+    proc = Popen(['git', 'clone', repo_url, wd],
+                 stdout=DEVNULL, stderr=DEVNULL)
+    proc.communicate()
     if proc.returncode != 0:
         raise GitError('git clone failed: {}'.format(repo_url))
 
 
 def checkout(commit, wd):
-    with open(os.devnull, 'w') as dev_null:
-        proc = Popen(['git', 'checkout', commit],
-                     cwd=wd, stdout=dev_null, stderr=dev_null)
-        proc.communicate()
+    # pylint: disable=consider-using-with
+    DEVNULL = open(os.devnull, 'w')
+    proc = Popen(['git', 'checkout', commit],
+                 cwd=wd, stdout=DEVNULL, stderr=DEVNULL)
+    proc.communicate()
     if proc.returncode != 0:
         raise GitError('git checkout failed: {}'.format(commit))
 
@@ -28,8 +30,9 @@ def checkout(commit, wd):
 def is_file_in_git_repo(file_path):
     real_path = os.path.realpath(file_path)
     dir_path = os.path.dirname(real_path)
-    with open(os.devnull, 'w') as dev_null:
-        proc = Popen(['git', 'git rev-parse', '--is-inside-work-tree'],
-                     cwd=dir_path, stdout=dev_null, stderr=dev_null)
-        proc.communicate()
+    # pylint: disable=consider-using-with
+    DEVNULL = open(os.devnull, 'w')
+    proc = Popen(['git', 'git rev-parse', '--is-inside-work-tree'],
+                 cwd=dir_path, stdout=DEVNULL, stderr=DEVNULL)
+    proc.communicate()
     return proc.returncode == 0

--- a/reconcile/utils/git.py
+++ b/reconcile/utils/git.py
@@ -8,21 +8,19 @@ class GitError(Exception):
 
 
 def clone(repo_url, wd):
-    # pylint: disable=consider-using-with
-    DEVNULL = open(os.devnull, 'w')
-    proc = Popen(['git', 'clone', repo_url, wd],
-                 stdout=DEVNULL, stderr=DEVNULL)
-    proc.communicate()
+    with open(os.devnull, 'w') as dev_null:
+        proc = Popen(['git', 'clone', repo_url, wd],
+                     stdout=dev_null, stderr=dev_null)
+        proc.communicate()
     if proc.returncode != 0:
         raise GitError('git clone failed: {}'.format(repo_url))
 
 
 def checkout(commit, wd):
-    # pylint: disable=consider-using-with
-    DEVNULL = open(os.devnull, 'w')
-    proc = Popen(['git', 'checkout', commit],
-                 cwd=wd, stdout=DEVNULL, stderr=DEVNULL)
-    proc.communicate()
+    with open(os.devnull, 'w') as dev_null:
+        proc = Popen(['git', 'checkout', commit],
+                     cwd=wd, stdout=dev_null, stderr=dev_null)
+        proc.communicate()
     if proc.returncode != 0:
         raise GitError('git checkout failed: {}'.format(commit))
 

--- a/reconcile/utils/git.py
+++ b/reconcile/utils/git.py
@@ -32,7 +32,7 @@ def is_file_in_git_repo(file_path):
     dir_path = os.path.dirname(real_path)
     # pylint: disable=consider-using-with
     DEVNULL = open(os.devnull, 'w')
-    proc = Popen(['git', 'git rev-parse', '--is-inside-work-tree'],
+    proc = Popen(['git', 'rev-parse', '--is-inside-work-tree'],
                  cwd=dir_path, stdout=DEVNULL, stderr=DEVNULL)
     proc.communicate()
     return proc.returncode == 0

--- a/reconcile/utils/git.py
+++ b/reconcile/utils/git.py
@@ -25,3 +25,10 @@ def checkout(commit, wd):
     proc.communicate()
     if proc.returncode != 0:
         raise GitError('git checkout failed: {}'.format(commit))
+
+
+def is_file_in_git_repo(file_path):
+    real_path = os.path.realpath(file_path)
+    dir_path = os.path.dirname(real_path)
+    git_path = os.path.join(dir_path, '.git')
+    return os.path.exists(git_path)

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -78,6 +78,7 @@ from sretoolbox.utils import threaded
 from reconcile.utils import gql
 from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.secret_reader import SecretReader
+from reconcile.utils.git import is_file_in_git_repo
 from reconcile.github_org import get_config
 from reconcile.utils.oc import StatusCodeError
 from reconcile.utils.gpg import gpg_key_valid
@@ -105,6 +106,11 @@ VARIABLE_KEYS = ['region', 'availability_zone', 'parameter_group',
 class UnknownProviderError(Exception):
     def __init__(self, msg):
         super().__init__("unknown provider error: " + str(msg))
+
+
+class PrintToFileInGitRepositoryError(Exception):
+    def __init__(self, msg):
+        super().__init__("can not print to a git repository: " + str(msg))
 
 
 def safe_resource_id(s):
@@ -2915,6 +2921,8 @@ class TerrascriptClient:
             working_dirs = existing_dirs
         for name, ts in self.tss.items():
             if print_to_file:
+                if is_file_in_git_repo(print_to_file):
+                    raise PrintToFileInGitRepositoryError(print_to_file)
                 with open(print_to_file, 'w') as f:
                     f.write('##### {} #####\n'.format(name))
                     f.write(str(ts))

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -2908,15 +2908,16 @@ class TerrascriptClient:
         with self.locks[account]:
             self.tss[account].add(tf_resource)
 
-    def dump(self, print_only=False, existing_dirs=None):
+    def dump(self, print_to_file=None, existing_dirs=None):
         if existing_dirs is None:
             working_dirs = {}
         else:
             working_dirs = existing_dirs
         for name, ts in self.tss.items():
-            if print_only:
-                print('##### {} #####'.format(name))
-                print(str(ts))
+            if print_to_file:
+                with open(print_to_file, 'w') as f:
+                    f.write('##### {} #####\n'.format(name))
+                    f.write(str(ts))
             if existing_dirs is None:
                 wd = tempfile.mkdtemp()
             else:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4208

this will prevent terraform printed configuration files from being leaked in an accidental commit