### PR TITLE
Update sms_role_ext_id iam role creation to use inline policies

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4501,7 +4501,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         }
 
         sms_role_inline_policy = {
-            "name": f'ocm-{identifier}-cognito-sms-policy',
+            "name": f"ocm-{identifier}-cognito-sms-policy",
             "policy": json.dumps(
                 {
                     "Statement": [
@@ -4510,12 +4510,12 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                             "Action": [
                                 "sns:Publish",
                             ],
-                            "Resource": "*"
+                            "Resource": "*",
                         }
                     ],
-                    "Version": "2012-10-17"
+                    "Version": "2012-10-17",
                 }
-            )
+            ),
         }
 
         sms_iam_role_resource = aws_iam_role(


### PR DESCRIPTION
This MR fixes a bug with `sms_iam_role_resource` in the rosa-authenticator provider.

The MR splits a combined `asssume_role_policy` into two, and assigns the new policy to the `inline_policies` parameter of an `aws_iam_role` terrascript resource.