### PR TITLE
use .version.raw_id for OSD cluster version

### DIFF
--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -153,7 +153,7 @@ class OCMProductOsd(OCMProduct):
             provider=cluster["cloud_provider"]["id"],
             region=cluster["region"]["id"],
             channel=cluster["version"]["channel_group"],
-            version=cluster["openshift_version"],
+            version=cluster["version"]["raw_id"],
             multi_az=cluster["multi_az"],
             instance_type=cluster["nodes"]["compute_machine_type"]["id"],
             storage=cluster["storage_quota"]["value"] // BYTES_IN_GIGABYTE,
@@ -320,6 +320,7 @@ class OCMProductRosa(OCMProduct):
             provider=cluster["cloud_provider"]["id"],
             region=cluster["region"]["id"],
             channel=cluster["version"]["channel_group"],
+            # should this be version=cluster["version"]["raw_id"] as for OSD ?
             version=cluster["openshift_version"],
             multi_az=cluster["multi_az"],
             instance_type=cluster["nodes"]["compute_machine_type"]["id"],

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -320,8 +320,7 @@ class OCMProductRosa(OCMProduct):
             provider=cluster["cloud_provider"]["id"],
             region=cluster["region"]["id"],
             channel=cluster["version"]["channel_group"],
-            # should this be version=cluster["version"]["raw_id"] as for OSD ?
-            version=cluster["openshift_version"],
+            version=cluster["version"]["raw_id"],
             multi_az=cluster["multi_az"],
             instance_type=cluster["nodes"]["compute_machine_type"]["id"],
             private=cluster["api"]["listening"] == "internal",


### PR DESCRIPTION
This allows to update the cluster version only once all nodes are upgraded