### PR TITLE
template-renderer: show diff of rendered and expected outputs

### DIFF
--- a/reconcile/template_tester.py
+++ b/reconcile/template_tester.py
@@ -1,3 +1,4 @@
+import difflib
 import logging
 import sys
 import yaml
@@ -51,10 +52,17 @@ def run(dry_run):
                 found = True
                 openshift_resource = orb.fetch_openshift_resource(r, n, settings)
                 if openshift_resource.body != expected_result:
+                    diff = difflib.unified_diff(
+                        yaml.safe_dump(expected_result).splitlines(keepends=True),
+                        yaml.safe_dump(openshift_resource.body).splitlines(
+                            keepends=True
+                        ),
+                        "expected",
+                        "rendered",
+                    )
                     logging.error(
                         f"rendered template is different from expected result in template test {tt['name']}:\n"
-                        f"rendered:\n{yaml.safe_dump(openshift_resource.body)}\n"
-                        f"expected result:\n{yaml.safe_dump(expected_result)}"
+                        f"{''.join(diff)}"
                     )
                     error = True
 


### PR DESCRIPTION
Currently, the `template-tester` will output the full content of both the rendered and the expected resources, leaving it to the user to find differences

This changes it so that using `difflib` we only show the differences in a familiar unified diff output

Sample of current output:
```
expected:
some: var
another:
  thing: inside
  thang: again
the: end

rendered:
some: var
another:
  thing: inside
  new: thing
  thang: again
the: end
```

Output after this change
```
--- expected
+++ rendered
@@ -2,5 +2,6 @@
 some: var
 another:
   thing: inside
+  new: thing
   thang: again
 the: end
```