### PR TITLE
qenerate: create __init__.py files after qgl classes generation to fix mypy errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,4 +96,5 @@ gql-introspection:
 
 gql-query-classes:
 	@$(VENV_CMD) qenerate code -i reconcile/gql_queries/introspection.json reconcile/gql_queries
+	find reconcile/gql_queries -path '*/__pycache__' -prune -o -type d -exec touch "{}/__init__.py" \;
 	@$(VENV_CMD) black reconcile/gql_queries


### PR DESCRIPTION
qenerate: create `__init__.py` files after qgl classes generation to fix mypy errors

APPSRE-6113
Ref: https://github.com/app-sre/qenerate/pull/27