### PR TITLE
[terraform-resources] cloudwatch validate elasticsearch domain exists

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -2953,6 +2953,13 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         es_identifier = common_values.get("es_identifier", None)
         if es_identifier is not None:
+            domain_tf_resource = self._find_resource_spec(
+                account, es_identifier, "elasticsearch"
+            )
+            if not domain_tf_resource:
+                raise FetchResourceError(
+                    f"failed to find elasticsearch domain {es_identifier}"
+                )
 
             assume_role_policy = {
                 "Version": "2012-10-17",


### PR DESCRIPTION
the cloudwatch provider accepts a field called `es_identifier` and assumes this resource exists. when it doesn't exist, apply fails, but plan passes.

with this PR, plan will fail.