### PR TITLE
[terraform-resources] disable per cluster

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -317,6 +317,9 @@ TF_NAMESPACES_QUERY = """
         region
       }
       internal
+      disable {
+        integrations
+      }
     }
   }
 }


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/68

the intention is that when terraform-resources is disabled per cluster, all terraform resources will still be created, but their output resources will not be reconciled on the disabled cluster.