### PR TITLE
[terraform-resources] consolidate external resource specs into terrascript

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -479,9 +479,6 @@ def setup(
     ri, oc_map = fetch_current_state(dry_run, tf_namespaces, thread_pool_size,
                                      internal, use_jump_host, account_name)
 
-    # build the resource specs
-    resource_specs = init_tf_resource_specs(tf_namespaces, account_name)
-
     # initialize terrascript (scripting engine to generate terraform manifests)
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size, settings=settings)
 
@@ -507,7 +504,7 @@ def setup(
                           ocm_map=ocm_map)
     ts.dump(print_to_file, existing_dirs=working_dirs)
 
-    return ri, oc_map, tf, resource_specs
+    return ri, oc_map, tf, ts.resource_spec_inventory
 
 
 def filter_tf_namespaces(
@@ -533,20 +530,6 @@ def filter_tf_namespaces(
                 break
 
     return tf_namespaces
-
-
-def init_tf_resource_specs(
-    namespaces: Iterable[Mapping[str, Any]], account_name: Optional[str]
-) -> ExternalResourceSpecInventory:
-    resource_specs: dict[ExternalResourceUniqueKey, ExternalResourceSpec] = {}
-    for namespace_info in namespaces:
-        if not managed_external_resources(namespace_info):
-            continue
-        tf_specs = get_external_resource_specs(namespace_info)
-        for spec in tf_specs:
-            if account_name is None or spec.provisioner_name == account_name:
-                resource_specs[spec.id_object()] = spec
-    return resource_specs
 
 
 def cleanup_and_exit(tf=None, status=False, working_dirs=None):

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -12,11 +12,7 @@ from reconcile.utils.external_resources import get_external_resource_specs, mana
 import reconcile.openshift_base as ob
 
 from reconcile import queries
-from reconcile.utils.external_resource_spec import (
-    ExternalResourceSpecInventory,
-    ExternalResourceUniqueKey,
-    ExternalResourceSpec,
-)
+from reconcile.utils.external_resource_spec import ExternalResourceSpecInventory
 from reconcile.utils import gql
 from reconcile.aws_iam_keys import run as disable_keys
 from reconcile.utils.aws_api import AWSApi

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -1,8 +1,4 @@
 import reconcile.terraform_resources as integ
-from reconcile.utils.external_resource_spec import (
-    ExternalResourceUniqueKey,
-    ExternalResourceSpec,
-)
 
 
 def test_filter_namespaces_no_managed_tf_resources():
@@ -125,68 +121,3 @@ def test_filter_tf_namespaces_no_tf_resources_with_account_filter():
     namespaces = [ns1, ns2]
     filtered = integ.filter_tf_namespaces(namespaces, "b")
     assert filtered == [ns1]
-
-
-def test_tf_disabled_namespace_with_resources():
-    """
-    even if a namespace has tf resources, they are not considered when the
-    namespace is not enabled for tf resource management
-    """
-    ra = {"identifier": "a", "provider": "p"}
-    ns1 = {
-        "name": "ns1",
-        "managedExternalResources": False,
-        "externalResources": [
-            {"provider": "aws", "provisioner": {"name": "a"}, "resources": [ra]}
-        ],
-        "cluster": {"name": "c"},
-    }
-    namespaces = [ns1]
-    resources = integ.init_tf_resource_specs(namespaces, None)
-    assert not resources
-
-
-def test_resource_specs_without_account_filter():
-    """
-    if no account filter is given, all resources of namespaces with
-    enabled tf resource management are expected to be returned
-    """
-    p = "aws"
-    pa = {"name": "a"}
-    ra = {"identifier": "a", "provider": "p"}
-    ns1 = {
-        "name": "ns1",
-        "managedExternalResources": True,
-        "externalResources": [{"provider": p, "provisioner": pa, "resources": [ra]}],
-        "cluster": {"name": "c"},
-    }
-    namespaces = [ns1]
-    resources = integ.init_tf_resource_specs(namespaces, None)
-    spec = ExternalResourceSpec(p, pa, ra, ns1)
-    assert resources == {ExternalResourceUniqueKey.from_spec(spec): spec}
-
-
-def test_resource_specs_with_account_filter():
-    """
-    if an account filter is given only the resources defined for
-    that account are expected
-    """
-    p = "aws"
-    pa = {"name": "a"}
-    ra = {"identifier": "a", "provider": "p"}
-    pb = {"name": "b"}
-    rb = {"identifier": "b", "provider": "p"}
-    ns1 = {
-        "name": "ns1",
-        "managedExternalResources": True,
-        "externalResources": [
-            {"provider": p, "provisioner": pa, "resources": [ra]},
-            {"provider": p, "provisioner": pb, "resources": [rb]},
-        ],
-        "cluster": {"name": "c"},
-    }
-    namespaces = [ns1]
-    resources = integ.init_tf_resource_specs(namespaces, "a")
-
-    spec = ExternalResourceSpec(p, pa, ra, ns1)
-    assert resources == {ExternalResourceUniqueKey.from_spec(spec): spec}

--- a/reconcile/test/test_utils_terrascript_aws_client.py
+++ b/reconcile/test/test_utils_terrascript_aws_client.py
@@ -1,6 +1,10 @@
 import pytest
 
 import reconcile.utils.terrascript_aws_client as tsclient
+from reconcile.utils.external_resource_spec import (
+    ExternalResourceSpec,
+    ExternalResourceUniqueKey,
+)
 
 
 def test_sanitize_resource_with_dots():
@@ -74,3 +78,70 @@ def test_use_previous_image_id_true(mocker, ts):
     )
     image = {"upstream": {"instance": {"name": "ci"}, "name": "job"}}
     assert ts._use_previous_image_id(image) == result
+
+
+def test_tf_disabled_namespace_with_resources(ts):
+    """
+    even if a namespace has tf resources, they are not considered when the
+    namespace is not enabled for tf resource management
+    """
+    ra = {"identifier": "a", "provider": "p"}
+    ns1 = {
+        "name": "ns1",
+        "managedExternalResources": False,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "a"}, "resources": [ra]}
+        ],
+        "cluster": {"name": "c"},
+    }
+    namespaces = [ns1]
+    ts.init_populate_specs(namespaces, None)
+    specs = ts.resource_spec_inventory
+    assert not specs
+
+
+def test_resource_specs_without_account_filter(ts):
+    """
+    if no account filter is given, all resources of namespaces with
+    enabled tf resource management are expected to be returned
+    """
+    p = "aws"
+    pa = {"name": "a"}
+    ra = {"identifier": "a", "provider": "p"}
+    ns1 = {
+        "name": "ns1",
+        "managedExternalResources": True,
+        "externalResources": [{"provider": p, "provisioner": pa, "resources": [ra]}],
+        "cluster": {"name": "c"},
+    }
+    namespaces = [ns1]
+    ts.init_populate_specs(namespaces, None)
+    specs = ts.resource_spec_inventory
+    spec = ExternalResourceSpec(p, pa, ra, ns1)
+    assert specs == {ExternalResourceUniqueKey.from_spec(spec): spec}
+
+
+def test_resource_specs_with_account_filter(ts):
+    """
+    if an account filter is given only the resources defined for
+    that account are expected
+    """
+    p = "aws"
+    pa = {"name": "a"}
+    ra = {"identifier": "a", "provider": "p"}
+    pb = {"name": "b"}
+    rb = {"identifier": "b", "provider": "p"}
+    ns1 = {
+        "name": "ns1",
+        "managedExternalResources": True,
+        "externalResources": [
+            {"provider": p, "provisioner": pa, "resources": [ra]},
+            {"provider": p, "provisioner": pb, "resources": [rb]},
+        ],
+        "cluster": {"name": "c"},
+    }
+    namespaces = [ns1]
+    ts.init_populate_specs(namespaces, "a")
+    specs = ts.resource_spec_inventory
+    spec = ExternalResourceSpec(p, pa, ra, ns1)
+    assert specs == {ExternalResourceUniqueKey.from_spec(spec): spec}

--- a/reconcile/test/test_utils_terrascript_aws_client.py
+++ b/reconcile/test/test_utils_terrascript_aws_client.py
@@ -1,3 +1,5 @@
+import pytest
+
 import reconcile.utils.terrascript_aws_client as tsclient
 
 
@@ -9,21 +11,24 @@ def test_sanitize_resource_with_wildcard():
     assert tsclient.safe_resource_id("*.foo.example.com") == "_star_foo_example_com"
 
 
-def test_aws_username_org():
-    ts = tsclient.TerrascriptClient("", "", 1, [])
+@pytest.fixture
+def ts():
+    return tsclient.TerrascriptClient("", "", 1, [])
+
+
+def test_aws_username_org(ts):
     result = "org"
     user = {"org_username": result}
     assert ts._get_aws_username(user) == result
 
 
-def test_aws_username_aws():
-    ts = tsclient.TerrascriptClient("", "", 1, [])
+def test_aws_username_aws(ts):
     result = "aws"
     user = {"org_username": "org", "aws_username": result}
     assert ts._get_aws_username(user) == result
 
 
-def test_validate_mandatory_policies():
+def test_validate_mandatory_policies(ts):
     mandatory_policy = {
         "name": "mandatory",
         "mandatory": True,
@@ -32,7 +37,6 @@ def test_validate_mandatory_policies():
         "name": "not-mandatory",
     }
     account = {"name": "acc", "policies": [mandatory_policy, not_mandatory_policy]}
-    ts = tsclient.TerrascriptClient("", "", 1, [])
     assert ts._validate_mandatory_policies(account, [mandatory_policy], "role") is True
     assert (
         ts._validate_mandatory_policies(account, [not_mandatory_policy], "role")
@@ -48,28 +52,25 @@ class MockJenkinsApi:
         return self.response
 
 
-def test_use_previous_image_id_no_upstream():
-    ts = tsclient.TerrascriptClient("", "", 1, [])
+def test_use_previous_image_id_no_upstream(ts):
     assert ts._use_previous_image_id({}) is False
 
 
-def test_use_previous_image_id_false(mocker):
+def test_use_previous_image_id_false(mocker, ts):
     result = False
     mocker.patch(
         "reconcile.utils.terrascript_aws_client.TerrascriptClient.init_jenkins",
         return_value=MockJenkinsApi(result),
     )
-    ts = tsclient.TerrascriptClient("", "", 1, [])
     image = {"upstream": {"instance": {"name": "ci"}, "name": "job"}}
     assert ts._use_previous_image_id(image) == result
 
 
-def test_use_previous_image_id_true(mocker):
+def test_use_previous_image_id_true(mocker, ts):
     result = True
     mocker.patch(
         "reconcile.utils.terrascript_aws_client.TerrascriptClient.init_jenkins",
         return_value=MockJenkinsApi(result),
     )
-    ts = tsclient.TerrascriptClient("", "", 1, [])
     image = {"upstream": {"instance": {"name": "ci"}, "name": "job"}}
     assert ts._use_previous_image_id(image) == result

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -85,7 +85,7 @@ from sretoolbox.utils import threaded
 
 from reconcile.utils import gql
 from reconcile.utils.aws_api import AWSApi
-from reconcile.utils.external_resource_spec import ExternalResourceSpec
+from reconcile.utils.external_resource_spec import ExternalResourceSpec, ExternalResourceSpecInventory
 from reconcile.utils.external_resources import PROVIDER_AWS, get_external_resource_specs
 from reconcile.utils.jenkins_api import JenkinsApi
 from reconcile.utils.ocm import OCMMap
@@ -933,6 +933,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
     def init_populate_specs(self, namespaces: Iterable[Mapping[str, Any]],
                             account_name: Optional[str]) -> None:
         self.account_resource_specs: dict[str, list[ExternalResourceSpec]] = {}
+        self.resource_spec_inventory: ExternalResourceSpecInventory = {}
 
         for namespace_info in namespaces:
             specs = get_external_resource_specs(namespace_info, provision_provider=PROVIDER_AWS)
@@ -944,6 +945,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 if account not in self.account_resource_specs:
                     self.account_resource_specs[account] = []
                 self.account_resource_specs[account].append(spec)
+                self.resource_spec_inventory[spec.id_object()] = spec
 
     def populate_tf_resources(self, populate_spec, existing_secrets,
                               ocm_map=None):

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -946,7 +946,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
     def populate_tf_resources(self, populate_spec, existing_secrets,
                               ocm_map=None):
         if populate_spec.provision_provider != PROVIDER_AWS:
-            return
+            raise UnknownProviderError(populate_spec.provision_provider)
+
         resource = populate_spec.resource
         namespace_info = populate_spec.namespace
         provider = populate_spec.provider

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -938,13 +938,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         for namespace_info in namespaces:
             specs = get_external_resource_specs(namespace_info, provision_provider=PROVIDER_AWS)
             for spec in specs:
-                account = spec.provisioner_name
-                # Skip if account_name is specified
-                if account_name and account != account_name:
+                if account_name and spec.provisioner_name != account_name:
                     continue
-                if account not in self.account_resource_specs:
-                    self.account_resource_specs[account] = []
-                self.account_resource_specs[account].append(spec)
+                self.account_resource_specs.setdefault(spec.provisioner_name, []).append(spec)
                 self.resource_spec_inventory[spec.id_object()] = spec
 
     def populate_tf_resources(self, populate_spec, existing_secrets,


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5833

the logic to collect external resource specs is duplicated in terraform-resources. this PR removes the duplication and adds resource specs into terrascript.