### PR TITLE
[aws-support-cases-sos] filter accounts without premium support

### DIFF
--- a/reconcile/aws_support_cases_sos.py
+++ b/reconcile/aws_support_cases_sos.py
@@ -12,7 +12,7 @@ QONTRACT_INTEGRATION = "aws-support-cases-sos"
 
 
 def filter_accounts(accounts):
-    return [a for a in accounts if a.get('premiumSupport')]
+    return [a for a in accounts if a.get("premiumSupport")]
 
 
 def get_deleted_keys(accounts):

--- a/reconcile/aws_support_cases_sos.py
+++ b/reconcile/aws_support_cases_sos.py
@@ -11,6 +11,10 @@ from reconcile.utils.aws_api import AWSApi
 QONTRACT_INTEGRATION = "aws-support-cases-sos"
 
 
+def filter_accounts(accounts):
+    return [a for a in accounts if a.get('premiumSupport')]
+
+
 def get_deleted_keys(accounts):
     return {
         account["name"]: account["deleteKeys"]
@@ -53,7 +57,7 @@ def act(dry_run, gitlab_project_id, accounts, keys_to_delete):
 
 
 def run(dry_run, gitlab_project_id=None, thread_pool_size=10, enable_deletion=False):
-    accounts = queries.get_aws_accounts()
+    accounts = filter_accounts(queries.get_aws_accounts())
     settings = queries.get_app_interface_settings()
     aws = AWSApi(thread_pool_size, accounts, settings=settings)
     deleted_keys = get_deleted_keys(accounts)

--- a/reconcile/test/test_aws_support_cases_sos.py
+++ b/reconcile/test/test_aws_support_cases_sos.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+import reconcile.aws_support_cases_sos as integ
+
+
+class TestSupportFunctions(TestCase):
+    def test_filter_accounts(self):
+        a = {"name": "a", "premiumSupport": True}
+        b = {"name": "b", "premiumSupport": False}
+        c = {"name": "c", "premiumSupport": None}
+        d = {"name": "d"}
+        accounts = [a, b, c, d]
+        filtered = integ.filter_accounts(accounts)
+        self.assertEqual(filtered, [a])
+
+    def test_get_deleted_keys(self):
+        a = {"name": "a", "deleteKeys": ["k1", "k2"]}
+        b = {"name": "b", "deleteKeys": None}
+        c = {"name": "c", "deleteKeys": []}
+        accounts = [a, b, c]
+        expected_result = {a["name"]: a["deleteKeys"]}
+        keys_to_delete = integ.get_deleted_keys(accounts)
+        self.assertEqual(keys_to_delete, expected_result)


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-4621

if premium support is not enabled, the integration can't do it's work. it's worthless to try :)