### PR TITLE
Locally scope cli.py imports to save memory usage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ branch = True
 omit = reconcile/test/*
 
 [report]
-fail_under = 34
+fail_under = 32.5

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -11,111 +11,6 @@ import sentry_sdk
 
 from reconcile.utils import config
 from reconcile.utils import gql
-import reconcile.dyn_traffic_director
-import reconcile.github_org
-import reconcile.github_owners
-import reconcile.github_users
-import reconcile.github_scanner
-import reconcile.github_validator
-import reconcile.openshift_clusterrolebindings
-import reconcile.openshift_rolebindings
-import reconcile.openshift_groups
-import reconcile.openshift_limitranges
-import reconcile.openshift_resourcequotas
-import reconcile.openshift_users
-import reconcile.openshift_resources
-import reconcile.openshift_vault_secrets
-import reconcile.openshift_routes
-import reconcile.openshift_namespace_labels
-import reconcile.openshift_namespaces
-import reconcile.openshift_network_policies
-import reconcile.openshift_serviceaccount_tokens
-import reconcile.openshift_saas_deploy
-import reconcile.openshift_saas_deploy_wrapper
-import reconcile.openshift_saas_deploy_trigger_moving_commits
-import reconcile.openshift_saas_deploy_trigger_upstream_jobs
-import reconcile.openshift_saas_deploy_trigger_configs
-import reconcile.openshift_saas_deploy_trigger_cleaner
-import reconcile.openshift_tekton_resources
-import reconcile.saas_file_owners
-import reconcile.gitlab_ci_skipper
-import reconcile.gitlab_labeler
-import reconcile.saas_file_validator
-import reconcile.quay_membership
-import reconcile.gcr_mirror
-import reconcile.quay_mirror
-import reconcile.quay_mirror_org
-import reconcile.quay_repos
-import reconcile.quay_permissions
-import reconcile.ldap_users
-import reconcile.terraform_resources
-import reconcile.terraform_users
-import reconcile.terraform_vpc_peerings
-import reconcile.terraform_tgw_attachments
-import reconcile.github_repo_invites
-import reconcile.github_repo_permissions_validator
-import reconcile.jenkins_roles
-import reconcile.jenkins_plugins
-import reconcile.jenkins_job_builder
-import reconcile.jenkins_job_cleaner
-import reconcile.jenkins_webhooks
-import reconcile.jenkins_webhooks_cleaner
-import reconcile.jira_watcher
-import reconcile.unleash_watcher
-import reconcile.openshift_upgrade_watcher
-import reconcile.slack_usergroups
-import reconcile.slack_cluster_usergroups
-import reconcile.gitlab_integrations
-import reconcile.gitlab_permissions
-import reconcile.gitlab_housekeeping
-import reconcile.gitlab_fork_compliance
-import reconcile.gitlab_members
-import reconcile.gitlab_owners
-import reconcile.gitlab_mr_sqs_consumer
-import reconcile.gitlab_projects
-import reconcile.aws_garbage_collector
-import reconcile.aws_iam_keys
-import reconcile.aws_iam_password_reset
-import reconcile.aws_ami_share
-import reconcile.aws_ecr_image_pull_secrets
-import reconcile.aws_support_cases_sos
-import reconcile.ocm_groups
-import reconcile.ocm_clusters
-import reconcile.ocm_external_configuration_labels
-import reconcile.ocm_machine_pools
-import reconcile.ocm_upgrade_scheduler
-import reconcile.ocm_addons
-import reconcile.ocm_aws_infrastructure_access
-import reconcile.ocm_github_idp
-import reconcile.ocm_additional_routers
-import reconcile.email_sender
-import reconcile.sentry_helper
-import reconcile.requests_sender
-import reconcile.service_dependencies
-import reconcile.sentry_config
-import reconcile.sql_query
-import reconcile.integrations_validator
-import reconcile.dashdotdb_cso
-import reconcile.ocp_release_mirror
-import reconcile.ecr_mirror
-import reconcile.kafka_clusters
-import reconcile.terraform_aws_route53
-import reconcile.prometheus_rules_tester
-import reconcile.template_tester
-import reconcile.query_validator
-import reconcile.dashdotdb_dvo
-import reconcile.sendgrid_teammates
-import reconcile.osd_mirrors_data_updater
-import reconcile.dashdotdb_slo
-import reconcile.jenkins_job_builds_cleaner
-import reconcile.cluster_deployment_mapper
-import reconcile.resource_scraper
-import reconcile.gabi_authorized_users
-import reconcile.status_page_components
-import reconcile.blackbox_exporter_endpoint_monitoring
-import reconcile.signalfx_endpoint_monitoring
-import reconcile.integrations_manager
-import reconcile.vpc_peerings_validator
 
 from reconcile.status import ExitCodes
 from reconcile.status import RunningState
@@ -553,6 +448,8 @@ def integration(
 def terraform_aws_route53(
     ctx, print_to_file, enable_deletion, thread_pool_size, account_name
 ):
+    import reconcile.terraform_aws_route53
+
     run_integration(
         reconcile.terraform_aws_route53,
         ctx.obj,
@@ -566,12 +463,16 @@ def terraform_aws_route53(
 @integration.command(short_help="Configures the teams and members in a GitHub org.")
 @click.pass_context
 def github(ctx):
+    import reconcile.github_org
+
     run_integration(reconcile.github_org, ctx.obj)
 
 
 @integration.command(short_help="Configures owners in a GitHub org.")
 @click.pass_context
 def github_owners(ctx):
+    import reconcile.github_owners
+
     run_integration(reconcile.github_owners, ctx.obj)
 
 
@@ -583,6 +484,8 @@ def github_owners(ctx):
 @send_mails(default=False)
 @click.pass_context
 def github_users(ctx, gitlab_project_id, thread_pool_size, enable_deletion, send_mails):
+    import reconcile.github_users
+
     run_integration(
         reconcile.github_users,
         ctx.obj,
@@ -603,6 +506,8 @@ def github_users(ctx, gitlab_project_id, thread_pool_size, enable_deletion, send
 @binary(["git", "git-secrets"])
 @click.pass_context
 def github_scanner(ctx, gitlab_project_id, thread_pool_size):
+    import reconcile.github_scanner
+
     run_integration(
         reconcile.github_scanner, ctx.obj, gitlab_project_id, thread_pool_size
     )
@@ -611,6 +516,8 @@ def github_scanner(ctx, gitlab_project_id, thread_pool_size):
 @integration.command(short_help="Validates GitHub organization settings.")
 @click.pass_context
 def github_validator(ctx):
+    import reconcile.github_validator
+
     run_integration(reconcile.github_validator, ctx.obj)
 
 
@@ -622,6 +529,8 @@ def github_validator(ctx):
 @use_jump_host()
 @click.pass_context
 def openshift_clusterrolebindings(ctx, thread_pool_size, internal, use_jump_host):
+    import reconcile.openshift_clusterrolebindings
+
     run_integration(
         reconcile.openshift_clusterrolebindings,
         ctx.obj,
@@ -639,6 +548,8 @@ def openshift_clusterrolebindings(ctx, thread_pool_size, internal, use_jump_host
 @use_jump_host()
 @click.pass_context
 def openshift_rolebindings(ctx, thread_pool_size, internal, use_jump_host):
+    import reconcile.openshift_rolebindings
+
     run_integration(
         reconcile.openshift_rolebindings,
         ctx.obj,
@@ -656,6 +567,8 @@ def openshift_rolebindings(ctx, thread_pool_size, internal, use_jump_host):
 @use_jump_host()
 @click.pass_context
 def openshift_groups(ctx, thread_pool_size, internal, use_jump_host):
+    import reconcile.openshift_groups
+
     run_integration(
         reconcile.openshift_groups, ctx.obj, thread_pool_size, internal, use_jump_host
     )
@@ -669,6 +582,8 @@ def openshift_groups(ctx, thread_pool_size, internal, use_jump_host):
 @use_jump_host()
 @click.pass_context
 def openshift_users(ctx, thread_pool_size, internal, use_jump_host):
+    import reconcile.openshift_users
+
     run_integration(
         reconcile.openshift_users, ctx.obj, thread_pool_size, internal, use_jump_host
     )
@@ -687,6 +602,8 @@ def openshift_users(ctx, thread_pool_size, internal, use_jump_host):
 def openshift_serviceaccount_tokens(
     ctx, thread_pool_size, internal, use_jump_host, vault_output_path
 ):
+    import reconcile.openshift_serviceaccount_tokens
+
     run_integration(
         reconcile.openshift_serviceaccount_tokens,
         ctx.obj,
@@ -700,12 +617,16 @@ def openshift_serviceaccount_tokens(
 @integration.command(short_help="Manage Jenkins roles association via REST API.")
 @click.pass_context
 def jenkins_roles(ctx):
+    import reconcile.jenkins_roles
+
     run_integration(reconcile.jenkins_roles, ctx.obj)
 
 
 @integration.command(short_help="Manage Jenkins plugins installation via REST API.")
 @click.pass_context
 def jenkins_plugins(ctx):
+    import reconcile.jenkins_plugins
+
     run_integration(reconcile.jenkins_plugins, ctx.obj)
 
 
@@ -720,6 +641,8 @@ def jenkins_plugins(ctx):
 @throughput
 @click.pass_context
 def jenkins_job_builder(ctx, io_dir, print_only, config_name, job_name, instance_name):
+    import reconcile.jenkins_job_builder
+
     run_integration(
         reconcile.jenkins_job_builder,
         ctx.obj,
@@ -734,24 +657,32 @@ def jenkins_job_builder(ctx, io_dir, print_only, config_name, job_name, instance
 @integration.command(short_help="Clean up jenkins job history.")
 @click.pass_context
 def jenkins_job_builds_cleaner(ctx):
+    import reconcile.jenkins_job_builds_cleaner
+
     run_integration(reconcile.jenkins_job_builds_cleaner, ctx.obj)
 
 
 @integration.command(short_help="Delete Jenkins jobs in multiple tenant instances.")
 @click.pass_context
 def jenkins_job_cleaner(ctx):
+    import reconcile.jenkins_job_cleaner
+
     run_integration(reconcile.jenkins_job_cleaner, ctx.obj)
 
 
 @integration.command(short_help="Manage web hooks to Jenkins jobs.")
 @click.pass_context
 def jenkins_webhooks(ctx):
+    import reconcile.jenkins_webhooks
+
     run_integration(reconcile.jenkins_webhooks, ctx.obj)
 
 
 @integration.command(short_help="Remove webhooks to previous Jenkins instances.")
 @click.pass_context
 def jenkins_webhooks_cleaner(ctx):
+    import reconcile.jenkins_webhooks_cleaner
+
     run_integration(reconcile.jenkins_webhooks_cleaner, ctx.obj)
 
 
@@ -759,6 +690,8 @@ def jenkins_webhooks_cleaner(ctx):
 @environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def jira_watcher(ctx):
+    import reconcile.jira_watcher
+
     run_integration(reconcile.jira_watcher, ctx.obj)
 
 
@@ -768,6 +701,8 @@ def jira_watcher(ctx):
 @environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def unleash_watcher(ctx):
+    import reconcile.unleash_watcher
+
     run_integration(reconcile.unleash_watcher, ctx.obj)
 
 
@@ -782,6 +717,8 @@ def unleash_watcher(ctx):
 @use_jump_host()
 @click.pass_context
 def openshift_upgrade_watcher(ctx, thread_pool_size, internal, use_jump_host):
+    import reconcile.openshift_upgrade_watcher
+
     run_integration(
         reconcile.openshift_upgrade_watcher,
         ctx.obj,
@@ -794,6 +731,8 @@ def openshift_upgrade_watcher(ctx, thread_pool_size, internal, use_jump_host):
 @integration.command(short_help="Manage Slack User Groups (channels and users).")
 @click.pass_context
 def slack_usergroups(ctx):
+    import reconcile.slack_usergroups
+
     run_integration(reconcile.slack_usergroups, ctx.obj)
 
 
@@ -803,12 +742,16 @@ def slack_usergroups(ctx):
 )
 @click.pass_context
 def slack_cluster_usergroups(ctx):
+    import reconcile.slack_cluster_usergroups
+
     run_integration(reconcile.slack_cluster_usergroups, ctx.obj)
 
 
 @integration.command(short_help="Manage integrations on GitLab projects.")
 @click.pass_context
 def gitlab_integrations(ctx):
+    import reconcile.gitlab_integrations
+
     run_integration(reconcile.gitlab_integrations, ctx.obj)
 
 
@@ -816,6 +759,8 @@ def gitlab_integrations(ctx):
 @threaded()
 @click.pass_context
 def gitlab_permissions(ctx, thread_pool_size):
+    import reconcile.gitlab_permissions
+
     run_integration(reconcile.gitlab_permissions, ctx.obj, thread_pool_size)
 
 
@@ -827,6 +772,8 @@ def gitlab_permissions(ctx, thread_pool_size):
 )
 @click.pass_context
 def gitlab_housekeeping(ctx, wait_for_pipeline):
+    import reconcile.gitlab_housekeeping
+
     run_integration(reconcile.gitlab_housekeeping, ctx.obj, wait_for_pipeline)
 
 
@@ -835,6 +782,8 @@ def gitlab_housekeeping(ctx, wait_for_pipeline):
 @click.argument("gitlab-project-id")
 @click.pass_context
 def gitlab_mr_sqs_consumer(ctx, gitlab_project_id):
+    import reconcile.gitlab_mr_sqs_consumer
+
     run_integration(reconcile.gitlab_mr_sqs_consumer, ctx.obj, gitlab_project_id)
 
 
@@ -842,6 +791,8 @@ def gitlab_mr_sqs_consumer(ctx, gitlab_project_id):
 @threaded()
 @click.pass_context
 def aws_garbage_collector(ctx, thread_pool_size):
+    import reconcile.aws_garbage_collector
+
     run_integration(reconcile.aws_garbage_collector, ctx.obj, thread_pool_size)
 
 
@@ -850,6 +801,8 @@ def aws_garbage_collector(ctx, thread_pool_size):
 @account_name
 @click.pass_context
 def aws_iam_keys(ctx, thread_pool_size, account_name):
+    import reconcile.aws_iam_keys
+
     run_integration(
         reconcile.aws_iam_keys, ctx.obj, thread_pool_size, account_name=account_name
     )
@@ -859,12 +812,16 @@ def aws_iam_keys(ctx, thread_pool_size, account_name):
 @environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def aws_iam_password_reset(ctx):
+    import reconcile.aws_iam_password_reset
+
     run_integration(reconcile.aws_iam_password_reset, ctx.obj)
 
 
 @integration.command(short_help="Share AMI and AMI tags between accounts.")
 @click.pass_context
 def aws_ami_share(ctx):
+    import reconcile.aws_ami_share
+
     run_integration(reconcile.aws_ami_share, ctx.obj)
 
 
@@ -874,6 +831,8 @@ def aws_ami_share(ctx):
 @vault_output_path
 @click.pass_context
 def aws_ecr_image_pull_secrets(ctx, vault_output_path):
+    import reconcile.aws_ecr_image_pull_secrets
+
     run_integration(reconcile.aws_ecr_image_pull_secrets, ctx.obj, vault_output_path)
 
 
@@ -886,6 +845,8 @@ def aws_ecr_image_pull_secrets(ctx, vault_output_path):
 @threaded()
 @click.pass_context
 def aws_support_cases_sos(ctx, gitlab_project_id, thread_pool_size):
+    import reconcile.aws_support_cases_sos
+
     run_integration(
         reconcile.aws_support_cases_sos, ctx.obj, gitlab_project_id, thread_pool_size
     )
@@ -903,6 +864,8 @@ def aws_support_cases_sos(ctx, gitlab_project_id, thread_pool_size):
 def openshift_resources(
     ctx, thread_pool_size, internal, use_jump_host, cluster_name, namespace_name
 ):
+    import reconcile.openshift_resources
+
     run_integration(
         reconcile.openshift_resources,
         ctx.obj,
@@ -935,6 +898,8 @@ def openshift_saas_deploy(
     env_name,
     gitlab_project_id,
 ):
+    import reconcile.openshift_saas_deploy
+
     run_integration(
         reconcile.openshift_saas_deploy,
         ctx.obj,
@@ -960,6 +925,8 @@ def openshift_saas_deploy(
 def openshift_saas_deploy_wrapper(
     ctx, thread_pool_size, io_dir, use_jump_host, gitlab_project_id
 ):
+    import reconcile.openshift_saas_deploy_wrapper
+
     run_integration(
         reconcile.openshift_saas_deploy_wrapper,
         ctx.obj,
@@ -973,6 +940,8 @@ def openshift_saas_deploy_wrapper(
 @integration.command(short_help="Validates Saas files.")
 @click.pass_context
 def saas_file_validator(ctx):
+    import reconcile.saas_file_validator
+
     run_integration(reconcile.saas_file_validator, ctx.obj)
 
 
@@ -988,6 +957,8 @@ def saas_file_validator(ctx):
 def openshift_saas_deploy_trigger_moving_commits(
     ctx, thread_pool_size, internal, use_jump_host, include_trigger_trace
 ):
+    import reconcile.openshift_saas_deploy_trigger_moving_commits
+
     run_integration(
         reconcile.openshift_saas_deploy_trigger_moving_commits,
         ctx.obj,
@@ -1010,6 +981,8 @@ def openshift_saas_deploy_trigger_moving_commits(
 def openshift_saas_deploy_trigger_upstream_jobs(
     ctx, thread_pool_size, internal, use_jump_host, include_trigger_trace
 ):
+    import reconcile.openshift_saas_deploy_trigger_upstream_jobs
+
     run_integration(
         reconcile.openshift_saas_deploy_trigger_upstream_jobs,
         ctx.obj,
@@ -1032,6 +1005,8 @@ def openshift_saas_deploy_trigger_upstream_jobs(
 def openshift_saas_deploy_trigger_configs(
     ctx, thread_pool_size, internal, use_jump_host, include_trigger_trace
 ):
+    import reconcile.openshift_saas_deploy_trigger_configs
+
     run_integration(
         reconcile.openshift_saas_deploy_trigger_configs,
         ctx.obj,
@@ -1052,6 +1027,8 @@ def openshift_saas_deploy_trigger_configs(
 def openshift_saas_deploy_trigger_cleaner(
     ctx, thread_pool_size, internal, use_jump_host
 ):
+    import reconcile.openshift_saas_deploy_trigger_cleaner
+
     run_integration(
         reconcile.openshift_saas_deploy_trigger_cleaner,
         ctx.obj,
@@ -1072,6 +1049,8 @@ def openshift_saas_deploy_trigger_cleaner(
 def openshift_tekton_resources(
     ctx, thread_pool_size, internal, use_jump_host, saas_file_name
 ):
+    import reconcile.openshift_tekton_resources
+
     run_integration(
         reconcile.openshift_tekton_resources,
         ctx.obj,
@@ -1096,6 +1075,8 @@ def openshift_tekton_resources(
 )
 @click.pass_context
 def saas_file_owners(ctx, gitlab_project_id, gitlab_merge_request_id, io_dir, compare):
+    import reconcile.saas_file_owners
+
     run_integration(
         reconcile.saas_file_owners,
         ctx.obj,
@@ -1111,6 +1092,8 @@ def saas_file_owners(ctx, gitlab_project_id, gitlab_merge_request_id, io_dir, co
 @click.argument("gitlab-merge-request-id")
 @click.pass_context
 def gitlab_ci_skipper(ctx, gitlab_project_id, gitlab_merge_request_id):
+    import reconcile.gitlab_ci_skipper
+
     run_integration(
         reconcile.gitlab_ci_skipper, ctx.obj, gitlab_project_id, gitlab_merge_request_id
     )
@@ -1124,6 +1107,8 @@ def gitlab_ci_skipper(ctx, gitlab_project_id, gitlab_merge_request_id):
 @click.argument("gitlab-merge-request-id")
 @click.pass_context
 def gitlab_labeler(ctx, gitlab_project_id, gitlab_merge_request_id):
+    import reconcile.gitlab_labeler
+
     run_integration(
         reconcile.gitlab_labeler, ctx.obj, gitlab_project_id, gitlab_merge_request_id
     )
@@ -1138,6 +1123,8 @@ def gitlab_labeler(ctx, gitlab_project_id, gitlab_merge_request_id):
 @use_jump_host()
 @click.pass_context
 def openshift_namespace_labels(ctx, thread_pool_size, internal, use_jump_host):
+    import reconcile.openshift_namespace_labels
+
     run_integration(
         reconcile.openshift_namespace_labels,
         ctx.obj,
@@ -1155,6 +1142,8 @@ def openshift_namespace_labels(ctx, thread_pool_size, internal, use_jump_host):
 @use_jump_host()
 @click.pass_context
 def openshift_namespaces(ctx, thread_pool_size, internal, use_jump_host):
+    import reconcile.openshift_namespaces
+
     run_integration(
         reconcile.openshift_namespaces,
         ctx.obj,
@@ -1172,6 +1161,8 @@ def openshift_namespaces(ctx, thread_pool_size, internal, use_jump_host):
 @use_jump_host()
 @click.pass_context
 def openshift_network_policies(ctx, thread_pool_size, internal, use_jump_host):
+    import reconcile.openshift_network_policies
+
     run_integration(
         reconcile.openshift_network_policies,
         ctx.obj,
@@ -1190,6 +1181,8 @@ def openshift_network_policies(ctx, thread_pool_size, internal, use_jump_host):
 @use_jump_host()
 @click.pass_context
 def openshift_limitranges(ctx, thread_pool_size, internal, use_jump_host, take_over):
+    import reconcile.openshift_limitranges
+
     run_integration(
         reconcile.openshift_limitranges,
         ctx.obj,
@@ -1209,6 +1202,8 @@ def openshift_limitranges(ctx, thread_pool_size, internal, use_jump_host, take_o
 @use_jump_host()
 @click.pass_context
 def openshift_resourcequotas(ctx, thread_pool_size, internal, use_jump_host, take_over):
+    import reconcile.openshift_resourcequotas
+
     run_integration(
         reconcile.openshift_resourcequotas,
         ctx.obj,
@@ -1231,6 +1226,8 @@ def openshift_resourcequotas(ctx, thread_pool_size, internal, use_jump_host, tak
 def openshift_vault_secrets(
     ctx, thread_pool_size, internal, use_jump_host, cluster_name, namespace_name
 ):
+    import reconcile.openshift_vault_secrets
+
     run_integration(
         reconcile.openshift_vault_secrets,
         ctx.obj,
@@ -1254,6 +1251,8 @@ def openshift_vault_secrets(
 def openshift_routes(
     ctx, thread_pool_size, internal, use_jump_host, cluster_name, namespace_name
 ):
+    import reconcile.openshift_routes
+
     run_integration(
         reconcile.openshift_routes,
         ctx.obj,
@@ -1268,6 +1267,8 @@ def openshift_routes(
 @integration.command(short_help="Configures the teams and members in Quay.")
 @click.pass_context
 def quay_membership(ctx):
+    import reconcile.quay_membership
+
     run_integration(reconcile.quay_membership, ctx.obj)
 
 
@@ -1277,6 +1278,8 @@ def quay_membership(ctx):
 @click.pass_context
 @binary(["skopeo"])
 def gcr_mirror(ctx):
+    import reconcile.gcr_mirror
+
     run_integration(reconcile.gcr_mirror, ctx.obj)
 
 
@@ -1284,6 +1287,8 @@ def gcr_mirror(ctx):
 @click.pass_context
 @binary(["skopeo"])
 def quay_mirror(ctx):
+    import reconcile.quay_mirror
+
     run_integration(reconcile.quay_mirror, ctx.obj)
 
 
@@ -1291,18 +1296,24 @@ def quay_mirror(ctx):
 @click.pass_context
 @binary(["skopeo"])
 def quay_mirror_org(ctx):
+    import reconcile.quay_mirror_org
+
     run_integration(reconcile.quay_mirror_org, ctx.obj)
 
 
 @integration.command(short_help="Creates and Manages Quay Repos.")
 @click.pass_context
 def quay_repos(ctx):
+    import reconcile.quay_repos
+
     run_integration(reconcile.quay_repos, ctx.obj)
 
 
 @integration.command(short_help="Manage permissions for Quay Repositories.")
 @click.pass_context
 def quay_permissions(ctx):
+    import reconcile.quay_permissions
+
     run_integration(reconcile.quay_permissions, ctx.obj)
 
 
@@ -1310,6 +1321,8 @@ def quay_permissions(ctx):
 @click.argument("gitlab-project-id")
 @click.pass_context
 def ldap_users(ctx, gitlab_project_id):
+    import reconcile.ldap_users
+
     run_integration(reconcile.ldap_users, ctx.obj, gitlab_project_id)
 
 
@@ -1341,6 +1354,8 @@ def terraform_resources(
     vault_output_path,
     account_name,
 ):
+    import reconcile.terraform_resources
+
     if print_to_file and is_file_in_git_repo(print_to_file):
         raise PrintToFileInGitRepositoryError(print_to_file)
     run_integration(
@@ -1374,6 +1389,8 @@ def terraform_users(
     send_mails,
     account_name,
 ):
+    import reconcile.terraform_users
+
     if print_to_file and is_file_in_git_repo(print_to_file):
         raise PrintToFileInGitRepositoryError(print_to_file)
     run_integration(
@@ -1398,6 +1415,8 @@ def terraform_users(
 def terraform_vpc_peerings(
     ctx, print_to_file, enable_deletion, thread_pool_size, account_name
 ):
+    import reconcile.terraform_vpc_peerings
+
     if print_to_file and is_file_in_git_repo(print_to_file):
         raise PrintToFileInGitRepositoryError(print_to_file)
     run_integration(
@@ -1415,6 +1434,8 @@ def terraform_vpc_peerings(
 )
 @click.pass_context
 def vpc_peerings_validator(ctx):
+    import reconcile.vpc_peerings_validator
+
     run_integration(
         reconcile.vpc_peerings_validator,
         ctx.obj,
@@ -1429,6 +1450,8 @@ def vpc_peerings_validator(ctx):
 @enable_deletion(default=False)
 @click.pass_context
 def terraform_tgw_attachments(ctx, print_to_file, enable_deletion, thread_pool_size):
+    import reconcile.terraform_tgw_attachments
+
     if print_to_file and is_file_in_git_repo(print_to_file):
         raise PrintToFileInGitRepositoryError(print_to_file)
     run_integration(
@@ -1445,6 +1468,8 @@ def terraform_tgw_attachments(ctx, print_to_file, enable_deletion, thread_pool_s
 )
 @click.pass_context
 def github_repo_invites(ctx):
+    import reconcile.github_repo_invites
+
     run_integration(reconcile.github_repo_invites, ctx.obj)
 
 
@@ -1452,18 +1477,24 @@ def github_repo_invites(ctx):
 @click.argument("instance-name")
 @click.pass_context
 def github_repo_permissions_validator(ctx, instance_name):
+    import reconcile.github_repo_permissions_validator
+
     run_integration(reconcile.github_repo_permissions_validator, ctx.obj, instance_name)
 
 
 @integration.command(short_help="Manage GitLab group members.")
 @click.pass_context
 def gitlab_members(ctx):
+    import reconcile.gitlab_members
+
     run_integration(reconcile.gitlab_members, ctx.obj)
 
 
 @integration.command(short_help="Create GitLab projects.")
 @click.pass_context
 def gitlab_projects(ctx):
+    import reconcile.gitlab_projects
+
     run_integration(reconcile.gitlab_projects, ctx.obj)
 
 
@@ -1471,6 +1502,8 @@ def gitlab_projects(ctx):
 @threaded()
 @click.pass_context
 def ocm_groups(ctx, thread_pool_size):
+    import reconcile.ocm_groups
+
     run_integration(reconcile.ocm_groups, ctx.obj, thread_pool_size)
 
 
@@ -1480,6 +1513,8 @@ def ocm_groups(ctx, thread_pool_size):
 @threaded()
 @click.pass_context
 def ocm_clusters(ctx, gitlab_project_id, thread_pool_size):
+    import reconcile.ocm_clusters
+
     run_integration(
         reconcile.ocm_clusters, ctx.obj, gitlab_project_id, thread_pool_size
     )
@@ -1489,6 +1524,8 @@ def ocm_clusters(ctx, gitlab_project_id, thread_pool_size):
 @threaded()
 @click.pass_context
 def ocm_external_configuration_labels(ctx, thread_pool_size):
+    import reconcile.ocm_external_configuration_labels
+
     run_integration(
         reconcile.ocm_external_configuration_labels, ctx.obj, thread_pool_size
     )
@@ -1498,6 +1535,8 @@ def ocm_external_configuration_labels(ctx, thread_pool_size):
 @threaded()
 @click.pass_context
 def ocm_machine_pools(ctx, thread_pool_size):
+    import reconcile.ocm_machine_pools
+
     run_integration(reconcile.ocm_machine_pools, ctx.obj, thread_pool_size)
 
 
@@ -1505,6 +1544,8 @@ def ocm_machine_pools(ctx, thread_pool_size):
 @environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def ocm_upgrade_scheduler(ctx):
+    import reconcile.ocm_upgrade_scheduler
+
     run_integration(reconcile.ocm_upgrade_scheduler, ctx.obj)
 
 
@@ -1512,6 +1553,8 @@ def ocm_upgrade_scheduler(ctx):
 @threaded()
 @click.pass_context
 def ocm_addons(ctx, thread_pool_size):
+    import reconcile.ocm_addons
+
     run_integration(reconcile.ocm_addons, ctx.obj, thread_pool_size)
 
 
@@ -1520,6 +1563,8 @@ def ocm_addons(ctx, thread_pool_size):
 )
 @click.pass_context
 def ocm_aws_infrastructure_access(ctx):
+    import reconcile.ocm_aws_infrastructure_access
+
     run_integration(reconcile.ocm_aws_infrastructure_access, ctx.obj)
 
 
@@ -1527,12 +1572,16 @@ def ocm_aws_infrastructure_access(ctx):
 @vault_input_path
 @click.pass_context
 def ocm_github_idp(ctx, vault_input_path):
+    import reconcile.ocm_github_idp
+
     run_integration(reconcile.ocm_github_idp, ctx.obj, vault_input_path)
 
 
 @integration.command(short_help="Manage additional routers in OCM.")
 @click.pass_context
 def ocm_additional_routers(ctx):
+    import reconcile.ocm_additional_routers
+
     run_integration(reconcile.ocm_additional_routers, ctx.obj)
 
 
@@ -1540,6 +1589,8 @@ def ocm_additional_routers(ctx):
 @environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def email_sender(ctx):
+    import reconcile.email_sender
+
     run_integration(reconcile.email_sender, ctx.obj)
 
 
@@ -1547,6 +1598,8 @@ def email_sender(ctx):
 @environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def sentry_helper(ctx):
+    import reconcile.sentry_helper
+
     run_integration(reconcile.sentry_helper, ctx.obj)
 
 
@@ -1556,18 +1609,24 @@ def sentry_helper(ctx):
 @environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def requests_sender(ctx):
+    import reconcile.requests_sender
+
     run_integration(reconcile.requests_sender, ctx.obj)
 
 
 @integration.command(short_help="Validate dependencies are defined for each service.")
 @click.pass_context
 def service_dependencies(ctx):
+    import reconcile.service_dependencies
+
     run_integration(reconcile.service_dependencies, ctx.obj)
 
 
 @integration.command(short_help="Configure and enforce sentry instance configuration.")
 @click.pass_context
 def sentry_config(ctx):
+    import reconcile.sentry_config
+
     run_integration(reconcile.sentry_config, ctx.obj)
 
 
@@ -1576,6 +1635,8 @@ def sentry_config(ctx):
 @enable_deletion(default=False)
 @click.pass_context
 def sql_query(ctx, enable_deletion):
+    import reconcile.sql_query
+
     run_integration(reconcile.sql_query, ctx.obj, enable_deletion)
 
 
@@ -1586,6 +1647,8 @@ def sql_query(ctx, enable_deletion):
 @threaded()
 @click.pass_context
 def gitlab_owners(ctx, thread_pool_size):
+    import reconcile.gitlab_owners
+
     run_integration(reconcile.gitlab_owners, ctx.obj, thread_pool_size)
 
 
@@ -1597,6 +1660,8 @@ def gitlab_owners(ctx, thread_pool_size):
 def gitlab_fork_compliance(
     ctx, gitlab_project_id, gitlab_merge_request_id, gitlab_maintainers_group
 ):
+    import reconcile.gitlab_fork_compliance
+
     run_integration(
         reconcile.gitlab_fork_compliance,
         ctx.obj,
@@ -1613,6 +1678,8 @@ def gitlab_fork_compliance(
 @threaded(default=2)
 @click.pass_context
 def dashdotdb_cso(ctx, thread_pool_size):
+    import reconcile.dashdotdb_cso
+
     run_integration(reconcile.dashdotdb_cso, ctx.obj, thread_pool_size)
 
 
@@ -1624,6 +1691,8 @@ def dashdotdb_cso(ctx, thread_pool_size):
 @click.pass_context
 @cluster_name
 def dashdotdb_dvo(ctx, thread_pool_size, cluster_name):
+    import reconcile.dashdotdb_dvo
+
     run_integration(reconcile.dashdotdb_dvo, ctx.obj, thread_pool_size, cluster_name)
 
 
@@ -1634,12 +1703,16 @@ def dashdotdb_dvo(ctx, thread_pool_size, cluster_name):
 @threaded(default=2)
 @click.pass_context
 def dashdotdb_slo(ctx, thread_pool_size):
+    import reconcile.dashdotdb_slo
+
     run_integration(reconcile.dashdotdb_slo, ctx.obj, thread_pool_size)
 
 
 @integration.command(short_help="Mirrors OCP release images.")
 @click.pass_context
 def ocp_release_mirror(ctx):
+    import reconcile.ocp_release_mirror
+
     run_integration(reconcile.ocp_release_mirror, ctx.obj)
 
 
@@ -1649,6 +1722,8 @@ def ocp_release_mirror(ctx):
 @gitlab_project_id
 @click.pass_context
 def osd_mirrors_data_updater(ctx, gitlab_project_id):
+    import reconcile.osd_mirrors_data_updater
+
     run_integration(reconcile.osd_mirrors_data_updater, ctx.obj, gitlab_project_id)
 
 
@@ -1656,6 +1731,8 @@ def osd_mirrors_data_updater(ctx, gitlab_project_id):
 @threaded()
 @click.pass_context
 def ecr_mirror(ctx, thread_pool_size):
+    import reconcile.ecr_mirror
+
     run_integration(reconcile.ecr_mirror, ctx.obj, thread_pool_size)
 
 
@@ -1670,6 +1747,8 @@ def ecr_mirror(ctx, thread_pool_size):
 def kafka_clusters(
     ctx, thread_pool_size, internal, use_jump_host, vault_throughput_path
 ):
+    import reconcile.kafka_clusters
+
     run_integration(
         reconcile.kafka_clusters,
         ctx.obj,
@@ -1685,6 +1764,8 @@ def kafka_clusters(
 )
 @click.pass_context
 def integrations_validator(ctx):
+    import reconcile.integrations_validator
+
     run_integration(
         reconcile.integrations_validator,
         ctx.obj,
@@ -1698,6 +1779,8 @@ def integrations_validator(ctx):
 @cluster_name
 @click.pass_context
 def prometheus_rules_tester(ctx, thread_pool_size, cluster_name):
+    import reconcile.prometheus_rules_tester
+
     run_integration(
         reconcile.prometheus_rules_tester, ctx.obj, thread_pool_size, cluster_name
     )
@@ -1706,6 +1789,8 @@ def prometheus_rules_tester(ctx, thread_pool_size, cluster_name):
 @integration.command(short_help="Tests templating of resources.")
 @click.pass_context
 def template_tester(ctx):
+    import reconcile.template_tester
+
     run_integration(reconcile.template_tester, ctx.obj)
 
 
@@ -1714,12 +1799,16 @@ def template_tester(ctx):
 )
 @click.pass_context
 def query_validator(ctx):
+    import reconcile.query_validator
+
     run_integration(reconcile.query_validator, ctx.obj)
 
 
 @integration.command(short_help="Manages SendGrid teammates for a given account.")
 @click.pass_context
 def sendgrid_teammates(ctx):
+    import reconcile.sendgrid_teammates
+
     run_integration(reconcile.sendgrid_teammates, ctx.obj)
 
 
@@ -1727,6 +1816,8 @@ def sendgrid_teammates(ctx):
 @vault_output_path
 @click.pass_context
 def cluster_deployment_mapper(ctx, vault_output_path):
+    import reconcile.cluster_deployment_mapper
+
     run_integration(reconcile.cluster_deployment_mapper, ctx.obj, vault_output_path)
 
 
@@ -1736,6 +1827,8 @@ def cluster_deployment_mapper(ctx, vault_output_path):
 @vault_output_path
 @click.pass_context
 def resource_scraper(ctx, namespace_name, resource_kind, vault_output_path):
+    import reconcile.resource_scraper
+
     run_integration(
         reconcile.resource_scraper,
         ctx.obj,
@@ -1753,6 +1846,8 @@ def resource_scraper(ctx, namespace_name, resource_kind, vault_output_path):
 @use_jump_host()
 @click.pass_context
 def gabi_authorized_users(ctx, thread_pool_size, internal, use_jump_host):
+    import reconcile.gabi_authorized_users
+
     run_integration(
         reconcile.gabi_authorized_users,
         ctx.obj,
@@ -1766,6 +1861,8 @@ def gabi_authorized_users(ctx, thread_pool_size, internal, use_jump_host):
 @enable_deletion(default=False)
 @click.pass_context
 def dyn_traffic_director(ctx, enable_deletion):
+    import reconcile.dyn_traffic_director
+
     run_integration(reconcile.dyn_traffic_director, ctx.obj, enable_deletion)
 
 
@@ -1774,6 +1871,8 @@ def dyn_traffic_director(ctx, enable_deletion):
 )
 @click.pass_context
 def status_page_components(ctx):
+    import reconcile.status_page_components
+
     run_integration(reconcile.status_page_components, ctx.obj)
 
 
@@ -1787,6 +1886,8 @@ def status_page_components(ctx):
 def blackbox_exporter_endpoint_monitoring(
     ctx, thread_pool_size, internal, use_jump_host
 ):
+    import reconcile.blackbox_exporter_endpoint_monitoring
+
     run_integration(
         reconcile.blackbox_exporter_endpoint_monitoring,
         ctx.obj,
@@ -1806,6 +1907,8 @@ def blackbox_exporter_endpoint_monitoring(
 def signalfx_prometheus_endpoint_monitoring(
     ctx, thread_pool_size, internal, use_jump_host
 ):
+    import reconcile.signalfx_endpoint_monitoring
+
     run_integration(
         reconcile.signalfx_endpoint_monitoring,
         ctx.obj,
@@ -1853,6 +1956,8 @@ def integrations_manager(
     use_jump_host,
     image_tag_from_ref,
 ):
+    import reconcile.integrations_manager
+
     run_integration(
         reconcile.integrations_manager,
         ctx.obj,


### PR DESCRIPTION
Every import in cli.py has to complete before any integration begins
running. This is because import statements are executed when the cli
module is imported, which happens as a result of console_scripts in
setup.py. Currently, memory usage can reach ~120MB before an integration
ever starts running. This change scopes the imports inside the integration
command functions so that the import only happens when the function
is executed (we only expect to execute a single integration function per
container).

There are probably more elegant ways to fix this issue, but for now
this should work and saves us 50MB or more of imports for many
integrations that don't require the importing of the majority of
qontract-reconcile modules.

## Testing

### Memory usage

Here are some rough estimates of how much memory usage we'll save from some of the tested integrations:

| Integration        | Memory           |
| ------------- |:-------------:|
| quay-membership      | >70MB |
| gitlab-housekeeping      | >50MB      | 
| slack-usergroups      | >50MB      | 
| terraform-resources | <10MB      |
| openshift-* | <10MB      |

For some integrations like quay-membership or gitlab-housekeeping, this is essentially cutting the memory in half. Some of the more memory hungry integrations, like terraform and openshift integrations, do not benefit a lot from this change. It seems that we have some memory hungry imports, in particular imports from `kubernetes.client` alone can account for 40+ MB.

The memory usage will only get worse as new integrations are added, so even if we only get modest decreases in usage for some of the memory hungry integrations, this will at least avoid piling on to the problem.

### Running integrations

All of the integrations above where run in dry-run mode to ensure there wasn't any change in behavior.