### PR TITLE
[ldap-users] avoid merge of invalid user files

### DIFF
--- a/helm/qontract-reconcile/values-internal.yaml
+++ b/helm/qontract-reconcile/values-internal.yaml
@@ -400,8 +400,8 @@ cronjobs:
       memory: 200Mi
       cpu: 200m
   extraArgs: ${APP_INTERFACE_PROJECT_ID}
-  # once a hour
-  cron: '0 * * * *'
+  # once a minute
+  cron: '* * * * *'
 - name: dashdotdb-cso
   concurrencyPolicy: Replace
   resources:

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -8297,7 +8297,7 @@ objects:
       app: qontract-reconcile-ldap-users
     name: qontract-reconcile-ldap-users
   spec:
-    schedule: "0 * * * *"
+    schedule: "* * * * *"
     concurrencyPolicy: Allow
     successfulJobHistoryLimit: 3
     failedJobHistoryLimit: 1

--- a/reconcile/ldap_users.py
+++ b/reconcile/ldap_users.py
@@ -1,8 +1,10 @@
+import sys
 import logging
 
 from collections import defaultdict
 
 from reconcile import queries
+from reconcile.status import ExitCodes
 from reconcile.utils.ldap_client import LdapClient
 
 from reconcile import mr_client_gateway
@@ -54,3 +56,8 @@ def run(dry_run, gitlab_project_id=None):
         if not dry_run:
             mr = CreateDeleteUser(username, paths)
             mr.submit(cli=mr_cli)
+
+    # this is to avoid merging user files
+    # which will be immediately deleted
+    if dry_run and users_to_delete:
+        sys.exit(ExitCodes.ERROR)


### PR DESCRIPTION
with the current implementation, the integration is considered successful when it wants to delete user files.

this creates situations like: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/37554
where an invalid user file was merged and immediately removed.

while the "proper" implementation would be to store in a state the users from the previous run, and check if a user being checked is "new", and only fail in that case - this implementation is much quicker. the only risk is the time between an existing user becoming invalid and to the time the user is deleted.