### PR TITLE
Assert that user is AWS account

### DIFF
--- a/reconcile/aws_iam_password_reset.py
+++ b/reconcile/aws_iam_password_reset.py
@@ -1,4 +1,6 @@
 import logging
+import sys
+from typing import Any, Mapping, Iterable, Optional
 
 from reconcile import queries
 
@@ -8,9 +10,27 @@ from reconcile.utils.state import State
 QONTRACT_INTEGRATION = "aws-iam-password-reset"
 
 
+def get_roles(
+    roles: Iterable[Mapping[str, Any]], org_username: str
+) -> Optional[Mapping[str, Any]]:
+    for d in roles:
+        if d["org_username"] == org_username:
+            return d
+    return None
+
+
+def account_in_roles(roles: Iterable[Mapping[str, Any]], aws_account: str) -> bool:
+    for role in roles:
+        for g in role.get("aws_groups") or []:
+            if g["account"]["name"] == aws_account:
+                return True
+    return False
+
+
 def run(dry_run):
     accounts = queries.get_aws_accounts(reset_passwords=True)
     settings = queries.get_app_interface_settings()
+    roles = queries.get_roles(aws=True)
     state = State(
         integration=QONTRACT_INTEGRATION, accounts=accounts, settings=settings
     )
@@ -27,6 +47,15 @@ def run(dry_run):
             state_key = f"{account_name}/{user_name}/{request_id}"
             if state.exists(state_key):
                 continue
+
+            role = get_roles(roles, user_name)
+            if not role:
+                logging.error(f"Expected a role to be found with name {user_name}")
+                sys.exit(1)
+
+            if not account_in_roles(role["roles"], account_name):
+                logging.error(f"User {user_name} is not in account {account_name}")
+                sys.exit(1)
 
             logging.info(["reset_password", account_name, user_name])
             if dry_run:

--- a/reconcile/test/test_aws_iam_password_reset.py
+++ b/reconcile/test/test_aws_iam_password_reset.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+import pytest
+from reconcile.aws_iam_password_reset import get_roles, account_in_roles
+
+
+@pytest.fixture
+def roles() -> list[dict[str, Any]]:
+    return [
+        {
+            "org_username": "foobar",
+            "roles": [
+                {"name": "test", "aws_groups": None},
+                {"name": "test2", "aws_groups": [{"account": {"name": "testaws1"}}]},
+            ],
+        },
+        {"org_username": "barfoo"},
+    ]
+
+
+def test_get_roles(roles: list[dict[str, Any]]):
+    r = get_roles(roles, "barfoo")
+    assert r and r["org_username"] == "barfoo"
+
+
+def test_account_in_roles(roles: list[dict[str, Any]]):
+    r = get_roles(roles, "foobar")
+    assert r and account_in_roles(r["roles"], "testaws1")
+    assert r and not account_in_roles(r["roles"], "a")

--- a/reconcile/test/test_aws_iam_password_reset.py
+++ b/reconcile/test/test_aws_iam_password_reset.py
@@ -21,6 +21,8 @@ def roles() -> list[dict[str, Any]]:
 def test_get_roles(roles: list[dict[str, Any]]):
     r = get_roles(roles, "barfoo")
     assert r and r["org_username"] == "barfoo"
+    r = get_roles(roles, "foo")
+    assert not r
 
 
 def test_account_in_roles(roles: list[dict[str, Any]]):


### PR DESCRIPTION
Prevents errors like: An error occurred (NoSuchEntity) when calling the DeleteLoginProfile operation: The user with name foobar cannot be found.