### PR TITLE
add support to pass kwargs to query()

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -246,9 +246,7 @@ def process_jinja2_template(body, vars=None, env=None):
     vars.update(
         {"github": lambda u, p, r, v=None: lookup_github_file_content(u, p, r, vars)}
     )
-    vars.update(
-        {"query": lambda path, **kwargs: lookup_graphql_query_results(path, **kwargs)}
-    )
+    vars.update({"query": lookup_graphql_query_results})
     try:
         env = jinja2.Environment(
             extensions=[B64EncodeExtension, RaiseErrorExtension],

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -232,8 +232,8 @@ def lookup_github_file_content(repo, path, ref, tvars=None):
 def lookup_graphql_query_results(query: str, kwargs: dict[str, Any] = {}) -> list[Any]:
     gqlapi = gql.get_api()
     resource = gqlapi.get_resource(query)["content"]
-    templated_resource = jinja2.Template(resource).render(kwargs)
-    results = list(gqlapi.query(templated_resource).values())[0]
+    rendered_resource = jinja2.Template(resource).render(kwargs)
+    results = list(gqlapi.query(rendered_resource).values())[0]
     return results
 
 

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -232,8 +232,8 @@ def lookup_github_file_content(repo, path, ref, tvars=None):
 def lookup_graphql_query_results(query: str, kwargs: dict[str, Any] = {}) -> list[Any]:
     gqlapi = gql.get_api()
     resource = gqlapi.get_resource(query)["content"]
-    resource = jinja2.Template(resource).render(kwargs)
-    results = list(gqlapi.query(resource).values())[0]
+    templated_resource = jinja2.Template(resource).render(kwargs)
+    results = list(gqlapi.query(templated_resource).values())[0]
     return results
 
 

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -229,10 +229,10 @@ def lookup_github_file_content(repo, path, ref, tvars=None):
     return c.decode("utf-8")
 
 
-def lookup_graphql_query_results(query: str, kwargs: dict[str, Any] = {}) -> list[Any]:
+def lookup_graphql_query_results(query: str, **kwargs) -> list[Any]:
     gqlapi = gql.get_api()
     resource = gqlapi.get_resource(query)["content"]
-    rendered_resource = jinja2.Template(resource).render(kwargs)
+    rendered_resource = jinja2.Template(resource).render(**kwargs)
     results = list(gqlapi.query(rendered_resource).values())[0]
     return results
 
@@ -247,7 +247,7 @@ def process_jinja2_template(body, vars=None, env=None):
         {"github": lambda u, p, r, v=None: lookup_github_file_content(u, p, r, vars)}
     )
     vars.update(
-        {"query": lambda path, **kwargs: lookup_graphql_query_results(path, kwargs)}
+        {"query": lambda path, **kwargs: lookup_graphql_query_results(path, **kwargs)}
     )
     try:
         env = jinja2.Environment(


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4750

follows up on #2272

this PR adds support to pass keyword arguments to a `query()` function in a templated resource, to allow us (for example) to query a resource by it's unique key.

for example:
```
{{ query('/queries/jira_boards.graphql', name=MYBOARD) }}
```
in this example, this is the content of /queries/jira_boards.graphql:
```
{
    jira_boards_v1
    (
        name: "{{ name }}"
    )
    {
        name
    }
}
```