### PR TITLE
Fix lint error on lru_cache usage

### DIFF
--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -137,7 +137,7 @@ class _VaultClient:
 
         return version
 
-    @functools.lru_cache(maxsize=None)
+    @functools.lru_cache(maxsize=2048)
     def _read_all_v2(self, path, version):
         path_split = path.split("/")
         mount_point = path_split[0]


### PR DESCRIPTION
It warns (rightly) that we can leak memory. A maxsize of 2048 items
looks enough for most cases, and will keep the linter happy.
