### PR TITLE
APPSRE-5552 Slack notification on cluster upgrade completion

### DIFF
--- a/reconcile/slack_base.py
+++ b/reconcile/slack_base.py
@@ -6,9 +6,11 @@ from reconcile.utils.slack_api import SlackApi, SlackApiConfig
 
 
 def slackapi_from_queries(
-    integration_name: str, init_usergroups: Optional[bool] = True
+    integration_name: str, init_usergroups: Optional[bool] = True, settings=None
 ) -> SlackApi:
-    app_interface_settings = queries.get_app_interface_settings()
+    app_interface_settings = settings
+    if not app_interface_settings:
+        app_interface_settings = queries.get_app_interface_settings()
     slack_workspace = {"workspace": queries.get_slack_workspace()}
     return slackapi_from_slack_workspace(
         slack_workspace, app_interface_settings, integration_name, init_usergroups

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -8,6 +8,8 @@ from reconcile import queries
 import reconcile.utils.ocm as ocmmod
 import reconcile.ocm_clusters as occ
 from reconcile.utils.mr import clusters_updates
+import reconcile.utils.state as statemod
+import reconcile.utils.slack_api as slackapimod
 
 from .fixtures import Fixtures
 
@@ -116,6 +118,11 @@ class TestRun(TestCase):
         self.update_cluster = self.mock_callable(
             self.ocm, "update_cluster"
         ).to_return_value(None)
+        self.state = StrictMock(statemod.State)
+        self.mock_constructor(statemod, "State").to_return_value(self.state)
+        self.mock_callable(self.state, "exists").to_return_value(False)
+        self.slackapi = StrictMock(slackapimod.SlackApi)
+        self.mock_callable(occ, "slackapi_from_queries").to_return_value(self.slackapi)
         self.mock_callable(sys, "exit").to_raise(ValueError)
         self.addCleanup(mock_callable.unpatch_all_callable_mocks)
 
@@ -140,6 +147,9 @@ class TestRun(TestCase):
         self.mock_callable(self.ocmmap, "cluster_specs").for_call().to_return_value(
             (current, {})
         ).and_assert_called_once()
+        self.mock_callable(
+            queries, "get_state_aws_accounts"
+        ).for_call().to_return_value([]).and_assert_not_called()
         self.mock_callable(occ, "get_cluster_update_spec").to_return_value(
             ({}, False)
         ).and_assert_called_once()
@@ -173,6 +183,9 @@ class TestRun(TestCase):
         self.mock_callable(self.ocmmap, "cluster_specs").for_call().to_return_value(
             (current, {})
         ).and_assert_called_once()
+        self.mock_callable(
+            queries, "get_state_aws_accounts"
+        ).for_call().to_return_value([]).and_assert_called_once()
         self.mock_callable(occ, "get_cluster_update_spec").to_return_value(
             ({}, False)
         ).and_assert_called_once()
@@ -204,6 +217,9 @@ class TestRun(TestCase):
         self.mock_callable(self.ocmmap, "cluster_specs").for_call().to_return_value(
             (current, {})
         ).and_assert_called_once()
+        self.mock_callable(
+            queries, "get_state_aws_accounts"
+        ).for_call().to_return_value([]).and_assert_called_once()
         self.mock_callable(occ, "get_cluster_update_spec").to_return_value(
             ({"id": "anid"}, False)
         ).and_assert_called_once()
@@ -248,6 +264,10 @@ class TestRun(TestCase):
             (current, {})
         ).and_assert_called_once()
 
+        self.mock_callable(
+            queries, "get_state_aws_accounts"
+        ).for_call().to_return_value([]).and_assert_called_once()
+
         create_clusters_updates = StrictMock(clusters_updates.CreateClustersUpdates)
         self.mock_constructor(
             clusters_updates, "CreateClustersUpdates"
@@ -290,6 +310,10 @@ class TestRun(TestCase):
         self.mock_callable(self.ocmmap, "cluster_specs").for_call().to_return_value(
             (current, {})
         ).and_assert_called_once()
+
+        self.mock_callable(
+            queries, "get_state_aws_accounts"
+        ).for_call().to_return_value([]).and_assert_called_once()
 
         create_clusters_updates = StrictMock(clusters_updates.CreateClustersUpdates)
         self.mock_constructor(


### PR DESCRIPTION
The choice here is to notify the slack channel when we create the MR to bump the cluster version.
This depends on https://github.com/app-sre/qontract-schemas/pull/166 and /data/dependencies/slack/coreos.yml needs to be updated in app-interface to grant ocm-clusters access to slack:

An other option would be to amend the `openshift-ugrade-watcher` integration. That would mean additional calls to OCM to get the version from there.