### PR TITLE
[slack-usergroups] early exit

### DIFF
--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -453,3 +453,9 @@ def run(dry_run):
     current_state = get_current_state(slack_map)
 
     act(current_state, desired_state, slack_map, dry_run)
+
+
+def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
+    return {
+        "permissions": queries.get_permissions_for_slack_usergroup(),
+    }


### PR DESCRIPTION
some integrations are "dynamic", such that they respond to changes that happen outside of app-interface.
for example, ocm-upgrade-scheduler decides on its own when to upgrade a cluster.
some integrations are "static", such that they only respond to changes that happen within app-interface.
for example, openshift-network-policies.

i suppose that a "dynamic" integration has other sources of truth except for app-interface.

slack-usergroup is somewhat "hybrid". it reconciles based on pagerduty schedules (dynamic) and also based on user-role-permission (static).

when running in dry-run, it means we are running within a MR. slack-usergroups should only run within a MR if that MR is changing data that is more "static". for example, when we see output from slack-usergroups within a MR that says something about changing a shift in app-sre-ic, it is considered noise.

hence, an early exit for slack-usergroups should be calculated solely based on the desired state (static content) in app-interface, and not based on the desired state in other sources of truth, such as pagerduty (dynamic content).

this PR adds an early exit for slack-usergroups, based only on the results of the permissions query. the query results are in fact the static content, and that is the only thing that matters in order to decide - to run, or not to run :skull: 