### PR TITLE
Slack workspaces require integrations

### DIFF
--- a/reconcile/slack_base.py
+++ b/reconcile/slack_base.py
@@ -27,6 +27,8 @@ def slackapi_from_slack_workspace(
     workspace_name = slack_workspace["workspace"]["name"]
     client_config = slack_workspace["workspace"].get("api_client")
 
+    if "integrations" not in slack_workspace["workspace"]:
+        raise ValueError('Slack workspace not containing any "integrations"')
     [slack_integration_config] = [
         i
         for i in slack_workspace["workspace"]["integrations"]


### PR DESCRIPTION
A slack-workspace scheme like the following (no integrations key) results in deploy-time errors

```
  File "/usr/local/lib/python3.9/site-packages/reconcile/openshift_saas_deploy.py", line 86, in run
    slack = slackapi_from_slack_workspace(slack_info,
  File "/usr/local/lib/python3.9/site-packages/reconcile/slack_base.py", line 30, in slackapi_from_slack_workspace
    [slack_integration_config] = [
TypeError: 'NoneType' object is not iterable
```

```yaml
---
$schema: /dependencies/slack-workspace-1.yml

labels:
  service: slack

name: workspaceName
description: workspaceDescription

token:
  path: /path/to/slack/token
  field: fieldName
  version: versionNumber
```