### PR TITLE
[integration-manager] shard_id metric label as identifier for workload buckets

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -153,10 +153,16 @@ objects:
             - name: http
               containerPort: 9090
           env:
+          {{- if $shard.shard_id }}
           - name: SHARDS
             value: "{{ $shard.shards }}"
           - name: SHARD_ID
             value: "{{ $shard.shard_id }}"
+          {{- end }}
+          {{- if $shard.shard_key }}
+          - name: SHARD_KEY
+            value: "{{ $shard.shard_key }}"
+          {{- end }}
           - name: DRY_RUN
             value: ${DRY_RUN}
           {{- if eq $integration.name "integrations-manager" }}

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -111,10 +111,6 @@ objects:
             - name: http
               containerPort: 9090
           env:
-          - name: SHARDS
-            value: "1"
-          - name: SHARD_ID
-            value: "0"
           - name: DRY_RUN
             value: ${DRY_RUN}
           - name: MANAGER_DRY_RUN

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1360,7 +1360,6 @@ def terraform_resources(
         light,
         vault_output_path,
         account_name=account_name,
-        extra_labels=ctx.obj.get("extra_labels", {}),
     )
 
 

--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -71,8 +71,8 @@ class StaticShardingStrategy(ShardingStrategy):
         shards = spec.get("shards") or 1
         return [
             {
-                "shard_id": s,
-                "shards": shards,
+                "shard_id": str(s),
+                "shards": str(shards),
                 "shard_name_suffix": f"-{s}" if shards > 1 else "",
                 "extra_args": "",
             }
@@ -93,14 +93,13 @@ class AWSAccountShardManager(ShardingStrategy):
             )
             return [
                 {
-                    "shard_id": shard_id,
-                    "shards": len(filtered_accounts),
+                    "shard_key": account["name"],
                     "shard_name_suffix": f"-{account['name']}"
                     if len(filtered_accounts) > 1
                     else "",
                     "extra_args": f"--account-name {account['name']}",
                 }
-                for shard_id, account in enumerate(filtered_accounts)
+                for account in filtered_accounts
             ]
         else:
             raise ValueError(

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -3,7 +3,7 @@ import shutil
 import sys
 
 from textwrap import indent
-from typing import Any, Iterable, MutableMapping, Optional, Mapping, Tuple, cast
+from typing import Any, Iterable, Optional, Mapping, Tuple, cast
 from jinja2 import Template
 
 from sretoolbox.utils import threaded
@@ -484,7 +484,6 @@ def setup(
     internal: str,
     use_jump_host: bool,
     account_name: Optional[str],
-    extra_labels: MutableMapping[str, str],
 ) -> Tuple[
     ResourceInventory,
     OC_Map,
@@ -498,7 +497,6 @@ def setup(
                     if n['name'] == account_name]
         if not accounts:
             raise ValueError(f"aws account {account_name} is not found")
-        extra_labels['shard_key'] = account_name
     settings = queries.get_app_interface_settings()
 
     # build a resource inventory for all the kube secrets managed by the
@@ -637,7 +635,6 @@ def run(
     light=False,
     vault_output_path="",
     account_name=None,
-    extra_labels=None,
     defer=None,
 ):
 
@@ -648,7 +645,6 @@ def run(
         internal,
         use_jump_host,
         account_name,
-        extra_labels,
     )
 
     if not dry_run:

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -351,7 +351,9 @@ def test_initialize_shard_specs_no_shards(
     this test shows how exactly one shard is created when no sharding has been configured
     """
     intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
-    expected = [{"shard_id": "0", "shards": "1", "shard_name_suffix": "", "extra_args": ""}]
+    expected = [
+        {"shard_id": "0", "shards": "1", "shard_name_suffix": "", "extra_args": ""}
+    ]
     assert (
         expected
         == collected_namespaces_env_test1[0]["integration_specs"][0]["shard_specs"]

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -351,7 +351,7 @@ def test_initialize_shard_specs_no_shards(
     this test shows how exactly one shard is created when no sharding has been configured
     """
     intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
-    expected = [{"shard_id": 0, "shards": 1, "shard_name_suffix": "", "extra_args": ""}]
+    expected = [{"shard_id": "0", "shards": "1", "shard_name_suffix": "", "extra_args": ""}]
     assert (
         expected
         == collected_namespaces_env_test1[0]["integration_specs"][0]["shard_specs"]
@@ -368,8 +368,8 @@ def test_initialize_shard_specs_two_shards(
     collected_namespaces_env_test1[0]["integration_specs"][0]["shards"] = 2
     intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
     expected = [
-        {"shard_id": 0, "shards": 2, "shard_name_suffix": "-0", "extra_args": ""},
-        {"shard_id": 1, "shards": 2, "shard_name_suffix": "-1", "extra_args": ""},
+        {"shard_id": "0", "shards": "2", "shard_name_suffix": "-0", "extra_args": ""},
+        {"shard_id": "1", "shards": "2", "shard_name_suffix": "-1", "extra_args": ""},
     ]
     assert (
         expected
@@ -390,8 +390,8 @@ def test_initialize_shard_specs_two_shards_explicit(
     collected_namespaces_env_test1[0]["integration_specs"][0]["shards"] = 2
     intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
     expected = [
-        {"shard_id": 0, "shards": 2, "shard_name_suffix": "-0", "extra_args": ""},
-        {"shard_id": 1, "shards": 2, "shard_name_suffix": "-1", "extra_args": ""},
+        {"shard_id": "0", "shards": "2", "shard_name_suffix": "-0", "extra_args": ""},
+        {"shard_id": "1", "shards": "2", "shard_name_suffix": "-1", "extra_args": ""},
     ]
     assert (
         expected
@@ -413,21 +413,18 @@ def test_initialize_shard_specs_aws_account_shards(
     intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
     expected = [
         {
-            "shard_id": 0,
-            "shards": 3,
             "shard_name_suffix": "-acc-1",
+            "shard_key": "acc-1",
             "extra_args": "--account-name acc-1",
         },
         {
-            "shard_id": 1,
-            "shards": 3,
             "shard_name_suffix": "-acc-2",
+            "shard_key": "acc-2",
             "extra_args": "--account-name acc-2",
         },
         {
-            "shard_id": 2,
-            "shards": 3,
             "shard_name_suffix": "-acc-3",
+            "shard_key": "acc-3",
             "extra_args": "--account-name acc-3",
         },
     ]
@@ -451,21 +448,18 @@ def test_initialize_shard_specs_extra_arg_agregation(
     intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
     expected = [
         {
-            "shard_id": 0,
-            "shards": 3,
             "shard_name_suffix": "-acc-1",
+            "shard_key": "acc-1",
             "extra_args": "--arg --account-name acc-1",
         },
         {
-            "shard_id": 1,
-            "shards": 3,
             "shard_name_suffix": "-acc-2",
+            "shard_key": "acc-2",
             "extra_args": "--arg --account-name acc-2",
         },
         {
-            "shard_id": 2,
-            "shards": 3,
             "shard_name_suffix": "-acc-3",
+            "shard_key": "acc-3",
             "extra_args": "--arg --account-name acc-3",
         },
     ]

--- a/reconcile/test/test_utils_helm.py
+++ b/reconcile/test/test_utils_helm.py
@@ -26,8 +26,8 @@ def values():
                 },
                 "shard_specs": [
                     {
-                        "shard_id": 0,
-                        "shards": 1,
+                        "shard_id": "0",
+                        "shards": "1",
                         "shard_name_suffix": "",
                     }
                 ],
@@ -103,13 +103,13 @@ def test_template_logs_slack(values):
 def test_template_shards(values):
     values["integrations"][0]["shard_specs"] = [
         {
-            "shard_id": 0,
-            "shards": 2,
+            "shard_id": "0",
+            "shards": "2",
             "shard_name_suffix": "-0",
         },
         {
-            "shard_id": 1,
-            "shards": 2,
+            "shard_id": "1",
+            "shards": "2",
             "shard_name_suffix": "-1",
         },
     ]
@@ -121,14 +121,14 @@ def test_template_shards(values):
 def test_template_aws_account_shards(values):
     values["integrations"][0]["shard_specs"] = [
         {
-            "shard_id": 0,
-            "shards": 2,
+            "shard_id": "0",
+            "shards": "2",
             "shard_name_suffix": "-acc-1",
             "extra_args": "--account-name acc-1",
         },
         {
-            "shard_id": 1,
-            "shards": 2,
+            "shard_id": "1",
+            "shards": "2",
             "shard_name_suffix": "-acc-2",
             "extra_args": "--account-name acc-2",
         },

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -1,25 +1,22 @@
 from prometheus_client import Gauge, Counter, Histogram
 
 
-extra_labels = {"shard_key": None}
-label_keys = list(extra_labels.keys())
-
 run_time = Gauge(
     name="qontract_reconcile_last_run_seconds",
     documentation="Last run duration in seconds",
-    labelnames=["integration", "shards", "shard_id"] + label_keys,
+    labelnames=["integration", "shards", "shard_id"],
 )
 
 run_status = Gauge(
     name="qontract_reconcile_last_run_status",
     documentation="Last run status",
-    labelnames=["integration", "shards", "shard_id"] + label_keys,
+    labelnames=["integration", "shards", "shard_id"],
 )
 
 execution_counter = Counter(
     name="qontract_reconcile_execution_counter",
     documentation="Counts started integration executions",
-    labelnames=["integration", "shards", "shard_id"] + label_keys,
+    labelnames=["integration", "shards", "shard_id"],
 )
 
 reconcile_time = Histogram(


### PR DESCRIPTION
shard_id has been an integer to identify a bucket of workloads within a collection of shards. since a hashing strategy is used to distribute workload based on the number of buckets, shard_id does not necessarily represent a stable bucket of workload but needs the `shards` label along with it.

this change seeks to make shard_id a true identifier for a workload bucket by allowing it to be one of the following
* shard-nrOfShards, e.g. 2-18
* sharding key, e.g. an aws account

the first option will be enabled by standard sharding (`static` strategy) while the second one will be served by other sharding strategies like the `per-aws-account` strategy.

alerting rule grouping based on `integration` and `shard_id` will be unaffected by this change (maybe short hickups during an initial rollout). also, the extra label feature, used exclusively by terraform-resources to accommodate for the wrapper functionality, will be obsolete.

obsoletes #2406

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>