### PR TITLE
Add early exit support to prometheus-rules-tester

### DIFF
--- a/reconcile/prometheus_rules_tester.py
+++ b/reconcile/prometheus_rules_tester.py
@@ -4,6 +4,7 @@ import re
 import sys
 import traceback
 import yaml
+from typing import Any
 
 from sretoolbox.utils import threaded
 
@@ -362,3 +363,12 @@ def run(dry_run, thread_pool_size=10, cluster_name=None):
 
     if invalid_rules or failed_tests:
         sys.exit(ExitCodes.ERROR)
+
+
+def early_exit_desired_state(thread_pool_size=10, cluster_name=None) -> dict[str, Any]:
+    settings = queries.get_app_interface_settings()
+
+    return {
+        "rules": get_prometheus_rules(cluster_name, settings),
+        "tests": get_prometheus_tests(),
+    }


### PR DESCRIPTION
State changes from this integration will come from rules changing
(either directly or via jinja parameters) or tests themselves changing.
This will certainly save some time, but not as much as we would like
since `get_prometheus_tests` is quite slow.

I will come back to the effort of refactoring the integration, or at
least the part that deals with fetching the prometheus rules.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>