### PR TITLE
move statuspage-component tests to pytest

### DIFF
--- a/reconcile/test/test_status_page_components.py
+++ b/reconcile/test/test_status_page_components.py
@@ -1,6 +1,8 @@
-from unittest import TestCase
 from unittest.mock import patch
 from typing import Optional
+import re
+
+import pytest
 
 from reconcile.status_page_components import (
   AtlassianComponent, AtlassianStatusPage, StatusComponent, StatusPage)
@@ -67,296 +69,275 @@ def stub_resolve_secret():
     return f
 
 
-class TestReconcileLogic(TestCase):
+@patch.object(VaultSecretRef, '_resolve_secret',
+              new_callable=stub_resolve_secret)
+@patch.object(AtlassianStatusPage, '_create_component')
+@patch.object(AtlassianStatusPage, '_fetch_components')
+def test_create_component(fetch_mock, create_mock, vault_mock):
+    """
+    Test if the creation logic is called for a component missing on the
+    status page.
+    """
+    fixture_name = "test_create_component.yaml"
+    fetch_mock.return_value = \
+        get_atlassian_component_fixtures(fixture_name, "page_1")
+    create_mock.return_value = None
+    page = get_page_fixtures(fixture_name)[0]
 
-    @staticmethod
-    @patch.object(VaultSecretRef, '_resolve_secret',
-                  new_callable=stub_resolve_secret)
-    @patch.object(AtlassianStatusPage, '_create_component')
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    def test_create_component(fetch_mock, create_mock, vault_mock):
-        """
-        Test if the creation logic is called for a component missing on the
-        status page.
-        """
-        fixture_name = "test_create_component.yaml"
-        fetch_mock.return_value = \
-            get_atlassian_component_fixtures(fixture_name, "page_1")
-        create_mock.return_value = None
-        page = get_page_fixtures(fixture_name)[0]
+    page.reconcile(False, StateStub())
 
-        page.reconcile(False, StateStub())
-
-        create_mock.assert_called_with(
-            component_to_dict(page.components[0], "group_id_1")
-        )
-
-    @staticmethod
-    @patch.object(VaultSecretRef, '_resolve_secret',
-                  new_callable=stub_resolve_secret)
-    @patch.object(StatusPage, '_bind_component')
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    def test_bind_component(fetch_mock, bind_mock, vault_mock):
-        """
-        Test if bind logic is called for a component that already exists on
-        the status page but is not bound to the one in desired state.
-        """
-        fixture_name = "test_bind_component.yaml"
-        fetch_mock.return_value = \
-            get_atlassian_component_fixtures(fixture_name, "page_1")
-        page = get_page_fixtures(fixture_name)[0]
-        state = StateStub()
-
-        # execute bind logic through reconciling
-        page.reconcile(False, state)
-
-        # check if binding was called
-        bind_mock.assert_called_with(False, page.components[0],
-                                     "comp_id_1", state)
-
-    @patch.object(VaultSecretRef, '_resolve_secret',
-                  new_callable=stub_resolve_secret)
-    @patch.object(AtlassianStatusPage, '_update_component')
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    def test_update_component(self, fetch_mock, update_mock, vault_mock):
-        """
-        Test if updates are triggered for components when their name, group
-        or description changes. The fixture for this test includes three
-        components, that need update for different reasons, and one component
-        that is up to date.
-        """
-        fixture_name = "test_update_component.yaml"
-        fetch_mock.return_value = \
-            get_atlassian_component_fixtures(fixture_name, "page_1")
-        update_mock.return_value = None
-        page = get_page_fixtures(fixture_name)[0]
-        self.assertEqual(len(page.components), 4)
-
-        page.reconcile(False, get_state_fixture(fixture_name))
-
-        update_mock.assert_any_call(
-            page.components[0].component_id,
-            component_to_dict(page.components[0], "group_id_1"))
-        update_mock.assert_any_call(
-            page.components[1].component_id,
-            component_to_dict(page.components[1], "group_id_1"))
-        update_mock.assert_any_call(
-            page.components[2].component_id,
-            component_to_dict(page.components[2], "group_id_1"))
-        self.assertEqual(update_mock.call_count, 3)
-
-    @patch.object(VaultSecretRef, '_resolve_secret',
-                  new_callable=stub_resolve_secret)
-    @patch.object(AtlassianStatusPage, 'delete_component')
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    def test_delete_component(self, fetch_mock, delete_mock, vault_mock):
-        """
-        Test if deletion is triggerd for a component that does not exist
-        anymore in app-interface, but is still known to the State and to
-        the status page.
-        """
-        fixture_name = "test_delete_component.yaml"
-        fetch_mock.return_value = \
-            get_atlassian_component_fixtures(fixture_name, "page_1")
-        delete_mock.return_value = None
-        page = get_page_fixtures(fixture_name)[0]
-        state = get_state_fixture(fixture_name)
-
-        page.reconcile(False, state)
-
-        delete_mock.assert_called_with(False, "comp_id_1")
-        self.assertEqual(delete_mock.call_count, 1)
-
-    @patch.object(VaultSecretRef, '_resolve_secret',
-                  new_callable=stub_resolve_secret)
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    def test_group_exists(self, fetch_mock, vault_mock):
-        """
-        Test if the creation logic is yielding an exception when a group is
-        referenced, that does not exist.
-        """
-        fixture_name = "test_group_does_not_exist.yaml"
-        fetch_mock.return_value = \
-            get_atlassian_component_fixtures(fixture_name, "page_1")
-        vault_mock.return_value = {"token": "token"}
-        page = get_page_fixtures(fixture_name)[0]
-        dry_run = True
-
-        with self.assertRaises(ValueError) as cm:
-            page.reconcile(dry_run, StateStub())
-        self.assertRegex(str(cm.exception), r"^Group.*does not exist$")
-
-
-class TestComponentOrdering(TestCase):
-
-    def test_place_component_in_empty_group(self):
-        pass
-
-    def test_place_component_in_group(self):
-        pass
-
-    def test_place_component_top_level(self):
-        pass
+    create_mock.assert_called_with(
+        component_to_dict(page.components[0], "group_id_1")
+    )
 
 
 @patch.object(VaultSecretRef, '_resolve_secret',
               new_callable=stub_resolve_secret)
-class TestStateManagement(TestCase):
+@patch.object(StatusPage, '_bind_component')
+@patch.object(AtlassianStatusPage, '_fetch_components')
+def test_bind_component(fetch_mock, bind_mock, vault_mock):
+    """
+    Test if bind logic is called for a component that already exists on
+    the status page but is not bound to the one in desired state.
+    """
+    fixture_name = "test_bind_component.yaml"
+    fetch_mock.return_value = \
+        get_atlassian_component_fixtures(fixture_name, "page_1")
+    page = get_page_fixtures(fixture_name)[0]
+    state = StateStub()
 
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    @patch.object(AtlassianStatusPage, 'apply_component')
-    def test_state_management_on_fetch(self, apply_mock, fetch_mock,
-                                       vault_mock):
-        """
-        Test if state management correctly relates component ids with
-        components declared in desired state.
-        """
-        fixture_name = "test_state_management_on_fetch.yaml"
-        apply_mock.return_value = None
-        fetch_mock.return_value = []
-        page = get_page_fixtures(fixture_name)[0]
+    # execute bind logic through reconciling
+    page.reconcile(False, state)
 
-        page.reconcile(True, get_state_fixture(fixture_name))
-
-        for c in page.components:
-            if c.name == "comp_1":
-                self.assertEqual(c.component_id, "comp_id_1")
-            elif c.name == "comp_2":
-                self.assertIsNone(c.component_id)
-
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    def test_state_management_on_bind(self, fetch_mock, vault_mock):
-        """
-        Test if state management correctly binds components with their
-        corresponding id on the status page.
-        """
-        fixture_name = "test_state_management_on_bind.yaml"
-        fetch_mock.return_value = \
-            get_atlassian_component_fixtures(fixture_name, "page_1")
-        state = StateStub()
-        page = get_page_fixtures(fixture_name)[0]
-
-        page.reconcile(False, state)
-
-        self.assertEqual(page.components[0].component_id, "comp_id_1")
-        self.assertEqual(state.get_all("")["comp_1"], "comp_id_1")
+    # check if binding was called
+    bind_mock.assert_called_with(False, page.components[0], "comp_id_1", state)
 
 
-class TestDryRunBehaviour(TestCase):
+@patch.object(VaultSecretRef, '_resolve_secret',
+              new_callable=stub_resolve_secret)
+@patch.object(AtlassianStatusPage, '_update_component')
+@patch.object(AtlassianStatusPage, '_fetch_components')
+def test_update_component(fetch_mock, update_mock, vault_mock):
+    """
+    Test if updates are triggered for components when their name, group
+    or description changes. The fixture for this test includes three
+    components, that need update for different reasons, and one component
+    that is up to date.
+    """
+    fixture_name = "test_update_component.yaml"
+    fetch_mock.return_value = \
+        get_atlassian_component_fixtures(fixture_name, "page_1")
+    update_mock.return_value = None
+    page = get_page_fixtures(fixture_name)[0]
+    assert len(page.components) == 4
 
-    @staticmethod
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    @patch.object(AtlassianStatusPage, "_create_component")
-    def test_dry_run_on_create(create_mock, fetch_mock):
-        TestDryRunBehaviour._exec_dry_run_test_on_create(True, create_mock,
-                                                         fetch_mock)
+    page.reconcile(False, get_state_fixture(fixture_name))
 
-    @staticmethod
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    @patch.object(AtlassianStatusPage, "_create_component")
-    def test_no_dry_run_on_create(create_mock, fetch_mock):
-        TestDryRunBehaviour._exec_dry_run_test_on_create(False, create_mock,
-                                                         fetch_mock)
-
-    @staticmethod
-    def _exec_dry_run_test_on_create(dry_run, create_mock, fetch_mock):
-        create_mock.create.return_value = "id"
-        fetch_mock.return_value = []
-        provider = AtlassianStatusPage(page_id="page_id",
-                                       api_url="https://a.com",
-                                       token="token")
-
-        component = StatusComponent(name="comp_1", displayName="comp_1",
-                                    groupName=None)
-        provider.apply_component(dry_run, component)
-
-        if dry_run:
-            create_mock.assert_not_called()
-        else:
-            create_mock.assert_called()
-
-    @staticmethod
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    @patch.object(AtlassianStatusPage, "_update_component")
-    def test_dry_run_on_update(update_mock, fetch_mock):
-        TestDryRunBehaviour._exec_dry_run_test_on_update(True, update_mock,
-                                                         fetch_mock)
-
-    @staticmethod
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    @patch.object(AtlassianStatusPage, "_update_component")
-    def test_no_dry_run_on_update(update_mock, fetch_mock):
-        TestDryRunBehaviour._exec_dry_run_test_on_update(False, update_mock,
-                                                         fetch_mock)
-
-    @staticmethod
-    def _exec_dry_run_test_on_update(dry_run, update_mock, fetch_mock):
-        fetch_mock.return_value = [
-            AtlassianComponent(
-                id="comp_id_1",
-                name="comp_1",
-                description="old description",
-                position=1,
-                status="ok"
-            )
-        ]
-        provider = AtlassianStatusPage(page_id="page_id",
-                                       api_url="https://a.com",
-                                       token="token")
-        provider.rebuild_state()
-
-        component = StatusComponent(name="comp_1", displayName="comp_1",
-                                    groupName=None)
-        provider.apply_component(dry_run, component)
-
-        if dry_run:
-            update_mock.assert_not_called()
-        else:
-            update_mock.assert_called()
+    update_mock.assert_any_call(
+        page.components[0].component_id,
+        component_to_dict(page.components[0], "group_id_1"))
+    update_mock.assert_any_call(
+        page.components[1].component_id,
+        component_to_dict(page.components[1], "group_id_1"))
+    update_mock.assert_any_call(
+        page.components[2].component_id,
+        component_to_dict(page.components[2], "group_id_1"))
+    assert update_mock.call_count == 3
 
 
-class TestComponentStatusUpdate(TestCase):
+@patch.object(VaultSecretRef, '_resolve_secret',
+              new_callable=stub_resolve_secret)
+@patch.object(AtlassianStatusPage, 'delete_component')
+@patch.object(AtlassianStatusPage, '_fetch_components')
+def test_delete_component(fetch_mock, delete_mock, vault_mock):
+    """
+    Test if deletion is triggerd for a component that does not exist
+    anymore in app-interface, but is still known to the State and to
+    the status page.
+    """
+    fixture_name = "test_delete_component.yaml"
+    fetch_mock.return_value = \
+        get_atlassian_component_fixtures(fixture_name, "page_1")
+    delete_mock.return_value = None
+    page = get_page_fixtures(fixture_name)[0]
+    state = get_state_fixture(fixture_name)
 
-    @patch.object(VaultSecretRef, '_resolve_secret',
-                  new_callable=stub_resolve_secret)
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    def test_update_missing_component(self, fetch_mock, vault_mock):
-        fixture_name = "test_component_status_update.yaml"
+    page.reconcile(False, state)
 
-        page = get_page_fixtures(fixture_name)[0]
-        fetch_mock.return_value = []
-        state = get_state_fixture(fixture_name)
+    delete_mock.assert_called_with(False, "comp_id_1")
+    assert delete_mock.call_count == 1
 
-        with self.assertRaises(ValueError):
-            page.update_component_status(True, "comp_x", "operational", state)
 
-    @staticmethod
-    @patch.object(VaultSecretRef, '_resolve_secret',
-                  new_callable=stub_resolve_secret)
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    @patch.object(AtlassianStatusPage, 'update_component_status')
-    def test_update(update_mock, fetch_mock, vault_mock):
-        fixture_name = "test_component_status_update.yaml"
+@patch.object(VaultSecretRef, '_resolve_secret',
+              new_callable=stub_resolve_secret)
+@patch.object(AtlassianStatusPage, '_fetch_components')
+def test_group_exists(fetch_mock, vault_mock):
+    """
+    Test if the creation logic is yielding an exception when a group is
+    referenced, that does not exist.
+    """
+    fixture_name = "test_group_does_not_exist.yaml"
+    fetch_mock.return_value = \
+        get_atlassian_component_fixtures(fixture_name, "page_1")
+    vault_mock.return_value = {"token": "token"}
+    page = get_page_fixtures(fixture_name)[0]
+    dry_run = True
 
-        page = get_page_fixtures(fixture_name)[0]
-        fetch_mock.return_value = \
-            get_atlassian_component_fixtures(fixture_name, page.name)
-        state = get_state_fixture(fixture_name)
+    with pytest.raises(ValueError) as ex:
+        page.reconcile(dry_run, StateStub())
+    assert re.match(r"^Group.*does not exist$", str(ex.value))
 
-        page.update_component_status(True, "comp_1", "operational", state)
 
-        update_mock.assert_called_with(True, "comp_id_1", "operational")
+@patch.object(VaultSecretRef, '_resolve_secret',
+              new_callable=stub_resolve_secret)
+@patch.object(AtlassianStatusPage, '_fetch_components')
+@patch.object(AtlassianStatusPage, 'apply_component')
+def test_state_management_on_fetch(apply_mock, fetch_mock, vault_mock):
+    """
+    Test if state management correctly relates component ids with
+    components declared in desired state.
+    """
+    fixture_name = "test_state_management_on_fetch.yaml"
+    apply_mock.return_value = None
+    fetch_mock.return_value = []
+    page = get_page_fixtures(fixture_name)[0]
 
-    @patch.object(VaultSecretRef, '_resolve_secret',
-                  new_callable=stub_resolve_secret)
-    @patch.object(AtlassianStatusPage, '_fetch_components')
-    def test_wrong_status(self, fetch_mock, vault_mock):
-        fixture_name = "test_component_status_update.yaml"
+    page.reconcile(True, get_state_fixture(fixture_name))
 
-        page = get_page_fixtures(fixture_name)[0]
-        fetch_mock.return_value = \
-            get_atlassian_component_fixtures(fixture_name, page.name)
-        state = get_state_fixture(fixture_name)
+    for c in page.components:
+        if c.name == "comp_1":
+            assert c.component_id == "comp_id_1"
+        elif c.name == "comp_2":
+            assert c.component_id is None
 
-        with self.assertRaises(ValueError):
-            page.update_component_status(True, "comp_1", "invalid", state)
+
+@patch.object(VaultSecretRef, '_resolve_secret',
+              new_callable=stub_resolve_secret)
+@patch.object(AtlassianStatusPage, '_fetch_components')
+def test_state_management_on_bind(fetch_mock, vault_mock):
+    """
+    Test if state management correctly binds components with their
+    corresponding id on the status page.
+    """
+    fixture_name = "test_state_management_on_bind.yaml"
+    fetch_mock.return_value = \
+        get_atlassian_component_fixtures(fixture_name, "page_1")
+    state = StateStub()
+    page = get_page_fixtures(fixture_name)[0]
+
+    page.reconcile(False, state)
+
+    assert page.components[0].component_id == "comp_id_1"
+    assert state.get_all("")["comp_1"] == "comp_id_1"
+
+
+@patch.object(AtlassianStatusPage, '_fetch_components')
+@patch.object(AtlassianStatusPage, "_create_component")
+def test_dry_run_on_create(create_mock, fetch_mock):
+    _exec_dry_run_test_on_create(True, create_mock, fetch_mock)
+
+
+@patch.object(AtlassianStatusPage, '_fetch_components')
+@patch.object(AtlassianStatusPage, "_create_component")
+def test_no_dry_run_on_create(create_mock, fetch_mock):
+    _exec_dry_run_test_on_create(False, create_mock, fetch_mock)
+
+
+def _exec_dry_run_test_on_create(dry_run, create_mock, fetch_mock):
+    create_mock.create.return_value = "id"
+    fetch_mock.return_value = []
+    provider = AtlassianStatusPage(page_id="page_id",
+                                   api_url="https://a.com",
+                                   token="token")
+
+    component = StatusComponent(name="comp_1", displayName="comp_1",
+                                groupName=None)
+    provider.apply_component(dry_run, component)
+
+    if dry_run:
+        create_mock.assert_not_called()
+    else:
+        create_mock.assert_called()
+
+
+@patch.object(AtlassianStatusPage, '_fetch_components')
+@patch.object(AtlassianStatusPage, "_update_component")
+def test_dry_run_on_update(update_mock, fetch_mock):
+    _exec_dry_run_test_on_update(True, update_mock, fetch_mock)
+
+
+@patch.object(AtlassianStatusPage, '_fetch_components')
+@patch.object(AtlassianStatusPage, "_update_component")
+def test_no_dry_run_on_update(update_mock, fetch_mock):
+    _exec_dry_run_test_on_update(False, update_mock, fetch_mock)
+
+
+def _exec_dry_run_test_on_update(dry_run, update_mock, fetch_mock):
+    fetch_mock.return_value = [
+        AtlassianComponent(
+            id="comp_id_1",
+            name="comp_1",
+            description="old description",
+            position=1,
+            status="ok"
+        )
+    ]
+    provider = AtlassianStatusPage(page_id="page_id",
+                                   api_url="https://a.com",
+                                   token="token")
+    provider.rebuild_state()
+
+    component = StatusComponent(name="comp_1", displayName="comp_1",
+                                groupName=None)
+    provider.apply_component(dry_run, component)
+
+    if dry_run:
+        update_mock.assert_not_called()
+    else:
+        update_mock.assert_called()
+
+
+@patch.object(VaultSecretRef, '_resolve_secret',
+              new_callable=stub_resolve_secret)
+@patch.object(AtlassianStatusPage, '_fetch_components')
+def test_update_missing_component(fetch_mock, vault_mock):
+    fixture_name = "test_component_status_update.yaml"
+
+    page = get_page_fixtures(fixture_name)[0]
+    fetch_mock.return_value = []
+    state = get_state_fixture(fixture_name)
+
+    with pytest.raises(ValueError):
+        page.update_component_status(True, "comp_x", "operational", state)
+
+
+@patch.object(VaultSecretRef, '_resolve_secret',
+              new_callable=stub_resolve_secret)
+@patch.object(AtlassianStatusPage, '_fetch_components')
+@patch.object(AtlassianStatusPage, 'update_component_status')
+def test_update(update_mock, fetch_mock, vault_mock):
+    fixture_name = "test_component_status_update.yaml"
+
+    page = get_page_fixtures(fixture_name)[0]
+    fetch_mock.return_value = \
+        get_atlassian_component_fixtures(fixture_name, page.name)
+    state = get_state_fixture(fixture_name)
+
+    page.update_component_status(True, "comp_1", "operational", state)
+
+    update_mock.assert_called_with(True, "comp_id_1", "operational")
+
+
+@patch.object(VaultSecretRef, '_resolve_secret',
+              new_callable=stub_resolve_secret)
+@patch.object(AtlassianStatusPage, '_fetch_components')
+def test_wrong_status(fetch_mock, vault_mock):
+    fixture_name = "test_component_status_update.yaml"
+
+    page = get_page_fixtures(fixture_name)[0]
+    fetch_mock.return_value = \
+        get_atlassian_component_fixtures(fixture_name, page.name)
+    state = get_state_fixture(fixture_name)
+
+    with pytest.raises(ValueError):
+        page.update_component_status(True, "comp_1", "invalid", state)

--- a/reconcile/test/test_status_page_components.py
+++ b/reconcile/test/test_status_page_components.py
@@ -1,5 +1,6 @@
 from typing import Optional
 import re
+from unittest.mock import ANY
 
 import pytest
 
@@ -74,10 +75,12 @@ def test_create_component(mocker):
     status page.
     """
     fixture_name = "test_create_component.yaml"
-    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components')
+    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components',
+                                     autospec=True)
     fetch_mock.return_value = \
         get_atlassian_component_fixtures(fixture_name, "page_1")
-    create_mock = mocker.patch.object(AtlassianStatusPage, '_create_component')
+    create_mock = mocker.patch.object(AtlassianStatusPage, '_create_component',
+                                      autospec=True)
     create_mock.return_value = None
     mocker.patch.object(VaultSecretRef, '_resolve_secret',
                         new_callable=stub_resolve_secret)
@@ -86,7 +89,7 @@ def test_create_component(mocker):
     page.reconcile(False, StateStub())
 
     create_mock.assert_called_with(
-        component_to_dict(page.components[0], "group_id_1")
+        ANY, component_to_dict(page.components[0], "group_id_1")
     )
 
 
@@ -96,10 +99,12 @@ def test_bind_component(mocker):
     the status page but is not bound to the one in desired state.
     """
     fixture_name = "test_bind_component.yaml"
-    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components')
+    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components',
+                                     autospec=True)
     fetch_mock.return_value = \
         get_atlassian_component_fixtures(fixture_name, "page_1")
-    bind_mock = mocker.patch.object(StatusPage, '_bind_component')
+    bind_mock = mocker.patch.object(StatusPage, '_bind_component',
+                                    autospec=True)
     mocker.patch.object(VaultSecretRef, '_resolve_secret',
                         new_callable=stub_resolve_secret)
 
@@ -110,7 +115,8 @@ def test_bind_component(mocker):
     page.reconcile(False, state)
 
     # check if binding was called
-    bind_mock.assert_called_with(False, page.components[0], "comp_id_1", state)
+    bind_mock.assert_called_with(ANY, False, page.components[0],
+                                 "comp_id_1", state)
 
 
 def test_update_component(mocker):
@@ -121,10 +127,12 @@ def test_update_component(mocker):
     that is up to date.
     """
     fixture_name = "test_update_component.yaml"
-    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components')
+    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components',
+                                     autospec=True)
     fetch_mock.return_value = \
         get_atlassian_component_fixtures(fixture_name, "page_1")
-    update_mock = mocker.patch.object(AtlassianStatusPage, '_update_component')
+    update_mock = mocker.patch.object(AtlassianStatusPage, '_update_component',
+                                      autospec=True)
     update_mock.return_value = None
     mocker.patch.object(VaultSecretRef, '_resolve_secret',
                         new_callable=stub_resolve_secret)
@@ -135,13 +143,13 @@ def test_update_component(mocker):
     page.reconcile(False, get_state_fixture(fixture_name))
 
     update_mock.assert_any_call(
-        page.components[0].component_id,
+        ANY, page.components[0].component_id,
         component_to_dict(page.components[0], "group_id_1"))
     update_mock.assert_any_call(
-        page.components[1].component_id,
+        ANY, page.components[1].component_id,
         component_to_dict(page.components[1], "group_id_1"))
     update_mock.assert_any_call(
-        page.components[2].component_id,
+        ANY, page.components[2].component_id,
         component_to_dict(page.components[2], "group_id_1"))
     assert update_mock.call_count == 3
 
@@ -153,10 +161,12 @@ def test_delete_component(mocker):
     the status page.
     """
     fixture_name = "test_delete_component.yaml"
-    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components')
+    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components',
+                                     autospec=True)
     fetch_mock.return_value = \
         get_atlassian_component_fixtures(fixture_name, "page_1")
-    delete_mock = mocker.patch.object(AtlassianStatusPage, 'delete_component')
+    delete_mock = mocker.patch.object(AtlassianStatusPage, 'delete_component',
+                                      autospec=True)
     delete_mock.return_value = None
     mocker.patch.object(VaultSecretRef, '_resolve_secret',
                         new_callable=stub_resolve_secret)
@@ -166,7 +176,7 @@ def test_delete_component(mocker):
 
     page.reconcile(False, state)
 
-    delete_mock.assert_called_with(False, "comp_id_1")
+    delete_mock.assert_called_with(ANY, False, "comp_id_1")
     assert delete_mock.call_count == 1
 
 
@@ -176,7 +186,8 @@ def test_group_exists(mocker):
     referenced, that does not exist.
     """
     fixture_name = "test_group_does_not_exist.yaml"
-    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components')
+    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components',
+                                     autospec=True)
     fetch_mock.return_value = \
         get_atlassian_component_fixtures(fixture_name, "page_1")
     vault_mock = mocker.patch.object(VaultSecretRef, '_resolve_secret',
@@ -196,9 +207,11 @@ def test_state_management_on_fetch(mocker):
     components declared in desired state.
     """
     fixture_name = "test_state_management_on_fetch.yaml"
-    apply_mock = mocker.patch.object(AtlassianStatusPage, 'apply_component')
+    apply_mock = mocker.patch.object(AtlassianStatusPage, 'apply_component',
+                                     autospec=True)
     apply_mock.return_value = None
-    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components')
+    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components',
+                                     autospec=True)
     fetch_mock.return_value = []
     mocker.patch.object(VaultSecretRef, '_resolve_secret',
                         new_callable=stub_resolve_secret)
@@ -219,7 +232,8 @@ def test_state_management_on_bind(mocker):
     corresponding id on the status page.
     """
     fixture_name = "test_state_management_on_bind.yaml"
-    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components')
+    fetch_mock = mocker.patch.object(AtlassianStatusPage, '_fetch_components',
+                                     autospec=True)
     fetch_mock.return_value = \
         get_atlassian_component_fixtures(fixture_name, "page_1")
     mocker.patch.object(VaultSecretRef, '_resolve_secret',
@@ -242,9 +256,11 @@ def test_no_dry_run_on_create(mocker):
 
 
 def _exec_dry_run_test_on_create(mocker, dry_run):
-    create_mock = mocker.patch.object(AtlassianStatusPage, "_create_component")
-    create_mock.create.return_value = "id"
-    fetch_mock = mocker.patch.object(AtlassianStatusPage, "_fetch_components")
+    create_mock = mocker.patch.object(AtlassianStatusPage, "_create_component",
+                                      autospec=True)
+    create_mock.return_value = "id"
+    fetch_mock = mocker.patch.object(AtlassianStatusPage, "_fetch_components",
+                                     autospec=True)
     fetch_mock.return_value = []
     provider = AtlassianStatusPage(page_id="page_id",
                                    api_url="https://a.com",
@@ -269,8 +285,10 @@ def test_no_dry_run_on_update(mocker):
 
 
 def _exec_dry_run_test_on_update(mocker, dry_run):
-    update_mock = mocker.patch.object(AtlassianStatusPage, "_update_component")
-    fetch_mock = mocker.patch.object(AtlassianStatusPage, "_fetch_components")
+    update_mock = mocker.patch.object(AtlassianStatusPage, "_update_component",
+                                      autospec=True)
+    fetch_mock = mocker.patch.object(AtlassianStatusPage, "_fetch_components",
+                                     autospec=True)
     fetch_mock.return_value = [
         AtlassianComponent(
             id="comp_id_1",
@@ -297,7 +315,8 @@ def _exec_dry_run_test_on_update(mocker, dry_run):
 
 def test_update_missing_component(mocker):
     fixture_name = "test_component_status_update.yaml"
-    fetch_mock = mocker.patch.object(AtlassianStatusPage, "_fetch_components")
+    fetch_mock = mocker.patch.object(AtlassianStatusPage, "_fetch_components",
+                                     autospec=True)
     fetch_mock.return_value = []
     mocker.patch.object(VaultSecretRef, '_resolve_secret',
                         new_callable=stub_resolve_secret)
@@ -315,16 +334,18 @@ def test_update(mocker):
     mocker.patch.object(VaultSecretRef, '_resolve_secret',
                         new_callable=stub_resolve_secret)
     page = get_page_fixtures(fixture_name)[0]
-    fetch_mock = mocker.patch.object(AtlassianStatusPage, "_fetch_components")
+    fetch_mock = mocker.patch.object(AtlassianStatusPage, "_fetch_components",
+                                     autospec=True)
     fetch_mock.return_value = \
         get_atlassian_component_fixtures(fixture_name, page.name)
     update_mock = mocker.patch.object(AtlassianStatusPage,
-                                      "update_component_status")
+                                      "update_component_status",
+                                      autospec=True)
     state = get_state_fixture(fixture_name)
 
     page.update_component_status(True, "comp_1", "operational", state)
 
-    update_mock.assert_called_with(True, "comp_id_1", "operational")
+    update_mock.assert_called_with(ANY, True, "comp_id_1", "operational")
 
 
 def test_wrong_status(mocker):
@@ -332,7 +353,8 @@ def test_wrong_status(mocker):
     mocker.patch.object(VaultSecretRef, '_resolve_secret',
                         new_callable=stub_resolve_secret)
     page = get_page_fixtures(fixture_name)[0]
-    fetch_mock = mocker.patch.object(AtlassianStatusPage, "_fetch_components")
+    fetch_mock = mocker.patch.object(AtlassianStatusPage, "_fetch_components",
+                                     autospec=True)
     fetch_mock.return_value = \
         get_atlassian_component_fixtures(fixture_name, page.name)
     state = get_state_fixture(fixture_name)


### PR DESCRIPTION
We're standarizing our test framework.

part of APPSRE-4190

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>