### PR TITLE
Bump minimum coverage to 34%

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ branch = True
 omit = reconcile/test/*
 
 [report]
-fail_under = 32.5
+fail_under = 34


### PR DESCRIPTION
redo #2297, which was reverted in #2573

we are currently at 34.19% coverage.