### PR TITLE
[prometheus-rules-tester] keep resource in variables

### DIFF
--- a/reconcile/prometheus_rules_tester.py
+++ b/reconcile/prometheus_rules_tester.py
@@ -102,9 +102,11 @@ def get_prometheus_rules(cluster_name):
             rules[path][cluster][namespace] = {"spec": openshift_resource.body["spec"]}
 
             # we keep variables to use them in the rule tests
-            variables = r.get("variables")
-            if variables:
-                rules[path][cluster][namespace]["variables"] = json.loads(variables)
+            raw_variables = r.get("variables")
+            variables = json.loads(raw_variables) if raw_variables else {}
+            # keep the resource as well
+            variables["resource"] = r
+            rules[path][cluster][namespace]["variables"] = variables
 
     # We return rules that are actually consumed from a namespace becaused
     # those are the only ones that can be resolved as they can be templates

--- a/reconcile/prometheus_rules_tester.py
+++ b/reconcile/prometheus_rules_tester.py
@@ -102,7 +102,7 @@ def get_prometheus_rules(cluster_name):
             rules[path][cluster][namespace] = {"spec": openshift_resource.body["spec"]}
 
             # we keep variables to use them in the rule tests
-            variables = json.loads(r.get("variables") or '{}')
+            variables = json.loads(r.get("variables") or "{}")
             # keep the resource as well
             variables["resource"] = r
             rules[path][cluster][namespace]["variables"] = variables

--- a/reconcile/prometheus_rules_tester.py
+++ b/reconcile/prometheus_rules_tester.py
@@ -102,8 +102,7 @@ def get_prometheus_rules(cluster_name):
             rules[path][cluster][namespace] = {"spec": openshift_resource.body["spec"]}
 
             # we keep variables to use them in the rule tests
-            raw_variables = r.get("variables")
-            variables = json.loads(raw_variables) if raw_variables else {}
+            variables = json.loads(r.get("variables") or '{}')
             # keep the resource as well
             variables["resource"] = r
             rules[path][cluster][namespace]["variables"] = variables


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4765

to allow adding a single prometheus rule to multiple namespace files and to retain ability to test it, we currently add the resource's variables to support templating of the prometheus rules tests. example: https://gitlab.cee.redhat.com/service/app-interface/-/blob/43dfaffd6eab6e771ad51ea84ed7a396d378f709/resources/services/backplane/backplane-api-prod-common.prometheusrules-test.yml#L26

this PR adds the actual resource to the variables, to support templating based on the resource itself (`resource.namespace.cluster.name` for example).

this is the same as we do for templating the resource itself:
https://github.com/app-sre/qontract-reconcile/blob/5a107eeedff8a579d06ad91a889862aac80f7adc/reconcile/openshift_resources_base.py#L508

example usage: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/37255/diffs?commit_id=9ba80af1b5823843f9d50d492d135888f5b25d7b

note: as of now, this integration can only test rules that are referenced from namespace files and not from shared-resources files. this PR also contributes to making that work.