### PR TITLE
qontract-cli - review-queue: support for other app-interface instances

### DIFF
--- a/reconcile/test/test_utils_jjb_client.py
+++ b/reconcile/test/test_utils_jjb_client.py
@@ -1,0 +1,51 @@
+import pytest
+from reconcile.utils.jjb_client import JJB
+
+
+@pytest.fixture
+def github_job_fixture():
+    return {
+        "name": "service-foobar2-build",
+        "properties": [{"github": {"url": "http://github.com"}}],
+        "triggers": [
+            {"github-pull-request": {"trigger-phrase": ".*"}},
+        ],
+    }
+
+
+@pytest.fixture
+def gitlab_job_fixture():
+    return {
+        "name": "service-foobar-pr-check",
+        "properties": [
+            {"github": {"url": "http://mygilabinstance.org/service/foobar"}},
+        ],
+        "triggers": [
+            {"gitlab": {"note-regex": "my_trigger_regex.*"}},
+        ],
+    }
+
+
+@pytest.fixture
+def patch_jjb(mocker, github_job_fixture, gitlab_job_fixture):
+    mocker.patch(
+        "reconcile.utils.jjb_client.JJB.__init__", return_value=None, autospec=True
+    )
+    return mocker.patch(
+        "reconcile.utils.jjb_client.JJB.get_all_jobs",
+        return_value={"ci": [github_job_fixture, gitlab_job_fixture]},
+        autospec=True,
+    )
+
+
+def test_get_job_by_repo_url(patch_jjb, gitlab_job_fixture):
+    jjb = JJB(None)
+    job = jjb.get_job_by_repo_url(
+        "http://mygilabinstance.org/service/foobar", "pr-check"
+    )
+    assert job["name"] == gitlab_job_fixture["name"]
+
+
+def test_get_trigger_phrases_regex(patch_jjb, gitlab_job_fixture):
+    jjb = JJB(None)
+    assert jjb.get_trigger_phrases_regex(gitlab_job_fixture) == "my_trigger_regex.*"

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -378,7 +378,7 @@ class SaasHerder:
     @staticmethod
     def _get_upstream_jobs(
         jjb: JJB,
-        all_jobs: Mapping[str, dict],
+        all_jobs: dict[str, list[dict]],
         url: str,
         ref: str,
     ) -> Iterable[UpstreamJob]:

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1101,8 +1101,8 @@ def app_interface_review_queue(ctx):
     merge_requests = gl.get_merge_requests(state=MRState.OPENED)
     secret_reader = SecretReader(settings=settings)
     jjb: JJB = init_jjb(secret_reader)
-    job = jjb.get_all_jobs(["service-app-interface-gl-pr-check"])["ci-int"][0]
-    trigger_phrases_regex = job["triggers"][0]["gitlab"]["note-regex"]
+    job = jjb.get_job_by_repo_url(settings["repoUrl"], job_type="gl-pr-check")
+    trigger_phrases_regex = jjb.get_trigger_phrases_regex(job)
 
     columns = [
         "id",


### PR DESCRIPTION
Refactor the review-queue command to support other app-interface instances (e.g. fedramp or app-interface-dev-data) hosted on GitLab or GitHub.

APPSRE-6086
