### PR TITLE
fix list comprehension returning empty dict when no accounts

### DIFF
--- a/reconcile/terraform_cloudflare_resources.py
+++ b/reconcile/terraform_cloudflare_resources.py
@@ -156,7 +156,7 @@ def run(
         QONTRACT_INTEGRATION,
         QONTRACT_INTEGRATION_VERSION,
         QONTRACT_TF_PREFIX,
-        [{"name": name for name in cf_clients.dump()}],
+        [{"name": name} for name in cf_clients.dump()],
         working_dirs,
         thread_pool_size,
     )


### PR DESCRIPTION
We want a list comprehension, not a list with a dict comprehension

The current behavior if no resources or account are present is this returns a list that contains an empty dict `[{}]` which is not what we want

The change will return an empty list if no resources are found, otherwise a list of dicts