### PR TITLE
Enable untyped def checks in Mypy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,271 @@ plugins = pydantic.mypy
 ; More context here: https://github.com/python/mypy/issues/9091
 no_implicit_optional = True
 
+check_untyped_defs = True
+
+; Below are a number of modules that have mypy errors that are being suppressed because there are untyped definitions.
+; Rather than continuing to let this list grow, we are making an exception for those that exist today and globally
+; enabling the checking of untyped defs. We can work on reducing this list by removing an item from the list and fixing
+; the issues to make CI pass.
+
+[mypy-reconcile.aws_ecr_image_pull_secrets.*]
+check_untyped_defs = False
+
+[mypy-reconcile.cli.*]
+check_untyped_defs = False
+
+[mypy-reconcile.cluster_deployment_mapper.*]
+check_untyped_defs = False
+
+[mypy-reconcile.github_org.*]
+check_untyped_defs = False
+
+[mypy-reconcile.github_owners.*]
+check_untyped_defs = False
+
+[mypy-reconcile.gitlab_members.*]
+check_untyped_defs = False
+
+[mypy-reconcile.gitlab_owners.*]
+check_untyped_defs = False
+
+[mypy-reconcile.jenkins_job_builder.*]
+check_untyped_defs = False
+
+[mypy-reconcile.jira_watcher.*]
+check_untyped_defs = False
+
+[mypy-reconcile.kafka_clusters.*]
+check_untyped_defs = False
+
+[mypy-reconcile.ocm_additional_routers.*]
+check_untyped_defs = False
+
+[mypy-reconcile.ocm_clusters.*]
+check_untyped_defs = False
+
+[mypy-reconcile.ocm_external_configuration_labels.*]
+check_untyped_defs = False
+
+[mypy-reconcile.ocm_groups.*]
+check_untyped_defs = False
+
+[mypy-reconcile.ocm_machine_pools.*]
+check_untyped_defs = False
+
+[mypy-reconcile.ocm_upgrade_scheduler.*]
+check_untyped_defs = False
+
+[mypy-reconcile.ocp_release_mirror.*]
+check_untyped_defs = False
+
+[mypy-reconcile.openshift_groups.*]
+check_untyped_defs = False
+
+[mypy-reconcile.openshift_limitranges.*]
+check_untyped_defs = False
+
+[mypy-reconcile.openshift_namespace_labels.*]
+check_untyped_defs = False
+
+[mypy-reconcile.openshift_resourcequotas.*]
+check_untyped_defs = False
+
+[mypy-reconcile.openshift_resources_base.*]
+check_untyped_defs = False
+
+[mypy-reconcile.openshift_saas_deploy_trigger_base.*]
+check_untyped_defs = False
+
+[mypy-reconcile.openshift_serviceaccount_tokens.*]
+check_untyped_defs = False
+
+[mypy-reconcile.prometheus_rules_tester.*]
+check_untyped_defs = False
+
+[mypy-reconcile.quay_mirror_org.*]
+check_untyped_defs = False
+
+[mypy-reconcile.saas_file_owners.*]
+check_untyped_defs = False
+
+[mypy-reconcile.sendgrid_teammates.*]
+check_untyped_defs = False
+
+[mypy-reconcile.sentry_config.*]
+check_untyped_defs = False
+
+[mypy-reconcile.sentry_helper.*]
+check_untyped_defs = False
+
+[mypy-reconcile.slack_cluster_usergroups.*]
+check_untyped_defs = False
+
+[mypy-reconcile.slack_usergroups.*]
+check_untyped_defs = False
+
+[mypy-reconcile.sql_query.*]
+check_untyped_defs = False
+
+[mypy-reconcile.terraform_resources.*]
+check_untyped_defs = False
+
+[mypy-reconcile.terraform_tgw_attachments.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_aggregated_list.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_auto_promoter.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_blackbox_exporter_endpoint_monitoring.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_checkpoint.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_gabi_authorized_users.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_gitlab_housekeeping.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_ocm_upgrade_scheduler.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_openshift_namespace_labels.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_openshift_resources_base.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_quay_repos.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_saasherder.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_slack_usergroups.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_status_page_components.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_terraform_vpc_peerings_build_desired_state.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_utils_data_structures.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_utils_expiration.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_utils_ocm.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_utils_oc_native.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_utils_oc.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_utils_state.*]
+check_untyped_defs = False
+
+[mypy-reconcile.test.test_vault_utils.*]
+check_untyped_defs = False
+
+[mypy-reconcile.user_validator.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.amtool.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.aws_api.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.binary.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.github_api.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.gpg.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.gql.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.jjb_client.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.jump_host.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.mr.auto_promoter.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.mr.aws_access.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.mr.cluster_service_install_config.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.mr.clusters_updates.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.mr.user_maintenance.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.ocm.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.oc.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.openshift_resource.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.promtool.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.repo_owners.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.saasherder.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.secret_reader.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.slack_api.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.smtp_client.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.state.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.terraform_client.*]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.terrascript_client.*]
+check_untyped_defs = False
+
+[mypy-tools.app_interface_reporter.*]
+check_untyped_defs = False
+
+[mypy-tools.qontract_cli.*]
+check_untyped_defs = False
+
+[mypy-tools.sre_checkpoints.util.*]
+check_untyped_defs = False
+
+[mypy-tools.test.test_sre_checkpoints.*]
+check_untyped_defs = False
+
 ; Below are all of the packages that don't implement stub packages. Mypy will throw an error if we don't ignore the
 ; missing imports. See: https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 


### PR DESCRIPTION
Mypy only checks typed methods by default. This can be a sane default
for teams starting out with types. Now that we're enforcing types, it
makes more sense to enable a stricter mode so that Mypy will always
check functions for errors. There are >80 files that have errors that
Mypy would detect currently, but they were being ignored because there
weren't type hints. This should stop that behavior for new code and for
files that don't have existing errors.

See this link for more information on the motivation: https://mypy.readthedocs.io/en/stable/common_issues.html#no-errors-reported-for-obviously-wrong-code