### PR TITLE
Add timeout to gql client

### DIFF
--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -204,7 +204,7 @@ def _init_gql_client(url: str, token: Optional[str]) -> Client:
         # The token stored in vault is already in the format 'Basic ...'
         req_headers = {"Authorization": token}
     # Here we are explicitly using sync strategy
-    return Client(transport=RequestsHTTPTransport(url, headers=req_headers))
+    return Client(transport=RequestsHTTPTransport(url, headers=req_headers, timeout=30))
 
 
 @retry(exceptions=requests.exceptions.HTTPError, max_attempts=5)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="qontract-reconcile",
-    version="0.6.4",
+    version="0.6.5",
     license="Apache License 2.0",
 
     author="Red Hat App-SRE Team",


### PR DESCRIPTION
Not setting timeout can lead to situations such as indefinite wait on network I/O, so if graphql server is down for example, the request library may indefinitely wait and cause current process to go under sleeping state. 

The `retry` decorator should automatically cover the retries as TimeoutError will be rethrown as `GqlApiError`.