### PR TITLE
[template-tester] introduce new integration

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -101,6 +101,7 @@ import reconcile.ecr_mirror
 import reconcile.kafka_clusters
 import reconcile.terraform_aws_route53
 import reconcile.prometheus_rules_tester
+import reconcile.template_tester
 import reconcile.dashdotdb_dvo
 import reconcile.sendgrid_teammates
 import reconcile.osd_mirrors_data_updater
@@ -1638,6 +1639,14 @@ def integrations_validator(ctx):
 def prometheus_rules_tester(ctx, thread_pool_size, cluster_name):
     run_integration(reconcile.prometheus_rules_tester, ctx.obj,
                     thread_pool_size, cluster_name)
+
+
+@integration.command(
+    short_help="Tests templating of resources."
+)
+@click.pass_context
+def template_tester(ctx):
+    run_integration(reconcile.template_tester, ctx.obj)
 
 
 @integration.command(

--- a/reconcile/template_tester.py
+++ b/reconcile/template_tester.py
@@ -45,8 +45,7 @@ def run(dry_run):
     for tt in template_tests:
         resource = tt["resource"]
         resource["add_path_to_prom_rules"] = False
-        parent = load_resource(tt["resourceParent"])
-        openshift_resource = orb.fetch_openshift_resource(tt["resource"], parent)
+        openshift_resource = orb.fetch_openshift_resource(tt["resource"], tt["resourceParent"])
         expected_result = load_resource(tt["expectedResult"])
         if openshift_resource.body != expected_result:
             logging.error(

--- a/reconcile/template_tester.py
+++ b/reconcile/template_tester.py
@@ -45,7 +45,9 @@ def run(dry_run):
     for tt in template_tests:
         resource = tt["resource"]
         resource["add_path_to_prom_rules"] = False
-        openshift_resource = orb.fetch_openshift_resource(tt["resource"], tt["resourceParent"])
+        openshift_resource = orb.fetch_openshift_resource(
+            tt["resource"], tt["resourceParent"]
+        )
         expected_result = load_resource(tt["expectedResult"])
         if openshift_resource.body != expected_result:
             logging.error(

--- a/reconcile/template_tester.py
+++ b/reconcile/template_tester.py
@@ -17,21 +17,11 @@ TEMPLATE_TESTS_QUERY = """
 {
   tests: template_tests_v1 {
     name
-    resource {
-      %s
-    }
-    resourceParent {
-      name
-      cluster {
-        name
-      }
-    }
+    resource_path
     expectedResult
   }
 }
-""" % indent(
-    orb.OPENSHIFT_RESOURCE, 2 * " "
-)
+"""
 
 
 def load_resource(path: str) -> dict:
@@ -43,17 +33,31 @@ def run(dry_run):
     template_tests = gqlapi.query(TEMPLATE_TESTS_QUERY)["tests"]
     error = False
     for tt in template_tests:
-        resource = tt["resource"]
-        resource["add_path_to_prom_rules"] = False
-        openshift_resource = orb.fetch_openshift_resource(
-            tt["resource"], tt["resourceParent"]
-        )
+        found = False
+        resource_path = tt["resource_path"]
         expected_result = load_resource(tt["expectedResult"])
-        if openshift_resource.body != expected_result:
+        for n in gqlapi.query(orb.NAMESPACES_QUERY)["namespaces"]:
+            openshift_resources = n.get("openshiftResources")
+            if not openshift_resources:
+                continue
+
+            for r in openshift_resources:
+                if resource_path != r["path"]:
+                    continue
+
+                found = True
+                openshift_resource = orb.fetch_openshift_resource(r, n)
+                if openshift_resource.body != expected_result:
+                    logging.error(
+                        f"rendered template is different from expected result in template test {tt['name']}:\n"
+                        f"rendered:\n{yaml.safe_dump(openshift_resource.body)}\n"
+                        f"expected result:\n{yaml.safe_dump(expected_result)}"
+                    )
+                    error = True
+
+        if not found:
             logging.error(
-                f"rendered template is different from expected result in template test {tt['name']}:\n"
-                f"rendered:\n{yaml.safe_dump(openshift_resource.body)}\n"
-                f"expected result:\n{yaml.safe_dump(expected_result)}"
+                f"resource defined in template tests {tt['name']} is not referenced from any namespaces"
             )
             error = True
 

--- a/reconcile/template_tester.py
+++ b/reconcile/template_tester.py
@@ -16,7 +16,7 @@ TEMPLATE_TESTS_QUERY = """
 {
   tests: template_tests_v1 {
     name
-    resource_path
+    resourcePath
     expectedResult
   }
 }
@@ -33,7 +33,7 @@ def run(dry_run):
     error = False
     for tt in template_tests:
         found = False
-        resource_path = tt["resource_path"]
+        resource_path = tt["resourcePath"]
         expected_result = load_resource(tt["expectedResult"])
         for n in gqlapi.query(orb.NAMESPACES_QUERY)["namespaces"]:
             openshift_resources = n.get("openshiftResources")

--- a/reconcile/template_tester.py
+++ b/reconcile/template_tester.py
@@ -3,7 +3,6 @@ import sys
 import yaml
 import reconcile.openshift_resources_base as orb
 
-from textwrap import indent
 from reconcile.status import ExitCodes
 from reconcile.utils import gql
 from reconcile.utils.semver_helper import make_semver

--- a/reconcile/template_tester.py
+++ b/reconcile/template_tester.py
@@ -1,0 +1,60 @@
+import logging
+import sys
+import yaml
+import reconcile.openshift_resources_base as orb
+
+from textwrap import indent
+from reconcile.status import ExitCodes
+from reconcile.utils import gql
+from reconcile.utils.semver_helper import make_semver
+
+
+QONTRACT_INTEGRATION = "template-tester"
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
+
+
+TEMPLATE_TESTS_QUERY = """
+{
+  tests: template_tests_v1 {
+    name
+    resource {
+      %s
+    }
+    resourceParent {
+      name
+      cluster {
+        name
+      }
+    }
+    expectedResult
+  }
+}
+""" % indent(
+    orb.OPENSHIFT_RESOURCE, 2 * " "
+)
+
+
+def load_resource(path: str) -> dict:
+    return yaml.safe_load(gql.get_resource(path)["content"])
+
+
+def run(dry_run):
+    gqlapi = gql.get_api()
+    template_tests = gqlapi.query(TEMPLATE_TESTS_QUERY)["tests"]
+    error = False
+    for tt in template_tests:
+        resource = tt["resource"]
+        resource["add_path_to_prom_rules"] = False
+        parent = load_resource(tt["resourceParent"])
+        openshift_resource = orb.fetch_openshift_resource(tt["resource"], parent)
+        expected_result = load_resource(tt["expectedResult"])
+        if openshift_resource.body != expected_result:
+            logging.error(
+                f"rendered template is different from expected result in template test {tt['name']}:\n"
+                f"rendered:\n{yaml.safe_dump(openshift_resource.body)}\n"
+                f"expected result:\n{yaml.safe_dump(expected_result)}"
+            )
+            error = True
+
+    if error:
+        sys.exit(ExitCodes.ERROR)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="qontract-reconcile",
-    version="0.5.3",
+    version="0.6.0",
     license="Apache License 2.0",
 
     author="Red Hat App-SRE Team",


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4750

depends on https://github.com/app-sre/qontract-schemas/pull/117

this PR adds a new integration called `template-tester` which tests templated resources and verifies that their result (rendered resource) matches an expected result.

the approach of this PR is similar to https://github.com/app-sre/qontract-reconcile/blob/master/reconcile/prometheus_rules_tester.py