### PR TITLE
[jjb] config_path loading via resource resolver

### DIFF
--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -28,7 +28,9 @@ QUERY = """
     }
     type
     config
-    config_path
+    config_path {
+      content
+    }
   }
 }
 """

--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -20,11 +20,9 @@ from jenkins_jobs.registry import ModuleRegistry
 from jenkins_jobs.errors import JenkinsJobsException
 from sretoolbox.utils import retry
 
-from reconcile.utils import gql
 from reconcile.utils import throughput
 from reconcile.utils.helpers import toggle_logger
 
-from reconcile.utils.exceptions import FetchResourceError
 
 JJB_INI = "[jenkins]\nurl = https://JENKINS_URL"
 
@@ -40,7 +38,6 @@ class JJB:  # pylint: disable=too-many-public-methods
         self.python_https_verify = str(int(ssl_verify))
 
     def collect_configs(self, configs):
-        gqlapi = gql.get_api()
         instances = {
             c["instance"]["name"]: {
                 "serverUrl": c["instance"]["serverUrl"],
@@ -79,13 +76,7 @@ class JJB:  # pylint: disable=too-many-public-methods
                     yaml.dump(yaml.load(config, Loader=yaml.FullLoader), f)
                     f.write("\n")
             else:
-                config_path = c["config_path"]
-                # get config data
-                try:
-                    config_resource = gqlapi.get_resource(config_path)
-                    config = config_resource["content"]
-                except gql.GqlGetResourceError as e:
-                    raise FetchResourceError(str(e))
+                config = c["config_path"]["content"]
                 with open(config_file_path, "a") as f:
                     f.write(config)
                     f.write("\n")


### PR DESCRIPTION
the jenkins job builder integration loads config_path resources one by one which results in slower reconciliation runs.
to improve that, we use the resource reference resolver feature from qontract-server introduced with https://github.com/app-sre/qontract-server/pull/147

while the impact on integration speed is not that hight for jenkins job builder, the resource resolution capability can be easily showcased on this integration so others like terraform-resources have a working example

part of https://issues.redhat.com/browse/APPSRE-6003
depends on schema change https://github.com/app-sre/qontract-schemas/pull/190

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>