### PR TITLE
[saas-file-owners] support referenced targets

### DIFF
--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -343,8 +343,8 @@ def run(
         saas_file_target_path = diff["target_path"]
         if saas_file_target_path:
             changed_path_matches = [
-            c for c in changed_paths_copy if c.endswith(saas_file_target_path)
-        ]
+                c for c in changed_paths_copy if c.endswith(saas_file_target_path)
+            ]
         if not changed_path_matches:
             # this diff was found in the graphql endpoint comparison
             # but is not a part of the changed paths.

--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -342,9 +342,9 @@ def run(
         ]
         saas_file_target_path = diff["target_path"]
         if saas_file_target_path:
-            changed_path_matches = [
+            changed_path_matches.extend(
                 c for c in changed_paths_copy if c.endswith(saas_file_target_path)
-            ]
+            )
         if not changed_path_matches:
             # this diff was found in the graphql endpoint comparison
             # but is not a part of the changed paths.

--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -108,6 +108,7 @@ def collect_state():
                         "upstream": target_upstream,
                         "disable": target_disable,
                         "delete": target_delete,
+                        "target_path": target.get("path"),
                     }
                 )
     return state
@@ -254,11 +255,16 @@ def check_if_lgtm(owners, comments):
 
 def check_saas_files_changes_only(changed_paths, diffs):
     saas_file_paths = [d["saas_file_path"] for d in diffs]
+    saas_file_target_paths = [d["target_path"] for d in diffs]
     non_saas_file_changed_paths = []
     for changed_path in changed_paths:
         found = False
         for saas_file_path in saas_file_paths:
             if changed_path.endswith(saas_file_path):
+                found = True
+                break
+        for saas_file_target_path in saas_file_target_paths:
+            if changed_path.endswith(saas_file_target_path):
                 found = True
                 break
         if not found:
@@ -333,6 +339,11 @@ def run(
         saas_file_path = diff["saas_file_path"]
         changed_path_matches = [
             c for c in changed_paths_copy if c.endswith(saas_file_path)
+        ]
+        saas_file_target_path = diff["target_path"]
+        if saas_file_target_path:
+            changed_path_matches = [
+            c for c in changed_paths_copy if c.endswith(saas_file_target_path)
         ]
         if not changed_path_matches:
             # this diff was found in the graphql endpoint comparison


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6028

this PR introduces support for the `saas-file-owners` integration such that tenants can self-service valid saas file changes, even if those changes happen in a referenced saas file target, rather then an inlined one (https://github.com/app-sre/qontract-schemas/pull/200).