### PR TITLE
OCM managed clusters improvements

### DIFF
--- a/reconcile/ocm/types.py
+++ b/reconcile/ocm/types.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, Extra
+from pydantic import BaseModel, Field, Extra, validator
 from typing import Optional, Union
 
 
@@ -39,9 +39,59 @@ class OSDClusterSpec(OCMClusterSpec):
     load_balancers: int
     storage: int
 
+    class Config:
+        extra = Extra.forbid
+
+
+class ROSAAWSAttrs(BaseModel):
+    creator_role_arn: str
+    installer_role_arn: Optional[str]
+    support_role_arn: Optional[str]
+    controlplane_role_arn: Optional[str]
+    worker_role_arn: Optional[str]
+
+    class Config:
+        extra = Extra.forbid
+
+
+class ROSAClusterAWSAccount(BaseModel):
+    uid: str
+    rosa: ROSAAWSAttrs
+
+    @validator("rosa", always=True)
+    @classmethod
+    def set_rosa(cls, rosa: ROSAAWSAttrs, values):
+        if not rosa.installer_role_arn:
+            rosa.installer_role_arn = (
+                f"arn:aws:iam::{values['uid']}:role/ManagedOpenShift-Installer-Role"
+            )
+
+        if not rosa.support_role_arn:
+            rosa.support_role_arn = (
+                f"arn:aws:iam::{values['uid']}:role/ManagedOpenShift-Support-Role"
+            )
+
+        if not rosa.controlplane_role_arn:
+            rosa.controlplane_role_arn = (
+                f"arn:aws:iam::{values['uid']}:role/ManagedOpenShift-ControlPlane-Role"
+            )
+
+        if not rosa.worker_role_arn:
+            rosa.worker_role_arn = (
+                f"arn:aws:iam::{values['uid']}:role/ManagedOpenShift-Worker-Role"
+            )
+
+        return rosa
+
+    class Config:
+        extra = Extra.forbid
+
 
 class ROSAClusterSpec(OCMClusterSpec):
-    pass
+    account: ROSAClusterAWSAccount
+
+    class Config:
+        extra = Extra.forbid
 
 
 class OCMSpec(BaseModel):

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -141,8 +141,8 @@ def get_cluster_ocm_update_spec(
 
     :param ocm: ocm implementation for an ocm product (osd, rosa)
     :param cluster: cluster name
-    :param current_spec: Cluster spec retreived from OCM api
-    :param desired_spec: luster spec retreived from App-Interface
+    :param current_spec: Cluster spec retrieved from OCM api
+    :param desired_spec: Cluster spec retrieved from App-Interface
     :return: a tuple with the updates to request to OCM and a bool to notify errors
     """
 
@@ -188,7 +188,7 @@ def get_cluster_ocm_update_spec(
         error = True
         logging.error(f"[{cluster}] invalid updates: {not_allowed_updates}")
 
-    return diffs, error
+    return updated_attrs, error
 
 
 def _app_interface_updates_mr(

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -651,6 +651,18 @@ CLUSTERS_QUERY = """
         storage
         load_balancers
       }
+      ... on ClusterSpecROSA_v1 {
+        account {
+          uid
+          rosa {
+            creator_role_arn
+            installer_role_arn
+            support_role_arn
+            controlplane_role_arn
+            worker_role_arn
+          }
+        }
+      }
       id
       external_id
       provider

--- a/reconcile/test/fixtures/clusters/rosa_spec.json
+++ b/reconcile/test/fixtures/clusters/rosa_spec.json
@@ -13,7 +13,7 @@
     "id": "aws",
     "href": "/api/clusters_mgmt/v1/cloud_providers/aws"
   },
-  "openshift_version": "4.10.5",
+  "openshift_version": "4.10.16",
   "subscription": {
     "kind": "SubscriptionLink",
     "id": "subscription_id",
@@ -61,7 +61,7 @@
   },
   "properties": {
     "rosa_cli_version": "1.1.11",
-    "rosa_creator_arn": "arn:aws:iam::249118421612:user/terraform"
+    "rosa_creator_arn": "arn:aws:iam::249118421612:role/ManagedOpenShift-OCM-Role-12147054"
   },
   "aws": {
     "private_link": false,
@@ -154,9 +154,9 @@
   },
   "version": {
     "kind": "Version",
-    "id": "openshift-v4.10.5",
+    "id": "openshift-v4.10.16",
     "href": "/api/clusters_mgmt/v1/versions/openshift-v4.10.5",
-    "raw_id": "4.10.5",
+    "raw_id": "4.10.16",
     "channel_group": "stable",
     "end_of_life_timestamp": "2022-12-10T00:00:00Z"
   },

--- a/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
@@ -1,0 +1,50 @@
+---
+$schema: /openshift/cluster-1.yml
+labels:
+  service: ocm-quay
+name: tst-jpr-rosa
+description: A test cluster
+consoleUrl: "https://console-url"
+kibanaUrl: ""
+prometheusUrl: ""
+alertmanagerUrl: ""
+serverUrl: "https://api-url"
+elbFQDN: "elb.apps.an-osd-test-cluster.k3s7.p1.openshiftapps.com"
+ocm:
+  name: non-existent-ocm
+  url: non-existent-ocm-url
+  accessTokenClientId: cloud-services
+  offlineToken:
+    path: "offline-token-secret-path"
+    field: "offline-token"
+spec:
+  product: rosa
+  account:
+    uid: '249118421612'
+    rosa:
+      creator_role_arn: "arn:aws:iam::249118421612:role/ManagedOpenShift-OCM-Role-12147054"
+      installer_role_arn: "arn:aws:iam::249118421612:role/ManagedOpenShift-Installer-Role"
+      support_role_arn: "arn:aws:iam::249118421612:role/ManagedOpenShift-Support-Role"
+      controlplane_role_arn: "arn:aws:iam::249118421612:role/ManagedOpenShift-ControlPlane-Role"
+      worker_role_arn: "arn:aws:iam::249118421612:role/ManagedOpenShift-Worker-Role"
+  id: "rosa-cluster-id"
+  external_id: "external-id"
+  provider: aws
+  region: us-east-1
+  channel: 2
+  version: 4.10.16
+  initial_version: 4.8.10
+  multi_az: false
+  instance_type: m5.xlarge
+  private: false
+  provision_shard_id: provision_shard_id
+  autoscale:
+    min_replicas: 21
+    max_replicas: 30
+  disable_user_workload_monitoring: true
+network:
+  type: OpenShiftSDN
+  vpc: 10.0.0.0/16
+  service: 172.30.0.0/16
+  pod: 10.128.0.0/14
+internal: false

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -441,25 +441,3 @@ def test_changed_ocm_spec_disable_uwm(
     assert _patch.call_count == 1
     assert _post.call_count == 0
     assert cluster_updates_mr_mock.call_count == 0
-
-
-def test_missing_ocm_spec_disable_uwm(
-    get_json_mock,
-    queries_mock,
-    ocm_mock,
-    ocm_osd_cluster_raw_spec,
-    ocm_osd_cluster_ai_spec,
-    cluster_updates_mr_mock,
-):
-    ocm_osd_cluster_ai_spec["spec"]["disable_user_workload_monitoring"] = None
-
-    get_json_mock.return_value = {"items": [ocm_osd_cluster_raw_spec]}
-    queries_mock[1].return_value = [ocm_osd_cluster_ai_spec]
-
-    with pytest.raises(SystemExit):
-        occ.run(dry_run=False)
-    _post, _patch = ocm_mock
-
-    assert _patch.call_count == 1
-    assert _post.call_count == 0
-    assert cluster_updates_mr_mock.call_count == 1

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -89,7 +89,6 @@ class OCMProduct:
 
 class OCMProductOsd(OCMProduct):
     ALLOWED_SPEC_UPDATE_FIELDS = {
-        SPEC_ATTR_INSTANCE_TYPE,
         SPEC_ATTR_STORAGE,
         SPEC_ATTR_LOAD_BALANCERS,
         SPEC_ATTR_PRIVATE,
@@ -231,10 +230,6 @@ class OCMProductOsd(OCMProduct):
     @staticmethod
     def _get_update_cluster_spec(update_spec: Mapping[str, Any]) -> dict[str, Any]:
         ocm_spec: dict[str, Any] = {}
-
-        instance_type = update_spec.get("instance_type")
-        if instance_type is not None:
-            ocm_spec["nodes"] = {"compute_machine_type": {"id": instance_type}}
 
         storage = update_spec.get("storage")
         if storage is not None:

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import functools
 import logging
+import random
 import re
 from abc import abstractmethod
+import string
 from typing import Any, Mapping, Optional, Tuple, Union
 
 import reconcile.utils.aws_helper as awsh
@@ -11,6 +13,8 @@ import requests
 from reconcile.ocm.types import (
     OCMClusterAutoscale,
     OCMClusterNetwork,
+    ROSAClusterAWSAccount,
+    ROSAAWSAttrs,
     OCMSpec,
     OSDClusterSpec,
     ROSAClusterSpec,
@@ -37,7 +41,7 @@ DISABLE_UWM_ATTR = "disable_user_workload_monitoring"
 BYTES_IN_GIGABYTE = 1024**3
 REQUEST_TIMEOUT_SEC = 60
 
-
+SPEC_ATTR_ACCOUNT = "account"
 SPEC_ATTR_DISABLE_UWM = "disable_user_workload_monitoring"
 SPEC_ATTR_AUTOSCALE = "autoscale"
 SPEC_ATTR_INSTANCE_TYPE = "instance_type"
@@ -276,11 +280,18 @@ class OCMProductRosa(OCMProduct):
         SPEC_ATTR_PROVISION_SHARD_ID,
         SPEC_ATTR_VERSION,
         SPEC_ATTR_INITIAL_VERSION,
+        SPEC_ATTR_ACCOUNT,
     }
 
     @staticmethod
     def create_cluster(ocm: OCM, name: str, cluster: OCMSpec, dry_run: bool):
-        raise NotImplementedError("create_cluster not implemeneted for ROSA")
+        ocm_spec = OCMProductRosa._get_create_cluster_spec(name, cluster)
+        api = f"{CS_API_BASE}/v1/clusters"
+        params = {}
+        if dry_run:
+            params["dryRun"] = "true"
+
+        ocm._post(api, ocm_spec, params)
 
     @staticmethod
     def update_cluster(ocm: OCM, cluster_name: str, update_spec: Mapping[str, Any]):
@@ -309,8 +320,24 @@ class OCMProductRosa(OCMProduct):
             else None
         )
 
+        account = ROSAClusterAWSAccount(
+            uid=cluster["properties"]["rosa_creator_arn"].split(":")[4],
+            rosa=ROSAAWSAttrs(
+                creator_role_arn=cluster["properties"]["rosa_creator_arn"],
+                installer_role_arn=cluster["aws"]["sts"]["role_arn"],
+                support_role_arn=cluster["aws"]["sts"]["support_role_arn"],
+                controlplane_role_arn=cluster["aws"]["sts"]["instance_iam_roles"][
+                    "master_role_arn"
+                ],
+                worker_role_arn=cluster["aws"]["sts"]["instance_iam_roles"][
+                    "worker_role_arn"
+                ],
+            ),
+        )
+
         spec = ROSAClusterSpec(
             product=cluster["product"]["id"],
+            account=account,
             id=cluster["id"],
             external_id=cluster["external_id"],
             provider=cluster["cloud_provider"]["id"],
@@ -347,7 +374,12 @@ class OCMProductRosa(OCMProduct):
 
     @staticmethod
     def _get_create_cluster_spec(cluster_name: str, cluster: OCMSpec) -> dict[str, Any]:
+        operator_roles_prefix = "".join(
+            "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+        )
+
         ocm_spec: dict[str, Any] = {
+            "api": {"listening": "internal" if cluster.spec.private else "external"},
             "name": cluster_name,
             "cloud_provider": {"id": cluster.spec.provider},
             "region": {"id": cluster.spec.region},
@@ -363,11 +395,9 @@ class OCMProductRosa(OCMProduct):
                 "service_cidr": cluster.network.service,
                 "pod_cidr": cluster.network.pod,
             },
-            "api": {"listening": "internal" if cluster.spec.private else "external"},
             "disable_user_workload_monitoring": cluster.spec.disable_user_workload_monitoring
             or True,
         }
-
         provision_shard_id = cluster.spec.provision_shard_id
         if provision_shard_id:
             ocm_spec.setdefault("properties", {})
@@ -378,6 +408,31 @@ class OCMProductRosa(OCMProduct):
             ocm_spec["nodes"]["autoscale_compute"] = autoscale.dict()
         else:
             ocm_spec["nodes"]["compute"] = cluster.spec.nodes
+
+        if isinstance(cluster.spec, ROSAClusterSpec):
+            rosa_spec: dict[str, Any] = {
+                "properties": {
+                    "rosa_creator_arn": cluster.spec.account.rosa.creator_role_arn
+                },
+                "product": {"id": "rosa"},
+                "ccs": {"enabled": True},
+                "aws": {
+                    "account_id": cluster.spec.account.uid,
+                    "sts": {
+                        "enabled": True,
+                        "auto_mode": True,
+                        "role_arn": cluster.spec.account.rosa.installer_role_arn,
+                        "support_role_arn": cluster.spec.account.rosa.support_role_arn,
+                        "instance_iam_roles": {
+                            "master_role_arn": cluster.spec.account.rosa.controlplane_role_arn,
+                            "worker_role_arn": cluster.spec.account.rosa.worker_role_arn,
+                        },
+                        "operator_role_prefix": f"{cluster_name}-{operator_roles_prefix}",
+                    },
+                },
+            }
+
+        ocm_spec.update(rosa_spec)
         return ocm_spec
 
     @staticmethod

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -264,7 +264,6 @@ class OCMProductOsd(OCMProduct):
 
 class OCMProductRosa(OCMProduct):
     ALLOWED_SPEC_UPDATE_FIELDS = {
-        SPEC_ATTR_INSTANCE_TYPE,
         SPEC_ATTR_CHANNEL,
         SPEC_ATTR_AUTOSCALE,
         SPEC_ATTR_NODES,
@@ -285,7 +284,11 @@ class OCMProductRosa(OCMProduct):
 
     @staticmethod
     def update_cluster(ocm: OCM, cluster_name: str, update_spec: Mapping[str, Any]):
-        raise NotImplementedError("update_cluster not implemeneted for ROSA")
+        ocm_spec = OCMProductRosa._get_update_cluster_spec(update_spec)
+        cluster_id = ocm.cluster_ids.get(cluster_name)
+        api = f"{CS_API_BASE}/v1/clusters/{cluster_id}"
+        params: dict[str, Any] = {}
+        ocm._patch(api, ocm_spec, params)
 
     @staticmethod
     def get_ocm_spec(
@@ -380,14 +383,6 @@ class OCMProductRosa(OCMProduct):
     @staticmethod
     def _get_update_cluster_spec(update_spec: Mapping[str, Any]) -> dict[str, Any]:
         ocm_spec: dict[str, Any] = {}
-
-        instance_type = update_spec.get("instance_type")
-        if instance_type is not None:
-            ocm_spec["nodes"] = {"compute_machine_type": {"id": instance_type}}
-
-        private = update_spec.get("private")
-        if private is not None:
-            ocm_spec["api"] = {"listening": "internal" if private else "external"}
 
         channel = update_spec.get("channel")
         if channel is not None:


### PR DESCRIPTION
## Changes

* Added logic to manage ROSA clusters in app-interface
* Fix cluster_updates diff logic
* Disable instance_type cluster updates: Instance_type attribute can not be updated in the default machine pool
* Remove disable_uwm_test: Removing this attribute from the spec is not going to change the attribute anymore

## Notes
Requires: https://github.com/app-sre/qontract-schemas/pull/233
Ticket: https://issues.redhat.com/browse/APPSRE-4268

