### PR TITLE
use jjb version that includes fips patch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "UnleashClient~=5.1",
         "prometheus-client~=0.8",
         "sentry-sdk~=0.14",
-        "jenkins-job-builder~=3.12.0",
+        "jenkins-job-builder==4.0.0",
         "parse==1.18.0",
         "sendgrid>=6.4.8,<6.5.0",
         "dnspython~=2.1",


### PR DESCRIPTION
Version 3.12.0 of the jenkins-job-builder dependency was not compliant with FIPS and caused the jjb integration to fail within the fedramp environment. Version 4.0.0 contains a patch that resolves this issue.