### PR TITLE
determine user key for openshift access

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -800,14 +800,15 @@ def aggregate_shared_resources(namespace_info, shared_resources_type):
 
 
 def determine_user_key_for_access(cluster_info: dict) -> str:
+    AUTH_METHOD_USER_KEY = {
+        "github-org": "github_username",
+        "github-org-team": "github_username",
+        "oidc": "org_username",
+    }
     service = cluster_info["auth"]["service"]
-    if service == "github-org":
-        return "github_username"
-    if service == "github-org-team":
-        return "github_username"
-    if service == "oidc":
-        return "org_username"
-
-    raise NotImplementedError(
-        f"[{cluster_info['name']} auth service not implemented: {service}]"
-    )
+    try:
+        return AUTH_METHOD_USER_KEY[service]
+    except KeyError:
+        raise NotImplementedError(
+            f"[{cluster_info['name']} auth service not implemented: {service}]"
+        )

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -797,3 +797,17 @@ def aggregate_shared_resources(namespace_info, shared_resources_type):
         else:
             namespace_type_resources = shared_type_resources_items
             namespace_info[shared_resources_type] = namespace_type_resources
+
+
+def determine_user_key_for_access(cluster_info: dict) -> str:
+    service = cluster_info["auth"]["service"]
+    if service == "github-org":
+        return "github_username"
+    if service == "github-org-team":
+        return "github_username"
+    if service == "oidc":
+        return "org_username"
+
+    raise NotImplementedError(
+        f"[{cluster_info['name']} auth service not implemented: {service}]"
+    )

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -103,7 +103,6 @@ def fetch_desired_state(ri, oc_map):
         if not permissions:
             continue
 
-        users = [user for user in role['users']]
         service_accounts = [bot['openshift_serviceaccount']
                             for bot in role['bots']
                             if bot.get('openshift_serviceaccount')]
@@ -114,7 +113,7 @@ def fetch_desired_state(ri, oc_map):
             if not oc_map.get(cluster):
                 continue
             user_key = ob.determine_user_key_for_access(cluster_info)
-            for user in users:
+            for user in role['users']:
                 # used by openshift-users and github integrations
                 # this is just to simplify things a bit on the their side
                 users_desired_state.append({

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -19,7 +19,6 @@ ROLES_QUERY = """
       github_username
     }
     bots {
-      github_username
       openshift_serviceaccount
     }
     access {
@@ -102,10 +101,6 @@ def fetch_desired_state(ri, oc_map):
 
         users = [user['github_username']
                  for user in role['users']]
-        bot_users = [bot['github_username']
-                     for bot in role['bots']
-                     if bot.get('github_username')]
-        users.extend(bot_users)
         service_accounts = [bot['openshift_serviceaccount']
                             for bot in role['bots']
                             if bot.get('openshift_serviceaccount')]

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -101,10 +101,6 @@ def fetch_desired_state(ri, oc_map):
 
         users = [user['github_username']
                  for user in role['users']]
-        bot_users = [bot['github_username']
-                     for bot in role['bots']
-                     if bot.get('github_username')]
-        users.extend(bot_users)
         service_accounts = [bot['openshift_serviceaccount']
                             for bot in role['bots']
                             if bot.get('openshift_serviceaccount')]

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -15,6 +15,7 @@ ROLES_QUERY = """
   roles: roles_v1 {
     name
     users {
+      org_username
       github_username
     }
     bots {
@@ -26,6 +27,9 @@ ROLES_QUERY = """
         managedRoles
         cluster {
           name
+          auth {
+            service
+          }
         }
       }
       role
@@ -89,7 +93,7 @@ def fetch_desired_state(ri, oc_map):
     roles = expiration.filter(gqlapi.query(ROLES_QUERY)['roles'])
     users_desired_state = []
     for role in roles:
-        permissions = [{'cluster': a['namespace']['cluster']['name'],
+        permissions = [{'cluster': a['namespace']['cluster'],
                         'namespace': a['namespace']['name'],
                         'role': a['role']}
                        for a in role['access'] or []
@@ -98,30 +102,31 @@ def fetch_desired_state(ri, oc_map):
         if not permissions:
             continue
 
-        users = [user['github_username']
-                 for user in role['users']]
+        users = [user for user in role['users']]
         service_accounts = [bot['openshift_serviceaccount']
                             for bot in role['bots']
                             if bot.get('openshift_serviceaccount')]
 
         for permission in permissions:
-            cluster = permission['cluster']
+            cluster_info = permission['cluster']
+            cluster = cluster_info['name']
             namespace = permission['namespace']
             if not is_in_shard(f"{cluster}/{namespace}"):
                 continue
             if oc_map and not oc_map.get(cluster):
                 continue
+            user_key = ob.determine_user_key_for_access(cluster_info)
             for user in users:
                 # used by openshift-users and github integrations
                 # this is just to simplify things a bit on the their side
                 users_desired_state.append({
                     'cluster': cluster,
-                    'user': user
+                    'user': user[user_key]
                 })
                 if ri is None:
                     continue
                 oc_resource, resource_name = \
-                    construct_user_oc_resource(permission['role'], user)
+                    construct_user_oc_resource(permission['role'], user[user_key])
                 try:
                     ri.add_desired(
                         cluster,

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -18,7 +18,6 @@ ROLES_QUERY = """
       github_username
     }
     bots {
-      github_username
       openshift_serviceaccount
     }
     access {

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -102,7 +102,6 @@ def fetch_desired_state(ri, oc_map):
         if not permissions:
             continue
 
-        users = [user for user in role['users']]
         service_accounts = [bot['openshift_serviceaccount']
                             for bot in role['bots']
                             if bot.get('openshift_serviceaccount')]
@@ -116,7 +115,7 @@ def fetch_desired_state(ri, oc_map):
             if oc_map and not oc_map.get(cluster):
                 continue
             user_key = ob.determine_user_key_for_access(cluster_info)
-            for user in users:
+            for user in role['users']:
                 # used by openshift-users and github integrations
                 # this is just to simplify things a bit on the their side
                 users_desired_state.append({

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -406,8 +406,15 @@ CLUSTERS_QUERY = """
     }
     auth {
       service
-      org
-      team
+      ... on ClusterAuthGithubOrg_v1 {
+        org
+      }
+      ... on ClusterAuthGithubOrgTeam_v1 {
+        org
+        team
+      }
+      # ... on ClusterAuthOIDC_v1 {
+      # }
     }
     ocm {
       name

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -1,4 +1,5 @@
 from typing import List, cast
+import pytest
 
 import testslide
 import reconcile.openshift_base as sut
@@ -222,3 +223,27 @@ class TestInitSpecsToFetch(testslide.TestCase):
             override_managed_types=["LimitRanges"],
         )
         self.assert_specs_match(rs, expected)
+
+
+def test_determine_user_key_for_access_github_org():
+    cluster_info = {"auth": {"service": "github-org"}}
+    user_key = sut.determine_user_key_for_access(cluster_info)
+    assert user_key == "github_username"
+
+
+def test_determine_user_key_for_access_github_org_team():
+    cluster_info = {"auth": {"service": "github-org-team"}}
+    user_key = sut.determine_user_key_for_access(cluster_info)
+    assert user_key == "github_username"
+
+
+def test_determine_user_key_for_access_oidc():
+    cluster_info = {"auth": {"service": "oidc"}}
+    user_key = sut.determine_user_key_for_access(cluster_info)
+    assert user_key == "org_username"
+
+
+def test_determine_user_key_for_access_not_implemented():
+    cluster_info = {"auth": {"service": "not-implemented"}, "name": "c"}
+    with pytest.raises(NotImplementedError):
+        sut.determine_user_key_for_access(cluster_info)


### PR DESCRIPTION
part of part of https://issues.redhat.com/browse/APPSRE-4663

depends on https://github.com/app-sre/qontract-schemas/pull/100

this PR introduces new logic to the following integrations:
- openshift-clusterrolebindings
- openshift-groups
- openshift-rolebindings
- openshift-users (because it uses `fetch_desired_state` from the above integrations)

instead of always using the `github_username` field, we choose which field to use based on the cluster auth `service`.
the addition in this PR - for `service: oidc` we use `org_username`.

note: this PR also removes logic to add github bots to cluster access since it is not something we need to do (and it's not used).