### PR TITLE
add bots to be saas file owners

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1887,6 +1887,9 @@ SAAS_FILES_QUERY_V2 = """
         org_username
         tag_on_merge_requests
       }
+      bots {
+        org_username
+      }
     }
   }
 }

--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -37,14 +37,17 @@ def collect_owners():
         if not owner_roles:
             continue
         for owner_role in owner_roles:
-            owner_users = owner_role.get("users")
-            if not owner_users:
-                continue
+            owner_users = owner_role.get("users") or []
             for owner_user in owner_users:
                 owner_username = owner_user["org_username"]
                 if owner_user.get("tag_on_merge_requests"):
                     owner_username = f"@{owner_username}"
                 owners[saas_file_name].add(owner_username)
+            owner_bots = owner_role.get("bots") or []
+            for bot in owner_bots:
+                bot_org_username = bot.get("org_username")
+                if bot_org_username:
+                    owners[saas_file_name].add(bot_org_username)
 
     # make owners suitable for json dump
     ans = {}


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5940

this change is required to support external flows to app-interface, and allow teams to use their own bots to submit saas-file-update MRs, and to be able to `/lgtm` them.

tested in https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/42134