### PR TITLE
reduce schemas for jenkins-job-builds-cleaner/cleaner and jenkins-roles

### DIFF
--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -4,7 +4,7 @@ import time
 
 from reconcile import queries
 
-from reconcile.utils.jenkins_api import init_jenkins_from_secret
+from reconcile.utils.jenkins_api import JenkinsApi
 from reconcile.utils.secret_reader import SecretReader
 
 QONTRACT_INTEGRATION = "jenkins-job-builds-cleaner"
@@ -85,7 +85,9 @@ def run(dry_run):
 
         token = instance["token"]
         instance_name = instance["name"]
-        jenkins = init_jenkins_from_secret(secret_reader, token, ssl_verify=False)
+        jenkins = JenkinsApi.init_jenkins_from_secret(
+            secret_reader, token, ssl_verify=False
+        )
         all_job_names = jenkins.get_job_names()
 
         builds_todel = find_builds(jenkins, all_job_names, cleanup_rules)

--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -4,7 +4,8 @@ import time
 
 from reconcile import queries
 
-from reconcile.utils.jenkins_api import JenkinsApi
+from reconcile.utils.jenkins_api import init_jenkins_from_secret
+from reconcile.utils.secret_reader import SecretReader
 
 QONTRACT_INTEGRATION = "jenkins-job-builds-cleaner"
 
@@ -62,7 +63,7 @@ def find_builds(jenkins, job_names, rules):
 
 def run(dry_run):
     jenkins_instances = queries.get_jenkins_instances()
-    settings = queries.get_app_interface_settings()
+    secret_reader = SecretReader(queries.get_secret_reader_settings())
 
     for instance in jenkins_instances:
         instance_cleanup_rules = instance.get("buildsCleanupRules", [])
@@ -84,7 +85,7 @@ def run(dry_run):
 
         token = instance["token"]
         instance_name = instance["name"]
-        jenkins = JenkinsApi(token, ssl_verify=False, settings=settings)
+        jenkins = init_jenkins_from_secret(secret_reader, token, ssl_verify=False)
         all_job_names = jenkins.get_job_names()
 
         builds_todel = find_builds(jenkins, all_job_names, cleanup_rules)

--- a/reconcile/jenkins_job_cleaner.py
+++ b/reconcile/jenkins_job_cleaner.py
@@ -3,7 +3,7 @@ import logging
 from reconcile import queries
 
 from reconcile.jenkins_job_builder import init_jjb
-from reconcile.utils.jenkins_api import init_jenkins_from_secret
+from reconcile.utils.jenkins_api import JenkinsApi
 from reconcile.utils.secret_reader import SecretReader
 
 QONTRACT_INTEGRATION = "jenkins-job-cleaner"
@@ -39,7 +39,7 @@ def run(dry_run):
             continue
 
         instance_name = instance["name"]
-        jenkins = init_jenkins_from_secret(
+        jenkins = JenkinsApi.init_jenkins_from_secret(
             secret_reader, instance["token"], ssl_verify=False
         )
         all_job_names = jenkins.get_job_names()

--- a/reconcile/jenkins_job_cleaner.py
+++ b/reconcile/jenkins_job_cleaner.py
@@ -3,7 +3,7 @@ import logging
 from reconcile import queries
 
 from reconcile.jenkins_job_builder import init_jjb
-from reconcile.utils.jenkins_api import JenkinsApi
+from reconcile.utils.jenkins_api import init_jenkins_from_secret
 from reconcile.utils.secret_reader import SecretReader
 
 QONTRACT_INTEGRATION = "jenkins-job-cleaner"
@@ -29,8 +29,7 @@ def get_desired_job_names(instance_name: str, secret_reader: SecretReader):
 
 def run(dry_run):
     jenkins_instances = queries.get_jenkins_instances()
-    settings = queries.get_app_interface_settings()
-    secret_reader = SecretReader(settings)
+    secret_reader = SecretReader(queries.get_secret_reader_settings())
 
     for instance in jenkins_instances:
         if instance.get("deleteMethod") != "manual":
@@ -40,8 +39,9 @@ def run(dry_run):
             continue
 
         instance_name = instance["name"]
-        token = instance["token"]
-        jenkins = JenkinsApi(token, ssl_verify=False, settings=settings)
+        jenkins = init_jenkins_from_secret(
+            secret_reader, instance["token"], ssl_verify=False
+        )
         all_job_names = jenkins.get_job_names()
         managed_job_names = get_managed_job_names(all_job_names, managed_projects)
         desired_job_names = get_desired_job_names(instance_name, secret_reader)

--- a/reconcile/jenkins_plugins.py
+++ b/reconcile/jenkins_plugins.py
@@ -4,7 +4,7 @@ from typing import Any, Mapping
 from reconcile.utils import gql
 from reconcile import queries
 
-from reconcile.utils.jenkins_api import JenkinsApi, init_jenkins_from_secret
+from reconcile.utils.jenkins_api import JenkinsApi
 from reconcile.utils.secret_reader import SecretReader
 
 
@@ -44,7 +44,9 @@ def get_jenkins_map(
             continue
 
         token = instance["token"]
-        jenkins = init_jenkins_from_secret(secret_reader, token, ssl_verify=False)
+        jenkins = JenkinsApi.init_jenkins_from_secret(
+            secret_reader, token, ssl_verify=False
+        )
         jenkins_map[instance_name] = jenkins
 
     return jenkins_map

--- a/reconcile/jenkins_roles.py
+++ b/reconcile/jenkins_roles.py
@@ -4,7 +4,7 @@ from reconcile.utils import gql
 from reconcile.utils import expiration
 from reconcile import queries
 
-from reconcile.utils.jenkins_api import JenkinsApi, init_jenkins_from_secret
+from reconcile.utils.jenkins_api import JenkinsApi
 from reconcile.utils.secret_reader import SecretReader
 
 
@@ -70,7 +70,9 @@ def get_jenkins_map() -> dict[str, JenkinsApi]:
             continue
 
         token = instance["token"]
-        jenkins = init_jenkins_from_secret(secret_reader, token, ssl_verify=False)
+        jenkins = JenkinsApi.init_jenkins_from_secret(
+            secret_reader, token, ssl_verify=False
+        )
         jenkins_map[instance_name] = jenkins
 
     return jenkins_map

--- a/reconcile/jenkins_roles.py
+++ b/reconcile/jenkins_roles.py
@@ -4,7 +4,8 @@ from reconcile.utils import gql
 from reconcile.utils import expiration
 from reconcile import queries
 
-from reconcile.utils.jenkins_api import JenkinsApi
+from reconcile.utils.jenkins_api import JenkinsApi, init_jenkins_from_secret
+from reconcile.utils.secret_reader import SecretReader
 
 
 PERMISSIONS_QUERY = """
@@ -54,10 +55,10 @@ ROLES_QUERY = """
 QONTRACT_INTEGRATION = "jenkins-roles"
 
 
-def get_jenkins_map():
+def get_jenkins_map() -> dict[str, JenkinsApi]:
     gqlapi = gql.get_api()
     permissions = gqlapi.query(PERMISSIONS_QUERY)["permissions"]
-    settings = queries.get_app_interface_settings()
+    secret_reader = SecretReader(queries.get_secret_reader_settings())
 
     jenkins_permissions = [p for p in permissions if p["service"] == "jenkins-role"]
 
@@ -69,7 +70,7 @@ def get_jenkins_map():
             continue
 
         token = instance["token"]
-        jenkins = JenkinsApi(token, ssl_verify=False, settings=settings)
+        jenkins = init_jenkins_from_secret(secret_reader, token, ssl_verify=False)
         jenkins_map[instance_name] = jenkins
 
     return jenkins_map

--- a/reconcile/utils/jenkins_api.py
+++ b/reconcile/utils/jenkins_api.py
@@ -8,20 +8,28 @@ from sretoolbox.utils import retry
 from reconcile.utils.secret_reader import SecretReader
 
 
+def init_jenkins_from_secret(
+    secret_reader: SecretReader, secret, ssl_verify=True
+) -> "JenkinsApi":
+    token_config = secret_reader.read(secret)
+    config = toml.loads(token_config)
+    return JenkinsApi(
+        config["jenkins"]["url"],
+        config["jenkins"]["user"],
+        config["jenkins"]["password"],
+        ssl_verify=ssl_verify,
+    )
+
+
 class JenkinsApi:
     """Wrapper around Jenkins API calls"""
 
-    def __init__(self, token, ssl_verify=True, settings=None):
-        secret_reader = SecretReader(settings=settings)
-        token_config = secret_reader.read(token)
-        config = toml.loads(token_config)
-
-        self.url = config["jenkins"]["url"]
-        self.user = config["jenkins"]["user"]
-        self.password = config["jenkins"]["password"]
+    def __init__(self, url: str, user: str, password: str, ssl_verify=True):
+        self.url = url
+        self.user = user
+        self.password = password
         self.ssl_verify = ssl_verify
         self.should_restart = False
-        self.settings = settings
 
     def get_job_names(self):
         url = f"{self.url}/api/json?tree=jobs[name]"

--- a/reconcile/utils/jenkins_api.py
+++ b/reconcile/utils/jenkins_api.py
@@ -8,21 +8,21 @@ from sretoolbox.utils import retry
 from reconcile.utils.secret_reader import SecretReader
 
 
-def init_jenkins_from_secret(
-    secret_reader: SecretReader, secret, ssl_verify=True
-) -> "JenkinsApi":
-    token_config = secret_reader.read(secret)
-    config = toml.loads(token_config)
-    return JenkinsApi(
-        config["jenkins"]["url"],
-        config["jenkins"]["user"],
-        config["jenkins"]["password"],
-        ssl_verify=ssl_verify,
-    )
-
-
 class JenkinsApi:
     """Wrapper around Jenkins API calls"""
+
+    @staticmethod
+    def init_jenkins_from_secret(
+        secret_reader: SecretReader, secret, ssl_verify=True
+    ) -> "JenkinsApi":
+        token_config = secret_reader.read(secret)
+        config = toml.loads(token_config)
+        return JenkinsApi(
+            config["jenkins"]["url"],
+            config["jenkins"]["user"],
+            config["jenkins"]["password"],
+            ssl_verify=ssl_verify,
+        )
 
     def __init__(self, url: str, user: str, password: str, ssl_verify=True):
         self.url = url

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -135,7 +135,7 @@ from reconcile.utils.external_resource_spec import (
     ExternalResourceSpecInventory,
 )
 from reconcile.utils.external_resources import PROVIDER_AWS, get_external_resource_specs
-from reconcile.utils.jenkins_api import JenkinsApi
+from reconcile.utils.jenkins_api import JenkinsApi, init_jenkins_from_secret
 from reconcile.utils.ocm import OCMMap
 from reconcile.utils.password_validator import PasswordPolicy, PasswordValidator
 from reconcile.utils.secret_reader import SecretReader
@@ -462,7 +462,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         return self.github
 
     def init_jenkins(self, instance: dict) -> JenkinsApi:
-        return JenkinsApi(instance["token"], settings=self.settings)
+        return init_jenkins_from_secret(SecretReader(self.settings), instance["token"])
 
     def filter_disabled_accounts(
         self, accounts: Iterable[dict[str, Any]]

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -135,7 +135,7 @@ from reconcile.utils.external_resource_spec import (
     ExternalResourceSpecInventory,
 )
 from reconcile.utils.external_resources import PROVIDER_AWS, get_external_resource_specs
-from reconcile.utils.jenkins_api import JenkinsApi, init_jenkins_from_secret
+from reconcile.utils.jenkins_api import JenkinsApi
 from reconcile.utils.ocm import OCMMap
 from reconcile.utils.password_validator import PasswordPolicy, PasswordValidator
 from reconcile.utils.secret_reader import SecretReader
@@ -462,7 +462,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         return self.github
 
     def init_jenkins(self, instance: dict) -> JenkinsApi:
-        return init_jenkins_from_secret(SecretReader(self.settings), instance["token"])
+        return JenkinsApi.init_jenkins_from_secret(
+            SecretReader(self.settings), instance["token"]
+        )
 
     def filter_disabled_accounts(
         self, accounts: Iterable[dict[str, Any]]


### PR DESCRIPTION
followup to https://github.com/app-sre/qontract-reconcile/pull/2558

schema reduction for `jenkins-job-builds-cleaner`, `jenkins-job-cleaner` and `jenkins-roles` was accomplished with narrow queries for SecretReader and JenkinsAPI instantiation

remaining schemas for jenkins-job-builds-cleaner

```
schemas:
- /app-sre/integration-1.yml
- /app-interface/app-interface-settings-1.yml # for secret reader
- /dependencies/jenkins-instance-1.yml # to find jobs
- /dependencies/jenkins-config-1.yml # to find jobs
```

remaining schemas for jenkins-job-cleaner

```
schemas:
- /app-sre/integration-1.yml
- /app-interface/app-interface-settings-1.yml # for secret reader
- /dependencies/jenkins-instance-1.yml # for jobs
- /dependencies/jenkins-config-1.yml # for jobs

```

remaining schemas for jenkins-roles

```
schemas:
- /app-sre/integration-1.yml
- /app-interface/app-interface-settings-1.yml # for secret reader
- /access/role-1.yml # fetching roles
- /access/user-1.yml # ... and the users
- /access/bot-1.yml # ... and bots
- /access/permission-1.yml # ... that have permissions
- /dependencies/jenkins-instance-1.yml # ... on jenkins instances
```

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>