### PR TITLE
run dashdotdb-dvo once an hour

### DIFF
--- a/helm/qontract-reconcile/values-internal.yaml
+++ b/helm/qontract-reconcile/values-internal.yaml
@@ -426,8 +426,8 @@ cronjobs:
     limits:
       memory: 600Mi
       cpu: 200m
-  # once a day
-  cron: '0 2 * * *'
+  # once an hour
+  cron: '0 * * * *'
   dashdotdb: true
 - name: dashdotdb-slo
   concurrencyPolicy: Replace

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -8418,7 +8418,7 @@ objects:
       app: qontract-reconcile-dashdotdb-dvo
     name: qontract-reconcile-dashdotdb-dvo
   spec:
-    schedule: "0 2 * * *"
+    schedule: "0 * * * *"
     concurrencyPolicy: Replace
     successfulJobHistoryLimit: 12
     failedJobHistoryLimit: 12


### PR DESCRIPTION
as we work on https://issues.redhat.com/browse/APPSRE-4765, we will get more traction on DVO metrics.

this means tenants would want to see their work reflected in dashboards.

with this job running once every 24 hours, the feedback loop will be too slow.

is there a reason not to run this job once an hour?