### PR TITLE
[saas-file-validator] validate allowed secret parameter paths

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1800,6 +1800,7 @@ SAAS_FILES_QUERY_V2 = """
     publishJobLogs
     clusterAdmin
     imagePatterns
+    allowedSecretParameterPaths
     use_channel_in_image_tag
     authentication {
       code {

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -127,7 +127,7 @@ class SaasHerder:
     def _validate_allowed_secret_parameter_paths(
         self,
         saas_file_name: str,
-        secret_parameters: dict[str, Any],
+        secret_parameters: Iterable[Mapping[str, Any]],
         allowed_secret_parameter_paths: Iterable[str],
     ) -> None:
         if not secret_parameters:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -138,6 +138,15 @@ class SaasHerder:
                 f"[{saas_file_name}] " f"missing allowedSecretParameterPaths section"
             )
             return
+        for sp in secret_parameters:
+            path = sp["secret"]["path"]
+            match = [a for a in allowed_secret_parameter_paths if path.startswith(a)]
+            if not match:
+                self.valid = False
+                logging.error(
+                    f"[{saas_file_name}] "
+                    f"secret parameter path '{path}' does not match any of allowedSecretParameterPaths"
+                )
 
     def _validate_saas_files(self):
         self.valid = True

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -126,10 +126,17 @@ class SaasHerder:
 
     def _validate_allowed_secret_parameter_paths(
         self,
+        saas_file_name: str,
         secret_parameters: dict[str, Any],
         allowed_secret_parameter_paths: Iterable[str],
     ) -> None:
         if not secret_parameters:
+            return
+        if not allowed_secret_parameter_paths:
+            self.valid = False
+            logging.error(
+                f"[{saas_file_name}] " f"missing allowedSecretParameterPaths section"
+            )
             return
 
     def _validate_saas_files(self):
@@ -158,13 +165,16 @@ class SaasHerder:
                 saas_file.get("allowedSecretParameterPaths") or []
             )
             self._validate_allowed_secret_parameter_paths(
-                saas_file.get("secretParameters"), allowed_secret_parameter_paths
+                saas_file_name,
+                saas_file.get("secretParameters"),
+                allowed_secret_parameter_paths,
             )
 
             for resource_template in saas_file["resourceTemplates"]:
                 resource_template_name = resource_template["name"]
                 resource_template_url = resource_template["url"]
                 self._validate_allowed_secret_parameter_paths(
+                    saas_file_name,
                     resource_template.get("secretParameters"),
                     allowed_secret_parameter_paths,
                 )
@@ -185,10 +195,14 @@ class SaasHerder:
                         target,
                     )
                     self._validate_allowed_secret_parameter_paths(
-                        target.get("secretParameters"), allowed_secret_parameter_paths
+                        saas_file_name,
+                        target.get("secretParameters"),
+                        allowed_secret_parameter_paths,
                     )
                     self._validate_allowed_secret_parameter_paths(
-                        environment.get("secretParameters"), allowed_secret_parameter_paths
+                        saas_file_name,
+                        environment.get("secretParameters"),
+                        allowed_secret_parameter_paths,
                     )
 
                     promotion = target.get("promotion")


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/210

required for #2646

this PR introduces logic to validate that secret parameter paths are allowed in a list: `allowedSecretParamterPaths`.
this is to allow full self-service over secretParameters, without allowing usage of unpermitted secrets.