### PR TITLE
jira-client ignore arg-type

### DIFF
--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -34,7 +34,7 @@ class JiraClient:
         while True:
             index = block_num * block_size
             issues = self.jira.search_issues(jql, index, block_size, **kwargs)
-            all_issues.extend(issues)
+            all_issues.extend(issues)  # type: ignore[arg-type]
             if len(issues) < block_size:
                 break
             block_num += 1

--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -34,6 +34,7 @@ class JiraClient:
         while True:
             index = block_num * block_size
             issues = self.jira.search_issues(jql, index, block_size, **kwargs)
+            # TODO: investigate why the arg-type ignore is needed in CI
             all_issues.extend(issues)  # type: ignore[arg-type]
             if len(issues) < block_size:
                 break


### PR DESCRIPTION
not able to reproduce this locally, but we need CI passing.
```
reconcile/utils/jira_client.py:37: error: Argument 1 to "extend" of "list" has incompatible type "Union[Dict[str, Any], ResultList[Issue]]"; expected "Iterable[Dict[str, Any]]"  [arg-type]
```