### PR TITLE
[tf-r]auto promote asg ami id

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -279,7 +279,9 @@ provider
   }
   variables
   image {
-    id
+    tag_name
+    url
+    ref
   }
   output_resource_name
   annotations

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -12,12 +12,14 @@ import tempfile
 from threading import Lock
 
 from typing import (
-    Any, Dict, List, Iterable, Mapping, MutableMapping, Optional
+    Any, Dict, List, Iterable, Mapping, MutableMapping, Optional, Tuple
 )
 from ipaddress import ip_network, ip_address
 
 import anymarkup
 import requests
+from github import Github
+
 
 from terrascript import (Terrascript, provider, Provider, Terraform,
                          Backend, Output, data)
@@ -223,6 +225,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                            for a in filtered_accounts}
         self.logtoes_zip = ''
         self.logtoes_zip_lock = Lock()
+        self.github = None
+        self.github_lock = Lock()
 
     def get_logtoes_zip(self, release_url):
         if not self.logtoes_zip:
@@ -250,6 +254,14 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             # pylint: disable=consider-using-with
             open(zip_file, 'wb').write(r.content)
         return zip_file
+
+    def init_github(self) -> Github:
+        if not self.github:
+            with self.github_lock:
+                if not self.github:
+                    token = get_default_config()['token']
+                    self.github = Github(token, base_url=GH_BASE_URL)
+        return self.github
 
     def filter_disabled_accounts(self, accounts):
         filtered_accounts = []
@@ -959,7 +971,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         elif provider == 'secrets-manager':
             self.populate_tf_resource_secrets_manager(resource, namespace_info)
         elif provider == 'asg':
-            self.populate_tf_resource_asg(resource, namespace_info)
+            self.populate_tf_resource_asg(resource, namespace_info,
+                                          existing_secrets)
         elif provider == 'route53-zone':
             self.populate_tf_resource_route53_zone(resource, namespace_info)
         else:
@@ -4073,17 +4086,68 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         self.add_resources(account, tf_resources)
 
-    def populate_tf_resource_asg(self, resource, namespace_info):
+    def _get_commit_sha(self, repo_info: dict) -> str:
+        url = repo_info['url']
+        ref = repo_info['ref']
+        pattern = r'^[0-9a-f]{40}$'
+        # get commit_sha from ref
+        if re.match(pattern, ref):
+            return ref
+        # get commit_sha from branch
+        elif 'github' in url:
+            github = self.init_github()
+            repo_name = url.rstrip("/").replace('https://github.com/', '')
+            repo = github.get_repo(repo_name)
+            commit = repo.get_commit(sha=ref)
+            return commit.sha
+        elif 'gitlab' in url:
+            raise NotImplementedError("dose not support gitlab repo for now")
+
+        return ''
+
+    def _get_asg_image_id(self, image: dict,
+                          account: str, region: str) -> Tuple[str, str]:
+        """
+        AMI ID comes form AWS Api filter result.
+        AMI needs to be shared by integration aws-ami-share.
+        AMI needs to be taged with a tag_name and
+        its value need to be the commit sha comes from upstream repo.
+        """
+        commit_sha = self._get_commit_sha(image)
+        tag_name = image['tag_name']
+
+        # Get the most recent AMI id
+        aws_account = self.accounts[account]
+        aws = AWSApi(1, [aws_account],
+                     settings=self.settings,
+                     init_users=False)
+        commit_sha = 'test'
+        tag = {
+            'Key': tag_name,
+            'Value': commit_sha
+        }
+        image_id = aws.get_image_id(account, region, tag)
+        if not image_id:
+            raise ValueError(f"could not find ami with tag {tag}"
+                             f"in account {account}")
+
+        return image_id, commit_sha
+
+    def populate_tf_resource_asg(self, resource: dict,
+                                 namespace_info: dict,
+                                 existing_secrets: dict) -> None:
         account, identifier, common_values, \
             output_prefix, output_resource_name, annotations = \
             self.init_values(resource, namespace_info)
 
-        tf_resources = []
+        tf_resources: List[Any] = []
         self.init_common_outputs(tf_resources, namespace_info, output_prefix,
                                  output_resource_name, annotations)
 
         tags = common_values['tags']
         tags['Name'] = identifier
+        region = common_values.get('region') or \
+            self.default_regions.get(account)
 
         template_values = {
             "name": identifier,
@@ -4106,11 +4170,10 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         }
 
         image = common_values.get('image')
-        image_id = image.get('id')
+        image_id, commit_sha = \
+            self._get_asg_image_id(image, account, region)
         template_values['image_id'] = image_id
 
-        region = common_values.get('region') or \
-            self.default_regions.get(account)
         if self._multiregion_account(account):
             template_values['provider'] = 'aws.' + region
 
@@ -4205,6 +4268,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         tf_resources.append(Output(output_name_0_13, value=output_value))
         output_name_0_13 = output_prefix + '__image_id'
         output_value = image_id
+        tf_resources.append(Output(output_name_0_13, value=output_value))
+        output_name_0_13 = output_prefix + '__commit_sha'
+        output_value = commit_sha
         tf_resources.append(Output(output_name_0_13, value=output_value))
 
         self.add_resources(account, tf_resources)


### PR DESCRIPTION
Depends on https://github.com/app-sre/qontract-schemas/pull/53

Part of https://issues.redhat.com/browse/APPSRE-3925

Design doc: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/34670

First implementation. Tf-r will fail when the packer job is running or failed, as the commit has been pushed but the AMI has not been built. Will add upstream info for checking Jenkins job state in a second PR.

Signed-off-by: Feng Huang <fehuang@redhat.com>