### PR TITLE
APPSRE-3528: Add a log statement about disabled auto-promotions

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -1455,6 +1455,12 @@ class SaasHerder():
                 all_saas_files, auto_only=True)
         trigger_promotion = False
 
+        if self.promotions and not auto_promote:
+            logging.info(
+                "Auto-promotions to next stages are disabled. This could"
+                "happen if the current stage does not make any change"
+            )
+
         for item in self.promotions:
             if item is None:
                 continue


### PR DESCRIPTION
Just add a log statement to print that auto-promotions are disabled in case someone reruns a stage that does not introduce any change. I think it's worth to add this msg to prevent misunderstandings.