### PR TITLE
remove the commitid from the pip version

### DIFF
--- a/release/test_version.py
+++ b/release/test_version.py
@@ -25,32 +25,24 @@ def test_semver_ordering():
 
 def test_version_pip():
     assert version.pip("0.4.0") == "0.4.0"
-    assert version.pip("0.4.0-6-gaaaaaaa") == "0.4.1.pre6+aaaaaaa"
-    # assert version.pip("0.4.0-6-gaaaaaaa") == "0.4.0.post6+aaaaaaa"
+    assert version.pip("0.4.0-6-gaaaaaaa") == "0.4.1.pre6"
+    # assert version.pip("0.4.0-6-gaaaaaaa") == "0.4.0.post6"
 
 
 def test_pep440_ordering():
     assert pep440.Version("0.4.1") > pep440.Version("0.4.0")
 
     # using pre-releases
-    assert pep440.Version("0.4.1.pre6+aaaaaaa") > pep440.Version("0.4.0")
-    assert pep440.Version("0.4.1.pre6+aaaaaaa") < pep440.Version("0.4.1")
-    # local versions (after '+') count in version comparisions
-    assert pep440.Version("0.4.1.pre6+aaaaaaa") != pep440.Version("0.4.1.pre6+bbbbbbb")
-    assert pep440.Version("0.4.1.pre6+aaaaaaa") > pep440.Version("0.4.1.pre5+bbbbbbb")
-    assert pep440.Version("0.4.1.pre50+aaaaaaa") > pep440.Version("0.4.1.pre6+ccccccc")
+    assert pep440.Version("0.4.1.pre6") > pep440.Version("0.4.0")
+    assert pep440.Version("0.4.1.pre6") < pep440.Version("0.4.1")
+    assert pep440.Version("0.4.1.pre6") > pep440.Version("0.4.1.pre5")
+    assert pep440.Version("0.4.1.pre50") > pep440.Version("0.4.1.pre6")
 
     # using post-releases
-    assert pep440.Version("0.4.0.post6+aaaaaaa") > pep440.Version("0.4.0")
-    assert pep440.Version("0.4.0.post6+aaaaaaa") < pep440.Version("0.4.1")
-    # local versions (after '+') count in version comparisions
-    assert pep440.Version("0.4.0.post6+aaaaaaa") != pep440.Version(
-        "0.4.0.post6+bbbbbbb"
-    )
-    assert pep440.Version("0.4.0.post6+aaaaaaa") > pep440.Version("0.4.0.post5+bbbbbbb")
-    assert pep440.Version("0.4.0.post50+aaaaaaa") > pep440.Version(
-        "0.4.0.post6+ccccccc"
-    )
+    assert pep440.Version("0.4.0.post6") > pep440.Version("0.4.0")
+    assert pep440.Version("0.4.0.post6") < pep440.Version("0.4.1")
+    assert pep440.Version("0.4.0.post6") > pep440.Version("0.4.0.post5")
+    assert pep440.Version("0.4.0.post50") > pep440.Version("0.4.0.post6")
 
 
 def test_version_docker():

--- a/release/version.py
+++ b/release/version.py
@@ -73,7 +73,7 @@ def pip(git_version: Optional[str] = None) -> str:
     - if a X.Y.Z tag is set on the current HEAD, we'll use this
     - else we'll use X.Y.(Z+1).pre<count>+<commitid> to respect PEP-0440 versioning
     """
-    return semver(git_version).replace("-", ".pre")
+    return semver(git_version).replace("-", ".pre").split("+", maxsplit=1)[0]
     # Alternatively, use postreleases
     # v = git_version or git()
     # m = re.match(r"(\d+)\.(\d+)\.(\d+)-(\d+)-g(.+)", v)
@@ -85,7 +85,7 @@ def pip(git_version: Optional[str] = None) -> str:
 
 def docker(git_version: Optional[str] = None) -> str:
     # docker tags don't like '+' characters, let's remove the buildinfo/commitid
-    return pip(git_version).split("+", maxsplit=1)[0]
+    return pip(git_version)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This seems to cause 'Can't use PEP 440 local versions'