### PR TITLE
Filter out clusters missing load_balancer_quota

### DIFF
--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -89,11 +89,37 @@ def test_get_cluster_aws_account_id_ok(mocker, ocm):
 @pytest.fixture
 def clusters_by_readiness():
     return [
-        ({"managed": False, "state": "ready", "storage_quota": 42}, False),
-        ({"managed": True, "state": "ready", "storage_quota": 42}, True),
-        ({"managed": True, "state": "not ready", "storage_quota": 42}, False),
-        # ROSA-like cluster
+        (
+            {
+                "managed": False,
+                "state": "ready",
+                "storage_quota": 42,
+                "load_balancer_quota": 55,
+            },
+            False,
+        ),
+        (
+            {
+                "managed": True,
+                "state": "ready",
+                "storage_quota": 42,
+                "load_balancer_quota": 55,
+            },
+            True,
+        ),
+        (
+            {
+                "managed": True,
+                "state": "not ready",
+                "storage_quota": 42,
+                "load_balancer_quota": 55,
+            },
+            False,
+        ),
+        # ROSA-like clusters
         ({"managed": True, "state": "ready"}, False),
+        ({"managed": True, "state": "ready", "load_balancer_quota": 55}, False),
+        ({"managed": True, "state": "ready", "storage_quota": 42}, False),
     ]
 
 

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -103,6 +103,7 @@ class OCM:  # pylint: disable=too-many-public-methods
             cluster["managed"]
             and cluster["state"] == STATUS_READY
             and "storage_quota" in cluster
+            and "load_balancer_quota" in cluster
         )
 
     def _init_clusters(self, init_provision_shards):

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -137,7 +137,7 @@ class _VaultClient:
 
         return version
 
-    @functools.lru_cache(maxsize=None)
+    @functools.lru_cache(maxsize=2048)
     def _read_all_v2(self, path, version):
         path_split = path.split("/")
         mount_point = path_split[0]


### PR DESCRIPTION
Skip from ocm.py clusters withot load_balancer_quota, based on the spec we've gotten in APPSRE-4790.

To be merged after #2323.