### PR TITLE
[sql-query] try not to use latest

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1437,6 +1437,7 @@ APP_INTERFACE_SQL_QUERIES_QUERY = """
         provider
         ... on NamespaceTerraformResourceRDS_v1
         {
+          account
           identifier
           output_resource_name
           defaults

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1440,6 +1440,7 @@ APP_INTERFACE_SQL_QUERIES_QUERY = """
           identifier
           output_resource_name
           defaults
+          overrides
         }
       }
       cluster

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -452,7 +452,9 @@ def run(dry_run, enable_deletion=False):
     # initiating terrascript with an empty list of accounts,
     # as we are not really initiating terraform configuration
     # but only using inner functions.
-    terrascript = Terrascript(QONTRACT_INTEGRATION, "", 1, accounts=[], settings=settings)
+    terrascript = Terrascript(
+        QONTRACT_INTEGRATION, "", 1, accounts=[], settings=settings
+    )
 
     queries_list = collect_queries(terrascript, settings=settings)
     remove_candidates = []

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -133,6 +133,10 @@ def get_tf_resource_info(namespace, identifier):
         defaults_ref = gql.get_api().get_resource(tf_resource["defaults"])
         defaults = yaml.safe_load(defaults_ref["content"])
         engine_version = defaults.get("engine_version", "latest")
+        raw_overrides = tf_resource.get("overrides")
+        if raw_overrides:
+            overrides = yaml.safe_load(raw_overrides)
+            engine_version = overrides.get("engine_version", engine_version)
 
         output_resource_name = tf_resource["output_resource_name"]
         if output_resource_name is None:

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -132,6 +132,7 @@ def get_tf_resource_info(namespace, identifier):
 
         defaults_ref = gql.get_api().get_resource(tf_resource["defaults"])
         defaults = yaml.safe_load(defaults_ref["content"])
+        engine_version = defaults.get("engine_version", "latest")
 
         output_resource_name = tf_resource["output_resource_name"]
         if output_resource_name is None:
@@ -143,7 +144,7 @@ def get_tf_resource_info(namespace, identifier):
             "cluster": namespace["cluster"]["name"],
             "output_resource_name": output_resource_name,
             "engine": defaults.get("engine", "postgres"),
-            "engine_version": defaults.get("engine_version", "latest"),
+            "engine_version": engine_version,
         }
 
 

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -142,7 +142,7 @@ def get_tf_resource_info(terrascript: Terrascript, namespace, identifier):
         }
 
 
-def collect_queries(terrascript: Terrascript, query_name=None, settings=None):
+def collect_queries(query_name=None, settings=None):
     """
     Consults the app-interface and constructs the list of queries
     to be executed.
@@ -164,6 +164,12 @@ def collect_queries(terrascript: Terrascript, query_name=None, settings=None):
     }
 
     sql_queries = queries.get_app_interface_sql_queries()
+    # initiating terrascript with an empty list of accounts,
+    # as we are not really initiating terraform configuration
+    # but only using inner functions.
+    terrascript = Terrascript(
+        QONTRACT_INTEGRATION, "", 1, accounts=[], settings=settings
+    )
 
     for sql_query in sql_queries:
         name = sql_query["name"]
@@ -447,14 +453,8 @@ def run(dry_run, enable_deletion=False):
     state = State(
         integration=QONTRACT_INTEGRATION, accounts=accounts, settings=settings
     )
-    # initiating terrascript with an empty list of accounts,
-    # as we are not really initiating terraform configuration
-    # but only using inner functions.
-    terrascript = Terrascript(
-        QONTRACT_INTEGRATION, "", 1, accounts=[], settings=settings
-    )
 
-    queries_list = collect_queries(terrascript, settings=settings)
+    queries_list = collect_queries(settings=settings)
     remove_candidates = []
     for query in queries_list:
         query_name = query["name"]

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -449,7 +449,7 @@ def run(dry_run, enable_deletion=False):
     state = State(
         integration=QONTRACT_INTEGRATION, accounts=accounts, settings=settings
     )
-    terrascript = Terrascript(QONTRACT_INTEGRATION, "", 1, accounts, settings=settings)
+    terrascript = Terrascript(QONTRACT_INTEGRATION, "", 1, accounts=[], settings=settings)
 
     queries_list = collect_queries(terrascript, settings=settings)
     remove_candidates = []

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -3,7 +3,6 @@ import sys
 import time
 
 from textwrap import indent
-from typing import Tuple
 
 import jinja2
 from ruamel import yaml
@@ -11,7 +10,6 @@ from ruamel import yaml
 from reconcile import openshift_base
 from reconcile import openshift_resources_base as orb
 from reconcile import queries
-from reconcile.utils import gql
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.oc import OC_Map
 from reconcile.utils.oc import StatusCodeError

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -132,10 +132,12 @@ def get_tf_resource_info(namespace, identifier):
 
         defaults_ref = gql.get_api().get_resource(tf_resource["defaults"])
         defaults = yaml.safe_load(defaults_ref["content"])
+        engine = defaults.get("engine", "postgres")
         engine_version = defaults.get("engine_version", "latest")
         raw_overrides = tf_resource.get("overrides")
         if raw_overrides:
             overrides = yaml.safe_load(raw_overrides)
+            engine = overrides.get("engine", engine)
             engine_version = overrides.get("engine_version", engine_version)
 
         output_resource_name = tf_resource["output_resource_name"]
@@ -147,7 +149,7 @@ def get_tf_resource_info(namespace, identifier):
         return {
             "cluster": namespace["cluster"]["name"],
             "output_resource_name": output_resource_name,
-            "engine": defaults.get("engine", "postgres"),
+            "engine": engine,
             "engine_version": engine_version,
         }
 

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -449,6 +449,9 @@ def run(dry_run, enable_deletion=False):
     state = State(
         integration=QONTRACT_INTEGRATION, accounts=accounts, settings=settings
     )
+    # initiating terrascript with an empty list of accounts,
+    # as we are not really initiating terraform configuration
+    # but only using inner functions.
     terrascript = Terrascript(QONTRACT_INTEGRATION, "", 1, accounts=[], settings=settings)
 
     queries_list = collect_queries(terrascript, settings=settings)

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -3,6 +3,7 @@ import sys
 import time
 
 from textwrap import indent
+from typing import Tuple
 
 import jinja2
 from ruamel import yaml
@@ -110,6 +111,20 @@ data:
 """
 
 
+def determine_engine(tf_resource: dict) -> Tuple[str, str]:
+    defaults_ref = gql.get_api().get_resource(tf_resource["defaults"])
+    defaults = yaml.safe_load(defaults_ref["content"])
+    engine = defaults.get("engine", "postgres")
+    engine_version = defaults.get("engine_version", "latest")
+    raw_overrides = tf_resource.get("overrides")
+    if raw_overrides:
+        overrides = yaml.safe_load(raw_overrides)
+        engine = overrides.get("engine", engine)
+        engine_version = overrides.get("engine_version", engine_version)
+
+    return engine, engine_version
+    
+
 def get_tf_resource_info(namespace, identifier):
     """
     Extracting the terraformResources information from the namespace
@@ -130,15 +145,7 @@ def get_tf_resource_info(namespace, identifier):
         if tf_resource["provider"] != "rds":
             continue
 
-        defaults_ref = gql.get_api().get_resource(tf_resource["defaults"])
-        defaults = yaml.safe_load(defaults_ref["content"])
-        engine = defaults.get("engine", "postgres")
-        engine_version = defaults.get("engine_version", "latest")
-        raw_overrides = tf_resource.get("overrides")
-        if raw_overrides:
-            overrides = yaml.safe_load(raw_overrides)
-            engine = overrides.get("engine", engine)
-            engine_version = overrides.get("engine_version", engine_version)
+        engine, engine_version = determine_engine(tf_resource)
 
         output_resource_name = tf_resource["output_resource_name"]
         if output_resource_name is None:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4765

the sql-query integrations creates Jobs (or CronJobs) in a tenant's namespace to perform a query against their database.
the integration currently tries to use the same image of the database engine, by looking for the version in the `defaults` file. however, the version may not be there, and may be in the `overrides` section.

this PR makes it so the integration searches for the version in the `overrides` section as well, by re-using the logic from terrascript_client:
https://github.com/app-sre/qontract-reconcile/blob/02252e58cf1f4579ffd3815ac12485cab68c17d2/reconcile/utils/terrascript_client.py#L3075-L3113

this will help us in running less with `latest`.

as a result, and this is why the linked ticket is about DVO, this will help remove `deployment_validation_operator_latest_tag` DVO alerts from tenants' namespaces, enabling https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/37255