### PR TITLE
OCM Cluster updates improvements

### DIFF
--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -141,8 +141,8 @@ def get_cluster_ocm_update_spec(
 
     :param ocm: ocm implementation for an ocm product (osd, rosa)
     :param cluster: cluster name
-    :param current_spec: Cluster spec retreived from OCM api
-    :param desired_spec: luster spec retreived from App-Interface
+    :param current_spec: Cluster spec retrieved from OCM api
+    :param desired_spec: Cluster spec retrieved from App-Interface
     :return: a tuple with the updates to request to OCM and a bool to notify errors
     """
 
@@ -188,7 +188,7 @@ def get_cluster_ocm_update_spec(
         error = True
         logging.error(f"[{cluster}] invalid updates: {not_allowed_updates}")
 
-    return diffs, error
+    return updated_attrs, error
 
 
 def _app_interface_updates_mr(

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -441,25 +441,3 @@ def test_changed_ocm_spec_disable_uwm(
     assert _patch.call_count == 1
     assert _post.call_count == 0
     assert cluster_updates_mr_mock.call_count == 0
-
-
-def test_missing_ocm_spec_disable_uwm(
-    get_json_mock,
-    queries_mock,
-    ocm_mock,
-    ocm_osd_cluster_raw_spec,
-    ocm_osd_cluster_ai_spec,
-    cluster_updates_mr_mock,
-):
-    ocm_osd_cluster_ai_spec["spec"]["disable_user_workload_monitoring"] = None
-
-    get_json_mock.return_value = {"items": [ocm_osd_cluster_raw_spec]}
-    queries_mock[1].return_value = [ocm_osd_cluster_ai_spec]
-
-    with pytest.raises(SystemExit):
-        occ.run(dry_run=False)
-    _post, _patch = ocm_mock
-
-    assert _patch.call_count == 1
-    assert _post.call_count == 0
-    assert cluster_updates_mr_mock.call_count == 1

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -266,7 +266,6 @@ class OCMProductOsd(OCMProduct):
 
 class OCMProductRosa(OCMProduct):
     ALLOWED_SPEC_UPDATE_FIELDS = {
-        SPEC_ATTR_INSTANCE_TYPE,
         SPEC_ATTR_CHANNEL,
         SPEC_ATTR_AUTOSCALE,
         SPEC_ATTR_NODES,
@@ -287,7 +286,11 @@ class OCMProductRosa(OCMProduct):
 
     @staticmethod
     def update_cluster(ocm: OCM, cluster_name: str, update_spec: Mapping[str, Any]):
-        raise NotImplementedError("update_cluster not implemeneted for ROSA")
+        ocm_spec = OCMProductRosa._get_update_cluster_spec(update_spec)
+        cluster_id = ocm.cluster_ids.get(cluster_name)
+        api = f"{CS_API_BASE}/v1/clusters/{cluster_id}"
+        params: dict[str, Any] = {}
+        ocm._patch(api, ocm_spec, params)
 
     @staticmethod
     def get_ocm_spec(
@@ -382,14 +385,6 @@ class OCMProductRosa(OCMProduct):
     @staticmethod
     def _get_update_cluster_spec(update_spec: Mapping[str, Any]) -> dict[str, Any]:
         ocm_spec: dict[str, Any] = {}
-
-        instance_type = update_spec.get("instance_type")
-        if instance_type is not None:
-            ocm_spec["nodes"] = {"compute_machine_type": {"id": instance_type}}
-
-        private = update_spec.get("private")
-        if private is not None:
-            ocm_spec["api"] = {"listening": "internal" if private else "external"}
 
         channel = update_spec.get("channel")
         if channel is not None:

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -91,7 +91,6 @@ class OCMProduct:
 
 class OCMProductOsd(OCMProduct):
     ALLOWED_SPEC_UPDATE_FIELDS = {
-        SPEC_ATTR_INSTANCE_TYPE,
         SPEC_ATTR_STORAGE,
         SPEC_ATTR_LOAD_BALANCERS,
         SPEC_ATTR_PRIVATE,
@@ -233,10 +232,6 @@ class OCMProductOsd(OCMProduct):
     @staticmethod
     def _get_update_cluster_spec(update_spec: Mapping[str, Any]) -> dict[str, Any]:
         ocm_spec: dict[str, Any] = {}
-
-        instance_type = update_spec.get("instance_type")
-        if instance_type is not None:
-            ocm_spec["nodes"] = {"compute_machine_type": {"id": instance_type}}
 
         storage = update_spec.get("storage")
         if storage is not None:


### PR DESCRIPTION
- Fix cluster_updates diff logic
- Disable instance_type cluster updates for OSD: Instance_type attribute can not be updated in the default machine pool
- Enable OCM ROSA Cluster updates
- Remove disable_uwm_test: Removing this attribute from the spec is not going to change the attribute anymore