### PR TITLE
[terraform-aws-route53] fix running per account

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2223,7 +2223,7 @@ def get_dns_zones(account_name=None):
     if account_name:
         zones = [z for z in zones if z["account"]["name"] == account_name]
 
-    return gqlapi.query(DNS_ZONES_QUERY)["zones"]
+    return zones
 
 
 SLACK_WORKSPACES_QUERY = """

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -195,7 +195,7 @@ def run(
     settings = queries.get_app_interface_settings()
     zones = queries.get_dns_zones(account_name=account_name)
 
-    all_accounts = queries.get_aws_accounts(name=account_name)
+    all_accounts = queries.get_aws_accounts()
     participating_account_names = [z["account"]["name"] for z in zones]
     participating_accounts = [
         a for a in all_accounts if a["name"] in participating_account_names


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5885

fixes #2474

some dns zones are delegating to zones in other accounts, so `all_accounts` should really be all accounts.