### PR TITLE
[gitlab-housekeeping] remove labels when not added by allowed users

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -203,9 +203,11 @@ def get_merge_requests(dry_run: bool, gl: GitLabApi) -> list:
         )
         label_events = mr.resourcelabelevents.list()
         for label in reversed(label_events):
-            if label.action == "add" and label.label["name"] in MERGE_LABELS_PRIORITY:
+            if label.action == "add":
+                added_by = label.user["username"]
+                if label.label["name"] in MERGE_LABELS_PRIORITY:
                 approved_at = label.created_at
-                approved_by = label.user["username"]
+                    approved_by = added_by
                 break
 
         item = {

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -186,8 +186,6 @@ def get_merge_requests(
         labels = mr.attributes.get("labels")
         if not labels:
             continue
-        if not is_good_to_merge(labels):
-            continue
 
         if SAAS_FILE_UPDATE in labels and LGTM in labels:
             logging.warning(
@@ -207,6 +205,9 @@ def get_merge_requests(
                     approved_at = label.created_at
                     approved_by = added_by
                     break
+
+        if not is_good_to_merge(labels):
+            continue
 
         label_priotiry = min(
             MERGE_LABELS_PRIORITY.index(merge_label)

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -197,14 +197,15 @@ def get_merge_requests(
             continue
 
         label_events = mr.resourcelabelevents.list()
+        approval_found = False
         for label in reversed(label_events):
             if label.action == "add":
                 label_name = label.label["name"]
                 added_by = label.user["username"]
-                if label_name in MERGE_LABELS_PRIORITY:
+                if label_name in MERGE_LABELS_PRIORITY and not approval_found:
+                    approval_found = True
                     approved_at = label.created_at
                     approved_by = added_by
-                    break
 
         if not is_good_to_merge(labels):
             continue

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -206,8 +206,9 @@ def get_merge_requests(
         label_events = mr.resourcelabelevents.list()
         for label in reversed(label_events):
             if label.action == "add":
+                label_name = label.label["name"]
                 added_by = label.user["username"]
-                if label.label["name"] in MERGE_LABELS_PRIORITY:
+                if label_name in MERGE_LABELS_PRIORITY:
                     approved_at = label.created_at
                     approved_by = added_by
                     break

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -204,15 +204,14 @@ def get_merge_requests(
             if label.action == "add":
                 label_name = label.label["name"]
                 added_by = label.user["username"]
-                if users_allowed_to_label:
-                    if added_by not in users_allowed_to_label:
-                        logging.warning(
-                            f"[{gl.project.name}/{mr.iid}] user {added_by} is "
-                            + f"not allowed to add labels. removing label {label_name}"
-                        )
-                        if not dry_run:
-                            gl.remove_label_from_merge_request(mr.iid, label_name)
-                        continue
+                if users_allowed_to_label and added_by not in users_allowed_to_label:
+                    logging.warning(
+                        f"[{gl.project.name}/{mr.iid}] user {added_by} is "
+                        + f"not allowed to add labels. removing label {label_name}"
+                    )
+                    if not dry_run:
+                        gl.remove_label_from_merge_request(mr.iid, label_name)
+                    continue
                 if label_name in MERGE_LABELS_PRIORITY and not approval_found:
                     approval_found = True
                     approved_at = label.created_at

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -171,7 +171,9 @@ def is_rebased(mr, gl: GitLabApi) -> bool:
 
 
 def get_merge_requests(
-    dry_run: bool, gl: GitLabApi, labels_allowed: Optional[Iterable[Mapping[str, Any]]]
+    dry_run: bool,
+    gl: GitLabApi,
+    labels_allowed: Optional[Iterable[Mapping[str, Any]]] = None,
 ) -> list:
     mrs = gl.get_merge_requests(state=MRState.OPENED)
     users_allowed_to_label = set()

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -198,11 +198,6 @@ def get_merge_requests(
                 gl.remove_label_from_merge_request(mr.iid, LGTM)
             continue
 
-        label_priotiry = min(
-            MERGE_LABELS_PRIORITY.index(merge_label)
-            for merge_label in MERGE_LABELS_PRIORITY
-            if merge_label in labels
-        )
         label_events = mr.resourcelabelevents.list()
         for label in reversed(label_events):
             if label.action == "add":
@@ -212,6 +207,12 @@ def get_merge_requests(
                     approved_at = label.created_at
                     approved_by = added_by
                     break
+
+        label_priotiry = min(
+            MERGE_LABELS_PRIORITY.index(merge_label)
+            for merge_label in MERGE_LABELS_PRIORITY
+            if merge_label in labels
+        )
 
         item = {
             "mr": mr,

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1315,6 +1315,13 @@ APPS_QUERY = """
         limit
         enable_closing
         pipeline_timeout
+        labels_allowed {
+          role {
+            users {
+              org_username
+            }
+          }
+        }
       }
       jira {
         serverUrl


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/212

example usage in https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/44367

with this PR, if a user adds a label but they are not within the allowed labels roles, the label will be removed. this is to handle users with Developer access adding labels to MRs in gitlab.