### PR TITLE
allow namespaces to use cluster-admin token for openshift resource mgmt

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -254,9 +254,9 @@ def wait_for_namespace_exists(oc, namespace):
         raise Exception(f'namespace {namespace} does not exist')
 
 
-def apply(dry_run, oc_map: OC_Map, cluster, namespace, resource_type, resource,
-          wait_for_namespace, recycle_pods: bool = True,
-          privileged: bool = False):
+def apply(dry_run: bool, oc_map: OC_Map, cluster: str, namespace: str,
+          resource_type: OR, resource, wait_for_namespace: bool,
+          recycle_pods: bool = True, privileged: bool = False) -> None:
     logging.info(['apply', cluster, namespace, resource_type, resource.name])
 
     oc = oc_map.get(cluster, privileged)
@@ -339,8 +339,9 @@ def create(dry_run, oc_map, cluster, namespace, resource_type, resource):
         oc.create(namespace, annotated)
 
 
-def delete(dry_run, oc_map, cluster, namespace, resource_type, name,
-           enable_deletion, privileged: bool = False):
+def delete(dry_run: bool, oc_map: OC_Map, cluster: str, namespace: str,
+           resource_type: str, name: str, enable_deletion: bool,
+           privileged: bool = False) -> None:
     logging.info(['delete', cluster, namespace, resource_type, name])
 
     if not enable_deletion:

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -71,7 +71,7 @@ def init_specs_to_fetch(ri: ResourceInventory, oc_map: OC_Map,
                 continue
 
             cluster = namespace_info['cluster']['name']
-            privileged = namespace_info.get("clusterAdmin", False)
+            privileged = namespace_info.get("clusterAdmin", False) is True
             oc = oc_map.get(cluster, privileged)
             if not oc:
                 if oc.log_level >= logging.ERROR:

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -255,7 +255,8 @@ def wait_for_namespace_exists(oc, namespace):
 
 
 def apply(dry_run, oc_map: OC_Map, cluster, namespace, resource_type, resource,
-          wait_for_namespace, privileged: bool, recycle_pods=True):
+          wait_for_namespace, recycle_pods: bool = True,
+          privileged: bool = False):
     logging.info(['apply', cluster, namespace, resource_type, resource.name])
 
     oc = oc_map.get(cluster, privileged)
@@ -339,7 +340,7 @@ def create(dry_run, oc_map, cluster, namespace, resource_type, resource):
 
 
 def delete(dry_run, oc_map, cluster, namespace, resource_type, name,
-           enable_deletion, privileged: bool):
+           enable_deletion, privileged: bool = False):
     logging.info(['delete', cluster, namespace, resource_type, name])
 
     if not enable_deletion:
@@ -373,7 +374,7 @@ def _realize_resource_data(unpacked_ri_item,
                            override_enable_deletion,
                            recycle_pods):
     cluster, namespace, resource_type, data = unpacked_ri_item
-    actions = []
+    actions: list[dict] = []
     if ri.has_error_registered(cluster=cluster):
         msg = (
             "[{}] skipping realize_data for "
@@ -447,7 +448,7 @@ def _realize_resource_data(unpacked_ri_item,
             privileged = data['use_admin_token'].get(name, False)
             apply(dry_run, oc_map, cluster, namespace,
                   resource_type, d_item, wait_for_namespace,
-                  privileged, recycle_pods=recycle_pods)
+                  recycle_pods, privileged)
             action = {
                 'action': ACTION_APPLIED,
                 'cluster': cluster,

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -87,6 +87,7 @@ NAMESPACES_QUERY = """
 {
   namespaces: namespaces_v1 {
     name
+    clusterAdmin
     managedResourceTypes
     managedResourceTypeOverrides {
       resource
@@ -131,6 +132,12 @@ NAMESPACES_QUERY = """
         pod
       }
       automationToken {
+        path
+        field
+        version
+        format
+      }
+      clusterAdminAutomationToken {
         path
         field
         version
@@ -541,7 +548,8 @@ def fetch_current_state(oc, ri, cluster, namespace, resource_type,
         )
 
 
-def fetch_desired_state(oc, ri, cluster, namespace, resource, parent):
+def fetch_desired_state(oc, ri, cluster, namespace, resource,
+                        parent, privileged: bool):
     global _log_lock
 
     if oc is None:
@@ -567,7 +575,8 @@ def fetch_desired_state(oc, ri, cluster, namespace, resource, parent):
             namespace,
             openshift_resource.kind,
             openshift_resource.name,
-            openshift_resource
+            openshift_resource,
+            privileged
         )
     except KeyError:
         # This is failing because in the managed_type loop (where the
@@ -606,7 +615,7 @@ def fetch_states(spec, ri):
         if spec.type == "desired":
             fetch_desired_state(spec.oc, ri, spec.cluster,
                                 spec.namespace, spec.resource,
-                                spec.parent)
+                                spec.parent, spec.privileged)
 
     except StatusCodeError as e:
         ri.register_error(cluster=spec.cluster)

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -30,7 +30,7 @@ class TestInitSpecsToFetch(testslide.TestCase):
 
         self.mock_callable(
             self.oc_map, 'get'
-        ).for_call("cs1").to_return_value("stuff")
+        ).for_call("cs1", False).to_return_value("stuff")
         self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
 
     def test_only_cluster_or_namespace(self) -> None:

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -431,3 +431,100 @@ class TestOCMapGetClusters(TestCase):
 
         self.assertEqual(oc_map.clusters(include_errors=True), cluster_names)
         self.assertIsInstance(oc_map.oc_map.get(cluster_1['name']), OCLogMsg)
+
+    @patch.object(reconcile.utils.oc, 'OC', autospec=True)
+    @patch.object(SecretReader, 'read', autospec=True)
+    def test_namespace_with_cluster_admin(self, mock_secret_reader, mock_oc):
+        cluster_1 = {
+            'name': 'cl1',
+            'serverUrl': 'http://localhost',
+            'clusterAdminAutomationToken': {
+                'path': 'some-path',
+                'field': 'some-field'
+            },
+            'automationToken': {
+                'path': 'some-path',
+                'field': 'some-field'
+            }
+        }
+        cluster_2 = {
+            'name': 'cl2',
+            'serverUrl': 'http://localhost',
+            'clusterAdminAutomationToken': {
+                'path': 'some-path',
+                'field': 'some-field'
+            },
+            'automationToken': {
+                'path': 'some-path',
+                'field': 'some-field'
+            }
+        }
+        namespace_1 = {
+            'name': 'ns1',
+            'clusterAdmin': True,
+            'cluster': cluster_1
+
+        }
+
+        namespace_2 = {
+            'name': 'ns2',
+            'cluster': cluster_2
+
+        }
+
+        oc_map = OC_Map(namespaces=[namespace_1, namespace_2])
+
+        self.assertEqual(oc_map.clusters(), ["cl1", "cl2"])
+        self.assertEqual(oc_map.clusters(privileged=True), ["cl1"])
+
+        # both clusters are present as non privileged clusters in the map
+        self.assertIsInstance(oc_map.get(cluster_1['name']), OC)
+        self.assertIsInstance(oc_map.get(cluster_2['name']), OC)
+
+        # only cluster_1 is present as privileged cluster in the map
+        self.assertIsInstance(
+            oc_map.get(cluster_1['name'], privileged=True),
+            OC
+        )
+        self.assertIsInstance(
+            oc_map.get(cluster_2['name'], privileged=True),
+            OCLogMsg
+        )
+
+    @patch.object(reconcile.utils.oc, 'OC', autospec=True)
+    @patch.object(SecretReader, 'read', autospec=True)
+    def test_missing_cluster_automation_token(self, mock_secret_reader,
+                                              mock_oc):
+        cluster_1 = {
+            'name': 'cl1',
+            'serverUrl': 'http://localhost',
+            'automationToken': {
+                'path': 'some-path',
+                'field': 'some-field'
+            }
+        }
+        namespace_1 = {
+            'name': 'ns1',
+            'clusterAdmin': True,
+            'cluster': cluster_1
+
+        }
+
+        oc_map = OC_Map(namespaces=[namespace_1])
+
+        # check that non-priv OC got instantiated but priv one not
+        self.assertEqual(oc_map.clusters(), ["cl1"])
+        self.assertEqual(oc_map.clusters(privileged=True), [])
+        self.assertEqual(
+            oc_map.clusters(include_errors=True, privileged=True),
+            [cluster_1['name']]
+        )
+
+        self.assertIsInstance(
+            oc_map.get(cluster_1['name']),
+            OC
+        )
+        self.assertIsInstance(
+            oc_map.get(cluster_1['name'], privileged=True),
+            OCLogMsg
+        )

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -524,7 +524,4 @@ class TestOCMapGetClusters(TestCase):
             oc_map.get(cluster_1['name']),
             OC
         )
-        self.assertIsInstance(
-            oc_map.get(cluster_1['name'], privileged=True),
-            OCLogMsg
-        )
+        self.assertFalse(oc_map.get(cluster_1['name'], privileged=True))

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1145,15 +1145,20 @@ class OC_Map:
 
         if privileged:
             automation_token = cluster_info.get('clusterAdminAutomationToken')
+            token_name = "admin automation token"
         else:
             automation_token = cluster_info.get('automationToken')
+            token_name = "automation token"
 
         if automation_token is None:
-            self.set_oc(cluster,
-                        OCLogMsg(log_level=logging.ERROR,
-                                 message=f"[{cluster}]"
-                                 " has no automation token"),
-                        privileged)
+            self.set_oc(
+                cluster,
+                OCLogMsg(
+                    log_level=logging.ERROR,
+                    message=f"[{cluster}] has no {token_name}"
+                ),
+                privileged
+            )
         # serverUrl isn't set when a new cluster is initially created.
         elif not cluster_info.get('serverUrl'):
             self.set_oc(

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -449,6 +449,12 @@ class ResourceInventory:
 
     def add_desired(self, cluster, namespace, resource_type, name, value,
                     privileged=False):
+        # privileged permissions to apply resources to clusters are managed on
+        # a per-namespace level in qontract-schema namespace files, but are
+        # tracked on a per-resource level in ResourceInventory and the
+        # state-specs that lead up to add_desired calls. while this is a
+        # mismatch between schema and implementation for now, it will enable
+        # us to implement per-resource configuration in the future
         with self._lock:
             desired = \
                 (self._clusters[cluster][namespace][resource_type]

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -443,10 +443,12 @@ class ResourceInventory:
         self._clusters[cluster].setdefault(namespace, {})
         self._clusters[cluster][namespace].setdefault(resource_type, {
             'current': {},
-            'desired': {}
+            'desired': {},
+            'use_admin_token': {}
         })
 
-    def add_desired(self, cluster, namespace, resource_type, name, value):
+    def add_desired(self, cluster, namespace, resource_type, name, value,
+                    privileged=False):
         with self._lock:
             desired = \
                 (self._clusters[cluster][namespace][resource_type]
@@ -454,6 +456,10 @@ class ResourceInventory:
             if name in desired:
                 raise ResourceKeyExistsError(name)
             desired[name] = value
+            admin_token_usage = \
+                (self._clusters[cluster][namespace][resource_type]
+                    ['use_admin_token'])
+            admin_token_usage[name] = privileged
 
     def add_current(self, cluster, namespace, resource_type, name, value):
         with self._lock:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -20,6 +20,7 @@ from reconcile.github_org import get_config
 from reconcile.utils.mr.auto_promoter import AutoPromoter
 from reconcile.utils.oc import OC, StatusCodeError
 from reconcile.utils.openshift_resource import (OpenshiftResource as OR,
+                                                ResourceInventory,
                                                 ResourceKeyExistsError)
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.state import State
@@ -797,12 +798,13 @@ class SaasHerder():
                     'instance_name': instance_name,
                     'upstream': target.get('upstream'),
                     'delete': target.get('delete'),
+                    'privileged': saas_file.get('clusterAdmin', False)
                 }
                 specs.append(spec)
 
         return specs
 
-    def populate_desired_state_saas_file(self, spec, ri):
+    def populate_desired_state_saas_file(self, spec, ri: ResourceInventory):
         if spec['delete']:
             # to delete resources, we avoid adding them to the desired state
             return
@@ -873,7 +875,8 @@ class SaasHerder():
                     namespace,
                     resource_kind,
                     resource_name,
-                    oc_resource
+                    oc_resource,
+                    privileged=spec['privileged']
                 )
             except ResourceKeyExistsError:
                 ri.register_error()

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -798,7 +798,7 @@ class SaasHerder():
                     'instance_name': instance_name,
                     'upstream': target.get('upstream'),
                     'delete': target.get('delete'),
-                    'privileged': saas_file.get('clusterAdmin', False)
+                    'privileged': saas_file.get('clusterAdmin', False) is True
                 }
                 specs.append(spec)
 


### PR DESCRIPTION
# Summary
This change introduces a field `clusterAdmin` in a `namespace-1.yml` file similar to how `saas` files use this flag. When it is set to true, the cluster-admin token of a cluster is used to reconcile resources.

~~This change needs more testing, i opened this MR to get a feeling what people think of the general approach~~


# Approach
Two things needed touching to implement this change: the OC_Map and the ResourceInventory initialisation and usage

## OC_Map
Instead of tracking all clusters in one dict and having either all of them authenticated with dedicated-admin or cluster-admin, this change introduces the ability for clusters being present in a cluster map both ways at the same time. This is mostly relevant (and necessary) for `OC_Map` initialisation based on a set of namespaces, where one namespace requires cluster-admin while another one on the same cluster can work with dedicated-admin.

An alternate approach would have been to initialise the cluster with the highest required permission, but that had apparent security problems, allowing a non-admin namespace to escalate permissions beyond what has been declared in the namespace file.

Due to this change, the API of `OC_Map` changed, specifically the `get(cluster)` method got a new optional parameter `privileged` (defaults to false). Client code using the get method needs to be aware what permissions are required and needs to provide the `privileged` parameter accordingly. The `openshift-saas-deploy` and `openshift-resources` integrations are the only ones leveraging cluster-admin permissions right now, and both of them have been changed to pass the `privileged` parameter based on the `clusterAdmin` field in saas and namespace files. All other integrations do not required cluster-admin permissions and will still automatically use the dedicated-admin authenticated oc client.

## ResourceInventory
The `ResourceInventory` will also keep track of which resource in the `desired` state can use privileged cluster access for reconciliation. For this the API of `ResourceInventory` changed: the `add_desired` method got an additional optional parameter `privileged` (defaults to false). `openshift_resource_base.py` and the `SaasHerder` have been changed to feed information based on their respective `clusterAdmin` sources through the state spec to the `privileged` parameter of `add_desired`.


Related schema change: https://github.com/app-sre/qontract-schemas/pull/41
Part of: https://issues.redhat.com/browse/APPSRE-4195

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>