### PR TITLE
unlink terraform integrations from aws-gc

### DIFF
--- a/reconcile/aws_garbage_collector.py
+++ b/reconcile/aws_garbage_collector.py
@@ -5,11 +5,9 @@ from reconcile.utils.aws_api import AWSApi
 QONTRACT_INTEGRATION = "aws-garbage-collector"
 
 
-def run(dry_run, thread_pool_size=10, io_dir="throughput/"):
+def run(dry_run, thread_pool_size=10):
     accounts = [a for a in queries.get_aws_accounts() if a.get("garbageCollection")]
     settings = queries.get_app_interface_settings()
     aws = AWSApi(thread_pool_size, accounts, settings=settings)
-    if dry_run:
-        aws.simulate_deleted_users(io_dir)
     aws.map_resources()
     aws.delete_resources_without_owner(dry_run)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -839,11 +839,10 @@ def gitlab_mr_sqs_consumer(ctx, gitlab_project_id):
 
 
 @integration.command(short_help="Delete orphan AWS resources.")
-@throughput
 @threaded()
 @click.pass_context
-def aws_garbage_collector(ctx, thread_pool_size, io_dir):
-    run_integration(reconcile.aws_garbage_collector, ctx.obj, thread_pool_size, io_dir)
+def aws_garbage_collector(ctx, thread_pool_size):
+    run_integration(reconcile.aws_garbage_collector, ctx.obj, thread_pool_size)
 
 
 @integration.command(short_help="Delete IAM access keys by access key ID.")
@@ -1322,7 +1321,6 @@ def user_validator(ctx):
 
 @integration.command(short_help="Manage AWS Resources using Terraform.")
 @print_to_file
-@throughput
 @vault_output_path
 @threaded(default=20)
 @binary(["terraform", "oc", "git"])
@@ -1342,7 +1340,6 @@ def terraform_resources(
     ctx,
     print_to_file,
     enable_deletion,
-    io_dir,
     thread_pool_size,
     internal,
     use_jump_host,
@@ -1357,7 +1354,6 @@ def terraform_resources(
         ctx.obj,
         print_to_file,
         enable_deletion,
-        io_dir,
         thread_pool_size,
         internal,
         use_jump_host,
@@ -1369,7 +1365,6 @@ def terraform_resources(
 
 @integration.command(short_help="Manage AWS users using Terraform.")
 @print_to_file
-@throughput
 @threaded(default=20)
 @binary(["terraform", "gpg", "git"])
 @binary_version("terraform", ["version"], TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
@@ -1381,7 +1376,6 @@ def terraform_users(
     ctx,
     print_to_file,
     enable_deletion,
-    io_dir,
     thread_pool_size,
     send_mails,
     account_name,
@@ -1393,7 +1387,6 @@ def terraform_users(
         ctx.obj,
         print_to_file,
         enable_deletion,
-        io_dir,
         thread_pool_size,
         send_mails,
         account_name=account_name,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -595,7 +595,6 @@ def run(
     dry_run,
     print_to_file=None,
     enable_deletion=False,
-    io_dir="throughput/",
     thread_pool_size=10,
     internal=None,
     use_jump_host=True,
@@ -627,7 +626,6 @@ def run(
         disabled_deletions_detected, err = tf.plan(enable_deletion)
         if err:
             cleanup_and_exit(tf, err)
-        tf.dump_deleted_users(io_dir)
         if disabled_deletions_detected:
             cleanup_and_exit(tf, disabled_deletions_detected)
 

--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -128,7 +128,6 @@ def run(
     dry_run: bool,
     print_to_file: Optional[str] = None,
     enable_deletion: bool = False,
-    io_dir: str = "throughput/",
     thread_pool_size: int = 10,
     send_mails: bool = True,
     account_name: Optional[str] = None,
@@ -163,7 +162,6 @@ def run(
     disabled_deletions_detected, err = tf.plan(enable_deletion)
     if err:
         cleanup_and_exit(tf, err)
-    tf.dump_deleted_users(io_dir)
     if disabled_deletions_detected:
         cleanup_and_exit(tf, disabled_deletions_detected)
 

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1,7 +1,5 @@
 import functools
-import json
 import logging
-import os
 import re
 import time
 
@@ -198,21 +196,6 @@ class AWSApi:  # pylint: disable=too-many-public-methods
             users = self.paginate(iam, "list_users", "Users")
             users = [u["UserName"] for u in users]
             self.users[account] = users
-
-    def simulate_deleted_users(self, io_dir):
-        src_integrations = ["terraform_resources", "terraform_users"]
-        if not os.path.exists(io_dir):
-            return
-        for i in src_integrations:
-            file_path = os.path.join(io_dir, i + ".json")
-            if not os.path.exists(file_path):
-                continue
-            with open(file_path, "r") as f:
-                deleted_users = json.load(f)
-            for deleted_user in deleted_users:
-                delete_from_account = deleted_user["account"]
-                delete_user = deleted_user["user"]
-                self.users[delete_from_account].remove(delete_user)
 
     def map_resources(self):
         threaded.run(self.map_resource, self.resource_types, self.thread_pool_size)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5833

reverts #94

back at the time, we were running integrations in pr-check with dependencies. this means that aws-garbage-collector would wait for terraform-resources and terraform-users to finish to give a true prediction of the expected changes.

since that time, we are no longer running aws-garbage-collector in pr-checks, so this change can be reverted (unused) and the code can be simplified.