### PR TITLE
Slack notification on cluster upgrade completion

### DIFF
--- a/reconcile/openshift_upgrade_watcher.py
+++ b/reconcile/openshift_upgrade_watcher.py
@@ -24,13 +24,14 @@ def cluster_slack_handle(cluster: str, slack: Optional[SlackApi]):
     return f"<!subteam^{usergroup_id}>"
 
 
-def slack_notify(
+def handle_slack_notification(
     msg: str,
     slack: Optional[SlackApi],
     state: State,
     state_key: str,
     state_value: Optional[str],
 ):
+    """Check notification status, notify if needed and update the notification status"""
     if state.exists(state_key) and state.get(state_key) == state_value:
         # already notified for this state key & value
         return
@@ -75,7 +76,7 @@ def notify_upgrades_start(
                 + f"cluster `{cluster}` is currently "
                 + f"being upgraded to version `{version}`"
             )
-            slack_notify(msg, slack, state, state_key, None)
+            handle_slack_notification(msg, slack, state, state_key, None)
 
 
 def notify_upgrades_done(
@@ -90,7 +91,7 @@ def notify_upgrades_done(
             f"{cluster_slack_handle(cluster, slack)}: "
             + f"cluster `{cluster}` is now running version `{version}`"
         )
-        slack_notify(msg, slack, state, state_key, version)
+        handle_slack_notification(msg, slack, state, state_key, version)
 
 
 @defer

--- a/reconcile/test/test_openshift_upgrade_watcher.py
+++ b/reconcile/test/test_openshift_upgrade_watcher.py
@@ -1,0 +1,138 @@
+from datetime import datetime, timedelta
+import pytest
+from reconcile import openshift_upgrade_watcher as ouw
+
+
+@pytest.fixture
+def state(mocker):
+    return mocker.patch("reconcile.utils.state.State", autospec=True).return_value
+
+
+@pytest.fixture
+def slack(mocker):
+    return mocker.patch(
+        "reconcile.utils.slack_api.SlackApi", autospec=True
+    ).return_value
+
+
+cluster_name = "cluster1"
+upgrade_at = datetime(2020, 6, 1, 0, 0, 0)
+old_version = "4.5.1"
+upgrade_version = "4.5.2"
+
+
+@pytest.fixture
+def oc_map(mocker):
+    map = mocker.patch("reconcile.utils.oc.OC_Map", autospec=True).return_value
+    map.clusters.return_value = [cluster_name]
+    oc = mocker.patch("reconcile.utils.oc.OCNative", autospec=True)
+    oc.get.return_value = {"items": []}
+    map.get.return_value = oc
+    return map
+
+
+@pytest.fixture
+def upgrade_config():
+    return {
+        "items": [
+            {
+                "spec": {
+                    "upgradeAt": upgrade_at.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "desired": {"version": upgrade_version},
+                }
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def dt(mocker):
+    return mocker.patch(
+        "reconcile.openshift_upgrade_watcher.datetime",
+        mocker.Mock(datetime, wraps=datetime),
+    )
+
+
+def test_new_upgrade_no_op(mocker, state, slack, oc_map):
+    """There is no UpgradeConfig on the cluster"""
+    ouw.notify_upgrades_start(oc_map, state=state, slack=slack)
+    assert slack.chat_post_message.call_count == 0
+    assert state.add.call_count == 0
+
+
+def test_new_upgrade_pending(mocker, state, slack, oc_map, upgrade_config, dt):
+    """There is an UpgradeConfig on the cluster but its upgradeAt is in the future"""
+    dt.utcnow.return_value = upgrade_at - timedelta(hours=1)
+    oc = oc_map.get.return_value
+    oc.get.return_value = upgrade_config
+    ouw.notify_upgrades_start(oc_map, state=state, slack=slack)
+    assert slack.chat_post_message.call_count == 0
+    assert state.add.call_count == 0
+
+
+def test_new_upgrade_notify(mocker, state, slack, oc_map, upgrade_config, dt):
+    """There is an UpgradeConfig on the cluster, its upgradeAt is in the past,
+    and we did not already notify"""
+    dt.utcnow.return_value = upgrade_at + timedelta(hours=1)
+    oc = oc_map.get.return_value
+    oc.get.return_value = upgrade_config
+    state.exists.return_value = False
+    ouw.notify_upgrades_start(oc_map, state=state, slack=slack)
+    assert slack.chat_post_message.call_count == 1
+    assert state.add.call_count == 1
+
+
+def test_new_upgrade_already_notified(mocker, state, slack, oc_map, upgrade_config, dt):
+    """There is an UpgradeConfig on the cluster, its upgradeAt is in the past,
+    and we already notified"""
+    dt.utcnow.return_value = upgrade_at + timedelta(hours=1)
+    oc = oc_map.get.return_value
+    oc.get.return_value = upgrade_config
+    state.exists.return_value = True
+    state.get.return_value = None
+    ouw.notify_upgrades_start(oc_map, state=state, slack=slack)
+    assert slack.chat_post_message.call_count == 0
+    assert state.add.call_count == 0
+
+
+@pytest.fixture
+def ocm_cluster(mocker):
+    o = mocker.patch("reconcile.ocm.types.OCMSpec", autospec=True)
+    c = mocker.patch("reconcile.ocm.types.OCMClusterSpec", autospec=True)
+    o.spec = c
+    o.spec.version = upgrade_version
+    return o
+
+
+@pytest.fixture
+def ocm_map(mocker, ocm_cluster):
+    map = mocker.patch("reconcile.utils.ocm.OCMMap", autospec=True).return_value
+    map.cluster_specs.return_value = ({cluster_name: ocm_cluster}, [])
+    return map
+
+
+def test_new_version_no_op(mocker, state, slack, ocm_map):
+    """We already notified for this cluster & version"""
+    state.exists.return_value = True
+    state.get.return_value = upgrade_version  # same version, already notified
+    ouw.notify_upgrades_done(ocm_map, state=state, slack=slack)
+    assert slack.chat_post_message.call_count == 0
+    assert state.add.call_count == 0
+
+
+def test_new_version_no_state(mocker, state, slack, ocm_map):
+    """We never notified for this cluster"""
+    state.exists.return_value = False  # never notified for this cluster
+    state.get.return_value = None
+    ouw.notify_upgrades_done(ocm_map, state=state, slack=slack)
+    assert slack.chat_post_message.call_count == 1
+    assert state.add.call_count == 1
+
+
+def test_new_version_notify(mocker, state, slack, ocm_map):
+    """We already notified for this cluster, but on an old version"""
+    state.exists.return_value = True
+    state.get.return_value = old_version  # different version
+    ouw.notify_upgrades_done(ocm_map, state=state, slack=slack)
+    assert slack.chat_post_message.call_count == 1
+    assert state.add.call_count == 1


### PR DESCRIPTION
Ref APPSRE-5552

We currently only notify Slack when a cluster upgrade starts. This adds a notification when the cluster upgrade completes, based on the fact that OCM gets the `version.raw_id` updated only at that time (ref #2408, #2467).

Contrarily to #2452 , this implementation is done in `openshift_upgrade_watcher`, which is more coherent.

Notes:
- during the first production loop, we will get a notification for each cluster we currently run.
- Since we query ocm clusters, the following schemas need to be granted in the `openshift-upgrade-watcher` app-interface integration defintion (https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/41318)
```
- /aws/group-1.yml
- /aws/vpc-1.yml
- /openshift/cluster-addon-1.yml
```