### PR TITLE
[integration-manager] automatic integration sharding based on AWS accounts in app-interface

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -6,8 +6,7 @@ metadata:
 objects:
 {{- range $i, $integration := .Values.integrations }}
 {{- $logs := $integration.logs | default dict -}}
-{{- $shards := int $integration.shards | default 1 }}
-{{- range $shard_id := until $shards }}
+{{- range $shard := $integration.shard_specs }}
 - apiVersion: apps/v1
   {{- if $integration.cache }}
   kind: StatefulSet
@@ -19,11 +18,7 @@ objects:
       app: qontract-reconcile-{{ $integration.name }}
     annotations:
       ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
-    {{- if gt $shards 1 }}
-    name: qontract-reconcile-{{ $integration.name }}-{{ $shard_id }}
-    {{- else }}
-    name: qontract-reconcile-{{ $integration.name }}
-    {{- end }}
+    name: qontract-reconcile-{{ $integration.name }}{{ $shard.shard_name_suffix }}
   spec:
     {{- if $integration.cache }}
     volumeClaimTemplates:
@@ -159,9 +154,9 @@ objects:
               containerPort: 9090
           env:
           - name: SHARDS
-            value: "{{ $shards }}"
+            value: "{{ $shard.shards }}"
           - name: SHARD_ID
-            value: "{{ $shard_id }}"
+            value: "{{ $shard.shard_id }}"
           - name: DRY_RUN
             value: ${DRY_RUN}
           {{- if eq $integration.name "integrations-manager" }}
@@ -170,9 +165,9 @@ objects:
           {{- end }}
           - name: INTEGRATION_NAME
             value: {{ $integration.name }}
-          {{- with $integration.extraArgs }}
+          {{- with $shard.extra_args }}
           - name: INTEGRATION_EXTRA_ARGS
-            value: "{{ $integration.extraArgs }}"
+            value: "{{ $shard.extra_args }}"
           {{- end }}
           - name: SLEEP_DURATION_SECS
             {{- if $integration.sleepDurationSecs }}

--- a/helm/qontract-reconcile/values-manager.yaml
+++ b/helm/qontract-reconcile/values-manager.yaml
@@ -11,3 +11,6 @@ integrations:
   environmentAware: true
   logs:
     slack: true
+  shard_specs:
+  - shard_id: 0
+    shards: 1

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1937,12 +1937,3 @@ def get_integration_cli_meta() -> dict[str, IntegrationMeta]:
             short_help=integration_cmd.short_help,  # type: ignore
         )
     return integration_meta
-
-
-if __name__ == "__main__":
-    integrations = get_integration_cli_meta()
-    json.dump(
-        {i: m.to_dict() for i, m in integrations.items()},
-        sys.stdout,
-        indent=4,
-    )

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1928,6 +1928,13 @@ def integrations_manager(
 
 
 def get_integration_cli_meta() -> dict[str, IntegrationMeta]:
+    """
+    returns all integrations known to cli.py via click introspection
+
+    todo(geoberle, janboll) - this needs rework in the long run, especially since go-integrations
+    are becoming relevant and this kind of meta programming just solves the python part, and even
+    the python part is not solved in a robust enough way
+    """
     integration_meta = {}
     for integration_name in integration.list_commands(None):  # type: ignore
         integration_cmd = integration.get_command(None, integration_name)  # type: ignore

--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -1,17 +1,18 @@
+from dataclasses import dataclass
 import os
 import sys
 import json
 import logging
 
 from github import Github
-from typing import Any, Dict, List, Mapping, Optional
+from typing import Any, Iterable, Mapping, Optional
 
 import reconcile.openshift_base as ob
 
 from reconcile.utils import helm
 from reconcile import queries
 from reconcile.status import ExitCodes
-from reconcile.utils.oc import OCDeprecated, OC_Map
+from reconcile.utils.oc import oc_process
 from reconcile.utils.semver_helper import make_semver
 from reconcile.github_org import GH_BASE_URL, get_default_config
 from reconcile.utils.openshift_resource import OpenshiftResource, ResourceInventory
@@ -22,10 +23,59 @@ QONTRACT_INTEGRATION = "integrations-manager"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
+@dataclass
+class IntegrationShardManager:
+
+    aws_accounts: list[dict[str, Any]]
+
+    def build_integration_shards(
+        self, integration: str, spec: Mapping[str, Any]
+    ) -> list[dict[str, Any]]:
+        extra_args = spec["extraArgs"] or ""
+        sharding_strategy = spec.get("shardingStrategy") or "static"
+        if sharding_strategy == "per-aws-account":
+            filtered_accounts = self._aws_accounts_for_integration(integration)
+            return [
+                {
+                    "shard_id": shard_id,
+                    "shards": len(filtered_accounts),
+                    "shard_name_suffix": f"-{account['name']}"
+                    if len(filtered_accounts) > 1
+                    else "",
+                    "extra_args": " ".join(
+                        a for a in [extra_args, "--account-name", account["name"]] if a
+                    ),
+                }
+                for shard_id, account in enumerate(filtered_accounts)
+            ]
+        elif sharding_strategy == "static":
+            shards = spec.get("shards") or 1
+            return [
+                {
+                    "shard_id": s,
+                    "shards": shards,
+                    "shard_name_suffix": f"-{s}" if shards > 1 else "",
+                    "extra_args": extra_args,
+                }
+                for s in range(0, shards)
+            ]
+        else:
+            raise ValueError(f"unsupported sharding strategy {sharding_strategy}")
+
+    def _aws_accounts_for_integration(self, integration: str) -> list[dict[str, Any]]:
+        return [
+            a
+            for a in self.aws_accounts
+            if a["disable"] is None
+            or "integrations" not in a["disable"]
+            or integration not in (a["disable"]["integrations"] or [])
+        ]
+
+
 def construct_values_file(
-    integration_specs: List[Mapping[str, Any]]
-) -> Mapping[str, Any]:
-    values: Dict[str, Any] = {
+    integration_specs: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    values: dict[str, Any] = {
         "integrations": [],
         "cronjobs": [],
     }
@@ -47,8 +97,8 @@ def collect_parameters(
     template: Mapping[str, Any],
     environment: Mapping[str, Any],
     image_tag_from_ref: Optional[Mapping[str, str]],
-) -> Mapping[str, Any]:
-    parameters: Dict[str, Any] = {}
+) -> dict[str, Any]:
+    parameters: dict[str, Any] = {}
     environment_parameters = environment.get("parameters")
     if environment_parameters:
         parameters.update(json.loads(environment_parameters))
@@ -70,14 +120,14 @@ def collect_parameters(
 
 def construct_oc_resources(
     namespace_info: Mapping[str, Any],
-    oc: OCDeprecated,
     image_tag_from_ref: Optional[Mapping[str, str]],
-) -> List[OpenshiftResource]:
+) -> list[OpenshiftResource]:
     template = helm.template(construct_values_file(namespace_info["integration_specs"]))
+
     parameters = collect_parameters(
         template, namespace_info["environment"], image_tag_from_ref
     )
-    resources = oc.process(template, parameters)
+    resources = oc_process(template, parameters)
     return [
         OpenshiftResource(
             r,
@@ -89,27 +139,33 @@ def construct_oc_resources(
     ]
 
 
+def initialize_shard_specs(
+    namespaces: Iterable[Mapping[str, Any]], shard_manager: IntegrationShardManager
+) -> None:
+    for namespace_info in namespaces:
+        for spec in namespace_info["integration_specs"]:
+            spec["shard_specs"] = shard_manager.build_integration_shards(
+                spec["name"], spec
+            )
+
+
 def fetch_desired_state(
-    namespaces: List[Mapping[str, Any]],
+    namespaces: Iterable[Mapping[str, Any]],
     ri: ResourceInventory,
-    oc_map: OC_Map,
     image_tag_from_ref: Optional[Mapping[str, str]],
-):
+) -> None:
     for namespace_info in namespaces:
         namespace = namespace_info["name"]
         cluster = namespace_info["cluster"]["name"]
-        oc = oc_map.get(cluster)
-        if not oc:
-            continue
-        oc_resources = construct_oc_resources(namespace_info, oc, image_tag_from_ref)
+        oc_resources = construct_oc_resources(namespace_info, image_tag_from_ref)
         for r in oc_resources:
             ri.add_desired(cluster, namespace, r.kind, r.name, r)
 
 
 def collect_namespaces(
-    integrations: List[Mapping[str, Any]], environment_name: str
-) -> List[Mapping[str, Any]]:
-    unique_namespaces: Dict[str, Dict[str, Any]] = {}
+    integrations: Iterable[Mapping[str, Any]], environment_name: str
+) -> list[dict[str, Any]]:
+    unique_namespaces: dict[str, dict[str, Any]] = {}
     for i in integrations:
         managed = i.get("managed") or []
         for m in managed:
@@ -152,7 +208,9 @@ def run(
         use_jump_host=use_jump_host,
     )
     defer(oc_map.cleanup)
-    fetch_desired_state(namespaces, ri, oc_map, image_tag_from_ref)
+    shard_manager = IntegrationShardManager(aws_accounts=queries.get_aws_accounts())
+    initialize_shard_specs(namespaces, shard_manager)
+    fetch_desired_state(namespaces, ri, image_tag_from_ref)
     ob.realize_data(dry_run, oc_map, ri, thread_pool_size)
 
     if ri.has_error_registered():

--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+from dataclasses import dataclass
 import os
 import sys
 import json
@@ -32,14 +33,11 @@ class ShardingStrategy:
         pass
 
 
+@dataclass
 class IntegrationShardManager:
-    def __init__(
-        self,
-        strategies: dict[str, ShardingStrategy],
-        integration_runtime_meta: dict[str, IntegrationMeta],
-    ):
-        self.integration_runtime_meta = integration_runtime_meta
-        self.strategies = strategies
+
+    strategies: dict[str, ShardingStrategy]
+    integration_runtime_meta: dict[str, IntegrationMeta]
 
     def build_integration_shards(
         self, integration: str, spec: Mapping[str, Any]

--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -1,4 +1,4 @@
-from abc import abstractmethod
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 import os
 import sys
@@ -25,7 +25,7 @@ QONTRACT_INTEGRATION = "integrations-manager"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
-class ShardingStrategy:
+class ShardingStrategy(ABC):
     @abstractmethod
     def build_integration_shards(
         self, integration_meta: IntegrationMeta, spec: Mapping[str, Any]

--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -69,7 +69,7 @@ class IntegrationShardManager:
                 for s in range(0, shards)
             ]
         else:
-            raise ValueError(f"unsupported sharding strategy {sharding_strategy}")
+            raise ValueError(f"unsupported sharding strategy '{sharding_strategy}'")
 
     def _aws_accounts_for_integration(self, integration: str) -> list[dict[str, Any]]:
         return [

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -211,6 +211,7 @@ INTEGRATIONS_QUERY = """
           }
         }
         shards
+        shardingStrategy
         sleepDurationSecs
         state
         storage

--- a/reconcile/test/fixtures/helm/aws_account_shards.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shards.yml
@@ -1,0 +1,446 @@
+---
+# Source: qontract-reconcile/templates/template.yaml
+apiVersion: v1
+kind: Template
+metadata:
+  name: qontract-reconcile
+objects:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: qontract-reconcile-integ
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
+    name: qontract-reconcile-integ-acc-1
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile-integ
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile-integ
+          component: qontract-reconcile
+      spec:
+        serviceAccountName: qontract-reconcile
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name integ
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          ports:
+            - name: http
+              containerPort: 9090
+          env:
+          - name: SHARDS
+            value: "2"
+          - name: SHARD_ID
+            value: "0"
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: integ
+          - name: INTEGRATION_EXTRA_ARGS
+            value: "--account-name acc-1"
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: GITHUB_API
+          - name: SENTRY_DSN
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
+          - name: UNLEASH_API_URL
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: API_URL
+          - name: UNLEASH_CLIENT_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: CLIENT_ACCESS_TOKEN
+          - name: SLOW_OC_RECONCILE_THRESHOLD
+            value: "${SLOW_OC_RECONCILE_THRESHOLD}"
+          - name: LOG_SLOW_OC_RECONCILE
+            value: "${LOG_SLOW_OC_RECONCILE}"
+          - name: USE_NATIVE_CLIENT
+            value: "${USE_NATIVE_CLIENT}"
+          resources:
+            limits:
+              cpu: ${INTEG_CPU_LIMIT}
+              memory: ${INTEG_MEMORY_LIMIT}
+            requests:
+              cpu: ${INTEG_CPU_REQUEST}
+              memory: ${INTEG_MEMORY_REQUEST}
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: qontract-reconcile-integ
+    annotations:
+      ignore-check.kube-linter.io/minimum-three-replicas : "qontract-reconcile integrations are sharded and not replicated"
+    name: qontract-reconcile-integ-acc-2
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: qontract-reconcile-integ
+    template:
+      metadata:
+        labels:
+          app: qontract-reconcile-integ
+          component: qontract-reconcile
+      spec:
+        serviceAccountName: qontract-reconcile
+        initContainers:
+        - name: config
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+          env:
+          - name: LOG_GROUP_NAME
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: log_group_name
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            # generate fluent.conf
+            cat > /fluentd/etc/fluent.conf <<EOF
+            <source>
+              @type tail
+              path /fluentd/log/integration.log
+              pos_file /fluentd/log/integration.log.pos
+              tag integration
+              <parse>
+                @type none
+              </parse>
+            </source>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /using gql endpoint/
+              </exclude>
+            </filter>
+
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /Certificate did not match expected hostname/
+              </exclude>
+            </filter>
+
+            <match integration>
+              @type copy
+              <store>
+                @type cloudwatch_logs
+                log_group_name ${LOG_GROUP_NAME}
+                log_stream_name integ
+                auto_create_stream true
+              </store>
+            </match>
+            EOF
+          volumeMounts:
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        containers:
+        - name: int
+          image: ${IMAGE}:${IMAGE_TAG}
+          ports:
+            - name: http
+              containerPort: 9090
+          env:
+          - name: SHARDS
+            value: "2"
+          - name: SHARD_ID
+            value: "1"
+          - name: DRY_RUN
+            value: ${DRY_RUN}
+          - name: INTEGRATION_NAME
+            value: integ
+          - name: INTEGRATION_EXTRA_ARGS
+            value: "--account-name acc-2"
+          - name: SLEEP_DURATION_SECS
+            value: ${SLEEP_DURATION_SECS}
+          - name: GITHUB_API
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: GITHUB_API
+          - name: SENTRY_DSN
+            valueFrom:
+              configMapKeyRef:
+                name: app-interface
+                key: SENTRY_DSN
+          - name: LOG_FILE
+            value: "${LOG_FILE}"
+          - name: UNLEASH_API_URL
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: API_URL
+          - name: UNLEASH_CLIENT_ACCESS_TOKEN
+            valueFrom:
+              secretKeyRef:
+                name: unleash
+                key: CLIENT_ACCESS_TOKEN
+          - name: SLOW_OC_RECONCILE_THRESHOLD
+            value: "${SLOW_OC_RECONCILE_THRESHOLD}"
+          - name: LOG_SLOW_OC_RECONCILE
+            value: "${LOG_SLOW_OC_RECONCILE}"
+          - name: USE_NATIVE_CLIENT
+            value: "${USE_NATIVE_CLIENT}"
+          resources:
+            limits:
+              cpu: ${INTEG_CPU_LIMIT}
+              memory: ${INTEG_MEMORY_LIMIT}
+            requests:
+              cpu: ${INTEG_CPU_REQUEST}
+              memory: ${INTEG_MEMORY_REQUEST}
+          volumeMounts:
+          - name: qontract-reconcile-toml
+            mountPath: /config
+          - name: logs
+            mountPath: /fluentd/log/
+        - name: fluentd
+          image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
+          imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
+          env:
+          - name: AWS_REGION
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_region
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_access_key_id
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: ${CLOUDWATCH_SECRET}
+                key: aws_secret_access_key
+          resources:
+            requests:
+              memory: 30Mi
+              cpu: 15m
+            limits:
+              memory: 120Mi
+              cpu: 25m
+          volumeMounts:
+          - name: logs
+            mountPath: /fluentd/log/
+          - name: fluentd-config
+            mountPath: /fluentd/etc/
+        volumes:
+        - name: qontract-reconcile-toml
+          secret:
+            secretName: qontract-reconcile-toml
+        - name: logs
+          emptyDir: {}
+        - name: fluentd-config
+          emptyDir: {}
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: qontract-reconcile
+    labels:
+      app: qontract-reconcile
+  spec:
+    ports:
+      - protocol: TCP
+        port: 80
+        targetPort: 9090
+        name: http
+    selector:
+      component: qontract-reconcile
+parameters:
+- name: IMAGE
+  value: quay.io/app-sre/qontract-reconcile
+- name: IMAGE_TAG
+  value: latest
+- name: BUSYBOX_IMAGE
+  value: quay.io/app-sre/ubi8-ubi-minimal
+- name: BUSYBOX_IMAGE_TAG
+  value: latest
+- name: BUSYBOX_IMAGE_PULL_POLICY
+  value: Always
+- name: FLUENTD_IMAGE
+  value: quay.io/app-sre/fluentd
+- name: FLUENTD_IMAGE_TAG
+  value: latest
+- name: FLUENTD_IMAGE_PULL_POLICY
+  value: Always
+- name: ENVIRONMENT_NAME
+  value: app-interface
+- name: DRY_RUN
+  value: --dry-run
+- name: MANAGER_DRY_RUN
+  value: --dry-run
+- name: SLEEP_DURATION_SECS
+  value: "300"
+- name: APP_INTERFACE_SQS_SECRET_NAME
+  value: app-interface-sqs
+- name: APP_INTERFACE_STATE_BUCKET_ACCOUNT
+  value: app-sre
+- name: APP_INTERFACE_PROJECT_ID
+  value: "0"
+- name: USER_ID
+  value: dummy
+- name: LOG_FILE
+  value: "/fluentd/log/integration.log"
+- name: SLACK_CHANNEL
+  value: "sd-app-sre-reconcile-stage"
+- name: SLACK_CHANNEL_TRIGGER
+  value: "sd-app-sre-triggers-stage"
+- name: SLACK_ICON_EMOJI
+  value: ":bust_in_silhouette:"
+- name: GITHUB_API
+  value: 'http://github-mirror.github-mirror-stage.svc.cluster.local'
+- name: CLOUDWATCH_SECRET
+  value: app-interface-cloudwatch
+- name: SENTRY_DSN
+  value: ""
+- name: SLOW_OC_RECONCILE_THRESHOLD
+  value: "600"
+- name: LOG_SLOW_OC_RECONCILE
+  value: "false"
+- name: USE_NATIVE_CLIENT
+  value: ""
+- name: INTERNAL_CERTIFICATES_IMAGE
+  value: quay.io/app-sre/internal-redhat-ca
+- name: INTERNAL_CERTIFICATES_IMAGE_TAG
+  value: latest
+- name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
+  value: Always
+- name: INTEG_CPU_LIMIT
+  value: 678
+- name: INTEG_MEMORY_LIMIT
+  value: 90Mi
+- name: INTEG_CPU_REQUEST
+  value: 123
+- name: INTEG_MEMORY_REQUEST
+  value: 45Mi

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -464,6 +464,21 @@ def test_initialize_shard_specs_extra_arg_agregation(
     )
 
 
+def test_initialize_shard_specs_unsupported_strategy(
+    collected_namespaces_env_test1: list[dict[str, Any]],
+    shard_manager: intop.IntegrationShardManager,
+):
+    """
+    this test shows how an unsupported sharding strategy fails the integration
+    """
+    collected_namespaces_env_test1[0]["integration_specs"][0][
+        "shardingStrategy"
+    ] = "based-on-moon-cycles"
+    with pytest.raises(ValueError) as e:
+        intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
+    assert e.value.args[0] == "unsupported sharding strategy 'based-on-moon-cycles'"
+
+
 def test_fetch_desired_state(
     collected_namespaces_env_test1: list[dict[str, Any]],
     shard_manager: intop.IntegrationShardManager,

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -352,7 +352,7 @@ def test_initialize_shard_specs_two_shards(
     shard_manager: intop.IntegrationShardManager,
 ):
     """
-    this test shows how the implicit static sharding strategy creates two shards
+    this test shows how the default static sharding strategy creates two shards
     """
     collected_namespaces_env_test1[0]["integration_specs"][0]["shards"] = 2
     intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -1,13 +1,14 @@
 import os
-from typing import Any, Dict, List, Mapping
+from typing import Any, Iterable, Mapping
 import pytest
 
 import reconcile.integrations_manager as intop
+from reconcile.utils.openshift_resource import ResourceInventory
 
 
 def test_construct_values_file_empty():
-    integrations_specs: List[Mapping[str, Any]] = []
-    expected: Dict[str, List] = {
+    integrations_specs: list[dict[str, Any]] = []
+    expected: dict[str, list] = {
         "integrations": [],
         "cronjobs": [],
     }
@@ -16,7 +17,7 @@ def test_construct_values_file_empty():
 
 
 def test_construct_values_file():
-    integrations_specs: List[Mapping[str, Any]] = [
+    integrations_specs: list[dict[str, Any]] = [
         {
             "name": "integ1",
         },
@@ -123,21 +124,21 @@ def test_collect_parameters_image_tag_from_ref(mocker):
 
 
 @pytest.fixture
-def resources():
+def resources() -> dict[str, Any]:
     return {
         "requests": {
-            "cpu": 1,
+            "cpu": "100m",
             "memory": "1Mi",
         },
         "limits": {
-            "cpu": 1,
+            "cpu": "100m",
             "memory": "1Mi",
         },
     }
 
 
 @pytest.fixture
-def integrations(resources):
+def integrations(resources: dict[str, Any]) -> Iterable[Mapping[str, Any]]:
     return [
         {
             "name": "integ-dont-run",
@@ -148,11 +149,14 @@ def integrations(resources):
                 {
                     "namespace": {
                         "path": "path1",
+                        "name": "ns1",
+                        "cluster": {"name": "cl1"},
                         "environment": {
                             "name": "test1",
                         },
                     },
                     "spec": {
+                        "extraArgs": None,
                         "resources": resources,
                     },
                 },
@@ -164,11 +168,14 @@ def integrations(resources):
                 {
                     "namespace": {
                         "path": "path2",
+                        "name": "ns2",
+                        "cluster": {"name": "cl2"},
                         "environment": {
                             "name": "test2",
                         },
                     },
                     "spec": {
+                        "extraArgs": None,
                         "resources": resources,
                     },
                 },
@@ -180,11 +187,14 @@ def integrations(resources):
                 {
                     "namespace": {
                         "path": "path2",
+                        "name": "ns3",
+                        "cluster": {"name": "cl3"},
                         "environment": {
                             "name": "test2",
                         },
                     },
                     "spec": {
+                        "extraArgs": None,
                         "resources": resources,
                     },
                 },
@@ -193,81 +203,269 @@ def integrations(resources):
     ]
 
 
-def test_collect_namespaces_single_ns(integrations, resources):
+def test_collect_namespaces_single_ns(
+    integrations: Iterable[Mapping[str, Any]], resources: dict[str, Any]
+):
     environment_name = "test1"
     namespaces = intop.collect_namespaces(integrations, environment_name)
     expected = [
         {
             "path": "path1",
+            "name": "ns1",
+            "cluster": {"name": "cl1"},
             "environment": {
                 "name": "test1",
             },
             "integration_specs": [
-                {
-                    "name": "integ1",
-                    "resources": resources,
-                },
+                {"name": "integ1", "resources": resources, "extraArgs": None},
             ],
         },
     ]
     assert namespaces == expected
 
 
-def test_collect_namespaces_multiple_ns(integrations, resources):
+def test_collect_namespaces_multiple_ns(
+    integrations: Iterable[Mapping[str, Any]], resources: dict[str, Any]
+):
     environment_name = "test2"
     namespaces = intop.collect_namespaces(integrations, environment_name)
     expected = [
         {
             "path": "path2",
+            "name": "ns2",
+            "cluster": {"name": "cl2"},
             "environment": {
                 "name": "test2",
             },
             "integration_specs": [
-                {
-                    "name": "integ2",
-                    "resources": resources,
-                },
-                {
-                    "name": "integ3",
-                    "resources": resources,
-                },
+                {"name": "integ2", "resources": resources, "extraArgs": None},
+                {"name": "integ3", "resources": resources, "extraArgs": None},
             ],
         },
     ]
     assert namespaces == expected
 
 
-def test_collect_namespaces_all_environments(integrations, resources):
+def test_collect_namespaces_all_environments(
+    integrations: Iterable[Mapping[str, Any]], resources: dict[str, Any]
+):
     environment_name = ""
     namespaces = intop.collect_namespaces(integrations, environment_name)
     expected = [
         {
             "path": "path1",
+            "name": "ns1",
+            "cluster": {"name": "cl1"},
             "environment": {
                 "name": "test1",
             },
             "integration_specs": [
-                {
-                    "name": "integ1",
-                    "resources": resources,
-                },
+                {"name": "integ1", "resources": resources, "extraArgs": None},
             ],
         },
         {
             "path": "path2",
+            "name": "ns2",
+            "cluster": {"name": "cl2"},
             "environment": {
                 "name": "test2",
             },
             "integration_specs": [
-                {
-                    "name": "integ2",
-                    "resources": resources,
-                },
-                {
-                    "name": "integ3",
-                    "resources": resources,
-                },
+                {"name": "integ2", "resources": resources, "extraArgs": None},
+                {"name": "integ3", "resources": resources, "extraArgs": None},
             ],
         },
     ]
     assert namespaces == expected
+
+
+@pytest.fixture
+def shard_manager() -> intop.IntegrationShardManager:
+    return intop.IntegrationShardManager(
+        aws_accounts=[
+            {"name": "acc-1", "disable": None},
+            {"name": "acc-2", "disable": {"integrations": None}},
+            {"name": "acc-3", "disable": {"integrations": []}},
+            {"name": "acc-4", "disable": {"integrations": ["integ1"]}},
+        ]
+    )
+
+
+def test_shard_manager_aws_account_filtering(
+    shard_manager: intop.IntegrationShardManager,
+):
+    assert ["acc-1", "acc-2", "acc-3", "acc-4"] == [
+        a["name"]
+        for a in shard_manager._aws_accounts_for_integration("another-integration")
+    ]
+
+
+def test_shard_manager_aws_account_filtering_disabled(
+    shard_manager: intop.IntegrationShardManager,
+):
+    assert ["acc-1", "acc-2", "acc-3"] == [
+        a["name"] for a in shard_manager._aws_accounts_for_integration("integ1")
+    ]
+
+
+@pytest.fixture
+def collected_namespaces_env_test1(
+    integrations: Iterable[Mapping[str, Any]]
+) -> list[dict[str, Any]]:
+    return intop.collect_namespaces(integrations, "test1")
+
+
+def test_initialize_shard_specs_no_shards(
+    collected_namespaces_env_test1: list[dict[str, Any]],
+    shard_manager: intop.IntegrationShardManager,
+):
+    """
+    this test shows how exactly one shard is created when no sharding has been configured
+    """
+    intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
+    expected = [{"shard_id": 0, "shards": 1, "shard_name_suffix": "", "extra_args": ""}]
+    assert (
+        expected
+        == collected_namespaces_env_test1[0]["integration_specs"][0]["shard_specs"]
+    )
+
+
+def test_initialize_shard_specs_two_shards(
+    collected_namespaces_env_test1: list[dict[str, Any]],
+    shard_manager: intop.IntegrationShardManager,
+):
+    """
+    this test shows how the implicit static sharding strategy creates two shards
+    """
+    collected_namespaces_env_test1[0]["integration_specs"][0]["shards"] = 2
+    intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
+    expected = [
+        {"shard_id": 0, "shards": 2, "shard_name_suffix": "-0", "extra_args": ""},
+        {"shard_id": 1, "shards": 2, "shard_name_suffix": "-1", "extra_args": ""},
+    ]
+    assert (
+        expected
+        == collected_namespaces_env_test1[0]["integration_specs"][0]["shard_specs"]
+    )
+
+
+def test_initialize_shard_specs_two_shards_explicit(
+    collected_namespaces_env_test1: list[dict[str, Any]],
+    shard_manager: intop.IntegrationShardManager,
+):
+    """
+    this test shows how the explicit static sharding strategy creates two shards
+    """
+    collected_namespaces_env_test1[0]["integration_specs"][0][
+        "shardingStrategy"
+    ] = "static"
+    collected_namespaces_env_test1[0]["integration_specs"][0]["shards"] = 2
+    intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
+    expected = [
+        {"shard_id": 0, "shards": 2, "shard_name_suffix": "-0", "extra_args": ""},
+        {"shard_id": 1, "shards": 2, "shard_name_suffix": "-1", "extra_args": ""},
+    ]
+    assert (
+        expected
+        == collected_namespaces_env_test1[0]["integration_specs"][0]["shard_specs"]
+    )
+
+
+def test_initialize_shard_specs_aws_account_shards_implicit(
+    collected_namespaces_env_test1: list[dict[str, Any]],
+    shard_manager: intop.IntegrationShardManager,
+):
+    """
+    this test shows how the per-aws-account strategy fills the shard_specs and ignores
+    aws accounts where the integration is disabled
+    """
+    collected_namespaces_env_test1[0]["integration_specs"][0][
+        "shardingStrategy"
+    ] = "per-aws-account"
+    intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
+    expected = [
+        {
+            "shard_id": 0,
+            "shards": 3,
+            "shard_name_suffix": "-acc-1",
+            "extra_args": "--account-name acc-1",
+        },
+        {
+            "shard_id": 1,
+            "shards": 3,
+            "shard_name_suffix": "-acc-2",
+            "extra_args": "--account-name acc-2",
+        },
+        {
+            "shard_id": 2,
+            "shards": 3,
+            "shard_name_suffix": "-acc-3",
+            "extra_args": "--account-name acc-3",
+        },
+    ]
+    assert (
+        expected
+        == collected_namespaces_env_test1[0]["integration_specs"][0]["shard_specs"]
+    )
+
+
+def test_initialize_shard_specs_extra_arg_agregation(
+    collected_namespaces_env_test1: list[dict[str, Any]],
+    shard_manager: intop.IntegrationShardManager,
+):
+    """
+    this test shows how extra args are aggregated
+    """
+    collected_namespaces_env_test1[0]["integration_specs"][0]["extraArgs"] = "--arg"
+    collected_namespaces_env_test1[0]["integration_specs"][0][
+        "shardingStrategy"
+    ] = "per-aws-account"
+    intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
+    expected = [
+        {
+            "shard_id": 0,
+            "shards": 3,
+            "shard_name_suffix": "-acc-1",
+            "extra_args": "--arg --account-name acc-1",
+        },
+        {
+            "shard_id": 1,
+            "shards": 3,
+            "shard_name_suffix": "-acc-2",
+            "extra_args": "--arg --account-name acc-2",
+        },
+        {
+            "shard_id": 2,
+            "shards": 3,
+            "shard_name_suffix": "-acc-3",
+            "extra_args": "--arg --account-name acc-3",
+        },
+    ]
+    assert (
+        expected
+        == collected_namespaces_env_test1[0]["integration_specs"][0]["shard_specs"]
+    )
+
+
+def test_fetch_desired_state(
+    collected_namespaces_env_test1: list[dict[str, Any]],
+    shard_manager: intop.IntegrationShardManager,
+):
+    intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
+    ri = ResourceInventory()
+    ri.initialize_resource_type("cl1", "ns1", "Deployment")
+    ri.initialize_resource_type("cl1", "ns1", "Service")
+    intop.fetch_desired_state(
+        namespaces=collected_namespaces_env_test1,
+        ri=ri,
+        image_tag_from_ref=None,
+    )
+
+    resources = [
+        (cluster, namespace, kind, list(data["desired"].keys()))
+        for cluster, namespace, kind, data in list(ri)
+    ]
+
+    assert len(resources) == 2
+    assert ("cl1", "ns1", "Deployment", ["qontract-reconcile-integ1"]) in resources
+    assert ("cl1", "ns1", "Service", ["qontract-reconcile"]) in resources

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -4,6 +4,7 @@ import pytest
 
 import reconcile.integrations_manager as intop
 from reconcile.utils.openshift_resource import ResourceInventory
+from reconcile.utils.runtime.meta import IntegrationMeta
 
 
 def test_construct_values_file_empty():
@@ -287,7 +288,14 @@ def shard_manager() -> intop.IntegrationShardManager:
             {"name": "acc-2", "disable": {"integrations": None}},
             {"name": "acc-3", "disable": {"integrations": []}},
             {"name": "acc-4", "disable": {"integrations": ["integ1"]}},
-        ]
+        ],
+        integration_runtime_meta={
+            "integ1": IntegrationMeta(
+                name="integ1", short_help="", args=["--arg", "--account-name"]
+            ),
+            "integ2": IntegrationMeta(name="integ2", short_help="", args=["--arg"]),
+            "integ3": IntegrationMeta(name="integ3", short_help="", args=[]),
+        },
     )
 
 
@@ -306,6 +314,15 @@ def test_shard_manager_aws_account_filtering_disabled(
     assert ["acc-1", "acc-2", "acc-3"] == [
         a["name"] for a in shard_manager._aws_accounts_for_integration("integ1")
     ]
+
+
+def test_shard_manager_supported_args(
+    shard_manager: intop.IntegrationShardManager,
+):
+    assert shard_manager._integration_supports_arg("integ1", "--account-name")
+    assert not shard_manager._integration_supports_arg(
+        "integ1", "--something-unsupported"
+    )
 
 
 @pytest.fixture

--- a/reconcile/test/test_utils_helm.py
+++ b/reconcile/test/test_utils_helm.py
@@ -24,6 +24,13 @@ def values():
                         "memory": "90Mi",
                     },
                 },
+                "shard_specs": [
+                    {
+                        "shard_id": 0,
+                        "shards": 1,
+                        "shard_name_suffix": "",
+                    }
+                ],
             }
         ]
     }
@@ -57,7 +64,7 @@ def test_template_disable_unleash(values):
 
 
 def test_template_extra_args(values):
-    values["integrations"][0]["extraArgs"] = "--test-extra-args"
+    values["integrations"][0]["shard_specs"][0]["extra_args"] = "--test-extra-args"
     template = helm.template(values)
     expected = yaml.safe_load(fxt.get("extra_args.yml"))
     assert template == expected
@@ -94,9 +101,40 @@ def test_template_logs_slack(values):
 
 
 def test_template_shards(values):
-    values["integrations"][0]["shards"] = 2
+    values["integrations"][0]["shard_specs"] = [
+        {
+            "shard_id": 0,
+            "shards": 2,
+            "shard_name_suffix": "-0",
+        },
+        {
+            "shard_id": 1,
+            "shards": 2,
+            "shard_name_suffix": "-1",
+        },
+    ]
     template = helm.template(values)
     expected = yaml.safe_load(fxt.get("shards.yml"))
+    assert template == expected
+
+
+def test_template_aws_account_shards(values):
+    values["integrations"][0]["shard_specs"] = [
+        {
+            "shard_id": 0,
+            "shards": 2,
+            "shard_name_suffix": "-acc-1",
+            "extra_args": "--account-name acc-1",
+        },
+        {
+            "shard_id": 1,
+            "shards": 2,
+            "shard_name_suffix": "-acc-2",
+            "extra_args": "--account-name acc-2",
+        },
+    ]
+    template = helm.template(values)
+    expected = yaml.safe_load(fxt.get("aws_account_shards.yml"))
     assert template == expected
 
 

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -193,6 +193,11 @@ class OCProcessReconcileTimeDecoratorMsg:
         self.is_log_slow_oc_reconcile = is_log_slow_oc_reconcile
 
 
+def oc_process(template, parameters=None):
+    oc = OCNative(server=None, local=True, cluster_name="cluster", token=None)
+    return oc.process(template, parameters)
+
+
 class OCDeprecated:  # pylint: disable=too-many-public-methods
     def __init__(
         self,

--- a/reconcile/utils/runtime/__init__.py
+++ b/reconcile/utils/runtime/__init__.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class IntegrationMeta:
+
+    name: str
+    options: list[str]

--- a/reconcile/utils/runtime/meta.py
+++ b/reconcile/utils/runtime/meta.py
@@ -1,0 +1,14 @@
+from dataclasses import dataclass
+import dataclasses
+from typing import Optional
+
+
+@dataclass
+class IntegrationMeta:
+
+    name: str
+    args: list[str]
+    short_help: Optional[str]
+
+    def to_dict(self):
+        return dataclasses.asdict(self)


### PR DESCRIPTION
# Change

enable integration-manager to shard integrations based on a sharding strategy.

# Implementation details
delegate the handling for shards to the `IntegrationShardManager` which knows how to react to different strategies and builds sharding specs for each integration.

a sharding spec is part of the generated `values` file within `integration_spec.shard_specs` which is passed to the helm chart.

## shard spec

a shard spec consists of the following fields:

* `shard_id`, `shards` - the backwards compatible fields for the `SHARD_ID` and `SHARDS` env vars, specifying which shard within a shard set a deployment will represent.
* `shard_name_suffix` - this i used to influence the `name` of the deployment/statefulset
* `extra_args` - contains the aggregation of an integrations global `extraArgs` and the shard specific extra args

## static strategy
this is the default and backward compatible strategy. an integration is running per default with the `static` sharding strategy with 1 shard. the `IntegrationsManager` creates one shard without any `shard_name_suffix`. if `spec.shards > 1` a respective number of `shard_specs` with proper `shard_name_suffixes` (e.g. -0, -1, -2, ...) is created

## per-aws-account-strategy
this strategy creates a shard for each AWS account in app-interface. if an integration is disabled on an account, no shard is created (or an existing one is deleted). the AWS account name is also used as the `shard_name_suffix`, which results in deployments/statefulsets being named `qontract-reconcile-$integration-$account`. this strategy also expects an integration to support an extra arg `--account-name` and provides it to `shard_spec.extra_args`.

## shard_spec use in helm chart
the Helm chart expects a list containing at least one `shard_specs` within an `integration_spec`.

# References
part of https://issues.redhat.com/browse/APPSRE-2963
design doc: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/qontract-operator-sharding.md
depends on https://github.com/app-sre/qontract-schemas/pull/157

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>