### PR TITLE
[WIP] [change-owners] resource template + query to attach datafiles to roles

### DIFF
--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
@@ -12,6 +12,17 @@ query SelfServiceRolesQuery {
         datafileSchema: schema
         path
       }
+      datafileProviders {
+        provider
+        ... on ResourceTemplateDatafileProvider_v1 {
+          template: path {
+            content
+          }
+          template_format: type
+          variables
+          enable_query_support
+        }
+      }
       resources
     }
     users {

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
@@ -29,6 +29,17 @@ query SelfServiceRolesQuery {
         datafileSchema: schema
         path
       }
+      datafileProviders {
+        provider
+        ... on ResourceTemplateDatafileProvider_v1 {
+          template: path {
+            content
+          }
+          template_format: type
+          variables
+          enable_query_support
+        }
+      }
       resources
     }
     users {
@@ -60,9 +71,39 @@ class DatafileObjectV1(BaseModel):
         extra = Extra.forbid
 
 
+class DatafileProviderV1(BaseModel):
+    provider: str = Field(..., alias="provider")
+
+    class Config:
+        smart_union = True
+        extra = Extra.forbid
+
+
+class ResourceV1(BaseModel):
+    content: str = Field(..., alias="content")
+
+    class Config:
+        smart_union = True
+        extra = Extra.forbid
+
+
+class ResourceTemplateDatafileProviderV1(DatafileProviderV1):
+    template: ResourceV1 = Field(..., alias="template")
+    template_format: Optional[str] = Field(..., alias="template_format")
+    variables: Optional[Json] = Field(..., alias="variables")
+    enable_query_support: Optional[bool] = Field(..., alias="enable_query_support")
+
+    class Config:
+        smart_union = True
+        extra = Extra.forbid
+
+
 class SelfServiceConfigV1(BaseModel):
     change_type: ChangeTypeV1 = Field(..., alias="change_type")
     datafiles: Optional[list[DatafileObjectV1]] = Field(..., alias="datafiles")
+    datafile_providers: Optional[
+        list[Union[ResourceTemplateDatafileProviderV1, DatafileProviderV1]]
+    ] = Field(..., alias="datafileProviders")
     resources: Optional[list[str]] = Field(..., alias="resources")
 
     class Config:

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -2431,7 +2431,7 @@
                             "args": [],
                             "type": {
                                 "kind": "OBJECT",
-                                "name": "jiraWatcherSettings_v1",
+                                "name": "JiraWatcherSettings_v1",
                                 "ofType": null
                             },
                             "isDeprecated": false,
@@ -8974,6 +8974,26 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "datafileProviders",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "INTERFACE",
+                                        "name": "DatafileProvider_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "resources",
                             "description": null,
                             "args": [],
@@ -9026,6 +9046,39 @@
                     "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
+                },
+                {
+                    "kind": "INTERFACE",
+                    "name": "DatafileProvider_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "provider",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": [
+                        {
+                            "kind": "OBJECT",
+                            "name": "ResourceTemplateDatafileProvider_v1",
+                            "ofType": null
+                        }
+                    ]
                 },
                 {
                     "kind": "OBJECT",
@@ -12594,9 +12647,13 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "OBJECT",
-                                "name": "Resource_v1",
-                                "ofType": null
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "Resource_v1",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -15951,6 +16008,46 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "upgradePolicyAllowedWorkloads",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "upgradePolicyAllowedMutexes",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "clusters",
                             "description": null,
                             "args": [],
@@ -17304,7 +17401,7 @@
                 },
                 {
                     "kind": "OBJECT",
-                    "name": "jiraWatcherSettings_v1",
+                    "name": "JiraWatcherSettings_v1",
                     "description": null,
                     "fields": [
                         {
@@ -20436,6 +20533,26 @@
                                             "name": "QontractQuery_v1",
                                             "ofType": null
                                         }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "resources",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "INTERFACE",
+                                        "name": "NamespaceOpenshiftResource_v1",
+                                        "ofType": null
                                     }
                                 }
                             },
@@ -25327,9 +25444,13 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "OBJECT",
-                                "name": "Resource_v1",
-                                "ofType": null
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "Resource_v1",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -25420,9 +25541,13 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "OBJECT",
-                                "name": "Resource_v1",
-                                "ofType": null
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "Resource_v1",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -25525,9 +25650,13 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "OBJECT",
-                                "name": "Resource_v1",
-                                "ofType": null
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "Resource_v1",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -32302,6 +32431,91 @@
                         {
                             "kind": "INTERFACE",
                             "name": "Permission_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "ResourceTemplateDatafileProvider_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "provider",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "Resource_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "variables",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "enable_query_support",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileProvider_v1",
                             "ofType": null
                         }
                     ],

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -110,6 +110,7 @@ def build_role(
                     name=change_type_name,
                 ),
                 datafiles=datafiles,
+                datafileProviders=None,
                 resources=None,
             )
         ],


### PR DESCRIPTION
this prototype uses resource templates with gql queries to select a list of datafiles to attach to a self-service role.

an usage example be seen here: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/48352/diffs

depends on https://github.com/app-sre/qontract-schemas/pull/258

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>