### PR TITLE
[terraform] detect deleted outputs

### DIFF
--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -196,6 +196,19 @@ class TerraformClient:
                 logging.info(['update', name, 'output', output_name])
                 self.should_apply = True
 
+        # A way to detect deleted outputs is by comparing
+        # the prior state with the output changes.
+        # the output changes do not contain deleted outputs
+        # while the prior state does. for the outputs to
+        # actually be deleted, we should apply.
+        prior_outputs = \
+            output.get('prior_state', {}).get('values', {}).get('outputs', {})
+        deleted_outputs = \
+            [po for po in prior_outputs if po not in output_changes]
+        for output_name in deleted_outputs:
+            logging.info(['delete', name, 'output', output_name])
+            self.should_apply = True
+
         resource_changes = output.get('resource_changes')
         if resource_changes is None:
             return disabled_deletion_detected, deleted_users, created_users


### PR DESCRIPTION
in some cases, there are outputs to be deleted without any resources being deleted. we currently can not detect that.
we decide whether or not to `terraform apply` based on resources changing, and a partial ability to find values changing for outputs.
this means that the outputs will never be removed. or, only removed the next time a resource is removed.

this PR adds a way to detect outputs being deleted and as a result, perform `terraform apply`.
