### PR TITLE
[openshift] redact Secret when unable to apply

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -17,7 +17,6 @@ from reconcile.utils.oc import MetaDataAnnotationsTooLongApplyError
 from reconcile.utils.oc import StatefulSetUpdateForbidden
 from reconcile.utils.oc import OC_Map
 from reconcile.utils.oc import StatusCodeError
-from reconcile.utils.oc import UnableToApplyError
 from reconcile.utils.oc import UnsupportedMediaTypeError
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.openshift_resource import ResourceInventory
@@ -524,7 +523,7 @@ def _realize_resource_data(
                 "privileged": privileged,
             }
             actions.append(action)
-        except (StatusCodeError, UnableToApplyError) as e:
+        except StatusCodeError as e:
             ri.register_error()
             err = (
                 str(e)

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -17,6 +17,7 @@ from reconcile.utils.oc import MetaDataAnnotationsTooLongApplyError
 from reconcile.utils.oc import StatefulSetUpdateForbidden
 from reconcile.utils.oc import OC_Map
 from reconcile.utils.oc import StatusCodeError
+from reconcile.utils.oc import UnableToApplyError
 from reconcile.utils.oc import UnsupportedMediaTypeError
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.openshift_resource import ResourceInventory
@@ -523,7 +524,7 @@ def _realize_resource_data(
                 "privileged": privileged,
             }
             actions.append(action)
-        except StatusCodeError as e:
+        except (StatusCodeError, UnableToApplyError) as e:
             ri.register_error()
             err = (
                 str(e)

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -98,10 +98,6 @@ class JobNotRunningError(Exception):
     pass
 
 
-class UnableToApplyError(Exception):
-    pass
-
-
 class OCDecorators:
     @classmethod
     def process_reconcile_time(cls, function):
@@ -772,7 +768,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
                     if ': primary clusterIP can not be unset' in err:
                         raise PrimaryClusterIPCanNotBeUnsetError(
                             f"[{self.server}]: {err}")
-                    raise UnableToApplyError(
+                    raise StatusCodeError(
                         f"[{self.server}]: {err}"
                     )
                 if 'metadata.annotations: Too long' in err:


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-4733

in this incident, we leaked a Secret because the raised exception was not caught to be REDACTED.
this is where we introduced redacting: #1768
this is where we introduced the uncaught exception: #1903

this PR changes the thrown exception to (the only) one that is caught.