### PR TITLE
[saas-file-validator] validate auto promotion used with commit sha

### DIFF
--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -81,6 +81,15 @@ class TestSaasFileValid(TestCase):
                                 },
                                 "parameters": {},
                             },
+                            {
+                                "namespace": {
+                                    "name": "ns",
+                                    "environment": {"name": "env4", "parameters": "{}"},
+                                    "cluster": {"name": "cluster"},
+                                },
+                                "ref": "2637b6c41bda7731b1bcaaf18b4a50d7c5e63e30",
+                                "parameters": {},
+                            },
                         ],
                     }
                 ],
@@ -121,6 +130,39 @@ class TestSaasFileValid(TestCase):
         self.saas_files[0][
             "name"
         ] = "long-name-which-is-too-long-to-produce-unique-combo"
+        saasherder = SaasHerder(
+            self.saas_files,
+            thread_pool_size=1,
+            gitlab=None,
+            integration="",
+            integration_version="",
+            settings={},
+            validate=True,
+        )
+
+        self.assertFalse(saasherder.valid)
+
+    def test_saas_file_auto_promotion_used_with_commit_sha(self):
+        self.saas_files[0]["resourceTemplates"][0]["targets"][3]["promotion"] = {
+            "auto": True
+        }
+        saasherder = SaasHerder(
+            self.saas_files,
+            thread_pool_size=1,
+            gitlab=None,
+            integration="",
+            integration_version="",
+            settings={},
+            validate=True,
+        )
+
+        self.assertTrue(saasherder.valid)
+
+    def test_saas_file_auto_promotion_not_used_with_commit_sha(self):
+        self.saas_files[0]["resourceTemplates"][0]["targets"][2]["ref"] = "main"
+        self.saas_files[0]["resourceTemplates"][0]["targets"][2]["promotion"] = {
+            "auto": True
+        }
         saasherder = SaasHerder(
             self.saas_files,
             thread_pool_size=1,

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -293,6 +293,11 @@ class SaasHerder:
                     self._check_saas_file_env_combo_unique(
                         saas_file_name, environment_name
                     )
+                    self._validate_auto_promotion_used_with_commit_sha(
+                        saas_file_name,
+                        resource_template_name,
+                        target,
+                    )
                     self._validate_upstream_not_used_with_commit_sha(
                         saas_file_name,
                         resource_template_name,
@@ -494,6 +499,31 @@ class SaasHerder:
             self.valid = False
         else:
             self.tkn_unique_pipelineruns[tkn_name] = tkn_long_name
+
+    def _validate_auto_promotion_used_with_commit_sha(
+        self,
+        saas_file_name: str,
+        resource_template_name: str,
+        target: dict,
+    ):
+        target_promotion = target.get("promotion") or {}
+        if not target_promotion:
+            return
+
+        target_auto = target_promotion.get("auto")
+        if not target_auto:
+            return
+
+        pattern = r"^[0-9a-f]{40}$"
+        ref = target["ref"]
+        if re.search(pattern, ref):
+            return
+
+        self.valid = False
+        logging.error(
+            f"[{saas_file_name}/{resource_template_name}] "
+            f"auto promotion should be used with commit sha instead of: {ref}"
+        )
 
     def _validate_upstream_not_used_with_commit_sha(
         self,


### PR DESCRIPTION
automated promotions rely on the git commit sha as the unique key that indicates if a previous step was published with success or failure.

as such, defining an automated promotion will cause the `ref` to be updated by the promotion automated MRs. this means that keeping this `ref` as master/main, or any other branch name, will be overridden pretty quickly.

this means that an auto promoted target can only rely on the change in ref in order to be triggered, and can should not rely on anything else:
- `ref: main`
- upstream jenkins job
- image push (#2833)

this PR adds a validation that when automated promotion is set, the only acceptable `ref` is a commit sha. there are already existing validations that when a commit sha is used, `upstream` can not be used, so that should cover our case as well.

this will prevent this case from happening: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/48774