### PR TITLE
Update validate_promotions to use the state instead of graphql

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -142,7 +142,7 @@ def run(dry_run, thread_pool_size=10, io_dir='throughput/',
 
     # validate that this deployment is valid
     # based on promotion information in targets
-    if not saasherder.validate_promotions(all_saas_files):
+    if not saasherder.validate_promotions():
         logging.error('invalid promotions')
         ri.register_error()
         sys.exit(ExitCodes.ERROR)

--- a/reconcile/test/fixtures/saasherder/saas.gql.yml
+++ b/reconcile/test/fixtures/saasherder/saas.gql.yml
@@ -239,11 +239,11 @@
                   ],
                   "promotion_data": [{
                     "channel": "test-saas-deployments-deploy",
-                    "data": {
+                    "data": [{
                       "type": "parent_saas_config",
                       "parent_saas": "test-saas-deployments-deploy",
                       "target_config_hash": "ed2af38cf21f268c"
-                    }
+                    }],
                   }],
                   "publish": null,
                 },

--- a/reconcile/test/fixtures/saasherder/saas_post_deploy.state.json
+++ b/reconcile/test/fixtures/saasherder/saas_post_deploy.state.json
@@ -18,11 +18,11 @@
     "promotion_data": [
         {
             "channel": "test-saas-deployments-deploy",
-            "data": {
+            "data": [{
                 "type": "parent_saas_config",
                 "parent_saas": "test-saas-deployments-deploy",
                 "target_config_hash": "ed2af38cf21f268c"
-            }
+            }]
         }
     ]
   },

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -680,6 +680,7 @@ class TestConfigHashPromotionsValidation(TestCase):
         result = self.saasherder.validate_promotions()
         self.assertTrue(result)
 
+
 class TestConfigHashTrigger(TestCase):
     """ TestCase to test Openshift SAAS deploy configs trigger. SaasHerder is
     initialized WITHOUT ResourceInventory population. Like is done in the
@@ -750,7 +751,7 @@ class TestConfigHashTrigger(TestCase):
 
         desired_tc = list(configs.values())[1]
         desired_promo_data = desired_tc["promotion"]["promotion_data"]
-        desired_promo_data[0]["data"][TARGET_CONFIG_HASH] = "Changed"
+        desired_promo_data[0]["data"][0][TARGET_CONFIG_HASH] = "Changed"
 
         job_specs = \
             self.saasherder.get_configs_diff_saas_file(self.saas_file)

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -622,30 +622,25 @@ class TestConfigHashPromotionsValidation(TestCase):
         self.assertIsNotNone(promotion[TARGET_CONFIG_HASH])
 
     def test_promotion_state_config_hash_match_validates(self):
-        """ A promotion is valid if the pusblisher state got from the state
-            is equal to the one set in the subscriber target promotion data.
-            This is the happy path, publisher job state target config hash is
-            the same set in the subscriber job
+        """ A promotion is valid if the parent target config_hash set in
+            the state is equal to the one set in the subscriber target
+            promotion data. This is the happy path.
         """
-        configs = \
-            self.saasherder.get_saas_targets_config(self.saas_file)
-
-        tcs = list(configs.values())
-        publisher_config_hash = tcs[0]['promotion'][TARGET_CONFIG_HASH]
-
         publisher_state = {
             "success": True,
             "saas_file": self.saas_file["name"],
-            TARGET_CONFIG_HASH: publisher_config_hash
+            TARGET_CONFIG_HASH: "ed2af38cf21f268c"
         }
         self.state_mock.get.return_value = publisher_state
-        result = self.saasherder.validate_promotions(self.all_saas_files)
+        result = self.saasherder.validate_promotions()
         self.assertTrue(result)
 
     def test_promotion_state_config_hash_not_match_no_validates(self):
         """ Promotion is not valid if the parent target config hash set in
-        promotion data is not the same set in the publisher job state. This
-        could happen if a new publisher job has before the subscriber job
+        the state does not match with the one set in the subsriber target
+        promotion_data. This could happen if the parent target has run again
+        with the same ref before before the subscriber target promotion MR is
+        merged.
         """
         publisher_state = {
             "success": True,
@@ -653,20 +648,37 @@ class TestConfigHashPromotionsValidation(TestCase):
             TARGET_CONFIG_HASH: "will_not_match"
         }
         self.state_mock.get.return_value = publisher_state
-        result = self.saasherder.validate_promotions(self.all_saas_files)
+        result = self.saasherder.validate_promotions()
         self.assertFalse(result)
 
     def test_promotion_without_state_config_hash_validates(self):
         """ Existent states won't have promotion data. If there is an ongoing
             promotion, this ensures it will happen.
         """
-        promotion_result = {
+        publisher_state = {
             "success": True,
         }
-        self.state_mock.get.return_value = promotion_result
-        result = self.saasherder.validate_promotions(self.all_saas_files)
+        self.state_mock.get.return_value = publisher_state
+        result = self.saasherder.validate_promotions()
         self.assertTrue(result)
 
+    def test_promotion_without_promotion_data_validates(self):
+        """ A manual promotion might be required, subsribed targets without
+            promotion_data should validate if the parent target job has succed
+            with the same ref.
+        """
+        publisher_state = {
+            "success": True,
+            "saas_file": self.saas_file["name"],
+            TARGET_CONFIG_HASH: "whatever"
+        }
+
+        # Remove promotion_data on the promoted target
+        self.saasherder.promotions[1]["promotion_data"] = None
+
+        self.state_mock.get.return_value = publisher_state
+        result = self.saasherder.validate_promotions()
+        self.assertTrue(result)
 
 class TestConfigHashTrigger(TestCase):
     """ TestCase to test Openshift SAAS deploy configs trigger. SaasHerder is

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -1295,7 +1295,7 @@ class SaasHerder():
                     state_config_hash = stateobj.get(TARGET_CONFIG_HASH)
                     promotion_data = item.get('promotion_data', None)
 
-                    # This code supports current saas deployments that does
+                    # This code supports current saas targets that does
                     # not have promotion_data yet
                     if not state_config_hash or \
                        not promotion_data:
@@ -1306,8 +1306,8 @@ class SaasHerder():
                         return True
 
                     # Validate the promotion_data section.
-                    # By now, just validate parent_saas_config hash
-                    # promotion_data type.
+                    # Just validate parent_saas_config hash
+                    # promotion_data type by now.
                     parent_saas_config = None
                     for pd in promotion_data:
                         pd_channel = pd.get("channel")
@@ -1318,10 +1318,10 @@ class SaasHerder():
                                 if t == "parent_saas_config":
                                     parent_saas_config = data
 
-                    # This section might not exist due to manual changes
-                    # on promoted changes that need to be applied.
+                    # This section might not exist due to a manual MR.
                     # Promotion shall continue if this data is missing.
-                    # The parent at the same ref succeed though.
+                    # The parent at the same ref has succeed if this code
+                    # is reached though.
                     if not parent_saas_config:
                         logging.info(
                             "Parent Saas config missing on target "
@@ -1330,8 +1330,7 @@ class SaasHerder():
                         return True
 
                     # Validate that the state config_hash set by the parent
-                    # is the same existent in the promotion_data on the same
-                    # ref.
+                    # matches with the hash set in promotion_data
                     promotion_target_config_hash = \
                         parent_saas_config.get(TARGET_CONFIG_HASH)
 


### PR DESCRIPTION
This PR solves a problem with the current saas file deployments based on config_changes. 

```
DeployTarget ------[promotes]---------> TestTarget
                                        - parent_config_hash
```

When a automatic promotion happens, a hash from the DeployTarget configuration is added to TestTarget  in an automated MR (AutoPromote). This MR validation uses `saasherder.validate_promotions` method to ensure the parent_config_hash set in the promotion matches the **current** DeployTarget configuration in app-interface. 

This is causing issues in pipelines that could run in parallel because only the last promotion is valid (configuration is matched with app-interface state).

To solve this, the validation is changed to match the hash in the success state of DeployTarget instead of app-interface. The state is stored for every ref(commit) where DeployTarget has run so every step will be matched with its real parent state insteda of the last one. 