### PR TITLE
if MR is not assigned it can not be last assigned

### DIFF
--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -524,6 +524,8 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
     def is_assigned_by_team(
         self, mr: ProjectMergeRequest, team_usernames: list[str]
     ) -> bool:
+        if not mr.assignee:
+            return False
         last_assignment = self.last_assignment(mr)
         if not last_assignment:
             return False


### PR DESCRIPTION
example where this is failing: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/43616