### PR TITLE
[integration-autoscaler] don't fail on missing integration metadata

### DIFF
--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -44,8 +44,16 @@ class IntegrationShardManager:
     ) -> list[dict[str, Any]]:
         sharding_strategy = spec.get("shardingStrategy") or "static"
         if sharding_strategy in self.strategies:
+            integration_meta = self.integration_runtime_meta.get(integration)
+            if not integration_meta:
+                # workaround until we can get metadata for non cli.py based integrations
+                integration_meta = IntegrationMeta(
+                    name=integration,
+                    args=[],
+                    short_help=None
+                )
             shards = self.strategies[sharding_strategy].build_integration_shards(
-                self.integration_runtime_meta[integration], spec
+                integration_meta, spec
             )
 
             # add the extra args of the integrations pr check spec to each shard

--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -48,9 +48,7 @@ class IntegrationShardManager:
             if not integration_meta:
                 # workaround until we can get metadata for non cli.py based integrations
                 integration_meta = IntegrationMeta(
-                    name=integration,
-                    args=[],
-                    short_help=None
+                    name=integration, args=[], short_help=None
                 )
             shards = self.strategies[sharding_strategy].build_integration_shards(
                 integration_meta, spec


### PR DESCRIPTION
this can happen for integration of e2e tests and go integrations because currently metadata about supported args is read from cli.py click metadata

this would only affect e2e or go integrations wanting to use the `per-aws-account` sharding strategy

this change is a workaround and needs fixing once we figured out a way to provide the required metadata

fixes #2428

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>