### PR TITLE
[terrascript] use external resource spec in populate methods

### DIFF
--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -128,15 +128,7 @@ def get_tf_resource_info(terrascript: Terrascript, namespace, identifier):
         if spec.identifier != identifier:
             continue
 
-        # setting account for backwards compatibility. any deeper
-        # change will require a refactor of this module, which will
-        # likely include passing spec to the init_values method
-        # instead of resource and namespace_info
-        spec.resource["account"] = spec.provisioner_name
-
-        _, _, values, _, output_resource_name, _ = terrascript.init_values(
-            spec.resource, namespace
-        )
+        _, _, values, _, output_resource_name, _ = terrascript.init_values(spec)
 
         return {
             "cluster": namespace["cluster"]["name"],


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5833

this PR aims to replace the current arguments that are currently passed to terrascript populate method: resource, namespace_info (existing_secrets will be replaced in a different PR)
instead, we will pass the external resource spec, which will contain all the needed information.