### PR TITLE
[APPSRE-4798] Add support for new parameter_group for RDS upgrade while keeping the old one intact.

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -46,7 +46,7 @@ provider
   defaults
   availability_zone
   parameter_group
-  new_parameter_group
+  old_parameter_group
   overrides
   output_resource_name
   enhanced_monitoring

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -46,6 +46,7 @@ provider
   defaults
   availability_zone
   parameter_group
+  new_parameter_group
   overrides
   output_resource_name
   enhanced_monitoring

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1271,8 +1271,15 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         new_parameter_group = values.pop("new_parameter_group", None)
         if new_parameter_group:
+            # discourage using new_parameter_group if parameter_group field is not utilized.
+            if parameter_group is None:
+                raise ValueError(
+                    "Cannot use new_parameter_group field without parameter_group."
+                    "This field is only used during RDS major version upgrade"
+                )
+
             new_pg_tf_resource = populate_parameter_group(new_parameter_group)
-            # pg_tf_resource will not be None as this validation is done at json-schema level.
+
             if new_pg_tf_resource.get("name") == pg_tf_resource.get("name"):
                 raise ValueError(
                     "Must supply a unique name value for new parameter group"

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1271,15 +1271,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         new_parameter_group = values.pop("new_parameter_group", None)
         if new_parameter_group:
-            # discourage using new_parameter_group if parameter_group field is not utilized.
-            if parameter_group is None:
-                raise ValueError(
-                    "Cannot use new_parameter_group field without parameter_group."
-                    "This field is only used during RDS major version upgrade"
-                )
-
             new_pg_tf_resource = populate_parameter_group(new_parameter_group)
-
+            # pg_tf_resource will not be None as this validation is done at json-schema level.
             if new_pg_tf_resource.get("name") == pg_tf_resource.get("name"):
                 raise ValueError(
                     "Must supply a unique name value for new parameter group"

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -178,7 +178,7 @@ VARIABLE_KEYS = [
     "region",
     "availability_zone",
     "parameter_group",
-    "new_parameter_group",
+    "old_parameter_group",
     "name",
     "enhanced_monitoring",
     "replica_source",
@@ -1269,27 +1269,23 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             # Associate parameter group to db instance
             values["parameter_group_name"] = pg_tf_resource.get("name")
 
-        new_parameter_group = values.pop("new_parameter_group", None)
-        if new_parameter_group:
-            # discourage using new_parameter_group if parameter_group field is not utilized.
+        old_parameter_group = values.pop("old_parameter_group", None)
+        if old_parameter_group:
+            # discourage using old_parameter_group if parameter_group field is not utilized.
             if parameter_group is None:
                 raise ValueError(
-                    "Cannot use new_parameter_group field without parameter_group."
+                    "Cannot use old_parameter_group field without parameter_group."
                     "This field is only used during RDS major version upgrade"
                 )
 
-            new_pg_tf_resource = populate_parameter_group(new_parameter_group)
+            old_pg_tf_resource = populate_parameter_group(old_parameter_group)
 
-            if new_pg_tf_resource.get("name") == pg_tf_resource.get("name"):
+            if old_pg_tf_resource.get("name") == pg_tf_resource.get("name"):
                 raise ValueError(
-                    "Must supply a unique name value for new parameter group"
+                    "Must supply a unique name value for parameter group"
                 )
 
-            tf_resources.append(new_pg_tf_resource)
-            deps += self.get_dependencies([new_pg_tf_resource])
-
-            # Override previously set value, so we know this is for the major version upgrade
-            values["parameter_group_name"] = new_pg_tf_resource.get("name")
+            tf_resources.append(old_pg_tf_resource)
 
         enhanced_monitoring = values.pop("enhanced_monitoring", None)
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1281,7 +1281,10 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             old_pg_tf_resource = populate_parameter_group(old_parameter_group)
 
             if old_pg_tf_resource.get("name") == pg_tf_resource.get("name"):
-                raise ValueError("Must supply a unique name value for parameter group")
+                raise ValueError(
+                    "Must supply a unique name value for parameter_group. You can add `name` field"
+                    "with a unique value in the file referenced by parameter_group"
+                )
 
             tf_resources.append(old_pg_tf_resource)
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1281,9 +1281,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             old_pg_tf_resource = populate_parameter_group(old_parameter_group)
 
             if old_pg_tf_resource.get("name") == pg_tf_resource.get("name"):
-                raise ValueError(
-                    "Must supply a unique name value for parameter group"
-                )
+                raise ValueError("Must supply a unique name value for parameter group")
 
             tf_resources.append(old_pg_tf_resource)
 


### PR DESCRIPTION
Related: APPSRE-4798

This change depends on https://github.com/app-sre/qontract-schemas/pull/242 

Background: The current process for major version upgrade involves updating parameter_group in place with new engine_version. Due to existing implementation this causes terraform to delete the old parameter group first before the upgrade is complete resulting into the error. 

This MR addresses the issue by allowing to specify new parameter group which will be used for upgrade while keeping the old parameter group intact.

Test cases using app-interface-dev-data:

1.  Create a new RDS instance. This is to ensure we don't break existing process.

```
  - provider: rds
    identifier: dev-bhthakur-rds
    defaults: /terraform/rds/bhthakur-rds-defaults.yml
    parameter_group: /terraform/rds/bhthakur-rds-params.yml
    output_resource_name: dev-bhthakur-rds-creds
```

2. Upgrade to new RDS version. This involves specifying `old_parameter_group`

```
  - provider: rds
    identifier: dev-bhthakur-rds
    defaults: /terraform/rds/bhthakur-rds-defaults.yml
    parameter_group: /terraform/rds/bhthakur-rds-params-1.yml
    old_parameter_group: /terraform/rds/bhthakur-rds-params.yml
    output_resource_name: dev-bhthakur-rds-creds
    overrides:
      engine_version: '12.11'
      apply_immediately: true
```
3. Do another consecutive upgrade

```
  - provider: rds
    identifier: dev-bhthakur-rds
    defaults: /terraform/rds/bhthakur-rds-defaults.yml
    parameter_group: /terraform/rds/bhthakur-rds-params-2.yml ## 
    old_parameter_group: /terraform/rds/bhthakur-rds-params-1.yml ## this refers to old_parameter_group from ex 2.
    output_resource_name: dev-bhthakur-rds-creds
    overrides:
      engine_version: '13.7'
      apply_immediately: true
```

A small refactor has been done to consolidate parameter_group terraform logic into a inner function. In addition, some safety checks have been implemented to ensure we have a unique name and `old_parameter_group` is used only when `parameter_group` is defined. 