### PR TITLE
remove logic to handle terraform resources

### DIFF
--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -6,17 +6,19 @@ from reconcile.utils.external_resource_spec import (
 
 
 def test_filter_namespaces_no_managed_tf_resources():
-    ra = {"account": "a", "identifier": "a", "provider": "p"}
+    ra = {"identifier": "a", "provider": "p"}
     ns1 = {
         "name": "ns1",
-        "managedTerraformResources": False,
-        "terraformResources": [],
+        "managedExternalResources": False,
+        "externalResources": [],
         "cluster": {"name": "c"},
     }
     ns2 = {
         "name": "ns2",
-        "managedTerraformResources": True,
-        "terraformResources": [ra],
+        "managedExternalResources": True,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "a"}, "resources": [ra]}
+        ],
         "cluster": {"name": "c"},
     }
     namespaces = [ns1, ns2]
@@ -25,18 +27,22 @@ def test_filter_namespaces_no_managed_tf_resources():
 
 
 def test_filter_namespaces_with_account_filter():
-    ra = {"account": "a", "identifier": "a", "provider": "p"}
-    rb = {"account": "b", "identifier": "b", "provider": "p"}
+    ra = {"identifier": "a", "provider": "p"}
+    rb = {"identifier": "b", "provider": "p"}
     ns1 = {
         "name": "ns1",
-        "managedTerraformResources": True,
-        "terraformResources": [ra],
+        "managedExternalResources": True,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "a"}, "resources": [ra]}
+        ],
         "cluster": {"name": "c"},
     }
     ns2 = {
         "name": "ns2",
-        "managedTerraformResources": True,
-        "terraformResources": [rb],
+        "managedExternalResources": True,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "b"}, "resources": [rb]}
+        ],
         "cluster": {"name": "c"},
     }
     namespaces = [ns1, ns2]
@@ -45,18 +51,22 @@ def test_filter_namespaces_with_account_filter():
 
 
 def test_filter_namespaces_no_account_filter():
-    ra = {"account": "a", "identifier": "a", "provider": "p"}
-    rb = {"account": "b", "identifier": "b", "provider": "p"}
+    ra = {"identifier": "a", "provider": "p"}
+    rb = {"identifier": "b", "provider": "p"}
     ns1 = {
         "name": "ns1",
-        "managedTerraformResources": True,
-        "terraformResources": [ra],
+        "managedExternalResources": True,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "a"}, "resources": [ra]}
+        ],
         "cluster": {"name": "c"},
     }
     ns2 = {
         "name": "ns2",
-        "managedTerraformResources": True,
-        "terraformResources": [rb],
+        "managedExternalResources": True,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "b"}, "resources": [rb]}
+        ],
         "cluster": {"name": "c"},
     }
     namespaces = [ns1, ns2]
@@ -70,17 +80,19 @@ def test_filter_namespaces_no_tf_resources_no_account_filter():
     attached. this way we can delete the last terraform resources that might have been
     defined on the namespace previously
     """
-    ra = {"account": "a", "identifier": "a", "provider": "p"}
+    ra = {"identifier": "a", "provider": "p"}
     ns1 = {
         "name": "ns1",
-        "managedTerraformResources": True,
-        "terraformResources": [],
+        "managedExternalResources": True,
+        "externalResources": [],
         "cluster": {"name": "c"},
     }
     ns2 = {
         "name": "ns2",
-        "managedTerraformResources": True,
-        "terraformResources": [ra],
+        "managedExternalResources": True,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "a"}, "resources": [ra]}
+        ],
         "cluster": {"name": "c"},
     }
 
@@ -95,17 +107,19 @@ def test_filter_tf_namespaces_no_tf_resources_with_account_filter():
     to enable terraform resource deletion. in contrast to that, a namespace with a resource
     that does not match the account will not be returned.
     """
-    ra = {"account": "a", "identifier": "a", "provider": "p"}
+    ra = {"identifier": "a", "provider": "p"}
     ns1 = {
         "name": "ns1",
-        "managedTerraformResources": True,
-        "terraformResources": [],
+        "managedExternalResources": True,
+        "externalResources": [],
         "cluster": {"name": "c"},
     }
     ns2 = {
         "name": "ns2",
-        "managedTerraformResources": True,
-        "terraformResources": [ra],
+        "managedExternalResources": True,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "a"}, "resources": [ra]}
+        ],
         "cluster": {"name": "c"},
     }
     namespaces = [ns1, ns2]
@@ -118,11 +132,13 @@ def test_tf_disabled_namespace_with_resources():
     even if a namespace has tf resources, they are not considered when the
     namespace is not enabled for tf resource management
     """
-    ra = {"account": "a", "identifier": "a", "provider": "p"}
+    ra = {"identifier": "a", "provider": "p"}
     ns1 = {
         "name": "ns1",
-        "managedTerraformResources": False,
-        "terraformResources": [ra],
+        "managedExternalResources": False,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "a"}, "resources": [ra]}
+        ],
         "cluster": {"name": "c"},
     }
     namespaces = [ns1]
@@ -135,11 +151,13 @@ def test_resource_specs_without_account_filter():
     if no account filter is given, all resources of namespaces with
     enabled tf resource management are expected to be returned
     """
-    ra = {"account": "a", "identifier": "a", "provider": "p"}
+    ra = {"identifier": "a", "provider": "p"}
     ns1 = {
         "name": "ns1",
-        "managedTerraformResources": True,
-        "terraformResources": [ra],
+        "managedExternalResources": True,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "a"}, "resources": [ra]}
+        ],
         "cluster": {"name": "c"},
     }
     namespaces = [ns1]
@@ -154,12 +172,15 @@ def test_resource_specs_with_account_filter():
     if an account filter is given only the resources defined for
     that account are expected
     """
-    ra = {"account": "a", "identifier": "a", "provider": "p"}
-    rb = {"account": "b", "identifier": "b", "provider": "p"}
+    ra = {"identifier": "a", "provider": "p"}
+    rb = {"identifier": "b", "provider": "p"}
     ns1 = {
         "name": "ns1",
-        "managedTerraformResources": True,
-        "terraformResources": [ra, rb],
+        "managedExternalResources": True,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "a"}, "resources": [ra]},
+            {"provider": "aws", "provisioner": {"name": "b"}, "resources": [rb]},
+        ],
         "cluster": {"name": "c"},
     }
     namespaces = [ns1]

--- a/reconcile/test/test_utils_external_resources.py
+++ b/reconcile/test/test_utils_external_resources.py
@@ -6,15 +6,19 @@ import reconcile.utils.external_resources as uer
 @pytest.fixture
 def namespace_info():
     return {
-        "managedTerraformResources": True,
-        "terraformResources": [
-            {
-                "provider": "rds",
-                "account": "acc1",
-            }
-        ],
         "managedExternalResources": True,
         "externalResources": [
+            {
+                "provider": uer.PROVIDER_AWS,
+                "provisioner": {
+                    "name": "acc1",
+                },
+                "resources": [
+                    {
+                        "provider": "rds",
+                    }
+                ],
+            },
             {
                 "provider": uer.PROVIDER_AWS,
                 "provisioner": {
@@ -57,25 +61,7 @@ def expected():
     ]
 
 
-def test_get_external_resources_terraform_resources(namespace_info, expected):
-    namespace_info["managedExternalResources"] = False
-    namespace_info["externalResources"] = None
-    results = uer.get_external_resources(
-        namespace_info, provision_provider=uer.PROVIDER_AWS
-    )
-    assert results == [expected[0]]
-
-
-def test_get_external_resources_external_resources(namespace_info, expected):
-    namespace_info["managedTerraformResources"] = False
-    namespace_info["terraformResources"] = None
-    results = uer.get_external_resources(
-        namespace_info, provision_provider=uer.PROVIDER_AWS
-    )
-    assert results == [expected[1]]
-
-
-def test_get_external_resources_external_both(namespace_info, expected):
+def test_get_external_resources(namespace_info, expected):
     results = uer.get_external_resources(
         namespace_info, provision_provider=uer.PROVIDER_AWS
     )
@@ -103,59 +89,22 @@ def test_get_external_resources_filter_other(namespace_info, expected_other):
     assert results == expected_other
 
 
-def test_get_provision_providers_terraform_resources(namespace_info):
-    namespace_info["managedExternalResources"] = False
-    namespace_info["externalResources"] = None
-    results = uer.get_provision_providers(namespace_info)
-    assert results == {uer.PROVIDER_AWS}
-
-
-def test_get_provision_providers_external_resources(namespace_info):
-    namespace_info["managedTerraformResources"] = False
-    namespace_info["terraformResources"] = None
-    results = uer.get_provision_providers(namespace_info)
-    assert results == {uer.PROVIDER_AWS, "other"}
-
-
-def test_get_provision_providers_both(namespace_info):
+def test_get_provision_providers(namespace_info):
     results = uer.get_provision_providers(namespace_info)
     assert results == {uer.PROVIDER_AWS, "other"}
 
 
 def test_get_provision_providers_none():
-    namespace_info = {
-        "managedTerraformResources": False,
-        "managedExternalResources": None,
-    }
+    namespace_info = {"managedExternalResources": False}
     results = uer.get_provision_providers(namespace_info)
     assert not results
 
 
-def test_managed_external_resources_terraform_resources():
-    namespace_info = {
-        "managedTerraformResources": True,
-    }
-    assert uer.managed_external_resources(namespace_info) is True
-
-
-def test_managed_external_resources_external_resources():
-    namespace_info = {
-        "managedExternalResources": True,
-    }
-    assert uer.managed_external_resources(namespace_info) is True
-
-
-def test_managed_external_resources_both():
-    namespace_info = {
-        "managedTerraformResources": True,
-        "managedExternalResources": True,
-    }
+def test_managed_external_resources():
+    namespace_info = {"managedExternalResources": True}
     assert uer.managed_external_resources(namespace_info) is True
 
 
 def test_managed_external_resources_none():
-    namespace_info = {
-        "managedTerraformResources": False,
-        "managedExternalResources": None,
-    }
+    namespace_info = {"managedExternalResources": False}
     assert uer.managed_external_resources(namespace_info) is False

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -11,11 +11,6 @@ def get_external_resources(
     if not managed_external_resources(namespace_info):
         return resources
 
-    terraform_resources = namespace_info.get("terraformResources") or []
-    for r in terraform_resources:
-        r["provision_provider"] = PROVIDER_AWS
-        resources.append(r)
-
     external_resources = namespace_info.get("externalResources") or []
     for e in external_resources:
         provisioner_name = e["provisioner"]["name"]
@@ -37,10 +32,6 @@ def get_provision_providers(namespace_info: Mapping[str, Any]) -> Set[str]:
     if not managed_external_resources(namespace_info):
         return providers
 
-    terraform_resources = namespace_info.get("terraformResources")
-    if terraform_resources:
-        providers.add(PROVIDER_AWS)
-
     external_resources = namespace_info.get("externalResources") or []
     for e in external_resources:
         providers.add(e["provider"])
@@ -49,8 +40,6 @@ def get_provision_providers(namespace_info: Mapping[str, Any]) -> Set[str]:
 
 
 def managed_external_resources(namespace_info: Mapping[str, Any]) -> bool:
-    if namespace_info.get("managedTerraformResources"):
-        return True
     if namespace_info.get("managedExternalResources"):
         return True
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5833

this PR will remove support for `terraformResources` from the inner logic. the inner logic itself is no longer used following #2465.