### PR TITLE
[terraform-resources] introduce TerraformConfigProvider

### DIFF
--- a/reconcile/utils/terraform/config_provider.py
+++ b/reconcile/utils/terraform/config_provider.py
@@ -46,11 +46,23 @@ class TerraformConfigProvider:
     def init_spec_inventory(
         self, namespaces: Iterable[Mapping[str, Any]], provisioner_name: Optional[str]
     ) -> None:
-        self.ts.init_populate_specs(namespaces, provisioner_name)
+        """
+        Initiates resource specs from the definitions in app-interface
+        (schemas/openshift/external-resource-1.yml).
+        :param namespaces: schemas/openshift/namespace-1.yml object
+        :param account_name: AWS account name
+        """
 
-    @property
-    def resource_spec_inventory(self):
-        return self.ts.resource_spec_inventory
+        self.resource_spec_inventory: ExternalResourceSpecInventory = {}
+
+        for namespace_info in namespaces:
+            specs = get_external_resource_specs(namespace_info)
+            for spec in specs:
+                if provisioner_name and spec.provisioner_name != provisioner_name:
+                    continue
+                self.resource_spec_inventory[spec.id_object()] = spec
+
+        self.ts.init_populate_specs(namespaces, provisioner_name)
 
     def populate_resources(self, ocm_map: Optional[OCMMap] = None) -> None:
         self.ts.populate_resources(ocm_map=ocm_map)

--- a/reconcile/utils/terraform/config_provider.py
+++ b/reconcile/utils/terraform/config_provider.py
@@ -7,6 +7,10 @@ from reconcile.utils.ocm import OCMMap
 from reconcile.utils.terrascript_aws_client import TerrascriptClient as Terrascript
 
 
+class UnknownProvisionProviderError(Exception):
+    pass
+
+
 @dataclass
 class TerraformConfigProvider:
     """
@@ -65,4 +69,12 @@ class TerraformConfigProvider:
         self.ts.init_populate_specs(namespaces, provisioner_name)
 
     def populate_resources(self, ocm_map: Optional[OCMMap] = None) -> None:
-        self.ts.populate_resources(ocm_map=ocm_map)
+        """
+        Populates the terraform configuration from resource specs.
+        :param ocm_map:
+        """
+        for spec in self.resource_spec_inventory.values():
+            if spec.provision_provider == PROVIDER_AWS:
+                self.ts.populate_resources(spec, ocm_map=ocm_map)
+            else:
+                raise UnknownProvisionProviderError(spec.provision_provider)

--- a/reconcile/utils/terraform/config_provider.py
+++ b/reconcile/utils/terraform/config_provider.py
@@ -1,0 +1,56 @@
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Optional
+from reconcile.utils.external_resource_spec import ExternalResourceSpecInventory
+from reconcile.utils.external_resources import PROVIDER_AWS, get_external_resource_specs
+from reconcile.utils.ocm import OCMMap
+
+from reconcile.utils.terrascript_aws_client import TerrascriptClient as Terrascript
+
+
+@dataclass
+class TerraformConfigProvider:
+    """
+    At a high-level, this class is responsible for generating Terraform configuration in
+    JSON format from app-interface schemas/openshift/external-resource-1.yml objects.
+
+    Usage example (mostly to demonstrate API):
+
+    cp = TerraformConfigProvider("terraform_resources", "qrtf", 20, provisioners, settings)
+    cp.init_spec_inventory(namespaces, provision_provider, provisioner_name)
+    cp.populate_resources(ocm_map=ocm_map)
+    cp.dump(print_to_file, existing_dirs=working_dirs)
+    """
+
+    integration: str
+    integration_prefix: str
+    thread_pool_size: int
+    provisioners: list[dict[str, Any]]
+    settings: Optional[Mapping[str, Any]] = None
+
+    def __post_init__(self):
+        self.ts = Terrascript(
+            self.integration,
+            self.integration_prefix,
+            self.thread_pool_size,
+            self.provisioners,
+            settings=self.settings,
+        )
+
+    def dump(
+        self,
+        print_to_file: Optional[str] = None,
+        existing_dirs: Optional[dict[str, str]] = None,
+    ) -> dict[str, str]:
+        return self.ts.dump(print_to_file, existing_dirs)
+
+    def init_spec_inventory(
+        self, namespaces: Iterable[Mapping[str, Any]], provisioner_name: Optional[str]
+    ) -> None:
+        self.ts.init_populate_specs(namespaces, provisioner_name)
+
+    @property
+    def resource_spec_inventory(self):
+        return self.ts.resource_spec_inventory
+
+    def populate_resources(self, ocm_map: Optional[OCMMap] = None) -> None:
+        self.ts.populate_resources(ocm_map=ocm_map)

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -988,7 +988,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 ).append(spec)
                 self.resource_spec_inventory[spec.id_object()] = spec
 
-    def populate_tf_resources(self, spec, ocm_map=None):
+    def populate_tf_resources(
+        self, spec: ExternalResourceSpec, ocm_map: Optional[OCMMap] = None
+    ):
         if spec.provision_provider != PROVIDER_AWS:
             raise UnknownProviderError(spec.provision_provider)
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -229,7 +229,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
     ts = TerrascriptClient("terraform_resources", "qrtf", 20, accounts, settings)
     ts.init_populate_specs(tf_namespaces, account_name)
-    ts.populate_resources(ocm_map=ocm_map)
+    for spec in get_external_resource_specs():
+        ts.populate_resources(spec, ocm_map=ocm_map)
     ts.dump(print_to_file, existing_dirs=working_dirs)
 
     More information on Terrascript: https://python-terrascript.readthedocs.io/en/develop/
@@ -953,15 +954,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         return results
 
-    def populate_resources(self, ocm_map: Optional[OCMMap] = None) -> None:
-        """
-        Populates the terraform configuration from resource specs.
-        :param ocm_map:
-        """
-        for specs in self.account_resource_specs.values():
-            for spec in specs:
-                self.populate_tf_resources(spec, ocm_map=ocm_map)
-
     def init_populate_specs(
         self, namespaces: Iterable[Mapping[str, Any]], account_name: Optional[str]
     ) -> None:
@@ -984,9 +976,14 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     spec.provisioner_name, []
                 ).append(spec)
 
-    def populate_tf_resources(
+    def populate_resources(
         self, spec: ExternalResourceSpec, ocm_map: Optional[OCMMap] = None
     ):
+        """
+        Populates the terraform configuration from a resource spec.
+        :param spec:
+        :param ocm_map:
+        """
         if spec.provision_provider != PROVIDER_AWS:
             raise UnknownProviderError(spec.provision_provider)
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -109,10 +109,8 @@ from sretoolbox.utils import threaded
 
 from reconcile.utils import gql
 from reconcile.utils.aws_api import AWSApi
-from reconcile.utils.external_resource_spec import (
-    ExternalResourceSpec,
-    ExternalResourceSpecInventory,
-)
+from reconcile.utils.external_resource_spec import ExternalResourceSpec
+
 from reconcile.utils.external_resources import PROVIDER_AWS, get_external_resource_specs
 from reconcile.utils.jenkins_api import JenkinsApi
 from reconcile.utils.ocm import OCMMap
@@ -974,7 +972,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         :param account_name: AWS account name
         """
         self.account_resource_specs: dict[str, list[ExternalResourceSpec]] = {}
-        self.resource_spec_inventory: ExternalResourceSpecInventory = {}
 
         for namespace_info in namespaces:
             specs = get_external_resource_specs(
@@ -986,7 +983,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 self.account_resource_specs.setdefault(
                     spec.provisioner_name, []
                 ).append(spec)
-                self.resource_spec_inventory[spec.id_object()] = spec
 
     def populate_tf_resources(
         self, spec: ExternalResourceSpec, ocm_map: Optional[OCMMap] = None


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5833

in our schemas, we represent external resources as an abstract entity. behind the scenes, the implementation of how to handle each external resource may defer.

this PR is beginning an alignment with this approach.

the reason we use terrascript is because it providers a way to get terraform configuration. so it is essentially a terraform configuration provider. in this PR, we replace terrascript in terraform-resources with a new class, TerraformConfigProvider.

this class exposes the required functionality, and under the hood, it utilizes terrascript itself.

the idea that is started in this PR is to slowly abstract away our usage of terrascript, until it is a detail behind ExternalResouceSpec. at that point, we will be able to use any tool we want to generate terraform configuration and replacing terrascript will be something we can do more easily.