### PR TITLE
early early-exit desired state diff performance

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -476,7 +476,7 @@ def early_exit_integration(
     # compare
     from deepdiff import DeepDiff
 
-    diff = DeepDiff(previous_desired_state, current_desired_state, ignore_order=True)
+    diff = DeepDiff(previous_desired_state, current_desired_state)
     return not diff
 
 


### PR DESCRIPTION
the current way to find out if the desired state of both bundles of an early exit check uses too much resources because it tries to ignore the order of elements in a list. ignoring the order is not really necessary (or might even be hurtful in some situations). this PR disables this feature.

tests showed the increased performance while not yielding false differences between the states.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>