### PR TITLE
[openshift-saas-deploy-trigger] add information on what caused a trigger

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -455,6 +455,17 @@ def enable_rebase(**kwargs):
     return f
 
 
+def include_trigger_trace(function):
+    help_msg = "If `true`, include traces of the triggering integration and reason."
+
+    function = click.option(
+        "--include-trigger-trace/--no-include-trigger-trace",
+        default=False,
+        help=help_msg,
+    )(function)
+    return function
+
+
 def run_integration(func_container, ctx, *args, **kwargs):
     try:
         int_name = func_container.QONTRACT_INTEGRATION.replace("_", "-")
@@ -958,9 +969,10 @@ def saas_file_validator(ctx):
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
+@include_trigger_trace
 @click.pass_context
 def openshift_saas_deploy_trigger_moving_commits(
-    ctx, thread_pool_size, internal, use_jump_host
+    ctx, thread_pool_size, internal, use_jump_host, include_trigger_trace
 ):
     run_integration(
         reconcile.openshift_saas_deploy_trigger_moving_commits,
@@ -968,6 +980,7 @@ def openshift_saas_deploy_trigger_moving_commits(
         thread_pool_size,
         internal,
         use_jump_host,
+        include_trigger_trace,
     )
 
 
@@ -978,9 +991,10 @@ def openshift_saas_deploy_trigger_moving_commits(
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
+@include_trigger_trace
 @click.pass_context
 def openshift_saas_deploy_trigger_upstream_jobs(
-    ctx, thread_pool_size, internal, use_jump_host
+    ctx, thread_pool_size, internal, use_jump_host, include_trigger_trace
 ):
     run_integration(
         reconcile.openshift_saas_deploy_trigger_upstream_jobs,
@@ -988,6 +1002,7 @@ def openshift_saas_deploy_trigger_upstream_jobs(
         thread_pool_size,
         internal,
         use_jump_host,
+        include_trigger_trace,
     )
 
 
@@ -998,9 +1013,10 @@ def openshift_saas_deploy_trigger_upstream_jobs(
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
+@include_trigger_trace
 @click.pass_context
 def openshift_saas_deploy_trigger_configs(
-    ctx, thread_pool_size, internal, use_jump_host
+    ctx, thread_pool_size, internal, use_jump_host, include_trigger_trace
 ):
     run_integration(
         reconcile.openshift_saas_deploy_trigger_configs,
@@ -1008,6 +1024,7 @@ def openshift_saas_deploy_trigger_configs(
         thread_pool_size,
         internal,
         use_jump_host,
+        include_trigger_trace,
     )
 
 

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -196,7 +196,6 @@ def trigger(
     # TODO: Convert these into a dataclass.
     saas_file_name = spec["saas_file_name"]
     provider_name = spec["pipelines_provider"]["provider"]
-    reason = spec["reason"]
 
     error = False
     if provider_name == Providers.TEKTON:
@@ -209,7 +208,6 @@ def trigger(
             trigger_type,
             integration,
             integration_version,
-            reason,
         )
     else:
         error = True
@@ -227,7 +225,6 @@ def _trigger_tekton(
     trigger_type,
     integration,
     integration_version,
-    reason,
 ):
     # TODO: Convert these into a dataclass.
     saas_file_name = spec["saas_file_name"]
@@ -275,7 +272,7 @@ def _trigger_tekton(
         integration,
         integration_version,
         saasherder.include_trigger_trace,
-        reason,
+        spec.get("reason"),
     )
 
     error = False
@@ -332,8 +329,8 @@ def _construct_tekton_trigger_resource(
         tkn_namespace_name (string): namespace where the pipeline runs
         integration (string): Name of calling integration
         integration_version (string): Version of calling integration
-        reason (string): The reason this trigger was created
         include_trigger_trace (bool): Should include traces of the triggering integration and reason
+        reason (string): The reason this trigger was created
 
     Returns:
         OpenshiftResource: OpenShift resource to be applied

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -57,6 +57,7 @@ def run(
         use_jump_host=use_jump_host,
         integration=integration,
         integration_version=integration_version,
+        include_trigger_trace=include_trigger_trace,
     )
     if error:
         return error
@@ -80,14 +81,20 @@ def run(
         trigger_type=trigger_type,
         integration=integration,
         integration_version=integration_version,
-        include_trigger_trace=include_trigger_trace,
     )
     errors.append(diff_err)
 
     return any(errors)
 
 
-def setup(thread_pool_size, internal, use_jump_host, integration, integration_version):
+def setup(
+    thread_pool_size,
+    internal,
+    use_jump_host,
+    integration,
+    integration_version,
+    include_trigger_trace,
+):
     """Setup required resources for triggering integrations
 
     Args:
@@ -96,6 +103,7 @@ def setup(thread_pool_size, internal, use_jump_host, integration, integration_ve
         use_jump_host (bool): Should use jump host to reach clusters
         integration (string): Name of calling integration
         integration_version (string): Version of calling integration
+        include_trigger_trace (bool): Should include traces of the triggering integration and reason
 
     Returns:
         saasherder (SaasHerder): a SaasHerder instance
@@ -148,6 +156,7 @@ def setup(thread_pool_size, internal, use_jump_host, integration, integration_ve
         settings=settings,
         jenkins_map=jenkins_map,
         accounts=accounts,
+        include_trigger_trace=include_trigger_trace,
     )
 
     return saasherder, jenkins_map, oc_map, settings, False
@@ -164,7 +173,6 @@ def trigger(
     trigger_type,
     integration,
     integration_version,
-    include_trigger_trace,
 ):
     """Trigger a deployment according to the specified pipelines provider
 
@@ -180,7 +188,6 @@ def trigger(
         trigger_type (string): Indicates which method to call to update state
         integration (string): Name of calling integration
         integration_version (string): Version of calling integration
-        include_trigger_trace (bool): Should include traces of the triggering integration and reason
 
     Returns:
         bool: True if there was an error, False otherwise
@@ -202,7 +209,6 @@ def trigger(
             trigger_type,
             integration,
             integration_version,
-            include_trigger_trace,
             reason,
         )
     else:
@@ -221,7 +227,6 @@ def _trigger_tekton(
     trigger_type,
     integration,
     integration_version,
-    include_trigger_trace,
     reason,
 ):
     # TODO: Convert these into a dataclass.
@@ -269,7 +274,7 @@ def _trigger_tekton(
         tkn_namespace_name,
         integration,
         integration_version,
-        include_trigger_trace,
+        saasherder.include_trigger_trace,
         reason,
     )
 

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -32,6 +32,7 @@ def run(
     thread_pool_size,
     internal,
     use_jump_host,
+    include_trigger_trace,
     defer=None,
 ):
     """Run trigger integration
@@ -45,6 +46,7 @@ def run(
         thread_pool_size (int): Thread pool size to use
         internal (bool): Should run for internal/extrenal/all clusters
         use_jump_host (bool): Should use jump host to reach clusters
+        include_trigger_trace (bool): Should include traces of the triggering integration and reason
 
     Returns:
         bool: True if there was an error, False otherwise
@@ -78,6 +80,7 @@ def run(
         trigger_type=trigger_type,
         integration=integration,
         integration_version=integration_version,
+        include_trigger_trace=include_trigger_trace,
     )
     errors.append(diff_err)
 
@@ -161,6 +164,7 @@ def trigger(
     trigger_type,
     integration,
     integration_version,
+    include_trigger_trace,
 ):
     """Trigger a deployment according to the specified pipelines provider
 
@@ -176,6 +180,7 @@ def trigger(
         trigger_type (string): Indicates which method to call to update state
         integration (string): Name of calling integration
         integration_version (string): Version of calling integration
+        include_trigger_trace (bool): Should include traces of the triggering integration and reason
 
     Returns:
         bool: True if there was an error, False otherwise
@@ -197,6 +202,7 @@ def trigger(
             trigger_type,
             integration,
             integration_version,
+            include_trigger_trace,
             reason,
         )
     else:
@@ -215,6 +221,7 @@ def _trigger_tekton(
     trigger_type,
     integration,
     integration_version,
+    include_trigger_trace,
     reason,
 ):
     # TODO: Convert these into a dataclass.
@@ -262,6 +269,7 @@ def _trigger_tekton(
         tkn_namespace_name,
         integration,
         integration_version,
+        include_trigger_trace,
         reason,
     )
 
@@ -306,6 +314,7 @@ def _construct_tekton_trigger_resource(
     tkn_namespace_name,
     integration,
     integration_version,
+    include_trigger_trace,
     reason,
 ):
     """Construct a resource (PipelineRun) to trigger a deployment via Tekton.
@@ -319,6 +328,7 @@ def _construct_tekton_trigger_resource(
         integration (string): Name of calling integration
         integration_version (string): Version of calling integration
         reason (string): The reason this trigger was created
+        include_trigger_trace (bool): Should include traces of the triggering integration and reason
 
     Returns:
         OpenshiftResource: OpenShift resource to be applied
@@ -331,20 +341,26 @@ def _construct_tekton_trigger_resource(
     # max name length can be 63. leaving 12 for the timestamp - 51
     name = f"{long_name[:UNIQUE_SAAS_FILE_ENV_COMBO_LEN]}-{ts}"
 
+    parameters = [
+        {"name": "saas_file_name", "value": saas_file_name},
+        {"name": "env_name", "value": env_name},
+        {"name": "tkn_cluster_console_url", "value": tkn_cluster_console_url},
+        {"name": "tkn_namespace_name", "value": tkn_namespace_name},
+    ]
+    if include_trigger_trace:
+        parameters.extend(
+            [
+                {"name": "trigger_integration", "value": integration},
+                {"name": "trigger_reason", "value": reason},
+            ]
+        )
     body = {
         "apiVersion": "tekton.dev/v1beta1",
         "kind": "PipelineRun",
         "metadata": {"name": name},
         "spec": {
             "pipelineRef": {"name": tkn_pipeline_name},
-            "params": [
-                {"name": "saas_file_name", "value": saas_file_name},
-                {"name": "env_name", "value": env_name},
-                {"name": "tkn_cluster_console_url", "value": tkn_cluster_console_url},
-                {"name": "tkn_namespace_name", "value": tkn_namespace_name},
-                {"name": "trigger_integration", "value": integration},
-                {"name": "trigger_reason", "value": reason},
-            ],
+            "params": parameters,
         },
     }
     return OR(body, integration, integration_version, error_details=name), long_name

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -184,6 +184,7 @@ def trigger(
     # TODO: Convert these into a dataclass.
     saas_file_name = spec["saas_file_name"]
     provider_name = spec["pipelines_provider"]["provider"]
+    reason = spec["reason"]
 
     error = False
     if provider_name == Providers.TEKTON:
@@ -196,6 +197,7 @@ def trigger(
             trigger_type,
             integration,
             integration_version,
+            reason,
         )
     else:
         error = True
@@ -213,6 +215,7 @@ def _trigger_tekton(
     trigger_type,
     integration,
     integration_version,
+    reason,
 ):
     # TODO: Convert these into a dataclass.
     saas_file_name = spec["saas_file_name"]
@@ -259,6 +262,7 @@ def _trigger_tekton(
         tkn_namespace_name,
         integration,
         integration_version,
+        reason,
     )
 
     error = False
@@ -302,6 +306,7 @@ def _construct_tekton_trigger_resource(
     tkn_namespace_name,
     integration,
     integration_version,
+    reason,
 ):
     """Construct a resource (PipelineRun) to trigger a deployment via Tekton.
 
@@ -313,6 +318,7 @@ def _construct_tekton_trigger_resource(
         tkn_namespace_name (string): namespace where the pipeline runs
         integration (string): Name of calling integration
         integration_version (string): Version of calling integration
+        reason (string): The reason this trigger was created
 
     Returns:
         OpenshiftResource: OpenShift resource to be applied
@@ -337,6 +343,7 @@ def _construct_tekton_trigger_resource(
                 {"name": "tkn_cluster_console_url", "value": tkn_cluster_console_url},
                 {"name": "tkn_namespace_name", "value": tkn_namespace_name},
                 {"name": "trigger_integration", "value": integration},
+                {"name": "trigger_reason", "value": reason},
             ],
         },
     }

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -336,6 +336,7 @@ def _construct_tekton_trigger_resource(
                 {"name": "env_name", "value": env_name},
                 {"name": "tkn_cluster_console_url", "value": tkn_cluster_console_url},
                 {"name": "tkn_namespace_name", "value": tkn_namespace_name},
+                {"name": "trigger_integration", "value": integration},
             ],
         },
     }

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -8,7 +8,7 @@ from reconcile.utils.semver_helper import make_semver
 
 
 QONTRACT_INTEGRATION = "openshift-saas-deploy-trigger-configs"
-QONTRACT_INTEGRATION_VERSION = make_semver(0, 2, 0)
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 3, 0)
 
 
 def run(

--- a/reconcile/openshift_saas_deploy_trigger_configs.py
+++ b/reconcile/openshift_saas_deploy_trigger_configs.py
@@ -11,7 +11,13 @@ QONTRACT_INTEGRATION = "openshift-saas-deploy-trigger-configs"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 2, 0)
 
 
-def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True):
+def run(
+    dry_run,
+    thread_pool_size=10,
+    internal=None,
+    use_jump_host=True,
+    include_trigger_trace=False,
+):
     error = osdt_base.run(
         dry_run=dry_run,
         trigger_type=TriggerTypes.CONFIGS,
@@ -20,6 +26,7 @@ def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True):
         thread_pool_size=thread_pool_size,
         internal=internal,
         use_jump_host=use_jump_host,
+        include_trigger_trace=include_trigger_trace,
     )
 
     if error:

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -11,7 +11,13 @@ QONTRACT_INTEGRATION = "openshift-saas-deploy-trigger-moving-commits"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 2, 0)
 
 
-def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True):
+def run(
+    dry_run,
+    thread_pool_size=10,
+    internal=None,
+    use_jump_host=True,
+    include_trigger_trace=False,
+):
     error = osdt_base.run(
         dry_run=dry_run,
         trigger_type=TriggerTypes.MOVING_COMMITS,
@@ -20,6 +26,7 @@ def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True):
         thread_pool_size=thread_pool_size,
         internal=internal,
         use_jump_host=use_jump_host,
+        include_trigger_trace=include_trigger_trace,
     )
 
     if error:

--- a/reconcile/openshift_saas_deploy_trigger_moving_commits.py
+++ b/reconcile/openshift_saas_deploy_trigger_moving_commits.py
@@ -8,7 +8,7 @@ from reconcile.utils.semver_helper import make_semver
 
 
 QONTRACT_INTEGRATION = "openshift-saas-deploy-trigger-moving-commits"
-QONTRACT_INTEGRATION_VERSION = make_semver(0, 2, 0)
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 3, 0)
 
 
 def run(

--- a/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
+++ b/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
@@ -8,7 +8,7 @@ from reconcile.utils.semver_helper import make_semver
 
 
 QONTRACT_INTEGRATION = "openshift-saas-deploy-trigger-upstream-jobs"
-QONTRACT_INTEGRATION_VERSION = make_semver(0, 2, 0)
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 3, 0)
 
 
 def run(

--- a/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
+++ b/reconcile/openshift_saas_deploy_trigger_upstream_jobs.py
@@ -11,7 +11,13 @@ QONTRACT_INTEGRATION = "openshift-saas-deploy-trigger-upstream-jobs"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 2, 0)
 
 
-def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True):
+def run(
+    dry_run,
+    thread_pool_size=10,
+    internal=None,
+    use_jump_host=True,
+    include_trigger_trace=False,
+):
     error = osdt_base.run(
         dry_run=dry_run,
         trigger_type=TriggerTypes.UPSTREAM_JOBS,
@@ -20,6 +26,7 @@ def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True):
         thread_pool_size=thread_pool_size,
         internal=internal,
         use_jump_host=use_jump_host,
+        include_trigger_trace=include_trigger_trace,
     )
 
     if error:

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1804,6 +1804,7 @@ SAAS_FILES_QUERY_V2 = """
         upstream {
           instance {
             name
+            serverUrl
           }
           name
         }

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -15,6 +15,7 @@ from reconcile.utils import gql
 APP_INTERFACE_SETTINGS_QUERY = """
 {
   settings: app_interface_settings_v1 {
+    instanceUrl
     vault
     kubeBinary
     mergeRequestGateway

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -339,6 +339,51 @@ class TestGetMovingCommitsDiffSaasFile(TestCase):
                 "pipelines_provider": "apipelineprovider",
                 "namespace_name": "ns",
                 "rt_name": "rt",
+            },
+            {
+                "saas_file_name": self.saas_files[0]["name"],
+                "env_name": "env2",
+                "timeout": None,
+                "ref": "secondary",
+                "commit_sha": "4242efg",
+                "cluster_name": "cluster2",
+                "pipelines_provider": "apipelineprovider",
+                "namespace_name": "ns",
+                "rt_name": "rt",
+            },
+        ]
+
+        self.assertEqual(
+            saasherder.get_moving_commits_diff_saas_file(self.saas_files[0], True),
+            expected,
+        )
+
+    def test_get_moving_commits_diff_saas_file_all_fine_include_trigger_trace(self):
+        saasherder = SaasHerder(
+            self.saas_files,
+            thread_pool_size=1,
+            gitlab=None,
+            integration="",
+            integration_version="",
+            settings={},
+            validate=False,
+            include_trigger_trace=True,
+        )
+        saasherder.state = MagicMock()
+        saasherder.state.get.return_value = "asha"
+        self.get_commit_sha.side_effect = ("abcd4242", "4242efg")
+        self.get_pipelines_provider.return_value = "apipelineprovider"
+        expected = [
+            {
+                "saas_file_name": self.saas_files[0]["name"],
+                "env_name": "env1",
+                "timeout": None,
+                "ref": "main",
+                "commit_sha": "abcd4242",
+                "cluster_name": "cluster1",
+                "pipelines_provider": "apipelineprovider",
+                "namespace_name": "ns",
+                "rt_name": "rt",
                 "reason": "http://github.com/user/repo/commit/abcd4242",
             },
             {

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -339,6 +339,7 @@ class TestGetMovingCommitsDiffSaasFile(TestCase):
                 "pipelines_provider": "apipelineprovider",
                 "namespace_name": "ns",
                 "rt_name": "rt",
+                "reason": "http://github.com/user/repo/commit/abcd4242",
             },
             {
                 "saas_file_name": self.saas_files[0]["name"],
@@ -350,6 +351,7 @@ class TestGetMovingCommitsDiffSaasFile(TestCase):
                 "pipelines_provider": "apipelineprovider",
                 "namespace_name": "ns",
                 "rt_name": "rt",
+                "reason": "http://github.com/user/repo/commit/4242efg",
             },
         ]
 

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -1188,6 +1188,7 @@ class SaasHerder:
                         "namespace_name": namespace_name,
                         "ref": ref,
                         "commit_sha": desired_commit_sha,
+                        "reason": f"{url}/commit/{desired_commit_sha}",
                     }
                     trigger_specs.append(job_spec)
                 except (GithubException, GitlabError):

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -20,6 +20,7 @@ from sretoolbox.utils import retry
 from sretoolbox.utils import threaded
 
 from reconcile.github_org import get_default_config
+from reconcile.status import RunningState
 from reconcile.utils.mr.auto_promoter import AutoPromoter
 from reconcile.utils.oc import OC, StatusCodeError
 from reconcile.utils.openshift_resource import (
@@ -1383,6 +1384,7 @@ class SaasHerder:
                 "cluster_name": cluster_name,
                 "namespace_name": namespace_name,
                 "target_config": desired_target_config,
+                "reason": f"app-interface:{RunningState().commit}",
             }
             trigger_specs.append(job_spec)
         return trigger_specs

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -1386,7 +1386,7 @@ class SaasHerder:
                 "cluster_name": cluster_name,
                 "namespace_name": namespace_name,
                 "target_config": desired_target_config,
-                "reason": f"app-interface:{RunningState().commit}",
+                "reason": f"{self.settings['instanceUrl']}/commit/{RunningState().commit}",
             }
             trigger_specs.append(job_spec)
         return trigger_specs

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -1191,8 +1191,9 @@ class SaasHerder:
                         "namespace_name": namespace_name,
                         "ref": ref,
                         "commit_sha": desired_commit_sha,
-                        "reason": f"{url}/commit/{desired_commit_sha}",
                     }
+                    if self.include_trigger_trace:
+                        job_spec["reason"] = f"{url}/commit/{desired_commit_sha}"
                     trigger_specs.append(job_spec)
                 except (GithubException, GitlabError):
                     logging.exception(
@@ -1313,8 +1314,9 @@ class SaasHerder:
                         "instance_name": instance_name,
                         "job_name": job_name,
                         "last_build_result": last_build_result,
-                        "reason": f"{upstream['instance']['serverUrl']}/job/{job_name}/{last_build_result_number}",
                     }
+                    if self.include_trigger_trace:
+                        job_spec["reason"] = f"{upstream['instance']['serverUrl']}/job/{job_name}/{last_build_result_number}"
                     trigger_specs.append(job_spec)
 
         return trigger_specs
@@ -1386,8 +1388,9 @@ class SaasHerder:
                 "cluster_name": cluster_name,
                 "namespace_name": namespace_name,
                 "target_config": desired_target_config,
-                "reason": f"{self.settings['instanceUrl']}/commit/{RunningState().commit}",
             }
+            if self.include_trigger_trace:
+                job_spec["reason"] = f"{self.settings['instanceUrl']}/commit/{RunningState().commit}"
             trigger_specs.append(job_spec)
         return trigger_specs
 

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -1310,6 +1310,7 @@ class SaasHerder:
                         "instance_name": instance_name,
                         "job_name": job_name,
                         "last_build_result": last_build_result,
+                        "reason": f"{upstream['instance']['serverUrl']}/job/{job_name}/{last_build_result_number}",
                     }
                     trigger_specs.append(job_spec)
 

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -75,6 +75,7 @@ class SaasHerder:
         jenkins_map=None,
         accounts=None,
         validate=False,
+        include_trigger_trace=False,
     ):
         self.saas_files = saas_files
         self.repo_urls = self._collect_repo_urls()
@@ -90,6 +91,7 @@ class SaasHerder:
         self.secret_reader = SecretReader(settings=settings)
         self.namespaces = self._collect_namespaces()
         self.jenkins_map = jenkins_map
+        self.include_trigger_trace = include_trigger_trace
         # each namespace is in fact a target,
         # so we can use it to calculate.
         divisor = len(self.namespaces) or 1

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -1316,7 +1316,9 @@ class SaasHerder:
                         "last_build_result": last_build_result,
                     }
                     if self.include_trigger_trace:
-                        job_spec["reason"] = f"{upstream['instance']['serverUrl']}/job/{job_name}/{last_build_result_number}"
+                        job_spec[
+                            "reason"
+                        ] = f"{upstream['instance']['serverUrl']}/job/{job_name}/{last_build_result_number}"
                     trigger_specs.append(job_spec)
 
         return trigger_specs
@@ -1390,7 +1392,9 @@ class SaasHerder:
                 "target_config": desired_target_config,
             }
             if self.include_trigger_trace:
-                job_spec["reason"] = f"{self.settings['instanceUrl']}/commit/{RunningState().commit}"
+                job_spec[
+                    "reason"
+                ] = f"{self.settings['instanceUrl']}/commit/{RunningState().commit}"
             trigger_specs.append(job_spec)
         return trigger_specs
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5484

currently we can trace what caused a deployment to be triggered only based on the time.
with this change, we will know what integration triggered a deployment and for what reason.

the reason will be:
- openshift-saas-deploy-trigger-moving-commits - the upstream commit
- openshift-saas-deploy-trigger-upstream-jobs - the jenkins job
- openshift-saas-deploy-trigger-configs - the app-interface commit

parameters are added in https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/39361