### PR TITLE
[gitlab-fork-compliance] make gitlab group optional

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1653,7 +1653,7 @@ def gitlab_owners(ctx, thread_pool_size):
 @integration.command(short_help="Ensures that forks of App Interface are compliant.")
 @click.argument("gitlab-project-id")
 @click.argument("gitlab-merge-request-id")
-@click.argument("gitlab-maintainers-group")
+@click.argument("gitlab-maintainers-group", required=False)
 @click.pass_context
 def gitlab_fork_compliance(
     ctx, gitlab_project_id, gitlab_merge_request_id, gitlab_maintainers_group

--- a/reconcile/gitlab_fork_compliance.py
+++ b/reconcile/gitlab_fork_compliance.py
@@ -56,16 +56,18 @@ class GitlabForkCompliance:
         # At this point, we know that the bot is a maintainer, so
         # we check if all the maintainers are in the fork, adding those
         # who are not
-        group = self.gl_cli.gl.groups.get(self.maintainers_group)
-        maintainers = group.members.list()
-        project_maintainers = self.src.get_project_maintainers()
-        for member in maintainers:
-            if member.username in project_maintainers:
-                continue
-            LOG.info([f"adding {member.username} as maintainer"])
-            user_payload = {"user_id": member.id, "access_level": MAINTAINER_ACCESS}
-            member = self.src.project.members.create(user_payload)
-            member.save()
+        if self.maintainers_group:
+            group = self.gl_cli.gl.groups.get(self.maintainers_group)
+            maintainers = group.members.list()
+            project_maintainers = self.src.get_project_maintainers()
+            for member in maintainers:
+                if member.username in project_maintainers:
+                    continue
+                LOG.info([f"adding {member.username} as maintainer"])
+                user_payload = {"user_id": member.id, "access_level": MAINTAINER_ACCESS}
+                member = self.src.project.members.create(user_payload)
+                member.save()
+
         # Last but not least, we remove the blocked label, in case
         # it is set
         mr_labels = self.gl_cli.get_merge_request_labels(self.mr.iid)


### PR DESCRIPTION
the most important thing about fork-compliance is to add a bot account to a fork.
not all tenants who want to use it have a gitlab group, but still want the bot added.

this PR makes the gitlab maintainers group argument optional to support that.