### PR TITLE
run make test as part of a push

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -5,7 +5,7 @@ mkdir -p "$DOCKER_CONF"
 docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
 # build images
-make build push
+make test build push
 
 # publish to pypi
 ./build_tag.sh


### PR DESCRIPTION
if tests are failing, we shouldn't proceed to build and push an image.

this is a safety net for merges with failing tests (like #2626 :facepalm:)