### PR TITLE
Bump sretoolbox to 1.4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_data={'reconcile': ['templates/*.j2']},
 
     install_requires=[
-        "sretoolbox~=1.2",
+        "sretoolbox~=1.4.0",
         "Click>=7.0,<9.0",
         "gql==3.1.0",
         "toml>=0.10.0,<0.11.0",


### PR DESCRIPTION
This version of sretoolbox properly compares simple single arch images
with multiarch images returning `False` instead of throwing an exception.
This will effectively make that every deep sync we will synchronize
these images although we may have the corresponding single arch image in
Quay. Unfortunately, sretoolbox does not yet support comparations such
as:

```
single_image in multi_image
````
so this is the best we can do for the moment.

xref: https://github.com/app-sre/sretoolbox/pull/72

part of https://issues.redhat.com/browse/APPSRE-6084

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>