### PR TITLE
Enable warn_unused_ignores option in Mypy

### DIFF
--- a/reconcile/checkpoint.py
+++ b/reconcile/checkpoint.py
@@ -133,7 +133,7 @@ def report_invalid_metadata(
     """
     if dry_run:
         do_cut = partial(
-            render_template,  # type: ignore
+            render_template,
             template=MISSING_DATA_TEMPLATE,
             name=app["name"],
             path=path,
@@ -152,7 +152,7 @@ def report_invalid_metadata(
     for field, validator in VALIDATORS.items():
         value = app.get(field)
         try:
-            if not validator(value):  # type: ignore
+            if not validator(value):
                 i = do_cut(field=field, bad_value=str(value))
                 logging.error(
                     f"Reporting bad field {field} with value {value}: {i}"

--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -12,16 +12,16 @@ from reconcile.utils.secret_reader import SecretReader
 # This is unlikely to be ever fixed as this repo has not been updated in 4 yrs
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    from dyn.tm import session as dyn_session  # type: ignore
-    from dyn.tm import services as dyn_services  # type: ignore
-    from dyn.tm import zones as dyn_zones  # type: ignore
-    from dyn.tm.services.dsf import DSFCNAMERecord  # type: ignore
-    from dyn.tm.services.dsf import DSFFailoverChain  # type: ignore
-    from dyn.tm.services.dsf import DSFRecordSet  # type: ignore
-    from dyn.tm.services.dsf import DSFResponsePool  # type: ignore
-    from dyn.tm.services.dsf import DSFRuleset  # type: ignore
-    from dyn.tm.services.dsf import TrafficDirector  # type: ignore
-    from dyn.tm.zones import Node  # type: ignore
+    from dyn.tm import session as dyn_session
+    from dyn.tm import services as dyn_services
+    from dyn.tm import zones as dyn_zones
+    from dyn.tm.services.dsf import DSFCNAMERecord
+    from dyn.tm.services.dsf import DSFFailoverChain
+    from dyn.tm.services.dsf import DSFRecordSet
+    from dyn.tm.services.dsf import DSFResponsePool
+    from dyn.tm.services.dsf import DSFRuleset
+    from dyn.tm.services.dsf import TrafficDirector
+    from dyn.tm.zones import Node
 
 QONTRACT_INTEGRATION = "dyn-traffic-director"
 

--- a/reconcile/test/test_gitlab_labeler.py
+++ b/reconcile/test/test_gitlab_labeler.py
@@ -18,7 +18,7 @@ class TestData:
     def apps(self) -> list[dict]:
         return self._apps
 
-    @apps.setter  # type: ignore[no-redef, attr-defined]
+    @apps.setter
     def apps(self, apps: list[dict]) -> None:
         if not isinstance(apps, list):
             raise TypeError(f"Expecting list, have {type(apps)}")

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -153,8 +153,7 @@ class TestInitSpecsToFetch(testslide.TestCase):
         self.assertEqual(rs, [])
 
     def test_namespaces_extra_managed_resource_name(self) -> None:
-        # mypy doesn't recognize that this is a list
-        self.namespaces[0]["managedResourceNames"].append(  # type: ignore
+        self.namespaces[0]["managedResourceNames"].append(
             {
                 "resource": "Secret",
                 "resourceNames": ["s1", "s2"],

--- a/reconcile/test/test_openshift_tekton_resources.py
+++ b/reconcile/test/test_openshift_tekton_resources.py
@@ -35,13 +35,13 @@ class TstData:
     def saas_files(self) -> list[dict[str, Any]]:
         return self._saas_files
 
-    @providers.setter  # type: ignore[no-redef, attr-defined]
+    @providers.setter
     def providers(self, providers: list[dict[str, Any]]) -> None:
         if not isinstance(providers, list):
             raise TypeError(f"Expecting list, have {type(providers)}")
         self._providers = providers
 
-    @saas_files.setter  # type: ignore[no-redef, attr-defined]
+    @saas_files.setter
     def saas_files(self, saas_files: list[dict[str, Any]]) -> None:
         if not isinstance(saas_files, list):
             raise TypeError(f"Expecting list, have {type(saas_files)}")

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,9 @@ no_implicit_optional = True
 ; Ensure that methods without type definitions are still checked
 check_untyped_defs = True
 
+; Ensure that ignore statements that are no longer doing anything are detected for cleanup
+warn_unused_ignores = True
+
 ; Enable error codes in Mypy so that specific error codes can be ignored if needed
 show_error_codes = True
 
@@ -280,6 +283,10 @@ ignore_missing_imports = True
 
 ; Supported with update
 [mypy-dns.*]
+ignore_missing_imports = True
+
+; Supported with update
+[mypy-dyn.tm.*]
 ignore_missing_imports = True
 
 ; Supported with update


### PR DESCRIPTION
This changes ensures that there aren't Mypy ignores that are stale
that could mask other type issues in the future. This also includes
the removal of several ignore statements that no longer appear to be
necessary, or were made unnecessary via other methods (ignoring
missing imports).