### PR TITLE
remove unsupported pylint ignores

### DIFF
--- a/reconcile/test/test_gabi_authorized_users.py
+++ b/reconcile/test/test_gabi_authorized_users.py
@@ -113,7 +113,6 @@ class TestGabiAuthorizedUser(TestCase):
         secret_read,
         get_settings,
     ):
-        # pylint: disable=no-self-use
         expirationDate = date.today()
         get_gabi_instances.return_value = mock_get_gabi_instances(expirationDate)
         mock_request.side_effect = delete_request
@@ -131,7 +130,6 @@ class TestGabiAuthorizedUser(TestCase):
         secret_read,
         get_settings,
     ):
-        # pylint: disable=no-self-use
         expirationDate = date.today() - timedelta(days=1)
         get_gabi_instances.return_value = mock_get_gabi_instances(expirationDate)
         mock_request.side_effect = delete_request

--- a/reconcile/test/test_instrumented_wrappers.py
+++ b/reconcile/test/test_instrumented_wrappers.py
@@ -11,7 +11,6 @@ class TestInstrumentedImage(TestCase):
     @patch.object(Counter, "labels")
     @patch.object(Image, "_get_manifest")
     def test_instrumented_reachout(self, getter, counter):
-        # pylint: disable=no-self-use
         i = instrumented.InstrumentedImage("aregistry/animage:atag")
         i._get_manifest()
         getter.assert_called_once_with()

--- a/reconcile/test/test_utils_mr_clusters_updates.py
+++ b/reconcile/test/test_utils_mr_clusters_updates.py
@@ -17,7 +17,6 @@ class TestProcess(TestCase):
         self.raw_clusters = fxt.get("cluster1.yml")
 
     def test_no_changes(self, cancel):
-        # pylint: disable=no-self-use
         cli = MagicMock()
         c = sut.CreateClustersUpdates({})
         c.branch = "abranch"

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -88,7 +88,6 @@ class TestGetOwnedPods(TestCase):
 @patch.dict(os.environ, {"USE_NATIVE_CLIENT": "False"}, clear=True)
 class TestValidatePodReady(TestCase):
     @patch.object(OCDeprecated, "get")
-    # pylint: disable=no-self-use
     def test_validate_pod_ready_all_good(self, oc_get):
         oc_get.return_value = {
             "status": {

--- a/reconcile/utils/terraform_resource_spec.py
+++ b/reconcile/utils/terraform_resource_spec.py
@@ -18,7 +18,7 @@ class OutputFormatProcessor:
     def render(self, vars: Mapping[str, str]) -> dict[str, str]:
         return {}
 
-    def validate_k8s_secret_key(self, key: Any) -> None:  # pylint: disable=R0201
+    def validate_k8s_secret_key(self, key: Any) -> None:
         if isinstance(key, str):
             if len(key) > SECRET_MAX_KEY_LENGTH:
                 raise ValueError(


### PR DESCRIPTION
with a recent pylint update, certain checks have been removed and trying to disable them results in failed linter execution

this change removes those `disables`

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>