### PR TITLE
Used black's force-exclude instead of extend-exclude.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 line-length = 88
 target-version = ['py39']
 include = '^.*\.py$'
-extend-exclude = '''
+force-exclude = '''
 ^/(
     reconcile/terraform_resources.py
     | reconcile/utils/terraform_client.py


### PR DESCRIPTION
When using VS code black plugin, because the filename is passed
explicitly, the file referred to in `extend-exclude` is not properly
excluded. Use `force-exclude` instead to say we really mean it.

see https://github.com/psf/black/issues/438
