### PR TITLE
Join slack channels

### DIFF
--- a/reconcile/jira_watcher.py
+++ b/reconcile/jira_watcher.py
@@ -87,6 +87,9 @@ def init_slack(jira_board):
         slack_api_kwargs['api_config'] = \
             SlackApiConfig.from_dict(client_config)
 
+    if channel:
+        slack_api_kwargs['init_join_channel'] = True
+
     slack = SlackApi(workspace_name, token, **slack_api_kwargs)
 
     return slack

--- a/reconcile/slack_base.py
+++ b/reconcile/slack_base.py
@@ -30,6 +30,9 @@ def init_slack(slack_info, integration, init_usergroups=True):
         slack_api_kwargs['api_config'] = \
             SlackApiConfig.from_dict(client_config)
 
+    if channel:
+        slack_api_kwargs['init_join_channel'] = True
+
     slack = SlackApi(workspace_name, token, **slack_api_kwargs)
 
     return slack

--- a/reconcile/unleash_watcher.py
+++ b/reconcile/unleash_watcher.py
@@ -99,6 +99,9 @@ def init_slack_map(unleash_instance):
             slack_api_kwargs['api_config'] = \
                 SlackApiConfig.from_dict(client_config)
 
+        if channel:
+            slack_api_kwargs['init_join_channel'] = True
+
         slack = SlackApi(workspace_name, token, **slack_api_kwargs)
 
         slack_map[channel] = slack


### PR DESCRIPTION
Join Slack channels, whenever required and possible.
Join only when initializing instances of SlackApi.

Related ticket: [APPSRE-3988](https://issues.redhat.com/browse/APPSRE-3988)