### PR TITLE
Different shard mechanism for tekton resources

### DIFF
--- a/reconcile/openshift_tekton_resources.py
+++ b/reconcile/openshift_tekton_resources.py
@@ -76,7 +76,7 @@ def fetch_saas_files(saas_file_name: Optional[str]) -> list[dict[str, Any]]:
 
         return [saas_file] if saas_file else []
 
-    return [s for s in saas_files if is_in_shard(s["name"])]
+    return saas_files
 
 
 def fetch_tkn_providers(saas_file_name: Optional[str]) -> dict[str, Any]:
@@ -115,7 +115,11 @@ def fetch_tkn_providers(saas_file_name: Optional[str]) -> dict[str, Any]:
 
         tkn_providers[provider_name]["saas_files"].append(sf)
 
-    return tkn_providers
+    return {
+        provider_name: sf
+        for provider_name, sf in tkn_providers.items()
+        if is_in_shard(provider_name)
+    }
 
 
 def fetch_desired_resources(


### PR DESCRIPTION
We want to remove the managedResourceNames and we need that every shard
sees full namespaces or different shards will try to remove resources
that are not part of its namespace (dynamically created) definition.

part of APPSRE-6031.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>