### PR TITLE
Support updates to a Deployment's label selector.

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -10,7 +10,12 @@ from sretoolbox.utils import retry
 from sretoolbox.utils import threaded
 
 from reconcile import queries
-from reconcile.utils.oc import FieldIsImmutableError, OCClient, OCLogMsg
+from reconcile.utils.oc import (
+    DeploymentFieldIsImmutableError,
+    FieldIsImmutableError,
+    OCClient,
+    OCLogMsg,
+)
 from reconcile.utils.oc import MayNotChangeOnceSetError
 from reconcile.utils.oc import PrimaryClusterIPCanNotBeUnsetError
 from reconcile.utils.oc import InvalidValueApplyError
@@ -345,47 +350,59 @@ def apply(
         except FieldIsImmutableError:
             # Add more resources types to the list when you're
             # sure they're safe.
-            if resource_type not in ["Route", "Service", "Secret", "Deployment"]:
+            if resource_type not in ["Route", "Service", "Secret"]:
+                raise
+            oc.delete(namespace=namespace, kind=resource_type, name=resource.name)
+            oc.apply(namespace=namespace, resource=annotated)
+        except DeploymentFieldIsImmutableError:
+            logging.info(["replace", cluster, namespace, resource_type, resource.name])
+            # spec.selector changes
+            current_resource = oc.get(namespace, resource_type, resource.name)
+
+            # check update strategy
+            if current_resource["spec"]["strategy"]["type"] != "RollingUpdate":
+                logging.error(
+                    f"Can't replace Deployment '{resource.name}' inplace w/o"
+                    "interruption because spec.strategy.type != 'RollingUpdate'"
+                )
                 raise
 
-            if resource_type == "Deployment":
-                logging.info(
-                    ["replace", cluster, namespace, resource_type, resource.name]
+            # Get active ReplicSet for old Deployment. We've to take care of it
+            # after the new Deployment is in place.
+            obsolete_rs = oc.get_replicaset(
+                namespace, current_resource, allow_empty=True
+            )
+
+            # delete old Deployment
+            oc.delete(
+                namespace=namespace,
+                kind=resource_type,
+                name=resource.name,
+                cascade=False,
+            )
+            # create new one
+            oc.apply(namespace=namespace, resource=annotated)
+            if obsolete_rs:
+                # refresh resources
+                deployment = oc.get(namespace, resource_type, resource.name)
+                new_rs = oc.get_replicaset(namespace, deployment)
+                obsolete_rs = oc.get(
+                    namespace, obsolete_rs["kind"], obsolete_rs["metadata"]["name"]
                 )
-                # spec.selector changes
-                current_resource = oc.get(namespace, resource_type, resource.name)
 
-                # check update strategy
-                if current_resource["spec"]["strategy"]["type"] != "RollingUpdate":
-                    logging.error(
-                        f"Can't replace Deployment '{resource.name}' inplace w/o interruption because spec.strategy.type != 'RollingUpdate'"
-                    )
-                    raise
-
-                # Get active ReplicSet for old Deployment. We've to delete it manually after
-                # the new Deployment is in place.
-                obsolete_rs = oc.get_replicaset(namespace, current_resource)
-
-                # delete old Deployment
-                oc.delete(
-                    namespace=namespace,
-                    kind=resource_type,
-                    name=resource.name,
-                    cascade=False,
-                )
-                # create new one
-                oc.apply(namespace=namespace, resource=annotated)
-                if obsolete_rs:
-                    oc.wait_for_deployment(namespace, resource.name)
-                    # delete old ReplicSet
-                    oc.delete(
-                        namespace=namespace,
-                        kind=obsolete_rs["kind"],
-                        name=obsolete_rs["metadata"]["name"],
-                    )
-            else:
-                oc.delete(namespace=namespace, kind=resource_type, name=resource.name)
-                oc.apply(namespace=namespace, resource=annotated)
+                # adopting old ReplicaSet to new Deployment
+                # labels must match spec.selector.matchLabels of the new Deployment
+                labels = deployment["spec"]["selector"]["matchLabels"]
+                labels["pod-template-hash"] = obsolete_rs["metadata"]["labels"][
+                    "pod-template-hash"
+                ]
+                obsolete_rs["metadata"]["labels"] = labels
+                # restore and set ownerReferences of old ReplicaSet
+                owner_references = new_rs["metadata"]["ownerReferences"]
+                # not allowed to set 'blockOwnerDeletion'
+                del owner_references[0]["blockOwnerDeletion"]
+                obsolete_rs["metadata"]["ownerReferences"] = owner_references
+                oc.apply(namespace=namespace, resource=OR(obsolete_rs, "", ""))
         except (MayNotChangeOnceSetError, PrimaryClusterIPCanNotBeUnsetError):
             if resource_type not in ["Service"]:
                 raise

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 import pytest
 import reconcile.utils.oc
-import sretoolbox.utils
 from reconcile.utils.oc import (
     LABEL_MAX_KEY_NAME_LENGTH,
     LABEL_MAX_KEY_PREFIX_LENGTH,

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -4,22 +4,26 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import pytest
-
 import reconcile.utils.oc
+import sretoolbox.utils
 from reconcile.utils.oc import (
     LABEL_MAX_KEY_NAME_LENGTH,
     LABEL_MAX_KEY_PREFIX_LENGTH,
     LABEL_MAX_VALUE_LENGTH,
     OC,
+    WAIT_FOR_DEPLOYMENT_MAX_ATTEMPTS,
+    DeploymentNotReadyError,
+    OC_Map,
     OCDeprecated,
+    OCLogMsg,
+    OCNative,
     PodNotReadyError,
     StatusCodeError,
+    equal_spec_template,
     validate_labels,
-    OC_Map,
-    OCLogMsg,
 )
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
-from reconcile.utils.secret_reader import SecretReader, SecretNotFound
+from reconcile.utils.secret_reader import SecretNotFound, SecretReader
 
 
 @patch.dict(os.environ, {"USE_NATIVE_CLIENT": "False"}, clear=True)
@@ -516,8 +520,8 @@ class TestOCMapGetClusters(TestCase):
 
 
 @pytest.fixture
-def oc():
-    os.environ["USE_NATIVE_CLIENT"] = "False"
+def oc(monkeypatch):
+    monkeypatch.setenv("USE_NATIVE_CLIENT", "False")
     return OC("cluster", "server", "token", local=True)
 
 
@@ -618,3 +622,275 @@ def test_oc_map_exception_on_missing_cluster():
 
     assert ctx.value.message == "[test-1] has no serverUrl"
     assert ctx.value.log_level == logging.ERROR
+
+
+@pytest.mark.parametrize(
+    "t1, t2, expected",
+    [
+        # trivial examples
+        ({"a": "b"}, {"a": "b"}, True),
+        ({"a": "b", "c": "d"}, {"c": "d", "a": "b"}, True),
+        ({"a": "b", "c": "d"}, {"a": "b"}, False),
+        # w/o pod-template-hash
+        (
+            # t1
+            {
+                "metadata": {},
+                "spec": {"containers": [{"command": ["foobar"], "image": "lalala"}]},
+            },
+            # t2
+            {
+                "metadata": {},
+                "spec": {"containers": [{"command": ["foobar"], "image": "lalala"}]},
+            },
+            # expected
+            True,
+        ),
+        (
+            # t1
+            {
+                "metadata": {},
+                "spec": {"containers": [{"command": ["foobar"], "image": "lalala"}]},
+            },
+            # t2
+            {
+                "metadata": {},
+                "spec": {
+                    "containers": [{"command": ["something else"], "image": "lalala"}]
+                },
+            },
+            # expected
+            False,
+        ),
+        # with pod-template-hash
+        (
+            # t1
+            {
+                "metadata": {
+                    "labels": {"a": "b", "pod-template-hash": "lala"},
+                },
+                "spec": {"containers": [{"command": ["foobar"], "image": "lalala"}]},
+            },
+            # t2
+            {
+                "metadata": {"labels": {"a": "b"}},
+                "spec": {"containers": [{"command": ["foobar"], "image": "lalala"}]},
+            },
+            # expected
+            True,
+        ),
+    ],
+)
+def test_equal_spec_template(t1, t2, expected):
+    assert equal_spec_template(t1, t2) == expected
+
+
+@pytest.fixture()
+def deployment():
+    return {
+        "apiVersion": "apps/v1",
+        "kind": "Deployment",
+        "metadata": {
+            "annotations": {"qontract.update": "2022-07-12T09:15:14"},
+            "creationTimestamp": "2022-07-12T07:36:50Z",
+            "generation": 5,
+            "name": "busybox",
+        },
+        "spec": {
+            "replicas": 2,
+            "selector": {"matchLabels": {"deployment": "busybox"}},
+            "strategy": {
+                "rollingUpdate": {"maxSurge": "25%", "maxUnavailable": "25%"},
+                "type": "RollingUpdate",
+            },
+            "template": {
+                "metadata": {"labels": {"deployment": "busybox"}},
+                "spec": {
+                    "containers": [
+                        {
+                            "command": ["/bin/sleep", "1000000"],
+                            "image": "busybox",
+                            "name": "busybox",
+                        }
+                    ]
+                },
+            },
+        },
+    }
+
+
+@pytest.fixture()
+def replicasets(deployment):
+    return [
+        # last active
+        {
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "metadata": {
+                "name": "busybox-current",
+                "creationTimestamp": "2022-07-12T09:37:12Z",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": True,
+                        "controller": True,
+                        "kind": "Deployment",
+                        "name": "busybox",
+                        "uid": "dab46569-9a6a-43d1-ab6d-53aa410fb737",
+                    }
+                ],
+            },
+            "spec": {
+                "replicas": 2,
+                "selector": {
+                    "matchLabels": {
+                        "deployment": "busybox",
+                        "pod-template-hash": "hashhashhash",
+                    }
+                },
+                "template": deployment["spec"]["template"],
+            },
+        },
+        # older rs
+        {
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "metadata": {
+                "name": "busybox-old-one",
+                "creationTimestamp": "2022-07-12T09:35:12Z",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": True,
+                        "controller": True,
+                        "kind": "Deployment",
+                        "name": "busybox",
+                        "uid": "dab46569-9a6a-43d1-ab6d-53aa410fb737",
+                    }
+                ],
+            },
+            "spec": {
+                "replicas": 2,
+                "selector": {
+                    "matchLabels": {
+                        "deployment": "busybox",
+                        "pod-template-hash": "hashhashhash",
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "deployment": "busybox",
+                            "pod-template-hash": "hashhashhash",
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "command": ["something different"],
+                                "image": "busybox",
+                                "name": "busybox",
+                            }
+                        ],
+                    },
+                },
+            },
+        },
+        # another RS
+        {
+            "apiVersion": "apps/v1",
+            "kind": "ReplicaSet",
+            "metadata": {
+                "name": "busybox-older-one",
+                "creationTimestamp": "2022-07-12T09:35:12Z",
+                "ownerReferences": [
+                    {
+                        "apiVersion": "apps/v1",
+                        "blockOwnerDeletion": True,
+                        "controller": True,
+                        "kind": "Deployment",
+                        "name": "busybox",
+                        "uid": "dab46569-9a6a-43d1-ab6d-53aa410fb737",
+                    }
+                ],
+            },
+            "spec": {
+                "replicas": 2,
+                "selector": {
+                    "matchLabels": {
+                        "deployment": "busybox",
+                        "pod-template-hash": "hashhashhash",
+                    }
+                },
+                "template": {
+                    "metadata": {
+                        "labels": {
+                            "deployment": "busybox",
+                            "pod-template-hash": "hashhashhash",
+                        }
+                    },
+                    "spec": {
+                        "containers": [
+                            {
+                                "command": ["something different whatever"],
+                                "image": "busybox",
+                                "name": "busybox",
+                            }
+                        ],
+                    },
+                },
+            },
+        },
+    ]
+
+
+def test_get_owned_replicasets(mocker, oc: OCNative, deployment):
+    oc__get = mocker.patch.object(oc, "get", autospec=True)
+    oc__get_obj_root_owner = mocker.patch.object(
+        oc, "get_obj_root_owner", autospec=True
+    )
+    oc__get.return_value = {"items": ["stub1", "stub2", "stub3"]}
+    oc__get_obj_root_owner.side_effect = [
+        deployment,
+        deployment,
+        {"kind": "ownerkind", "metadata": {"name": "notownername"}},
+    ]
+    owned_replicasets = oc.get_owned_replicasets("namespace", deployment)
+    assert len(owned_replicasets) == 2
+
+
+def test_get_replicaset(mocker, oc: OCNative, deployment, replicasets):
+    oc__get_owned_replicasets = mocker.patch.object(
+        oc, "get_owned_replicasets", autospec=True
+    )
+    oc__get_owned_replicasets.return_value = replicasets
+
+    assert (
+        oc.get_replicaset("namespace", deployment)["metadata"]["name"]
+        == "busybox-current"
+    )
+
+
+def test_wait_for_deployment_fail(patch_sleep, mocker, oc: OCNative):
+    oc__get = mocker.patch.object(oc, "get", autospec=True)
+    oc__get.return_value = {
+        "status": {"conditions": [{"type": "Available", "status": "False"}]}
+    }
+    with pytest.raises(DeploymentNotReadyError):
+        oc.wait_for_deployment("namespace", "deployment_name")
+    assert oc__get.call_count == WAIT_FOR_DEPLOYMENT_MAX_ATTEMPTS
+
+    oc__get = mocker.patch.object(oc, "get", autospec=True)
+    oc__get.return_value = {}
+    with pytest.raises(DeploymentNotReadyError):
+        oc.wait_for_deployment("namespace", "deployment_name")
+    assert oc__get.call_count == WAIT_FOR_DEPLOYMENT_MAX_ATTEMPTS
+
+
+def test_wait_for_deployment(patch_sleep, mocker, oc: OCNative):
+    oc__get = mocker.patch.object(oc, "get", autospec=True)
+    oc__get.return_value = {
+        "status": {"conditions": [{"type": "Available", "status": "True"}]}
+    }
+    oc.wait_for_deployment("namespace", "deployment_name")
+    assert oc__get.call_count == 1

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -11,7 +11,6 @@ from reconcile.utils.oc import (
     LABEL_MAX_VALUE_LENGTH,
     OC,
     GET_REPLICASET_MAX_ATTEMPTS,
-    DeploymentNotReadyError,
     OC_Map,
     OCDeprecated,
     OCLogMsg,

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -113,10 +113,6 @@ class JobNotRunningError(Exception):
     pass
 
 
-class DeploymentNotReadyError(Exception):
-    pass
-
-
 class OCDecorators:
     @classmethod
     def process_reconcile_time(cls, function):


### PR DESCRIPTION
Procedure:
* openshift_base.apply handles FieldIsImmutableError for Deployments
* Checks that the update strategy is RollingUpdate for the current running Deployment; otherwise, reraise FieldIsImmutableError
* Remove old Deployments without removing the last ReplicaSet and Pods
* Apply new Deployment
* Adapt ownership of old ReplicaSet, it'll be removed automatically afterward when the new Deployment is ready

See APPSRE-5728
