### PR TITLE
update es log group name

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -3545,7 +3545,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         domain_identifier: str, log_type: ElasticSearchLogGroupType
     ) -> str:
         log_type_name = log_type.value.lower()
-        return f"OpenSearchService__{domain_identifier}__{log_type_name}"
+        return f"OpenSearchService/{domain_identifier}/{log_type_name}"
 
     def _elasticsearch_get_all_log_group_infos(
         self, account: str
@@ -3669,7 +3669,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             log_type_identifier = TerrascriptClient.elasticsearch_log_group_identifier(
                 domain_identifier=identifier,
                 log_type=t,
-            )
+            ).replace("/", "-")
             log_group_values = {
                 "name": log_type_identifier,
                 "tags": {},


### PR DESCRIPTION
AWS suggests using a path kind name to manage cloudwatch log group.

<img width="631" alt="WX20220825-160847@2x" src="https://user-images.githubusercontent.com/32001821/186758929-3ded8588-e5fb-47b5-88fc-0a5ae96858e8.png">



Signed-off-by: Feng Huang <fehuang@redhat.com>