### PR TITLE
toggle logger

### DIFF
--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -4,6 +4,7 @@ import warnings
 
 from reconcile import queries
 from reconcile.utils.config import ConfigNotFound, get_config
+from reconcile.utils.helpers import toggle_logger
 from reconcile.utils.secret_reader import SecretReader
 
 # Dirty hack to silence annoying SyntaxWarnings present as of dyn==1.8.1
@@ -502,7 +503,11 @@ def run(dry_run: bool, enable_deletion: bool):
         raise ConfigNotFound("Dyn config missing from config file")
 
     creds = secret_reader.read_all({"path": creds_path})
-    dyn_session.DynectSession(creds["customer"], creds["dyn_id"], creds["password"])
+    # avoid logging these info messages
+    # INFO Establishing SSL connection to api.dynect.net:443
+    # INFO DynectSession Authentication Successful
+    with toggle_logger():
+        dyn_session.DynectSession(creds["customer"], creds["dyn_id"], creds["password"])
 
     desired = fetch_desired_state()
     current = fetch_current_state()

--- a/reconcile/test/test_utils_helpers.py
+++ b/reconcile/test/test_utils_helpers.py
@@ -1,0 +1,51 @@
+import logging
+import pytest
+
+from reconcile.utils.helpers import DEFAULT_TOGGLE_LEVEL, toggle_logger
+
+
+@pytest.fixture
+def default_level():
+    default_level = logging.INFO
+    assert default_level != DEFAULT_TOGGLE_LEVEL
+
+    return default_level
+
+
+@pytest.fixture
+def custom_level(default_level):
+    custom_level = logging.WARNING
+    assert custom_level != default_level
+    assert custom_level != DEFAULT_TOGGLE_LEVEL
+
+    return custom_level
+
+
+@pytest.fixture
+def logger(default_level):
+    logger = logging.getLogger()
+    logger.level = default_level
+    assert logger.level == default_level
+
+    return logger
+
+
+def test_toggle_logger_default_toggle_level(logger, default_level):
+    with toggle_logger():
+        assert logger.level == DEFAULT_TOGGLE_LEVEL
+
+    assert logger.level == default_level
+
+
+def test_toggle_logger_custom_level(logger, custom_level, default_level):
+    with toggle_logger(custom_level):
+        assert logger.level == custom_level
+
+    assert logger.level == default_level
+
+
+def test_toggle_logger_default_level(logger, default_level):
+    with toggle_logger(default_level):
+        assert logger.level == default_level
+
+    assert logger.level == default_level

--- a/reconcile/utils/helpers.py
+++ b/reconcile/utils/helpers.py
@@ -7,10 +7,10 @@ DEFAULT_TOGGLE_LEVEL = logging.ERROR
 
 
 @contextmanager
-def toggle_logger(log_level: str = DEFAULT_TOGGLE_LEVEL):
+def toggle_logger(log_level: int = DEFAULT_TOGGLE_LEVEL):
     logger = logging.getLogger()
     default_level = logger.level
     try:
-        yield logger.setLevel(log_level)
+        yield logger.setLevel(log_level)  # type: ignore[func-returns-value]
     finally:
         logger.setLevel(default_level)

--- a/reconcile/utils/helpers.py
+++ b/reconcile/utils/helpers.py
@@ -1,0 +1,16 @@
+import logging
+
+from contextlib import contextmanager
+
+
+DEFAULT_TOGGLE_LEVEL = logging.ERROR
+
+
+@contextmanager
+def toggle_logger(log_level: str = DEFAULT_TOGGLE_LEVEL):
+    logger = logging.getLogger()
+    default_level = logger.level
+    try:
+        yield logger.setLevel(log_level)
+    finally:
+        logger.setLevel(default_level)

--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -9,7 +9,6 @@ import json
 import re
 
 from os import path
-from contextlib import contextmanager
 from subprocess import PIPE, STDOUT, CalledProcessError
 
 import filecmp
@@ -23,6 +22,7 @@ from sretoolbox.utils import retry
 
 from reconcile.utils import gql
 from reconcile.utils import throughput
+from reconcile.utils.helpers import toggle_logger
 
 
 from reconcile.utils.secret_reader import SecretReader
@@ -258,7 +258,7 @@ class JJB:  # pylint: disable=too-many-public-methods
 
     def execute(self, args):
         jjb = self.get_jjb(args)
-        with self.toggle_logger():
+        with toggle_logger():
             jjb.execute()
 
     def modify_logger(self):
@@ -266,15 +266,6 @@ class JJB:  # pylint: disable=too-many-public-methods
         formatter = logging.Formatter("%(levelname)s: %(message)s")
         logger = logging.getLogger()
         logger.handlers[0].setFormatter(formatter)
-        self.default_logging = logger.level
-
-    @contextmanager
-    def toggle_logger(self):
-        logger = logging.getLogger()
-        try:
-            yield logger.setLevel(logging.ERROR)
-        finally:
-            logger.setLevel(self.default_logging)
 
     def cleanup(self):
         for wd in self.working_dirs.values():


### PR DESCRIPTION
our integrations attempt to log only things that are acted on. any logging from imported packages are attempted to be silenced.

this PR consolidates the logger toggling around the code base.