### PR TITLE
Properly handle return type from jira_client

### DIFF
--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -38,10 +38,10 @@ class JiraClient:
             )
             if not isinstance(issues, ResultList):
                 # if search_issues was executed with json_result=True, then we have a Dict.
-                # However, we require a ResultList.
+                # However, we require a ResultList[Issue].
                 # See https://github.com/pycontribs/jira/commit/cc2508485c12232a4a9c4a56ee74175ed818ee20
                 logging.warning(
-                    "Jira client did not receive a ResultList."
+                    "Jira client did not receive a ResultList[Issue]."
                     " Maybe the call was made with json_result=True which is"
                     " currently not supported."
                 )


### PR DESCRIPTION
The `jira` module had a wrong type hint which was recently fixed https://github.com/pycontribs/jira/commit/cc2508485c12232a4a9c4a56ee74175ed818ee20

Our current logic expects a `ResultList` to be returned.

This PR ensures that only `ResultList` is processed and occurrences of `Dict` log a warning.

**Local Test on Prod Data**

```
qontract-reconcile_1  | [2022-08-08 10:57:57] [INFO] [gql.py:init_from_config:250] - using gql endpoint http://qontract-server:4000/graphqlsha/eb59c0d13fd7232954c7aa3eb3fd74509a9bece78a486261f9b49864cf669578
qontract-reconcile_1  | [2022-08-08 10:58:01] [INFO] [jira_watcher.py:act:84] - https://issues.redhat.com/browse/ASIC-273 ([FIRING:1] QontractReconcileIntegrationStuck2hours app-sre-prod-01 app-interface) status change: Done -> To Do
qontract-reconcile_1  | [2022-08-08 10:58:01] [INFO] [jira_watcher.py:act:84] - https://issues.redhat.com/browse/ASIC-283 ([FIRING:1] QontractReconcileIntegrationStuck2hours appsrep05ue1 app-interface) status change: Done -> To Do
```