### PR TITLE
extract safe_resource_id helper method to reconcile.utils.terraform

### DIFF
--- a/reconcile/test/test_utils_terraform.py
+++ b/reconcile/test/test_utils_terraform.py
@@ -1,0 +1,9 @@
+from reconcile.utils.terraform import safe_resource_id
+
+
+def test_sanitize_resource_with_dots():
+    assert safe_resource_id("foo.example.com") == "foo_example_com"
+
+
+def test_sanitize_resource_with_wildcard():
+    assert safe_resource_id("*.foo.example.com") == "_star_foo_example_com"

--- a/reconcile/test/test_utils_terrascript_aws_client.py
+++ b/reconcile/test/test_utils_terrascript_aws_client.py
@@ -7,14 +7,6 @@ from reconcile.utils.external_resource_spec import (
 )
 
 
-def test_sanitize_resource_with_dots():
-    assert tsclient.safe_resource_id("foo.example.com") == "foo_example_com"
-
-
-def test_sanitize_resource_with_wildcard():
-    assert tsclient.safe_resource_id("*.foo.example.com") == "_star_foo_example_com"
-
-
 @pytest.fixture
 def ts():
     return tsclient.TerrascriptClient("", "", 1, [])

--- a/reconcile/utils/terraform/__init__.py
+++ b/reconcile/utils/terraform/__init__.py
@@ -1,0 +1,5 @@
+def safe_resource_id(s: str) -> str:
+    """Sanitize a string into a valid terraform resource id"""
+    res = s.translate({ord(c): "_" for c in "."})
+    res = res.replace("*", "_star")
+    return res

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -162,6 +162,7 @@ from reconcile.utils.elasticsearch_exceptions import (
 )
 import reconcile.openshift_resources_base as orb
 import reconcile.utils.aws_helper as awsh
+from reconcile.utils.terraform import safe_resource_id
 
 
 GH_BASE_URL = os.environ.get("GITHUB_API", "https://api.github.com")
@@ -227,13 +228,6 @@ class StateInaccessibleException(Exception):
 class UnknownProviderError(Exception):
     def __init__(self, msg):
         super().__init__("unknown provider error: " + str(msg))
-
-
-def safe_resource_id(s):
-    """Sanitize a string into a valid terraform resource id"""
-    res = s.translate({ord(c): "_" for c in "."})
-    res = res.replace("*", "_star")
-    return res
 
 
 class aws_ecrpublic_repository(Resource):


### PR DESCRIPTION
Small change to extract the helper method `safe_resource_id` into `reconcile.utils.terraform` as suggested here https://github.com/app-sre/qontract-reconcile/pull/2691#discussion_r945878684

PTAL @bhushanthakur93 