### PR TITLE
[change-owners] approval-flow dry-run

### DIFF
--- a/reconcile/change_owners.py
+++ b/reconcile/change_owners.py
@@ -299,6 +299,17 @@ def compare_object_ctx_identifier(
     raise CannotCompare() from None
 
 
+def parse_resource_file_content(content: Optional[Any]) -> Any:
+    if content:
+        try:
+            return anymarkup.parse(content, force_types=None)
+        except Exception:
+            # not parsable content - we will just deal with the plain content
+            return content
+    else:
+        return None
+
+
 def create_bundle_file_change(
     path: str,
     schema: Optional[str],
@@ -317,10 +328,8 @@ def create_bundle_file_change(
 
     # try to parse the content if a resourcefile has a schema
     if file_type == BundleFileType.RESOURCEFILE and schema:
-        if old_file_content:
-            old_file_content = anymarkup.parse(old_file_content, force_types=None)
-        if new_file_content:
-            new_file_content = anymarkup.parse(new_file_content, force_types=None)
+        old_file_content = parse_resource_file_content(old_file_content)
+        new_file_content = parse_resource_file_content(new_file_content)
 
     diffs: list[Diff] = []
     if old_file_content and new_file_content:

--- a/reconcile/change_owners.py
+++ b/reconcile/change_owners.py
@@ -949,7 +949,11 @@ def write_coverage_report_to_mr(
         results, ["file", "change", "status", "approvers"], table_format="github"
     )
     gl.add_comment_to_merge_request(
-        mr_id, f"{change_coverage_report_header}\n{coverage_report}"
+        mr_id,
+        f"{change_coverage_report_header}<br/> "
+        "All changes require an `/lgtm` from a listed approver\n"
+        f"{coverage_report}\n\n"
+        f"Supported commands: {' '.join([f'`{d.value}`' for d in DecisionCommand])} ",
     )
 
 

--- a/reconcile/change_owners.py
+++ b/reconcile/change_owners.py
@@ -921,9 +921,10 @@ def write_coverage_report_to_mr(
     comments = gl.get_merge_request_comments(mr_id, include_description=True)
     # delete previous report comment
     for c in sorted(comments, key=lambda k: k["created_at"]):
-        if c["username"] == "devtools-bot":
-            if c["body"].startswith(change_coverage_report_header):
-                gl.delete_gitlab_comment(mr_id, c["id"])
+        if c["username"] == gl.user.username and c["body"].startswith(
+            change_coverage_report_header
+        ):
+            gl.delete_gitlab_comment(mr_id, c["id"])
 
     # add new report comment
     results = []

--- a/reconcile/change_owners.py
+++ b/reconcile/change_owners.py
@@ -836,10 +836,10 @@ class ChangeDecision:
 
 
 class DecisionCommand(Enum):
-    APPROVED = "/passt"
-    CANCEL_APPROVED = "/na doch net"
-    HOLD = "/wort amol"
-    CANCEL_HOLD = "/moch weiter"
+    APPROVED = "/lgtm"
+    CANCEL_APPROVED = "/lgtm cancel"
+    HOLD = "/hold"
+    CANCEL_HOLD = "/hold cancel"
 
 
 def get_approver_decisions(comments: list[dict[str, str]]) -> dict[str, Decision]:

--- a/reconcile/change_owners.py
+++ b/reconcile/change_owners.py
@@ -901,10 +901,11 @@ def apply_decisions_to_changes(
             diff_decisions.append(dc)
             for change_type_context in d.covered_by:
                 for approver in change_type_context.approvers:
-                    if approver_decisions[approver.org_username].approve:
-                        dc.decision.approve |= True
-                    if approver_decisions[approver.org_username].hold:
-                        dc.decision.hold |= True
+                    if approver.org_username in approver_decisions:
+                        if approver_decisions[approver.org_username].approve:
+                            dc.decision.approve |= True
+                        if approver_decisions[approver.org_username].hold:
+                            dc.decision.hold |= True
     return diff_decisions
 
 

--- a/reconcile/change_owners.py
+++ b/reconcile/change_owners.py
@@ -180,16 +180,22 @@ class BundleFileChange:
                     affected_context_paths = new_contexts - old_contexts
                 elif c.context.when == "removed":
                     affected_context_paths = old_contexts - new_contexts
-                contexts.extend(
-                    [
-                        FileRef(
-                            schema=change_type.context_schema,
-                            path=path,
-                            file_type=BundleFileType.DATAFILE,
-                        )
-                        for path in affected_context_paths
-                    ]
-                )
+                elif c.context.when is None and old_contexts == new_contexts:
+                    affected_context_paths = old_contexts
+                else:
+                    affected_context_paths = None
+
+                if affected_context_paths:
+                    contexts.extend(
+                        [
+                            FileRef(
+                                schema=change_type.context_schema,
+                                path=path,
+                                file_type=BundleFileType.DATAFILE,
+                            )
+                            for path in affected_context_paths
+                        ]
+                    )
         return contexts
 
     def cover_changes(self, change_type_context: "ChangeTypeContext") -> list[Diff]:

--- a/reconcile/change_owners.py
+++ b/reconcile/change_owners.py
@@ -795,19 +795,19 @@ def run(
             labels=labels,
             condition=self_servicable and hold,
             true_label=HOLD,
-            dry_run=mr_management_enabled,
+            dry_run=not mr_management_enabled,
         )
         labels = manage_conditional_label(
             labels=labels,
             condition=self_servicable and approved,
             true_label=APPROVED,
-            dry_run=mr_management_enabled,
+            dry_run=not mr_management_enabled,
         )
         labels = manage_conditional_label(
             labels=labels,
             condition=self_servicable and not approved,
             true_label=AWAITING_APPROVAL,
-            dry_run=mr_management_enabled,
+            dry_run=not mr_management_enabled,
         )
         gl.set_labels_on_merge_request(gitlab_merge_request_id, labels)
 

--- a/reconcile/change_owners.py
+++ b/reconcile/change_owners.py
@@ -913,9 +913,8 @@ def write_coverage_report_to_mr(
         mr_id, f"{change_coverage_report_header}\n{coverage_report}"
     )
 
-def write_coverage_report_to_stdout(
-    change_decisions: list[ChangeDecision]
-) -> None:
+
+def write_coverage_report_to_stdout(change_decisions: list[ChangeDecision]) -> None:
     results = []
     for d in change_decisions:
         item = {

--- a/reconcile/change_owners.py
+++ b/reconcile/change_owners.py
@@ -528,6 +528,7 @@ class Approver(Protocol):
     """
 
     org_username: str
+    tag_on_merge_requests: Optional[bool]
 
 
 @dataclass
@@ -741,7 +742,8 @@ def run(
                         if decisions[approver.org_username].hold:
                             dc.decision.hold |= True
 
-        write_coverage_report_to_mr(diff_coverage, gitlab_merge_request_id, gl)
+        if not dry_run:
+            write_coverage_report_to_mr(diff_coverage, gitlab_merge_request_id, gl)
 
     except BaseException:
         logging.error(traceback.format_exc())
@@ -804,7 +806,7 @@ def write_coverage_report_to_mr(diff_coverage: list[DiffCoverage], mr_id: int, g
     results = []
     for dc in diff_coverage:
         approvers = [
-            f"{ctctx.context}: { ', '.join([a.org_username for a in ctctx.approvers]) }"
+            f"{ctctx.context} - { ' '.join([f'@{a.org_username}' if a.tag_on_merge_requests else a.org_username for a in ctctx.approvers]) }"
             for ctctx in dc.diff.covered_by
         ]
         if not approvers:

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2141,8 +2141,22 @@ def integrations_manager(
     "--comparison-sha",
     help="bundle sha to compare to to find changes",
 )
+@click.option(
+    "--change-type-processing-mode",
+    help="if `limited` (default) the integration will not make any final decisions on the MR, but if `authorative` it will ",
+    required=True,
+    default="limited",
+    type=click.Choice(['limited', 'authorative'], case_sensitive=True)
+
+)
+@click.option(
+    "--mr-management",
+    is_flag=True,
+    default=os.environ.get("MR_MANAGEMENT", False),
+    help="Manage MR labels and comments (default to false)",
+)
 @click.pass_context
-def change_owners(ctx, gitlab_project_id, gitlab_merge_request_id, comparison_sha):
+def change_owners(ctx, gitlab_project_id, gitlab_merge_request_id, comparison_sha, change_type_processing_mode):
     import reconcile.change_owners
 
     run_integration(
@@ -2151,6 +2165,7 @@ def change_owners(ctx, gitlab_project_id, gitlab_merge_request_id, comparison_sh
         gitlab_project_id,
         gitlab_merge_request_id,
         comparison_sha,
+        change_type_processing_mode,
     )
 
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2146,8 +2146,7 @@ def integrations_manager(
     help="if `limited` (default) the integration will not make any final decisions on the MR, but if `authorative` it will ",
     required=True,
     default="limited",
-    type=click.Choice(['limited', 'authorative'], case_sensitive=True)
-
+    type=click.Choice(["limited", "authorative"], case_sensitive=True),
 )
 @click.option(
     "--mr-management",
@@ -2156,7 +2155,13 @@ def integrations_manager(
     help="Manage MR labels and comments (default to false)",
 )
 @click.pass_context
-def change_owners(ctx, gitlab_project_id, gitlab_merge_request_id, comparison_sha, change_type_processing_mode):
+def change_owners(
+    ctx,
+    gitlab_project_id,
+    gitlab_merge_request_id,
+    comparison_sha,
+    change_type_processing_mode,
+):
     import reconcile.change_owners
 
     run_integration(

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2135,17 +2135,21 @@ def integrations_manager(
 @integration.command(
     short_help="Detects owners for changes in app-interface PRs and allows them to self-service merge."
 )
+@click.argument("gitlab-project-id")
+@click.argument("gitlab-merge-request-id")
 @click.option(
     "--comparison-sha",
     help="bundle sha to compare to to find changes",
 )
 @click.pass_context
-def change_owners(ctx, comparison_sha):
+def change_owners(ctx, gitlab_project_id, gitlab_merge_request_id, comparison_sha):
     import reconcile.change_owners
 
     run_integration(
         reconcile.change_owners,
         ctx.obj,
+        gitlab_project_id,
+        gitlab_merge_request_id,
         comparison_sha,
     )
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2154,6 +2154,12 @@ def integrations_manager(
     default=os.environ.get("MR_MANAGEMENT", False),
     help="Manage MR labels and comments (default to false)",
 )
+@click.option(
+    "--mr-management",
+    is_flag=True,
+    default=os.environ.get("MR_MANAGEMENT", False),
+    help="Manage MR labels and comments (default to false)",
+)
 @click.pass_context
 def change_owners(
     ctx,
@@ -2161,6 +2167,7 @@ def change_owners(
     gitlab_merge_request_id,
     comparison_sha,
     change_type_processing_mode,
+    mr_management,
 ):
     import reconcile.change_owners
 
@@ -2171,6 +2178,7 @@ def change_owners(
         gitlab_merge_request_id,
         comparison_sha,
         change_type_processing_mode,
+        mr_management,
     )
 
 

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
@@ -18,5 +18,8 @@ query SelfServiceRolesQuery {
       org_username
       tag_on_merge_requests
     }
+    bots {
+      org_username
+    }
   }
 }

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
@@ -16,6 +16,7 @@ query SelfServiceRolesQuery {
     }
     users {
       org_username
+      tag_on_merge_requests
     }
   }
 }

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
@@ -35,6 +35,9 @@ query SelfServiceRolesQuery {
       org_username
       tag_on_merge_requests
     }
+    bots {
+      org_username
+    }
   }
 }
 """
@@ -76,11 +79,20 @@ class UserV1(BaseModel):
         extra = Extra.forbid
 
 
+class BotV1(BaseModel):
+    org_username: Optional[str] = Field(..., alias="org_username")
+
+    class Config:
+        smart_union = True
+        extra = Extra.forbid
+
+
 class RoleV1(BaseModel):
     name: str = Field(..., alias="name")
     path: str = Field(..., alias="path")
     self_service: Optional[list[SelfServiceConfigV1]] = Field(..., alias="self_service")
     users: list[UserV1] = Field(..., alias="users")
+    bots: list[BotV1] = Field(..., alias="bots")
 
     class Config:
         smart_union = True

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
@@ -33,6 +33,7 @@ query SelfServiceRolesQuery {
     }
     users {
       org_username
+      tag_on_merge_requests
     }
   }
 }
@@ -68,6 +69,7 @@ class SelfServiceConfigV1(BaseModel):
 
 class UserV1(BaseModel):
     org_username: str = Field(..., alias="org_username")
+    tag_on_merge_requests: Optional[bool] = Field(..., alias="tag_on_merge_requests")
 
     class Config:
         smart_union = True

--- a/reconcile/test/fixtures/change_owners/changetype_cluster_owner.yml
+++ b/reconcile/test/fixtures/change_owners/changetype_cluster_owner.yml
@@ -1,0 +1,13 @@
+name: cluser-owner
+
+contextType: datafile
+contextSchema: /openshift/cluster-1.yml
+
+changes:
+- provider: jsonPath
+  changeSchema: /openshift/namespace-1.yml
+  jsonPathSelectors:
+  - $
+  context:
+    selector: cluster.'$ref'
+    when: null

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -99,7 +99,7 @@ def build_role(
                 resources=None,
             )
         ],
-        users=[UserV1(org_username=u) for u in users or []],
+        users=[UserV1(org_username=u, tag_on_merge_requests=False) for u in users or []],
     )
 
 
@@ -955,7 +955,7 @@ def test_cover_changes_one_file(
     ctx = ChangeTypeContext(
         change_type_processor=build_change_type_processor(saas_file_changetype),
         context="RoleV1 - some-role",
-        approvers=[UserV1(org_username="user")],
+        approvers=[UserV1(org_username="user", tag_on_merge_requests=False)],
     )
     covered_diffs = saas_file_change.cover_changes(ctx)
     assert covered_diffs == saas_file_change.diffs
@@ -969,7 +969,7 @@ def test_uncovered_change_one_file(
     ctx = ChangeTypeContext(
         change_type_processor=build_change_type_processor(saas_file_changetype),
         context="RoleV1 - some-role",
-        approvers=[UserV1(org_username="user")],
+        approvers=[UserV1(org_username="user", tag_on_merge_requests=False)],
     )
     saas_file_change.cover_changes(ctx)
 
@@ -990,7 +990,7 @@ def test_partially_covered_change_one_file(
     ctx = ChangeTypeContext(
         change_type_processor=build_change_type_processor(saas_file_changetype),
         context="RoleV1 - some-role",
-        approvers=[UserV1(org_username="user")],
+        approvers=[UserV1(org_username="user", tag_on_merge_requests=False)],
     )
 
     covered_diffs = saas_file_change.cover_changes(ctx)

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -1108,6 +1108,11 @@ def test_change_coverage(
             assert d.covered_by[0].approvers[0].org_username == expected_approver
 
 
+#
+# test MR decision comment parsing
+#
+
+
 def test_approver_decision_approve_and_hold():
     comments = [
         {

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -102,7 +102,9 @@ def build_role(
                 resources=None,
             )
         ],
-        users=[UserV1(org_username=u, tag_on_merge_requests=False) for u in users or []],
+        users=[
+            UserV1(org_username=u, tag_on_merge_requests=False) for u in users or []
+        ],
         bots=[BotV1(org_username=b) for b in bots or []],
     )
 
@@ -1069,20 +1071,14 @@ def test_approver_decision_approve_and_hold():
     comments = [
         {
             "username": "user-1",
-            "body": (
-                "nice\n"
-                f"{DecisionCommand.APPROVED.value}"
-            ),
+            "body": ("nice\n" f"{DecisionCommand.APPROVED.value}"),
             "created_at": "2020-01-01T00:00:00Z",
         },
         {
             "username": "user-2",
-            "body": (
-                f"{DecisionCommand.HOLD.value}\n"
-                "oh wait... big problems"
-            ),
+            "body": (f"{DecisionCommand.HOLD.value}\n" "oh wait... big problems"),
             "created_at": "2020-01-02T00:00:00Z",
-        }
+        },
     ]
     assert get_approver_decisions(comments) == {
         "user-1": Decision(approve=True, hold=False),
@@ -1094,10 +1090,7 @@ def test_approver_approve_and_cancel():
     comments = [
         {
             "username": "user-1",
-            "body": (
-                "nice\n"
-                f"{DecisionCommand.APPROVED.value}"
-            ),
+            "body": ("nice\n" f"{DecisionCommand.APPROVED.value}"),
             "created_at": "2020-01-01T00:00:00Z",
         },
         {
@@ -1107,7 +1100,7 @@ def test_approver_approve_and_cancel():
                 "oh wait... changed my mind"
             ),
             "created_at": "2020-01-02T00:00:00Z",
-        }
+        },
     ]
     assert get_approver_decisions(comments) == {
         "user-1": Decision(approve=False, hold=False),
@@ -1118,20 +1111,16 @@ def test_approver_hold_and_unhold():
     comments = [
         {
             "username": "user-1",
-            "body": (
-                "wait...\n"
-                f"{DecisionCommand.HOLD.value}"
-            ),
+            "body": ("wait...\n" f"{DecisionCommand.HOLD.value}"),
             "created_at": "2020-01-01T00:00:00Z",
         },
         {
             "username": "user-1",
             "body": (
-                f"{DecisionCommand.CANCEL_HOLD.value}\n"
-                "oh never mind... keep going"
+                f"{DecisionCommand.CANCEL_HOLD.value}\n" "oh never mind... keep going"
             ),
             "created_at": "2020-01-02T00:00:00Z",
-        }
+        },
     ]
     assert get_approver_decisions(comments) == {
         "user-1": Decision(approve=False, hold=False),
@@ -1143,17 +1132,13 @@ def test_unordered_approval_comments():
         {
             "username": "user-1",
             "body": (
-                f"{DecisionCommand.CANCEL_HOLD.value}\n"
-                "oh never mind... keep going"
+                f"{DecisionCommand.CANCEL_HOLD.value}\n" "oh never mind... keep going"
             ),
             "created_at": "2020-01-02T00:00:00Z",
         },
         {
             "username": "user-1",
-            "body": (
-                "wait...\n"
-                f"{DecisionCommand.HOLD.value}"
-            ),
+            "body": ("wait...\n" f"{DecisionCommand.HOLD.value}"),
             "created_at": "2020-01-01T00:00:00Z",
         },
     ]

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -1247,6 +1247,15 @@ def test_label_management_condition_true():
         condition=True,
         true_label="true-label",
         false_label="false-label",
+        dry_run=False,
+    )
+
+    assert ["existing-label"] == manage_conditional_label(
+        labels=["existing-label"],
+        condition=True,
+        true_label="true-label",
+        false_label="false-label",
+        dry_run=True,
     )
 
 
@@ -1256,6 +1265,15 @@ def test_label_management_condition_false():
         condition=False,
         true_label="true-label",
         false_label="false-label",
+        dry_run=False,
+    )
+
+    assert ["existing-label"] == manage_conditional_label(
+        labels=["existing-label"],
+        condition=False,
+        true_label="true-label",
+        false_label="false-label",
+        dry_run=True,
     )
 
 
@@ -1265,6 +1283,15 @@ def test_label_management_true_to_false():
         condition=False,
         true_label="true-label",
         false_label="false-label",
+        dry_run=False,
+    )
+
+    assert ["existing-label", "true-label"] == manage_conditional_label(
+        labels=["existing-label", "true-label"],
+        condition=False,
+        true_label="true-label",
+        false_label="false-label",
+        dry_run=True,
     )
 
 
@@ -1274,4 +1301,13 @@ def test_label_management_false_to_true():
         condition=True,
         true_label="true-label",
         false_label="false-label",
+        dry_run=False,
+    )
+
+    assert ["existing-label", "false-label"] == manage_conditional_label(
+        labels=["existing-label", "false-label"],
+        condition=True,
+        true_label="true-label",
+        false_label="false-label",
+        dry_run=True,
     )

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -11,8 +11,8 @@ from reconcile.change_owners import (
     create_bundle_file_change,
     cover_changes_with_self_service_roles,
     deepdiff_path_to_jsonpath,
-    get_approver_decisions,
-    decide_on_changes,
+    get_approver_decisions_from_mr_comments,
+    apply_decisions_to_changes,
     manage_conditional_label,
     DecisionCommand,
     Decision,
@@ -1128,7 +1128,7 @@ def test_approver_decision_approve_and_hold():
             "created_at": "2020-01-02T00:00:00Z",
         },
     ]
-    assert get_approver_decisions(comments) == {
+    assert get_approver_decisions_from_mr_comments(comments) == {
         "user-1": Decision(approve=True, hold=False),
         "user-2": Decision(approve=False, hold=True),
     }
@@ -1150,7 +1150,7 @@ def test_approver_approve_and_cancel():
             "created_at": "2020-01-02T00:00:00Z",
         },
     ]
-    assert get_approver_decisions(comments) == {
+    assert get_approver_decisions_from_mr_comments(comments) == {
         "user-1": Decision(approve=False, hold=False),
     }
 
@@ -1170,7 +1170,7 @@ def test_approver_hold_and_unhold():
             "created_at": "2020-01-02T00:00:00Z",
         },
     ]
-    assert get_approver_decisions(comments) == {
+    assert get_approver_decisions_from_mr_comments(comments) == {
         "user-1": Decision(approve=False, hold=False),
     }
 
@@ -1190,7 +1190,7 @@ def test_unordered_approval_comments():
             "created_at": "2020-01-01T00:00:00Z",
         },
     ]
-    assert get_approver_decisions(comments) == {
+    assert get_approver_decisions_from_mr_comments(comments) == {
         "user-1": Decision(approve=False, hold=False),
     }
 
@@ -1222,7 +1222,7 @@ def test_change_decision():
         )
     ]
 
-    change_decision = decide_on_changes(
+    change_decision = apply_decisions_to_changes(
         approver_decisions={
             yea_user: Decision(approve=True, hold=False),
             nay_sayer: Decision(approve=False, hold=True),

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -13,7 +13,8 @@ from reconcile.change_owners import (
     deepdiff_path_to_jsonpath,
     get_approver_decisions,
     DecisionCommand,
-    Decision
+    Decision,
+    Approver,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import (
     ChangeTypeChangeDetectorV1,
@@ -25,6 +26,7 @@ from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
     RoleV1,
     SelfServiceConfigV1,
     UserV1,
+    BotV1,
 )
 
 from .fixtures import Fixtures
@@ -85,7 +87,8 @@ def build_role(
     name: str,
     change_type_name: str,
     datafiles: Optional[list[DatafileObjectV1]],
-    users: Optional[list[str]],
+    users: Optional[list[str]] = None,
+    bots: Optional[list[str]] = None,
 ) -> RoleV1:
     return RoleV1(
         name=name,
@@ -100,6 +103,7 @@ def build_role(
             )
         ],
         users=[UserV1(org_username=u, tag_on_merge_requests=False) for u in users or []],
+        bots=[BotV1(org_username=b) for b in bots or []],
     )
 
 
@@ -955,7 +959,7 @@ def test_cover_changes_one_file(
     ctx = ChangeTypeContext(
         change_type_processor=build_change_type_processor(saas_file_changetype),
         context="RoleV1 - some-role",
-        approvers=[UserV1(org_username="user", tag_on_merge_requests=False)],
+        approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
     )
     covered_diffs = saas_file_change.cover_changes(ctx)
     assert covered_diffs == saas_file_change.diffs
@@ -969,7 +973,7 @@ def test_uncovered_change_one_file(
     ctx = ChangeTypeContext(
         change_type_processor=build_change_type_processor(saas_file_changetype),
         context="RoleV1 - some-role",
-        approvers=[UserV1(org_username="user", tag_on_merge_requests=False)],
+        approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
     )
     saas_file_change.cover_changes(ctx)
 
@@ -990,7 +994,7 @@ def test_partially_covered_change_one_file(
     ctx = ChangeTypeContext(
         change_type_processor=build_change_type_processor(saas_file_changetype),
         context="RoleV1 - some-role",
-        approvers=[UserV1(org_username="user", tag_on_merge_requests=False)],
+        approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
     )
 
     covered_diffs = saas_file_change.cover_changes(ctx)

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -13,6 +13,7 @@ from reconcile.change_owners import (
     deepdiff_path_to_jsonpath,
     get_approver_decisions,
     decide_on_changes,
+    manage_conditional_label,
     DecisionCommand,
     Decision,
     Approver,
@@ -1233,3 +1234,44 @@ def test_change_decision():
     assert change_decision[0].decision.hold
     assert change_decision[0].diff == change.diffs[0]
     assert change_decision[0].file == change.fileref
+
+
+#
+# test label management
+#
+
+
+def test_label_management_condition_true():
+    assert ["existing-label", "true-label"] == manage_conditional_label(
+        labels=["existing-label"],
+        condition=True,
+        true_label="true-label",
+        false_label="false-label",
+    )
+
+
+def test_label_management_condition_false():
+    assert ["existing-label", "false-label"] == manage_conditional_label(
+        labels=["existing-label"],
+        condition=False,
+        true_label="true-label",
+        false_label="false-label",
+    )
+
+
+def test_label_management_true_to_false():
+    assert ["existing-label", "false-label"] == manage_conditional_label(
+        labels=["existing-label", "true-label"],
+        condition=False,
+        true_label="true-label",
+        false_label="false-label",
+    )
+
+
+def test_label_management_false_to_true():
+    assert ["existing-label", "true-label"] == manage_conditional_label(
+        labels=["existing-label", "false-label"],
+        condition=True,
+        true_label="true-label",
+        false_label="false-label",
+    )

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -373,6 +373,11 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         mr_labels += labels
         self.update_labels(merge_request, "merge-request", mr_labels)
 
+    def set_labels_on_merge_request(self, mr_id, labels):
+        """Set labels to a Merge Request"""
+        merge_request = self.project.mergerequests.get(mr_id)
+        self.update_labels(merge_request, "merge-request", labels)
+
     def remove_label_from_merge_request(self, mr_id, label):
         merge_request = self.project.mergerequests.get(mr_id)
         labels = merge_request.attributes.get("labels")

--- a/reconcile/utils/mr/labels.py
+++ b/reconcile/utils/mr/labels.py
@@ -9,3 +9,5 @@ HOLD = "bot/hold"
 LGTM = "lgtm"
 SAAS_FILE_UPDATE = "saas-file-update"
 SKIP_CI = "bot/skip-ci"
+
+SELF_SERVICE = "self-service"

--- a/reconcile/utils/mr/labels.py
+++ b/reconcile/utils/mr/labels.py
@@ -10,4 +10,5 @@ LGTM = "lgtm"
 SAAS_FILE_UPDATE = "saas-file-update"
 SKIP_CI = "bot/skip-ci"
 
-SELF_SERVICE = "self-service"
+SELF_SERVICEABLE = "self-servicable"
+NOT_SELF_SERVICEABLE = "not-self-servicable"

--- a/reconcile/utils/output.py
+++ b/reconcile/utils/output.py
@@ -30,7 +30,7 @@ def print_output(
         pass  # error
 
 
-def print_table(content, columns, table_format="simple"):
+def format_table(content, columns, table_format="simple") -> str:
     headers = [column.upper() for column in columns]
     table_data = []
     for item in content:
@@ -50,5 +50,8 @@ def print_table(content, columns, table_format="simple"):
                     cell = "\n".join(cell)
             row_data.append(cell)
         table_data.append(row_data)
+    return tabulate(table_data, headers=headers, tablefmt=table_format)
 
-    print(tabulate(table_data, headers=headers, tablefmt=table_format))
+
+def print_table(content, columns, table_format="simple"):
+    print(format_table(content, columns, table_format))


### PR DESCRIPTION
this PR adds to following functionality to change-owners

* parse basic decision commands from MR comments (`/lgtm`, `/lgtm cancel`, `/hold`, `/hold cancel`) and manage `bot/approved` `bot/hold` and `awaiting-approval` labels when not running in dry-run mode
* support bots as approvers
* honor `tag_on_merge_requests` flag when mentioning users in MR comments
* add `self-servicable` and `not-self-serviceable` labels to MRs to indicate if all changes are approvable by tenants (a.k.a. covered by change-types)
* manage bot-approved, bot-hold
* write MR decision state command if not running in dry-run mode
* add new integration parameter `--change-type-processing-mode` and supported `limited` and `authorative`
* make `changes.context.when` to optional and react according to the semantics described in https://github.com/app-sre/qontract-schemas/pull/248

### details on change type processing mode

change-owners acts only on bundle content and is therefore unaware if something changed in an app-interface MR that can't be covered by change-types, e.g. .env, scripts, ... 
in such situations the integration is started with `--change-type-processing-mode limited` which prevents the integration to act on the MR. even if all bundle changes would be self-servicable via change-types, the `not-self-servicable` label is added.

if the MR contains only changes that are reflected in the bundle, ´--change-type-processing-mode authorative` is provided to the integration to let it know that it is safe to act.

theoretically we could have queried the changed paths of the MR and figure it out within the integration itself but that would imply that change-owners would need to know details about the app-interface repo structure, which is best to avoid to keep the flexibility in the repo layout. it will be `select-integrations.py` responsibility to set this flag appropriately.


Depends on https://github.com/app-sre/qontract-schemas/pull/248
Must be promoted along with https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/48000