### PR TITLE
shorten integration name

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1084,13 +1084,13 @@ def openshift_saas_deploy_trigger_upstream_jobs(
 @use_jump_host()
 @include_trigger_trace
 @click.pass_context
-def openshift_saas_deploy_trigger_container_images(
+def openshift_saas_deploy_trigger_images(
     ctx, thread_pool_size, internal, use_jump_host, include_trigger_trace
 ):
-    import reconcile.openshift_saas_deploy_trigger_container_images
+    import reconcile.openshift_saas_deploy_trigger_images
 
     run_integration(
-        reconcile.openshift_saas_deploy_trigger_container_images,
+        reconcile.openshift_saas_deploy_trigger_images,
         ctx.obj,
         thread_pool_size,
         internal,

--- a/reconcile/openshift_saas_deploy_trigger_images.py
+++ b/reconcile/openshift_saas_deploy_trigger_images.py
@@ -7,7 +7,7 @@ from reconcile.utils.saasherder import TriggerTypes
 from reconcile.utils.semver_helper import make_semver
 
 
-QONTRACT_INTEGRATION = "openshift-saas-deploy-trigger-container-images"
+QONTRACT_INTEGRATION = "openshift-saas-deploy-trigger-images"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 


### PR DESCRIPTION
qontract-reconcile-openshift-saas-deploy-trigger-container-images is too long for Kubernetes. shortening the name,