### PR TITLE
[bug] terrascript_client initiates terraform state backend with wrong region when aws_api is initiated

### DIFF
--- a/reconcile/test/test_utils_aws_helper.py
+++ b/reconcile/test/test_utils_aws_helper.py
@@ -37,29 +37,29 @@ def test_get_account_uid_from_role_link():
     assert result == expected
 
 
-class MockSecretReader():
+class MockSecretReader:
     def read_all(self, token):
         return token
 
 
 def test_get_tf_secrets():
-    account = {'name': 'a', 'automationToken': 'at'}
+    account = {"name": "a", "automationToken": "at"}
     secret_reader = MockSecretReader()
     result = awsh.get_tf_secrets(secret_reader, account)
-    assert result == ('a', 'at')
+    assert result == ("a", "at")
 
 
 def test_get_account_found():
-    acc_a = {'name': 'a'}
+    acc_a = {"name": "a"}
     accounts = [
         acc_a,
-        {'name': 'b'},
+        {"name": "b"},
     ]
-    result = awsh.get_account(accounts, 'a')
+    result = awsh.get_account(accounts, "a")
     assert result == acc_a
 
 
 def test_get_account_not_found():
     accounts = []
     with pytest.raises(awsh.AccountNotFoundError):
-        awsh.get_account(accounts, 'a')
+        awsh.get_account(accounts, "a")

--- a/reconcile/test/test_utils_aws_helper.py
+++ b/reconcile/test/test_utils_aws_helper.py
@@ -46,7 +46,7 @@ class MockSecretReader:
 def test_get_tf_secrets():
     account = {"name": "a", "automationToken": "at"}
     secret_reader = MockSecretReader()
-    result = awsh.get_tf_secrets(secret_reader, account)
+    result = awsh.get_tf_secrets(account, secret_reader)
     assert result == ("a", "at")
 
 

--- a/reconcile/test/test_utils_aws_helper.py
+++ b/reconcile/test/test_utils_aws_helper.py
@@ -1,3 +1,4 @@
+import pytest
 import reconcile.utils.aws_helper as awsh
 
 
@@ -34,3 +35,31 @@ def test_get_account_uid_from_role_link():
     expected = "12345"
     result = awsh.get_account_uid_from_role_link(role_link)
     assert result == expected
+
+
+class MockSecretReader():
+    def read_all(self, token):
+        return token
+
+
+def test_get_tf_secrets():
+    account = {'name': 'a', 'automationToken': 'at'}
+    secret_reader = MockSecretReader()
+    result = awsh.get_tf_secrets(secret_reader, account)
+    assert result == ('a', 'at')
+
+
+def test_get_account_found():
+    acc_a = {'name': 'a'}
+    accounts = [
+        acc_a,
+        {'name': 'b'},
+    ]
+    result = awsh.get_account(accounts, 'a')
+    assert result == acc_a
+
+
+def test_get_account_not_found():
+    accounts = []
+    with pytest.raises(awsh.AccountNotFoundError):
+        awsh.get_account(accounts, 'a')

--- a/reconcile/test/test_utils_aws_helper.py
+++ b/reconcile/test/test_utils_aws_helper.py
@@ -38,7 +38,8 @@ def test_get_account_uid_from_role_link():
 
 
 class MockSecretReader:
-    def read_all(self, token):
+    @staticmethod
+    def read_all(token):
         return token
 
 

--- a/reconcile/test/test_wrong_region.py
+++ b/reconcile/test/test_wrong_region.py
@@ -69,7 +69,13 @@ def test_wrong_region_terrascript(terrascript, accounts, tf_bucket_region):
         assert terrascript.configs[a["name"]]["region"] == tf_bucket_region
 
 
-def test_wrong_region_both(aws_api, terrascript, accounts, default_region, tf_bucket_region):
+def test_wrong_region_both_aws_api_first(aws_api, terrascript, accounts, default_region, tf_bucket_region):
     for a in accounts:
         assert aws_api.sessions[a["name"]].region_name == default_region
         assert terrascript.configs[a["name"]]["region"] == tf_bucket_region
+
+
+def test_wrong_region_both_tf_client_first(terrascript, aws_api, accounts, tf_bucket_region, default_region):
+    for a in accounts:
+        assert terrascript.configs[a["name"]]["region"] == tf_bucket_region
+        assert aws_api.sessions[a["name"]].region_name == default_region

--- a/reconcile/test/test_wrong_region.py
+++ b/reconcile/test/test_wrong_region.py
@@ -1,0 +1,75 @@
+import pytest
+
+from reconcile.utils.aws_api import AWSApi
+from reconcile.utils.terrascript_client import TerrascriptClient
+
+
+@pytest.fixture
+def default_region():
+    return "default-region"
+
+
+@pytest.fixture
+def tf_bucket_region():
+    return "tf-bucket-region"
+
+
+@pytest.fixture
+def accounts(default_region):
+    return [
+        {
+            "name": "some-account",
+            "automationToken": {
+                "path": "path",
+            },
+            "resourcesDefaultRegion": default_region,
+            "supportedDeploymentRegions": [default_region],
+            "providerVersion": "1.2.3",
+            "uid": "123",
+        }
+    ]
+
+
+@pytest.fixture
+def secret(tf_bucket_region):
+    return {
+        "aws_access_key_id": "key_id",
+        "aws_secret_access_key": "access_key",
+        "region": tf_bucket_region,
+        "bucket": "tf-bucket-name",
+        "_key": "tf_key.tfstate"
+    }
+
+
+@pytest.fixture
+def aws_api(accounts, secret, mocker):
+    mock_secret_reader = mocker.patch(
+        "reconcile.utils.aws_api.SecretReader", autospec=True
+    )
+    mock_secret_reader.return_value.read_all.return_value = secret
+    return AWSApi(1, accounts, init_users=False)
+
+
+@pytest.fixture
+def terrascript(accounts, secret, mocker):
+    mock_secret_reader = mocker.patch(
+        "reconcile.utils.terrascript_client.SecretReader", autospec=True
+    )
+    mock_secret_reader.return_value.read_all.return_value = secret
+    return TerrascriptClient("", "", 1, accounts)
+
+
+def test_wrong_region_aws_api(aws_api, accounts, default_region):
+    for a in accounts:
+        assert aws_api.sessions[a["name"]].region_name == default_region
+
+
+def test_wrong_region_terrascript(terrascript, accounts, tf_bucket_region):
+    for a in accounts:
+        assert terrascript.configs[a["name"]]["region"] == tf_bucket_region
+
+
+def test_wrong_region_both(aws_api, terrascript, accounts, default_region, tf_bucket_region):
+    for a in accounts:
+        assert aws_api.sessions[a["name"]].region_name == default_region
+        assert terrascript.configs[a["name"]]["region"] == tf_bucket_region

--- a/reconcile/test/test_wrong_region.py
+++ b/reconcile/test/test_wrong_region.py
@@ -37,7 +37,7 @@ def secret(tf_bucket_region):
         "aws_secret_access_key": "access_key",
         "region": tf_bucket_region,
         "bucket": "tf-bucket-name",
-        "_key": "tf_key.tfstate"
+        "_key": "tf_key.tfstate",
     }
 
 
@@ -69,13 +69,9 @@ def test_wrong_region_terrascript(terrascript, accounts, tf_bucket_region):
         assert terrascript.configs[a["name"]]["region"] == tf_bucket_region
 
 
-def test_wrong_region_both_aws_api_first(aws_api, terrascript, accounts, default_region, tf_bucket_region):
+def test_wrong_region_both(
+    aws_api, terrascript, accounts, default_region, tf_bucket_region
+):
     for a in accounts:
         assert aws_api.sessions[a["name"]].region_name == default_region
         assert terrascript.configs[a["name"]]["region"] == tf_bucket_region
-
-
-def test_wrong_region_both_tf_client_first(terrascript, aws_api, accounts, tf_bucket_region, default_region):
-    for a in accounts:
-        assert terrascript.configs[a["name"]]["region"] == tf_bucket_region
-        assert aws_api.sessions[a["name"]].region_name == default_region

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -103,7 +103,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         for account, secret in results:
             access_key = secret['aws_access_key_id']
             secret_key = secret['aws_secret_access_key']
-            region_name = secret['region']
+            region_name = [a for a in accounts if a["name"] == account][0]["resourcesDefaultRegion"]
             session = Session(
                 aws_access_key_id=access_key,
                 aws_secret_access_key=secret_key,
@@ -139,8 +139,6 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         account_name = account['name']
         automation_token = account['automationToken']
         secret = self.secret_reader.read_all(automation_token)
-        # Override the terraform state bucket region
-        secret['region'] = account['resourcesDefaultRegion']
         return (account_name, secret)
 
     def init_users(self):

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -14,6 +14,7 @@ from boto3 import Session
 from sretoolbox.utils import threaded
 import botocore
 
+import reconcile.utils.aws_helper as awsh
 import reconcile.utils.lean_terraform_client as terraform
 
 from reconcile.utils.secret_reader import SecretReader
@@ -45,7 +46,6 @@ class MissingARNError(Exception):
     pass
 
 
-Account = Dict[str, Any]
 KeyStatus = Union[Literal['Active'], Literal['Inactive']]
 
 
@@ -95,22 +95,23 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         self.get_transit_gateway_vpc_attachments = functools.lru_cache()(
             self.get_transit_gateway_vpc_attachments)
 
-    def init_sessions_and_resources(self, accounts: Iterable[Account]):
-        results = threaded.run(self.get_tf_secrets, accounts,
+    def init_sessions_and_resources(self, accounts: Iterable[awsh.Account]):
+        results = threaded.run(awsh.get_tf_secrets, accounts,
                                self.thread_pool_size)
         self.sessions: Dict[str, Session] = {}
         self.resources: Dict[str, Any] = {}
-        for account, secret in results:
+        for account_name, secret in results:
+            account = awsh.get_account(accounts, account_name)
             access_key = secret['aws_access_key_id']
             secret_key = secret['aws_secret_access_key']
-            region_name = [a for a in accounts if a["name"] == account][0]["resourcesDefaultRegion"]
+            region_name = account['resourcesDefaultRegion']
             session = Session(
                 aws_access_key_id=access_key,
                 aws_secret_access_key=secret_key,
                 region_name=region_name,
             )
-            self.sessions[account] = session
-            self.resources[account] = {}
+            self.sessions[account_name] = session
+            self.resources[account_name] = {}
 
     def get_session(self, account: str) -> Session:
         return self.sessions[account]
@@ -134,12 +135,6 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         session = self.get_session(account_name)
         region = region_name if region_name else session.region_name
         return session.client('route53', region_name=region)
-
-    def get_tf_secrets(self, account):
-        account_name = account['name']
-        automation_token = account['automationToken']
-        secret = self.secret_reader.read_all(automation_token)
-        return (account_name, secret)
 
     def init_users(self):
         self.users = {}
@@ -721,7 +716,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         self.auth_tokens = auth_tokens
 
     @staticmethod
-    def _get_account_assume_data(account: Account) -> Tuple[str, str, str]:
+    def _get_account_assume_data(account: awsh.Account) -> Tuple[str, str, str]:
         """
         returns mandatory data to be able to assume a role with this account:
         (account_name, assume_role, assume_region)

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -97,7 +97,8 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
     def init_sessions_and_resources(self, accounts: Iterable[awsh.Account]):
         results = threaded.run(awsh.get_tf_secrets, accounts,
-                               self.thread_pool_size)
+                               self.thread_pool_size,
+                               secret_reader=self.secret_reader)
         self.sessions: Dict[str, Session] = {}
         self.resources: Dict[str, Any] = {}
         for account_name, secret in results:
@@ -693,7 +694,8 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
         auth_tokens = {}
         results = threaded.run(self.get_tf_secrets, accounts_with_ecr,
-                               self.thread_pool_size)
+                               self.thread_pool_size,
+                               secret_reader=self.secret_reader)
         account_secrets = dict(results)
         for account in accounts_with_ecr:
             account_name = account['name']

--- a/reconcile/utils/aws_helper.py
+++ b/reconcile/utils/aws_helper.py
@@ -42,7 +42,7 @@ def get_account_uid_from_role_link(role_link):
     return uid
 
 
-def get_tf_secrets(secret_reader: SecretReader, account: Account) -> Tuple[str, Dict]:
+def get_tf_secrets(account: Account, secret_reader: SecretReader) -> Tuple[str, Dict]:
     account_name = account["name"]
     automation_token = account["automationToken"]
     secret = secret_reader.read_all(automation_token)

--- a/reconcile/utils/aws_helper.py
+++ b/reconcile/utils/aws_helper.py
@@ -1,3 +1,14 @@
+from typing import Any, Dict, Iterable, Tuple
+from reconcile.utils.secret_reader import SecretReader
+
+
+class AccountNotFoundError(Exception):
+    pass
+
+
+Account = Dict[str, Any]
+
+
 def get_user_id_from_arn(arn):
     # arn:aws:iam::12345:user/id --> id
     return arn.split("/")[1]
@@ -29,3 +40,18 @@ def get_role_arn_from_role_link(role_link):
 def get_account_uid_from_role_link(role_link):
     uid, _ = get_details_from_role_link(role_link)
     return uid
+
+
+def get_tf_secrets(secret_reader: SecretReader, account: Account) -> Tuple[str, Dict]:
+    account_name = account["name"]
+    automation_token = account["automationToken"]
+    secret = secret_reader.read_all(automation_token)
+    return (account_name, secret)
+
+
+def get_account(accounts: Iterable[Account], account_name: str) -> Account:
+    for a in accounts:
+        if a["name"] == account_name:
+            return a
+
+    raise AccountNotFoundError(account_name)

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -283,7 +283,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
     def populate_configs(self, accounts: Iterable[awsh.Account]):
         results = threaded.run(awsh.get_tf_secrets, accounts,
-                               self.thread_pool_size)
+                               self.thread_pool_size,
+                               secret_reader=self.secret_reader)
         self.configs: Dict[str, Dict] = {}
         for account_name, config in results:
             account = awsh.get_account(accounts, account_name)


### PR DESCRIPTION
if the state bucket region (coming from the vault secret) is different from the account's resources default region (coming from the account file) - the region selected for the terraform backend configuration is the wrong one. it should be the region of the state bucket, coming from the vault secret.
when `aws_api` and `terrascript_client` are initiated, they interfere with each other if `resourcesDefaultRegion` is different from the terraform bucket region.

this issue was introduced in #2165 (famous last words indeed), where we actually started overriding the state bucket region with the resources default region.

this PR starts by adding tests that are expected to pass. the fact that they are failing proves the existence of the bug.

i've isolated the "fix" to this single commit: https://github.com/app-sre/qontract-reconcile/pull/2257/commits/cab02840957cb4a39c02f2441abda7f8e9d01eb3

but if i'm honest, i have no idea why this bug happens, and this fix is a workaround.
i'm not sure if this bug has more symptoms, so one may wonder if there is really a bug...
i believe the bug has something to do with `functools.lru_cache` and AWSApi leaks. more information in #1947.