### PR TITLE
Cleanup Mypy errors for amtool, slack_api, and secret_reader

### DIFF
--- a/reconcile/utils/amtool.py
+++ b/reconcile/utils/amtool.py
@@ -1,5 +1,5 @@
 import tempfile
-from subprocess import run, PIPE
+from subprocess import run, PIPE, CalledProcessError
 
 
 class AmtoolResult:
@@ -28,7 +28,7 @@ def _run_yaml_str_cmd(cmd, yaml_str):
             fp.flush()
             cmd.append(fp.name)
             result = run(cmd, stdout=PIPE, stderr=PIPE, check=True)
-    except Exception as e:
+    except CalledProcessError as e:
         msg = f'Error running amtool command [{" ".join(cmd)}]'
         if e.stdout:
             msg += f" {e.stdout.decode()}"

--- a/reconcile/utils/secret_reader.py
+++ b/reconcile/utils/secret_reader.py
@@ -24,7 +24,7 @@ class SecretReader:
         containing `value: true` if Vault is to be used as the secret backend.
         """
         self.settings = settings
-        self._vault_client = None
+        self._vault_client: Optional[VaultClient] = None
 
     @property
     def vault_client(self):

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -216,7 +216,7 @@ class SlackApi:
         [channel_id] = [k for k in channels_found if
                         channels_found[k] == self.channel]
         info = self._sc.conversations_info(channel=channel_id)
-        if not info.data['channel']['is_member']:
+        if not info.data['channel']['is_member']:  # type: ignore
             self._sc.conversations_join(channel=channel_id)
 
     def get_usergroup_id(self, handle):

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -216,7 +216,7 @@ class SlackApi:
         [channel_id] = [k for k in channels_found if
                         channels_found[k] == self.channel]
         info = self._sc.conversations_info(channel=channel_id)
-        if not info.data['channel']['is_member']:  # type: ignore
+        if not info.data['channel']['is_member']:  # type: ignore[call-overload]
             self._sc.conversations_join(channel=channel_id)
 
     def get_usergroup_id(self, handle):

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,10 @@ plugins = pydantic.mypy
 ; More context here: https://github.com/python/mypy/issues/9091
 no_implicit_optional = True
 
+; Ensure that methods without type definitions are still checked
 check_untyped_defs = True
+
+; Enable error codes in Mypy so that specific error codes can be ignored if needed
 show_error_codes = True
 
 ; Below are a number of modules that have mypy errors that are being suppressed because there are untyped definitions.

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ plugins = pydantic.mypy
 no_implicit_optional = True
 
 check_untyped_defs = True
+show_error_codes = True
 
 ; Below are a number of modules that have mypy errors that are being suppressed because there are untyped definitions.
 ; Rather than continuing to let this list grow, we are making an exception for those that exist today and globally

--- a/setup.cfg
+++ b/setup.cfg
@@ -186,9 +186,6 @@ check_untyped_defs = False
 [mypy-reconcile.user_validator.*]
 check_untyped_defs = False
 
-[mypy-reconcile.utils.amtool.*]
-check_untyped_defs = False
-
 [mypy-reconcile.utils.aws_api.*]
 check_untyped_defs = False
 
@@ -241,12 +238,6 @@ check_untyped_defs = False
 check_untyped_defs = False
 
 [mypy-reconcile.utils.saasherder.*]
-check_untyped_defs = False
-
-[mypy-reconcile.utils.secret_reader.*]
-check_untyped_defs = False
-
-[mypy-reconcile.utils.slack_api.*]
 check_untyped_defs = False
 
 [mypy-reconcile.utils.smtp_client.*]


### PR DESCRIPTION
The docs for SlackResponse indicate that it can also be accessed by a dict
because __getitem__ is implemented. So, by avoiding the direct access of the
data attribute, we can avoid the need to deal with the potential for the data
to be bytes.

Related to the amtool error, you cannot catch the broad Exception and then
access attributes like stdout that only exist on certain types of exceptions.


I didn't perform any manual testing of these errors given the limited scope of the changes.