### PR TITLE
[openshift-saas-deploy-trigger-configs] consider target name for uniqueness

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1982,6 +1982,7 @@ SAAS_FILES_QUERY_V2 = """
       }
       targets {
         path
+        name
         namespace {
           name
           environment {

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -87,6 +87,7 @@ class TriggerSpecBase:
 
 @dataclass
 class TriggerSpecConfig(TriggerSpecBase):
+    target_name: Optional[str] = None
     reason: Optional[str] = None
 
     @property
@@ -95,6 +96,8 @@ class TriggerSpecConfig(TriggerSpecBase):
             f"{self.saas_file_name}/{self.resource_template_name}/{self.cluster_name}/"
             f"{self.namespace_name}/{self.env_name}"
         )
+        if self.target_name:
+            key += f"/{self.target_name}"
         return key
 
 
@@ -1119,6 +1122,7 @@ class SaasHerder:
                     resource_template_name=rt_name,
                     cluster_name=cluster,
                     namespace_name=namespace,
+                    target_name=target.get("name"),
                     state_content=None,
                 ).state_key
                 digest = SaasHerder.get_target_config_hash(
@@ -1532,6 +1536,7 @@ class SaasHerder:
                     resource_template_name=rt_name,
                     cluster_name=cluster_name,
                     namespace_name=namespace_name,
+                    target_name=desired_target_config.get("name"),
                     state_content=serializable_target_config,
                 )
                 configs[trigger_spec.state_key] = trigger_spec


### PR DESCRIPTION
2nd attempt at #2778 (following refactors in #2782 and #2786)

we can't deploy the same resource template to the same namespace twice right now, due to a problem with `openshift-saas-deploy-trigger-configs`. it stores the current state of the configuration of each target in s3, and compares the desired state against it to know what to trigger.

it stores the state in a key that is calculated by: https://github.com/app-sre/qontract-reconcile/blob/2a987af604abe212b40a6e1feed91587cafbce5e/reconcile/utils/saasherder.py#L92-L98

so in case there is a saas file with a resource template that has 2 targets of the same namespace, you can see how this key is not unique.

with the addition of `name` to a saas file target, we can use the name to allow uniqueness: https://github.com/app-sre/qontract-schemas/commit/7d6a2d18176b7ba8793d4285eed250b4792266fc#diff-6bad3cee90319b7494304e3ce4e439992becd03f9d8825eca7f44687f8184ee9R2007

that is what this PR does. if there is a `name` - use it for the state key path.