### PR TITLE
[saas-file-owners] consider MR description as comment

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -322,7 +322,9 @@ def run(
         gl.remove_label_from_merge_request(gitlab_merge_request_id, APPROVED)
         return
 
-    comments = gl.get_merge_request_comments(gitlab_merge_request_id)
+    comments = gl.get_merge_request_comments(
+        gitlab_merge_request_id, include_description=True
+    )
     comment_lines = {}
     hold = False
     for diff in diffs:

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -290,7 +290,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             changed_paths.add(new_path)
         return list(changed_paths)
 
-    def get_merge_request_comments(self, mr_id, include_description=False):
+    def get_merge_request_comments(self, mr_id: int, include_description: bool = False):
         comments = []
         merge_request = self.project.mergerequests.get(mr_id)
         if include_description:

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -14,6 +14,9 @@ from reconcile.utils.secret_reader import SecretReader
 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
+MR_DESCRIPTION_COMMENT_ID = 0
+
+
 class MRState:
     """
     Data class to help users selecting the correct Merge Request state.
@@ -287,9 +290,18 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             changed_paths.add(new_path)
         return list(changed_paths)
 
-    def get_merge_request_comments(self, mr_id):
+    def get_merge_request_comments(self, mr_id, include_description=False):
         comments = []
         merge_request = self.project.mergerequests.get(mr_id)
+        if include_description:
+            comments.append(
+                {
+                    "username": merge_request.author["username"],
+                    "body": merge_request.description,
+                    "created_at": merge_request.created_at,
+                    "id": MR_DESCRIPTION_COMMENT_ID,
+                }
+            )
         for note in merge_request.notes.list(all=True):
             if note.system:
                 continue

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from urllib.parse import urlparse
 from sretoolbox.utils import retry
@@ -290,7 +291,9 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             changed_paths.add(new_path)
         return list(changed_paths)
 
-    def get_merge_request_comments(self, mr_id: int, include_description: bool = False):
+    def get_merge_request_comments(
+        self, mr_id: int, include_description: bool = False
+    ) -> list[dict[str, Any]]:
         comments = []
         merge_request = self.project.mergerequests.get(mr_id)
         if include_description:

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -293,14 +293,11 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         for note in merge_request.notes.list(all=True):
             if note.system:
                 continue
-            username = note.author["username"]
-            body = note.body
-            created_at = note.created_at
             comments.append(
                 {
-                    "username": username,
-                    "body": body,
-                    "created_at": created_at,
+                    "username": note.author["username"],
+                    "body": note.body,
+                    "created_at": note.created_at,
                     "id": note.id,
                 }
             )


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5940

allow creating a MR, including a `/lgtm` in the MR description, which will be considered as a `/lgtm` comment.

this will be mostly used for creating promotion MRs that will be automatically merged. the main use case is usage by bots (following up on #2539).