### PR TITLE
Change the default security policy for ELB

### DIFF
--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -3993,7 +3993,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             'load_balancer_arn': f'${{{lb_tf_resource.arn}}}',
             'port': 443,
             'protocol': 'HTTPS',
-            'ssl_policy': 'ELBSecurityPolicy-2016-08',
+            'ssl_policy': 'ELBSecurityPolicy-TLS-1-2-2017-01',
             'certificate_arn': resource['certificate_arn'],
             'default_action': {
                 'type': 'forward',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="qontract-reconcile",
-    version="0.5.2",
+    version="0.5.3",
     license="Apache License 2.0",
 
     author="Red Hat App-SRE Team",


### PR DESCRIPTION
The current one allows for deprecated, insecure, and banned inside Red
Hat TLS protocols. We must use at least TLSv1.2, which is 11 years
old. It should be compatible with everything under the sun.

Refs https://issues.redhat.com/browse/APPSRE-4803
