### PR TITLE
CronJob SQL Query Deletion - APPSRE-3787

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1590,6 +1590,7 @@ APP_INTERFACE_SQL_QUERIES_QUERY = """
     }
     output
     schedule
+    delete
     query
     queries
   }

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -264,6 +264,11 @@ def collect_queries(query_name=None, settings=None):
         if schedule:
             item["schedule"] = schedule
 
+        # Logic to allow users to delete cronjobs
+        delete = sql_query.get("delete")
+        if delete:
+            item["delete"] = delete
+
         queries_list.append(item)
 
     return queries_list
@@ -534,7 +539,7 @@ def run(dry_run, enable_deletion=False):
             state[query_name] = time.time()
 
     for candidate in remove_candidates:
-        if not query["cronjob"] and time.time() < candidate["timestamp"] + JOB_TTL:
+        if not candidate["is_cronjob"] and time.time() < candidate["timestamp"] + JOB_TTL:
             continue
 
         try:

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -538,7 +538,10 @@ def run(dry_run, enable_deletion=False):
             state[query_name] = time.time()
 
     for candidate in remove_candidates:
-        if not candidate["is_cronjob"] and time.time() < candidate["timestamp"] + JOB_TTL:
+        if (
+            not candidate["is_cronjob"]
+            and time.time() < candidate["timestamp"] + JOB_TTL
+        ):
             continue
 
         try:

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -3,7 +3,6 @@ import sys
 import time
 
 from textwrap import indent
-from graphql import is_composite_type
 
 import jinja2
 from ruamel import yaml


### PR DESCRIPTION
Depends on https://github.com/app-sre/qontract-schemas/pull/175

Part of [APPSRE-3787](https://issues.redhat.com/browse/APPSRE-3787), this MR adds new behavior to the SQL query feature in App Interface to delete CronJobs after they have been created in OpenShift by adding a `delete: true` flag to the SQL query schema. Meaning that tenants will now be able to delete those queries without manual AppSRE intervention required. Tested this on dashdotdb staging, details in linked Jira issue.