### PR TITLE
APPSRE-3409 prepare migration towards ES auth

### DIFF
--- a/reconcile/test/test_utils_password_validator.py
+++ b/reconcile/test/test_utils_password_validator.py
@@ -1,0 +1,155 @@
+import pytest
+
+from reconcile.utils.password_validator import (
+    NOT_ENOUGH_DIGITS_MSG,
+    NOT_ENOUGH_LOWER_CASE_CHARS_MSG,
+    NOT_ENOUGH_SPECIAL_CHARS_MSG,
+    NOT_ENOUGH_UPPER_CASE_CHARS_MSG,
+    PasswordPolicy,
+    PasswordValidator,
+    PasswordValidationError,
+)
+
+
+def test_password_policy_default():
+    """By default any password is fine -> also empty ones"""
+    validator = PasswordValidator()
+    password = ""
+    validator.validate(password)
+
+
+def test_password_policy_missing_upper():
+    """Password misses one upper case letter"""
+    validator = PasswordValidator(policy_flags=PasswordPolicy.HAS_UPPER_CASE_CHAR)
+    password = "abc123"
+    with pytest.raises(PasswordValidationError) as e:
+        validator.validate(password)
+
+    assert NOT_ENOUGH_UPPER_CASE_CHARS_MSG in str(e.value)
+
+
+def test_password_policy_has_upper():
+    """Password has at least one upper case letter"""
+    validator = PasswordValidator(policy_flags=PasswordPolicy.HAS_UPPER_CASE_CHAR)
+    password = "Abc123"
+    validator.validate(password)
+
+
+def test_password_policy_missing_lower():
+    """Password misses one lower case letter"""
+    validator = PasswordValidator(policy_flags=PasswordPolicy.HAS_LOWER_CASE_CHAR)
+    password = "ABC123"
+    with pytest.raises(PasswordValidationError) as e:
+        validator.validate(password)
+
+    assert NOT_ENOUGH_LOWER_CASE_CHARS_MSG in str(e.value)
+
+
+def test_password_policy_has_lower():
+    """Password has at least one lower case letter"""
+    validator = PasswordValidator(policy_flags=PasswordPolicy.HAS_UPPER_CASE_CHAR)
+    password = "Abc123"
+    validator.validate(password)
+
+
+def test_password_policy_missing_digit():
+    """Password misses one digit"""
+    validator = PasswordValidator(policy_flags=PasswordPolicy.HAS_DIGIT)
+    password = "ABC@a"
+    with pytest.raises(PasswordValidationError) as e:
+        validator.validate(password)
+
+    assert NOT_ENOUGH_DIGITS_MSG in str(e.value)
+
+
+def test_password_policy_has_digit():
+    """Password has at least one lower case letter"""
+    validator = PasswordValidator(policy_flags=PasswordPolicy.HAS_DIGIT)
+    password = "Abc123"
+    validator.validate(password)
+
+
+def test_password_policy_missing_special_char():
+    """Password misses one special letter"""
+    validator = PasswordValidator(policy_flags=PasswordPolicy.HAS_SPECIAL_CHAR)
+    password = "ABC12a"
+    with pytest.raises(PasswordValidationError) as e:
+        validator.validate(password)
+
+    assert NOT_ENOUGH_SPECIAL_CHARS_MSG in str(e.value)
+
+
+def test_password_policy_has_special_char():
+    """Password has at least one special letter"""
+    validator = PasswordValidator(policy_flags=PasswordPolicy.HAS_SPECIAL_CHAR)
+    password = "Abc123@"
+    validator.validate(password)
+
+
+def test_password_policy_not_enough_letters():
+    """Password does not have enough letters"""
+    validator = PasswordValidator(minimum_length=5)
+    password = "Ab1@"
+    with pytest.raises(PasswordValidationError) as e:
+        validator.validate(password)
+
+    assert "Your password does not have at least 5 characters." in str(e.value)
+
+
+def test_password_policy_has_enough_letters():
+    """Password has enough letters"""
+    validator = PasswordValidator(minimum_length=5)
+    password = "aaaaa"
+    validator.validate(password)
+
+
+def test_password_policy_all_flags_valid():
+    """Password has upper, lower, digit, special and at least 8 chars"""
+    validator = PasswordValidator(
+        policy_flags=(
+            PasswordPolicy.HAS_UPPER_CASE_CHAR
+            | PasswordPolicy.HAS_LOWER_CASE_CHAR
+            | PasswordPolicy.HAS_DIGIT
+            | PasswordPolicy.HAS_SPECIAL_CHAR
+        ),
+        minimum_length=8,
+    )
+    password = "Abc123@!gh"
+    validator.validate(password)
+
+
+def test_password_policy_all_flags_invalid():
+    """Password has upper, lower, special and at least 8 chars, but misses digit."""
+    validator = PasswordValidator(
+        policy_flags=(
+            PasswordPolicy.HAS_UPPER_CASE_CHAR
+            | PasswordPolicy.HAS_LOWER_CASE_CHAR
+            | PasswordPolicy.HAS_DIGIT
+            | PasswordPolicy.HAS_SPECIAL_CHAR
+        ),
+        minimum_length=8,
+    )
+    password = "AbcXYZ@!gh"
+    with pytest.raises(PasswordValidationError) as e:
+        validator.validate(password)
+
+    assert NOT_ENOUGH_DIGITS_MSG in str(e.value)
+
+
+def test_password_policy_multiple_failing():
+    """Password misses digits and special letters."""
+    validator = PasswordValidator(
+        policy_flags=(
+            PasswordPolicy.HAS_UPPER_CASE_CHAR
+            | PasswordPolicy.HAS_LOWER_CASE_CHAR
+            | PasswordPolicy.HAS_DIGIT
+            | PasswordPolicy.HAS_SPECIAL_CHAR
+        ),
+        minimum_length=8,
+    )
+    password = "AbcXYZsgh"
+    with pytest.raises(PasswordValidationError) as e:
+        validator.validate(password)
+
+    assert NOT_ENOUGH_DIGITS_MSG in str(e.value)
+    assert NOT_ENOUGH_SPECIAL_CHARS_MSG in str(e.value)

--- a/reconcile/utils/password_validator.py
+++ b/reconcile/utils/password_validator.py
@@ -1,0 +1,64 @@
+from enum import IntFlag
+import string
+
+
+NOT_ENOUGH_DIGITS_MSG = "Your password does not have at least one digit."
+NOT_ENOUGH_SPECIAL_CHARS_MSG = (
+    "Your password does not have at least one special character (non-alphanumeric)."
+)
+NOT_ENOUGH_LOWER_CASE_CHARS_MSG = (
+    "Your password does not have at least one lower case character."
+)
+NOT_ENOUGH_UPPER_CASE_CHARS_MSG = (
+    "Your password does not have at least one upper case character."
+)
+
+
+class PasswordPolicy(IntFlag):
+    HAS_UPPER_CASE_CHAR = 1
+    HAS_LOWER_CASE_CHAR = 2
+    HAS_DIGIT = 4
+    HAS_SPECIAL_CHAR = 8
+
+
+class PasswordValidationError(Exception):
+    pass
+
+
+class PasswordValidator:
+    def __init__(self, policy_flags: int = 0, minimum_length: int = 0):
+        self._policy_flags = policy_flags
+        self._mininum_length = minimum_length
+
+    def validate(self, password: str):
+        errors: list[str] = []
+
+        if len(password) < self._mininum_length:
+            errors.append(
+                f"Your password does not have at least {self._mininum_length} characters."
+            )
+
+        password_set = set(password)
+        if self._policy_flags & PasswordPolicy.HAS_UPPER_CASE_CHAR:
+            if not any(password_set.intersection(set(string.ascii_uppercase))):
+                errors.append(NOT_ENOUGH_UPPER_CASE_CHARS_MSG)
+
+        if self._policy_flags & PasswordPolicy.HAS_LOWER_CASE_CHAR:
+            if not any(password_set.intersection(set(string.ascii_lowercase))):
+                errors.append(NOT_ENOUGH_LOWER_CASE_CHARS_MSG)
+
+        if self._policy_flags & PasswordPolicy.HAS_DIGIT:
+            if not any(password_set.intersection(set(string.digits))):
+                errors.append(NOT_ENOUGH_DIGITS_MSG)
+
+        if self._policy_flags & PasswordPolicy.HAS_SPECIAL_CHAR:
+            has_special_char = False
+            # TODO: maybe this could be done more efficient if we had a pre-defined set of alnums
+            for c in password:
+                has_special_char |= not str.isalnum(c)
+
+            if not has_special_char:
+                errors.append(NOT_ENOUGH_SPECIAL_CHARS_MSG)
+
+        if errors:
+            raise PasswordValidationError("\n".join(errors))

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -3647,7 +3647,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 "advanced_security_options"
             ] = self._build_es_advanced_security_options(auth_options)
 
-        # TODO: @fishi0x01 remove after migration
+        # TODO: @fishi0x01 remove after migration APPSRE-3409
         # ++++++++ START: REMOVE +++++++++
         else:
 
@@ -3693,7 +3693,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         self.add_resources(account, tf_resources)
 
-    # TODO: @fishi0x01 remove this function after migration
+    # TODO: @fishi0x01 remove this function after migration APPSRE-3409
     def _build_es_advanced_security_options_deprecated(
         self, advanced_security_options: MutableMapping[str, Any]
     ) -> MutableMapping[str, Any]:


### PR DESCRIPTION
All ES domains must have auth enabled. 

In the first step, this PR adds an `auth` feature for ES domains. This is fully backwards compatible.
Once this is merged, we start migrating existing ES domains to use the new `auth` feature. This migration work will be coordinated with each team individually.

When the migration is done, we will make the `auth` feature mandatory and remove backwards compatible code, which is also marked in this PR as `TODO`.

Corresponding schema change: https://github.com/app-sre/qontract-schemas/pull/170