### PR TITLE
[saasherder] fix url paths in error messages

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -743,7 +743,7 @@ class SaasHerder:
                 )
             except Exception as e:
                 logging.error(
-                    f"[{url}/{path}:{target_ref}] "
+                    f"[{url}/blob/{target_ref}{path}] "
                     + f"error fetching template: {str(e)}"
                 )
                 return None, None, None
@@ -827,7 +827,7 @@ class SaasHerder:
                 )
             except Exception as e:
                 logging.error(
-                    f"[{url}/{path}:{target_ref}] "
+                    f"[{url}/tree/{target_ref}{path}] "
                     + f"error fetching directory: {str(e)}"
                 )
                 return None, None, None


### PR DESCRIPTION
fix the url from logs to something that is a valid link.
we've seen tenants assuming that the broken link means a problem with the integration, so let's at least get that out of the way.