### PR TITLE
APPSRE-4229 ocm-clusters network type

### DIFF
--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -87,6 +87,10 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
     error = False
     clusters_updates = {}
     for cluster_name, desired_spec in desired_state.items():
+        # Set the default network type
+        if not desired_spec['network'].get('type'):
+            desired_spec['network']['type'] = 'OpenShiftSDN'
+
         current_spec = current_state.get(cluster_name)
         if current_spec:
             clusters_updates[cluster_name] = {'spec': {}, 'root': {}}

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -428,6 +428,7 @@ CLUSTERS_QUERY = """
       route_selectors
     }
     network {
+      type
       vpc
       service
       pod

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -122,6 +122,7 @@ class OCM:
                 DISABLE_UWM_ATTR: cluster[DISABLE_UWM_ATTR]
             },
             'network': {
+                'type': cluster['network'].get('type') or 'OpenShiftSDN',
                 'vpc': cluster['network']['machine_cidr'],
                 'service': cluster['network']['service_cidr'],
                 'pod': cluster['network']['pod_cidr']
@@ -178,6 +179,7 @@ class OCM:
             },
             'load_balancer_quota': cluster_spec['load_balancers'],
             'network': {
+                'type': cluster_network.get('type') or 'OpenShiftSDN',
                 'machine_cidr': cluster_network['vpc'],
                 'service_cidr': cluster_network['service'],
                 'pod_cidr': cluster_network['pod'],


### PR DESCRIPTION
Enable network type selection clusters
Linked to https://github.com/app-sre/qontract-schemas/pull/52
The default is the current only value: `OpenshiftSDN`