### PR TITLE
Add website values support for s3 provider [rosa-authenticator]

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1517,6 +1517,10 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             values[
                 "server_side_encryption_configuration"
             ] = server_side_encryption_configuration
+        # Support static website hosting [rosa-authenticator]
+        website = common_values.get("website")
+        if website:
+            values["website"] = website
         lifecycle_rules = common_values.get("lifecycle_rules")
         if lifecycle_rules:
             # common_values['lifecycle_rules'] is a list of lifecycle_rules

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1521,6 +1521,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         website = common_values.get("website")
         if website:
             values["website"] = website
+        request_payer = common_values.get("request_payer")
+        if request_payer:
+            values["request_payer"] = request_payer
         lifecycle_rules = common_values.get("lifecycle_rules")
         if lifecycle_rules:
             # common_values['lifecycle_rules'] is a list of lifecycle_rules


### PR DESCRIPTION
This MR adds support for the "website" and "request_payer" parameters for the S3 provider in terrascrit_aws_client.py.

This property is passed to the provider via a customized defaults file, but is not assigned because of specific property callouts in the S3 provider pattern.