### PR TITLE
APPSRE-3528: Auto-promote targets only if there are changes

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -175,8 +175,12 @@ def run(dry_run, thread_pool_size=10, io_dir='throughput/',
     success = not ri.has_error_registered()
     # only publish promotions for deployment jobs (a single saas file)
     if notify:
+        # Auto-promote next stages onlye if there are changes in the
+        # current stage. This prevents promotions made on job re-runs
+        auto_promote = len(actions) > 0
         mr_cli = mr_client_gateway.init(gitlab_project_id=gitlab_project_id)
-        saasherder.publish_promotions(success, all_saas_files, mr_cli)
+        saasherder.publish_promotions(success, all_saas_files,
+                                      mr_cli, auto_promote)
 
     if not success:
         sys.exit(ExitCodes.ERROR)

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -175,8 +175,8 @@ def run(dry_run, thread_pool_size=10, io_dir='throughput/',
     success = not ri.has_error_registered()
     # only publish promotions for deployment jobs (a single saas file)
     if notify:
-        # Auto-promote next stages onlye if there are changes in the
-        # current stage. This prevents promotions made on job re-runs
+        # Auto-promote next stages only if there are changes in the
+        # promoting stage. This prevents trigger promotions on job re-runs
         auto_promote = len(actions) > 0
         mr_cli = mr_client_gateway.init(gitlab_project_id=gitlab_project_id)
         saasherder.publish_promotions(success, all_saas_files,

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -1372,7 +1372,8 @@ class SaasHerder():
                         return False
         return True
 
-    def publish_promotions(self, success, all_saas_files, mr_cli):
+    def publish_promotions(self, success,
+                           all_saas_files, mr_cli, auto_promote=False):
         """
         If there were promotion sections in the participating saas file
         publish the results for future promotion validations. """
@@ -1404,13 +1405,14 @@ class SaasHerder():
                     # collect data to trigger promotion
                     subscribed_saas_file_paths = \
                         subscribe_saas_file_path_map.get(channel)
+
                     if subscribed_saas_file_paths:
                         all_subscribed_saas_file_paths.update(
                             subscribed_saas_file_paths)
 
                 item['saas_file_paths'] = list(all_subscribed_saas_file_paths)
 
-                if all_subscribed_saas_file_paths:
+                if auto_promote and all_subscribed_saas_file_paths:
                     trigger_promotion = True
 
         if success and trigger_promotion:


### PR DESCRIPTION
## Overview 
This PR introduces a control to do automatic promotions only if there are changes in the promoting stage. 

## Why? 
Saas deployments are basically a desired/current resources reconciliation. If a deployment succeeds, it can trigger promotions to other saas deployments that comes next in the pipeline. If a deployment succeeds without doing anything (no changes to reconcile) it will trigger its promotions causing the pipeline to advance to the next steps. This can cause undesired effects when a target needs to run before moving to the next stage. 

### Example: 
Deployment(stage) --- > Test(stage) ---> Deployment(production)  --> ... 

Imagine this example pipeline runs and fails at `Test(stage)`. The pipeline won't continue because failed, but if `Test(Stage)` is rerun from the console, tests won't run because the test `Job` already exists in the cluster, but the stage will succeed and promote the production deployment ☠️ 

Introducing this change will prevent this behavior because a change is required to go further in the pipeline. The case explained above could be avoided adding a random suffix on the  `Job` names that is being documented, but this step is required to prevent this to happen if that workaround is not implemented.   
