### PR TITLE
gitlab-housekeeper fix check for unmergable MRs

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -202,7 +202,10 @@ def get_merge_requests(
     mrs = gl.get_merge_requests(state=MRState.OPENED)
     results = []
     for mr in mrs:
-        if mr.merge_status == MRStatus.CANNOT_BE_MERGED:
+        if mr.merge_status in [
+            MRStatus.CANNOT_BE_MERGED,
+            MRStatus.CANNOT_BE_MERGED_RECHECK,
+        ]:
             continue
         if mr.work_in_progress:
             continue
@@ -296,12 +299,6 @@ def rebase_merge_requests(
     ]
     for mr in merge_requests:
         if is_rebased(mr, gl):
-            continue
-
-        if mr.merge_error:
-            logging.info(
-                ["rebase", gl.project.name, mr.iid, "not rebasable", mr.merge_error]
-            )
             continue
 
         pipelines = mr.pipelines()


### PR DESCRIPTION
the previous attempt to check for unmergable MRs failed because the attribute `merge_error` is not present all the time in MR objects. additionally the place to check is the `get_merge_request` function.

this change removes the check for `merge_error` in favour of the `merge_status` check and adds a check for the gitlab status `cannot_be_merged_recheck` (a.k.a. last time i checked it was not mergable but currently checking)

fixes https://github.com/app-sre/qontract-reconcile/pull/2745

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>