### PR TITLE
[terraform-resources] refactor desired state and vault handling

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -13,7 +13,7 @@ import reconcile.openshift_base as ob
 from reconcile import queries
 from reconcile.utils.terraform_resource_spec import (
     TerraformResourceSpecDict,
-    TerraformResourceIdentifier,
+    TerraformResourceUniqueKey,
     TerraformResourceSpec,
 )
 from reconcile.utils import gql
@@ -524,14 +524,14 @@ def filter_tf_namespaces(
 def init_tf_resource_specs(
     namespaces: Iterable[Mapping[str, Any]], account_name: Optional[str]
 ) -> TerraformResourceSpecDict:
-    resource_specs: dict[TerraformResourceIdentifier, TerraformResourceSpec] = {}
+    resource_specs: dict[TerraformResourceUniqueKey, TerraformResourceSpec] = {}
     for namespace_info in namespaces:
         if not namespace_info.get("managedTerraformResources"):
             continue
         tf_resources = namespace_info.get("terraformResources") or []
         for resource in tf_resources:
             if account_name is None or resource["account"] == account_name:
-                identifier = TerraformResourceIdentifier.from_dict(resource)
+                identifier = TerraformResourceUniqueKey.from_dict(resource)
                 resource_specs[identifier] = TerraformResourceSpec(
                     resource=resource,
                     namespace=namespace_info,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -3,7 +3,7 @@ import shutil
 import sys
 
 from textwrap import indent
-from typing import Any, Optional, Mapping, Tuple, cast
+from typing import Any, Iterable, Optional, Mapping, Tuple, cast
 
 from sretoolbox.utils import threaded
 
@@ -445,7 +445,7 @@ def setup(
     internal: str,
     use_jump_host: bool,
     account_name: Optional[str],
-    extra_labels,
+    extra_labels: dict[str, str],
 ) -> Tuple[
     ResourceInventory,
     OC_Map,
@@ -501,7 +501,7 @@ def setup(
 
 
 def filter_tf_namespaces(
-    namespaces: list[dict[str, Any]], account_name: Optional[str]
+    namespaces: Iterable[dict[str, Any]], account_name: Optional[str]
 ) -> list[dict[str, Any]]:
     tf_namespaces = []
     for namespace_info in namespaces:
@@ -550,10 +550,10 @@ def cleanup_and_exit(tf=None, status=False, working_dirs=None):
     sys.exit(status)
 
 
-def write_outputs_to_vault(vault_path: str, resoure_specs: TerraformResourceSpecDict) -> None:
+def write_outputs_to_vault(vault_path: str, resource_specs: TerraformResourceSpecDict) -> None:
     integration_name = QONTRACT_INTEGRATION.replace('_', '-')
     vault_client = cast(_VaultClient, VaultClient())
-    for spec in resoure_specs.values():
+    for spec in resource_specs.values():
         secret_path = f"{vault_path}/{integration_name}/{spec.cluster_name}/{spec.namespace_name}/{spec.output_resource_name}"
         # vault only stores strings as values - by converting to str upfront, we can compare current to desired
         stringified_secret = {k: str(v) for k, v in spec.secret.items()}

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -3,7 +3,7 @@ import shutil
 import sys
 
 from textwrap import indent
-from typing import Any, Iterable, Optional, Mapping, Tuple, cast
+from typing import Any, Iterable, MutableMapping, Optional, Mapping, Tuple, cast
 
 from sretoolbox.utils import threaded
 
@@ -445,7 +445,7 @@ def setup(
     internal: str,
     use_jump_host: bool,
     account_name: Optional[str],
-    extra_labels: dict[str, str],
+    extra_labels: MutableMapping[str, str],
 ) -> Tuple[
     ResourceInventory,
     OC_Map,
@@ -501,8 +501,8 @@ def setup(
 
 
 def filter_tf_namespaces(
-    namespaces: Iterable[dict[str, Any]], account_name: Optional[str]
-) -> list[dict[str, Any]]:
+    namespaces: Iterable[Mapping[str, Any]], account_name: Optional[str]
+) -> list[Mapping[str, Any]]:
     tf_namespaces = []
     for namespace_info in namespaces:
         if not namespace_info.get('managedTerraformResources'):
@@ -522,9 +522,9 @@ def filter_tf_namespaces(
 
 
 def init_tf_resource_specs(
-    namespaces: list[dict[str, Any]], account_name: Optional[str]
+    namespaces: Iterable[Mapping[str, Any]], account_name: Optional[str]
 ) -> TerraformResourceSpecDict:
-    resource_specs: TerraformResourceSpecDict = {}
+    resource_specs: dict[TerraformResourceIdentifier, TerraformResourceSpec] = {}
     for namespace_info in namespaces:
         if not namespace_info.get("managedTerraformResources"):
             continue

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -3,7 +3,7 @@ import shutil
 import sys
 
 from textwrap import indent
-from typing import Any, Optional, Mapping
+from typing import Any, Optional, Mapping, Tuple
 
 from sretoolbox.utils import threaded
 
@@ -11,6 +11,11 @@ from sretoolbox.utils import threaded
 import reconcile.openshift_base as ob
 
 from reconcile import queries
+from reconcile.utils.terraform_resource_spec import (
+    TerraformResourceSpecDict,
+    TerraformResourceIdentifier,
+    TerraformResourceSpec,
+)
 from reconcile.utils import gql
 from reconcile.aws_iam_keys import run as disable_keys
 from reconcile.utils.aws_api import AWSApi
@@ -421,7 +426,6 @@ def fetch_current_state(dry_run, namespaces, thread_pool_size,
 
 def init_working_dirs(accounts: list[dict[str, Any]],
                       thread_pool_size: int,
-                      oc_map: Optional[OCMMap] = None,
                       settings: Optional[Mapping[str, Any]] = None
                       ) -> tuple[Terrascript, dict[str, str]]:
     ts = Terrascript(QONTRACT_INTEGRATION,
@@ -433,8 +437,21 @@ def init_working_dirs(accounts: list[dict[str, Any]],
     return ts, working_dirs
 
 
-def setup(dry_run, print_to_file, thread_pool_size, internal,
-          use_jump_host, account_name, extra_labels):
+def setup(
+    dry_run: bool,
+    print_to_file: str,
+    thread_pool_size: int,
+    internal: str,
+    use_jump_host: bool,
+    account_name: Optional[str],
+    extra_labels,
+) -> Tuple[
+    ResourceInventory,
+    OC_Map,
+    Terraform,
+    list[dict[str, Any]],
+    TerraformResourceSpecDict,
+]:
     gqlapi = gql.get_api()
     accounts = queries.get_aws_accounts()
     if account_name:
@@ -444,12 +461,22 @@ def setup(dry_run, print_to_file, thread_pool_size, internal,
             raise ValueError(f"aws account {account_name} is not found")
         extra_labels['shard_key'] = account_name
     settings = queries.get_app_interface_settings()
+
+    # build a resource inventory for all the kube secrets managed by the
+    # app-interface managed terraform resources
     namespaces = gqlapi.query(TF_NAMESPACES_QUERY)['namespaces']
     tf_namespaces = filter_tf_namespaces(namespaces, account_name)
     ri, oc_map = fetch_current_state(dry_run, tf_namespaces, thread_pool_size,
                                      internal, use_jump_host, account_name)
-    ts, working_dirs = init_working_dirs(accounts, thread_pool_size,
-                                         settings=settings)
+
+    # build the resource specs
+    resource_specs = init_tf_resource_specs(tf_namespaces, account_name)
+
+    # initialize terrascript (scripting engine to generate terraform manifests)
+    ts, working_dirs = init_working_dirs(accounts, thread_pool_size, settings=settings)
+
+    # initialize terraform client
+    # it used to plan and apply according to the output of terrascript
     aws_api = AWSApi(1, accounts, settings=settings, init_users=False)
     tf = Terraform(QONTRACT_INTEGRATION,
                    QONTRACT_INTEGRATION_VERSION,
@@ -470,10 +497,12 @@ def setup(dry_run, print_to_file, thread_pool_size, internal,
                           ocm_map=ocm_map)
     ts.dump(print_to_file, existing_dirs=working_dirs)
 
-    return ri, oc_map, tf, tf_namespaces
+    return ri, oc_map, tf, tf_namespaces, resource_specs
 
 
-def filter_tf_namespaces(namespaces, account_name):
+def filter_tf_namespaces(
+    namespaces: list[dict[str, Any]], account_name: Optional[str]
+) -> list[dict[str, Any]]:
     tf_namespaces = []
     for namespace_info in namespaces:
         if not namespace_info.get('managedTerraformResources'):
@@ -490,6 +519,24 @@ def filter_tf_namespaces(namespaces, account_name):
                 tf_namespaces.append(namespace_info)
                 break
     return tf_namespaces
+
+
+def init_tf_resource_specs(
+    namespaces: list[dict[str, Any]], account_name: Optional[str]
+) -> TerraformResourceSpecDict:
+    resource_specs: TerraformResourceSpecDict = {}
+    for namespace_info in namespaces:
+        if not namespace_info.get("managedTerraformResources"):
+            continue
+        tf_resources = namespace_info.get("terraformResources") or []
+        for resource in tf_resources:
+            if account_name is None or resource["account"] == account_name:
+                identifier = TerraformResourceIdentifier.from_dict(resource)
+                resource_specs[identifier] = TerraformResourceSpec(
+                    resource=resource,
+                    namespace=namespace_info,
+                )
+    return resource_specs
 
 
 def cleanup_and_exit(tf=None, status=False, working_dirs=None):
@@ -515,15 +562,30 @@ def write_outputs_to_vault(vault_path, ri):
 
 
 @defer
-def run(dry_run, print_to_file=None,
-        enable_deletion=False, io_dir='throughput/',
-        thread_pool_size=10, internal=None, use_jump_host=True,
-        light=False, vault_output_path='',
-        account_name=None, extra_labels=None, defer=None):
+def run(
+    dry_run,
+    print_to_file=None,
+    enable_deletion=False,
+    io_dir="throughput/",
+    thread_pool_size=10,
+    internal=None,
+    use_jump_host=True,
+    light=False,
+    vault_output_path="",
+    account_name=None,
+    extra_labels=None,
+    defer=None,
+):
 
-    ri, oc_map, tf, tf_namespaces = \
-        setup(dry_run, print_to_file, thread_pool_size, internal,
-              use_jump_host, account_name, extra_labels)
+    ri, oc_map, tf, tf_namespaces, resource_specs = setup(
+        dry_run,
+        print_to_file,
+        thread_pool_size,
+        internal,
+        use_jump_host,
+        account_name,
+        extra_labels,
+    )
 
     if not dry_run:
         defer(oc_map.cleanup)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -12,7 +12,7 @@ import reconcile.openshift_base as ob
 
 from reconcile import queries
 from reconcile.utils.terraform_resource_spec import (
-    TerraformResourceSpecDict,
+    TerraformResourceSpecInventory,
     TerraformResourceUniqueKey,
     TerraformResourceSpec,
 )
@@ -450,7 +450,7 @@ def setup(
     ResourceInventory,
     OC_Map,
     Terraform,
-    TerraformResourceSpecDict,
+    TerraformResourceSpecInventory,
 ]:
     gqlapi = gql.get_api()
     accounts = queries.get_aws_accounts()
@@ -523,7 +523,7 @@ def filter_tf_namespaces(
 
 def init_tf_resource_specs(
     namespaces: Iterable[Mapping[str, Any]], account_name: Optional[str]
-) -> TerraformResourceSpecDict:
+) -> TerraformResourceSpecInventory:
     resource_specs: dict[TerraformResourceUniqueKey, TerraformResourceSpec] = {}
     for namespace_info in namespaces:
         if not namespace_info.get("managedTerraformResources"):
@@ -550,7 +550,7 @@ def cleanup_and_exit(tf=None, status=False, working_dirs=None):
     sys.exit(status)
 
 
-def write_outputs_to_vault(vault_path: str, resource_specs: TerraformResourceSpecDict) -> None:
+def write_outputs_to_vault(vault_path: str, resource_specs: TerraformResourceSpecInventory) -> None:
     integration_name = QONTRACT_INTEGRATION.replace('_', '-')
     vault_client = cast(_VaultClient, VaultClient())
     for spec in resource_specs.values():
@@ -561,7 +561,7 @@ def write_outputs_to_vault(vault_path: str, resource_specs: TerraformResourceSpe
         vault_client.write(desired_secret)
 
 
-def populate_desired_state(ri: ResourceInventory, resource_specs: TerraformResourceSpecDict) -> None:
+def populate_desired_state(ri: ResourceInventory, resource_specs: TerraformResourceSpecInventory) -> None:
     for spec in resource_specs.values():
         if ri.is_cluster_present(spec.cluster_name):
             oc_resource = spec.build_oc_secret(

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -476,7 +476,7 @@ def setup(
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size, settings=settings)
 
     # initialize terraform client
-    # it used to plan and apply according to the output of terrascript
+    # it is used to plan and apply according to the output of terrascript
     aws_api = AWSApi(1, accounts, settings=settings, init_users=False)
     tf = Terraform(QONTRACT_INTEGRATION,
                    QONTRACT_INTEGRATION_VERSION,
@@ -564,7 +564,7 @@ def write_outputs_to_vault(vault_path: str, resoure_specs: TerraformResourceSpec
 def populate_desired_state(ri: ResourceInventory, resource_specs: TerraformResourceSpecDict) -> None:
     for spec in resource_specs.values():
         if ri.is_cluster_present(spec.cluster_name):
-            oc_resource = spec.construct_oc_resource(
+            oc_resource = spec.build_oc_secret(
                 QONTRACT_INTEGRATION,
                 QONTRACT_INTEGRATION_VERSION
             )
@@ -633,7 +633,7 @@ def run(
         resource_specs=resource_specs,
         init_rds_replica_source=True
     )
-    # populate resourceinventory with latest output data
+    # populate the resource inventory with latest output data
     populate_desired_state(ri, resource_specs)
 
     actions = ob.realize_data(dry_run, oc_map, ri, thread_pool_size,

--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -4,6 +4,7 @@ from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.openshift_resource import (
     OpenshiftResource as OR,
     ConstructResourceError,
+    build_secret,
 )
 
 
@@ -180,3 +181,28 @@ def test_managed_cluster_label_ignore():
     c_r = OR(current, TEST_INT, TEST_INT_VER)
     assert d_r == c_r
     assert d_r.sha256sum() == c_r.sha256sum()
+
+
+def test_build_secret():
+    value = "value"
+    encoded_value = "dmFsdWU="
+    res = build_secret(
+        name="name",
+        integration=TEST_INT,
+        integration_version=TEST_INT_VER,
+        unencoded_data={
+            "field": value,
+            "empty": "",
+        },
+    )
+
+    # test metadata
+    assert res.kind == "Secret"
+    assert res.name == "name"
+    assert res.integration == TEST_INT
+    assert res.integration_version == TEST_INT_VER
+
+    # assert data section
+    assert len(res.body["data"]) == 2
+    assert res.body["data"]["field"] == encoded_value
+    assert not res.body["data"]["empty"]

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -1,6 +1,6 @@
 import reconcile.terraform_resources as integ
 from reconcile.utils.terraform_resource_spec import (
-    TerraformResourceIdentifier as TRI,
+    TerraformResourceUniqueKey,
     TerraformResourceSpec,
 )
 
@@ -144,7 +144,9 @@ def test_resource_specs_without_account_filter():
     }
     namespaces = [ns1]
     resources = integ.init_tf_resource_specs(namespaces, None)
-    assert resources == {TRI.from_dict(ra): TerraformResourceSpec(ra, ns1)}
+    assert resources == {
+        TerraformResourceUniqueKey.from_dict(ra): TerraformResourceSpec(ra, ns1)
+    }
 
 
 def test_resource_specs_with_account_filter():
@@ -162,4 +164,6 @@ def test_resource_specs_with_account_filter():
     }
     namespaces = [ns1]
     resources = integ.init_tf_resource_specs(namespaces, "a")
-    assert resources == {TRI.from_dict(ra): TerraformResourceSpec(ra, ns1)}
+    assert resources == {
+        TerraformResourceUniqueKey.from_dict(ra): TerraformResourceSpec(ra, ns1)
+    }

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -1,30 +1,165 @@
-from unittest import TestCase
 import reconcile.terraform_resources as integ
+from reconcile.utils.terraform_resource_spec import (
+    TerraformResourceIdentifier as TRI,
+    TerraformResourceSpec,
+)
 
 
-class TestSupportFunctions(TestCase):
-    def test_filter_no_managed_tf_resources(self):
-        ra = {"account": "a"}
-        ns1 = {"managedTerraformResources": False, "terraformResources": []}
-        ns2 = {"managedTerraformResources": True, "terraformResources": [ra]}
-        namespaces = [ns1, ns2]
-        filtered = integ.filter_tf_namespaces(namespaces, None)
-        self.assertEqual(filtered, [ns2])
+def test_filter_namespaces_no_managed_tf_resources():
+    ra = {"account": "a", "identifier": "a", "provider": "p"}
+    ns1 = {
+        "name": "ns1",
+        "managedTerraformResources": False,
+        "terraformResources": [],
+        "cluster": {"name": "c"},
+    }
+    ns2 = {
+        "name": "ns2",
+        "managedTerraformResources": True,
+        "terraformResources": [ra],
+        "cluster": {"name": "c"},
+    }
+    namespaces = [ns1, ns2]
+    filtered = integ.filter_tf_namespaces(namespaces, None)
+    assert filtered == [ns2]
 
-    def test_filter_tf_namespaces_with_account_name(self):
-        ra = {"account": "a"}
-        rb = {"account": "b"}
-        ns1 = {"managedTerraformResources": True, "terraformResources": [ra]}
-        ns2 = {"managedTerraformResources": True, "terraformResources": [rb]}
-        namespaces = [ns1, ns2]
-        filtered = integ.filter_tf_namespaces(namespaces, "a")
-        self.assertEqual(filtered, [ns1])
 
-    def test_filter_tf_namespaces_without_account_name(self):
-        ra = {"account": "a"}
-        rb = {"account": "b"}
-        ns1 = {"managedTerraformResources": True, "terraformResources": [ra]}
-        ns2 = {"managedTerraformResources": True, "terraformResources": [rb]}
-        namespaces = [ns1, ns2]
-        filtered = integ.filter_tf_namespaces(namespaces, None)
-        self.assertEqual(filtered, namespaces)
+def test_filter_namespaces_with_account_filter():
+    ra = {"account": "a", "identifier": "a", "provider": "p"}
+    rb = {"account": "b", "identifier": "b", "provider": "p"}
+    ns1 = {
+        "name": "ns1",
+        "managedTerraformResources": True,
+        "terraformResources": [ra],
+        "cluster": {"name": "c"},
+    }
+    ns2 = {
+        "name": "ns2",
+        "managedTerraformResources": True,
+        "terraformResources": [rb],
+        "cluster": {"name": "c"},
+    }
+    namespaces = [ns1, ns2]
+    filtered = integ.filter_tf_namespaces(namespaces, "a")
+    assert filtered == [ns1]
+
+
+def test_filter_namespaces_no_account_filter():
+    ra = {"account": "a", "identifier": "a", "provider": "p"}
+    rb = {"account": "b", "identifier": "b", "provider": "p"}
+    ns1 = {
+        "name": "ns1",
+        "managedTerraformResources": True,
+        "terraformResources": [ra],
+        "cluster": {"name": "c"},
+    }
+    ns2 = {
+        "name": "ns2",
+        "managedTerraformResources": True,
+        "terraformResources": [rb],
+        "cluster": {"name": "c"},
+    }
+    namespaces = [ns1, ns2]
+    filtered = integ.filter_tf_namespaces(namespaces, None)
+    assert filtered == namespaces
+
+
+def test_filter_namespaces_no_tf_resources_no_account_filter():
+    """
+    this test makes sure that a namespace is returned even if it has no resources
+    attached. this way we can delete the last terraform resources that might have been
+    defined on the namespace previously
+    """
+    ra = {"account": "a", "identifier": "a", "provider": "p"}
+    ns1 = {
+        "name": "ns1",
+        "managedTerraformResources": True,
+        "terraformResources": [],
+        "cluster": {"name": "c"},
+    }
+    ns2 = {
+        "name": "ns2",
+        "managedTerraformResources": True,
+        "terraformResources": [ra],
+        "cluster": {"name": "c"},
+    }
+
+    namespaces = [ns1, ns2]
+    filtered = integ.filter_tf_namespaces(namespaces, None)
+    assert filtered == [ns1, ns2]
+
+
+def test_filter_tf_namespaces_no_tf_resources_with_account_filter():
+    """
+    even if an account filter is defined, a namespace without resources is returned
+    to enable terraform resource deletion. in contrast to that, a namespace with a resource
+    that does not match the account will not be returned.
+    """
+    ra = {"account": "a", "identifier": "a", "provider": "p"}
+    ns1 = {
+        "name": "ns1",
+        "managedTerraformResources": True,
+        "terraformResources": [],
+        "cluster": {"name": "c"},
+    }
+    ns2 = {
+        "name": "ns2",
+        "managedTerraformResources": True,
+        "terraformResources": [ra],
+        "cluster": {"name": "c"},
+    }
+    namespaces = [ns1, ns2]
+    filtered = integ.filter_tf_namespaces(namespaces, "b")
+    assert filtered == [ns1]
+
+
+def test_tf_disabled_namespace_with_resources():
+    """
+    even if a namespace has tf resources, they are not considered when the
+    namespace is not enabled for tf resource management
+    """
+    ra = {"account": "a", "identifier": "a", "provider": "p"}
+    ns1 = {
+        "name": "ns1",
+        "managedTerraformResources": False,
+        "terraformResources": [ra],
+        "cluster": {"name": "c"},
+    }
+    namespaces = [ns1]
+    resources = integ.init_tf_resource_specs(namespaces, None)
+    assert not resources
+
+
+def test_resource_specs_without_account_filter():
+    """
+    if no account filter is given, all resources of namespaces with
+    enabled tf resource management are expected to be returned
+    """
+    ra = {"account": "a", "identifier": "a", "provider": "p"}
+    ns1 = {
+        "name": "ns1",
+        "managedTerraformResources": True,
+        "terraformResources": [ra],
+        "cluster": {"name": "c"},
+    }
+    namespaces = [ns1]
+    resources = integ.init_tf_resource_specs(namespaces, None)
+    assert resources == {TRI.from_dict(ra): TerraformResourceSpec(ra, ns1)}
+
+
+def test_resource_specs_with_account_filter():
+    """
+    if an account filter is given only the resources defined for
+    that account are expected
+    """
+    ra = {"account": "a", "identifier": "a", "provider": "p"}
+    rb = {"account": "b", "identifier": "b", "provider": "p"}
+    ns1 = {
+        "name": "ns1",
+        "managedTerraformResources": True,
+        "terraformResources": [ra, rb],
+        "cluster": {"name": "c"},
+    }
+    namespaces = [ns1]
+    resources = integ.init_tf_resource_specs(namespaces, "a")
+    assert resources == {TRI.from_dict(ra): TerraformResourceSpec(ra, ns1)}

--- a/reconcile/test/test_utils_terraform_client.py
+++ b/reconcile/test/test_utils_terraform_client.py
@@ -164,7 +164,7 @@ def test_get_replicas_info_via_overrides_with_defaults_present(mocker: MockerFix
     assert result == expected
 
 
-def test_construct_oc_resource():
+def test_build_oc_secret():
     integration = "integ"
     integration_version = "v1"
     account = "account"
@@ -192,7 +192,7 @@ def test_construct_oc_resource():
         "qontract.recycle": "true",
     }
 
-    resource = spec.construct_oc_resource(integration, integration_version)
+    resource = spec.build_oc_secret(integration, integration_version)
 
     # check metadata
     assert resource.caller == account

--- a/reconcile/test/test_utils_terraform_client.py
+++ b/reconcile/test/test_utils_terraform_client.py
@@ -5,7 +5,7 @@ from pytest_mock import MockerFixture  # type: ignore
 
 from reconcile.utils.terraform_resource_spec import (
     TerraformResourceSpec,
-    TerraformResourceIdentifier as TRI,
+    TerraformResourceUniqueKey,
 )
 import reconcile.utils.terraform_client as tfclient
 from reconcile.utils.aws_api import AWSApi
@@ -234,7 +234,7 @@ def test_populate_terraform_output_secret():
     }
 
     tfclient.TerraformClient._populate_terraform_output_secrets(
-        {TRI.from_dict(s.resource): s for s in resource_specs},
+        {TerraformResourceUniqueKey.from_dict(s.resource): s for s in resource_specs},
         existing_secrets,
         integration_prefix,
         {},

--- a/reconcile/test/test_utils_terraform_resource_spec.py
+++ b/reconcile/test/test_utils_terraform_resource_spec.py
@@ -1,3 +1,4 @@
+from pydantic import ValidationError
 import pytest
 from reconcile.utils.terraform_resource_spec import (
     TerraformResourceIdentifier as TRI,
@@ -13,18 +14,18 @@ def test_identifier_creation_from_dict():
 
 
 def test_identifier_missing():
-    with pytest.raises(ValueError):
-        TRI.from_dict({"provider": "p", "account": "a"})
+    with pytest.raises(ValidationError):
+        TRI.from_dict({"identifier": None, "provider": "p", "account": "a"})
 
 
 def test_identifier_account_missing():
-    with pytest.raises(ValueError):
-        TRI.from_dict({"identifier": "i", "provider": "p"})
+    with pytest.raises(ValidationError):
+        TRI.from_dict({"identifier": "i", "account": None, "provider": "p"})
 
 
 def test_identifier_provider_missing():
-    with pytest.raises(ValueError):
-        TRI.from_dict({"identifier": "i", "account": "a"})
+    with pytest.raises(ValidationError):
+        TRI.from_dict({"identifier": "i", "account": "a", "provider": None})
 
 
 def test_spec_output_prefix():

--- a/reconcile/test/test_utils_terraform_resource_spec.py
+++ b/reconcile/test/test_utils_terraform_resource_spec.py
@@ -65,7 +65,7 @@ def test_spec_annotation_parsing():
         },
         namespace={},
     )
-    assert s.annotations == {"key": "value"}
+    assert s._annotations() == {"key": "value"}
 
 
 def test_spec_annotation_parsing_none_present():
@@ -77,4 +77,4 @@ def test_spec_annotation_parsing_none_present():
         },
         namespace={},
     )
-    assert s.annotations == {}
+    assert s._annotations() == {}

--- a/reconcile/test/test_utils_terraform_resource_spec.py
+++ b/reconcile/test/test_utils_terraform_resource_spec.py
@@ -20,6 +20,8 @@ def test_identifier_missing():
         TerraformResourceUniqueKey.from_dict(
             {"identifier": None, "provider": "p", "account": "a"}
         )
+    with pytest.raises(KeyError):
+        TerraformResourceUniqueKey.from_dict({"provider": "p", "account": "a"})
 
 
 def test_identifier_account_missing():
@@ -27,6 +29,8 @@ def test_identifier_account_missing():
         TerraformResourceUniqueKey.from_dict(
             {"identifier": "i", "account": None, "provider": "p"}
         )
+    with pytest.raises(KeyError):
+        TerraformResourceUniqueKey.from_dict({"identifier": "i", "provider": "p"})
 
 
 def test_identifier_provider_missing():
@@ -34,6 +38,8 @@ def test_identifier_provider_missing():
         TerraformResourceUniqueKey.from_dict(
             {"identifier": "i", "account": "a", "provider": None}
         )
+    with pytest.raises(KeyError):
+        TerraformResourceUniqueKey.from_dict({"identifier": "i", "account": "a"})
 
 
 def test_spec_output_prefix():

--- a/reconcile/test/test_utils_terraform_resource_spec.py
+++ b/reconcile/test/test_utils_terraform_resource_spec.py
@@ -1,0 +1,86 @@
+import pytest
+from reconcile.utils.terraform_resource_spec import (
+    TerraformResourceIdentifier as TRI,
+    TerraformResourceSpec,
+)
+
+
+def test_identifier_creation_from_dict():
+    id = TRI.from_dict({"identifier": "i", "provider": "p", "account": "a"})
+    assert id.identifier == "i"
+    assert id.provider == "p"
+    assert id.account == "a"
+
+
+def test_identifier_creation_from_output_prefix():
+    id = TRI.from_output_prefix("i-p", "a")
+    assert id.identifier == "i"
+    assert id.provider == "p"
+    assert id.account == "a"
+
+
+def test_identifier_missing():
+    with pytest.raises(ValueError):
+        TRI.from_dict({"provider": "p", "account": "a"})
+
+
+def test_identifier_account_missing():
+    with pytest.raises(ValueError):
+        TRI.from_dict({"identifier": "i", "provider": "p"})
+
+
+def test_identifier_provider_missing():
+    with pytest.raises(ValueError):
+        TRI.from_dict({"identifier": "i", "account": "a"})
+
+
+def test_spec_output_prefix():
+    s = TerraformResourceSpec(
+        resource={"identifier": "i", "provider": "p", "account": "a"}, namespace={}
+    )
+    assert s.output_prefix == "i-p"
+
+
+def test_spec_implicit_output_resource_name():
+    s = TerraformResourceSpec(
+        resource={"identifier": "i", "provider": "p", "account": "a"}, namespace={}
+    )
+    assert s.output_resource_name == "i-p"
+
+
+def test_spec_explicit_output_resource_name():
+    s = TerraformResourceSpec(
+        resource={
+            "identifier": "i",
+            "provider": "p",
+            "account": "a",
+            "output_resource_name": "explicit",
+        },
+        namespace={},
+    )
+    assert s.output_resource_name == "explicit"
+
+
+def test_spec_annotation_parsing():
+    s = TerraformResourceSpec(
+        resource={
+            "identifier": "i",
+            "provider": "p",
+            "account": "a",
+            "annotations": '{"key": "value"}',
+        },
+        namespace={},
+    )
+    assert s.annotations == {"key": "value"}
+
+
+def test_spec_annotation_parsing_none_present():
+    s = TerraformResourceSpec(
+        resource={
+            "identifier": "i",
+            "provider": "p",
+            "account": "a",
+        },
+        namespace={},
+    )
+    assert s.annotations == {}

--- a/reconcile/test/test_utils_terraform_resource_spec.py
+++ b/reconcile/test/test_utils_terraform_resource_spec.py
@@ -12,13 +12,6 @@ def test_identifier_creation_from_dict():
     assert id.account == "a"
 
 
-def test_identifier_creation_from_output_prefix():
-    id = TRI.from_output_prefix("i-p", "a")
-    assert id.identifier == "i"
-    assert id.provider == "p"
-    assert id.account == "a"
-
-
 def test_identifier_missing():
     with pytest.raises(ValueError):
         TRI.from_dict({"provider": "p", "account": "a"})

--- a/reconcile/test/test_utils_terraform_resource_spec.py
+++ b/reconcile/test/test_utils_terraform_resource_spec.py
@@ -1,13 +1,15 @@
 from pydantic import ValidationError
 import pytest
 from reconcile.utils.terraform_resource_spec import (
-    TerraformResourceIdentifier as TRI,
+    TerraformResourceUniqueKey,
     TerraformResourceSpec,
 )
 
 
 def test_identifier_creation_from_dict():
-    id = TRI.from_dict({"identifier": "i", "provider": "p", "account": "a"})
+    id = TerraformResourceUniqueKey.from_dict(
+        {"identifier": "i", "provider": "p", "account": "a"}
+    )
     assert id.identifier == "i"
     assert id.provider == "p"
     assert id.account == "a"
@@ -15,17 +17,23 @@ def test_identifier_creation_from_dict():
 
 def test_identifier_missing():
     with pytest.raises(ValidationError):
-        TRI.from_dict({"identifier": None, "provider": "p", "account": "a"})
+        TerraformResourceUniqueKey.from_dict(
+            {"identifier": None, "provider": "p", "account": "a"}
+        )
 
 
 def test_identifier_account_missing():
     with pytest.raises(ValidationError):
-        TRI.from_dict({"identifier": "i", "account": None, "provider": "p"})
+        TerraformResourceUniqueKey.from_dict(
+            {"identifier": "i", "account": None, "provider": "p"}
+        )
 
 
 def test_identifier_provider_missing():
     with pytest.raises(ValidationError):
-        TRI.from_dict({"identifier": "i", "account": "a", "provider": None})
+        TerraformResourceUniqueKey.from_dict(
+            {"identifier": "i", "account": "a", "provider": None}
+        )
 
 
 def test_spec_output_prefix():

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -512,6 +512,9 @@ class ResourceInventory:
             resource_type, {"current": {}, "desired": {}, "use_admin_token": {}}
         )
 
+    def is_cluster_present(self, cluster: str) -> bool:
+        return cluster in self._clusters
+
     def add_desired(
         self, cluster, namespace, resource_type, name, value, privileged=False
     ):

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -4,7 +4,7 @@ import datetime
 import hashlib
 import json
 import re
-from typing import Union
+from typing import Mapping, Optional, Union
 
 from threading import Lock
 
@@ -554,3 +554,41 @@ class ResourceInventory:
         if cluster is not None:
             return self._error_registered_clusters.get(cluster, False)
         return self._error_registered
+
+
+def build_secret(
+    name: str,
+    integration: str,
+    integration_version: str,
+    unencoded_data: Mapping[str, str],
+    error_details: str = "",
+    caller_name: Optional[str] = None,
+    annotations: Optional[Mapping[str, str]] = None,
+) -> OpenshiftResource:
+
+    encoded_data = {
+        k: base64_encode_secret_field_value(v) for k, v in unencoded_data.items()
+    }
+
+    body = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "type": "Opaque",
+        "metadata": {"name": name, "annotations": annotations or {}},
+        "data": encoded_data,
+    }
+
+    return OpenshiftResource(
+        body,
+        integration,
+        integration_version,
+        error_details=error_details,
+        caller_name=caller_name,
+    )
+
+
+def base64_encode_secret_field_value(value: str) -> Optional[str]:
+    if value == "":
+        return None
+    else:
+        return base64.b64encode(str(value).encode()).decode("utf-8")

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -12,7 +12,7 @@ from typing import Iterable, Mapping, Any
 from python_terraform import Terraform, IsFlagged, TerraformCommandError
 from sretoolbox.utils import retry
 from sretoolbox.utils import threaded
-from reconcile.utils.terraform_resource_spec import TerraformResourceSpec, TerraformResourceSpecDict
+from reconcile.utils.terraform_resource_spec import TerraformResourceSpec, TerraformResourceSpecInventory
 
 import reconcile.utils.lean_terraform_client as lean_tf
 
@@ -420,7 +420,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
             return data[list(data.keys())[0]]
         return data
 
-    def populate_terraform_output_secrets(self, resource_specs: TerraformResourceSpecDict,
+    def populate_terraform_output_secrets(self, resource_specs: TerraformResourceSpecInventory,
                                           init_rds_replica_source: bool = False) -> None:
         """
         find the terraform output data for each resource spec and populate its `secret` field.
@@ -439,7 +439,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         )
 
     @staticmethod
-    def _populate_terraform_output_secrets(resource_specs: TerraformResourceSpecDict,
+    def _populate_terraform_output_secrets(resource_specs: TerraformResourceSpecInventory,
                                            terraform_output_secrets: Mapping[str, Mapping[str, Mapping[str, str]]],
                                            integration_prefix: str,
                                            replica_sources: Mapping[str, Mapping[str, str]]) -> None:

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -2,7 +2,6 @@ import logging
 import json
 import os
 import shutil
-import copy
 
 from datetime import datetime
 from collections import defaultdict
@@ -470,14 +469,14 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     def _populate_terraform_output_secrets(resource_specs: TerraformResourceSpecDict,
-                                           existing_secrets: dict[str, dict[str, dict[str, str]]],
+                                           existing_secrets: Mapping[str, Mapping[str, Mapping[str, str]]],
                                            integration_prefix: str,
-                                           replica_sources: dict[str, dict[str, str]]) -> None:
+                                           replica_sources: Mapping[str, Mapping[str, str]]) -> None:
         for spec in resource_specs.values():
             secret = existing_secrets.get(spec.account, {}).get(spec.output_prefix, None)
             if not secret:
                 continue
-            secret_copy = copy.deepcopy(secret)
+            secret_copy = dict(secret)
 
             # find out about replica source
             replica_source = replica_sources.get(spec.account, {}).get(spec.output_prefix)

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -1,8 +1,8 @@
-import base64
 import logging
 import json
 import os
 import shutil
+import copy
 
 from datetime import datetime
 from collections import defaultdict
@@ -14,12 +14,12 @@ from python_terraform import Terraform, IsFlagged, TerraformCommandError
 from ruamel import yaml
 from sretoolbox.utils import retry
 from sretoolbox.utils import threaded
+from reconcile.utils.terraform_resource_spec import TerraformResourceSpec, TerraformResourceSpecDict
 
 import reconcile.utils.lean_terraform_client as lean_tf
 
 from reconcile.utils import gql
 from reconcile.utils.aws_api import AWSApi
-from reconcile.utils.openshift_resource import OpenshiftResource as OR
 
 ALLOWED_TF_SHOW_FORMAT_VERSION = "0.1"
 DATE_FORMAT = '%Y-%m-%d'
@@ -331,7 +331,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         error = self.check_output(name, 'apply', return_code, stdout, stderr)
         return error
 
-    def get_terraform_output_secrets(self):
+    def get_terraform_output_secrets(self) -> dict[str, dict[str, dict[str, str]]]:
         data = {}
         for account, output in self.outputs.items():
             data[account] = \
@@ -339,112 +339,58 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
 
         return data
 
-    def populate_desired_state(self, ri, oc_map, tf_namespaces, account_name):
-        self.init_outputs()  # get updated output
-
-        # Dealing with credentials for RDS replicas
-        replicas_info = self.get_replicas_info(namespaces=tf_namespaces)
-
-        for account, output in self.outputs.items():
-            if account_name and account != account_name:
-                continue
-
-            formatted_output = self.format_output(
-                output, self.OUTPUT_TYPE_SECRETS)
-
-            for name, data in formatted_output.items():
-                # Grabbing the username/password from the
-                # replica_source and using them in the
-                # replica. This is needed because we can't
-                # set username/password for a replica in
-                # terraform.
-                if account in replicas_info:
-                    if name in replicas_info[account]:
-                        replica_src_name = replicas_info[account][name]
-                        data['db.user'] = \
-                            formatted_output[replica_src_name]['db.user']
-                        data['db.password'] = \
-                            formatted_output[replica_src_name]['db.password']
-
-                cluster = data['{}_cluster'.format(self.integration_prefix)]
-                if not oc_map.get(cluster):
-                    continue
-                namespace = \
-                    data['{}_namespace'.format(self.integration_prefix)]
-                resource = data['{}_resource'.format(self.integration_prefix)]
-                output_resource_name = data['{}_output_resource_name'.format(
-                    self.integration_prefix)]
-                annotations = data.get('{}_annotations'.format(
-                    self.integration_prefix))
-
-                oc_resource = \
-                    self.construct_oc_resource(output_resource_name, data,
-                                               account, annotations)
-                ri.add_desired(
-                    cluster,
-                    namespace,
-                    resource,
-                    output_resource_name,
-                    oc_resource
-                )
-
     @staticmethod
-    def get_replicas_info(namespaces):
-        replicas_info = defaultdict(dict)
+    def get_replicas_info(resource_specs: Iterable[TerraformResourceSpec]) -> dict[str, dict[str, str]]:
+        """
+        finds the source resources of RDS replicas
 
-        for tf_namespace in namespaces:
-            tf_resources = tf_namespace.get('terraformResources')
-            if tf_resources is None:
+        the key of the returned dict is the identifier of the replica
+        and the value is the resource of the replicas master db
+        """
+        replicas_info: dict[str, dict[str, str]] = defaultdict(dict)
+
+        for spec in resource_specs:
+            tf_resource = spec.resource
+            # First, we have to find the terraform resources
+            # that have a replica_source defined in app-interface
+            replica_src = tf_resource.get('replica_source')
+
+            if replica_src is None:
+                # When replica_source is not there, we look for
+                # replicate_source_db in the defaults
+                replica_src_db = None
+                defaults_ref = tf_resource.get('defaults')
+                if defaults_ref is not None:
+                    defaults_res = gql.get_resource(
+                        defaults_ref
+                    )
+                    defaults = yaml.safe_load(defaults_res['content'])
+                    replica_src_db = defaults.get('replicate_source_db')
+
+                # Also, we look for replicate_source_db in the overrides
+                override_replica_src_db = None
+                overrides = tf_resource.get('overrides')
+                if overrides is not None:
+                    override_replica_src_db = json.loads(overrides).get(
+                        'replicate_source_db'
+                    )
+                if override_replica_src_db is not None:
+                    replica_src_db = override_replica_src_db
+
+                # Getting whatever we probed here
+                replica_src = replica_src_db
+
+            if replica_src is None:
+                # No replica source information anywhere
                 continue
 
-            for tf_resource in tf_namespace['terraformResources']:
-                # First, we have to find the terraform resources
-                # that have a replica_source defined in app-interface
-                replica_src = tf_resource.get('replica_source')
+            # The replica source name, as found in the
+            # self.format_output()
+            replica_source_name = f'{replica_src}-{tf_resource.get("provider")}'
 
-                if replica_src is None:
-                    # When replica_source is not there, we look for
-                    # replicate_source_db in the defaults
-                    replica_src_db = None
-                    defaults_ref = tf_resource.get('defaults')
-                    if defaults_ref is not None:
-                        defaults_res = gql.get_resource(
-                            defaults_ref
-                        )
-                        defaults = yaml.safe_load(defaults_res['content'])
-                        replica_src_db = defaults.get('replicate_source_db')
-
-                    # Also, we look for replicate_source_db in the overrides
-                    override_replica_src_db = None
-                    overrides = tf_resource.get('overrides')
-                    if overrides is not None:
-                        override_replica_src_db = json.loads(overrides).get(
-                            'replicate_source_db'
-                        )
-                    if override_replica_src_db is not None:
-                        replica_src_db = override_replica_src_db
-
-                    # Getting whatever we probed here
-                    replica_src = replica_src_db
-
-                if replica_src is None:
-                    # No replica source information anywhere
-                    continue
-
-                # The replica name, as found in the
-                # self.format_output()
-                replica_name = (f'{tf_resource.get("identifier")}-'
-                                f'{tf_resource.get("provider")}')
-
-                # The replica source name, as found in the
-                # self.format_output()
-                replica_source_name = (f'{replica_src}-'
-                                       f'{tf_resource.get("provider")}')
-
-                # Creating a dict that is convenient to use inside the
-                # loop processing the formatted_output
-                tf_account = tf_resource.get('account')
-                replicas_info[tf_account][replica_name] = replica_source_name
+            # Creating a dict that is convenient to use inside the
+            # loop processing the formatted_output
+            replicas_info[spec.account][spec.output_prefix] = replica_source_name
 
         return replicas_info
 
@@ -511,38 +457,51 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
             return data[list(data.keys())[0]]
         return data
 
-    def construct_oc_resource(self, name, data, account, annotations):
-        body = {
-            "apiVersion": "v1",
-            "kind": "Secret",
-            "type": "Opaque",
-            "metadata": {
-                "name": name,
-                "annotations": {
-                    "qontract.recycle": "true"
-                }
-            },
-            "data": {}
-        }
+    def populate_terraform_output_secrets(self, resource_specs: TerraformResourceSpecDict, init_rds_replica_source: bool = False) -> None:
+        """
+        find the terraform output data for each resource spec and populate its `secret` field.
+        if the `init_rds_replica_source` a replica RDS gets its DB user and password fields populated
+        by looking at the replica source DB.
+        """
+        self.init_outputs()  # get updated output
+        existing_secets = self.get_terraform_output_secrets()
+        if init_rds_replica_source:
+            replicas_info = self.get_replicas_info(resource_specs.values())
+        else:
+            replicas_info = {}
 
-        if annotations:
-            anno_dict = json.loads(base64.b64decode(annotations))
-            body["metadata"]["annotations"].update(anno_dict)
+        self._populate_terraform_output_secrets(resource_specs, existing_secets, self.integration_prefix, replicas_info)
 
-        for k, v in data.items():
-            if self.integration_prefix in k:
+    @staticmethod
+    def _populate_terraform_output_secrets(resource_specs: TerraformResourceSpecDict, existing_secrets: dict[str, dict[str, dict[str, str]]], integration_prefix: str, replica_sources: dict[str, dict[str, str]]) -> None:
+        for spec in resource_specs.values():
+            secret = existing_secrets.get(spec.account, {}).get(spec.output_prefix, None)
+            if not secret:
                 continue
-            if v == "":
-                v = None
-            else:
-                # convert to str to maintain compatability
-                # as ports are now ints and not strs
-                v = base64.b64encode(str(v).encode()).decode('utf-8')
-            body['data'][k] = v
+            secret_copy = copy.deepcopy(secret)
 
-        return OR(body, self.integration, self.integration_version,
-                  error_details=name,
-                  caller_name=account)
+            # find out about replica source
+            replica_source = replica_sources.get(spec.account, {}).get(spec.output_prefix)
+            if replica_source:
+                # Grabbing the username/password from the
+                # replica_source and using them in the
+                # replica. This is needed because we can't
+                # set username/password for a replica in
+                # terraform.
+                replica_source_secret = existing_secrets.get(spec.account, {}).get(replica_source)
+                if replica_source_secret:
+                    replica_src_user = replica_source_secret.get("db.user")
+                    replica_src_password = replica_source_secret.get("db.password")
+                    if replica_src_user and replica_src_password:
+                        secret_copy["db.user"] = replica_src_user
+                        secret_copy["db.password"] = replica_src_password
+
+            # clean metadata
+            for key in secret.keys():
+                if integration_prefix in key:
+                    secret_copy.pop(key)
+
+            spec.secret = secret_copy
 
     def check_output(self, name, cmd, return_code, stdout, stderr):
         error_occured = False

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -457,23 +457,23 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         populated by looking at the replica source DB.
         """
         self.init_outputs()  # get updated output
-        existing_secets = self.get_terraform_output_secrets()
+        terraform_output_secrets = self.get_terraform_output_secrets()
         if init_rds_replica_source:
             replicas_info = self.get_replicas_info(resource_specs.values())
         else:
             replicas_info = {}
 
         self._populate_terraform_output_secrets(
-            resource_specs, existing_secets, self.integration_prefix, replicas_info
+            resource_specs, terraform_output_secrets, self.integration_prefix, replicas_info
         )
 
     @staticmethod
     def _populate_terraform_output_secrets(resource_specs: TerraformResourceSpecDict,
-                                           existing_secrets: Mapping[str, Mapping[str, Mapping[str, str]]],
+                                           terraform_output_secrets: Mapping[str, Mapping[str, Mapping[str, str]]],
                                            integration_prefix: str,
                                            replica_sources: Mapping[str, Mapping[str, str]]) -> None:
         for spec in resource_specs.values():
-            secret = existing_secrets.get(spec.account, {}).get(spec.output_prefix, None)
+            secret = terraform_output_secrets.get(spec.account, {}).get(spec.output_prefix, None)
             if not secret:
                 continue
             secret_copy = dict(secret)
@@ -486,7 +486,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                 # replica. This is needed because we can't
                 # set username/password for a replica in
                 # terraform.
-                replica_source_secret = existing_secrets.get(spec.account, {}).get(replica_source)
+                replica_source_secret = terraform_output_secrets.get(spec.account, {}).get(replica_source)
                 if replica_source_secret:
                     replica_src_user = replica_source_secret.get("db.user")
                     replica_src_password = replica_source_secret.get("db.password")

--- a/reconcile/utils/terraform_resource_spec.py
+++ b/reconcile/utils/terraform_resource_spec.py
@@ -54,7 +54,7 @@ class TerraformResourceSpec:
     def id_object(self) -> "TerraformResourceIdentifier":
         return TerraformResourceIdentifier.from_dict(self.resource)
 
-    def construct_oc_resource(self, integration: str, integration_version: str) -> OR:
+    def build_oc_secret(self, integration: str, integration_version: str) -> OR:
         annotations = dict(self.annotations)
         annotations["qontract.recycle"] = "true"
 
@@ -106,17 +106,6 @@ class TerraformResourceIdentifier:
             identifier=cast(str, data["identifier"]),
             provider=cast(str, data["provider"]),
             account=cast(str, data["account"]),
-        )
-
-    @staticmethod
-    def from_output_prefix(
-        output_prefix: str, account: str
-    ) -> "TerraformResourceIdentifier":
-        identifier, provider = output_prefix.rsplit("-", 1)
-        return TerraformResourceIdentifier(
-            identifier=identifier,
-            provider=provider,
-            account=account,
         )
 
 

--- a/reconcile/utils/terraform_resource_spec.py
+++ b/reconcile/utils/terraform_resource_spec.py
@@ -1,0 +1,88 @@
+from dataclasses import dataclass, field
+import json
+from typing import Any, Optional, cast
+
+
+@dataclass
+class TerraformResourceSpec:
+
+    resource: dict[str, Any]
+    namespace: dict[str, Any]
+    secret: dict[str, str] = field(init=False, default_factory=lambda: {})
+
+    @property
+    def provider(self):
+        return self.resource.get("provider")
+
+    @property
+    def identifier(self):
+        return self.resource.get("identifier")
+
+    @property
+    def account(self):
+        return self.resource.get("account")
+
+    @property
+    def namespace_name(self) -> str:
+        return self.namespace["name"]
+
+    @property
+    def cluster_name(self) -> str:
+        return self.namespace["cluster"]["name"]
+
+    @property
+    def output_prefix(self):
+        return f"{self.identifier}-{self.provider}"
+
+    @property
+    def output_resource_name(self):
+        return self.resource.get("output_resource_name") or self.output_prefix
+
+    @property
+    def annotations(self) -> dict[str, str]:
+        annotation_str = self.resource.get("annotations")
+        if annotation_str:
+            return json.loads(annotation_str)
+        else:
+            return {}
+
+    def get_secret_field(self, field: str) -> Optional[str]:
+        return self.secret.get(field)
+
+
+@dataclass(frozen=True)
+class TerraformResourceIdentifier:
+
+    identifier: str
+    provider: str
+    account: str
+
+    @property
+    def output_prefix(self) -> str:
+        return f"{self.identifier}-{self.provider}"
+
+    @staticmethod
+    def from_dict(data: dict[str, Any]) -> "TerraformResourceIdentifier":
+        if "identifier" not in data or "provider" not in data or "account" not in data:
+            raise ValueError(
+                "dict does not include required both keys 'identifier' and 'provider'"
+            )
+        return TerraformResourceIdentifier(
+            identifier=cast(str, data["identifier"]),
+            provider=cast(str, data["provider"]),
+            account=cast(str, data["account"]),
+        )
+
+    @staticmethod
+    def from_output_prefix(
+        output_prefix: str, account: str
+    ) -> "TerraformResourceIdentifier":
+        identifier, provider = output_prefix.rsplit("-", 1)
+        return TerraformResourceIdentifier(
+            identifier=identifier,
+            provider=provider,
+            account=account,
+        )
+
+
+TerraformResourceSpecDict = dict[TerraformResourceIdentifier, TerraformResourceSpec]

--- a/reconcile/utils/terraform_resource_spec.py
+++ b/reconcile/utils/terraform_resource_spec.py
@@ -83,7 +83,11 @@ class TerraformResourceUniqueKey:
 
     @staticmethod
     def from_dict(data: Mapping[str, Any]) -> "TerraformResourceUniqueKey":
-        return TerraformResourceUniqueKey(**data)
+        return TerraformResourceUniqueKey(
+            identifier=data["identifier"],
+            provider=data["provider"],
+            account=data["account"],
+        )
 
 
 TerraformResourceSpecDict = Mapping[TerraformResourceUniqueKey, TerraformResourceSpec]

--- a/reconcile/utils/terraform_resource_spec.py
+++ b/reconcile/utils/terraform_resource_spec.py
@@ -90,4 +90,6 @@ class TerraformResourceUniqueKey:
         )
 
 
-TerraformResourceSpecDict = Mapping[TerraformResourceUniqueKey, TerraformResourceSpec]
+TerraformResourceSpecInventory = Mapping[
+    TerraformResourceUniqueKey, TerraformResourceSpec
+]

--- a/reconcile/utils/terraform_resource_spec.py
+++ b/reconcile/utils/terraform_resource_spec.py
@@ -1,8 +1,9 @@
-from dataclasses import dataclass, field
+from dataclasses import field
+from pydantic.dataclasses import dataclass
 import json
-from typing import Any, Optional, cast
+from typing import Any, Optional
 import base64
-from reconcile.utils.openshift_resource import OpenshiftResource as OR
+from reconcile.utils.openshift_resource import OpenshiftResource
 
 
 @dataclass
@@ -54,7 +55,9 @@ class TerraformResourceSpec:
     def id_object(self) -> "TerraformResourceIdentifier":
         return TerraformResourceIdentifier.from_dict(self.resource)
 
-    def build_oc_secret(self, integration: str, integration_version: str) -> OR:
+    def build_oc_secret(
+        self, integration: str, integration_version: str
+    ) -> OpenshiftResource:
         annotations = dict(self.annotations)
         annotations["qontract.recycle"] = "true"
 
@@ -76,7 +79,7 @@ class TerraformResourceSpec:
             "data": secret_data,
         }
 
-        return OR(
+        return OpenshiftResource(
             body,
             integration,
             integration_version,
@@ -98,15 +101,7 @@ class TerraformResourceIdentifier:
 
     @staticmethod
     def from_dict(data: dict[str, Any]) -> "TerraformResourceIdentifier":
-        if "identifier" not in data or "provider" not in data or "account" not in data:
-            raise ValueError(
-                "dict does not include required both keys 'identifier' and 'provider'"
-            )
-        return TerraformResourceIdentifier(
-            identifier=cast(str, data["identifier"]),
-            provider=cast(str, data["provider"]),
-            account=cast(str, data["account"]),
-        )
+        return TerraformResourceIdentifier(**data)
 
 
 TerraformResourceSpecDict = dict[TerraformResourceIdentifier, TerraformResourceSpec]

--- a/reconcile/utils/terraform_resource_spec.py
+++ b/reconcile/utils/terraform_resource_spec.py
@@ -1,7 +1,7 @@
 from dataclasses import field
 from pydantic.dataclasses import dataclass
 import json
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 import base64
 from reconcile.utils.openshift_resource import OpenshiftResource
 
@@ -9,9 +9,9 @@ from reconcile.utils.openshift_resource import OpenshiftResource
 @dataclass
 class TerraformResourceSpec:
 
-    resource: dict[str, Any]
-    namespace: dict[str, Any]
-    secret: dict[str, str] = field(init=False, default_factory=lambda: {})
+    resource: Mapping[str, Any]
+    namespace: Mapping[str, Any]
+    secret: Mapping[str, str] = field(init=False, default_factory=lambda: {})
 
     @property
     def provider(self):
@@ -41,8 +41,7 @@ class TerraformResourceSpec:
     def output_resource_name(self):
         return self.resource.get("output_resource_name") or self.output_prefix
 
-    @property
-    def annotations(self) -> dict[str, str]:
+    def _annotations(self) -> dict[str, str]:
         annotation_str = self.resource.get("annotations")
         if annotation_str:
             return json.loads(annotation_str)
@@ -58,7 +57,7 @@ class TerraformResourceSpec:
     def build_oc_secret(
         self, integration: str, integration_version: str
     ) -> OpenshiftResource:
-        annotations = dict(self.annotations)
+        annotations = self._annotations()
         annotations["qontract.recycle"] = "true"
 
         secret_data = {}
@@ -100,8 +99,8 @@ class TerraformResourceIdentifier:
         return f"{self.identifier}-{self.provider}"
 
     @staticmethod
-    def from_dict(data: dict[str, Any]) -> "TerraformResourceIdentifier":
+    def from_dict(data: Mapping[str, Any]) -> "TerraformResourceIdentifier":
         return TerraformResourceIdentifier(**data)
 
 
-TerraformResourceSpecDict = dict[TerraformResourceIdentifier, TerraformResourceSpec]
+TerraformResourceSpecDict = Mapping[TerraformResourceIdentifier, TerraformResourceSpec]

--- a/reconcile/utils/terraform_resource_spec.py
+++ b/reconcile/utils/terraform_resource_spec.py
@@ -50,8 +50,8 @@ class TerraformResourceSpec:
     def get_secret_field(self, field: str) -> Optional[str]:
         return self.secret.get(field)
 
-    def id_object(self) -> "TerraformResourceIdentifier":
-        return TerraformResourceIdentifier.from_dict(self.resource)
+    def id_object(self) -> "TerraformResourceUniqueKey":
+        return TerraformResourceUniqueKey.from_dict(self.resource)
 
     def build_oc_secret(
         self, integration: str, integration_version: str
@@ -71,7 +71,7 @@ class TerraformResourceSpec:
 
 
 @dataclass(frozen=True)
-class TerraformResourceIdentifier:
+class TerraformResourceUniqueKey:
 
     identifier: str
     provider: str
@@ -82,8 +82,8 @@ class TerraformResourceIdentifier:
         return f"{self.identifier}-{self.provider}"
 
     @staticmethod
-    def from_dict(data: Mapping[str, Any]) -> "TerraformResourceIdentifier":
-        return TerraformResourceIdentifier(**data)
+    def from_dict(data: Mapping[str, Any]) -> "TerraformResourceUniqueKey":
+        return TerraformResourceUniqueKey(**data)
 
 
-TerraformResourceSpecDict = Mapping[TerraformResourceIdentifier, TerraformResourceSpec]
+TerraformResourceSpecDict = Mapping[TerraformResourceUniqueKey, TerraformResourceSpec]

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -901,7 +901,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
     def populate_resources(self, namespaces: Iterable[Mapping[str, Any]],
                            existing_secrets: Mapping[str, Any],
-                           account_name: str,
+                           account_name: Optional[str],
                            ocm_map: Optional[OCMMap] = None) -> None:
         """
         Populates the terraform configuration from the definitions in app-interface
@@ -918,7 +918,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                                            ocm_map=ocm_map)
 
     def init_populate_specs(self, namespaces: Iterable[Mapping[str, Any]],
-                            account_name: str) -> None:
+                            account_name: Optional[str]) -> None:
         self.account_resources: dict[str, list[dict[str, Any]]] = {}
         for namespace_info in namespaces:
             # Skip if namespace has no terraformResources


### PR DESCRIPTION
## Goal
Refactor the desired state and vault handling for terraform resource output. This change introduces additional unittesting and typehints, to prepare for future changes like terraform output formats and shared terraform resources.

_Scope:_ refactor the the use of terraform resources from qontrac-server within terraform-resources and terraform-client.
_Out of scope:_ terrascript-client was not touched to keep the size of this change manageable and reviewable. A followup change will start using the changes of this MR.

## How to review
Please review commit by commit. Each commit contains a smaller logical change along with a detailed commit message and respective type hints and unittests.

## What changed?

### TerraformResourceSpec dataclass
This refactor introduces a dataclass `TerraformResourceSpec` that holds data and context for terraform resources, namely:
* the raw resource specification from qontract-server
* the raw namespace and cluster data from qontract-server
* the output data from the last terraform run
this way a resource spec can be passed around with its close context. also frequently used fields are defined as properties with typehints.

### Desired state management
The population of the `ResourceInventory` and creation of the kube `Secret` have been extracted from `terraform_client.py` to `TerraformResourceSpec`. This way the terraform client can concentrate exclusively on terraform matters and is not concerned with close kubernetes matters like `Secret` management. terraform-client keeps the responsibility of parsing terraform output, and making the per-resource grouped outputs available as the `secret` field of the `TerraformResourceSpec` - see `populate_terraform_output_secrets`

This change also makes sense since the required context to build a `Secret` is now available within `TerraformResourceSpec`. Also, implementation of [terraform output formats](https://github.com/app-sre/qontract-schemas/pull/119) will be contained within the `TerraformResourceSpec`.

### Use TerraformResourceSpec as source for Vault population
The secret embedded in `TerraformResourceSpec` is used to write the terraform out data to vault. Previously the `ResourceInventory` was used for that. Upcoming changes will introduce [terraform output formats](https://github.com/app-sre/qontract-schemas/pull/119), that will change the way the kuberrnetes secret resources are rendered, and therefore the value in the `ResourceInventory` will not necessary the format anymore that needs to be written to Vault.

### Typehints & Tests
Typehints and tests were introduced where code was changed or where it was necessary for mypy to be happy.

## How this change was tested

* dry running for all major accounts with the code before and after the change resulted in the same terraform files
* added extensive tests to the central functions that were touched
* comparing desired and current state for kubernetes secrets with production data
* comparing desired and current state for vault data with production data
