### PR TITLE
Draft: Add gitlab-sync-push integration to support fedramp

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -557,6 +557,15 @@ def github_owners(ctx):
     run_integration(reconcile.github_owners, ctx.obj)
 
 
+@integration.command(short_help="Pushes latest versions of git repos to S3.")
+@threaded()
+@click.pass_context
+def gitlab_sync_push(ctx, thread_pool_size):
+    import reconcile.gitlab_sync_push
+
+    run_integration(reconcile.gitlab_sync_push, ctx.obj, thread_pool_size)
+
+
 @integration.command(short_help="Validate compliance of GitHub user profiles.")
 @environ(["gitlab_pr_submitter_queue_url"])
 @gitlab_project_id

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -557,7 +557,7 @@ def github_owners(ctx):
     run_integration(reconcile.github_owners, ctx.obj)
 
 
-@integration.command(short_help="Pushes latest versions of git repos to S3.")
+@integration.command(short_help="Uploads gpg encrypte gitlab projects to S3.")
 @threaded()
 @click.pass_context
 def gitlab_sync_push(ctx, thread_pool_size):

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -557,7 +557,7 @@ def github_owners(ctx):
     run_integration(reconcile.github_owners, ctx.obj)
 
 
-@integration.command(short_help="Uploads gpg encrypte gitlab projects to S3.")
+@integration.command(short_help="Uploads gpg encrypted gitlab projects to S3.")
 @threaded()
 @click.pass_context
 def gitlab_sync_push(ctx, thread_pool_size):

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -6,7 +6,7 @@ import logging
 
 from typing import Any, Dict, List
 from git import Repo
-from gnupg import GPG
+from gnupg import GPG # type: ignore
 
 from reconcile import queries
 from reconcile.utils.gitlab_api import GitLabApi
@@ -187,7 +187,7 @@ def run(dry_run, thread_pool_size=10):
     sync_enabled = queries.get_gitlab_sync_repos(server=instance["url"])
     all_accounts = queries.get_aws_accounts()
 
-    account_to_syncs: Dict[str, List[Any]] = {}
+    account_to_syncs: Dict[str, List[Dict[str, Any]]] = {}
     for sync in sync_enabled:
         account_to_syncs.setdefault(sync["bucket_account"]["name"], []).append(sync)
     accounts = [a for a in all_accounts if a["name"] in account_to_syncs]

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -6,9 +6,7 @@ import gnupg
 import logging
 
 from typing import Any, Dict, List
-from unicodedata import name
 from git import Repo
-from codecs import ignore_errors
 
 from reconcile import queries
 from reconcile.utils.gitlab_api import GitLabApi
@@ -192,7 +190,7 @@ def run(dry_run, thread_pool_size=10):
     account_to_syncs: Dict[str, List[Any]] = {}
     for sync in sync_enabled:
         account_to_syncs.setdefault(sync["bucket_account"]["name"], []).append(sync)
-    accounts = [a for a in all_accounts if a.get("name") in account_to_syncs]
+    accounts = [a for a in all_accounts if a["name"] in account_to_syncs]
     aws = AWSApi(thread_pool_size, accounts, settings=settings)
     acct_bucket_keys = get_acct_bucket_keys(aws, account_to_syncs)
     repos = [s["origin_url"] for s in sync_enabled]

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -126,15 +126,16 @@ def get_acct_bucket_keys(aws, accts_to_syncs) -> dict[str, dict[str, list[str]]]
                 logging.error(err)
                 result = None
             # TODO: handle IsTruncated == True (more than 1k items returned)
-            if result is not None and "Contents" in result:
+            if result is not None:
                 keys = []
-                for obj in result["Contents"]:
-                    # remove file extension
-                    b64_key = obj["Key"].split(".", 1)[0]
-                    b64_bytes = b64_key.encode("ascii")
-                    decoded_bytes = base64.b64decode(b64_bytes)
-                    decoded_key = decoded_bytes.decode("ascii")
-                    keys.append(decoded_key)
+                if "Contents" in result:
+                    for obj in result["Contents"]:
+                        # remove file extension
+                        b64_key = obj["Key"].split(".", 1)[0]
+                        b64_bytes = b64_key.encode("ascii")
+                        decoded_bytes = base64.b64decode(b64_bytes)
+                        decoded_key = decoded_bytes.decode("ascii")
+                        keys.append(decoded_key)
                 acct_bucket_keys[a][sync["bucket_name"]] = keys
     return acct_bucket_keys
 

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -104,7 +104,9 @@ def get_latest_commits(repos, instance, settings) -> dict[str, str]:
     for repo in repos:
         gl = GitLabApi(instance, project_url=repo["url"], settings=settings)
         project = gl.get_project(repo_url=repo["url"])
-        gitlab_commits[repo["url"]] = project.commits.list(ref_name=repo["branch"])[0].id
+        gitlab_commits[repo["url"]] = project.commits.list(ref_name=repo["branch"])[
+            0
+        ].id
     return gitlab_commits
 
 

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -188,7 +188,7 @@ def run(dry_run, thread_pool_size=10):
     sync_enabled = queries.get_gitlab_sync_repos(server=instance["url"])
     all_accounts = queries.get_aws_accounts()
 
-    account_to_syncs = {}
+    account_to_syncs: dict[str, list[any]] = {}
     for sync in sync_enabled:
         account_to_syncs.setdefault(sync["bucket_account"]["name"], []).append(sync)
     accounts = [a for a in all_accounts if a.get("name") in account_to_syncs]

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -1,6 +1,6 @@
 import base64
 import os
-import sh
+import sh # type: ignore
 import sys
 import shutil
 import logging

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -20,7 +20,7 @@ QONTRACT_INTEGRATION = "gitlab-sync-push"
 
 # Inspired by https://github.com/app-sre/git-keeper
 class GitArchive:
-    gpgs = {}
+    gpgs: dict[str, dict[str, Any]] = {}
 
     def __init__(
         self, origin, destination, commit, key, vault_gpg_path, workdir="clone-workdir"
@@ -113,7 +113,7 @@ def get_acct_bucket_keys(aws, accts_to_syncs) -> dict[str, dict[str, list[str]]]
     """
     Returns dict of accout names to bucket names to decoded object keys
     """
-    acct_bucket_keys = {}
+    acct_bucket_keys: dict[str, dict[str, list[str]]] = {}
     for a, syncs in accts_to_syncs.items():
         s = aws.sessions[a]
         s3 = s.client("s3")
@@ -147,7 +147,7 @@ def get_objects_to_update(
     """
     to_update = {}
     for acct, buckets in acct_bucket_keys.items():
-        out_of_date_buckets = {}
+        out_of_date_buckets: dict[str, list[GitArchive]] = {}
         for sync in acct_syncs[acct]:
             i = 0
             to_delete_key = ""
@@ -188,7 +188,7 @@ def run(dry_run, thread_pool_size=10):
     sync_enabled = queries.get_gitlab_sync_repos(server=instance["url"])
     all_accounts = queries.get_aws_accounts()
 
-    account_to_syncs: dict[str, list[any]] = {}
+    account_to_syncs: Dict[str, list[Any]] = {}
     for sync in sync_enabled:
         account_to_syncs.setdefault(sync["bucket_account"]["name"], []).append(sync)
     accounts = [a for a in all_accounts if a.get("name") in account_to_syncs]

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -2,11 +2,11 @@ import base64
 import os
 import sys
 import shutil
-import gnupg
 import logging
 
 from typing import Any, Dict, List
 from git import Repo
+from gnupg import GPG
 
 from reconcile import queries
 from reconcile.utils.gitlab_api import GitLabApi
@@ -48,7 +48,7 @@ class GitArchive:
                         "field": sync["public_key"]["field"],
                     }
                 )
-                gpg = gnupg.GPG()
+                gpg = GPG()
                 gpg.import_keys(key_data)
                 recipients = [k["fingerprint"] for k in gpg.list_keys()]
                 GitArchive.gpgs[sync["public_key"]["path"]] = {

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -80,7 +80,7 @@ class GitArchive:
         # get local copy of repo
         clone_url = self.origin + ".git"
         repo_dir = os.path.join(self.workdir, os.path.basename(clone_url))
-        repo = Repo.clone_from(clone_url, repo_dir, None, None, None, bare=True)
+        Repo.clone_from(clone_url, repo_dir, None, None, None, bare=True)
         # archive and encrypt repo
         repo_tar = repo_dir + ".tar"
         self.tar(repo_tar, repo_dir)

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -1,6 +1,5 @@
 import base64
 import os
-import sh
 import sys
 import shutil
 import gnupg
@@ -32,7 +31,6 @@ class GitArchive:
         self.to_delete_key = key
         self.vault_gpg_path = vault_gpg_path
         self.workdir = workdir
-        self.tar = sh.tar.bake("-cf")
 
     @staticmethod
     def b64_encode(original) -> str:
@@ -75,7 +73,8 @@ class GitArchive:
         repo = Repo.clone_from(clone_url, repo_dir)
         # archive and encrypt repo
         repo_tar = repo_dir + ".tar"
-        self.tar(repo_tar, repo_dir)
+        with open(repo_tar, "wb") as f:
+            repo.archive(f)
         repo_gpg = repo_tar + ".gpg"
         with open(repo_tar, "rb") as f:
             GitArchive.gpgs[self.vault_gpg_path]["gpg"].encrypt_file(

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -1,0 +1,227 @@
+import base64
+import os
+import sh
+import sys
+import shutil
+import gnupg
+import logging
+
+from unicodedata import name
+from git import Repo
+from codecs import ignore_errors
+
+from reconcile import queries
+from reconcile.utils.gitlab_api import GitLabApi
+from reconcile.utils.aws_api import AWSApi
+from reconcile.utils.vault import VaultClient
+
+
+QONTRACT_INTEGRATION = "gitlab-sync-push"
+
+
+# Inspired by https://github.com/app-sre/git-keeper
+class GitArchive:
+    gpgs = {}
+
+    def __init__(
+        self, origin, destination, commit, key, vault_gpg_path, workdir="clone-workdir"
+    ):
+        self.origin = origin
+        self.destination = destination
+        self.commit = commit
+        self.to_delete_key = key
+        self.vault_gpg_path = vault_gpg_path
+        self.workdir = workdir
+        self.tar = sh.tar.bake("-cf")
+
+    @staticmethod
+    def b64_encode(original) -> str:
+        to_b64_bytes = original.encode("ascii")
+        b64_bytes = base64.b64encode(to_b64_bytes)
+        b64_str = b64_bytes.decode("ascii")
+        return b64_str
+
+    @staticmethod
+    def init_gpgs(vault_client, sync_enabled):
+        for sync in sync_enabled:
+            if sync["public_key"]["path"] not in GitArchive.gpgs:
+                key_data = vault_client.read(
+                    {
+                        "path": sync["public_key"]["path"],
+                        "field": sync["public_key"]["field"],
+                    }
+                )
+                gpg = gnupg.GPG()
+                gpg.import_keys(key_data)
+                recipients = [k["fingerprint"] for k in gpg.list_keys()]
+                GitArchive.gpgs[sync["public_key"]["path"]] = {
+                    "gpg": gpg,
+                    "recipients": recipients,
+                }
+
+    def clean_working_dir(self):
+        shutil.rmtree(self.workdir, ignore_errors=True)
+        os.makedirs(self.workdir, exist_ok=True)
+
+    def upload_encrypted_clone(self, s3_session, bucket_name):
+        """
+        Clones git repo, archives and encrypts it, uploads to s3 and deletes old version
+        Uploaded object names are base64_encoded(destination_url/commit_sha).tar.gpg
+        """
+        self.clean_working_dir()
+        # get local copy of repo
+        clone_url = self.origin + ".git"
+        repo_dir = os.path.join(self.workdir, os.path.basename(clone_url))
+        repo = Repo.clone_from(clone_url, repo_dir)
+        # archive and encrypt repo
+        repo_tar = repo_dir + ".tar"
+        self.tar(repo_tar, repo_dir)
+        repo_gpg = repo_tar + ".gpg"
+        with open(repo_tar, "rb") as f:
+            GitArchive.gpgs[self.vault_gpg_path]["gpg"].encrypt_file(
+                f,
+                recipients=GitArchive.gpgs[self.vault_gpg_path]["recipients"],
+                output=repo_gpg,
+                armor=True,
+                always_trust=True,
+            )
+        # upload to s3
+        to_b64_name = self.destination + "/" + self.commit
+        b64_name = GitArchive.b64_encode(to_b64_name)
+        obj_key = b64_name + ".tar.gpg"
+        s3 = s3_session.client("s3")
+        s3.upload_file(repo_gpg, bucket_name, obj_key)
+        # TODO check for success and delete old if successful uploading new
+        # to_delete_key is empty for newly enabled gitsync
+        if len(self.to_delete_key) > 0:
+            b64_to_delete_key = GitArchive.b64_encode(self.to_delete_key)
+            b64_to_delete_key = b64_to_delete_key + ".tar.gpg"
+            s3.delete_object(Bucket=bucket_name, Key=b64_to_delete_key)
+        self.clean_working_dir()
+
+
+def get_latest_commits(repos, instance, settings) -> dict[str, str]:
+    """Returns dict of repo name to latest commit sha for gitlab projects"""
+    gitlab_commits = {}
+    for repo in repos:
+        gl = GitLabApi(instance, project_url=repo, settings=settings)
+        project = gl.get_project(repo_url=repo)
+        gitlab_commits[repo] = project.commits.list()[0].id
+    return gitlab_commits
+
+
+def get_acct_bucket_keys(aws, accts_to_syncs) -> dict[str, dict[str, list[str]]]:
+    """
+    Returns dict of accout names to bucket names to decoded object keys
+    """
+    acct_bucket_keys = {}
+    for a, syncs in accts_to_syncs.items():
+        s = aws.sessions[a]
+        s3 = s.client("s3")
+        acct_bucket_keys[a] = {}
+        for sync in syncs:
+            try:
+                result = s3.list_objects_v2(Bucket=sync["bucket_name"])
+            except Exception as err:
+                logging.error(err)
+                result = None
+            # TODO: handle IsTruncated == True (more than 1k items returned)
+            if result is not None and "Contents" in result:
+                keys = []
+                for obj in result["Contents"]:
+                    # remove file extension
+                    b64_key = obj["Key"].split(".", 1)[0]
+                    b64_bytes = b64_key.encode("ascii")
+                    decoded_bytes = base64.b64decode(b64_bytes)
+                    decoded_key = decoded_bytes.decode("ascii")
+                    keys.append(decoded_key)
+                acct_bucket_keys[a][sync["bucket_name"]] = keys
+    return acct_bucket_keys
+
+
+def get_objects_to_update(
+    acct_bucket_keys, acct_syncs, gitlab_commits
+) -> dict[str, dict[str, list[GitArchive]]]:
+    """
+    Returns dict of acct name to dict of buckets within
+    account with corresponding list of ToUpdate objects
+    """
+    to_update = {}
+    for acct, buckets in acct_bucket_keys.items():
+        out_of_date_buckets = {}
+        for sync in acct_syncs[acct]:
+            i = 0
+            to_delete_key = ""
+            for key in buckets[sync["bucket_name"]]:
+                # separate destination project and commit
+                dest_and_commit = key.rsplit("/", 1)
+                destination = dest_and_commit[0]
+                commit = dest_and_commit[1]
+                # remove file extension
+                commit = commit.split(".", 1)[0]
+                if destination == sync["destination_url"]:
+                    if gitlab_commits[sync["origin_url"]] != commit:
+                        to_delete_key = key
+                    break
+                i += 1
+            # if out of date object was found OR
+            # if all objects were checked and none had name of repo (a new repo added to sync)
+            if len(to_delete_key) > 0 or i == len(buckets[sync["bucket_name"]]):
+                out_of_date_buckets.setdefault(sync["bucket_name"], []).append(
+                    GitArchive(
+                        sync["origin_url"],
+                        sync["destination_url"],
+                        gitlab_commits[sync["origin_url"]],
+                        to_delete_key,
+                        sync["public_key"]["path"],
+                    )
+                )
+        to_update[acct] = out_of_date_buckets
+    return to_update
+
+
+def run(dry_run, thread_pool_size=10):
+    # https://github.com/app-sre/git-keeper#future-enhancements
+    os.environ["GIT_SSL_NO_VERIFY"] = "true"
+
+    instance = queries.get_gitlab_instance()
+    settings = queries.get_app_interface_settings()
+    sync_enabled = queries.get_gitlab_sync_repos(server=instance["url"])
+    all_accounts = queries.get_aws_accounts()
+
+    account_to_syncs = {}
+    for sync in sync_enabled:
+        account_to_syncs.setdefault(sync["bucket_account"]["name"], []).append(sync)
+    accounts = [a for a in all_accounts if a.get("name") in account_to_syncs]
+    aws = AWSApi(thread_pool_size, accounts, settings=settings)
+    acct_bucket_keys = get_acct_bucket_keys(aws, account_to_syncs)
+    repos = [s["origin_url"] for s in sync_enabled]
+
+    gitlab_commits = get_latest_commits(repos, instance, settings)
+    GitArchive.init_gpgs(VaultClient(), sync_enabled)
+
+    to_update = get_objects_to_update(
+        acct_bucket_keys, account_to_syncs, gitlab_commits
+    )
+
+    err_count = 0
+    for acct, buckets in to_update.items():
+        for name, objects in buckets.items():
+            for obj in objects:
+                if dry_run:
+                    logging.info(
+                        f"[DRY RUN] Encrypted archive for {obj.destination} within {name} bucket will be updated"
+                    )
+                else:
+                    try:
+                        obj.upload_encrypted_clone(aws.sessions[acct], name)
+                    except Exception as err:
+                        logging.error(err)
+                        err_count += 1
+                        continue
+                    logging.info(
+                        f"Encrypted archive for {obj.destination} within {name} bucket successfully updated"
+                    )
+
+    if err_count > 0:
+        sys.exit(1)

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -1,6 +1,6 @@
 import base64
 import os
-import sh # type: ignore
+import sh  # type: ignore
 import sys
 import shutil
 import logging

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -6,7 +6,7 @@ import logging
 
 from typing import Any, Dict, List
 from git import Repo
-from gnupg import GPG # type: ignore
+from gnupg import GPG  # type: ignore
 
 from reconcile import queries
 from reconcile.utils.gitlab_api import GitLabApi

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -5,6 +5,7 @@ import shutil
 import gnupg
 import logging
 
+from typing import Any, Dict, List
 from unicodedata import name
 from git import Repo
 from codecs import ignore_errors
@@ -20,7 +21,7 @@ QONTRACT_INTEGRATION = "gitlab-sync-push"
 
 # Inspired by https://github.com/app-sre/git-keeper
 class GitArchive:
-    gpgs: dict[str, dict[str, Any]] = {}
+    gpgs: Dict[str, Dict[str, Any]] = {}
 
     def __init__(
         self, origin, destination, commit, key, vault_gpg_path, workdir="clone-workdir"
@@ -113,7 +114,7 @@ def get_acct_bucket_keys(aws, accts_to_syncs) -> dict[str, dict[str, list[str]]]
     """
     Returns dict of accout names to bucket names to decoded object keys
     """
-    acct_bucket_keys: dict[str, dict[str, list[str]]] = {}
+    acct_bucket_keys: Dict[str, Dict[str, List[str]]] = {}
     for a, syncs in accts_to_syncs.items():
         s = aws.sessions[a]
         s3 = s.client("s3")
@@ -147,7 +148,7 @@ def get_objects_to_update(
     """
     to_update = {}
     for acct, buckets in acct_bucket_keys.items():
-        out_of_date_buckets: dict[str, list[GitArchive]] = {}
+        out_of_date_buckets: Dict[str, List[GitArchive]] = {}
         for sync in acct_syncs[acct]:
             i = 0
             to_delete_key = ""
@@ -188,7 +189,7 @@ def run(dry_run, thread_pool_size=10):
     sync_enabled = queries.get_gitlab_sync_repos(server=instance["url"])
     all_accounts = queries.get_aws_accounts()
 
-    account_to_syncs: Dict[str, list[Any]] = {}
+    account_to_syncs: Dict[str, List[Any]] = {}
     for sync in sync_enabled:
         account_to_syncs.setdefault(sync["bucket_account"]["name"], []).append(sync)
     accounts = [a for a in all_accounts if a.get("name") in account_to_syncs]

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -80,7 +80,7 @@ class GitArchive:
                 f,
                 recipients=GitArchive.gpgs[self.vault_gpg_path]["recipients"],
                 output=repo_gpg,
-                armor=True,
+                armor=False,
                 always_trust=True,
             )
         # upload to s3

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -165,12 +165,10 @@ def get_objects_to_update(
             i = 0
             to_delete_key = ""
             for key in buckets[sync["bucket_name"]]:
-                # separate destination project and commit
-                dest_and_commit = key.rsplit("/", 1)
-                destination = dest_and_commit[0]
-                commit = dest_and_commit[1]
-                # remove file extension
-                commit = commit.split(".", 1)[0]
+                # separate destination project, commit, and branch
+                dest_commit_branch = key.rsplit("/", 2)
+                destination = dest_commit_branch[0]
+                commit = dest_commit_branch[1]
                 if destination == sync["destination_url"]:
                     if gitlab_commits[sync["origin_url"]] != commit:
                         to_delete_key = key

--- a/reconcile/gitlab_sync_push.py
+++ b/reconcile/gitlab_sync_push.py
@@ -1,5 +1,6 @@
 import base64
 import os
+import sh
 import sys
 import shutil
 import logging
@@ -30,6 +31,7 @@ class GitArchive:
         self.to_delete_key = key
         self.vault_gpg_path = vault_gpg_path
         self.workdir = workdir
+        self.tar = sh.tar.bake("-cf")
 
     @staticmethod
     def b64_encode(original) -> str:
@@ -72,8 +74,7 @@ class GitArchive:
         repo = Repo.clone_from(clone_url, repo_dir)
         # archive and encrypt repo
         repo_tar = repo_dir + ".tar"
-        with open(repo_tar, "wb") as f:
-            repo.archive(f)
+        self.tar(repo_tar, repo_dir)
         repo_gpg = repo_tar + ".gpg"
         with open(repo_tar, "rb") as f:
             GitArchive.gpgs[self.vault_gpg_path]["gpg"].encrypt_file(

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1445,6 +1445,7 @@ APPS_QUERY = """
           field
         }
         destination_url
+        origin_branch
       }
       resource
       gitlabRepoOwners {

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1518,12 +1518,12 @@ def get_repos(server="") -> list[str]:
     return repos
 
 
-def get_gitlab_sync_repos(server="") -> list[dict[str, str]]:
+def get_gitlab_sync_repos(server="") -> list[dict[str, Any]]:
     """Returns all repos defined under codeComponents with sync enabled
     Optional arguments:
     server: url of the server to return. for example: https://github.com
     """
-    sync_enabled_repos: list[dict[str, str]] = []
+    sync_enabled_repos: list[dict[str, Any]] = []
     apps = get_apps()
     for a in apps:
         if a["codeComponents"] is not None:

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1435,6 +1435,17 @@ APPS_QUERY = """
     }
     codeComponents {
       url
+      gitlabSync {
+        bucket_name
+        bucket_account {
+          name
+        }
+        public_key {
+          path
+          field
+        }
+        destination_url
+      }
       resource
       gitlabRepoOwners {
         enabled
@@ -1505,6 +1516,23 @@ def get_repos(server="") -> list[str]:
                 if c["url"].startswith(server):
                     repos.append(c["url"])
     return repos
+
+
+def get_gitlab_sync_repos(server="") -> list[dict[str, str]]:
+    """Returns all repos defined under codeComponents with sync enabled
+    Optional arguments:
+    server: url of the server to return. for example: https://github.com
+    """
+    sync_enabled_repos: list[dict[str, str]] = []
+    apps = get_apps()
+    for a in apps:
+        if a["codeComponents"] is not None:
+            for c in a["codeComponents"]:
+                if c["gitlabSync"] is not None and c["url"].startswith(server):
+                    sync_enabled_repos.append(
+                        {"origin_url": c["url"]} | c["gitlabSync"]
+                    )
+    return sync_enabled_repos
 
 
 def get_repos_gitlab_owner(server=""):

--- a/setup.py
+++ b/setup.py
@@ -6,18 +6,14 @@ setup(
     name="qontract-reconcile",
     version=version.pip(),
     license="Apache License 2.0",
-
     author="Red Hat App-SRE Team",
     author_email="sd-app-sre@redhat.com",
     python_requires=">=3.9",
     description="Collection of tools to reconcile services with their desired "
-                "state as defined in the app-interface DB.",
-
-    url='https://github.com/app-sre/qontract-reconcile',
-
-    packages=find_packages(exclude=('tests',)),
-    package_data={'reconcile': ['templates/*.j2', "gql_queries/*/*.gql"]},
-
+    "state as defined in the app-interface DB.",
+    url="https://github.com/app-sre/qontract-reconcile",
+    packages=find_packages(exclude=("tests",)),
+    package_data={"reconcile": ["templates/*.j2", "gql_queries/*/*.gql"]},
     install_requires=[
         "sretoolbox~=1.6.0",
         "python-gnupg>=0.5.0",
@@ -70,21 +66,19 @@ setup(
         "deepdiff6==6.2.0",
         "jsonpath-ng~=1.5",
     ],
-
     test_suite="tests",
-
     classifiers=[
-        'Development Status :: 2 - Pre-Alpha',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
+        "Development Status :: 2 - Pre-Alpha",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
     ],
     entry_points={
-        'console_scripts': [
-            'qontract-reconcile = reconcile.cli:integration',
-            'e2e-tests = e2e_tests.cli:test',
-            'app-interface-reporter = tools.app_interface_reporter:main',
-            'qontract-cli = tools.qontract_cli:root',
+        "console_scripts": [
+            "qontract-reconcile = reconcile.cli:integration",
+            "e2e-tests = e2e_tests.cli:test",
+            "app-interface-reporter = tools.app_interface_reporter:main",
+            "qontract-cli = tools.qontract_cli:root",
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     install_requires=[
         "sretoolbox~=1.6.0",
         "python-gnupg>=0.5.0",
+        "sh>=1.14.0",
         "gitpython>=3.1.27",
         "Click>=7.0,<9.0",
         "gql==3.1.0",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,10 @@ setup(
 
     install_requires=[
         "sretoolbox~=1.6.0",
+        "python-gnupg>=0.5.0",
+        "sh>=1.14.0",
+        "gitpython>=3.1.27",
+        "sretoolbox~=1.5.0",
         "Click>=7.0,<9.0",
         "gql==3.1.0",
         "toml>=0.10.0,<0.11.0",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     install_requires=[
         "sretoolbox~=1.6.0",
         "python-gnupg>=0.5.0",
-        "sh>=1.14.0",
         "gitpython>=3.1.27",
         "Click>=7.0,<9.0",
         "gql==3.1.0",

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
         "python-gnupg>=0.5.0",
         "sh>=1.14.0",
         "gitpython>=3.1.27",
-        "sretoolbox~=1.5.0",
         "Click>=7.0,<9.0",
         "gql==3.1.0",
         "toml>=0.10.0,<0.11.0",


### PR DESCRIPTION
SUMMARY
Automate the rebase process for projects within partitioned GitLab instances.

ticket: https://issues.redhat.com/browse/APPSRE-6166

dependent q-schema PR: https://github.com/app-sre/qontract-schemas/pull/268

DESCRIPTION
comprehensive documentation: https://docs.google.com/document/d/1Lo4lrZxKfwuoENJ76A0yFv6w81xTMSX-TsaX2ynYK8k/edit?usp=sharing

This PR implements a new integration `gitlab-sync-push`. This integration queries qontract-schema `/app-sre/app-1.yml`  files for optional `gitlabSync` definitions within `codeComponents`. 

For each `gitlabSync`, the integration attempts the following steps:
1. Retrieve latest commit sha for corresponding codeComponent gitlab project
2. Query Vault for specified public gpg key
3. Query specified s3 bucket and determine if corresponding s3 object is out of date
4. If outdated/new sync, clone latest version of gitlab project, archive, encrypt, and update object within s3