### PR TITLE
Do not crash OCM if storage_quota isn't defined

### DIFF
--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import pytest
-
 from reconcile.utils.ocm import OCM
 
 
@@ -85,3 +84,19 @@ def test_get_cluster_aws_account_id_ok(mocker, ocm):
     role_grants_mock.return_value = [(None, None, None, console_url)]
     result = ocm.get_cluster_aws_account_id("cluster")
     assert result == expected
+
+
+@pytest.fixture
+def clusters_by_readiness():
+    return [
+        ({"managed": False, "state": "ready", "storage_quota": 42}, False),
+        ({"managed": True, "state": "ready", "storage_quota": 42}, True),
+        ({"managed": True, "state": "not ready", "storage_quota": 42}, False),
+        # ROSA-like cluster
+        ({"managed": True, "state": "ready"}, False),
+    ]
+
+
+def test__ready_for_app_interface(clusters_by_readiness, ocm):
+    for cluster, readiness in clusters_by_readiness:
+        assert ocm._ready_for_app_interface(cluster) == readiness

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -27,6 +27,7 @@ AUTOSCALE_DESIRED_KEYS = {"min_replicas", "max_replicas"}
 CLUSTER_ADDON_DESIRED_KEYS = {"id", "parameters"}
 
 DISABLE_UWM_ATTR = "disable_user_workload_monitoring"
+BYTES_IN_GIGABYTE = 1024**3
 
 
 class OCM:  # pylint: disable=too-many-public-methods
@@ -123,7 +124,7 @@ class OCM:  # pylint: disable=too-many-public-methods
                 "version": cluster["openshift_version"],
                 "multi_az": cluster["multi_az"],
                 "instance_type": cluster["nodes"]["compute_machine_type"]["id"],
-                "storage": int(cluster["storage_quota"]["value"] / 1073741824),
+                "storage": cluster["storage_quota"]["value"] // BYTES_IN_GIGABYTE,
                 "load_balancers": cluster["load_balancer_quota"],
                 "private": cluster["api"]["listening"] == "internal",
                 "provision_shard_id": self.get_provision_shard(cluster["id"])["id"]
@@ -177,7 +178,7 @@ class OCM:  # pylint: disable=too-many-public-methods
             "multi_az": cluster_spec["multi_az"],
             "nodes": {"compute_machine_type": {"id": cluster_spec["instance_type"]}},
             "storage_quota": {
-                "value": float(cluster_spec["storage"] * 1073741824)  # 1024^3
+                "value": float(cluster_spec["storage"] * BYTES_IN_GIGABYTE)
             },
             "load_balancer_quota": cluster_spec["load_balancers"],
             "network": {


### PR DESCRIPTION
Clusters created with ROSA lack some fields we rely on, such as `storage_quota`. If they are missing, we simply skip them since app-interface won't handle them anyways.

Refs https://issues.redhat.com/browse/APPSRE-4790
