### PR TITLE
make resource end result consistent

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -708,7 +708,10 @@ def _validate_resources_used_exist(
     for used_name, used_keys in used_resources.items():
         # perhaps used resource is deployed together with the using resource?
         resource = ri.get_desired(cluster, namespace, used_kind, used_name)
-        if not resource:
+        if resource:
+            # get the body to match with the possible result from oc.get
+            resource = resource.body
+        else:
             # no. perhaps used resource exists in the namespace?
             resource = oc.get(
                 namespace, used_kind, name=used_name, allow_not_found=True


### PR DESCRIPTION
fixes #2261

```
Traceback (most recent call last):
  File "/usr/local/bin/qontract-reconcile", line 8, in <module>
    sys.exit(integration())
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/environ.py", line 17, in f_environ
    f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/environ.py", line 17, in f_environ
    f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/binary.py", line 22, in f_binary
    f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/binary.py", line 72, in f_binary_version
    f(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/cli.py", line 930, in openshift_saas_deploy_wrapper
    run_integration(
  File "/usr/local/lib/python3.9/site-packages/reconcile/cli.py", line 391, in run_integration
    func_container.run(dry_run, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/openshift_saas_deploy_wrapper.py", line 51, in run
    exit_codes = threaded.run(
  File "/usr/local/lib/python3.9/site-packages/sretoolbox/utils/threaded.py", line 41, in run
    return pool.map(func_partial, iterable)
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 364, in map
    return self._map_async(func, iterable, mapstar, chunksize).get()
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 771, in get
    raise self._value
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 125, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib64/python3.9/multiprocessing/pool.py", line 48, in mapstar
    return list(map(*args))
  File "/usr/local/lib/python3.9/site-packages/sretoolbox/utils/threaded.py", line 81, in wrapper
    return func(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/openshift_saas_deploy_wrapper.py", line 23, in osd_run_wrapper
    osd.run(
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/defer.py", line 18, in func_wrapper
    return func(*args, defer=defer, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/openshift_saas_deploy.py", line 180, in run
    ob.validate_planned_data(ri, oc_map)
  File "/usr/local/lib/python3.9/site-packages/reconcile/openshift_base.py", line 740, in validate_planned_data
    _validate_resources_used_exist(
  File "/usr/local/lib/python3.9/site-packages/reconcile/openshift_base.py", line 723, in _validate_resources_used_exist
    missing_keys = used_keys - resource["data"].keys()
TypeError: 'OpenshiftResource' object is not subscriptable
```