### PR TITLE
[saas-file-validator] validate saas file repos are in codeComponents

### DIFF
--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -183,7 +183,7 @@ def validate_repos_and_admins(jjb, additional_repo_urls):
     app_int_repos = queries.get_repos()
     missing_repos = [r for r in jjb_repos if r not in app_int_repos]
     for r in missing_repos:
-        logging.error('repo is missing from codeComponents: {}'.format(r))
+        logging.error(f'repo is missing from codeComponents: {r}')
     jjb_admins = jjb.get_admins()
     app_int_users = queries.get_users()
     app_int_bots = queries.get_bots()

--- a/reconcile/saas_file_validator.py
+++ b/reconcile/saas_file_validator.py
@@ -2,6 +2,7 @@ import sys
 import logging
 
 from reconcile import queries
+from reconcile.status import ExitCodes
 
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.saasherder import SaasHerder
@@ -27,4 +28,4 @@ def run(dry_run):
     for r in missing_repos:
         logging.error(f'repo is missing from codeComponents: {r}')
     if not saasherder.valid or missing_repos:
-        sys.exit(1)
+        sys.exit(ExitCodes.ERROR)

--- a/reconcile/saas_file_validator.py
+++ b/reconcile/saas_file_validator.py
@@ -1,4 +1,5 @@
 import sys
+import logging
 
 from reconcile import queries
 
@@ -20,5 +21,10 @@ def run(dry_run):
         integration_version=QONTRACT_INTEGRATION_VERSION,
         settings=settings,
         validate=True)
-    if not saasherder.valid:
+    app_int_repos = queries.get_repos()
+    missing_repos = [r for r in saasherder.repo_urls
+                     if r not in app_int_repos]
+    for r in missing_repos:
+        logging.error(f'repo is missing from codeComponents: {r}')
+    if not saasherder.valid or missing_repos:
         sys.exit(1)

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -353,6 +353,33 @@ class TestPopulateDesiredState(TestCase):
         self.assertEqual(5, cnt, "expected 5 resources, found less")
 
 
+class TestCollectRepoUrls(TestCase):
+    def test_collect_repo_urls(self):
+        repo_url = 'git-repo'
+        saas_files = [
+            {
+                'path': 'path1',
+                'name': 'name1',
+                'managedResourceTypes': [],
+                'resourceTemplates': [
+                    {
+                        'url': repo_url
+                    }
+                ]
+            }
+        ]
+
+        saasherder = SaasHerder(
+            saas_files,
+            thread_pool_size=1,
+            gitlab=None,
+            integration='',
+            integration_version='',
+            settings={}
+        )
+        self.assertEqual({repo_url}, saasherder.repo_urls)
+
+
 class TestGetSaasFileAttribute(TestCase):
     def test_attribute_none(self):
         saas_files = [

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -23,6 +23,7 @@ class TestCheckSaasFileEnvComboUnique(TestCase):
                 [
                     {
                         'name': 'rt',
+                        'url': 'url',
                         'targets':
                         [
                             {

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -81,6 +81,7 @@ class TestCheckSaasFileEnvComboUnique(TestCase):
                 [
                     {
                         'name': 'rt',
+                        'url': 'url',
                         'targets':
                         [
                             {
@@ -364,7 +365,9 @@ class TestCollectRepoUrls(TestCase):
                 'managedResourceTypes': [],
                 'resourceTemplates': [
                     {
-                        'url': repo_url
+                        'name': 'name',
+                        'url': repo_url,
+                        'targets': []
                     }
                 ]
             }

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -66,6 +66,7 @@ class SaasHerder():
         self.settings = settings
         self.secret_reader = SecretReader(settings=settings)
         self.namespaces = self._collect_namespaces()
+        self.repo_urls = self._collect_repo_urls()
         self.jenkins_map = jenkins_map
         # each namespace is in fact a target,
         # so we can use it to calculate.
@@ -246,6 +247,14 @@ class SaasHerder():
                     namespace['managedResourceTypes'] = managed_resource_types
                     namespaces.append(namespace)
         return namespaces
+
+    def _collect_repo_urls(self):
+        repo_urls = set()
+        for saas_file in self.saas_files:
+            resource_templates = saas_file['resourceTemplates']
+            for rt in resource_templates:
+                repo_urls.add(rt['url'])
+        return repo_urls
 
     def _initiate_state(self, accounts):
         self.state = State(


### PR DESCRIPTION
adding repos to a `codeComponent` section gives us some benefits:
- the repo is being backed up automatically by git-keeper.
- any github invitations to that repo will be accepted automatically.

it's worth while to validate that all repos from saas files (`.resourceTemplates[].url`) are in `codeComponents` section.

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/32054