### PR TITLE
add fake empty value for env section compare

### DIFF
--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -100,7 +100,6 @@ class OpenshiftResource:
                             v["value"] = ""
                     if not self.obj_intersect_equal(obj1_v, obj2_v):
                         return False
-                    pass
                 elif obj1_k == "cpu":
                     equal = self.cpu_equal(obj1_v, obj2_v)
                     if not equal:

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -94,6 +94,13 @@ class OpenshiftResource:
                     ]
                     if diff or not self.obj_intersect_equal(obj1_v, obj2_v):
                         return False
+                elif obj1_k == "env":
+                    for v in obj2_v:
+                        if "name" in v and len(v) == 1:
+                            v["value"] = ""
+                    if not self.obj_intersect_equal(obj1_v, obj2_v):
+                        return False
+                    pass
                 elif obj1_k == "cpu":
                     equal = self.cpu_equal(obj1_v, obj2_v)
                     if not equal:


### PR DESCRIPTION
another attempt similar to #2375 (which was partially reverted in #2378), but from a different approach.

instead of only "fixing" our own template to not have empty values (which are hard to compare), this PR adds a special handle to compare environment variables.

if an current environment variable only has the `name` key, it means the desired value that was applied is empty (`""`). 
by "faking" an empty `value`, we are able to compare (and not apply when "equal").