### PR TITLE
[helm] CronJob should use service account

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -331,6 +331,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -8125,6 +8125,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}
@@ -8182,6 +8183,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}
@@ -8239,6 +8241,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}
@@ -8296,6 +8299,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}
@@ -8358,6 +8362,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}
@@ -8420,6 +8425,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}
@@ -8482,6 +8488,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}
@@ -8543,6 +8550,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}
@@ -8602,6 +8610,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}
@@ -8661,6 +8670,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}
@@ -8720,6 +8730,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -25752,6 +25752,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}
@@ -25809,6 +25810,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}
@@ -25866,6 +25868,7 @@ objects:
       spec:
         template:
           spec:
+            serviceAccountName: qontract-reconcile
             containers:
             - name: int
               image: ${IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4758

this PR adds usage of the qontract-reconcile ServiceAccount instead of using the default ServiceAccount.