### PR TITLE
run integration with current work dir near source code

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -51,12 +51,12 @@ FROM quay.io/app-sre/qontract-reconcile-base:0.8.1 as prod-image
 # This layer is not needed in the final image, so we can leverage a cache mount
 # to get rid of it. Implement the cache mount un the RUN command when we are able to
 # to use the buildkit features.
-COPY --from=build-image /work/ /tmp/work/
-#RUN --mount=type=cache,target=/tmp/work/,from=build-image,source=/work \
+COPY --from=build-image /work/ /reconcile/
+WORKDIR /reconcile
+#RUN --mount=type=cache,target=/reconcile/,from=build-image,source=/work \
 
 RUN microdnf upgrade -y && \
     python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
-    python3 -m pip install --no-cache-dir --no-index --find-links=/tmp/work/wheels qontract-reconcile && \
-    cp /tmp/work/run-integration.py /run-integration.py
+    python3 -m pip install --no-cache-dir --no-index --find-links=/reconcile/wheels qontract-reconcile
 
-CMD [ "/run-integration.py" ]
+CMD [ "./run-integration.py" ]

--- a/dockerfiles/structure-test.yaml
+++ b/dockerfiles/structure-test.yaml
@@ -2,7 +2,7 @@ schemaVersion: 2.0.0
 
 fileExistenceTests:
 - name: run-integration.py
-  path: /run-integration.py
+  path: /reconcile/run-integration.py
   shouldExist: true
   permissions: -rwxr-xr-x
   uid: 0
@@ -27,6 +27,14 @@ fileExistenceTests:
 
 - name: Terraform
   path: /usr/local/bin/terraform
+  shouldExist: true
+  permissions: -rwxr-xr-x
+  uid: 0
+  gid: 0
+  isExecutableBy: other
+
+- name: Helm
+  path: /usr/local/bin/helm
   shouldExist: true
   permissions: -rwxr-xr-x
   uid: 0


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2963

the integrations-manager integration is failing with the following message:
```
reconcile.utils.helm.HelmTemplateError: Error running helm template [helm template ./helm/qontract-reconcile -n qontract-reconcile -f /tmp/tmpc9kul414] Error: path "./helm/qontract-reconcile" not found
```

this PR should make the integration run from a location where `./helm` exists.