### PR TITLE
(fedramp) rosa: create userpool_ui resource

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4683,14 +4683,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         )
         tf_resources.append(cognito_user_pool_domain_resource)
 
+        user_pool_url = f"https://{cognito_user_pool_domain_resource.domain}.auth-fips.us-gov-west-1.amazoncognito.com"
+
         # POOL UI
         cognito_user_pool_ui_customization_resource = aws_cognito_user_pool_ui_customization(
             "userpool_ui",
             image_file='filebase64("' + redhat_logo_png_filepath + '")',
             user_pool_id="${aws_cognito_user_pool_domain.userpool_domain.user_pool_id}",
         )
-
-        user_pool_url = f"https://{cognito_user_pool_domain_resource.domain}.auth-fips.us-gov-west-1.amazoncognito.com"
+        tf_resources.append(cognito_user_pool_ui_customization_resource)
 
         # POOL GATEWAY RESOURCE SERVER
         cognito_resource_server_gateway_resource = aws_cognito_resource_server(

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -101,6 +101,7 @@ from terrascript.resource import (
     aws_launch_template,
     aws_autoscaling_group,
     aws_cognito_user_pool,
+    aws_cognito_user_pool_ui_customization,
     aws_cognito_user_pool_client,
     aws_cognito_user_pool_domain,
     aws_cognito_resource_server,
@@ -4586,9 +4587,16 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         tf_resources.append(cognito_pre_signup_lambda_resource)
 
         # setup s3_client
-        settings = queries.get_app_interface_settings()
+        # pattern followed from utils/state.py
+        # The variable "account" is the name of the AWS account we are reconciling
+        # against. We assume the target s3 bucket is in the same AWS account as the
+        # rosa-authenticator. We need to grab details of said AWS account from
+        # app-interface, and feed those details to the AWSApi class.
         thread_pool_size = 1
-        aws_api = AWSApi(thread_pool_size, [account], settings=settings)
+        settings = queries.get_app_interface_settings()
+        target_account_arr = queries.get_aws_accounts(name=account)
+        # target_account_arr = [a for a in all_accounts if a["name"] == account]
+        aws_api = AWSApi(thread_pool_size, target_account_arr, settings=settings)
         session = aws_api.get_session(account)
         s3_client = session.client("s3")
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -101,7 +101,6 @@ from terrascript.resource import (
     aws_launch_template,
     aws_autoscaling_group,
     aws_cognito_user_pool,
-    aws_cognito_user_pool_ui_customization,
     aws_cognito_user_pool_client,
     aws_cognito_user_pool_domain,
     aws_cognito_resource_server,
@@ -235,6 +234,12 @@ class time(Provider):
 # that supports this resource
 # https://github.com/mjuenema/python-terrascript/pull/166
 class time_sleep(Resource):
+    pass
+
+
+# temporary until we upgrade to a terrascript release
+# that supports this resource
+class aws_cognito_user_pool_ui_customization(Resource):
     pass
 
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4620,7 +4620,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             )
 
         # todo: probably remove 'RedHat' from the object/variable/filepath
-        # names to keep the code RedHat-agnostic
+        # names to keep the code RedHat-agnostic?
+        # (then again: ROSA literally means "Red Hat OpenShift Service on AWS")
 
         # download redhat-logo-png file
         redhat_logo_png_obj_name = "Logo-RedHat-B-Color-RGB.png"

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -29,6 +29,8 @@ import requests
 from github import Github
 
 
+from botocore.errorfactory import ClientError
+
 from terrascript import (
     Terrascript,
     provider,
@@ -198,6 +200,8 @@ VARIABLE_KEYS = [
 
 TMP_DIR_PREFIX = "terrascript-aws-"
 
+class StateInaccessibleException(Exception):
+    pass
 
 class UnknownProviderError(Exception):
     def __init__(self, msg):

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -123,6 +123,8 @@ from terrascript.resource import (
 from terrascript import Resource, Data
 from sretoolbox.utils import threaded
 
+from reconcile import queries
+
 from reconcile.utils import gql
 from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.external_resource_spec import (
@@ -4584,7 +4586,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         tf_resources.append(cognito_pre_signup_lambda_resource)
 
         # setup s3_client
-        aws_api = AWSApi(1, [account], settings=settings, init_users=False)
+        settings = queries.get_app_interface_settings()
+        thread_pool_size = 1
+        aws_api = AWSApi(thread_pool_size, [account], settings=settings)
         session = aws_api.get_session(account)
         s3_client = session.client("s3")
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4619,6 +4619,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 f"Bucket {bucket_name} is not accessible - {str(details)}"
             )
 
+        # todo: probably remove 'RedHat' from the object/variable/filepath
+        # names to keep the code RedHat-agnostic
+
         # download redhat-logo-png file
         redhat_logo_png_obj_name = "Logo-RedHat-B-Color-RGB.png"
         redhat_logo_png_filepath = "/tmp/Logo-RedHat-B-Color-RGB.png"

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4605,8 +4605,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         # app-interface, and feed those details to the AWSApi class.
         thread_pool_size = 1
         settings = queries.get_app_interface_settings()
-        target_account_arr = queries.get_aws_accounts(name=account)
-        # target_account_arr = [a for a in all_accounts if a["name"] == account]
+        all_aws_accounts = queries.get_aws_accounts()
+        target_account_arr = [a for a in all_aws_accounts if a["name"] == account]
         aws_api = AWSApi(thread_pool_size, target_account_arr, settings=settings)
         session = aws_api.get_session(account)
         s3_client = session.client("s3")

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -200,8 +200,10 @@ VARIABLE_KEYS = [
 
 TMP_DIR_PREFIX = "terrascript-aws-"
 
+
 class StateInaccessibleException(Exception):
     pass
+
 
 class UnknownProviderError(Exception):
     def __init__(self, msg):


### PR DESCRIPTION
Somehow we missed provisioning this resource in our code: https://gitlab.redhat-osd.local/service/terraform-ocm-cognito-api-gw/-/blob/efaf6e75e080a71e439fb8f7c06e16aaf6da124d/cognito.tf#L279-283

This PR fixes that.

Basically, this just adds the redhat logo to the cognito signin page.

The redhat-logo PNG file is pulled from the "cognito_callback_bucket".