### PR TITLE
consider self-service configs for saas file ownership

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2072,6 +2072,17 @@ SAAS_FILES_QUERY_V2 = """
         org_username
       }
     }
+    selfService {
+      roles {
+        users {
+          org_username
+          tag_on_merge_requests
+        }
+        bots {
+          org_username
+        }
+      }
+    }
   }
 }
 """ % (

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2072,15 +2072,13 @@ SAAS_FILES_QUERY_V2 = """
         org_username
       }
     }
-    selfService {
-      roles {
-        users {
-          org_username
-          tag_on_merge_requests
-        }
-        bots {
-          org_username
-        }
+    selfServiceRoles {
+      users {
+        org_username
+        tag_on_merge_requests
+      }
+      bots {
+        org_username
       }
     }
   }

--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -33,10 +33,8 @@ def collect_owners():
     for saas_file in saas_files:
         saas_file_name = saas_file["name"]
         owners[saas_file_name] = set()
-        owner_roles = saas_file.get("roles")
-        if not owner_roles:
-            continue
-        for owner_role in owner_roles:
+        # roles with owned saas files
+        for owner_role in saas_file.get("roles") or []:
             owner_users = owner_role.get("users") or []
             for owner_user in owner_users:
                 owner_username = owner_user["org_username"]
@@ -48,6 +46,21 @@ def collect_owners():
                 bot_org_username = bot.get("org_username")
                 if bot_org_username:
                     owners[saas_file_name].add(bot_org_username)
+        # self-service configs
+        for self_service in saas_file.get("selfService") or []:
+            owner_roles = self_service.get("roles") or []
+            for owner_role in owner_roles:
+                owner_users = owner_role.get("users") or []
+                for owner_user in owner_users:
+                    owner_username = owner_user["org_username"]
+                    if owner_user.get("tag_on_merge_requests"):
+                        owner_username = f"@{owner_username}"
+                    owners[saas_file_name].add(owner_username)
+                owner_bots = owner_role.get("bots") or []
+                for bot in owner_bots:
+                    bot_org_username = bot.get("org_username")
+                    if bot_org_username:
+                        owners[saas_file_name].add(bot_org_username)
 
     # make owners suitable for json dump
     ans = {}

--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -47,20 +47,18 @@ def collect_owners():
                 if bot_org_username:
                     owners[saas_file_name].add(bot_org_username)
         # self-service configs
-        for self_service in saas_file.get("selfService") or []:
-            owner_roles = self_service.get("roles") or []
-            for owner_role in owner_roles:
-                owner_users = owner_role.get("users") or []
-                for owner_user in owner_users:
-                    owner_username = owner_user["org_username"]
-                    if owner_user.get("tag_on_merge_requests"):
-                        owner_username = f"@{owner_username}"
-                    owners[saas_file_name].add(owner_username)
-                owner_bots = owner_role.get("bots") or []
-                for bot in owner_bots:
-                    bot_org_username = bot.get("org_username")
-                    if bot_org_username:
-                        owners[saas_file_name].add(bot_org_username)
+        for self_service_role in saas_file.get("selfServiceRoles") or []:
+            owner_users = self_service_role.get("users") or []
+            for owner_user in owner_users:
+                owner_username = owner_user["org_username"]
+                if owner_user.get("tag_on_merge_requests"):
+                    owner_username = f"@{owner_username}"
+                owners[saas_file_name].add(owner_username)
+            owner_bots = self_service_role.get("bots") or []
+            for bot in owner_bots:
+                bot_org_username = bot.get("org_username")
+                if bot_org_username:
+                    owners[saas_file_name].add(bot_org_username)
 
     # make owners suitable for json dump
     ans = {}

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -69,6 +69,9 @@ class TestSaasFileValid(TestCase):
                     }
                 ],
                 "roles": [{"users": [{"org_username": "myname"}]}],
+                "selfService": [
+                    {"roles": [{"users": [{"org_username": "theirname"}]}]}
+                ],
             }
         ]
         jjb_mock_data = {

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -69,9 +69,7 @@ class TestSaasFileValid(TestCase):
                     }
                 ],
                 "roles": [{"users": [{"org_username": "myname"}]}],
-                "selfService": [
-                    {"roles": [{"users": [{"org_username": "theirname"}]}]}
-                ],
+                "selfServiceRoles": [{"users": [{"org_username": "theirname"}]}],
             }
         ]
         jjb_mock_data = {

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -242,8 +242,7 @@ class SaasHerder:
                 u["org_username"] for r in saas_file["roles"] for u in r["users"]
             ] + [
                 u["org_username"]
-                for s in saas_file["selfService"]
-                for r in s["roles"]
+                for r in saas_file["selfServiceRoles"]
                 for u in r["users"]
             ]
             if not saas_file_owners:

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -240,6 +240,11 @@ class SaasHerder:
 
             saas_file_owners = [
                 u["org_username"] for r in saas_file["roles"] for u in r["users"]
+            ] + [
+                u["org_username"]
+                for s in saas_file["selfService"]
+                for r in s["roles"]
+                for u in r["users"]
             ]
             if not saas_file_owners:
                 msg = "saas file {} has no owners: {}"


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/246

with the changes introduced in https://github.com/app-sre/qontract-schemas/pull/220, we will slowly begin our migration of saas file ownership through `saas_file_owners` to `self_service`.

this PR introduces changes to consider `self_service` alongside `saas_file_owners` for a backwards compatible migration:
this PR updates saas-file-validator and saas-file-owners.