### PR TITLE
Update AWSApi.get_support_cases to use us-east-1 for the support API

### DIFF
--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -51,6 +51,10 @@ class MissingARNError(Exception):
 
 KeyStatus = Union[Literal['Active'], Literal['Inactive']]
 
+# The AWS support API uses a us-east-1 endpoint for all regions
+# https://docs.aws.amazon.com/general/latest/gr/awssupport.html
+AWS_SUPPORT_REGION = 'us-east-1'
+
 
 class AWSApi:  # pylint: disable=too-many-public-methods
     """Wrapper around AWS SDK"""
@@ -685,7 +689,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
             if not self.accounts[account].get('premiumSupport'):
                 continue
             try:
-                support = s.client('support')
+                support = s.client('support', region_name=AWS_SUPPORT_REGION)
                 support_cases = support.describe_cases(
                     includeResolvedCases=True,
                     includeCommunications=True

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -51,10 +51,6 @@ class MissingARNError(Exception):
 
 KeyStatus = Union[Literal['Active'], Literal['Inactive']]
 
-# The AWS support API uses a us-east-1 endpoint for all regions
-# https://docs.aws.amazon.com/general/latest/gr/awssupport.html
-AWS_SUPPORT_REGION = 'us-east-1'
-
 
 class AWSApi:  # pylint: disable=too-many-public-methods
     """Wrapper around AWS SDK"""
@@ -688,8 +684,9 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         for account, s in self.sessions.items():
             if not self.accounts[account].get('premiumSupport'):
                 continue
+            support_region = self._get_aws_support_api_region(s.region_name)
             try:
-                support = s.client('support', region_name=AWS_SUPPORT_REGION)
+                support = s.client('support', region_name=support_region)
                 support_cases = support.describe_cases(
                     includeResolvedCases=True,
                     includeCommunications=True
@@ -700,6 +697,18 @@ class AWSApi:  # pylint: disable=too-many-public-methods
                 logging.error(msg.format(account, str(e)))
 
         return all_support_cases
+
+    def _get_aws_support_api_region(self, region: str) -> str:
+        """
+        The AWS support API is only available in a single region for standard AWS and
+        GovCloud.
+        """
+        if region.startswith('us-gov'):
+            support_region = 'us-gov-west-1'
+        else:
+            support_region = 'us-east-1'
+
+        return support_region
 
     def init_ecr_auth_tokens(self, accounts):
         accounts_with_ecr = [a for a in accounts if a.get('ecrs')]

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -701,7 +701,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
     def _get_aws_support_api_region(self, region: str) -> str:
         """
         The AWS support API is only available in a single region for standard AWS and
-        GovCloud.
+        GovCloud. See: https://docs.aws.amazon.com/general/latest/gr/awssupport.html
         """
         if region.startswith('us-gov'):
             support_region = 'us-gov-west-1'

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -698,7 +698,8 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
         return all_support_cases
 
-    def _get_aws_support_api_region(self, region: str) -> str:
+    @staticmethod
+    def _get_aws_support_api_region(region: str) -> str:
         """
         The AWS support API is only available in a single region for standard AWS and
         GovCloud. See: https://docs.aws.amazon.com/general/latest/gr/awssupport.html


### PR DESCRIPTION
A recent change, #2257, changed the way that the AWS region is determined for sessions that are created in `AWSApi`. One consequence of this is that some AWS services are only located in `us-east-1`, in this case the support API.

Before this change:

```
$ qontract-reconcile --config config.prod.toml --dry-run --log-level INFO aws-support-cases-sos
[2022-03-23 14:58:12] [INFO] [gql.py:init_from_config:220] - using gql endpoint http://localhost:4000/graphqlsha/514f61fcfa6299538bd9e172211f230df64ae191e53db006d3a87c40e8d558d6
[2022-03-23 14:59:58] [ERROR] [aws_api.py:get_support_cases:696] - [account-name] error getting support cases. details: Could not connect to the endpoint URL: "https://support.eu-central-1.amazonaws.com/"
```

With this change the integration runs without errors.