### PR TITLE
[integrations-manager] add support for image-tag-from-ref

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1840,10 +1840,11 @@ def parse_image_tag_from_ref(ctx, param, value) -> Optional[Dict[str, str]]:
     if value:
         result = {}
         for v in value:
-            if v.count("=") != 1 or v.find("=") == 0:
-                raise ValueError(
-                    'image-tag-from-ref should be of the form "<env_name>=<ref>"'
+            if v.count("=") != 1 or v.startswith("=") or v.endswith("="):
+                logging.error(
+                    f'image-tag-from-ref "{v}" should be of the form "<env_name>=<ref>"'
                 )
+                sys.exit(ExitCodes.ERROR)
             k, v = v.split("=")
             result[k] = v
         return result

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1839,7 +1839,7 @@ def signalfx_prometheus_endpoint_monitoring(
 def validate_image_tag_from_ref(ctx, param, value):
     if value:
         for v in value:
-            if v.count("=") != 1:
+            if v.count("=") != 1 or v.find("=") == 0:
                 raise ValueError(
                     'image-tag-from-ref should be of the form "<env_name>=<ref>"'
                 )

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1836,6 +1836,16 @@ def signalfx_prometheus_endpoint_monitoring(
     )
 
 
+def validate_image_tag_from_ref(ctx, param, value):
+    if value:
+        for v in value:
+            if v.count("=") != 1:
+                raise ValueError(
+                    'image-tag-from-ref should be of the form "<env_name>=<ref>"'
+                )
+        return value
+
+
 @integration.command(short_help="Manages Qontract Reconcile integrations.")
 @environment_name
 @threaded()
@@ -1848,6 +1858,7 @@ def signalfx_prometheus_endpoint_monitoring(
     "-r",
     help="git ref to use as IMAGE_TAG for given environment. example: '--image-tag-from-ref app-interface-dev=master'.",
     multiple=True,
+    callback=validate_image_tag_from_ref,
 )
 @click.pass_context
 def integrations_manager(

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1843,9 +1843,20 @@ def signalfx_prometheus_endpoint_monitoring(
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
+@click.option(
+    "--image-tag-from-ref",
+    "-r",
+    help="git ref to use as IMAGE_TAG for given environment. example: '--image-tag-from-ref app-interface-dev=master'.",
+    multiple=True,
+)
 @click.pass_context
 def integrations_manager(
-    ctx, environment_name, thread_pool_size, internal, use_jump_host
+    ctx,
+    environment_name,
+    thread_pool_size,
+    internal,
+    use_jump_host,
+    image_tag_from_ref,
 ):
     run_integration(
         reconcile.integrations_manager,
@@ -1854,4 +1865,5 @@ def integrations_manager(
         thread_pool_size,
         internal,
         use_jump_host,
+        image_tag_from_ref,
     )

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1836,14 +1836,18 @@ def signalfx_prometheus_endpoint_monitoring(
     )
 
 
-def validate_image_tag_from_ref(ctx, param, value):
+def parse_image_tag_from_ref(ctx, param, value) -> Optional[Dict[str, str]]:
     if value:
+        result = {}
         for v in value:
             if v.count("=") != 1 or v.find("=") == 0:
                 raise ValueError(
                     'image-tag-from-ref should be of the form "<env_name>=<ref>"'
                 )
-        return value
+            k, v = v.split("=")
+            result[k] = v
+        return result
+    return None
 
 
 @integration.command(short_help="Manages Qontract Reconcile integrations.")
@@ -1858,7 +1862,7 @@ def validate_image_tag_from_ref(ctx, param, value):
     "-r",
     help="git ref to use as IMAGE_TAG for given environment. example: '--image-tag-from-ref app-interface-dev=master'.",
     multiple=True,
-    callback=validate_image_tag_from_ref,
+    callback=parse_image_tag_from_ref,
 )
 @click.pass_context
 def integrations_manager(

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -4,6 +4,8 @@ import os
 import sys
 import re
 
+from typing import Dict, Optional
+
 import click
 import sentry_sdk
 

--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -4,7 +4,7 @@ import json
 import logging
 
 from github import Github
-from typing import Any, Dict, List, Mapping, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 import reconcile.openshift_base as ob
 
@@ -46,7 +46,7 @@ def get_image_tag_from_ref(ref: str) -> str:
 def collect_parameters(
     template: Mapping[str, Any],
     environment: Mapping[str, Any],
-    image_tag_from_ref: Tuple[str],
+    image_tag_from_ref: Optional[Tuple[str]],
 ) -> Mapping[str, Any]:
     parameters: Dict[str, Any] = {}
     environment_parameters = environment.get("parameters")
@@ -60,10 +60,11 @@ def collect_parameters(
             if p["name"] in os.environ
         }
         parameters.update(tp_env_vars)
-    for itr in image_tag_from_ref:
-        e, r = itr.split("=")
-        if environment["name"] == e:
-            parameters["IMAGE_TAG"] = get_image_tag_from_ref(r)
+    if image_tag_from_ref:
+        for itr in image_tag_from_ref:
+            e, r = itr.split("=")
+            if environment["name"] == e:
+                parameters["IMAGE_TAG"] = get_image_tag_from_ref(r)
 
     return parameters
 
@@ -71,7 +72,7 @@ def collect_parameters(
 def construct_oc_resources(
     namespace_info: Mapping[str, Any],
     oc: OCDeprecated,
-    image_tag_from_ref: Tuple[str],
+    image_tag_from_ref: Optional[Tuple[str]],
 ) -> List[OpenshiftResource]:
     template = helm.template(construct_values_file(namespace_info["integration_specs"]))
     parameters = collect_parameters(
@@ -93,7 +94,7 @@ def fetch_desired_state(
     namespaces: List[Mapping[str, Any]],
     ri: ResourceInventory,
     oc_map: OC_Map,
-    image_tag_from_ref: Tuple[str],
+    image_tag_from_ref: Optional[Tuple[str]],
 ):
     for namespace_info in namespaces:
         namespace = namespace_info["name"]

--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -3,7 +3,8 @@ import sys
 import json
 import logging
 
-from typing import Any, Dict, List, Mapping
+from github import Github
+from typing import Any, Dict, List, Mapping, Tuple
 
 import reconcile.openshift_base as ob
 
@@ -12,6 +13,7 @@ from reconcile import queries
 from reconcile.status import ExitCodes
 from reconcile.utils.oc import OCDeprecated, OC_Map
 from reconcile.utils.semver_helper import make_semver
+from reconcile.github_org import GH_BASE_URL, get_default_config
 from reconcile.utils.openshift_resource import OpenshiftResource, ResourceInventory
 from reconcile.utils.defer import defer
 
@@ -33,8 +35,18 @@ def construct_values_file(
     return values
 
 
+def get_image_tag_from_ref(ref: str) -> str:
+    settings = queries.get_app_interface_settings()
+    gh_token = get_default_config()["token"]
+    github = Github(gh_token, base_url=GH_BASE_URL)
+    commit_sha = github.get_repo("app-sre/qontract-reconcile").get_commit(sha=ref).sha
+    return commit_sha[: settings["hashLength"]]
+
+
 def collect_parameters(
-    template: Mapping[str, Any], environment: Mapping[str, Any]
+    template: Mapping[str, Any],
+    environment: Mapping[str, Any],
+    image_tag_from_ref: Tuple[str],
 ) -> Mapping[str, Any]:
     parameters: Dict[str, Any] = {}
     environment_parameters = environment.get("parameters")
@@ -48,15 +60,23 @@ def collect_parameters(
             if p["name"] in os.environ
         }
         parameters.update(tp_env_vars)
+    for itr in image_tag_from_ref:
+        e, r = itr.split("=")
+        if environment["name"] == e:
+            parameters["IMAGE_TAG"] = get_image_tag_from_ref(r)
 
     return parameters
 
 
 def construct_oc_resources(
-    namespace_info: Mapping[str, Any], oc: OCDeprecated
+    namespace_info: Mapping[str, Any],
+    oc: OCDeprecated,
+    image_tag_from_ref: Tuple[str],
 ) -> List[OpenshiftResource]:
     template = helm.template(construct_values_file(namespace_info["integration_specs"]))
-    parameters = collect_parameters(template, namespace_info["environment"])
+    parameters = collect_parameters(
+        template, namespace_info["environment"], image_tag_from_ref
+    )
     resources = oc.process(template, parameters)
     return [
         OpenshiftResource(
@@ -70,7 +90,10 @@ def construct_oc_resources(
 
 
 def fetch_desired_state(
-    namespaces: List[Mapping[str, Any]], ri: ResourceInventory, oc_map: OC_Map
+    namespaces: List[Mapping[str, Any]],
+    ri: ResourceInventory,
+    oc_map: OC_Map,
+    image_tag_from_ref: Tuple[str],
 ):
     for namespace_info in namespaces:
         namespace = namespace_info["name"]
@@ -78,7 +101,7 @@ def fetch_desired_state(
         oc = oc_map.get(cluster)
         if not oc:
             continue
-        oc_resources = construct_oc_resources(namespace_info, oc)
+        oc_resources = construct_oc_resources(namespace_info, oc, image_tag_from_ref)
         for r in oc_resources:
             ri.add_desired(cluster, namespace, r.kind, r.name, r)
 
@@ -109,6 +132,7 @@ def run(
     thread_pool_size=10,
     internal=None,
     use_jump_host=True,
+    image_tag_from_ref=None,
     defer=None,
 ):
     namespaces = collect_namespaces(
@@ -128,7 +152,7 @@ def run(
         use_jump_host=use_jump_host,
     )
     defer(oc_map.cleanup)
-    fetch_desired_state(namespaces, ri, oc_map)
+    fetch_desired_state(namespaces, ri, oc_map, image_tag_from_ref)
     ob.realize_data(dry_run, oc_map, ri, thread_pool_size)
 
     if ri.has_error_registered():

--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -46,7 +46,7 @@ def get_image_tag_from_ref(ref: str) -> str:
 def collect_parameters(
     template: Mapping[str, Any],
     environment: Mapping[str, Any],
-    image_tag_from_ref: Optional[Tuple[str]],
+    image_tag_from_ref: Optional[Mapping[str, str]],
 ) -> Mapping[str, Any]:
     parameters: Dict[str, Any] = {}
     environment_parameters = environment.get("parameters")
@@ -61,8 +61,7 @@ def collect_parameters(
         }
         parameters.update(tp_env_vars)
     if image_tag_from_ref:
-        for itr in image_tag_from_ref:
-            e, r = itr.split("=")
+        for e, r in image_tag_from_ref.items():
             if environment["name"] == e:
                 parameters["IMAGE_TAG"] = get_image_tag_from_ref(r)
 
@@ -72,7 +71,7 @@ def collect_parameters(
 def construct_oc_resources(
     namespace_info: Mapping[str, Any],
     oc: OCDeprecated,
-    image_tag_from_ref: Optional[Tuple[str]],
+    image_tag_from_ref: Optional[Mapping[str, str]],
 ) -> List[OpenshiftResource]:
     template = helm.template(construct_values_file(namespace_info["integration_specs"]))
     parameters = collect_parameters(
@@ -94,7 +93,7 @@ def fetch_desired_state(
     namespaces: List[Mapping[str, Any]],
     ri: ResourceInventory,
     oc_map: OC_Map,
-    image_tag_from_ref: Optional[Tuple[str]],
+    image_tag_from_ref: Optional[Mapping[str, str]],
 ):
     for namespace_info in namespaces:
         namespace = namespace_info["name"]

--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -4,7 +4,7 @@ import json
 import logging
 
 from github import Github
-from typing import Any, Dict, List, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional
 
 import reconcile.openshift_base as ob
 

--- a/reconcile/test/test_cli.py
+++ b/reconcile/test/test_cli.py
@@ -1,3 +1,5 @@
+import pytest
+
 from click.testing import CliRunner
 
 import reconcile.cli as reconcile_cli
@@ -7,3 +9,34 @@ def test_config_is_required():
     runner = CliRunner()
     result = runner.invoke(reconcile_cli.integration)
     assert result.exit_code == 0
+
+
+def test_parse_image_tag_from_ref_valid():
+    t = ("env=main",)
+    expected = {"env": "main"}
+    result = reconcile_cli.parse_image_tag_from_ref(None, None, t)
+    assert result == expected
+
+
+def test_parse_image_tag_from_ref_invalid_1():
+    t = ("env=",)
+    with pytest.raises(SystemExit):
+        reconcile_cli.parse_image_tag_from_ref(None, None, t)
+
+
+def test_parse_image_tag_from_ref_invalid_2():
+    t = ("=main",)
+    with pytest.raises(SystemExit):
+        reconcile_cli.parse_image_tag_from_ref(None, None, t)
+
+
+def test_parse_image_tag_from_ref_invalid_3():
+    t = ("=",)
+    with pytest.raises(SystemExit):
+        reconcile_cli.parse_image_tag_from_ref(None, None, t)
+
+
+def test_parse_image_tag_from_ref_invalid_4():
+    t = ("env=main=test",)
+    with pytest.raises(SystemExit):
+        reconcile_cli.parse_image_tag_from_ref(None, None, t)

--- a/reconcile/test/test_cli.py
+++ b/reconcile/test/test_cli.py
@@ -3,9 +3,7 @@ from click.testing import CliRunner
 import reconcile.cli as reconcile_cli
 
 
-class TestCli:
-    @staticmethod
-    def test_config_is_required():
-        runner = CliRunner()
-        result = runner.invoke(reconcile_cli.integration)
-        assert result.exit_code == 0
+def test_config_is_required():
+    runner = CliRunner()
+    result = runner.invoke(reconcile_cli.integration)
+    assert result.exit_code == 0

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -111,7 +111,7 @@ def test_collect_parameters_image_tag_from_ref(mocker):
         "name": "env",
         "parameters": '{"IMAGE_TAG": "default"}',
     }
-    image_tag_from_ref = ("env=f44e417",)
+    image_tag_from_ref = {"env": "f44e417"}
     mocker.patch(
         "reconcile.integrations_manager.get_image_tag_from_ref", return_value="f44e417"
     )

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -50,7 +50,7 @@ def test_collect_parameters():
     environment = {
         "parameters": '{"env_param": "test"}',
     }
-    parameters = intop.collect_parameters(template, environment)
+    parameters = intop.collect_parameters(template, environment, ())
     expected = {
         "env_param": "test",
         "tplt_param": "override",
@@ -70,7 +70,7 @@ def test_collect_parameters_env_stronger():
     environment = {
         "parameters": '{"env_param": "override"}',
     }
-    parameters = intop.collect_parameters(template, environment)
+    parameters = intop.collect_parameters(template, environment, ())
     expected = {
         "env_param": "override",
     }
@@ -90,9 +90,34 @@ def test_collect_parameters_os_env_strongest():
     environment = {
         "parameters": '{"env_param": "override"}',
     }
-    parameters = intop.collect_parameters(template, environment)
+    parameters = intop.collect_parameters(template, environment, ())
     expected = {
         "env_param": "strongest",
+    }
+    assert parameters == expected
+
+
+def test_collect_parameters_image_tag_from_ref(mocker):
+    template = {
+        "parameters": [
+            {
+                "name": "IMAGE_TAG",
+                "value": "dummy",
+            }
+        ]
+    }
+    os.environ["IMAGE_TAG"] = "override"
+    environment = {
+        "name": "env",
+        "parameters": '{"IMAGE_TAG": "default"}',
+    }
+    image_tag_from_ref = ("env=f44e417",)
+    mocker.patch(
+        "reconcile.integrations_manager.get_image_tag_from_ref", return_value="f44e417"
+    )
+    parameters = intop.collect_parameters(template, environment, image_tag_from_ref)
+    expected = {
+        "IMAGE_TAG": "f44e417",
     }
     assert parameters == expected
 

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List, Mapping
+from typing import Any, Dict, List, Mapping, Tuple
 import pytest
 
 import reconcile.integrations_manager as intop
@@ -50,7 +50,7 @@ def test_collect_parameters():
     environment = {
         "parameters": '{"env_param": "test"}',
     }
-    parameters = intop.collect_parameters(template, environment, ())
+    parameters = intop.collect_parameters(template, environment, None)
     expected = {
         "env_param": "test",
         "tplt_param": "override",
@@ -70,7 +70,7 @@ def test_collect_parameters_env_stronger():
     environment = {
         "parameters": '{"env_param": "override"}',
     }
-    parameters = intop.collect_parameters(template, environment, ())
+    parameters = intop.collect_parameters(template, environment, None)
     expected = {
         "env_param": "override",
     }
@@ -90,7 +90,7 @@ def test_collect_parameters_os_env_strongest():
     environment = {
         "parameters": '{"env_param": "override"}',
     }
-    parameters = intop.collect_parameters(template, environment, ())
+    parameters = intop.collect_parameters(template, environment, None)
     expected = {
         "env_param": "strongest",
     }

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -1,5 +1,5 @@
 import os
-from typing import Any, Dict, List, Mapping, Tuple
+from typing import Any, Dict, List, Mapping
 import pytest
 
 import reconcile.integrations_manager as intop


### PR DESCRIPTION
when running integrations-manager against multiple environments, each such environment may have a different version of integrations-manager running. as a result, managed integrations in different environments will be using a different `IMAGE_TAG`.

for this reason, running integrations-manager without environment awareness (`ENVIRONMENT_NAME`, `IMAGE_TAG` env vars) will result in the integration wanting to update all integrations in all environments to use `latest` (the default from the OpenShift template).

this PR adds an option to pass a list of environments, and for each of them - which `ref` of the qontract-reconcile repository should be used.

with this change, integrations-manager can run (specifically in dry-run) without showing any changes when there aren't any changes required.