### PR TITLE
jira_client: fix type error

### DIFF
--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -5,7 +5,7 @@ from jira.client import ResultList
 
 from reconcile.utils.secret_reader import SecretReader
 
-from typing import Any, Iterable, Mapping, Optional, Union
+from typing import Any, Iterable, Mapping, Optional
 
 
 class JiraClient:
@@ -41,9 +41,7 @@ class JiraClient:
             kwargs["fields"] = ",".join(fields)
         while True:
             index = block_num * block_size
-            issues: Union[dict[str, Any], ResultList[Issue]] = self.jira.search_issues(
-                jql, index, block_size, **kwargs
-            )
+            issues = self.jira.search_issues(jql, index, block_size, **kwargs)
             if not isinstance(issues, ResultList):
                 # if search_issues was executed with json_result=True, then we have a Dict.
                 # However, we require a ResultList[Issue].


### PR DESCRIPTION
Fixes a typing error where the variable type did not match the method's return type, causing mypy to complain. we can let it infer from the method return type

```
reconcile/utils/jira_client.py:44: error: Incompatible types in assignment (expression has type "Union[List[Dict[str, Any]], ResultList[Issue]]", variable has type "Union[Dict[str, Any], ResultList[Issue]]")  [assignment]
```

Because we check that the variable is of instance ResultList this was never an issue other than a type mismatch