### PR TITLE
Fix RDS ignored modifications logic to be region aware [APPSRE-5483]

### DIFF
--- a/reconcile/test/test_utils_aws_helper.py
+++ b/reconcile/test/test_utils_aws_helper.py
@@ -65,3 +65,15 @@ def test_get_account_found():
 def test_get_account_not_found():
     with pytest.raises(awsh.AccountNotFoundError):
         awsh.get_account([], "a")
+
+
+@pytest.mark.parametrize(
+    "az,region",
+    [
+        ("us-east-1c", "us-east-1"),
+        ("eu-central-1a", "eu-central-1"),
+        ("us-west-2b", "us-west-2"),
+    ],
+)
+def test_get_region_from_availability_zone(az, region):
+    assert awsh.get_region_from_availability_zone(az) == region

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1392,13 +1392,22 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         return images[0]["ImageId"]
 
     def describe_rds_db_instance(
-        self, account_name: str, db_instance_name: str
+        self,
+        account_name: str,
+        db_instance_name: str,
+        region_name: Optional[str] = None,
     ) -> DBInstanceMessageTypeDef:
         """
         Describe a single RDS instance.
         :param account_name: the name of the account in app-interface
         :param db_instance_name: the name of the database (ex. some-database-stage)
+        :param region_name: AWS region name for the resource, otherwise fallback to default
         :return: https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBInstances.html#API_DescribeDBInstances_ResponseElements
         """
-        rds = self._account_rds_client(account_name)
+        optional_kwargs = {}
+
+        if region_name:
+            optional_kwargs.update({"region_name": region_name})
+
+        rds = self._account_rds_client(account_name, **optional_kwargs)
         return rds.describe_db_instances(DBInstanceIdentifier=db_instance_name)

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1407,7 +1407,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         optional_kwargs = {}
 
         if region_name:
-            optional_kwargs.update({"region_name": region_name})
+            optional_kwargs["region_name"] = region_name
 
         rds = self._account_rds_client(account_name, **optional_kwargs)
         return rds.describe_db_instances(DBInstanceIdentifier=db_instance_name)

--- a/reconcile/utils/aws_helper.py
+++ b/reconcile/utils/aws_helper.py
@@ -55,3 +55,7 @@ def get_account(accounts: Iterable[Account], account_name: str) -> Account:
             return a
 
     raise AccountNotFoundError(account_name)
+
+
+def get_region_from_availability_zone(availability_zone: str) -> str:
+    return availability_zone[:-1]

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -12,6 +12,8 @@ from typing import Iterable, Mapping, Any
 from python_terraform import Terraform, IsFlagged, TerraformCommandError
 from sretoolbox.utils import retry
 from sretoolbox.utils import threaded
+
+from reconcile.utils.aws_helper import get_region_from_availability_zone
 from reconcile.utils.terraform_resource_spec import TerraformResourceSpec, TerraformResourceSpecInventory
 
 import reconcile.utils.lean_terraform_client as lean_tf
@@ -519,8 +521,9 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         ]
         if len(changed_terraform_args) == 1 \
                 and 'engine_version' in changed_terraform_args:
+            region_name = get_region_from_availability_zone(before['availability_zone'])
             response = \
-                self._aws_api.describe_rds_db_instance(account_name, resource_name)
+                self._aws_api.describe_rds_db_instance(account_name, resource_name, region_name=region_name)
             pending_modified_values = response['DBInstances'][0][
                 'PendingModifiedValues']
             if 'EngineVersion' in pending_modified_values and \

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -523,7 +523,8 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                 and 'engine_version' in changed_terraform_args:
             region_name = get_region_from_availability_zone(before['availability_zone'])
             response = \
-                self._aws_api.describe_rds_db_instance(account_name, resource_name, region_name=region_name)
+                self._aws_api.describe_rds_db_instance(account_name, resource_name,
+                                                       region_name=region_name)
             pending_modified_values = response['DBInstances'][0][
                 'PendingModifiedValues']
             if 'EngineVersion' in pending_modified_values and \


### PR DESCRIPTION
We are seeing errors when upgrading a database in a region other than `us-east-1`. This is because there is logic to check whether a RDS change should skip `terraform apply`, but that logic doesn't account for RDS instances in regions other than `us-east-1`.

The error that we'd see was:

```
botocore.errorfactory.DBInstanceNotFoundFault: An error occurred (DBInstanceNotFound) when calling the DescribeDBInstances operation: DBInstance <database-name> not found.
```

**Testing**

- Changed the `engine_version` of a database in `us-west-2` and observed the error above
- Applied the code fix in the PR and the error was no longer present in dry-run mode
- Changed the `engine_version` of a database in `us-east-1` and confirmed dry-run finished successfully