### PR TITLE
[openshift-resources] validate managed resource names

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -147,7 +147,7 @@ def init_specs_to_fetch(
                 )
                 state_specs.append(c_spec)
                 managed_types.remove(kind)
-                ri.initalize_resource_names(cluster, namespace, kind, names)
+                ri.initialize_resource_names(cluster, namespace, kind, names)
 
             # Produce "empty" StateSpec's for any resource type that
             # doesn't have an explicit managedResourceName listed in

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -147,6 +147,7 @@ def init_specs_to_fetch(
                 )
                 state_specs.append(c_spec)
                 managed_types.remove(kind)
+                ri.initalize_resource_names(cluster, namespace, kind, names)
 
             # Produce "empty" StateSpec's for any resource type that
             # doesn't have an explicit managedResourceName listed in

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -25,6 +25,10 @@ class TestInitSpecsToFetch(testslide.TestCase):
             self.resource_inventory, "initialize_resource_type"
         ).for_call("cs1", "ns1", "Template").to_return_value(None)
 
+        self.mock_callable(
+            self.resource_inventory, "initialize_resource_names"
+        ).for_call("cs1", "ns1", "Template", ["tp1", "tp2"]).to_return_value(None)
+
         self.mock_callable(self.oc_map, "get").for_call("cs1", False).to_return_value(
             "stuff"
         )

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -522,14 +522,12 @@ class ResourceInventory:
         # mismatch between schema and implementation for now, it will enable
         # us to implement per-resource configuration in the future
         with self._lock:
-            desired = self._clusters[cluster][namespace][resource_type]["desired"]
+            inventory = self._clusters[cluster][namespace][resource_type]
+            desired = inventory["desired"]
             if name in desired:
                 raise ResourceKeyExistsError(name)
             desired[name] = value
-            admin_token_usage = self._clusters[cluster][namespace][resource_type][
-                "use_admin_token"
-            ]
-            admin_token_usage[name] = privileged
+            inventory["use_admin_token"][name] = privileged
 
     def add_current(self, cluster, namespace, resource_type, name, value):
         with self._lock:

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -15,6 +15,10 @@ class ResourceKeyExistsError(Exception):
     pass
 
 
+class ResourceNameUnauthorized(Exception):
+    pass
+
+
 class ConstructResourceError(Exception):
     def __init__(self, msg):
         super().__init__("error constructing openshift resource: " + str(msg))
@@ -536,6 +540,9 @@ class ResourceInventory:
         # us to implement per-resource configuration in the future
         with self._lock:
             inventory = self._clusters[cluster][namespace][resource_type]
+            managed_resource_names = inventory["managed_resource_names"]
+            if managed_resource_names and name not in managed_resource_names:
+                raise ResourceNameUnauthorized(name)
             desired = inventory["desired"]
             if name in desired:
                 raise ResourceKeyExistsError(name)

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -509,8 +509,21 @@ class ResourceInventory:
         self._clusters.setdefault(cluster, {})
         self._clusters[cluster].setdefault(namespace, {})
         self._clusters[cluster][namespace].setdefault(
-            resource_type, {"current": {}, "desired": {}, "use_admin_token": {}}
+            resource_type,
+            {
+                "current": {},
+                "desired": {},
+                "use_admin_token": {},
+                "managed_resource_names": [],
+            },
         )
+
+    def initalize_resource_names(
+        self, cluster, namespace, resource_type, resource_names
+    ):
+        self._clusters[cluster][namespace][resource_type][
+            "managed_resource_names"
+        ] = resource_names
 
     def add_desired(
         self, cluster, namespace, resource_type, name, value, privileged=False

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -522,7 +522,7 @@ class ResourceInventory:
             },
         )
 
-    def initalize_resource_names(
+    def initialize_resource_names(
         self, cluster, namespace, resource_type, resource_names
     ):
         self._clusters[cluster][namespace][resource_type][

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="qontract-reconcile",
-    version="0.6.4",
+    version="0.6.5",
     license="Apache License 2.0",
 
     author="Red Hat App-SRE Team",


### PR DESCRIPTION
this PR applies to all openshift-resources based integrations:
- openshift-resources
- openshift-vault-secrets
- openshift-routes

when a `managedResourceNames` section is defined, we should validate that all desired items under `openshiftResources` are one of the list.