### PR TITLE
Do not mirror images part of multi-arch ones

### DIFF
--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -8,7 +8,7 @@ import time
 from collections import defaultdict, namedtuple
 from typing import Any
 
-from sretoolbox.container.image import ImageComparisonError
+from sretoolbox.container.image import ImageComparisonError, ImageContainsError
 from sretoolbox.container.skopeo import SkopeoCmdError
 
 from reconcile import queries
@@ -228,6 +228,13 @@ class QuayMirror:
                                 upstream,
                             )
                             continue
+                        elif downstream.is_part_of(upstream):
+                            _LOG.debug(
+                                "Image %s is part of mirror multi-arch image %s",
+                                downstream,
+                                upstream,
+                            )
+                            continue
                     except ImageComparisonError as details:
                         _LOG.error(
                             "Error comparing image %s and %s - %s",
@@ -236,6 +243,10 @@ class QuayMirror:
                             details,
                         )
                         continue
+                    except ImageContainsError:
+                        # Upstream and downstream images are different and not part
+                        # of each other. We will mirror them.
+                        pass
 
                     _LOG.debug(
                         "Image %s and mirror %s are out of sync", downstream, upstream

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     package_data={'reconcile': ['templates/*.j2', "gql_queries/*/*.gql"]},
 
     install_requires=[
-        "sretoolbox~=1.5.0",
+        "sretoolbox~=1.6.0",
         "Click>=7.0,<9.0",
         "gql==3.1.0",
         "toml>=0.10.0,<0.11.0",


### PR DESCRIPTION
We make use of the new `Image.is_part_of` method.

See https://github.com/app-sre/sretoolbox/pull/78

part of APPSRE-6202

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>