### PR TITLE
url makes sense no verify

### DIFF
--- a/reconcile/checkpoint.py
+++ b/reconcile/checkpoint.py
@@ -42,7 +42,7 @@ def url_makes_sense(url: str) -> bool:
     if not url:
         return False
     try:
-        rs = requests.get(url)
+        rs = requests.get(url, verify=False)
     except requests.exceptions.ConnectionError:
         return False
     # Codes above NOT_FOUND mean the URL to the document doesn't


### PR DESCRIPTION
we use this function as part of the openshift resources `url` templating (check if a url exists).
when an SSL issue exists (as happens with gitlab for example), we deem the url bad, while it is in fact good.

instead of getting caught up on SSL (which we care about in other perspectives of course), let's let this through without verifying SSL.