### PR TITLE
[prometheus-rules-tester] variables may be None

### DIFF
--- a/reconcile/prometheus_rules_tester.py
+++ b/reconcile/prometheus_rules_tester.py
@@ -102,10 +102,9 @@ def get_prometheus_rules(cluster_name):
             rules[path][cluster][namespace] = {"spec": openshift_resource.body["spec"]}
 
             # we keep variables to use them in the rule tests
-            if "variables" in r:
-                rules[path][cluster][namespace]["variables"] = json.loads(
-                    r["variables"]
-                )
+            variables = r["variables"]
+            if variables:
+                rules[path][cluster][namespace]["variables"] = json.loads(variables)
 
     # We return rules that are actually consumed from a namespace becaused
     # those are the only ones that can be resolved as they can be templates


### PR DESCRIPTION
if a PrometheusRule is templated and does not have `variables` - the integration fails:
```
Traceback (most recent call last):
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/venv/bin/qontract-reconcile", line 33, in <module>
    sys.exit(load_entry_point('qontract-reconcile', 'console_scripts', 'qontract-reconcile')())
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/venv/lib64/python3.10/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/venv/lib64/python3.10/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/venv/lib64/python3.10/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/venv/lib64/python3.10/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/venv/lib64/python3.10/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/reconcile/utils/binary.py", line 22, in f_binary
    f(*args, **kwargs)
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/venv/lib64/python3.10/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/reconcile/cli.py", line 1638, in prometheus_rules_tester
    run_integration(reconcile.prometheus_rules_tester, ctx.obj,
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/reconcile/cli.py", line 440, in run_integration
    func_container.run(dry_run, *args, **kwargs)
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/reconcile/prometheus_rules_tester.py", line 308, in run
    rules = get_prometheus_rules(cluster_name)
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/reconcile/prometheus_rules_tester.py", line 106, in get_prometheus_rules
    rules[path][cluster][namespace]["variables"] = json.loads(
  File "/usr/lib64/python3.10/json/__init__.py", line 339, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
```

this is because `variables` is returning from graphql, hence it exists in the query with a value of `None`.
```
>>> "variables" in {"variables": None}
True
```