### PR TITLE
enabling terraform state schema logic into more integrations that dep…

### DIFF
--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -60,7 +60,7 @@ def run(
     account_name=None,
     defer=None,
 ):
-    accounts = filter_accounts(queries.get_aws_accounts(), account_name)
+    accounts = filter_accounts(queries.get_aws_accounts(terraform_state=True), account_name)
     if not accounts:
         logging.debug("nothing to do here")
         # using return because terraform-resources

--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -60,7 +60,9 @@ def run(
     account_name=None,
     defer=None,
 ):
-    accounts = filter_accounts(queries.get_aws_accounts(terraform_state=True), account_name)
+    accounts = filter_accounts(
+        queries.get_aws_accounts(terraform_state=True), account_name
+    )
     if not accounts:
         logging.debug("nothing to do here")
         # using return because terraform-resources

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -146,7 +146,7 @@ def run(
     participating_account_names = [a["name"] for a in participating_accounts]
     accounts = [
         a
-        for a in queries.get_aws_accounts()
+        for a in queries.get_aws_accounts(terraform_state=True)
         if a["name"] in participating_account_names
     ]
 


### PR DESCRIPTION
…end on it

Part of [APPSRE-4516](https://issues.redhat.com/browse/APPSRE-4516)

During q-r promote, there were a few integrations that complained about not having a `terraformState`, mainly `aws-iam-keys` and `terraform-tgw-attachments`. This PR will make that schema visible to these integrations

Signed-off-by: Suzana Nesic <snesic@redhat.com>