### PR TITLE
[aws-ami-share] check that AMI is available

### DIFF
--- a/reconcile/test/test_utils_aws_api.py
+++ b/reconcile/test/test_utils_aws_api.py
@@ -102,6 +102,7 @@ def test_filter_amis_regex(aws_api):
     expected = {'image_id': 'id1', 'tags': []}
     assert results == [expected]
 
+
 def test_filter_amis_state(aws_api):
     regex = '^match.*$'
     images = [

--- a/reconcile/test/test_utils_aws_api.py
+++ b/reconcile/test/test_utils_aws_api.py
@@ -82,17 +82,39 @@ def test_default_region(aws_api, accounts):
             a['resourcesDefaultRegion']
 
 
-def test_filter_amis(aws_api):
+def test_filter_amis_regex(aws_api):
     regex = '^match.*$'
     images = [
         {
             'Name': 'match-regex',
             'ImageId': 'id1',
+            'State': 'available',
             'Tags': []
         },
         {
             'Name': 'no-match-regex',
             'ImageId': 'id2',
+            'State': 'available',
+            'Tags': []
+        }
+    ]
+    results = aws_api._filter_amis(images, regex)
+    expected = {'image_id': 'id1', 'tags': []}
+    assert results == [expected]
+
+def test_filter_amis_state(aws_api):
+    regex = '^match.*$'
+    images = [
+        {
+            'Name': 'match-regex-1',
+            'ImageId': 'id1',
+            'State': 'available',
+            'Tags': []
+        },
+        {
+            'Name': 'match-regex-2',
+            'ImageId': 'id2',
+            'State': 'pending',
             'Tags': []
         }
     ]

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -898,12 +898,13 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         results = []
         pattern = re.compile(regex)
         for i in images:
-            if re.search(pattern, i['Name']):
-                item = {
-                    'image_id': i['ImageId'],
-                    'tags': i.get('Tags', [])
-                }
-                results.append(item)
+            if not re.search(pattern, i['Name']):
+                continue
+            item = {
+                'image_id': i['ImageId'],
+                'tags': i.get('Tags', [])
+            }
+            results.append(item)
 
         return results
 

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -900,6 +900,8 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         for i in images:
             if not re.search(pattern, i['Name']):
                 continue
+            if i['State'] != "available":
+                continue
             item = {
                 'image_id': i['ImageId'],
                 'tags': i.get('Tags', [])


### PR DESCRIPTION
follows up on #2216

we can not share an AMI that is not available. this PR filters these AMIs out.

error: https://coreos.slack.com/archives/CS0E65QCV/p1646740896836509
```
Error running qontract-reconcile
Traceback (most recent call last):
  File "/run-integration.py", line 150, in main
    command.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/cli.py", line 819, in aws_ami_share
    run_integration(reconcile.aws_ami_share, ctx.obj)
  File "/usr/local/lib/python3.9/site-packages/reconcile/cli.py", line 440, in run_integration
    func_container.run(dry_run, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/aws_ami_share.py", line 68, in run
    aws_api.share_ami(
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/aws_api.py", line 927, in share_ami
    image.modify_attribute(LaunchPermission=launch_permission)
  File "/usr/local/lib/python3.9/site-packages/boto3/resources/factory.py", line 520, in do_action
    response = action(self, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/boto3/resources/action.py", line 83, in __call__
    response = getattr(parent.meta.client, operation_name)(*args, **params)
  File "/usr/local/lib/python3.9/site-packages/botocore/client.py", line 386, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.9/site-packages/botocore/client.py", line 705, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidAMIID.Unavailable) when calling the ModifyImageAttribute operation: The AMI ID 'ami-xxx' is currently pending and may not be used for this operation
```