### PR TITLE
reconcile/checkpoint: catch bad URLs exceptions

### DIFF
--- a/reconcile/checkpoint.py
+++ b/reconcile/checkpoint.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping, Union
 
 import requests
+from requests.exceptions import ConnectionError, InvalidURL, MissingSchema
 from jinja2 import Template
 from jira import Issue
 
@@ -40,7 +41,11 @@ def url_makes_sense(url: str) -> bool:
     The URL is non-sensical if the server is crashing, the document
     doesn't exist or the specified URL can't be even probed with GET.
     """
-    rs = requests.get(url)
+    try:
+        rs = requests.get(url)
+    except (ConnectionError, InvalidURL,  MissingSchema):
+        return False
+
     # Codes above NOT_FOUND mean the URL to the document doesn't
     # exist, that the URL is very malformed or that it points to a
     # broken resource


### PR DESCRIPTION
Catch exceptions related to invalid or malformed URLs

```
# https://TODO
HTTPSConnectionPool(host='todo', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7fba13c41670>: Failed to establish a new connection: [Errno -2] Name or service not known'))
```

```
# TODO
requests.exceptions.MissingSchema: Invalid URL 'TODO': No schema supplied. Perhaps you meant http://TODO?
```

```
# https:/TODO
requests.exceptions.InvalidURL: Invalid URL 'http:/todo': No host supplied
```