### PR TITLE
Add rosa-authenticator infrastructure support

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4884,6 +4884,16 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(api_gateway_integration_token_resource)
 
+            api_gateway_integration_response_resource = aws_api_gateway_integration_response_resource(
+                "gw_integration_response_token",
+                rest_api_id=api_gateway_rest_api_resource.id,
+                resource_id=api_gateway_resource.id,
+                http_method=api_gateway_method_resource.http_method,
+                status_code=api_gateway_method_token_get_response_resource.status_code,
+                depends_on=[api_gateway_integration_token_resource]
+            )
+            tf_resources.append(api_gateway_integration_response_resource)
+
             waf_acl_args_values = self.get_values("waf_acl_properties")
             waf_acl_resource = aws_wafv2_web_acl(
                 "api_waf",

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1015,10 +1015,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                                           existing_secrets)
         elif provider == 'route53-zone':
             self.populate_tf_resource_route53_zone(resource, namespace_info)
-        elif provider == 'cognito':
-            self.populate_tf_resource_cognito(resource, namespace_info)
-        elif provider == 'api-gateway':
-            self.populate_tf_resource_api_gateway(resource, namespace_info)
+        elif provider == 'rosa-authentication':
+            self.populate_tf_resource_rosa_authentication(resource, namespace_info)
         else:
             raise UnknownProviderError(provider)
 
@@ -4526,7 +4524,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         self.add_resources(account, tf_resources)
 
-    def populate_tf_resource_cognito(self, resource, namespace_info):
+    def populate_tf_resource_rosa_authentication(self, resource, namespace_info):
         account, identifier, common_values, output_prefix, \
             output_resource_name, annotations = \
             self.init_values(resource, namespace_info)

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4663,7 +4663,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             handler="index.handler",
             filename=zip_file,
             source_code_hash='${filebase64sha256("' + zip_file + '")}',
-            tracing_config={'mode':'PassThrough'}
+            tracing_config={'mode': 'PassThrough'}
         )
         tf_resources.append(cognito_pre_signup_lambda_resource)
 
@@ -4678,7 +4678,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             handler="index.handler",
             filename=zip_file,
             source_code_hash='${filebase64sha256("' + zip_file + '")}',
-            tracing_config={'mode':'PassThrough'}
+            tracing_config={'mode': 'PassThrough'}
         )
         tf_resources.append(cognito_pre_signup_lambda_resource)
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4536,8 +4536,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         self.init_common_outputs(tf_resources, namespace_info, output_prefix,
                                  output_resource_name, annotations)
 
-        organization_name = self.get_values("identifier")
-
         sms_role_policy = {
             "Version": "2012-10-17",
             "Statement": [
@@ -4567,7 +4565,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         sms_iam_role_resource = aws_iam_role(
             "sms_role",
-            name=f'{organization_name}-SMS',
+            name=f'{identifier}-SMS',
             description="role for applicant cognito, send sms",
             assume_role_policy=sms_role_policy,
             force_detach_policies=False,
@@ -4585,7 +4583,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             pool_args_values = self.get_values('pool_args')
             cognito_user_pool_resource = aws_cognito_user_pool(
                 "pool",
-                name=f'{organization_name}-pool',
+                name=f'{identifier}-pool',
                 **pool_args_values
             )
             tf_resources.append(cognito_user_pool_resource)
@@ -4615,8 +4613,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         self.init_common_outputs(tf_resources, namespace_info, output_prefix,
                                  output_resource_name, annotations)
-
-        organization_name = self.get_values("identifier")
 
         # FIXME
         # I need to find an example of this pattern. Creating a dependent resource in an outside
@@ -4651,7 +4647,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             gateway_authorizer_args_values = self.get_values("gateway_authorizer_properties")
             api_gateway_authorizer_resource = aws_api_gateway_authorizer(
                 "gw_authorizer",
-                name=f'{organization_name}-authorizer',
+                name=f'{identifier}-authorizer',
                 rest_api_id=api_gateway_rest_api_resource.id,
                 provider_arns=[cognito_user_pool_arn],  # FIXME
                 **gateway_authorizer_args_values

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4636,7 +4636,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         managed_policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         region = common_values.get('region') or \
             self.default_regions.get(account)
-        if region == "us-gov-west-1" or region == "us-gov-east-1":
+        if region in ("us-gov-west-1", "us-gov-east-1"):
             managed_policy_arn = "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 
         lambda_iam_role_resource = aws_iam_role(
@@ -4695,12 +4695,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         integration_token_args = common_values.get("integration_token_properties", None)
         waf_acl_args = common_values.get("waf_acl_properties", None)
 
-        # Build the rest of the TF infrastructure
-        if pool_args and pool_client_args and rest_api_args and gateway_method_any_args and \
-           gateway_method_token_get_args and gateway_method_token_get_response_args and \
-           gateway_authorizer_args and integration_proxy_args and integration_token_args and \
-           waf_acl_args:
+        args_presence_one = pool_args and pool_client_args and \
+            rest_api_args and gateway_method_any_args
+        args_presence_two = gateway_method_token_get_args and gateway_method_token_get_response_args
+        args_presence_three = gateway_authorizer_args and integration_proxy_args and \
+            integration_token_args
+        args_presence_four = waf_acl_args
 
+        # Build the rest of the TF infrastructure
+        if args_presence_one and args_presence_two and args_presence_three and args_presence_four:
             # Spin up the user pool
             pool_args_values = self.get_values('pool_args')
             cognito_user_pool_resource = aws_cognito_user_pool(
@@ -4871,12 +4874,12 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 rest_api_id=api_gateway_rest_api_resource.id,
                 triggers={
                     "redeployment": '${sha1(jsonencode([' +
-                                      api_gateway_proxy_resource.id + ',' +
-                                      api_gateway_token_resource.id + ',' +
-                                      api_gateway_method_any_resource.id + ',' +
-                                      api_gateway_method_token_get_resource.id + ',' +
-                                      api_gateway_integration_proxy_resource.id + ',' +
-                                      api_gateway_integration_token_resource.id + ')}'
+                                    api_gateway_proxy_resource.id + ',' +
+                                    api_gateway_token_resource.id + ',' +
+                                    api_gateway_method_any_resource.id + ',' +
+                                    api_gateway_method_token_get_resource.id + ',' +
+                                    api_gateway_integration_proxy_resource.id + ',' +
+                                    api_gateway_integration_token_resource.id + ')}'
                 },
                 lifecycle={"create_before_destroy": True}
             )

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4530,12 +4530,12 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         account, identifier, common_values, output_prefix, \
             output_resource_name, annotations = \
             self.init_values(resource, namespace_info)
-        
+
         tf_resources = []
-        
+
         self.init_common_outputs(tf_resources, namespace_info, output_prefix,
-                                output_resource_name, annotations)
-        
+                                 output_resource_name, annotations)
+
         organization_name = self.get_values("identifier")
 
         sms_role_policy = {
@@ -4580,7 +4580,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         pool_args = common_values.get("user_pool_properties", None)
         pool_client_args = common_values.get("user_pool_client_properties", None)
-        
+
         if pool_args and pool_client_args:
             pool_args_values = self.get_values('pool_args')
             cognito_user_pool_resource = aws_cognito_user_pool(
@@ -4605,32 +4605,32 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(cognito_user_pool_client)
         self.add_resources(account, tf_resources)
-    
+
     def populate_tf_resource_api_gateway(self, resource, namespace_info):
         account, identifier, common_values, output_prefix, \
             output_resource_name, annotations = \
             self.init_values(resource, namespace_info)
-        
+
         tf_resources = []
 
         self.init_common_outputs(tf_resources, namespace_info, output_prefix,
-                                output_resource_name, annotations)
-        
+                                 output_resource_name, annotations)
+
         organization_name = self.get_values("identifier")
-        
+
         # FIXME
         # I need to find an example of this pattern. Creating a dependent resource in an outside
         # provider and referencing it here
         cognito_user_pool_arn = "foobar"
 
-        rest_api_args = values.get("rest_api_properties", None)
-        gateway_args = values.get("gateway_resource_properties", None)
-        gateway_authorizer_args = values.get("gateway_authorizer_properties", None)
-        gateway_method_args = values.get("gateway_method_properties", None)
-        integration_args = values.get("integration_properties", None)
+        rest_api_args = common_values.get("rest_api_properties", None)
+        gateway_args = common_values.get("gateway_resource_properties", None)
+        gateway_authorizer_args = common_values.get("gateway_authorizer_properties", None)
+        gateway_method_args = common_values.get("gateway_method_properties", None)
+        integration_args = common_values.get("integration_properties", None)
 
         if rest_api_args and gateway_args and gateway_method_args and \
-            gateway_authorizer_args and integration_args:
+           gateway_authorizer_args and integration_args:
 
             rest_api_args_values = self.get_values("rest_api_properties")
             api_gateway_rest_api_resource = aws_api_gateway_rest_api(
@@ -4653,7 +4653,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 "gw_authorizer",
                 name=f'{organization_name}-authorizer',
                 rest_api_id=api_gateway_rest_api_resource.id,
-                provider_arns=[cognito_user_pool_arn], #FIXME
+                provider_arns=[cognito_user_pool_arn],  # FIXME
                 **gateway_authorizer_args_values
             )
             tf_resources.append(api_gateway_authorizer_resource)
@@ -4667,7 +4667,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 **gateway_method_args_values
             )
             tf_resources.append(api_gateway_method_resource)
-            
+
             # FIXME: need a solution to this HCL -> terrascript adaptation
             # as defined in terraform, triggers block looks like this:
             # triggers = {
@@ -4683,8 +4683,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             api_gateway_deployment_resource = aws_api_gateway_deployment(
                 "gw_deployment",
                 rest_api_id=api_gateway_rest_api_resource.id,
-                triggers={}, #FIXME
-                lifecycle={"create_before_destroy":True}
+                triggers={},  # FIXME
+                lifecycle={"create_before_destroy": True}
             )
             tf_resources.append(api_gateway_deployment_resource)
 
@@ -4716,7 +4716,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(api_gateway_stage_resource)
 
-            # hardcoding VPC_LINK re: 
+            # hardcoding VPC_LINK re:
             # https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/38690#note_4123843
             integration_args_values = self.get_values("integration_properties")
             api_gateway_integration_resource = aws_api_gateway_integration(
@@ -4724,8 +4724,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 rest_api_id=api_gateway_rest_api_resource.id,
                 resource_id=api_gateway_resource.id,
                 http_method=api_gateway_method_resource.http_method,
-                connection_type="VPC_LINK", # updated by request in MR review comment above
-                connection_id=api_gateway_vpc_link_resource.id, # updated by request in MR review comment above
+                connection_type="VPC_LINK",  # updated by request in MR review comment above
+                connection_id=api_gateway_vpc_link_resource.id,  # updated by request in MR review comment above
                 **integration_args_values
             )
             tf_resources.append(api_gateway_integration_resource)

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4723,7 +4723,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 "gw_integration",
                 rest_api_id=api_gateway_rest_api_resource.id,
                 resource_id=api_gateway_resource.id,
-                http_method=aws_api_gateway_method_resource.http_method,
+                http_method=api_gateway_method_resource.http_method,
                 connection_type="VPC_LINK", # updated by request in MR review comment above
                 connection_id=api_gateway_vpc_link_resource.id, # updated by request in MR review comment above
                 **integration_args_values

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4788,7 +4788,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             api_gateway_method_any_resource = aws_api_gateway_method(
                 "gw_method_any",
                 rest_api_id=api_gateway_rest_api_resource.id,
-                resource_id=api_gateway_resource.id,
+                resource_id=api_gateway_proxy_resource.id,
                 authorizer_id=api_gateway_authorizer_resource.id,
                 **gateway_method_any_args_values
             )
@@ -4798,7 +4798,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             api_gateway_method_token_get_resource = aws_api_gateway_method(
                 "gw_method_token_get",
                 rest_api_id=api_gateway_rest_api_resource.id,
-                resource_id=api_gateway_resource.id,
+                resource_id=api_gateway_token_resource.id,
                 **gateway_method_token_get_args_values
             )
             tf_resources.append(api_gateway_method_token_get_resource)
@@ -4830,7 +4830,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(api_gateway_vpc_link_resource)
 
-            api_gateway_stage_resource = aws_api_gateway_stage(
+            api_gateway_stage_resource = aws_api_gateway_stage(  # MOVE
                 "gw_stage",
                 deployment_id=api_gateway_deployment_resource.id,
                 rest_api_id=api_gateway_rest_api_resource.id,
@@ -4843,8 +4843,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             api_gateway_integration_proxy_resource = aws_api_gateway_integration(
                 "gw_integration_proxy",
                 rest_api_id=api_gateway_rest_api_resource.id,
-                resource_id=api_gateway_resource.id,
-                http_method=api_gateway_method_resource.http_method,
+                resource_id=api_gateway_proxy_resource.id,
+                http_method=api_gateway_method_any_resource.http_method,
                 connection_type="VPC_LINK",
                 connection_id=api_gateway_vpc_link_resource.id,
                 **integration_proxy_args_values
@@ -4856,18 +4856,18 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             api_gateway_integration_token_resource = aws_api_gateway_integration(
                 "gw_integration_token",
                 rest_api_id=api_gateway_rest_api_resource.id,
-                resource_id=api_gateway_resource.id,
-                http_method=api_gateway_method_resource.http_method,
+                resource_id=api_gateway_token_resource.id,
+                http_method=api_gateway_method_token_get_resource.http_method,
                 connection_type="VPC_LINK",
                 connection_id=api_gateway_vpc_link_resource.id,
                 **integration_token_args_values
             )
             tf_resources.append(api_gateway_integration_token_resource)
 
-            api_gateway_integration_response_resource = aws_api_gateway_integration_response_resource(
+            api_gateway_integration_response_resource = aws_api_gateway_integration_response(
                 "gw_integration_response_token",
                 rest_api_id=api_gateway_rest_api_resource.id,
-                resource_id=api_gateway_resource.id,
+                resource_id=api_gateway_token_resource.id,
                 http_method=api_gateway_method_resource.http_method,
                 status_code=api_gateway_method_token_get_response_resource.status_code,
                 depends_on=[api_gateway_integration_token_resource]
@@ -4878,13 +4878,13 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 "gw_deployment",
                 rest_api_id=api_gateway_rest_api_resource.id,
                 triggers={
-                    "redeployment": '${sha1(jsonencode([' + \
-                                       api_gateway_proxy_resource.id + ',' +
-                                       api_gateway_token_resource.id + ',' +
-                                       api_gateway_method_any_resource.id + ',' +
-                                       api_gateway_method_token_get_resource.id + ',' +
-                                       api_gateway_integration_proxy_resource.id + ',' +
-                                       api_gateway_integration_token_resource.id +')}'
+                    "redeployment": '${sha1(jsonencode([' +
+                        api_gateway_proxy_resource.id + ',' +
+                        api_gateway_token_resource.id + ',' +
+                        api_gateway_method_any_resource.id + ',' +
+                        api_gateway_method_token_get_resource.id + ',' +
+                        api_gateway_integration_proxy_resource.id + ',' +
+                        api_gateway_integration_token_resource.id +')}'
                 },
                 lifecycle={"create_before_destroy": True}
             )

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -316,7 +316,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     if not self.rosa_authenticator_pre_signup_zip:
                         self.token = get_default_config()['token']
                         self.rosa_authenticator_pre_signup_zip = \
-                            self.download_rosa_authenticator_zip(ROSA_AUTHENTICATOR_RELEASE, target)
+                            self.download_rosa_authenticator_zip(ROSA_AUTHENTICATOR_PRE_SIGNUP_RELEASE, target)
         elif target == 'pre-token':
             if not self.rosa_authenticator_pre_token_zip:
                 with self.rosa_authenticator_pre_token_zip_lock:
@@ -324,7 +324,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     if not self.rosa_authenticator_pre_token_zip:
                         self.token = get_default_config()['token']
                         self.rosa_authenticator_pre_token_zip = \
-                            self.download_rosa_authenticator_zip(ROSA_AUTHENTICATOR_RELEASE, target)
+                            self.download_rosa_authenticator_zip(ROSA_AUTHENTICATOR_PRE_TOKEN_RELEASE, target)
         if release_url == ROSA_AUTHENTICATOR_PRE_SIGNUP_RELEASE:
             return self.rosa_authenticator_pre_signup_zip
         elif release_url == ROSA_AUTHENTICATOR_PRE_TOKEN_RELEASE:

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4884,7 +4884,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                         api_gateway_method_any_resource.id + ',' +
                         api_gateway_method_token_get_resource.id + ',' +
                         api_gateway_integration_proxy_resource.id + ',' +
-                        api_gateway_integration_token_resource.id +')}'
+                        api_gateway_integration_token_resource.id + ')}'
                 },
                 lifecycle={"create_before_destroy": True}
             )

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4715,12 +4715,17 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(cognito_user_pool_domain_resource)
 
-            # POOL RESOURCE SERVER
-            cognito_resource_server_args_values = self.get_values('cognito_resource_server_args')
-            cognito_resource_server_resource = aws_cognito_resource_server(
-                "userpool_service_resource_server",
+            ## POOL GATEWAY RESOURCE SERVER
+            cognito_resource_server_gateway_resource = aws_cognito_resource_server(
+                "userpool_gateway_resource_server",
                 user_pool_id=cognito_user_pool_resource.id,
-                **cognito_resource_server_args_values
+                name="API Gateway",
+                identifier="gateway",
+                scope={
+                    "scope_name": "AccessToken",
+                    "scope_description": "Scope used to support Access Token " + 
+                                         "authorization in API Gateway",
+                }
             )
             tf_resources.append(cognito_resource_server_resource)
 
@@ -4735,6 +4740,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 **pool_client_args_values
             )
             tf_resources.append(cognito_user_pool_client)
+
+            # POOL RESOURCE SERVER
+            cognito_resource_server_args_values = self.get_values('cognito_resource_server_args')
+            cognito_resource_server_resource = aws_cognito_resource_server(
+                "userpool_service_resource_server",
+                user_pool_id=cognito_user_pool_resource.id,
+                **cognito_resource_server_args_values
+            )
+            tf_resources.append(cognito_resource_server_resource)
 
             # SERVICE ACCOUNT CLIENTS
             pool_client_service_account_common_args_values = self.get_values(

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4705,7 +4705,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             # Continue with pool resources
             cognito_user_pool_domain_resource = aws_cognito_user_pool_domain(
                 "userpool_domain",
-                domain=self.get_values("domain"),
+                domain=f'ocm-{identifier}-domain',
                 user_pool_id=cognito_user_pool_resource.id
             )
             tf_resources.append(cognito_user_pool_domain_resource)
@@ -4713,7 +4713,10 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             pool_client_args_values = self.get_values("user_pool_client_properties")
             cognito_user_pool_client = aws_cognito_user_pool_client(
                 "userpool_client",
+                name=f'ocm-{identifier}-pool-client',
                 user_pool_id=cognito_user_pool_resource.id,
+                callback_urls=[f'{self.get_values("bucket_domain")}/token.html',
+                depends_on=[
                 **pool_client_args_values
             )
             tf_resources.append(cognito_user_pool_client)

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4860,7 +4860,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 "gw_integration_response_token",
                 rest_api_id=api_gateway_rest_api_resource.id,
                 resource_id=api_gateway_token_resource.id,
-                http_method=api_gateway_method_resource.http_method,
+                http_method=api_gateway_token_resource.http_method,
                 status_code=api_gateway_method_token_get_response_resource.status_code,
                 depends_on=[api_gateway_integration_token_resource]
             )
@@ -4871,12 +4871,12 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 rest_api_id=api_gateway_rest_api_resource.id,
                 triggers={
                     "redeployment": '${sha1(jsonencode([' +
-                        api_gateway_proxy_resource.id + ',' +
-                        api_gateway_token_resource.id + ',' +
-                        api_gateway_method_any_resource.id + ',' +
-                        api_gateway_method_token_get_resource.id + ',' +
-                        api_gateway_integration_proxy_resource.id + ',' +
-                        api_gateway_integration_token_resource.id + ')}'
+                                      api_gateway_proxy_resource.id + ',' +
+                                      api_gateway_token_resource.id + ',' +
+                                      api_gateway_method_any_resource.id + ',' +
+                                      api_gateway_method_token_get_resource.id + ',' +
+                                      api_gateway_integration_proxy_resource.id + ',' +
+                                      api_gateway_integration_token_resource.id + ')}'
                 },
                 lifecycle={"create_before_destroy": True}
             )

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4634,7 +4634,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         }
 
         managed_policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-
+        region = common_values.get('region') or \
+            self.default_regions.get(account)
         if region == "us-gov-west-1" or region == "us-gov-east-1":
             managed_policy_arn = "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4715,7 +4715,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(cognito_user_pool_domain_resource)
 
-            ## POOL GATEWAY RESOURCE SERVER
+            # POOL GATEWAY RESOURCE SERVER
             cognito_resource_server_gateway_resource = aws_cognito_resource_server(
                 "userpool_gateway_resource_server",
                 user_pool_id=cognito_user_pool_resource.id,
@@ -4754,6 +4754,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             pool_client_service_account_common_args_values = self.get_values(
                 "pool_client_service_account_common_properties"
             )
+            # AMS
             ams_service_account_pool_client_resource = aws_cognito_user_pool_client(
                 "ocm_ams_service_account",
                 name=f'ocm-{identifier}-ams-service-account',
@@ -4763,7 +4764,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 **pool_client_service_account_common_args_values
             )
             tf_resources.append(ams_service_account_pool_client_resource)
-
+            
+            # CS
             cs_service_account_pool_client_resource = aws_cognito_user_pool_client(
                 "ocm_cs_service_account",
                 name=f'ocm-{identifier}-cs-service-account',
@@ -4774,7 +4776,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(cs_service_account_pool_client_resource)
 
-
+            # OSL
             osl_service_account_pool_client_resource = aws_cognito_user_pool_client(
                 "ocm_osl_service_account",
                 name=f'ocm-{identifier}-osl-service-account',
@@ -4784,7 +4786,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 **pool_client_service_account_common_args_values
             )
             tf_resources.append(osl_service_account_pool_client_resource)
-            # User pool complete
+            # USER POOL COMPLETE
 
             # API GATEWAY
             rest_api_args_values = self.get_values("rest_api_properties")
@@ -4795,6 +4797,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(api_gateway_rest_api_resource)
 
+            # PROXY
             api_gateway_proxy_resource = aws_api_gateway_resource(
                 "gw_resource_proxy",
                 parent_id=api_gateway_rest_api_resource.root_resource_id,
@@ -4803,6 +4806,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(api_gateway_proxy_resource)
 
+            # TOKEN
             api_gateway_token_resource = aws_api_gateway_resource(
                 "gw_resource_token",
                 parent_id=api_gateway_rest_api_resource.root_resource_id,
@@ -4811,6 +4815,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(api_gateway_token_resource)
 
+            # AUTH
             api_gateway_auth_resource = aws_api_gateway_resource(
                 "gw_resource_token",
                 parent_id=api_gateway_rest_api_resource.root_resource_id,
@@ -4819,16 +4824,19 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(api_gateway_auth_resource)
 
+            # AUTHORIZER
             gateway_authorizer_args_values = self.get_values("gateway_authorizer_properties")
             api_gateway_authorizer_resource = aws_api_gateway_authorizer(
                 "gw_authorizer",
-                name=f'{identifier}-authorizer',
+                name=f'ocm-{identifier}-authorizer',
                 rest_api_id=api_gateway_rest_api_resource.id,
                 provider_arns=[cognito_user_pool_resource.arn],
                 **gateway_authorizer_args_values
             )
             tf_resources.append(api_gateway_authorizer_resource)
 
+            # RESUME HERE
+            # ANY METHOD
             gateway_method_any_args_values = self.get_values("gateway_method_any_args")
             api_gateway_method_any_resource = aws_api_gateway_method(
                 "gw_method_any",
@@ -4839,6 +4847,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(api_gateway_method_any_resource)
 
+            # GET TOKEN METHOD
             gateway_method_token_get_args_values = self.get_values("gateway_method_token_get_args")
             api_gateway_method_token_get_resource = aws_api_gateway_method(
                 "gw_method_token_get",
@@ -4848,6 +4857,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(api_gateway_method_token_get_resource)
 
+            # GET TOKEN RESPONSE
             gateway_method_token_get_response_args_values = self.get_values(
                 "gateway_method_token_get_response_args")
             api_gateway_method_token_get_response_resource = aws_api_gateway_method_response(

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4786,10 +4786,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             tf_resources.append(osl_service_account_pool_client_resource)
             # User pool complete
 
-            # API Gateway + associated resources
+            # API GATEWAY
             rest_api_args_values = self.get_values("rest_api_properties")
             api_gateway_rest_api_resource = aws_api_gateway_rest_api(
                 "gw_api",
+                name=f'ocm-{identifier}-rest-api',
                 **rest_api_args_values
             )
             tf_resources.append(api_gateway_rest_api_resource)
@@ -4809,6 +4810,14 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 path_part="token"
             )
             tf_resources.append(api_gateway_token_resource)
+
+            api_gateway_auth_resource = aws_api_gateway_resource(
+                "gw_resource_token",
+                parent_id=api_gateway_rest_api_resource.root_resource_id,
+                rest_api_id=api_gateway_rest_api_resource.id,
+                path_part="auth"
+            )
+            tf_resources.append(api_gateway_auth_resource)
 
             gateway_authorizer_args_values = self.get_values("gateway_authorizer_properties")
             api_gateway_authorizer_resource = aws_api_gateway_authorizer(

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4830,14 +4830,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(api_gateway_vpc_link_resource)
 
-            api_gateway_stage_resource = aws_api_gateway_stage(  # MOVE
-                "gw_stage",
-                deployment_id=api_gateway_deployment_resource.id,
-                rest_api_id=api_gateway_rest_api_resource.id,
-                stage_name="stage"
-            )
-            tf_resources.append(api_gateway_stage_resource)
-
             # FIXME: review
             integration_proxy_args_values = self.get_values("integration_proxy_properties")
             api_gateway_integration_proxy_resource = aws_api_gateway_integration(
@@ -4889,6 +4881,14 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 lifecycle={"create_before_destroy": True}
             )
             tf_resources.append(api_gateway_deployment_resource)
+
+            api_gateway_stage_resource = aws_api_gateway_stage(
+                "gw_stage",
+                deployment_id=api_gateway_deployment_resource.id,
+                rest_api_id=api_gateway_rest_api_resource.id,
+                stage_name="stage"
+            )
+            tf_resources.append(api_gateway_stage_resource)
 
             waf_acl_args_values = self.get_values("waf_acl_properties")
             waf_acl_resource = aws_wafv2_web_acl(

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4599,8 +4599,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                             "sts:ExternalId": self.get_values("sms_role_ext_id")
                         }
                     }
-                }, # FIXME: this combined policy may not work on application. as written,
-                {  # it is an inline policy
+                },  # FIXME: this combined policy may not work on application. as written,
+                {   # it is an inline policy
                     "Effect": "Allow",
                     "Action": [
                         "sns:Publish",

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4694,10 +4694,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
            gateway_method_args and gateway_authorizer_args and integration_args and \
            waf_acl_args:
 
+            # Spin up the user pool
             pool_args_values = self.get_values('pool_args')
             cognito_user_pool_resource = aws_cognito_user_pool(
                 "pool",
                 name=f'{identifier}-pool',
+                lambda_config={
+                    "pre_sign_up": cognito_pre_signup_lambda_resource.arn,
+                    "pre_token_generation": cognito_pre_token_lambda_resource.arn,
+                },
                 **pool_args_values
             )
             tf_resources.append(cognito_user_pool_resource)
@@ -4721,6 +4726,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
             tf_resources.append(cognito_pre_token_lambda_permission_resource)
 
+            # Continue with pool resources
             cognito_user_pool_domain_resource = aws_cognito_user_pool_domain(
                 "userpool_domain",
                 domain=self.get_values("domain"),


### PR DESCRIPTION
# Add rosa-authenticator support to terrascript_client

This MR adds support for multiple terraform resource creation via Terrascript -> Terraform.

This MR depends on MR #38690 in Gitlab, the design document documenting the use case and technical decisions that go into this change.

In addition, this MR will depend on updates to qontract-schemas (https://github.com/app-sre/qontract-schemas/pull/151), forcing default value requirements for associated yaml files. 

App-interface representation of new resources:

```
terraformResources:

- provider: rosa-authenticator
  account: appsrefrp01ugw1
  identifier: rosa-cognito
  domain: cognito.fedramp.devshift.net
  sms_role_ext_id: foobar
  defaults: /terraform/rosa-authenticator-1.yml
```