### PR TITLE
[change-owners] log debug information

### DIFF
--- a/reconcile/change_owners.py
+++ b/reconcile/change_owners.py
@@ -721,7 +721,7 @@ def run(
     change_type_processing_mode: str,
     mr_management_enabled: bool = False,
 ) -> None:
-    comparision_gql_api = gql.get_api_for_sha(
+    comparison_gql_api = gql.get_api_for_sha(
         comparison_sha, QONTRACT_INTEGRATION, validate_schemas=False
     )
 
@@ -752,10 +752,10 @@ def run(
     # get change types from the comparison bundle to prevent privilege escalation
     logging.info(
         f"fetching change types and permissions from comparison bundle "
-        f"(sha={comparison_sha}, commit_id={comparision_gql_api.commit}, "
-        f"build_time {comparision_gql_api.commit_timestamp_utc})"
+        f"(sha={comparison_sha}, commit_id={comparison_gql_api.commit}, "
+        f"build_time {comparison_gql_api.commit_timestamp_utc})"
     )
-    change_type_processors = fetch_change_type_processors(comparision_gql_api)
+    change_type_processors = fetch_change_type_processors(comparison_gql_api)
 
     # an error while trying to cover changes will not fail the integration
     # and the PR check - self service merges will not be available though
@@ -767,7 +767,7 @@ def run(
         cover_changes(
             changes,
             change_type_processors,
-            comparision_gql_api,
+            comparison_gql_api,
         )
 
         self_servicable = (

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2168,15 +2168,8 @@ def integrations_manager(
 @click.option(
     "--change-type-processing-mode",
     help="if `limited` (default) the integration will not make any final decisions on the MR, but if `authorative` it will ",
-    required=True,
-    default="limited",
+    default=os.environ.get("CHANGE_TYPE_PROCESSING_MODE", "limited"),
     type=click.Choice(["limited", "authorative"], case_sensitive=True),
-)
-@click.option(
-    "--mr-management",
-    is_flag=True,
-    default=os.environ.get("MR_MANAGEMENT", False),
-    help="Manage MR labels and comments (default to false)",
 )
 @click.option(
     "--mr-management",


### PR DESCRIPTION
log additional information for debugging purposes. this includes

* the `reconcile.utils.gql` module has been changes to provide commit id und build timestamp from the bundle represented by a SHA
* comparison bundle metadata (commit id, bundle build timestamp)
* information and details about run-mode (limited vs authorative)

contains also typos and minor fixes not worth of a dedicated PR 