### PR TITLE
Pin cryptography module to avoid cert issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ setup(
         # this is really needed only in lint and type validations.
         # Is there any better place to put this in?
         "packaging~=21.3",
+        # Needed to fix issues with router's certificates
+        "cryptography==36.0.2",
     ],
 
     test_suite="tests",


### PR DESCRIPTION
We're having issues with version 37.0.1 in routers as we're getting the
default cluster cert instead of the router one.

See [APPSRE-5475](https://issues.redhat.com/browse/APPSRE-5475)

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>