### PR TITLE
terraform-resources: set S3 bucket ACL for cloudfront logging

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -132,6 +132,10 @@ class aws_ecrpublic_repository(Resource):
     pass
 
 
+class aws_s3_bucket_acl(Resource):
+    pass
+
+
 # temporary until we upgrade to a terrascript release
 # that supports this provider
 # https://github.com/mjuenema/python-terrascript/pull/166
@@ -239,6 +243,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         self.locks: dict[str, Lock] = locks
         """AWS account name to Lock mapping."""
+
+        for name in self.tss:
+            self.add_resource(name, data.aws_canonical_user_id("current"))
 
         self.accounts = {a['name']: a for a in filtered_accounts}
         self.uids = {a['name']: a['uid'] for a in filtered_accounts}
@@ -921,6 +928,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
     def init_populate_specs(self, namespaces: Iterable[Mapping[str, Any]],
                             account_name: Optional[str]) -> None:
         self.account_resources: dict[str, list[dict[str, Any]]] = {}
+
         for namespace_info in namespaces:
             tf_resources = get_external_resources(namespace_info, provision_provider=PROVIDER_AWS)
             for resource in tf_resources:
@@ -1388,7 +1396,12 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         versioning = common_values.get('versioning') or True
         values['versioning'] = {"enabled": versioning}
         values['tags'] = common_values['tags']
-        values['acl'] = common_values.get('acl') or 'private'
+        if "acl" in common_values:
+            values['acl'] = common_values['acl']
+        else:
+            # ACL grants will be set out of this resource.
+            # the following `ignore_change` allows to avoid conflicts
+            values.setdefault("lifecycle", {}).setdefault("ignore_changes", []).append("grant")
         server_side_encryption_configuration = \
             common_values.get('server_side_encryption_configuration')
         if server_side_encryption_configuration:
@@ -2450,6 +2463,40 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         output_value = 'origin-access-identity/cloudfront/' + \
             '${' + cf_oai_tf_resource.id + '}'
         tf_resources.append(Output(output_name_0_13, value=output_value))
+
+        # aws_s3_bucket_acl
+        values = common_values.get('distribution_config', {})
+        if 'logging_config' in values.keys():
+            logging_config_bucket = values['logging_config']
+            values = {}
+            access_control_policy = {
+                'owner': {
+                    'id': '${data.aws_canonical_user_id.current.id}',
+                },
+                'grant': [
+                    {
+                        'grantee': {
+                            'id': '${data.aws_canonical_user_id.current.id}',
+                            'type': 'CanonicalUser',
+                        },
+                        'permission': 'FULL_CONTROL',
+                    },
+                    {
+                        'grantee': {
+                            # well known id for cloudfront logs delivery:
+                            # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsBucketAndFileOwnership
+                            'id': 'c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0',
+                            'type': 'CanonicalUser',
+                        },
+                        'permission': 'FULL_CONTROL',
+                    },
+                ],
+            }
+            values['access_control_policy'] = access_control_policy
+            values['bucket'] = logging_config_bucket.get('bucket').split(".")[0]
+
+            aws_s3_bucket_acl_resource = aws_s3_bucket_acl(identifier, **values)
+            tf_resources.append(aws_s3_bucket_acl_resource)
 
         self.add_resources(account, tf_resources)
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -80,7 +80,7 @@ from terrascript.resource import (
     random_id,
 )
 # temporary to create aws_ecrpublic_repository
-from terrascript import Resource
+from terrascript import Resource, Data
 from sretoolbox.utils import threaded
 
 from reconcile.utils import gql
@@ -133,6 +133,10 @@ class aws_ecrpublic_repository(Resource):
 
 
 class aws_s3_bucket_acl(Resource):
+    pass
+
+
+class aws_cloudfront_log_delivery_canonical_user_id(Data):
     pass
 
 
@@ -2467,6 +2471,10 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         # aws_s3_bucket_acl
         values = common_values.get('distribution_config', {})
         if 'logging_config' in values.keys():
+            # we could set this at a global level with a standard name like "cloudfront"
+            # but we need all aws accounts upgraded to aws provider >3.60 first
+            tf_resources.append(aws_cloudfront_log_delivery_canonical_user_id(identifier))
+
             logging_config_bucket = values['logging_config']
             values = {}
             access_control_policy = {
@@ -2483,9 +2491,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     },
                     {
                         'grantee': {
-                            # well known id for cloudfront logs delivery:
                             # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsBucketAndFileOwnership
-                            'id': 'c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0',
+                            'id': f'${{data.aws_cloudfront_log_delivery_canonical_user_id.{identifier}.id}}',
                             'type': 'CanonicalUser',
                         },
                         'permission': 'FULL_CONTROL',


### PR DESCRIPTION
APPSRE-5533

New tentative after the revert of https://github.com/app-sre/qontract-reconcile/pull/2423.

The problem was that `data.aws_canonical_user_id("current")` was added only when `--account-name` was set and not for each account shard.