### PR TITLE
[jenkins-job-builder] reduce required schemas for integration run

### DIFF
--- a/reconcile/github_repo_permissions_validator.py
+++ b/reconcile/github_repo_permissions_validator.py
@@ -4,11 +4,13 @@ import sys
 
 
 from github import Github
+from reconcile import queries
 
 from reconcile.github_repo_invites import run as get_invitations
 from reconcile.jenkins_job_builder import init_jjb
 from reconcile.github_org import get_default_config
 from reconcile.utils.jjb_client import JJB
+from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.semver_helper import make_semver
 
 
@@ -31,7 +33,8 @@ def init_github():
 
 
 def run(dry_run, instance_name):
-    jjb: JJB = init_jjb()
+    secret_reader = SecretReader(queries.get_secret_reader_settings())
+    jjb: JJB = init_jjb(secret_reader)
     pr_check_jobs = get_jobs(jjb, instance_name)
     if not pr_check_jobs:
         logging.error(f"no jobs found for instance {instance_name}")

--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -7,7 +7,8 @@ from reconcile import queries
 
 from reconcile.utils.defer import defer
 from reconcile.utils.jjb_client import JJB
-from reconcile.utils.state import State
+from reconcile.utils.secret_reader import SecretReader
+from reconcile.utils.state import init_state
 
 
 QUERY = """
@@ -41,7 +42,7 @@ def get_openshift_saas_deploy_job_name(saas_file_name, env_name, settings):
     return f"{job_template_name}-{saas_file_name}-{env_name}"
 
 
-def collect_configs(instance_name, config_name, settings):
+def collect_configs(instance_name, config_name):
     gqlapi = gql.get_api()
     configs = gqlapi.query(QUERY)["jenkins_configs"]
     if instance_name is not None:
@@ -62,16 +63,18 @@ def collect_configs(instance_name, config_name, settings):
 
 
 def init_jjb(
+    secret_reader: SecretReader,
     instance_name: Optional[str] = None,
     config_name: Optional[str] = None,
     print_only: bool = False,
 ) -> JJB:
-    settings = queries.get_app_interface_settings()
-    configs = collect_configs(instance_name, config_name, settings)
-    return JJB(configs, ssl_verify=False, settings=settings, print_only=print_only)
+    configs = collect_configs(instance_name, config_name)
+    return JJB(
+        configs, ssl_verify=False, secret_reader=secret_reader, print_only=print_only
+    )
 
 
-def validate_repos_and_admins(jjb):
+def validate_repos_and_admins(jjb: JJB):
     jjb_repos = jjb.get_repos()
     app_int_repos = queries.get_repos()
     missing_repos = [r for r in jjb_repos if r not in app_int_repos]
@@ -105,7 +108,8 @@ def run(
 ):
     if not print_only and config_name is not None:
         raise Exception("--config-name must works with --print-only mode")
-    jjb: JJB = init_jjb(instance_name, config_name, print_only)
+    secret_reader = SecretReader(queries.get_secret_reader_settings())
+    jjb: JJB = init_jjb(secret_reader, instance_name, config_name, print_only)
     defer(jjb.cleanup)
 
     if print_only:
@@ -114,10 +118,7 @@ def run(
             jjb.generate(io_dir, "printout")
         sys.exit(0)
 
-    accounts = queries.get_state_aws_accounts()
-    state = State(
-        integration=QONTRACT_INTEGRATION, accounts=accounts, settings=jjb.settings
-    )
+    state = init_state(QONTRACT_INTEGRATION, secret_reader)
 
     if dry_run:
         validate_repos_and_admins(jjb)

--- a/reconcile/jenkins_job_cleaner.py
+++ b/reconcile/jenkins_job_cleaner.py
@@ -4,6 +4,7 @@ from reconcile import queries
 
 from reconcile.jenkins_job_builder import init_jjb
 from reconcile.utils.jenkins_api import JenkinsApi
+from reconcile.utils.secret_reader import SecretReader
 
 QONTRACT_INTEGRATION = "jenkins-job-cleaner"
 
@@ -18,8 +19,8 @@ def get_managed_job_names(job_names, managed_projects):
     return list(managed_jobs)
 
 
-def get_desired_job_names(instance_name):
-    jjb = init_jjb()
+def get_desired_job_names(instance_name: str, secret_reader: SecretReader):
+    jjb = init_jjb(secret_reader)
     desired_jobs = jjb.get_all_jobs(instance_name=instance_name, include_test=True)[
         instance_name
     ]
@@ -29,6 +30,7 @@ def get_desired_job_names(instance_name):
 def run(dry_run):
     jenkins_instances = queries.get_jenkins_instances()
     settings = queries.get_app_interface_settings()
+    secret_reader = SecretReader(settings)
 
     for instance in jenkins_instances:
         if instance.get("deleteMethod") != "manual":
@@ -42,7 +44,7 @@ def run(dry_run):
         jenkins = JenkinsApi(token, ssl_verify=False, settings=settings)
         all_job_names = jenkins.get_job_names()
         managed_job_names = get_managed_job_names(all_job_names, managed_projects)
-        desired_job_names = get_desired_job_names(instance_name)
+        desired_job_names = get_desired_job_names(instance_name, secret_reader)
         delete_job_names = [j for j in managed_job_names if j not in desired_job_names]
 
         for job_name in delete_job_names:

--- a/reconcile/jenkins_webhooks.py
+++ b/reconcile/jenkins_webhooks.py
@@ -6,6 +6,7 @@ from reconcile import queries
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.jenkins_job_builder import init_jjb
 from reconcile.utils.jjb_client import JJB
+from reconcile.utils.secret_reader import SecretReader
 
 QONTRACT_INTEGRATION = "jenkins-webhooks"
 
@@ -38,7 +39,8 @@ def get_hooks_to_add(desired_state, gl):
 
 
 def run(dry_run):
-    jjb: JJB = init_jjb()
+    secret_reader = SecretReader(queries.get_secret_reader_settings())
+    jjb: JJB = init_jjb(secret_reader)
     gl = get_gitlab_api()
 
     desired_state = jjb.get_job_webhooks_data()

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -5,11 +5,30 @@ import itertools
 import shlex
 
 from textwrap import indent
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
 
 from jinja2 import Template
 
 from reconcile.utils import gql
+
+
+SECRET_READER_SETTINGS = """
+{
+  settings: app_interface_settings_v1 {
+    vault
+  }
+}
+"""
+
+
+def get_secret_reader_settings() -> Optional[Mapping[str, Any]]:
+    """Returns SecretReader settings"""
+    gqlapi = gql.get_api()
+    settings = gqlapi.query(SECRET_READER_SETTINGS)["settings"]
+    if settings:
+        # assuming a single settings file for now
+        return settings[0]
+    return None
 
 
 APP_INTERFACE_SETTINGS_QUERY = """

--- a/reconcile/saas_file_validator.py
+++ b/reconcile/saas_file_validator.py
@@ -4,6 +4,7 @@ import logging
 from reconcile import queries
 from reconcile.status import ExitCodes
 from reconcile.utils.jjb_client import JJB
+from reconcile.utils.secret_reader import SecretReader
 
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.saasherder import SaasHerder
@@ -16,6 +17,7 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 def run(dry_run):
     saas_files = queries.get_saas_files()
     settings = queries.get_app_interface_settings()
+    secret_reader = SecretReader(settings)
     saasherder = SaasHerder(
         saas_files,
         thread_pool_size=1,
@@ -29,7 +31,7 @@ def run(dry_run):
     missing_repos = [r for r in saasherder.repo_urls if r not in app_int_repos]
     for r in missing_repos:
         logging.error(f"repo is missing from codeComponents: {r}")
-    jjb: JJB = init_jjb()
+    jjb: JJB = init_jjb(secret_reader)
     saasherder.validate_upstream_jobs(jjb)
     if not saasherder.valid or missing_repos:
         sys.exit(ExitCodes.ERROR)

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -95,11 +95,15 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         thread_pool_size,
         accounts,
         settings=None,
+        secret_reader=None,
         init_ecr_auth_tokens=False,
         init_users=True,
     ):
         self.thread_pool_size = thread_pool_size
-        self.secret_reader = SecretReader(settings=settings)
+        if secret_reader:
+            self.secret_reader = secret_reader
+        else:
+            self.secret_reader = SecretReader(settings=settings)
         self.init_sessions_and_resources(accounts)
         if init_ecr_auth_tokens:
             self.init_ecr_auth_tokens(accounts)

--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -24,8 +24,6 @@ from reconcile.utils import gql
 from reconcile.utils import throughput
 from reconcile.utils.helpers import toggle_logger
 
-
-from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.exceptions import FetchResourceError
 
 JJB_INI = "[jenkins]\nurl = https://JENKINS_URL"
@@ -34,11 +32,9 @@ JJB_INI = "[jenkins]\nurl = https://JENKINS_URL"
 class JJB:  # pylint: disable=too-many-public-methods
     """Wrapper around Jenkins Jobs"""
 
-    def __init__(self, configs, ssl_verify=True, settings=None, print_only=False):
-        self.settings = settings
+    def __init__(self, configs, ssl_verify=True, secret_reader=None, print_only=False):
         self.print_only = print_only
-        if not print_only:
-            self.secret_reader = SecretReader(settings=settings)
+        self.secret_reader = secret_reader
         self.collect_configs(configs)
         self.modify_logger()
         self.python_https_verify = str(int(ssl_verify))

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -221,15 +221,16 @@ class Report:
 
 
 def get_apps_data(date, month_delta=1, thread_pool_size=10):
+    settings = queries.get_app_interface_settings()
+    secret_reader = SecretReader(settings)
+
     apps = queries.get_apps()
     saas_files = queries.get_saas_files()
-    jjb: JJB = init_jjb()
+    jjb: JJB = init_jjb(secret_reader)
     jenkins_map = jenkins_base.get_jenkins_map()
     time_limit = date - relativedelta(months=month_delta)
     timestamp_limit = int(time_limit.replace(tzinfo=timezone.utc).timestamp())
 
-    settings = queries.get_app_interface_settings()
-    secret_reader = SecretReader(settings=settings)
     secret_content = secret_reader.read_all({"path": DASHDOTDB_SECRET})
     dashdotdb_url = secret_content["url"]
     dashdotdb_user = secret_content["username"]

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -646,7 +646,8 @@ def sshuttle_command(ctx, jumphost_hostname: str, cluster_name: Optional[str]):
 @click.argument("job_name")
 @click.pass_context
 def jenkins_job_vault_secrets(ctx, instance_name, job_name):
-    jjb: JJB = init_jjb(instance_name, config_name=None, print_only=True)
+    secret_reader = SecretReader(queries.get_secret_reader_settings())
+    jjb: JJB = init_jjb(secret_reader, instance_name, config_name=None, print_only=True)
     jobs = jjb.get_all_jobs([job_name], instance_name)[instance_name]
     if not jobs:
         print(f"{instance_name}/{job_name} not found.")


### PR DESCRIPTION
the jenkins-job-builder integration declares a lot more schemas than it actually queries, because it uses some generic app-interface-settings and aws-account queries that are too broad.

this change introduces a `get_secret_reader_settings()` query that fetches minimal information for secret reader initialization. also the `State` can be initialized with a new function `init_state` that requires minimal data about the involved account.

as a result, a lot of schemas can be removed from the jenkins-jobs-builders `integration-1.schemas` list in app-interface, which has positive side effects for PR checks. also the `integration-1.pr_check.run_for_valid_saas_file_changes` option can be removed for this integration, since the saas-file-2 schema is not required to be in the schema list anymore. the remaining schemas are

```yaml
    schemas:
    - /app-sre/integration-1.yml
    - /app-interface/app-interface-settings-1.yml # for secret reader
    - /dependencies/jenkins-config-1.yml # for jobs
    - /dependencies/jenkins-instance-1.yml # for jobs
    - /aws/account-1.yml # for state
    - /app-sre/app-1.yml # for code components
    - /access/user-1.yml # for crosscheck repo admins
    - /access/external-user-1.yml # for crosscheck repo admins
    - /access/bot-1.yml # for crosscheck repo admins
```

this commit touches several integration to provide the required `SecretReader` to `init_jjb`. all these integrations and their dependencies will also be reworked to require less schemas. but that will be work for followup PRs.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>