### PR TITLE
[sql-query] cronjob delete keyerror fix

### DIFF
--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -470,7 +470,7 @@ def run(dry_run, enable_deletion=False):
             query_state = state[query_name]
             is_cronjob = query.get("schedule")
             if (query_state != "DONE" and not is_cronjob) or (
-                query_state != "DONE" and is_cronjob and query["delete"]
+                query_state != "DONE" and is_cronjob and query.get("delete")
             ):
                 remove_candidates.append(
                     {


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3787

follows up on #2494

since the `delete` key is only added if `delete` is set to true: https://github.com/app-sre/qontract-reconcile/blob/28957384ffaa6a0d98124442d012b1bf349cffda/reconcile/sql_query.py#L269

this condition will encounter a KeyError for every CronJob that does not have `delete` set to true: https://github.com/app-sre/qontract-reconcile/blob/28957384ffaa6a0d98124442d012b1bf349cffda/reconcile/sql_query.py#L473

this is causing the sql-query integration to endlessly apply.