### PR TITLE
consider shared resources in tester integrations

### DIFF
--- a/reconcile/prometheus_rules_tester.py
+++ b/reconcile/prometheus_rules_tester.py
@@ -10,6 +10,7 @@ from sretoolbox.utils import threaded
 from reconcile import queries
 from reconcile.utils import gql
 from reconcile.utils import promtool
+import reconcile.openshift_base as ob
 import reconcile.openshift_resources_base as orb
 
 from reconcile.utils.semver_helper import make_semver
@@ -77,6 +78,7 @@ def get_prometheus_rules(cluster_name):
         ):
             continue
 
+        ob.aggregate_shared_resources(n, "openshiftResources")
         openshift_resources = n.get("openshiftResources")
         if not openshift_resources:
             logging.warning(

--- a/reconcile/template_tester.py
+++ b/reconcile/template_tester.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 import yaml
+import reconcile.openshift_base as ob
 import reconcile.openshift_resources_base as orb
 
 from reconcile.status import ExitCodes
@@ -36,6 +37,7 @@ def run(dry_run):
         resource_path = tt["resourcePath"]
         expected_result = load_resource(tt["expectedResult"])
         for n in gqlapi.query(orb.NAMESPACES_QUERY)["namespaces"]:
+            ob.aggregate_shared_resources(n, "openshiftResources")
             openshift_resources = n.get("openshiftResources")
             if not openshift_resources:
                 continue


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4765

this PR adds the option to test resources referenced by shared resources files referenced from namespace files. without this change, only resources defined in a namespace's `openshiftResources` section can be tested.

this is the function being used:
https://github.com/app-sre/qontract-reconcile/blob/a3285f140702cdd9386a4faa7357b0c7ac149af5/reconcile/openshift_base.py#L775-L799

this PR enables https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/37591