### PR TITLE
Patch jenkins_jobs.builder for md5 in fips env

### DIFF
--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -52,7 +52,8 @@ def monkey_patch_md5(to_patch):
 
 
 modules_to_patch = [
-    'jenkins_jobs.xml_config'
+    'jenkins_jobs.xml_config',
+    'jenkins_jobs.builder',
 ]
 
 try:


### PR DESCRIPTION
This MR is a follow on to the jjb monkey patch MR, expanding the module list for patching.