### PR TITLE
[openshift-saas-deploy-trigger-configs] consider target name for uniqueness

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1970,6 +1970,7 @@ SAAS_FILES_QUERY_V2 = """
       }
       targets {
         path
+        name
         namespace {
           name
           environment {

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -1495,6 +1495,9 @@ class SaasHerder:
                     f"{saas_file_name}/{rt_name}/{cluster_name}/"
                     f"{namespace_name}/{env_name}"
                 )
+                target_name = desired_target_config.get("name")
+                if target_name:
+                    key += f"/{target_name}"
                 # Convert to dict, ChainMap is not JSON serializable
                 # desired_target_config needs to be serialized to generate
                 # its config hash and to be stored in S3
@@ -1535,6 +1538,9 @@ class SaasHerder:
             f"{saas_file_name}/{rt_name}/{cluster_name}/"
             + f"{namespace_name}/{env_name}"
         )
+        target_name = target_config.get("name")
+        if target_name:
+            key += f"/{target_name}"
         self.state.add(key, value=target_config, force=True)
 
     def validate_promotions(self):


### PR DESCRIPTION
we can't deploy the same resource template to the same namespace twice right now, due to a problem with `openshift-saas-deploy-trigger-configs`. it stores the current state of the configuration of each target in s3, and compares the desired state against it to know what to trigger.

it stores the state in a key that is calculated by: https://github.com/app-sre/qontract-reconcile/blob/3087bd06936744b11c3ac5df10b11667c477260a/reconcile/utils/saasherder.py#L1534-L1538

so in case there is a saas file with a resource template that has 2 targets of the same namespace, you can see how this key is not unique.

with the addition of `name` to a saas file target, we can use the name to allow uniqueness: https://github.com/app-sre/qontract-schemas/commit/7d6a2d18176b7ba8793d4285eed250b4792266fc#diff-6bad3cee90319b7494304e3ce4e439992becd03f9d8825eca7f44687f8184ee9R2007

that is what this PR does. if there is a `name` - use it for the state key path.