### PR TITLE
[change-owners] jsonpath root ($) matches all changes in files

### DIFF
--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -192,8 +192,9 @@ class BundleFileChange:
                 self.fileref, file_content
             ):
                 for dc in diffs:
-                    covered = str(dc.diff.path).startswith(allowed_path)
-                    if covered:
+                    if change_path_covered_by_allowed_path(
+                        str(dc.diff.path), allowed_path
+                    ):
                         covered_diffs[str(dc.diff.path)] = dc.diff
                         dc.coverage.append(change_type_context)
         return covered_diffs
@@ -351,3 +352,10 @@ class ChangeTypeContext:
     change_type_processor: ChangeTypeProcessor
     context: str
     approvers: list[Approver]
+
+
+JSON_PATH_ROOT = "$"
+
+
+def change_path_covered_by_allowed_path(changed_path: str, allowed_path: str) -> bool:
+    return changed_path.startswith(allowed_path) or allowed_path == JSON_PATH_ROOT

--- a/reconcile/test/fixtures/change_owners/changetype_cluster_owner.yml
+++ b/reconcile/test/fixtures/change_owners/changetype_cluster_owner.yml
@@ -1,4 +1,4 @@
-name: cluser-owner
+name: cluster-owner
 
 contextType: datafile
 contextSchema: /openshift/cluster-1.yml

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -220,7 +220,6 @@ def test_extract_context_file_refs_selector(
             },
         },
         new_file_content={
-            "because": "we are just testing the context extraction",
             "cluster": {
                 "$ref": cluster,
             },
@@ -1118,6 +1117,40 @@ def test_partially_covered_change_one_file(
 
     covered_diffs = saas_file_change.cover_changes(ctx)
     assert [ref_update_diff.diff] == covered_diffs
+
+
+def test_root_change_type(cluster_owner_change_type: ChangeTypeV1, saas_file: TestFile):
+    namespace_change = create_bundle_file_change(
+        path="/my/namespace.yml",
+        schema="/openshift/namespace-1.yml",
+        file_type=BundleFileType.DATAFILE,
+        old_file_content={
+            "cluster": {
+                "$ref": "cluster.yml",
+            },
+            "networkPolicy": [
+                {"$ref": "networkpolicy.yml"},
+            ],
+        },
+        new_file_content={
+            "cluster": {
+                "$ref": "cluster.yml",
+            },
+            "networkPolicy": [
+                {"$ref": "networkpolicy.yml"},
+                {"$ref": "new-networkpolicy.yml"},
+            ],
+        },
+    )
+    assert namespace_change
+    ctx = ChangeTypeContext(
+        change_type_processor=build_change_type_processor(cluster_owner_change_type),
+        context="RoleV1 - some-role",
+        approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
+    )
+
+    covered_diffs = namespace_change.cover_changes(ctx)
+    assert covered_diffs
 
 
 #


### PR DESCRIPTION
the `$` sign represents the document root in jsonpath. if this is used as a path for change coverage, every change in a document is covered by it.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>