### PR TITLE
reduce schemas for integrations

### DIFF
--- a/reconcile/gitlab_mr_sqs_consumer.py
+++ b/reconcile/gitlab_mr_sqs_consumer.py
@@ -5,28 +5,27 @@ SQS Consumer to create Gitlab merge requests.
 import json
 import logging
 import sys
-from typing import Any
 
 from reconcile import queries
 
 from reconcile.utils import mr
 from reconcile.utils.sqs_gateway import SQSGateway
 from reconcile.utils.gitlab_api import GitLabApi
+from reconcile.utils.secret_reader import SecretReader
 
 
 QONTRACT_INTEGRATION = "gitlab-mr-sqs-consumer"
 
 
 def run(dry_run, gitlab_project_id):
-    settings = queries.get_app_interface_settings()
+    secret_reader = SecretReader(queries.get_secret_reader_settings())
 
     accounts = queries.get_queue_aws_accounts()
-    sqs_cli = SQSGateway(accounts, settings=settings)
+    sqs_cli = SQSGateway(accounts, secret_reader)
 
     instance = queries.get_gitlab_instance()
-    saas_files: list[dict[str, Any]] = queries.get_saas_files_minimal()
     gitlab_cli = GitLabApi(
-        instance, project_id=gitlab_project_id, settings=settings, saas_files=saas_files
+        instance, project_id=gitlab_project_id, secret_reader=secret_reader
     )
 
     errors_occured = False

--- a/reconcile/jenkins_webhooks.py
+++ b/reconcile/jenkins_webhooks.py
@@ -11,10 +11,9 @@ from reconcile.utils.secret_reader import SecretReader
 QONTRACT_INTEGRATION = "jenkins-webhooks"
 
 
-def get_gitlab_api():
+def get_gitlab_api(secret_reader: SecretReader):
     instance = queries.get_gitlab_instance()
-    settings = queries.get_app_interface_settings()
-    return GitLabApi(instance, settings=settings)
+    return GitLabApi(instance, secret_reader=secret_reader)
 
 
 def get_hooks_to_add(desired_state, gl):
@@ -41,7 +40,7 @@ def get_hooks_to_add(desired_state, gl):
 def run(dry_run):
     secret_reader = SecretReader(queries.get_secret_reader_settings())
     jjb: JJB = init_jjb(secret_reader)
-    gl = get_gitlab_api()
+    gl = get_gitlab_api(secret_reader)
 
     desired_state = jjb.get_job_webhooks_data()
     diff = get_hooks_to_add(desired_state, gl)

--- a/reconcile/jenkins_webhooks.py
+++ b/reconcile/jenkins_webhooks.py
@@ -11,7 +11,7 @@ from reconcile.utils.secret_reader import SecretReader
 QONTRACT_INTEGRATION = "jenkins-webhooks"
 
 
-def get_gitlab_api(secret_reader: SecretReader):
+def get_gitlab_api(secret_reader: SecretReader) -> GitLabApi:
     instance = queries.get_gitlab_instance()
     return GitLabApi(instance, secret_reader=secret_reader)
 

--- a/reconcile/jira_watcher.py
+++ b/reconcile/jira_watcher.py
@@ -4,6 +4,7 @@ from reconcile import queries
 from reconcile.slack_base import slackapi_from_slack_workspace
 
 from reconcile.utils.jira_client import JiraClient
+from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.sharding import is_in_shard_round_robin
 from reconcile.utils.state import State
 
@@ -63,12 +64,12 @@ def calculate_diff(server, current_state, previous_state):
 
 
 def init_slack(jira_board):
-    settings = queries.get_app_interface_settings()
+    secret_reader = SecretReader(queries.get_secret_reader_settings())
     slack_info = jira_board["slack"]
 
     return slackapi_from_slack_workspace(
         slack_info,
-        settings,
+        secret_reader,
         QONTRACT_INTEGRATION,
         channel=slack_info.get("channel"),
         init_usergroups=False,

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -9,6 +9,7 @@ from reconcile import queries
 from reconcile import mr_client_gateway
 from reconcile.slack_base import slackapi_from_slack_workspace
 from reconcile.status import ExitCodes
+from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.defer import defer
 from reconcile.utils.gitlab_api import GitLabApi
@@ -78,7 +79,6 @@ def run(
 ):
     all_saas_files = queries.get_saas_files()
     saas_files = queries.get_saas_files(saas_file_name, env_name)
-    app_interface_settings = queries.get_app_interface_settings()
     if not saas_files:
         logging.error("no saas files found")
         sys.exit(ExitCodes.ERROR)
@@ -94,7 +94,7 @@ def run(
         if slack_info:
             slack = slackapi_from_slack_workspace(
                 slack_info,
-                app_interface_settings,
+                SecretReader(queries.get_secret_reader_settings()),
                 QONTRACT_INTEGRATION,
                 init_usergroups=False,
             )

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1495,6 +1495,7 @@ ROLES_QUERY = """
     roles {
       name
       path
+      {% if permissions %}
       permissions {
         name
         path
@@ -1514,6 +1515,7 @@ ROLES_QUERY = """
           team
         }
       }
+      {% endif %}
       tag_on_cluster_updates
       access {
         cluster {
@@ -1559,10 +1561,10 @@ ROLES_QUERY = """
 """
 
 
-def get_roles(aws=True, saas_files=True, sendgrid=False):
+def get_roles(aws=True, saas_files=True, sendgrid=False, permissions=True):
     gqlapi = gql.get_api()
     query = Template(ROLES_QUERY).render(
-        aws=aws, saas_files=saas_files, sendgrid=sendgrid
+        aws=aws, saas_files=saas_files, sendgrid=sendgrid, permissions=permissions
     )
     return gqlapi.query(query)["users"]
 
@@ -2366,7 +2368,7 @@ def get_slack_workspace():
     slack_workspaces = gqlapi.query(SLACK_WORKSPACES_QUERY)["slack_workspaces"]
     if len(slack_workspaces) != 1:
         logging.warning("multiple Slack workspaces found.")
-    return gqlapi.query(SLACK_WORKSPACES_QUERY)["slack_workspaces"][0]
+    return slack_workspaces[0]
 
 
 OCP_RELEASE_ECR_MIRROR_QUERY = """

--- a/reconcile/slack_base.py
+++ b/reconcile/slack_base.py
@@ -1,6 +1,7 @@
 from typing import Mapping, Any, Optional
 
 from reconcile import queries
+from reconcile.utils.secret_reader import SecretReader
 
 from reconcile.utils.slack_api import SlackApi, SlackApiConfig
 
@@ -8,16 +9,16 @@ from reconcile.utils.slack_api import SlackApi, SlackApiConfig
 def slackapi_from_queries(
     integration_name: str, init_usergroups: Optional[bool] = True
 ) -> SlackApi:
-    app_interface_settings = queries.get_app_interface_settings()
+    secret_reader = SecretReader(queries.get_secret_reader_settings())
     slack_workspace = {"workspace": queries.get_slack_workspace()}
     return slackapi_from_slack_workspace(
-        slack_workspace, app_interface_settings, integration_name, init_usergroups
+        slack_workspace, secret_reader, integration_name, init_usergroups
     )
 
 
 def slackapi_from_slack_workspace(
     slack_workspace: Mapping[str, Any],
-    app_interface_settings: Mapping[str, Any],
+    secret_reader: SecretReader,
     integration_name: str,
     init_usergroups: Optional[bool] = True,
     channel: Optional[str] = None,
@@ -53,7 +54,7 @@ def slackapi_from_slack_workspace(
     api = SlackApi(
         workspace_name,
         token,
-        app_interface_settings=app_interface_settings,
+        secret_reader,
         channel=channel,
         api_config=api_config,
         init_usergroups=init_usergroups,
@@ -66,7 +67,7 @@ def slackapi_from_slack_workspace(
 
 def slackapi_from_permissions(
     permissions: Mapping[str, Any],
-    app_interface_settings: Mapping[str, Any],
+    secret_reader: SecretReader,
     init_usergroups: Optional[bool] = True,
 ) -> SlackApi:
     if "workspace" not in permissions:
@@ -84,7 +85,7 @@ def slackapi_from_permissions(
     api = SlackApi(
         workspace_name,
         token,
-        app_interface_settings=app_interface_settings,
+        secret_reader,
         init_usergroups=init_usergroups,
         api_config=api_config,
     )

--- a/reconcile/slack_cluster_usergroups.py
+++ b/reconcile/slack_cluster_usergroups.py
@@ -63,7 +63,9 @@ def get_desired_state(slack):
     :rtype: dict
     """
     desired_state = {}
-    all_users = queries.get_roles()
+    all_users = queries.get_roles(
+        sendgrid=False, saas_files=False, aws=False, permissions=False
+    )
     all_clusters = queries.get_clusters(minimal=True)
     clusters = [
         c

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -1,6 +1,7 @@
 import logging
 
 from datetime import datetime
+from typing import Any
 from urllib.parse import urlparse
 from sretoolbox.utils import retry
 from github.GithubException import UnknownObjectException
@@ -35,7 +36,7 @@ class GitApi:
         raise ValueError(f"Unable to handle URL: {url}")
 
 
-def get_slack_map(secret_reader: SecretReader):
+def get_slack_map(secret_reader: SecretReader) -> dict[str, dict[str, Any]]:
     permissions = queries.get_permissions_for_slack_usergroup()
     slack_map = {}
     for sp in permissions:

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -11,6 +11,7 @@ from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.pagerduty_api import PagerDutyMap
 from reconcile.utils.repo_owners import RepoOwners
 from reconcile.utils.slack_api import SlackApiError
+from reconcile.utils.secret_reader import SecretReader
 from reconcile import queries
 
 
@@ -34,8 +35,7 @@ class GitApi:
         raise ValueError(f"Unable to handle URL: {url}")
 
 
-def get_slack_map():
-    settings = queries.get_app_interface_settings()
+def get_slack_map(secret_reader: SecretReader):
     permissions = queries.get_permissions_for_slack_usergroup()
     slack_map = {}
     for sp in permissions:
@@ -45,7 +45,7 @@ def get_slack_map():
             continue
 
         workspace_spec = {
-            "slack": slackapi_from_permissions(sp, settings),
+            "slack": slackapi_from_permissions(sp, secret_reader),
             "managed_usergroups": workspace["managedUsergroups"],
         }
         slack_map[workspace_name] = workspace_spec
@@ -439,7 +439,8 @@ def act(current_state, desired_state, slack_map, dry_run=True):
 
 
 def run(dry_run):
-    slack_map = get_slack_map()
+    secret_reader = SecretReader(queries.get_secret_reader_settings())
+    slack_map = get_slack_map(secret_reader)
     pagerduty_map = get_pagerduty_map()
     desired_state = get_desired_state(slack_map, pagerduty_map)
     current_state = get_current_state(slack_map)

--- a/reconcile/test/test_ldap_users.py
+++ b/reconcile/test/test_ldap_users.py
@@ -38,7 +38,7 @@ def patched_queries_get_users(mocker):
 @pytest.fixture
 def patched_queries_get_app_interface_settings(mocker):
     queries_get_app_interface_settings = mocker.patch.object(
-        ldap_users.queries, "get_app_interface_settings", autospec=True
+        ldap_users, "get_ldap_settings", autospec=True
     )
     queries_get_app_interface_settings.return_value = {}
     return queries_get_app_interface_settings

--- a/reconcile/test/test_slack_base.py
+++ b/reconcile/test/test_slack_base.py
@@ -4,6 +4,7 @@ from reconcile.slack_base import (
     slackapi_from_slack_workspace,
     slackapi_from_permissions,
 )
+from reconcile.utils.secret_reader import SecretReader
 
 
 def create_api_config():
@@ -92,13 +93,13 @@ def patch__initiate_usergroups(mocker):
 
 def test_slack_workspace_raises():
     with pytest.raises(ValueError):
-        slackapi_from_slack_workspace({}, {}, "foo")
+        slackapi_from_slack_workspace({}, SecretReader(), "foo")
 
 
 def test_slack_workspace_ok(
     patch_secret_reader, patch__initiate_usergroups, slack_workspace
 ):
-    slack_api = slackapi_from_slack_workspace(slack_workspace, {}, "dummy")
+    slack_api = slackapi_from_slack_workspace(slack_workspace, SecretReader(), "dummy")
     patch_secret_reader.assert_called_once()
     patch__initiate_usergroups.assert_called_once()
     assert slack_api.channel == "test"
@@ -110,7 +111,7 @@ def test_slack_workspace_channel_overwrite(
     patch_secret_reader, patch__initiate_usergroups, slack_workspace
 ):
     slack_api = slackapi_from_slack_workspace(
-        slack_workspace, {}, "dummy", channel="foo"
+        slack_workspace, SecretReader(), "dummy", channel="foo"
     )
     assert slack_api.channel == "foo"
 
@@ -119,7 +120,7 @@ def test_unleash_workspace_ok(
     patch_secret_reader, patch__initiate_usergroups, unleash_slack_workspace
 ):
     slack_api = slackapi_from_slack_workspace(
-        unleash_slack_workspace, {}, "unleash-watcher"
+        unleash_slack_workspace, SecretReader(), "unleash-watcher"
     )
     patch_secret_reader.assert_called_once()
     patch__initiate_usergroups.assert_called_once()
@@ -131,14 +132,16 @@ def test_unleash_workspace_ok(
 def test_slack_workspace_no_init(
     patch_secret_reader, patch__initiate_usergroups, slack_workspace
 ):
-    slackapi_from_slack_workspace(slack_workspace, {}, "dummy", init_usergroups=False)
+    slackapi_from_slack_workspace(
+        slack_workspace, SecretReader(), "dummy", init_usergroups=False
+    )
     patch__initiate_usergroups.assert_not_called()
 
 
 def test_permissions_workspace(
     patch_secret_reader, patch__initiate_usergroups, permissions_workspace
 ):
-    slack_api = slackapi_from_permissions(permissions_workspace, {})
+    slack_api = slackapi_from_permissions(permissions_workspace, SecretReader())
     patch_secret_reader.assert_called_once()
     patch__initiate_usergroups.assert_called_once()
 

--- a/reconcile/test/test_slack_usergroups.py
+++ b/reconcile/test/test_slack_usergroups.py
@@ -8,6 +8,7 @@ import pytest
 import reconcile.slack_usergroups as integ
 import reconcile.slack_base as slackbase
 from reconcile.slack_usergroups import act
+from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.slack_api import SlackApi
 from reconcile import queries
 
@@ -97,7 +98,7 @@ class TestSupportFunctions(TestCase):
                 "managed_usergroups": ["app-sre-team", "app-sre-ic"],
             }
         }
-        result = integ.get_slack_map()
+        result = integ.get_slack_map(SecretReader())
         mock_slack_api.assert_called_once()
         self.assertEqual(
             result["coreos"]["managed_usergroups"],

--- a/reconcile/test/test_utils_slack_api.py
+++ b/reconcile/test/test_utils_slack_api.py
@@ -32,7 +32,9 @@ def slack_api(mocker):
     mock_slack_client.return_value.retry_handlers = []
 
     token = {"path": "some/path", "field": "some-field"}
-    slack_api = SlackApi("some-workspace", token)
+    slack_api = SlackApi(
+        "some-workspace", token, reconcile.utils.slack_api.SecretReader()
+    )
 
     SlackApiMock = namedtuple(
         "SlackApiMock", "client mock_secret_reader " "mock_slack_client"
@@ -98,7 +100,9 @@ def test_instantiate_slack_api_with_config(mocker):
     config = SlackApiConfig()
 
     token = {"path": "some/path", "field": "some-field"}
-    slack_api = SlackApi("some-workspace", token, config)
+    slack_api = SlackApi(
+        "some-workspace", token, reconcile.utils.slack_api.SecretReader(), config
+    )
 
     assert slack_api.config is config
 
@@ -344,7 +348,10 @@ def test_slack_api__client_throttle_raise(mock_sleep, mock_secret_reader):
     )
 
     slack_client = SlackApi(
-        "workspace", {"path": "some/path", "field": "some-field"}, init_usergroups=False
+        "workspace",
+        {"path": "some/path", "field": "some-field"},
+        reconcile.utils.slack_api.SecretReader(),
+        init_usergroups=False,
     )
 
     with pytest.raises(SlackApiError):
@@ -373,7 +380,10 @@ def test_slack_api__client_throttle_doesnt_raise(mock_sleep, mock_secret_reader)
     httpretty.register_uri(*uri_args, **uri_kwargs_failure)
 
     slack_client = SlackApi(
-        "workspace", {"path": "some/path", "field": "some-field"}, init_usergroups=False
+        "workspace",
+        {"path": "some/path", "field": "some-field"},
+        reconcile.utils.slack_api.SecretReader(),
+        init_usergroups=False,
     )
 
     slack_client._sc.api_call("users.list")
@@ -394,7 +404,10 @@ def test_slack_api__client_5xx_raise(mock_sleep, mock_secret_reader):
     )
 
     slack_client = SlackApi(
-        "workspace", {"path": "some/path", "field": "some-field"}, init_usergroups=False
+        "workspace",
+        {"path": "some/path", "field": "some-field"},
+        reconcile.utils.slack_api.SecretReader(),
+        init_usergroups=False,
     )
 
     with pytest.raises(SlackApiError):
@@ -422,7 +435,10 @@ def test_slack_api__client_5xx_doesnt_raise(mock_sleep, mock_secret_reader):
     httpretty.register_uri(*uri_args, **uri_kwargs_failure)
 
     slack_client = SlackApi(
-        "workspace", {"path": "some/path", "field": "some-field"}, init_usergroups=False
+        "workspace",
+        {"path": "some/path", "field": "some-field"},
+        reconcile.utils.slack_api.SecretReader(),
+        init_usergroups=False,
     )
 
     slack_client._sc.api_call("users.list")
@@ -443,7 +459,10 @@ def test_slack_api__client_dont_retry(mock_sleep, mock_secret_reader):
     )
 
     slack_client = SlackApi(
-        "workspace", {"path": "some/path", "field": "some-field"}, init_usergroups=False
+        "workspace",
+        {"path": "some/path", "field": "some-field"},
+        reconcile.utils.slack_api.SecretReader(),
+        init_usergroups=False,
     )
 
     with pytest.raises(SlackApiError):

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -38,12 +38,14 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         project_id=None,
         ssl_verify=True,
         settings=None,
+        secret_reader=None,
         project_url=None,
         saas_files=None,
         timeout=30,
     ):
         self.server = instance["url"]
-        secret_reader = SecretReader(settings=settings)
+        if not secret_reader:
+            secret_reader = SecretReader(settings=settings)
         token = secret_reader.read(instance["token"])
         ssl_verify = instance["sslVerify"]
         if ssl_verify is None:

--- a/reconcile/utils/mr/README.md
+++ b/reconcile/utils/mr/README.md
@@ -92,11 +92,12 @@ then create the SQS Client instance:
 from reconcile import queries
 
 from reconcile.utils.sqs_gateway import SQSGateway
+from reconcile.utils.secret_reader import SecretReader
 
 
 accounts = queries.get_queue_aws_accounts()
-settings = queries.get_app_interface_settings()
-sqs_cli = SQSGateway(accounts, settings=settings)
+secretReader = SecretReader(queries.get_secret_reader_settings())
+sqs_cli = SQSGateway(accounts, secret_reader=secret_reader)
 ```
 
 and then submit the merge request to the SQS:
@@ -115,12 +116,14 @@ first get the SQS messages:
 from reconcile import queries
 
 from reconcile.utils.sqs_gateway import SQSGateway
+from reconcile.utils.secret_reader import SecretReader
 
 
 accounts = queries.get_queue_aws_accounts()
 settings = queries.get_app_interface_settings()
 
-sqs_cli = SQSGateway(accounts, settings=settings)
+secretReader = SecretReader(queries.get_secret_reader_settings())
+sqs_cli = SQSGateway(accounts, secret_reader=secret_reader)
 messages = sqs_cli.receive_messages()
 ```
 
@@ -132,7 +135,7 @@ from reconcile.utils.gitlab_api import GitLabApi
 instance = queries.get_gitlab_instance()
 saas_files = queries.get_saas_files_minimal()
 gitlab_cli = GitLabApi(instance, project_id=gitlab_project_id,
-                       settings=settings, saas_files=saas_files)
+                       settings=settings)
 ```
 
 and then loop the messages, creating the MergeRequest objects and submitting

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -114,8 +114,8 @@ class SlackApi:
         self,
         workspace_name: str,
         token: Mapping[str, str],
+        secret_reader: SecretReader,
         api_config: Optional[SlackApiConfig] = None,
-        app_interface_settings: Optional[Mapping[str, Any]] = None,
         init_usergroups=True,
         channel: Optional[str] = None,
         **chat_kwargs,
@@ -123,8 +123,8 @@ class SlackApi:
         """
         :param workspace_name: Slack workspace name (ex. coreos)
         :param token: data to pass to SecretReader.read() to get the token
+        :param secret_reader: secret reader to access slack credentials
         :param api_config: Slack API configuration
-        :param app_interface_settings: settings to pass to SecretReader
         :param init_usergroups: whether or not to get a list of all Slack
         usergroups when instantiated
         :param channel: the Slack channel to post messages to, only used
@@ -139,7 +139,6 @@ class SlackApi:
         else:
             self.config = SlackApiConfig()
 
-        secret_reader = SecretReader(settings=app_interface_settings)
         slack_token = secret_reader.read(token)
 
         self._sc = WebClient(token=slack_token, timeout=self.config.timeout)

--- a/reconcile/utils/sqs_gateway.py
+++ b/reconcile/utils/sqs_gateway.py
@@ -2,6 +2,7 @@ import os
 import json
 
 from reconcile.utils.aws_api import AWSApi
+from reconcile.utils.secret_reader import SecretReader
 
 
 class SQSGatewayInitError(Exception):
@@ -11,11 +12,11 @@ class SQSGatewayInitError(Exception):
 class SQSGateway:
     """Wrapper around SQS AWS SDK"""
 
-    def __init__(self, accounts, settings=None):
+    def __init__(self, accounts, secret_reader: SecretReader):
         queue_url = os.environ["gitlab_pr_submitter_queue_url"]
         account = self.get_queue_account(accounts, queue_url)
         accounts = [a for a in accounts if a["name"] == account]
-        aws_api = AWSApi(1, accounts, settings=settings, init_users=False)
+        aws_api = AWSApi(1, accounts, secret_reader=secret_reader, init_users=False)
         session = aws_api.get_session(account)
 
         self.sqs = session.client("sqs")


### PR DESCRIPTION
followup to https://github.com/app-sre/qontract-reconcile/pull/2560

schema reduction for jenkins-webhooks, ldap-users, gitlab-mr-sqs-consumer and slack-cluster-user-groups was accomplished with narrow queries for SecretReader, roles and slack permissions. most importantly none of these require the saas-2 schema anymore and that brings us closer to depcrecate `run_for_valid_saas_files` flag in the integration-1 schema.

remaining schemas for jenkins-webhooks

```
schemas:
- /app-sre/integration-1.yml
- /app-interface/app-interface-settings-1.yml # for secret reader
- /dependencies/gitlab-instance-1.yml # find projects to add webhooks to
- /dependencies/jenkins-config-1.yml # the jenkins config ...
- /dependencies/jenkins-instance-1.yml # ... and instances to add webhooks to
```

remaining schemas for ldap-users

```
schemas:
- /app-sre/integration-1.yml
- /app-interface/app-interface-settings-1.yml # for secret reader, ldap settings and MR gateway
- /access/user-1.yml # app-interface users to search in LDAP
- /dependencies/gitlab-instance-1.yml # to open user MRs via the MR gateway
```

remaining schemas for gitlab-mr-sqs-consumer 

```
schemas:
- /app-sre/integration-1.yml
- /app-interface/app-interface-settings-1.yml # for secret reader
- /aws/account-1.yml # for sqs MR queue
- /dependencies/gitlab-instance-1.yml # for MR creation
```

remaining schemas for slack-cluster-user-groups

```
schemas:
- /app-sre/integration-1.yml
- /app-interface/app-interface-settings-1.yml # for secret reader
- /dependencies/slack-workspace-1.yml # the slack workspace to operate on

# find clusters for user
- /access/user-1.yml
- /access/role-1.yml
- /access/bot-1.yml
- /openshift/cluster-1.yml
- /openshift/jump-host-1.yml
- /openshift/namespace-1.yml
- /openshift/openshift-cluster-manager-1.yml
```

part of https://issues.redhat.com/browse/APPSRE-5968