### PR TITLE
fix helm template to accomodate failedJobHistoryLimit with value 0 (integer)

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -362,7 +362,7 @@ objects:
     schedule: "{{ $integration.cron }}"
     concurrencyPolicy: {{ $integration.concurrencyPolicy | default "Allow" }}
     successfulJobHistoryLimit: {{ $integration.successfulJobHistoryLimit | default "3" }}
-    failedJobHistoryLimit: {{ $integration.failedJobHistoryLimit | default "1" }}
+    failedJobHistoryLimit: {{ if not (kindIs "invalid" $integration.failedJobHistoryLimit) }}{{ $integration.failedJobHistoryLimit }}{{ else }}{{ 1 }}{{ end }}
     jobTemplate:
       spec:
         template:


### PR DESCRIPTION
`failedJobHistoryLimit` is currently set as a string, while it should be an integer. the reason it is not an integer is because the value `0` is interpreted as non-exists, and the default value of `1` is being used.

this PR fixes it so integer with value `0` is working as expected.

reference: https://github.com/helm/helm/issues/3164#issuecomment-709537506

history: #1344