### PR TITLE
[saas-file-validator] consider Services's serving-cert secrets

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -710,6 +710,31 @@ def _validate_resources_used_exist(
     for used_name, used_keys in used_resources.items():
         # perhaps used resource is deployed together with the using resource?
         resource = ri.get_desired(cluster, namespace, used_kind, used_name)
+        # if not, perhaps it's a secret that will be created from a Service's
+        # serving-cert that is deployed along with the using resource?
+        # lets iterate through all resources and find Services that have the annotation
+        if not resource and used_kind == "Secret":
+            found_serving_cert = False
+            for (cname, nname, restype, res) in ri:
+                # consider only Service resources in the same namespace
+                if cname == cluster and nname == namespace and restype == "Service":
+                    # Check serving-cert-secret-name annotation on every Service
+                    for desired in res["desired"].values():
+                        metadata = desired.body.get("metadata", {})
+                        annotations = metadata.get("annotations", {})
+                        value = annotations.get(
+                            "service.alpha.openshift.io/serving-cert-secret-name", False
+                        )
+                        # we found one! does it's value (secret name) match the
+                        # using resource's?
+                        if value == used_name:
+                            # found a match. we assume the serving cert secret will
+                            # be present at some point soon after the Service is deployed
+                            found_serving_cert = True
+                            resource = desired
+                            break
+                    if found_serving_cert:
+                        break
         if resource:
             # get the body to match with the possible result from oc.get
             resource = resource.body

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -714,27 +714,25 @@ def _validate_resources_used_exist(
         # serving-cert that is deployed along with the using resource?
         # lets iterate through all resources and find Services that have the annotation
         if not resource and used_kind == "Secret":
-            found_serving_cert = False
+            # consider only Service resources that are in the same cluster & namespace
+            service_resources = []
             for (cname, nname, restype, res) in ri:
-                # consider only Service resources in the same namespace
                 if cname == cluster and nname == namespace and restype == "Service":
-                    # Check serving-cert-secret-name annotation on every Service
-                    for desired in res["desired"].values():
-                        metadata = desired.body.get("metadata", {})
-                        annotations = metadata.get("annotations", {})
-                        value = annotations.get(
-                            "service.alpha.openshift.io/serving-cert-secret-name", False
-                        )
-                        # we found one! does it's value (secret name) match the
-                        # using resource's?
-                        if value == used_name:
-                            # found a match. we assume the serving cert secret will
-                            # be present at some point soon after the Service is deployed
-                            found_serving_cert = True
-                            resource = desired
-                            break
-                    if found_serving_cert:
-                        break
+                    service_resources.extend(res["desired"].values())
+            # Check serving-cert-secret-name annotation on every considered resource
+            for service in service_resources:
+                metadata = service.body.get("metadata", {})
+                annotations = metadata.get("annotations", {})
+                value = annotations.get(
+                    "service.alpha.openshift.io/serving-cert-secret-name", False
+                )
+                # we found one! does it's value (secret name) match the
+                # using resource's?
+                if value == used_name:
+                    # found a match. we assume the serving cert secret will
+                    # be present at some point soon after the Service is deployed
+                    resource = service
+                    break
         if resource:
             # get the body to match with the possible result from oc.get
             resource = resource.body

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -723,12 +723,12 @@ def _validate_resources_used_exist(
             for service in service_resources:
                 metadata = service.body.get("metadata", {})
                 annotations = metadata.get("annotations", {})
-                value = annotations.get(
+                serving_cert_secret_name = annotations.get(
                     "service.alpha.openshift.io/serving-cert-secret-name", False
                 )
                 # we found one! does it's value (secret name) match the
                 # using resource's?
-                if value == used_name:
+                if serving_cert_secret_name == used_name:
                     # found a match. we assume the serving cert secret will
                     # be present at some point soon after the Service is deployed
                     resource = service


### PR DESCRIPTION
it is possible that a resource being deployed references a Secret that originates from a Service object's `serving-cert-secret-name` annotation. When that Service resource is initially deployed alongside the using resource, the secret is not present and thus we have to look for such a service and annotation

As such we iterate through all the Services that are being deployed along with the saas-file objects (same
cluster, same namespace) and we check if such an annotation exists and has the same name as the using resource

I have tested this locally and it fixes the issue that prompted this change: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/44658