### PR TITLE
Create local OC class to allow for meaningful errors

### DIFF
--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -217,7 +217,7 @@ class OcpReleaseMirror:
         # want to run this against any cluster or via
         # a jump host
         # oc_cli = OC("cluster", None, None, local=True)
-        oc_cli = OCLocal("cluster", None, local=True)
+        oc_cli = OCLocal("cluster", None)
         oc_cli.release_mirror(
             from_release=ocp_release,
             to=dest_ocp_art_dev,

--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -8,7 +8,7 @@ from collections import namedtuple
 from sretoolbox.container import Image
 from reconcile.utils.external_resources import get_external_resource_specs
 
-from reconcile.utils.oc import OC
+from reconcile.utils.oc import OCLocal
 from reconcile.utils.oc import OC_Map
 from reconcile.utils.ocm import OCMMap
 
@@ -216,7 +216,8 @@ class OcpReleaseMirror:
         # Creating a new, bare, OC client since we don't
         # want to run this against any cluster or via
         # a jump host
-        oc_cli = OC("cluster", None, None, local=True)
+        # oc_cli = OC("cluster", None, None, local=True)
+        oc_cli = OCLocal("cluster", None, local=True)
         oc_cli.release_mirror(
             from_release=ocp_release,
             to=dest_ocp_art_dev,

--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -217,7 +217,7 @@ class OcpReleaseMirror:
         # want to run this against any cluster or via
         # a jump host
         # oc_cli = OC("cluster", None, None, local=True)
-        oc_cli = OCLocal("cluster", None)
+        oc_cli = OCLocal("cluster")
         oc_cli.release_mirror(
             from_release=ocp_release,
             to=dest_ocp_art_dev,

--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -216,7 +216,7 @@ class OcpReleaseMirror:
         # Creating a new, bare, OC client since we don't
         # want to run this against any cluster or via
         # a jump host
-        oc_cli = OCLocal("cluster")
+        oc_cli = OCLocal("cluster", None, None)
         oc_cli.release_mirror(
             from_release=ocp_release,
             to=dest_ocp_art_dev,

--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -216,7 +216,6 @@ class OcpReleaseMirror:
         # Creating a new, bare, OC client since we don't
         # want to run this against any cluster or via
         # a jump host
-        # oc_cli = OC("cluster", None, None, local=True)
         oc_cli = OCLocal("cluster")
         oc_cli.release_mirror(
             from_release=ocp_release,

--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -216,7 +216,7 @@ class OcpReleaseMirror:
         # Creating a new, bare, OC client since we don't
         # want to run this against any cluster or via
         # a jump host
-        oc_cli = OCLocal("cluster", None, None)
+        oc_cli = OCLocal("cluster", None, None, local=True)
         oc_cli.release_mirror(
             from_release=ocp_release,
             to=dest_ocp_art_dev,

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -579,6 +579,8 @@ def test_populate_current_state_unknown_kind(
     get_item_mock.assert_not_called()
 
 
+## fix this!!!
+@patch("reconcile.utils.oc.OCNative")
 def test_populate_current_state_resource_name_filtering(
     resource_inventory: resource.ResourceInventory, oc_cs1: oc.OCNative, mocker
 ):

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -2,11 +2,13 @@ import logging
 from typing import Any, cast
 import pytest
 import yaml
+from unittest.mock import patch
 
 import reconcile.openshift_base as sut
 import reconcile.utils.openshift_resource as resource
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils import oc
+from reconcile.utils.oc import OCNative
 from reconcile.utils.semver_helper import make_semver
 
 fxt = Fixtures("namespaces")
@@ -37,8 +39,11 @@ def namespaces() -> list[dict[str, Any]]:
 
 
 @pytest.fixture
-def oc_cs1() -> oc.OCNative:
-    return cast(oc.OCNative, oc.OC(cluster_name="cs1", server="", token="", local=True))
+@patch("reconcile.utils.oc.OCNative")
+# @patch("reconcile.utils.oc.OCNative")
+def oc_cs1(self) -> oc.OCClient:
+    # return cast(oc.OCNative, oc.OC(cluster_name="cs1", server="", token="", local=True))
+    return oc.OCNative(cluster_name="cs1", server="server", token="token", local=True)
 
 
 @pytest.fixture
@@ -56,6 +61,7 @@ def oc_map(mocker, oc_cs1: oc.OCNative) -> oc.OC_Map:
     oc_map = mocker.patch("reconcile.utils.oc.OC_Map", autospec=True).return_value
     oc_map.get.mock_add_spec(oc.OC_Map.get)
     oc_map.get.side_effect = get_cluster
+    # print(oc_map)
     return oc_map
 
 

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -39,9 +39,7 @@ def namespaces() -> list[dict[str, Any]]:
 
 @pytest.fixture
 @patch("reconcile.utils.oc.OCNative")
-# @patch("reconcile.utils.oc.OCNative")
 def oc_cs1(self) -> oc.OCClient:
-    # return cast(oc.OCNative, oc.OC(cluster_name="cs1", server="", token="", local=True))
     return oc.OCNative(cluster_name="cs1", server="server", token="token", local=True)
 
 
@@ -60,7 +58,6 @@ def oc_map(mocker, oc_cs1: oc.OCNative) -> oc.OC_Map:
     oc_map = mocker.patch("reconcile.utils.oc.OC_Map", autospec=True).return_value
     oc_map.get.mock_add_spec(oc.OC_Map.get)
     oc_map.get.side_effect = get_cluster
-    # print(oc_map)
     return oc_map
 
 

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, cast
+from typing import Any
 import pytest
 import yaml
 from unittest.mock import patch
@@ -8,7 +8,6 @@ import reconcile.openshift_base as sut
 import reconcile.utils.openshift_resource as resource
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils import oc
-from reconcile.utils.oc import OCNative
 from reconcile.utils.semver_helper import make_semver
 
 fxt = Fixtures("namespaces")
@@ -579,7 +578,6 @@ def test_populate_current_state_unknown_kind(
     get_item_mock.assert_not_called()
 
 
-## fix this!!!
 @patch("reconcile.utils.oc.OCNative")
 def test_populate_current_state_resource_name_filtering(
     resource_inventory: resource.ResourceInventory, oc_cs1: oc.OCNative, mocker

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -154,11 +154,14 @@ def test_fetch_current_state_ri_initialized(oc_cs1: oc.OCClient, tmpl1: dict[str
     assert resource["current"]["tmpl1"].kind == "Template"
 
 
+@pytest.fixture
+@patch("reconcile.utils.oc.OCNative")
 def test_fetch_current_state_kind_not_supported(
     oc_cs1: oc.OCNative, tmpl1: dict[str, Any]
 ):
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "AnUnsupportedKind")
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]  # type: ignore[assignment]
     orb.fetch_current_state(
         oc=oc_cs1,
         ri=ri,
@@ -191,11 +194,14 @@ def test_fetch_current_state_long_kind(oc_cs1: oc.OCClient, tmpl1: dict[str, Any
     assert resource["current"]["tmpl1"].kind == "Template"
 
 
+@pytest.fixture
+@patch("reconcile.utils.oc.OCNative")
 def test_fetch_current_state_long_kind_not_supported(
     oc_cs1: oc.OCNative, tmpl1: dict[str, Any]
 ):
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "UnknownKind.mysterious.io")
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]  # type: ignore[assignment]
     orb.fetch_current_state(
         oc=oc_cs1,
         ri=ri,

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -1,4 +1,4 @@
-from typing import Any, cast
+from typing import Any
 from unittest.mock import Mock
 from unittest.mock import patch
 import pytest
@@ -8,7 +8,6 @@ from reconcile.test.fixtures import Fixtures
 from reconcile import openshift_resources_base as orb
 from reconcile.openshift_resources_base import canonicalize_namespaces, ob
 from reconcile.utils import oc
-from reconcile.utils.oc import OCNative
 from reconcile.utils.openshift_resource import ResourceInventory
 
 

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -178,7 +178,7 @@ def test_fetch_current_state_kind_not_supported(
 def test_fetch_current_state_long_kind(oc_cs1: oc.OCClient, tmpl1: dict[str, Any]):
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "Template.template.openshift.io")
-    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]  # type: ignore[assignment]
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
     orb.fetch_current_state(
         oc=oc_cs1,
         ri=ri,
@@ -201,7 +201,7 @@ def test_fetch_current_state_long_kind_not_supported(
 ):
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "UnknownKind.mysterious.io")
-    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]  # type: ignore[assignment]
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
     orb.fetch_current_state(
         oc=oc_cs1,
         ri=ri,

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -111,6 +111,7 @@ def test_no_overrides(namespaces: list[dict[str, Any]], mocker):
     ns, override = canonicalize_namespaces(namespaces, ["resource"])
     assert (ns, override) == expected
 
+
 @pytest.fixture
 @patch("reconcile.utils.oc.OCNative")
 def test_fetch_current_state_ri_not_initialized(
@@ -153,6 +154,7 @@ def test_fetch_current_state_ri_initialized(oc_cs1: oc.OCClient, tmpl1: dict[str
     assert "tmpl1" in resource["current"]
     assert resource["current"]["tmpl1"].kind == "Template"
 
+
 def test_fetch_current_state_kind_not_supported(
     oc_cs1: oc.OCNative, tmpl1: dict[str, Any]
 ):
@@ -188,6 +190,7 @@ def test_fetch_current_state_long_kind(oc_cs1: oc.OCClient, tmpl1: dict[str, Any
     assert len(resource["current"]) == 1
     assert "tmpl1" in resource["current"]
     assert resource["current"]["tmpl1"].kind == "Template"
+
 
 def test_fetch_current_state_long_kind_not_supported(
     oc_cs1: oc.OCNative, tmpl1: dict[str, Any]

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -161,7 +161,7 @@ def test_fetch_current_state_kind_not_supported(
 ):
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "AnUnsupportedKind")
-    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]  # type: ignore[assignment]
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
     orb.fetch_current_state(
         oc=oc_cs1,
         ri=ri,
@@ -178,7 +178,7 @@ def test_fetch_current_state_kind_not_supported(
 def test_fetch_current_state_long_kind(oc_cs1: oc.OCClient, tmpl1: dict[str, Any]):
     ri = ResourceInventory()
     ri.initialize_resource_type("cs1", "ns1", "Template.template.openshift.io")
-    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]
+    oc_cs1.get_items = lambda kind, **kwargs: [tmpl1]  # type: ignore
     orb.fetch_current_state(
         oc=oc_cs1,
         ri=ri,

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -370,9 +370,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
             "-f",
             "-",
         ] + parameters_to_process
-        result = self._run(
-            self, cmd, stdin=json.dumps(template, sort_keys=True)
-        )
+        result = self._run(cmd, stdin=json.dumps(template, sort_keys=True))
         return json.loads(result)["items"]
 
     def release_mirror(self, from_release, to, to_release, dockerconfig):

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -964,9 +964,14 @@ class OCNative(OCDeprecated):
         if server:
             self.client = self._get_client(server, token)
             self.api_kind_version = self.get_api_resources()
-        else:
+        elif not server and not token and local:
             init_api_resources = False
             init_projects = False
+        else:
+            raise Exception("a server value is needed")
+        # else:
+        #     init_api_resources = False
+        #     init_projects = False
 
         self.object_clients = {}
         self.init_projects = init_projects
@@ -983,6 +988,9 @@ class OCNative(OCDeprecated):
 
     @retry(exceptions=(ServerTimeoutError, InternalServerError, ForbiddenError))
     def _get_client(self, server, token):
+        logging.debug(token)
+        logging.debug("this is the server")
+        logging.debug(server)
         opts = dict(
             api_key={"authorization": f"Bearer {token}"},
             host=server,

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -964,7 +964,6 @@ class OCNative(OCDeprecated):
             self.client = self._get_client(server, token)
             self.api_kind_version = self.get_api_resources()
         else:
-            # raise ValueError("Server value cannot be found")
             init_api_resources = False
             init_projects = False
 

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1214,7 +1214,7 @@ class OCLocal(OCDeprecated):
             token=token,
         )
         oc_base_cmd = ["oc", "--kubeconfig", "/dev/null"]
-        # oc_base_cmd = oc_base_cmd
+        oc_base_cmd = oc_base_cmd
 
 
 class OC:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -195,7 +195,8 @@ class OCProcessReconcileTimeDecoratorMsg:
 
 
 def oc_process(template, parameters=None):
-    oc = OCNative(server=None, local=True, cluster_name="cluster", token=None)
+    # oc = OCNative(server=None, local=True, cluster_name="cluster", token=None)
+    oc = OCLocal(cluster_name="cluster", token=None)
     return oc.process(template, parameters)
 
 

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -195,7 +195,6 @@ class OCProcessReconcileTimeDecoratorMsg:
 
 
 def oc_process(template, parameters=None):
-    # oc = OCNative(server=None, local=True, cluster_name="cluster", token=None)
     oc = OCLocal(cluster_name="cluster", server=None, token=None)
     return oc.process(template, parameters)
 
@@ -975,7 +974,7 @@ class OCNative(OCDeprecated):
             self.client = self._get_client(server, token)
             self.api_kind_version = self.get_api_resources()
         else:
-            raise Exception("a server value is needed")
+            raise Exception("A method relies on client/api_kind_version to be set")
 
         self.object_clients = {}
         self.init_projects = init_projects

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -195,7 +195,7 @@ class OCProcessReconcileTimeDecoratorMsg:
 
 
 def oc_process(template, parameters=None):
-    oc = OCLocal(cluster_name="cluster", server=None, token=None)
+    oc = OCLocal(cluster_name="cluster", server=None, token=None, local=True)
     return oc.process(template, parameters)
 
 
@@ -1207,11 +1207,13 @@ class OCLocal(OCDeprecated):
         cluster_name,
         server,
         token,
+        local=False,
     ):
         super().__init__(
             cluster_name=cluster_name,
             server=server,
             token=token,
+            local=local,
         )
 
 

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1209,8 +1209,9 @@ class OCLocal(OCDeprecated):
         super().__init__(
             cluster_name=cluster_name,
         )
-    oc_base_cmd=["oc", "--kubeconfig", "/dev/null"]
-    oc_base_cmd = oc_base_cmd
+        oc_base_cmd = ["oc", "--kubeconfig", "/dev/null"]
+        oc_base_cmd = oc_base_cmd
+
 
 class OC:
     client_status = Counter(

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1208,10 +1208,9 @@ class OCLocal(OCDeprecated):
     ):
         super().__init__(
             cluster_name=cluster_name,
-            oc_base_cmd=["oc", "--kubeconfig", "/dev/null"],
-            # oc_base_cmd = oc_base_cmd,
         )
-
+    oc_base_cmd=["oc", "--kubeconfig", "/dev/null"]
+    oc_base_cmd = oc_base_cmd
 
 class OC:
     client_status = Counter(

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -462,29 +462,29 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
         cmd = ["adm", "groups", "new", group]
         self._run(cmd)
 
-    def release_mirror(self, from_release, to, to_release, dockerconfig):
-        with tempfile.NamedTemporaryFile() as fp:
-            content = json.dumps(dockerconfig)
-            fp.write(content.encode())
-            fp.seek(0)
+    # def release_mirror(self, from_release, to, to_release, dockerconfig):
+    #     with tempfile.NamedTemporaryFile() as fp:
+    #         content = json.dumps(dockerconfig)
+    #         fp.write(content.encode())
+    #         fp.seek(0)
 
-            cmd = [
-                "adm",
-                "--registry-config",
-                fp.name,
-                "release",
-                "mirror",
-                "--from",
-                from_release,
-                "--to",
-                to,
-                "--to-release-image",
-                to_release,
-                "--max-per-registry",
-                "1",
-            ]
+    #         cmd = [
+    #             "adm",
+    #             "--registry-config",
+    #             fp.name,
+    #             "release",
+    #             "mirror",
+    #             "--from",
+    #             from_release,
+    #             "--to",
+    #             to,
+    #             "--to-release-image",
+    #             to_release,
+    #             "--max-per-registry",
+    #             "1",
+    #         ]
 
-            self._run(cmd)
+    #         self._run(cmd)
 
     def delete_group(self, group):
         cmd = ["delete", "group", group]
@@ -1200,20 +1200,9 @@ class OCLocal:
     def __init__(
         self,
         cluster_name,
-        jh=None,
-        settings=None,
-        insecure_skip_tls_verify=False,
     ):
         self.cluster_name = cluster_name
         oc_base_cmd = ["oc", "--kubeconfig", "/dev/null"]
-        if insecure_skip_tls_verify:
-            oc_base_cmd.extend(["--insecure-skip-tls-verify"])
-
-        self.jump_host = None
-        if jh is not None:
-            self.jump_host = JumpHostSSH(jh, settings=settings)
-            oc_base_cmd = self.jump_host.get_ssh_base_cmd() + oc_base_cmd
-
         self.oc_base_cmd = oc_base_cmd
 
     def process(self, template, parameters=None):
@@ -1231,6 +1220,30 @@ class OCLocal:
             self, cmd, stdin=json.dumps(template, sort_keys=True)
         )
         return json.loads(result)["items"]
+
+    def release_mirror(self, from_release, to, to_release, dockerconfig):
+        with tempfile.NamedTemporaryFile() as fp:
+            content = json.dumps(dockerconfig)
+            fp.write(content.encode())
+            fp.seek(0)
+
+            cmd = [
+                "adm",
+                "--registry-config",
+                fp.name,
+                "release",
+                "mirror",
+                "--from",
+                from_release,
+                "--to",
+                to,
+                "--to-release-image",
+                to_release,
+                "--max-per-registry",
+                "1",
+            ]
+
+            self._run(cmd)
 
 
 class OC:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -196,7 +196,7 @@ class OCProcessReconcileTimeDecoratorMsg:
 
 def oc_process(template, parameters=None):
     # oc = OCNative(server=None, local=True, cluster_name="cluster", token=None)
-    oc = OCLocal(cluster_name="cluster", token=None)
+    oc = OCLocal(cluster_name="cluster")
     return oc.process(template, parameters)
 
 

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -195,7 +195,8 @@ class OCProcessReconcileTimeDecoratorMsg:
 
 
 def oc_process(template, parameters=None):
-    oc = OCLocal(cluster_name="cluster", server=None, token=None)
+    oc = OCNative(server=None, local=True, cluster_name="cluster", token=None)
+    # oc = OCLocal(cluster_name="cluster", server=None, token=None)
     return oc.process(template, parameters)
 
 
@@ -1213,8 +1214,6 @@ class OCLocal(OCDeprecated):
             server=server,
             token=token,
         )
-        oc_base_cmd = ["oc", "--kubeconfig", "/dev/null"]
-        oc_base_cmd = oc_base_cmd
 
 
 class OC:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -195,8 +195,8 @@ class OCProcessReconcileTimeDecoratorMsg:
 
 
 def oc_process(template, parameters=None):
-    oc = OCNative(server=None, local=True, cluster_name="cluster", token=None)
-    # oc = OCLocal(cluster_name="cluster", server=None, token=None)
+    # oc = OCNative(server=None, local=True, cluster_name="cluster", token=None)
+    oc = OCLocal(cluster_name="cluster", server=None, token=None)
     return oc.process(template, parameters)
 
 
@@ -1206,8 +1206,8 @@ class OCLocal(OCDeprecated):
     def __init__(
         self,
         cluster_name,
-        server=None,
-        token=None,
+        server,
+        token,
     ):
         super().__init__(
             cluster_name=cluster_name,

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -339,20 +339,6 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
             cmd.append("--all-namespaces")
         return self._run_json(cmd)
 
-    # def process(self, template, parameters=None):
-    #     if parameters is None:
-    #         parameters = {}
-    #     parameters_to_process = [f"{k}={v}" for k, v in parameters.items()]
-    #     cmd = [
-    #         "process",
-    #         "--local",
-    #         "--ignore-unknown-parameters",
-    #         "-f",
-    #         "-",
-    #     ] + parameters_to_process
-    #     result = self._run(cmd, stdin=json.dumps(template, sort_keys=True))
-    #     return json.loads(result)["items"]
-
     def remove_last_applied_configuration(self, namespace, kind, name):
         cmd = [
             "annotate",
@@ -974,8 +960,6 @@ class OCNative(OCDeprecated):
         # thrown here instead to avoid AttributeErrors when accessing
         # methods that rely on client/api_kind_version to be set.
 
-        # if not server:
-        #     raise NotFoundError("Server cannot be found")
 
         if server:
             self.client = self._get_client(server, token)
@@ -1219,38 +1203,13 @@ class OCLocal:
         cluster_name,
         jh=None,
         settings=None,
-        # init_projects=False,
-        # init_api_resources=False,
         local=False,
         insecure_skip_tls_verify=False,
     ):
-        # super().__init__(
-        #     cluster_name,
-        #     jh,
-        #     settings,
-        #     # init_projects=False,
-        #     # init_api_resources=False,
-        #     local=local,
-        #     insecure_skip_tls_verify=insecure_skip_tls_verify,
-        # )
-        # if server:
-        #     self.client = self._get_client(server, token)
-        #     self.api_kind_version = self.get_api_resources()
-        # else:
-        #     # raise ValueError("Server value cannot be found")
-        #     init_api_resources = False
-        #     init_projects = False
-
         self.cluster_name = cluster_name
-        # self.server = server
         oc_base_cmd = ["oc", "--kubeconfig", "/dev/null"]
         if insecure_skip_tls_verify:
             oc_base_cmd.extend(["--insecure-skip-tls-verify"])
-        # if server:
-        #     oc_base_cmd.extend(["--server", server])
-
-        # if token:
-        #     oc_base_cmd.extend(["--token", token])
 
         self.jump_host = None
         if jh is not None:
@@ -1270,69 +1229,8 @@ class OCLocal:
             "-f",
             "-",
         ] + parameters_to_process
-        result = self._run(cmd, stdin=json.dumps(template, sort_keys=True))
+        result = OCDeprecated._run(self,cmd, stdin=json.dumps(template, sort_keys=True))
         return json.loads(result)["items"]
-    
-    @retry(exceptions=(StatusCodeError, NoOutputError), max_attempts=10)
-    def _run(self, cmd, **kwargs):
-        if kwargs.get("stdin"):
-            stdin = PIPE
-            stdin_text = kwargs.get("stdin").encode()
-        else:
-            stdin = None
-            stdin_text = None
-
-        p = Popen(  # pylint: disable=consider-using-with
-            self.oc_base_cmd + cmd, stdin=stdin, stdout=PIPE, stderr=PIPE
-        )
-        out, err = p.communicate(stdin_text)
-
-        code = p.returncode
-
-        allow_not_found = kwargs.get("allow_not_found")
-
-        if code != 0:
-            err = err.decode("utf-8")
-            if "Unable to connect to the server" in err:
-                raise StatusCodeError(f"[{self.server}]: {err}")
-            if kwargs.get("apply"):
-                if "Invalid value: 0x0" in err:
-                    raise InvalidValueApplyError(f"[{self.server}]: {err}")
-                if "Invalid value: " in err:
-                    if ": field is immutable" in err:
-                        if "The Deployment" in err:
-                            raise DeploymentFieldIsImmutableError(
-                                f"[{self.server}]: {err}"
-                            )
-                        else:
-                            raise FieldIsImmutableError(f"[{self.server}]: {err}")
-                    if ": may not change once set" in err:
-                        raise MayNotChangeOnceSetError(f"[{self.server}]: {err}")
-                    if ": primary clusterIP can not be unset" in err:
-                        raise PrimaryClusterIPCanNotBeUnsetError(
-                            f"[{self.server}]: {err}"
-                        )
-                    raise StatusCodeError(f"[{self.server}]: {err}")
-                if "metadata.annotations: Too long" in err:
-                    raise MetaDataAnnotationsTooLongApplyError(
-                        f"[{self.server}]: {err}"
-                    )
-                if "UnsupportedMediaType" in err:
-                    raise UnsupportedMediaTypeError(f"[{self.server}]: {err}")
-                if "updates to statefulset spec for fields other than" in err:
-                    raise StatefulSetUpdateForbidden(f"[{self.server}]: {err}")
-                if "the object has been modified" in err:
-                    raise ObjectHasBeenModifiedError(f"[{self.server}]: {err}")
-            if not (allow_not_found and "NotFound" in err):
-                raise StatusCodeError(f"[{self.server}]: {err}")
-
-        if not out:
-            if allow_not_found:
-                return "{}"
-            else:
-                raise NoOutputError(err)
-
-        return out.strip()
 
 
 class OC:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1206,9 +1206,11 @@ class OCLocal(OCDeprecated):
         self,
         cluster_name,
     ):
-        self.cluster_name = cluster_name
-        oc_base_cmd = ["oc", "--kubeconfig", "/dev/null"]
-        self.oc_base_cmd = oc_base_cmd
+        super().__init__(
+            cluster_name=cluster_name,
+            oc_base_cmd=["oc", "--kubeconfig", "/dev/null"],
+            # oc_base_cmd = oc_base_cmd,
+        )
 
 
 class OC:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1201,7 +1201,6 @@ class OCLocal:
         cluster_name,
         jh=None,
         settings=None,
-        # local=False,
         insecure_skip_tls_verify=False,
     ):
         self.cluster_name = cluster_name

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1205,12 +1205,16 @@ class OCLocal(OCDeprecated):
     def __init__(
         self,
         cluster_name,
+        server,
+        token,
     ):
         super().__init__(
             cluster_name=cluster_name,
+            server=server,
+            token=token,
         )
         oc_base_cmd = ["oc", "--kubeconfig", "/dev/null"]
-        oc_base_cmd = oc_base_cmd
+        # oc_base_cmd = oc_base_cmd
 
 
 class OC:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -960,7 +960,6 @@ class OCNative(OCDeprecated):
         # thrown here instead to avoid AttributeErrors when accessing
         # methods that rely on client/api_kind_version to be set.
 
-
         if server:
             self.client = self._get_client(server, token)
             self.api_kind_version = self.get_api_resources()
@@ -1203,7 +1202,7 @@ class OCLocal:
         cluster_name,
         jh=None,
         settings=None,
-        local=False,
+        # local=False,
         insecure_skip_tls_verify=False,
     ):
         self.cluster_name = cluster_name
@@ -1229,7 +1228,9 @@ class OCLocal:
             "-f",
             "-",
         ] + parameters_to_process
-        result = OCDeprecated._run(self,cmd, stdin=json.dumps(template, sort_keys=True))
+        result = OCDeprecated._run(
+            self, cmd, stdin=json.dumps(template, sort_keys=True)
+        )
         return json.loads(result)["items"]
 
 

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -339,19 +339,19 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
             cmd.append("--all-namespaces")
         return self._run_json(cmd)
 
-    def process(self, template, parameters=None):
-        if parameters is None:
-            parameters = {}
-        parameters_to_process = [f"{k}={v}" for k, v in parameters.items()]
-        cmd = [
-            "process",
-            "--local",
-            "--ignore-unknown-parameters",
-            "-f",
-            "-",
-        ] + parameters_to_process
-        result = self._run(cmd, stdin=json.dumps(template, sort_keys=True))
-        return json.loads(result)["items"]
+    # def process(self, template, parameters=None):
+    #     if parameters is None:
+    #         parameters = {}
+    #     parameters_to_process = [f"{k}={v}" for k, v in parameters.items()]
+    #     cmd = [
+    #         "process",
+    #         "--local",
+    #         "--ignore-unknown-parameters",
+    #         "-f",
+    #         "-",
+    #     ] + parameters_to_process
+    #     result = self._run(cmd, stdin=json.dumps(template, sort_keys=True))
+    #     return json.loads(result)["items"]
 
     def remove_last_applied_configuration(self, namespace, kind, name):
         cmd = [
@@ -1207,6 +1207,45 @@ class OCNative(OCDeprecated):
 
 OCClient = Union[OCNative, OCDeprecated]
 
+
+class OCLocal:
+    def __init__(
+        self,
+        cluster_name,
+        server,
+        token,
+        jh=None,
+        settings=None,
+        init_projects=False,
+        init_api_resources=False,
+        local=False,
+        insecure_skip_tls_verify=False,
+    ):
+        super().__init__(
+            cluster_name,
+            server,
+            token,
+            jh,
+            settings,
+            init_projects=False,
+            init_api_resources=False,
+            local=local,
+            insecure_skip_tls_verify=insecure_skip_tls_verify,
+        )
+    
+    def process(self, template, parameters=None):
+        if parameters is None:
+            parameters = {}
+        parameters_to_process = [f"{k}={v}" for k, v in parameters.items()]
+        cmd = [
+            "process",
+            "--local",
+            "--ignore-unknown-parameters",
+            "-f",
+            "-",
+        ] + parameters_to_process
+        result = self._run(cmd, stdin=json.dumps(template, sort_keys=True))
+        return json.loads(result)["items"]
 
 class OC:
     client_status = Counter(

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -964,9 +964,9 @@ class OCNative(OCDeprecated):
         if server:
             self.client = self._get_client(server, token)
             self.api_kind_version = self.get_api_resources()
-        elif not server and not token and local:
-            init_api_resources = False
-            init_projects = False
+        # elif not server and not token and local:
+        #     init_api_resources = False
+        #     init_projects = False
         else:
             raise Exception("a server value is needed")
         # else:
@@ -989,8 +989,10 @@ class OCNative(OCDeprecated):
     @retry(exceptions=(ServerTimeoutError, InternalServerError, ForbiddenError))
     def _get_client(self, server, token):
         logging.debug(token)
+        print(token)
         logging.debug("this is the server")
         logging.debug(server)
+        print(server)
         opts = dict(
             api_key={"authorization": f"Bearer {token}"},
             host=server,
@@ -998,16 +1000,19 @@ class OCNative(OCDeprecated):
             # default timeout seems to be 1+ minutes
             retries=5,
         )
-
+        print(opts)
+        print("I'm here")
         if self.jump_host:
             # the ports could be parameterized, but at this point
             # we only have need of 1 tunnel for 1 service
             self.jump_host.create_ssh_tunnel()
             local_port = self.jump_host.local_port
+            print(local_port)
             opts["proxy"] = f"http://localhost:{local_port}"
-
+            print(opts["proxy"])
+        print("I'm here now")
         configuration = Configuration()
-
+        print("I'm here now pt2")
         # the kubernetes client configuration takes a limited set
         # of parameters during initialization, but there are a lot
         # more options that can be set to tweak the behavior of the
@@ -1018,6 +1023,7 @@ class OCNative(OCDeprecated):
             setattr(configuration, k, v)
 
         k8s_client = ApiClient(configuration)
+        print(k8s_client)
         try:
             return DynamicClient(k8s_client, discoverer=OpenshiftLazyDiscoverer)
         except urllib3.exceptions.MaxRetryError as e:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -370,7 +370,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
             "-f",
             "-",
         ] + parameters_to_process
-        result = OCDeprecated._run(
+        result = self._run(
             self, cmd, stdin=json.dumps(template, sort_keys=True)
         )
         return json.loads(result)["items"]

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -973,12 +973,16 @@ class OCNative(OCDeprecated):
         # functionality outside of this class would allow an exception to be
         # thrown here instead to avoid AttributeErrors when accessing
         # methods that rely on client/api_kind_version to be set.
-        if server:
-            self.client = self._get_client(server, token)
-            self.api_kind_version = self.get_api_resources()
-        else:
-            init_api_resources = False
-            init_projects = False
+
+        if not server:
+            raise NotFoundError("Server cannot be found")
+
+        # if server:
+        #     self.client = self._get_client(server, token)
+        #     self.api_kind_version = self.get_api_resources()
+        # else:
+        #     init_api_resources = False
+        #     init_projects = False
 
         self.object_clients = {}
         self.init_projects = init_projects

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -195,7 +195,7 @@ class OCProcessReconcileTimeDecoratorMsg:
 
 
 def oc_process(template, parameters=None):
-    oc = OCLocal(cluster_name="cluster")
+    oc = OCLocal(cluster_name="cluster", server=None, token=None)
     return oc.process(template, parameters)
 
 
@@ -1205,8 +1205,8 @@ class OCLocal(OCDeprecated):
     def __init__(
         self,
         cluster_name,
-        server,
-        token,
+        server=None,
+        token=None,
     ):
         super().__init__(
             cluster_name=cluster_name,

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -532,7 +532,7 @@ class ResourceInventory:
         self._clusters = {}
         self._error_registered = False
         self._error_registered_clusters = {}
-        self._lock = Lock() 
+        self._lock = Lock()
 
     def initialize_resource_type(self, cluster, namespace, resource_type):
         self._clusters.setdefault(cluster, {})

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -534,6 +534,9 @@ class ResourceInventory:
         self._error_registered_clusters = {}
         self._lock = Lock()
 
+    def __str__(self):
+        return f"cluster {self._clusters} and error registed {self._error_registered} and error registered clusters {self._error_registered}"
+
     def initialize_resource_type(self, cluster, namespace, resource_type):
         self._clusters.setdefault(cluster, {})
         self._clusters[cluster].setdefault(namespace, {})

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -532,10 +532,7 @@ class ResourceInventory:
         self._clusters = {}
         self._error_registered = False
         self._error_registered_clusters = {}
-        self._lock = Lock()
-
-    def __str__(self):
-        return f"cluster {self._clusters} and error registed {self._error_registered} and error registered clusters {self._error_registered}"
+        self._lock = Lock() 
 
     def initialize_resource_type(self, cluster, namespace, resource_type):
         self._clusters.setdefault(cluster, {})

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -883,7 +883,7 @@ class SaasHerder:
                     )
                     return None, None, None
 
-            oc = OCLocal("cluster", None)
+            oc = OCLocal("cluster")
             try:
                 resources = oc.process(template, consolidated_parameters)
             except StatusCodeError as e:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -33,7 +33,7 @@ from sretoolbox.utils import threaded
 from reconcile.github_org import get_default_config
 from reconcile.status import RunningState
 from reconcile.utils.mr.auto_promoter import AutoPromoter
-from reconcile.utils.oc import OCLocal, StatusCodeError
+from reconcile.utils.oc import OC, OCLocal, StatusCodeError
 from reconcile.utils.openshift_resource import (
     OpenshiftResource as OR,
     ResourceInventory,
@@ -884,7 +884,8 @@ class SaasHerder:
                     return None, None, None
 
             # oc = OC("cluster", None, None, local=True)
-            oc = OCLocal("cluster", None, None, local=True)
+            oc = OCLocal("cluster", None, local=True)
+            # oc = OCLocal()
             try:
                 resources = oc.process(template, consolidated_parameters)
             except StatusCodeError as e:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -883,7 +883,7 @@ class SaasHerder:
                     )
                     return None, None, None
 
-            oc = OCLocal("cluster", None, None)
+            oc = OCLocal("cluster", None, None, local=True)
             try:
                 resources = oc.process(template, consolidated_parameters)
             except StatusCodeError as e:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -883,9 +883,7 @@ class SaasHerder:
                     )
                     return None, None, None
 
-            # oc = OC("cluster", None, None, local=True)
             oc = OCLocal("cluster", None, local=True)
-            # oc = OCLocal()
             try:
                 resources = oc.process(template, consolidated_parameters)
             except StatusCodeError as e:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -33,7 +33,7 @@ from sretoolbox.utils import threaded
 from reconcile.github_org import get_default_config
 from reconcile.status import RunningState
 from reconcile.utils.mr.auto_promoter import AutoPromoter
-from reconcile.utils.oc import OC, StatusCodeError
+from reconcile.utils.oc import OCLocal, StatusCodeError
 from reconcile.utils.openshift_resource import (
     OpenshiftResource as OR,
     ResourceInventory,
@@ -883,7 +883,8 @@ class SaasHerder:
                     )
                     return None, None, None
 
-            oc = OC("cluster", None, None, local=True)
+            # oc = OC("cluster", None, None, local=True)
+            oc = OCLocal("cluster", None, None, local=True)
             try:
                 resources = oc.process(template, consolidated_parameters)
             except StatusCodeError as e:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -883,7 +883,7 @@ class SaasHerder:
                     )
                     return None, None, None
 
-            oc = OCLocal("cluster")
+            oc = OCLocal("cluster", None, None)
             try:
                 resources = oc.process(template, consolidated_parameters)
             except StatusCodeError as e:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -883,7 +883,7 @@ class SaasHerder:
                     )
                     return None, None, None
 
-            oc = OCLocal("cluster", None, local=True)
+            oc = OCLocal("cluster", None)
             try:
                 resources = oc.process(template, consolidated_parameters)
             except StatusCodeError as e:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -33,7 +33,7 @@ from sretoolbox.utils import threaded
 from reconcile.github_org import get_default_config
 from reconcile.status import RunningState
 from reconcile.utils.mr.auto_promoter import AutoPromoter
-from reconcile.utils.oc import OC, OCLocal, StatusCodeError
+from reconcile.utils.oc import OCLocal, StatusCodeError
 from reconcile.utils.openshift_resource import (
     OpenshiftResource as OR,
     ResourceInventory,


### PR DESCRIPTION
Part of [APPSRE-3866](https://issues.redhat.com/browse/APPSRE-3866)

We have two integrations that rely on server having the value of None in the OC class since it relies on one method in said class. The goal of this MR is to take that method out into its own class and refactor OC to return meaningful errors whenever client/api_kind_version need to be set