### PR TITLE
get region from resources instead of openshift cluster

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -3381,8 +3381,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 # res.get('', []) won't work, as publish_log_types is
                 # explicitly set to None if not set
                 log_types = res["publish_log_types"] or []
-                region = \
-                    res.get("region") or self.default_regions.get(account)
+                region = res.get("region") or self.default_regions.get(account)
                 for log_type in log_types:
                     account_id = self.accounts[account]["uid"]
                     lg_identifier = (
@@ -3395,7 +3394,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                         ElasticSearchLogGroupInfo(
                             account=account,
                             account_id=account_id,
-                            region=region,
+                            region=str(region),
                             log_group_identifier=lg_identifier,
                         )
                     )

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -3376,14 +3376,14 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             for spec in specs:
                 account = spec.provisioner_name
                 res = spec.resource
-                ns = spec.namespace
                 if res.get("provider") != "elasticsearch":
                     continue
                 # res.get('', []) won't work, as publish_log_types is
                 # explicitly set to None if not set
                 log_types = res["publish_log_types"] or []
+                region = \
+                    res.get("region") or self.default_regions.get(account)
                 for log_type in log_types:
-                    region = ns["cluster"]["spec"]["region"]
                     account_id = self.accounts[account]["uid"]
                     lg_identifier = (
                         TerrascriptClient.elasticsearch_log_group_identifier(


### PR DESCRIPTION
I am trying to update terraform provider for insights-fedramp-stage but found tf-r has been disabled. Someone manually added a log_publishing_options to its kibana-elasticsearch. Due to a [aws API bug ](https://github.com/hashicorp/terraform-provider-aws/issues/5752), terraform can not remove it once it gets added. So I need to persist log_publishing_options in app-interface to prevent it from [continuously updating](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/32936) and enable tf-r on that account. However, in our code we get region info for log_groups_policy from the openshift cluster spec, while crcgovs02ue1 does not manage by us and we don't have spec info for that cluster. So without this change, I can not persist log_publishing_options in insights-fedramp-stage. Meanwhile, I think we should get region info from terraform resources instead of the openshift cluster. They are not related.

Furthermore, we also need to update the code for generating log_publishing_options. If we need to delete log publishing, we need to explicitly turn them off with `enabled = false` instead of removing the log configurations. 

Signed-off-by: Feng Huang <fehuang@redhat.com>