### PR TITLE
Container integration loop for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ OpenShift templates can be found [here](/openshift/qontract-reconcile.yaml). In 
 
 ## Installation
 
-This project targets Python version 3.6.x for best compatibility. Verify the Python3 version that your shell is using with `python3 --version`. You can optionally use a tool like [pyenv](https://github.com/pyenv/pyenv) to manage Python versions on your computer.
+This project targets Python version 3.9.x for best compatibility. Verify the Python3 version that your shell is using with `python3 --version`. You can optionally use a tool like [pyenv](https://github.com/pyenv/pyenv) to manage Python versions on your computer.
 
 Create and enter the [virtualenv](https://virtualenv.pypa.io/en/latest/) environment:
 
@@ -208,7 +208,33 @@ tox -e type
 tox -e type -- reconcile/utils/slack_api.py
 ```
 
+## Run reconcile loop for an integration locally in a container
 
+ This is currently only tested with the docker container engine.
+
+### Prepare config.toml
+
+Make sure the file  [`./config.dev.toml`](https://vault.devshift.net/ui/vault/secrets/app-sre/show/creds/app-interface-dev-config-toml) exists and contains your current configuration.
+Your `config.dev.toml` should point to the following qontract-server address:
+
+```
+[graphql]
+server = "http://host.docker.internal:4000/graphql"
+```
+
+### Run qontract-server
+
+Start the [qontract-server](https://github.com/app-sre/qontract-server) in a different window, e.g., via:
+
+```
+qontract-server$ make dev
+```
+
+### Trigger integration
+
+```
+make dev-reconcile-loop INTEGRATION_NAME=terraform-resources DRY_RUN=--dry-run INTEGRATION_EXTRA_ARGS=--light SLEEP_DURATION_SECS=100
+```
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ tox -e type -- reconcile/utils/slack_api.py
 
 ### Prepare config.toml
 
-Make sure the file  [`./config.dev.toml`](https://vault.devshift.net/ui/vault/secrets/app-sre/show/creds/app-interface-dev-config-toml) exists and contains your current configuration.
+Make sure the file `./config.dev.toml` exists and contains your current configuration.
 Your `config.dev.toml` should point to the following qontract-server address:
 
 ```

--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -55,7 +55,7 @@ def build_entry_point_args(command: click.Command, config: str,
                            dry_run: Optional[str], integration_name: str,
                            extra_args: Optional[str]) -> list[str]:
     args = ['--config', config]
-    if dry_run is not None:
+    if dry_run in ['--dry-run', '--no-dry-run']:
         args.append(dry_run)
 
     # if the integration_name is a known sub command, we add it right before the extra_args

--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -55,7 +55,7 @@ def build_entry_point_args(command: click.Command, config: str,
                            dry_run: Optional[str], integration_name: str,
                            extra_args: Optional[str]) -> list[str]:
     args = ['--config', config]
-    if dry_run in ['--dry-run', '--no-dry-run']:
+    if dry_run is not None:
         args.append(dry_run)
 
     # if the integration_name is a known sub command, we add it right before the extra_args


### PR DESCRIPTION
**Motivation**

The reconcile loop can be triggered in local dev env, however, it requires proper binaries to be in `PATH`. I see 2 ways to automate this issue away:

1. Run reconcile dev loop inside a container
2. Add make target which downloads binaries to repo local `./bin` directory and add an .env script to source those bins as prefix to PATH

This PR targets the first approach.

**Proposed Changes**

- added a make target to run reconcile loop inside a docker container
- added documentation about that new make target
- set 3.9.x as compatibility target (same as in `setup.py`)