### PR TITLE
[PROPOSAL] versioning automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ config.toml
 config.*.toml
 .container_tmp
 .idea
+
+GIT_VERSION

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include GIT_VERSION

--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,24 @@ CTR_STRUCTURE_IMG := quay.io/app-sre/container-structure-test:latest
 help: ## Prints help for targets with comments
 	@grep -E '^[a-zA-Z0-9.\ _-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-build:
+# this will write a GIT_VERSION file in the current dir, which allows to get the info from a non-git-repo folder, like during docker build
+git_version:
+	rm -f GIT_VERSION
+	python3 --version
+	./version --git
+
+build: git_version
 	@DOCKER_BUILDKIT=1 $(CONTAINER_ENGINE) build -t $(IMAGE_NAME):latest -f dockerfiles/Dockerfile --target prod-image . --progress=plain
 	@$(CONTAINER_ENGINE) tag $(IMAGE_NAME):latest $(IMAGE_NAME):$(IMAGE_TAG)
 
-build-dev:
+build-dev: git_version
 	@DOCKER_BUILDKIT=1 $(CONTAINER_ENGINE) build --build-arg CONTAINER_UID=$(CONTAINER_UID) -t $(IMAGE_NAME)-dev:latest -f dockerfiles/Dockerfile --target dev-image .
 
 push:
 	@$(CONTAINER_ENGINE) --config=$(DOCKER_CONF) push $(IMAGE_NAME):latest
 	@$(CONTAINER_ENGINE) --config=$(DOCKER_CONF) push $(IMAGE_NAME):$(IMAGE_TAG)
 
-rc:
+rc: git_version
 	@$(CONTAINER_ENGINE) build -t $(IMAGE_NAME):$(IMAGE_TAG)-rc -f dockerfiles/Dockerfile --target prod-image .
 	@$(CONTAINER_ENGINE) --config=$(DOCKER_CONF) push $(IMAGE_NAME):$(IMAGE_TAG)-rc
 
@@ -69,7 +75,7 @@ dev-reconcile-loop: build-dev ## Trigger the reconcile loop inside a container f
 		$(IMAGE_NAME)-dev:latest
 
 clean:
-	@rm -rf .tox .eggs reconcile.egg-info build .pytest_cache venv
+	@rm -rf .tox .eggs reconcile.egg-info build .pytest_cache venv GIT_VERSION
 	@find . -name "__pycache__" -type d -print0 | xargs -0 rm -rf
 	@find . -name "*.pyc" -delete
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,11 @@ make dev-reconcile-loop INTEGRATION_NAME=terraform-resources DRY_RUN=--dry-run I
 
 ## Release
 
-Each PR must update setup.py (`version`) with the new version according to [semver](https://semver.org/). CI tests will fail if version is not bumped.
+Release version are calculated from git tags of the form X.Y.Z.
+- If the current commit has such a tag, it will be used as is
+- Otherwise the latest tag of that format is used and:
+  - the patch label (Z) is incremented
+  - the string `.pre<count>+<commitid>` is appended. `<count>` is the number of commits since the X.Y.Z tag. `<commitid> is... the current commitid.
 
 After the PR is merged, a CI job will be triggered that will publish the package to pypi: https://pypi.org/project/qontract-reconcile.
 

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -8,8 +8,4 @@ docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 make build push
 
 # publish to pypi
-set -e
-
-python3 -m pip install --user twine wheel
-python3 setup.py bdist_wheel
-python3 -m twine upload dist/*
+./build_tag.sh

--- a/build_tag.sh
+++ b/build_tag.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+python3 -m pip install --user twine wheel
+python3 setup.py bdist_wheel
+python3 -m twine upload dist/*

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -4,8 +4,10 @@ WORKDIR /work
 
 COPY e2e_tests e2e_tests
 COPY reconcile reconcile
+COPY release release
 COPY tools tools
 COPY setup.py .
+COPY GIT_VERSION .
 COPY dockerfiles/hack/run-integration.py .
 
 RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \

--- a/reconcile/test/test_version_bump.py
+++ b/reconcile/test/test_version_bump.py
@@ -3,7 +3,7 @@ import requests
 import pkg_resources
 import pytest
 
-from reconcile.utils.semver_helper import is_version_bumped
+import packaging.version as pep440
 
 
 @pytest.mark.skipif(
@@ -15,6 +15,4 @@ def test_version_bump():
     pypi_version = requests.get("https://pypi.org/pypi/qontract-reconcile/json").json()[
         "info"
     ]["version"]
-    assert (
-        is_version_bumped(current_version, pypi_version) is True
-    ), "setup.py version must be bumped. see README.md#release for details"
+    assert pep440.Version(current_version) > pep440.Version(pypi_version)

--- a/release/test_version.py
+++ b/release/test_version.py
@@ -1,0 +1,59 @@
+import packaging.version as pep440
+
+from reconcile.utils.semver_helper import parse_semver
+
+from release import version
+
+
+def test_version_semver():
+    assert version.semver("0.4.0") == "0.4.0"
+    assert version.semver("0.4.0-6-gaaaaaaa") == "0.4.1-6+aaaaaaa"
+
+
+def test_semver_ordering():
+    # 6 commits after 0.4.0
+    assert parse_semver("0.4.1-6+aaaaaaa") > parse_semver("0.4.0")
+    # prerelease version are lower than release ones
+    assert parse_semver("0.4.0") > parse_semver("0.4.0-6+aaaaaaa")
+    # build info (after '+') don't count in semver comparisons
+    assert parse_semver("0.4.0-6+bbbbbbb") == parse_semver("0.4.0-6+aaaaaa")
+    # 7 commits after 0.4.0 is a higher version than 6 commits after 0.4.0
+    assert parse_semver("0.4.1-7+aaaaaaa") > parse_semver("0.4.1-6+aaaaaaa")
+    # number of commits (prerelease) is treated as a number, not as a string: 50 > 6
+    assert parse_semver("0.4.1-50+aaaaaaa") > parse_semver("0.4.1-6+aaaaaaa")
+
+
+def test_version_pip():
+    assert version.pip("0.4.0") == "0.4.0"
+    assert version.pip("0.4.0-6-gaaaaaaa") == "0.4.1.pre6+aaaaaaa"
+    # assert version.pip("0.4.0-6-gaaaaaaa") == "0.4.0.post6+aaaaaaa"
+
+
+def test_pep440_ordering():
+    assert pep440.Version("0.4.1") > pep440.Version("0.4.0")
+
+    # using pre-releases
+    assert pep440.Version("0.4.1.pre6+aaaaaaa") > pep440.Version("0.4.0")
+    assert pep440.Version("0.4.1.pre6+aaaaaaa") < pep440.Version("0.4.1")
+    # local versions (after '+') count in version comparisions
+    assert pep440.Version("0.4.1.pre6+aaaaaaa") != pep440.Version("0.4.1.pre6+bbbbbbb")
+    assert pep440.Version("0.4.1.pre6+aaaaaaa") > pep440.Version("0.4.1.pre5+bbbbbbb")
+    assert pep440.Version("0.4.1.pre50+aaaaaaa") > pep440.Version("0.4.1.pre6+ccccccc")
+
+    # using post-releases
+    assert pep440.Version("0.4.0.post6+aaaaaaa") > pep440.Version("0.4.0")
+    assert pep440.Version("0.4.0.post6+aaaaaaa") < pep440.Version("0.4.1")
+    # local versions (after '+') count in version comparisions
+    assert pep440.Version("0.4.0.post6+aaaaaaa") != pep440.Version(
+        "0.4.0.post6+bbbbbbb"
+    )
+    assert pep440.Version("0.4.0.post6+aaaaaaa") > pep440.Version("0.4.0.post5+bbbbbbb")
+    assert pep440.Version("0.4.0.post50+aaaaaaa") > pep440.Version(
+        "0.4.0.post6+ccccccc"
+    )
+
+
+def test_version_docker():
+    assert version.docker("0.4.0") == "0.4.0"
+    assert version.docker("0.4.0-6-gaaaaaaa") == "0.4.1.pre6"
+    # assert version.docker("0.4.0-6-gaaaaaaa") == "0.4.0.post6"

--- a/release/version.py
+++ b/release/version.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from typing import Optional
+import re
+import subprocess
+from subprocess import PIPE
+
+GIT_VERSION_FILE = "GIT_VERSION"
+
+
+def git() -> str:
+    """get the version from git. Can be
+    - X.Y.Z if a tag is set on the current HEAD
+    - X.Y.Z-<count>-g<commitid> otherwise where
+        - X.Y.Z is the latest version tag found
+        - <count> is the number of commits since then
+        - <commitid> is the current HEAD commitid
+    """
+    cmd = "git describe --tags --match=[0-9]*.[0-9]*.[0-9]*"
+    try:
+        p = subprocess.run(cmd.split(" "), stdout=PIPE, stderr=PIPE, check=True)
+        v = p.stdout.decode("utf-8").strip()
+        # tox is running setup.py sdist from the git repo, and then runs again outside
+        # of the git repo. At this second step, we cannot run git commands.
+        # So we save the git version in a file and include it in the source distribution
+        with open(GIT_VERSION_FILE, "w") as f:
+            f.write(v)
+        return v
+    except subprocess.CalledProcessError as e:
+        # if we're not in a git repo, try reading out from the GIT_VERSION file
+        if os.path.exists(GIT_VERSION_FILE):
+            with open(GIT_VERSION_FILE, "r") as f:
+                return f.read()
+        print(e.stderr)
+        raise e
+
+
+def commit(length: int = 7) -> str:
+    """get the current git commitid"""
+    cmd = f"git rev-parse --short={length} HEAD"
+    p = subprocess.run(cmd.split(" "), stdout=PIPE, stderr=PIPE, check=True)
+    return p.stdout.decode("utf-8").strip()
+
+
+def semver(git_version: Optional[str] = None) -> str:
+    """get a semantic version out of the input git version (see git())
+    - if a X.Y.Z tag is set on the current HEAD, we'll use this
+    - else we'll use X.Y.<Z+1>-<count>+<commitid> to respect semver and version
+      ordering. <count> is the prerelease id, <commitid> is a buildinfo
+    """
+    v = git_version or git()
+    m = re.match(r"(\d+)\.(\d+)\.(\d+)-(\d+)-g(.+)", v)
+    if m:
+        major, minor, patch, prerelease, buildinfo = m.groups()
+        # semver prerelase are supposed to show build increments *prior* to a release.
+        # So we're bumping the patch number to show what the next release would be.
+        # this allows correct version ordering
+        patch = str(int(patch) + 1)
+        # X.Y.Z-<count>-g<commitid> is not a valid as <count>-g<commitid> would be
+        # compared as a string, leading to (count=50) < (count=6)
+        # X.Y.Z-<count>+<commitid> is valid .
+        #   <count> is then the prerelease field, treated as a numeric.
+        #   <commitid> is then a buildinfo string, not used in version comparisons
+        v = f"{major}.{minor}.{patch}-{prerelease}+{buildinfo}"
+    return str(v)
+
+
+def pip(git_version: Optional[str] = None) -> str:
+    """get a pip version out of the input git version (see git()),
+    according to https://peps.python.org/pep-0440/
+    - if a X.Y.Z tag is set on the current HEAD, we'll use this
+    - else we'll use X.Y.(Z+1).pre<count>+<commitid> to respect PEP-0440 versioning
+    """
+    return semver(git_version).replace("-", ".pre")
+    # Alternatively, use postreleases
+    # v = git_version or git()
+    # m = re.match(r"(\d+)\.(\d+)\.(\d+)-(\d+)-g(.+)", v)
+    # if m:
+    #     major, minor, patch, count, commitid = m.groups()
+    #     v = f"{major}.{minor}.{patch}.post{count}+{commitid}"
+    # return str(v)
+
+
+def docker(git_version: Optional[str] = None) -> str:
+    # docker tags don't like '+' characters, let's remove the buildinfo/commitid
+    return pip(git_version).split("+", maxsplit=1)[0]
+
+
+if __name__ == "__main__":
+    type_param = sys.argv[1] if len(sys.argv) > 1 else "--git"
+    v = {
+        "--git": git(),
+        "--commit": commit(),
+        "--semver": semver(),
+        "--pip": pip(),
+        "--docker": docker(),
+    }[type_param]
+    print(v)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 from setuptools import find_packages, setup
 
+from release import version
+
 setup(
     name="qontract-reconcile",
-    version="0.6.5",
+    version=version.pip(),
     license="Apache License 2.0",
 
     author="Red Hat App-SRE Team",
@@ -57,6 +59,9 @@ setup(
         "transity-statuspageio>=0.0.3,<0.1",
         "pydantic~=1.9.0",
         "MarkupSafe==2.1.1",
+        # this is really needed only in lint and type validations.
+        # Is there any better place to put this in?
+        "packaging~=21.3",
     ],
 
     test_suite="tests",

--- a/tox.ini
+++ b/tox.ini
@@ -13,13 +13,13 @@ parallel_show_output = true
 
 [testenv:format]
 skip_install = true
-commands = black {posargs:--check reconcile tools e2e_tests}
+commands = black {posargs:--check reconcile tools release e2e_tests}
 deps = -r{toxinidir}/requirements/requirements-format.txt
 
 [testenv:lint]
 commands =
-    flake8 reconcile tools e2e_tests
-    pylint --extension-pkg-whitelist='pydantic' reconcile tools e2e_tests
+    flake8 reconcile tools release e2e_tests
+    pylint --extension-pkg-whitelist='pydantic' reconcile tools release e2e_tests
 
 [testenv:type]
 commands = mypy {posargs}

--- a/version
+++ b/version
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 ./release/version.py "$@"


### PR DESCRIPTION
Releasing proposal
Why:
- avoid merge conflicts due to manual version bumping
- version each commit automatically
- simple X.Y.Z version management: simply git tag & push.

Challenges
- Python does not strictly follow Semver: https://peps.python.org/pep-0440/
- docker image tags don't support `+` signs, so dropping it there
- we run setup.py without git repos in several cases (tox does sdist and then setup again, docker builds don't include .git, rightfully). So the git version is first saved as a file GIT_VERSION.