### PR TITLE
Fix memory requests for SQL jobs / cronJobs

### DIFF
--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -31,7 +31,7 @@ JOB_TTL = 604800  # 7 days
 POD_TTL = 3600  # 1 hour (used only when output is "filesystem")
 QUERY_CONFIG_MAP_CHUNK_SIZE = 512 * 1024  # 512 KB
 
-REQUESTS_MEM = "64Mi"
+REQUESTS_MEM = "128Mi"
 REQUESTS_CPU = "100m"
 LIMITS_MEM = "512Mi"
 LIMITS_CPU = "1"


### PR DESCRIPTION
With the default limits from app interface the ratio between the memory request and the limit should be
4 or less. With request_mem at 64Mi the ratio is 8, so in some namespaces, this leads to errors

https://coreos.slack.com/archives/CCRND57FW/p1659958449416839