### PR TITLE
[cli] get/clusters-egress-ips handle account without infra assume role

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -475,6 +475,8 @@ def clusters_egress_ips(ctx):
         account = tfvpc._build_infrastructure_assume_role(
             management_account, cluster, ocm_map.get(cluster_name)
         )
+        if not account:
+            continue
         account["resourcesDefaultRegion"] = management_account["resourcesDefaultRegion"]
         aws_api = AWSApi(1, [account], settings=settings)
         egress_ips = aws_api.get_cluster_nat_gateways_egress_ips(account)


### PR DESCRIPTION
during a cluster provisioning, and before a cluster has AWS infrastructure access set up, this command will fail.
with this PR, such a cluster will be skipped.