### PR TITLE
[openshift_base] handle resources without data when validating

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -725,7 +725,7 @@ def _validate_resources_used_exist(
             ri.register_error()
             continue
         # here it is! let's make sure it has all the required keys
-        missing_keys = used_keys - resource["data"].keys()
+        missing_keys = used_keys - resource.get("data", {}).keys()
         if missing_keys:
             logging.error(f"{err_base} does not contain keys: {missing_keys}")
             ri.register_error()


### PR DESCRIPTION
ConfigMap or Secret can exist without a `data` field.

This changes handles cases when `data` is not present in the resource