### PR TITLE
sort clusters according to their version and soakDays before considering their upgrade

### DIFF
--- a/reconcile/test/test_ocm_upgrade_scheduler.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler.py
@@ -206,3 +206,81 @@ class TestUpgradeLock:
 
         expected = [self.expected_cluster1]
         assert diffs == expected
+
+
+class TestDesiredState(TestCase):
+    @staticmethod
+    def cluster(name, version, soakDays):
+        return {
+            "name": name,
+            "spec": {
+                "version": version,
+                "channel": None,
+            },
+            "upgradePolicy": {
+                "conditions": {
+                    "soakDays": soakDays,
+                },
+            },
+        }
+
+    @staticmethod
+    def policy(name, version, soakDays):
+        return {
+            "cluster": name,
+            "current_version": version,
+            "channel": None,
+            "conditions": {
+                "soakDays": soakDays,
+            },
+        }
+
+    # cluster upgrades are prioritized according to their current versions
+    def test_sorted_version(self):
+        clusters = [
+            self.cluster("cluster2", "4.2.0", 0),
+            self.cluster("cluster1", "4.1.0", 0),
+            self.cluster("cluster3", "4.3.0", 0),
+        ]
+        expected = [
+            self.policy("cluster1", "4.1.0", 0),
+            self.policy("cluster2", "4.2.0", 0),
+            self.policy("cluster3", "4.3.0", 0),
+        ]
+        state = ous.fetch_desired_state(clusters)
+        self.assertEqual(state, expected)
+
+    # cluster upgrades are prioritized according to their soakdays
+    def test_sorted_soakDays(self):
+        clusters = [
+            self.cluster("cluster2", "4.1.0", 2),
+            self.cluster("cluster1", "4.1.0", 1),
+            self.cluster("cluster3", "4.1.0", 3),
+        ]
+        expected = [
+            self.policy("cluster1", "4.1.0", 1),
+            self.policy("cluster2", "4.1.0", 2),
+            self.policy("cluster3", "4.1.0", 3),
+        ]
+        state = ous.fetch_desired_state(clusters)
+        self.assertEqual(state, expected)
+
+    # cluster upgrades are prioritized according to their curent version and soakdays
+    # in that order
+    # The test TestUpgradeLock.test_calculate_diff_inter_lock above ensures that
+    # only the first cluster with a given mutex will get upgraded.
+    def test_sorted_version_soakDays(self):
+        clusters = [
+            self.cluster("cluster22", "4.2.0", 2),
+            self.cluster("cluster12", "4.1.0", 2),
+            self.cluster("cluster11", "4.1.0", 1),
+            self.cluster("cluster21", "4.2.0", 1),
+        ]
+        expected = [
+            self.policy("cluster11", "4.1.0", 1),
+            self.policy("cluster12", "4.1.0", 2),
+            self.policy("cluster21", "4.2.0", 1),
+            self.policy("cluster22", "4.2.0", 2),
+        ]
+        state = ous.fetch_desired_state(clusters)
+        self.assertEqual(state, expected)


### PR DESCRIPTION
This allows to prioritize clusters sharing the same upgrade mutex.

The cluster with lower version, or lower soakDays (when versions are equal) will get upgraded first

@maorfr PTAL. Do you think that's fine ? I am actually wondering if higher version clusters should not upgrade first. It's a matter of taste..