### PR TITLE
[gabi-authorized-users] add expiration to ConfigMap

### DIFF
--- a/reconcile/gabi_authorized_users.py
+++ b/reconcile/gabi_authorized_users.py
@@ -16,12 +16,17 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 EXPIRATION_MAX = 90
 
 
-def construct_gabi_oc_resource(name: str, users: Iterable[str]) -> OpenshiftResource:
+def construct_gabi_oc_resource(
+    name: str, users: Iterable[str], exp_date: date
+) -> OpenshiftResource:
     body = {
         "apiVersion": "v1",
         "kind": "ConfigMap",
         "metadata": {"name": name, "annotations": {"qontract.recycle": "true"}},
-        "data": {"authorized-users.yaml": "\n".join(users)},
+        "data": {
+            "authorized-users.yaml": "\n".join(users),
+            "expiration": str(exp_date),
+        },
     }
     return OpenshiftResource(
         body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION, error_details=name
@@ -41,7 +46,7 @@ def fetch_desired_state(
                 f'The maximum expiration date of {g["name"]} '
                 f"shall not exceed {EXPIRATION_MAX} days form today"
             )
-        resource = construct_gabi_oc_resource(g["name"], users)
+        resource = construct_gabi_oc_resource(g["name"], users, exp_date)
         for i in g["instances"]:
             namespace = i["namespace"]
             account = i["account"]

--- a/reconcile/test/fixtures/gabi_authorized_users/apply.yml
+++ b/reconcile/test/fixtures/gabi_authorized_users/apply.yml
@@ -61,3 +61,4 @@ desired:
     authorized-users.yaml: |-
       user1
       user2
+    expiration: 'OVERRIDE_ME'

--- a/reconcile/test/fixtures/gabi_authorized_users/delete.yml
+++ b/reconcile/test/fixtures/gabi_authorized_users/delete.yml
@@ -21,6 +21,7 @@ server:
         authorized-users.yaml: |-
           user1
           user2
+        expiration: '2000-01-01'
   apis:
     kind: APIGroupList
     groups:
@@ -49,3 +50,4 @@ desired:
       qontract.recycle: 'true'
   data:
     authorized-users.yaml: ''
+    expiration: '2000-01-01'

--- a/reconcile/test/test_gabi_authorized_users.py
+++ b/reconcile/test/test_gabi_authorized_users.py
@@ -90,6 +90,7 @@ class TestGabiAuthorizedUser(TestCase):
         get_settings,
     ):
         expirationDate = date.today()
+        apply["desired"]["data"]["expiration"] = str(expirationDate)
         get_gabi_instances.return_value = mock_get_gabi_instances(expirationDate)
         mock_request.side_effect = apply_request
         gabi_u.run(dry_run=False)
@@ -132,7 +133,7 @@ class TestGabiAuthorizedUser(TestCase):
         get_settings,
     ):
         # pylint: disable=no-self-use
-        expirationDate = date.today() - timedelta(days=1)
+        expirationDate = "2000-01-01"
         get_gabi_instances.return_value = mock_get_gabi_instances(expirationDate)
         mock_request.side_effect = delete_request
         gabi_u.run(dry_run=False)


### PR DESCRIPTION
when a user attempts to query a Gabi instance, they may not be authorized, or the expiration for the instance had passed:
https://github.com/app-sre/gabi/blob/b4be98ac40fe91c7911f4347339b8ddc7db9e0ee/pkg/handlers/query.go#L49

there is little we can say in addition to "Unauthorized" when a user is unauthorized, but we could check for the instance expiration and output a more informative message.

this PR adds the instance expiration date to the Gabi ConfigMap, which will allow a Gabi instance to output a message about expiration. this part needs to be implemented in Gabi itself, so this PR is only a preparation for that: https://github.com/app-sre/gabi/pull/27