### PR TITLE
[terraform-resources] ASG add support for upstream job

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -282,6 +282,17 @@ provider
     tag_name
     url
     ref
+    upstream {
+      instance {
+        token {
+          path
+          field
+          version
+          format
+        }
+      }
+      name
+    }
   }
   output_resource_name
   annotations

--- a/reconcile/test/test_utils_terrascript_client.py
+++ b/reconcile/test/test_utils_terrascript_client.py
@@ -46,3 +46,38 @@ def test_validate_mandatory_policies():
         account, [mandatory_policy], 'role') is True
     assert ts._validate_mandatory_policies(
         account, [not_mandatory_policy], 'role') is False
+
+
+class MockJenkinsApi:
+    def __init__(self, response):
+        self.response = response
+
+    def is_job_running(self, name):
+        return self.response
+
+
+def test_use_previous_image_id_no_upstream():
+    ts = tsclient.TerrascriptClient('', '', 1, [])
+    assert ts._use_previous_image_id({}) is False
+
+
+def test_use_previous_image_id_false(mocker):
+    result = False
+    mocker.patch(
+        'reconcile.utils.terrascript_client.TerrascriptClient.init_jenkins',
+        return_value=MockJenkinsApi(result)
+    )
+    ts = tsclient.TerrascriptClient('', '', 1, [])
+    image = {'upstream': {'instance': {'name': 'ci'}, 'name': 'job'}}
+    assert ts._use_previous_image_id(image) == result
+
+
+def test_use_previous_image_id_true(mocker):
+    result = True
+    mocker.patch(
+        'reconcile.utils.terrascript_client.TerrascriptClient.init_jenkins',
+        return_value=MockJenkinsApi(result)
+    )
+    ts = tsclient.TerrascriptClient('', '', 1, [])
+    image = {'upstream': {'instance': {'name': 'ci'}, 'name': 'job'}}
+    assert ts._use_previous_image_id(image) == result

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1283,7 +1283,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
             logging.error(f'[{account_name}] unhandled exception: {e}')
 
     def get_image_id(self, account_name: str, region_name: str,
-                     tag: Mapping[str, str]) -> str:
+                     tag: Mapping[str, str]) -> Optional[str]:
         """
         Get AMI ID matching the specified criteria.
 
@@ -1302,5 +1302,5 @@ class AWSApi:  # pylint: disable=too-many-public-methods
                 f"found multiple AMI with tag {tag} " +
                 f"in account {account_name}")
         elif not images:
-            return ''
+            return None
         return images[0]['ImageId']

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -4106,7 +4106,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         return ''
 
     def _get_asg_image_id(self, image: dict,
-                          account: str, region: str) -> Tuple[str, str]:
+                          account: str, region: str) -> Tuple[Optional[str], str]:
         """
         AMI ID comes form AWS Api filter result.
         AMI needs to be shared by integration aws-ami-share.
@@ -4126,9 +4126,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             'Value': commit_sha
         }
         image_id = aws.get_image_id(account, region, tag)
-        if not image_id:
-            raise ValueError(f"could not find ami with tag {tag} "
-                             f"in account {account}")
 
         return image_id, commit_sha
 
@@ -4171,6 +4168,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         image = common_values.get('image')
         image_id, commit_sha = \
             self._get_asg_image_id(image, account, region)
+        if not image_id:
+            raise ValueError(f"could not find ami for commit {commit_sha} "
+                             f"in account {account}")
         template_values['image_id'] = image_id
 
         if self._multiregion_account(account):

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -4184,6 +4184,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         if not image_id:
             if self._use_previous_image_id(image):
                 image_id = existing_secrets[account][output_prefix]['image_id']
+                commit_sha = existing_secrets[account][output_prefix]['commit_sha']
+                logging.warning(
+                    f"[{account}] ami {image_id} not yet available. "
+                    f"using ami for previous commit {commit_sha}."
+                )
             else:
                 raise ValueError(f"could not find ami for commit {commit_sha} "
                                  f"in account {account}")

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -4134,7 +4134,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         return image_id, commit_sha
 
     def _use_previous_image_id(self, image: dict) -> bool:
-        # if upstream job is running - use previous commit
         upstream = image.get('upstream')
         if upstream:
             jenkins = self.init_jenkins(upstream['instance'])

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -4186,7 +4186,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 image_id = existing_secrets[account][output_prefix]['image_id']
             else:
                 raise ValueError(f"could not find ami for commit {commit_sha} "
-                                f"in account {account}")
+                                 f"in account {account}")
         template_values['image_id'] = image_id
 
         if self._multiregion_account(account):


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-3925

depends on https://github.com/app-sre/qontract-schemas/pull/95

now that we have support for continuous deployment of AMIs, we want to avoid failing under healthy conditions.
for example, once a new commit is pushed, the integration tries to use a corresponding AMI. initially, that AMI is being built, which means it doesn't exist yet.

to be able to not fail in this condition, and to improve visibility from the ASG definition, this PR adds support for an upstream job to wait for (like saas files).
