### PR TITLE
openshift-resources: fix error on non-existing env in current state

### DIFF
--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -107,7 +107,7 @@ class OpenshiftResource:
                     if diff or not self.obj_intersect_equal(obj1_v, obj2_v, depth + 1):
                         return False
                 elif obj1_k == "env":
-                    for v in obj2_v:
+                    for v in obj2_v or []:
                         if "name" in v and len(v) == 1:
                             v["value"] = ""
                     if not self.obj_intersect_equal(obj1_v, obj2_v, depth + 1):


### PR DESCRIPTION
When there is no `env` in the current state and an `env` is being added (or even set to `null`), `openshift-resources complains it cannot iterate over `NoneType`.