### PR TITLE
[integrations-manager] self dry-run

### DIFF
--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -24,7 +24,11 @@ INTEGRATION_NAME = os.environ['INTEGRATION_NAME']
 COMMAND_NAME = os.environ.get('COMMAND_NAME', 'qontract-reconcile')
 
 RUN_ONCE = os.environ.get('RUN_ONCE')
-DRY_RUN = os.environ.get('DRY_RUN')
+DRY_RUN = (
+    os.environ.get("MANAGER_DRY_RUN")
+    if INTEGRATION_NAME == "integrations-manager"
+    else os.environ.get("DRY_RUN")
+)
 INTEGRATION_EXTRA_ARGS = os.environ.get('INTEGRATION_EXTRA_ARGS')
 CONFIG = os.environ.get('CONFIG', '/config/config.toml')
 

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -163,11 +163,11 @@ objects:
           - name: SHARD_ID
             value: "{{ $shard_id }}"
           - name: DRY_RUN
-            {{- if eq $integration.name "integrations-manager" }}
-            value: ${MANAGER_DRY_RUN}
-            {{- else }}
             value: ${DRY_RUN}
-            {{- end }}
+          {{- if eq $integration.name "integrations-manager" }}
+          - name: MANAGER_DRY_RUN
+            value: ${MANAGER_DRY_RUN}
+          {{- end }}
           - name: INTEGRATION_NAME
             value: {{ $integration.name }}
           {{- with $integration.extraArgs }}

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -116,6 +116,8 @@ objects:
           - name: SHARD_ID
             value: "0"
           - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: MANAGER_DRY_RUN
             value: ${MANAGER_DRY_RUN}
           - name: INTEGRATION_NAME
             value: integrations-manager

--- a/reconcile/test/fixtures/helm/integrations_manager.yml
+++ b/reconcile/test/fixtures/helm/integrations_manager.yml
@@ -98,6 +98,8 @@ objects:
           - name: SHARD_ID
             value: "0"
           - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: MANAGER_DRY_RUN
             value: ${MANAGER_DRY_RUN}
           - name: INTEGRATION_NAME
             value: integrations-manager


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2963

fixes a bug introduced in #2384

the issue is that `integrations-manager` should be able to run in non dry-run mode, and at the same time create integrations that run in dry-run mode.

since the container env vars override app-interface environment parameters, the `MANAGER_DRY_RUN` was actually considered as the `DRY_RUN` for the managed integrations:
https://github.com/app-sre/qontract-reconcile/blob/faa5da9f4918cb8f6b79c2bc010091d7a0546be5/reconcile/test/test_integrations_manager.py#L80-L97

this PR splits the dry-run to have different template parameters for `integrations-manager` and for managed integrations.