### PR TITLE
Persist session

### DIFF
--- a/reconcile/checkpoint.py
+++ b/reconcile/checkpoint.py
@@ -18,6 +18,7 @@ from jira import Issue
 
 from reconcile.utils.constants import PROJ_ROOT
 from reconcile.utils.jira_client import JiraClient
+from reconcile.utils.requests import global_session_cache
 
 DEFAULT_CHECKPOINT_LABELS = ("sre-checkpoint",)
 
@@ -34,7 +35,9 @@ local_session = threading.local()
 def get_local_session() -> requests.Session:
     s = getattr(local_session, "session", None)
     if not s:
-        local_session.session = requests.session()
+        s = requests.Session()
+        local_session.session = s
+        global_session_cache.add_session(s)
     return local_session.session
 
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -125,6 +125,7 @@ from reconcile.utils.gql import GqlApiErrorForbiddenSchema, GqlApiIntegrationNot
 from reconcile.utils.aggregated_list import RunnerException
 from reconcile.utils.binary import binary, binary_version
 from reconcile.utils.environ import environ
+from reconcile.utils.requests import global_session_cache
 from reconcile.utils.unleash import get_feature_toggle_state
 from reconcile.utils.exceptions import PrintToFileInGitRepositoryError
 from reconcile.utils.git import is_file_in_git_repo
@@ -529,6 +530,20 @@ def integration(
     ctx.obj["gql_sha_url"] = gql_sha_url
     ctx.obj["gql_url_print"] = gql_url_print
     ctx.obj["dump_schemas_file"] = dump_schemas_file
+
+
+@integration.result_callback()
+def exit_integration(
+    ctx,
+    configfile,
+    dry_run,
+    validate_schemas,
+    dump_schemas_file,
+    log_level,
+    gql_sha_url,
+    gql_url_print,
+):
+    global_session_cache.close_all()
 
 
 @integration.command(short_help="Manage AWS Route53 resources using Terraform.")

--- a/reconcile/test/test_checkpoint.py
+++ b/reconcile/test/test_checkpoint.py
@@ -51,7 +51,7 @@ def test_invalid_owners_remain_invalid(valid_owner, invalid_owner):
 
 def test_url_makes_sense_ok(mocker):
     """Good URLs are accepted."""
-    get = mocker.patch.object(requests, "get", autospec=True)
+    get = mocker.patch.object(requests.Session, "get", autospec=True)
     r = requests.Response()
     r.status_code = HTTPStatus.OK
     get.return_value = r

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -197,17 +197,14 @@ def get_resource(path: str) -> dict[str, Any]:
 class PersistentRequestsHTTPTransport(RequestsHTTPTransport):
     def connect(self):
         if self.session is None:
-            # Creating a session that can later be re-use to configure custom mechanisms
+            # Copied over from RequestsHTTPTransport
             self.session = requests.Session()
-
-            # If we specified some retries, we provide a predefined retry-logic
             if self.retries > 0:
                 adapter = HTTPAdapter(
                     max_retries=Retry(
                         total=self.retries,
                         backoff_factor=0.1,
                         status_forcelist=[500, 502, 503, 504],
-                        allowed_methods=None,
                     )
                 )
             for prefix in "http://", "https://":

--- a/reconcile/utils/promtool.py
+++ b/reconcile/utils/promtool.py
@@ -1,5 +1,4 @@
 import copy
-import logging
 import os
 import subprocess
 import tempfile

--- a/reconcile/utils/promtool.py
+++ b/reconcile/utils/promtool.py
@@ -1,4 +1,5 @@
 import copy
+import logging
 import os
 import subprocess
 import tempfile

--- a/reconcile/utils/requests.py
+++ b/reconcile/utils/requests.py
@@ -1,0 +1,46 @@
+import weakref
+from threading import Lock
+
+import requests
+
+
+class SessionClosingCache:
+    """
+    SessionClosingCache:
+        Add session objects to cache
+        Cache will hold weakreference to that session object
+        The weakreference will also close the session
+        Additionally on ending the program, close_all should be called
+        Technically it could happen we call close() twice on a session
+    """
+
+    def __init__(self):
+        self.foo = "bar"
+        self.cache: list[weakref] = []
+        self.finalizer = []
+        self.cache_lock = Lock()
+
+    @staticmethod
+    def __default_finalizer(s: requests.Session):
+        s.close()
+
+    def add_session(self, session: requests.Session):
+        self.cache_lock.acquire(blocking=True)
+        self.cache.append(weakref.ref(session))
+
+        # This finalizer
+        self.finalizer.append(
+            weakref.finalize(session, self.__default_finalizer, session)
+        )
+        self.cache_lock.release()
+
+    def close_all(self):
+        self.cache_lock.acquire(blocking=True)
+        for s in self.cache:
+            session = s()
+            if session:
+                session.close()
+        self.cache_lock.release()
+
+
+global_session_cache = SessionClosingCache()

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -21,6 +21,7 @@ from reconcile.jenkins_job_builder import init_jjb
 from reconcile.utils.jjb_client import JJB
 from reconcile.utils.oc import OC_Map
 from reconcile.utils.ocm import OCMMap
+from reconcile.utils.requests import global_session_cache
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.semver_helper import parse_semver
 from reconcile.utils.state import State
@@ -63,6 +64,11 @@ def root(ctx, configfile):
     ctx.ensure_object(dict)
     config.init_from_toml(configfile)
     gql.init_from_config()
+
+
+@root.result_callback()
+def exit_cli(ctx, confifile):
+    global_session_cache.close_all()
 
 
 @root.group()


### PR DESCRIPTION
Persisting session eliminates the need to create a new HTTPS session for every query and HTTP lookup. In my tests, this sped up integration prometheus-rule-tester by up to 15%

Ticket: [APPSRE-5616](https://issues.redhat.com/browse/APPSRE-5616)