### PR TITLE
[WIP] remove prometheus extra labels (shard-key)

### DIFF
--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -13,7 +13,7 @@ import click
 from reconcile.status import ExitCodes
 from reconcile.cli import LOG_FMT, LOG_DATEFMT
 from reconcile.utils.metrics import (
-  run_time, run_status, extra_labels, execution_counter
+  run_time, run_status, execution_counter
 )
 
 
@@ -150,13 +150,11 @@ def main():
             integration=INTEGRATION_NAME,
             shards=SHARDS,
             shard_id=SHARD_ID,
-            **extra_labels
         ).inc()
         try:
             with command.make_context(info_name=COMMAND_NAME, args=args) \
               as ctx:
                 ctx.ensure_object(dict)
-                ctx.obj['extra_labels'] = extra_labels
                 command.invoke(ctx)
                 return_code = 0
         # This is for when the integration explicitly
@@ -173,11 +171,9 @@ def main():
         time_spent = time.monotonic() - start_time
 
         run_time.labels(integration=INTEGRATION_NAME,
-                        shards=SHARDS, shard_id=SHARD_ID,
-                        **extra_labels).set(time_spent)
+                        shards=SHARDS, shard_id=SHARD_ID).set(time_spent)
         run_status.labels(integration=INTEGRATION_NAME,
-                          shards=SHARDS, shard_id=SHARD_ID,
-                          **extra_labels).set(return_code)
+                          shards=SHARDS, shard_id=SHARD_ID).set(return_code)
 
         if RUN_ONCE:
             sys.exit(return_code)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1329,7 +1329,6 @@ def terraform_resources(
         light,
         vault_output_path,
         account_name=account_name,
-        extra_labels=ctx.obj.get("extra_labels", {}),
     )
 
 
@@ -1374,7 +1373,6 @@ def terraform_resources_wrapper(
         use_jump_host,
         light,
         vault_output_path,
-        extra_labels=ctx.obj.get("extra_labels", {}),
     )
 
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -3,7 +3,7 @@ import shutil
 import sys
 
 from textwrap import indent
-from typing import Any, Iterable, MutableMapping, Optional, Mapping, Tuple, cast
+from typing import Any, Iterable, Optional, Mapping, Tuple, cast
 
 from sretoolbox.utils import threaded
 
@@ -461,7 +461,6 @@ def setup(
     internal: str,
     use_jump_host: bool,
     account_name: Optional[str],
-    extra_labels: MutableMapping[str, str],
 ) -> Tuple[
     ResourceInventory,
     OC_Map,
@@ -475,7 +474,6 @@ def setup(
                     if n['name'] == account_name]
         if not accounts:
             raise ValueError(f"aws account {account_name} is not found")
-        extra_labels['shard_key'] = account_name
     settings = queries.get_app_interface_settings()
 
     # build a resource inventory for all the kube secrets managed by the
@@ -610,7 +608,6 @@ def run(
     light=False,
     vault_output_path="",
     account_name=None,
-    extra_labels=None,
     defer=None,
 ):
 
@@ -621,7 +618,6 @@ def run(
         internal,
         use_jump_host,
         account_name,
-        extra_labels,
     )
 
     if not dry_run:

--- a/reconcile/terraform_resources_wrapper.py
+++ b/reconcile/terraform_resources_wrapper.py
@@ -40,7 +40,6 @@ def tfr_run_wrapper(
     use_jump_host,
     light,
     vault_output_path,
-    extra_labels,
 ):
     exit_code = 0
     try:
@@ -55,7 +54,6 @@ def tfr_run_wrapper(
             light=light,
             vault_output_path=vault_output_path,
             account_name=account_name,
-            extra_labels=extra_labels,
         )
     except SystemExit as e:
         exit_code = e.code
@@ -72,7 +70,6 @@ def run(
     use_jump_host=True,
     light=False,
     vault_output_path="",
-    extra_labels=None,
 ):
     account_names = [
         name
@@ -97,7 +94,6 @@ def run(
         use_jump_host=use_jump_host,
         light=light,
         vault_output_path=vault_output_path,
-        extra_labels=extra_labels,
     )
 
     if any(exit_codes):

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -1,25 +1,22 @@
 from prometheus_client import Gauge, Counter, Histogram
 
 
-extra_labels = {"shard_key": None}
-label_keys = list(extra_labels.keys())
-
 run_time = Gauge(
     name="qontract_reconcile_last_run_seconds",
     documentation="Last run duration in seconds",
-    labelnames=["integration", "shards", "shard_id"] + label_keys,
+    labelnames=["integration", "shards", "shard_id"],
 )
 
 run_status = Gauge(
     name="qontract_reconcile_last_run_status",
     documentation="Last run status",
-    labelnames=["integration", "shards", "shard_id"] + label_keys,
+    labelnames=["integration", "shards", "shard_id"],
 )
 
 execution_counter = Counter(
     name="qontract_reconcile_execution_counter",
     documentation="Counts started integration executions",
-    labelnames=["integration", "shards", "shard_id"] + label_keys,
+    labelnames=["integration", "shards", "shard_id"],
 )
 
 reconcile_time = Histogram(


### PR DESCRIPTION
extra labels were only used by terraform-resources-wrapper to set the account name of a processing thread into the `shard_key` extra label. this is not working reliably because the extra_label dict is shared between all account threads so metrics reporting is not per account thread but interleaved between all account threads.

even if threading would not be a problem. metrics reporting works on the level of integration runs. in the case of the terraform-resource-wrapper it implies a full run of terraform-resources for each account in the shard. so all accounts run the exact same amount of times and individual reporting is not meaningful.

on hold until integration-manager dynamic sharding is available and proves if it services the tracability purpose given by extra-labels

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>