### PR TITLE
[pagerduty] get schedule users if user is not deleted

### DIFF
--- a/reconcile/utils/pagerduty_api.py
+++ b/reconcile/utils/pagerduty_api.py
@@ -51,7 +51,8 @@ class PagerDutyApi:
             time_zone='UTC')
         entries = s['final_schedule']['rendered_schedule_entries']
 
-        return [self.get_user(entry['user']['id']) for entry in entries]
+        return [self.get_user(entry['user']['id']) for entry in entries
+                if not entry['user'].get('deleted_at')]
 
     def get_escalation_policy_users(self, escalation_policy_id, now):
         ep = pypd.EscalationPolicy.fetch(


### PR DESCRIPTION
apparently users can be inactive in PD: https://coreos.slack.com/archives/CS0E65QCV/p1640860881303600

there is no direct api to get inactive users: https://community.pagerduty.com/forum/t/getting-a-list-of-inactive-or-unused-pagerduty-users/1789
so this has to be done from the schedule perspective.