### PR TITLE
APPSRE-5962 qenerate naming collision strategy

### DIFF
--- a/reconcile/gql_definitions/vpc_peerings_validator/vpc_peerings_validator.gql
+++ b/reconcile/gql_definitions/vpc_peerings_validator/vpc_peerings_validator.gql
@@ -1,4 +1,5 @@
 # qenerate: plugin=pydantic_v1
+# qenerate: naming_collision_strategy=ENUMERATE
 
 query VpcPeeringsValidator {
   clusters: clusters_v1 {

--- a/reconcile/gql_definitions/vpc_peerings_validator/vpc_peerings_validator.py
+++ b/reconcile/gql_definitions/vpc_peerings_validator/vpc_peerings_validator.py
@@ -68,7 +68,7 @@ class ClusterPeeringConnectionV1(BaseModel):
         extra = Extra.forbid
 
 
-class ClusterPeeringConnectionClusterRequesterV1_ClusterV1_ClusterSpecV1(BaseModel):
+class ClusterSpecV1__2(BaseModel):
     private: bool = Field(..., alias="private")
 
     class Config:
@@ -76,11 +76,9 @@ class ClusterPeeringConnectionClusterRequesterV1_ClusterV1_ClusterSpecV1(BaseMod
         extra = Extra.forbid
 
 
-class ClusterPeeringConnectionClusterRequesterV1_ClusterV1(BaseModel):
+class ClusterV1__2(BaseModel):
     name: str = Field(..., alias="name")
-    spec: Optional[
-        ClusterPeeringConnectionClusterRequesterV1_ClusterV1_ClusterSpecV1
-    ] = Field(..., alias="spec")
+    spec: Optional[ClusterSpecV1__2] = Field(..., alias="spec")
     internal: Optional[bool] = Field(..., alias="internal")
 
     class Config:
@@ -89,16 +87,14 @@ class ClusterPeeringConnectionClusterRequesterV1_ClusterV1(BaseModel):
 
 
 class ClusterPeeringConnectionClusterRequesterV1(ClusterPeeringConnectionV1):
-    cluster: ClusterPeeringConnectionClusterRequesterV1_ClusterV1 = Field(
-        ..., alias="cluster"
-    )
+    cluster: ClusterV1__2 = Field(..., alias="cluster")
 
     class Config:
         smart_union = True
         extra = Extra.forbid
 
 
-class ClusterPeeringConnectionClusterAccepterV1_ClusterV1_ClusterSpecV1(BaseModel):
+class ClusterSpecV1__3(BaseModel):
     private: bool = Field(..., alias="private")
 
     class Config:
@@ -106,11 +102,9 @@ class ClusterPeeringConnectionClusterAccepterV1_ClusterV1_ClusterSpecV1(BaseMode
         extra = Extra.forbid
 
 
-class ClusterPeeringConnectionClusterAccepterV1_ClusterV1(BaseModel):
+class ClusterV1__3(BaseModel):
     name: str = Field(..., alias="name")
-    spec: Optional[
-        ClusterPeeringConnectionClusterAccepterV1_ClusterV1_ClusterSpecV1
-    ] = Field(..., alias="spec")
+    spec: Optional[ClusterSpecV1__3] = Field(..., alias="spec")
     internal: Optional[bool] = Field(..., alias="internal")
 
     class Config:
@@ -119,9 +113,7 @@ class ClusterPeeringConnectionClusterAccepterV1_ClusterV1(BaseModel):
 
 
 class ClusterPeeringConnectionClusterAccepterV1(ClusterPeeringConnectionV1):
-    cluster: ClusterPeeringConnectionClusterAccepterV1_ClusterV1 = Field(
-        ..., alias="cluster"
-    )
+    cluster: ClusterV1__3 = Field(..., alias="cluster")
 
     class Config:
         smart_union = True

--- a/reconcile/test/test_vpc_peerings_validator.py
+++ b/reconcile/test/test_vpc_peerings_validator.py
@@ -2,8 +2,8 @@ import pytest
 
 from reconcile.gql_definitions.vpc_peerings_validator.vpc_peerings_validator import (
     ClusterPeeringConnectionClusterAccepterV1,
-    ClusterPeeringConnectionClusterAccepterV1_ClusterV1,
-    ClusterPeeringConnectionClusterAccepterV1_ClusterV1_ClusterSpecV1,
+    ClusterV1__3,
+    ClusterSpecV1__3,
     ClusterPeeringV1,
     ClusterSpecV1,
     ClusterV1,
@@ -27,11 +27,9 @@ def query_data_i2p() -> VpcPeeringsValidatorQueryData:
                     connections=[
                         ClusterPeeringConnectionClusterAccepterV1(
                             provider="cluster-vpc-accepter",
-                            cluster=ClusterPeeringConnectionClusterAccepterV1_ClusterV1(
+                            cluster=ClusterV1__3(
                                 name="cluster2",
-                                spec=ClusterPeeringConnectionClusterAccepterV1_ClusterV1_ClusterSpecV1(
-                                    private=False
-                                ),
+                                spec=ClusterSpecV1__3(private=False),
                                 internal=False,
                             ),
                         ),
@@ -75,11 +73,9 @@ def query_data_p2p() -> VpcPeeringsValidatorQueryData:
                     connections=[
                         ClusterPeeringConnectionClusterAccepterV1(
                             provider="cluster-vpc-accepter",
-                            cluster=ClusterPeeringConnectionClusterAccepterV1_ClusterV1(
+                            cluster=ClusterV1__3(
                                 name="cluster2",
-                                spec=ClusterPeeringConnectionClusterAccepterV1_ClusterV1_ClusterSpecV1(
-                                    private=False
-                                ),
+                                spec=ClusterSpecV1__3(private=False),
                                 internal=False,
                             ),
                         ),

--- a/requirements/requirements-type.txt
+++ b/requirements/requirements-type.txt
@@ -11,4 +11,4 @@ types-setuptools
 types-tabulate
 types-toml
 boto3-stubs[ec2,s3,rds,iam,route53]==1.24.29
-qenerate==0.2.2
+qenerate==0.2.4


### PR DESCRIPTION
qenerate now supports different naming collision strategies. By default, the parent class name is prefixed if a collision is detected. However, the `vpc_peerings_validator` enumerates now, instead of prefixing the parent class name.

cc @maorfr 