### PR TITLE
[aws-iam-keys] filter accounts without delete keys

### DIFF
--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -11,6 +11,7 @@ QONTRACT_INTEGRATION = "aws-iam-keys"
 
 
 def filter_accounts(accounts, account_name):
+    accounts = [a for a in accounts if a.get("deleteKeys")]
     if account_name:
         accounts = [a for a in accounts if a["name"] == account_name]
     return accounts

--- a/reconcile/test/test_aws_iam_keys.py
+++ b/reconcile/test/test_aws_iam_keys.py
@@ -4,18 +4,25 @@ import reconcile.aws_iam_keys as integ
 
 class TestSupportFunctions(TestCase):
     def test_filter_accounts_with_account_name(self):
-        a = {"name": "a"}
-        b = {"name": "b"}
+        a = {"name": "a", "deleteKeys": ["AKIA"]}
+        b = {"name": "b", "deleteKeys": ["AKIA"]}
         accounts = [a, b]
         filtered = integ.filter_accounts(accounts, a["name"])
         self.assertEqual(filtered, [a])
 
     def test_filter_accounts_without_account_name(self):
-        a = {"name": "a"}
-        b = {"name": "b"}
+        a = {"name": "a", "deleteKeys": ["AKIA"]}
+        b = {"name": "b", "deleteKeys": ["AKIA"]}
         accounts = [a, b]
         filtered = integ.filter_accounts(accounts, None)
         self.assertEqual(filtered, accounts)
+
+    def test_filter_accounts_without_delete_keys(self):
+        a = {"name": "a", "deleteKeys": ["AKIA"]}
+        b = {"name": "b"}
+        accounts = [a, b]
+        filtered = integ.filter_accounts(accounts, None)
+        self.assertEqual(filtered, [a])
 
     def test_get_keys_to_delete(self):
         a = {"name": "a", "deleteKeys": ["k1", "k2"]}


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-4621

if there is nothing to do, why not filter it.