### PR TITLE
[terraform-resources] only disable keys when tf should apply

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -666,9 +666,10 @@ def run(
     actions = ob.realize_data(dry_run, oc_map, ri, thread_pool_size,
                               caller=account_name)
 
-    disable_keys(dry_run, thread_pool_size,
-                 disable_service_account_keys=True,
-                 account_name=account_name)
+    if not light and tf.should_apply:
+        disable_keys(dry_run, thread_pool_size,
+                     disable_service_account_keys=True,
+                     account_name=account_name)
 
     if actions and vault_output_path:
         write_outputs_to_vault(vault_output_path, resource_specs)


### PR DESCRIPTION
`tf.should_apply` should be true after creating an access key (after a leaked one was removed from state).
in this case, it should disable keys. in any other case, we can skip this call altogether.