### PR TITLE
gitlab-housingkeeping: fix retrieval of mr label events

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -214,7 +214,7 @@ def get_merge_requests(
                 gl.remove_label_from_merge_request(mr.iid, LGTM)
             continue
 
-        label_events = mr.resourcelabelevents.list()
+        label_events = gl.get_merge_request_label_events(mr)
         approval_found = False
         labels_by_unauthorized_users = set()
         labels_by_authorized_users = set()

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -298,6 +298,9 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
     def get_merge_requests(self, state):
         return self.get_items(self.project.mergerequests.list, state=state)
 
+    def get_merge_request_label_events(self, mr: ProjectMergeRequest):
+        return self.get_items(mr.resourcelabelevents.list)
+
     def get_merge_request_changed_paths(self, mr_id: int) -> list[str]:
         merge_request = self.project.mergerequests.get(mr_id)
         changes = merge_request.changes()["changes"]


### PR DESCRIPTION
use pagination properly
