### PR TITLE
Speed up GQL-related tests by ~300x

### DIFF
--- a/reconcile/test/test_utils_gql.py
+++ b/reconcile/test/test_utils_gql.py
@@ -1,9 +1,12 @@
 import pytest
 import requests
 from gql.transport.exceptions import TransportQueryError
-from reconcile.utils.gql import (GqlApi, GqlApiError,
-                                 GqlApiErrorForbiddenSchema,
-                                 GqlApiIntegrationNotFound)
+from reconcile.utils.gql import (
+    GqlApi,
+    GqlApiError,
+    GqlApiErrorForbiddenSchema,
+    GqlApiIntegrationNotFound,
+)
 
 TEST_QUERY = """
 {

--- a/reconcile/test/test_utils_gql.py
+++ b/reconcile/test/test_utils_gql.py
@@ -1,13 +1,9 @@
-import requests
-
-from reconcile.utils.gql import (
-    GqlApi,
-    GqlApiError,
-    GqlApiErrorForbiddenSchema,
-    GqlApiIntegrationNotFound,
-)
-from gql.transport.exceptions import TransportQueryError
 import pytest
+import requests
+from gql.transport.exceptions import TransportQueryError
+from reconcile.utils.gql import (GqlApi, GqlApiError,
+                                 GqlApiErrorForbiddenSchema,
+                                 GqlApiIntegrationNotFound)
 
 TEST_QUERY = """
 {
@@ -25,7 +21,7 @@ def test_gqlapi_throws_gqlapierror_when_generic_exception_thrown(mocker):
     patched_client.side_effect = Exception("Something went wrong!")
     with pytest.raises(GqlApiError):
         gql_api = GqlApi("test_url", "test_token", validate_schemas=False)
-        gql_api.query(TEST_QUERY)
+        gql_api.query.__wrapped__(gql_api, TEST_QUERY)
 
 
 def test_gqlapi_throws_gqlapierror_when_connectionerror_exception_thrown(mocker):
@@ -35,7 +31,7 @@ def test_gqlapi_throws_gqlapierror_when_connectionerror_exception_thrown(mocker)
     )
     with pytest.raises(GqlApiError):
         gql_api = GqlApi("test_url", "test_token", validate_schemas=False)
-        gql_api.query(TEST_QUERY)
+        gql_api.query.__wrapped__(gql_api, TEST_QUERY)
 
 
 def test_gqlapi_throws_gqlapierror_when_transportqueryerror_exception_thrown(mocker):
@@ -43,7 +39,7 @@ def test_gqlapi_throws_gqlapierror_when_transportqueryerror_exception_thrown(moc
     patched_client.side_effect = TransportQueryError("Error in GraphQL payload")
     with pytest.raises(GqlApiError):
         gql_api = GqlApi("test_url", "test_token", validate_schemas=False)
-        gql_api.query(TEST_QUERY)
+        gql_api.query.__wrapped__(gql_api, TEST_QUERY)
 
 
 def test_gqlapi_throws_gqlapierror_when_assertionerror_exception_thrown(mocker):
@@ -53,7 +49,7 @@ def test_gqlapi_throws_gqlapierror_when_assertionerror_exception_thrown(mocker):
     )
     with pytest.raises(GqlApiError):
         gql_api = GqlApi("test_url", "test_token", validate_schemas=False)
-        gql_api.query(TEST_QUERY)
+        gql_api.query.__wrapped__(gql_api, TEST_QUERY)
 
 
 def test_gqlapi_throws_gqlapiintegrationnotfound_exception(mocker):
@@ -66,7 +62,7 @@ def test_gqlapi_throws_gqlapiintegrationnotfound_exception(mocker):
         gql_api = GqlApi(
             "test_url", "test_token", "INTEGRATION_NOT_FOUND", validate_schemas=True
         )
-        gql_api.query(TEST_QUERY)
+        gql_api.query.__wrapped__(gql_api, TEST_QUERY)
 
 
 def test_gqlapi_throws_gqlapierrorforbiddenschema_exception(mocker):
@@ -78,4 +74,4 @@ def test_gqlapi_throws_gqlapierrorforbiddenschema_exception(mocker):
 
     with pytest.raises(GqlApiErrorForbiddenSchema):
         gql_api = GqlApi("test_url", "test_token", "INTEGRATION", validate_schemas=True)
-        gql_api.query(TEST_QUERY)
+        gql_api.query.__wrapped__(gql_api, TEST_QUERY)

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -137,7 +137,7 @@ class _VaultClient:
 
         return version
 
-    @functools.lru_cache(maxsize=None)
+    @functools.lru_cache(maxsize=2048)
     def _read_all_v2(self, path, version):
         path_split = path.split("/")
         mount_point = path_split[0]


### PR DESCRIPTION
Test directly the relevant function instead of the decorated one.

The retry decorator introduces sleeps that slow us down and we don't
want to test within this file.  More reading:
https://service.pages.redhat.com/dev-guidelines/docs/appsre/python-testing-guide/#testing-decorated-methods

To be merged after #2323
