### PR TITLE
gitlab-housekeeping if MR status is unchcked for automerge - check it harder

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -124,7 +124,7 @@ def handle_stale_items(dry_run, gl, days_interval, enable_closing, item_type):
                 # this call triggers a status recheck
                 item = gl.get_merge_request(item_iid)
             if item.merge_status == MRStatus.CANNOT_BE_MERGED:
-            close_item(dry_run, gl, enable_closing, item_type, item)
+                close_item(dry_run, gl, enable_closing, item_type, item)
         notes = item.notes.list()
         note_dates = [
             datetime.strptime(note.attributes.get("updated_at"), DATE_FORMAT)

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -119,7 +119,11 @@ def handle_stale_items(dry_run, gl, days_interval, enable_closing, item_type):
     for item in items:
         item_iid = item.attributes.get("iid")
         item_labels = item.attributes.get("labels")
-        if AUTO_MERGE in item_labels and item.merge_status == MRStatus.CANNOT_BE_MERGED:
+        if AUTO_MERGE in item_labels:
+            if item.merge_status == MRStatus.UNCHECKED:
+                # this call triggers a status recheck
+                item = gl.get_merge_request(item_iid)
+            if item.merge_status == MRStatus.CANNOT_BE_MERGED:
             close_item(dry_run, gl, enable_closing, item_type, item)
         notes = item.notes.list()
         note_dates = [


### PR DESCRIPTION
when listing MRs, some come back with `merge_status: unchcked`. calling the merge request endpoint gets this information.

follows up on #2673

ref: https://docs.gitlab.com/ee/api/merge_requests.html#merge-requests-list-response-notes