### PR TITLE
[terraform-vpc-peerings] use explicit infra account to mng vpc peerings

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -534,6 +534,21 @@ CLUSTERS_QUERY = """
               }
               accessLevel
             }
+            awsInfrastructureManagementAccounts {
+              account {
+                name
+                uid
+                terraformUsername
+                automationToken {
+                  path
+                  field
+                  version
+                  format
+                }
+              }
+              accessLevel
+              default
+            }
             peering {
               connections {
                 name
@@ -543,6 +558,17 @@ CLUSTERS_QUERY = """
                   name
                   cluster {
                     name
+                  }
+                  awsInfrastructureManagementAccount {
+                    name
+                    uid
+                    terraformUsername
+                    automationToken {
+                      path
+                      field
+                      version
+                      format
+                    }
                   }
                 }
               }

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -161,8 +161,9 @@ def build_desired_state_single_cluster(cluster_info, ocm: OCM,
                                           'cluster-vpc-accepter')
         if not peer_info:
             raise BadTerraformPeeringState(
-                "could not find a matching peering connection for "
-                f"cluster {cluster_name}, connection {peer_connection_name}"
+                "[no_matching_peering] could not find a matching peering "
+                f"connection for cluster {cluster_name}, connection "
+                f"{peer_connection_name}"
             )
 
         accepter_manage_routes = peer_info.get('manageRoutes')

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -74,11 +74,11 @@ def aws_assume_roles_for_cluster_vpc_peering(
     # check if dedicated infra accounts have been declared on the
     # accepters peering connection or on the accepters cluster
 
-    allowed_accounts = [
+    allowed_accounts = {
         a["account"]["name"]
         for a in accepter_cluster.get("awsInfrastructureManagementAccounts")
-        or [] if a.get("accessLevel") == "network-mgmt"
-    ]
+        or [] if a["accessLevel"] == "network-mgmt"
+    }
 
     # check if a dedicated infra accounts have been declared on the
     # accepters peering connection
@@ -97,7 +97,7 @@ def aws_assume_roles_for_cluster_vpc_peering(
         cluster_infra_accounts = \
             accepter_cluster.get("awsInfrastructureManagementAccounts")
         for infra_account_def in cluster_infra_accounts or []:
-            if infra_account_def.get("accessLevel") == "network-mgmt" and \
+            if infra_account_def["accessLevel"] == "network-mgmt" and \
                     infra_account_def.get("default") is True:
                 account = infra_account_def.get("account")
                 break
@@ -119,8 +119,8 @@ def aws_assume_roles_for_cluster_vpc_peering(
     if req_aws is None:
         raise BadTerraformPeeringState(
             f"[assume_role_not_found] unable to find assume role "
-            f"for cluster {requester_cluster['name']} "
-            f"in account {account['name']}"
+            f"on cluster-vpc-requester for account {account['name']} and "
+            f"cluster {requester_cluster['name']} "
         )
     acc_aws = _build_infrastructure_assume_role(
         account,
@@ -130,8 +130,8 @@ def aws_assume_roles_for_cluster_vpc_peering(
     if acc_aws is None:
         raise BadTerraformPeeringState(
             f"[assume_role_not_found] unable to find assume role "
-            f"for cluster {accepter_cluster['name']} "
-            f"in account {account['name']}"
+            f"on cluster-vpc-accepter for account {account['name']} and "
+            f"cluster {accepter_cluster['name']} "
         )
 
     return req_aws, acc_aws

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -73,16 +73,15 @@ def aws_assume_roles_for_cluster_vpc_peering(
                     Tuple[dict[str, Any], dict[str, Any]]:
     # check if dedicated infra accounts have been declared on the
     # accepters peering connection or on the accepters cluster
-
     allowed_accounts = {
         a["account"]["name"]
-        for a in accepter_cluster.get("awsInfrastructureManagementAccounts")
+        for a in accepter_cluster["awsInfrastructureManagementAccounts"]
         or [] if a["accessLevel"] == "network-mgmt"
     }
 
     # check if a dedicated infra accounts have been declared on the
     # accepters peering connection
-    account = accepter_connection.get("awsInfrastructureManagementAccount")
+    account = accepter_connection["awsInfrastructureManagementAccount"]
     if account and account["name"] not in allowed_accounts:
         raise BadTerraformPeeringState(
             "[account_not_allowed] "
@@ -95,11 +94,11 @@ def aws_assume_roles_for_cluster_vpc_peering(
         # look for a network-mgmt account marked as default on the accepters
         # clusters awsInfrastructureManagementAccounts
         cluster_infra_accounts = \
-            accepter_cluster.get("awsInfrastructureManagementAccounts")
+            accepter_cluster["awsInfrastructureManagementAccounts"]
         for infra_account_def in cluster_infra_accounts or []:
             if infra_account_def["accessLevel"] == "network-mgmt" and \
                     infra_account_def.get("default") is True:
-                account = infra_account_def.get("account")
+                account = infra_account_def["account"]
                 break
 
     if not account:

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 import json
-from typing import Optional
+from typing import Any, Optional, Tuple
 
 from reconcile import queries
 from reconcile.utils import aws_api
@@ -23,7 +23,7 @@ class BadTerraformPeeringState(Exception):
     pass
 
 
-def find_matching_peering(from_cluster, peering, to_cluster, desired_provider):
+def find_matching_peering(from_cluster, to_cluster, desired_provider):
     """
     Ensures there is a matching peering with the desired provider type
     going from the destination (to) cluster back to this one (from)
@@ -40,32 +40,101 @@ def find_matching_peering(from_cluster, peering, to_cluster, desired_provider):
     return None
 
 
-def aws_account_from_infrastructure_access(cluster, access_level: str,
-                                           ocm: OCM):
-    """
-    Generate an AWS account object from a cluster's awsInfrastructureAccess
-    groups and access levels
-    """
-    account = None
-    for awsAccess in cluster['awsInfrastructureAccess']:
-        if awsAccess.get('accessLevel', "") == access_level:
-            account = {
-                'name': awsAccess['awsGroup']['account']['name'],
-                'uid': awsAccess['awsGroup']['account']['uid'],
-                'terraformUsername':
-                    awsAccess['awsGroup']['account']['terraformUsername'],
-                'automationToken':
-                    awsAccess['awsGroup']['account']['automationToken'],
-                'assume_role':
-                    ocm.get_aws_infrastructure_access_terraform_assume_role(
-                        cluster['name'],
-                        awsAccess['awsGroup']['account']['uid'],
-                        awsAccess['awsGroup']['account']['terraformUsername'],
-                    ),
-                'assume_region': cluster['spec']['region'],
-                'assume_cidr': cluster['network']['vpc']
-            }
-    return account
+def _build_infrastructure_assume_role(
+                    account: dict[str, Any],
+                    cluster: dict[str, Any],
+                    ocm: OCM) -> Optional[dict[str, Any]]:
+    assume_role = ocm.get_aws_infrastructure_access_terraform_assume_role(
+        cluster['name'],
+        account['uid'],
+        account['terraformUsername'],
+    )
+    if assume_role:
+        return {
+            'name': account['name'],
+            'uid': account['uid'],
+            'terraformUsername':
+                account['terraformUsername'],
+            'automationToken':
+                account['automationToken'],
+            'assume_role': assume_role,
+            'assume_region': cluster['spec']['region'],
+            'assume_cidr': cluster['network']['vpc']
+        }
+    else:
+        return None
+
+
+def aws_assume_roles_for_cluster_vpc_peering(
+                requester_cluster: dict[str, Any],
+                accepter_connection: dict[str, Any],
+                accepter_cluster: dict[str, Any],
+                ocm: OCM) -> \
+                    Tuple[dict[str, Any], dict[str, Any]]:
+    # check if dedicated infra accounts have been declared on the
+    # accepters peering connection or on the accepters cluster
+
+    allowed_accounts = [
+        a["account"]["name"]
+        for a in accepter_cluster.get("awsInfrastructureManagementAccounts")
+        or [] if a.get("accessLevel") == "network-mgmt"
+    ]
+
+    # check if a dedicated infra accounts have been declared on the
+    # accepters peering connection
+    account = accepter_connection.get("awsInfrastructureManagementAccount")
+    if account and account["name"] not in allowed_accounts:
+        raise BadTerraformPeeringState(
+            "[account_not_allowed] "
+            f"account {account['name']} used on the peering accepter of "
+            f"cluster {accepter_cluster['name']} is not listed as a "
+            "network-mgmt in awsInfrastructureManagementAccounts"
+        )
+
+    if not account:
+        # look for a network-mgmt account marked as default on the accepters
+        # clusters awsInfrastructureManagementAccounts
+        cluster_infra_accounts = \
+            accepter_cluster.get("awsInfrastructureManagementAccounts")
+        for infra_account_def in cluster_infra_accounts or []:
+            if infra_account_def.get("accessLevel") == "network-mgmt" and \
+                    infra_account_def.get("default") is True:
+                account = infra_account_def.get("account")
+                break
+
+    if not account:
+        raise BadTerraformPeeringState(
+            f"[no_account_available] unable to find infra account "
+            f"for {accepter_cluster['name']} to manage the VPC peering "
+            f"with {requester_cluster['name']}"
+        )
+
+    # a dedicated infra account was found on the accepter side
+    # let's use it for both legs
+    req_aws = _build_infrastructure_assume_role(
+        account,
+        requester_cluster,
+        ocm
+    )
+    if req_aws is None:
+        raise BadTerraformPeeringState(
+            f"[assume_role_not_found] unable to find assume role "
+            f"for cluster {requester_cluster['name']} "
+            f"in account {account['name']}"
+        )
+    acc_aws = _build_infrastructure_assume_role(
+        account,
+        accepter_cluster,
+        ocm
+    )
+    if acc_aws is None:
+        raise BadTerraformPeeringState(
+            f"[assume_role_not_found] unable to find assume role "
+            f"for cluster {accepter_cluster['name']} "
+            f"in account {account['name']}"
+        )
+
+    return req_aws, acc_aws
 
 
 def build_desired_state_single_cluster(cluster_info, ocm: OCM,
@@ -73,16 +142,6 @@ def build_desired_state_single_cluster(cluster_info, ocm: OCM,
     cluster_name = cluster_info['name']
 
     peerings = []
-    # Find an aws account with the "network-mgmt" access level on the
-    # requester cluster and use that as the account for the requester
-    req_aws = aws_account_from_infrastructure_access(cluster_info,
-                                                     'network-mgmt',
-                                                     ocm)
-    if not req_aws:
-        raise BadTerraformPeeringState(
-            "could not find an AWS account with the "
-            f"'network-mgmt' access level on the cluster {cluster_name}"
-        )
 
     peering_info = cluster_info['peering']
     peer_connections = peering_info['connections']
@@ -98,7 +157,6 @@ def build_desired_state_single_cluster(cluster_info, ocm: OCM,
         requester_manage_routes = peer_connection.get('manageRoutes')
         # Ensure we have a matching peering connection
         peer_info = find_matching_peering(cluster_info,
-                                          peer_connection,
                                           peer_cluster,
                                           'cluster-vpc-accepter')
         if not peer_info:
@@ -108,6 +166,13 @@ def build_desired_state_single_cluster(cluster_info, ocm: OCM,
             )
 
         accepter_manage_routes = peer_info.get('manageRoutes')
+
+        req_aws, acc_aws = aws_assume_roles_for_cluster_vpc_peering(
+            cluster_info,
+            peer_info,
+            peer_cluster,
+            ocm
+        )
 
         requester_vpc_id, requester_route_table_ids, _ = \
             awsapi.get_cluster_vpc_details(
@@ -127,19 +192,6 @@ def build_desired_state_single_cluster(cluster_info, ocm: OCM,
             'account': req_aws
         }
 
-        # Find an aws account with the "network-mgmt" access level on
-        # the peer cluster and use that as the account for the
-        # accepter
-        acc_aws = aws_account_from_infrastructure_access(peer_cluster,
-                                                         'network-mgmt',
-                                                         ocm)
-        if not acc_aws:
-            raise BadTerraformPeeringState(
-                "could not find an AWS account with the "
-                f"'network-mgmt' access level on cluster {cluster_name}, "
-                f"peering {peer_connection_name}"
-            )
-
         accepter_vpc_id, accepter_route_table_ids, _ = \
             awsapi.get_cluster_vpc_details(
                 acc_aws,
@@ -147,7 +199,7 @@ def build_desired_state_single_cluster(cluster_info, ocm: OCM,
             )
         if accepter_vpc_id is None:
             raise BadTerraformPeeringState(
-                f'{peer_cluster_name} could not find VPC ID for cluster'
+                f'[{peer_cluster_name}] could not find VPC ID for cluster'
             )
 
         requester['peer_owner_id'] = acc_aws['assume_role'].split(':')[4]

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -101,7 +101,7 @@ def build_cluster(name: str, vpc: Optional[str] = None,
     if read_only_accounts or network_mgmt_accounts:
         cluster["awsInfrastructureManagementAccounts"] = []
         if read_only_accounts:
-            for idx, acc in enumerate(read_only_accounts):
+            for acc in read_only_accounts:
                 cluster["awsInfrastructureManagementAccounts"].append({  # type: ignore # noqa: E501
                     "account": {
                         "name": acc,

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -1,7 +1,10 @@
 import sys
+from typing import Any, Optional
 import testslide
+import pytest
 
 import reconcile.terraform_vpc_peerings as integ
+from reconcile.terraform_vpc_peerings import BadTerraformPeeringState
 from reconcile.utils import aws_api
 import reconcile.utils.terraform_client as terraform
 import reconcile.utils.terrascript_client as terrascript
@@ -10,57 +13,281 @@ from reconcile.utils import ocm
 
 
 class MockOCM:
-    @staticmethod
-    def get_aws_infrastructure_access_terraform_assume_role(cluster,
+
+    def __init__(self) -> None:
+        self.assumes: dict[str, str] = {}
+
+    def register(self, cluster: str, tf_account_id: str, tf_user: str,
+                 assume_role: str) -> 'MockOCM':
+        self.assumes[f"{cluster}/{tf_account_id}/{tf_user}"] = assume_role
+        return self
+
+    def get_aws_infrastructure_access_terraform_assume_role(self, cluster,
                                                             tf_account_id,
                                                             tf_user):
-        return f"{cluster}/{tf_account_id}/{tf_user}"
+        return self.assumes.get(f"{cluster}/{tf_account_id}/{tf_user}")
 
 
-class TestAWSAccountFromInfrastructureAccess(testslide.TestCase):
-    def setUp(self):
-        self.cluster = {
-            'name': 'cluster',
-            'spec': {
-                'region': 'region'
-            },
-            'network': {
-                'vpc': 'vpc'
-            },
-            'awsInfrastructureAccess': [
-                {
-                    'awsGroup': {
-                        'account': {
-                            'name': 'account',
-                            'uid': 'uid',
-                            'terraformUsername': 'terraform',
-                            'automationToken': 'token'
-                        }
+def build_cluster(name: str, vpc: Optional[str] = None,
+                  read_only_accounts: Optional[list[str]] = None,
+                  network_mgmt_accounts: Optional[list[str]] = None,
+                  peering_connections: Optional[list[dict[str, Any]]] = None):
+    if not vpc:
+        vpc = name
+    cluster = {
+        "name": name,
+        "spec": {
+            "region": "region"
+        },
+        "network": {
+            "vpc": vpc
+        },
+        "peering": {
+            "connections": peering_connections or []
+        },
+        "awsInfrastructureManagementAccounts": None
+    }
+
+    if read_only_accounts or network_mgmt_accounts:
+        cluster["awsInfrastructureManagementAccounts"] = []
+        if read_only_accounts:
+            for idx, acc in enumerate(read_only_accounts):
+                cluster["awsInfrastructureManagementAccounts"].append({  # type: ignore # noqa: E501
+                    "account": {
+                        "name": acc,
+                        "uid": acc,
+                        "terraformUsername": "terraform",
+                        "automationToken": {}
                     },
-                    'accessLevel': 'read-only'
-                }
-            ]
-        }
-        self.ocm = MockOCM()
+                    "accessLevel": "read-only",
+                    "default": None
+                })
+        if network_mgmt_accounts:
+            for idx, acc in enumerate(network_mgmt_accounts):
+                cluster["awsInfrastructureManagementAccounts"].append({  # type: ignore # noqa: E501
+                    "account": {
+                        "name": acc,
+                        "uid": acc,
+                        "terraformUsername": "terraform",
+                        "automationToken": {}
+                    },
+                    "accessLevel": "network-mgmt",
+                    "default": True if idx == 0 else None
+                })
+    return cluster
 
-    def test_aws_account_from_infrastructure_access(self):
-        expected_result = {
-            'name': 'account',
-            'uid': 'uid',
-            'terraformUsername': 'terraform',
-            'automationToken': 'token',
-            'assume_role': 'cluster/uid/terraform',
-            'assume_region': 'region',
-            'assume_cidr': 'vpc'
-        }
-        account = integ.aws_account_from_infrastructure_access(
-            self.cluster, 'read-only', self.ocm)
-        self.assertEqual(account, expected_result)
 
-    def test_aws_account_from_infrastructure_access_none(self):
-        account = integ.aws_account_from_infrastructure_access(
-            self.cluster, 'not-read-only', self.ocm)
-        self.assertIsNone(account)
+def build_requester_connection(name: str, manage_routes: bool = True):
+    return {
+        "name": name,
+        "provider": "cluster-vpc-requester",
+        "manageRoutes": manage_routes,
+    }
+
+
+def build_accepter_connection(name: str, cluster: str,
+                              aws_infra_acc: Optional[str] = None,
+                              manage_routes: bool = True):
+    connection = {
+        "name": name,
+        "provider": "cluster-vpc-accepter",
+        "manageRoutes": manage_routes,
+        "cluster": {
+            "name": cluster
+        },
+        "awsInfrastructureManagementAccount": None
+    }
+    if aws_infra_acc:
+        connection["awsInfrastructureManagementAccount"] = {
+            "name": aws_infra_acc,
+            "uid": aws_infra_acc,
+            "terraformUsername": "terraform",
+            "automationToken": {}
+        }
+    return connection
+
+
+def test_c2c_vpc_peering_assume_role_accepter_connection_acc_overwrite():
+    """
+    makes sure the peer connection account overwrite on the accepter is used
+    when available. in this test, the overwrite is also allowed
+    """
+    requester_cluster = build_cluster(name="r_c")
+    accepter_cluster = build_cluster(
+        name="a_c",
+        network_mgmt_accounts=["acc", "acc_overwrite"])
+    accepter_connection = build_accepter_connection(
+        name="a_c", cluster="a_c",
+        aws_infra_acc="acc_overwrite"
+    )
+
+    ocm = MockOCM().register(
+        "r_c", "acc_overwrite", "terraform", "arn:r_acc_overwrite"
+    ).register(
+        "r_c", "acc", "terraform", "arn:r_acc"
+    ).register(
+        "a_c", "acc_overwrite", "terraform", "arn:a_acc_overwrite"
+    ).register(
+        "a_c", "acc", "terraform", "arn:a_acc"
+    )
+    req_aws, acc_aws = integ.aws_assume_roles_for_cluster_vpc_peering(
+        requester_cluster,
+        accepter_connection,
+        accepter_cluster,
+        ocm
+    )
+
+    expected_req_aws = {
+        'name': 'acc_overwrite',
+        'uid': 'acc_overwrite',
+        'terraformUsername': 'terraform',
+        'automationToken': {},
+        'assume_role': 'arn:r_acc_overwrite',
+        'assume_region': 'region',
+        'assume_cidr': 'r_c'
+    }
+    assert req_aws == expected_req_aws
+
+    expected_acc_aws = {
+        'name': 'acc_overwrite',
+        'uid': 'acc_overwrite',
+        'terraformUsername': 'terraform',
+        'automationToken': {},
+        'assume_role': 'arn:a_acc_overwrite',
+        'assume_region': 'region',
+        'assume_cidr': 'a_c'
+    }
+    assert acc_aws == expected_acc_aws
+
+
+def test_c2c_vpc_peering_assume_role_accepter_connection_acc_overwrite_fail():
+    """
+    try overwrite the account to be used on the accepter connection with an
+    account not listed on the accepter cluster
+    """
+    requester_cluster = build_cluster(name="r_c")
+    accepter_cluster = build_cluster(
+        name="a_c",
+        network_mgmt_accounts=["acc"])
+    accepter_connection = build_accepter_connection(
+        name="a_c", cluster="a_c",
+        aws_infra_acc="acc_overwrite"
+    )
+
+    ocm = MockOCM().register(
+        "r_c", "acc", "terraform", "arn:r_acc"
+    ).register(
+        "a_c", "acc", "terraform", "arn:a_acc"
+    )
+    with pytest.raises(BadTerraformPeeringState) as ex:
+        integ.aws_assume_roles_for_cluster_vpc_peering(
+            requester_cluster,
+            accepter_connection,
+            accepter_cluster,
+            ocm
+        )
+    assert str(ex.value).startswith("[account_not_allowed]")
+
+
+def test_c2c_vpc_peering_assume_role_accepter_cluster_account():
+    """
+    makes sure the clusters default infra account is used when no peer
+    connection overwrite exists
+    """
+    requester_cluster = build_cluster(name="r_c")
+    accepter_cluster = build_cluster(
+        name="a_c",
+        network_mgmt_accounts=["default_acc", "other_acc"]
+    )
+    accepter_connection = build_accepter_connection(
+        name="a_c", cluster="a_c"
+    )
+
+    ocm = MockOCM().register(
+        "r_c", "default_acc", "terraform", "arn:r_default_acc"
+    ).register(
+        "r_c", "other_acc", "terraform", "arn:r_other_acc"
+    ).register(
+        "a_c", "default_acc", "terraform", "arn:a_default_acc"
+    ).register(
+        "a_c", "other_acc", "terraform", "arn:a_other_acc"
+    )
+    req_aws, acc_aws = integ.aws_assume_roles_for_cluster_vpc_peering(
+        requester_cluster,
+        accepter_connection,
+        accepter_cluster,
+        ocm
+    )
+
+    expected_req_aws = {
+        'name': 'default_acc',
+        'uid': 'default_acc',
+        'terraformUsername': 'terraform',
+        'automationToken': {},
+        'assume_role': 'arn:r_default_acc',
+        'assume_region': 'region',
+        'assume_cidr': 'r_c'
+    }
+    assert req_aws == expected_req_aws
+
+    expected_acc_aws = {
+        'name': 'default_acc',
+        'uid': 'default_acc',
+        'terraformUsername': 'terraform',
+        'automationToken': {},
+        'assume_role': 'arn:a_default_acc',
+        'assume_region': 'region',
+        'assume_cidr': 'a_c'
+    }
+    assert acc_aws == expected_acc_aws
+
+
+def test_c2c_vpc_peering_missing_ocm_assume_role():
+    """
+    makes sure the clusters infra account is used when no peer connection
+    overwrite exists
+    """
+    requester_cluster = build_cluster(name="r_c")
+    accepter_cluster = build_cluster(
+        name="a_c",
+        network_mgmt_accounts=["acc"]
+    )
+    accepter_connection = build_accepter_connection(
+        name="a_c", cluster="a_c"
+    )
+
+    ocm = MockOCM()
+
+    with pytest.raises(BadTerraformPeeringState) as ex:
+        integ.aws_assume_roles_for_cluster_vpc_peering(
+            requester_cluster,
+            accepter_connection,
+            accepter_cluster,
+            ocm
+        )
+    assert str(ex.value).startswith("[assume_role_not_found]")
+
+
+def test_c2c_vpc_peering_missing_account():
+    """
+    test the fallback logic, looking for network-mgmt groups accounts
+    """
+    requester_cluster = build_cluster(name="r_c")
+    accepter_cluster = build_cluster(name="a_c")
+    accepter_connection = build_accepter_connection(
+        name="a_c", cluster="a_c"
+    )
+
+    ocm = MockOCM()
+
+    with pytest.raises(BadTerraformPeeringState) as ex:
+        integ.aws_assume_roles_for_cluster_vpc_peering(
+            requester_cluster,
+            accepter_connection,
+            accepter_cluster,
+            ocm
+        )
+    assert str(ex.value).startswith("[no_account_available]")
 
 
 class TestRun(testslide.TestCase):

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -233,7 +233,7 @@ class TestBuildDesiredStateSingleCluster(testslide.TestCase):
             self.peer_cluster, 'network-mgmt', self.ocm
         ).to_return_value(self.aws_account).and_assert_called_once()
         self.find_matching_peering.for_call(
-            self.cluster, self.cluster['peering']['connections'][0],
+            self.cluster,
             self.peer_cluster,
             'cluster-vpc-accepter'
         ).to_return_value(self.peer).and_assert_called_once()
@@ -301,7 +301,7 @@ class TestBuildDesiredStateSingleCluster(testslide.TestCase):
         self.cluster['peering']['connections'] = []
         self.mock_callable(
             sut, 'aws_account_from_infrastructure_access'
-        ).to_return_value(self.aws_account).and_assert_called_once()
+        ).to_return_value(self.aws_account).and_assert_not_called()
         rs = sut.build_desired_state_single_cluster(
             self.cluster, self.ocm, self.awsapi
         )
@@ -347,9 +347,7 @@ class TestBuildDesiredStateSingleCluster(testslide.TestCase):
         self.find_matching_peering.to_return_value(self.peer)
         self.mock_callable(
             self.awsapi, 'get_cluster_vpc_details'
-        ).to_return_value(
-            ('vpcid', ['route_table_id'], {})
-        ).and_assert_called_once()
+        ).and_assert_not_called()
 
         with self.assertRaises(sut.BadTerraformPeeringState):
             sut.build_desired_state_single_cluster(

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -1,358 +1,335 @@
+import pytest
 import testslide
 
 from reconcile.utils import aws_api
 import reconcile.terraform_vpc_peerings as sut
 from reconcile.utils import ocm
+from reconcile.test.test_terraform_vpc_peerings import (
+    MockOCM, MockAWSAPI, build_cluster, build_accepter_connection,
+    build_requester_connection
+)
 
 
-class TestBuildDesiredStateAllClusters(testslide.TestCase):
-
-    def setUp(self):
-        super().setUp()
-        self.clusters = [
-            {
-                'name': 'clustername',
-                'spec': {
-                    'region': 'mars-plain-1',
-                },
-                'network': {
-                    'vpc': '172.16.0.0/12',
-                    'service': '10.0.0.0/8',
-                    'pod': '192.168.0.0/16',
-                },
-                'peering': {
-                    'connections': [
-                        {
-                            'provider': 'cluster-vpc-requester',
-                            'name': 'peername',
-                            'vpc': {
-                                '$ref': '/aws/account/vpcs/mars-plain-1'
-                            },
-                            'manageRoutes': True,
-                        },
-                    ]
-                }
-            }
-        ]
-        self.ocm = testslide.StrictMock(ocm.OCM)
-        self.ocm_map = testslide.StrictMock(ocm.OCMMap)
-        self.ocm_map.get = lambda clustername: self.ocm
-        self.awsapi = testslide.StrictMock(aws_api.AWSApi)
-        self.aws_account = {
-            'name': 'accountname',
-            'uid': 'anuid',
-            'terraformUserName': 'aterraformusename',
-            'automationtoken': 'anautomationtoken',
-            'assume_role': 'arole:very:useful:indeed:it:is',
-            'assume_region': 'moon-tranquility-1',
-            'assume_cidr': '172.25.0.0/12',
-        }
-
-        self.peer = {
-            'vpc': '172.17.0.0/12',
-            'service': '10.1.0.0/8',
-            'pod': '192.168.1.0/16',
-        }
-        self.peer_cluster = {
-                'name': 'apeerclustername',
-                'spec': {
-                    'region': 'mars-olympus-2',
-                },
-                'network': self.peer,
-                'peering': {
-                    'connections': [
-                        {
-                            'provider': 'cluster-vpc-requester',
-                            'name': 'peername',
-                            'vpc': {
-                                '$ref': '/aws/account/vpcs/mars-plain-1'
-                            },
-                            'manageRoutes': True,
-                        },
-                    ]
-                }
-            }
-        self.clusters[0]['peering']['connections'][0]['cluster'] = \
-            self.peer_cluster
-        self.build_single_cluster = self.mock_callable(
-            sut, 'build_desired_state_single_cluster'
-        )
-        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
-
-    def test_one_cluster(self):
-
-        expected = [
-            {
-                'connection_provider': 'cluster-vpc-requester',
-                'connection_name': 'peername',
-                'requester': {
-                    'vpc_id': 'vpcid',
-                    'route_table_ids': ['route_table_id'],
-                    'region': 'mars-plain-1',
-                    'cidr_block': '172.16.0.0/12',
-                    'peer_owner_id': 'it',
-                    'account': {
-                        'assume_region': 'mars-olympus-2',
-                        'assume_cidr': '172.17.0.0/12',
-                        **self.aws_account,
-                    }
-                },
-                'accepter': {
-                    'vpc_id': 'acceptervpcid',
-                    'route_table_ids': ['accepterroutetableid'],
-                    'region': 'mars-olympus-2',
-                    'cidr_block': '172.17.0.0/12',
-                    'account': {
-                        'assume_region': 'mars-olympus-2',
-                        'assume_cidr': '172.17.0.0/12',
-                        **self.aws_account,
-                    }
-                },
-                'deleted': False
-            }
-        ]
-        self.build_single_cluster.for_call(
-            self.clusters[0], self.ocm, self.awsapi
-        ).to_return_value(expected).and_assert_called_once()
-
-        rs = sut.build_desired_state_all_clusters(
-            self.clusters, self.ocm_map, self.awsapi
-        )
-        self.assertEqual(rs, (expected, False))
-
-    def test_one_cluster_failing_recoverable(self):
-        self.build_single_cluster.to_raise(
-            sut.BadTerraformPeeringState
-        ).and_assert_called_once()
-        self.assertEqual(
-            sut.build_desired_state_all_clusters(
-                self.clusters, self.ocm_map, self.awsapi
-                ),
-            ([], True))
-
-    def test_one_cluster_failing_weird(self):
-        self.build_single_cluster.to_raise(
-            ValueError("Nope")
-        ).and_assert_called_once()
-        with self.assertRaises(ValueError):
-            sut.build_desired_state_all_clusters(
-                self.clusters, self.ocm_map, self.awsapi
+def test_c2c_all_clusters():
+    """
+    happy path
+    """
+    accepter_cluster = build_cluster(
+        name="accepter_cluster", vpc="accepter_vpc",
+        network_mgmt_accounts=["acc"],
+        peering_connections=[
+            build_accepter_connection(
+                name="peername",
+                cluster="requester_cluster"
             )
+        ]
+    )
+    requester_cluster = build_cluster(
+        name="requester_cluster", vpc="requester_vpc",
+        network_mgmt_accounts=["acc"],
+        peering_connections=[
+            build_requester_connection(
+                name="peername",
+                peer_cluster=accepter_cluster
+            )
+        ]
+    )
+    ocm_map = {
+        "requester_cluster":
+            MockOCM()
+            .register("requester_cluster", "acc", "terraform", "r")
+            .register("accepter_cluster", "acc", "terraform", "a")
+    }
 
+    awsapi = MockAWSAPI() \
+        .register(
+            vpc="accepter_vpc", vpc_id="accepter_vpc_id",
+            route_tables=["accepter_rt_id"]
+        ).register(
+            vpc="requester_vpc", vpc_id="requester_vpc_id",
+            route_tables=["requester_rt_id"]
+        )
 
-class TestBuildDesiredStateSingleCluster(testslide.TestCase):
-    def setUp(self):
-        super().setUp()
-        self.cluster = {
-            'name': 'clustername',
-            'spec': {
-                'region': 'mars-plain-1',
+    result, error = sut.build_desired_state_all_clusters(
+        [requester_cluster], ocm_map, awsapi
+    )
+    expected = [
+        {
+            "connection_provider": "cluster-vpc-requester",
+            "connection_name": "peername",
+            "requester": {
+                "cidr_block": "requester_vpc",
+                "region": "region",
+                "vpc_id": "requester_vpc_id",
+                "route_table_ids": ["requester_rt_id"],
+                "account": {
+                    "name": "acc",
+                    "uid": "acc",
+                    "terraformUsername": "terraform",
+                    "automationToken": {},
+                    "assume_role": "arn::::r",
+                    "assume_region": "region",
+                    "assume_cidr": "requester_vpc"
+                },
+                "peer_owner_id": "a"
             },
-            'network': {
-                'vpc': '172.16.0.0/12',
-                'service': '10.0.0.0/8',
-                'pod': '192.168.0.0/16',
-            },
-            'peering': {
-                'connections': [
-                    {
-                        'provider': 'cluster-vpc-requester',
-                        'name': 'peername',
-                        'vpc': {
-                            '$ref': '/aws/account/vpcs/mars-plain-1'
-                        },
-                        'manageRoutes': True,
-                    },
-                ]
-            }
-        }
-        self.peer = {
-            'vpc': '172.17.0.0/12',
-            'service': '10.1.0.0/8',
-            'pod': '192.168.1.0/16',
-        }
-        self.peer_cluster = {
-                'name': 'apeerclustername',
-                'spec': {
-                    'region': 'mars-olympus-2',
-                },
-                'network': self.peer,
-                'peering': {
-                    'connections': [
-                        {
-                            'provider': 'cluster-vpc-requester',
-                            'name': 'peername',
-                            'vpc': {
-                                '$ref': '/aws/account/vpcs/mars-plain-1'
-                            },
-                            'manageRoutes': True,
-                        },
-                    ]
+            "accepter": {
+                "cidr_block": "accepter_vpc",
+                "region": "region",
+                "vpc_id": "accepter_vpc_id",
+                "route_table_ids": ["accepter_rt_id"],
+                "account": {
+                    "name": "acc",
+                    "uid": "acc",
+                    "terraformUsername":
+                    "terraform",
+                    "automationToken": {},
+                    "assume_role": "arn::::a",
+                    "assume_region": "region",
+                    "assume_cidr": "accepter_vpc"
                 }
-            }
-        self.cluster['peering']['connections'][0]['cluster'] = \
-            self.peer_cluster
-        self.aws_account = {
-            'name': 'accountname',
-            'uid': 'anuid',
-            'terraformUserName': 'aterraformusename',
-            'automationtoken': 'anautomationtoken',
-            'assume_role': 'arole:very:useful:indeed:it:is',
-            'assume_region': 'moon-tranquility-1',
-            'assume_cidr': '172.25.0.0/12',
+            },
+            "deleted": False
         }
-        self.peer_vpc = {
-            'cidr_block': '172.30.0.0/12',
-            'vpc_id': 'peervpcid',
-            'route_table_ids': ['peer_route_table_id']
-        }
-        self.ocm = testslide.StrictMock(ocm.OCM)
-        self.ocm_map = testslide.StrictMock(ocm.OCMMap)
-        self.ocm_map.get = lambda clustername: self.ocm
-        self.awsapi = testslide.StrictMock(aws_api.AWSApi)
-        self.mock_constructor(
-            aws_api, 'AWSApi'
-        ).to_return_value(self.awsapi)
-        self.maxDiff = None
-        self.find_matching_peering = self.mock_callable(
-            sut, 'find_matching_peering'
-        )
-        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
+    ]
+    assert expected == result
+    assert not error
 
-    def test_base(self):
-        self.mock_callable(
-            sut, 'aws_account_from_infrastructure_access'
-        ).for_call(
-            self.cluster, 'network-mgmt', self.ocm
-        ).to_return_value(
-            self.aws_account
-        ).and_assert_called_once()
-        self.mock_callable(
-            sut, 'aws_account_from_infrastructure_access'
-        ).for_call(
-            self.peer_cluster, 'network-mgmt', self.ocm
-        ).to_return_value(self.aws_account).and_assert_called_once()
-        self.find_matching_peering.for_call(
-            self.cluster,
-            self.peer_cluster,
-            'cluster-vpc-accepter'
-        ).to_return_value(self.peer).and_assert_called_once()
-        aws_req = {
-            'assume_region': 'mars-plain-1',
-            'assume_cidr': '172.16.0.0/12',
-            **self.aws_account
-        }
-        self.mock_callable(
-            self.awsapi, 'get_cluster_vpc_details'
-        ).for_call(
-            aws_req, route_tables=True
-        ).to_return_value(
-            ('vpcid', ['route_table_id'], {})
-        ).and_assert_called_once()
-        aws_req = {
-            'assume_region': 'mars-olympus-2',
-            'assume_cidr': '172.17.0.0/12',
-            **self.aws_account
-        }
-        self.mock_callable(
-            self.awsapi, 'get_cluster_vpc_details'
-        ).for_call(
-            aws_req, route_tables=None
-        ).to_return_value(
-            ('acceptervpcid', ['accepterroutetableid'], {})
-        ).and_assert_called_once()
 
-        expected = [
-            {
-                'connection_provider': 'cluster-vpc-requester',
-                'connection_name': 'peername',
-                'requester': {
-                    'vpc_id': 'vpcid',
-                    'route_table_ids': ['route_table_id'],
-                    'region': 'mars-plain-1',
-                    'cidr_block': '172.16.0.0/12',
-                    'peer_owner_id': 'it',
-                    'account': {
-                        'assume_region': 'mars-olympus-2',
-                        'assume_cidr': '172.17.0.0/12',
-                        **self.aws_account,
-                    }
-                },
-                'accepter': {
-                    'vpc_id': 'acceptervpcid',
-                    'route_table_ids': ['accepterroutetableid'],
-                    'region': 'mars-olympus-2',
-                    'cidr_block': '172.17.0.0/12',
-                    'account': {
-                        'assume_region': 'mars-olympus-2',
-                        'assume_cidr': '172.17.0.0/12',
-                        **self.aws_account,
-                    }
-                },
-                'deleted': False
-            }
+def test_c2c_one_cluster_failing_recoverable(mocker):
+    """
+    in this scenario, the handling of a single cluster fails with known
+    exceptions
+    """
+    build_desired_state_single_cluster = mocker.patch.object(
+        sut, 'build_desired_state_single_cluster')
+    build_desired_state_single_cluster.side_effect = \
+        sut.BadTerraformPeeringState("something bad")
+
+    result, error = \
+        sut.build_desired_state_all_clusters([{"name": "cluster"}], {}, {})
+
+    assert not result
+    assert error
+
+
+def test_c2c_one_cluster_failing_weird(mocker):
+    """
+    in this scenario, the handling of a single cluster fails with unexpected
+    exceptions
+    """
+    build_desired_state_single_cluster = mocker.patch.object(
+        sut, 'build_desired_state_single_cluster')
+    SOMETHING_UNEXPECTED = "nobody expects the spanish inquisition"
+    build_desired_state_single_cluster.side_effect = \
+        ValueError(SOMETHING_UNEXPECTED)
+
+    with pytest.raises(ValueError) as ex:
+        sut.build_desired_state_all_clusters([{"name": "cluster"}], {}, {})
+
+    assert str(ex.value) == SOMETHING_UNEXPECTED
+
+
+def test_c2c_base():
+    """
+    happy path
+    """
+    accepter_cluster = build_cluster(
+        name="accepter_cluster", vpc="accepter_vpc",
+        network_mgmt_accounts=["acc"],
+        peering_connections=[
+            build_accepter_connection(
+                name="peername",
+                cluster="requester_cluster"
+            )
         ]
-        rs = sut.build_desired_state_single_cluster(
-            self.cluster, self.ocm, self.awsapi
+    )
+    requester_cluster = build_cluster(
+        name="requester_cluster", vpc="requester_vpc",
+        network_mgmt_accounts=["acc"],
+        peering_connections=[
+            build_requester_connection(
+                name="peername",
+                peer_cluster=accepter_cluster
+            )
+        ]
+    )
+    ocm = MockOCM() \
+        .register("requester_cluster", "acc", "terraform", "r") \
+        .register("accepter_cluster", "acc", "terraform", "a")
+
+    awsapi = MockAWSAPI() \
+        .register(
+            vpc="accepter_vpc", vpc_id="accepter_vpc_id",
+            route_tables=["accepter_rt_id"]
+        ).register(
+            vpc="requester_vpc", vpc_id="requester_vpc_id",
+            route_tables=["requester_rt_id"]
         )
-        self.assertEqual(rs, expected)
 
-    def test_no_peerings(self):
-        self.cluster['peering']['connections'] = []
-        self.mock_callable(
-            sut, 'aws_account_from_infrastructure_access'
-        ).to_return_value(self.aws_account).and_assert_not_called()
-        rs = sut.build_desired_state_single_cluster(
-            self.cluster, self.ocm, self.awsapi
+    result = sut.build_desired_state_single_cluster(
+        requester_cluster, ocm, awsapi
+    )
+    expected = [
+        {
+            "connection_provider": "cluster-vpc-requester",
+            "connection_name": "peername",
+            "requester": {
+                "cidr_block": "requester_vpc",
+                "region": "region",
+                "vpc_id": "requester_vpc_id",
+                "route_table_ids": ["requester_rt_id"],
+                "account": {
+                    "name": "acc",
+                    "uid": "acc",
+                    "terraformUsername": "terraform",
+                    "automationToken": {},
+                    "assume_role": "arn::::r",
+                    "assume_region": "region",
+                    "assume_cidr": "requester_vpc"
+                },
+                "peer_owner_id": "a"
+            },
+            "accepter": {
+                "cidr_block": "accepter_vpc",
+                "region": "region",
+                "vpc_id": "accepter_vpc_id",
+                "route_table_ids": ["accepter_rt_id"],
+                "account": {
+                    "name": "acc",
+                    "uid": "acc",
+                    "terraformUsername":
+                    "terraform",
+                    "automationToken": {},
+                    "assume_role": "arn::::a",
+                    "assume_region": "region",
+                    "assume_cidr": "accepter_vpc"
+                }
+            },
+            "deleted": False
+        }
+    ]
+    assert expected == result
+
+
+def test_c2c_no_peerings():
+    """
+    in this scenario, the requester cluster has no peerings defines,
+    which results in an empty desired state
+    """
+    requester_cluster = build_cluster(
+        name="requester_cluster", vpc="requester_vpc",
+        network_mgmt_accounts=["acc"],
+        peering_connections=[]
+    )
+    result = sut.build_desired_state_single_cluster(
+        requester_cluster, MockOCM(), MockAWSAPI()
+    )
+    assert not result
+
+
+def test_c2c_no_matches():
+    """
+    in this scenario, the accepter cluster has no cluster-vpc-accepter
+    connection that references back to the requester cluster
+    """
+    accepter_cluster = build_cluster(
+        name="accepter_cluster", vpc="accepter_vpc",
+        network_mgmt_accounts=["acc"],
+        peering_connections=[
+            build_accepter_connection(
+                name="peername",
+                cluster="not_a_matching_cluster"
+            )
+        ]
+    )
+    requester_cluster = build_cluster(
+        name="requester_cluster", vpc="requester_vpc",
+        network_mgmt_accounts=["acc"],
+        peering_connections=[
+            build_requester_connection(
+                name="peername",
+                peer_cluster=accepter_cluster
+            )
+        ]
+    )
+
+    with pytest.raises(sut.BadTerraformPeeringState) as ex:
+        sut.build_desired_state_single_cluster(
+            requester_cluster, MockOCM(), MockAWSAPI()
         )
-        self.assertEqual(rs, [])
+    assert str(ex.value).startswith("[no_matching_peering]")
 
-    def test_no_matches(self):
-        self.mock_callable(
-            sut, 'aws_account_from_infrastructure_access'
-        ).to_return_value(self.aws_account)
-        self.find_matching_peering.to_return_value(None)
-        with self.assertRaises(sut.BadTerraformPeeringState):
-            sut.build_desired_state_single_cluster(
-                self.cluster, self.ocm, self.awsapi
+
+def test_c2c_no_vpc_in_aws():
+    """
+    in this scenario, there are no VPCs found in AWS
+    """
+    accepter_cluster = build_cluster(
+        name="accepter_cluster", vpc="accepter_vpc",
+        network_mgmt_accounts=["acc"],
+        peering_connections=[
+            build_accepter_connection(
+                name="peername",
+                cluster="requester_cluster"
             )
-
-    def test_no_vpc_in_aws(self):
-        self.mock_callable(
-            sut, 'aws_account_from_infrastructure_access'
-        ).to_return_value(self.aws_account)
-        self.find_matching_peering.to_return_value(
-            self.peer
-        ).and_assert_called_once()
-        self.mock_callable(
-            self.awsapi, 'get_cluster_vpc_details'
-        ).to_return_value((None, None, {})).and_assert_called_once()
-
-        with self.assertRaises(sut.BadTerraformPeeringState):
-            sut.build_desired_state_single_cluster(
-                self.cluster, self.ocm, self.awsapi
+        ]
+    )
+    requester_cluster = build_cluster(
+        name="requester_cluster", vpc="requester_vpc",
+        network_mgmt_accounts=["acc"],
+        peering_connections=[
+            build_requester_connection(
+                name="peername",
+                peer_cluster=accepter_cluster
             )
+        ]
+    )
 
-    def test_no_peer_account(self):
-        self.mock_callable(
-            sut, 'aws_account_from_infrastructure_access'
-        ).for_call(
-            self.cluster, 'network-mgmt', self.ocm
-        ).to_return_value(self.aws_account)
-        self.mock_callable(
-            sut, 'aws_account_from_infrastructure_access'
-        ).for_call(
-            self.peer_cluster, 'network-mgmt', self.ocm
-        ).to_return_value(None).and_assert_called_once()
-        self.find_matching_peering.to_return_value(self.peer)
-        self.mock_callable(
-            self.awsapi, 'get_cluster_vpc_details'
-        ).and_assert_not_called()
+    ocm = MockOCM() \
+        .register("requester_cluster", "acc", "terraform", "r") \
+        .register("accepter_cluster", "acc", "terraform", "a")
 
-        with self.assertRaises(sut.BadTerraformPeeringState):
-            sut.build_desired_state_single_cluster(
-                self.cluster, self.ocm, self.awsapi
+    awsapi = MockAWSAPI()
+
+    with pytest.raises(sut.BadTerraformPeeringState) as ex:
+        sut.build_desired_state_single_cluster(requester_cluster, ocm, awsapi)
+    assert str(ex.value).endswith("could not find VPC ID for cluster")
+
+
+def test_c2c_no_peer_account():
+    """
+    in this scenario, the accepters connection and the accepters cluster
+    have no aws infrastructura account available to set up the peering″
+    """
+    accepter_cluster = build_cluster(
+        # no network_mgmt_accounts here
+        name="accepter_cluster", vpc="accepter_vpc",
+        peering_connections=[
+            build_accepter_connection(
+                # no network_mgmt_accounts here
+                name="peername",
+                cluster="requester_cluster"
             )
+        ]
+    )
+    requester_cluster = build_cluster(
+        name="requester_cluster", vpc="requester_vpc",
+        network_mgmt_accounts=["acc"],
+        peering_connections=[
+            build_requester_connection(
+                name="peername",
+                peer_cluster=accepter_cluster
+            )
+        ]
+    )
+
+    ocm = MockOCM()
+    awsapi = MockAWSAPI()
+
+    with pytest.raises(sut.BadTerraformPeeringState) as ex:
+        sut.build_desired_state_single_cluster(requester_cluster, ocm, awsapi)
+    assert str(ex.value).startswith("[no_account_available]")
 
 
 class TestBuildDesiredStateVpcMesh(testslide.TestCase):


### PR DESCRIPTION
**Why do we need this change?**
Currently, VPC peerings (and other aws infra integrations) refer to the `cluster-1#awsInfrastructureAccess` section and use the last group with network-mgmt permissions for terraform interaction. 

This change is about to make this explicit!

**Change description**
The default account from the `cluster-1#awsInfrastructureManagementAccounts` list is used to manage `cluster-vpc-accepter` peering endpoints. the `cluster-vpc-requester` just follows the lead of the accepter. This makes it consistent with how account-vpc works, where the VPC plays the role of the accepter and the account of the VPC is used.

The `awsInfrastructureManagementAccounts` list remains optional to adhere to the qontract-schema evolution strategy of backwards compatibility, the current account resolution strategy has been removed though (last `network-mgmt` account referenced in `awsInfrastructureAccess`). This means that this integration will fail until the `awsInfrastructureManagementAccounts` has been configured correctly for all relevant clusters. This implies, that the schema changes in https://github.com/app-sre/qontract-schemas/pull/71 will be rolled out first, followed by the respective changes in app-interface, and only then this change will be merged.

To support per-peering connection overwrite, the `cluster-vpc-requester` typed connection uses `peerings.connections.awsInfrastructureManagementAccount` field. again, the `cluster-vpc-requester` peering budy will follow the account choice of the accepter.

Note: only network-mgmt accounts listed in the accepters cluster in `awsInfrastructureManagementAccounts` can be used for overwrites. This will not only prevent certain copy-paste errors but will also ensure the listed accounts have the proper assume role permissions once the `ocm-aws-infrastructure-access` integrating starts leveraring `awsInfrastructureManagementAccounts` to grant the `terraform` user assume role permissions (see APPSRE-4397)

This changes does not yet make use of the recently introduced assumeRole field on cluster-vpc-requester and cluster-vpc-accepter. Adopting those will be implemented in a followup change.

**Testing the change**
Since this change touches an integration of delicate nature, more tests have been added (and the existing testslide based tests for the cluster-vpc part have been migrated to pytest). I also generated tensorflow xxx.tf files for each account before and after the change. The files are identical, which indicates that the integration is behaving the same (for current configs).

You can test it for yourself once https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/33323 has been merged

```shell
git checkout master
qontract-reconcile --config config.debug.toml --dry-run terraform-vpc-peerings --print-to-file /tmp/current.tf
gh pr checkout 2163
qontract-reconcile --config config.debug.toml --dry-run terraform-vpc-peerings --print-to-file /tmp/after_change.tf

md5sum /tmp/*.tf
diff /tmp/current.tf /tmp/after_change.tf
```

**Refs**
Part of APPSRE-4391
Requires schema change - https://github.com/app-sre/qontract-schemas/pull/71

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>