### PR TITLE
use jjb version with fips patch

### DIFF
--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -30,6 +30,7 @@ from reconcile.utils.exceptions import FetchResourceError
 
 JJB_INI = "[jenkins]\nurl = https://JENKINS_URL"
 
+
 class JJB:  # pylint: disable=too-many-public-methods
     """Wrapper around Jenkins Jobs"""
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "UnleashClient~=5.1",
         "prometheus-client~=0.8",
         "sentry-sdk~=0.14",
-        "jenkins-job-builder~=3.12.0",
+        "jenkins-job-builder~=4.0.0",
         "parse==1.18.0",
         "sendgrid>=6.4.8,<6.5.0",
         "dnspython~=2.1",


### PR DESCRIPTION
Version 3.12.0 of the jenkins-job-builder dependency was not compliant with FIPS and caused the jjb integration to fail within the fedramp environment. 

Changes:
- Update to version 4.0.0, which contains FIPS patch
- Monkey patch attempt within `jjb_client.py` removed

Note: dry-run against commercial and fedramp environments yields no diffs between `current/` and `desired/`

Ticket: https://issues.redhat.com/browse/APPSRE-4411