### PR TITLE
revert USE_NATIVE_CLIENT unleash var to empty string

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -485,7 +485,7 @@ parameters:
 - name: LOG_SLOW_OC_RECONCILE
   value: "false"
 - name: USE_NATIVE_CLIENT
-  value: "true"
+  value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
   value: quay.io/app-sre/internal-redhat-ca
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG

--- a/openshift/qontract-reconcile-fedramp.yaml
+++ b/openshift/qontract-reconcile-fedramp.yaml
@@ -3518,7 +3518,7 @@ parameters:
 - name: LOG_SLOW_OC_RECONCILE
   value: "false"
 - name: USE_NATIVE_CLIENT
-  value: "true"
+  value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
   value: quay.io/app-sre/internal-redhat-ca
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG

--- a/openshift/qontract-reconcile-internal.yaml
+++ b/openshift/qontract-reconcile-internal.yaml
@@ -8871,7 +8871,7 @@ parameters:
 - name: LOG_SLOW_OC_RECONCILE
   value: "false"
 - name: USE_NATIVE_CLIENT
-  value: "true"
+  value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
   value: quay.io/app-sre/internal-redhat-ca
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG

--- a/openshift/qontract-reconcile.yaml
+++ b/openshift/qontract-reconcile.yaml
@@ -28157,7 +28157,7 @@ parameters:
 - name: LOG_SLOW_OC_RECONCILE
   value: "false"
 - name: USE_NATIVE_CLIENT
-  value: "true"
+  value: ""
 - name: INTERNAL_CERTIFICATES_IMAGE
   value: quay.io/app-sre/internal-redhat-ca
 - name: INTERNAL_CERTIFICATES_IMAGE_TAG


### PR DESCRIPTION
the meaning of USE_NATIVE_CLIENT is defined as follows
* true/yes - use native client
* other non empty string - use deprecated client
* empty string - use unleash per-cluster feature toggle to determine which client to use

reverts part of https://github.com/app-sre/qontract-reconcile/pull/2375

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>