### PR TITLE
introduce query-validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Additional tools that use the libraries created by the reconciliations are also 
   quay-mirror-org                 Mirrors entire Quay orgs.
   quay-permissions                Manage permissions for Quay Repositories.
   quay-repos                      Creates and Manages Quay Repos.
+  query-validator                 Validate queries to maintain consumer schema
+                                  compatibility.
   requests-sender                 Send emails to users based on requests
                                   submitted to app-interface.
   saas-file-owners                Manages labels on merge requests based on

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -105,6 +105,7 @@ import reconcile.kafka_clusters
 import reconcile.terraform_aws_route53
 import reconcile.prometheus_rules_tester
 import reconcile.template_tester
+import reconcile.query_validator
 import reconcile.dashdotdb_dvo
 import reconcile.sendgrid_teammates
 import reconcile.osd_mirrors_data_updater
@@ -1738,6 +1739,14 @@ def prometheus_rules_tester(ctx, thread_pool_size, cluster_name):
 @click.pass_context
 def template_tester(ctx):
     run_integration(reconcile.template_tester, ctx.obj)
+
+
+@integration.command(
+    short_help="Validate queries to maintain consumer schema compatibility."
+)
+@click.pass_context
+def query_validator(ctx):
+    run_integration(reconcile.query_validator, ctx.obj)
 
 
 @integration.command(short_help="Manages SendGrid teammates for a given account.")

--- a/reconcile/query_validator.py
+++ b/reconcile/query_validator.py
@@ -1,3 +1,7 @@
+import logging
+import sys
+
+from reconcile.status import ExitCodes
 from reconcile.utils import gql
 from reconcile.utils.semver_helper import make_semver
 
@@ -21,6 +25,14 @@ QUERY_VALIDATIONS_QUERY = """
 def run(dry_run):
     gqlapi = gql.get_api()
     query_validations = gqlapi.query(QUERY_VALIDATIONS_QUERY)["validations"]
+    error = False
     for qv in query_validations:
         for q in qv["queries"]:
-            gqlapi.query(gql.get_resource(q["path"])["content"])
+            try:
+                gqlapi.query(gql.get_resource(q["path"])["content"])
+            except (gql.GqlGetResourceError, gql.GqlApiError) as e:
+                error = True
+                logging.error(f"query validation error in {qv['name']}: {str(e)}")
+
+    if error:
+        sys.exit(ExitCodes.ERROR)

--- a/reconcile/query_validator.py
+++ b/reconcile/query_validator.py
@@ -1,0 +1,26 @@
+from reconcile.utils import gql
+from reconcile.utils.semver_helper import make_semver
+
+
+QONTRACT_INTEGRATION = "query-validator"
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
+
+
+QUERY_VALIDATIONS_QUERY = """
+{
+  validations: query_validations_v1 {
+    name
+    queries {
+      path
+    }
+  }
+}
+"""
+
+
+def run(dry_run):
+    gqlapi = gql.get_api()
+    query_validations = gqlapi.query(QUERY_VALIDATIONS_QUERY)["validations"]
+    for qv in query_validations:
+        for q in qv["queries"]:
+            gqlapi.query(gql.get_resource(q["path"])["content"])


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5561

depends on https://github.com/app-sre/qontract-schemas/pull/153

design doc: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/schema-compatibility.md

this PR adds an integration (`query-validator`). This integration acts on `query-validation-1` files. The integration will be pretty straight forward: For each entry in the `queries` list, execute the query. If it fails - fail the integration.

This integration will only run within app-interface pr-check to gate merges of schema promotions that break the tenants' queries. In case this integration fails, we will contact the responsible team to make adjustments to their source code and to the queries in app-interface.