### PR TITLE
[run-integration] expose integration start counter

### DIFF
--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -142,13 +142,13 @@ def main():
         start_time = time.monotonic()
         # Running the integration via Click, so we don't have to replicate
         # the CLI logic here
+        execution_counter.labels(
+            integration=INTEGRATION_NAME,
+            shards=SHARDS,
+            shard_id=SHARD_ID,
+            **extra_labels
+        ).inc()
         try:
-            execution_counter.labels(
-                integration=INTEGRATION_NAME,
-                shards=SHARDS,
-                shard_id=SHARD_ID,
-                **extra_labels
-            ).inc()
             with command.make_context(info_name=COMMAND_NAME, args=args) \
               as ctx:
                 ctx.ensure_object(dict)

--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -12,9 +12,9 @@ import click
 
 from reconcile.status import ExitCodes
 from reconcile.cli import LOG_FMT, LOG_DATEFMT
-from reconcile.utils.metrics import run_time
-from reconcile.utils.metrics import run_status
-from reconcile.utils.metrics import extra_labels
+from reconcile.utils.metrics import (
+  run_time, run_status, extra_labels, execution_counter
+)
 
 
 SHARDS = int(os.environ.get('SHARDS', 1))
@@ -143,6 +143,12 @@ def main():
         # Running the integration via Click, so we don't have to replicate
         # the CLI logic here
         try:
+            execution_counter.labels(
+                integration=INTEGRATION_NAME,
+                shards=SHARDS,
+                shard_id=SHARD_ID,
+                **extra_labels
+            ).inc()
             with command.make_context(info_name=COMMAND_NAME, args=args) \
               as ctx:
                 ctx.ensure_object(dict)

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -16,6 +16,12 @@ run_status = Gauge(
     labelnames=["integration", "shards", "shard_id"] + label_keys,
 )
 
+execution_counter = Counter(
+    name="qontract_reconcile_execution_counter",
+    documentation="Counts started integration executions",
+    labelnames=["integration", "shards", "shard_id"] + label_keys,
+)
+
 reconcile_time = Histogram(
     name="qontract_reconcile_function_" "elapsed_seconds_since_bundle_commit",
     documentation="Run time seconds for tracked " "functions",


### PR DESCRIPTION
increase an execution counter on integration run start.
if the counter does not increase for a while, we can assume a stuck integration

```yaml
sum(increase(qontract_reconcile_execution_counter[1h])) by (integration, shards, shard_id) == 0
```

Part of https://issues.redhat.com/browse/APPSRE-4904

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>