### PR TITLE
Temp fix to handle the comparation of OCI images

### DIFF
--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -232,8 +232,26 @@ class QuayMirror:
                             )
                             continue
                     except ImageComparisonError as details:
-                        _LOG.error("[%s]", details)
+                        _LOG.error(
+                            "Error comparing image %s and %s - %s",
+                            downstream,
+                            upstream,
+                            details,
+                        )
                         continue
+                    # Temporary fix while sretoolbox cannot handle comparing OCI images
+                    # with content-type: "application/vnd.oci.image.index.v1+json"
+                    except KeyError as details:
+                        if "mediaType" in str(details):
+                            _LOG.error(
+                                "Error comparing image %s and %s - Missing 'mediaType' "
+                                "key in manifest",
+                                downstream,
+                                upstream,
+                            )
+                            continue
+                        else:
+                            raise
 
                     _LOG.debug(
                         "Image %s and mirror %s are out of sync", downstream, upstream


### PR DESCRIPTION
sretoolbox currently doesn't handle well the comparation of OCI images
with content-type 'application/vnd.oci.image.index.v1+json'. These are
manifest list type of images that don't have `mediaType` in their
manifest so sretoolbox logic fails.

The real fix is in sretoolbox.container.image module, but that's going
to take a bit longer since we will need to change how image comparation
is done as it will need to inspect the manifest headers instead of the
manifest itself.

In the meantime, we have this to avoid the integration to crash.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>