### PR TITLE
pin pylint - follow-up pr will remove this

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -2,7 +2,7 @@ anymarkup==0.7.0
 flake8~=3.9
 httpretty
 kubernetes~=12.0
-pylint~=2.6
+pylint<=2.12
 pytest~=6.2
 pytest-cov~=2.12
 pytest-mock~=3.6


### PR DESCRIPTION
Newest pylint release 2.13 currently breaks the linting check. Temporarily pin to lower version to unblock CI.