### PR TITLE
Add --no-github flag to openshift -rolebindings and -clusterrolebindings

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -553,8 +553,8 @@ def github_validator(ctx):
 )
 @click.option('--no-github',
               is_flag=True,
-              help='use org_username instead of github_username for ' + 
-                    'user <> clusterrolebinding associations')
+              help='use org_username instead of github_username for ' +
+              'user <> clusterrolebinding associations')
 @threaded()
 @binary(['oc', 'ssh'])
 @binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
@@ -573,8 +573,8 @@ def openshift_clusterrolebindings(ctx, no_github, thread_pool_size,
 )
 @click.option('--no-github',
               is_flag=True,
-              help='use org_username instead of github_username for ' + 
-                    'user <> rolebinding associations')
+              help='use org_username instead of github_username for ' +
+              'user <> rolebinding associations')
 @threaded()
 @binary(['oc', 'ssh'])
 @binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -551,6 +551,10 @@ def github_validator(ctx):
 @integration.command(
     short_help="Configures ClusterRolebindings in OpenShift clusters."
 )
+@click.option('--no-github',
+              is_flag=True,
+              help='use org_username instead of github_username for ' + 
+                    'user <> clusterrolebinding associations')
 @threaded()
 @binary(['oc', 'ssh'])
 @binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
@@ -558,24 +562,30 @@ def github_validator(ctx):
 @use_jump_host()
 @click.pass_context
 def openshift_clusterrolebindings(ctx, thread_pool_size, internal,
-                                  use_jump_host):
+                                  use_jump_host, no_github):
     run_integration(reconcile.openshift_clusterrolebindings,
                     ctx.obj, thread_pool_size, internal,
-                    use_jump_host)
+                    use_jump_host, no_github)
 
 
 @integration.command(
     short_help="Configures Rolebindings in OpenShift clusters."
 )
+@click.option('--no-github',
+              is_flag=True,
+              help='use org_username instead of github_username for ' + 
+                    'user <> rolebinding associations')
 @threaded()
 @binary(['oc', 'ssh'])
 @binary_version('oc', ['version', '--client'], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
 @click.pass_context
-def openshift_rolebindings(ctx, thread_pool_size, internal, use_jump_host):
+def openshift_rolebindings(ctx, thread_pool_size, internal, use_jump_host,
+                           no_github):
     run_integration(reconcile.openshift_rolebindings, ctx.obj,
-                    thread_pool_size, internal, use_jump_host)
+                    thread_pool_size, internal, use_jump_host,
+                    no_github)
 
 
 @integration.command(

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -561,8 +561,8 @@ def github_validator(ctx):
 @internal()
 @use_jump_host()
 @click.pass_context
-def openshift_clusterrolebindings(ctx, thread_pool_size, internal,
-                                  use_jump_host, no_github):
+def openshift_clusterrolebindings(ctx, no_github, thread_pool_size,
+                                  internal, use_jump_host):
     run_integration(reconcile.openshift_clusterrolebindings,
                     ctx.obj, thread_pool_size, internal,
                     use_jump_host, no_github)
@@ -581,8 +581,8 @@ def openshift_clusterrolebindings(ctx, thread_pool_size, internal,
 @internal()
 @use_jump_host()
 @click.pass_context
-def openshift_rolebindings(ctx, thread_pool_size, internal, use_jump_host,
-                           no_github):
+def openshift_rolebindings(ctx, no_github, thread_pool_size, internal,
+                           use_jump_host):
     run_integration(reconcile.openshift_rolebindings, ctx.obj,
                     thread_pool_size, internal, use_jump_host,
                     no_github)

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -106,7 +106,6 @@ def fetch_desired_state(ri, oc_map, no_github):
         bot_users = []
 
         if no_github is True:
-            print("FEDRAMP TRUE")
             users = [user['org_username']
                     for user in role['users']]
             bot_users = [bot['org_username']

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -20,6 +20,7 @@ ROLES_QUERY = """
       github_username
     }
     bots {
+      org_username
       github_username
       openshift_serviceaccount
     }
@@ -175,8 +176,8 @@ def fetch_desired_state(ri, oc_map, no_github):
 
 
 @defer
-def run(dry_run, thread_pool_size=10, internal=None,
-        use_jump_host=True, defer=None, no_github=False):
+def run(dry_run, no_github, thread_pool_size=10, internal=None,
+        use_jump_host=True, defer=None):
     clusters = [cluster_info for cluster_info
                 in queries.get_clusters()
                 if cluster_info.get('managedClusterRoles')]

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -107,16 +107,16 @@ def fetch_desired_state(ri, oc_map, no_github):
 
         if no_github is True:
             users = [user['org_username']
-                    for user in role['users']]
+                     for user in role['users']]
             bot_users = [bot['org_username']
-                        for bot in role['bots']
-                        if bot.get('org_username')]
+                         for bot in role['bots']
+                         if bot.get('org_username')]
         else:
             users = [user['github_username']
-                    for user in role['users']]
+                     for user in role['users']]
             bot_users = [bot['github_username']
-                        for bot in role['bots']
-                        if bot.get('github_username')]
+                         for bot in role['bots']
+                         if bot.get('github_username')]
 
         users.extend(bot_users)
         service_accounts = [bot['openshift_serviceaccount']

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -106,17 +106,17 @@ def fetch_desired_state(ri, oc_map, no_github):
 
         if no_github is True:
             users = [user['org_username']
-                    for user in role['users']]
+                     for user in role['users']]
             bot_users = [bot['org_username']
-                        for bot in role['bots']
-                        if bot.get('org_username')]
+                         for bot in role['bots']
+                         if bot.get('org_username')]
         else:
             users = [user['github_username']
-                    for user in role['users']]
+                     for user in role['users']]
             bot_users = [bot['github_username']
-                        for bot in role['bots']
-                        if bot.get('github_username')]
-        
+                         for bot in role['bots']
+                         if bot.get('github_username')]
+
         users.extend(bot_users)
         service_accounts = [bot['openshift_serviceaccount']
                             for bot in role['bots']

--- a/reconcile/openshift_users.py
+++ b/reconcile/openshift_users.py
@@ -55,7 +55,7 @@ def fetch_current_state(thread_pool_size, internal, use_jump_host):
 def fetch_desired_state(oc_map):
     desired_state = []
     flat_rolebindings_desired_state = openshift_rolebindings.fetch_desired_state(
-        ri=None, oc_map=oc_map
+        ri=None, oc_map=oc_map, no_github=False
     )
     desired_state.extend(flat_rolebindings_desired_state)
 


### PR DESCRIPTION
This MR adds support for general IDP providers outside of github when associating users with rolebindings and clusterrolebindings.

The option `--no-github` has been added to both click commands for the integrations. The graphql query has been updated for both users and bots, and `fetch_desired_state` branches to either github_username or org_username depending on the flag.