### PR TITLE
add smtp settings to app-interface settings

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -18,7 +18,7 @@ APP_INTERFACE_SETTINGS_QUERY = """
     saasDeployJobTemplate
     hashLength
     smtp {
-      mailAdress
+      mailAddress
       credentials {
         path
         field

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -17,6 +17,15 @@ APP_INTERFACE_SETTINGS_QUERY = """
     mergeRequestGateway
     saasDeployJobTemplate
     hashLength
+    smtp {
+      mailAdress
+      credentials {
+        path
+        field
+        version
+        format
+      }
+    }
     dependencies {
       type
       services {

--- a/reconcile/test/test_utils_slack_api.py
+++ b/reconcile/test/test_utils_slack_api.py
@@ -258,33 +258,29 @@ def test_update_usergroup_users_empty_list(mock_get_deleted, slack_api):
            call(usergroup='ABCD', users=['a-deleted-user'])
 
 
-@patch('reconcile.utils.slack_api.get_config', autospec=True)
-def test_get_user_id_by_name_user_not_found(get_config_mock, slack_api):
+def test_get_user_id_by_name_user_not_found(slack_api):
     """
     Check that UserNotFoundException will be raised under expected conditions.
     """
-    get_config_mock.return_value = {'smtp': {'mail_address': 'redhat.com'}}
     slack_api.mock_slack_client.return_value\
         .users_lookupByEmail.side_effect = \
         SlackApiError('Some error message', {'error': 'users_not_found'})
 
     with pytest.raises(UserNotFoundException):
-        slack_api.client.get_user_id_by_name('someuser')
+        slack_api.client.get_user_id_by_name('someuser', 'redhat.com')
 
 
-@patch('reconcile.utils.slack_api.get_config', autospec=True)
-def test_get_user_id_by_name_reraise(get_config_mock, slack_api):
+def test_get_user_id_by_name_reraise(slack_api):
     """
     Check that SlackApiError is re-raised when not otherwise handled as a user
     not found error.
     """
-    get_config_mock.return_value = {'smtp': {'mail_address': 'redhat.com'}}
     slack_api.mock_slack_client.return_value\
         .users_lookupByEmail.side_effect = \
         SlackApiError('Some error message', {'error': 'internal_error'})
 
     with pytest.raises(SlackApiError):
-        slack_api.client.get_user_id_by_name('someuser')
+        slack_api.client.get_user_id_by_name('someuser', 'redhat.com')
 
 
 def test_update_usergroups_users_empty_no_raise(mocker, slack_api):

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -8,7 +8,6 @@ from slack_sdk.http_retry import RateLimitErrorRetryHandler, RetryHandler, \
     RetryState, HttpRequest, HttpResponse
 
 from reconcile.utils.secret_reader import SecretReader
-from reconcile.utils.config import get_config
 
 MAX_RETRIES = 5
 TIMEOUT = 30
@@ -289,7 +288,7 @@ class SlackApi:
                       'empty usergroup will not work')
         return ''
 
-    def get_user_id_by_name(self, user_name: str) -> str:
+    def get_user_id_by_name(self, user_name: str, mail_address: str) -> str:
         """
         Get user id from their username.
 
@@ -299,9 +298,6 @@ class SlackApi:
         Slack API
         :raises UserNotFoundException: if the Slack user is not found
         """
-        config = get_config()
-        mail_address = config['smtp']['mail_address']
-
         try:
             result = self._sc.users_lookupByEmail(
                 email=f"{user_name}@{mail_address}"

--- a/reconcile/utils/smtp_client.py
+++ b/reconcile/utils/smtp_client.py
@@ -8,20 +8,16 @@ from email.utils import formataddr
 from sretoolbox.utils import retry
 
 from reconcile.utils.secret_reader import SecretReader
-from reconcile.utils.config import get_config
 
 
 class SmtpClient:
     def __init__(self, settings):
-        config = get_config()
-
-        smtp_secret_path = config['smtp']['secret_path']
-        smtp_config = self.get_smtp_config(smtp_secret_path, settings)
+        smtp_config = self.get_smtp_config(settings)
         self.host = smtp_config['server']
         self.port = str(smtp_config['port'])
         self.user = smtp_config['username']
         self.passwd = smtp_config['password']
-        self.mail_address = config['smtp']['mail_address']
+        self.mail_address = settings['smtp']['mailAddress']
 
         self._client = None
         self._server = None
@@ -43,12 +39,12 @@ class SmtpClient:
         return self._server
 
     @staticmethod
-    def get_smtp_config(path, settings):
+    def get_smtp_config(settings):
         config = {}
         required_keys = ('password', 'port', 'require_tls', 'server',
                          'username')
         secret_reader = SecretReader(settings=settings)
-        data = secret_reader.read_all({'path': path})
+        data = secret_reader.read_all(settings['smtp']['credentials'])
         try:
             for k in required_keys:
                 config[k] = data[k]

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -857,10 +857,12 @@ def slack_usergroup(ctx, workspace, usergroup, username):
     Use an org_username as the username.
     To empty a slack usergroup, pass '' (empty string) as the username.
     """
+    settings = queries.get_app_interface_settings()
     slack = init_slack_workspace('qontract-cli')
     ugid = slack.get_usergroup_id(usergroup)
     if username:
-        users = [slack.get_user_id_by_name(username)]
+        mail_address = settings['smtp']['mailAddress']
+        users = [slack.get_user_id_by_name(username, mail_address)]
     else:
         users = [slack.get_random_deleted_user()]
     slack.update_usergroup_users(ugid, users)


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/72

we currently store the smtp settings in the qontract-reconcile toml file.

this PR adds support to get smtp settings from app-interface settings.