### PR TITLE
Split DNS support by separating zone name and ID

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2365,6 +2365,7 @@ DNS_ZONES_QUERY = """
 {
   zones: dns_zone_v1 {
     name
+    domain_name
     account {
       name
       uid

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -43,14 +43,14 @@ def build_desired_state(
         domain_name = zone.get("domain_name")
         if domain_name:
             zone_name = domain_name
-            zone_id = zone["name"]
+            resource_name = zone["name"]
         else:
             zone_name = zone["name"]
-            zone_id = zone["name"]
+            resource_name = zone["name"]
 
         zone_values = {
             "name": zone_name,
-            "id": zone_id,
+            "resource_name": resource_name,
             "account_name": account_name,
             "records": [],
         }

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -37,8 +37,23 @@ def build_desired_state(
         account = zone["account"]
         account_name = account["name"]
 
-        zone_name = zone["name"]
-        zone_values = {"name": zone_name, "account_name": account_name, "records": []}
+        # optionally decouple the name of the DNS file from the domain
+        # it is creating records for to allow split view DNS
+        # https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-considerations.html#hosted-zone-private-considerations-split-view-dns
+        domain_name = zone.get("domain_name")
+        if domain_name:
+            zone_name = domain_name
+            zone_id = zone["name"]
+        else:
+            zone_name = zone["name"]
+            zone_id = zone["name"]
+
+        zone_values = {
+            "name": zone_name,
+            "id": zone_id,
+            "account_name": account_name,
+            "records": [],
+        }
 
         # a vpc will be referenced for a zone to be considered private
         vpc = zone.get("vpc")

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -781,7 +781,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             acct_name = zone["account_name"]
 
             # Ensure zone is in the state for the given account
-            zone_id = safe_resource_id(f"{zone['name']}")
+            # zone_id refers to the terraform identifier, not the AWS
+            # route 53 zone ID that is generated after the zone is created
+            zone_id = safe_resource_id(f"{zone['id']}")
             zone_values = {
                 "name": zone["name"],
                 "vpc": zone.get("vpc"),

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -780,16 +780,13 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         for zone in desired_state:
             acct_name = zone["account_name"]
 
-            # Ensure zone is in the state for the given account
-            # zone_id refers to the terraform identifier, not the AWS
-            # route 53 zone ID that is generated after the zone is created
-            zone_id = safe_resource_id(f"{zone['id']}")
+            zone_res_name = safe_resource_id(f"{zone['resource_name']}")
             zone_values = {
                 "name": zone["name"],
                 "vpc": zone.get("vpc"),
                 "comment": "Managed by Terraform",
             }
-            zone_resource = aws_route53_zone(zone_id, **zone_values)
+            zone_resource = aws_route53_zone(zone_res_name, **zone_values)
             self.add_resource(acct_name, zone_resource)
 
             counts = {}


### PR DESCRIPTION
[APPSRE-6143](https://issues.redhat.com/browse/APPSRE-6143)

Schemas update here: https://github.com/app-sre/qontract-schemas/pull/232

Optionally split the Terraform/App Interface identifier for a Route 53 zone from the name of the zone as defined in App Interface. With this change we should be able to define both a private and public DNS zone within the same AWS account that refer to the same domain name.

This will allow us to do [split view DNS](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zone-private-considerations.html#hosted-zone-private-considerations-split-view-dns) within the Fedramp environment for our work to get certificates working.