### PR TITLE
[openshift-resources] early exit monkey patch to context manager

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -68,7 +68,7 @@ def early_exit_monkey_patch():
         yield early_exit_monkey_patch_assign(
             lambda path, key, version=None, tvars=None, settings=None: f"vault({path}, {key}, {version})",
             lambda repo, path, ref, tvars=None, settings=None: f"github({repo}, {path}, {ref})",
-            lambda url: False,  # type: ignore[assignment]
+            lambda url: False,
             lambda data, path, alertmanager_config_key, decode_base64=False: True,
         )
     finally:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6098

fixes #2711

monkey patching is causing a faulty behavior in case early exit determined a full dry-run is needed.
this PR makes the monkey patching use a context manager, to restore the previous functions.