### PR TITLE
[tf-resources] remove RDS/elasticache creds lookup fallback in secrets

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -395,7 +395,6 @@ def init_working_dirs(accounts, thread_pool_size,
                      QONTRACT_TF_PREFIX,
                      thread_pool_size,
                      accounts,
-                     oc_map,
                      settings=settings)
     working_dirs = ts.dump()
     return ts, working_dirs
@@ -417,7 +416,6 @@ def setup(dry_run, print_to_file, thread_pool_size, internal,
     ri, oc_map = fetch_current_state(dry_run, tf_namespaces, thread_pool_size,
                                      internal, use_jump_host, account_name)
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size,
-                                         oc_map=oc_map,
                                          settings=settings)
     tf = Terraform(QONTRACT_INTEGRATION,
                    QONTRACT_INTEGRATION_VERSION,


### PR DESCRIPTION
*motivation for this change*
the `determine_db_password` function in terrascript_client is used as
a fallback mechanism to extract RDS or elasticache credentials from
kubernetes secrets, when the respective outputs can't be found in the
terraform state file. this secret lookup mechanism was useful for tf
resource takeover of previously non-tf managed resources, since in those
cases the tf statefile did not contain any outputs for those credentials.

*why do we need this change*
we don't need this fallback mechanism anymore and it is the reason
an OC_Map is dragged through the terraform_client call stack. while
this isolated change does not seem to have a purpose on its own, it
is a step forward into refactoring terraform_resources, terrascript_client
and terraform_client.

Part of https://issues.redhat.com/browse/APPSRE-4424

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>