### PR TITLE
Fix cases where console_url and server_url were missing

### DIFF
--- a/reconcile/ocm/types.py
+++ b/reconcile/ocm/types.py
@@ -55,3 +55,5 @@ class OCMSpec(BaseModel):
 
     class Config:
         smart_union = True
+        # This is need to populate by either console_url or consoleUrl, for instance
+        allow_population_by_field_name = True


### PR DESCRIPTION
When using Pydantic, a Field alias will be used to override the name of
a field when it's initialized. In order to use both the field name and
alias, which is useful when dealing with snake case (Python) and camel
case (JSON), the allow_population_by_field_name config can be used.

## Testing

### Before

```
[2022-07-01 15:45:33] [INFO] [ocm_clusters.py:_app_interface_updates_mr:213] - [<cluster_name>] desired root key consoleUrl will be updated automatically with value None
[2022-07-01 15:45:33] [INFO] [ocm_clusters.py:_app_interface_updates_mr:213] - [<cluster_name>] desired root key serverUrl will be updated automatically with value None
```

### After

```
[2022-07-01 15:46:29] [INFO] [ocm_clusters.py:_app_interface_updates_mr:213] - [<cluster_name>] desired root key consoleUrl will be updated automatically with value <real_url>
[2022-07-01 15:46:29] [INFO] [ocm_clusters.py:_app_interface_updates_mr:213] - [<cluster_name>] desired root key serverUrl will be updated automatically with value <real_url>

```