### PR TITLE
[review-queue][gitlab-housekeeper] handle self-serviceable label like saas-file-update

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -152,7 +152,10 @@ def manage_conditional_label(
 
 
 def write_coverage_report_to_mr(
-    change_decisions: list[ChangeDecision], mr_id: int, gl: GitLabApi
+    self_serviceable: bool,
+    change_decisions: list[ChangeDecision],
+    mr_id: int,
+    gl: GitLabApi,
 ) -> None:
     """
     adds the change coverage report and decision summary as a comment
@@ -191,13 +194,14 @@ def write_coverage_report_to_mr(
     coverage_report = format_table(
         results, ["file", "change", "status", "approvers"], table_format="github"
     )
-    gl.add_comment_to_merge_request(
-        mr_id,
-        f"{change_coverage_report_header}<br/> "
-        "All changes require an `/lgtm` from a listed approver\n"
-        f"{coverage_report}\n\n"
-        f"Supported commands: {' '.join([f'`{d.value}`' for d in DecisionCommand])} ",
-    )
+    if self_serviceable:
+        gl.add_comment_to_merge_request(
+            mr_id,
+            f"{change_coverage_report_header}<br/> "
+            "All changes require an `/lgtm` from a listed approver\n"
+            f"{coverage_report}\n\n"
+            f"Supported commands: {' '.join([f'`{d.value}`' for d in DecisionCommand])} ",
+        )
 
 
 def write_coverage_report_to_stdout(change_decisions: list[ChangeDecision]) -> None:
@@ -340,7 +344,9 @@ def run(
         #
 
         if mr_management_enabled:
-            write_coverage_report_to_mr(change_decisions, gitlab_merge_request_id, gl)
+            write_coverage_report_to_mr(
+                self_serviceable, change_decisions, gitlab_merge_request_id, gl
+            )
         write_coverage_report_to_stdout(change_decisions)
 
         #

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -23,6 +23,7 @@ from reconcile.utils.mr.labels import (
     HOLD,
     LGTM,
     SAAS_FILE_UPDATE,
+    SELF_SERVICEABLE,
 )
 
 MERGE_LABELS_PRIORITY = [APPROVED, AUTO_MERGE, LGTM]
@@ -216,10 +217,12 @@ def get_merge_requests(
         if not labels:
             continue
 
-        if SAAS_FILE_UPDATE in labels and LGTM in labels:
+        if (
+            SAAS_FILE_UPDATE in labels or SELF_SERVICEABLE in labels
+        ) and LGTM in labels:
             logging.warning(
                 f"[{gl.project.name}/{mr.iid}] 'lgtm' label not "
-                + "suitable for saas file update. removing 'lgtm' label"
+                + "suitable for self serviceable MRs. removing 'lgtm' label"
             )
             if not dry_run:
                 gl.remove_label_from_merge_request(mr.iid, LGTM)

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -34,7 +34,7 @@ from reconcile.utils.environ import environ
 from reconcile.jenkins_job_builder import init_jjb
 from reconcile.utils.gitlab_api import GitLabApi, MRState, MRStatus
 from reconcile.utils.jjb_client import JJB
-from reconcile.utils.mr.labels import SAAS_FILE_UPDATE
+from reconcile.utils.mr.labels import SAAS_FILE_UPDATE, SELF_SERVICEABLE
 from reconcile.utils.oc import OC_Map
 from reconcile.utils.ocm import OCMMap
 from reconcile.utils.output import print_output
@@ -1136,6 +1136,8 @@ def app_interface_review_queue(ctx):
         if "stale" in labels:
             continue
         if SAAS_FILE_UPDATE in labels:
+            continue
+        if SELF_SERVICEABLE in labels:
             continue
 
         pipelines = mr.pipelines()


### PR DESCRIPTION
* the review queue will not show MRs with the label self-servicable anymore
* gitlab housekeeper will remove the `lgtm` label when an MR has the `self-serviceable` label because it expects people to /lgtm which yield the `bot/approved` label

`change-owners` will not manage the `self-serviceable` label (and even remove it) if the integration runs without activated `--mr-management`

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>