### PR TITLE
[openshift-resources] early exit enable query support

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -62,6 +62,7 @@ provider
   validate_json
   validate_alertmanager_config
   alertmanager_config_key
+  enable_query_support
 }
 ... on NamespaceOpenshiftResourceResourceTemplate_v1 {
   path
@@ -69,6 +70,7 @@ provider
   variables
   validate_alertmanager_config
   alertmanager_config_key
+  enable_query_support
 }
 ... on NamespaceOpenshiftResourceVaultSecret_v1 {
   path


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-6098

depends on https://github.com/app-sre/qontract-schemas/pull/225

resources with dynamic content (generated based on graphql query results) must be checked, but only them.
with this field, we will know exactly the ones to check. we will add a validation that if the query() function is used, this option must be set to true.