### PR TITLE
Quay error on repo actions when managedRepos is set to false

### DIFF
--- a/reconcile/quay_permissions.py
+++ b/reconcile/quay_permissions.py
@@ -14,6 +14,7 @@ QUAY_REPOS_QUERY = """
     quayRepos {
       org {
         name
+        managedRepos
         automationToken {
           path
           field
@@ -63,6 +64,14 @@ def run(dry_run):
             instance_name = quay_repo_config["org"]["instance"]["name"]
             org_name = quay_repo_config["org"]["name"]
             org_key = (instance_name, org_name)
+
+            if not quay_repo_config["org"]["managedRepos"]:
+                logging.error(
+                    f"[{app['name']}] Can not manage repo permissions in {org_name} "
+                    "since managedRepos is set to false."
+                )
+                error = True
+                continue
 
             # processing quayRepos section
             logging.debug(["app", app["name"], instance_name, org_name])

--- a/reconcile/quay_repos.py
+++ b/reconcile/quay_repos.py
@@ -12,6 +12,7 @@ from reconcile.status import ExitCodes
 QUAY_REPOS_QUERY = """
 {
   apps: apps_v1 {
+    name
     quayRepos {
       org {
         name
@@ -75,11 +76,15 @@ def fetch_desired_state(quay_api_store):
             continue
 
         for quay_repo in quay_repos:
+            org_name = quay_repo["org"]["name"]
             if not quay_repo["org"]["managedRepos"]:
-                continue
+                logging.error(
+                    f"[{app['name']}] Can not manage repos in {org_name} "
+                    "since managedRepos is set to false."
+                )
+                sys.exit(ExitCodes.ERROR)
 
             instance_name = quay_repo["org"]["instance"]["name"]
-            org_name = quay_repo["org"]["name"]
             org_key = OrgKey(instance_name, org_name)
 
             for repo_item in quay_repo["items"]:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="qontract-reconcile",
-    version="0.6.0",
+    version="0.6.1",
     license="Apache License 2.0",
 
     author="Red Hat App-SRE Team",


### PR DESCRIPTION
part of https://issues.redhat.com/browse/ASIC-208

we currently fail silently when we should error out.