### PR TITLE
[openshift-saas-deploy] take ownership of resources with missing caller

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -683,6 +683,7 @@ def realize_data(
     thread_pool_size,
     take_over=False,
     caller=None,
+    all_callers=None,
     wait_for_namespace=False,
     no_dry_run_skip_compare=False,
     override_enable_deletion=None,
@@ -699,6 +700,8 @@ def realize_data(
     :param caller: name of the calling entity.
                    enables multiple running instances of the same integration
                    to deploy to the same namespace
+    :param all_callers: names of all possible callers. used in conjunction with
+                    caller to allow renaming of saas files.
     :param wait_for_namespace: wait for namespace to exist before applying
     :param no_dry_run_skip_compare: when running without dry-run, skip compare
     :param override_enable_deletion: override calculated enable_deletion value

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -187,6 +187,7 @@ def run(
         ri,
         thread_pool_size,
         caller=saas_file_name,
+        all_callers=[sf["name"] for sf in all_saas_files],
         wait_for_namespace=True,
         no_dry_run_skip_compare=(not saasherder.compare),
         take_over=saasherder.take_over,


### PR DESCRIPTION
following up on #2694

apparently, there are many resources with a stale caller annotation. until the above PR, it was fine. now pipelines are failing.
the use cases we've seen so far are related to saas files being renamed.
so this PR is really an enhancement to allow renaming saas files.

occurrences:
- https://coreos.slack.com/archives/CCRND57FW/p1660201791354399
- https://coreos.slack.com/archives/C01V4S8GXPD/p1660221678123869

current workaround:
manually update the caller annotation on a resource that is causing pipelines to fail to the current name of the saas file (make sure the current value no longer exist).