### PR TITLE
[terraform-aws-route53] add support for target namespace zone

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2130,6 +2130,19 @@ DNS_ZONES_QUERY = """
         name
         elbFQDN
       }
+      _target_namespace_zone {
+        namespace {
+          terraformResources {
+            provider
+            ... on NamespaceTerraformResourceRoute53Zone_v1 {
+              account
+              region
+              name
+            }
+          }
+        }
+        name
+      }
     }
   }
 }

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -19,10 +19,8 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
 def build_desired_state(
-        zones: list[dict],
-        all_accounts: list[dict],
-        settings: dict
-    ) -> list[dict]:
+    zones: list[dict], all_accounts: list[dict], settings: dict
+) -> list[dict]:
     """
     Build the desired state from the app-interface resources
 

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -7,6 +7,7 @@ from reconcile import queries
 
 from reconcile.status import ExitCodes
 from reconcile.utils import dnsutils
+from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.defer import defer
 from reconcile.utils.terrascript_client import TerrascriptClient as Terrascript
@@ -17,7 +18,7 @@ QONTRACT_INTEGRATION = "terraform_aws_route53"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
-def build_desired_state(zones):
+def build_desired_state(zones, all_accounts, settings):
     """
     Build the desired state from the app-interface resources
 
@@ -116,6 +117,50 @@ def build_desired_state(zones):
                 logging.debug(msg)
                 record["records"] = record_values
 
+            # Process '_target_namespace_zone'
+            target_namespace_zone = record.pop("_target_namespace_zone", None)
+            if target_namespace_zone:
+                tf_resources = target_namespace_zone["namespace"]["terraformResources"]
+                tf_zone_name = target_namespace_zone["name"]
+                tf_zone_resources = [
+                    tfr
+                    for tfr in tf_resources
+                    if tfr["provider"] == "route53-zone" and tfr["name"] == tf_zone_name
+                ]
+                if not tf_zone_resources:
+                    logging.error(
+                        f"{zone_name}: field `_target_namespace_zone` found "
+                        f"for record {record_name}, but target zone not found: "
+                        f"{tf_zone_name}"
+                    )
+                    sys.exit(ExitCodes.ERROR)
+                tf_zone_resource = tf_zone_resources[0]
+                tf_zone_account_name = tf_zone_resource["account"]
+                zone_account = [
+                    a for a in all_accounts if a["name"] == tf_zone_account_name
+                ][0]
+                awsapi = AWSApi(1, [zone_account], settings=settings, init_users=False)
+                tf_zone_region = (
+                    tf_zone_resource.get("region")
+                    or zone_account["resourcesDefaultRegion"]
+                )
+                tf_zone_ns_records = awsapi.get_route53_zone_ns_records(
+                    tf_zone_account_name, tf_zone_name, tf_zone_region
+                )
+                if not tf_zone_ns_records:
+                    logging.warning(
+                        f"{zone_name}: field `_target_namespace_zone` found "
+                        f"for record {record_name}, but target zone not found (yet): "
+                        f"{tf_zone_name}"
+                    )
+                    continue
+                logging.debug(
+                    f"{zone_name}: field `_target_namespace_zone` found "
+                    f"for record {record_name}, Values are: "
+                    f"{tf_zone_ns_records}"
+                )
+                record["records"] = tf_zone_ns_records
+
             # Process '_healthcheck'
             healthcheck = record.pop("_healthcheck", None)
             if healthcheck:
@@ -143,11 +188,10 @@ def run(
     settings = queries.get_app_interface_settings()
     zones = queries.get_dns_zones()
 
+    all_accounts = queries.get_aws_accounts()
     participating_account_names = [z["account"]["name"] for z in zones]
     participating_accounts = [
-        a
-        for a in queries.get_aws_accounts()
-        if a["name"] in participating_account_names
+        a for a in all_accounts if a["name"] in participating_account_names
     ]
 
     ts = Terrascript(
@@ -158,7 +202,7 @@ def run(
         settings=settings,
     )
 
-    desired_state = build_desired_state(zones)
+    desired_state = build_desired_state(zones, all_accounts, settings)
 
     ts.populate_route53(desired_state)
     working_dirs = ts.dump(print_to_file=print_to_file)

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import sys
+from typing import Iterable, Mapping
 
 
 from reconcile import queries
@@ -19,7 +20,7 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
 def build_desired_state(
-    zones: list[dict], all_accounts: list[dict], settings: dict
+    zones: Iterable[Mapping], all_accounts: Iterable[Mapping], settings: Mapping
 ) -> list[dict]:
     """
     Build the desired state from the app-interface resources

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -18,7 +18,11 @@ QONTRACT_INTEGRATION = "terraform_aws_route53"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
-def build_desired_state(zones, all_accounts, settings):
+def build_desired_state(
+        zones: list[dict],
+        all_accounts: list[dict],
+        settings: dict
+    ) -> list[dict]:
     """
     Build the desired state from the app-interface resources
 

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -28,13 +28,13 @@ if TYPE_CHECKING:
     from mypy_boto3_iam import IAMClient
     from mypy_boto3_iam.type_defs import AccessKeyMetadataTypeDef
     from mypy_boto3_route53 import Route53Client
-    from mypy_boto3_route53.type_defs import ResourceRecordSetTypeDef, HostedZoneTypeDef
+    from mypy_boto3_route53.type_defs import ResourceRecordSetTypeDef, ResourceRecordTypeDef, HostedZoneTypeDef
 else:
     EC2Client = EC2ServiceResource = RouteTableTypeDef = SubnetTypeDef = TransitGatewayTypeDef = \
         TransitGatewayVpcAttachmentTypeDef = VpcTypeDef = IAMClient = \
         AccessKeyMetadataTypeDef = ImageTypeDef = TagTypeDef = \
         LaunchPermissionModificationsTypeDef = FilterTypeDef = \
-        Route53Client = ResourceRecordSetTypeDef = HostedZoneTypeDef = object
+        Route53Client = ResourceRecordSetTypeDef = ResourceRecordTypeDef = HostedZoneTypeDef = object
 
 
 class InvalidResourceTypeError(Exception):
@@ -1188,7 +1188,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         return [r for r in record_sets if r["Name"] == f"{zone_name}." and r["Type"] == zone_type]
 
     @staticmethod
-    def _extract_records(resource_records: List[ResourceRecordSetTypeDef]) -> list[str]:
+    def _extract_records(resource_records: List[ResourceRecordTypeDef]) -> list[str]:
         # [{'Value': 'ns.example.com.'}, ...]
         return [r['Value'].rstrip(".") for r in resource_records]
 

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1167,8 +1167,8 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
         return results
 
-    def _get_hosted_zone_record_sets(self,
-                                     route53: Route53Client,
+    @staticmethod
+    def _get_hosted_zone_record_sets(route53: Route53Client,
                                      zone_name: str) -> List[ResourceRecordSetTypeDef]:
         zones = route53.list_hosted_zones_by_name(DNSName=zone_name)["HostedZones"]
         if not zones:

--- a/requirements/requirements-type.txt
+++ b/requirements/requirements-type.txt
@@ -9,4 +9,4 @@ types-PyYAML
 types-requests
 types-tabulate
 types-toml
-boto3-stubs[ec2,s3,rds,iam]
+boto3-stubs[ec2,s3,rds,iam,route53]


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4705

depends on https://github.com/app-sre/qontract-schemas/pull/98

similar to using `_target_cluster` to obtain the elb fqdn, we can target a namespace with a route53-zone provisioned in it to automatically obtain NS records of that zone (instead of hard coding them): `target_namespace_zone`.

example: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/35369