### PR TITLE
Add more context about the failed account for stale terraform errors

### DIFF
--- a/reconcile/utils/lean_terraform_client.py
+++ b/reconcile/utils/lean_terraform_client.py
@@ -29,8 +29,8 @@ def show_json(working_dir, out_file):
     )
     out, err = proc.communicate()
     if proc.returncode:
+        # out_file is the name of the account as well
         msg = f"[{out_file}] terraform show failed: {str(err)}"
         logging.warning(msg)
-        # out_file is the name of the account as well
         raise Exception(msg)
     return json.loads(out)

--- a/reconcile/utils/lean_terraform_client.py
+++ b/reconcile/utils/lean_terraform_client.py
@@ -29,7 +29,8 @@ def show_json(working_dir, out_file):
     )
     out, err = proc.communicate()
     if proc.returncode:
-        logging.warning(err)
+        msg = f"[{out_file}] terraform show failed: {str(err)}"
+        logging.warning(msg)
         # out_file is the name of the account as well
-        raise Exception(f"[{out_file}] terraform show failed: {str(err)}")
+        raise Exception(msg)
     return json.loads(out)


### PR DESCRIPTION
Without this change, we don't see which account is causing issues unless
Exception was raised 3 times (due to retry() usage elsewhere in the code).