### PR TITLE
[ocm-aws-infrastructure-access] explicitly define terraform user access

### DIFF
--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -43,7 +43,8 @@ def fetch_desired_state():
     desired_state = []
 
     # get desired state defined in awsInfrastructureAccess
-    # section of cluster files
+    # or awsInfrastructureManagementAccounts
+    # sections of cluster files
     clusters = queries.get_clusters()
     for cluster_info in clusters:
         cluster = cluster_info['name']
@@ -66,14 +67,20 @@ def fetch_desired_state():
                 }
                 desired_state.append(item)
 
-            # add terraform user account with network management access level
+        aws_infra_management_items = \
+            cluster_info.get('awsInfrastructureManagementAccounts') or []
+        for aws_infra_management in aws_infra_management_items:
+            aws_account = aws_infra_management['account']
+            access_level = aws_infra_management['accessLevel']
+            aws_account_uid = aws_account['uid']
+            # add terraform user account
             tf_user = aws_account.get('terraformUsername')
             if tf_user:
                 item = {
                     'cluster': cluster,
                     'user_arn':
                         f"arn:aws:iam::{aws_account_uid}:user/{tf_user}",
-                    'access_level': 'network-mgmt'
+                    'access_level': access_level
                 }
                 desired_state.append(item)
 

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -44,19 +44,19 @@ def fetch_desired_state():
 
     # get desired state defined in awsInfrastructureAccess
     # section of cluster files
-    clusters = [c for c in queries.get_clusters()
-                if c.get('awsInfrastructureAccess') is not None]
+    clusters = queries.get_clusters()
     for cluster_info in clusters:
         cluster = cluster_info['name']
-        aws_infra_access_items = cluster_info['awsInfrastructureAccess']
+        aws_infra_access_items = \
+            cluster_info.get('awsInfrastructureAccess') or []
         for aws_infra_access in aws_infra_access_items:
             aws_group = aws_infra_access['awsGroup']
             access_level = aws_infra_access['accessLevel']
             aws_account = aws_group['account']
             aws_account_uid = aws_account['uid']
             users = [user['org_username']
-                     for role in aws_group['roles']
-                     for user in role['users']]
+                        for role in aws_group['roles']
+                        for user in role['users']]
 
             for user in users:
                 item = {

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -56,8 +56,8 @@ def fetch_desired_state():
             aws_account = aws_group['account']
             aws_account_uid = aws_account['uid']
             users = [user['org_username']
-                        for role in aws_group['roles']
-                        for user in role['users']]
+                     for role in aws_group['roles']
+                     for user in role['users']]
 
             for user in users:
                 item = {

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -339,6 +339,25 @@ def get_queue_aws_accounts():
     return get_aws_accounts(uid=uid)
 
 
+AWS_INFRA_MANAGEMENT_ACCOUNT = """
+awsInfrastructureManagementAccounts {
+  account {
+    name
+    uid
+    terraformUsername
+    automationToken {
+      path
+      field
+      version
+      format
+    }
+  }
+  accessLevel
+  default
+}
+"""
+
+
 CLUSTERS_QUERY = """
 {
   clusters: clusters_v1 {
@@ -403,21 +422,7 @@ CLUSTERS_QUERY = """
       }
       accessLevel
     }
-    awsInfrastructureManagementAccounts {
-      account {
-        name
-        uid
-        terraformUsername
-        automationToken {
-          path
-          field
-          version
-          format
-        }
-      }
-      accessLevel
-      default
-    }
+    %s
     spec {
       id
       external_id
@@ -551,21 +556,7 @@ CLUSTERS_QUERY = """
               }
               accessLevel
             }
-            awsInfrastructureManagementAccounts {
-              account {
-                name
-                uid
-                terraformUsername
-                automationToken {
-                  path
-                  field
-                  version
-                  format
-                }
-              }
-              accessLevel
-              default
-            }
+            %s
             peering {
               connections {
                 name
@@ -613,7 +604,8 @@ CLUSTERS_QUERY = """
     }
   }
 }
-"""
+""" % (indent(AWS_INFRA_MANAGEMENT_ACCOUNT, 4*' '),
+       indent(AWS_INFRA_MANAGEMENT_ACCOUNT, 12*' '))
 
 
 CLUSTERS_MINIMAL_QUERY = """

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -403,6 +403,21 @@ CLUSTERS_QUERY = """
       }
       accessLevel
     }
+    awsInfrastructureManagementAccounts {
+      account {
+        name
+        uid
+        terraformUsername
+        automationToken {
+          path
+          field
+          version
+          format
+        }
+      }
+      accessLevel
+      default
+    }
     spec {
       id
       external_id


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4397

this PR changes the way we (implicitly) add `network-mgmt` role grants to terraform users, to (explicitly) define accounts that their terraform user should get a role grant.