### PR TITLE
mark git as external tox dep

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,7 @@ deps = -r{toxinidir}/requirements/requirements-type.txt
 [testenv:generate]
 # We want to ensure that there is no drift between introspection.json
 # and generated classes.
+allowlist_externals = git
 commands =
     qenerate code -i reconcile/gql_queries/introspection.json gql_queries
     black reconcile/gql_queries


### PR DESCRIPTION
Fix

```
generate run-test: commands[2] | git diff --exit-code
WARNING: test command found but not installed in testenv
  cmd: /usr/bin/git
  env: /package/.tox/generate
Maybe you forgot to specify a dependency? See also the allowlist_externals envconfig setting.

DEPRECATION WARNING: this will be an error in tox 4 and above!
```

--> git must be marked as external dependency that is not managed by tox.