### PR TITLE
Draft: Terraform config more than 1 provider

### DIFF
--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -179,4 +179,6 @@ class ExternalResourceUniqueKey:
         )
 
 
-ExternalResourceSpecInventory = Mapping[ExternalResourceUniqueKey, ExternalResourceSpec]
+ExternalResourceSpecInventory = MutableMapping[
+    ExternalResourceUniqueKey, ExternalResourceSpec
+]

--- a/reconcile/utils/terraform_config.py
+++ b/reconcile/utils/terraform_config.py
@@ -1,69 +1,94 @@
-from dataclasses import dataclass
-from typing import Any, Iterable, Mapping, Optional
-from reconcile.utils.external_resource_spec import ExternalResourceSpecInventory
-from reconcile.utils.external_resources import PROVIDER_AWS, get_external_resource_specs
-from reconcile.utils.ocm import OCMMap
+from typing import Iterable, Optional, Protocol
+from reconcile.utils.external_resource_spec import (
+    ExternalResourceSpecInventory,
+    ExternalResourceSpec,
+)
 
-from reconcile.utils.terrascript_aws_client import TerrascriptClient as Terrascript
+from reconcile.utils.ocm import OCMMap
 
 
 class UnknownProvisionProviderError(Exception):
     pass
 
 
-@dataclass
+class ProvisionProviderAlreadyRegisteredError(Exception):
+    pass
+
+
+class TerraformClientProtocol(Protocol):
+    def dump(
+        self,
+        print_to_file: Optional[str] = None,
+        existing_dirs: Optional[dict[str, str]] = None,
+    ) -> dict[str, str]:
+        ...
+
+    def init_populate_specs(
+        self, specs: Iterable[ExternalResourceSpec], account_name: Optional[str]
+    ) -> None:
+        ...
+
+    def populate_resources(
+        self, spec: ExternalResourceSpec, ocm_map: Optional[OCMMap] = None
+    ):
+        ...
+
+
 class TerraformConfigProvider:
     """
     At a high-level, this class is responsible for generating Terraform configuration in
     JSON format from app-interface schemas/openshift/external-resource-1.yml objects.
     Usage example (mostly to demonstrate API):
-    cp = TerraformConfigProvider("terraform_resources", "qrtf", 20, provisioners, settings)
-    cp.init_spec_inventory(namespaces, provision_provider, provisioner_name)
+
+    cp = TerraformConfigProvider()
+    cp.register_terraform_client("aws", terrascript_aws_client)
+    cp.init_spec_inventory(specs, provision_provider, provisioner_name)
     cp.populate_resources(ocm_map=ocm_map)
     cp.dump(print_to_file, existing_dirs=working_dirs)
     """
 
-    integration: str
-    integration_prefix: str
-    thread_pool_size: int
-    provisioners: list[dict[str, Any]]
-    settings: Optional[Mapping[str, Any]] = None
+    def __init__(self):
+        self.resource_spec_inventory: ExternalResourceSpecInventory = {}
+        self._terraform_clients: dict[str, TerraformClientProtocol] = {}
 
-    def __post_init__(self):
-        self.ts = Terrascript(
-            self.integration,
-            self.integration_prefix,
-            self.thread_pool_size,
-            self.provisioners,
-            settings=self.settings,
-        )
+    def register_terraform_client(
+        self, provision_provider: str, client: TerraformClientProtocol
+    ):
+        if not self._terraform_clients.get(provision_provider):
+            self._terraform_clients[provision_provider] = client
+        else:
+            raise ProvisionProviderAlreadyRegisteredError(
+                f"There can only be one client for each provision provider, {provision_provider} was already registered"
+            )
 
     def dump(
         self,
         print_to_file: Optional[str] = None,
         existing_dirs: Optional[dict[str, str]] = None,
     ) -> dict[str, str]:
-        return self.ts.dump(print_to_file, existing_dirs)
+        # TODO: need to verify that passing in existing_dirs to each client will be
+        # okay as long as they only modify what's needed.
+        working_dirs = {}
+        for client in self._terraform_clients.values():
+            working_dirs.update(client.dump(print_to_file, existing_dirs))
+        return working_dirs
 
     def init_spec_inventory(
-        self, namespaces: Iterable[Mapping[str, Any]], provisioner_name: Optional[str]
+        self, specs: Iterable[ExternalResourceSpec], provisioner_name: Optional[str]
     ) -> None:
         """
         Initiates resource specs from the definitions in app-interface
         (schemas/openshift/external-resource-1.yml).
-        :param namespaces: schemas/openshift/namespace-1.yml object
-        :param account_name: AWS account name
+        :param specs: external resource specs
+        :param provisioner_name: name of the provisioner
         """
-        self.resource_spec_inventory: ExternalResourceSpecInventory = {}
+        for spec in specs:
+            if provisioner_name and spec.provisioner_name != provisioner_name:
+                continue
+            self.resource_spec_inventory[spec.id_object()] = spec
 
-        for namespace_info in namespaces:
-            specs = get_external_resource_specs(namespace_info)
-            for spec in specs:
-                if provisioner_name and spec.provisioner_name != provisioner_name:
-                    continue
-                self.resource_spec_inventory[spec.id_object()] = spec
-
-        self.ts.init_populate_specs(namespaces, provisioner_name)
+        for client in self._terraform_clients.values():
+            client.init_populate_specs(specs, provisioner_name)
 
     def populate_resources(self, ocm_map: Optional[OCMMap] = None) -> None:
         """
@@ -71,7 +96,9 @@ class TerraformConfigProvider:
         :param ocm_map:
         """
         for spec in self.resource_spec_inventory.values():
-            if spec.provision_provider == PROVIDER_AWS:
-                self.ts.populate_resources(spec, ocm_map=ocm_map)
-            else:
+            try:
+                self._terraform_clients[spec.provision_provider].populate_resources(
+                    spec, ocm_map=ocm_map
+                )
+            except KeyError:
                 raise UnknownProvisionProviderError(spec.provision_provider)

--- a/reconcile/utils/terraform_config.py
+++ b/reconcile/utils/terraform_config.py
@@ -1,0 +1,77 @@
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Optional
+from reconcile.utils.external_resource_spec import ExternalResourceSpecInventory
+from reconcile.utils.external_resources import PROVIDER_AWS, get_external_resource_specs
+from reconcile.utils.ocm import OCMMap
+
+from reconcile.utils.terrascript_aws_client import TerrascriptClient as Terrascript
+
+
+class UnknownProvisionProviderError(Exception):
+    pass
+
+
+@dataclass
+class TerraformConfigProvider:
+    """
+    At a high-level, this class is responsible for generating Terraform configuration in
+    JSON format from app-interface schemas/openshift/external-resource-1.yml objects.
+    Usage example (mostly to demonstrate API):
+    cp = TerraformConfigProvider("terraform_resources", "qrtf", 20, provisioners, settings)
+    cp.init_spec_inventory(namespaces, provision_provider, provisioner_name)
+    cp.populate_resources(ocm_map=ocm_map)
+    cp.dump(print_to_file, existing_dirs=working_dirs)
+    """
+
+    integration: str
+    integration_prefix: str
+    thread_pool_size: int
+    provisioners: list[dict[str, Any]]
+    settings: Optional[Mapping[str, Any]] = None
+
+    def __post_init__(self):
+        self.ts = Terrascript(
+            self.integration,
+            self.integration_prefix,
+            self.thread_pool_size,
+            self.provisioners,
+            settings=self.settings,
+        )
+
+    def dump(
+        self,
+        print_to_file: Optional[str] = None,
+        existing_dirs: Optional[dict[str, str]] = None,
+    ) -> dict[str, str]:
+        return self.ts.dump(print_to_file, existing_dirs)
+
+    def init_spec_inventory(
+        self, namespaces: Iterable[Mapping[str, Any]], provisioner_name: Optional[str]
+    ) -> None:
+        """
+        Initiates resource specs from the definitions in app-interface
+        (schemas/openshift/external-resource-1.yml).
+        :param namespaces: schemas/openshift/namespace-1.yml object
+        :param account_name: AWS account name
+        """
+        self.resource_spec_inventory: ExternalResourceSpecInventory = {}
+
+        for namespace_info in namespaces:
+            specs = get_external_resource_specs(namespace_info)
+            for spec in specs:
+                if provisioner_name and spec.provisioner_name != provisioner_name:
+                    continue
+                self.resource_spec_inventory[spec.id_object()] = spec
+
+        self.ts.init_populate_specs(namespaces, provisioner_name)
+
+    def populate_resources(self, ocm_map: Optional[OCMMap] = None) -> None:
+        """
+        Populates the terraform configuration from resource specs.
+        :param ocm_map:
+        """
+        for spec in self.resource_spec_inventory.values():
+            if spec.provision_provider == PROVIDER_AWS:
+                self.ts.populate_resources(spec, ocm_map=ocm_map)
+            else:
+                raise UnknownProvisionProviderError(spec.provision_provider)

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -957,26 +957,22 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         return results
 
     def init_populate_specs(
-        self, namespaces: Iterable[Mapping[str, Any]], account_name: Optional[str]
+        self, specs: Iterable[ExternalResourceSpec], account_name: Optional[str]
     ) -> None:
         """
         Initiates resource specs from the definitions in app-interface
         (schemas/openshift/terraform-resource-1.yml).
-        :param namespaces: schemas/openshift/namespace-1.yml object
+        :param specs: external resource specs
         :param account_name: AWS account name
         """
         self.account_resource_specs: dict[str, list[ExternalResourceSpec]] = {}
 
-        for namespace_info in namespaces:
-            specs = get_external_resource_specs(
-                namespace_info, provision_provider=PROVIDER_AWS
+        for spec in specs:
+            if account_name and spec.provisioner_name != account_name:
+                continue
+            self.account_resource_specs.setdefault(spec.provisioner_name, []).append(
+                spec
             )
-            for spec in specs:
-                if account_name and spec.provisioner_name != account_name:
-                    continue
-                self.account_resource_specs.setdefault(
-                    spec.provisioner_name, []
-                ).append(spec)
 
     def populate_resources(
         self, spec: ExternalResourceSpec, ocm_map: Optional[OCMMap] = None

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -956,15 +956,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         return results
 
-    def populate_resources(self, ocm_map: Optional[OCMMap] = None) -> None:
-        """
-        Populates the terraform configuration from resource specs.
-        :param ocm_map:
-        """
-        for specs in self.account_resource_specs.values():
-            for spec in specs:
-                self.populate_tf_resources(spec, ocm_map=ocm_map)
-
     def init_populate_specs(
         self, namespaces: Iterable[Mapping[str, Any]], account_name: Optional[str]
     ) -> None:
@@ -975,7 +966,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         :param account_name: AWS account name
         """
         self.account_resource_specs: dict[str, list[ExternalResourceSpec]] = {}
-        self.resource_spec_inventory: ExternalResourceSpecInventory = {}
 
         for namespace_info in namespaces:
             specs = get_external_resource_specs(
@@ -987,9 +977,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 self.account_resource_specs.setdefault(
                     spec.provisioner_name, []
                 ).append(spec)
-                self.resource_spec_inventory[spec.id_object()] = spec
 
-    def populate_tf_resources(self, spec, ocm_map=None):
+    def populate_resources(
+        self, spec: ExternalResourceSpec, ocm_map: Optional[OCMMap] = None
+    ):
+        """
+        Populates the terraform configuration from a resource spec.
+        :param spec:
+        :param ocm_map:
+        """
         if spec.provision_provider != PROVIDER_AWS:
             raise UnknownProviderError(spec.provision_provider)
 


### PR DESCRIPTION
This is an early version of the PR that is being shared as part of the design doc. The first commit was the groundwork that Maor setup in #2493 and the remaining commits will be based on my feedback from that MR.

I'm currently floating the idea of having a separate `terraform-resources-cloudflare` integration as I think it'd simplify things, particularly related to account name sharding. I'll bring this up in the design doc and with team members that might be interested. This PR can essentially go away if we have a separate integration.