### PR TITLE
consolidate external resources and spec

### DIFF
--- a/reconcile/ecr_mirror.py
+++ b/reconcile/ecr_mirror.py
@@ -137,6 +137,12 @@ def run(dry_run, thread_pool_size=10):
             if spec.resource.get("mirror") is None:
                 continue
 
+            # setting account for backwards compatibility. any deeper
+            # change will require a refactor of this module, which will
+            # likely include passing source_info to the init_values method
+            # instead of resource and namespace_info
+            spec.resource["account"] = spec.provisioner_name
+
             tfrs_to_mirror.append(spec.resource)
 
     work_list = threaded.run(

--- a/reconcile/ecr_mirror.py
+++ b/reconcile/ecr_mirror.py
@@ -8,7 +8,7 @@ from sretoolbox.utils import threaded
 
 from reconcile import queries
 from reconcile.utils.external_resources import (
-    get_external_resources,
+    get_external_resource_specs,
     managed_external_resources,
 )
 from reconcile.utils.aws_api import AWSApi
@@ -130,14 +130,14 @@ def run(dry_run, thread_pool_size=10):
         if not managed_external_resources(namespace):
             continue
 
-        for tfr in get_external_resources(namespace):
-            if tfr["provider"] != "ecr":
+        for spec in get_external_resource_specs(namespace):
+            if spec.provider != "ecr":
                 continue
 
-            if tfr["mirror"] is None:
+            if spec.resource.get("mirror") is None:
                 continue
 
-            tfrs_to_mirror.append(tfr)
+            tfrs_to_mirror.append(spec.resource)
 
     work_list = threaded.run(
         EcrMirror, tfrs_to_mirror, thread_pool_size=thread_pool_size, dry_run=dry_run

--- a/reconcile/gabi_authorized_users.py
+++ b/reconcile/gabi_authorized_users.py
@@ -52,7 +52,7 @@ def fetch_desired_state(
             for spec in specs:
                 if spec.provider != "rds":
                     continue
-                if (spec.account, spec.identifier) == (account, identifier):
+                if (spec.provisioner_name, spec.identifier) == (account, identifier):
                     found = True
                     break
             if not found:

--- a/reconcile/gabi_authorized_users.py
+++ b/reconcile/gabi_authorized_users.py
@@ -2,7 +2,7 @@ import logging
 import sys
 from datetime import datetime, date
 from typing import Iterable, Mapping, Optional
-from reconcile.utils.external_resources import get_external_resources
+from reconcile.utils.external_resources import get_external_resource_specs
 from reconcile.status import ExitCodes
 
 from reconcile.utils.aggregated_list import RunnerException
@@ -47,12 +47,12 @@ def fetch_desired_state(
             namespace = i["namespace"]
             account = i["account"]
             identifier = i["identifier"]
-            tf_resources = get_external_resources(namespace)
+            specs = get_external_resource_specs(namespace)
             found = False
-            for t in tf_resources:
-                if t["provider"] != "rds":
+            for spec in specs:
+                if spec.provider != "rds":
                     continue
-                if (t["account"], t["identifier"]) == (account, identifier):
+                if (spec.account, spec.identifier) == (account, identifier):
                     found = True
                     break
             if not found:

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -116,7 +116,7 @@ def fetch_desired_state():
             if aws_infrastructure_access is None:
                 continue
             aws_account_uid = [
-                a["uid"] for a in aws_accounts if a["name"] == spec.account
+                a["uid"] for a in aws_accounts if a["name"] == spec.provisioner_name
             ][0]
             cluster = aws_infrastructure_access["cluster"]["name"]
             access_level = aws_infrastructure_access["access_level"]

--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -306,10 +306,10 @@ class OcpReleaseMirror:
     def _get_tf_resource_info(namespace, identifier):
         specs = get_external_resource_specs(namespace)
         for spec in specs:
-            if spec.identifier != identifier:
+            if spec.provider != "ecr":
                 continue
 
-            if spec.provider != "ecr":
+            if spec.identifier != identifier:
                 continue
 
             return {

--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -313,7 +313,7 @@ class OcpReleaseMirror:
                 continue
 
             return {
-                "account": spec.account,
+                "account": spec.provisioner_name,
                 "region": spec.resource.get("region"),
             }
 

--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 from collections import namedtuple
 
 from sretoolbox.container import Image
-from reconcile.utils.external_resources import get_external_resources
+from reconcile.utils.external_resources import get_external_resource_specs
 
 from reconcile.utils.oc import OC
 from reconcile.utils.oc import OC_Map
@@ -304,20 +304,17 @@ class OcpReleaseMirror:
 
     @staticmethod
     def _get_tf_resource_info(namespace, identifier):
-        tf_resources = get_external_resources(namespace)
-        for tf_resource in tf_resources:
-            if "identifier" not in tf_resource:
+        specs = get_external_resource_specs(namespace)
+        for spec in specs:
+            if spec.identifier != identifier:
                 continue
 
-            if tf_resource["identifier"] != identifier:
-                continue
-
-            if tf_resource["provider"] != "ecr":
+            if spec.provider != "ecr":
                 continue
 
             return {
-                "account": tf_resource["account"],
-                "region": tf_resource.get("region"),
+                "account": spec.account,
+                "region": spec.resource.get("region"),
             }
 
     def _get_image_uri(self, account, repository):

--- a/reconcile/osd_mirrors_data_updater.py
+++ b/reconcile/osd_mirrors_data_updater.py
@@ -70,7 +70,9 @@ def run(dry_run, gitlab_project_id=None):
         if not managed_external_resources(namespace):
             continue
 
-        for spec in get_external_resource_specs(namespace, provision_provider=PROVIDER_AWS):
+        for spec in get_external_resource_specs(
+            namespace, provision_provider=PROVIDER_AWS
+        ):
             if spec.provider != "ecr":
                 continue
             if spec.resource.get("mirror") is None:

--- a/reconcile/osd_mirrors_data_updater.py
+++ b/reconcile/osd_mirrors_data_updater.py
@@ -23,7 +23,7 @@ def get_ecr_tf_resource_info(namespace, identifier):
     """
     specs = get_external_resource_specs(namespace)
     for spec in specs:
-        if specs.identifier != identifier:
+        if spec.identifier != identifier:
             continue
 
         if spec.provider != "ecr":

--- a/reconcile/osd_mirrors_data_updater.py
+++ b/reconcile/osd_mirrors_data_updater.py
@@ -23,10 +23,10 @@ def get_ecr_tf_resource_info(namespace, identifier):
     """
     specs = get_external_resource_specs(namespace)
     for spec in specs:
-        if spec.identifier != identifier:
+        if spec.provider != "ecr":
             continue
 
-        if spec.provider != "ecr":
+        if spec.identifier != identifier:
             continue
 
         return spec.resource

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -10,7 +10,7 @@ from ruamel import yaml
 from reconcile import openshift_base
 from reconcile import openshift_resources_base as orb
 from reconcile import queries
-from reconcile.utils.external_resources import get_external_resources
+from reconcile.utils.external_resources import get_external_resource_specs
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.oc import OC_Map
 from reconcile.utils.oc import StatusCodeError
@@ -120,19 +120,16 @@ def get_tf_resource_info(terrascript: Terrascript, namespace, identifier):
     :param identifier: the identifier we are looking for
     :return: the terraform resource information dictionary
     """
-    tf_resources = get_external_resources(namespace)
-    for tf_resource in tf_resources:
-        if "identifier" not in tf_resource:
+    specs = get_external_resource_specs(namespace)
+    for spec in specs:
+        if spec.identifier != identifier:
             continue
 
-        if tf_resource["identifier"] != identifier:
-            continue
-
-        if tf_resource["provider"] != "rds":
+        if spec.provider != "rds":
             continue
 
         _, _, values, _, output_resource_name, _ = terrascript.init_values(
-            tf_resource, namespace
+            spec.resource, namespace
         )
 
         return {

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -125,8 +125,11 @@ def get_tf_resource_info(terrascript: Terrascript, namespace, identifier):
         if spec.identifier != identifier:
             continue
 
-        if spec.provider != "rds":
-            continue
+        # setting account for backwards compatibility. any deeper
+        # change will require a refactor of this module, which will
+        # likely include passing spec to the init_values method
+        # instead of resource and namespace_info
+        spec.resource["account"] = spec.provisioner_name
 
         _, _, values, _, output_resource_name, _ = terrascript.init_values(
             spec.resource, namespace

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -122,6 +122,9 @@ def get_tf_resource_info(terrascript: Terrascript, namespace, identifier):
     """
     specs = get_external_resource_specs(namespace)
     for spec in specs:
+        if spec.provider != "rds":
+            continue
+
         if spec.identifier != identifier:
             continue
 

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -129,7 +129,8 @@ def build_desired_state(
                 )
                 tf_zone_name = target_namespace_zone["name"]
                 tf_zone_specs = [
-                    spec for spec in specs
+                    spec
+                    for spec in specs
                     if spec.provider == "route53-zone"
                     and spec.resource.get("name") == tf_zone_name
                 ]

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -5,7 +5,7 @@ from typing import Iterable, Mapping
 
 
 from reconcile import queries
-from reconcile.utils.external_resources import PROVIDER_AWS, get_external_resources
+from reconcile.utils.external_resources import PROVIDER_AWS, get_external_resource_specs
 
 from reconcile.status import ExitCodes
 from reconcile.utils import dnsutils
@@ -124,14 +124,14 @@ def build_desired_state(
             # Process '_target_namespace_zone'
             target_namespace_zone = record.pop("_target_namespace_zone", None)
             if target_namespace_zone:
-                tf_resources = get_external_resources(
+                specs = get_external_resource_specs(
                     target_namespace_zone["namespace"], provision_provider=PROVIDER_AWS
                 )
                 tf_zone_name = target_namespace_zone["name"]
                 tf_zone_resources = [
-                    tfr
-                    for tfr in tf_resources
-                    if tfr["provider"] == "route53-zone" and tfr["name"] == tf_zone_name
+                    spec.resource
+                    for spec in specs
+                    if spec.provider == "route53-zone" and spec.resource.get("name") == tf_zone_name
                 ]
                 if not tf_zone_resources:
                     logging.error(

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -131,7 +131,8 @@ def build_desired_state(
                 tf_zone_resources = [
                     spec.resource
                     for spec in specs
-                    if spec.provider == "route53-zone" and spec.resource.get("name") == tf_zone_name
+                    if spec.provider == "route53-zone"
+                    and spec.resource.get("name") == tf_zone_name
                 ]
                 if not tf_zone_resources:
                     logging.error(

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -128,27 +128,26 @@ def build_desired_state(
                     target_namespace_zone["namespace"], provision_provider=PROVIDER_AWS
                 )
                 tf_zone_name = target_namespace_zone["name"]
-                tf_zone_resources = [
-                    spec.resource
-                    for spec in specs
+                tf_zone_specs = [
+                    spec for spec in specs
                     if spec.provider == "route53-zone"
                     and spec.resource.get("name") == tf_zone_name
                 ]
-                if not tf_zone_resources:
+                if not tf_zone_specs:
                     logging.error(
                         f"{zone_name}: field `_target_namespace_zone` found "
                         f"for record {record_name}, but target zone not found: "
                         f"{tf_zone_name}"
                     )
                     sys.exit(ExitCodes.ERROR)
-                tf_zone_resource = tf_zone_resources[0]
-                tf_zone_account_name = tf_zone_resource["account"]
+                tf_zone_spec = tf_zone_specs[0]
+                tf_zone_account_name = tf_zone_spec.provisioner_name
                 zone_account = [
                     a for a in all_accounts if a["name"] == tf_zone_account_name
                 ][0]
                 awsapi = AWSApi(1, [zone_account], settings=settings, init_users=False)
                 tf_zone_region = (
-                    tf_zone_resource.get("region")
+                    tf_zone_spec.resource.get("region")
                     or zone_account["resourcesDefaultRegion"]
                 )
                 tf_zone_ns_records = awsapi.get_route53_zone_ns_records(

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -547,6 +547,8 @@ def init_tf_resource_specs(
             if account_name is None or resource["account"] == account_name:
                 identifier = ExternalResourceUniqueKey.from_dict(resource)
                 resource_specs[identifier] = ExternalResourceSpec(
+                    provision_provider=resource["provision_provider"],
+                    provisioner=resource["provisioner"],
                     resource=resource,
                     namespace=namespace_info,
                 )

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -6,7 +6,7 @@ from textwrap import indent
 from typing import Any, Iterable, Optional, Mapping, Tuple, cast
 
 from sretoolbox.utils import threaded
-from reconcile.utils.external_resources import get_external_resource_specs, get_external_resources, managed_external_resources
+from reconcile.utils.external_resources import get_external_resource_specs, managed_external_resources
 
 
 import reconcile.openshift_base as ob
@@ -522,13 +522,13 @@ def filter_tf_namespaces(
             tf_namespaces.append(namespace_info)
             continue
 
-        resources = get_external_resources(namespace_info)
-        if not resources:
+        specs = get_external_resource_specs(namespace_info)
+        if not specs:
             tf_namespaces.append(namespace_info)
             continue
 
-        for r in resources:
-            if r["account"] == account_name:
+        for spec in specs:
+            if spec.account == account_name:
                 tf_namespaces.append(namespace_info)
                 break
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -551,7 +551,7 @@ def init_tf_resource_specs(
                     resource=resource,
                     namespace=namespace_info,
                 )
-                identifier = ExternalResourceUniqueKey.from_dict(resource)
+                identifier = ExternalResourceUniqueKey.from_spec(spec)
                 resource_specs[identifier] = spec
     return resource_specs
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -551,8 +551,7 @@ def init_tf_resource_specs(
                     resource=resource,
                     namespace=namespace_info,
                 )
-                identifier = ExternalResourceUniqueKey.from_spec(spec)
-                resource_specs[identifier] = spec
+                resource_specs[spec.id_object] = spec
     return resource_specs
 
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -528,7 +528,7 @@ def filter_tf_namespaces(
             continue
 
         for spec in specs:
-            if spec.account == account_name:
+            if spec.provisioner_name == account_name:
                 tf_namespaces.append(namespace_info)
                 break
 
@@ -544,7 +544,7 @@ def init_tf_resource_specs(
             continue
         tf_specs = get_external_resource_specs(namespace_info)
         for spec in tf_specs:
-            if account_name is None or spec.account == account_name:
+            if account_name is None or spec.provisioner_name == account_name:
                 resource_specs[spec.id_object] = spec
     return resource_specs
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -545,7 +545,7 @@ def init_tf_resource_specs(
         tf_specs = get_external_resource_specs(namespace_info)
         for spec in tf_specs:
             if account_name is None or spec.provisioner_name == account_name:
-                resource_specs[spec.id_object] = spec
+                resource_specs[spec.id_object()] = spec
     return resource_specs
 
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -6,7 +6,7 @@ from textwrap import indent
 from typing import Any, Iterable, Optional, Mapping, Tuple, cast
 
 from sretoolbox.utils import threaded
-from reconcile.utils.external_resources import get_external_resources, managed_external_resources
+from reconcile.utils.external_resources import get_external_resource_specs, get_external_resources, managed_external_resources
 
 
 import reconcile.openshift_base as ob
@@ -542,15 +542,9 @@ def init_tf_resource_specs(
     for namespace_info in namespaces:
         if not managed_external_resources(namespace_info):
             continue
-        tf_resources = get_external_resources(namespace_info)
-        for resource in tf_resources:
-            if account_name is None or resource["account"] == account_name:
-                spec = ExternalResourceSpec(
-                    provision_provider=resource["provision_provider"],
-                    provisioner=resource["provisioner"],
-                    resource=resource,
-                    namespace=namespace_info,
-                )
+        tf_specs = get_external_resource_specs(namespace_info)
+        for spec in tf_specs:
+            if account_name is None or spec.account == account_name:
                 resource_specs[spec.id_object] = spec
     return resource_specs
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -545,13 +545,14 @@ def init_tf_resource_specs(
         tf_resources = get_external_resources(namespace_info)
         for resource in tf_resources:
             if account_name is None or resource["account"] == account_name:
-                identifier = ExternalResourceUniqueKey.from_dict(resource)
-                resource_specs[identifier] = ExternalResourceSpec(
+                spec = ExternalResourceSpec(
                     provision_provider=resource["provision_provider"],
                     provisioner=resource["provisioner"],
                     resource=resource,
                     namespace=namespace_info,
                 )
+                identifier = ExternalResourceUniqueKey.from_dict(resource)
+                resource_specs[identifier] = spec
     return resource_specs
 
 

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -151,20 +151,19 @@ def test_resource_specs_without_account_filter():
     if no account filter is given, all resources of namespaces with
     enabled tf resource management are expected to be returned
     """
+    p = "aws"
+    pa = {"name": "a"}
     ra = {"identifier": "a", "provider": "p"}
     ns1 = {
         "name": "ns1",
         "managedExternalResources": True,
-        "externalResources": [
-            {"provider": "aws", "provisioner": {"name": "a"}, "resources": [ra]}
-        ],
+        "externalResources": [{"provider": p, "provisioner": pa, "resources": [ra]}],
         "cluster": {"name": "c"},
     }
     namespaces = [ns1]
     resources = integ.init_tf_resource_specs(namespaces, None)
-    assert resources == {
-        ExternalResourceUniqueKey.from_dict(ra): ExternalResourceSpec(ra, ns1)
-    }
+    spec = ExternalResourceSpec(p, pa, ra, ns1)
+    assert resources == {ExternalResourceUniqueKey.from_spec(spec): spec}
 
 
 def test_resource_specs_with_account_filter():
@@ -172,19 +171,22 @@ def test_resource_specs_with_account_filter():
     if an account filter is given only the resources defined for
     that account are expected
     """
+    p = "aws"
+    pa = {"name": "a"}
     ra = {"identifier": "a", "provider": "p"}
+    pb = {"name": "b"}
     rb = {"identifier": "b", "provider": "p"}
     ns1 = {
         "name": "ns1",
         "managedExternalResources": True,
         "externalResources": [
-            {"provider": "aws", "provisioner": {"name": "a"}, "resources": [ra]},
-            {"provider": "aws", "provisioner": {"name": "b"}, "resources": [rb]},
+            {"provider": p, "provisioner": pa, "resources": [ra]},
+            {"provider": p, "provisioner": pb, "resources": [rb]},
         ],
         "cluster": {"name": "c"},
     }
     namespaces = [ns1]
     resources = integ.init_tf_resource_specs(namespaces, "a")
-    assert resources == {
-        ExternalResourceUniqueKey.from_dict(ra): ExternalResourceSpec(ra, ns1)
-    }
+
+    spec = ExternalResourceSpec(p, pa, ra, ns1)
+    assert resources == {ExternalResourceUniqueKey.from_spec(spec): spec}

--- a/reconcile/test/test_utils_external_resource_spec.py
+++ b/reconcile/test/test_utils_external_resource_spec.py
@@ -251,9 +251,7 @@ def test_terraform_unknown_output_format_provider(spec: ExternalResourceSpec):
     given. while the schema usually protects against such cases, additional protection
     in code is a good thing.
     """
-    spec.resource["output_format"] = {
-        "provider": "unknown-provider"
-    }
+    spec.resource["output_format"] = {"provider": "unknown-provider"}
     with pytest.raises(ValueError):
         spec.build_oc_secret("int", "1.0")
 

--- a/reconcile/test/test_utils_external_resource_spec.py
+++ b/reconcile/test/test_utils_external_resource_spec.py
@@ -13,17 +13,27 @@ from reconcile.utils.external_resource_spec import (
 
 def test_identifier_creation_from_dict():
     id = ExternalResourceUniqueKey.from_dict(
-        {"identifier": "i", "provider": "p", "account": "a"}
+        {
+            "provision_provider": "p",
+            "provisioner": {"name": "a"},
+            "identifier": "i",
+            "provider": "p",
+        }
     )
     assert id.identifier == "i"
     assert id.provider == "p"
-    assert id.account == "a"
+    assert id.provisioner_name == "a"
 
 
 def test_identifier_missing():
     with pytest.raises(ValidationError):
         ExternalResourceUniqueKey.from_dict(
-            {"identifier": None, "provider": "p", "account": "a"}
+            {
+                "provision_provider": "p",
+                "provisioner": {"name": "a"},
+                "identifier": None,
+                "provider": "p",
+            }
         )
     with pytest.raises(KeyError):
         ExternalResourceUniqueKey.from_dict({"provider": "p", "account": "a"})
@@ -32,7 +42,12 @@ def test_identifier_missing():
 def test_identifier_account_missing():
     with pytest.raises(ValidationError):
         ExternalResourceUniqueKey.from_dict(
-            {"identifier": "i", "account": None, "provider": "p"}
+            {
+                "provision_provider": "p",
+                "provisioner": {"name": None},
+                "identifier": "i",
+                "provider": "p",
+            }
         )
     with pytest.raises(KeyError):
         ExternalResourceUniqueKey.from_dict({"identifier": "i", "provider": "p"})
@@ -41,7 +56,12 @@ def test_identifier_account_missing():
 def test_identifier_provider_missing():
     with pytest.raises(ValidationError):
         ExternalResourceUniqueKey.from_dict(
-            {"identifier": "i", "account": "a", "provider": None}
+            {
+                "provision_provider": "p",
+                "provisioner": {"name": "a"},
+                "identifier": "i",
+                "provider": None,
+            }
         )
     with pytest.raises(KeyError):
         ExternalResourceUniqueKey.from_dict({"identifier": "i", "account": "a"})
@@ -49,24 +69,31 @@ def test_identifier_provider_missing():
 
 def test_spec_output_prefix():
     s = ExternalResourceSpec(
-        resource={"identifier": "i", "provider": "p", "account": "a"}, namespace={}
+        provision_provider="aws",
+        provisioner={"name": "a"},
+        resource={"identifier": "i", "provider": "p"},
+        namespace={},
     )
     assert s.output_prefix == "i-p"
 
 
 def test_spec_implicit_output_resource_name():
     s = ExternalResourceSpec(
-        resource={"identifier": "i", "provider": "p", "account": "a"}, namespace={}
+        provision_provider="aws",
+        provisioner={"name": "a"},
+        resource={"identifier": "i", "provider": "p"},
+        namespace={},
     )
     assert s.output_resource_name == "i-p"
 
 
 def test_spec_explicit_output_resource_name():
     s = ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": "a"},
         resource={
             "identifier": "i",
             "provider": "p",
-            "account": "a",
             "output_resource_name": "explicit",
         },
         namespace={},
@@ -76,10 +103,11 @@ def test_spec_explicit_output_resource_name():
 
 def test_spec_annotation_parsing():
     s = ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": "a"},
         resource={
             "identifier": "i",
             "provider": "p",
-            "account": "a",
             "annotations": '{"key": "value"}',
         },
         namespace={},
@@ -89,10 +117,11 @@ def test_spec_annotation_parsing():
 
 def test_spec_annotation_parsing_none_present():
     s = ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": "a"},
         resource={
             "identifier": "i",
             "provider": "p",
-            "account": "a",
         },
         namespace={},
     )
@@ -107,10 +136,11 @@ def resource_secret() -> dict[str, Any]:
 @pytest.fixture
 def spec() -> ExternalResourceSpec:
     return ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": "a"},
         resource={
             "identifier": "i",
             "provider": "p",
-            "account": "a",
         },
         namespace={},
     )

--- a/reconcile/test/test_utils_external_resource_spec.py
+++ b/reconcile/test/test_utils_external_resource_spec.py
@@ -11,14 +11,17 @@ from reconcile.utils.external_resource_spec import (
 )
 
 
-def test_identifier_creation_from_dict():
-    id = ExternalResourceUniqueKey.from_dict(
-        {
-            "provision_provider": "p",
-            "provisioner": {"name": "a"},
-            "identifier": "i",
-            "provider": "p",
-        }
+def test_identifier_creation_from_spec():
+    id = ExternalResourceUniqueKey.from_spec(
+        ExternalResourceSpec(
+            provision_provider="p",
+            provisioner={"name": "a"},
+            resource={
+                "identifier": "i",
+                "provider": "p",
+            },
+            namespace={},
+        )
     )
     assert id.identifier == "i"
     assert id.provider == "p"
@@ -27,44 +30,81 @@ def test_identifier_creation_from_dict():
 
 def test_identifier_missing():
     with pytest.raises(ValidationError):
-        ExternalResourceUniqueKey.from_dict(
-            {
-                "provision_provider": "p",
-                "provisioner": {"name": "a"},
-                "identifier": None,
-                "provider": "p",
-            }
+        ExternalResourceUniqueKey.from_spec(
+            ExternalResourceSpec(
+                provision_provider="p",
+                provisioner={"name": "a"},
+                resource={
+                    "identifier": None,
+                    "provider": "p",
+                },
+                namespace={},
+            )
         )
     with pytest.raises(KeyError):
-        ExternalResourceUniqueKey.from_dict({"provider": "p", "account": "a"})
+        ExternalResourceUniqueKey.from_spec(
+            ExternalResourceSpec(
+                provision_provider="p",
+                provisioner={"name": "a"},
+                resource={
+                    "provider": "p",
+                },
+                namespace={},
+            )
+        )
 
 
 def test_identifier_account_missing():
     with pytest.raises(ValidationError):
-        ExternalResourceUniqueKey.from_dict(
-            {
-                "provision_provider": "p",
-                "provisioner": {"name": None},
-                "identifier": "i",
-                "provider": "p",
-            }
+        ExternalResourceUniqueKey.from_spec(
+            ExternalResourceSpec(
+                provision_provider="p",
+                provisioner={"name": None},
+                resource={
+                    "identifier": "i",
+                    "provider": "p",
+                },
+                namespace={},
+            )
         )
     with pytest.raises(KeyError):
-        ExternalResourceUniqueKey.from_dict({"identifier": "i", "provider": "p"})
+        ExternalResourceUniqueKey.from_spec(
+            ExternalResourceSpec(
+                provision_provider="p",
+                provisioner={},
+                resource={
+                    "identifier": "i",
+                    "provider": "p",
+                },
+                namespace={},
+            )
+        )
 
 
 def test_identifier_provider_missing():
     with pytest.raises(ValidationError):
-        ExternalResourceUniqueKey.from_dict(
-            {
-                "provision_provider": "p",
-                "provisioner": {"name": "a"},
-                "identifier": "i",
-                "provider": None,
-            }
+        ExternalResourceUniqueKey.from_spec(
+            ExternalResourceSpec(
+                provision_provider="p",
+                provisioner={"name": "a"},
+                resource={
+                    "identifier": "i",
+                    "provider": None,
+                },
+                namespace={},
+            )
         )
     with pytest.raises(KeyError):
-        ExternalResourceUniqueKey.from_dict({"identifier": "i", "account": "a"})
+        ExternalResourceUniqueKey.from_spec(
+            ExternalResourceSpec(
+                provision_provider="p",
+                provisioner={"name": "a"},
+                resource={
+                    "identifier": "i",
+                },
+                namespace={},
+            )
+        )
 
 
 def test_spec_output_prefix():

--- a/reconcile/test/test_utils_external_resource_spec.py
+++ b/reconcile/test/test_utils_external_resource_spec.py
@@ -199,7 +199,7 @@ def test_terraform_output_with_when_no_secret(spec: ExternalResourceSpec):
 def test_terraform_generic_secret_output_format(
     spec: ExternalResourceSpec, resource_secret: dict[str, Any]
 ):
-    spec.resource["output_format"] = {  # type: ignore[index]
+    spec.resource["output_format"] = {
         "provider": "generic-secret",
         "data": """
             motd: The {{ mood }} Yakk {{ yakk_name }} is {{ visual_characteristics }}.
@@ -220,7 +220,7 @@ def test_terraform_generic_secret_output_format_no_data(
     this test shows backwards compatibility with the simple dict output when
     no data is given but the provider is specified
     """
-    spec.resource["output_format"] = {  # type: ignore[index]
+    spec.resource["output_format"] = {
         "provider": "generic-secret",
     }
     spec.secret = resource_secret
@@ -251,7 +251,7 @@ def test_terraform_unknown_output_format_provider(spec: ExternalResourceSpec):
     given. while the schema usually protects against such cases, additional protection
     in code is a good thing.
     """
-    spec.resource["output_format"] = {  # type: ignore[index]
+    spec.resource["output_format"] = {
         "provider": "unknown-provider"
     }
     with pytest.raises(ValueError):
@@ -265,7 +265,7 @@ def test_terraform_generic_secret_output_format_not_a_dict(
     this test shows how a data template for a generic-secret provider must result
     in a valid dict and fails otherwise
     """
-    spec.resource["output_format"] = {  # type: ignore[index]
+    spec.resource["output_format"] = {
         "provider": "generic-secret",
         "data": "not_a_dict",
     }
@@ -282,7 +282,7 @@ def test_terraform_generic_secret_output_format_not_str_keys(
     this test shows how a data template for a generic-secret provider must produce
     string keys
     """
-    spec.resource["output_format"] = {  # type: ignore[index]
+    spec.resource["output_format"] = {
         "provider": "generic-secret",
         "data": "1: value",
     }
@@ -299,7 +299,7 @@ def test_terraform_generic_secret_output_format_not_str_val(
     this test shows how a data template for a generic-secret provider must produce
     string values
     """
-    spec.resource["output_format"] = {  # type: ignore[index]
+    spec.resource["output_format"] = {
         "provider": "generic-secret",
         "data": "key: 1",
     }
@@ -316,7 +316,7 @@ def test_terraform_generic_secret_output_key_too_long(
     tests for too long secret keys (max length in kubernetes is 253 characters )
     """
     long_key = "a" * (SECRET_MAX_KEY_LENGTH + 1)
-    spec.resource["output_format"] = {  # type: ignore[index]
+    spec.resource["output_format"] = {
         "provider": "generic-secret",
         "data": f"{ long_key }: value",
     }

--- a/reconcile/test/test_utils_external_resources.py
+++ b/reconcile/test/test_utils_external_resources.py
@@ -1,4 +1,5 @@
 import pytest
+from reconcile.utils.external_resource_spec import ExternalResourceSpec
 
 import reconcile.utils.external_resources as uer
 
@@ -46,46 +47,53 @@ def namespace_info():
 
 
 @pytest.fixture
-def expected():
+def expected(namespace_info):
     return [
-        {
-            "provision_provider": uer.PROVIDER_AWS,
-            "provider": "rds",
-            "provisioner": {"name": "acc1"},
-        },
-        {
-            "provision_provider": uer.PROVIDER_AWS,
-            "provider": "rds",
-            "provisioner": {"name": "acc2"},
-        },
+        ExternalResourceSpec(
+            provision_provider=uer.PROVIDER_AWS,
+            resource={"provider": "rds"},
+            provisioner={"name": "acc1"},
+            namespace=namespace_info,
+        ),
+        ExternalResourceSpec(
+            provision_provider=uer.PROVIDER_AWS,
+            resource={"provider": "rds"},
+            provisioner={"name": "acc2"},
+            namespace=namespace_info,
+        ),
     ]
 
 
-def test_get_external_resources(namespace_info, expected):
-    results = uer.get_external_resources(
+def test_get_external_resource_specs(namespace_info, expected):
+    results = uer.get_external_resource_specs(
         namespace_info, provision_provider=uer.PROVIDER_AWS
     )
     assert results == expected
 
 
 @pytest.fixture
-def expected_other():
+def expected_other(namespace_info):
     return [
-        {
-            "provision_provider": "other",
-            "provider": "other",
-            "provisioner": {"name": "acc3"},
-        },
+        ExternalResourceSpec(
+            provision_provider="other",
+            resource={"provider": "other"},
+            provisioner={"name": "acc3"},
+            namespace=namespace_info,
+        ),
     ]
 
 
-def test_get_external_resources_no_filter(namespace_info, expected, expected_other):
-    results = uer.get_external_resources(namespace_info)
+def test_get_external_resource_specs_no_filter(
+    namespace_info, expected, expected_other
+):
+    results = uer.get_external_resource_specs(namespace_info)
     assert results == expected + expected_other
 
 
-def test_get_external_resources_filter_other(namespace_info, expected_other):
-    results = uer.get_external_resources(namespace_info, provision_provider="other")
+def test_get_external_resource_specs_filter_other(namespace_info, expected_other):
+    results = uer.get_external_resource_specs(
+        namespace_info, provision_provider="other"
+    )
     assert results == expected_other
 
 

--- a/reconcile/test/test_utils_external_resources.py
+++ b/reconcile/test/test_utils_external_resources.py
@@ -51,12 +51,12 @@ def expected():
         {
             "provision_provider": uer.PROVIDER_AWS,
             "provider": "rds",
-            "account": "acc1",
+            "provisioner": {"name": "acc1"},
         },
         {
             "provision_provider": uer.PROVIDER_AWS,
             "provider": "rds",
-            "account": "acc2",
+            "provisioner": {"name": "acc2"},
         },
     ]
 
@@ -74,7 +74,7 @@ def expected_other():
         {
             "provision_provider": "other",
             "provider": "other",
-            "account": "acc3",
+            "provisioner": {"name": "acc3"},
         },
     ]
 

--- a/reconcile/test/test_utils_terraform_client.py
+++ b/reconcile/test/test_utils_terraform_client.py
@@ -65,8 +65,9 @@ def test_expiration_value_error(aws_api):
 def test_get_replicas_info_via_replica_source():
     resource_specs = [
         ExternalResourceSpec(
+            provision_provider="aws",
+            provisioner={"name": "acc"},
             resource={
-                "account": "acc",
                 "identifier": "replica-id",
                 "provider": "rds",
                 "defaults": "defaults-ref",
@@ -86,8 +87,9 @@ def test_build_oc_secret():
     account = "account"
 
     spec = ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": account},
         resource={
-            "account": account,
             "identifier": "replica-id",
             "provider": "rds",
             "output_resource_name": "name",
@@ -132,8 +134,9 @@ def test_populate_terraform_output_secret():
     account = "account"
     resource_specs = [
         ExternalResourceSpec(
+            provision_provider="aws",
+            provisioner={"name": account},
             resource={
-                "account": account,
                 "identifier": "id",
                 "provider": "provider",
             },
@@ -150,7 +153,7 @@ def test_populate_terraform_output_secret():
     }
 
     tfclient.TerraformClient._populate_terraform_output_secrets(
-        {ExternalResourceUniqueKey.from_dict(s.resource): s for s in resource_specs},
+        {ExternalResourceUniqueKey.from_spec(s): s for s in resource_specs},
         existing_secrets,
         integration_prefix,
         {},
@@ -165,16 +168,18 @@ def test_populate_terraform_output_secret_with_replica_credentials():
     integration_prefix = "integ_pfx"
     account = "account"
     replica = ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": account},
         resource={
-            "account": account,
             "identifier": "replica-db",
             "provider": "rds",
         },
         namespace={},
     )
     replica_source = ExternalResourceSpec(
+        provision_provider="aws",
+        provisioner={"name": account},
         resource={
-            "account": account,
             "identifier": "main-db",
             "provider": "rds",
         },

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -86,11 +86,11 @@ class ExternalResourceSpec:
 
     @property
     def provider(self):
-        return self.resource.get("provider")
+        return self.resource["provider"]
 
     @property
     def identifier(self):
-        return self.resource.get("identifier")
+        return self.resource["identifier"]
 
     @property
     def provisioner_name(self):
@@ -159,15 +159,6 @@ class ExternalResourceUniqueKey:
     @property
     def output_prefix(self) -> str:
         return f"{self.identifier}-{self.provider}"
-
-    @staticmethod
-    def from_dict(data: Mapping[str, Any]) -> "ExternalResourceUniqueKey":
-        return ExternalResourceUniqueKey(
-            provision_provider=data["provision_provider"],
-            provisioner_name=data["provisioner"]["name"],
-            identifier=data["identifier"],
-            provider=data["provider"],
-        )
 
     @staticmethod
     def from_spec(spec: ExternalResourceSpec) -> "ExternalResourceUniqueKey":

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -2,7 +2,7 @@ from abc import abstractmethod
 from dataclasses import field
 from pydantic.dataclasses import dataclass
 import json
-from typing import Any, Mapping, Optional, cast
+from typing import Any, Mapping, MutableMapping, Optional, cast
 
 import yaml
 from reconcile.utils.openshift_resource import (
@@ -80,7 +80,7 @@ class ExternalResourceSpec:
 
     provision_provider: str
     provisioner: Mapping[str, Any]
-    resource: Mapping[str, Any]
+    resource: MutableMapping[str, Any]
     namespace: Mapping[str, Any]
     secret: Mapping[str, str] = field(init=False, default_factory=lambda: {})
 

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -136,7 +136,7 @@ class ExternalResourceSpec:
             integration=integration,
             integration_version=integration_version,
             error_details=self.output_resource_name,
-            caller_name=self.account,
+            caller_name=self.provisioner_name,
             annotations=annotations,
             unencoded_data=self._output_format().render(self.secret),
         )
@@ -155,7 +155,6 @@ class ExternalResourceUniqueKey:
     provisioner_name: str
     identifier: str
     provider: str
-    account: str
 
     @property
     def output_prefix(self) -> str:

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -93,10 +93,6 @@ class ExternalResourceSpec:
         return self.resource.get("identifier")
 
     @property
-    def account(self):
-        return self.provisioner["name"]
-
-    @property
     def provisioner_name(self):
         return self.provisioner["name"]
 
@@ -172,7 +168,6 @@ class ExternalResourceUniqueKey:
             provisioner_name=data["provisioner"]["name"],
             identifier=data["identifier"],
             provider=data["provider"],
-            account=data["account"],
         )
 
     @staticmethod
@@ -182,7 +177,6 @@ class ExternalResourceUniqueKey:
             provisioner_name=spec.provisioner_name,
             identifier=spec.identifier,
             provider=spec.provider,
-            account=spec.provisioner_name,
         )
 
 

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -127,7 +127,7 @@ class ExternalResourceSpec:
         return self.secret.get(field)
 
     def id_object(self) -> "ExternalResourceUniqueKey":
-        return ExternalResourceUniqueKey.from_dict(self.resource)
+        return ExternalResourceUniqueKey.from_spec(self)
 
     def build_oc_secret(
         self, integration: str, integration_version: str
@@ -173,6 +173,16 @@ class ExternalResourceUniqueKey:
             identifier=data["identifier"],
             provider=data["provider"],
             account=data["account"],
+        )
+
+    @staticmethod
+    def from_spec(spec: ExternalResourceSpec) -> "ExternalResourceUniqueKey":
+        return ExternalResourceUniqueKey(
+            provision_provider=spec.provision_provider,
+            provisioner_name=spec.provisioner_name,
+            identifier=spec.identifier,
+            provider=spec.provider,
+            account=spec.provisioner_name,
         )
 
 

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -78,6 +78,8 @@ class OutputFormat:
 @dataclass
 class ExternalResourceSpec:
 
+    provision_provider: str
+    provisioner: Mapping[str, Any]
     resource: Mapping[str, Any]
     namespace: Mapping[str, Any]
     secret: Mapping[str, str] = field(init=False, default_factory=lambda: {})
@@ -92,7 +94,11 @@ class ExternalResourceSpec:
 
     @property
     def account(self):
-        return self.resource.get("account")
+        return self.provisioner["name"]
+
+    @property
+    def provisioner_name(self):
+        return self.provisioner["name"]
 
     @property
     def namespace_name(self) -> str:
@@ -149,6 +155,8 @@ class ExternalResourceSpec:
 @dataclass(frozen=True)
 class ExternalResourceUniqueKey:
 
+    provision_provider: str
+    provisioner_name: str
     identifier: str
     provider: str
     account: str
@@ -160,6 +168,8 @@ class ExternalResourceUniqueKey:
     @staticmethod
     def from_dict(data: Mapping[str, Any]) -> "ExternalResourceUniqueKey":
         return ExternalResourceUniqueKey(
+            provision_provider=data["provision_provider"],
+            provisioner_name=data["provisioner"]["name"],
             identifier=data["identifier"],
             provider=data["provider"],
             account=data["account"],

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -16,6 +16,7 @@ def get_external_resources(
         provisioner = e["provisioner"]
         for r in e["resources"]:
             r["provision_provider"] = e["provider"]
+            r["provisioner"] = provisioner
             r["account"] = provisioner["name"]
             resources.append(r)
 

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -1,4 +1,4 @@
-from typing import Mapping, List, Dict, Any, Optional, Set
+from typing import Mapping, List, Any, Optional, Set
 
 from reconcile.utils.external_resource_spec import ExternalResourceSpec
 

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -10,40 +10,24 @@ def get_external_resource_specs(
     namespace_info: Mapping[str, Any], provision_provider: Optional[str] = None
 ) -> List[ExternalResourceSpec]:
     specs: List[ExternalResourceSpec] = []
-    resources = get_external_resources(namespace_info, provision_provider)
-    for resource in resources:
-        spec = ExternalResourceSpec(
-            provision_provider=resource["provision_provider"],
-            provisioner=resource["provisioner"],
-            resource=resource,
-            namespace=namespace_info,
-        )
-        specs.append(spec)
-
-    return specs
-
-
-def get_external_resources(
-    namespace_info: Mapping[str, Any], provision_provider: Optional[str] = None
-) -> List[Dict[str, Any]]:
-    resources: List[Dict[str, Any]] = []
     if not managed_external_resources(namespace_info):
-        return resources
+        return specs
 
     external_resources = namespace_info.get("externalResources") or []
     for e in external_resources:
-        provisioner = e["provisioner"]
         for r in e["resources"]:
-            r["provision_provider"] = e["provider"]
-            r["provisioner"] = provisioner
-            resources.append(r)
+            spec = ExternalResourceSpec(
+                provision_provider=e["provider"],
+                provisioner=e["provisioner"],
+                resource=r,
+                namespace=namespace_info,
+            )
+            specs.append(spec)
 
     if provision_provider:
-        resources = [
-            r for r in resources if r["provision_provider"] == provision_provider
-        ]
+        specs = [s for s in specs if s.provision_provider == provision_provider]
 
-    return resources
+    return specs
 
 
 def get_provision_providers(namespace_info: Mapping[str, Any]) -> Set[str]:

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -1,7 +1,26 @@
 from typing import Mapping, List, Dict, Any, Optional, Set
 
+from reconcile.utils.external_resource_spec import ExternalResourceSpec
+
 
 PROVIDER_AWS = "aws"
+
+
+def get_external_resource_specs(
+    namespace_info: Mapping[str, Any], provision_provider: Optional[str] = None
+) -> List[ExternalResourceSpec]:
+    specs: List[ExternalResourceSpec] = []
+    resources = get_external_resources(namespace_info, provision_provider)
+    for resource in resources:
+        spec = ExternalResourceSpec(
+            provision_provider=resource["provision_provider"],
+            provisioner=resource["provisioner"],
+            resource=resource,
+            namespace=namespace_info,
+        )
+        specs.append(spec)
+
+    return specs
 
 
 def get_external_resources(

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -13,10 +13,10 @@ def get_external_resources(
 
     external_resources = namespace_info.get("externalResources") or []
     for e in external_resources:
-        provisioner_name = e["provisioner"]["name"]
+        provisioner = e["provisioner"]
         for r in e["resources"]:
             r["provision_provider"] = e["provider"]
-            r["account"] = provisioner_name
+            r["account"] = provisioner["name"]
             resources.append(r)
 
     if provision_provider:

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -36,7 +36,6 @@ def get_external_resources(
         for r in e["resources"]:
             r["provision_provider"] = e["provider"]
             r["provisioner"] = provisioner
-            r["account"] = provisioner["name"]
             resources.append(r)
 
     if provision_provider:

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -355,7 +355,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                 replica_source_name = f'{replica_src}-{tf_resource.get("provider")}'
                 # Creating a dict that is convenient to use inside the
                 # loop processing the formatted_output
-                replicas_info[spec.account][spec.output_prefix] = replica_source_name
+                replicas_info[spec.provisioner_name][spec.output_prefix] = replica_source_name
 
         return replicas_info
 
@@ -446,20 +446,20 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                                            integration_prefix: str,
                                            replica_sources: Mapping[str, Mapping[str, str]]) -> None:
         for spec in resource_specs.values():
-            secret = terraform_output_secrets.get(spec.account, {}).get(spec.output_prefix, None)
+            secret = terraform_output_secrets.get(spec.provisioner_name, {}).get(spec.output_prefix, None)
             if not secret:
                 continue
             secret_copy = dict(secret)
 
             # find out about replica source
-            replica_source = replica_sources.get(spec.account, {}).get(spec.output_prefix)
+            replica_source = replica_sources.get(spec.provisioner_name, {}).get(spec.output_prefix)
             if replica_source:
                 # Grabbing the username/password from the
                 # replica_source and using them in the
                 # replica. This is needed because we can't
                 # set username/password for a replica in
                 # terraform.
-                replica_source_secret = terraform_output_secrets.get(spec.account, {}).get(replica_source)
+                replica_source_secret = terraform_output_secrets.get(spec.provisioner_name, {}).get(replica_source)
                 if replica_source_secret:
                     replica_src_user = replica_source_secret.get("db.user")
                     replica_src_password = replica_source_secret.get("db.password")

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -952,11 +952,13 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         resource = populate_spec.resource
         namespace_info = populate_spec.namespace
         provider = populate_spec.provider
+
         # setting account for backwards compatibility. any deeper
         # change will require a refactor of this module, which will
         # likely include passing populate_spec to the different population
         # methods instead of resource, namespace_info, existing_secrets.
         resource["account"] = populate_spec.provisioner_name
+
         if provider == 'rds':
             self.populate_tf_resource_rds(resource, namespace_info,
                                           existing_secrets)

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -925,14 +925,14 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         :param ocm_map:
         """
         self.init_populate_specs(namespaces, account_name)
-        for specs in self.account_resources.values():
+        for specs in self.account_resource_specs.values():
             for spec in specs:
                 self.populate_tf_resources(spec, existing_secrets,
                                            ocm_map=ocm_map)
 
     def init_populate_specs(self, namespaces: Iterable[Mapping[str, Any]],
                             account_name: Optional[str]) -> None:
-        self.account_resources: dict[str, list[ExternalResourceSpec]] = {}
+        self.account_resource_specs: dict[str, list[ExternalResourceSpec]] = {}
 
         for namespace_info in namespaces:
             specs = get_external_resource_specs(namespace_info, provision_provider=PROVIDER_AWS)
@@ -941,9 +941,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 # Skip if account_name is specified
                 if account_name and account != account_name:
                     continue
-                if account not in self.account_resources:
-                    self.account_resources[account] = []
-                self.account_resources[account].append(spec)
+                if account not in self.account_resource_specs:
+                    self.account_resource_specs[account] = []
+                self.account_resource_specs[account].append(spec)
 
     def populate_tf_resources(self, populate_spec, existing_secrets,
                               ocm_map=None):
@@ -1354,10 +1354,10 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                             source: str,
                             provider: str
                             ) -> Optional[ExternalResourceSpec]:
-        if account not in self.account_resources:
+        if account not in self.account_resource_specs:
             return None
 
-        for spec in self.account_resources[account]:
+        for spec in self.account_resource_specs[account]:
             if spec.identifier == source and spec.provider == provider:
                 return spec
         return None
@@ -3375,7 +3375,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         an account-wide resource policy.
         """
         log_group_infos = []
-        for specs in self.account_resources.values():
+        for specs in self.account_resource_specs.values():
             for spec in specs:
                 res = spec.resource
                 ns = spec.namespace

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -936,7 +936,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         for namespace_info in namespaces:
             specs = get_external_resource_specs(namespace_info, provision_provider=PROVIDER_AWS)
             for spec in specs:
-                account = spec.account
+                account = spec.provisioner_name
                 # Skip if account_name is specified
                 if account_name and account != account_name:
                     continue

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -949,6 +949,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         if populate_spec.provision_provider != PROVIDER_AWS:
             return
         resource = populate_spec.resource
+        # setting account for backwards compatibility. any deeper
+        # change will require a refactor of this module, which will
+        # likely include passing populate_spec to the different population
+        # methods instead of resource, namespace_info, existing_secrets.
+        resource["account"] = populate_spec.provisioner_name
         namespace_info = populate_spec.namespace
         provider = populate_spec.provider
         if provider == 'rds':

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -85,6 +85,7 @@ from sretoolbox.utils import threaded
 
 from reconcile.utils import gql
 from reconcile.utils.aws_api import AWSApi
+from reconcile.utils.external_resource_spec import ExternalResourceSpec
 from reconcile.utils.external_resources import PROVIDER_AWS, get_external_resource_specs
 from reconcile.utils.jenkins_api import JenkinsApi
 from reconcile.utils.ocm import OCMMap
@@ -931,7 +932,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
     def init_populate_specs(self, namespaces: Iterable[Mapping[str, Any]],
                             account_name: Optional[str]) -> None:
-        self.account_resources: dict[str, list[dict[str, Any]]] = {}
+        self.account_resources: dict[str, list[ExternalResourceSpec]] = {}
 
         for namespace_info in namespaces:
             specs = get_external_resource_specs(namespace_info, provision_provider=PROVIDER_AWS)

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -950,13 +950,13 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         if populate_spec.provision_provider != PROVIDER_AWS:
             return
         resource = populate_spec.resource
+        namespace_info = populate_spec.namespace
+        provider = populate_spec.provider
         # setting account for backwards compatibility. any deeper
         # change will require a refactor of this module, which will
         # likely include passing populate_spec to the different population
         # methods instead of resource, namespace_info, existing_secrets.
         resource["account"] = populate_spec.provisioner_name
-        namespace_info = populate_spec.namespace
-        provider = populate_spec.provider
         if provider == 'rds':
             self.populate_tf_resource_rds(resource, namespace_info,
                                           existing_secrets)

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1169,7 +1169,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 raise ValueError(
                     "only one of replicate_source_db or replica_source " +
                     "can be defined")
-            source_info = self._find_resource(account, replica_source, 'rds')
+            source_info = self._find_resource_spec(account, replica_source, 'rds')
             if source_info:
                 values['backup_retention_period'] = 0
                 deps.append("aws_db_instance." +
@@ -1262,7 +1262,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             if kms_key_id.startswith("arn:"):
                 values['kms_key_id'] = kms_key_id
             else:
-                kms_key = self._find_resource(account, kms_key_id, 'kms')
+                kms_key = self._find_resource_spec(account, kms_key_id, 'kms')
                 if kms_key:
                     kms_res = "aws_kms_key." + \
                         kms_key.identifier
@@ -1349,17 +1349,17 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         return False
 
-    def _find_resource(self,
-                       account: str,
-                       source: str,
-                       provider: str
-                       ) -> Optional[Mapping[str, Any]]:
+    def _find_resource_spec(self,
+                            account: str,
+                            source: str,
+                            provider: str
+                            ) -> Optional[ExternalResourceSpec]:
         if account not in self.account_resources:
             return None
 
         for spec in self.account_resources[account]:
             if spec.identifier == source and spec.provider == provider:
-                return spec.resource
+                return spec
         return None
 
     @staticmethod
@@ -2109,7 +2109,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     if kms_master_key_id.startswith("arn:"):
                         values['kms_master_key_id'] = kms_master_key_id
                     else:
-                        kms_key = self._find_resource(
+                        kms_key = self._find_resource_spec(
                             account, kms_master_key_id, 'kms')
                         if kms_key:
                             kms_res = "aws_kms_key." + \

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -85,7 +85,7 @@ from sretoolbox.utils import threaded
 
 from reconcile.utils import gql
 from reconcile.utils.aws_api import AWSApi
-from reconcile.utils.external_resources import PROVIDER_AWS, get_external_resources
+from reconcile.utils.external_resources import PROVIDER_AWS, get_external_resource_specs
 from reconcile.utils.jenkins_api import JenkinsApi
 from reconcile.utils.ocm import OCMMap
 from reconcile.utils.secret_reader import SecretReader
@@ -934,15 +934,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         self.account_resources: dict[str, list[dict[str, Any]]] = {}
 
         for namespace_info in namespaces:
-            tf_resources = get_external_resources(namespace_info, provision_provider=PROVIDER_AWS)
-            for resource in tf_resources:
-                account = resource['account']
+            specs = get_external_resource_specs(namespace_info, provision_provider=PROVIDER_AWS)
+            for spec in specs:
+                account = spec.account
                 # Skip if account_name is specified
                 if account_name and account != account_name:
                     continue
                 if account not in self.account_resources:
                     self.account_resources[account] = []
-                populate_spec = {'resource': resource,
+                populate_spec = {'resource': spec.resource,
                                  'provision_provider': PROVIDER_AWS,
                                  'namespace_info': namespace_info}
                 self.account_resources[account].append(populate_spec)

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -942,18 +942,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     continue
                 if account not in self.account_resources:
                     self.account_resources[account] = []
-                populate_spec = {'resource': spec.resource,
-                                 'provision_provider': PROVIDER_AWS,
-                                 'namespace_info': namespace_info}
-                self.account_resources[account].append(populate_spec)
+                self.account_resources[account].append(spec)
 
     def populate_tf_resources(self, populate_spec, existing_secrets,
                               ocm_map=None):
-        if populate_spec['provision_provider'] != PROVIDER_AWS:
+        if populate_spec.provision_provider != PROVIDER_AWS:
             return
-        resource = populate_spec['resource']
-        namespace_info = populate_spec['namespace_info']
-        provider = resource['provider']
+        resource = populate_spec.resource
+        namespace_info = populate_spec.namespace
+        provider = populate_spec.provider
         if provider == 'rds':
             self.populate_tf_resource_rds(resource, namespace_info,
                                           existing_secrets)

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1178,6 +1178,13 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                         replica_az)
                 else:
                     replica_region = self.default_regions.get(account)
+
+                # setting account for backwards compatibility. any deeper
+                # change will require a refactor of this module, which will
+                # likely include passing source_info to the init_values method
+                # instead of resource and namespace_info
+                source_info.resource["account"] = source_info.provisioner_name
+
                 _, _, source_values, _, _, _ = self.init_values(
                     source_info.resource, source_info.namespace)
                 if replica_region == region:

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -693,7 +693,7 @@ def aws_terraform_resources(ctx):
             get_external_resource_specs(ns_info, provision_provider=PROVIDER_AWS) or []
         )
         for spec in specs:
-            account = spec.account
+            account = spec.provisioner_name
             item = {"name": account, "total": 0}
             item = results.setdefault(account, item)
             total = {"name": "total", "total": 0}
@@ -976,7 +976,7 @@ def service_owners_for_rds_instance(ctx, aws_account, identifier):
         for spec in get_external_resource_specs(namespace_info):
             if (
                 spec.provider == "rds"
-                and spec.account == aws_account
+                and spec.provisioner_name == aws_account
                 and spec.identifier == identifier
             ):
                 service_owners = namespace_info["app"]["serviceOwners"]


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5833

following up on #2472, this PR consolidates the two approaches that were used for external resources - `dicts` and `ExternalResourceSpec` (previously called TerraformResourceSpec). it also replaces the use of `account` with `provisioner_name`, making things more generic.

review recommendations:

start from looking at the changes in `reconcile/utils/external_resource_spec.py` and `reconcile/utils/external_resources.py`.
these files hold the changes that are reflected in the rest of the files.

you can review commit by commit to see how each one is really not changing much. this whole PR is really a refactor, and should mostly not have any logic changes.