### PR TITLE
[openshift-network-policies] use kubernetes.io/metadata.name instead of name

### DIFF
--- a/reconcile/openshift_network_policies.py
+++ b/reconcile/openshift_network_policies.py
@@ -61,7 +61,17 @@ def construct_oc_resource(name, source_ns):
         "metadata": {"name": name},
         "spec": {
             "ingress": [
-                {"from": [{"namespaceSelector": {"matchLabels": {"kubernetes.io/metadata.name": source_ns}}}]}
+                {
+                    "from": [
+                        {
+                            "namespaceSelector": {
+                                "matchLabels": {
+                                    "kubernetes.io/metadata.name": source_ns
+                                }
+                            }
+                        }
+                    ]
+                }
             ],
             "podSelector": {},
             "policyTypes": ["Ingress"],

--- a/reconcile/openshift_network_policies.py
+++ b/reconcile/openshift_network_policies.py
@@ -61,7 +61,7 @@ def construct_oc_resource(name, source_ns):
         "metadata": {"name": name},
         "spec": {
             "ingress": [
-                {"from": [{"namespaceSelector": {"matchLabels": {"name": source_ns}}}]}
+                {"from": [{"namespaceSelector": {"matchLabels": {"kubernetes.io/metadata.name": source_ns}}}]}
             ],
             "podSelector": {},
             "policyTypes": ["Ingress"],


### PR DESCRIPTION
to create NetworkPolicies, we rely on a `name` label present on the namespace/project.

this label is added to specific projects (as can be seen in this example: https://github.com/openshift/managed-cluster-config/pull/374)

automatic labeling was added in Kubernetes 1.21: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/#automatic-labelling
OpenShift version 4.8 uses Kubernetes 1.21: https://docs.openshift.com/container-platform/4.8/release_notes/ocp-4-8-release-notes.html

this PR changes the openshift-network-policies integration to create a NetworkPolicy using the new automatically added label instead of relying on a `name` label to exist.