### PR TITLE
Unleash client refactor

### DIFF
--- a/reconcile/test/test_unleash.py
+++ b/reconcile/test/test_unleash.py
@@ -1,0 +1,100 @@
+import os
+
+from UnleashClient.features import Feature
+from UnleashClient.strategies import Strategy
+
+from reconcile.utils.unleash import (
+    _get_unleash_api_client,
+    get_feature_toggle_default,
+    get_feature_toggle_state,
+    get_feature_toggles,
+    get_feature_toggle_strategies,
+)
+
+
+class Local:
+    client: None
+
+
+def test__get_unleash_api_client(mocker):
+    a = mocker.patch("UnleashClient.UnleashClient.initialize_client")
+    c = _get_unleash_api_client("https://u/api", "foo", local=Local)
+
+    assert a.call_count == 1
+    assert Local.client == c
+
+
+def test__get_unleash_api_client_skip_create(mocker):
+    u = mocker.patch("UnleashClient.UnleashClient")
+    Local.client = u
+    a = mocker.patch("UnleashClient.UnleashClient.initialize_client")
+    c = _get_unleash_api_client("https://u/api", "foo", local=Local)
+
+    assert a.call_count == 0
+    assert Local.client == c == u
+
+
+def test_get_feature_toggle_default():
+    assert get_feature_toggle_default(None, None)
+
+
+def test_get_feature_toggle_state_env_missing():
+    assert get_feature_toggle_state("foo")
+
+
+def test_get_feature_toggle_state(mocker):
+    def enabled_func(feature, fallback_function):
+        return feature == "enabled"
+
+    os.environ["UNLEASH_API_URL"] = "foo"
+    os.environ["UNLEASH_CLIENT_ACCESS_TOKEN"] = "bar"
+
+    defaultfunc = mocker.patch(
+        "reconcile.utils.unleash.get_feature_toggle_default", return_value=True
+    )
+    mocker.patch("UnleashClient.UnleashClient.initialize_client")
+    mocker.patch("UnleashClient.UnleashClient.is_enabled", side_effect=enabled_func)
+
+    assert get_feature_toggle_state("enabled")
+    assert get_feature_toggle_state("disabled") is False
+    assert defaultfunc.call_count == 0
+
+
+def test_get_feature_toggles(mocker):
+    c = mocker.patch("UnleashClient.UnleashClient")
+    c.features = {
+        "foo": Feature("foo", False, []),
+        "bar": Feature("bar", True, []),
+    }
+
+    mocker.patch("reconcile.utils.unleash._get_unleash_api_client", return_value=c)
+    toggles = get_feature_toggles("api", "token")
+
+    assert toggles["foo"] == "disabled"
+    assert toggles["bar"] == "enabled"
+
+
+def test_get_feature_toggle_strategies_env_missing():
+    assert get_feature_toggle_strategies("foo") is None
+
+
+def test_get_feature_toggle_strategies(mocker):
+    os.environ["UNLEASH_API_URL"] = "foo"
+    os.environ["UNLEASH_CLIENT_ACCESS_TOKEN"] = "bar"
+
+    c = mocker.patch("UnleashClient.UnleashClient")
+    c.features = {
+        "foo": Feature("foo", False, [Strategy(parameters={"foo": "bar"})]),
+        "bar": Feature("bar", True, []),
+    }
+
+    mocker.patch("reconcile.utils.unleash._get_unleash_api_client", return_value=c)
+
+    strategies = get_feature_toggle_strategies("foo")
+    assert strategies is not None and len(strategies) == 1
+    assert strategies[0].parameters["foo"] == "bar"
+
+    strategies = get_feature_toggle_strategies("bar")
+    assert strategies is not None and len(strategies) == 0
+
+    assert get_feature_toggle_strategies("rab") is None

--- a/reconcile/test/test_unleash.py
+++ b/reconcile/test/test_unleash.py
@@ -90,7 +90,7 @@ def setup_unleash_httpretty(enabled: bool):
             {
                 "strategies": [
                     {
-                        "name": "perCluster",
+                        "name": "disableCluster",
                         "constraints": [],
                         "parameters": {"cluster_name": "foo"},
                     }

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1231,7 +1231,7 @@ class OC:
             use_native = use_native.lower() in ["true", "yes"]
         else:
             enable_toggle = "openshift-resources-native-client"
-            strategies = get_feature_toggle_strategies(enable_toggle, ["perCluster"])
+            strategies = get_feature_toggle_strategies(enable_toggle)
 
             # only use the native client if the toggle is enabled and this
             # server is listed in the perCluster strategy

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1231,18 +1231,8 @@ class OC:
             use_native = use_native.lower() in ["true", "yes"]
         else:
             enable_toggle = "openshift-resources-native-client"
-            strategies = get_feature_toggle_strategies(enable_toggle)
-
-            # only use the native client if the toggle is enabled and this
-            # server is listed in the perCluster strategy
-            cluster_in_strategy = False
-            if strategies:
-                for s in strategies:
-                    if cluster_name in s.parameters["cluster_name"].split(","):
-                        cluster_in_strategy = True
-                        break
-            use_native = (
-                get_feature_toggle_state(enable_toggle) and not cluster_in_strategy
+            use_native = get_feature_toggle_state(
+                enable_toggle, context={"cluster_name": cluster_name}
             )
 
         if use_native:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -39,10 +39,7 @@ from kubernetes.dynamic.client import DynamicClient
 from kubernetes.dynamic.discovery import ResourceGroup, LazyDiscoverer
 from kubernetes.dynamic.resource import ResourceList
 
-from reconcile.utils.unleash import (
-    get_feature_toggle_strategies,
-    get_feature_toggle_state,
-)
+from reconcile.utils.unleash import get_feature_toggle_state
 
 urllib3.disable_warnings()
 

--- a/reconcile/utils/unleash.py
+++ b/reconcile/utils/unleash.py
@@ -1,117 +1,94 @@
 import os
-import tempfile
-import shutil
 import threading
+from typing import Mapping, Optional, Any
 
-from UnleashClient import UnleashClient
+from UnleashClient import UnleashClient, BaseCache
 from UnleashClient import strategies
+from UnleashClient.strategies import Strategy
 
-from reconcile.utils.defer import defer
 from reconcile.utils.helpers import toggle_logger
 
-log_lock = threading.Lock()
+client_local = threading.local()
+
+custom_strategies = ["perCluster", "perClusterNamespace"]
+
+
+class CacheDict(BaseCache):
+    def __init__(self):
+        self.cache = {}
+
+    def set(self, key: str, value: Any):
+        self.cache[key] = value
+
+    def mset(self, data: dict):
+        self.cache.update(data)
+
+    def get(self, key: str, default: Optional[Any] = None):
+        return self.cache.get(key, default)
+
+    def exists(self, key: str):
+        return key in self.cache
+
+    def destroy(self):
+        self.cache = {}
+
+
+def _get_unleash_api_client(
+    api_url: str, auth_head: str, local=client_local
+) -> UnleashClient:
+    if getattr(local, "client", None) is None:
+        headers = {"Authorization": f"Bearer {auth_head}"}
+        c = UnleashClient(
+            url=api_url,
+            app_name="qontract-reconcile",
+            custom_headers=headers,
+            cache=CacheDict(),
+            custom_strategies={name: strategies.Strategy for name in custom_strategies},
+        )
+        c.initialize_client()
+        local.client = c
+
+    return local.client
 
 
 def get_feature_toggle_default(feature_name, context):
     return True
 
 
-@defer
-def get_feature_toggle_state(integration_name, defer=None):
+def get_feature_toggle_state(integration_name: str) -> bool:
     api_url = os.environ.get("UNLEASH_API_URL")
     client_access_token = os.environ.get("UNLEASH_CLIENT_ACCESS_TOKEN")
     if not (api_url and client_access_token):
-        return True
+        return get_feature_toggle_default(None, None)
 
-    # create temporary cache dir
-    cache_dir = tempfile.mkdtemp()
-    defer(lambda: shutil.rmtree(cache_dir))
-
-    # hide INFO logging from UnleashClient
-    with log_lock:
-        with toggle_logger():
-            # create Unleash client
-            headers = {"Authorization": f"Bearer {client_access_token}"}
-            client = UnleashClient(
-                url=api_url,
-                app_name="qontract-reconcile",
-                custom_headers=headers,
-                cache_directory=cache_dir,
-            )
-            client.initialize_client()
-
-            # get feature toggle state
-            state = client.is_enabled(
-                integration_name, fallback_function=get_feature_toggle_default
-            )
-            client.destroy()
-
-        return state
-
-
-@defer
-def get_feature_toggles(api_url, client_access_token, defer=None):
     # hide INFO logging from UnleashClient
     with toggle_logger():
-        # create temporary cache dir
-        cache_dir = tempfile.mkdtemp()
-        defer(lambda: shutil.rmtree(cache_dir))
-
-        # create Unleash client
-        headers = {"Authorization": f"Bearer {client_access_token}"}
-        client = UnleashClient(
-            url=api_url,
-            app_name="qontract-reconcile",
-            custom_headers=headers,
-            cache_directory=cache_dir,
+        c = _get_unleash_api_client(
+            api_url,
+            client_access_token,
         )
-        client.initialize_client()
-        defer(client.destroy)
 
-    return {
-        k: "enabled" if v.enabled else "disabled" for k, v in client.features.items()
-    }
+    return c.is_enabled(integration_name, fallback_function=get_feature_toggle_default)
 
 
-@defer
-def get_unleash_strategies(api_url, token, strategy_names, defer=None):
-    # create strategy mapping
-    unleash_strategies = {name: strategies.Strategy for name in strategy_names}
-
-    # create temporary cache dir
-    cache_dir = tempfile.mkdtemp()
-    defer(lambda: shutil.rmtree(cache_dir))
-
+def get_feature_toggles(api_url: str, client_access_token: str) -> Mapping[str, str]:
     # hide INFO logging from UnleashClient
-    with log_lock:
-        with toggle_logger():
-            # create Unleash client
-            headers = {"Authorization": f"Bearer {token}"}
-            client = UnleashClient(
-                url=api_url,
-                app_name="qontract-reconcile",
-                custom_headers=headers,
-                cache_directory=cache_dir,
-                custom_strategies=unleash_strategies,
-            )
-            client.initialize_client()
+    with toggle_logger():
+        c = _get_unleash_api_client(api_url, client_access_token)
 
-            strats = {
-                name: toggle.strategies for name, toggle in client.features.items()
-            }
-            client.destroy()
-
-        return strats
+    return {k: "enabled" if v.enabled else "disabled" for k, v in c.features.items()}
 
 
-def get_feature_toggle_strategies(toggle_name, strategy_names):
+def get_feature_toggle_strategies(toggle_name: str) -> Optional[list[Strategy]]:
     api_url = os.environ.get("UNLEASH_API_URL")
     client_access_token = os.environ.get("UNLEASH_CLIENT_ACCESS_TOKEN")
     if not (api_url and client_access_token):
         return None
 
-    all_strategies = get_unleash_strategies(
-        api_url=api_url, token=client_access_token, strategy_names=strategy_names
-    )
+    with toggle_logger():
+        c = _get_unleash_api_client(api_url, client_access_token)
+        all_strategies = {
+            name: toggle.strategies for name, toggle in c.features.items()
+        }
 
     return all_strategies[toggle_name] if toggle_name in all_strategies else None

--- a/reconcile/utils/unleash.py
+++ b/reconcile/utils/unleash.py
@@ -36,6 +36,7 @@ class CacheDict(BaseCache):
 def _get_unleash_api_client(
     api_url: str, auth_head: str, local=client_local
 ) -> UnleashClient:
+    # Setting the local parameter is intended for running this in tests only!
     if getattr(local, "client", None) is None:
         headers = {"Authorization": f"Bearer {auth_head}"}
         c = UnleashClient(

--- a/reconcile/utils/unleash.py
+++ b/reconcile/utils/unleash.py
@@ -31,7 +31,7 @@ class CacheDict(BaseCache):
         self.cache = {}
 
 
-class DisableNativeClientStrategy(Strategy):
+class DisableClusterStrategy(Strategy):
     def load_provisioning(self) -> list:
         return [x.strip() for x in self.parameters["cluster_name"].split(",")]
 
@@ -58,7 +58,7 @@ def _get_unleash_api_client(api_url: str, auth_head: str) -> UnleashClient:
                 app_name="qontract-reconcile",
                 custom_headers=headers,
                 cache=CacheDict(),
-                custom_strategies={"perCluster": DisableNativeClientStrategy},
+                custom_strategies={"disableCluster": DisableClusterStrategy},
             )
             client.initialize_client()
     return client

--- a/reconcile/utils/unleash.py
+++ b/reconcile/utils/unleash.py
@@ -35,10 +35,10 @@ class DisableNativeClientStrategy(Strategy):
     def load_provisioning(self) -> list:
         return [x.strip() for x in self.parameters["cluster_name"].split(",")]
 
-    def apply(self, context: dict = None) -> bool:
+    def apply(self, context: Optional[dict] = None) -> bool:
         enable = True
 
-        if "cluster_name" in context.keys():
+        if context and "cluster_name" in context.keys():
             # if cluster in context is in clusters sent from server, disable
             enable = context["cluster_name"] not in self.parsed_provisioning
 

--- a/reconcile/utils/unleash.py
+++ b/reconcile/utils/unleash.py
@@ -38,6 +38,9 @@ def _get_unleash_api_client(api_url: str, auth_head: str) -> UnleashClient:
     global client
     with client_lock:
         if client is None:
+            logging.getLogger("apscheduler.executors.default").setLevel(logging.ERROR)
+            logging.getLogger("apscheduler.scheduler").setLevel(logging.ERROR)
+            logging.getLogger("UnleashClient").setLevel(logging.ERROR)
             headers = {"Authorization": f"Bearer {auth_head}"}
             client = UnleashClient(
                 url=api_url,
@@ -49,8 +52,6 @@ def _get_unleash_api_client(api_url: str, auth_head: str) -> UnleashClient:
                 },
             )
             client.initialize_client()
-        logging.getLogger("apscheduler.executors.default").setLevel(logging.ERROR)
-        logging.getLogger("UnleashClient").setLevel(logging.ERROR)
     return client
 
 


### PR DESCRIPTION
Standard Strategies used in the last try, see https://github.com/app-sre/qontract-reconcile/pull/2616 returned wrong results.

Added `DisableNativeClientStrategy`, which returns True, unless a cluster is added to the cluster_name list of the feature.  If the feature is disabled it is also set to false (see https://github.com/Unleash/unleash-client-python/blob/main/UnleashClient/features/Feature.py#L64). Additionally, I did add some tests, that use httpretty to ensure this behavior.