### PR TITLE
[openshift-saas-deploy] consider planned data optional resources

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -704,7 +704,9 @@ def _validate_resources_used_exist(
     name: str,
     used_kind: str,
 ) -> None:
-    used_resources = oc.get_resources_used_in_pod_spec(spec, used_kind)
+    used_resources = oc.get_resources_used_in_pod_spec(
+        spec, used_kind, include_optional=False
+    )
     for used_name, used_keys in used_resources.items():
         # perhaps used resource is deployed together with the using resource?
         resource = ri.get_desired(cluster, namespace, used_kind, used_name)

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -817,10 +817,11 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     def get_resources_used_in_pod_spec(
-        spec: Dict[str, Any], kind: str
+        spec: Dict[str, Any], kind: str, include_optional: bool = True,
     ) -> Dict[str, Set[str]]:
         if kind not in ("Secret", "ConfigMap"):
             raise KeyError(f"unsupported resource kind: {kind}")
+        optional = "optional"
         if kind == "Secret":
             volume_kind, volume_kind_ref, env_from_kind, env_kind, env_ref = (
                 "secret",
@@ -842,6 +843,8 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
         for v in spec.get("volumes", []):
             try:
                 volume_ref = v[volume_kind]
+                if volume_ref.get(optional) and not include_optional:
+                    continue
                 resource_name = volume_ref[volume_kind_ref]
                 resources.setdefault(resource_name, set())
             except (KeyError, TypeError):
@@ -850,6 +853,8 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
             for e in c.get("envFrom", []):
                 try:
                     resource_ref = e[env_from_kind]
+                    if resource_ref.get(optional) and not include_optional:
+                        continue
                     resource_name = resource_ref[env_ref]
                     resources.setdefault(resource_name, set())
                 except (KeyError, TypeError):
@@ -857,6 +862,8 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
             for e in c.get("env", []):
                 try:
                     resource_ref = e["valueFrom"][env_kind]
+                    if resource_ref.get(optional) and not include_optional:
+                        continue
                     resource_name = resource_ref[env_ref]
                     resources.setdefault(resource_name, set())
                     secret_key = resource_ref["key"]

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -841,14 +841,16 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
         resources: Dict[str, Set[str]] = {}
         for v in spec.get("volumes", []):
             try:
-                resource_name = v[volume_kind][volume_kind_ref]
+                volume_ref = v[volume_kind]
+                resource_name = volume_ref[volume_kind_ref]
                 resources.setdefault(resource_name, set())
             except (KeyError, TypeError):
                 continue
         for c in spec["containers"] + spec.get("initContainers", []):
             for e in c.get("envFrom", []):
                 try:
-                    resource_name = e[env_from_kind][env_ref]
+                    resource_ref = e[env_from_kind]
+                    resource_name = resource_ref[env_ref]
                     resources.setdefault(resource_name, set())
                 except (KeyError, TypeError):
                     continue

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -817,7 +817,9 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     def get_resources_used_in_pod_spec(
-        spec: Dict[str, Any], kind: str, include_optional: bool = True,
+        spec: Dict[str, Any],
+        kind: str,
+        include_optional: bool = True,
     ) -> Dict[str, Set[str]]:
         if kind not in ("Secret", "ConfigMap"):
             raise KeyError(f"unsupported resource kind: {kind}")


### PR DESCRIPTION
follows up on #2261

dependent resources can be defined as optional: https://kubernetes.io/docs/concepts/configuration/secret/#restriction-secret-must-exist

in such cases, we don't want to fail a deployment.