### PR TITLE
[ocm-aws-infrastructure-access] do not delete deleting role grants

### DIFF
--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -3,7 +3,7 @@ import logging
 from reconcile.utils import gql
 from reconcile import queries
 
-from reconcile.utils.ocm import OCMMap
+from reconcile.utils.ocm import STATUS_DELETING, STATUS_FAILED, OCMMap
 from reconcile.terraform_resources import TF_NAMESPACES_QUERY
 
 QONTRACT_INTEGRATION = 'ocm-aws-infrastructure-access'
@@ -29,9 +29,9 @@ def fetch_current_state():
                 'user_arn': user_arn,
                 'access_level': access_level
             }
-            if state == 'failed':
+            if state == STATUS_FAILED:
                 current_failed.append(item)
-            elif state == 'deleting':
+            elif state == STATUS_DELETING:
                 current_deleting.append(item)
             else:
                 current_state.append(item)

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -110,7 +110,8 @@ def fetch_desired_state():
     return desired_state
 
 
-def act(dry_run, ocm_map, current_state, current_failed, desired_state, current_deleting):
+def act(dry_run, ocm_map, current_state, current_failed, desired_state,
+        current_deleting):
     to_delete = [c for c in current_state if c not in desired_state]
     to_delete = to_delete + current_failed
     for item in to_delete:
@@ -123,7 +124,8 @@ def act(dry_run, ocm_map, current_state, current_failed, desired_state, current_
             ocm = ocm_map.get(cluster)
             ocm.del_user_from_aws_infrastructure_access_role_grants(
                 cluster, user_arn, access_level)
-    to_add = [d for d in desired_state if d not in current_state + current_deleting]
+    to_add = [d for d in desired_state if d
+              not in current_state + current_deleting]
     for item in to_add:
         cluster = item['cluster']
         user_arn = item['user_arn']
@@ -139,4 +141,5 @@ def act(dry_run, ocm_map, current_state, current_failed, desired_state, current_
 def run(dry_run):
     ocm_map, current_state, current_failed, current_deleting = fetch_current_state()
     desired_state = fetch_desired_state()
-    act(dry_run, ocm_map, current_state, current_failed, desired_state, current_deleting)
+    act(dry_run, ocm_map, current_state, current_failed, desired_state,
+        current_deleting)

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -139,7 +139,8 @@ def act(dry_run, ocm_map, current_state, current_failed, desired_state,
 
 
 def run(dry_run):
-    ocm_map, current_state, current_failed, current_deleting = fetch_current_state()
+    ocm_map, current_state, current_failed, current_deleting = \
+        fetch_current_state()
     desired_state = fetch_desired_state()
     act(dry_run, ocm_map, current_state, current_failed, desired_state,
         current_deleting)

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -10,6 +10,7 @@ from reconcile.utils.secret_reader import SecretReader
 
 STATUS_READY = 'ready'
 STATUS_FAILED = 'failed'
+STATUS_DELETING = 'deleting'
 
 AMS_API_BASE = '/api/accounts_mgmt'
 CS_API_BASE = '/api/clusters_mgmt'


### PR DESCRIPTION
related to:
- https://issues.redhat.com/browse/SDA-4422
- https://issues.redhat.com/browse/OHSS-9286

some role grants are "stuck" in Deleting. if we try to delete those, we get a 5xx error from OCM.
this PR updates the behavior to avoid deleting role grants in the "deleting" state.

the implementation is to remove any "Deleting" role grants from the current state, preventing them from being attempted to be deleted. because we remove these role grants from the current state, they will be attempted to be added because they may be in the desired state. we prevent that by removing any role grants in "Deleting" from the role grants to be added.