### PR TITLE
utils/jjb_client: fix subprocess's CompletedProcess method name

### DIFF
--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -239,11 +239,11 @@ class JJB:
                                         check=True,
                                         stdout=PIPE,
                                         stderr=STDOUT)
-                out_str = result.output.decode("utf-8")
+                out_str = result.stdout.decode("utf-8")
                 if re.search("updated: [1-9]", out_str):
                     logging.info(out_str)
             except CalledProcessError as ex:
-                msg = ex.output.decode("utf-8")
+                msg = ex.stdout.decode("utf-8")
                 logging.error(msg)
 
     @staticmethod


### PR DESCRIPTION
#2151 introduced a bug causing the integration to fail with
```
ERROR: Error running qontract-reconcile
Traceback (most recent call last):
  File "/run-integration.py", line 150, in main
    command.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/environ.py", line 15, in f_environ
    f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/cli.py", line 624, in jenkins_job_builder
    run_integration(reconcile.jenkins_job_builder, ctx.obj, io_dir,
  File "/usr/local/lib/python3.9/site-packages/reconcile/cli.py", line 439, in run_integration
    func_container.run(dry_run, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/defer.py", line 15, in func_wrapper
    return func(*args, defer=defer, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/jenkins_job_builder.py", line 231, in run
    jjb.update()
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/jjb_client.py", line 242, in update
    out_str = result.output.decode("utf-8")
AttributeError: 'CompletedProcess' object has no attribute 'output'
```

This should fix it by calling the correct method on CompletedProcess