### PR TITLE
Use correct sms role for cognito user pool [rosa-authenticator]

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4621,7 +4621,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             },
             sms_configuration={
                 "external_id": common_values.get("sms_role_ext_id"),
-                "sns_caller_arn": f"${{{lambda_iam_role_resource.arn}}}",
+                "sns_caller_arn": f"${{{sms_iam_role_resource.arn}}}",
             },
             **pool_args,
         )


### PR DESCRIPTION
This MR fixes a bug with the sms role arn - fixing the reference to point to the correct iam resource.