### PR TITLE
Create the IAM user even when only user_policies have been defined

### DIFF
--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -500,8 +500,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     policy = \
                         policy.replace('${aws:accountid}', account_uid)
 
-                    # Ref: terraform aws_iam_policy
+                    # Ref: terraform aws iam_user
                     tf_iam_user = self.get_tf_iam_user(user_name)
+                    self.add_resource(account_name, tf_iam_user)
+
+                    # Ref: terraform aws_iam_policy
                     identifier = f'{user_name}-{policy_name}'
                     tf_aws_iam_policy = aws_iam_policy(
                         identifier,


### PR DESCRIPTION
The IAM user creation was only accounted for in the handling of
aws_groups, so it was skipped when only user_policies were defined.

I need to run through a couple of manual tests, but this was discovered when a user that had a role attached that only defined `user_polices`. The error seen was:

```
12:46:58 [2022-04-19 16:46:58] [ERROR] [terraform_client.py:check_output:559] - [account-name - plan] A managed resource "aws_iam_user" "[redacted]" has not been declared in the root
```

Adding this code unblocked the dry-run because the IAM user resource is now being added.

I also tested:
* add a new user with a role assigned containing both `aws_groups` and `user-policies`
* print-to-file before and after included the same output (with the exception of location that the `aws_iam_user` block is on, which didn't produce any diff in dry-run)