### PR TITLE
Logic to retrieve bucket information from new terraform state schema

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -450,12 +450,23 @@ AWS_ACCOUNTS_QUERY = """
       }
     }
     {% endif %}
+    {% if terraform_state %}
+    terraform_state {
+        provider
+        bucket
+        region
+        integrations {
+            key
+            integration
+        }
+    }
+    {% endif %}
   }
 }
 """
 
 
-def get_aws_accounts(reset_passwords=False, name=None, uid=None, sharing=False):
+def get_aws_accounts(reset_passwords=False, name=None, uid=None, sharing=False, terraform_state=False):
     """Returns all AWS accounts"""
     gqlapi = gql.get_api()
     search = name or uid
@@ -465,6 +476,7 @@ def get_aws_accounts(reset_passwords=False, name=None, uid=None, sharing=False):
         name=name,
         uid=uid,
         sharing=sharing,
+        terraform_state=terraform_state,
     )
     return gqlapi.query(query)["accounts"]
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -452,13 +452,13 @@ AWS_ACCOUNTS_QUERY = """
     {% endif %}
     {% if terraform_state %}
     terraform_state {
-        provider
-        bucket
-        region
-        integrations {
-            key
-            integration
-        }
+      provider
+      bucket
+      region
+      integrations {
+          key
+          integration
+      }
     }
     {% endif %}
   }

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -451,7 +451,7 @@ AWS_ACCOUNTS_QUERY = """
     }
     {% endif %}
     {% if terraform_state %}
-    terraform_state {
+    terraformState {
       provider
       bucket
       region
@@ -466,7 +466,9 @@ AWS_ACCOUNTS_QUERY = """
 """
 
 
-def get_aws_accounts(reset_passwords=False, name=None, uid=None, sharing=False, terraform_state=False):
+def get_aws_accounts(
+    reset_passwords=False, name=None, uid=None, sharing=False, terraform_state=False
+):
     """Returns all AWS accounts"""
     gqlapi = gql.get_api()
     search = name or uid

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -196,7 +196,7 @@ def run(
     settings = queries.get_app_interface_settings()
     zones = queries.get_dns_zones(account_name=account_name)
 
-    all_accounts = queries.get_aws_accounts()
+    all_accounts = queries.get_aws_accounts(terraform_state=True)
     participating_account_names = [z["account"]["name"] for z in zones]
     participating_accounts = [
         a for a in all_accounts if a["name"] in participating_account_names

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -484,7 +484,7 @@ def setup(
     account_name: Optional[str],
 ) -> Tuple[ResourceInventory, OC_Map, Terraform, ExternalResourceSpecInventory]:
     gqlapi = gql.get_api()
-    accounts = queries.get_aws_accounts()
+    accounts = queries.get_aws_accounts(terraform_state=True)
     if account_name:
         accounts = [n for n in accounts if n["name"] == account_name]
         if not accounts:

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -127,7 +127,7 @@ def run(
         # on the tgw defition in the cluster file.
         ocm_map = {}
 
-    accounts = queries.get_aws_accounts()
+    accounts = queries.get_aws_accounts(terraform_state=True)
     awsapi = AWSApi(1, accounts, settings=settings, init_users=False)
 
     # Fetch desired state for cluster-to-vpc(account) VPCs

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -64,7 +64,7 @@ def setup(
     print_to_file, thread_pool_size: int, account_name: Optional[str] = None
 ) -> tuple[list[dict[str, Any]], dict[str, str], bool, AWSApi]:
     gqlapi = gql.get_api()
-    accounts = queries.get_aws_accounts()
+    accounts = queries.get_aws_accounts(terraform_state=True)
     if account_name:
         accounts = [n for n in accounts if n["name"] == account_name]
         if not accounts:

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -478,7 +478,7 @@ def run(
         # on the vpc peering defition in the cluster file.
         ocm_map = None
 
-    accounts = queries.get_aws_accounts()
+    accounts = queries.get_aws_accounts(terraform_state=True)
     awsapi = aws_api.AWSApi(1, accounts, settings=settings, init_users=False)
 
     desired_state = []

--- a/reconcile/test/test_utils_terrascript_aws_client.py
+++ b/reconcile/test/test_utils_terrascript_aws_client.py
@@ -145,3 +145,28 @@ def test_resource_specs_with_account_filter(ts):
     specs = ts.resource_spec_inventory
     spec = ExternalResourceSpec(p, pa, ra, ns1)
     assert specs == {ExternalResourceUniqueKey.from_spec(spec): spec}
+
+
+def test_terraform_state(ts):
+    account_name = "some-account"
+    integration_name = "terraform-resources-wrapper"
+    config_test = {
+        "aws_access_key_id": "SOMEKEY123",
+        "aws_secret_access_key": "somesecretkey",
+        "bucket": "some-bucket",
+        "key": "qontract-reconcile.tfstate",
+        "region": "us-east-1",
+        "terraform-resources-wrapper_key": "qontract-reconcile.tfstate",
+        "terraformState": {
+            "provider": "s3",
+            "bucket": "some-bucket",
+            "region": "some-region",
+            "integrations": [
+                {
+                    "key": "terraform-resources-wrapper",
+                    "integration": "qontract-reconcile.tfstate",
+                },
+            ],
+        },
+    }
+    assert ts.state_bucket_for_account(integration_name, account_name, config_test)

--- a/reconcile/test/test_wrong_region.py
+++ b/reconcile/test/test_wrong_region.py
@@ -26,6 +26,7 @@ def accounts(default_region):
             "supportedDeploymentRegions": [default_region],
             "providerVersion": "1.2.3",
             "uid": "123",
+            "terraformState": {},
         }
     ]
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -332,13 +332,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
             access_key_backend_value = config["aws_access_key_id"]
             secret_key_backend_value = config["aws_secret_access_key"]
-            bucket_backend_value = ""
-            key_backend_value = ""
-            region_backend_value = ""
 
             for filtered_account in filtered_accounts:
                 if filtered_account.get("name") == name:
                     terraform_state = filtered_account.get("terraformState")
+                    bucket_backend_value, key_backend_value, region_backend_value = (
+                        "",
+                        "",
+                        "",
+                    )
                     if not terraform_state:
                         bucket_backend_value = config["bucket"]
                         key_backend_value = config["{}_key".format(integration)]
@@ -346,6 +348,10 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     else:
                         tf_state_integration = terraform_state["integrations"]
                         for key in tf_state_integration:
+                            if "key" not in tf_state_integration.keys():
+                                bucket_backend_value = config["bucket"]
+                                key_backend_value = config["{}_key".format(integration)]
+                                region_backend_value = config["region"]
                             key_value = key.get("key")
                             integration_value = key.get("integration")
                             transformed_integration = str(integration_value).replace(

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -330,51 +330,10 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
             ts += provider.template(version="2.2.0")
 
-            # access_key_backend_value = config["aws_access_key_id"]
-            # secret_key_backend_value = config["aws_secret_access_key"]
-
-            # for filtered_account in filtered_accounts:
-            #     if filtered_account.get("name") == name:
-            #         terraform_state = filtered_account.get("terraformState")
-            #         bucket_backend_value, key_backend_value, region_backend_value = (
-            #             "",
-            #             "",
-            #             "",
-            #         )
-            #         if not terraform_state:
-            #             bucket_backend_value = config["bucket"]
-            #             key_backend_value = config["{}_key".format(integration)]
-            #             region_backend_value = config["region"]
-            #         else:
-            #             tf_state_integration = terraform_state["integrations"]
-            #             for key in tf_state_integration:
-            #                 if "key" not in tf_state_integration.keys():
-            #                     bucket_backend_value = config["bucket"]
-            #                     key_backend_value = config["{}_key".format(integration)]
-            #                     region_backend_value = config["region"]
-            #                 key_value = key.get("key")
-            #                 integration_value = key.get("integration")
-            #                 transformed_integration = str(integration_value).replace(
-            #                     "-", "_"
-            #                 )
-            #                 if transformed_integration == self.integration:
-            #                     bucket_backend_value = terraform_state.get("bucket")
-            #                     key_backend_value = str(key_value)
-            #                     region_backend_value = terraform_state.get("region")
-            #                 else:
-            #                     continue
-
-            # b = Backend(
-            #     "s3",
-            #     access_key=access_key_backend_value,
-            #     secret_key=secret_key_backend_value,
-            #     bucket=bucket_backend_value,
-            #     key=key_backend_value,
-            #     region=region_backend_value,
-            # )
-            # ts += Terraform(backend=b)
             ts += Terraform(
-                backend=TerrascriptClient.state_bucket_for_account(self.integration, name, config)
+                backend=TerrascriptClient.state_bucket_for_account(
+                    self.integration, name, config
+                )
             )
             tss[name] = ts
             locks[name] = Lock()
@@ -404,7 +363,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         self.github_lock = Lock()
 
     @staticmethod
-    def state_bucket_for_account(integration: str, account_name: str, config: dict[str, Any]) -> Backend:
+    def state_bucket_for_account(
+        integration: str, account_name: str, config: dict[str, Any]
+    ) -> Backend:
         # creds
         access_key_backend_value = config["aws_access_key_id"]
         secret_key_backend_value = config["aws_secret_access_key"]
@@ -413,7 +374,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         bucket_backend_value = config.get("bucket")
         key_backend_value = config.get("{}_key".format(integration))
         region_backend_value = config.get("region")
-
         terraform_state = config["terraformState"]
         if terraform_state:
             tf_state_integration = terraform_state["integrations"]

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -337,47 +337,24 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             region_backend_value = ""
 
             for filtered_account in filtered_accounts:
-                logging.debug("This is the filtered account")
-                logging.debug(filtered_account)
                 if filtered_account.get("name") == name:
-                    logging.debug("Account name matches!")
                     terraform_state = filtered_account.get("terraformState")
                     if not terraform_state:
-                        logging.debug("There is no terraform state")
                         bucket_backend_value = config["bucket"]
-                        logging.debug("bucket value")
-                        logging.debug(bucket_backend_value)
                         key_backend_value = config["{}_key".format(integration)]
-                        logging.debug("key value")
-                        logging.debug(key_backend_value)
                         region_backend_value = config["region"]
-                        logging.debug("region value")
-                        logging.debug(region_backend_value)
                     else:
-                        logging.debug("There is a terraform state")
                         tf_state_integration = terraform_state["integrations"]
                         for key in tf_state_integration:
                             key_value = key.get("key")
-                            logging.debug("This is the key value")
-                            logging.debug(key_value)
                             integration_value = key.get("integration")
                             transformed_integration = str(integration_value).replace(
                                 "-", "_"
                             )
-                            # logging.debug("This is the transformed key value:")
-                            # logging.debug(transformed_key)
-                            logging.debug("This is the integration value")
-                            logging.debug(self.integration)
                             if transformed_integration == self.integration:
                                 bucket_backend_value = terraform_state.get("bucket")
-                                logging.debug("bucket value")
-                                logging.debug(bucket_backend_value)
                                 key_backend_value = str(key_value)
-                                logging.debug("key value")
-                                logging.debug(key_backend_value)
                                 region_backend_value = terraform_state.get("region")
-                                logging.debug("region value")
-                                logging.debug(region_backend_value)
                             else:
                                 continue
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -10,8 +10,6 @@ import string
 import tempfile
 import imghdr
 
-from reconcile import queries
-
 from threading import Lock
 
 from typing import (

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -424,8 +424,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     key_backend_value = key.get("key")
                     region_backend_value = terraform_state.get("region")
                     break
-                else:
-                    continue
+                continue
 
         if bucket_backend_value and key_backend_value and region_backend_value:
             return Backend(

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -10,6 +10,8 @@ import string
 import tempfile
 import imghdr
 
+from reconcile import queries
+
 from threading import Lock
 
 from typing import (

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -333,7 +333,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             access_key_backend_value = config["aws_access_key_id"]
             secret_key_backend_value = config["aws_secret_access_key"]
             bucket_backend_value = ""
-            key_backend_value = "",
+            key_backend_value = ""
             region_backend_value = ""
 
             for filtered_account in filtered_accounts:
@@ -341,18 +341,18 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     terraform_state = filtered_account.get("terraformState")
                     if not terraform_state:
                         bucket_backend_value = config["bucket"]
-                        key_backend_value = config['{}_key'.format(integration)],
-                        region_backend_value = config['region']
+                        key_backend_value = config["{}_key".format(integration)]
+                        region_backend_value = config["region"]
                     else:
-                        tf_state_integration = terraform_state['integrations']
+                        tf_state_integration = terraform_state["integrations"]
                         for key in tf_state_integration:
                             key_value = key.get("key")
-                            transformed_key = str(key_value).replace("-","_")
+                            transformed_key = str(key_value).replace("-", "_")
                             logging.debug("This is the transformed key value:")
                             logging.debug(transformed_key)
                             if transformed_key == self.integration:
                                 bucket_backend_value = filtered_account.get("bucket")
-                                key_backend_value = str(key_value),
+                                key_backend_value = str(key_value)
                                 region_backend_value = filtered_account.get("region")
 
             b = Backend(

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -330,13 +330,38 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
             ts += provider.template(version="2.2.0")
 
+            access_key_backend_value = config["aws_access_key_id"]
+            secret_key_backend_value = config["aws_secret_access_key"]
+            bucket_backend_value = ""
+            key_backend_value = "",
+            region_backend_value = ""
+
+            for filtered_account in filtered_accounts:
+                if filtered_account.get("name") == name:
+                    terraform_state = filtered_account.get("terraformState")
+                    if not terraform_state:
+                        bucket_backend_value = config["bucket"]
+                        key_backend_value = config['{}_key'.format(integration)],
+                        region_backend_value = config['region']
+                    else:
+                        tf_state_integration = terraform_state['integrations']
+                        for key in tf_state_integration:
+                            key_value = key.get("key")
+                            transformed_key = str(key_value).replace("-","_")
+                            logging.debug("This is the transformed key value:")
+                            logging.debug(transformed_key)
+                            if transformed_key == self.integration:
+                                bucket_backend_value = filtered_account.get("bucket")
+                                key_backend_value = str(key_value),
+                                region_backend_value = filtered_account.get("region")
+
             b = Backend(
                 "s3",
-                access_key=config["aws_access_key_id"],
-                secret_key=config["aws_secret_access_key"],
-                bucket=config["bucket"],
-                key=config["{}_key".format(integration)],
-                region=config["region"],
+                access_key=access_key_backend_value,
+                secret_key=secret_key_backend_value,
+                bucket=bucket_backend_value,
+                key=key_backend_value,
+                region=region_backend_value,
             )
             ts += Terraform(backend=b)
             tss[name] = ts

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -337,23 +337,49 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             region_backend_value = ""
 
             for filtered_account in filtered_accounts:
+                logging.debug("This is the filtered account")
+                logging.debug(filtered_account)
                 if filtered_account.get("name") == name:
+                    logging.debug("Account name matches!")
                     terraform_state = filtered_account.get("terraformState")
                     if not terraform_state:
+                        logging.debug("There is no terraform state")
                         bucket_backend_value = config["bucket"]
+                        logging.debug("bucket value")
+                        logging.debug(bucket_backend_value)
                         key_backend_value = config["{}_key".format(integration)]
+                        logging.debug("key value")
+                        logging.debug(key_backend_value)
                         region_backend_value = config["region"]
+                        logging.debug("region value")
+                        logging.debug(region_backend_value)
                     else:
+                        logging.debug("There is a terraform state")
                         tf_state_integration = terraform_state["integrations"]
                         for key in tf_state_integration:
                             key_value = key.get("key")
-                            transformed_key = str(key_value).replace("-", "_")
-                            logging.debug("This is the transformed key value:")
-                            logging.debug(transformed_key)
-                            if transformed_key == self.integration:
-                                bucket_backend_value = filtered_account.get("bucket")
+                            logging.debug("This is the key value")
+                            logging.debug(key_value)
+                            integration_value = key.get("integration")
+                            transformed_integration = str(integration_value).replace(
+                                "-", "_"
+                            )
+                            # logging.debug("This is the transformed key value:")
+                            # logging.debug(transformed_key)
+                            logging.debug("This is the integration value")
+                            logging.debug(self.integration)
+                            if transformed_integration == self.integration:
+                                bucket_backend_value = terraform_state.get("bucket")
+                                logging.debug("bucket value")
+                                logging.debug(bucket_backend_value)
                                 key_backend_value = str(key_value)
-                                region_backend_value = filtered_account.get("region")
+                                logging.debug("key value")
+                                logging.debug(key_backend_value)
+                                region_backend_value = terraform_state.get("region")
+                                logging.debug("region value")
+                                logging.debug(region_backend_value)
+                            else:
+                                continue
 
             b = Backend(
                 "s3",


### PR DESCRIPTION
We have implemented a new schema change that displays terraform state information through an account file

Schema setup for a file tf-state-test.yml:
```
---
$schema: /dependencies/terraform-state-1.yml
provider: s3
bucket: someBucket
region: someRegion
integrations:
- integration: terraform-resources
  key:  qontract-reconcile.tfstate
- integration: terraform-tgw-attachements
  key: qontract-reconcile-tgw-attachments.tfstate
```

AWS account file call:
```
terraformState:
  $ref: /aws/app-sre-stage/tf-state-test.yml
```

This MR will implement logic that will check if the new schema changes are present within app-interface and if it is, it will execute logic to retrieve bucket information the new way (looking within app-interface and extracting the information) or the current way (looking within vault to retrieve that information).

Part of [APPSRE-4516](https://issues.redhat.com/browse/APPSRE-4516)

Signed-off-by: Suzana Nesic <snesic@redhat.com>