### PR TITLE
check if blackbox-exporter monitoring provider uses only allowed modules

### DIFF
--- a/reconcile/blackbox_exporter_endpoint_monitoring.py
+++ b/reconcile/blackbox_exporter_endpoint_monitoring.py
@@ -141,7 +141,7 @@ def get_endpoints() -> dict[EndpointMonitoringProvider, list[Endpoint]]:
     return endpoints
 
 
-def get_blackbox_providers() -> list:
+def get_blackbox_providers() -> list[EndpointMonitoringProvider]:
     return [
         EndpointMonitoringProvider(**p)
         for p in queries.get_blackbox_exporter_monitoring_provider()
@@ -173,7 +173,8 @@ def run(dry_run: bool, thread_pool_size: int, internal: bool,
     verification_errors = False
     if allowed_modules:
         for p in get_blackbox_providers():
-            if p.blackboxExporter.module not in allowed_modules:
+            if p.blackboxExporter and \
+                 p.blackboxExporter.module not in allowed_modules:
                 LOG.error(
                     f"endpoint monitoring provider {p.name} uses "
                     f"blackbox-exporter module {p.blackboxExporter.module} "

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -53,6 +53,7 @@ APP_INTERFACE_SETTINGS_QUERY = """
       }
     }
     alertingServices
+    endpointMonitoringBlackboxExporterModules
   }
 }
 """
@@ -2670,3 +2671,28 @@ def get_app_metadata(app_path: str) -> dict:
     app_query = APP_METADATA.replace("APATH", shlex.quote(app_path))
     gqlapi = gql.get_api()
     return gqlapi.query(app_query)['apps']
+
+
+BLACKBOX_EXPORTER_MONITORING_PROVIDER = """
+{
+  providers: endpoint_monitoring_provider_v1 {
+    name
+    provider
+    description
+    ... on EndpointMonitoringProviderBlackboxExporter_v1 {
+      blackboxExporter {
+        module
+        namespace {
+          name
+        }
+        exporterUrl
+      }
+    }
+  }
+}
+"""
+
+
+def get_blackbox_exporter_monitoring_provider() -> dict:
+    gqlapi = gql.get_api()
+    return gqlapi.query(BLACKBOX_EXPORTER_MONITORING_PROVIDER)['providers']


### PR DESCRIPTION
if a blackbox-exporter endpoint monitoring provider uses a module not listed in app-interface-settings, fail the integration (and as such also PR checks introducing invalid changes). if the app-interface-settings do not mention any allowed blackbox-exporter modules, no check will be conducted.

Part of: https://issues.redhat.com/browse/APPSRE-4523
Depends on schema change: https://github.com/app-sre/qontract-schemas/pull/80

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>