### PR TITLE
[WIP] detect the affected shard for an openshift resource change in an MR

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -5,6 +5,8 @@ import reconcile.openshift_resources_base as orb
 
 from reconcile.utils.semver_helper import make_semver
 
+from deepdiff import DeepDiff
+
 QONTRACT_INTEGRATION = "openshift_resources"
 QONTRACT_INTEGRATION_VERSION = make_semver(1, 9, 3)
 PROVIDERS = ["resource", "resource-template"]
@@ -40,3 +42,7 @@ def run(
 
 def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
     return orb.early_exit_desired_state(PROVIDERS)
+
+
+def run_with_desired_state_diff(diff: DeepDiff, *args, **kwargs):
+    orb.run_with_desired_state_diff(diff, run, *args, **kwargs)

--- a/reconcile/openshift_routes.py
+++ b/reconcile/openshift_routes.py
@@ -4,6 +4,8 @@ import reconcile.openshift_resources_base as orb
 
 from reconcile.utils.semver_helper import make_semver
 
+from deepdiff import DeepDiff
+
 QONTRACT_INTEGRATION = "openshift-routes"
 QONTRACT_INTEGRATION_VERSION = make_semver(1, 9, 3)
 PROVIDERS = ["route"]
@@ -34,3 +36,7 @@ def run(
 
 def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
     return orb.early_exit_desired_state(PROVIDERS)
+
+
+def run_with_desired_state_diff(diff: DeepDiff, *args, **kwargs):
+    orb.run_with_desired_state_diff(diff, run, *args, **kwargs)

--- a/reconcile/openshift_vault_secrets.py
+++ b/reconcile/openshift_vault_secrets.py
@@ -4,6 +4,8 @@ import reconcile.openshift_resources_base as orb
 
 from reconcile.utils.semver_helper import make_semver
 
+from deepdiff import DeepDiff
+
 QONTRACT_INTEGRATION = "openshift-vault-secrets"
 QONTRACT_INTEGRATION_VERSION = make_semver(1, 9, 3)
 PROVIDERS = ["vault-secret"]
@@ -38,3 +40,7 @@ def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
     return {
         "namespaces": namespaces,
     }
+
+
+def run_with_desired_state_diff(diff: DeepDiff, *args, **kwargs):
+    orb.run_with_desired_state_diff(diff, run, *args, **kwargs)

--- a/reconcile/prometheus_rules_tester.py
+++ b/reconcile/prometheus_rules_tester.py
@@ -7,6 +7,7 @@ import yaml
 from typing import Any
 
 from sretoolbox.utils import threaded
+from deepdiff import DeepDiff
 
 from reconcile import queries
 from reconcile.utils import gql
@@ -370,3 +371,7 @@ def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
     )
     state["tests"] = get_prometheus_tests()
     return state
+
+
+def run_with_desired_state_diff(diff: DeepDiff, *args, **kwargs):
+    orb.run_with_desired_state_diff(diff, run, *args, **kwargs)

--- a/reconcile/utils/early_exit.py
+++ b/reconcile/utils/early_exit.py
@@ -1,0 +1,75 @@
+from dataclasses import dataclass
+import logging
+from types import ModuleType
+from typing import Optional
+
+from reconcile.utils import gql
+
+from deepdiff import DeepDiff
+
+EARLY_EXIT_DESIRED_STATE_FUNCTION = "early_exit_desired_state"
+
+
+def integration_supports(func_container: ModuleType, func_name: str) -> bool:
+    return func_name in dir(func_container)
+
+
+@dataclass
+class DesiredStateDiff:
+
+    previous_desired_state: dict
+    current_desired_state: dict
+    diff: DeepDiff
+
+    def can_exit_early(self) -> bool:
+        return not self.diff
+
+
+def find_desired_state_diff(
+    int_name: str, compare_sha: str, func_container: ModuleType, *args, **kwargs
+) -> Optional[DesiredStateDiff]:
+    # does the integration support early exit?
+    if not integration_supports(func_container, EARLY_EXIT_DESIRED_STATE_FUNCTION):
+        logging.warning(
+            f"{int_name} does not support early exit. it does not offer a "
+            f"function called {EARLY_EXIT_DESIRED_STATE_FUNCTION}"
+        )
+        return None
+
+    # get desired state from comparison bundle
+    try:
+        gql.init_from_config(
+            sha=compare_sha,
+            integration=int_name,
+            validate_schemas=True,
+            print_url=True,
+        )
+        previous_desired_state = func_container.early_exit_desired_state(
+            *args, **kwargs
+        )
+    except Exception:
+        logging.exception(
+            f"Failed to fetch desired state for comparison bundle {compare_sha} failed"
+        )
+        return None
+
+    # get desired state from current bundle
+    try:
+        gql.init_from_config(
+            autodetect_sha=True,
+            integration=int_name,
+            validate_schemas=True,
+            print_url=True,
+        )
+        current_desired_state = func_container.early_exit_desired_state(*args, **kwargs)
+    except Exception:
+        logging.exception("Failed to fetch desired state for current bundle failed")
+        return None
+
+    # compare
+    diff = DeepDiff(previous_desired_state, current_desired_state, view="tree")
+    return DesiredStateDiff(
+        previous_desired_state=previous_desired_state,
+        current_desired_state=current_desired_state,
+        diff=diff,
+    )


### PR DESCRIPTION
if an MR only changes openshift resources in a single cluster (shard), the integrations `openshift-resources`, `openshift-routes`, `openshift-vault-secrets` and `prometheus-rule-tester` can be run on that shard alone, which is A LOT faster than processing all clusters.

the general idea is, that an integration can provide a function `run_with_desired_state_diff` which is called instead of the integrations `run` function if a diff in desired state has been detected. the integration can then inspect the provided diff and decide if it is worth running shareded mode or not.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>