### PR TITLE
pin openshift version to 0.12

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "dnspython~=2.1",
         "requests==2.22.0",
         "kubernetes~=12.0",
-        "openshift>=0.11.2",
+        "openshift~=0.12",
         "websocket-client<0.55.0,>=0.35",
         "sshtunnel>=0.4.0",
         "croniter>=1.0.15,<1.1.0",

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "dnspython~=2.1",
         "requests==2.22.0",
         "kubernetes~=12.0",
-        "openshift~=0.12",
+        "openshift>=0.11.2,<0.13.0",
         "websocket-client<0.55.0,>=0.35",
         "sshtunnel>=0.4.0",
         "croniter>=1.0.15,<1.1.0",


### PR DESCRIPTION
pr-checks are failing with this error:
```
Collecting openshift>=0.11.2
  Using cached openshift-0.13.0.tar.gz (19 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  �� python setup.py egg_info did not run successfully.
  ��� exit code: 1
  ������> [8 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/tmp/pip-install-y5_ve9lz/openshift_9620710db4714da49b0e912964f4c572/setup.py", line 49, in <module>
          install_requires=extract_requirements('requirements.txt'),
        File "/tmp/pip-install-y5_ve9lz/openshift_9620710db4714da49b0e912964f4c572/setup.py", line 36, in extract_requirements
          with open(filename, 'r') as requirements_file:
      FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

�� Encountered error while generating package metadata.
������> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

seems to be related to a new release: https://pypi.org/project/openshift/0.13.0/
upstream issue: https://github.com/openshift/openshift-restclient-python/issues/425