### PR TITLE
aws api use the account default region instead of terraform state bucket region as default

### DIFF
--- a/reconcile/test/test_utils_aws_api.py
+++ b/reconcile/test/test_utils_aws_api.py
@@ -12,7 +12,7 @@ def accounts():
             'automationToken': {
                 'path': 'path',
             },
-            'resourcesDefaultRegion': 'region'
+            'resourcesDefaultRegion': 'default-region'
         }
     ]
 
@@ -24,7 +24,7 @@ def aws_api(accounts, mocker):
     mock_secret_reader.return_value.read_all.return_value = {
         'aws_access_key_id': 'key_id',
         'aws_secret_access_key': 'access_key',
-        'region': 'region',
+        'region': 'tf_state_bucket_region',
     }
     return AWSApi(1, accounts, init_users=False)
 
@@ -74,3 +74,9 @@ def test_get_user_key_status(aws_api, iam_client):
     key = aws_api.get_user_keys(iam_client, 'user')[0]
     status = aws_api.get_user_key_status(iam_client, 'user', key)
     assert status == 'Active'
+
+
+def test_default_region(aws_api, accounts):
+    for a in accounts:
+        assert aws_api.sessions[a['name']].region_name == \
+            a['resourcesDefaultRegion']

--- a/reconcile/test/test_utils_aws_api.py
+++ b/reconcile/test/test_utils_aws_api.py
@@ -11,7 +11,8 @@ def accounts():
             'name': 'some-account',
             'automationToken': {
                 'path': 'path',
-            }
+            },
+            'resourcesDefaultRegion': 'region'
         }
     ]
 

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -114,6 +114,8 @@ class AWSApi:
         account_name = account['name']
         automation_token = account['automationToken']
         secret = self.secret_reader.read_all(automation_token)
+        # Override the terraform state bucket region
+        secret['region'] = account['resourcesDefaultRegion']
         return (account_name, secret)
 
     def init_users(self):


### PR DESCRIPTION
similar to #1971

the default region to initiate the Session should be the account's default region and not the region where the terraform state bucket is located. since this is only the default region, this change is not expected to cause any issues (famous last words).