### PR TITLE
APPSRE-4225: Improve Exception handling

### DIFF
--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -231,4 +231,5 @@ def run(dry_run, io_dir='throughput/', print_only=False,
         jjb.update()
         configs = jjb.get_configs()
         for name, desired_config in configs.items():
-            state.add(name, value=desired_config, force=True)
+            print(name)
+#            state.add(name, value=desired_config, force=True)

--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -232,4 +232,4 @@ def run(dry_run, io_dir='throughput/', print_only=False,
         configs = jjb.get_configs()
         for name, desired_config in configs.items():
             print(name)
-#            state.add(name, value=desired_config, force=True)
+            state.add(name, value=desired_config, force=True)

--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -231,5 +231,4 @@ def run(dry_run, io_dir='throughput/', print_only=False,
         jjb.update()
         configs = jjb.get_configs()
         for name, desired_config in configs.items():
-            print(name)
             state.add(name, value=desired_config, force=True)

--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -238,13 +238,16 @@ class JJB:
                 result = subprocess.run(cmd,
                                         check=True,
                                         stdout=PIPE,
-                                        stderr=STDOUT)
-                out_str = result.stdout.decode("utf-8")
-                if re.search("updated: [1-9]", out_str):
-                    logging.info(out_str)
+                                        stderr=STDOUT,
+                                        encoding="utf-8")
+                if re.search("updated: [1-9]", result.stdout):
+                    logging.info(result.stdout)
             except CalledProcessError as ex:
-                msg = ex.stdout.decode("utf-8")
-                logging.error(msg)
+                logging.exception(ex.stdout)
+                raise
+            except Exception as e:
+                logging.exception(e)
+                raise
 
     @staticmethod
     def get_jjb(args):

--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -223,7 +223,7 @@ class JJB:
         else:
             return file_name.replace('current', 'desired')
 
-    def update(self):
+    def update(self) -> None:
         for name, wd in self.working_dirs.items():
             ini_path = '{}/{}.ini'.format(wd, name)
             config_path = '{}/config.yaml'.format(wd)
@@ -243,10 +243,7 @@ class JJB:
                 if re.search("updated: [1-9]", result.stdout):
                     logging.info(result.stdout)
             except CalledProcessError as ex:
-                logging.exception(ex.stdout)
-                raise
-            except Exception as e:
-                logging.exception(e)
+                logging.error(ex.stdout)
                 raise
 
     @staticmethod


### PR DESCRIPTION
Improved two aspects: 
* Set `encoding` to `subprocess.run()` to avoid calling decode. 
* Add generic Exception handling. CalledProcessError is only raised if the process could run. If, for example, `jenkins-jobs` executable file does not exist, a `FileNotFoundException` is raised instead of CPE.