### PR TITLE
Create SNS event notification for S3 

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -52,6 +52,13 @@ provider
   overrides
   sqs_identifier
   s3_events
+  event_notifications {
+    destination_type
+    destination
+    event_type
+    filter_prefix
+    filter_suffix
+  }
   bucket_policy
   output_resource_name
   storage_class


### PR DESCRIPTION
### Why:
Be able to create SNS notification through App Interface for existing topic and bucket.
### What:
1. Change the query to get the event_notification information;
2. Add it in the terraform-resources integration to loop through event_notification and create SNS topic;
### Validation:
Local run was able to create it.