### PR TITLE
[openshift-resources + saas] allow full-qualified kinds in managedResourceTypes

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1,7 +1,8 @@
+from dataclasses import dataclass
 import logging
 import itertools
 
-from typing import Optional, Iterable, Mapping
+from typing import Any, Optional, Iterable, Mapping, Union
 
 import yaml
 
@@ -9,7 +10,7 @@ from sretoolbox.utils import retry
 from sretoolbox.utils import threaded
 
 from reconcile import queries
-from reconcile.utils.oc import FieldIsImmutableError
+from reconcile.utils.oc import FieldIsImmutableError, OCClient
 from reconcile.utils.oc import MayNotChangeOnceSetError
 from reconcile.utils.oc import PrimaryClusterIPCanNotBeUnsetError
 from reconcile.utils.oc import InvalidValueApplyError
@@ -34,28 +35,41 @@ class ValidationErrorJobFailed(Exception):
     pass
 
 
-class StateSpec:
-    def __init__(
-        self,
-        type,
-        oc,
-        cluster,
-        namespace,
-        resource,
-        parent=None,
-        resource_type_override=None,
-        resource_names=None,
-        privileged=False,
-    ):
-        self.type = type
-        self.oc = oc
-        self.cluster = cluster
-        self.namespace = namespace
-        self.resource = resource
-        self.parent = parent
-        self.resource_type_override = resource_type_override
-        self.resource_names = resource_names
-        self.privileged = privileged
+@dataclass
+class BaseStateSpec:
+
+    oc: OCClient
+    cluster: str
+    namespace: str
+
+    def __str__(self) -> str:
+        return f"cluster: {self.cluster}, namespace: {self.namespace}"
+
+
+@dataclass
+class CurrentStateSpec(BaseStateSpec):
+
+    kind: str
+    resource_names: Optional[Iterable[str]]
+
+    def __str__(self) -> str:
+        return (
+            f"current spec - {super().__str__()}, resource_names: {self.resource_names}"
+        )
+
+
+@dataclass
+class DesiredStateSpec(BaseStateSpec):
+
+    resource: Mapping[str, Any]
+    parent: Mapping[Any, Any]
+    privileged: bool = False
+
+    def __str__(self) -> str:
+        return f"desired spec - {super().__str__()}, privileged: {self.privileged}"
+
+
+StateSpec = Union[CurrentStateSpec, DesiredStateSpec]
 
 
 def init_specs_to_fetch(
@@ -66,7 +80,7 @@ def init_specs_to_fetch(
     override_managed_types: Optional[Iterable[str]] = None,
     managed_types_key: str = "managedResourceTypes",
 ) -> list[StateSpec]:
-    state_specs = []
+    state_specs: list[StateSpec] = []
 
     if clusters and namespaces:
         raise KeyError("expected only one of clusters or namespaces.")
@@ -96,9 +110,7 @@ def init_specs_to_fetch(
                 namespace_info.get("managedResourceTypeOverrides") or []
             )
 
-            # Initialize current state specs
-            for resource_type in managed_types:
-                ri.initialize_resource_type(cluster, namespace, resource_type)
+            # Prepare resource names
             resource_names = {}
             resource_type_overrides = {}
             for mrn in managed_resource_names:
@@ -118,6 +130,7 @@ def init_specs_to_fetch(
                         f"{cluster}/{namespace} (valid kinds: {managed_types})"
                     )
 
+            # Prepare type overrides
             for o in managed_resource_type_overrides:
                 # Current implementation guarantees only one
                 # override of each managed type
@@ -135,48 +148,35 @@ def init_specs_to_fetch(
                         f"{cluster}/{namespace} (valid kinds: {managed_types})"
                     )
 
-            for kind, names in resource_names.items():
-                c_spec = StateSpec(
-                    "current",
-                    oc,
-                    cluster,
-                    namespace,
-                    kind,
-                    resource_type_override=resource_type_overrides.get(kind),
-                    resource_names=names,
+            # Initialized current state specs
+            for kind in managed_types:
+                managed_names = resource_names.get(kind)
+                kind = resource_type_overrides.get(kind, kind)
+                ri.initialize_resource_type(cluster, namespace, kind)
+                state_specs.append(
+                    CurrentStateSpec(
+                        oc=oc,
+                        cluster=cluster,
+                        namespace=namespace,
+                        kind=kind,
+                        resource_names=managed_names,
+                    )
                 )
-                state_specs.append(c_spec)
-                managed_types.remove(kind)
-
-            # Produce "empty" StateSpec's for any resource type that
-            # doesn't have an explicit managedResourceName listed in
-            # the namespace
-            state_specs.extend(
-                StateSpec(
-                    "current",
-                    oc,
-                    cluster,
-                    namespace,
-                    t,
-                    resource_type_override=resource_type_overrides.get(t),
-                    resource_names=None,
-                )
-                for t in managed_types
-            )
 
             # Initialize desired state specs
             openshift_resources = namespace_info.get("openshiftResources")
             for openshift_resource in openshift_resources or []:
-                d_spec = StateSpec(
-                    "desired",
-                    oc,
-                    cluster,
-                    namespace,
-                    openshift_resource,
-                    namespace_info,
-                    privileged=privileged,
+                state_specs.append(
+                    DesiredStateSpec(
+                        oc=oc,
+                        cluster=cluster,
+                        namespace=namespace,
+                        resource=openshift_resource,
+                        parent=namespace_info,
+                        privileged=privileged,
+                    )
                 )
-                state_specs.append(d_spec)
+
     elif clusters:
         # set namespace to something indicative
         namespace = "cluster"
@@ -191,38 +191,65 @@ def init_specs_to_fetch(
 
             # we currently only use override_managed_types,
             # and not allow a `managedResourcesTypes` field in a cluster file
-            for resource_type in override_managed_types or []:
-                ri.initialize_resource_type(cluster, namespace, resource_type)
+            for kind in override_managed_types or []:
+                ri.initialize_resource_type(cluster, namespace, kind)
+
                 # Initialize current state specs
-                c_spec = StateSpec("current", oc, cluster, namespace, resource_type)
-                state_specs.append(c_spec)
+                state_specs.append(
+                    CurrentStateSpec(
+                        oc=oc,
+                        cluster=cluster,
+                        namespace=namespace,
+                        kind=kind,
+                        resource_names=[],
+                    )
+                )
                 # Initialize desired state specs
-                d_spec = StateSpec("desired", oc, cluster, namespace, resource_type)
-                state_specs.append(d_spec)
+                # it seems this StateSpec has no effect and can be disabled. the only code path
+                # leading to this place is from openshift_clusterrolebindings > ob.fetch_current_state >
+                # init_specs_to_fetch. ob_fetch_current_state then uses the specs return from here
+                # to populate the current state in an ResourceInventory (populate_current), which does not
+                # differentiate between StateSpecs of type current and desired and just populates the
+                # ResourceInventory spec with it. that is also the reason that it is not a problem that
+                # the resource field in the desired StateSpec can be a resource_type instead of being
+                # a resource dict like usual.
+                #
+                # running the openshift-clusterrolebinding integration showed a clean log after disabling
+                # this line, which indicates no change in behaviour. even a dry-run mode with some deleted
+                # roles showed expected behaviour.
+                #
+                # following this reasoning - i'm going to disable this line for now and will remove it
+                # before merging this PR if i get no objection.
+                #
+                # d_spec = StateSpec("desired", oc, cluster, namespace, resource_type)
+
     else:
         raise KeyError("expected one of clusters or namespaces.")
 
     return state_specs
 
 
-def populate_current_state(spec, ri, integration, integration_version):
-    oc = spec.oc
-    if oc is None:
-        return
-    api_resources = oc.api_resources
-    if api_resources and spec.resource not in api_resources:
-        msg = f"[{spec.cluster}] cluster has no API resource {spec.resource}."
+def populate_current_state(
+    spec: CurrentStateSpec,
+    ri: ResourceInventory,
+    integration: str,
+    integration_version: str,
+):
+    # if spec.oc is None: - oc can't be none because init_namespace_specs_to_fetch does not create specs if oc is none
+    #    return
+    if spec.oc.init_api_resources and not spec.oc.is_kind_supported(spec.kind):
+        msg = f"[{spec.cluster}] cluster has no API resource {spec.kind}."
         logging.warning(msg)
         return
     try:
-        for item in oc.get_items(
-            spec.resource, namespace=spec.namespace, resource_names=spec.resource_names
+        for item in spec.oc.get_items(
+            spec.kind, namespace=spec.namespace, resource_names=spec.resource_names
         ):
             openshift_resource = OR(item, integration, integration_version)
             ri.add_current(
                 spec.cluster,
                 spec.namespace,
-                spec.resource,
+                spec.kind,
                 openshift_resource.name,
                 openshift_resource,
             )

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -141,14 +141,14 @@ def init_specs_to_fetch(
             # Initialized current state specs
             for kind in managed_types:
                 managed_names = resource_names.get(kind)
-                kind = resource_type_overrides.get(kind, kind)
-                ri.initialize_resource_type(cluster, namespace, kind)
+                kind_to_use = resource_type_overrides.get(kind, kind)
+                ri.initialize_resource_type(cluster, namespace, kind_to_use)
                 state_specs.append(
                     CurrentStateSpec(
                         oc=oc,
                         cluster=cluster,
                         namespace=namespace,
-                        kind=kind,
+                        kind=kind_to_use,
                         resource_names=managed_names,
                     )
                 )

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -38,12 +38,9 @@ class ValidationErrorJobFailed(Exception):
 @dataclass
 class BaseStateSpec:
 
-    oc: OCClient = field(compare=False)
+    oc: OCClient = field(compare=False, repr=False)
     cluster: str
     namespace: str
-
-    def __str__(self) -> str:
-        return f"cluster: {self.cluster}, namespace: {self.namespace}"
 
 
 @dataclass
@@ -52,21 +49,13 @@ class CurrentStateSpec(BaseStateSpec):
     kind: str
     resource_names: Optional[Iterable[str]]
 
-    def __str__(self) -> str:
-        return (
-            f"current spec - {super().__str__()}, resource_names: {self.resource_names}"
-        )
-
 
 @dataclass
 class DesiredStateSpec(BaseStateSpec):
 
     resource: Mapping[str, Any]
-    parent: Mapping[Any, Any]
+    parent: Mapping[Any, Any] = field(repr=False)
     privileged: bool = False
-
-    def __str__(self) -> str:
-        return f"desired spec - {super().__str__()}, privileged: {self.privileged}"
 
 
 StateSpec = Union[CurrentStateSpec, DesiredStateSpec]

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import logging
 import itertools
 
@@ -38,7 +38,7 @@ class ValidationErrorJobFailed(Exception):
 @dataclass
 class BaseStateSpec:
 
-    oc: OCClient
+    oc: OCClient = field(compare=False)
     cluster: str
     namespace: str
 

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -634,11 +634,9 @@ def fetch_desired_state(oc, ri, cluster, namespace, resource, parent, privileged
 
     # add to inventory
     try:
-        ri.add_desired(
+        ri.add_desired_resource(
             cluster,
             namespace,
-            openshift_resource.kind,
-            openshift_resource.name,
             openshift_resource,
             privileged,
         )

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -578,7 +578,7 @@ def fetch_current_state(
 ):
     global _log_lock
 
-    msg = "Fetching {}s from {}/{}".format(kind, cluster, namespace)
+    msg = f"Fetching {kind} from {cluster}/{namespace}"
     _log_lock.acquire()  # pylint: disable=consider-using-with
     logging.debug(msg)
     _log_lock.release()

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -366,16 +366,15 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 5, 2)
 QONTRACT_TF_PREFIX = 'qrtf'
 
 
-def populate_oc_resources(spec, ri, account_name):
+def populate_oc_resources(spec: ob.CurrentStateSpec, ri: ResourceInventory, account_name: Optional[str]):
     if spec.oc is None:
         return
-
     logging.debug("[populate_oc_resources] cluster: " + spec.cluster
                   + " namespace: " + spec.namespace
-                  + " resource: " + spec.resource)
+                  + " resource: " + spec.kind)
 
     try:
-        for item in spec.oc.get_items(spec.resource,
+        for item in spec.oc.get_items(spec.kind,
                                       namespace=spec.namespace):
             openshift_resource = OR(item,
                                     QONTRACT_INTEGRATION,
@@ -388,7 +387,7 @@ def populate_oc_resources(spec, ri, account_name):
             ri.add_current(
                 spec.cluster,
                 spec.namespace,
-                spec.resource,
+                spec.kind,
                 openshift_resource.name,
                 openshift_resource
             )
@@ -398,7 +397,7 @@ def populate_oc_resources(spec, ri, account_name):
         msg += 'namespace: {},'
         msg += 'resource: {},'
         msg += 'exception: {}'
-        msg = msg.format(spec.cluster, spec.namespace, spec.resource, str(e))
+        msg = msg.format(spec.cluster, spec.namespace, spec.kind, str(e))
         logging.error(msg)
 
 
@@ -419,8 +418,12 @@ def fetch_current_state(dry_run, namespaces, thread_pool_size,
             namespaces=namespaces,
             override_managed_types=['Secret']
         )
-    threaded.run(populate_oc_resources, state_specs, thread_pool_size, ri=ri,
-                 account_name=account_name)
+    current_state_specs: list[ob.CurrentStateSpec] = [s for s in state_specs if isinstance(s, ob.CurrentStateSpec)]
+    threaded.run(
+        populate_oc_resources, current_state_specs,
+        thread_pool_size, ri=ri,
+        account_name=account_name
+    )
 
     return ri, oc_map
 

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, List, cast
+from typing import Any, cast
 import pytest
 
 import reconcile.openshift_base as sut
@@ -64,15 +64,6 @@ def test_no_cluster_or_namespace(
         )
 
 
-def assert_specs_match(
-    result: List[sut.StateSpec], expected: List[sut.StateSpec]
-) -> None:
-    """Assert that two list of StateSpec are equal. Needed since StateSpec
-    doesn't implement __eq__ and it's not worth to add for we will convert
-    it to a dataclass when we move to Python 3.9"""
-    assert [r.__dict__ for r in result] == [e.__dict__ for e in expected]
-
-
 def test_namespaces_managed(
     resource_inventory: resource.ResourceInventory,
     namespaces: list[dict[str, Any]],
@@ -101,7 +92,7 @@ def test_namespaces_managed(
         oc_map,
         namespaces=namespaces,
     )
-    assert_specs_match(rs, expected)
+    assert rs == expected
 
 
 def test_namespaces_managed_with_overrides(
@@ -135,7 +126,7 @@ def test_namespaces_managed_with_overrides(
         namespaces=namespaces,
     )
 
-    assert_specs_match(rs, expected)
+    assert rs == expected
 
 
 def test_namespaces_no_managedresourcenames(
@@ -167,7 +158,7 @@ def test_namespaces_no_managedresourcenames(
         oc_map,
         namespaces=namespaces,
     )
-    assert_specs_match(rs, expected)
+    assert rs == expected
 
 
 def test_namespaces_no_managedresourcetypes(
@@ -257,7 +248,7 @@ def test_namespaces_override_managed_type(
         namespaces=namespaces,
         override_managed_types=["LimitRanges"],
     )
-    assert_specs_match(rs, expected)
+    assert rs == expected
 
     registrations = list(resource_inventory)
     # make sure only the override_managed_type LimitRange is present

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -1,7 +1,7 @@
-from typing import List, cast
+import logging
+from typing import Any, List, cast
 import pytest
 
-import testslide
 import reconcile.openshift_base as sut
 import reconcile.utils.openshift_resource as resource
 from reconcile.test.fixtures import Fixtures
@@ -10,219 +10,261 @@ from reconcile.utils import oc
 fxt = Fixtures("namespaces")
 
 
-class TestInitSpecsToFetch(testslide.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.resource_inventory = cast(
-            resource.ResourceInventory, testslide.StrictMock(resource.ResourceInventory)
-        )
+@pytest.fixture
+def resource_inventory() -> resource.ResourceInventory:
+    return resource.ResourceInventory()
 
-        self.oc_map = cast(oc.OC_Map, testslide.StrictMock(oc.OC_Map))
-        self.mock_constructor(oc, "OC_Map").to_return_value(self.oc_map)
-        self.namespaces = [fxt.get_anymarkup("valid-ns.yml")]
 
-        self.mock_callable(
-            self.resource_inventory, "initialize_resource_type"
-        ).for_call("cs1", "ns1", "Template").to_return_value(None)
+@pytest.fixture
+def namespaces() -> list[dict[str, Any]]:
+    return [fxt.get_anymarkup("valid-ns.yml")]
 
-        self.mock_callable(self.oc_map, "get").for_call("cs1", False).to_return_value(
-            "stuff"
-        )
-        self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
 
-    def test_only_cluster_or_namespace(self) -> None:
-        with self.assertRaises(KeyError):
-            sut.init_specs_to_fetch(
-                self.resource_inventory,
-                self.oc_map,
-                [{"foo": "bar"}],
-                [{"name": "cluster1"}],
+@pytest.fixture
+def oc_cs1() -> oc.OCClient:
+    return cast(oc.OCNative, oc.OC(cluster_name="cs1", server="", token="", local=True))
+
+
+@pytest.fixture
+def oc_map(mocker, oc_cs1: oc.OCNative) -> oc.OC_Map:
+    def get_cluster(cluster: str, privileged: bool = False):
+        if cluster == "cs1":
+            return oc_cs1
+        else:
+            return (
+                oc.OCLogMsg(
+                    log_level=logging.DEBUG, message=f"[{cluster}] cluster skipped"
+                ),
             )
 
-    def test_no_cluster_or_namespace(self) -> None:
-        with self.assertRaises(KeyError):
-            sut.init_specs_to_fetch(self.resource_inventory, self.oc_map)
+    oc_map = mocker.patch("reconcile.utils.oc.OC_Map", autospec=True).return_value
+    oc_map.get.mock_add_spec(oc.OC_Map.get)
+    oc_map.get.side_effect = get_cluster
+    return oc_map
 
-    def assert_specs_match(
-        self, result: List[sut.StateSpec], expected: List[sut.StateSpec]
-    ) -> None:
-        """Assert that two list of StateSpec are equal. Needed since StateSpec
-        doesn't implement __eq__ and it's not worth to add for we will convert
-        it to a dataclass when we move to Python 3.9"""
-        self.assertEqual(
-            [r.__dict__ for r in result],
-            [e.__dict__ for e in expected],
+
+def test_only_cluster_or_namespace(
+    resource_inventory: resource.ResourceInventory, oc_map: oc.OC_Map
+) -> None:
+    with pytest.raises(KeyError):
+        sut.init_specs_to_fetch(
+            ri=resource_inventory,
+            oc_map=oc_map,
+            namespaces=[{"foo": "bar"}],
+            clusters=[{"name": "cs1"}],
         )
 
-    def test_namespaces_managed(self) -> None:
-        expected = [
-            sut.StateSpec(
-                type="current",
-                oc="stuff",
-                cluster="cs1",
-                namespace="ns1",
-                resource="Template",
-                resource_names=["tp1", "tp2"],
-            ),
-            sut.StateSpec(
-                type="desired",
-                oc="stuff",
-                cluster="cs1",
-                namespace="ns1",
-                resource={"provider": "resource", "path": "/some/path.yml"},
-                parent=self.namespaces[0],
-            ),
-        ]
 
-        rs = sut.init_specs_to_fetch(
-            self.resource_inventory,
-            self.oc_map,
-            namespaces=self.namespaces,
-        )
-        self.assert_specs_match(rs, expected)
-
-    def test_namespaces_managed_with_overrides(self) -> None:
-        self.namespaces[0]["managedResourceTypeOverrides"] = [
-            {"resource": "Template", "override": "something.template"}
-        ]
-        expected = [
-            sut.StateSpec(
-                type="current",
-                oc="stuff",
-                cluster="cs1",
-                namespace="ns1",
-                resource="Template",
-                resource_names=["tp1", "tp2"],
-                resource_type_override="something.template",
-            ),
-            sut.StateSpec(
-                type="desired",
-                oc="stuff",
-                cluster="cs1",
-                namespace="ns1",
-                resource={"provider": "resource", "path": "/some/path.yml"},
-                parent=self.namespaces[0],
-            ),
-        ]
-        rs = sut.init_specs_to_fetch(
-            self.resource_inventory,
-            self.oc_map,
-            namespaces=self.namespaces,
+def test_no_cluster_or_namespace(
+    resource_inventory: resource.ResourceInventory, oc_map: oc.OC_Map
+) -> None:
+    with pytest.raises(KeyError):
+        sut.init_specs_to_fetch(
+            ri=resource_inventory, oc_map=oc_map, namespaces=None, clusters=None
         )
 
-        self.assert_specs_match(rs, expected)
 
-    def test_namespaces_no_managedresourcenames(self) -> None:
-        self.namespaces[0]["managedResourceNames"] = None
-        self.namespaces[0]["managedResourceTypeOverrides"] = None
-        self.maxDiff = None
-        expected = [
-            sut.StateSpec(
-                type="current",
-                oc="stuff",
-                cluster="cs1",
-                namespace="ns1",
-                parent=None,
-                resource="Template",
-                resource_names=None,
-                resource_type_override=None,
-            ),
-            sut.StateSpec(
-                type="desired",
-                oc="stuff",
-                cluster="cs1",
-                namespace="ns1",
-                resource={"provider": "resource", "path": "/some/path.yml"},
-                parent=self.namespaces[0],
-            ),
-        ]
-        rs = sut.init_specs_to_fetch(
-            self.resource_inventory,
-            self.oc_map,
-            namespaces=self.namespaces,
+def assert_specs_match(
+    result: List[sut.StateSpec], expected: List[sut.StateSpec]
+) -> None:
+    """Assert that two list of StateSpec are equal. Needed since StateSpec
+    doesn't implement __eq__ and it's not worth to add for we will convert
+    it to a dataclass when we move to Python 3.9"""
+    assert [r.__dict__ for r in result] == [e.__dict__ for e in expected]
+
+
+def test_namespaces_managed(
+    resource_inventory: resource.ResourceInventory,
+    namespaces: list[dict[str, Any]],
+    oc_map: oc.OC_Map,
+    oc_cs1: oc.OCClient,
+) -> None:
+    expected: list[sut.StateSpec] = [
+        sut.CurrentStateSpec(
+            oc=oc_cs1,
+            cluster="cs1",
+            namespace="ns1",
+            kind="Template",
+            resource_names=["tp1", "tp2"],
+        ),
+        sut.DesiredStateSpec(
+            oc=oc_cs1,
+            cluster="cs1",
+            namespace="ns1",
+            resource={"provider": "resource", "path": "/some/path.yml"},
+            parent=namespaces[0],
+        ),
+    ]
+
+    rs = sut.init_specs_to_fetch(
+        resource_inventory,
+        oc_map,
+        namespaces=namespaces,
+    )
+    assert_specs_match(rs, expected)
+
+
+def test_namespaces_managed_with_overrides(
+    resource_inventory: resource.ResourceInventory,
+    namespaces: list[dict[str, Any]],
+    oc_map: oc.OC_Map,
+    oc_cs1: oc.OCClient,
+) -> None:
+    namespaces[0]["managedResourceTypeOverrides"] = [
+        {"resource": "Template", "override": "something.template"}
+    ]
+    expected: list[sut.StateSpec] = [
+        sut.CurrentStateSpec(
+            oc=oc_cs1,
+            cluster="cs1",
+            namespace="ns1",
+            kind="something.template",
+            resource_names=["tp1", "tp2"],
+        ),
+        sut.DesiredStateSpec(
+            oc=oc_cs1,
+            cluster="cs1",
+            namespace="ns1",
+            resource={"provider": "resource", "path": "/some/path.yml"},
+            parent=namespaces[0],
+        ),
+    ]
+    rs = sut.init_specs_to_fetch(
+        resource_inventory,
+        oc_map,
+        namespaces=namespaces,
+    )
+
+    assert_specs_match(rs, expected)
+
+
+def test_namespaces_no_managedresourcenames(
+    resource_inventory: resource.ResourceInventory,
+    namespaces: list[dict[str, Any]],
+    oc_map: oc.OC_Map,
+    oc_cs1: oc.OCClient,
+) -> None:
+    namespaces[0]["managedResourceNames"] = None
+    namespaces[0]["managedResourceTypeOverrides"] = None
+    expected: list[sut.StateSpec] = [
+        sut.CurrentStateSpec(
+            oc=oc_cs1,
+            cluster="cs1",
+            namespace="ns1",
+            kind="Template",
+            resource_names=None,
+        ),
+        sut.DesiredStateSpec(
+            oc=oc_cs1,
+            cluster="cs1",
+            namespace="ns1",
+            resource={"provider": "resource", "path": "/some/path.yml"},
+            parent=namespaces[0],
+        ),
+    ]
+    rs = sut.init_specs_to_fetch(
+        resource_inventory,
+        oc_map,
+        namespaces=namespaces,
+    )
+    assert_specs_match(rs, expected)
+
+
+def test_namespaces_no_managedresourcetypes(
+    resource_inventory: resource.ResourceInventory,
+    namespaces: list[dict[str, Any]],
+    oc_map: oc.OC_Map,
+) -> None:
+    namespaces[0]["managedResourceTypes"] = None
+    rs = sut.init_specs_to_fetch(
+        resource_inventory,
+        oc_map,
+        namespaces=namespaces,
+    )
+
+    assert not rs
+
+
+def test_namespaces_extra_managed_resource_name(
+    resource_inventory: resource.ResourceInventory,
+    namespaces: list[dict[str, Any]],
+    oc_map: oc.OC_Map,
+) -> None:
+    namespaces[0]["managedResourceNames"].append(
+        {
+            "resource": "Secret",
+            "resourceNames": ["s1", "s2"],
+        },
+    )
+
+    with pytest.raises(KeyError):
+        sut.init_specs_to_fetch(
+            resource_inventory,
+            oc_map,
+            namespaces=namespaces,
         )
-        self.assert_specs_match(rs, expected)
 
-    def test_namespaces_no_managedresourcetypes(self) -> None:
-        self.namespaces[0]["managedResourceTypes"] = None
-        rs = sut.init_specs_to_fetch(
-            self.resource_inventory,
-            self.oc_map,
-            namespaces=self.namespaces,
-        )
 
-        self.assertEqual(rs, [])
+def test_namespaces_extra_override(
+    resource_inventory: resource.ResourceInventory,
+    namespaces: list[dict[str, Any]],
+    oc_map: oc.OC_Map,
+) -> None:
+    namespaces[0]["managedResourceTypeOverrides"] = [
+        {
+            "resource": "Project",
+            "override": "something.project",
+        }
+    ]
 
-    def test_namespaces_extra_managed_resource_name(self) -> None:
-        self.namespaces[0]["managedResourceNames"].append(
-            {
-                "resource": "Secret",
-                "resourceNames": ["s1", "s2"],
-            },
-        )
+    with pytest.raises(KeyError):
+        sut.init_specs_to_fetch(resource_inventory, oc_map, namespaces=namespaces)
 
-        with self.assertRaises(KeyError):
-            sut.init_specs_to_fetch(
-                self.resource_inventory,
-                self.oc_map,
-                namespaces=self.namespaces,
-            )
 
-    def test_namespaces_extra_override(self) -> None:
-        self.namespaces[0]["managedResourceTypeOverrides"] = [
-            {
-                "resource": "Project",
-                "override": "something.project",
-            }
-        ]
+def test_namespaces_override_managed_type(
+    resource_inventory: resource.ResourceInventory,
+    namespaces: list[dict[str, Any]],
+    oc_map: oc.OC_Map,
+    oc_cs1: oc.OCClient,
+) -> None:
+    namespaces[0]["managedResourceTypeOverrides"] = [
+        {
+            "resource": "Project",
+            "override": "wonderful.project",
+        }
+    ]
 
-        with self.assertRaises(KeyError):
-            sut.init_specs_to_fetch(
-                self.resource_inventory, self.oc_map, namespaces=self.namespaces
-            )
+    expected: list[sut.StateSpec] = [
+        sut.CurrentStateSpec(
+            oc=oc_cs1,
+            cluster="cs1",
+            namespace="ns1",
+            kind="LimitRanges",
+            resource_names=None,
+        ),
+        sut.DesiredStateSpec(
+            oc=oc_cs1,
+            cluster="cs1",
+            namespace="ns1",
+            resource={"provider": "resource", "path": "/some/path.yml"},
+            parent=namespaces[0],
+        ),
+    ]
 
-    def test_namespaces_override_managed_type(self) -> None:
-        self.namespaces[0]["managedResourceTypeOverrides"] = [
-            {
-                "resource": "Project",
-                "override": "wonderful.project",
-            }
-        ]
+    rs = sut.init_specs_to_fetch(
+        resource_inventory,
+        oc_map=oc_map,
+        namespaces=namespaces,
+        override_managed_types=["LimitRanges"],
+    )
+    assert_specs_match(rs, expected)
 
-        expected = [
-            sut.StateSpec(
-                type="current",
-                oc="stuff",
-                cluster="cs1",
-                namespace="ns1",
-                parent=None,
-                resource="LimitRanges",
-                resource_names=None,
-                resource_type_override=None,
-            ),
-            sut.StateSpec(
-                type="desired",
-                oc="stuff",
-                cluster="cs1",
-                namespace="ns1",
-                resource={"provider": "resource", "path": "/some/path.yml"},
-                parent=self.namespaces[0],
-            ),
-        ]
-
-        self.maxDiff = None
-        self.mock_callable(
-            self.resource_inventory, "initialize_resource_type"
-        ).for_call("cs1", "ns1", "LimitRanges").to_return_value(
-            None
-        ).and_assert_called_once()
-        rs = sut.init_specs_to_fetch(
-            self.resource_inventory,
-            oc_map=self.oc_map,
-            namespaces=self.namespaces,
-            override_managed_types=["LimitRanges"],
-        )
-        self.assert_specs_match(rs, expected)
+    registrations = list(resource_inventory)
+    # make sure only the override_managed_type LimitRange is present
+    # and not the Template from the namespace
+    assert len(registrations) == 1
+    cluster, namespace, kind, _ = registrations[0]
+    assert (cluster, namespace, kind) == ("cs1", "ns1", "LimitRanges")
 
 
 def test_determine_user_key_for_access_github_org():

--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -16,116 +16,114 @@ TEST_INT = "test_openshift_resources"
 TEST_INT_VER = make_semver(1, 9, 2)
 
 
-class TestOpenshiftResource:
-    @staticmethod
-    def test_verify_valid_k8s_object():
-        resource = fxt.get_anymarkup("valid_resource.yml")
-        openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
+def test_verify_valid_k8s_object():
+    resource = fxt.get_anymarkup("valid_resource.yml")
+    openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
 
+    assert openshift_resource.verify_valid_k8s_object() is None
+
+
+def test_verify_valid_k8s_object_false():
+    resource = fxt.get_anymarkup("invalid_resource.yml")
+
+    with pytest.raises(ConstructResourceError):
+        openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
         assert openshift_resource.verify_valid_k8s_object() is None
 
-    @staticmethod
-    def test_verify_valid_k8s_object_false():
-        resource = fxt.get_anymarkup("invalid_resource.yml")
 
-        with pytest.raises(ConstructResourceError):
-            openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
-            assert openshift_resource.verify_valid_k8s_object() is None
+def test_invalid_name_format():
+    resource = fxt.get_anymarkup("invalid_resource_name_format.yml")
 
-    @staticmethod
-    def test_invalid_name_format():
-        resource = fxt.get_anymarkup("invalid_resource_name_format.yml")
-
-        with pytest.raises(ConstructResourceError):
-            openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
-            assert openshift_resource.verify_valid_k8s_object() is None
-
-    @staticmethod
-    def test_invalid_name_too_long():
-        resource = fxt.get_anymarkup("invalid_resource_name_too_long.yml")
-
-        with pytest.raises(ConstructResourceError):
-            openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
-            assert openshift_resource.verify_valid_k8s_object() is None
-
-    @staticmethod
-    def test_invalid_container_name_format():
-        resource = fxt.get_anymarkup("invalid_resource_container_name_format.yml")
-
-        with pytest.raises(ConstructResourceError):
-            openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
-            assert openshift_resource.verify_valid_k8s_object() is None
-
-    @staticmethod
-    def test_invalid_container_name_too_long():
-        resource = fxt.get_anymarkup("invalid_resource_container_name_too_long.yml")
-
-        with pytest.raises(ConstructResourceError):
-            openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
-            assert openshift_resource.verify_valid_k8s_object() is None
-
-    @staticmethod
-    def test_annotates_resource():
-        resource = fxt.get_anymarkup("annotates_resource.yml")
+    with pytest.raises(ConstructResourceError):
         openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
+        assert openshift_resource.verify_valid_k8s_object() is None
 
-        assert openshift_resource.has_qontract_annotations() is False
 
-        annotated = openshift_resource.annotate()
-        assert annotated.has_qontract_annotations() is True
+def test_invalid_name_too_long():
+    resource = fxt.get_anymarkup("invalid_resource_name_too_long.yml")
 
-    @staticmethod
-    def test_sha256sum_properly_ignores_some_params():
-        resources = fxt.get_anymarkup("ignores_params.yml")
-
-        assert (
-            OR(resources[0], TEST_INT, TEST_INT_VER).annotate().sha256sum()
-            == OR(resources[1], TEST_INT, TEST_INT_VER).annotate().sha256sum()
-        )
-
-    @staticmethod
-    def test_sha256sum():
-        resource = fxt.get_anymarkup("sha256sum.yml")
-
+    with pytest.raises(ConstructResourceError):
         openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
+        assert openshift_resource.verify_valid_k8s_object() is None
 
-        assert (
-            openshift_resource.sha256sum()
-            == "1366d8ef31f0d83419d25b446e61008b16348b9efee2216873856c49cede6965"
-        )
 
-        annotated = openshift_resource.annotate()
+def test_invalid_container_name_format():
+    resource = fxt.get_anymarkup("invalid_resource_container_name_format.yml")
 
-        assert (
-            annotated.sha256sum()
-            == "1366d8ef31f0d83419d25b446e61008b16348b9efee2216873856c49cede6965"
-        )
-
-        assert annotated.has_valid_sha256sum()
-
-        annotated.body["metadata"]["annotations"]["qontract.sha256sum"] = "test"
-
-        assert (
-            annotated.sha256sum()
-            == "1366d8ef31f0d83419d25b446e61008b16348b9efee2216873856c49cede6965"
-        )
-
-        assert not annotated.has_valid_sha256sum()
-
-    @staticmethod
-    def test_has_owner_reference_true():
-        resource = {
-            "kind": "kind",
-            "metadata": {"name": "resource", "ownerReferences": [{"name": "owner"}]},
-        }
+    with pytest.raises(ConstructResourceError):
         openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
-        assert openshift_resource.has_owner_reference()
+        assert openshift_resource.verify_valid_k8s_object() is None
 
-    @staticmethod
-    def test_has_owner_reference_false():
-        resource = {"kind": "kind", "metadata": {"name": "resource"}}
+
+def test_invalid_container_name_too_long():
+    resource = fxt.get_anymarkup("invalid_resource_container_name_too_long.yml")
+
+    with pytest.raises(ConstructResourceError):
         openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
-        assert not openshift_resource.has_owner_reference()
+        assert openshift_resource.verify_valid_k8s_object() is None
+
+
+def test_annotates_resource():
+    resource = fxt.get_anymarkup("annotates_resource.yml")
+    openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
+
+    assert openshift_resource.has_qontract_annotations() is False
+
+    annotated = openshift_resource.annotate()
+    assert annotated.has_qontract_annotations() is True
+
+
+def test_sha256sum_properly_ignores_some_params():
+    resources = fxt.get_anymarkup("ignores_params.yml")
+
+    assert (
+        OR(resources[0], TEST_INT, TEST_INT_VER).annotate().sha256sum()
+        == OR(resources[1], TEST_INT, TEST_INT_VER).annotate().sha256sum()
+    )
+
+
+def test_sha256sum():
+    resource = fxt.get_anymarkup("sha256sum.yml")
+
+    openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
+
+    assert (
+        openshift_resource.sha256sum()
+        == "1366d8ef31f0d83419d25b446e61008b16348b9efee2216873856c49cede6965"
+    )
+
+    annotated = openshift_resource.annotate()
+
+    assert (
+        annotated.sha256sum()
+        == "1366d8ef31f0d83419d25b446e61008b16348b9efee2216873856c49cede6965"
+    )
+
+    assert annotated.has_valid_sha256sum()
+
+    annotated.body["metadata"]["annotations"]["qontract.sha256sum"] = "test"
+
+    assert (
+        annotated.sha256sum()
+        == "1366d8ef31f0d83419d25b446e61008b16348b9efee2216873856c49cede6965"
+    )
+
+    assert not annotated.has_valid_sha256sum()
+
+
+def test_has_owner_reference_true():
+    resource = {
+        "kind": "kind",
+        "metadata": {"name": "resource", "ownerReferences": [{"name": "owner"}]},
+    }
+    openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
+    assert openshift_resource.has_owner_reference()
+
+
+def test_has_owner_reference_false():
+    resource = {"kind": "kind", "metadata": {"name": "resource"}}
+    openshift_resource = OR(resource, TEST_INT, TEST_INT_VER)
+    assert not openshift_resource.has_owner_reference()
 
 
 def test_secret_string_data():

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -1,75 +1,239 @@
-from unittest import TestCase
-from unittest.mock import patch
+from typing import Any, cast
+from unittest.mock import Mock
+import pytest
+from reconcile.openshift_base import CurrentStateSpec
 from reconcile.test.fixtures import Fixtures
 
+from reconcile import openshift_resources_base as orb
 from reconcile.openshift_resources_base import canonicalize_namespaces, ob
+from reconcile.utils import oc
+from reconcile.utils.openshift_resource import ResourceInventory
 
 
-@patch.object(ob, "aggregate_shared_resources", autospec=True)
-class TestCanonicalizeNamespaces(TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.fixture = Fixtures("namespaces")
+fxt = Fixtures("namespaces")
 
-    def setUp(self):
-        self.namespaces = [self.fixture.get_anymarkup("openshift-resources-only.yml")]
 
-    def test_secret(self, ob):
-        ns, override = canonicalize_namespaces(self.namespaces, ["vault-secret"])
-        self.assertEqual(
-            (ns, override),
-            (
-                [
+@pytest.fixture
+def namespaces() -> list[dict[str, Any]]:
+    return [fxt.get_anymarkup("openshift-resources-only.yml")]
+
+
+@pytest.fixture
+def oc_cs1() -> oc.OCClient:
+    client = oc.OC(cluster_name="cs1", server="", token="", local=True)
+    client.init_api_resources = True
+    client.api_kind_version = {
+        "Template": ["template.openshift.io/v1"],
+        "Subscription": ["apps.open-cluster-management.io/v1", "operators.coreos.com"],
+    }
+    client.api_resources = client.api_kind_version.keys()
+    client.get_items = lambda kind, **kwargs: []
+    return cast(oc.OCNative, client)
+
+
+@pytest.fixture
+def tmpl1() -> dict[str, Any]:
+    return {
+        "kind": "Template",
+        "apiVersion": "template.openshift.io/v1",
+        "metadata": {"name": "tmpl1"},
+    }
+
+
+@pytest.fixture
+def current_state_spec(oc_cs1: oc.OCClient) -> CurrentStateSpec:
+    return CurrentStateSpec(
+        oc=oc_cs1, cluster="cs1", namespace="ns1", kind="Template", resource_names=None
+    )
+
+
+def test_secret(namespaces: list[dict[str, Any]], mocker):
+    mocker.patch.object(ob, "aggregate_shared_resources", autospec=True)
+    expected = (
+        [
+            {
+                "name": "ns1",
+                "cluster": {"name": "cs1"},
+                "managedResourceTypes": ["Template"],
+                "openshiftResources": [
                     {
-                        "name": "ns1",
-                        "cluster": {"name": "cs1"},
-                        "managedResourceTypes": ["Template"],
-                        "openshiftResources": [
-                            {
-                                "provider": "vault-secret",
-                                "path": "/secret/place.yml",
-                            }
-                        ],
+                        "provider": "vault-secret",
+                        "path": "/secret/place.yml",
                     }
                 ],
-                ["Secret"],
-            ),
+            }
+        ],
+        ["Secret"],
+    )
+
+    ns, override = canonicalize_namespaces(namespaces, ["vault-secret"])
+    assert (ns, override) == expected
+
+
+def test_route(namespaces: list[dict[str, Any]], mocker):
+    mocker.patch.object(ob, "aggregate_shared_resources", autospec=True)
+    expected = (
+        [
+            {
+                "name": "ns1",
+                "cluster": {"name": "cs1"},
+                "managedResourceTypes": ["Template"],
+                "openshiftResources": [
+                    {"provider": "route", "path": "/route/network.yml"}
+                ],
+            }
+        ],
+        ["Route"],
+    )
+    ns, override = canonicalize_namespaces(namespaces, ["route"])
+    assert (ns, override) == expected
+
+
+def test_no_overrides(namespaces: list[dict[str, Any]], mocker):
+    mocker.patch.object(ob, "aggregate_shared_resources", autospec=True)
+    expected = (
+        [
+            {
+                "name": "ns1",
+                "cluster": {"name": "cs1"},
+                "managedResourceTypes": ["Template"],
+                "openshiftResources": [
+                    {"provider": "resource", "path": "/some/path.yml"}
+                ],
+            }
+        ],
+        None,
+    )
+
+    ns, override = canonicalize_namespaces(namespaces, ["resource"])
+    assert (ns, override) == expected
+
+
+def test_fetch_current_state_ri_not_initialized(
+    oc_cs1: oc.OCClient, tmpl1: dict[str, Any]
+):
+    ri = ResourceInventory()
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
+    ri.initialize_resource_type("cs1", "wrong_namespace", "Template")
+    ri.initialize_resource_type("wrong_cluster", "ns1", "Template")
+    ri.initialize_resource_type("cs1", "ns1", "wrong_kind")
+    with pytest.raises(KeyError):
+        orb.fetch_current_state(
+            oc=oc_cs1,
+            ri=ri,
+            cluster="cs1",
+            namespace="ns1",
+            kind="Template",
+            resource_names=[],
         )
 
-    def test_route(self, ob):
-        ns, override = canonicalize_namespaces(self.namespaces, ["route"])
-        self.assertEqual(
-            (ns, override),
-            (
-                [
-                    {
-                        "name": "ns1",
-                        "cluster": {"name": "cs1"},
-                        "managedResourceTypes": ["Template"],
-                        "openshiftResources": [
-                            {"provider": "route", "path": "/route/network.yml"}
-                        ],
-                    }
-                ],
-                ["Route"],
-            ),
-        )
+    for _, _, _, resource in ri:
+        assert len(resource["current"]) == 0
 
-    def test_no_overrides(self, ob):
-        ns, override = canonicalize_namespaces(self.namespaces, ["resource"])
-        self.assertEqual(
-            (ns, override),
-            (
-                [
-                    {
-                        "name": "ns1",
-                        "cluster": {"name": "cs1"},
-                        "managedResourceTypes": ["Template"],
-                        "openshiftResources": [
-                            {"provider": "resource", "path": "/some/path.yml"}
-                        ],
-                    }
-                ],
-                None,
-            ),
-        )
+
+def test_fetch_current_state_ri_initialized(oc_cs1: oc.OCClient, tmpl1: dict[str, Any]):
+    ri = ResourceInventory()
+    ri.initialize_resource_type("cs1", "ns1", "Template")
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
+    orb.fetch_current_state(
+        oc=oc_cs1,
+        ri=ri,
+        cluster="cs1",
+        namespace="ns1",
+        kind="Template",
+        resource_names=[],
+    )
+
+    _, _, _, resource = list(ri)[0]
+    assert len(resource["current"]) == 1
+    assert "tmpl1" in resource["current"]
+    assert resource["current"]["tmpl1"].kind == "Template"
+
+
+def test_fetch_current_state_kind_not_supported(
+    oc_cs1: oc.OCClient, tmpl1: dict[str, Any]
+):
+    ri = ResourceInventory()
+    ri.initialize_resource_type("cs1", "ns1", "AnUnsupportedKind")
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
+    orb.fetch_current_state(
+        oc=oc_cs1,
+        ri=ri,
+        cluster="cs1",
+        namespace="ns1",
+        kind="AnUnsupportedKind",
+        resource_names=[],
+    )
+
+    _, _, _, resource = list(ri)[0]
+    assert len(resource["current"]) == 0
+
+
+def test_fetch_current_state_long_kind(oc_cs1: oc.OCClient, tmpl1: dict[str, Any]):
+    ri = ResourceInventory()
+    ri.initialize_resource_type("cs1", "ns1", "Template.template.openshift.io")
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
+    orb.fetch_current_state(
+        oc=oc_cs1,
+        ri=ri,
+        cluster="cs1",
+        namespace="ns1",
+        kind="Template.template.openshift.io",
+        resource_names=[],
+    )
+
+    _, _, _, resource = list(ri)[0]
+    assert len(resource["current"]) == 1
+    assert "tmpl1" in resource["current"]
+    assert resource["current"]["tmpl1"].kind == "Template"
+
+
+def test_fetch_current_state_long_kind_not_supported(
+    oc_cs1: oc.OCClient, tmpl1: dict[str, Any]
+):
+    ri = ResourceInventory()
+    ri.initialize_resource_type("cs1", "ns1", "UnknownKind.mysterious.io")
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
+    orb.fetch_current_state(
+        oc=oc_cs1,
+        ri=ri,
+        cluster="cs1",
+        namespace="ns1",
+        kind="UnknownKind.mysterious.io",
+        resource_names=[],
+    )
+
+    _, _, _, resource = list(ri)[0]
+    assert len(resource["current"]) == 0
+
+
+def test_fetch_states(current_state_spec: CurrentStateSpec, tmpl1: dict[str, Any]):
+    ri = ResourceInventory()
+    ri.initialize_resource_type("cs1", "ns1", "Template")
+    current_state_spec.oc.get_items = lambda kind, **kwargs: [tmpl1]
+    orb.fetch_states(ri=ri, spec=current_state_spec)
+    _, _, _, resource = list(ri)[0]
+    assert len(resource["current"]) == 1
+    assert "tmpl1" in resource["current"]
+    assert resource["current"]["tmpl1"].kind == "Template"
+
+
+def test_fetch_states_unknown_kind(current_state_spec: CurrentStateSpec):
+    current_state_spec.kind = "UnknownKind"
+    ri = ResourceInventory()
+    ri.initialize_resource_type("cs1", "ns1", "UnknownKind")
+    orb.fetch_states(ri=ri, spec=current_state_spec)
+    _, _, _, resource = list(ri)[0]
+    assert len(resource["current"]) == 0
+
+
+def test_fetch_states_oc_error(current_state_spec: CurrentStateSpec):
+    current_state_spec.oc.get_items = Mock(
+        side_effect=oc.StatusCodeError("something wrong with openshift")
+    )
+    ri = ResourceInventory()
+    ri.initialize_resource_type("cs1", "ns1", "Template")
+    orb.fetch_states(ri=ri, spec=current_state_spec)
+    assert ri.has_error_registered("cs1")
+    _, _, _, resource = list(ri)[0]
+    assert len(resource["current"]) == 0

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -20,7 +20,9 @@ def namespaces() -> list[dict[str, Any]]:
 
 @pytest.fixture
 def oc_cs1() -> oc.OCClient:
-    client = oc.OC(cluster_name="cs1", server="", token="", local=True)
+    client = cast(
+        oc.OCNative, oc.OC(cluster_name="cs1", server="", token="", local=True)
+    )
     client.init_api_resources = True
     client.api_kind_version = {
         "Template": ["template.openshift.io/v1"],
@@ -28,7 +30,7 @@ def oc_cs1() -> oc.OCClient:
     }
     client.api_resources = client.api_kind_version.keys()
     client.get_items = lambda kind, **kwargs: []
-    return cast(oc.OCNative, client)
+    return client
 
 
 @pytest.fixture
@@ -113,7 +115,7 @@ def test_fetch_current_state_ri_not_initialized(
     oc_cs1: oc.OCClient, tmpl1: dict[str, Any]
 ):
     ri = ResourceInventory()
-    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]  # type: ignore[assignment]
     ri.initialize_resource_type("cs1", "wrong_namespace", "Template")
     ri.initialize_resource_type("wrong_cluster", "ns1", "Template")
     ri.initialize_resource_type("cs1", "ns1", "wrong_kind")
@@ -134,7 +136,7 @@ def test_fetch_current_state_ri_not_initialized(
 def test_fetch_current_state_ri_initialized(oc_cs1: oc.OCClient, tmpl1: dict[str, Any]):
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "Template")
-    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]  # type: ignore[assignment]
     orb.fetch_current_state(
         oc=oc_cs1,
         ri=ri,
@@ -155,7 +157,7 @@ def test_fetch_current_state_kind_not_supported(
 ):
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "AnUnsupportedKind")
-    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]  # type: ignore[assignment]
     orb.fetch_current_state(
         oc=oc_cs1,
         ri=ri,
@@ -172,7 +174,7 @@ def test_fetch_current_state_kind_not_supported(
 def test_fetch_current_state_long_kind(oc_cs1: oc.OCClient, tmpl1: dict[str, Any]):
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "Template.template.openshift.io")
-    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]  # type: ignore[assignment]
     orb.fetch_current_state(
         oc=oc_cs1,
         ri=ri,
@@ -193,7 +195,7 @@ def test_fetch_current_state_long_kind_not_supported(
 ):
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "UnknownKind.mysterious.io")
-    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]  # type: ignore[assignment]
     orb.fetch_current_state(
         oc=oc_cs1,
         ri=ri,
@@ -210,7 +212,7 @@ def test_fetch_current_state_long_kind_not_supported(
 def test_fetch_states(current_state_spec: CurrentStateSpec, tmpl1: dict[str, Any]):
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "Template")
-    current_state_spec.oc.get_items = lambda kind, **kwargs: [tmpl1]
+    current_state_spec.oc.get_items = lambda kind, **kwargs: [tmpl1]  # type: ignore[assignment]
     orb.fetch_states(ri=ri, spec=current_state_spec)
     _, _, _, resource = list(ri)[0]
     assert len(resource["current"]) == 1
@@ -228,7 +230,7 @@ def test_fetch_states_unknown_kind(current_state_spec: CurrentStateSpec):
 
 
 def test_fetch_states_oc_error(current_state_spec: CurrentStateSpec):
-    current_state_spec.oc.get_items = Mock(
+    current_state_spec.oc.get_items = Mock(  # type: ignore[assignment]
         side_effect=oc.StatusCodeError("something wrong with openshift")
     )
     ri = ResourceInventory()

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from unittest import TestCase
 from unittest.mock import patch
@@ -602,3 +603,19 @@ def test_configmap_used_in_pod_true(oc, pod):
 def test_configmap_used_in_pod_false(oc, pod):
     result = oc.configmap_used_in_pod("configmap9999", pod)
     assert result is False
+
+
+def test_oc_map_exception_on_missing_cluster():
+    cluster = {
+        "name": "test-1",
+        "serverUrl": "",
+        "automationToken": {"path": "some-path", "field": "some-field"},
+    }
+    oc_map = OC_Map(clusters=[cluster])
+
+    assert isinstance(oc_map.get(cluster["name"]), OCLogMsg)
+    with pytest.raises(OCLogMsg) as ctx:
+        oc_map.get_cluster(cluster["name"])
+
+    assert ctx.value.message == "[test-1] has no serverUrl"
+    assert ctx.value.log_level == logging.ERROR

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1405,6 +1405,13 @@ class OC_Map:
             OCLogMsg(log_level=logging.DEBUG, message=f"[{cluster}] cluster skipped"),
         )
 
+    def get_cluster(self, cluster: str, privileged: bool = False) -> OCClient:
+        result = self.get(cluster, privileged)
+        if isinstance(result, OCLogMsg):
+            raise result
+        else:
+            return result
+
     def clusters(
         self, include_errors: bool = False, privileged: bool = False
     ) -> List[str]:
@@ -1428,12 +1435,13 @@ class OC_Map:
                 oc.cleanup()
 
 
-class OCLogMsg:
+class OCLogMsg(Exception):
     """
     Track log messages associated with initializing OC clients in OC_Map.
     """
 
     def __init__(self, log_level, message):
+        super().__init__()
         self.log_level = log_level
         self.message = message
 

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -180,7 +180,7 @@ class OpenshiftResource:
 
     @property
     def kind_and_group(self):
-        return full_qualified_kind(self.kind, self.body["apiVersion"])
+        return fully_qualified_kind(self.kind, self.body["apiVersion"])
 
     @property
     def caller(self):
@@ -502,7 +502,7 @@ class OpenshiftResource:
         return m.hexdigest()
 
 
-def full_qualified_kind(kind: str, api_version: str) -> str:
+def fully_qualified_kind(kind: str, api_version: str) -> str:
     if "/" in api_version:
         group = api_version.split("/")[0]
         return f"{kind}.{group}"
@@ -533,7 +533,7 @@ class ResourceInventory:
         namespace: str,
         resource: OpenshiftResource,
         privileged: bool = False,
-    ):
+    ) -> None:
         if resource.kind_and_group in self._clusters[cluster][namespace]:
             kind = resource.kind_and_group
         else:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -25,7 +25,7 @@ from reconcile.utils.oc import OC, StatusCodeError
 from reconcile.utils.openshift_resource import (
     OpenshiftResource as OR,
     ResourceInventory,
-    full_qualified_kind,
+    fully_qualified_kind,
     ResourceKeyExistsError,
 )
 from reconcile.utils.secret_reader import SecretReader
@@ -1059,7 +1059,7 @@ class SaasHerder:
         for r in resources:
             if isinstance(r, dict) and "kind" in r and "apiVersion" in r:
                 kind = cast(str, r.get("kind"))
-                kind_and_group = full_qualified_kind(
+                kind_and_group = fully_qualified_kind(
                     kind, cast(str, r.get("apiVersion"))
                 )
                 if (


### PR DESCRIPTION
# What changed?

## Core Change idea
The core change of this PR enables the use of full qualified kube `kinds` (resource types) in `managedResourceTypes` of `saas` files and `namespace` files. This replaces the need for `managedResourceTypeOverrides` in saas files and enables resource handling in saas files where the proposed `kind` is not unique without the `group`.

https://issues.redhat.com/browse/APPSRE-4915

e.g. instead of

```yaml
managedResourceTypeOverrides:
- resource: Subscription
  override: Subscription.operators.coreos.com

managedResourceTypes:
- Subscription
```

this change enables the declaration to look like this

```yaml
managedResourceTypes:
- Subscription.operators.coreos.com
```

Both declarations will lead to the same results but the latter one also enables saas files and namespaces files to managed same-named kinds from different groups, e.g.

```yaml
managedResourceTypes:
- Subscription.operators.coreos.com
- Subscription.open-cluster-management.io
```

Mixed declarations of short and full-qualified kinds are supported for backwards compatibility

```yaml
managedResourceTypes:
- Subscription.operators.coreos.com
- Deployment
```

## Core change implementation details
* in both cases of either a defined override or full-qualified resource type declaration, the kind tracked within the `StateSpec` and `ResourceInventory` will be the full-qualified type
* as such, the `kind` passed to `ResourceInventory.add_current` and `add_desires` need to match the registered `kind` in the inventory
* a convenience method `add_desired_resource` has been added to `ResourceInventory` to automatically use the short or full-qualified `kind` depending on how the `kind` was registered with the inventory in the first place

## Companion changes to support the core change
To make the implementation of the core change easier, a couple of additional changes have been introduced, mostly to make it easier to reason about the data passed between code components. The idea of those changes therefore is:
* have type hints for all relevant parts
* know which fields are nullable and which ones can be relied on

### StateSpec
StateSpec management for openshift resources was refactored into dataclasses. the previous `StateSpec` class tried to serve the purpose of current and desired state at the same, while having different sets of fields only relevant to one of both cases. The new `BaseStateSpec` holds the fields common to current and desired spec, and the respective subclasses cover each case with strongly typed sets of fields where the expectations of what field can be None is explicitely defined.

### OC_Map get_cluster
A new method `get_cluster` was introduced on the OC_Map to have a typehintable version of the `get` method. The `get` method returned either an OC client (one of `OCDeprecated` or `OCNative`) or an `OCLogMsg` object indicating an error and also acting as a boolean so it could be used in places to check for non existing clients or error situations with a `not oc`. This is non-obvious magic going on and  `not oc` vs `oc is not None` behave differently which is very subtle and a trap for developers.

The `get_cluster` method always deliveres a valid oc client or raises `OCLogMsg` as an exception, which can be dealth with directly. The `get` method has not been removed by this change and only the code in the scope of this change was adapted to leverage `get_cluster`.

### Tests
A lot of tests have been introduced for code that was touched. Additionally `TestSlide` tests have been migrated to `pytest` where feasible.

# How was the change tested?

Besides extensive addition of unittests, most integrations dealing with `openshift_base.init_specs_to_fetch` have been dry-runned and results have been verified.
Not all integrations have been tested though. This PR was opened anyways to gather feedback during the testing process.
