### PR TITLE
Switch usage of AWSApi in terraform integrations to skip init_users

### DIFF
--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -209,7 +209,7 @@ def run(
 
     ts.populate_route53(desired_state)
     working_dirs = ts.dump(print_to_file=print_to_file)
-    aws_api = AWSApi(1, participating_accounts, settings)
+    aws_api = AWSApi(1, participating_accounts, settings=settings, init_users=False)
 
     if print_to_file:
         sys.exit(ExitCodes.SUCCESS)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -449,7 +449,7 @@ def setup(dry_run, print_to_file, thread_pool_size, internal,
                                      internal, use_jump_host, account_name)
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size,
                                          settings=settings)
-    aws_api = AWSApi(1, accounts, settings=settings)
+    aws_api = AWSApi(1, accounts, settings=settings, init_users=False)
     tf = Terraform(QONTRACT_INTEGRATION,
                    QONTRACT_INTEGRATION_VERSION,
                    QONTRACT_TF_PREFIX,

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -156,7 +156,7 @@ def run(
     ts.populate_additional_providers(participating_accounts)
     ts.populate_tgw_attachments(desired_state)
     working_dirs = ts.dump(print_to_file=print_to_file)
-    aws_api = AWSApi(1, accounts, settings)
+    aws_api = AWSApi(1, accounts, settings=settings, init_users=False)
 
     if print_to_file:
         sys.exit()

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -73,7 +73,7 @@ def setup(print_to_file, thread_pool_size: int) \
                      settings=settings)
     err = ts.populate_users(tf_roles)
     working_dirs = ts.dump(print_to_file)
-    aws_api = AWSApi(1, accounts, settings)
+    aws_api = AWSApi(1, accounts, settings=settings, init_users=False)
 
     return accounts, working_dirs, err, aws_api
 


### PR DESCRIPTION
The initialization of these AWSApi objects was introduced in #2254,
so this should not break existing functionality. This should avoid
needing to initialize users where it doesn't seem necessary to do
so. Also fixed cases where settings weren't properly defined as a
kwarg.

For testing I ran through the same tests for `terraform-resources` as what was described in #2254. The rest of the terraform integrations should not even be using `AWSApi` at this point given that this is a new dependency that was added to `TerraformClient`.