### PR TITLE
[aws-ami-share] introduce new integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Additional tools that use the libraries created by the reconciliations are also 
 ### qontract-reconcile
 
 ```
+  aws-ami-share                   Share AMI and AMI tags between accounts.
   aws-ecr-image-pull-secrets      Generate AWS ECR image pull secrets and
                                   store them in Vault.
 

--- a/helm/qontract-reconcile/values-external.yaml
+++ b/helm/qontract-reconcile/values-external.yaml
@@ -20,6 +20,16 @@ integrations:
   logs:
     slack: true
   state: true
+- name: aws-ami-share
+  resources:
+    requests:
+      memory: 100Mi
+      cpu: 100m
+    limits:
+      memory: 200Mi
+      cpu: 200m
+  logs:
+    slack: true
 - name: dyn-traffic-director
   resources:
     requests:

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -406,6 +406,201 @@ objects:
   kind: Deployment
   metadata:
     labels:
+      app: qontract-reconcile-aws-ami-share
+    name: qontract-reconcile-aws-ami-share
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile-aws-ami-share
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile-aws-ami-share
+          component: qontract-reconcile
+      spec:
+        serviceAccountName: qontract-reconcile
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: SLACK_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                key: slack.webhook_url
+                name: app-interface
+          - name: SLACK_CHANNEL
+            value: ${SLACK_CHANNEL}
+          - name: SLACK_ICON_EMOJI
+            value: ${SLACK_ICON_EMOJI}
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type slack
+                webhook_url ${SLACK_WEBHOOK_URL}
+                channel ${SLACK_CHANNEL}
+                icon_emoji ${SLACK_ICON_EMOJI}
+                username sd-app-sre-bot
+                flush_interval 10s
+                message "\`\`\`[aws-ami-share] %s\`\`\`"
+              </store>
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name aws-ami-share
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          ports:
+            - name: http
+              containerPort: 9090
+          env:
+          - name: SHARDS
+            value: "1"
+          - name: SHARD_ID
+            value: "0"
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: aws-ami-share
+          - name: INTEGRATION_EXTRA_ARGS
+            value: ""
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: GITHUB_API
+          - name: SENTRY_DSN
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
+          - name: UNLEASH_API_URL
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: API_URL
+          - name: UNLEASH_CLIENT_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: CLIENT_ACCESS_TOKEN
+          - name: SLOW_OC_RECONCILE_THRESHOLD
+            value: "${SLOW_OC_RECONCILE_THRESHOLD}"
+          - name: LOG_SLOW_OC_RECONCILE
+            value: "${LOG_SLOW_OC_RECONCILE}"
+          - name: USE_NATIVE_CLIENT
+            value: "${USE_NATIVE_CLIENT}"
+          resources:
+            limits:
+              cpu: ${AWS_AMI_SHARE_CPU_LIMIT}
+              memory: ${AWS_AMI_SHARE_MEMORY_LIMIT}
+            requests:
+              cpu: ${AWS_AMI_SHARE_CPU_REQUEST}
+              memory: ${AWS_AMI_SHARE_MEMORY_REQUEST}
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
       app: qontract-reconcile-dyn-traffic-director
     name: qontract-reconcile-dyn-traffic-director
   spec:
@@ -25802,6 +25997,14 @@ parameters:
 - name: AWS_IAM_PASSWORD_RESET_CPU_REQUEST
   value: 100m
 - name: AWS_IAM_PASSWORD_RESET_MEMORY_REQUEST
+  value: 100Mi
+- name: AWS_AMI_SHARE_CPU_LIMIT
+  value: 200m
+- name: AWS_AMI_SHARE_MEMORY_LIMIT
+  value: 200Mi
+- name: AWS_AMI_SHARE_CPU_REQUEST
+  value: 100m
+- name: AWS_AMI_SHARE_MEMORY_REQUEST
   value: 100Mi
 - name: DYN_TRAFFIC_DIRECTOR_CPU_LIMIT
   value: 200m

--- a/reconcile/aws_ami_share.py
+++ b/reconcile/aws_ami_share.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Iterable, Mapping
 
 from reconcile import queries
 
@@ -10,7 +10,7 @@ QONTRACT_INTEGRATION = "aws-ami-share"
 MANAGED_TAG = TagTypeDef(Key="managed_by_integration", Value=QONTRACT_INTEGRATION)
 
 
-def filter_accounts(accounts: list[dict[str, Any]]):
+def filter_accounts(accounts: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
     sharing_account_names = set()
     for a in accounts:
         sharing = a.get("sharing")
@@ -23,7 +23,9 @@ def filter_accounts(accounts: list[dict[str, Any]]):
 
 
 def get_region(
-    share: dict[str, Any], src_account: dict[str, Any], dst_account: dict[str, Any]
+    share: Mapping[str, Any],
+    src_account: Mapping[str, Any],
+    dst_account: Mapping[str, Any],
 ) -> str:
     region = share.get("region") or src_account["resourcesDefaultRegion"]
     if region not in dst_account["supportedDeploymentRegions"]:

--- a/reconcile/aws_ami_share.py
+++ b/reconcile/aws_ami_share.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from reconcile import queries
 
@@ -8,7 +9,7 @@ QONTRACT_INTEGRATION = "aws-ami-share"
 MANAGED_TAG = {"Key": "managed_by_integration", "Value": QONTRACT_INTEGRATION}
 
 
-def filter_accounts(accounts):
+def filter_accounts(accounts: list[dict[str, Any]]):
     sharing_account_names = set()
     for a in accounts:
         sharing = a.get("sharing")

--- a/reconcile/aws_ami_share.py
+++ b/reconcile/aws_ami_share.py
@@ -1,0 +1,74 @@
+import logging
+
+from reconcile import queries
+
+from reconcile.utils.aws_api import AWSApi
+
+QONTRACT_INTEGRATION = "aws-ami-share"
+MANAGED_TAG = {"Key": "managed_by_integration", "Value": QONTRACT_INTEGRATION}
+
+
+def filter_accounts(accounts):
+    sharing_account_names = set()
+    for a in accounts:
+        sharing = a.get("sharing")
+        if sharing:
+            sharing_account_names.add(a["name"])
+            for s in sharing:
+                sharing_account_names.add(s["account"]["name"])
+
+    return [a for a in accounts if a["name"] in sharing_account_names]
+
+
+def run(dry_run):
+    accounts = queries.get_aws_accounts(sharing=True)
+    sharing_accounts = filter_accounts(accounts)
+    settings = queries.get_app_interface_settings()
+    aws_api = AWSApi(1, sharing_accounts, settings=settings)
+
+    for src_account in sharing_accounts:
+        sharing = src_account.get("sharing")
+        if not sharing:
+            continue
+        for share in sharing:
+            if share["provider"] != "ami":
+                continue
+            dst_account = share["account"]
+            regex = share["regex"]
+            src_amis = aws_api.get_amis_details(src_account, src_account, regex)
+            dst_amis = aws_api.get_amis_details(dst_account, src_account, regex)
+
+            for src_ami in src_amis:
+                src_ami_id = src_ami["image_id"]
+                found_dst_amis = [d for d in dst_amis if d["image_id"] == src_ami_id]
+                if not found_dst_amis:
+                    logging.info(
+                        [
+                            "share_ami",
+                            src_account["name"],
+                            dst_account["name"],
+                            src_ami_id,
+                        ]
+                    )
+                    if not dry_run:
+                        aws_api.share_ami(src_account, dst_account, src_ami_id)
+                    # we assume an unshared ami does not have tags
+                    found_dst_amis = [{"image_id": src_ami_id, "tags": []}]
+
+                dst_ami = found_dst_amis[0]
+                dst_ami_id = dst_ami["image_id"]
+                dst_ami_tags = dst_ami["tags"]
+                if MANAGED_TAG not in dst_ami_tags:
+                    logging.info(
+                        ["tag_shared_ami", dst_account["name"], dst_ami_id, MANAGED_TAG]
+                    )
+                    if not dry_run:
+                        aws_api.create_tag(dst_account, dst_ami_id, MANAGED_TAG)
+                src_ami_tags = src_ami["tags"]
+                for src_tag in src_ami_tags:
+                    if src_tag not in dst_ami_tags:
+                        logging.info(
+                            ["tag_shared_ami", dst_account["name"], dst_ami_id, src_tag]
+                        )
+                        if not dry_run:
+                            aws_api.create_tag(dst_account, dst_ami_id, src_tag)

--- a/reconcile/aws_ami_share.py
+++ b/reconcile/aws_ami_share.py
@@ -9,7 +9,7 @@ QONTRACT_INTEGRATION = "aws-ami-share"
 MANAGED_TAG = {"Key": "managed_by_integration", "Value": QONTRACT_INTEGRATION}
 
 
-def filter_accounts(accounts: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:
+def filter_accounts(accounts: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     sharing_account_names = set()
     for a in accounts:
         sharing = a.get("sharing")

--- a/reconcile/aws_ami_share.py
+++ b/reconcile/aws_ami_share.py
@@ -4,9 +4,10 @@ from typing import Any
 from reconcile import queries
 
 from reconcile.utils.aws_api import AWSApi
+from mypy_boto3_ec2.type_defs import TagTypeDef
 
 QONTRACT_INTEGRATION = "aws-ami-share"
-MANAGED_TAG = {"Key": "managed_by_integration", "Value": QONTRACT_INTEGRATION}
+MANAGED_TAG = TagTypeDef(Key="managed_by_integration", Value=QONTRACT_INTEGRATION)
 
 
 def filter_accounts(accounts: list[dict[str, Any]]):

--- a/reconcile/aws_ami_share.py
+++ b/reconcile/aws_ami_share.py
@@ -65,7 +65,9 @@ def run(dry_run):
                         ]
                     )
                     if not dry_run:
-                        aws_api.share_ami(src_account, dst_account, src_ami_id)
+                        aws_api.share_ami(
+                            src_account, dst_account["uid"], src_ami_id, region
+                        )
                     # we assume an unshared ami does not have tags
                     found_dst_amis = [{"image_id": src_ami_id, "tags": []}]
 

--- a/reconcile/aws_ami_share.py
+++ b/reconcile/aws_ami_share.py
@@ -4,10 +4,9 @@ from typing import Any, Iterable, Mapping
 from reconcile import queries
 
 from reconcile.utils.aws_api import AWSApi
-from mypy_boto3_ec2.type_defs import TagTypeDef
 
 QONTRACT_INTEGRATION = "aws-ami-share"
-MANAGED_TAG = TagTypeDef(Key="managed_by_integration", Value=QONTRACT_INTEGRATION)
+MANAGED_TAG = {"Key": "managed_by_integration", "Value": QONTRACT_INTEGRATION}
 
 
 def filter_accounts(accounts: Iterable[Mapping[str, Any]]) -> list[dict[str, Any]]:

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -75,6 +75,7 @@ import reconcile.gitlab_projects
 import reconcile.aws_garbage_collector
 import reconcile.aws_iam_keys
 import reconcile.aws_iam_password_reset
+import reconcile.aws_ami_share
 import reconcile.aws_ecr_image_pull_secrets
 import reconcile.aws_support_cases_sos
 import reconcile.ocm_groups
@@ -808,6 +809,14 @@ def aws_iam_keys(ctx, thread_pool_size, account_name):
 @click.pass_context
 def aws_iam_password_reset(ctx):
     run_integration(reconcile.aws_iam_password_reset, ctx.obj)
+
+
+@integration.command(
+    short_help="Share AMI and AMI tags between accounts."
+)
+@click.pass_context
+def aws_ami_share(ctx):
+    run_integration(reconcile.aws_ami_share, ctx.obj)
 
 
 @integration.command(

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -322,7 +322,7 @@ AWS_ACCOUNTS_QUERY = """
       }
       ... on AWSAccountSharingOptionAMI_v1 {
         regex
-        supportedDeploymentRegions
+        region
       }
     }
     {% endif %}

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -313,12 +313,25 @@ AWS_ACCOUNTS_QUERY = """
       region
     }
     partition
+    {% if sharing %}
+    sharing {
+      provider
+      account {
+        name
+        uid
+      }
+      ... on AWSAccountSharingOptionAMI_v1 {
+        regex
+      }
+    }
+    {% endif %}
   }
 }
 """
 
 
-def get_aws_accounts(reset_passwords=False, name=None, uid=None):
+def get_aws_accounts(reset_passwords=False, name=None, uid=None,
+                     sharing=False):
     """ Returns all AWS accounts """
     gqlapi = gql.get_api()
     search = name or uid
@@ -327,6 +340,7 @@ def get_aws_accounts(reset_passwords=False, name=None, uid=None):
         search=search,
         name=name,
         uid=uid,
+        sharing=sharing,
     )
     return gqlapi.query(query)['accounts']
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -319,6 +319,7 @@ AWS_ACCOUNTS_QUERY = """
       account {
         name
         uid
+        supportedDeploymentRegions
       }
       ... on AWSAccountSharingOptionAMI_v1 {
         regex

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -322,6 +322,7 @@ AWS_ACCOUNTS_QUERY = """
       }
       ... on AWSAccountSharingOptionAMI_v1 {
         regex
+        supportedDeploymentRegions
       }
     }
     {% endif %}

--- a/reconcile/test/test_aws_ami_share.py
+++ b/reconcile/test/test_aws_ami_share.py
@@ -7,38 +7,62 @@ import reconcile.aws_ami_share as integ
 def accounts():
     return [
         {
-            'name': 'some-account',
-            'automationToken': {
-                'path': 'path',
+            "name": "some-account",
+            "automationToken": {
+                "path": "path",
             },
-            'resourcesDefaultRegion': 'default-region',
-            'sharing': [
+            "resourcesDefaultRegion": "default-region",
+            "sharing": [
                 {
-                    'provider': 'ami',
-                    'account': {
-                        'name': 'shared-account',
-                        'uid': 123,
-                    }
+                    "provider": "ami",
+                    "account": {
+                        "name": "shared-account",
+                        "uid": 123,
+                    },
                 }
-            ]
+            ],
         },
         {
-            'name': 'some-account-too',
-            'automationToken': {
-                'path': 'path',
+            "name": "some-account-too",
+            "automationToken": {
+                "path": "path",
             },
-            'resourcesDefaultRegion': 'default-region',
+            "resourcesDefaultRegion": "default-region",
         },
         {
-            'name': 'shared-account',
-            'automationToken': {
-                'path': 'path',
+            "name": "shared-account",
+            "automationToken": {
+                "path": "path",
             },
-            'resourcesDefaultRegion': 'default-region',
-        }
+            "resourcesDefaultRegion": "default-region",
+        },
     ]
 
 
 def test_filter_accounts(accounts):
-    filtered = [a['name'] for a in integ.filter_accounts(accounts)]
-    assert filtered == ['some-account', 'shared-account']
+    filtered = [a["name"] for a in integ.filter_accounts(accounts)]
+    assert filtered == ["some-account", "shared-account"]
+
+
+def test_get_region_share_valid():
+    share = {"region": "valid"}
+    src_account = {"resourcesDefaultRegion": "doesnt-matter"}
+    dst_account = {"supportedDeploymentRegions": ["valid"]}
+    result = integ.get_region(share, src_account, dst_account)
+    assert result == "valid"
+
+
+def test_get_region_default_no_share():
+    share = {}
+    src_account = {"resourcesDefaultRegion": "valid"}
+    dst_account = {"supportedDeploymentRegions": ["valid"]}
+    result = integ.get_region(share, src_account, dst_account)
+    assert result == "valid"
+
+
+def test_get_region_share_invalid():
+    share = {"region": "invalid"}
+    src_account = {"resourcesDefaultRegion": "doesnt-matter"}
+    dst_account = {"name": "really", "supportedDeploymentRegions": ["valid"]}
+    with pytest.raises(ValueError):
+        integ.get_region(share, src_account, dst_account)

--- a/reconcile/test/test_aws_ami_share.py
+++ b/reconcile/test/test_aws_ami_share.py
@@ -1,0 +1,44 @@
+import pytest
+
+import reconcile.aws_ami_share as integ
+
+
+@pytest.fixture
+def accounts():
+    return [
+        {
+            'name': 'some-account',
+            'automationToken': {
+                'path': 'path',
+            },
+            'resourcesDefaultRegion': 'default-region',
+            'sharing': [
+                {
+                    'provider': 'ami',
+                    'account': {
+                        'name': 'shared-account',
+                        'uid': 123,
+                    }
+                }
+            ]
+        },
+        {
+            'name': 'some-account-too',
+            'automationToken': {
+                'path': 'path',
+            },
+            'resourcesDefaultRegion': 'default-region',
+        },
+        {
+            'name': 'shared-account',
+            'automationToken': {
+                'path': 'path',
+            },
+            'resourcesDefaultRegion': 'default-region',
+        }
+    ]
+
+
+def test_filter_accounts(accounts):
+    filtered = [a['name'] for a in integ.filter_accounts(accounts)]
+    assert filtered == ['some-account', 'shared-account']

--- a/reconcile/test/test_aws_ami_share.py
+++ b/reconcile/test/test_aws_ami_share.py
@@ -53,7 +53,7 @@ def test_get_region_share_valid():
 
 
 def test_get_region_default_no_share():
-    share = {}
+    share = {'region': None}
     src_account = {"resourcesDefaultRegion": "valid"}
     dst_account = {"supportedDeploymentRegions": ["valid"]}
     result = integ.get_region(share, src_account, dst_account)

--- a/reconcile/test/test_aws_ami_share.py
+++ b/reconcile/test/test_aws_ami_share.py
@@ -53,7 +53,7 @@ def test_get_region_share_valid():
 
 
 def test_get_region_default_no_share():
-    share = {'region': None}
+    share = {"region": None}
     src_account = {"resourcesDefaultRegion": "valid"}
     dst_account = {"supportedDeploymentRegions": ["valid"]}
     result = integ.get_region(share, src_account, dst_account)

--- a/reconcile/test/test_utils_aws_api.py
+++ b/reconcile/test/test_utils_aws_api.py
@@ -80,3 +80,22 @@ def test_default_region(aws_api, accounts):
     for a in accounts:
         assert aws_api.sessions[a['name']].region_name == \
             a['resourcesDefaultRegion']
+
+
+def test_filter_amis(aws_api):
+    regex = '^match.*$'
+    images = [
+        {
+            'Name': 'match-regex',
+            'ImageId': 'id1',
+            'Tags': []
+        },
+        {
+            'Name': 'no-match-regex',
+            'ImageId': 'id2',
+            'Tags': []
+        }
+    ]
+    results = aws_api._filter_amis(images, regex)
+    expected = {'image_id': 'id1', 'tags': []}
+    assert results == [expected]

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -894,7 +894,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         return results
 
     @staticmethod
-    def _filter_amis(images: List[ImageTypeDef], regex: str) -> List[Dict[str, Any]]:
+    def _filter_amis(images: Iterable[ImageTypeDef], regex: str) -> List[Dict[str, Any]]:
         results = []
         pattern = re.compile(regex)
         for i in images:
@@ -908,8 +908,8 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         return results
 
     def get_amis_details(self,
-                         account: dict[str, Any],
-                         owner_account: dict[str, Any],
+                         account: Mapping[str, Any],
+                         owner_account: Mapping[str, Any],
                          regex: str,
                          region: Optional[str] = None) -> List[Dict[str, Any]]:
         ec2 = self._account_ec2_client(account['name'], region_name=region)
@@ -917,7 +917,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         return self._filter_amis(images, regex)
 
     def share_ami(self,
-                  account: dict[str, Any],
+                  account: Mapping[str, Any],
                   share_account_uid: str,
                   image_id: str,
                   region: Optional[str] = None):
@@ -927,9 +927,9 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         image.modify_attribute(LaunchPermission=launch_permission)
 
     def create_tag(self,
-                   account: dict[str, Any],
+                   account: Mapping[str, Any],
                    resource_id: str,
-                   tag: Dict[str, str]):
+                   tag: Mapping[str, str]):
         ec2 = self._account_ec2_client(account['name'])
         tag_type_def = TagTypeDef(Key=tag['Key'], Value=tag['Value'])
         ec2.create_tags(Resources=[resource_id], Tags=[tag_type_def])

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -886,10 +886,11 @@ class AWSApi:  # pylint: disable=too-many-public-methods
     def get_amis_details(self,
                          account: dict[str, Any],
                          owner_account: dict[str, Any],
-                         regex: str) -> list[str]:
+                         regex: str,
+                         region: Optional[str] = None) -> list[str]:
         results = []
         pattern = re.compile(regex)
-        ec2 = self._account_ec2_client(account['name'])
+        ec2 = self._account_ec2_client(account['name'], region_name=region)
         images = self.get_account_amis(ec2, owner=owner_account['uid'])
         for i in images:
             if re.search(pattern, i['Name']):

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -917,9 +917,10 @@ class AWSApi:  # pylint: disable=too-many-public-methods
     def create_tag(self,
                    account: dict[str, Any],
                    resource_id: str,
-                   tag: TagTypeDef):
+                   tag: Dict[str, str]):
         ec2 = self._account_ec2_client(account['name'])
-        ec2.create_tags(Resources=[resource_id], Tags=[tag])
+        tag_type_def = TagTypeDef(Key=tag['Key'], Value=tag['Value'])
+        ec2.create_tags(Resources=[resource_id], Tags=[tag_type_def])
 
     def get_alb_network_interface_ips(self, account, service_name):
         assumed_role_data = self._get_account_assume_data(account)

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -885,15 +885,10 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
         return results
 
-    def get_amis_details(self,
-                         account: dict[str, Any],
-                         owner_account: dict[str, Any],
-                         regex: str,
-                         region: Optional[str] = None) -> List[Dict[str, Any]]:
+    @staticmethod
+    def _filter_amis(images: List[ImageTypeDef], regex: str) -> List[Dict[str, Any]]:
         results = []
         pattern = re.compile(regex)
-        ec2 = self._account_ec2_client(account['name'], region_name=region)
-        images = self.get_account_amis(ec2, owner=owner_account['uid'])
         for i in images:
             if re.search(pattern, i['Name']):
                 item = {
@@ -903,6 +898,15 @@ class AWSApi:  # pylint: disable=too-many-public-methods
                 results.append(item)
 
         return results
+
+    def get_amis_details(self,
+                         account: dict[str, Any],
+                         owner_account: dict[str, Any],
+                         regex: str,
+                         region: Optional[str] = None) -> List[Dict[str, Any]]:
+        ec2 = self._account_ec2_client(account['name'], region_name=region)
+        images = self.get_account_amis(ec2, owner=owner_account['uid'])
+        return self._filter_amis(images, regex)
 
     def share_ami(self,
                   account: dict[str, Any],

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -883,7 +883,10 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
         return results
 
-    def get_amis_details(self, account, owner_account, regex):
+    def get_amis_details(self,
+                         account: dict[str, Any],
+                         owner_account: dict[str, Any],
+                         regex: str) -> list[str]:
         results = []
         pattern = re.compile(regex)
         ec2 = self._account_ec2_client(account['name'])
@@ -898,14 +901,20 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
         return results
 
-    def share_ami(self, account, share_account, image_id):
+    def share_ami(self,
+                  account: dict[str, Any],
+                  share_account: dict[str, Any],
+                  image_id: str):
         session = self.sessions[account['name']]
         ec2 = session.resource('ec2')
         image = ec2.Image(image_id)
         launch_permission = {'Add': [{'UserId': share_account['uid']}]}
         image.modify_attribute(LaunchPermission=launch_permission)
 
-    def create_tag(self, account, resource_id, tag):
+    def create_tag(self,
+                   account: dict[str, Any],
+                   resource_id: str,
+                   tag: dict):
         ec2 = self._account_ec2_client(account['name'])
         ec2.create_tags(Resources=[resource_id], Tags=[tag])
 

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -7,7 +7,7 @@ import time
 
 from datetime import datetime
 from threading import Lock
-from typing import Collection, Literal, Sequence, Union, TYPE_CHECKING
+from typing import Literal, Union, TYPE_CHECKING
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
 
 from boto3 import Session
@@ -889,7 +889,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
                          account: dict[str, Any],
                          owner_account: dict[str, Any],
                          regex: str,
-                         region: Optional[str] = None) -> List[Dict[str, Sequence[Collection[str]]]]:
+                         region: Optional[str] = None) -> List[Dict[str, Any]]:
         results = []
         pattern = re.compile(regex)
         ec2 = self._account_ec2_client(account['name'], region_name=region)

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -22,14 +22,14 @@ if TYPE_CHECKING:
     from mypy_boto3_ec2 import EC2Client
     from mypy_boto3_ec2.type_defs import (
         RouteTableTypeDef, SubnetTypeDef, TransitGatewayTypeDef,
-        TransitGatewayVpcAttachmentTypeDef, VpcTypeDef, ImagesTypeDef
+        TransitGatewayVpcAttachmentTypeDef, VpcTypeDef, ImageTypeDef
     )
     from mypy_boto3_iam import IAMClient
     from mypy_boto3_iam.type_defs import AccessKeyMetadataTypeDef
 else:
     EC2Client = RouteTableTypeDef = SubnetTypeDef = TransitGatewayTypeDef = \
         TransitGatewayVpcAttachmentTypeDef = VpcTypeDef = IAMClient = \
-        AccessKeyMetadataTypeDef = ImagesTypeDef = object
+        AccessKeyMetadataTypeDef = ImageTypeDef = object
 
 
 class InvalidResourceTypeError(Exception):
@@ -767,7 +767,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     # pylint: disable=method-hidden
-    def get_account_amis(ec2: EC2Client, owner: str) -> List[ImagesTypeDef]:
+    def get_account_amis(ec2: EC2Client, owner: str) -> List[ImageTypeDef]:
         amis = ec2.describe_images(Owners=[owner])
         return amis.get('Images', [])
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4621

depends on https://github.com/app-sre/qontract-schemas/pull/91

design doc: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/34669

this integration is an idea from @BumbleFeng and will help simplify this: https://github.com/app-sre/qontract-reconcile/pull/2100#discussion_r817030105

this PR introduces a new integration that shares AMIs between AWS accounts.
by defining a `sharing` section in an AWS account file, we turn on sharing, according to the `provider`.
we start out by only supporting the `ami` provider, which will share images and copy image tags.

still TODO: tests and type hints