### PR TITLE
APPSRE-5972 obey to default GQL nullable standard

### DIFF
--- a/reconcile/gql_queries/introspection.json
+++ b/reconcile/gql_queries/introspection.json
@@ -4144,9 +4144,89 @@
                         }
                     ],
                     "inputFields": null,
-                    "interfaces": [],
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
                     "enumValues": null,
                     "possibleTypes": null
+                },
+                {
+                    "kind": "INTERFACE",
+                    "name": "DatafileObject_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": [
+                        {
+                            "kind": "OBJECT",
+                            "name": "App_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "Role_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "SaasFile_v2",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "SRECheckpoint_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "Integration_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "Report_v1",
+                            "ofType": null
+                        }
+                    ]
                 },
                 {
                     "kind": "OBJECT",
@@ -5551,6 +5631,22 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "self_service",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "SelfServiceConfig_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "users",
                             "description": null,
                             "args": [],
@@ -5584,7 +5680,13 @@
                         }
                     ],
                     "inputFields": null,
-                    "interfaces": [],
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
                     "enumValues": null,
                     "possibleTypes": null
                 },
@@ -8446,7 +8548,13 @@
                         }
                     ],
                     "inputFields": null,
-                    "interfaces": [],
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
                     "enumValues": null,
                     "possibleTypes": null
                 },
@@ -9880,6 +9988,61 @@
                 },
                 {
                     "kind": "OBJECT",
+                    "name": "SelfServiceConfig_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "datafiles",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "INTERFACE",
+                                    "name": "DatafileObject_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "resources",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
                     "name": "Bot_v1",
                     "description": null,
                     "fields": [
@@ -11022,6 +11185,18 @@
                         },
                         {
                             "name": "issueResolveState",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "issueReopenState",
                             "description": null,
                             "args": [],
                             "type": {
@@ -12911,7 +13086,13 @@
                         }
                     ],
                     "inputFields": null,
-                    "interfaces": [],
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
                     "enumValues": null,
                     "possibleTypes": null
                 },
@@ -17842,7 +18023,13 @@
                         }
                     ],
                     "inputFields": null,
-                    "interfaces": [],
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
                     "enumValues": null,
                     "possibleTypes": null
                 },
@@ -17929,6 +18116,18 @@
                         },
                         {
                             "name": "run_for_valid_saas_file_changes",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "early_exit",
                             "description": null,
                             "args": [],
                             "type": {
@@ -18472,7 +18671,13 @@
                         }
                     ],
                     "inputFields": null,
-                    "interfaces": [],
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
                     "enumValues": null,
                     "possibleTypes": null
                 },

--- a/reconcile/gql_queries/quay_membership/quay_membership.py
+++ b/reconcile/gql_queries/quay_membership/quay_membership.py
@@ -59,8 +59,8 @@ class BotV1(BaseModel):
 
 
 class RoleV1(BaseModel):
-    users: Optional[list[UserV1]] = Field(..., alias="users")
-    bots: Optional[list[BotV1]] = Field(..., alias="bots")
+    users: Optional[list[Optional[UserV1]]] = Field(..., alias="users")
+    bots: Optional[list[Optional[BotV1]]] = Field(..., alias="bots")
     expiration_date: Optional[str] = Field(..., alias="expirationDate")
 
     class Config:
@@ -71,7 +71,7 @@ class RoleV1(BaseModel):
 class PermissionQuayOrgTeamV1(PermissionV1):
     quay_org: QuayOrgV1 = Field(..., alias="quayOrg")
     team: str = Field(..., alias="team")
-    roles: Optional[list[RoleV1]] = Field(..., alias="roles")
+    roles: Optional[list[Optional[RoleV1]]] = Field(..., alias="roles")
 
     class Config:
         smart_union = True
@@ -79,9 +79,9 @@ class PermissionQuayOrgTeamV1(PermissionV1):
 
 
 class QuayMembershipQueryData(BaseModel):
-    permissions: Optional[list[Union[PermissionQuayOrgTeamV1, PermissionV1]]] = Field(
-        ..., alias="permissions"
-    )
+    permissions: Optional[
+        list[Optional[Union[PermissionQuayOrgTeamV1, PermissionV1]]]
+    ] = Field(..., alias="permissions")
 
     class Config:
         smart_union = True

--- a/reconcile/gql_queries/service_dependencies/service_dependencies.py
+++ b/reconcile/gql_queries/service_dependencies/service_dependencies.py
@@ -149,7 +149,7 @@ class NamespaceV1(BaseModel):
     managed_external_resources: Optional[bool] = Field(
         ..., alias="managedExternalResources"
     )
-    external_resources: Optional[list[NamespaceExternalResourceV1]] = Field(
+    external_resources: Optional[list[Optional[NamespaceExternalResourceV1]]] = Field(
         ..., alias="externalResources"
     )
     kafka_cluster: Optional[KafkaClusterV1] = Field(..., alias="kafkaCluster")
@@ -161,16 +161,18 @@ class NamespaceV1(BaseModel):
 
 class AppV1(BaseModel):
     name: str = Field(..., alias="name")
-    dependencies: Optional[list[DependencyV1]] = Field(..., alias="dependencies")
-    code_components: Optional[list[AppCodeComponentsV1]] = Field(
+    dependencies: Optional[list[Optional[DependencyV1]]] = Field(
+        ..., alias="dependencies"
+    )
+    code_components: Optional[list[Optional[AppCodeComponentsV1]]] = Field(
         ..., alias="codeComponents"
     )
-    jenkins_configs: Optional[list[JenkinsConfigV1]] = Field(
+    jenkins_configs: Optional[list[Optional[JenkinsConfigV1]]] = Field(
         ..., alias="jenkinsConfigs"
     )
-    saas_files: Optional[list[SaasFileV2]] = Field(..., alias="saasFiles")
-    quay_repos: Optional[list[AppQuayReposV1]] = Field(..., alias="quayRepos")
-    namespaces: Optional[list[NamespaceV1]] = Field(..., alias="namespaces")
+    saas_files: Optional[list[Optional[SaasFileV2]]] = Field(..., alias="saasFiles")
+    quay_repos: Optional[list[Optional[AppQuayReposV1]]] = Field(..., alias="quayRepos")
+    namespaces: Optional[list[Optional[NamespaceV1]]] = Field(..., alias="namespaces")
 
     class Config:
         smart_union = True
@@ -178,7 +180,7 @@ class AppV1(BaseModel):
 
 
 class ServiceDependenciesQueryData(BaseModel):
-    apps: Optional[list[AppV1]] = Field(..., alias="apps")
+    apps: Optional[list[Optional[AppV1]]] = Field(..., alias="apps")
 
     class Config:
         smart_union = True

--- a/reconcile/gql_queries/vpc_peerings_validator/vpc_peerings_validator.py
+++ b/reconcile/gql_queries/vpc_peerings_validator/vpc_peerings_validator.py
@@ -121,7 +121,7 @@ class ClusterV1(BaseModel):
 
 
 class VpcPeeringsValidatorQueryData(BaseModel):
-    clusters: Optional[list[ClusterV1]] = Field(..., alias="clusters")
+    clusters: Optional[list[Optional[ClusterV1]]] = Field(..., alias="clusters")
 
     class Config:
         smart_union = True

--- a/reconcile/quay_membership.py
+++ b/reconcile/quay_membership.py
@@ -18,6 +18,7 @@ from reconcile.utils.aggregated_list import (
     AggregatedList,
     RunnerException,
 )
+from .utils.helpers import filter_null
 from reconcile.utils.quay_api import QuayTeamNotFoundException
 
 QONTRACT_INTEGRATION = "quay-membership"
@@ -93,11 +94,14 @@ def fetch_desired_state():
     for permission in permissions:
         p = process_permission(permission)
         members: list[str] = []
+        roles: list[RoleV1] = filter_null(permission.roles)
         filtered_roles: list[RoleV1] = [
-            cast(RoleV1, r) for r in expiration.filter(permission.roles)
+            cast(RoleV1, r) for r in expiration.filter(roles)
         ]
         for role in filtered_roles:
-            members += get_usernames(role.users or []) + get_usernames(role.bots or [])
+            users: list[UserV1] = filter_null(role.users)
+            bots: list[BotV1] = filter_null(role.bots)
+            members += get_usernames(users) + get_usernames(bots)
 
         state.add(p, members)
 

--- a/reconcile/quay_membership.py
+++ b/reconcile/quay_membership.py
@@ -18,7 +18,7 @@ from reconcile.utils.aggregated_list import (
     AggregatedList,
     RunnerException,
 )
-from .utils.helpers import filter_null
+from reconcile.utils.helpers import filter_null
 from reconcile.utils.quay_api import QuayTeamNotFoundException
 
 QONTRACT_INTEGRATION = "quay-membership"

--- a/reconcile/utils/helpers.py
+++ b/reconcile/utils/helpers.py
@@ -1,6 +1,7 @@
 import logging
 
 from contextlib import contextmanager
+from typing import Any, Iterable, Optional
 
 
 DEFAULT_TOGGLE_LEVEL = logging.ERROR
@@ -14,3 +15,15 @@ def toggle_logger(log_level: int = DEFAULT_TOGGLE_LEVEL):
         yield logger.setLevel(log_level)  # type: ignore[func-returns-value]
     finally:
         logger.setLevel(default_level)
+
+
+def filter_null(arr: Optional[Iterable[Any]]) -> list[Any]:
+    """
+    GQL is null by default. Once we harden our schema with
+    more NonNull types, we can reduce the number
+    of callers of this function.
+
+    This function can be removed, when our schema only allows
+    non-nullable lists: [Obj!]!
+    """
+    return [a for a in arr or [] if a]

--- a/reconcile/vpc_peerings_validator.py
+++ b/reconcile/vpc_peerings_validator.py
@@ -6,10 +6,12 @@ from reconcile.gql_queries.vpc_peerings_validator import vpc_peerings_validator
 from reconcile.gql_queries.vpc_peerings_validator.vpc_peerings_validator import (
     ClusterPeeringConnectionClusterAccepterV1,
     ClusterPeeringConnectionClusterRequesterV1,
+    ClusterV1,
     VpcPeeringsValidatorQueryData,
 )
 from reconcile.status import ExitCodes
 from reconcile.utils import gql
+from reconcile.utils.helpers import filter_null
 
 
 QONTRACT_INTEGRATION = "vpc-peerings-validator"
@@ -21,7 +23,8 @@ def validate_no_internal_to_public_peerings(
     """Iterate over VPC peerings of internal clusters and validate the peer is not public."""
     valid = True
     found_pairs: list[set[str]] = []
-    for cluster in query_data.clusters or []:
+    clusters: list[ClusterV1] = filter_null(query_data.clusters)
+    for cluster in clusters:
         if not cluster.internal or not cluster.peering:
             continue
         for connection in cluster.peering.connections or []:
@@ -59,7 +62,8 @@ def validate_no_public_to_public_peerings(
     """Iterate over VPC peerings of public clusters and validate the peer is not public."""
     valid = True
     found_pairs: list[set[str]] = []
-    for cluster in query_data.clusters or []:
+    clusters: list[ClusterV1] = filter_null(query_data.clusters)
+    for cluster in clusters:
         if (
             cluster.internal
             or (cluster.spec and cluster.spec.private)

--- a/requirements/requirements-type.txt
+++ b/requirements/requirements-type.txt
@@ -11,4 +11,4 @@ types-setuptools
 types-tabulate
 types-toml
 boto3-stubs[ec2,s3,rds,iam,route53]==1.24.29
-qenerate==0.1.1
+qenerate==0.1.5


### PR DESCRIPTION
qenerate received an [update](https://github.com/app-sre/qenerate/pull/34) which aligns it closer to the GQL standard.

Currently, our GQL schema allows null elements in lists in many places. Sadly, this results in more `Optional` fields and more null checks in the code.

Note, that in order to avoid these `Optional`s, we must adjust our GQL schema properly to enforce `NonNull` fields in lists (see https://issues.redhat.com/browse/APPSRE-6153).

**Validation**

Ran integrations locally in dry-run mode