### PR TITLE
[terraform-resources] provider driven terraform secret output format

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -32,6 +32,12 @@ from reconcile.utils.vault import _VaultClient, VaultClient
 
 
 TF_RESOURCE = """
+output_format {
+  provider
+  ... on NamespaceTerraformResourceGenericSecretOutputFormat_v1 {
+    data
+  }
+}
 provider
 ... on NamespaceTerraformResourceRDS_v1 {
   account

--- a/reconcile/test/test_utils_terraform_resource_spec.py
+++ b/reconcile/test/test_utils_terraform_resource_spec.py
@@ -1,5 +1,7 @@
+from typing import Any
 from pydantic import ValidationError
 import pytest
+from reconcile.utils.openshift_resource import base64_encode_secret_field_value
 from reconcile.utils.terraform_resource_spec import (
     TerraformResourceUniqueKey,
     TerraformResourceSpec,
@@ -92,3 +94,142 @@ def test_spec_annotation_parsing_none_present():
         namespace={},
     )
     assert s._annotations() == {}
+
+
+@pytest.fixture
+def resource_secret() -> dict[str, Any]:
+    return {"yakk_name": "Furry", "visual_characteristics": "furry", "mood": "grumpy"}
+
+
+@pytest.fixture
+def spec() -> TerraformResourceSpec:
+    return TerraformResourceSpec(
+        resource={
+            "identifier": "i",
+            "provider": "p",
+            "account": "a",
+        },
+        namespace={},
+    )
+
+
+#
+# tests for terraform output format
+#
+
+
+def test_terraform_generic_secret_output_format(
+    spec: TerraformResourceSpec, resource_secret: dict[str, Any]
+):
+    spec.resource["output_format"] = {  # type: ignore[index]
+        "provider": "generic-secret",
+        "data": """
+            motd: The {{ mood }} Yakk {{ yakk_name }} is {{ visual_characteristics }}.
+        """,
+    }
+    spec.secret = resource_secret
+
+    output_secret = spec.build_oc_secret("int", "1.0")
+    assert output_secret.body["data"]["motd"] == base64_encode_secret_field_value(
+        "The grumpy Yakk Furry is furry."
+    )
+
+
+def test_terraform_generic_secret_output_format_no_data(
+    spec: TerraformResourceSpec, resource_secret: dict[str, Any]
+):
+    """
+    this test shows backwards compatibility with the simple dict output when
+    no data is given but the provider is specified
+    """
+    spec.resource["output_format"] = {  # type: ignore[index]
+        "provider": "generic-secret",
+    }
+    spec.secret = resource_secret
+
+    output_secret = spec.build_oc_secret("int", "1.0")
+    assert len(output_secret.body["data"]) == len(resource_secret)
+    for k, v in resource_secret.items():
+        assert output_secret.body["data"][k] == base64_encode_secret_field_value(v)
+
+
+def test_terraform_no_output_format_provider(
+    spec: TerraformResourceSpec, resource_secret: dict[str, Any]
+):
+    """
+    this test shows full backwards compatibility when no provider has been specified
+    """
+    spec.secret = resource_secret
+
+    output_secret = spec.build_oc_secret("int", "1.0")
+    assert len(output_secret.body["data"]) == len(resource_secret)
+    for k, v in resource_secret.items():
+        assert output_secret.body["data"][k] == base64_encode_secret_field_value(v)
+
+
+def test_terraform_generic_secret_output_format_not_a_dict(
+    spec: TerraformResourceSpec, resource_secret: dict[str, Any]
+):
+    """
+    this test shows how a data template for a generic-secret provider must result
+    in a valid dict and fails otherwise
+    """
+    spec.resource["output_format"] = {  # type: ignore[index]
+        "provider": "generic-secret",
+        "data": "not_a_dict",
+    }
+    spec.secret = resource_secret
+
+    with pytest.raises(ValueError):
+        spec.build_oc_secret("int", "1.0")
+
+
+def test_terraform_generic_secret_output_format_not_str_keys(
+    spec: TerraformResourceSpec, resource_secret: dict[str, Any]
+):
+    """
+    this test shows how a data template for a generic-secret provider must produce
+    string keys
+    """
+    spec.resource["output_format"] = {  # type: ignore[index]
+        "provider": "generic-secret",
+        "data": "1: value",
+    }
+    spec.secret = resource_secret
+
+    with pytest.raises(ValueError):
+        spec.build_oc_secret("int", "1.0")
+
+
+def test_terraform_generic_secret_output_format_not_str_val(
+    spec: TerraformResourceSpec, resource_secret: dict[str, Any]
+):
+    """
+    this test shows how a data template for a generic-secret provider must produce
+    string values
+    """
+    spec.resource["output_format"] = {  # type: ignore[index]
+        "provider": "generic-secret",
+        "data": "key: 1",
+    }
+    spec.secret = resource_secret
+
+    with pytest.raises(ValueError):
+        spec.build_oc_secret("int", "1.0")
+
+
+def test_terraform_generic_secret_output_key_too_long(
+    spec: TerraformResourceSpec, resource_secret: dict[str, Any]
+):
+    """
+    tests for too long secret keys (max length in kubernetes is 253 characters )
+    """
+    long_key = "a" * 254
+    spec.resource["output_format"] = {  # type: ignore[index]
+        "provider": "generic-secret",
+        "data": f"{ long_key }: value",
+    }
+    spec.secret = resource_secret
+
+    with pytest.raises(ValueError):
+        spec.build_oc_secret("int", "1.0")

--- a/reconcile/test/test_utils_terraform_resource_spec.py
+++ b/reconcile/test/test_utils_terraform_resource_spec.py
@@ -1,7 +1,10 @@
 from typing import Any
 from pydantic import ValidationError
 import pytest
-from reconcile.utils.openshift_resource import base64_encode_secret_field_value
+from reconcile.utils.openshift_resource import (
+    SECRET_MAX_KEY_LENGTH,
+    base64_encode_secret_field_value,
+)
 from reconcile.utils.terraform_resource_spec import (
     TerraformResourceUniqueKey,
     TerraformResourceSpec,
@@ -242,7 +245,7 @@ def test_terraform_generic_secret_output_key_too_long(
     """
     tests for too long secret keys (max length in kubernetes is 253 characters )
     """
-    long_key = "a" * 254
+    long_key = "a" * (SECRET_MAX_KEY_LENGTH + 1)
     spec.resource["output_format"] = {  # type: ignore[index]
         "provider": "generic-secret",
         "data": f"{ long_key }: value",

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -11,6 +11,9 @@ from threading import Lock
 import semver
 
 
+SECRET_MAX_KEY_LENGTH = 253
+
+
 class ResourceKeyExistsError(Exception):
     pass
 

--- a/reconcile/utils/terraform_resource_spec.py
+++ b/reconcile/utils/terraform_resource_spec.py
@@ -64,8 +64,7 @@ class OutputFormat:
         if self.provider == "generic-secret":
             return GenericSecretOutputFormatConfig(data=self.data)
         else:
-            # default to generic-secret as provider for backwards compatibility
-            return GenericSecretOutputFormatConfig()
+            raise ValueError(f"unknown output format provider {self.provider}")
 
     def render(self, vars: Mapping[str, str]) -> dict[str, str]:
         return self._formatter().render(vars)

--- a/reconcile/utils/terraform_resource_spec.py
+++ b/reconcile/utils/terraform_resource_spec.py
@@ -1,8 +1,74 @@
+from abc import abstractmethod
 from dataclasses import field
 from pydantic.dataclasses import dataclass
 import json
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, cast
+
+import yaml
 from reconcile.utils.openshift_resource import OpenshiftResource, build_secret
+from reconcile import openshift_resources_base
+
+
+class OutputFormatProcessor:
+    @abstractmethod
+    def render(self, vars: Mapping[str, str]) -> dict[str, str]:
+        return {}
+
+    @staticmethod
+    def validate_k8s_secret_key(key: Any) -> None:
+        if isinstance(key, str):
+            if len(key) > 253:
+                raise ValueError(f"secret key {key} is longer than 253 chars")
+        else:
+            raise ValueError(f"secret key '{key}' is not a string")
+
+    @staticmethod
+    def validate_k8s_secret_data(data: Any) -> None:
+        if isinstance(data, dict):
+            for k, v in data.items():
+                OutputFormatProcessor.validate_k8s_secret_key(k)
+                if not isinstance(v, str):
+                    raise ValueError(
+                        f"dictionary value '{v}' under '{k}' is not a string"
+                    )
+        else:
+            raise ValueError("k8s secret data must be a dictionary")
+
+
+@dataclass
+class GenericSecretOutputFormatConfig(OutputFormatProcessor):
+
+    data: Optional[str] = None
+
+    def render(self, vars: Mapping[str, str]) -> dict[str, str]:
+        if self.data:
+            # the jinja2 rendering has the capabilitiy to change the passed
+            # vars dict - make a copy to protect against it
+            rendered_data = openshift_resources_base.process_jinja2_template(
+                self.data, dict(vars)
+            )
+            parsed_data = yaml.safe_load(rendered_data)
+            OutputFormatProcessor.validate_k8s_secret_data(parsed_data)
+            return cast(dict[str, str], parsed_data)
+        else:
+            return dict(vars)
+
+
+@dataclass
+class OutputFormat:
+
+    provider: str
+    data: Optional[str] = None
+
+    def _formatter(self) -> OutputFormatProcessor:
+        if self.provider == "generic-secret":
+            return GenericSecretOutputFormatConfig(data=self.data)
+        else:
+            # default to generic-secret as provider for backwards compatibility
+            return GenericSecretOutputFormatConfig()
+
+    def render(self, vars: Mapping[str, str]) -> dict[str, str]:
+        return self._formatter().render(vars)
 
 
 @dataclass
@@ -66,8 +132,16 @@ class TerraformResourceSpec:
             error_details=self.output_resource_name,
             caller_name=self.account,
             annotations=annotations,
-            unencoded_data=self.secret,
+            unencoded_data=self._output_format().render(self.secret),
         )
+
+    def _output_format(self) -> OutputFormat:
+        if self.resource.get("output_format") is not None:
+            return OutputFormat(
+                **cast(dict[str, Any], self.resource.get("output_format"))
+            )
+        else:
+            return OutputFormat(provider="generic-secret")
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
this PR implements the `generic-secret` provider, that can render output secret content based on jinja2 templates, e.g.

```yaml
 ---
  $schema: /openshift/namespace-1.yml
  ...
  terraformResources:
  - provider: aws-iam-service-account
    output_format:
      provider: generic-secret
      data:
        aws_access_key_id: {{ aws_access_key_id }}
        aws_secret_access_key: {{ aws_secret_access_key }}
        credentials: >-
          [default]
          aws_access_key_id = {{ aws_access_key_id }}
          aws_secret_access_key = {{ aws_secret_access_key }}
```

design doc: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/terraform-output-secret-format.md
part of https://issues.redhat.com/browse/APPSRE-4766

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>