### PR TITLE
[openshift-routes] early exit

### DIFF
--- a/reconcile/openshift_routes.py
+++ b/reconcile/openshift_routes.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import reconcile.openshift_resources_base as orb
 
 from reconcile.utils.semver_helper import make_semver
@@ -28,3 +30,17 @@ def run(
         cluster_name=cluster_name,
         namespace_name=namespace_name,
     )
+
+
+def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
+    namespaces, _ = orb.get_namespaces(PROVIDERS)
+    resources = [
+        orb.fetch_provider_resource(r["path"]).body
+        for ns_info in namespaces
+        for r in ns_info["openshiftResources"]
+    ]
+
+    return {
+        "namespaces": namespaces,
+        "resources": resources,
+    }


### PR DESCRIPTION
the desired state for routes is captured within namespaces and referenced resources.
there is also a part if vault (TLS), but in case the vault path/version does not change, we can safely ignore it.

using `fetch_provider_resource` fetches the resource, and is really the only relevant part of `fetch_provider_route`: https://github.com/app-sre/qontract-reconcile/blob/af0a7fcdf102686075bc79450e0fd73710c1db33/reconcile/openshift_resources_base.py#L441

the rest is validations and adding tls data from vault.

depends on https://github.com/app-sre/qontract-reconcile/pull/2706