### PR TITLE
support providing name field to route53 zones

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -288,6 +288,7 @@ provider
   account
   region
   identifier
+  name
   output_resource_name
   annotations
 }

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -98,7 +98,7 @@ import reconcile.openshift_resources_base as orb
 
 GH_BASE_URL = os.environ.get('GITHUB_API', 'https://api.github.com')
 LOGTOES_RELEASE = 'repos/app-sre/logs-to-elasticsearch-lambda/releases/latest'
-VARIABLE_KEYS = ['region', 'availability_zone', 'parameter_group',
+VARIABLE_KEYS = ['region', 'availability_zone', 'parameter_group', 'name',
                  'enhanced_monitoring', 'replica_source',
                  'output_resource_db_name', 'reset_password', 'ca_cert',
                  'sqs_identifier', 's3_events', 'bucket_policy',
@@ -4219,7 +4219,7 @@ class TerrascriptClient:
 
         # https://www.terraform.io/docs/providers/aws/r/route53_zone.html
         values = {
-            'name': identifier,
+            'name': common_values['name'],
             'tags': common_values['tags'],
         }
         zone_id = safe_resource_id(identifier)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/OSD-8770

depends on https://github.com/app-sre/qontract-schemas/pull/85

follows up on #1962

this will allow us to define a "safe" identifier (without dots), and a `name`, such as `dns.example.com`.