### PR TITLE
Bump sretoolbox to 1.5.0

### DIFF
--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -236,19 +236,6 @@ class QuayMirror:
                             details,
                         )
                         continue
-                    # Temporary fix while sretoolbox cannot handle comparing OCI images
-                    # with content-type: "application/vnd.oci.image.index.v1+json"
-                    except KeyError as details:
-                        if "mediaType" in str(details):
-                            _LOG.error(
-                                "Error comparing image %s and %s - Missing 'mediaType' "
-                                "key in manifest",
-                                downstream,
-                                upstream,
-                            )
-                            continue
-                        else:
-                            raise
 
                     _LOG.debug(
                         "Image %s and mirror %s are out of sync", downstream, upstream

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_data={'reconcile': ['templates/*.j2', "gql_queries/*/*.gql"]},
 
     install_requires=[
-        "sretoolbox~=1.4.0",
+        "sretoolbox~=1.5.0",
         "Click>=7.0,<9.0",
         "gql==3.1.0",
         "toml>=0.10.0,<0.11.0",


### PR DESCRIPTION
This brings the support of OCI images comparation so we can remove now
the workaround introduced in #2675.

part of APPSRE-6101.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>