### PR TITLE
[terraform-aws-route53] add identifier to support split view dns

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1917,6 +1917,7 @@ DNS_ZONES_QUERY = """
 {
   zones: dns_zone_v1 {
     name
+    identifier
     account {
       name
       uid

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -33,8 +33,10 @@ def build_desired_state(zones):
         account_name = account['name']
 
         zone_name = zone['name']
+        zone_identifier = zone.get('identifier') or zone_name
         zone_values = {
             'name': zone_name,
+            'identifier': zone_identifier,
             'account_name': account_name,
             'records': []
         }

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -488,7 +488,7 @@ class TerrascriptClient:
             acct_name = zone['account_name']
 
             # Ensure zone is in the state for the given account
-            zone_id = safe_resource_id(f"{zone['name']}")
+            zone_id = safe_resource_id(f"{zone.pop('identifier')}")
             zone_values = {
                 'name': zone['name'],
                 'vpc': zone.get('vpc'),

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -488,7 +488,8 @@ class TerrascriptClient:
             acct_name = zone['account_name']
 
             # Ensure zone is in the state for the given account
-            zone_id = safe_resource_id(f"{zone.pop('identifier')}")
+            zone_id = zone.pop('identifier', None)
+            zone_id = safe_resource_id(zone_id)
             zone_values = {
                 'name': zone['name'],
                 'vpc': zone.get('vpc'),


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/43

with a unique identifier, we can specify multiple zones of the same name to support features such as split view DNS: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-considerations.html#hosted-zone-private-considerations-split-view-dns