### PR TITLE
Fix deep sync mode

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1366,12 +1366,49 @@ def gcr_mirror(ctx):
 
 
 @integration.command(short_help="Mirrors external images into Quay.")
+@click.option(
+    "-d",
+    "--control-file-dir",
+    help="Directory where integration control file will be created. This file controls "
+    "when to compare tags (very slow) apart from mirroring new tags.",
+)
+@click.option(
+    "-f",
+    "--force-compare-tags",
+    help="Forces the integration to do tag comparation no matter what the control file "
+    "says.",
+    type=bool,
+    default=False,
+)
+@click.option(
+    "-c",
+    "--compare-tags-interval",
+    help="Time to wait between compare-tags runs (in seconds). It defaults to 86400 "
+    "(24h).",
+    type=int,
+    default=86400,
+)
+@click.option(
+    "-i",
+    "--image",
+    help="Only considers this image to mirror. It can be specified multiple times.",
+    multiple=True,
+)
 @click.pass_context
 @binary(["skopeo"])
-def quay_mirror(ctx):
+def quay_mirror(
+    ctx, control_file_dir, force_compare_tags, compare_tags_interval, image
+):
     import reconcile.quay_mirror
 
-    run_integration(reconcile.quay_mirror, ctx.obj)
+    run_integration(
+        reconcile.quay_mirror,
+        ctx.obj,
+        control_file_dir,
+        force_compare_tags,
+        compare_tags_interval,
+        image,
+    )
 
 
 @integration.command(short_help="Mirrors entire Quay orgs.")

--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -6,7 +6,7 @@ import tempfile
 import time
 
 from collections import defaultdict, namedtuple
-from typing import Any
+from typing import Any, Iterable, Optional
 
 from sretoolbox.container.image import ImageComparisonError, ImageContainsError
 from sretoolbox.container.skopeo import SkopeoCmdError
@@ -24,6 +24,7 @@ from reconcile.utils.instrumented_wrappers import (
 _LOG = logging.getLogger(__name__)
 
 QONTRACT_INTEGRATION = "quay-mirror"
+CONTROL_FILE_NAME = "qontract-reconcile-quay-mirror.timestamp"
 
 OrgKey = namedtuple("OrgKey", ["instance", "org_name"])
 
@@ -54,15 +55,39 @@ class QuayMirror:
         shard_id=sharding.SHARD_ID,
     )
 
-    def __init__(self, dry_run=False):
+    def __init__(
+        self,
+        dry_run: bool = False,
+        control_file_dir: Optional[str] = None,
+        force_compare_tags: bool = False,
+        compare_tags_interval: int = 86400,
+        images: Optional[Iterable[str]] = None,
+    ) -> None:
         self.dry_run = dry_run
         self.gqlapi = gql.get_api()
         settings = queries.get_app_interface_settings()
         self.secret_reader = SecretReader(settings=settings)
         self.skopeo_cli = Skopeo(dry_run)
         self.push_creds = self._get_push_creds()
+        self.force_compare_tags = force_compare_tags
+        self.compare_tags_interval = compare_tags_interval
+        self.images = images
 
-    def run(self):
+        if control_file_dir:
+            if not os.path.isdir(control_file_dir):
+                raise FileNotFoundError(
+                    f"'{control_file_dir}' does not exist or it is not a directory"
+                )
+
+            self.control_file_path = os.path.join(control_file_dir, CONTROL_FILE_NAME)
+        else:
+            self.control_file_path = os.path.join(
+                tempfile.gettempdir(), CONTROL_FILE_NAME
+            )
+
+        self._has_enough_time_passed_since_last_compare_tags: Optional[bool] = None
+
+    def run(self) -> None:
         sync_tasks = self.process_sync_tasks()
         for org, data in sync_tasks.items():
             for item in data:
@@ -76,8 +101,13 @@ class QuayMirror:
                 except SkopeoCmdError as details:
                     _LOG.error("[%s]", details)
 
+        if self.is_compare_tags:
+            self.record_timestamp(self.control_file_path)
+
     @classmethod
-    def process_repos_query(cls):
+    def process_repos_query(
+        cls, images: Optional[Iterable[str]] = None
+    ) -> defaultdict[OrgKey, list[dict[str, Any]]]:
         apps = queries.get_quay_repos()
 
         summary = defaultdict(list)
@@ -94,6 +124,9 @@ class QuayMirror:
                 server_url = quay_repo["org"]["instance"]["url"]
 
                 for item in quay_repo["items"]:
+                    if images and item["name"] not in images:
+                        continue
+
                     if item["mirror"] is None:
                         continue
 
@@ -116,7 +149,6 @@ class QuayMirror:
                             "server_url": server_url,
                         }
                     )
-
         return summary
 
     @staticmethod
@@ -140,10 +172,7 @@ class QuayMirror:
         return True
 
     def process_sync_tasks(self):
-        twenty_four_hours = 86400  # 60 * 60 * 24
-        is_deep_sync = self._is_deep_sync(interval=twenty_four_hours)
-
-        summary = self.process_repos_query()
+        summary = self.process_repos_query(self.images)
         sync_tasks = defaultdict(list)
         for org_key, data in summary.items():
             org = org_key.org_name
@@ -200,21 +229,11 @@ class QuayMirror:
                         sync_tasks[org_key].append(task)
                         continue
 
-                    # Deep (slow) check only in non dry-run mode
-                    if self.dry_run:
+                    # Compare tags (slow) only from time to time.
+                    if not self.is_compare_tags:
                         _LOG.debug(
-                            "Running in dry-run mode. We won't check if %s and %s "
-                            "are actually in sync",
-                            downstream,
-                            upstream,
-                        )
-                        continue
-
-                    # Deep (slow) check only from time to time
-                    if not is_deep_sync:
-                        _LOG.debug(
-                            "Running in non deep-sync mode. We won't check if %s and "
-                            "%s are actually in sync",
+                            "Running in non compare-tags mode. We won't check if %s "
+                            "and %s are actually in sync",
                             downstream,
                             upstream,
                         )
@@ -261,25 +280,40 @@ class QuayMirror:
 
         return sync_tasks
 
-    def _is_deep_sync(self, interval):
-        control_file_name = "qontract-reconcile-quay-mirror.timestamp"
-        control_file_path = os.path.join(tempfile.gettempdir(), control_file_name)
+    @property
+    def is_compare_tags(self) -> bool:
+        return (
+            self.force_compare_tags
+            or self.has_enough_time_passed_since_last_compare_tags
+        )
+
+    @property
+    def has_enough_time_passed_since_last_compare_tags(self) -> bool:
+        if self._has_enough_time_passed_since_last_compare_tags is None:
+            self._has_enough_time_passed_since_last_compare_tags = (
+                self.check_compare_tags_elapsed_time(
+                    self.control_file_path, self.compare_tags_interval
+                )
+            )
+
+        return self._has_enough_time_passed_since_last_compare_tags
+
+    @staticmethod
+    def check_compare_tags_elapsed_time(path, interval) -> bool:
         try:
-            with open(control_file_path, "r") as file_obj:
-                last_deep_sync = float(file_obj.read())
+            with open(path, "r") as file_obj:
+                last_compare_tags = float(file_obj.read())
         except FileNotFoundError:
-            self._record_timestamp(control_file_path)
             return True
 
-        next_deep_sync = last_deep_sync + interval
-        if time.time() >= next_deep_sync:
-            self._record_timestamp(control_file_path)
+        next_compare_tags = last_compare_tags + interval
+        if time.time() >= next_compare_tags:
             return True
 
         return False
 
     @staticmethod
-    def _record_timestamp(path):
+    def record_timestamp(path) -> None:
         with open(path, "w") as file_object:
             file_object.write(str(time.time()))
 
@@ -301,8 +335,16 @@ class QuayMirror:
         return creds
 
 
-def run(dry_run):
-    quay_mirror = QuayMirror(dry_run)
+def run(
+    dry_run,
+    control_file_dir: Optional[str],
+    force_compare_tags: bool,
+    compare_tags_interval: int,
+    images: Optional[Iterable[str]],
+):
+    quay_mirror = QuayMirror(
+        dry_run, control_file_dir, force_compare_tags, compare_tags_interval, images
+    )
     quay_mirror.run()
 
 

--- a/reconcile/test/test_quay_mirror.py
+++ b/reconcile/test/test_quay_mirror.py
@@ -1,0 +1,60 @@
+import os
+import tempfile
+
+import pytest
+
+from reconcile.quay_mirror import QuayMirror, CONTROL_FILE_NAME
+
+
+def test_check_compare_tags_no_control_file():
+    assert QuayMirror.check_compare_tags_elapsed_time("/no-such-file", 100)
+
+
+def test_check_compare_tags_with_file(mocker):
+    now = 1662124612.995397
+    mocker.patch("time.time", return_value=now)
+
+    with tempfile.NamedTemporaryFile() as fp:
+        fp.write(str(now - 100.0).encode())
+        fp.seek(0)
+
+        assert QuayMirror.check_compare_tags_elapsed_time(fp.name, 10)
+        assert not QuayMirror.check_compare_tags_elapsed_time(fp.name, 1000)
+
+
+def test_control_file_dir_does_not_exist(mocker):
+    mocker.patch("reconcile.utils.gql.get_api", autospec=True)
+    mocker.patch("reconcile.queries.get_app_interface_settings", return_value={})
+
+    with pytest.raises(FileNotFoundError):
+        QuayMirror(control_file_dir="/no-such-dir")
+
+
+def test_control_file_path_from_given_dir(mocker):
+    mocker.patch("reconcile.utils.gql.get_api", autospec=True)
+    mocker.patch("reconcile.queries.get_app_interface_settings", return_value={})
+
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        qm = QuayMirror(control_file_dir=tmp_dir_name)
+        assert qm.control_file_path == os.path.join(tmp_dir_name, CONTROL_FILE_NAME)
+
+
+def test_is_compare_tags(mocker):
+    now = 1662124612.995397
+    mocker.patch("time.time", return_value=now)
+    mocker.patch("reconcile.utils.gql.get_api", autospec=True)
+    mocker.patch("reconcile.queries.get_app_interface_settings", return_value={})
+
+    with tempfile.TemporaryDirectory() as tmp_dir_name:
+        with open(os.path.join(tmp_dir_name, CONTROL_FILE_NAME), "w") as fh:
+            fh.write(str(now - 100.0))
+
+        qm = QuayMirror(control_file_dir=tmp_dir_name, compare_tags_interval=1000)
+        assert not qm.is_compare_tags
+
+        qm = QuayMirror(
+            control_file_dir=tmp_dir_name,
+            compare_tags_interval=10,
+            force_compare_tags=True,
+        )
+        assert qm.is_compare_tags


### PR DESCRIPTION
Compare tags (previously known as deep-sync) control file was updated
at the beginning of the run. Hence, even if the run was unsuccesful,
the next one would have seen that the previous execution of the
integration was a compare-tags one and would run in non-compare-tags
mode, which would mask any potential issue with the slow mode. This
patch fixes by changing the moment of the update of the control file to
the end of the execution of the integration.

In order to be able to properly test these changes without needing to
modify the source code, a few options have been added to the
integration to control:

* where the control file is created.
* how often to compare tags.
* to force the comparation of tags.
* to specify a certain image.

The first one is particularly interesting as it can allow us to create
the control file outside the container, which can allow us to avoid a
compare tags run every time the pod is restarted/recreated.

part of APPSRE-6102

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>