### PR TITLE
[sql-query] fix usage of terrascript

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1538,6 +1538,12 @@ APP_INTERFACE_SQL_QUERIES_QUERY = """
           overrides
         }
       }
+      app {
+        name
+      }
+      environment {
+        name
+      }
       cluster
       {
         name


### PR DESCRIPTION
since sql-query is using terrascript to get info of the DB to be queries, we need to conform to the namespace required fields that were added in #2386