### PR TITLE
(fedramp) rosa-authenticator: fix http_method references

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4825,14 +4825,12 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         # ANY RESPONSE
         # args are shared with this resource  + token get repsonse resource
-        api_gateway_method_proxy_any_response_resource = (
-            aws_api_gateway_method_response(
-                "gw_method_proxy_any_response",
-                http_method=api_gateway_method_proxy_any_resource.http_method,
-                resource_id=f"${{{api_gateway_proxy_resource.id}}}",
-                rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
-                **gateway_method_get_response_args,
-            )
+        api_gateway_method_proxy_any_response_resource = aws_api_gateway_method_response(
+            "gw_method_proxy_any_response",
+            http_method=f"${{aws_api_gateway_method.gw_method_proxy_any.http_method}}",
+            resource_id=f"${{{api_gateway_proxy_resource.id}}}",
+            rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
+            **gateway_method_get_response_args,
         )
         tf_resources.append(api_gateway_method_proxy_any_response_resource)
 
@@ -4846,14 +4844,12 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         tf_resources.append(api_gateway_method_token_get_resource)
 
         # GET TOKEN RESPONSE
-        api_gateway_method_token_get_response_resource = (
-            aws_api_gateway_method_response(
-                "gw_method_token_get_response",
-                http_method=api_gateway_method_token_get_resource.http_method,
-                resource_id=f"${{{api_gateway_token_resource.id}}}",
-                rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
-                **gateway_method_get_response_args,
-            )
+        api_gateway_method_token_get_response_resource = aws_api_gateway_method_response(
+            "gw_method_token_get_response",
+            http_method=f"${{aws_api_gateway_method.gw_method_token_get.http_method}}",
+            resource_id=f"${{{api_gateway_token_resource.id}}}",
+            rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
+            **gateway_method_get_response_args,
         )
         tf_resources.append(api_gateway_method_token_get_response_resource)
 
@@ -4869,7 +4865,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         # GET AUTH RESPONSE
         api_gateway_method_auth_get_response_resource = aws_api_gateway_method_response(
             "gw_method_auth_get_response",
-            http_method=api_gateway_method_auth_get_resource.http_method,
+            http_method=f"${{aws_api_gateway_method.gw_method_auth_get.http_method}}",
             resource_id=f"${{{api_gateway_auth_resource.id}}}",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             **gateway_method_auth_get_response_args,
@@ -4889,7 +4885,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "gw_integration_proxy",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             resource_id=f"${{{api_gateway_proxy_resource.id}}}",
-            http_method=api_gateway_method_proxy_any_response_resource.http_method,
+            http_method=f"${{aws_api_gateway_method.gw_method_proxy_any.http_method}}",
             connection_id=f"${{{api_gateway_vpc_link_resource.id}}}",
             uri=f'{common_values.get("api_proxy_uri")}/api/{{proxy}}',
             **integration_proxy_args,
@@ -4901,7 +4897,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "gw_integration_token",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             resource_id=f"${{{api_gateway_token_resource.id}}}",
-            http_method=api_gateway_method_token_get_resource.http_method,
+            http_method=f"${{aws_api_gateway_method.gw_method_token_get.http_method}}",
             connection_id=f"${{{api_gateway_vpc_link_resource.id}}}",
             uri=f"{bucket_url}/token.html",
             **integration_token_args,
@@ -4913,34 +4909,30 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "gw_integration_auth",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             resource_id=f"${{{api_gateway_auth_resource.id}}}",
-            http_method=api_gateway_method_auth_get_resource.http_method,
+            http_method=f"${{aws_api_gateway_method.gw_method_auth_get.http_method}}",
             **integration_auth_args,
         )
         tf_resources.append(api_gateway_integration_auth_resource)
 
         # PROXY
-        api_gateway_integration_proxy_response_resource = (
-            aws_api_gateway_integration_response(
-                "gw_integration_response_proxy",
-                rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
-                resource_id=f"${{{api_gateway_proxy_resource.id}}}",
-                http_method=api_gateway_method_proxy_any_resource.http_method,
-                status_code=api_gateway_method_token_get_response_resource.status_code,
-                depends_on=["aws_api_gateway_integration.gw_integration_token"],
-            )
+        api_gateway_integration_proxy_response_resource = aws_api_gateway_integration_response(
+            "gw_integration_response_proxy",
+            rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
+            resource_id=f"${{{api_gateway_proxy_resource.id}}}",
+            http_method=f"${{aws_api_gateway_method.gw_method_proxy_any.http_method}}",
+            status_code=api_gateway_method_token_get_response_resource.status_code,
+            depends_on=["aws_api_gateway_integration.gw_integration_token"],
         )
         tf_resources.append(api_gateway_integration_proxy_response_resource)
 
         # TOKEN
-        api_gateway_integration_token_response_resource = (
-            aws_api_gateway_integration_response(
-                "gw_integration_response_token",
-                rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
-                resource_id=f"${{{api_gateway_token_resource.id}}}",
-                http_method=api_gateway_method_token_get_resource.http_method,
-                status_code=api_gateway_method_token_get_response_resource.status_code,
-                depends_on=["aws_api_gateway_integration.gw_integration_token"],
-            )
+        api_gateway_integration_token_response_resource = aws_api_gateway_integration_response(
+            "gw_integration_response_token",
+            rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
+            resource_id=f"${{{api_gateway_token_resource.id}}}",
+            http_method=f"${{aws_api_gateway_method.gw_method_token_get.http_method}}",
+            status_code=api_gateway_method_token_get_response_resource.status_code,
+            depends_on=["aws_api_gateway_integration.gw_integration_token"],
         )
         tf_resources.append(api_gateway_integration_token_response_resource)
 
@@ -4949,7 +4941,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "gw_integration_response_auth",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             resource_id=f"${{{api_gateway_auth_resource.id}}}",
-            http_method=api_gateway_method_auth_get_resource.http_method,
+            http_method=f"${{aws_api_gateway_method.gw_method_auth_get.http_method}}",
             status_code=api_gateway_method_auth_get_response_resource.status_code,
             response_parameters={
                 "method.response.header.Location": f"{user_pool_url}/oauth2/authorize?client_id="

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4827,7 +4827,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         # args are shared with this resource  + token get repsonse resource
         api_gateway_method_proxy_any_response_resource = aws_api_gateway_method_response(
             "gw_method_proxy_any_response",
-            http_method=f"${{aws_api_gateway_method.gw_method_proxy_any.http_method}}",
+            http_method="${{aws_api_gateway_method.gw_method_proxy_any.http_method}}",
             resource_id=f"${{{api_gateway_proxy_resource.id}}}",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             **gateway_method_get_response_args,
@@ -4846,7 +4846,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         # GET TOKEN RESPONSE
         api_gateway_method_token_get_response_resource = aws_api_gateway_method_response(
             "gw_method_token_get_response",
-            http_method=f"${{aws_api_gateway_method.gw_method_token_get.http_method}}",
+            http_method="${{aws_api_gateway_method.gw_method_token_get.http_method}}",
             resource_id=f"${{{api_gateway_token_resource.id}}}",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             **gateway_method_get_response_args,
@@ -4865,7 +4865,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         # GET AUTH RESPONSE
         api_gateway_method_auth_get_response_resource = aws_api_gateway_method_response(
             "gw_method_auth_get_response",
-            http_method=f"${{aws_api_gateway_method.gw_method_auth_get.http_method}}",
+            http_method="${{aws_api_gateway_method.gw_method_auth_get.http_method}}",
             resource_id=f"${{{api_gateway_auth_resource.id}}}",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             **gateway_method_auth_get_response_args,
@@ -4885,7 +4885,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "gw_integration_proxy",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             resource_id=f"${{{api_gateway_proxy_resource.id}}}",
-            http_method=f"${{aws_api_gateway_method.gw_method_proxy_any.http_method}}",
+            http_method="${{aws_api_gateway_method.gw_method_proxy_any.http_method}}",
             connection_id=f"${{{api_gateway_vpc_link_resource.id}}}",
             uri=f'{common_values.get("api_proxy_uri")}/api/{{proxy}}',
             **integration_proxy_args,
@@ -4897,7 +4897,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "gw_integration_token",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             resource_id=f"${{{api_gateway_token_resource.id}}}",
-            http_method=f"${{aws_api_gateway_method.gw_method_token_get.http_method}}",
+            http_method="${{aws_api_gateway_method.gw_method_token_get.http_method}}",
             connection_id=f"${{{api_gateway_vpc_link_resource.id}}}",
             uri=f"{bucket_url}/token.html",
             **integration_token_args,
@@ -4909,7 +4909,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "gw_integration_auth",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             resource_id=f"${{{api_gateway_auth_resource.id}}}",
-            http_method=f"${{aws_api_gateway_method.gw_method_auth_get.http_method}}",
+            http_method="${{aws_api_gateway_method.gw_method_auth_get.http_method}}",
             **integration_auth_args,
         )
         tf_resources.append(api_gateway_integration_auth_resource)
@@ -4919,7 +4919,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "gw_integration_response_proxy",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             resource_id=f"${{{api_gateway_proxy_resource.id}}}",
-            http_method=f"${{aws_api_gateway_method.gw_method_proxy_any.http_method}}",
+            http_method="${{aws_api_gateway_method.gw_method_proxy_any.http_method}}",
             status_code=api_gateway_method_token_get_response_resource.status_code,
             depends_on=["aws_api_gateway_integration.gw_integration_token"],
         )
@@ -4930,7 +4930,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "gw_integration_response_token",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             resource_id=f"${{{api_gateway_token_resource.id}}}",
-            http_method=f"${{aws_api_gateway_method.gw_method_token_get.http_method}}",
+            http_method="${{aws_api_gateway_method.gw_method_token_get.http_method}}",
             status_code=api_gateway_method_token_get_response_resource.status_code,
             depends_on=["aws_api_gateway_integration.gw_integration_token"],
         )
@@ -4941,7 +4941,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "gw_integration_response_auth",
             rest_api_id=f"${{{api_gateway_rest_api_resource.id}}}",
             resource_id=f"${{{api_gateway_auth_resource.id}}}",
-            http_method=f"${{aws_api_gateway_method.gw_method_auth_get.http_method}}",
+            http_method="${{aws_api_gateway_method.gw_method_auth_get.http_method}}",
             status_code=api_gateway_method_auth_get_response_resource.status_code,
             response_parameters={
                 "method.response.header.Location": f"{user_pool_url}/oauth2/authorize?client_id="


### PR DESCRIPTION
This will hopefully feed these variables to terraform in a format that it is perhaps strictly expecting.

This is very similar to https://github.com/app-sre/qontract-reconcile/pull/2519, but will hopefully do as actually intended.