### PR TITLE
[saas-file-validator] fail validation when IMAGE_TAG matches ref

### DIFF
--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -30,7 +30,8 @@ class TestSaasFileValid(TestCase):
                                 'namespace': {
                                     'name': 'ns',
                                     'environment': {
-                                        'name': 'env1'
+                                        'name': 'env1',
+                                        'parameters': '{}'
                                     },
                                     'cluster': {
                                         'name': 'cluster'
@@ -49,7 +50,8 @@ class TestSaasFileValid(TestCase):
                                 'namespace': {
                                     'name': 'ns',
                                     'environment': {
-                                        'name': 'env2'
+                                        'name': 'env2',
+                                        'parameters': '{}'
                                     },
                                     'cluster': {
                                         'name': 'cluster'
@@ -117,6 +119,38 @@ class TestSaasFileValid(TestCase):
     def test_check_saas_file_upstream_used_with_commit_sha(self):
         self.saas_files[0]['resourceTemplates'][0]['targets'][0]['ref'] = \
             '2637b6c41bda7731b1bcaaf18b4a50d7c5e63e30'
+        saasherder = SaasHerder(
+            self.saas_files,
+            thread_pool_size=1,
+            gitlab=None,
+            integration='',
+            integration_version='',
+            settings={},
+            validate=True
+        )
+
+        self.assertFalse(saasherder.valid)
+
+    def test_validate_image_tag_not_equals_ref_valid(self):
+        self.saas_files[0]['resourceTemplates'][0]['targets'][0]['parameters'] = \
+            '{"IMAGE_TAG": "2637b6c"}'
+        saasherder = SaasHerder(
+            self.saas_files,
+            thread_pool_size=1,
+            gitlab=None,
+            integration='',
+            integration_version='',
+            settings={},
+            validate=True
+        )
+
+        self.assertTrue(saasherder.valid)
+
+    def test_validate_image_tag_not_equals_ref_invalid(self):
+        self.saas_files[0]['resourceTemplates'][0]['targets'][0]['ref'] = \
+            '2637b6c41bda7731b1bcaaf18b4a50d7c5e63e30'
+        self.saas_files[0]['resourceTemplates'][0]['targets'][0]['parameters'] = \
+            '{"IMAGE_TAG": "2637b6c"}'
         saasherder = SaasHerder(
             self.saas_files,
             thread_pool_size=1,

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -344,7 +344,6 @@ class SaasHerder():
             )
             self.valid = False
 
-
     def _collect_namespaces(self):
         # namespaces may appear more then once in the result
         namespaces = []

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -162,6 +162,12 @@ class SaasHerder():
                     if not target_parameters:
                         continue
                     target_parameters = json.loads(target_parameters)
+                    self._validate_image_tag_not_equals_ref(
+                        saas_file_name,
+                        resource_template_name,
+                        target['ref'],
+                        target_parameters
+                    )
                     environment_parameters = environment['parameters']
                     if not environment_parameters:
                         continue
@@ -321,6 +327,23 @@ class SaasHerder():
                     f'[{saas_file_name}/{resource_template_name}] '
                     f'upstream used with commit sha: {ref}')
                 self.valid = False
+
+    def _validate_image_tag_not_equals_ref(
+            self,
+            saas_file_name: str,
+            resource_template_name: str,
+            ref: str,
+            parameters: dict,
+    ):
+        image_tag = parameters.get('IMAGE_TAG')
+        if image_tag and str(ref).startswith(str(image_tag)):
+            logging.error(
+                f'[{saas_file_name}/{resource_template_name}] '
+                f'IMAGE_TAG {image_tag} is the same as ref {ref}. '
+                'please remove the IMAGE_TAG parameter, it is automatically generated.'
+            )
+            self.valid = False
+
 
     def _collect_namespaces(self):
         # namespaces may appear more then once in the result


### PR DESCRIPTION
as the IMAGE_TAG parameter is automatically generated, we should enforce cleaner configuration.
if IMAGE_TAG is the same as the ref, IMAGE_TAG is not required.

https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/continuous-delivery-in-app-interface.md#automatically-generated-parameters