### PR TITLE
change-owners rely on checksum if no diffs found in file

### DIFF
--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -8,7 +8,12 @@ import jsonpath_ng
 import jsonpath_ng.ext
 import anymarkup
 
-from reconcile.change_owners.diff import Diff, DiffType, extract_diffs
+from reconcile.change_owners.diff import (
+    SHA256SUM_FIELD_NAME,
+    Diff,
+    DiffType,
+    extract_diffs,
+)
 from reconcile.gql_definitions.change_owners.queries.change_types import (
     ChangeTypeV1,
     ChangeTypeChangeDetectorJsonPathProviderV1,
@@ -298,7 +303,9 @@ def build_change_type_processor(change_type: ChangeTypeV1) -> ChangeTypeProcesso
         if isinstance(c, ChangeTypeChangeDetectorJsonPathProviderV1):
             change_schema = c.change_schema or change_type.context_schema
             if change_schema:
-                for jsonpath_expression in c.json_path_selectors:
+                for jsonpath_expression in c.json_path_selectors + [
+                    f"'{SHA256SUM_FIELD_NAME}'"
+                ]:
                     file_type = BundleFileType[change_type.context_type.upper()]
                     expressions_by_file_type_schema[(file_type, change_schema)].append(
                         jsonpath_ng.ext.parse(jsonpath_expression)

--- a/reconcile/change_owners/diff.py
+++ b/reconcile/change_owners/diff.py
@@ -97,6 +97,9 @@ def compare_object_ctx_identifier(
     raise CannotCompare() from None
 
 
+SHA256SUM_FIELD_NAME = "$file_sha256sum"
+
+
 def extract_diffs(
     schema: Optional[str], old_file_content: Any, new_file_content: Any
 ) -> list[Diff]:
@@ -172,6 +175,12 @@ def extract_diffs(
                 for path, change in deep_diff.get("iterable_item_removed", {}).items()
             ]
         )
+
+        # if real changes have been detected, we are going to delete the
+        # diff for the checksum field
+        if len(diffs) > 1:
+            diffs = [d for d in diffs if str(d.path) != SHA256SUM_FIELD_NAME]
+
     elif old_file_content:
         # file was deleted
         diffs.append(


### PR DESCRIPTION
not all changes to datafile survive the transformation from YAML in the app-interface repo to JSON in the qontract-server bundle (newlines, comments). therefore https://github.com/app-sre/qontract-validator/pull/45 adds a checksum to each datafile during bundling so a file change is at least reflected in the checksum and can be used in `change-owners` to drive the decision process about an MR.

if the only change in a file is the checksum, then a change invisble to the integrations is assumed (newlines, comments). as such, the change itself has no impact on the integrations themselves. since it is still a change, that needs to be approved, every person who is a potential approver on such a file, can lgtm such changes.

depends lightly on https://github.com/app-sre/qontract-validator/pull/45 but keep current behaviour if the checksums are not present in the both compared bundles. so it is safe to promote in arbitrary order

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>