### PR TITLE
[openshift-saas-deploy] validate planned data

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass, field
 import logging
 import itertools
 
-from typing import Any, Optional, Iterable, Mapping, Union
+from typing import Any, Dict, Optional, Iterable, Mapping, Union
 
 import yaml
 
@@ -21,7 +21,7 @@ from reconcile.utils.oc import PrimaryClusterIPCanNotBeUnsetError
 from reconcile.utils.oc import InvalidValueApplyError
 from reconcile.utils.oc import MetaDataAnnotationsTooLongApplyError
 from reconcile.utils.oc import StatefulSetUpdateForbidden
-from reconcile.utils.oc import OC_Map
+from reconcile.utils.oc import OCDeprecated, OC_Map
 from reconcile.utils.oc import StatusCodeError
 from reconcile.utils.oc import UnsupportedMediaTypeError
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
@@ -694,8 +694,56 @@ def realize_data(
     return list(itertools.chain.from_iterable(results))
 
 
+def _validate_resources_used_exist(
+    ri: ResourceInventory,
+    oc: OCDeprecated,
+    spec: Dict[str, Any],
+    cluster: str,
+    namespace: str,
+    kind: str,
+    name: str,
+    used_kind: str,
+) -> None:
+    used_resources = oc.get_resources_used_in_pod_spec(spec, used_kind)
+    for used_name, used_keys in used_resources.items():
+        # perhaps used resource is deployed together with the using resource?
+        resource = ri.get_desired(cluster, namespace, used_kind, used_name)
+        if not resource:
+            # no. perhaps used resource exists in the namespace?
+            resource = oc.get(
+                namespace, used_kind, name=used_name, allow_not_found=True
+            )
+        err_base = f"[{kind}/{name}] {used_kind} {used_name}"
+        if not resource:
+            # no. where is used resource hiding? we can't find it anywhere
+            logging.error(f"{err_base} does not exist")
+            ri.register_error()
+            continue
+        # here it is! let's make sure it has all the required keys
+        missing_keys = used_keys - resource["data"].keys()
+        if missing_keys:
+            logging.error(f"{err_base} does not contain keys: {missing_keys}")
+            ri.register_error()
+            continue
+
+
+def validate_planned_data(ri: ResourceInventory, oc_map: OC_Map) -> None:
+    for cluster, namespace, kind, data in ri:
+        oc = oc_map.get(cluster)
+
+        for name, d_item in data["desired"].items():
+            if kind in ("Deployment", "DeploymentConfig"):
+                spec = d_item.body["spec"]["template"]["spec"]
+                _validate_resources_used_exist(
+                    ri, oc, spec, cluster, namespace, kind, name, "Secret"
+                )
+                _validate_resources_used_exist(
+                    ri, oc, spec, cluster, namespace, kind, name, "ConfigMap"
+                )
+
+
 @retry(exceptions=(ValidationError), max_attempts=100)
-def validate_data(oc_map, actions):
+def validate_realized_data(actions: Iterable[Dict[str, str]], oc_map: OC_Map):
     """
     Validate the realized desired state.
 

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -175,6 +175,10 @@ def run(
         ri.register_error()
         sys.exit(ExitCodes.ERROR)
 
+    # validate that the deployment will succeed
+    # to the best of our ability to predict
+    ob.validate_planned_data(ri, oc_map)
+
     # if saas_file_name is defined, the integration
     # is being called from multiple running instances
     actions = ob.realize_data(
@@ -196,7 +200,7 @@ def run(
                 logging.error(str(e))
                 ri.register_error()
         try:
-            ob.validate_data(oc_map, actions)
+            ob.validate_realized_data(actions, oc_map)
         except Exception as e:
             logging.error(str(e))
             ri.register_error()

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -576,6 +576,12 @@ class ResourceInventory:
             ]
             admin_token_usage[name] = privileged
 
+    def get_desired(self, cluster, namespace, resource_type, name):
+        try:
+            return self._clusters[cluster][namespace][resource_type]["desired"][name]
+        except KeyError:
+            return None
+
     def add_current(self, cluster, namespace, resource_type, name, value):
         with self._lock:
             current = self._clusters[cluster][namespace][resource_type]["current"]


### PR DESCRIPTION
depends on #2260

this PR adds logic to validate resources to be deployed before they are actually deployed.
this allows us to gradually add checks as we discover use cases that can be validated pre-deployment.

this PR adds the first condition - validate that all Secrets[1] used by a Deployment[2] exist[3] along with the required keys[4].

[1] or ConfigMaps
[2] or DeploymentConfig
[3] or will exist
[4] where applicable

this will reduce load from AppSRE by automating a pretty routine check, and will help onboarding tenants by validating that what they are trying to deploy makes sense.
in addition, we see multiple MRs to app-interface which promote a saas file target together with a secret from vault. as these secrets need to be updated in advance to contain any new keys, this PR will force a split of the MR - secret first, saas file after. this alone will reduce:
- review time of the IC
- debug time of tenant and the IC in case the Deployment gets updated before the Secret and the deployment pipeline fails.

TODO: tests