### PR TITLE
[saas-file-owners] fix diff not found in changed paths bug

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -327,10 +327,13 @@ def run(
     )
     comment_lines = {}
     hold = False
+    changed_paths_copy = changed_paths.copy()
     for diff in diffs:
         # check if this diff was actually changed in the current MR
         saas_file_path = diff["saas_file_path"]
-        changed_path_matches = [c for c in changed_paths if c.endswith(saas_file_path)]
+        changed_path_matches = [
+            c for c in changed_paths_copy if c.endswith(saas_file_path)
+        ]
         if not changed_path_matches:
             # this diff was found in the graphql endpoint comparison
             # but is not a part of the changed paths.

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -280,7 +280,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
     def get_merge_requests(self, state):
         return self.get_items(self.project.mergerequests.list, state=state)
 
-    def get_merge_request_changed_paths(self, mr_id: int) -> list:
+    def get_merge_request_changed_paths(self, mr_id: int) -> list[str]:
         merge_request = self.project.mergerequests.get(mr_id)
         changes = merge_request.changes()["changes"]
         changed_paths = set()

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -280,7 +280,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
     def get_merge_requests(self, state):
         return self.get_items(self.project.mergerequests.list, state=state)
 
-    def get_merge_request_changed_paths(self, mr_id):
+    def get_merge_request_changed_paths(self, mr_id: int) -> list:
         merge_request = self.project.mergerequests.get(mr_id)
         changes = merge_request.changes()["changes"]
         changed_paths = set()


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-3029

fixes a bug that was introduced in #1404

this bug shows itself when there are multiple promotions within the same saas file to different environments.

since we use `changed_paths` and update it while we iterate over the `diffs`, if there are 2 changes to the same saas file to different environments - they are considered 2 differents `diffs`, but only one changed path. when we remove this path from `changed_paths`, and get to the 2nd iteration - the integration is mistaken to think it is not a part of the MR, but it is.

the outcome of this bug is not harmful at all - only logging a warning.

it is, however, very confusing.

to resolve it, we will keep the current behavior and usage of `changed_paths` exactly as is, but when checking if a diff is a part of the changed paths, we will compare it against a copy of `changed_paths`, which we will not modify.