### PR TITLE
enable option to template resources with graphql query results

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -229,6 +229,13 @@ def lookup_github_file_content(repo, path, ref, tvars=None):
     return c.decode("utf-8")
 
 
+def lookup_graphql_query_results(query: str) -> list[Any]:
+    gqlapi = gql.get_api()
+    resource = gqlapi.get_resource(query)["content"]
+    results = list(gqlapi.query(resource).values())[0]
+    return results
+
+
 def process_jinja2_template(body, vars=None, env=None):
     if vars is None:
         vars = {}
@@ -238,6 +245,7 @@ def process_jinja2_template(body, vars=None, env=None):
     vars.update(
         {"github": lambda u, p, r, v=None: lookup_github_file_content(u, p, r, vars)}
     )
+    vars.update({"query": lookup_graphql_query_results})
     try:
         env = jinja2.Environment(
             extensions=[B64EncodeExtension, RaiseErrorExtension],


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4750

with this PR, we can add sections to be templated based on graphql query results.
for example:
```
{{ query('/queries/jira_boards.graphql') }}
```
this will results in an iterable which we can use to template.
in this example, this is the content of /queries/jira_boards.graphql:
```
{
    jira_boards_v1 {
        name
    }
}
```