### PR TITLE
terraform --print-to-file handle output for multiple accounts

### DIFF
--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3002,7 +3002,7 @@ class TerrascriptClient:
         for name, ts in self.tss.items():
             if print_to_file:
                 with open(print_to_file, 'a') as f:
-                    f.write('##### {} #####\n'.format(name))
+                    f.write(f'##### {name} #####\n')
                     f.write(str(ts))
                     f.write('\n')
             if existing_dirs is None:

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -2993,10 +2993,11 @@ class TerrascriptClient:
         else:
             working_dirs = existing_dirs
 
-        if print_to_file and is_file_in_git_repo(print_to_file):
-            raise PrintToFileInGitRepositoryError(print_to_file)
-        if os.path.isfile(print_to_file):
-            os.remove(print_to_file)
+        if print_to_file:
+            if is_file_in_git_repo(print_to_file):
+                raise PrintToFileInGitRepositoryError(print_to_file)
+            if os.path.isfile(print_to_file):
+                os.remove(print_to_file)
 
         for name, ts in self.tss.items():
             if print_to_file:

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3004,7 +3004,7 @@ class TerrascriptClient:
                 with open(print_to_file, 'a') as f:
                     f.write('##### {} #####\n'.format(name))
                     f.write(str(ts))
-                    f.write("\n")
+                    f.write('\n')
             if existing_dirs is None:
                 wd = tempfile.mkdtemp()
             else:

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -2992,13 +2992,18 @@ class TerrascriptClient:
             working_dirs = {}
         else:
             working_dirs = existing_dirs
+
+        if print_to_file and is_file_in_git_repo(print_to_file):
+            raise PrintToFileInGitRepositoryError(print_to_file)
+        if os.path.isfile(print_to_file):
+            os.remove(print_to_file)
+
         for name, ts in self.tss.items():
             if print_to_file:
-                if is_file_in_git_repo(print_to_file):
-                    raise PrintToFileInGitRepositoryError(print_to_file)
-                with open(print_to_file, 'w') as f:
+                with open(print_to_file, 'a') as f:
                     f.write('##### {} #####\n'.format(name))
                     f.write(str(ts))
+                    f.write("\n")
             if existing_dirs is None:
                 wd = tempfile.mkdtemp()
             else:


### PR DESCRIPTION
the --print-to-file flag of terraform integrations results in the contents managed by terrascript to be dumped to a file. currently, only the contents of the last handled account is present in the file, because the dump loop keeps overwriting the same file over and over again.

this change makes sure that the file will contain the tf information from all accounts, delimited by `##### account name #####`

Ref: https://issues.redhat.com/browse/APPSRE-4421
Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>