### PR TITLE
github-repo-permissions-validator validate repo permissions for more jobs in more instances

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1474,12 +1474,11 @@ def github_repo_invites(ctx):
 
 
 @integration.command(short_help="Validates permissions in github repositories.")
-@click.argument("instance-name")
 @click.pass_context
-def github_repo_permissions_validator(ctx, instance_name):
+def github_repo_permissions_validator(ctx):
     import reconcile.github_repo_permissions_validator
 
-    run_integration(reconcile.github_repo_permissions_validator, ctx.obj, instance_name)
+    run_integration(reconcile.github_repo_permissions_validator, ctx.obj)
 
 
 @integration.command(short_help="Manage GitLab group members.")


### PR DESCRIPTION
this integration was assuming that jobs in github can only be in a single instance. that is not true.

it would also be beneficial to enforce write permissions in build jobs, so we will be able to update commit status after a push, and not only in pr-checks.