### PR TITLE
Use a newer unleash client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "ruamel.yaml>=0.16.5,<0.17.0",
         "terrascript==0.9.0",
         "tabulate>=0.8.6,<0.9.0",
-        "UnleashClient>=3.4.2,<3.5.0",
+        "UnleashClient~=5.1",
         "prometheus-client~=0.8",
         "sentry-sdk~=0.14",
         "jenkins-job-builder~=3.12.0",


### PR DESCRIPTION
After merging a newer tzinfo, we are stuck with a dependency chain
that relies on a very old API, causing a lot of messages like

```
/usr/local/lib/python3.9/site-packages/apscheduler/triggers/interval.py:66: PytzUsageWarning: The normalize method is no longer necessary, as this time zone supports the fold attribute (PEP 495). For more details on migrating to a PEP 495-compliant implementation, see https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html
```

A newer UnleashClient fixes these dependencies and uses non-deprecated
APIs.
