### PR TITLE
[query-validator] add option to validate resources with queries

### DIFF
--- a/reconcile/query_validator.py
+++ b/reconcile/query_validator.py
@@ -49,7 +49,7 @@ def run(dry_run):
                 logging.error(f"query validation error in {qv_name}: {str(e)}")
         for r in qv.get("resources") or []:
             try:
-                fetch_openshift_resource(r, qv, settings=settings)
+                fetch_openshift_resource(r, qv, settings=settings, skip_validation=True)
             except Exception as e:
                 error = True
                 logging.error(f"query validation error in {qv_name}: {str(e)}")

--- a/reconcile/query_validator.py
+++ b/reconcile/query_validator.py
@@ -27,12 +27,13 @@ def run(dry_run):
     query_validations = gqlapi.query(QUERY_VALIDATIONS_QUERY)["validations"]
     error = False
     for qv in query_validations:
+        qv_name = qv["name"]
         for q in qv["queries"]:
             try:
                 gqlapi.query(gql.get_resource(q["path"])["content"])
             except (gql.GqlGetResourceError, gql.GqlApiError) as e:
                 error = True
-                logging.error(f"query validation error in {qv['name']}: {str(e)}")
+                logging.error(f"query validation error in {qv_name}: {str(e)}")
 
     if error:
         sys.exit(ExitCodes.ERROR)


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-4709

depends on https://github.com/app-sre/qontract-schemas/pull/255

query-validator currently only validates that queries are executed successfully.

with the addition of resources, we can do everything we already can in openshiftResources (jinja2 for example). with this addition, we can validate the actual data, and not only the query results.