### PR TITLE
If a RS is resized but there are pods with ownerrefs where the owner …

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -515,7 +515,7 @@ class OCDeprecated:
         pods = self.get(namespace, 'Pod')['items']
         owned_pods = []
         for p in pods:
-            owner = self.get_obj_root_owner(namespace, p)
+            owner = self.get_obj_root_owner(namespace, p, allow_not_found=True)
             if (resource.kind, resource.name) == \
                     (owner['kind'], owner['metadata']['name']):
                 owned_pods.append(p)


### PR DESCRIPTION
…object does not exist, then the openshift-resources will error out.  The code desires to find the pods that are controlled by the RS being resizedso they can be restarted, so having the controller not exist shouldn't impact how things work and allow handling the above issue.