### PR TITLE
[openshift-saas-deploy-trigger-*] fix skip check images condition for saas files v2

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -739,7 +739,7 @@ class SaasHerder():
         github = self._initiate_github(saas_file)
         image_auth = self._initiate_image_auth(saas_file)
 
-        # Instance exists in v1 saas files only.
+        # Instance exists in this level in v1 saas files only.
         instance = saas_file.get('instance')
         instance_name = instance['name'] if instance else None
 
@@ -778,6 +778,19 @@ class SaasHerder():
                 )
                 digest = SaasHerder.get_target_config_hash(target_configs[key])
 
+                upstream = target.get('upstream')
+                if upstream and not instance:
+                    # in case upstream is defined and instance is
+                    # not defined at the saas file level,
+                    # this is a saas file v2.
+                    # the upstream section looks like this:
+                    # upstream:
+                    #   instance:
+                    #     $ref: /path/to/instance.yml
+                    #   name: job-name
+                    instance_name = upstream['instance']['name']
+                    upstream = upstream['name']
+
                 process_template_options = {
                     'saas_file_name': saas_file_name,
                     'resource_template_name': rt_name,
@@ -805,7 +818,7 @@ class SaasHerder():
                     'process_template_options': process_template_options,
                     'check_images_options_base': check_images_options_base,
                     'instance_name': instance_name,
-                    'upstream': target.get('upstream'),
+                    'upstream': upstream,
                     'delete': target.get('delete'),
                     'privileged': saas_file.get('clusterAdmin', False) is True
                 }


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4365

in this section we are trying to skip checking images a deployment while a build job is running: https://github.com/app-sre/qontract-reconcile/blob/bc75e5c30424e500f22b11e5fa90cce4ac3a6365/reconcile/utils/saasherder.py#L854-L860

with this PR, we are fixing this condition to also work for saas files v2.
this is mostly used during pr-checks, and the goal is to avoid failing them when images do not (yet) exist.

if an `upstream` section exists for a target, it means that it should be pointing at a moving ref, like master/main. the openshift-saas-deploy-trigger-moving-commits integration is already skipping targets with an upstream section: https://github.com/app-sre/qontract-reconcile/blob/bc75e5c30424e500f22b11e5fa90cce4ac3a6365/reconcile/utils/saasherder.py#L947-L949

so this PR should be safe.