### PR TITLE
canonicalize ACM ManagedCluster CR

### DIFF
--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -156,3 +156,55 @@ def test_secret_string_data():
     }
     result = OR.canonicalize(resource)
     assert result == expected
+
+
+def test_managed_cluster_drift():
+    d1 = {
+        "apiVersion": "cluster.open-cluster-management.io/v1",
+        "kind": "ManagedCluster",
+        "metadata": {
+            "labels": {
+                "cluster.open-cluster-management.io/clusterset": "default",
+            },
+            "name": "xxx"
+        },
+        "spec": {
+            "hubAcceptsClient": True
+        }
+    }
+    o1 = OR(d1, TEST_INT, TEST_INT_VER)
+    d2 = {
+        "apiVersion": "cluster.open-cluster-management.io/v1",
+        "kind": "ManagedCluster",
+        "metadata": {
+            "labels": {
+                "cloud": "Amazon",
+                "cluster.open-cluster-management.io/clusterset": "default",
+                "name": "xxx",
+                "vendor": "OpenShift",
+                "clusterID": "yyy",
+                "feature.open-cluster-management.io/addon-work-manager": "available",
+                "managed-by": "platform",
+                "openshiftVersion": "x.y.z"
+            },
+            "name": "xxx"
+        },
+        "spec": {
+            "hubAcceptsClient": True,
+            "leaseDurationSeconds": 60,
+            "managedClusterClientConfigs": [
+                {
+                    "caBundle": "xxx",
+                    "url": "https://api.xxx:6443"
+                }
+            ]
+        },
+        "status": {
+        }
+    }
+    o2 = OR(d2, TEST_INT, TEST_INT_VER)
+    assert o1 != o2
+
+    c1 = OR(OR.canonicalize(o1.body), TEST_INT, TEST_INT_VER)
+    c2 = OR(OR.canonicalize(o2.body), TEST_INT, TEST_INT_VER)
+    assert c1 == c2

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -350,17 +350,13 @@ class OpenshiftResource:
                 "feature.open-cluster-management.io/addon-work-manager",
                 "clusterID",
                 "managed-by",
-                "openshiftVersion"
+                "openshiftVersion",
             }
             for l in drop_labels:
                 if l in labels:
-                    labels.pop(
-                        l, None
-                    )
+                    labels.pop(l, None)
             if "open-cluster-management/created-via" in annotations:
-                annotations.pop(
-                    "open-cluster-management/created-via", None
-                )
+                annotations.pop("open-cluster-management/created-via", None)
             body["spec"].pop("managedClusterClientConfigs", None)
             for taint in body["spec"].get("taints", []):
                 taint.pop("timeAdded", None)


### PR DESCRIPTION
the ACM ManagedCluster CR has lots fields/labels/annotations that
are applied and removed dynamically by ACM controllers. removing
them in the canonicalization step (and thus removing them from the
comparision logic to detect drift) allows the a-i management of those
CRs.

part of https://issues.redhat.com/browse/APPSRE-4619

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>