### PR TITLE
[terraform-resources] update _is_ignored_rds_modification to handle missing keys

### DIFF
--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -517,7 +517,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         before = resource_change['before']
         after = resource_change['after']
         changed_terraform_args = [
-            key for key, value in before.items() if value != after[key]
+            key for key, value in before.items() if value != after.get(key)
         ]
         if len(changed_terraform_args) == 1 \
                 and 'engine_version' in changed_terraform_args:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/bin/qontract-reconcile", line 8, in <module>
    sys.exit(integration())
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/binary.py", line 22, in f_binary
    f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/binary.py", line 72, in f_binary_version
    f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/binary.py", line 72, in f_binary_version
    f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/cli.py", line 1322, in terraform_resources
    run_integration(
  File "/usr/local/lib/python3.9/site-packages/reconcile/cli.py", line 485, in run_integration
    func_container.run(dry_run, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/defer.py", line 18, in func_wrapper
    return func(*args, defer=defer, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/terraform_resources.py", line 643, in run
    disabled_deletions_detected, err = tf.plan(enable_deletion)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/terraform_client.py", line 135, in plan
    results = threaded.run(self.terraform_plan, self.specs,
  File "/usr/local/lib/python3.9/site-packages/sretoolbox/utils/threaded.py", line 41, in run
    return pool.map(func_partial, iterable)
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 364, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 771, in get
    raise self._value
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/usr/local/lib/python3.9/site-packages/sretoolbox/utils/threaded.py", line 81, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/sretoolbox/utils/retry.py", line 78, in f_retry
    raise exception
  File "/usr/local/lib/python3.9/site-packages/sretoolbox/utils/retry.py", line 73, in f_retry
    return function(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/terraform_client.py", line 169, in terraform_plan
    self.log_plan_diff(name, tf, enable_deletion)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/terraform_client.py", line 240, in log_plan_diff
    self._is_ignored_rds_modification(
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/terraform_client.py", line 519, in _is_ignored_rds_modification
    changed_terraform_args = [
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/terraform_client.py", line 520, in <listcomp>
    key for key, value in before.items() if value != after[key]
KeyError: 'monitoring_role_arn'
```