### PR TITLE
Skip Terraform apply when the only RDS update would be engine_version

### DIFF
--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -209,6 +209,7 @@ def run(
 
     ts.populate_route53(desired_state)
     working_dirs = ts.dump(print_to_file=print_to_file)
+    aws_api = AWSApi(1, participating_accounts, settings)
 
     if print_to_file:
         sys.exit(ExitCodes.SUCCESS)
@@ -220,6 +221,7 @@ def run(
         participating_accounts,
         working_dirs,
         thread_pool_size,
+        aws_api,
     )
 
     if tf is None:

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -13,6 +13,7 @@ import reconcile.openshift_base as ob
 from reconcile import queries
 from reconcile.utils import gql
 from reconcile.aws_iam_keys import run as disable_keys
+from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.defer import defer
 from reconcile.utils.oc import OC_Map
@@ -448,12 +449,14 @@ def setup(dry_run, print_to_file, thread_pool_size, internal,
                                      internal, use_jump_host, account_name)
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size,
                                          settings=settings)
+    aws_api = AWSApi(1, accounts, settings=settings)
     tf = Terraform(QONTRACT_INTEGRATION,
                    QONTRACT_INTEGRATION_VERSION,
                    QONTRACT_TF_PREFIX,
                    accounts,
                    working_dirs,
-                   thread_pool_size)
+                   thread_pool_size,
+                   aws_api)
     existing_secrets = tf.get_terraform_output_secrets()
     clusters = [c for c in queries.get_clusters()
                 if c.get('ocm') is not None]

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -156,6 +156,7 @@ def run(
     ts.populate_additional_providers(participating_accounts)
     ts.populate_tgw_attachments(desired_state)
     working_dirs = ts.dump(print_to_file=print_to_file)
+    aws_api = AWSApi(1, accounts, settings)
 
     if print_to_file:
         sys.exit()
@@ -167,6 +168,7 @@ def run(
         accounts,
         working_dirs,
         thread_pool_size,
+        aws_api,
     )
 
     if tf is None:

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -1,6 +1,7 @@
 import sys
 
 from textwrap import indent
+from typing import Any
 
 from reconcile.utils import expiration
 from reconcile.utils import gql
@@ -56,7 +57,8 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 4, 2)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 
-def setup(print_to_file, thread_pool_size):
+def setup(print_to_file, thread_pool_size: int) \
+        -> tuple[list[dict[str, Any]], dict[str, str], bool, AWSApi]:
     gqlapi = gql.get_api()
     accounts = queries.get_aws_accounts()
     settings = queries.get_app_interface_settings()

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -4,6 +4,7 @@ from textwrap import indent
 
 from reconcile.utils import expiration
 from reconcile.utils import gql
+from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.smtp_client import SmtpClient
 from reconcile import queries
 
@@ -70,8 +71,9 @@ def setup(print_to_file, thread_pool_size):
                      settings=settings)
     err = ts.populate_users(tf_roles)
     working_dirs = ts.dump(print_to_file)
+    aws_api = AWSApi(1, accounts, settings)
 
-    return accounts, working_dirs, err
+    return accounts, working_dirs, err, aws_api
 
 
 def send_email_invites(new_users, settings):
@@ -115,7 +117,7 @@ def run(dry_run, print_to_file=None,
     # setup errors should skip resources that will lead
     # to terraform errors. we should still do our best
     # to reconcile all valid resources for all accounts.
-    accounts, working_dirs, setup_err = setup(print_to_file, thread_pool_size)
+    accounts, working_dirs, setup_err, aws_api = setup(print_to_file, thread_pool_size)
     if print_to_file:
         cleanup_and_exit()
     if not working_dirs:
@@ -128,6 +130,7 @@ def run(dry_run, print_to_file=None,
                    accounts,
                    working_dirs,
                    thread_pool_size,
+                   aws_api,
                    init_users=True)
     if tf is None:
         err = True

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -5,8 +5,8 @@ from typing import Any, Optional, Tuple
 
 from reconcile import queries
 from reconcile.utils import aws_api
-from reconcile.utils.aws_api import AWSApi
 from reconcile.utils import ocm
+from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.ocm import OCM, OCMMap
 import reconcile.utils.terraform_client as terraform
 import reconcile.utils.terrascript_client as terrascript
@@ -528,7 +528,8 @@ def run(dry_run, print_to_file=None,
         "",
         accounts,
         working_dirs,
-        thread_pool_size)
+        thread_pool_size,
+        awsapi)
 
     if tf is None or any(errors):
         sys.exit(1)

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -240,7 +240,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                 if action == 'update' and resource_type == 'aws_db_instance' and \
                         self._is_ignored_rds_modification(
                             name, resource_name, resource_change, output):
-                    logging.warning(
+                    logging.debug(
                         f"Not setting should_apply for {resource_name} because the "
                         f"only change is EngineVersion and that setting is in "
                         f"PendingModifiedValues")

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -239,7 +239,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                 # unnecessary Terraform state updates until they complete.
                 if action == 'update' and resource_type == 'aws_db_instance' and \
                         self._is_ignored_rds_modification(
-                            name, resource_name, resource_change, output):
+                            name, resource_name, resource_change):
                     logging.debug(
                         f"Not setting should_apply for {resource_name} because the "
                         f"only change is EngineVersion and that setting is in "
@@ -579,10 +579,10 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
             shutil.rmtree(wd)
 
     def _is_ignored_rds_modification(self, account_name: str, resource_name: str,
-                                     resource_change: Mapping[str, Any],
-                                     output: Mapping[str, Any]) -> bool:
+                                     resource_change: Mapping[str, Any]) -> bool:
         """
-        Determines whether the RDS resource changes are cases that we don't care about
+        Determine whether the RDS resource changes are cases where a terraform apply
+        should be skipped.
         """
         before = resource_change['before']
         after = resource_change['after']

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -451,10 +451,8 @@ def clusters_aws_account_ids(ctx):
 
 @get.command()
 @click.pass_context
-def terraform_users_credentials(ctx):
-    accounts, working_dirs, _ = tfu.setup(False, 1)
-    settings = queries.get_app_interface_settings()
-    aws_api = AWSApi(1, accounts, settings=settings)
+def terraform_users_credentials(ctx) -> None:
+    accounts, working_dirs, _, aws_api = tfu.setup(False, 1)
     tf = Terraform(tfu.QONTRACT_INTEGRATION,
                    tfu.QONTRACT_INTEGRATION_VERSION,
                    tfu.QONTRACT_TF_PREFIX,

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -453,12 +453,15 @@ def clusters_aws_account_ids(ctx):
 @click.pass_context
 def terraform_users_credentials(ctx):
     accounts, working_dirs, _ = tfu.setup(False, 1)
+    settings = queries.get_app_interface_settings()
+    aws_api = AWSApi(1, accounts, settings=settings)
     tf = Terraform(tfu.QONTRACT_INTEGRATION,
                    tfu.QONTRACT_INTEGRATION_VERSION,
                    tfu.QONTRACT_TF_PREFIX,
                    accounts,
                    working_dirs,
                    10,
+                   aws_api,
                    init_users=True)
     credentials = []
     for account, output in tf.outputs.items():


### PR DESCRIPTION
RDS engine_version changes are unique because a tenant may want to change
this value, but allow RDS to upgrade the instance during the next maintenance
window. This window could be up to 7 days away, which in the meantime would
cause Terraform to apply the change every time that the integration runs (as
well as log the change, which is more annoying than harmful). Unnecessary
apply operations will result in state changes and any instances of
terraform-resources running will need to restart (think PR checks).

The manual tests that I performed so far were:

1. Upgrade RDS `engine_version` without `apply_immediately` and confirm that the next time terraform-resources runs, it skips the Terraform `apply`
2. After doing above, set `apply_immediately: true` and run again, then RDS is upgraded immediately. This tests both that >1 change will still cause an apply, but also the special case where we decide after the fact that RDS should be upgraded immediately.

The output from these tests:

```
# Update the database without apply_immediately
$ qontract-reconcile --config config.dev.toml --log-level INFO terraform-resources --account-name app-int-example-01
[2022-03-22 12:38:08] [INFO] [gql.py:init_from_config:220] - using gql endpoint http://localhost:4000/graphqlsha/9326e854260d26c1e7c03e9c37cebe68d766b240c9d45f7f740d20c96ca930a6
[2022-03-22 12:38:33] [INFO] [terraform_client.py:log_plan_diff:249] - ['update', 'app-int-example-01', 'aws_db_instance', 'app-int-example-01-rds']

# Run again with no changes to app-interface
$ qontract-reconcile --config config.dev.toml --log-level DEBUG terraform-resources --account-name app-int-example-01 2>&1 | grep 'INFO\|Not setting should_apply'
[2022-03-22 12:40:21] [INFO] [gql.py:init_from_config:220] - using gql endpoint http://localhost:4000/graphqlsha/9326e854260d26c1e7c03e9c37cebe68d766b240c9d45f7f740d20c96ca930a6
[2022-03-22 12:40:47] [DEBUG] [terraform_client.py:log_plan_diff:243] - Not setting should_apply for app-int-example-01-rds because the only change is EngineVersion and that setting is in PendingModifiedValues

# Add apply_immediately: true and the upgrade occurs
$ qontract-reconcile --config config.dev.toml --log-level DEBUG terraform-resources --account-name app-int-example-01 2>&1 | grep 'INFO\|Not setting should_apply'
[2022-03-22 12:43:05] [INFO] [gql.py:init_from_config:220] - using gql endpoint http://localhost:4000/graphqlsha/808f987d6009ec56c55c2e01b5355275486e9d5b94b413aea32f62fe7d791b50
[2022-03-22 12:43:30] [INFO] [terraform_client.py:log_plan_diff:249] - ['update', 'app-int-example-01', 'aws_db_instance', 'app-int-example-01-rds']
```

Additionally, I ran the `terraform-*` integrations in dry-run mode with `app-sre/app-interface` data. This provides some basic reassurances. Ultimately, these changes will be tested in staging as well because the creation of `AWSApi` and passing of the object into `TerraformClient` happen in dry-run mode.

Related: [APPSRE-4645](https://issues.redhat.com/browse/APPSRE-4645)