### PR TITLE
replace openshift-saas-deploy-wrapper with o-s-d-change-tester

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1019,6 +1019,43 @@ def openshift_saas_deploy_wrapper(
     )
 
 
+@integration.command(
+    short_help="Runs openshift-saas-deploy for each saas-file that changed within a bundle."
+)
+@click.argument("gitlab-project-id")
+@click.argument("gitlab-merge-request-id")
+@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
+@environ(["gitlab_pr_submitter_queue_url"])  # do we need this???
+@threaded()
+@click.option(
+    "--comparison-sha",
+    help="bundle sha to compare to to find changes",
+)
+@binary(["oc", "ssh"])
+@binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
+@use_jump_host()
+@click.pass_context
+def openshift_saas_deploy_change_tester(
+    ctx,
+    gitlab_project_id,
+    gitlab_merge_request_id,
+    thread_pool_size,
+    comparison_sha,
+    use_jump_host,
+):
+    import reconcile.openshift_saas_deploy_change_tester
+
+    run_integration(
+        reconcile.openshift_saas_deploy_change_tester,
+        ctx.obj,
+        gitlab_project_id,
+        gitlab_merge_request_id,
+        thread_pool_size,
+        comparison_sha,
+        use_jump_host,
+    )
+
+
 @integration.command(short_help="Validates Saas files.")
 @click.pass_context
 def saas_file_validator(ctx):

--- a/reconcile/openshift_saas_deploy_change_tester.py
+++ b/reconcile/openshift_saas_deploy_change_tester.py
@@ -83,10 +83,22 @@ def collect_state(saas_files: list[dict[str, Any]]):
                 parameters.update(saas_file_parameters)
                 parameters.update(resource_template_parameters)
                 parameters.update(target_parameters)
-                secret_parameters = []
-                secret_parameters.extend(saas_file_secret_parameters)
-                secret_parameters.extend(resource_template_secret_parameters)
-                secret_parameters.extend(target_secret_parameters)
+                secret_parameters = {}
+                secret_parameters.update(
+                    {
+                        s.get("name"): s.get("secret")
+                        for s in saas_file_secret_parameters
+                    }
+                )
+                secret_parameters.update(
+                    {
+                        s.get("name"): s.get("secret")
+                        for s in resource_template_secret_parameters
+                    }
+                )
+                secret_parameters.update(
+                    {s.get("name"): s.get("secret") for s in target_secret_parameters}
+                )
                 state.append(
                     {
                         "saas_file_path": saas_file_path,

--- a/reconcile/openshift_saas_deploy_change_tester.py
+++ b/reconcile/openshift_saas_deploy_change_tester.py
@@ -1,0 +1,110 @@
+import sys
+
+from sretoolbox.utils import threaded
+
+from reconcile import queries
+from reconcile.utils.gitlab_api import GitLabApi
+from reconcile.utils import gql
+import reconcile.openshift_saas_deploy as osd
+from reconcile.saas_file_owners import collect_state, collect_compare_diffs
+
+from reconcile.utils.semver_helper import make_semver
+
+
+QONTRACT_INTEGRATION = "openshift-saas-deploy-change-tester"
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
+
+
+def osd_run_wrapper(
+    diff, dry_run, available_thread_pool_size, use_jump_host, gitlab_project_id
+):
+    saas_file_name = diff["saas_file_name"]
+    env_name = diff["environment"]
+    exit_code = 0
+    try:
+        osd.run(
+            dry_run=dry_run,
+            thread_pool_size=available_thread_pool_size,
+            use_jump_host=use_jump_host,
+            saas_file_name=saas_file_name,
+            env_name=env_name,
+            gitlab_project_id=gitlab_project_id,
+        )
+    except SystemExit as e:
+        exit_code = e.code
+    return exit_code
+
+
+def init_gitlab(gitlab_project_id):
+    instance = queries.get_gitlab_instance()
+    settings = queries.get_app_interface_settings()
+    return GitLabApi(instance, project_id=gitlab_project_id, settings=settings)
+
+
+def update_mr_with_ref_diffs(
+    gitlab_project_id, gitlab_merge_request_id, current_state, desired_state
+):
+    """
+    Update the merge request with links to the differences in the referenced commits.
+    """
+    instance = queries.get_gitlab_instance()
+    gl = GitLabApi(
+        instance,
+        project_id=gitlab_project_id,
+        settings=queries.get_secret_reader_settings(),
+    )
+    changed_paths = gl.get_merge_request_changed_paths(gitlab_merge_request_id)
+    compare_diffs = collect_compare_diffs(current_state, desired_state, changed_paths)
+    if compare_diffs:
+        compare_diffs_comment_body = "Diffs:\n" + "\n".join(
+            [f"- {d}" for d in compare_diffs]
+        )
+        gl.add_comment_to_merge_request(
+            gitlab_merge_request_id, compare_diffs_comment_body
+        )
+
+
+def run(
+    dry_run: bool,
+    gitlab_project_id: str,
+    gitlab_merge_request_id: str,
+    thread_pool_size: int,
+    comparison_sha: str,
+    use_jump_host: bool,
+):
+    comparison_gql_api = gql.get_api_for_sha(
+        comparison_sha, QONTRACT_INTEGRATION, validate_schemas=False
+    )
+
+    # find the differences in saas-file state
+    comparison_saas_file_state = collect_state(comparison_gql_api)
+    desired_saas_file_state = collect_state(gql.get_api())
+    saas_file_state_diffs = [
+        s for s in desired_saas_file_state if s not in comparison_saas_file_state
+    ]
+    if not saas_file_state_diffs:
+        return
+
+    update_mr_with_ref_diffs(
+        gitlab_project_id,
+        gitlab_merge_request_id,
+        comparison_saas_file_state,
+        desired_saas_file_state,
+    )
+
+    available_thread_pool_size = threaded.estimate_available_thread_pool_size(
+        thread_pool_size, len(saas_file_state_diffs)
+    )
+
+    exit_codes = threaded.run(
+        osd_run_wrapper,
+        saas_file_state_diffs,
+        thread_pool_size,
+        dry_run=dry_run,
+        available_thread_pool_size=available_thread_pool_size,
+        use_jump_host=use_jump_host,
+        gitlab_project_id=gitlab_project_id,
+    )
+
+    if [ec for ec in exit_codes if ec]:
+        sys.exit(1)

--- a/reconcile/openshift_saas_deploy_change_tester.py
+++ b/reconcile/openshift_saas_deploy_change_tester.py
@@ -1,4 +1,8 @@
 import sys
+import json
+import copy
+import logging
+from typing import Any
 
 from sretoolbox.utils import threaded
 
@@ -6,7 +10,6 @@ from reconcile import queries
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils import gql
 import reconcile.openshift_saas_deploy as osd
-from reconcile.saas_file_owners import collect_state, collect_compare_diffs
 
 from reconcile.utils.semver_helper import make_semver
 
@@ -39,6 +42,108 @@ def init_gitlab(gitlab_project_id):
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()
     return GitLabApi(instance, project_id=gitlab_project_id, settings=settings)
+
+
+def collect_state(saas_files: list[dict[str, Any]]):
+    state = []
+    for saas_file in saas_files:
+        saas_file_path = saas_file["path"]
+        saas_file_name = saas_file["name"]
+        saas_file_deploy_resources = saas_file.get("deployResources")
+        saas_file_parameters = json.loads(saas_file.get("parameters") or "{}")
+        saas_file_secret_parameters = saas_file.get("secretParameters") or []
+        saas_file_definitions = {
+            "managed_resource_types": saas_file["managedResourceTypes"],
+            "image_patterns": saas_file["imagePatterns"],
+            "use_channel_in_image_tag": saas_file.get("use_channel_in_image_tag")
+            or False,
+        }
+        resource_templates = saas_file["resourceTemplates"]
+        for resource_template in resource_templates:
+            resource_template_name = resource_template["name"]
+            resource_template_parameters = json.loads(
+                resource_template.get("parameters") or "{}"
+            )
+            resource_template_secret_parameters = (
+                resource_template.get("secretParameters") or []
+            )
+            resource_template_url = resource_template["url"]
+            for target in resource_template["targets"]:
+                namespace_info = target["namespace"]
+                namespace = namespace_info["name"]
+                cluster = namespace_info["cluster"]["name"]
+                environment = namespace_info["environment"]["name"]
+                target_ref = target["ref"]
+                target_upstream = target.get("upstream")
+                target_disable = target.get("disable")
+                target_delete = target.get("delete")
+                target_parameters = json.loads(target.get("parameters") or "{}")
+                target_secret_parameters = target.get("secretParameters") or []
+                parameters = {}
+                parameters.update(saas_file_parameters)
+                parameters.update(resource_template_parameters)
+                parameters.update(target_parameters)
+                secret_parameters = []
+                secret_parameters.extend(saas_file_secret_parameters)
+                secret_parameters.extend(resource_template_secret_parameters)
+                secret_parameters.extend(target_secret_parameters)
+                state.append(
+                    {
+                        "saas_file_path": saas_file_path,
+                        "saas_file_name": saas_file_name,
+                        "saas_file_deploy_resources": saas_file_deploy_resources,
+                        "resource_template_name": resource_template_name,
+                        "cluster": cluster,
+                        "namespace": namespace,
+                        "environment": environment,
+                        "url": resource_template_url,
+                        "ref": target_ref,
+                        "parameters": parameters,
+                        "secret_parameters": secret_parameters,
+                        "saas_file_definitions": copy.deepcopy(saas_file_definitions),
+                        "upstream": target_upstream,
+                        "disable": target_disable,
+                        "delete": target_delete,
+                        "target_path": target.get("path"),
+                    }
+                )
+    return state
+
+
+def collect_compare_diffs(current_state, desired_state, changed_paths):
+    """Collect a list of URLs in a git diff format
+    for each change in the merge request"""
+    compare_diffs = set()
+    for d in desired_state:
+        # check if this diff was actually changed in the current MR
+        changed_path_matches = [
+            c for c in changed_paths if c.endswith(d["saas_file_path"])
+        ]
+        if not changed_path_matches:
+            # this diff was found in the graphql endpoint comparison
+            # but is not a part of the changed paths.
+            # the only known case for this currently is if a previous MR
+            # that changes another saas file was merged but is not yet
+            # reflected in the baseline graphql endpoint.
+            # https://issues.redhat.com/browse/APPSRE-3029
+            logging.debug(f"Diff not found in changed paths, skipping: {str(d)}")
+            continue
+        for c in current_state:
+            if d["saas_file_name"] != c["saas_file_name"]:
+                continue
+            if d["resource_template_name"] != c["resource_template_name"]:
+                continue
+            if d["environment"] != c["environment"]:
+                continue
+            if d["cluster"] != c["cluster"]:
+                continue
+            if d["namespace"] != c["namespace"]:
+                continue
+            if d["ref"] == c["ref"]:
+                continue
+            compare_diffs.add(f"{d['url']}/compare/{c['ref']}...{d['ref']}")
+
+    return compare_diffs
 
 
 def update_mr_with_ref_diffs(
@@ -77,8 +182,12 @@ def run(
     )
 
     # find the differences in saas-file state
-    comparison_saas_file_state = collect_state(comparison_gql_api)
-    desired_saas_file_state = collect_state(gql.get_api())
+    comparison_saas_file_state = collect_state(
+        queries.get_saas_files(gqlapi=comparison_gql_api)
+    )
+    desired_saas_file_state = collect_state(
+        queries.get_saas_files(gqlapi=gql.get_api())
+    )
     saas_file_state_diffs = [
         s for s in desired_saas_file_state if s not in comparison_saas_file_state
     ]

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2086,9 +2086,9 @@ SAAS_FILES_QUERY_V2 = """
 
 
 def get_saas_files(
-    saas_file_name=None,
-    env_name=None,
-    app_name=None,
+    saas_file_name: Optional[str] = None,
+    env_name: Optional[str] = None,
+    app_name: Optional[str] = None,
     gqlapi: Optional[gql.GqlApi] = None,
 ):
     """Returns SaasFile resources defined in app-interface."""

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2085,9 +2085,15 @@ SAAS_FILES_QUERY_V2 = """
 )
 
 
-def get_saas_files(saas_file_name=None, env_name=None, app_name=None):
+def get_saas_files(
+    saas_file_name=None,
+    env_name=None,
+    app_name=None,
+    gqlapi: Optional[gql.GqlApi] = None,
+):
     """Returns SaasFile resources defined in app-interface."""
-    gqlapi = gql.get_api()
+    if gqlapi is None:
+        gqlapi = gql.get_api()
     saas_files = gqlapi.query(SAAS_FILES_QUERY_V2)["saas_files"]
 
     if saas_file_name is None and env_name is None and app_name is None:

--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -4,7 +4,7 @@ import copy
 import logging
 
 from reconcile import queries
-from reconcile.utils import throughput
+from reconcile.utils import throughput, gql
 
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.mr.labels import APPROVED, HOLD, SAAS_FILE_UPDATE
@@ -55,9 +55,9 @@ def collect_owners():
     return ans
 
 
-def collect_state():
+def collect_state(gqlapi):
     state = []
-    saas_files = queries.get_saas_files()
+    saas_files = queries.get_saas_files(gqlapi=gqlapi)
     for saas_file in saas_files:
         saas_file_path = saas_file["path"]
         saas_file_name = saas_file["name"]
@@ -124,7 +124,7 @@ def collect_state():
 
 def collect_baseline():
     owners = collect_owners()
-    state = collect_state()
+    state = collect_state(gql.get_api())
     return {"owners": owners, "state": state}
 
 
@@ -302,7 +302,7 @@ def run(
     baseline = read_baseline_from_file(io_dir)
     owners = baseline["owners"]
     current_state = baseline["state"]
-    desired_state = collect_state()
+    desired_state = collect_state(gql.get_api())
     diffs = [s for s in desired_state if s not in current_state]
     changed_paths = gl.get_merge_request_changed_paths(gitlab_merge_request_id)
 

--- a/reconcile/saas_file_owners.py
+++ b/reconcile/saas_file_owners.py
@@ -4,7 +4,11 @@ import copy
 import logging
 
 from reconcile import queries
-from reconcile.utils import throughput, gql
+from reconcile.openshift_saas_deploy_change_tester import (
+    collect_state,
+    collect_compare_diffs,
+)
+from reconcile.utils import throughput
 
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.mr.labels import APPROVED, HOLD, SAAS_FILE_UPDATE
@@ -55,113 +59,11 @@ def collect_owners():
     return ans
 
 
-def collect_state(gqlapi):
-    state = []
-    saas_files = queries.get_saas_files(gqlapi=gqlapi)
-    for saas_file in saas_files:
-        saas_file_path = saas_file["path"]
-        saas_file_name = saas_file["name"]
-        saas_file_deploy_resources = saas_file.get("deployResources")
-        saas_file_parameters = json.loads(saas_file.get("parameters") or "{}")
-        saas_file_secret_parameters = saas_file.get("secretParameters") or []
-        saas_file_definitions = {
-            "managed_resource_types": saas_file["managedResourceTypes"],
-            "image_patterns": saas_file["imagePatterns"],
-            "use_channel_in_image_tag": saas_file.get("use_channel_in_image_tag")
-            or False,
-        }
-        resource_templates = saas_file["resourceTemplates"]
-        for resource_template in resource_templates:
-            resource_template_name = resource_template["name"]
-            resource_template_parameters = json.loads(
-                resource_template.get("parameters") or "{}"
-            )
-            resource_template_secret_parameters = (
-                resource_template.get("secretParameters") or []
-            )
-            resource_template_url = resource_template["url"]
-            for target in resource_template["targets"]:
-                namespace_info = target["namespace"]
-                namespace = namespace_info["name"]
-                cluster = namespace_info["cluster"]["name"]
-                environment = namespace_info["environment"]["name"]
-                target_ref = target["ref"]
-                target_upstream = target.get("upstream")
-                target_disable = target.get("disable")
-                target_delete = target.get("delete")
-                target_parameters = json.loads(target.get("parameters") or "{}")
-                target_secret_parameters = target.get("secretParameters") or []
-                parameters = {}
-                parameters.update(saas_file_parameters)
-                parameters.update(resource_template_parameters)
-                parameters.update(target_parameters)
-                secret_parameters = []
-                secret_parameters.extend(saas_file_secret_parameters)
-                secret_parameters.extend(resource_template_secret_parameters)
-                secret_parameters.extend(target_secret_parameters)
-                state.append(
-                    {
-                        "saas_file_path": saas_file_path,
-                        "saas_file_name": saas_file_name,
-                        "saas_file_deploy_resources": saas_file_deploy_resources,
-                        "resource_template_name": resource_template_name,
-                        "cluster": cluster,
-                        "namespace": namespace,
-                        "environment": environment,
-                        "url": resource_template_url,
-                        "ref": target_ref,
-                        "parameters": parameters,
-                        "secret_parameters": secret_parameters,
-                        "saas_file_definitions": copy.deepcopy(saas_file_definitions),
-                        "upstream": target_upstream,
-                        "disable": target_disable,
-                        "delete": target_delete,
-                        "target_path": target.get("path"),
-                    }
-                )
-    return state
-
-
 def collect_baseline():
     owners = collect_owners()
-    state = collect_state(gql.get_api())
+    saas_files = queries.get_saas_files()
+    state = collect_state(saas_files)
     return {"owners": owners, "state": state}
-
-
-def collect_compare_diffs(current_state, desired_state, changed_paths):
-    """Collect a list of URLs in a git diff format
-    for each change in the merge request"""
-    compare_diffs = set()
-    for d in desired_state:
-        # check if this diff was actually changed in the current MR
-        changed_path_matches = [
-            c for c in changed_paths if c.endswith(d["saas_file_path"])
-        ]
-        if not changed_path_matches:
-            # this diff was found in the graphql endpoint comparison
-            # but is not a part of the changed paths.
-            # the only known case for this currently is if a previous MR
-            # that changes another saas file was merged but is not yet
-            # reflected in the baseline graphql endpoint.
-            # https://issues.redhat.com/browse/APPSRE-3029
-            logging.debug(f"Diff not found in changed paths, skipping: {str(d)}")
-            continue
-        for c in current_state:
-            if d["saas_file_name"] != c["saas_file_name"]:
-                continue
-            if d["resource_template_name"] != c["resource_template_name"]:
-                continue
-            if d["environment"] != c["environment"]:
-                continue
-            if d["cluster"] != c["cluster"]:
-                continue
-            if d["namespace"] != c["namespace"]:
-                continue
-            if d["ref"] == c["ref"]:
-                continue
-            compare_diffs.add(f"{d['url']}/compare/{c['ref']}...{d['ref']}")
-
-    return compare_diffs
 
 
 def write_baseline_to_file(io_dir, baseline):
@@ -302,7 +204,7 @@ def run(
     baseline = read_baseline_from_file(io_dir)
     owners = baseline["owners"]
     current_state = baseline["state"]
-    desired_state = collect_state(gql.get_api())
+    desired_state = collect_state(queries.get_saas_files())
     diffs = [s for s in desired_state if s not in current_state]
     changed_paths = gl.get_merge_request_changed_paths(gitlab_merge_request_id)
 

--- a/reconcile/test/test_openshift_saas_deploy_change_tester.py
+++ b/reconcile/test/test_openshift_saas_deploy_change_tester.py
@@ -1,0 +1,263 @@
+from typing import Any
+import pytest
+import copy
+
+from reconcile.openshift_saas_deploy_change_tester import (
+    collect_state,
+    collect_compare_diffs,
+)
+
+
+@pytest.fixture
+def saas_files() -> list[dict[str, Any]]:
+    return [
+        {
+            "path": "/path.yml",
+            "name": "saas-file-name",
+            "app": {"name": "ccx-data-pipeline"},
+            "deployResources": {
+                "requests": {"cpu": "1500m", "memory": "700Mi"},
+                "limits": {"cpu": "2000m", "memory": "1Gi"},
+            },
+            "managedResourceTypes": [
+                "Deployment",
+            ],
+            "takeover": None,
+            "deprecated": None,
+            "compare": None,
+            "clusterAdmin": None,
+            "imagePatterns": [
+                "quay.io/some-org",
+            ],
+            "allowedSecretParameterPaths": None,
+            "use_channel_in_image_tag": None,
+            "parameters": '{"SAAS_DEFAULT_1":"saas", "SAAS_DEFAULT_2":"saas"}',
+            "secretParameters": [
+                {
+                    "name": "saas_default_1",
+                    "secret": {
+                        "field": "saas_field_1",
+                        "path": "saas_path_1",
+                        "version": 1,
+                    },
+                },
+                {
+                    "name": "saas_default_2",
+                    "secret": {
+                        "field": "saas_field_2",
+                        "path": "saas_path_2",
+                        "version": 1,
+                    },
+                },
+            ],
+            "resourceTemplates": [
+                {
+                    "name": "tmpl",
+                    "url": "https://github.com/some-org/some-repo.git",
+                    "path": "/deploy.yaml",
+                    "hash_length": 7,
+                    "parameters": '{"TMPL_DEFAULT_1":"tmpl", "TMPL_DEFAULT_2":"tmpl"}',  # used in collect_state but not saasherder
+                    "secretParameters": [  # used in collect_state but saasherder
+                        {
+                            "name": "tmpl_default_1",
+                            "secret": {
+                                "field": "tmpl_field_1",
+                                "path": "tmpl_path_1",
+                                "version": 1,
+                            },
+                        },
+                        {
+                            "name": "tmpl_default_2",
+                            "secret": {
+                                "field": "tmpl_field_2",
+                                "path": "tmpl_path_2",
+                                "version": 1,
+                            },
+                        },
+                    ],
+                    "targets": [
+                        {
+                            "name": "target",
+                            "namespace": {
+                                "name": "namespace",
+                                "environment": {
+                                    "name": "env-name",
+                                    "parameters": {  # used in collect_state but not saas_file_owners
+                                        "ENV_DEFAULT_1": "env",
+                                        "ENV_DEFAULT_2": "env",
+                                    },
+                                    "secretParameters": [
+                                        {
+                                            "name": "env_default_1",
+                                            "secret": {
+                                                "field": "env_field_1",
+                                                "path": "env_path_1",
+                                                "version": 1,
+                                            },
+                                        },
+                                        {
+                                            "name": "env_default_2",
+                                            "secret": {
+                                                "field": "env_field_2",
+                                                "path": "env_path_2",
+                                                "version": 1,
+                                            },
+                                        },
+                                    ],
+                                },
+                                "app": {"name": "app"},
+                                "cluster": {"name": "cluster"},
+                            },
+                            "ref": "master",
+                            "promotion": None,
+                            "parameters": '{"TARGET":"target", "ENV_DEFAULT_1":"target", "SAAS_DEFAULT_1":"target", "TMPL_DEFAULT_1":"target"}',
+                            "secretParameters": [
+                                {
+                                    "name": "target_default",
+                                    "secret": {
+                                        "field": "target_field",
+                                        "path": "target_path",
+                                        "version": 1,
+                                    },
+                                },
+                                {
+                                    "name": "saas_default_1",
+                                    "secret": {
+                                        "field": "target_field",
+                                        "path": "target_path",
+                                        "version": 1,
+                                    },
+                                },
+                                {
+                                    "name": "tmpl_default_1",
+                                    "secret": {
+                                        "field": "target_field",
+                                        "path": "target_path",
+                                        "version": 1,
+                                    },
+                                },
+                                {
+                                    "name": "env_default_1",
+                                    "secret": {
+                                        "field": "target_field",
+                                        "path": "target_path",
+                                        "version": 1,
+                                    },
+                                },
+                            ],
+                            "upstream": {
+                                "instance": {
+                                    "name": "ci",
+                                    "serverUrl": "https://ci.example.net",
+                                },
+                                "name": "job-name",
+                            },
+                            "image": None,
+                            "disable": None,
+                            "delete": None,
+                        },
+                    ],
+                }
+            ],
+        }
+    ]
+
+
+def test_collect_state(saas_files: list[dict[str, Any]]) -> None:
+    state = collect_state(saas_files)
+    expected = {
+        "saas_file_path": "/path.yml",
+        "saas_file_name": "saas-file-name",
+        "saas_file_deploy_resources": {
+            "requests": {"cpu": "1500m", "memory": "700Mi"},
+            "limits": {"cpu": "2000m", "memory": "1Gi"},
+        },
+        "resource_template_name": "tmpl",
+        "namespace": "namespace",
+        "environment": "env-name",
+        "cluster": "cluster",
+        "url": "https://github.com/some-org/some-repo.git",
+        "ref": "master",
+        "parameters": {
+            "SAAS_DEFAULT_1": "target",
+            "SAAS_DEFAULT_2": "saas",
+            "ENV_DEFAULT_1": "target",
+            # "ENV_DEFAULT_2": "env", # todo - check if it is a bug or on purpose that environment-1 params are not loaded
+            "TMPL_DEFAULT_1": "target",
+            "TMPL_DEFAULT_2": "tmpl",
+            "TARGET": "target",
+        },
+        "secret_parameters": {
+            "target_default": {
+                "field": "target_field",
+                "path": "target_path",
+                "version": 1,
+            },
+            "saas_default_1": {
+                "field": "target_field",
+                "path": "target_path",
+                "version": 1,
+            },
+            "saas_default_2": {
+                "field": "saas_field_2",
+                "path": "saas_path_2",
+                "version": 1,
+            },
+            "env_default_1": {
+                "field": "target_field",
+                "path": "target_path",
+                "version": 1,
+            },
+            # environment-1 secrets should be present since saasherder uses them but collect_state does sadly not
+            # "env_default_2": {
+            #    "field": "env_field_2",
+            #    "path": "env_path_2",
+            #    "version": 1,
+            # },
+            "tmpl_default_1": {
+                "field": "target_field",
+                "path": "target_path",
+                "version": 1,
+            },
+            "tmpl_default_2": {
+                "field": "tmpl_field_2",
+                "path": "tmpl_path_2",
+                "version": 1,
+            },
+        },
+        "upstream": {
+            "instance": {"name": "ci", "serverUrl": "https://ci.example.net"},
+            "name": "job-name",
+        },
+        "saas_file_definitions": {
+            "managed_resource_types": ["Deployment"],
+            "image_patterns": ["quay.io/some-org"],
+            "use_channel_in_image_tag": False,
+        },
+        "disable": None,
+        "delete": None,
+        "target_path": None,
+    }
+    assert state == [expected]
+
+
+def test_collect_compare_diffs(saas_files: list[dict[str, Any]]):
+    state_1 = collect_state(saas_files)
+    state_2 = copy.deepcopy(state_1)
+    state_1[0]["ref"] = "another-branch"
+    diffs = collect_compare_diffs(
+        state_1, state_2, changed_paths=[state_1[0]["saas_file_path"]]
+    )
+    assert diffs == {
+        "https://github.com/some-org/some-repo.git/compare/another-branch...master"
+    }
+
+
+def test_collect_compare_diffs_other_paths(saas_files: list[dict[str, Any]]):
+    state_1 = collect_state(saas_files)
+    state_2 = copy.deepcopy(state_1)
+    state_1[0]["ref"] = "another-branch"
+    diffs = collect_compare_diffs(
+        state_1, state_2, changed_paths=["/some/other-path.yml"]
+    )
+    assert diffs == set()

--- a/reconcile/test/test_openshift_saas_deploy_change_tester.py
+++ b/reconcile/test/test_openshift_saas_deploy_change_tester.py
@@ -164,6 +164,18 @@ def saas_files() -> list[dict[str, Any]]:
 
 
 def test_collect_state(saas_files: list[dict[str, Any]]) -> None:
+    """
+    this implementation of collect_state may contain a bug when compared to the
+    saas_herder way to of collecting parameters and secrets.
+    there are 4 places where parameters and secrets can be defined with qontract-schema:
+    1) environment-1
+    2) saas-file-2
+    3) saas-file-2.resourceTemplates
+    4) saas-file-2.resourceTemplates.targets
+
+    - saas-herder collects from 1), 2), 4)
+    - collect_state collects from 2), 3), 4)
+    """
     state = collect_state(saas_files)
     expected = {
         "saas_file_path": "/path.yml",


### PR DESCRIPTION
# Why

`saas-file-owners` and `openshift-saas-deploy-wrapper` are closely related integrations. `saas-file-owners` creates an input file about saas-file that have changed that is passed to `openshift-saas-deploy-wrapper`, so it can run `openshift-saas-deploy` for each changed saas-file to verify the content.

when we switch from `saas-file-owners` to `change-owners` for self-service approvals, `saas-file-owners` will not run as part of `app-interface` PR checks anymore, so the input `openshift-saas-deploy-wrapper` expects is not there anymore.

# What changed

This MR introduces a new integration `openshift-saas-deploy-change-tester` which takes over the responsibility to run `openshift-saas-deploy` for each changed saas-file. This integration will be able to detect for itself what saas-files changed without the need of `saas-file-owners` passing information. `openshift-saas-deploy-change-tester` is using the dual-bundle `qontract-server` during app-interface PR checks to find the differences in saas-files.

`saas-file-owners` had another responsibility, namely adding a commit to the checked MR about the saas-file target `refs` that changed (`Diff: github.com/somethingsomething/old_ref....new_ref`). This functionality has been moved to `openshift-saas-deploy-change-tester` as well. This means that `saas-file-owners` and `openshift-saas-deploy-wrapper` can be safely disabled during PR checks (and removed later on) when `change-owners` and `openshift-saas-deploy-change-tester` are running instead.

# Alternatives considered

I considered changing `openshift-saas-deploy-wrapper` instead of creating a new integration but leaving both `saas-file-owner` and `openshift-saas-deploy-wrapper` unchanged brings flexibility about when and how to do the switch to the granular permission model with `change-owners`. It even allows reverting an app-interface instance back to using `saas-file-owners` in case of bugs in `change-owners` without reverting code, simply by enabling or disabling integrations for the PR checks. It also allows one app-interface instance running with `change-owners` while another one still runs `saas-file-owner`.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>