### PR TITLE
disable DVO minimum-three-replicas check for integrations

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -17,6 +17,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-{{ $integration.name }}
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     {{- if gt $shards 1 }}
     name: qontract-reconcile-{{ $integration.name }}-{{ $shard_id }}
     {{- else }}

--- a/openshift/qontract-reconcile-fedramp.yaml
+++ b/openshift/qontract-reconcile-fedramp.yaml
@@ -10,6 +10,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-namespace-labels
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-namespace-labels
   spec:
     replicas: 1
@@ -184,6 +186,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-namespaces
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-namespaces
   spec:
     replicas: 1
@@ -351,6 +355,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-network-policies
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-network-policies
   spec:
     replicas: 1
@@ -518,6 +524,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources
   spec:
     replicas: 1
@@ -685,6 +693,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-routes
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-routes
   spec:
     replicas: 1
@@ -852,6 +862,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets
   spec:
     replicas: 1
@@ -1019,6 +1031,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-aws-route53
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-aws-route53
   spec:
     replicas: 1
@@ -1186,6 +1200,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources
   spec:
     replicas: 1
@@ -1353,6 +1369,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-tgw-attachments
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-tgw-attachments
   spec:
     replicas: 1
@@ -1520,6 +1538,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-vpc-peerings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-vpc-peerings
   spec:
     replicas: 1
@@ -1687,6 +1707,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-jenkins-job-builder
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-jenkins-job-builder
   spec:
     volumeClaimTemplates:
@@ -1872,6 +1894,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-jenkins-webhooks
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-jenkins-webhooks
   spec:
     volumeClaimTemplates:
@@ -2050,6 +2074,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-configs
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-configs-0
   spec:
     replicas: 1
@@ -2224,6 +2250,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-configs
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-configs-1
   spec:
     replicas: 1
@@ -2398,6 +2426,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-configs
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-configs-2
   spec:
     replicas: 1
@@ -2572,6 +2602,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-tekton-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-tekton-resources
   spec:
     replicas: 1
@@ -2739,6 +2771,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-users
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-users
   spec:
     replicas: 1
@@ -2906,6 +2940,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-gitlab-housekeeping
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-gitlab-housekeeping
   spec:
     replicas: 1
@@ -3073,6 +3109,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings
   spec:
     replicas: 1
@@ -3240,6 +3278,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-clusterrolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-clusterrolebindings
   spec:
     replicas: 1

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -10,6 +10,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-slack-usergroups
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-slack-usergroups
   spec:
     replicas: 1
@@ -205,6 +207,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings
   spec:
     replicas: 1
@@ -414,6 +418,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-clusterrolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-clusterrolebindings
   spec:
     replicas: 1
@@ -623,6 +629,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-users
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-users
   spec:
     replicas: 1
@@ -818,6 +826,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-upgrade-watcher
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-upgrade-watcher
   spec:
     replicas: 1
@@ -1002,6 +1012,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-groups
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-groups
   spec:
     replicas: 1
@@ -1197,6 +1209,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-namespace-labels
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-namespace-labels
   spec:
     replicas: 1
@@ -1413,6 +1427,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-namespaces
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-namespaces
   spec:
     replicas: 1
@@ -1622,6 +1638,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-network-policies
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-network-policies
   spec:
     replicas: 1
@@ -1831,6 +1849,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-limitranges
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-limitranges
   spec:
     replicas: 1
@@ -2026,6 +2046,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resourcequotas
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resourcequotas
   spec:
     replicas: 1
@@ -2203,6 +2225,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources
   spec:
     replicas: 1
@@ -2394,6 +2418,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets
   spec:
     replicas: 1
@@ -2585,6 +2611,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-routes
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-routes
   spec:
     replicas: 1
@@ -2762,6 +2790,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-serviceaccount-tokens
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-serviceaccount-tokens
   spec:
     replicas: 1
@@ -2971,6 +3001,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-configs
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-configs-0
   spec:
     replicas: 1
@@ -3173,6 +3205,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-configs
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-configs-1
   spec:
     replicas: 1
@@ -3375,6 +3409,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-configs
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-configs-2
   spec:
     replicas: 1
@@ -3577,6 +3613,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-moving-commits
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-moving-commits-0
   spec:
     replicas: 1
@@ -3779,6 +3817,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-moving-commits
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-moving-commits-1
   spec:
     replicas: 1
@@ -3981,6 +4021,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-moving-commits
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-moving-commits-2
   spec:
     replicas: 1
@@ -4183,6 +4225,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-moving-commits
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-moving-commits-3
   spec:
     replicas: 1
@@ -4385,6 +4429,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-moving-commits
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-moving-commits-4
   spec:
     replicas: 1
@@ -4587,6 +4633,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-upstream-jobs
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-upstream-jobs-0
   spec:
     replicas: 1
@@ -4789,6 +4837,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-upstream-jobs
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-upstream-jobs-1
   spec:
     replicas: 1
@@ -4991,6 +5041,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-upstream-jobs
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-upstream-jobs-2
   spec:
     replicas: 1
@@ -5193,6 +5245,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-saas-deploy-trigger-cleaner
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-saas-deploy-trigger-cleaner
   spec:
     replicas: 1
@@ -5388,6 +5442,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-tekton-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-tekton-resources
   spec:
     replicas: 1
@@ -5597,6 +5653,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources
   spec:
     replicas: 1
@@ -5788,6 +5846,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-gitlab-projects
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-gitlab-projects
   spec:
     replicas: 1
@@ -5983,6 +6043,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-gitlab-members
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-gitlab-members
   spec:
     replicas: 1
@@ -6178,6 +6240,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-gitlab-permissions
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-gitlab-permissions
   spec:
     replicas: 1
@@ -6373,6 +6437,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-gitlab-owners
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-gitlab-owners
   spec:
     replicas: 1
@@ -6550,6 +6616,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-gitlab-housekeeping
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-gitlab-housekeeping
   spec:
     replicas: 1
@@ -6727,6 +6795,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-jenkins-job-builder
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-jenkins-job-builder
   spec:
     volumeClaimTemplates:
@@ -6922,6 +6992,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-jenkins-job-cleaner
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-jenkins-job-cleaner
   spec:
     volumeClaimTemplates:
@@ -7128,6 +7200,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-jenkins-roles
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-jenkins-roles
   spec:
     replicas: 1
@@ -7323,6 +7397,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-jenkins-webhooks
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-jenkins-webhooks
   spec:
     volumeClaimTemplates:
@@ -7529,6 +7605,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-jenkins-webhooks-cleaner
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-jenkins-webhooks-cleaner
   spec:
     replicas: 1
@@ -7724,6 +7802,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-gitlab-mr-sqs-consumer
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-gitlab-mr-sqs-consumer
   spec:
     replicas: 1
@@ -7913,6 +7993,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-status-page-components
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-status-page-components
   spec:
     replicas: 1

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -10,6 +10,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-aws-iam-keys
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-aws-iam-keys
   spec:
     replicas: 1
@@ -205,6 +207,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-aws-iam-password-reset
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-aws-iam-password-reset
   spec:
     replicas: 1
@@ -407,6 +411,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-aws-ami-share
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-aws-ami-share
   spec:
     replicas: 1
@@ -602,6 +608,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-dyn-traffic-director
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-dyn-traffic-director
   spec:
     replicas: 1
@@ -797,6 +805,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-github
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-github
   spec:
     replicas: 1
@@ -992,6 +1002,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-github-owners
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-github-owners
   spec:
     replicas: 1
@@ -1187,6 +1199,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-github-repo-invites
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-github-repo-invites
   spec:
     replicas: 1
@@ -1382,6 +1396,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-quay-membership
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-quay-membership
   spec:
     replicas: 1
@@ -1577,6 +1593,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-quay-mirror
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-quay-mirror
   spec:
     replicas: 1
@@ -1754,6 +1772,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-quay-mirror-org
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-quay-mirror-org
   spec:
     replicas: 1
@@ -1931,6 +1951,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-gcr-mirror
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-gcr-mirror
   spec:
     replicas: 1
@@ -2108,6 +2130,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-ecr-mirror
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-ecr-mirror
   spec:
     replicas: 1
@@ -2285,6 +2309,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-quay-repos
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-quay-repos
   spec:
     replicas: 1
@@ -2480,6 +2506,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-quay-permissions
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-quay-permissions
   spec:
     replicas: 1
@@ -2675,6 +2703,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-jira-watcher
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-jira-watcher
   spec:
     replicas: 1
@@ -2859,6 +2889,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-unleash-watcher
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-unleash-watcher
   spec:
     replicas: 1
@@ -3043,6 +3075,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-aws-support-cases-sos
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-aws-support-cases-sos
   spec:
     replicas: 1
@@ -3225,6 +3259,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-users
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-users
   spec:
     replicas: 1
@@ -3420,6 +3456,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-groups
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-groups-0
   spec:
     replicas: 1
@@ -3615,6 +3653,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-groups
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-groups-1
   spec:
     replicas: 1
@@ -3810,6 +3850,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-groups
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-groups-2
   spec:
     replicas: 1
@@ -4005,6 +4047,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-groups
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-groups-3
   spec:
     replicas: 1
@@ -4200,6 +4244,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-groups
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-groups-4
   spec:
     replicas: 1
@@ -4395,6 +4441,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-namespace-labels
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-namespace-labels
   spec:
     replicas: 1
@@ -4597,6 +4645,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-namespaces
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-namespaces
   spec:
     replicas: 1
@@ -4792,6 +4842,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-clusterrolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-clusterrolebindings
   spec:
     replicas: 1
@@ -4987,6 +5039,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-0
   spec:
     replicas: 1
@@ -5182,6 +5236,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-1
   spec:
     replicas: 1
@@ -5377,6 +5433,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-2
   spec:
     replicas: 1
@@ -5572,6 +5630,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-3
   spec:
     replicas: 1
@@ -5767,6 +5827,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-4
   spec:
     replicas: 1
@@ -5962,6 +6024,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-5
   spec:
     replicas: 1
@@ -6157,6 +6221,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-6
   spec:
     replicas: 1
@@ -6352,6 +6418,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-7
   spec:
     replicas: 1
@@ -6547,6 +6615,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-8
   spec:
     replicas: 1
@@ -6742,6 +6812,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-9
   spec:
     replicas: 1
@@ -6937,6 +7009,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-10
   spec:
     replicas: 1
@@ -7132,6 +7206,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-11
   spec:
     replicas: 1
@@ -7327,6 +7403,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-12
   spec:
     replicas: 1
@@ -7522,6 +7600,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-13
   spec:
     replicas: 1
@@ -7717,6 +7797,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-rolebindings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-rolebindings-14
   spec:
     replicas: 1
@@ -7912,6 +7994,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-network-policies
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-network-policies-0
   spec:
     replicas: 1
@@ -8107,6 +8191,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-network-policies
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-network-policies-1
   spec:
     replicas: 1
@@ -8302,6 +8388,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-network-policies
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-network-policies-2
   spec:
     replicas: 1
@@ -8497,6 +8585,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-network-policies
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-network-policies-3
   spec:
     replicas: 1
@@ -8692,6 +8782,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-network-policies
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-network-policies-4
   spec:
     replicas: 1
@@ -8887,6 +8979,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-network-policies
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-network-policies-5
   spec:
     replicas: 1
@@ -9082,6 +9176,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-network-policies
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-network-policies-6
   spec:
     replicas: 1
@@ -9277,6 +9373,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-network-policies
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-network-policies-7
   spec:
     replicas: 1
@@ -9472,6 +9570,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-network-policies
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-network-policies-8
   spec:
     replicas: 1
@@ -9667,6 +9767,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-network-policies
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-network-policies-9
   spec:
     replicas: 1
@@ -9862,6 +9964,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-limitranges
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-limitranges
   spec:
     replicas: 1
@@ -10057,6 +10161,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resourcequotas
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resourcequotas
   spec:
     replicas: 1
@@ -10234,6 +10340,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-0
   spec:
     replicas: 1
@@ -10411,6 +10519,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-1
   spec:
     replicas: 1
@@ -10588,6 +10698,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-2
   spec:
     replicas: 1
@@ -10765,6 +10877,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-3
   spec:
     replicas: 1
@@ -10942,6 +11056,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-4
   spec:
     replicas: 1
@@ -11119,6 +11235,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-5
   spec:
     replicas: 1
@@ -11296,6 +11414,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-6
   spec:
     replicas: 1
@@ -11473,6 +11593,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-7
   spec:
     replicas: 1
@@ -11650,6 +11772,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-8
   spec:
     replicas: 1
@@ -11827,6 +11951,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-9
   spec:
     replicas: 1
@@ -12004,6 +12130,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-10
   spec:
     replicas: 1
@@ -12181,6 +12309,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-11
   spec:
     replicas: 1
@@ -12358,6 +12488,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-12
   spec:
     replicas: 1
@@ -12535,6 +12667,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-13
   spec:
     replicas: 1
@@ -12712,6 +12846,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-14
   spec:
     replicas: 1
@@ -12889,6 +13025,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-15
   spec:
     replicas: 1
@@ -13066,6 +13204,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-16
   spec:
     replicas: 1
@@ -13243,6 +13383,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-17
   spec:
     replicas: 1
@@ -13420,6 +13562,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-18
   spec:
     replicas: 1
@@ -13597,6 +13741,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-resources
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-resources-19
   spec:
     replicas: 1
@@ -13774,6 +13920,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-0
   spec:
     replicas: 1
@@ -13951,6 +14099,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-1
   spec:
     replicas: 1
@@ -14128,6 +14278,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-2
   spec:
     replicas: 1
@@ -14305,6 +14457,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-3
   spec:
     replicas: 1
@@ -14482,6 +14636,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-4
   spec:
     replicas: 1
@@ -14659,6 +14815,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-5
   spec:
     replicas: 1
@@ -14836,6 +14994,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-6
   spec:
     replicas: 1
@@ -15013,6 +15173,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-7
   spec:
     replicas: 1
@@ -15190,6 +15352,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-8
   spec:
     replicas: 1
@@ -15367,6 +15531,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-9
   spec:
     replicas: 1
@@ -15544,6 +15710,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-10
   spec:
     replicas: 1
@@ -15721,6 +15889,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-11
   spec:
     replicas: 1
@@ -15898,6 +16068,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-12
   spec:
     replicas: 1
@@ -16075,6 +16247,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-13
   spec:
     replicas: 1
@@ -16252,6 +16426,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-14
   spec:
     replicas: 1
@@ -16429,6 +16605,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-15
   spec:
     replicas: 1
@@ -16606,6 +16784,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-16
   spec:
     replicas: 1
@@ -16783,6 +16963,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-17
   spec:
     replicas: 1
@@ -16960,6 +17142,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-18
   spec:
     replicas: 1
@@ -17137,6 +17321,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-vault-secrets
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-vault-secrets-19
   spec:
     replicas: 1
@@ -17314,6 +17500,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-routes
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-routes-0
   spec:
     replicas: 1
@@ -17491,6 +17679,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-routes
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-routes-1
   spec:
     replicas: 1
@@ -17668,6 +17858,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-routes
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-routes-2
   spec:
     replicas: 1
@@ -17845,6 +18037,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-routes
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-routes-3
   spec:
     replicas: 1
@@ -18022,6 +18216,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-openshift-routes
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-openshift-routes-4
   spec:
     replicas: 1
@@ -18199,6 +18395,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-aws-route53
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-aws-route53
   spec:
     replicas: 1
@@ -18394,6 +18592,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources-wrapper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources-wrapper-0
   spec:
     replicas: 1
@@ -18589,6 +18789,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources-wrapper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources-wrapper-1
   spec:
     replicas: 1
@@ -18784,6 +18986,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources-wrapper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources-wrapper-2
   spec:
     replicas: 1
@@ -18979,6 +19183,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources-wrapper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources-wrapper-3
   spec:
     replicas: 1
@@ -19174,6 +19380,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources-wrapper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources-wrapper-4
   spec:
     replicas: 1
@@ -19369,6 +19577,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources-wrapper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources-wrapper-5
   spec:
     replicas: 1
@@ -19564,6 +19774,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources-wrapper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources-wrapper-6
   spec:
     replicas: 1
@@ -19759,6 +19971,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources-wrapper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources-wrapper-7
   spec:
     replicas: 1
@@ -19954,6 +20168,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources-wrapper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources-wrapper-8
   spec:
     replicas: 1
@@ -20149,6 +20365,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources-wrapper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources-wrapper-9
   spec:
     replicas: 1
@@ -20344,6 +20562,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources-wrapper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources-wrapper-10
   spec:
     replicas: 1
@@ -20539,6 +20759,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources-wrapper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources-wrapper-11
   spec:
     replicas: 1
@@ -20734,6 +20956,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-resources-wrapper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-resources-wrapper-12
   spec:
     replicas: 1
@@ -20929,6 +21153,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-users
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-users
   spec:
     replicas: 1
@@ -21124,6 +21350,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-vpc-peerings
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-vpc-peerings
   spec:
     replicas: 1
@@ -21319,6 +21547,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-terraform-tgw-attachments
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-terraform-tgw-attachments
   spec:
     replicas: 1
@@ -21514,6 +21744,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-ocm-addons
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-ocm-addons
   spec:
     replicas: 1
@@ -21709,6 +21941,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-ocm-groups
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-ocm-groups
   spec:
     replicas: 1
@@ -21904,6 +22138,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-ocm-clusters
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-ocm-clusters
   spec:
     replicas: 1
@@ -22104,6 +22340,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-ocm-aws-infrastructure-access
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-ocm-aws-infrastructure-access
   spec:
     replicas: 1
@@ -22299,6 +22537,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-ocm-github-idp
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-ocm-github-idp
   spec:
     replicas: 1
@@ -22494,6 +22734,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-ocm-machine-pools
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-ocm-machine-pools
   spec:
     replicas: 1
@@ -22689,6 +22931,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-ocm-upgrade-scheduler
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-ocm-upgrade-scheduler
   spec:
     replicas: 1
@@ -22891,6 +23135,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-ocm-external-configuration-labels
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-ocm-external-configuration-labels
   spec:
     replicas: 1
@@ -23086,6 +23332,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-ocm-additional-routers
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-ocm-additional-routers
   spec:
     replicas: 1
@@ -23281,6 +23529,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-kafka-clusters
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-kafka-clusters
   spec:
     replicas: 1
@@ -23476,6 +23726,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-email-sender
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-email-sender
   spec:
     replicas: 1
@@ -23678,6 +23930,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-requests-sender
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-requests-sender
   spec:
     replicas: 1
@@ -23880,6 +24134,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-sentry-config
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-sentry-config
   spec:
     replicas: 1
@@ -24057,6 +24313,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-sentry-helper
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-sentry-helper
   spec:
     replicas: 1
@@ -24241,6 +24499,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-sql-query
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-sql-query
   spec:
     replicas: 1
@@ -24443,6 +24703,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-slack-cluster-usergroups
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-slack-cluster-usergroups
   spec:
     replicas: 1
@@ -24638,6 +24900,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-ocp-release-mirror
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-ocp-release-mirror
   spec:
     replicas: 1
@@ -24815,6 +25079,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-sendgrid-teammates
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-sendgrid-teammates
   spec:
     replicas: 1
@@ -25010,6 +25276,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-gabi-authorized-users
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-gabi-authorized-users
   spec:
     replicas: 1
@@ -25205,6 +25473,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-blackbox-exporter-endpoint-monitoring
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-blackbox-exporter-endpoint-monitoring
   spec:
     replicas: 1
@@ -25382,6 +25652,8 @@ objects:
   metadata:
     labels:
       app: qontract-reconcile-signalfx-prometheus-endpoint-monitoring
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
     name: qontract-reconcile-signalfx-prometheus-endpoint-monitoring
   spec:
     replicas: 1


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4765

docs: https://www.civo.com/learn/yaml-best-practices-using-kubelinter#ignoring-a-check

this PR disables the DVO check of minimum 3 replicas for integrations, as our scaling mechanism is shards and not replicas.