### PR TITLE
Parallelize tox runs in Dockerfile.test

### DIFF
--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -1,5 +1,7 @@
 FROM quay.io/app-sre/qontract-reconcile-builder:0.2.0
 
+ENV TOX_PARALLEL_NO_SPINNER=1
+
 WORKDIR /package
 COPY . /package
 

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -7,4 +7,4 @@ RUN microdnf upgrade -y && \
     python3 -m pip install --upgrade pip && \
     python3 -m pip install tox
 
-CMD [ "tox" ]
+CMD ["tox","-p"]

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ envlist =
 commands =
     pytest {posargs:--cov=reconcile --cov-report=term-missing --cov-report xml}
 deps = -r{toxinidir}/requirements/requirements-test.txt
+parallel_show_output = true
 
 [testenv:format]
 skip_install = true
@@ -18,7 +19,7 @@ deps = -r{toxinidir}/requirements/requirements-format.txt
 [testenv:lint]
 commands =
     flake8 reconcile tools e2e_tests
-    pylint -j0 --extension-pkg-whitelist='pydantic' reconcile tools e2e_tests
+    pylint --extension-pkg-whitelist='pydantic' reconcile tools e2e_tests
 
 [testenv:type]
 commands = mypy {posargs}


### PR DESCRIPTION
pylint was using all available core due to the '-j0' option. It seems
that running tox environments in parallel will provide better improvements
in the total execution time.

On my laptop, this ran in `7m7.225s` compared to `8m56.947s` without tox parallelization. We can get more real-life data from our builds over the next week or two.