### PR TITLE
add support for default github org

### DIFF
--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -90,21 +90,25 @@ def get_config(default=False):
     settings = queries.get_app_interface_settings()
     secret_reader = SecretReader(settings=settings)
     config = {'github': {}}
-    default_found = False
+    found_defaults = []
     for org in orgs:
         org_name = org['name']
-        is_default_org = org.get('default')
-        if default and not is_default_org:
+        if org.get('default'):
+            found_defaults.append(org_name)
+        elif default:
             continue
-        if default_found:
-            raise KeyError('multiple default github org configs found')
-        default_found = True
         token = secret_reader.read(org['token'])
         org_config = {'token': token, 'managed_teams': org['managedTeams']}
         config['github'][org_name] = org_config
 
-    if default and not config['github']:
-        raise KeyError('default github org config not found')
+    if default:
+        if len(found_defaults) == 0:
+            raise KeyError('default github org config not found')
+        if len(found_defaults) > 1:
+            raise KeyError(
+                'multiple default github org configs found: '
+                f'{found_defaults}'
+            )
 
     return config
 

--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -90,11 +90,15 @@ def get_config(default=False):
     settings = queries.get_app_interface_settings()
     secret_reader = SecretReader(settings=settings)
     config = {'github': {}}
+    default_found = False
     for org in orgs:
         org_name = org['name']
         is_default_org = org.get('default')
         if default and not is_default_org:
             continue
+        if default_found:
+            raise KeyError('multiple default github org configs found')
+        default_found = True
         token = secret_reader.read(org['token'])
         org_config = {'token': token, 'managed_teams': org['managedTeams']}
         config['github'][org_name] = org_config

--- a/reconcile/github_owners.py
+++ b/reconcile/github_owners.py
@@ -77,10 +77,10 @@ def get_current_github_usernames(github_org_name, github, raw_github):
 
 def run(dry_run):
     base_url = os.environ.get('GITHUB_API', 'https://api.github.com')
+    config = get_config()
     desired_state = fetch_desired_state()
 
     for github_org_name, desired_github_usernames in desired_state.items():
-        config = get_config(desired_org_name=github_org_name)
         token = config['github'][github_org_name]['token']
         gh = Github(token, base_url=base_url)
         raw_gh = RawGithubApi(token)

--- a/reconcile/github_repo_permissions_validator.py
+++ b/reconcile/github_repo_permissions_validator.py
@@ -7,7 +7,7 @@ from github import Github
 
 from reconcile.github_repo_invites import run as get_invitations
 from reconcile.jenkins_job_builder import init_jjb
-from reconcile.github_org import get_config
+from reconcile.github_org import get_default_config
 from reconcile.utils.semver_helper import make_semver
 
 
@@ -25,21 +25,20 @@ def get_jobs(jjb, instance_name):
     return pr_check_jobs
 
 
-def init_github(bot_token_org_name):
+def init_github():
     base_url = os.environ.get('GITHUB_API', 'https://api.github.com')
-    config = get_config(desired_org_name=bot_token_org_name)
-    token = config['github'][bot_token_org_name]['token']
+    token = get_default_config()['token']
     return Github(token, base_url=base_url)
 
 
-def run(dry_run, instance_name, bot_token_org_name):
+def run(dry_run, instance_name):
     jjb, _ = init_jjb()
     pr_check_jobs = get_jobs(jjb, instance_name)
     if not pr_check_jobs:
         logging.error(f'no jobs found for instance {instance_name}')
         sys.exit(1)
 
-    gh = init_github(bot_token_org_name)
+    gh = init_github()
 
     invitations = get_invitations(dry_run=True)
 

--- a/reconcile/github_users.py
+++ b/reconcile/github_users.py
@@ -10,7 +10,7 @@ from sretoolbox.utils import threaded
 
 from reconcile import queries
 from reconcile import mr_client_gateway
-from reconcile.github_org import get_config
+from reconcile.github_org import get_default_config
 from reconcile.ldap_users import init_users as init_users_and_paths
 from reconcile.utils.mr import CreateDeleteUser
 from reconcile.utils.smtp_client import SmtpClient
@@ -22,9 +22,7 @@ QONTRACT_INTEGRATION = 'github-users'
 
 
 def init_github():
-    config = get_config()
-    github_config = config['github']
-    token = github_config['app-sre']['token']
+    token = get_default_config()['token']
     return Github(token, base_url=GH_BASE_URL)
 
 

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -17,7 +17,7 @@ from sretoolbox.container import Image
 from sretoolbox.utils import retry
 from sretoolbox.utils import threaded
 
-from reconcile.github_org import get_config
+from reconcile.github_org import get_default_config
 from reconcile.utils.mr.auto_promoter import AutoPromoter
 from reconcile.utils.oc import OC, StatusCodeError
 from reconcile.utils.openshift_resource import (OpenshiftResource as OR,
@@ -689,10 +689,7 @@ class SaasHerder():
         if auth_code:
             token = self.secret_reader.read(auth_code)
         else:
-            # use the app-sre token by default
-            default_org_name = 'app-sre'
-            config = get_config(desired_org_name=default_org_name)
-            token = config['github'][default_org_name]['token']
+            token = get_default_config()['token']
 
         base_url = os.environ.get('GITHUB_API', 'https://api.github.com')
         # This is a threaded world. Let's define a big

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -79,7 +79,7 @@ from reconcile.utils import gql
 from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.git import is_file_in_git_repo
-from reconcile.github_org import get_config
+from reconcile.github_org import get_default_config
 from reconcile.utils.oc import StatusCodeError
 from reconcile.utils.gpg import gpg_key_valid
 from reconcile.utils.exceptions import (FetchResourceError,
@@ -211,8 +211,7 @@ class TerrascriptClient:
             with self.logtoes_zip_lock:
                 # this may have already happened, so we check again
                 if not self.logtoes_zip:
-                    github_config = get_config()['github']
-                    self.token = github_config['app-sre']['token']
+                    self.token = get_default_config()['token']
                     self.logtoes_zip = \
                         self.download_logtoes_zip(LOGTOES_RELEASE)
         if release_url == LOGTOES_RELEASE:


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/74

instead of hard coding the name of our org, we can define it as `default: true` in app-interface, allowing other consumers to do the same.