### PR TITLE
[terraform-users] replace inline policies with managed policies

### DIFF
--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -444,9 +444,10 @@ class TerrascriptClient:
 
                     # Ref: terraform aws iam_user_policy
                     tf_iam_user = self.get_tf_iam_user(user_name)
+                    identifier = f'{user_name}-{policy_name}'
                     tf_aws_iam_user_policy = aws_iam_user_policy(
-                        user_name + '-' + policy_name,
-                        name=user_name + '-' + policy_name,
+                        identifier,
+                        name=identifier,
                         user=user_name,
                         policy=policy,
                         depends_on=self.get_dependencies([tf_iam_user])

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -442,18 +442,27 @@ class TerrascriptClient:
                     policy = \
                         policy.replace('${aws:accountid}', account_uid)
 
-                    # Ref: terraform aws iam_user_policy
+                    # Ref: terraform aws_iam_policy
                     tf_iam_user = self.get_tf_iam_user(user_name)
                     identifier = f'{user_name}-{policy_name}'
-                    tf_aws_iam_user_policy = aws_iam_user_policy(
+                    tf_aws_iam_policy = aws_iam_policy(
                         identifier,
                         name=identifier,
-                        user=user_name,
                         policy=policy,
-                        depends_on=self.get_dependencies([tf_iam_user])
                     )
                     self.add_resource(account_name,
-                                      tf_aws_iam_user_policy)
+                                      tf_aws_iam_policy)
+                    # Ref: terraform aws_iam_user_policy_attachment
+                    tf_iam_user_policy_attachment = \
+                        aws_iam_user_policy_attachment(
+                            identifier,
+                            user=user_name,
+                            policy_arn=f"${{{tf_aws_iam_policy.arn}}}",
+                            depends_on=self.get_dependencies(
+                                [tf_iam_user, tf_aws_iam_policy])
+                        )
+                    self.add_resource(account_name,
+                                      tf_iam_user_policy_attachment)
 
     def populate_users(self, roles):
         self.populate_iam_groups(roles)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4505

AWS best practices recommends using customer managed policies instead of inline policies: https://docs.aws.amazon.com/IAM/latest/UserGuide/best-practices.html#best-practice-managed-vs-inline

with this approach, we are no longer using inline policies, which have a limit of 2048 chars:
```
LimitExceeded: Maximum policy size of 2048 bytes exceeded for user
```