### PR TITLE
Add support for creating SNS topic and RDS event notification

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -58,6 +58,11 @@ provider
     format
   }
   annotations
+  event_notifications {
+    destination
+    source_type
+    event_categories
+  }
 }
 ... on NamespaceTerraformResourceS3_v1 {
   region
@@ -66,7 +71,7 @@ provider
   overrides
   sqs_identifier
   s3_events
-  event_notifications {
+  sns_event_notifications: event_notifications {
     destination_type
     destination
     event_type
@@ -131,6 +136,20 @@ provider
       value
     }
   }
+}
+... on NamespaceTerraformResourceSNSTopic_v1 {
+  defaults
+  region
+  identifier
+  output_resource_name
+  fifo_topic
+  inline_policy
+  annotations
+  subscriptions
+   {
+     protocol
+     endpoint
+   }
 }
 ... on NamespaceTerraformResourceDynamoDB_v1 {
   region


### PR DESCRIPTION
#### What:
For terraform-resources integration,
* Add support for creating SNS topics
* Add support for creating  RDS event subscription to SNS topics

#### Why:
<!--- Please include the context and background for your change. 
For example, why are you requesting this permission, any 
justification or approval you can provide is helpful. -->
We want to provide tenants the ability to be able subscribe to email notifications about their RDS instances's activity. 
Design doc [here](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/rds-upgrades-and-maintenance.md#database-maintenance-notifications).

#### Validation:
* Running terraform-resources integration through dry-run mode and check the output consistent with the yml defined in open source App Interface.
* Running the integration without dry-run mode against ter-int-dev AWS account and was able to see SNS topics and RDS event subscriptions created( and deleted) as intended. This includes multiple subscriptions, multiple event notification, with optional fields and without them.
Core yml that was used:
```
externalResources:
  - provider: aws
    provisioner:
      $ref: /aws/app-int-example/account.yml
    resources:
    - provider: rds
      identifier: app-int-example-01
      defaults: /terraform/rds/free-tier-1.yml
      output_resource_name: db-creds
      overrides:
        publicly_accessible: true
      event_notifications:
        - destination: test-sns-1
          source_type: db-instance
          event_categories: 
            - creation 
            - deletion
    - provider: sns
      identifier: test-sns-1
      defaults: /terraform/sns/sns-1.yml
      subscriptions:
        - protocol: email
          endpoint: foo@redhat.com
```
#### Dependencies: 
Depending on https://github.com/app-sre/qontract-schemas/pull/188