### PR TITLE
Monkey patch JJB / MD5 usage for fedramp

### DIFF
--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -52,8 +52,7 @@ def monkey_patch_md5(to_patch):
 
 
 modules_to_patch = [
-    'jenkins_jobs',
-    'hashlib'
+    'jenkins_jobs.xml_config'
 ]
 
 try:

--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -7,6 +7,7 @@ import tempfile
 import xml.etree.ElementTree as et
 import json
 import re
+import importlib
 
 from os import path
 from contextlib import contextmanager
@@ -29,6 +30,37 @@ from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.exceptions import FetchResourceError
 
 JJB_INI = "[jenkins]\nurl = https://JENKINS_URL"
+
+
+# Monkey patch md5 for fedramp fips compliance
+# http://blog.serindu.com/2019/11/12/django-in-fips-mode/
+
+
+def _non_security_md5(*args, **kwargs):
+    kwargs['usedforsecurity'] = False
+    return hashlib.md5(*args, **kwargs)
+
+
+def monkey_patch_md5(to_patch):
+    HASHLIB_SPEC = importlib.util.find_spec('hashlib')
+    patched_hashlib = importlib.util.module_from_spec(HASHLIB_SPEC)
+    HASHLIB_SPEC.loader.exec_module(patched_hashlib)
+    patched_hashlib.md5 = _non_security_md5
+    for module_name in to_patch:
+        module = importlib.import_module(module_name)
+        module.hashlib = patched_hashlib
+
+
+modules_to_patch = [
+    'jenkins_jobs',
+    'hashlib'
+]
+
+try:
+    import hashlib
+    hashlib.md5()
+except ValueError:
+    monkey_patch_md5(modules_to_patch)
 
 
 class JJB:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -9,3 +9,4 @@ pytest-mock~=3.6
 responses
 testslide~=2.6
 moto~=2.2
+MarkupSafe==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         "dyn~=1.8.1",
         "transity-statuspageio>=0.0.3,<0.1",
         "pydantic~=1.9.0",
+        "MarkupSafe==2.0.1",
     ],
 
     test_suite="tests",


### PR DESCRIPTION
This MR monkey-patches the use of md5 in jenkins-job-builder to support fedramp environment.

Concept: http://blog.serindu.com/2019/11/12/django-in-fips-mode/

I tested the code changes by rshing into a running container in fedramp and executing the changes. Calling hashlib.md5 on its own in a fedramp environment will cause a ValueError normally, however this shell snippet shows otherwise.

```
Python 3.9.6 (default, Aug 11 2021, 06:39:25) 
[GCC 8.5.0 20210514 (Red Hat 8.5.0-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import importlib
>>> import hashlib
>>> import jenkins_jobs
>>> jenkins_jobs
<module 'jenkins_jobs' from '/usr/local/lib/python3.9/site-packages/jenkins_jobs/__init__.py'>
>>> def _non_security_md5(*args, **kwargs):
...     kwargs['usedforsecurity'] = False
...     return hashlib.md5(*args, **kwargs)
... 
>>> 
>>> 
>>> def monkey_patch_md5(to_patch):
...     HASHLIB_SPEC = importlib.util.find_spec('hashlib')
...     patched_hashlib = importlib.util.module_from_spec(HASHLIB_SPEC)
...     HASHLIB_SPEC.loader.exec_module(patched_hashlib)
...     patched_hashlib.md5 = _non_security_md5
...     for module_name in to_patch:
...         module = importlib.import_module(module_name)
...         module.hashlib = patched_hashlib
... 
>>> modules_to_patch = [
...     'jenkins_jobs'
... ]
>>> try:
...     import hashlib
...     hashlib.md5()
... except ValueError:
...     print(f'Patching module {modules_to_patch}')
...     monkey_patch_md5(modules_to_patch)
... 
Patching module ['jenkins_jobs']
>>> 
>>> jenkins_jobs.hashlib.md5()
<md5 _hashlib.HASH object @ 0x7f5887d0ddf0>
```