### PR TITLE
2nd try - openshift-resource/route/prometheus-rule-tester resource resolution and early-exit performance

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -1,12 +1,8 @@
-from contextlib import contextmanager
 from typing import Any
-from sretoolbox.utils import threaded
 
 import reconcile.openshift_base as ob
 import reconcile.openshift_resources_base as orb
 
-from reconcile import queries
-from reconcile.utils import gql
 from reconcile.utils.semver_helper import make_semver
 
 QONTRACT_INTEGRATION = "openshift_resources"
@@ -43,66 +39,4 @@ def run(
 
 
 def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
-    gqlapi = gql.get_api()
-    settings = queries.get_secret_reader_settings()
-    namespaces, _ = orb.get_namespaces(PROVIDERS)
-    fetch_specs = [
-        (r, ns_info) for ns_info in namespaces for r in ns_info["openshiftResources"]
-    ]
-    with early_exit_monkey_patch():
-        resources = threaded.run(
-            get_resource,
-            fetch_specs,
-            thread_pool_size=10,
-            gqlapi=gqlapi,
-            settings=settings,
-        )
-    return {
-        "namespaces": namespaces,
-        "resources": resources,
-    }
-
-
-def get_resource(spec, gqlapi, settings):
-    resource = spec[0]
-    ns_info = spec[1]
-    if resource.get("enable_query_support"):
-        return orb.fetch_openshift_resource(resource, ns_info, settings=settings).body
-    else:
-        return gqlapi.get_resource(resource["path"])
-
-
-@contextmanager
-def early_exit_monkey_patch():
-    """Avoid looking outside of app-interface on early-exit pr-check."""
-    lookup_secret = orb.lookup_secret
-    lookup_github_file_content = orb.lookup_github_file_content
-    url_makes_sense = orb.url_makes_sense
-    check_alertmanager_config = orb.check_alertmanager_config
-
-    try:
-        yield early_exit_monkey_patch_assign(
-            lambda path, key, version=None, tvars=None, settings=None: f"vault({path}, {key}, {version})",
-            lambda repo, path, ref, tvars=None, settings=None: f"github({repo}, {path}, {ref})",
-            lambda url: False,
-            lambda data, path, alertmanager_config_key, decode_base64=False: True,
-        )
-    finally:
-        early_exit_monkey_patch_assign(
-            lookup_secret,
-            lookup_github_file_content,
-            url_makes_sense,
-            check_alertmanager_config,
-        )
-
-
-def early_exit_monkey_patch_assign(
-    lookup_secret,
-    lookup_github_file_content,
-    url_makes_sense,
-    check_alertmanager_config,
-):
-    orb.lookup_secret = lookup_secret
-    orb.lookup_github_file_content = lookup_github_file_content
-    orb.url_makes_sense = url_makes_sense
-    orb.check_alertmanager_config = check_alertmanager_config
+    return orb.early_exit_desired_state(PROVIDERS)

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -572,6 +572,7 @@ def fetch_openshift_resource(
     elif provider == "vault-secret":
         path = resource["path"]
         version = resource["version"]
+        _locked_log(_log_lock, "Processing {}: {} - {}".format(provider, path, version))
         rn = resource["name"]
         name = path.split("/")[-1] if rn is None else rn
         rl = resource["labels"]

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -1,6 +1,6 @@
 import base64
 from contextlib import contextmanager
-from functools import lru_cache
+from functools import cache
 import json
 import logging
 import sys
@@ -248,7 +248,7 @@ def lookup_graphql_query_results(query: str, **kwargs) -> list[Any]:
     return results
 
 
-@lru_cache
+@cache
 def compile_jinja2_template(body, extra_curly: bool = False):
     env: dict = {}
     if extra_curly:

--- a/reconcile/openshift_routes.py
+++ b/reconcile/openshift_routes.py
@@ -33,14 +33,4 @@ def run(
 
 
 def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
-    namespaces, _ = orb.get_namespaces(PROVIDERS)
-    resources = [
-        orb.fetch_provider_resource(r["path"]).body
-        for ns_info in namespaces
-        for r in ns_info["openshiftResources"]
-    ]
-
-    return {
-        "namespaces": namespaces,
-        "resources": resources,
-    }
+    return orb.early_exit_desired_state(PROVIDERS)

--- a/reconcile/prometheus_rules_tester.py
+++ b/reconcile/prometheus_rules_tester.py
@@ -11,7 +11,6 @@ from sretoolbox.utils import threaded
 from reconcile import queries
 from reconcile.utils import gql
 from reconcile.utils import promtool
-import reconcile.openshift_base as ob
 import reconcile.openshift_resources_base as orb
 
 from reconcile.utils.semver_helper import make_semver
@@ -25,6 +24,8 @@ MAX_CONFIGMAP_SIZE = 0.5 * 1024 * 1024
 
 QONTRACT_INTEGRATION = "prometheus_rules_tester"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
+
+PROVIDERS = ["resource", "resource-template"]
 
 PROMETHEUS_RULES_PATHS_QUERY = """
 {
@@ -65,12 +66,11 @@ def get_prometheus_tests():
 #    (...)
 def get_prometheus_rules(cluster_name, settings):
     """Returns a dict of dicts indexed by path with rule data"""
-    gqlapi = gql.get_api()
     rules = {}
-    for r in gqlapi.query(PROMETHEUS_RULES_PATHS_QUERY)["resources"]:
-        rules[r["path"]] = {}
-
-    for n in gqlapi.query(orb.NAMESPACES_QUERY)["namespaces"]:
+    namespaces_with_prom_rules, _ = orb.get_namespaces(
+        PROVIDERS, resource_schema_filter="/openshift/prometheus-rule-1.yml"
+    )
+    for n in namespaces_with_prom_rules:
         namespace = n["name"]
         cluster = n["cluster"]["name"]
 
@@ -83,7 +83,6 @@ def get_prometheus_rules(cluster_name, settings):
         ):
             continue
 
-        ob.aggregate_shared_resources(n, "openshiftResources")
         openshift_resources = n.get("openshiftResources")
         if not openshift_resources:
             logging.warning(
@@ -95,7 +94,7 @@ def get_prometheus_rules(cluster_name, settings):
         for r in openshift_resources:
             path = r["resource"]["path"]
             if path not in rules:
-                continue
+                rules[path] = {}
 
             # Or we will get an unexepected and confusing html_url annotation
             if "add_path_to_prom_rules" not in r:

--- a/reconcile/prometheus_rules_tester.py
+++ b/reconcile/prometheus_rules_tester.py
@@ -364,10 +364,9 @@ def run(dry_run, thread_pool_size=10, cluster_name=None):
         sys.exit(ExitCodes.ERROR)
 
 
-def early_exit_desired_state(thread_pool_size=10, cluster_name=None) -> dict[str, Any]:
-    settings = queries.get_app_interface_settings()
-
-    return {
-        "rules": get_prometheus_rules(cluster_name, settings),
-        "tests": get_prometheus_tests(),
-    }
+def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
+    state = orb.early_exit_desired_state(
+        PROVIDERS, resource_schema_filter="/openshift/prometheus-rule-1.yml"
+    )
+    state["tests"] = get_prometheus_tests()
+    return state

--- a/reconcile/prometheus_rules_tester.py
+++ b/reconcile/prometheus_rules_tester.py
@@ -93,7 +93,7 @@ def get_prometheus_rules(cluster_name, settings):
             continue
 
         for r in openshift_resources:
-            path = r["path"]
+            path = r["resource"]["path"]
             if path not in rules:
                 continue
 

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -50,14 +50,21 @@ CONTROLLER_MANAGED_LABELS: dict[str, set[Union[str, re.Pattern]]] = {
 
 class OpenshiftResource:
     def __init__(
-        self, body, integration, integration_version, error_details="", caller_name=None
+        self,
+        body,
+        integration,
+        integration_version,
+        error_details="",
+        caller_name=None,
+        validate_k8s_object=True,
     ):
         self.body = body
         self.integration = integration
         self.integration_version = integration_version
         self.error_details = error_details
         self.caller_name = caller_name
-        self.verify_valid_k8s_object()
+        if validate_k8s_object:
+            self.verify_valid_k8s_object()
 
     def __eq__(self, other):
         return self.obj_intersect_equal(self.body, other.body)


### PR DESCRIPTION
this PR refactors the openshift-resources, openshift-route and prometheus-rules-tester to work with qontract-server resource resolution (instead of sequential fetching). the openshift-resources early-exit code has been refactored so it can be reused by the other mentioned integrations as well.

at the same time, general performance issues for early-exit have been adressed by:

not parsing resource YAML during early exit - this is not required because the content of a resource is sufficient to drive a decision for early-exit
jinja2 template compilation caching
(!) review commit by commit

depends on https://github.com/app-sre/qontract-schemas/pull/229
relates to relates to https://issues.redhat.com/browse/APPSRE-6098