### PR TITLE
update version once all nodes are upgraded

### DIFF
--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -133,7 +133,8 @@ class OCM:  # pylint: disable=too-many-public-methods
                 "provider": cluster["cloud_provider"]["id"],
                 "region": cluster["region"]["id"],
                 "channel": cluster["version"]["channel_group"],
-                "version": cluster["openshift_version"],
+                # cluster["openshift_version"] gets updated before all nodes are upgraded
+                "version": cluster["version"]["raw_id"],
                 "multi_az": cluster["multi_az"],
                 "instance_type": cluster["nodes"]["compute_machine_type"]["id"],
                 "storage": cluster["storage_quota"]["value"] // BYTES_IN_GIGABYTE,


### PR DESCRIPTION
use `cluster["version"]["raw_id"]` to get the version as this field gets updated only after the upgrade is fully complete, nodes included.
`cluster["openshift_version"]` gets updated before that.

@maorfr could you PTAL ? I did not find anything that could have a bad side effect.
Looking at our clusters, it seems `["version"]["raw_id"]` is always present for OSD clusters. If we want to be sure, we could also use `cluster["version"].get("raw_id") or cluster["openshift_version"]`