### PR TITLE
[openshift-resources] add support to test if a url exists within a resource

### DIFF
--- a/reconcile/checkpoint.py
+++ b/reconcile/checkpoint.py
@@ -9,7 +9,7 @@ import re
 from functools import partial, lru_cache
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Union
+from typing import Any, Callable, Dict, Iterable, Mapping, Union
 
 import requests
 from jinja2 import Template
@@ -64,7 +64,7 @@ def valid_owners(owners: Iterable[Mapping[str, str]]) -> bool:
     )
 
 
-VALIDATORS = {
+VALIDATORS: Dict[str, Callable] = {
     "sopsUrl": url_makes_sense,
     "architectureDocument": url_makes_sense,
     "grafanaUrls": lambda x: all(url_makes_sense(y["url"]) for y in x),

--- a/reconcile/checkpoint.py
+++ b/reconcile/checkpoint.py
@@ -6,7 +6,7 @@ https://gitlab.cee.redhat.com/app-sre/contract/-/blob/master/content/process/sre
 """
 import logging
 import re
-from functools import partial
+from functools import partial, lru_cache
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Union
@@ -30,6 +30,7 @@ MISSING_DATA_TEMPLATE = (
 )
 
 
+@lru_cache
 def url_makes_sense(url: str) -> bool:
     """Guesses whether the URL may have a meaningful document.
 

--- a/reconcile/checkpoint.py
+++ b/reconcile/checkpoint.py
@@ -40,7 +40,10 @@ def url_makes_sense(url: str) -> bool:
     The URL is non-sensical if the server is crashing, the document
     doesn't exist or the specified URL can't be even probed with GET.
     """
-    rs = requests.get(url)
+    try:
+        rs = requests.get(url)
+    except requests.exceptions.ConnectionError:
+        return False
     # Codes above NOT_FOUND mean the URL to the document doesn't
     # exist, that the URL is very malformed or that it points to a
     # broken resource

--- a/reconcile/checkpoint.py
+++ b/reconcile/checkpoint.py
@@ -40,6 +40,8 @@ def url_makes_sense(url: str) -> bool:
     The URL is non-sensical if the server is crashing, the document
     doesn't exist or the specified URL can't be even probed with GET.
     """
+    if not url:
+        return False
     try:
         rs = requests.get(url)
     except requests.exceptions.ConnectionError:

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -12,6 +12,7 @@ from sretoolbox.utils import threaded
 
 import anymarkup
 import jinja2
+from reconcile.checkpoint import url_makes_sense
 
 import reconcile.openshift_base as ob
 from reconcile import queries
@@ -247,6 +248,7 @@ def process_jinja2_template(body, vars=None, env=None):
         {"github": lambda u, p, r, v=None: lookup_github_file_content(u, p, r, vars)}
     )
     vars.update({"query": lookup_graphql_query_results})
+    vars.update({"url": url_makes_sense})
     try:
         env = jinja2.Environment(
             extensions=[B64EncodeExtension, RaiseErrorExtension],

--- a/reconcile/test/test_checkpoint.py
+++ b/reconcile/test/test_checkpoint.py
@@ -68,6 +68,16 @@ def test_url_makes_sense_unknown(mocker):
     assert not sut.url_makes_sense("https://www.redhat.com/nonexisting")
 
 
+def test_url_makes_sense_error():
+    """Ensure rejection of URLs returning ConnectionError."""
+    assert not sut.url_makes_sense("https://TODO")
+
+
+def test_url_makes_sense_empty():
+    """Ensure rejection of empty URLs."""
+    assert not sut.url_makes_sense("")
+
+
 def test_render_template():
     """Confirm rendering of all placeholders in the ticket template."""
     txt = sut.render_template(


### PR DESCRIPTION
this will allow us to test the existence of a url and template based on the results.
the `url_makes_sense` function was introduced in https://github.com/app-sre/qontract-reconcile/pull/2141/commits/fcbd19d35d93bcf84d3d9b0707ae221e6e95b4b5.

the intention behind this PR is to use it for the same purpose - to check if an `architectureDocument` link makes sense.

example usage: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/36181