### PR TITLE
[saas-file-validator] validate that upstream is not used when ref is a commit sha

### DIFF
--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -189,66 +189,8 @@ class TestSaasFileValid(TestCase):
         self.assertFalse(saasherder.valid)
 
     def test_check_saas_file_upstream_not_used_with_commit_sha(self):
-        saas_files = [
-            {
-                'path': 'path1',
-                'name': 'a1',
-                'managedResourceTypes': [],
-                'resourceTemplates':
-                [
-                    {
-                        'name': 'rt',
-                        'url': 'url',
-                        'targets':
-                        [
-                            {
-                                'namespace': {
-                                    'name': 'ns',
-                                    'environment': {
-                                        'name': 'env1'
-                                    },
-                                    'cluster': {
-                                        'name': 'cluster'
-                                    }
-                                },
-                                'ref': 'main',
-                                'upstream': {
-                                    'instance': {
-                                        'name': 'ci'
-                                    },
-                                    'name': 'job'
-                                },
-                                'parameters': {}
-                            },
-                            {
-                                'namespace': {
-                                    'name': 'ns',
-                                    'environment': {
-                                        'name': 'env2'
-                                    },
-                                    'cluster': {
-                                        'name': 'cluster'
-                                    }
-                                },
-                                'ref': 'master',
-                                'upstream': {
-                                    'instance': {
-                                        'name': 'ci'
-                                    },
-                                    'name': 'job'
-                                },
-                                'parameters': {}
-                            }
-                        ]
-                    }
-                ],
-                'roles': [
-                    {'users': [{'org_username': 'myname'}]}
-                ]
-            }
-        ]
         saasherder = SaasHerder(
-            saas_files,
+            self.saas_files,
             thread_pool_size=1,
             gitlab=None,
             integration='',

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -74,52 +74,8 @@ class TestSaasFileValid(TestCase):
         ]
 
     def test_check_saas_file_env_combo_unique(self):
-        saas_files = [
-            {
-                'path': 'path1',
-                'name': 'a1',
-                'managedResourceTypes': [],
-                'resourceTemplates':
-                [
-                    {
-                        'name': 'rt',
-                        'url': 'url',
-                        'targets':
-                        [
-                            {
-                                'namespace': {
-                                    'name': 'ns',
-                                    'environment': {
-                                        'name': 'env1'
-                                    },
-                                    'cluster': {
-                                        'name': 'cluster'
-                                    }
-                                },
-                                'parameters': {}
-                            },
-                            {
-                                'namespace': {
-                                    'name': 'ns',
-                                    'environment': {
-                                        'name': 'env2'
-                                    },
-                                    'cluster': {
-                                        'name': 'cluster'
-                                    }
-                                },
-                                'parameters': {}
-                            }
-                        ]
-                    }
-                ],
-                'roles': [
-                    {'users': [{'org_username': 'myname'}]}
-                ]
-            }
-        ]
         saasherder = SaasHerder(
-            saas_files,
+            self.saas_files,
             thread_pool_size=1,
             gitlab=None,
             integration='',

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -13,6 +13,66 @@ from .fixtures import Fixtures
 
 
 class TestSaasFileValid(TestCase):
+    def setUp(self):
+        self.saas_files = [
+            {
+                'path': 'path1',
+                'name': 'a1',
+                'managedResourceTypes': [],
+                'resourceTemplates':
+                [
+                    {
+                        'name': 'rt',
+                        'url': 'url',
+                        'targets':
+                        [
+                            {
+                                'namespace': {
+                                    'name': 'ns',
+                                    'environment': {
+                                        'name': 'env1'
+                                    },
+                                    'cluster': {
+                                        'name': 'cluster'
+                                    }
+                                },
+                                'ref': 'main',
+                                'upstream': {
+                                    'instance': {
+                                        'name': 'ci'
+                                    },
+                                    'name': 'job'
+                                },
+                                'parameters': {}
+                            },
+                            {
+                                'namespace': {
+                                    'name': 'ns',
+                                    'environment': {
+                                        'name': 'env2'
+                                    },
+                                    'cluster': {
+                                        'name': 'cluster'
+                                    }
+                                },
+                                'ref': 'master',
+                                'upstream': {
+                                    'instance': {
+                                        'name': 'ci'
+                                    },
+                                    'name': 'job'
+                                },
+                                'parameters': {}
+                            }
+                        ]
+                    }
+                ],
+                'roles': [
+                    {'users': [{'org_username': 'myname'}]}
+                ]
+            }
+        ]
+
     def test_check_saas_file_env_combo_unique(self):
         saas_files = [
             {

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -202,6 +202,7 @@ class TestCheckSaasFileUpstreamNotUsedWithCommitSha(TestCase):
         self.assertTrue(saasherder.valid)
 
     def test_check_saas_file_upstream_used_with_commit_sha(self):
+        commit_sha = '2637b6c41bda7731b1bcaaf18b4a50d7c5e63e30'
         saas_files = [
             {
                 'path': 'path1',
@@ -244,7 +245,7 @@ class TestCheckSaasFileUpstreamNotUsedWithCommitSha(TestCase):
                                         'name': 'cluster'
                                     }
                                 },
-                                'ref': '2637b6c41bda7731b1bcaaf18b4a50d7c5e63e30',
+                                'ref': commit_sha,
                                 'upstream': {
                                     'instance': {
                                         'name': 'ci'

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -87,53 +87,10 @@ class TestSaasFileValid(TestCase):
         self.assertTrue(saasherder.valid)
 
     def test_check_saas_file_env_combo_not_unique(self):
-        saas_files = [
-            {
-                'path': 'path1',
-                'name':
-                'long-name-which-is-too-long-to-produce-unique-combo',
-                'managedResourceTypes': [],
-                'resourceTemplates':
-                [
-                    {
-                        'name': 'rt',
-                        'url': 'url',
-                        'targets':
-                        [
-                            {
-                                'namespace': {
-                                    'name': 'ns',
-                                    'environment': {
-                                        'name': 'env1'
-                                    },
-                                    'cluster': {
-                                        'name': 'cluster'
-                                    }
-                                },
-                                'parameters': {}
-                            },
-                            {
-                                'namespace': {
-                                    'name': 'ns',
-                                    'environment': {
-                                        'name': 'env2'
-                                    },
-                                    'cluster': {
-                                        'name': 'cluster'
-                                    }
-                                },
-                                'parameters': {}
-                            }
-                        ]
-                    }
-                ],
-                'roles': [
-                    {'users': [{'org_username': 'myname'}]}
-                ]
-            }
-        ]
+        self.saas_files[0]['name'] = \
+            'long-name-which-is-too-long-to-produce-unique-combo'
         saasherder = SaasHerder(
-            saas_files,
+            self.saas_files,
             thread_pool_size=1,
             gitlab=None,
             integration='',

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -129,6 +129,151 @@ class TestCheckSaasFileEnvComboUnique(TestCase):
         self.assertFalse(saasherder.valid)
 
 
+class TestCheckSaasFileUpstreamNotUsedWithCommitSha(TestCase):
+    def test_check_saas_file_upstream_not_used_with_commit_sha(self):
+        saas_files = [
+            {
+                'path': 'path1',
+                'name': 'a1',
+                'managedResourceTypes': [],
+                'resourceTemplates':
+                [
+                    {
+                        'name': 'rt',
+                        'url': 'url',
+                        'targets':
+                        [
+                            {
+                                'namespace': {
+                                    'name': 'ns',
+                                    'environment': {
+                                        'name': 'env1'
+                                    },
+                                    'cluster': {
+                                        'name': 'cluster'
+                                    }
+                                },
+                                'ref': 'main',
+                                'upstream': {
+                                    'instance': {
+                                        'name': 'ci'
+                                    },
+                                    'name': 'job'
+                                },
+                                'parameters': {}
+                            },
+                            {
+                                'namespace': {
+                                    'name': 'ns',
+                                    'environment': {
+                                        'name': 'env2'
+                                    },
+                                    'cluster': {
+                                        'name': 'cluster'
+                                    }
+                                },
+                                'ref': 'master',
+                                'upstream': {
+                                    'instance': {
+                                        'name': 'ci'
+                                    },
+                                    'name': 'job'
+                                },
+                                'parameters': {}
+                            }
+                        ]
+                    }
+                ],
+                'roles': [
+                    {'users': [{'org_username': 'myname'}]}
+                ]
+            }
+        ]
+        saasherder = SaasHerder(
+            saas_files,
+            thread_pool_size=1,
+            gitlab=None,
+            integration='',
+            integration_version='',
+            settings={},
+            validate=True
+        )
+
+        self.assertTrue(saasherder.valid)
+
+    def test_check_saas_file_upstream_used_with_commit_sha(self):
+        saas_files = [
+            {
+                'path': 'path1',
+                'name':
+                'long-name-which-is-too-long-to-produce-unique-combo',
+                'managedResourceTypes': [],
+                'resourceTemplates':
+                [
+                    {
+                        'name': 'rt',
+                        'url': 'url',
+                        'targets':
+                        [
+                            {
+                                'namespace': {
+                                    'name': 'ns',
+                                    'environment': {
+                                        'name': 'env1'
+                                    },
+                                    'cluster': {
+                                        'name': 'cluster'
+                                    }
+                                },
+                                'ref': 'main',
+                                'upstream': {
+                                    'instance': {
+                                        'name': 'ci'
+                                    },
+                                    'name': 'job'
+                                },
+                                'parameters': {}
+                            },
+                            {
+                                'namespace': {
+                                    'name': 'ns',
+                                    'environment': {
+                                        'name': 'env2'
+                                    },
+                                    'cluster': {
+                                        'name': 'cluster'
+                                    }
+                                },
+                                'ref': '2637b6c41bda7731b1bcaaf18b4a50d7c5e63e30',
+                                'upstream': {
+                                    'instance': {
+                                        'name': 'ci'
+                                    },
+                                    'name': 'job'
+                                },
+                                'parameters': {}
+                            }
+                        ]
+                    }
+                ],
+                'roles': [
+                    {'users': [{'org_username': 'myname'}]}
+                ]
+            }
+        ]
+        saasherder = SaasHerder(
+            saas_files,
+            thread_pool_size=1,
+            gitlab=None,
+            integration='',
+            integration_version='',
+            settings={},
+            validate=True
+        )
+
+        self.assertFalse(saasherder.valid)
+
+
 class TestGetMovingCommitsDiffSaasFile(TestCase):
     def setUp(self):
         self.saas_files = [

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -12,7 +12,7 @@ from reconcile.utils.saasherder import TARGET_CONFIG_HASH
 from .fixtures import Fixtures
 
 
-class TestCheckSaasFileEnvComboUnique(TestCase):
+class TestSaasFileValid(TestCase):
     def test_check_saas_file_env_combo_unique(self):
         saas_files = [
             {
@@ -128,8 +128,6 @@ class TestCheckSaasFileEnvComboUnique(TestCase):
 
         self.assertFalse(saasherder.valid)
 
-
-class TestCheckSaasFileUpstreamNotUsedWithCommitSha(TestCase):
     def test_check_saas_file_upstream_not_used_with_commit_sha(self):
         saas_files = [
             {

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -202,68 +202,10 @@ class TestSaasFileValid(TestCase):
         self.assertTrue(saasherder.valid)
 
     def test_check_saas_file_upstream_used_with_commit_sha(self):
-        commit_sha = '2637b6c41bda7731b1bcaaf18b4a50d7c5e63e30'
-        saas_files = [
-            {
-                'path': 'path1',
-                'name':
-                'long-name-which-is-too-long-to-produce-unique-combo',
-                'managedResourceTypes': [],
-                'resourceTemplates':
-                [
-                    {
-                        'name': 'rt',
-                        'url': 'url',
-                        'targets':
-                        [
-                            {
-                                'namespace': {
-                                    'name': 'ns',
-                                    'environment': {
-                                        'name': 'env1'
-                                    },
-                                    'cluster': {
-                                        'name': 'cluster'
-                                    }
-                                },
-                                'ref': 'main',
-                                'upstream': {
-                                    'instance': {
-                                        'name': 'ci'
-                                    },
-                                    'name': 'job'
-                                },
-                                'parameters': {}
-                            },
-                            {
-                                'namespace': {
-                                    'name': 'ns',
-                                    'environment': {
-                                        'name': 'env2'
-                                    },
-                                    'cluster': {
-                                        'name': 'cluster'
-                                    }
-                                },
-                                'ref': commit_sha,
-                                'upstream': {
-                                    'instance': {
-                                        'name': 'ci'
-                                    },
-                                    'name': 'job'
-                                },
-                                'parameters': {}
-                            }
-                        ]
-                    }
-                ],
-                'roles': [
-                    {'users': [{'org_username': 'myname'}]}
-                ]
-            }
-        ]
+        self.saas_files[0]['resourceTemplates'][0]['targets'][0]['ref'] = \
+            '2637b6c41bda7731b1bcaaf18b4a50d7c5e63e30'
         saasherder = SaasHerder(
-            saas_files,
+            self.saas_files,
             thread_pool_size=1,
             gitlab=None,
             integration='',

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -235,9 +235,9 @@ class SaasHerder():
 
     def _validate_upstream_not_used_with_commit_sha(
             self,
-            saas_file_name,
-            resource_template_name,
-            target
+            saas_file_name: str,
+            resource_template_name: str,
+            target: dict,
     ):
         upstream = target.get('upstream')
         if upstream:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -55,6 +55,7 @@ class SaasHerder():
                  accounts=None,
                  validate=False):
         self.saas_files = saas_files
+        self.repo_urls = self._collect_repo_urls()
         if validate:
             self._validate_saas_files()
             if not self.valid:
@@ -66,7 +67,6 @@ class SaasHerder():
         self.settings = settings
         self.secret_reader = SecretReader(settings=settings)
         self.namespaces = self._collect_namespaces()
-        self.repo_urls = self._collect_repo_urls()
         self.jenkins_map = jenkins_map
         # each namespace is in fact a target,
         # so we can use it to calculate.


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4366

it makes less sense to specify a commit sha as `ref` and using `upstream`, because even if we trigger a deployment after each build, the deployment will change nothing in the environment. the template is identical, and the image that is deployed is either automatically generated according to the `ref` or is hard coded as `IMAGE_TAG` in the parameters. in either case, a new deployment will not change anything.