### PR TITLE
add support to define region for rds instances

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -29,6 +29,7 @@ TF_RESOURCE = """
 provider
 ... on NamespaceTerraformResourceRDS_v1 {
   account
+  region
   identifier
   defaults
   availability_zone

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -1017,11 +1017,12 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         else:
             az = values.get('availability_zone', None)
         provider = ''
-        if az is not None and self._multiregion_account(account):
+        if self._multiregion_account(account):
             # To get the provider we should use, we get the region
             # and use that as an alias in the provider definition
-            provider = 'aws.' + self._region_from_availability_zone(az)
-            values['provider'] = provider
+            if az:
+                provider = 'aws.' + self._region_from_availability_zone(az)
+                values['provider'] = provider
 
         # 'deps' should contain a list of terraform resource names
         # (not full objects) that must be created

--- a/reconcile/utils/terrascript_client.py
+++ b/reconcile/utils/terrascript_client.py
@@ -1017,12 +1017,20 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         else:
             az = values.get('availability_zone', None)
         provider = ''
+        region = values.pop('region', None)
         if self._multiregion_account(account):
             # To get the provider we should use, we get the region
             # and use that as an alias in the provider definition
             if az:
                 provider = 'aws.' + self._region_from_availability_zone(az)
                 values['provider'] = provider
+            if region:
+                provider_region = f'aws.{region}'
+                if not provider:
+                    provider = provider_region
+                    values['provider'] = provider
+                elif provider != provider_region:
+                    raise ValueError('region does not match availability zone')
 
         # 'deps' should contain a list of terraform resource names
         # (not full objects) that must be created


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/131

this included some changes around how we handle `availability_zone`, to add a validation that there is no conflict.