### PR TITLE
don't b64 decode the tf output secret on vault write

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -558,7 +558,7 @@ def write_outputs_to_vault(vault_path: str, resource_specs: TerraformResourceSpe
         # vault only stores strings as values - by converting to str upfront, we can compare current to desired
         stringified_secret = {k: str(v) for k, v in spec.secret.items()}
         desired_secret = {'path': secret_path, 'data': stringified_secret}
-        vault_client.write(desired_secret)
+        vault_client.write(desired_secret, decode_base64=False)
 
 
 def populate_desired_state(ri: ResourceInventory, resource_specs: TerraformResourceSpecInventory) -> None:


### PR DESCRIPTION
https://github.com/app-sre/qontract-reconcile/pull/2331 started using the tf output secrets for vault writing instead of the ResourceInventory secrets.
former ones are not b64 encoded, latter ones are, so the vault write must not try to decode the secret otherwise the write fails because of the failed b64 decoding

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>