### PR TITLE
[terraform-resources-wrapper] fix calling integraions name for filtering out clusters

### DIFF
--- a/reconcile/terraform_resources_wrapper.py
+++ b/reconcile/terraform_resources_wrapper.py
@@ -43,6 +43,8 @@ def tfr_run_wrapper(
     extra_labels,
 ):
     exit_code = 0
+    tfr.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION
+    tfr.QONTRACT_INTEGRATION_VERSION = QONTRACT_INTEGRATION_VERSION
     try:
         tfr.run(
             dry_run=dry_run,


### PR DESCRIPTION
when disabling terraform-resources from a cluster, the cluster doesn't understand that the calling integration is the wrapper.
ref: https://github.com/app-sre/qontract-reconcile/blob/55751e39d6bf49c2fa43c0bd80cebcbb1c85fa06/reconcile/terraform_resources.py#L429

this approach is similar to: https://github.com/app-sre/qontract-reconcile/blob/55751e39d6bf49c2fa43c0bd80cebcbb1c85fa06/reconcile/openshift_vault_secrets.py#L19-L20