### PR TITLE
Fix Cluster updates when OCM generated fields are not yet set on cluster creation

### DIFF
--- a/reconcile/ocm/types.py
+++ b/reconcile/ocm/types.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, Extra
+from pydantic import BaseModel, Field, Extra, validator
 from typing import Optional, Union
 
 
@@ -57,3 +57,9 @@ class OCMSpec(BaseModel):
         smart_union = True
         # This is need to populate by either console_url or consoleUrl, for instance
         allow_population_by_field_name = True
+        validate_assignment = True
+
+    @validator("server_url", "console_url", "elb_fqdn", pre=True, always=True)
+    @classmethod
+    def none_to_empty_str(cls, _str):
+        return _str or ""

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -221,6 +221,35 @@ def get_json_mock():
         yield get_json
 
 
+def test_ocm_spec_none_to_empty_str_using_constructor(ocm_osd_cluster_spec):
+    n = OCMSpec(
+        console_url=None,
+        server_url="server_url",
+        domain="domain",
+        spec=ocm_osd_cluster_spec.spec,
+        network=ocm_osd_cluster_spec.network,
+    )
+    assert n.console_url == ""
+
+
+def test_ocm_spec_none_to_empty_str_using_attribute_assignment(ocm_osd_cluster_spec):
+    n = ocm_osd_cluster_spec
+    # Pydantic should convert None to ""
+    n.console_url = None
+    assert n.console_url == ""
+
+
+def test_populate_fields_by_attr_name(ocm_osd_cluster_spec):
+    n = OCMSpec(
+        console_url="console_url",
+        server_url="server_url",
+        domain="domain",
+        spec=ocm_osd_cluster_spec.spec,
+        network=ocm_osd_cluster_spec.network,
+    )
+    assert n.server_url == "server_url"
+
+
 def test_ocm_spec_population_rosa(rosa_cluster_fxt):
     n = OCMSpec(**rosa_cluster_fxt)
     assert isinstance(n.spec, ROSAClusterSpec)


### PR DESCRIPTION
OCM returns None on some url attributes when a cluster is being created. This PR ensures those fields are set to empty strings instead of None when the OCMSpec object is populated

https://github.com/app-sre/qontract-reconcile/blob/master/reconcile/utils/ocm.py#L178-L179
