### PR TITLE
[terraform-resources] add support for external resources

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -543,19 +543,18 @@ def filter_tf_namespaces(
 ) -> list[Mapping[str, Any]]:
     tf_namespaces = []
     for namespace_info in namespaces:
-        if not namespace_info.get('managedTerraformResources'):
-            continue
-        if account_name is None:
-            tf_namespaces.append(namespace_info)
-            continue
-        tf_resources = namespace_info.get('terraformResources')
-        if not tf_resources:
-            tf_namespaces.append(namespace_info)
-            continue
-        for resource in tf_resources:
-            if resource['account'] == account_name:
+        if namespace_info.get('managedTerraformResources'):
+            if account_name is None:
                 tf_namespaces.append(namespace_info)
-                break
+                continue
+            tf_resources = namespace_info.get('terraformResources')
+            if not tf_resources:
+                tf_namespaces.append(namespace_info)
+                continue
+            for resource in tf_resources:
+                if resource['account'] == account_name:
+                    tf_namespaces.append(namespace_info)
+                    break
     return tf_namespaces
 
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -31,7 +31,7 @@ from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.vault import _VaultClient, VaultClient
 
 
-TF_RESOURCE = """
+TF_RESOURCE_AWS = """
 output_format {
   provider
   ... on NamespaceTerraformResourceGenericSecretOutputFormat_v1 {
@@ -378,7 +378,7 @@ TF_NAMESPACES_QUERY = """
     }
   }
 }
-""" % (indent(TF_RESOURCE, 6*' '))
+""" % (indent(TF_RESOURCE_AWS, 6*' '))
 
 QONTRACT_INTEGRATION = 'terraform_resources'
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 5, 2)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -4,6 +4,7 @@ import sys
 
 from textwrap import indent
 from typing import Any, Iterable, MutableMapping, Optional, Mapping, Tuple, cast
+from jinja2 import Template
 
 from sretoolbox.utils import threaded
 
@@ -40,7 +41,7 @@ output_format {
 }
 provider
 ... on NamespaceTerraformResourceRDS_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -61,7 +62,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceS3_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -81,7 +82,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceElastiCache_v1 {
-  account
+  {% if account %}account{% endif %}
   identifier
   defaults
   parameter_group
@@ -91,7 +92,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceServiceAccount_v1 {
-  account
+  {% if account %}account{% endif %}
   identifier
   variables
   policies
@@ -107,14 +108,14 @@ provider
   }
 }
 ... on NamespaceTerraformResourceSecretsManagerServiceAccount_v1 {
-  account
+  {% if account %}account{% endif %}
   identifier
   secrets_prefix
   output_resource_name
   annotations
 }
 ... on NamespaceTerraformResourceRole_v1 {
-  account
+  {% if account %}account{% endif %}
   identifier
   assume_role {
     AWS
@@ -126,7 +127,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceSQS_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   output_resource_name
@@ -140,7 +141,7 @@ provider
   }
 }
 ... on NamespaceTerraformResourceDynamoDB_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   output_resource_name
@@ -154,7 +155,7 @@ provider
   }
 }
 ... on NamespaceTerraformResourceECR_v1 {
-  account
+  {% if account %}account{% endif %}
   identifier
   region
   output_resource_name
@@ -162,7 +163,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceS3CloudFront_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -171,7 +172,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceS3SQS_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -181,7 +182,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceCloudWatch_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -191,7 +192,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceKMS_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -200,7 +201,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceElasticSearch_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -209,7 +210,7 @@ provider
   publish_log_types
 }
 ... on NamespaceTerraformResourceACM_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   secret {
@@ -226,7 +227,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceKinesis_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -234,7 +235,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceS3CloudFrontPublicKey_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   secret {
@@ -247,7 +248,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceALB_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   vpc {
@@ -279,7 +280,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceSecretsManager_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   secret {
@@ -292,7 +293,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceASG_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -322,7 +323,7 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceRoute53Zone_v1 {
-  account
+  {% if account %}account{% endif %}
   region
   identifier
   name
@@ -378,7 +379,9 @@ TF_NAMESPACES_QUERY = """
     }
   }
 }
-""" % (indent(TF_RESOURCE_AWS, 6*' '))
+""" % (
+    indent(Template(TF_RESOURCE_AWS).render(account=True), 6*' ')
+)
 
 QONTRACT_INTEGRATION = 'terraform_resources'
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 5, 2)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -555,6 +555,20 @@ def filter_tf_namespaces(
                 if resource['account'] == account_name:
                     tf_namespaces.append(namespace_info)
                     break
+
+        if namespace_info.get('managedExternalResources'):
+            if account_name is None:
+                tf_namespaces.append(namespace_info)
+                continue
+            external_resources = namespace_info.get('externalResources')
+            if not external_resources:
+                tf_namespaces.append(namespace_info)
+                continue
+            for resource in external_resources:
+                if resource['provisioner']['name'] == account_name:
+                    tf_namespaces.append(namespace_info)
+                    break
+
     return tf_namespaces
 
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -341,6 +341,18 @@ TF_NAMESPACES_QUERY = """
     terraformResources {
       %s
     }
+    managedExternalResources
+    externalResources {
+      provider
+      provisioner {
+        name
+      }
+      ... on NamespaceTerraformProviderResourceAWS_v1 {
+        resources {
+          %s
+        }
+      }
+    }
     environment {
       name
     }
@@ -380,7 +392,8 @@ TF_NAMESPACES_QUERY = """
   }
 }
 """ % (
-    indent(Template(TF_RESOURCE_AWS).render(account=True), 6*' ')
+    indent(Template(TF_RESOURCE_AWS).render(account=True), 6*' '),
+    indent(Template(TF_RESOURCE_AWS).render(account=False), 6*' '),
 )
 
 QONTRACT_INTEGRATION = 'terraform_resources'

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -923,14 +923,14 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         for namespace_info in namespaces:
             tf_resources = namespace_info.get('terraformResources') or []
             for resource in tf_resources:
-                populate_spec = {'resource': resource,
-                                 'namespace_info': namespace_info}
                 account = resource['account']
                 # Skip if account_name is specified
                 if account_name and account != account_name:
                     continue
                 if account not in self.account_resources:
                     self.account_resources[account] = []
+                populate_spec = {'resource': resource,
+                                 'namespace_info': namespace_info}
                 self.account_resources[account].append(populate_spec)
 
     def populate_tf_resources(self, populate_spec, existing_secrets,

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -929,12 +929,36 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     continue
                 if account not in self.account_resources:
                     self.account_resources[account] = []
+                # terraformResources is aws specific
+                provision_provider = 'aws'
                 populate_spec = {'resource': resource,
+                                 'provision_provider': provision_provider,
                                  'namespace_info': namespace_info}
                 self.account_resources[account].append(populate_spec)
 
+            external_resources = namespace_info.get('externalResources') or []
+            for resource in external_resources:
+                provision_provider = resource['provider']
+                # Skip if provision provider is not aws
+                if provision_provider != 'aws':
+                    continue
+                account = resource['provisioner']['name']
+                # Skip if account_name is specified
+                if account_name and account != account_name:
+                    continue
+                if account not in self.account_resources:
+                    self.account_resources[account] = []
+                for resource in resource['resources']:
+                    resource['account'] = account
+                    populate_spec = {'resource': resource,
+                                     'provision_provider': provision_provider,
+                                     'namespace_info': namespace_info}
+                    self.account_resources[account].append(populate_spec)
+
     def populate_tf_resources(self, populate_spec, existing_secrets,
                               ocm_map=None):
+        if populate_spec['provision_provider'] != 'aws':
+            return
         resource = populate_spec['resource']
         namespace_info = populate_spec['namespace_info']
         provider = resource['provider']

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -921,10 +921,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                             account_name: Optional[str]) -> None:
         self.account_resources: dict[str, list[dict[str, Any]]] = {}
         for namespace_info in namespaces:
-            # Skip if namespace has no terraformResources
-            tf_resources = namespace_info.get('terraformResources')
-            if not tf_resources:
-                continue
+            tf_resources = namespace_info.get('terraformResources') or []
             for resource in tf_resources:
                 populate_spec = {'resource': resource,
                                  'namespace_info': namespace_info}


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4611

design doc: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/additional-terraform-providers.md

replaces #2203

depends on https://github.com/app-sre/qontract-schemas/pull/87

this PR adds support to provision resources using `externalResources`, and prepares for addition of new provision providers, such as gcp, CNA, cloudflare, and more.