### PR TITLE
[openshift-resources] add support to template resources from github files

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -217,7 +217,7 @@ def lookup_github_file_content(repo, path, ref, tvars=None):
 
     gh = init_github()
     c = gh.get_repo(repo).get_contents(path, ref).decoded_content
-    return repr(c.decode('utf-8'))
+    return c.decode('utf-8')
 
 
 def process_jinja2_template(body, vars=None, env=None):


### PR DESCRIPTION
similar to the way we can use `vault()`, this PR adds support to template using `github()`. example:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: example
data:
  public_policy.json: |-
    {{ github('org/repo', 'path/to/file', 'ref') }}
```
```