### PR TITLE
deprecate terraformResources

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -903,36 +903,6 @@ NAMESPACES_QUERY = """
         email
       }
     }
-    managedTerraformResources
-    terraformResources {
-      provider
-      ... on NamespaceTerraformResourceRDS_v1
-      {
-        account
-        identifier
-        output_resource_name
-        defaults
-        replica_source
-      }
-      ... on NamespaceTerraformResourceECR_v1
-      {
-        account
-        region
-        identifier
-        output_resource_name
-        mirror {
-          url
-          pullCredentials {
-            path
-            field
-            version
-            format
-          }
-          tags
-          tagsExclude
-        }
-      }
-    }
     managedExternalResources
     externalResources {
       provider
@@ -1566,19 +1536,6 @@ APP_INTERFACE_SQL_QUERIES_QUERY = """
     namespace
     {
       name
-      managedTerraformResources
-      terraformResources
-      {
-        provider
-        ... on NamespaceTerraformResourceRDS_v1
-        {
-          account
-          identifier
-          output_resource_name
-          defaults
-          overrides
-        }
-      }
       managedExternalResources
       externalResources {
         provider
@@ -2234,15 +2191,6 @@ DNS_ZONES_QUERY = """
       }
       _target_namespace_zone {
         namespace {
-          managedTerraformResources
-          terraformResources {
-            provider
-            ... on NamespaceTerraformResourceRoute53Zone_v1 {
-              account
-              region
-              name
-            }
-          }
           managedExternalResources
           externalResources {
             provider
@@ -2371,18 +2319,6 @@ OCP_RELEASE_ECR_MIRROR_QUERY = """
     }
     ecrResourcesNamespace {
       name
-      managedTerraformResources
-      terraformResources
-      {
-        provider
-        ... on NamespaceTerraformResourceECR_v1
-        {
-          account
-          region
-          identifier
-          output_resource_name
-        }
-      }
       managedExternalResources
       externalResources {
         provider
@@ -2590,16 +2526,6 @@ GABI_INSTANCES_QUERY = """
       identifier
       namespace{
         name
-        managedTerraformResources
-        terraformResources
-        {
-          provider
-          ... on NamespaceTerraformResourceRDS_v1
-          {
-            account
-            identifier
-          }
-        }
         managedExternalResources
         externalResources {
           provider

--- a/reconcile/service_dependencies.py
+++ b/reconcile/service_dependencies.py
@@ -33,7 +33,6 @@ APPS_QUERY = """
       }
     }
     namespaces {
-      managedTerraformResources
       managedExternalResources
       externalResources {
         provider

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -338,10 +338,6 @@ TF_NAMESPACES_QUERY = """
 {
   namespaces: namespaces_v1 {
     name
-    managedTerraformResources
-    terraformResources {
-      %s
-    }
     managedExternalResources
     externalResources {
       provider
@@ -393,7 +389,6 @@ TF_NAMESPACES_QUERY = """
   }
 }
 """ % (
-    indent(Template(TF_RESOURCE_AWS).render(account=True), 6*' '),
     indent(Template(TF_RESOURCE_AWS).render(account=False), 6*' '),
 )
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -4,7 +4,6 @@ import sys
 
 from textwrap import indent
 from typing import Any, Iterable, Optional, Mapping, Tuple, cast
-from jinja2 import Template
 
 from sretoolbox.utils import threaded
 from reconcile.utils.external_resources import get_external_resources, managed_external_resources
@@ -42,7 +41,6 @@ output_format {
 }
 provider
 ... on NamespaceTerraformResourceRDS_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -63,7 +61,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceS3_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -83,7 +80,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceElastiCache_v1 {
-  {% if account %}account{% endif %}
   identifier
   defaults
   parameter_group
@@ -93,7 +89,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceServiceAccount_v1 {
-  {% if account %}account{% endif %}
   identifier
   variables
   policies
@@ -109,14 +104,12 @@ provider
   }
 }
 ... on NamespaceTerraformResourceSecretsManagerServiceAccount_v1 {
-  {% if account %}account{% endif %}
   identifier
   secrets_prefix
   output_resource_name
   annotations
 }
 ... on NamespaceTerraformResourceRole_v1 {
-  {% if account %}account{% endif %}
   identifier
   assume_role {
     AWS
@@ -128,7 +121,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceSQS_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   output_resource_name
@@ -142,7 +134,6 @@ provider
   }
 }
 ... on NamespaceTerraformResourceDynamoDB_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   output_resource_name
@@ -156,7 +147,6 @@ provider
   }
 }
 ... on NamespaceTerraformResourceECR_v1 {
-  {% if account %}account{% endif %}
   identifier
   region
   output_resource_name
@@ -164,7 +154,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceS3CloudFront_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -173,7 +162,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceS3SQS_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -183,7 +171,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceCloudWatch_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -193,7 +180,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceKMS_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -202,7 +188,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceElasticSearch_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -211,7 +196,6 @@ provider
   publish_log_types
 }
 ... on NamespaceTerraformResourceACM_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   secret {
@@ -228,7 +212,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceKinesis_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -236,7 +219,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceS3CloudFrontPublicKey_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   secret {
@@ -249,7 +231,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceALB_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   vpc {
@@ -281,7 +262,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceSecretsManager_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   secret {
@@ -294,7 +274,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceASG_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   defaults
@@ -324,7 +303,6 @@ provider
   annotations
 }
 ... on NamespaceTerraformResourceRoute53Zone_v1 {
-  {% if account %}account{% endif %}
   region
   identifier
   name
@@ -389,7 +367,7 @@ TF_NAMESPACES_QUERY = """
   }
 }
 """ % (
-    indent(Template(TF_RESOURCE_AWS).render(account=False), 6*' '),
+    indent(TF_RESOURCE_AWS, 6*' '),
 )
 
 QONTRACT_INTEGRATION = 'terraform_resources'

--- a/reconcile/test/fixtures/expiration/expiration_date_check.yml
+++ b/reconcile/test/fixtures/expiration/expiration_date_check.yml
@@ -8,10 +8,13 @@ gql_response:
       identifier: expirationCheck-db
       namespace:
         name: expirationCheck-db
-        managedTerraformResources: True
-        terraformResources:
+        managedExternalResources: True
+        externalResources:
+        - provider: aws
+          provisioner:
+            name: app-sre
+          resources:
           - provider: rds
-            account: app-sre
             identifier: expirationCheck-db
         cluster:
           name: server

--- a/reconcile/test/fixtures/gabi_authorized_users/apply.yml
+++ b/reconcile/test/fixtures/gabi_authorized_users/apply.yml
@@ -8,10 +8,13 @@ gql_response:
       identifier: gabi-db
       namespace:
         name: gabi-db
-        managedTerraformResources: True
-        terraformResources:
+        managedExternalResources: True
+        externalResources:
+        - provider: aws
+          provisioner:
+            name: app-sre
+          resources:
           - provider: rds
-            account: app-sre
             identifier: gabi-db
         cluster:
           name: server

--- a/reconcile/test/fixtures/openshift_resource/invalid_expiration_date.yml
+++ b/reconcile/test/fixtures/openshift_resource/invalid_expiration_date.yml
@@ -9,10 +9,13 @@ gql_response:
       identifier: expirationCheck-db
       namespace:
         name: expirationCheck-db
-        managedTerraformResources: True
-        terraformResources:
+        managedExternalResources: True
+        externalResources:
+        - provider: aws
+          provisioner:
+            name: app-sre
+          resources:
           - provider: rds
-            account: app-sre
             identifier: expirationCheck-db
         cluster:
           name: server


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5726

this is essentially the opposite of #2447

once all accounts in all app-interface instances were migrated to externalResources, we can deprecate them terraformResources (this PR).