### PR TITLE
[quay-mirror] early exit

### DIFF
--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -6,6 +6,7 @@ import tempfile
 import time
 
 from collections import defaultdict, namedtuple
+from typing import Any
 
 from sretoolbox.container.image import ImageComparisonError
 from sretoolbox.container.skopeo import SkopeoCmdError
@@ -305,3 +306,11 @@ class QuayMirror:
 def run(dry_run):
     quay_mirror = QuayMirror(dry_run)
     quay_mirror.run()
+
+
+def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
+    quay_mirror = QuayMirror(dry_run=True)
+    return {
+        "repos": quay_mirror.process_repos_query(),
+        "orgs": quay_mirror.push_creds,
+    }


### PR DESCRIPTION
based on #2672

following #2700, quay-mirror now fails when it attempts to mirror a repo from docker hub publicly. this failure will happen when the integration runs.
this integration was disabled from running on pr-checks in the commercial app-interface in https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/21108, to remediate extensive calls to docker hub.

this means that MRs with public mirroring may be merged, and only later quay-mirror will start failing. we need to catch these cases in pr-check.

at the same time, running quay-mirror on pr-check is time consuming. the integration takes a lot of time to run. if only there was a way to run this integration only when relevant content is being changed... oh, wait! early exit!

this PR implements early exit for quay-mirror, such that it fails (really really) fast in case someone tries to publicly mirror a repo, and it will actually run in dry-run only when relevant content is changed. 