### PR TITLE
Enable clusterAdmin attribute for terraform-resources integration

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -327,6 +327,7 @@ TF_NAMESPACES_QUERY = """
 {
   namespaces: namespaces_v1 {
     name
+    clusterAdmin
     managedExternalResources
     externalResources {
       provider
@@ -362,6 +363,12 @@ TF_NAMESPACES_QUERY = """
         }
       }
       automationToken {
+        path
+        field
+        version
+        format
+      }
+      clusterAdminAutomationToken {
         path
         field
         version


### PR DESCRIPTION
Enable cluster-admin token for terraform-resources inteagration. There are some cases where this integration need cluster-admin access. 
e.g: `aws-iam-service-account` within a `openshift-*` namespace needs cluster-admin permissions to populate the secret. 