### PR TITLE
APPSRE-4119 ES log publishing feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ coverage.xml
 dist
 venv
 throughput
+config.prod.toml
 config.dev.toml
 config.debug.toml
 .container_tmp

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -182,6 +182,7 @@ provider
   defaults
   output_resource_name
   annotations
+  publish_log_types
 }
 ... on NamespaceTerraformResourceACM_v1 {
   account

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3134,6 +3134,7 @@ class TerrascriptClient:
         self, identifier, account,
         resource, values, output_prefix
     ):
+        ES_LOG_GROUP_RETENTION_DAYS = 180
         tf_resources = []
         publishing_options = []
         # https://docs.aws.amazon.com/opensearch-service/latest/developerguide/createdomain-configure-slow-logs.html
@@ -3175,7 +3176,7 @@ class TerrascriptClient:
             log_group_values = {
                 'name': log_type_identifier,
                 'tags': {},
-                'retention_in_days': 90,
+                'retention_in_days': ES_LOG_GROUP_RETENTION_DAYS,
             }
             region = values.get('region') or \
                 self.default_regions.get(account)

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3139,8 +3139,8 @@ class TerrascriptClient:
         pattern = r'^[a-z][a-z0-9-]+$'
         return re.search(pattern, name)
 
-    def _elasticsearch_log_group_identifier(
-        self,
+    @staticmethod
+    def elasticsearch_log_group_identifier(
         domain_identifier: str,
         log_type: ElasticSearchLogGroupType
     ) -> str:
@@ -3168,10 +3168,11 @@ class TerrascriptClient:
                     region = ns.get('cluster').get('spec').get('region')
                     account = res['account']
                     account_id = self.accounts[account]['uid']
-                    lg_identifier = self._elasticsearch_log_group_identifier(
-                        domain_identifier=res['identifier'],
-                        log_type=ElasticSearchLogGroupType(log_type),
-                    )
+                    lg_identifier = \
+                        TerrascriptClient.elasticsearch_log_group_identifier(
+                            domain_identifier=res['identifier'],
+                            log_type=ElasticSearchLogGroupType(log_type),
+                        )
                     tup = (account, region, account_id, lg_identifier)
                     log_group_identifiers.append(tup)
         return log_group_identifiers
@@ -3234,7 +3235,7 @@ class TerrascriptClient:
             log_types = []
         for log_type in log_types:
             log_type_identifier = \
-                self._elasticsearch_log_group_identifier(
+                TerrascriptClient.elasticsearch_log_group_identifier(
                     domain_identifier=identifier,
                     log_type=ElasticSearchLogGroupType(log_type),
                 )

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3156,7 +3156,7 @@ class TerrascriptClient:
         log_type_name = log_type.value.lower()
         return f'OpenSearchService__{domain_identifier}__{log_type_name}'
 
-    def _elasticsearch_aggregate_log_groups_per_account(
+    def _elasticsearch_get_all_log_group_infos(
         self
     ) -> list[ElasticSearchLogGroupInfo]:
         log_group_infos = []
@@ -3164,8 +3164,6 @@ class TerrascriptClient:
             for i in resources:
                 res = i['resource']
                 ns = i['namespace_info']
-                if not ns.get('managedTerraformResources'):
-                    continue
                 if res.get('provider') != 'elasticsearch':
                     continue
                 # res.get('', []) won't work, as publish_log_types is
@@ -3205,7 +3203,7 @@ class TerrascriptClient:
         account first.
         '''
         log_group_infos = \
-            self._elasticsearch_aggregate_log_groups_per_account()
+            self._elasticsearch_get_all_log_group_infos()
 
         log_groups_policy = {
             'Version': '2012-10-17',

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3204,7 +3204,7 @@ class TerrascriptClient:
             }
             region = values.get('region') or \
                 self.default_regions.get(account)
-            if self._multiregion_account_(account):
+            if self._multiregion_account(account):
                 log_group_values['provider'] = f'aws.{region}'
             log_group_tf_resource = \
                 aws_cloudwatch_log_group(log_type_identifier,

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3159,11 +3159,11 @@ class TerrascriptClient:
     def _elasticsearch_get_all_log_group_infos(
         self
     ) -> list[ElasticSearchLogGroupInfo]:
-        '''
+        """
         Gather all cloud_watch_log_groups for the
         current account. This is required to set
         an account-wide resource policy.
-        '''
+        """
         log_group_infos = []
         for resources in self.account_resources.values():
             for i in resources:
@@ -3196,7 +3196,7 @@ class TerrascriptClient:
     def _get_elasticsearch_account_wide_resource_policy(
         self, account: str
     ) -> Optional[aws_cloudwatch_log_resource_policy]:
-        '''
+        """
         https://docs.aws.amazon.com/opensearch-service/latest/developerguide/createdomain-configure-slow-logs.html
         CloudWatch Logs supports 10 resource policies per Region.
         If you plan to enable logs for several OpenSearch Service domains,
@@ -3207,7 +3207,7 @@ class TerrascriptClient:
 
         This function returns None, if no log groups are found for that
         account.
-        '''
+        """
         log_group_infos = \
             self._elasticsearch_get_all_log_group_infos()
 
@@ -3249,12 +3249,12 @@ class TerrascriptClient:
         resource: Mapping[str, Any], values: Mapping[str, Any],
         output_prefix: str
     ) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
-        '''
+        """
         Generate cloud_watch_log_group terraform_resources
         for the given resource. Further, generate
         publishing_options blocks which will be further used
         by the consumer.
-        '''
+        """
         ES_LOG_GROUP_RETENTION_DAYS = 90
         tf_resources = []
         publishing_options = []

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3344,6 +3344,13 @@ class TerrascriptClient:
             es_values["vpc_options"]['security_group_ids'] = security_group_ids
 
         advanced_options = values.get('advanced_options', None)
+        if advanced_options and \
+           not advanced_options.get('override_main_response_version', None):
+            '''
+            By default terraform expects this to be False. If not set (null),
+            then this results in an 'Update' request on each plan/apply.
+            '''
+            advanced_options['override_main_response_version'] = False
         if advanced_options is not None:
             es_values["advanced_options"] = advanced_options
 

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3202,11 +3202,6 @@ class TerrascriptClient:
             )
             output_value = log_type_identifier
             tf_resources.append(Output(output_name_0_13, value=output_value))
-
-            if log_type == 'AUDIT_LOGS':
-                # Audit logs require special attention - manual step for now
-                # https://docs.aws.amazon.com/opensearch-service/latest/developerguide/audit-logs.html
-                continue
             publishing_options.append(
                 {
                     'log_type': log_type,

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3188,7 +3188,7 @@ class TerrascriptClient:
                     )
         return log_group_infos
 
-    def _get_tf_resource_elasticsearch_resource_policy(
+    def _get_elasticsearch_account_wide_resource_policy(
         self, account: str
     ) -> aws_cloudwatch_log_resource_policy:
         '''
@@ -3324,7 +3324,7 @@ class TerrascriptClient:
             )
         tf_resources += log_group_resources
 
-        resource_policy = self._get_tf_resource_elasticsearch_resource_policy(
+        resource_policy = self._get_elasticsearch_account_wide_resource_policy(
             account=account,
         )
         tf_resources.append(resource_policy)


### PR DESCRIPTION
**Motivation**

Allow to specify which kinds of ES logs should be published.
Related schema change https://github.com/app-sre/qontract-schemas/pull/63

**Changes**

- support log_types: [`INDEX_SLOW_LOGS`, `SEARCH_SLOW_LOGS`, `ES_APPLICATION_LOGS`]
- create one dedicated cloudwatch loggroup per log_type per ES domain (AWS recommended)
- create ES resource policy to allow ES to create a logstream. Single policy per account required, as there is a limit of 10 per account.

**Tests**

Test data: https://github.com/app-sre/app-interface/pull/15
3 ES domains bootstrapped in dev account. 1 had a single log. 1 had all 3 logs. 1 had zerio logs. Logs (where expected) were successfully published.

Further, there was no plan diff on prod data.