### PR TITLE
APPSRE-6255: Different way to get ServiceAccount's token

### DIFF
--- a/reconcile/openshift_serviceaccount_tokens.py
+++ b/reconcile/openshift_serviceaccount_tokens.py
@@ -87,7 +87,9 @@ def fetch_desired_state(namespaces: list[dict], ri: ResourceInventory, oc_map: O
                 )
                 if cur:
                     for token in sa_token_list:
-                        if token["data"]["token"] == cur.body.get("data", {}).get("token"):
+                        if token["data"]["token"] == cur.body.get("data", {}).get(
+                            "token"
+                        ):
                             sa_token = token["data"]["token"]
             except KeyError:
                 logging.log(

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -589,6 +589,12 @@ class ResourceInventory:
         except KeyError:
             return None
 
+    def get_current(self, cluster, namespace, resource_type, name):
+        try:
+            return self._clusters[cluster][namespace][resource_type]["current"][name]
+        except KeyError:
+            return None
+
     def add_current(self, cluster, namespace, resource_type, name, value):
         with self._lock:
             current = self._clusters[cluster][namespace][resource_type]["current"]


### PR DESCRIPTION
### Why:
Now that we are on Openshift 4.11( Kubernetes 1.24) which means that 
`oc serviceaccounts get-token` does not work anymore ([see this post for detail explanation](https://itnext.io/big-change-in-k8s-1-24-about-serviceaccounts-and-their-secrets-4b909a4af4e0).

Our openshift-serviceaccount-tokens integration need to use a different method to find the token.

### What:
* Filter all secrets in the namespace to find the one created with the service account, since now the secret is no longer discoverable through 'oc sa get-token' command. 
* Remove base64 encoding since the new method is getting the encoded verion.
* Remove unused variable.

### Validation:
* Created SA manually in OpenShift 4.11 cluster and verified that 1. token still created under a similar pattern but`oc sa get-token` not longer work with error msg "error: could not find a service account token for service account "xyz""
* Use the open source app interface targeting `appint-ex-01` cluster and validated the integration can run as before.