### PR TITLE
reduce schemas for gh-repo-permissions-validdator and gh-repo-invites

### DIFF
--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -93,8 +93,7 @@ QONTRACT_INTEGRATION = "github"
 def get_config(default=False):
     gqlapi = gql.get_api()
     orgs = gqlapi.query(ORGS_QUERY)["orgs"]
-    settings = queries.get_app_interface_settings()
-    secret_reader = SecretReader(settings=settings)
+    secret_reader = SecretReader(queries.get_secret_reader_settings())
     config = {"github": {}}
     found_defaults = []
     for org in orgs:

--- a/reconcile/github_repo_invites.py
+++ b/reconcile/github_repo_invites.py
@@ -10,17 +10,6 @@ from reconcile.utils.secret_reader import SecretReader
 from reconcile import queries
 
 
-REPOS_QUERY = """
-{
-    apps_v1 {
-        codeComponents {
-            url
-            resource
-        }
-    }
-}
-"""
-
 QONTRACT_INTEGRATION = "github-repo-invites"
 
 
@@ -76,16 +65,41 @@ def _accept_invitations(
     return accepted_invitations
 
 
+SETTINGS_QUERY = """
+{
+  settings: app_interface_settings_v1 {
+    vault
+    githubRepoInvites {
+      credentials {
+        path
+        field
+        version
+        format
+      }
+    }
+  }
+}
+"""
+
+
+def get_settings() -> Optional[Mapping[str, Any]]:
+    gqlapi = gql.get_api()
+    settings = gqlapi.query(SETTINGS_QUERY)["settings"]
+    if settings:
+        # assuming a single settings file for now
+        return settings[0]
+    return None
+
+
 def run(dry_run):
     gqlapi = gql.get_api()
-    result = gqlapi.query(REPOS_QUERY)
-    settings = queries.get_app_interface_settings()
+    settings = get_settings()
     secret_reader = SecretReader(settings=settings)
-    secret = settings["githubRepoInvites"]["credentials"]
-    token = secret_reader.read(secret)
+    result = gqlapi.query(queries.CODE_COMPONENT_REPO_QUERY)
+    token = secret_reader.read(settings["githubRepoInvites"]["credentials"])
     g = raw_github_api.RawGithubApi(token)
 
-    code_components = _parse_code_components(result["apps_v1"])
+    code_components = _parse_code_components(result["apps"])
     accepted_invitations = _accept_invitations(g, code_components, dry_run)
 
     return accepted_invitations

--- a/reconcile/github_repo_invites.py
+++ b/reconcile/github_repo_invites.py
@@ -82,13 +82,14 @@ SETTINGS_QUERY = """
 """
 
 
-def get_settings() -> Optional[Mapping[str, Any]]:
+def get_settings() -> Mapping[str, Any]:
     gqlapi = gql.get_api()
     settings = gqlapi.query(SETTINGS_QUERY)["settings"]
     if settings:
         # assuming a single settings file for now
         return settings[0]
-    return None
+    else:
+        raise ValueError("no app-interface-settings found")
 
 
 def run(dry_run):

--- a/reconcile/github_repo_permissions_validator.py
+++ b/reconcile/github_repo_permissions_validator.py
@@ -18,7 +18,7 @@ QONTRACT_INTEGRATION = "github-repo-permissions-validator"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
-def get_jobs(jjb, instance_name):
+def get_jobs(jjb: JJB, instance_name: str):
     pr_check_jobs = jjb.get_all_jobs(
         job_types=["gh-pr-check"], instance_name=instance_name
     ).get(instance_name)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1313,6 +1313,16 @@ APPS_QUERY = """
 }
 """
 
+CODE_COMPONENT_REPO_QUERY = """
+{
+  apps: apps_v1 {
+    codeComponents {
+      url
+    }
+  }
+}
+"""
+
 
 def get_apps():
     """Returns all Apps."""
@@ -1330,14 +1340,18 @@ def get_code_components():
     return code_components
 
 
-def get_repos(server=""):
+def get_repos(server="") -> list[str]:
     """Returns all repos defined under codeComponents
     Optional arguments:
     server: url of the server to return. for example: https://github.com
     """
-    code_components = get_code_components()
-    repos = [c["url"] for c in code_components if c["url"].startswith(server)]
-
+    apps = gql.get_api().query(CODE_COMPONENT_REPO_QUERY)["apps"]
+    repos: list[str] = []
+    for a in apps:
+        if a["codeComponents"] is not None:
+            for c in a["codeComponents"]:
+                if c["url"].startswith(server):
+                    repos.append(c["url"])
     return repos
 
 


### PR DESCRIPTION
the motivation for this change is the same as for https://github.com/app-sre/qontract-reconcile/pull/2547, namely getting rid of as many required schemas as possible so these integrations run less frequently during PR checks. the most important change though is the removal of the saas-file-2 schema. as a result the `run_for_valid_saas_file_changes` flag in `integration-1.pr_check` might not be relevant anymore, reducing complexity in our CI pipeline.

the schema reduction is mostly driven by special queries for github repos and secret reader settings

the remaining schemas for github-repo-permissions-validdator are

```
schemas:
- /app-sre/integration-1.yml
- /app-interface/app-interface-settings-1.yml # for secret reader
- /dependencies/jenkins-config-1.yml # for pr check jobs
- /dependencies/jenkins-instance-1.yml # for pr check jobs
- /dependencies/github-org-1.yml
- /app-sre/app-1.yml # for code components
```

the ones for github-repo-invites are

```
schemas:
- /app-sre/integration-1.yml
- /app-interface/app-interface-settings-1.yml # for secret reader and github settings
- /app-sre/app-1.yml # for code components and repos
```

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>