### PR TITLE
APPSRE-4731: Use official graphql library

### DIFF
--- a/reconcile/test/test_utils_gql.py
+++ b/reconcile/test/test_utils_gql.py
@@ -23,7 +23,7 @@ TEST_QUERY = """
 
 @pytest.fixture
 def mocked_client(mocker):
-    mocked_client = mocker.Mock(spec=Client, create_autospec=True)
+    mocked_client = mocker.create_autospec(Client)
     return mocked_client
 
 

--- a/reconcile/test/test_utils_gql.py
+++ b/reconcile/test/test_utils_gql.py
@@ -6,8 +6,8 @@ from reconcile.utils.gql import (
     GqlApiErrorForbiddenSchema,
     GqlApiIntegrationNotFound,
 )
-from gql import Client  # type: ignore
-from gql.transport.exceptions import TransportQueryError  # type: ignore
+from gql import Client
+from gql.transport.exceptions import TransportQueryError
 import pytest
 
 TEST_QUERY = """

--- a/reconcile/test/test_utils_gql.py
+++ b/reconcile/test/test_utils_gql.py
@@ -6,8 +6,8 @@ from reconcile.utils.gql import (
     GqlApiErrorForbiddenSchema,
     GqlApiIntegrationNotFound,
 )
-from gql import Client
-from gql.transport.exceptions import TransportQueryError
+from gql import Client  # type: ignore
+from gql.transport.exceptions import TransportQueryError  # type: ignore
 import pytest
 
 TEST_QUERY = """

--- a/reconcile/test/test_utils_gql.py
+++ b/reconcile/test/test_utils_gql.py
@@ -1,0 +1,72 @@
+import requests
+
+from reconcile.utils.gql import (
+    GqlApi,
+    GqlApiError,
+    GqlApiErrorForbiddenSchema,
+    GqlApiIntegrationNotFound,
+)
+from gql import Client
+from gql.transport.exceptions import TransportQueryError
+import pytest
+
+TEST_QUERY = """
+{
+    integrations: integrations_v1 {
+        name
+        description
+        schemas
+    }
+}
+"""
+
+
+def test_gqlapi_throws_gqlapierror_exception(mocker):
+    mocked_client = mocker.Mock(spec=Client)
+
+    mocked_client.execute.side_effect = Exception("Something went wrong!")
+    with pytest.raises(GqlApiError):
+        gql_api = GqlApi(mocked_client, validate_schemas=False)
+        gql_api.query(TEST_QUERY)
+
+    mocked_client.execute.side_effect = requests.exceptions.ConnectionError(
+        "Could not connect with GraphQL API"
+    )
+    with pytest.raises(GqlApiError):
+        gql_api = GqlApi(mocked_client, validate_schemas=False)
+        gql_api.query(TEST_QUERY)
+
+    mocked_client.execute.side_effect = TransportQueryError("Error in GraphQL payload")
+    with pytest.raises(GqlApiError):
+        gql_api = GqlApi(mocked_client, validate_schemas=False)
+        gql_api.query(TEST_QUERY)
+
+    mocked_client.execute.side_effect = AssertionError(
+        "Transport returned an ExecutionResult without data or errors"
+    )
+    with pytest.raises(GqlApiError):
+        gql_api = GqlApi(mocked_client, validate_schemas=False)
+        gql_api.query(TEST_QUERY)
+
+
+def test_gqlapi_throws_gqlapiintegrationnotfound_exception(mocker):
+    mocked_client = mocker.Mock(spec=Client)
+    mocked_client.execute.return_value.formatted = {
+        "data": {"integrations": [{"name": "INTEGRATION", "schemas": "TEST_SCHEMA"}]}
+    }
+
+    with pytest.raises(GqlApiIntegrationNotFound):
+        gql_api = GqlApi(mocked_client, "INTEGRATION_NOT_FOUND", validate_schemas=True)
+        gql_api.query(TEST_QUERY)
+
+
+def test_gqlapi_throws_gqlapierrorforbiddenschema_exception(mocker):
+    mocked_client = mocker.Mock(spec=Client)
+    mocked_client.execute.return_value.formatted = {
+        "data": {"integrations": [{"name": "INTEGRATION", "schemas": "TEST_SCHEMA"}]},
+        "extensions": {"schemas": ["TEST_SCHEMA", "FORBIDDEN_TEST_SCHEMA"]},
+    }
+
+    with pytest.raises(GqlApiErrorForbiddenSchema):
+        gql_api = GqlApi(mocked_client, "INTEGRATION", validate_schemas=True)
+        gql_api.query(TEST_QUERY)

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -169,6 +169,7 @@ def init(url, token=None, integration=None, validate_schemas=False):
 
 
 def _init_gql_client(url, token) -> Client:
+    req_headers = None
     if token:
         # The token stored in vault is already in the format 'Basic ...'
         req_headers = {"Authorization": token}

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -127,9 +127,7 @@ class GqlApi:
 
         if self.validate_schemas and not skip_validation:
             forbidden_schemas = [
-                schema
-                for schema in query_schemas
-                if schema not in self._valid_schemas
+                schema for schema in query_schemas if schema not in self._valid_schemas
             ]
             if forbidden_schemas:
                 raise GqlApiErrorForbiddenSchema(forbidden_schemas)

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -1,6 +1,6 @@
 import logging
 import textwrap
-from typing import Set, Any, Optional, Dict, cast, Iterable
+from typing import Set, Any, Optional, Dict, cast
 
 from urllib.parse import urlparse
 
@@ -127,7 +127,8 @@ class GqlApi:
 
         if self.validate_schemas and not skip_validation:
             forbidden_schemas = [
-                schema for schema in query_schemas if schema not in cast(Iterable, self._valid_schemas)
+                # Here we are explicitly type casting _valid_schemas to list as mypy is unable to infer the type
+                schema for schema in query_schemas if schema not in cast(list, self._valid_schemas)
             ]
             if forbidden_schemas:
                 raise GqlApiErrorForbiddenSchema(forbidden_schemas)

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -127,7 +127,6 @@ class GqlApi:
 
         if self.validate_schemas and not skip_validation:
             forbidden_schemas = [
-                # Here we are explicitly type casting _valid_schemas to list as mypy is unable to infer the type
                 schema
                 for schema in query_schemas
                 if schema not in self._valid_schemas

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -80,7 +80,7 @@ class GqlApi:
     _valid_schemas = None
     _queried_schemas: Set[Any] = set()
 
-    def __init__(self, client, int_name=None, validate_schemas=False) -> None:
+    def __init__(self, client: Client, int_name=None, validate_schemas=False) -> None:
         self.integration = int_name
         self.validate_schemas = validate_schemas
         self.client = client
@@ -168,7 +168,7 @@ def init(url, token=None, integration=None, validate_schemas=False):
     return _gqlapi
 
 
-def _init_gql_client(url, token) -> Client:
+def _init_gql_client(url: str, token: str) -> Client:
     req_headers = None
     if token:
         # The token stored in vault is already in the format 'Basic ...'

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -85,13 +85,13 @@ class GqlApi:
         self.token = token
         self.integration = int_name
         self.validate_schemas = validate_schemas
-        self.req_headers = None
+        self._req_headers = None
         if token:
             # The token stored in vault is already in the format 'Basic ...'
-            self.req_headers = {"Authorization": token}
+            self._req_headers = {"Authorization": token}
         # Here we are explicitly using sync strategy
         self.client = Client(
-            transport=RequestsHTTPTransport(self.url, headers=self.req_headers)
+            transport=RequestsHTTPTransport(self.url, headers=self._req_headers)
         )
 
         if validate_schemas and not int_name:
@@ -135,7 +135,7 @@ class GqlApi:
             if forbidden_schemas:
                 raise GqlApiErrorForbiddenSchema(forbidden_schemas)
 
-        return result.get("data")
+        return result["data"]
 
     def get_resource(self, path):
         query = """

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -16,6 +16,9 @@ from reconcile.status import RunningState
 from gql import gql, Client
 from gql.transport.requests import RequestsHTTPTransport
 
+from typing import Dict
+
+
 _gqlapi = None
 
 
@@ -111,7 +114,7 @@ class GqlApi:
                 raise GqlApiIntegrationNotFound(int_name)
 
     @retry(exceptions=GqlApiError, max_attempts=5, hook=capture_and_forget)
-    def query(self, query, variables=None, skip_validation=False):
+    def query(self, query, variables=None, skip_validation=False) -> Dict[str, Dict]:
         try:
             result = self.client.execute(
                 gql(query), variables, get_execution_result=True

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -13,10 +13,9 @@ from sentry_sdk import capture_exception
 from reconcile.utils.config import get_config
 from reconcile.status import RunningState
 
-from gql import gql, Client
-from gql.transport.requests import RequestsHTTPTransport
-from gql.transport.exceptions import TransportQueryError
-
+from gql import gql, Client  # type: ignore
+from gql.transport.requests import RequestsHTTPTransport  # type: ignore
+from gql.transport.exceptions import TransportQueryError  # type: ignore
 
 _gqlapi = None
 
@@ -126,7 +125,7 @@ class GqlApi:
 
         if self.validate_schemas and not skip_validation:
             forbidden_schemas = [
-                schema for schema in query_schemas if schema not in self._valid_schemas
+                schema for schema in query_schemas if schema not in self._valid_schemas  # type: ignore
             ]
             if forbidden_schemas:
                 raise GqlApiErrorForbiddenSchema(forbidden_schemas)

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -1,6 +1,6 @@
 import logging
 import textwrap
-from typing import Set, Any, Optional, Dict, Any
+from typing import Set, Any, Optional, Dict, cast
 
 from urllib.parse import urlparse
 
@@ -127,7 +127,7 @@ class GqlApi:
 
         if self.validate_schemas and not skip_validation:
             forbidden_schemas = [
-                schema for schema in query_schemas if schema not in self._valid_schemas  # type: ignore
+                schema for schema in query_schemas if schema not in cast(list, self._valid_schemas)
             ]
             if forbidden_schemas:
                 raise GqlApiErrorForbiddenSchema(forbidden_schemas)

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -1,6 +1,6 @@
 import logging
 import textwrap
-from typing import Set, Any, Optional, Dict, cast
+from typing import Set, Any, Optional, Dict
 
 from urllib.parse import urlparse
 

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -128,7 +128,9 @@ class GqlApi:
         if self.validate_schemas and not skip_validation:
             forbidden_schemas = [
                 # Here we are explicitly type casting _valid_schemas to list as mypy is unable to infer the type
-                schema for schema in query_schemas if schema not in cast(list, self._valid_schemas)
+                schema
+                for schema in query_schemas
+                if schema not in cast(list, self._valid_schemas)
             ]
             if forbidden_schemas:
                 raise GqlApiErrorForbiddenSchema(forbidden_schemas)

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -77,7 +77,7 @@ class GqlGetResourceError(Exception):
 
 
 class GqlApi:
-    _valid_schemas = None
+    _valid_schemas: list[str] = []
     _queried_schemas: Set[Any] = set()
 
     def __init__(self, client: Client, int_name=None, validate_schemas=False) -> None:
@@ -130,7 +130,7 @@ class GqlApi:
                 # Here we are explicitly type casting _valid_schemas to list as mypy is unable to infer the type
                 schema
                 for schema in query_schemas
-                if schema not in cast(list, self._valid_schemas)
+                if schema not in self._valid_schemas
             ]
             if forbidden_schemas:
                 raise GqlApiErrorForbiddenSchema(forbidden_schemas)

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -1,6 +1,6 @@
 import logging
 import textwrap
-from typing import Set, Any, Optional, Dict, cast
+from typing import Set, Any, Optional, Dict, cast, Iterable
 
 from urllib.parse import urlparse
 
@@ -127,7 +127,7 @@ class GqlApi:
 
         if self.validate_schemas and not skip_validation:
             forbidden_schemas = [
-                schema for schema in query_schemas if schema not in cast(list, self._valid_schemas)
+                schema for schema in query_schemas if schema not in cast(Iterable, self._valid_schemas)
             ]
             if forbidden_schemas:
                 raise GqlApiErrorForbiddenSchema(forbidden_schemas)

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -13,9 +13,9 @@ from sentry_sdk import capture_exception
 from reconcile.utils.config import get_config
 from reconcile.status import RunningState
 
-from gql import gql, Client  # type: ignore
-from gql.transport.requests import RequestsHTTPTransport  # type: ignore
-from gql.transport.exceptions import TransportQueryError  # type: ignore
+from gql import gql, Client
+from gql.transport.requests import RequestsHTTPTransport
+from gql.transport.exceptions import TransportQueryError
 
 _gqlapi = None
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     install_requires=[
         "sretoolbox~=1.2",
         "Click>=7.0,<8.0",
-        "graphqlclient>=0.2.4,<0.3.0",
+        "gql==3.1.0",
         "toml>=0.10.0,<0.11.0",
         "jsonpath-rw>=1.4.0,<1.5.0",
         "PyGithub>=1.55,<1.56",


### PR DESCRIPTION
This MR replaces `graphqlclient` which is a library unmaintained since 2018 with the official graphql client per https://github.com/graphql-python/gql

I tested some of the integrations locally and they seem to work well. However to get 100% confident I suggest we deploy this in our staging and let it observe for couple of days just to ensure there aren't any missing edge cases. 

I have verified the client displays detailed error message which was hampering our troubleshooting earlier.
```
reconcile.utils.gql.GqlApiError: Could not connect to GraphQL server ({'message': 'Cannot query field "booh" on type "User_v1".', 'locations': [{'line': 10, 'column': 5}], 'extensions': {'code': 'GRAPHQL_VALIDATION_FAILED'}})
```

