### PR TITLE
make jump host known hosts a resource ref

### DIFF
--- a/reconcile/gql_queries/introspection.json
+++ b/reconcile/gql_queries/introspection.json
@@ -15762,13 +15762,9 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
+                                "kind": "OBJECT",
+                                "name": "Resource_v1",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -180,7 +180,9 @@ def get_credentials_requests():
 
 JUMPHOST_FIELDS = """
 hostname
-knownHosts
+knownHosts {
+  content
+}
 user
 port
 identity {

--- a/reconcile/utils/jump_host.py
+++ b/reconcile/utils/jump_host.py
@@ -7,11 +7,8 @@ from typing import Dict, List
 
 from sshtunnel import SSHTunnelForwarder
 
-from reconcile.utils import gql
 from reconcile.utils.helpers import toggle_logger
 from reconcile.utils.secret_reader import SecretReader
-
-from reconcile.utils.exceptions import FetchResourceError
 
 # https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml
 DYNAMIC_PORT_MIN = 49152

--- a/reconcile/utils/jump_host.py
+++ b/reconcile/utils/jump_host.py
@@ -53,7 +53,7 @@ class JumpHostSSH(JumpHostBase):
     def __init__(self, jh, settings=None):
         JumpHostBase.__init__(self, jh, settings=settings)
 
-        self.known_hosts = self.get_known_hosts(jh)
+        self.known_hosts = jh["knownHosts"]["content"]
         self.init_known_hosts_file()
         self.local_port = (
             self.get_random_port()
@@ -70,17 +70,6 @@ class JumpHostSSH(JumpHostBase):
                 port = random.randint(DYNAMIC_PORT_MIN, DYNAMIC_PORT_MAX)
             JumpHostSSH.local_ports.append(port)
             return port
-
-    @staticmethod
-    def get_known_hosts(jh):
-        known_hosts_path = jh["knownHosts"]
-        gqlapi = gql.get_api()
-
-        try:
-            known_hosts = gqlapi.get_resource(known_hosts_path)
-        except gql.GqlGetResourceError as e:
-            raise FetchResourceError(str(e))
-        return known_hosts["content"]
 
     def init_known_hosts_file(self):
         known_hosts_file = self._identity_dir + "/known_hosts"


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/224

use the resource reference resolver feature from qontract-server introduced with https://github.com/app-sre/qontract-server/pull/147 to get the content of the knows hosts file.