### PR TITLE
[terraform-vpc-peerings] account filter capability

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1399,8 +1399,11 @@ def terraform_users(
 @binary(["terraform", "git"])
 @binary_version("terraform", ["version"], TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @enable_deletion(default=False)
+@account_name
 @click.pass_context
-def terraform_vpc_peerings(ctx, print_to_file, enable_deletion, thread_pool_size):
+def terraform_vpc_peerings(
+    ctx, print_to_file, enable_deletion, thread_pool_size, account_name
+):
     if print_to_file and is_file_in_git_repo(print_to_file):
         raise PrintToFileInGitRepositoryError(print_to_file)
     run_integration(
@@ -1409,6 +1412,7 @@ def terraform_vpc_peerings(ctx, print_to_file, enable_deletion, thread_pool_size
         print_to_file,
         enable_deletion,
         thread_pool_size,
+        account_name,
     )
 
 

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -167,6 +167,18 @@ def build_desired_state_single_cluster(
         req_aws, acc_aws = aws_assume_roles_for_cluster_vpc_peering(
             cluster_info, peer_info, peer_cluster, ocm
         )
+
+        # verify that the infra mgmt account for both sides of a peering is the same
+        # this is a restriction we might lift in the future but it
+        # requires work in `populate_vpc_peerings` where the tf resources are hooked up
+        if req_aws["name"] != acc_aws["name"]:
+            raise BadTerraformPeeringState(
+                f"different infra mgmt accounts for peering "
+                f"requester ({cluster_name} - {req_aws['name']}) and "
+                f"accepter ({peer_connection_name} - {acc_aws['name']}) "
+                "are not suppored"
+            )
+
         # filter on account
         if account_filter and acc_aws["name"] != account_filter:
             continue

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -168,6 +168,10 @@ def build_desired_state_single_cluster(
             cluster_info, peer_info, peer_cluster, ocm
         )
 
+        # filter on account
+        if account_filter and acc_aws["name"] != account_filter:
+            continue
+
         # verify that the infra mgmt account for both sides of a peering is the same
         # this is a restriction we might lift in the future but it
         # requires work in `populate_vpc_peerings` where the tf resources are hooked up
@@ -178,10 +182,6 @@ def build_desired_state_single_cluster(
                 f"accepter ({peer_connection_name} - {acc_aws['name']}) "
                 "are not suppored"
             )
-
-        # filter on account
-        if account_filter and acc_aws["name"] != account_filter:
-            continue
 
         requester_vpc_id, requester_route_table_ids, _ = awsapi.get_cluster_vpc_details(
             req_aws, route_tables=requester_manage_routes

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -337,7 +337,7 @@ class TestRun(testslide.TestCase):
         self.ocmmap = testslide.StrictMock(ocm.OCMMap)
         self.mock_constructor(ocm, "OCMMap").to_return_value(self.ocmmap)
         self.mock_callable(queries, "get_aws_accounts").to_return_value(
-            [{"name": "desired_requester_account"}]
+            [{"name": "desired_account"}]
         )
         self.clusters = (
             self.mock_callable(queries, "get_clusters")
@@ -368,8 +368,8 @@ class TestRun(testslide.TestCase):
                 [
                     {
                         "connection_name": "desired_vpc_conn",
-                        "requester": {"account": {"name": "desired_requester_account"}},
-                        "accepter": {"account": {"name": "desired_accepter_account"}},
+                        "requester": {"account": {"name": "desired_account"}},
+                        "accepter": {"account": {"name": "desired_account"}},
                     },
                 ],
                 error_code,
@@ -380,12 +380,10 @@ class TestRun(testslide.TestCase):
                 [
                     {
                         "connection_name": "all_clusters_vpc_conn",
-                        "requester": {
-                            "account": {"name": "all_clusters_requester_account"}
-                        },
+                        "requester": {"account": {"name": "all_clusters_account"}},
                         "accepter": {
                             "account": {
-                                "name": "all_clusters_accepter_account",
+                                "name": "all_clusters_account",
                             }
                         },
                     }
@@ -399,10 +397,10 @@ class TestRun(testslide.TestCase):
                     {
                         "connection_name": "mesh_vpc_conn",
                         "requester": {
-                            "account": {"name": "mesh_requester_account"},
+                            "account": {"name": "mesh_account"},
                         },
                         "accepter": {
-                            "account": {"name": "mesh_accepter_account"},
+                            "account": {"name": "mesh_account"},
                         },
                     }
                 ],
@@ -412,12 +410,12 @@ class TestRun(testslide.TestCase):
 
         self.mock_callable(self.terrascript, "populate_additional_providers").for_call(
             [
-                {"name": "desired_requester_account"},
-                {"name": "mesh_requester_account"},
-                {"name": "all_clusters_requester_account"},
-                {"name": "desired_accepter_account"},
-                {"name": "mesh_accepter_account"},
-                {"name": "all_clusters_accepter_account"},
+                {"name": "desired_account"},
+                {"name": "mesh_account"},
+                {"name": "all_clusters_account"},
+                {"name": "desired_account"},
+                {"name": "mesh_account"},
+                {"name": "all_clusters_account"},
             ]
         ).to_return_value(None).and_assert_called_once()
 


### PR DESCRIPTION
implement account filtering capabilities for terraform-vpc-peerings to allow account based sharding by integration-manager

the relevant account for filtering is the acceptors account

* for cluster to cluster VPC peering, the infrastructure management account on the acceptor cluster is used for filtering
* for cluster to account (normal peerings and mesh peering), the account plays the role of the acceptor and is used for filtering

Ref: https://issues.redhat.com/browse/APPSRE-5917

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>