### PR TITLE
APPSRE-4404 move data from toml to app-interface

### DIFF
--- a/reconcile/github_repo_invites.py
+++ b/reconcile/github_repo_invites.py
@@ -1,6 +1,9 @@
 import logging
 import os
 
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Optional
+
 from reconcile.utils import gql
 from reconcile.utils import raw_github_api
 from reconcile.utils.secret_reader import SecretReader
@@ -23,22 +26,21 @@ REPOS_QUERY = """
 QONTRACT_INTEGRATION = "github-repo-invites"
 
 
-def run(dry_run):
-    gqlapi = gql.get_api()
-    result = gqlapi.query(REPOS_QUERY)
-    config = get_config()["github-repo-invites"]
-    settings = queries.get_app_interface_settings()
-    secret_reader = SecretReader(settings=settings)
-    secret = {"path": config["secret_path"], "field": config["secret_field"]}
-    token = secret_reader.read(secret)
-    g = raw_github_api.RawGithubApi(token)
+@dataclass
+class CodeComponents:
+    urls: set[str]
+    known_orgs: set[str]
 
+
+def _parse_code_components(
+    raw: Optional[Iterable[Mapping[str, Any]]]
+) -> CodeComponents:
     urls = set()
     known_orgs = set()
-    for app in result["apps_v1"]:
+    for app in raw or []:
         code_components = app["codeComponents"]
 
-        if code_components is None:
+        if not code_components:
             continue
 
         for code_component in app["codeComponents"]:
@@ -46,9 +48,19 @@ def run(dry_run):
             urls.add(url)
             org = url[: url.rindex("/")]
             known_orgs.add(org)
+    return CodeComponents(
+        urls=urls,
+        known_orgs=known_orgs,
+    )
 
-    invitations = set()
-    for i in g.repo_invitations():
+
+def _accept_invitations(
+    github: raw_github_api.RawGithubApi, code_components: CodeComponents, dry_run: bool
+) -> set[str]:
+    accepted_invitations = set()
+    urls = code_components.urls
+    known_orgs = code_components.known_orgs
+    for i in github.repo_invitations():
         invitation_id = i["id"]
         invitation_url = i["html_url"]
 
@@ -57,11 +69,35 @@ def run(dry_run):
         accept = url in urls or any(url.startswith(org) for org in known_orgs)
         if accept:
             logging.info(["accept", url])
-            invitations.add(url)
+            accepted_invitations.add(url)
 
             if not dry_run:
-                g.accept_repo_invitation(invitation_id)
+                github.accept_repo_invitation(invitation_id)
         else:
             logging.debug(["skipping", url])
+    return accepted_invitations
 
-    return invitations
+
+def run(dry_run):
+    gqlapi = gql.get_api()
+    result = gqlapi.query(REPOS_QUERY)
+    settings = queries.get_app_interface_settings()
+    secret_reader = SecretReader(settings=settings)
+
+    # TODO kfischer: This is placed for backwards compatibility.
+    # Once all app-interfaces added the new 'githubRepoInvites' section,
+    # then we can remove this.
+    secret = {}
+    if not settings.get("githubRepoInvites"):
+        config = get_config()["github-repo-invites"]
+        secret = {"path": config["secret_path"], "field": config["secret_field"]}
+    else:
+        secret = settings["githubRepoInvites"]["credentials"]
+
+    token = secret_reader.read(secret)
+    g = raw_github_api.RawGithubApi(token)
+
+    code_components = _parse_code_components(result["apps_v1"])
+    accepted_invitations = _accept_invitations(g, code_components, dry_run)
+
+    return accepted_invitations

--- a/reconcile/github_repo_invites.py
+++ b/reconcile/github_repo_invites.py
@@ -9,8 +9,6 @@ from reconcile.utils import raw_github_api
 from reconcile.utils.secret_reader import SecretReader
 from reconcile import queries
 
-from reconcile.utils.config import get_config
-
 
 REPOS_QUERY = """
 {
@@ -83,17 +81,7 @@ def run(dry_run):
     result = gqlapi.query(REPOS_QUERY)
     settings = queries.get_app_interface_settings()
     secret_reader = SecretReader(settings=settings)
-
-    # TODO kfischer: This is placed for backwards compatibility.
-    # Once all app-interfaces added the new 'githubRepoInvites' section,
-    # then we can remove this.
-    secret = {}
-    if not settings.get("githubRepoInvites"):
-        config = get_config()["github-repo-invites"]
-        secret = {"path": config["secret_path"], "field": config["secret_field"]}
-    else:
-        secret = settings["githubRepoInvites"]["credentials"]
-
+    secret = settings["githubRepoInvites"]["credentials"]
     token = secret_reader.read(secret)
     g = raw_github_api.RawGithubApi(token)
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -27,6 +27,14 @@ APP_INTERFACE_SETTINGS_QUERY = """
         format
       }
     }
+    githubRepoInvites {
+      credentials {
+        path
+        field
+        version
+        format
+      }
+    }
     ldap {
       serverUrl
       baseDn

--- a/reconcile/test/test_github_repo_invites.py
+++ b/reconcile/test/test_github_repo_invites.py
@@ -1,0 +1,116 @@
+from unittest.mock import MagicMock
+from reconcile import github_repo_invites
+from typing import Any, Iterable, Mapping
+
+from reconcile.utils.raw_github_api import RawGithubApi
+
+import pytest
+
+
+def test_parse_null_code_components():
+    raw_code_components = None
+    expected = github_repo_invites.CodeComponents(
+        urls=set(),
+        known_orgs=set(),
+    )
+    assert github_repo_invites._parse_code_components(raw_code_components) == expected
+
+
+def test_parse_valid_code_components():
+    raw_code_components: Iterable[Mapping[str, Any]] = [
+        {
+            "codeComponents": [
+                {
+                    "url": "org1/project1",
+                    "resource": "upstream",
+                },
+                {
+                    "url": "org2/project1",
+                    "resource": "upstream",
+                },
+            ],
+        },
+        {
+            "codeComponents": [],
+        },
+        {
+            "codeComponents": [
+                {
+                    "url": "org2/project2",
+                    "resource": "upstream",
+                }
+            ],
+        },
+    ]
+    expected = github_repo_invites.CodeComponents(
+        urls=set(
+            [
+                "org1/project1",
+                "org2/project1",
+                "org2/project2",
+            ]
+        ),
+        known_orgs=set(
+            [
+                "org1",
+                "org2",
+            ]
+        ),
+    )
+    assert github_repo_invites._parse_code_components(raw_code_components) == expected
+
+
+@pytest.fixture
+def github():
+    mock = MagicMock(spec=RawGithubApi)
+    mock.repo_invitations = MagicMock()
+    mock.accept_repo_invitation = MagicMock()
+    return mock
+
+
+def test_accept_invitations_no_dry_run(github):
+    github.repo_invitations.side_effect = [
+        [
+            {
+                "id": "123",
+                "html_url": "org1/project1",
+            },
+            {
+                "id": "456",
+                "html_url": "org3/project1",
+            },
+        ]
+    ]
+    code_components = github_repo_invites.CodeComponents(
+        urls=set(["org1/project1"]),
+        known_orgs=set(["org1"]),
+    )
+    dry_run = False
+    accepted_invitations = github_repo_invites._accept_invitations(
+        github, code_components, dry_run
+    )
+
+    github.accept_repo_invitation.assert_called_once_with("123")
+    assert accepted_invitations == set(["org1"])
+
+
+def test_accept_invitations_dry_run(github):
+    github.repo_invitations.side_effect = [
+        [
+            {
+                "id": "123",
+                "html_url": "org1/project1",
+            },
+        ],
+    ]
+    code_components = github_repo_invites.CodeComponents(
+        urls=set(["org1/project1"]),
+        known_orgs=set(["org1"]),
+    )
+    dry_run = True
+    accepted_invitations = github_repo_invites._accept_invitations(
+        github, code_components, dry_run
+    )
+
+    github.accept_repo_invitation.assert_not_called()
+    assert accepted_invitations == set(["org1"])

--- a/reconcile/test/test_github_repo_invites.py
+++ b/reconcile/test/test_github_repo_invites.py
@@ -21,11 +21,11 @@ def test_parse_valid_code_components():
         {
             "codeComponents": [
                 {
-                    "url": "org1/project1",
+                    "url": "https://github.com/org1/project1",
                     "resource": "upstream",
                 },
                 {
-                    "url": "org2/project1",
+                    "url": "https://github.com/org2/project1",
                     "resource": "upstream",
                 },
             ],
@@ -36,7 +36,7 @@ def test_parse_valid_code_components():
         {
             "codeComponents": [
                 {
-                    "url": "org2/project2",
+                    "url": "https://github.com/org2/project2",
                     "resource": "upstream",
                 }
             ],
@@ -45,15 +45,15 @@ def test_parse_valid_code_components():
     expected = github_repo_invites.CodeComponents(
         urls=set(
             [
-                "org1/project1",
-                "org2/project1",
-                "org2/project2",
+                "https://github.com/org1/project1",
+                "https://github.com/org2/project1",
+                "https://github.com/org2/project2",
             ]
         ),
         known_orgs=set(
             [
-                "org1",
-                "org2",
+                "https://github.com/org1",
+                "https://github.com/org2",
             ]
         ),
     )
@@ -69,43 +69,46 @@ def github():
 
 
 def test_accept_invitations_no_dry_run(github):
+    expected_id = "123"
+    expected_org = "https://github.com/org1"
     github.repo_invitations.side_effect = [
         [
             {
-                "id": "123",
-                "html_url": "org1/project1",
+                "id": expected_id,
+                "html_url": f"{expected_org}/project1",
             },
             {
                 "id": "456",
-                "html_url": "org3/project1",
+                "html_url": "https://github.com/org3/project1",
             },
         ]
     ]
     code_components = github_repo_invites.CodeComponents(
-        urls=set(["org1/project1"]),
-        known_orgs=set(["org1"]),
+        urls=set([f"{expected_org}/project1"]),
+        known_orgs=set([expected_org]),
     )
     dry_run = False
     accepted_invitations = github_repo_invites._accept_invitations(
         github, code_components, dry_run
     )
 
-    github.accept_repo_invitation.assert_called_once_with("123")
-    assert accepted_invitations == set(["org1"])
+    github.accept_repo_invitation.assert_called_once_with(expected_id)
+    assert accepted_invitations == set([expected_org])
 
 
 def test_accept_invitations_dry_run(github):
+    expected_org = "https://github.com/org1"
     github.repo_invitations.side_effect = [
         [
             {
                 "id": "123",
-                "html_url": "org1/project1",
+                "html_url": f"{expected_org}/project1",
             },
         ],
     ]
     code_components = github_repo_invites.CodeComponents(
-        urls=set(["org1/project1"]),
-        known_orgs=set(["org1"]),
+        urls=set([f"{expected_org}/project1"]),
+        known_orgs=set([expected_org]),
     )
     dry_run = True
     accepted_invitations = github_repo_invites._accept_invitations(
@@ -113,4 +116,4 @@ def test_accept_invitations_dry_run(github):
     )
 
     github.accept_repo_invitation.assert_not_called()
-    assert accepted_invitations == set(["org1"])
+    assert accepted_invitations == set([expected_org])


### PR DESCRIPTION
**Motivation**

We currently store configuration for the github-repo-invites integration in our config.toml. This PR makes `github-repo-invites` read the configuration from `app-interface`, making the `[github-repo-invites]` section redundant.

Further, this PR refactors the `github-repo-invites` integration and adds unit tests for it.

~This PR keeps backwards compatibility by using `config.toml` if gql does not return required data. Once all app-interfaces are migrated, we can remove this backwards compatibility option.~ Backwards compatibility is not required, as there is only one app-interface using this integration.

**Test**

- Successfully ran with `--dry-run` for corresponding schema https://github.com/app-sre/qontract-schemas/pull/97
- added unit tests to cover the important logic