### PR TITLE
[gitlab] replace all=True occurences with pagination

### DIFF
--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -685,8 +685,8 @@ class SaasHerder:
             if not self.gitlab:
                 raise Exception("gitlab is not initialized")
             project = self.gitlab.get_project(url)
-            for f in project.repository_tree(
-                path=path.lstrip("/"), ref=commit_sha, all=True
+            for f in self.gitlab.get_items(
+                project.repository_tree, path=path.lstrip("/"), ref=commit_sha
             ):
                 file_contents = project.files.get(file_path=f["path"], ref=commit_sha)
                 resource = yaml.safe_load(file_contents.decode())


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6349

when using `all=True` there is still pagination going on, but we do not control it.
in an effort to reduce API calls from gitlab, using our `get_items` pagination method, we use a higher value for `page_size`, causing less API calls (larger payloads per call).