### PR TITLE
pin boto3-stubs to 1.24.29

### DIFF
--- a/requirements/requirements-type.txt
+++ b/requirements/requirements-type.txt
@@ -10,5 +10,5 @@ types-requests
 types-setuptools
 types-tabulate
 types-toml
-boto3-stubs[ec2,s3,rds,iam,route53]
+boto3-stubs[ec2,s3,rds,iam,route53]==1.24.29
 qenerate


### PR DESCRIPTION
boto3-stubs 1.24.30 was released a few hours ago and causing mypy tests to fail with the following

```
reconcile/utils/aws_api.py:11: error: Module "boto3" has no attribute "Session"; maybe "session"?  [attr-defined]
```

This pins boto3-stubs to 1.24.29 for now