### PR TITLE
[saas-file-owners] handle null comment body

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -234,7 +234,7 @@ def check_if_lgtm(owners, comments):
         commenter = comment["username"]
         if commenter not in owners:
             continue
-        for line in comment["body"].split("\n"):
+        for line in comment.get("body", "").split("\n"):
             if line == "/lgtm":
                 lgtm_comment = True
                 approved = True


### PR DESCRIPTION
following #2540 where we started treating the MR description as a comment, this MR allows for the MR body to be null, to avoid crashing on such a scenario.