### PR TITLE
[ASG] add max_instance_lifetime param

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4962,6 +4962,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "min_size": common_values.get("min_size"),
             "vpc_zone_identifier": common_values.get("vpc_zone_identifier"),
             "capacity_rebalance": common_values.get("capacity_rebalance"),
+            "max_instance_lifetime": common_values.get("max_instance_lifetime"),
             "mixed_instances_policy": {
                 "instances_distribution": common_values.get("instances_distribution"),
                 "launch_template": {


### PR DESCRIPTION
[APPSRE-6297](https://issues.redhat.com/browse/APPSRE-6297)

Schema change here: https://github.com/app-sre/qontract-schemas/pull/260

Add support for max_instance_lifetime for AWS auto-scaling groups. Such that image builder workers can be ephemeral in nature. Following up with a QR change.

Tested locally by changing ASG defaults for image-builder workers and then running QR in dry-run mode.