### PR TITLE
Fix remove_none_values method

### DIFF
--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -713,6 +713,15 @@ class TestConfigHashTrigger(TestCase):
             self.saasherder.get_configs_diff_saas_file(self.saas_file)
         self.assertEqual(len(job_specs), 1)
 
+    def test_non_existent_config_triggers(self):
+        self.state_mock.get.side_effect = [
+            self.deploy_current_state_fxt,
+            None
+        ]
+        job_specs = \
+            self.saasherder.get_configs_diff_saas_file(self.saas_file)
+        self.assertEqual(len(job_specs), 1)
+
 
 class TestRemoveNonAttributes(TestCase):
     def testSimpleDict(self):

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -714,7 +714,6 @@ class TestConfigHashTrigger(TestCase):
         self.assertEqual(len(job_specs), 1)
 
 
-
 class TestRemoveNonAttributes(TestCase):
     def testSimpleDict(self):
         input = {

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -712,3 +712,32 @@ class TestConfigHashTrigger(TestCase):
         job_specs = \
             self.saasherder.get_configs_diff_saas_file(self.saas_file)
         self.assertEqual(len(job_specs), 1)
+
+
+
+class TestRemoveNonAttributes(TestCase):
+    def testSimpleDict(self):
+        input = {
+            "a": 1,
+            "b": {},
+            "d": None,
+            "e": {
+                "aa": "aa",
+                "bb": None
+            }
+        }
+        expected = {
+            "a": 1,
+            "b": {},
+            "e": {
+                "aa": "aa"
+            }
+        }
+        res = SaasHerder.remove_none_values(input)
+        self.assertEqual(res, expected)
+
+    def testNoneValue(self):
+        input = None
+        expected = {}
+        res = SaasHerder.remove_none_values(input)
+        self.assertEqual(res, expected)

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -723,7 +723,7 @@ class TestConfigHashTrigger(TestCase):
         self.assertEqual(len(job_specs), 1)
 
 
-class TestRemoveNonAttributes(TestCase):
+class TestRemoveNoneAttributes(TestCase):
     def testSimpleDict(self):
         input = {
             "a": 1,

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -1107,6 +1107,8 @@ class SaasHerder():
 
     @staticmethod
     def remove_none_values(d):
+        if d is None:
+            return {}
         new = {}
         for k, v in d.items():
             if v is not None:


### PR DESCRIPTION
## Description 

remove_none_value method has been changed to work with a None value input. This could happen when a new saas target is deployed and there is no current configuration stored in the State
