### PR TITLE
[endpoint monitoring] integration backed by blackbox-exporter

### DIFF
--- a/helm/qontract-reconcile/values-internal.yaml
+++ b/helm/qontract-reconcile/values-internal.yaml
@@ -361,6 +361,14 @@ integrations:
       memory: 200Mi
       cpu: 200m
   state: true
+- name: blackbox-exporter-endpoint-monitoring
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 100m
+    limits:
+      memory: 200Mi
+      cpu: 200m
 cronjobs:
 - name: jenkins-job-builds-cleaner
   concurrencyPolicy: "Forbid"

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -7933,6 +7933,183 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: qontract-reconcile-blackbox-exporter-endpoint-monitoring
+    name: qontract-reconcile-blackbox-exporter-endpoint-monitoring
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile-blackbox-exporter-endpoint-monitoring
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile-blackbox-exporter-endpoint-monitoring
+          component: qontract-reconcile
+      spec:
+        serviceAccountName: qontract-reconcile
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name blackbox-exporter-endpoint-monitoring
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          ports:
+            - name: http
+              containerPort: 9090
+          env:
+          - name: SHARDS
+            value: "1"
+          - name: SHARD_ID
+            value: "0"
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: blackbox-exporter-endpoint-monitoring
+          - name: INTEGRATION_EXTRA_ARGS
+            value: ""
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: GITHUB_API
+          - name: SENTRY_DSN
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
+          - name: UNLEASH_API_URL
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: API_URL
+          - name: UNLEASH_CLIENT_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: CLIENT_ACCESS_TOKEN
+          - name: SLOW_OC_RECONCILE_THRESHOLD
+            value: "${SLOW_OC_RECONCILE_THRESHOLD}"
+          - name: LOG_SLOW_OC_RECONCILE
+            value: "${LOG_SLOW_OC_RECONCILE}"
+          - name: USE_NATIVE_CLIENT
+            value: "${USE_NATIVE_CLIENT}"
+          resources:
+            limits:
+              cpu: ${BLACKBOX_EXPORTER_ENDPOINT_MONITORING_CPU_LIMIT}
+              memory: ${BLACKBOX_EXPORTER_ENDPOINT_MONITORING_MEMORY_LIMIT}
+            requests:
+              cpu: ${BLACKBOX_EXPORTER_ENDPOINT_MONITORING_CPU_REQUEST}
+              memory: ${BLACKBOX_EXPORTER_ENDPOINT_MONITORING_MEMORY_REQUEST}
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
 - apiVersion: batch/v1beta1
   kind: CronJob
   metadata:
@@ -8677,6 +8854,14 @@ parameters:
 - name: STATUS_PAGE_COMPONENTS_CPU_REQUEST
   value: 100m
 - name: STATUS_PAGE_COMPONENTS_MEMORY_REQUEST
+  value: 100Mi
+- name: BLACKBOX_EXPORTER_ENDPOINT_MONITORING_CPU_LIMIT
+  value: 200m
+- name: BLACKBOX_EXPORTER_ENDPOINT_MONITORING_MEMORY_LIMIT
+  value: 200Mi
+- name: BLACKBOX_EXPORTER_ENDPOINT_MONITORING_CPU_REQUEST
+  value: 100m
+- name: BLACKBOX_EXPORTER_ENDPOINT_MONITORING_MEMORY_REQUEST
   value: 100Mi
 - name: JENKINS_JOB_BUILDS_CLEANER_CPU_LIMIT
   value: 200m

--- a/reconcile/blackbox_exporter_endpoint_monitoring.py
+++ b/reconcile/blackbox_exporter_endpoint_monitoring.py
@@ -130,8 +130,7 @@ def get_endpoints() -> dict[EndpointMonitoringProvider, list[Endpoint]]:
             if monitoring:
                 if monitoring["provider"]["provider"] == "blackbox-exporter":
                     ep = Endpoint(**ep_data)
-                    if ep.monitoring.provider not in endpoints:
-                        endpoints[ep.monitoring.provider] = []
+                    endpoints.setdefault(ep.monitoring.provider, [])
                     endpoints[ep.monitoring.provider].append(ep)
 
     return endpoints

--- a/reconcile/blackbox_exporter_endpoint_monitoring.py
+++ b/reconcile/blackbox_exporter_endpoint_monitoring.py
@@ -1,0 +1,176 @@
+import logging
+import sys
+from urllib.parse import urlparse
+from typing import Any, Optional
+import json
+from dataclasses import field
+
+from pydantic.dataclasses import dataclass
+
+from reconcile import queries
+from reconcile.utils.openshift_resource import (
+    OpenshiftResource, ResourceInventory)
+from reconcile.utils.defer import defer
+from reconcile.utils.semver_helper import make_semver
+import reconcile.openshift_base as ob
+
+QONTRACT_INTEGRATION = "blackbox-exporter-endpoint-monitoring"
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
+
+LOG = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, eq=True)
+class BlackboxMonitoringProvider:
+
+    module: str
+    namespace: dict[str, Any] = field(compare=False, hash=False)
+    exporterUrl: str
+
+
+@dataclass(frozen=True, eq=True)
+class EndpointMonitoringProvider:
+
+    name: str
+    provider: str
+    description: str
+    timeout: Optional[str] = None
+    checkInterval: Optional[str] = None
+    blackboxExporter: Optional[BlackboxMonitoringProvider] = None
+    metricLabels: Optional[str] = None
+
+    @property
+    def metric_labels(self):
+        return json.loads(self.metricLabels) if self.metricLabels else {}
+
+
+@dataclass
+class Endpoint:
+
+    name: str
+    description: str
+    url: str
+
+    @dataclass
+    class Monitoring:
+
+        provider: EndpointMonitoringProvider
+
+    monitoring: Monitoring
+
+
+def parse_prober_url(url: str) -> dict[str, str]:
+    parsed_url = urlparse(url)
+    if parsed_url.scheme not in ["http", "https"]:
+        raise ValueError(
+            "the prober URL needs to be an http:// or https:// one "
+            f"but is {url}"
+        )
+    data = {
+        "url": parsed_url.netloc,
+        "scheme": parsed_url.scheme
+    }
+    if parsed_url.path:
+        data["path"] = parsed_url.path
+    return data
+
+
+def build_probe(provider: EndpointMonitoringProvider,
+                endpoints: list[Endpoint]) -> Optional[OpenshiftResource]:
+    blackbox_exporter = provider.blackboxExporter
+    if blackbox_exporter:
+        prober_url = parse_prober_url(blackbox_exporter.exporterUrl)
+        body = {
+            "apiVersion": "monitoring.coreos.com/v1",
+            "kind": "Probe",
+            "metadata": {
+                "name": f"endpoint-monitoring-{provider.name}",
+                "namespace": blackbox_exporter.namespace.get("name"),
+                "labels": {
+                    "prometheus": "app-sre"
+                }
+            },
+            "spec": {
+                "jobName": f"endpoint-monitoring-{provider.name}",
+                "interval": provider.checkInterval,
+                "module": blackbox_exporter.module,
+                "prober": prober_url,
+                "targets": {
+                    "staticConfig": {
+                        "relabelingConfigs": {
+                            "action": "labeldrop",
+                            "regex": "namespace"
+                        },
+                        "labels": provider.metric_labels,
+                        "static": [
+                            ep.url for ep in endpoints
+                        ]
+                    }
+                }
+            }
+        }
+        return OpenshiftResource(
+            body,
+            QONTRACT_INTEGRATION,
+            QONTRACT_INTEGRATION_VERSION
+        )
+    else:
+        return None
+
+
+def get_endpoints() -> dict[EndpointMonitoringProvider, list[Endpoint]]:
+    endpoints: dict[EndpointMonitoringProvider, list[Endpoint]] = {}
+    for app in queries.get_service_monitoring_endpoints():
+        for ep_data in app.get("endPoints") or []:
+            monitoring = ep_data.get("monitoring")
+            if monitoring:
+                if monitoring["provider"]["provider"] == "blackbox-exporter":
+                    ep = Endpoint(**ep_data)
+                    if ep.monitoring.provider not in endpoints:
+                        endpoints[ep.monitoring.provider] = []
+                    endpoints[ep.monitoring.provider].append(ep)
+
+    return endpoints
+
+
+def fill_desired_state(provider: EndpointMonitoringProvider,
+                       endpoints: list[Endpoint],
+                       ri: ResourceInventory) -> None:
+    probe = build_probe(provider, endpoints)
+    if probe and provider.blackboxExporter:
+        ns = provider.blackboxExporter.namespace
+        ri.add_desired(
+            cluster=ns["cluster"]["name"],
+            namespace=ns["name"],
+            resource_type=probe.kind,
+            name=probe.name,
+            value=probe
+        )
+
+
+@defer
+def run(dry_run: bool, thread_pool_size: int, defer=None) -> None:
+    # prepare
+    desired_endpoints = get_endpoints()
+    namespaces = {
+        p.blackboxExporter.namespace.get("name"):
+        p.blackboxExporter.namespace
+        for p in desired_endpoints
+        if p.blackboxExporter
+    }
+    ri, oc_map = ob.fetch_current_state(
+        namespaces.values(),
+        thread_pool_size=thread_pool_size,
+        integration=QONTRACT_INTEGRATION,
+        integration_version=QONTRACT_INTEGRATION_VERSION,
+        override_managed_types=["Probe"]
+    )
+    defer(oc_map.cleanup)
+
+    # reconcile
+    for provider, endpoints in desired_endpoints.items():
+        fill_desired_state(provider, endpoints, ri)
+    ob.realize_data(dry_run, oc_map, ri, thread_pool_size)
+
+    if ri.has_error_registered():
+        sys.exit(1)

--- a/reconcile/blackbox_exporter_endpoint_monitoring.py
+++ b/reconcile/blackbox_exporter_endpoint_monitoring.py
@@ -24,6 +24,8 @@ LOG = logging.getLogger(__name__)
 class BlackboxMonitoringProvider:
 
     module: str
+    # the namespace of a blackbox-exporter provider is mapped as dict
+    # since its only use with ob.fetch_current_state is as a dict
     namespace: dict[str, Any] = field(compare=False, hash=False)
     exporterUrl: str
 

--- a/reconcile/blackbox_exporter_endpoint_monitoring.py
+++ b/reconcile/blackbox_exporter_endpoint_monitoring.py
@@ -58,7 +58,7 @@ class Endpoint:
 
         provider: EndpointMonitoringProvider
 
-    monitoring: Monitoring
+    monitoring: list[Monitoring]
 
 
 def parse_prober_url(url: str) -> dict[str, str]:
@@ -130,11 +130,14 @@ def get_endpoints() -> dict[EndpointMonitoringProvider, list[Endpoint]]:
         for ep_data in app.get("endPoints") or []:
             monitoring = ep_data.get("monitoring")
             if monitoring:
-                if monitoring["provider"]["provider"] == "blackbox-exporter":
-                    ep = Endpoint(**ep_data)
-                    endpoints.setdefault(ep.monitoring.provider, [])
-                    endpoints[ep.monitoring.provider].append(ep)
-
+                ep_data["monitoring"] = [
+                    m for m in monitoring
+                    if m["provider"]["provider"] == "blackbox-exporter"
+                ]
+                ep = Endpoint(**ep_data)
+                for mon in ep.monitoring:
+                    endpoints.setdefault(mon.provider, [])
+                    endpoints[mon.provider].append(ep)
     return endpoints
 
 

--- a/reconcile/blackbox_exporter_endpoint_monitoring.py
+++ b/reconcile/blackbox_exporter_endpoint_monitoring.py
@@ -84,14 +84,14 @@ def build_probe(provider: EndpointMonitoringProvider,
             "apiVersion": "monitoring.coreos.com/v1",
             "kind": "Probe",
             "metadata": {
-                "name": f"endpoint-monitoring-{provider.name}",
+                "name": provider.name,
                 "namespace": blackbox_exporter.namespace.get("name"),
                 "labels": {
                     "prometheus": "app-sre"
                 }
             },
             "spec": {
-                "jobName": f"endpoint-monitoring-{provider.name}",
+                "jobName": provider.name,
                 "interval": provider.checkInterval or "10s",
                 "module": blackbox_exporter.module,
                 "prober": prober_url,

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -108,6 +108,7 @@ import reconcile.jenkins_job_builds_cleaner
 import reconcile.cluster_deployment_mapper
 import reconcile.gabi_authorized_users
 import reconcile.status_page_components
+import reconcile.blackbox_exporter_endpoint_monitoring
 
 from reconcile.status import ExitCodes
 from reconcile.status import RunningState
@@ -1456,3 +1457,11 @@ def dyn_traffic_director(ctx, enable_deletion):
 @click.pass_context
 def status_page_components(ctx):
     run_integration(reconcile.status_page_components, ctx.obj)
+
+
+@integration.command()
+@threaded()
+@click.pass_context
+def blackbox_exporter_endpoint_monitoring(ctx, thread_pool_size):
+    run_integration(reconcile.blackbox_exporter_endpoint_monitoring,
+                    ctx.obj, thread_pool_size)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2434,3 +2434,53 @@ STATUS_PAGE_QUERY = """
 def get_status_pages():
     gqlapi = gql.get_api()
     return gqlapi.query(STATUS_PAGE_QUERY)['status_pages']
+
+
+CLOSED_BOX_MONITORING_PROBES_QUERY = """
+{
+  apps: apps_v1 {
+    name
+    labels
+    onboardingStatus
+    endPoints {
+      name
+      description
+      url
+      monitoring {
+        provider {
+          name
+          description
+          provider
+          metricLabels
+          timeout
+          checkInterval
+          ... on EndpointMonitoringProviderBlackboxExporter_v1 {
+            blackboxExporter {
+              module
+              namespace {
+                name
+                cluster {
+                  name
+                  serverUrl
+                  automationToken {
+                    path
+                    field
+                    version
+                  }
+                  internal
+                }
+              }
+              exporterUrl
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def get_service_monitoring_endpoints():
+    gqlapi = gql.get_api()
+    return gqlapi.query(CLOSED_BOX_MONITORING_PROBES_QUERY)['apps']

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2439,9 +2439,6 @@ def get_status_pages():
 CLOSED_BOX_MONITORING_PROBES_QUERY = """
 {
   apps: apps_v1 {
-    name
-    labels
-    onboardingStatus
     endPoints {
       name
       description

--- a/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_endpoint.yaml
+++ b/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_endpoint.yaml
@@ -5,11 +5,11 @@ appInterface:
       description: test
       url: https://httpstat.us/200
       monitoring:
-        provider:
+      - provider:
           name: blackbox-exporter-http-2xx
           description: Checks a URL for HTTP 2xx status codes via blackbox-exporter
           provider: blackbox-exporter
-          timeout: null,
+          timeout: null
           checkInterval: null
           blackboxExporter:
             module: http_2xx
@@ -23,3 +23,5 @@ appInterface:
                   path: app-sre/creds/kube-configs/app-sre-stage-01
                   field: token
             exporterUrl: http://exporterhost:9115/probe
+      - provider:
+          provider: other

--- a/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_endpoint.yaml
+++ b/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_endpoint.yaml
@@ -1,0 +1,28 @@
+appInterface:
+  apps:
+  - name: testapp
+    onboardingStatus: OnBoarded
+    labels: "{\"service\":\"testservice\"}"
+    endPoints:
+    - name: test
+      description: test
+      url: https://httpstat.us/200
+      monitoring:
+        provider:
+          name: blackbox-exporter-http-2xx
+          description: Checks a URL for HTTP 2xx status codes via blackbox-exporter
+          provider: blackbox-exporter
+          timeout: null,
+          checkInterval: null
+          blackboxExporter:
+            module: http_2xx
+            namespace:
+              name: openshift-customer-monitoring
+              cluster:
+                name: app-sre-stage-01
+                serverUrl: http://asdf:6443
+                internal: false
+                automationToken:
+                  path: app-sre/creds/kube-configs/app-sre-stage-01
+                  field: token
+            exporterUrl: http://exporterhost:9115/probe

--- a/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_endpoint.yaml
+++ b/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_endpoint.yaml
@@ -1,9 +1,6 @@
 appInterface:
   apps:
-  - name: testapp
-    onboardingStatus: OnBoarded
-    labels: "{\"service\":\"testservice\"}"
-    endPoints:
+  - endPoints:
     - name: test
       description: test
       url: https://httpstat.us/200

--- a/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_invalid_endpoints.yaml
+++ b/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_invalid_endpoints.yaml
@@ -14,7 +14,7 @@ appInterface:
       description: test
       url: https://httpstat.us/200
       monitoring:
-        provider:
+      - provider:
           name: blackbox-exporter-http-2xx
           description: Checks a URL for HTTP 2xx status codes via blackbox-exporter
           provider: another-provider

--- a/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_invalid_endpoints.yaml
+++ b/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_invalid_endpoints.yaml
@@ -1,0 +1,21 @@
+appInterface:
+  apps:
+  - name: app-without-endpoints
+    onboardingStatus: OnBoarded
+  - name: app-with-endpoints-but-no-monitors
+    onboardingStatus: OnBoarded
+    endPoints:
+    - name: test
+      description: test
+      url: https://httpstat.us/200
+  - name: app-with-endpoints-but-different-provider
+    onboardingStatus: OnBoarded
+    endPoints:
+    - name: test
+      description: test
+      url: https://httpstat.us/200
+      monitoring:
+        provider:
+          name: blackbox-exporter-http-2xx
+          description: Checks a URL for HTTP 2xx status codes via blackbox-exporter
+          provider: another-provider

--- a/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_invalid_endpoints.yaml
+++ b/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_invalid_endpoints.yaml
@@ -1,16 +1,15 @@
 appInterface:
   apps:
-  - name: app-without-endpoints
-    onboardingStatus: OnBoarded
+  - name: xxx
+  - endPoints: null
+  - endPoints: []
   - name: app-with-endpoints-but-no-monitors
     onboardingStatus: OnBoarded
     endPoints:
     - name: test
       description: test
       url: https://httpstat.us/200
-  - name: app-with-endpoints-but-different-provider
-    onboardingStatus: OnBoarded
-    endPoints:
+  - endPoints:
     - name: test
       description: test
       url: https://httpstat.us/200

--- a/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_multiple_providers_per_endpoint.yaml
+++ b/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_multiple_providers_per_endpoint.yaml
@@ -24,7 +24,25 @@ appInterface:
                   path: app-sre/creds/kube-configs/app-sre-stage-01
                   field: token
             exporterUrl: http://exporterhost:9115/probe
-  - endPoints:
+      - provider:
+          name: blackbox-exporter-http-3xx
+          description: Checks a URL for HTTP 3xx status codes via blackbox-exporter
+          provider: blackbox-exporter
+          metricLabels: "{\"environment\":\"staging\"}"
+          timeout: 25s
+          checkInterval: 10s
+          blackboxExporter:
+            module: http_3xx
+            namespace:
+              name: openshift-customer-monitoring
+              cluster:
+                name: app-sre-stage-01
+                serverUrl: http://asdf:6443
+                internal: false
+                automationToken:
+                  path: app-sre/creds/kube-configs/app-sre-stage-01
+                  field: token
+            exporterUrl: http://exporterhost:9115/probe
     - name: test_2
       description: test_2
       url: https://test2.url
@@ -38,6 +56,25 @@ appInterface:
           checkInterval: 10s
           blackboxExporter:
             module: http_2xx
+            namespace:
+              name: openshift-customer-monitoring
+              cluster:
+                name: app-sre-stage-01
+                serverUrl: http://asdf:6443
+                internal: false
+                automationToken:
+                  path: app-sre/creds/kube-configs/app-sre-stage-01
+                  field: token
+            exporterUrl: http://exporterhost:9115/probe
+      - provider:
+          name: blackbox-exporter-http-3xx
+          description: Checks a URL for HTTP 3xx status codes via blackbox-exporter
+          provider: blackbox-exporter
+          metricLabels: "{\"environment\":\"staging\"}"
+          timeout: 25s
+          checkInterval: 10s
+          blackboxExporter:
+            module: http_3xx
             namespace:
               name: openshift-customer-monitoring
               cluster:

--- a/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_probe_building.yaml
+++ b/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_probe_building.yaml
@@ -13,8 +13,8 @@ appInterface:
           description: Checks a URL for HTTP 2xx status codes via blackbox-exporter
           provider: blackbox-exporter
           metricLabels: "{\"environment\":\"staging\"}"
-          timeout: null,
-          checkInterval: null
+          timeout: 25s
+          checkInterval: 10s
           blackboxExporter:
             module: http_2xx
             namespace:
@@ -40,8 +40,8 @@ appInterface:
           description: Checks a URL for HTTP 2xx status codes via blackbox-exporter
           provider: blackbox-exporter
           metricLabels: "{\"environment\":\"staging\"}"
-          timeout: null,
-          checkInterval: null
+          timeout: 25s
+          checkInterval: 10s
           blackboxExporter:
             module: http_2xx
             namespace:

--- a/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_probe_building.yaml
+++ b/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_probe_building.yaml
@@ -1,0 +1,56 @@
+appInterface:
+  apps:
+  - name: testapp_1
+    onboardingStatus: OnBoarded
+    labels: "{\"service\":\"testservice\"}"
+    endPoints:
+    - name: test_1
+      description: test_1
+      url: https://test1.url
+      monitoring:
+        provider:
+          name: blackbox-exporter-http-2xx
+          description: Checks a URL for HTTP 2xx status codes via blackbox-exporter
+          provider: blackbox-exporter
+          metricLabels: "{\"environment\":\"staging\"}"
+          timeout: null,
+          checkInterval: null
+          blackboxExporter:
+            module: http_2xx
+            namespace:
+              name: openshift-customer-monitoring
+              cluster:
+                name: app-sre-stage-01
+                serverUrl: http://asdf:6443
+                internal: false
+                automationToken:
+                  path: app-sre/creds/kube-configs/app-sre-stage-01
+                  field: token
+            exporterUrl: http://exporterhost:9115/probe
+  - name: testapp_2
+    onboardingStatus: OnBoarded
+    labels: "{\"service\":\"testservice\"}"
+    endPoints:
+    - name: test_2
+      description: test_2
+      url: https://test2.url
+      monitoring:
+        provider:
+          name: blackbox-exporter-http-2xx
+          description: Checks a URL for HTTP 2xx status codes via blackbox-exporter
+          provider: blackbox-exporter
+          metricLabels: "{\"environment\":\"staging\"}"
+          timeout: null,
+          checkInterval: null
+          blackboxExporter:
+            module: http_2xx
+            namespace:
+              name: openshift-customer-monitoring
+              cluster:
+                name: app-sre-stage-01
+                serverUrl: http://asdf:6443
+                internal: false
+                automationToken:
+                  path: app-sre/creds/kube-configs/app-sre-stage-01
+                  field: token
+            exporterUrl: http://exporterhost:9115/probe

--- a/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_probe_building.yaml
+++ b/reconcile/test/fixtures/blackbox_exporter_endpoint_monitoring/test_probe_building.yaml
@@ -1,9 +1,6 @@
 appInterface:
   apps:
-  - name: testapp_1
-    onboardingStatus: OnBoarded
-    labels: "{\"service\":\"testservice\"}"
-    endPoints:
+  - endPoints:
     - name: test_1
       description: test_1
       url: https://test1.url
@@ -27,10 +24,7 @@ appInterface:
                   path: app-sre/creds/kube-configs/app-sre-stage-01
                   field: token
             exporterUrl: http://exporterhost:9115/probe
-  - name: testapp_2
-    onboardingStatus: OnBoarded
-    labels: "{\"service\":\"testservice\"}"
-    endPoints:
+  - endPoints:
     - name: test_2
       description: test_2
       url: https://test2.url

--- a/reconcile/test/test_blackbox_exporter_endpoint_monitoring.py
+++ b/reconcile/test/test_blackbox_exporter_endpoint_monitoring.py
@@ -30,9 +30,9 @@ def test_endpoint_loading(mocker):
     assert len(endpoints) == 1
 
     provider = list(endpoints.keys())[0]
+    assert provider.provider == "blackbox-exporter"
     ep = endpoints.get(provider)[0]
-
-    assert ep.monitoring.provider.provider == "blackbox-exporter"
+    assert len(ep.monitoring) == 1
 
 
 def test_parse_prober_url():
@@ -103,3 +103,16 @@ def test_filling_desired_state(mocker):
         name="blackbox-exporter-http-2xx",
         value=ANY
     )
+
+
+def test_loading_multiple_providers_per_endpoint(mocker):
+    ep_query = mocker.patch.object(queries, 'get_service_monitoring_endpoints')
+    ep_query.return_value = \
+        get_endpoint_fixtures("test_multiple_providers_per_endpoint.yaml")
+    endpoints = get_endpoints()
+
+    assert len(endpoints) == 2
+
+    for provider, eps in endpoints.items():
+        assert provider.provider == "blackbox-exporter"
+        assert len(eps) == 2

--- a/reconcile/test/test_blackbox_exporter_endpoint_monitoring.py
+++ b/reconcile/test/test_blackbox_exporter_endpoint_monitoring.py
@@ -100,6 +100,6 @@ def test_filling_desired_state(mocker):
         cluster="app-sre-stage-01",
         namespace="openshift-customer-monitoring",
         resource_type="Probe",
-        name="endpoint-monitoring-blackbox-exporter-http-2xx",
+        name="blackbox-exporter-http-2xx",
         value=ANY
     )

--- a/reconcile/test/test_blackbox_exporter_endpoint_monitoring.py
+++ b/reconcile/test/test_blackbox_exporter_endpoint_monitoring.py
@@ -77,6 +77,11 @@ def test_probe_building(mocker):
     labels = spec["targets"]["staticConfig"]["labels"]
     assert labels.get("environment") == "staging"
 
+    # verify timeout and interval
+    assert spec["scrapeTimeout"] == provider.timeout
+    assert spec["interval"] == provider.checkInterval
+
+    # verify targets
     assert "https://test1.url" in spec["targets"]["staticConfig"]["static"]
     assert "https://test2.url" in spec["targets"]["staticConfig"]["static"]
 

--- a/reconcile/test/test_blackbox_exporter_endpoint_monitoring.py
+++ b/reconcile/test/test_blackbox_exporter_endpoint_monitoring.py
@@ -1,0 +1,100 @@
+from unittest.mock import ANY
+import pytest
+
+from reconcile.blackbox_exporter_endpoint_monitoring import (
+    queries, get_endpoints, build_probe, parse_prober_url, fill_desired_state)
+from reconcile.utils.openshift_resource import ResourceInventory
+from .fixtures import Fixtures
+
+
+fxt = Fixtures('blackbox_exporter_endpoint_monitoring')
+
+
+def get_endpoint_fixtures(path: str) -> dict:
+    return fxt.get_anymarkup(path)["appInterface"]["apps"]
+
+
+def test_invalid_endpoints(mocker):
+    query = mocker.patch.object(queries, 'get_service_monitoring_endpoints')
+    query.return_value = get_endpoint_fixtures("test_invalid_endpoints.yaml")
+
+    endpoints = get_endpoints()
+    assert len(endpoints) == 0
+
+
+def test_endpoint_loading(mocker):
+    ep_query = mocker.patch.object(queries, 'get_service_monitoring_endpoints')
+    ep_query.return_value = get_endpoint_fixtures("test_endpoint.yaml")
+
+    endpoints = get_endpoints()
+    assert len(endpoints) == 1
+
+    provider = list(endpoints.keys())[0]
+    ep = endpoints.get(provider)[0]
+
+    assert ep.monitoring.provider.provider == "blackbox-exporter"
+
+
+def test_parse_prober_url():
+    assert parse_prober_url("http://host:1234/path") == {
+        "url": "host:1234",
+        "scheme": "http",
+        "path": "/path"
+    }
+
+    assert parse_prober_url("http://host") == {
+        "url": "host",
+        "scheme": "http"
+    }
+
+
+def test_invalid_prober_url():
+    # scheme missing
+    with pytest.raises(ValueError):
+        parse_prober_url("host:1234/path")
+
+
+def test_probe_building(mocker):
+    ep_query = mocker.patch.object(queries, 'get_service_monitoring_endpoints')
+    ep_query.return_value = get_endpoint_fixtures("test_probe_building.yaml")
+
+    endpoints = get_endpoints()
+    assert len(endpoints) == 1
+
+    provider = list(endpoints.keys())[0]
+    probe_resource = build_probe(provider, endpoints.get(provider))
+    assert probe_resource is not None
+
+    # verify prober url decomposition
+    spec = probe_resource.body.get("spec")
+    assert spec.get("prober") == {
+        "url": "exporterhost:9115",
+        "scheme": "http",
+        "path": "/probe"
+    }
+
+    # verify labels
+    labels = spec["targets"]["staticConfig"]["labels"]
+    assert labels.get("environment") == "staging"
+
+    assert "https://test1.url" in spec["targets"]["staticConfig"]["static"]
+    assert "https://test2.url" in spec["targets"]["staticConfig"]["static"]
+
+
+def test_filling_desired_state(mocker):
+    ep_query = mocker.patch.object(queries, 'get_service_monitoring_endpoints')
+    ep_query.return_value = get_endpoint_fixtures("test_endpoint.yaml")
+    add_desired_mock = mocker.patch.object(ResourceInventory, 'add_desired')
+
+    endpoints = get_endpoints()
+    provider = list(endpoints.keys())[0]
+    fill_desired_state(provider, endpoints[provider], ResourceInventory())
+
+    assert add_desired_mock.call_count == 1
+    add_desired_mock.assert_called_with(
+        cluster="app-sre-stage-01",
+        namespace="openshift-customer-monitoring",
+        resource_type="Probe",
+        name="endpoint-monitoring-blackbox-exporter-http-2xx",
+        value=ANY
+    )

--- a/reconcile/utils/vaultsecretref.py
+++ b/reconcile/utils/vaultsecretref.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from reconcile.utils.vault import VaultClient, _VaultClient
 
 
-@dataclass(frozen=True, eq=True)
+@dataclass
 class VaultSecretRef:
 
     _ALL_FIELDS = "all"

--- a/reconcile/utils/vaultsecretref.py
+++ b/reconcile/utils/vaultsecretref.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from reconcile.utils.vault import VaultClient, _VaultClient
 
 
-@dataclass
+@dataclass(frozen=True, eq=True)
 class VaultSecretRef:
 
     _ALL_FIELDS = "all"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,6 @@
 [mypy]
 files = reconcile,tools,e2e_tests
+plugins = pydantic.mypy
 
 ; More context here: https://github.com/python/mypy/issues/9091
 no_implicit_optional = True

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         "croniter>=1.0.15,<1.1.0",
         "dyn~=1.8.1",
         "transity-statuspageio>=0.0.3,<0.1",
-        "pydantic>=1.8.2,<1.9.0",
+        "pydantic~=1.9.0",
     ],
 
     test_suite="tests",


### PR DESCRIPTION
## Scope
this new integration `blackbox-exporter-endpoint-monitoring` implements the blackbox-exporter part (phase 1) of service
endpoint monitoring as defined in this [design doc](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/service-endpoint-monitoring.md)

Schema change: https://github.com/app-sre/qontract-schemas/pull/45
Part of: https://issues.redhat.com/browse/APPSRE-4209

## What was introduced
With this change, tenants can declare blackbox-exporter backed `EndpointMonitoringProviders` and attach app endpoints to it to setup basic closed box monitoring. This concept of `EndpointMonitoringProviders` will be enhanced in a followup PR where Catchpoint probes are going to be implemented as an additional provider (phase 2 of design doc).

## Divergence from design docs
* use `Probe` instead of `ServiceMonitor` to declare scrape configs for Prometheus because referencing the in-cluster blackbox-exporter via `ServiceMonitor` would result in scraping all blackbox-exporter pods
* the schema `/dependencies/endpoint-monitoring-provider-1.yml` defines an additional field (dict) `metricLabels`. those are added as target labels while scraping to give a bit more context to define alerts

## Example

```yaml
---
$schema: /dependencies/endpoint-monitoring-provider-1.yml

name: blackbox-exporter-http-2xx-stage
description: Checks a URL for HTTP 2xx status codes via blackbox-exporter
provider: blackbox-exporter
metricLabels:
  environment: staging
blackboxExporter:
  namespace:
    $ref: /services/observability/namespaces/openshift-customer-monitoring.xxxx.yml
  exporterUrl: xxxx.svc.cluster.local:9115/probe
  module: http_2xx
```

and

```yaml
---
$schema: /app-sre/app-1.yml
...
endPoints:
- name: test
  description: test
  url: https://httpstat.us/200
  monitoring:
    provider:
      $ref: /dependencies/monitoring/blackbox-exporter-http-2xx-stage.yml
```

this would result in a `Probe` CR (similar to a `ServiceMonitor` but with concrete URLs instead of `Endpoint` discovery)

```yaml
apiVersion: monitoring.coreos.com/v1
kind: Probe
metadata:
  name: blackbox-exporter-http-2xx-stage
  namespace: blackbox_exporter.namespace.name
  labels:
    prometheus: app-sre
spec: 
  jobName: blackbox-exporter-http-2xx-stage
  module: http_2xx
  prober:
    scheme: http
    url: xxxx.svc.cluster.local:9115
    path: /probe
  targets:
    staticConfig: 
      relabelingConfigs:
        action: labeldrop
        regex: namespace
      labels:
        environment: staging
      static: 
      - https://httpstat.us/200
```

This will then result in the following metrics produced by scraping blackbox-exporter

```
up{job="${provider.name}", ${metricLabels}, instance="${app.endPoint.url}"}
probe_*{job="${provider.name}", ${metricLabels}, instance="{app.endPoint.url}", ...}
```

which boils down to

```
up{job="blackbox-exporter-http-2xx-stage", environment="staging", instance="https://httpstat.us/200"}
probe_*{job="blackbox-exporter-http-2xx-stage", environment="staging", instance="https://httpstat.us/200", ...}
```

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>