### PR TITLE
[openshift-tekton-resources] allow missing section

### DIFF
--- a/reconcile/openshift_tekton_resources.py
+++ b/reconcile/openshift_tekton_resources.py
@@ -259,7 +259,7 @@ def build_one_per_saas_file_pipeline(pipeline_template_config: dict[str, str],
         pipeline_template_config['name'], saas_file['name'])
 
     for section in ['tasks', 'finally']:
-        for task in pipeline['spec'][section]:
+        for task in pipeline['spec'].get(section, []):
             if task['name'] not in task_templates_types:
                 raise OpenshiftTektonResourcesBadConfigError(
                     f"Unknown task {task['name']} in pipeline template "


### PR DESCRIPTION
some pipelines may not have one of the sections (specifically, `finally`).
as the sections are currently "mandatory", we can define them as empty (`finally: []`). that creates a never ending attempt to reconcile, since the resource on the cluster will not contain the section at all.

this PR changes the behavior to allow missing sections from the desired resource.