### PR TITLE
bump version to release to pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="qontract-reconcile",
-    version="0.3.0",
+    version="0.4.0",
     license="Apache License 2.0",
 
     author="Red Hat App-SRE Team",


### PR DESCRIPTION
i think we'd want to start enforcing that every PR requires a bump of the version.

and after that, probably change the release to pypi from tag based to push based.

cc @fishi0x01 @Piojo 