### PR TITLE
[dyn-traffic-director] early exit

### DIFF
--- a/reconcile/dyn_traffic_director.py
+++ b/reconcile/dyn_traffic_director.py
@@ -522,3 +522,9 @@ def run(dry_run: bool, enable_deletion: bool):
     process_tds(
         current["tds"], desired["tds"], dry_run=dry_run, enable_deletion=enable_deletion
     )
+
+
+def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
+    return {
+        "traffic_directors": queries.get_dyn_traffic_directors(),
+    }


### PR DESCRIPTION
since this integration has a tendency to fail from time to time and potentially blocking MRs, implementing early exit to prevent it from running in the first place.