### PR TITLE
[change-owners] MR handling fixes

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -36,7 +36,6 @@ from reconcile.utils.mr.labels import (
     NOT_SELF_SERVICEABLE,
     HOLD,
     APPROVED,
-    AWAITING_APPROVAL,
 )
 
 
@@ -389,12 +388,6 @@ def run(
             labels=labels,
             condition=self_servicable and approved,
             true_label=APPROVED,
-            dry_run=not mr_management_enabled,
-        )
-        labels = manage_conditional_label(
-            labels=labels,
-            condition=self_servicable and not approved,
-            true_label=AWAITING_APPROVAL,
             dry_run=not mr_management_enabled,
         )
         gl.set_labels_on_merge_request(gitlab_merge_request_id, labels)

--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from collections import defaultdict
 from enum import Enum
+from typing import Any
 
 from reconcile.change_owners.diff import Diff
 from reconcile.change_owners.change_types import (
@@ -25,12 +26,13 @@ class DecisionCommand(Enum):
 
 
 def get_approver_decisions_from_mr_comments(
-    comments: list[dict[str, str]]
+    comments: list[dict[str, Any]]
 ) -> dict[str, Decision]:
     decisions_by_users: dict[str, Decision] = defaultdict(Decision)
     for c in sorted(comments, key=lambda k: k["created_at"]):
         commenter = c["username"]
-        for line in c.get("body", "").split("\n"):
+        comment_body = c.get("body")
+        for line in comment_body.split("\n") if comment_body else []:
             if line == DecisionCommand.APPROVED.value:
                 decisions_by_users[commenter].approve = True
             if line == DecisionCommand.CANCEL_APPROVED.value:

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -1228,6 +1228,17 @@ def test_unordered_approval_comments():
     }
 
 
+def test_approval_comments_none_body():
+    comments = [
+        {
+            "username": "user-1",
+            "body": None,
+            "created_at": "2020-01-02T00:00:00Z",
+        },
+    ]
+    assert not get_approver_decisions_from_mr_comments(comments)
+
+
 #
 # test decide on changes
 #


### PR DESCRIPTION
* skip processing if the MR is not open anymore (closed, locked, merged)
* skip processing if the MR has been opened by the app-interface gitlab bot itself (e.g. auto promotions)
* fix bug when parsing MR comments with no body (e.g. the MR description itself)
* remove management of the `awaiting-approval` label - it is not something `saas-file-owners` does so lets not do this for now