### PR TITLE
add support for role expiration to all integrations

### DIFF
--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -7,6 +7,7 @@ from github.GithubObject import NotSet  # type: ignore
 from sretoolbox.utils import retry
 
 from reconcile.utils import gql
+from reconcile.utils import expiration
 from reconcile.utils.secret_reader import SecretReader
 from reconcile import openshift_users
 from reconcile import queries
@@ -53,6 +54,7 @@ ROLES_QUERY = """
         team
       }
     }
+    expirationDate
   }
 }
 """
@@ -165,7 +167,7 @@ def fetch_desired_state(infer_clusters=True):
     gqlapi = gql.get_api()
     state = AggregatedList()
 
-    roles = gqlapi.query(ROLES_QUERY)['roles']
+    roles = expiration.filter(gqlapi.query(ROLES_QUERY)['roles'])
     for role in roles:
         permissions = list(filter(
             lambda p: p.get('service') in ['github-org', 'github-org-team'],

--- a/reconcile/github_owners.py
+++ b/reconcile/github_owners.py
@@ -5,6 +5,7 @@ from github import Github
 from sretoolbox.utils import retry
 
 from reconcile.utils import gql
+from reconcile.utils import expiration
 
 from reconcile.github_org import get_config
 from reconcile.utils.raw_github_api import RawGithubApi
@@ -31,6 +32,7 @@ ROLES_QUERY = """
         role
       }
     }
+    expirationDate
   }
 }
 """
@@ -41,7 +43,7 @@ QONTRACT_INTEGRATION = 'github-owners'
 def fetch_desired_state():
     desired_state = {}
     gqlapi = gql.get_api()
-    roles = gqlapi.query(ROLES_QUERY)['roles']
+    roles = expiration.filter(gqlapi.query(ROLES_QUERY)['roles'])
     for role in roles:
         permissions = [p for p in role['permissions']
                        if p.get('service')

--- a/reconcile/jenkins_roles.py
+++ b/reconcile/jenkins_roles.py
@@ -1,6 +1,7 @@
 import logging
 
 from reconcile.utils import gql
+from reconcile.utils import expiration
 from reconcile import queries
 
 from reconcile.utils.jenkins_api import JenkinsApi
@@ -45,6 +46,7 @@ ROLES_QUERY = """
         }
       }
     }
+    expirationDate
   }
 }
 """
@@ -95,7 +97,7 @@ def get_current_state(jenkins_map):
 
 def get_desired_state():
     gqlapi = gql.get_api()
-    roles = gqlapi.query(ROLES_QUERY)['roles']
+    roles = expiration.filter(gqlapi.query(ROLES_QUERY)['roles'])
 
     desired_state = []
     for r in roles:

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -8,6 +8,7 @@ from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.openshift_resource import (OpenshiftResource as OR,
                                                 ResourceKeyExistsError)
 from reconcile.utils.defer import defer
+from reconcile.utils import expiration
 
 
 ROLES_QUERY = """
@@ -27,6 +28,7 @@ ROLES_QUERY = """
       }
       clusterRole
     }
+    expirationDate
   }
 }
 """
@@ -86,7 +88,7 @@ def construct_sa_oc_resource(role, namespace, sa_name):
 
 def fetch_desired_state(ri, oc_map):
     gqlapi = gql.get_api()
-    roles = gqlapi.query(ROLES_QUERY)['roles']
+    roles = expiration.filter(gqlapi.query(ROLES_QUERY)['roles'])
     users_desired_state = []
     # set namespace to something indicative
     namepsace = 'cluster'

--- a/reconcile/quay_membership.py
+++ b/reconcile/quay_membership.py
@@ -88,11 +88,11 @@ def fetch_current_state(quay_api_store):
 
 def fetch_desired_state():
     gqlapi = gql.get_api()
-    result = expiration.filter(gqlapi.query(QUAY_ORG_QUERY))
+    roles = expiration.filter(gqlapi.query(QUAY_ORG_QUERY)['roles'])
 
     state = AggregatedList()
 
-    for role in result['roles']:
+    for role in roles:
         permissions = [
             process_permission(p)
             for p in role['permissions']

--- a/reconcile/quay_membership.py
+++ b/reconcile/quay_membership.py
@@ -2,6 +2,7 @@ import logging
 import sys
 
 from reconcile.utils import gql
+from reconcile.utils import expiration
 
 from reconcile.utils.aggregated_list import (AggregatedList,
                                              AggregatedDiffRunner,
@@ -34,6 +35,7 @@ QUAY_ORG_QUERY = """
         team
       }
     }
+    expirationDate
   }
 }
 """
@@ -86,7 +88,7 @@ def fetch_current_state(quay_api_store):
 
 def fetch_desired_state():
     gqlapi = gql.get_api()
-    result = gqlapi.query(QUAY_ORG_QUERY)
+    result = expiration.filter(gqlapi.query(QUAY_ORG_QUERY))
 
     state = AggregatedList()
 

--- a/reconcile/sentry_config.py
+++ b/reconcile/sentry_config.py
@@ -6,6 +6,7 @@ from github.GithubException import UnknownObjectException
 
 from reconcile import queries
 from reconcile.utils import gql
+from reconcile.utils import expiration
 
 from reconcile.github_users import init_github
 from reconcile.utils.secret_reader import SecretReader
@@ -67,6 +68,7 @@ SENTRY_USERS_QUERY = """
       }
       role
     }
+    expirationDate
   }
 }
 """
@@ -454,7 +456,7 @@ def fetch_desired_state(gqlapi, sentry_instance, ghapi):
     # Query for users that should be in sentry
     team_members = {}
     sentryUrl = sentry_instance['consoleUrl']
-    result = gqlapi.query(SENTRY_USERS_QUERY)
+    result = expiration.filter(gqlapi.query(SENTRY_USERS_QUERY))
     for role in result['roles']:
         if role['sentry_teams'] is None:
             continue

--- a/reconcile/sentry_config.py
+++ b/reconcile/sentry_config.py
@@ -456,8 +456,8 @@ def fetch_desired_state(gqlapi, sentry_instance, ghapi):
     # Query for users that should be in sentry
     team_members = {}
     sentryUrl = sentry_instance['consoleUrl']
-    result = expiration.filter(gqlapi.query(SENTRY_USERS_QUERY))
-    for role in result['roles']:
+    roles = expiration.filter(gqlapi.query(SENTRY_USERS_QUERY)['roles'])
+    for role in roles:
         if role['sentry_teams'] is None:
             continue
 

--- a/reconcile/test/fixtures/github_org/desired_state_simple.yml
+++ b/reconcile/test/fixtures/github_org/desired_state_simple.yml
@@ -4,6 +4,7 @@ gql_response:
     - github_username: user1
     bots: []
     name: role1
+    expirationDate: null
     permissions:
     - org: org_a
       service: github-org

--- a/reconcile/test/fixtures/quay_membership/desired_state_simple.yml
+++ b/reconcile/test/fixtures/quay_membership/desired_state_simple.yml
@@ -5,6 +5,7 @@ gql_response:
     - quay_username: user2
     bots: []
     name: role1
+    expirationDate: null
     permissions:
     - service: quay-membership
       quayOrg:


### PR DESCRIPTION
follows up on:
- #2125
- #2033

this PR adds support for role expiration for all remaining integrations which are calculating their desired state based on roles.