### PR TITLE
openshift-vault-secrets: do not continuously sync empty secrets

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -403,8 +403,6 @@ def fetch_provider_vault_secret(
     }
     if labels:
         body["metadata"]["labels"] = labels
-    if raw_data.items():
-        body["data"] = {}
 
     # populate data
     for k, v in raw_data.items():
@@ -415,7 +413,7 @@ def fetch_provider_vault_secret(
             v = v.replace("\n", "")
         elif v is not None:
             v = base64.b64encode(v.encode()).decode("utf-8")
-        body["data"][k] = v
+        body.setdefault("data", {})[k] = v
 
     try:
         return OR(body, integration, integration_version, error_details=path)


### PR DESCRIPTION
ref APPSRE-5810

**Problem statement**
When a vault secret is empty (or has no field with non-empty values), we currently sync it at each iteration.
That's because we have this in the desired state
```
  data: {}
```
but the data field is not even present in the current state.

Note that this occurs also when all secret 'values' in vault are set to an empty string as we just ignore those today. This could be challenged and part of an other change.

**Implementation proposal**
do not add the `data` field in the desired state when there is no secret key being set