### PR TITLE
Add cronjobs to run e2e-tests; Add dry_run mode to e2e_tests.

### DIFF
--- a/e2e_tests/cli.py
+++ b/e2e_tests/cli.py
@@ -33,12 +33,20 @@ def run_test(func, *args):
     help="log-level of the command. Defaults to INFO.",
     type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]),
 )
+@click.option(
+    "--dry-run/--no-dry-run",
+    "dry_run",
+    default=False,
+    help="Only print the planned actions if `true`",
+)
 @click.pass_context
-def test(ctx, configfile, log_level):
+def test(ctx, configfile, log_level, dry_run):
     ctx.ensure_object(dict)
 
     level = getattr(logging, log_level) if log_level else logging.INFO
     logging.basicConfig(format="%(levelname)s: %(message)s", level=level)
+
+    ctx.obj["dry_run"] = dry_run
 
     config.init_from_toml(configfile)
 
@@ -49,7 +57,7 @@ def test(ctx, configfile, log_level):
 @threaded()
 @click.pass_context
 def create_namespace(ctx, thread_pool_size):
-    run_test(e2e_tests.create_namespace.run, thread_pool_size)
+    run_test(e2e_tests.create_namespace.run, thread_pool_size, ctx.obj["dry_run"])
 
 
 @test.command()

--- a/e2e_tests/create_namespace.py
+++ b/e2e_tests/create_namespace.py
@@ -12,24 +12,25 @@ from reconcile.utils.defer import defer
 QONTRACT_E2E_TEST = "create-namespace"
 
 
-def test_cluster(cluster, oc_map, ns_under_test):
+def test_cluster(cluster, oc_map, ns_under_test, dry_run):
     oc = oc_map.get(cluster)
     logging.info("[{}] Creating namespace '{}'".format(cluster, ns_under_test))
 
-    try:
-        oc.new_project(ns_under_test)
-        time.sleep(5)  # allow time for resources to be created
-        dat.test_project_admin_rolebindings(oc, ns_under_test)
-        npt.test_project_network_policies(oc, ns_under_test)
-    except Exception:
-        logging.error(f"[{cluster}] failed test {QONTRACT_E2E_TEST}")
-    finally:
-        logging.info(f"[{cluster}] Deleting namespace '{ns_under_test}'")
-        oc.delete_project(ns_under_test)
+    if not dry_run:
+        try:
+            oc.new_project(ns_under_test)
+            time.sleep(5)  # allow time for resources to be created
+            dat.test_project_admin_rolebindings(oc, ns_under_test)
+            npt.test_project_network_policies(oc, ns_under_test)
+        except Exception:
+            logging.error(f"[{cluster}] failed test {QONTRACT_E2E_TEST}")
+        finally:
+            logging.info(f"[{cluster}] Deleting namespace '{ns_under_test}'")
+            oc.delete_project(ns_under_test)
 
 
 @defer
-def run(thread_pool_size=10, defer=None):
+def run(thread_pool_size=10, dry_run=False, defer=None):
     oc_map = tb.get_oc_map(QONTRACT_E2E_TEST)
     defer(oc_map.cleanup)
     ns_under_test = tb.get_test_namespace_name()
@@ -39,4 +40,5 @@ def run(thread_pool_size=10, defer=None):
         thread_pool_size,
         oc_map=oc_map,
         ns_under_test=ns_under_test,
+        dry_run=dry_run,
     )

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -310,8 +310,18 @@ objects:
   kind: CronJob
   metadata:
     labels:
+      {{- if $integration.command }}
+        {{- if eq $integration.command "e2e-tests" }}
+      app: e2e-tests-{{ $integration.name }}
+    name: e2e-tests-{{ $integration.name }}
+        {{- else }}
+      app: qontract-reconcile-{{ $integration.name }}
+    name: qontract-reconcile-{{ $integration.name }} 
+        {{- end }}
+      {{- else }}
       app: qontract-reconcile-{{ $integration.name }}
     name: qontract-reconcile-{{ $integration.name }}
+      {{- end }}
   spec:
     schedule: "{{ $integration.cron }}"
     concurrencyPolicy: {{ $integration.concurrencyPolicy | default "Allow" }}

--- a/helm/qontract-reconcile/values-internal.yaml
+++ b/helm/qontract-reconcile/values-internal.yaml
@@ -461,3 +461,55 @@ cronjobs:
   - name: XDG_CACHE_HOME
     value: /tmp/.cache
   extraArgs: --gitlab-project-id=${APP_INTERFACE_PROJECT_ID} --reports-path=/tmp/report
+- name: create-namespace
+  command: e2e-tests
+  concurrencyPolicy: Replace
+  restartPolicy: Never
+  resources:
+    requests:
+      memory: 300Mi
+      cpu: 100m
+    limits:
+      memory: 400Mi
+      cpu: 200m
+  cron: '0 8,20 * * *'
+  extraArgs: --thread-pool-size 1
+- name: dedicated-admin-rolebindings
+  command: e2e-tests
+  concurrencyPolicy: Replace
+  restartPolicy: Never
+  resources:
+    requests:
+      memory: 300Mi
+      cpu: 100m
+    limits:
+      memory: 400Mi
+      cpu: 200m
+  cron: '0 8,20 * * *'
+  extraArgs: --thread-pool-size 1
+- name: default-project-labels
+  command: e2e-tests
+  concurrencyPolicy: Replace
+  restartPolicy: Never
+  resources:
+    requests:
+      memory: 300Mi
+      cpu: 100m
+    limits:
+      memory: 400Mi
+      cpu: 200m
+  cron: '0 8,20 * * *'
+  extraArgs: --thread-pool-size 1
+- name: default-network-policies
+  command: e2e-tests
+  concurrencyPolicy: Replace
+  restartPolicy: Never
+  resources:
+    requests:
+      memory: 300Mi
+      cpu: 100m
+    limits:
+      memory: 400Mi
+      cpu: 200m
+  cron: '0 8,20 * * *'
+  extraArgs: --thread-pool-size 1

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -8528,6 +8528,242 @@ objects:
             - name: qontract-reconcile-toml
               secret:
                 secretName: qontract-reconcile-toml
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  metadata:
+    labels:
+      app: e2e-tests-create-namespace
+    name: e2e-tests-create-namespace
+  spec:
+    schedule: "0 8,20 * * *"
+    concurrencyPolicy: Replace
+    successfulJobHistoryLimit: 3
+    failedJobHistoryLimit: 1
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: int
+              image: ${IMAGE}:${IMAGE_TAG}
+              env:
+              - name: RUN_ONCE
+                value: 'true'
+              - name: DRY_RUN
+                value: ${DRY_RUN}
+              - name: COMMAND_NAME
+                value: e2e-tests
+              - name: INTEGRATION_NAME
+                value: create-namespace
+              - name: INTEGRATION_EXTRA_ARGS
+                value: "--thread-pool-size 1"
+              - name: GITHUB_API
+                valueFrom:
+                  configMapKeyRef:
+                    name: app-interface
+                    key: GITHUB_API
+              - name: UNLEASH_API_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: API_URL
+              - name: UNLEASH_CLIENT_ACCESS_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: CLIENT_ACCESS_TOKEN
+              volumeMounts:
+              - name: qontract-reconcile-toml
+                mountPath: /config
+              resources:
+                limits:
+                  cpu: ${CREATE_NAMESPACE_CPU_LIMIT}
+                  memory: ${CREATE_NAMESPACE_MEMORY_LIMIT}
+                requests:
+                  cpu: ${CREATE_NAMESPACE_CPU_REQUEST}
+                  memory: ${CREATE_NAMESPACE_MEMORY_REQUEST}
+            restartPolicy: Never
+            volumes:
+            - name: qontract-reconcile-toml
+              secret:
+                secretName: qontract-reconcile-toml
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  metadata:
+    labels:
+      app: e2e-tests-dedicated-admin-rolebindings
+    name: e2e-tests-dedicated-admin-rolebindings
+  spec:
+    schedule: "0 8,20 * * *"
+    concurrencyPolicy: Replace
+    successfulJobHistoryLimit: 3
+    failedJobHistoryLimit: 1
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: int
+              image: ${IMAGE}:${IMAGE_TAG}
+              env:
+              - name: RUN_ONCE
+                value: 'true'
+              - name: DRY_RUN
+                value: ${DRY_RUN}
+              - name: COMMAND_NAME
+                value: e2e-tests
+              - name: INTEGRATION_NAME
+                value: dedicated-admin-rolebindings
+              - name: INTEGRATION_EXTRA_ARGS
+                value: "--thread-pool-size 1"
+              - name: GITHUB_API
+                valueFrom:
+                  configMapKeyRef:
+                    name: app-interface
+                    key: GITHUB_API
+              - name: UNLEASH_API_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: API_URL
+              - name: UNLEASH_CLIENT_ACCESS_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: CLIENT_ACCESS_TOKEN
+              volumeMounts:
+              - name: qontract-reconcile-toml
+                mountPath: /config
+              resources:
+                limits:
+                  cpu: ${DEDICATED_ADMIN_ROLEBINDINGS_CPU_LIMIT}
+                  memory: ${DEDICATED_ADMIN_ROLEBINDINGS_MEMORY_LIMIT}
+                requests:
+                  cpu: ${DEDICATED_ADMIN_ROLEBINDINGS_CPU_REQUEST}
+                  memory: ${DEDICATED_ADMIN_ROLEBINDINGS_MEMORY_REQUEST}
+            restartPolicy: Never
+            volumes:
+            - name: qontract-reconcile-toml
+              secret:
+                secretName: qontract-reconcile-toml
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  metadata:
+    labels:
+      app: e2e-tests-default-project-labels
+    name: e2e-tests-default-project-labels
+  spec:
+    schedule: "0 8,20 * * *"
+    concurrencyPolicy: Replace
+    successfulJobHistoryLimit: 3
+    failedJobHistoryLimit: 1
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: int
+              image: ${IMAGE}:${IMAGE_TAG}
+              env:
+              - name: RUN_ONCE
+                value: 'true'
+              - name: DRY_RUN
+                value: ${DRY_RUN}
+              - name: COMMAND_NAME
+                value: e2e-tests
+              - name: INTEGRATION_NAME
+                value: default-project-labels
+              - name: INTEGRATION_EXTRA_ARGS
+                value: "--thread-pool-size 1"
+              - name: GITHUB_API
+                valueFrom:
+                  configMapKeyRef:
+                    name: app-interface
+                    key: GITHUB_API
+              - name: UNLEASH_API_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: API_URL
+              - name: UNLEASH_CLIENT_ACCESS_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: CLIENT_ACCESS_TOKEN
+              volumeMounts:
+              - name: qontract-reconcile-toml
+                mountPath: /config
+              resources:
+                limits:
+                  cpu: ${DEFAULT_PROJECT_LABELS_CPU_LIMIT}
+                  memory: ${DEFAULT_PROJECT_LABELS_MEMORY_LIMIT}
+                requests:
+                  cpu: ${DEFAULT_PROJECT_LABELS_CPU_REQUEST}
+                  memory: ${DEFAULT_PROJECT_LABELS_MEMORY_REQUEST}
+            restartPolicy: Never
+            volumes:
+            - name: qontract-reconcile-toml
+              secret:
+                secretName: qontract-reconcile-toml
+- apiVersion: batch/v1beta1
+  kind: CronJob
+  metadata:
+    labels:
+      app: e2e-tests-default-network-policies
+    name: e2e-tests-default-network-policies
+  spec:
+    schedule: "0 8,20 * * *"
+    concurrencyPolicy: Replace
+    successfulJobHistoryLimit: 3
+    failedJobHistoryLimit: 1
+    jobTemplate:
+      spec:
+        template:
+          spec:
+            containers:
+            - name: int
+              image: ${IMAGE}:${IMAGE_TAG}
+              env:
+              - name: RUN_ONCE
+                value: 'true'
+              - name: DRY_RUN
+                value: ${DRY_RUN}
+              - name: COMMAND_NAME
+                value: e2e-tests
+              - name: INTEGRATION_NAME
+                value: default-network-policies
+              - name: INTEGRATION_EXTRA_ARGS
+                value: "--thread-pool-size 1"
+              - name: GITHUB_API
+                valueFrom:
+                  configMapKeyRef:
+                    name: app-interface
+                    key: GITHUB_API
+              - name: UNLEASH_API_URL
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: API_URL
+              - name: UNLEASH_CLIENT_ACCESS_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: unleash
+                    key: CLIENT_ACCESS_TOKEN
+              volumeMounts:
+              - name: qontract-reconcile-toml
+                mountPath: /config
+              resources:
+                limits:
+                  cpu: ${DEFAULT_NETWORK_POLICIES_CPU_LIMIT}
+                  memory: ${DEFAULT_NETWORK_POLICIES_MEMORY_LIMIT}
+                requests:
+                  cpu: ${DEFAULT_NETWORK_POLICIES_CPU_REQUEST}
+                  memory: ${DEFAULT_NETWORK_POLICIES_MEMORY_REQUEST}
+            restartPolicy: Never
+            volumes:
+            - name: qontract-reconcile-toml
+              secret:
+                secretName: qontract-reconcile-toml
 - apiVersion: v1
   kind: Service
   metadata:
@@ -8919,3 +9155,35 @@ parameters:
   value: 100m
 - name: APP_INTERFACE_REPORTER_MEMORY_REQUEST
   value: 400Mi
+- name: CREATE_NAMESPACE_CPU_LIMIT
+  value: 200m
+- name: CREATE_NAMESPACE_MEMORY_LIMIT
+  value: 400Mi
+- name: CREATE_NAMESPACE_CPU_REQUEST
+  value: 100m
+- name: CREATE_NAMESPACE_MEMORY_REQUEST
+  value: 300Mi
+- name: DEDICATED_ADMIN_ROLEBINDINGS_CPU_LIMIT
+  value: 200m
+- name: DEDICATED_ADMIN_ROLEBINDINGS_MEMORY_LIMIT
+  value: 400Mi
+- name: DEDICATED_ADMIN_ROLEBINDINGS_CPU_REQUEST
+  value: 100m
+- name: DEDICATED_ADMIN_ROLEBINDINGS_MEMORY_REQUEST
+  value: 300Mi
+- name: DEFAULT_PROJECT_LABELS_CPU_LIMIT
+  value: 200m
+- name: DEFAULT_PROJECT_LABELS_MEMORY_LIMIT
+  value: 400Mi
+- name: DEFAULT_PROJECT_LABELS_CPU_REQUEST
+  value: 100m
+- name: DEFAULT_PROJECT_LABELS_MEMORY_REQUEST
+  value: 300Mi
+- name: DEFAULT_NETWORK_POLICIES_CPU_LIMIT
+  value: 200m
+- name: DEFAULT_NETWORK_POLICIES_MEMORY_LIMIT
+  value: 400Mi
+- name: DEFAULT_NETWORK_POLICIES_CPU_REQUEST
+  value: 100m
+- name: DEFAULT_NETWORK_POLICIES_MEMORY_REQUEST
+  value: 300Mi


### PR DESCRIPTION
#### What:
* Add dry_run mode to e2e_tests.
* Add cronjobs to run e2e-tests in cluster.
 
#### Why:
As part of efforts to pivoting away from Jenkins.

#### Tickets:
APPSRE-3615

#### Validation:
Deployed yaml contains only new e2e related cronjobs to Staging and they ran successfully.

