### PR TITLE
Improve gitlab-labeler

### DIFF
--- a/reconcile/gitlab_labeler.py
+++ b/reconcile/gitlab_labeler.py
@@ -54,6 +54,9 @@ def guess_onboarding_status(changed_paths: Iterable[str],
                 if child_app in apps:
                     app = apps[child_app]
                     labels.add(app['onboardingStatus'])
+                else:
+                    app = apps[app_name]
+                    labels.add(app['onboardingStatus'])
             else:
                 if app_name in apps:
                     app = apps[app_name]
@@ -88,8 +91,10 @@ def guess_labels(project_labels: Iterable[str],
         path_dir = os.path.dirname(path)
         path_tokens = path_dir.split('/')
 
-        tenants += [t for t in path_tokens if t not in ignore_tokens and
-                    t in apps]
+        if 'data/services/' in path:
+            tenants += [t for t in path_tokens if t not in ignore_tokens and
+                        t in apps]
+
         matches += [t for t in path_tokens if t not in ignore_tokens and
                     t in project_labels]
 

--- a/reconcile/test/fixtures/apps/parentapp.json
+++ b/reconcile/test/fixtures/apps/parentapp.json
@@ -1,0 +1,21 @@
+{
+    "path": "/services/parentapp/app.yml",
+    "name": "parentapp",
+    "onboardingStatus": "OnBoarded",
+    "serviceOwners": [
+        {
+            "name": "Service Owner",
+            "email": "serviceowner@test.com"
+        }
+    ],
+    "parentApp": null,
+    "codeComponents": [
+        {
+            "url": "https://github.com/test",
+            "resource": "upstream",
+            "gitlabRepoOwners": null,
+            "gitlabHousekeeping": null,
+            "jira": null
+        }
+    ]
+}

--- a/reconcile/test/test_gitlab_labeler.py
+++ b/reconcile/test/test_gitlab_labeler.py
@@ -35,6 +35,7 @@ class TestOnboardingGuesser():
         self.app1 = self.fxt.get_json('app1.json')
         self.app2 = self.fxt.get_json('app2.json')
         self.app3 = self.fxt.get_json('childapp.json')
+        self.app4 = self.fxt.get_json('parentapp.json')
 
         # Patcher for GqlApi methods
         self.gql_patcher = patch.object(gql, 'get_api', autospec=True)
@@ -86,6 +87,15 @@ class TestOnboardingGuesser():
 
         t = gl.guess_onboarding_status(changed_paths, apps, parents)
         assert t == 'BestEffort'
+
+    def test_guess_onboarding_status_parent(self):
+        self.test_data.apps = [self.app1, self.app2, self.app3, self.app4]
+        parents = gl.get_parents_list()
+        apps = gl.get_app_list()
+        changed_paths = ['data/services/parentapp/test']
+
+        t = gl.guess_onboarding_status(changed_paths, apps, parents)
+        assert t == 'OnBoarded'
 
     def test_guess_onboarding_status_normal(self):
         self.test_data.apps = [self.app1, self.app2, self.app3]


### PR DESCRIPTION
* correctly add onboarding status on parent apps without "child" updates on the MR
* Only add tenant information if path is under data/services