### PR TITLE
[APPSRE-6355] Additional repos for review queue

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -107,6 +107,10 @@ APP_INTERFACE_SETTINGS_QUERY = """
       readTimeout
       connectTimeout
     }
+    reviewRepos {
+      name
+      repoUrl
+    }
   }
 }
 """

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -109,7 +109,7 @@ APP_INTERFACE_SETTINGS_QUERY = """
     }
     reviewRepos {
       name
-      repoUrl
+      url
     }
   }
 }

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1477,6 +1477,7 @@ CODE_COMPONENT_REPO_QUERY = """
 }
 """
 
+
 def get_apps():
     """Returns all Apps."""
     gqlapi = gql.get_api()
@@ -1492,14 +1493,15 @@ def get_code_components():
     code_components = list(itertools.chain.from_iterable(code_components_lists))
     return code_components
 
+
 def get_review_repos():
-  """Returns name and url of code components marked for review"""
-  code_components = get_code_components()
-  return [
-    {"url": c["url"], "name": c["name"]}
-    for c in code_components
-    if c is not None and c["showInReviewQueue"] is not None
-  ]
+    """Returns name and url of code components marked for review"""
+    code_components = get_code_components()
+    return [
+        {"url": c["url"], "name": c["name"]}
+        for c in code_components
+        if c is not None and c["showInReviewQueue"] is not None
+    ]
 
 
 def get_repos(server="") -> list[str]:

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -107,10 +107,6 @@ APP_INTERFACE_SETTINGS_QUERY = """
       readTimeout
       connectTimeout
     }
-    reviewRepos {
-      name
-      url
-    }
   }
 }
 """
@@ -1438,8 +1434,10 @@ APPS_QUERY = """
       name
     }
     codeComponents {
+      name
       url
       resource
+      showInReviewQueue
       gitlabRepoOwners {
         enabled
       }
@@ -1479,7 +1477,6 @@ CODE_COMPONENT_REPO_QUERY = """
 }
 """
 
-
 def get_apps():
     """Returns all Apps."""
     gqlapi = gql.get_api()
@@ -1494,6 +1491,15 @@ def get_code_components():
     ]
     code_components = list(itertools.chain.from_iterable(code_components_lists))
     return code_components
+
+def get_review_repos():
+  """Returns name and url of code components marked for review"""
+  code_components = get_code_components()
+  return [
+    {"url": c["url"], "name": c["name"]}
+    for c in code_components
+    if c is not None and c["showInReviewQueue"] is not None
+  ]
 
 
 def get_repos(server="") -> list[str]:

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1114,7 +1114,7 @@ def app_interface_review_queue(ctx):
         "updated_at",
         "labels",
     ]
-    
+
     def get_mrs(repo, url) -> list:
         gl = GitLabApi(instance, project_url=url, settings=settings)
         merge_requests = gl.get_merge_requests(state=MRState.OPENED)

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1191,7 +1191,7 @@ def app_interface_review_queue(ctx):
     review_repos = settings["reviewRepos"]
     if review_repos:
         for repo in review_repos:
-            queue_data.extend(get_mrs(repo["name"]))
+            queue_data.extend(get_mrs(repo["name"], repo["url"]))
 
     queue_data.sort(key=itemgetter("updated_at"))
     ctx.obj["options"]["sort"] = False  # do not sort

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1169,8 +1169,10 @@ def app_interface_review_queue(ctx):
             if is_last_action_by_app_sre:
                 last_comment = gl.last_comment(mr, exclude_bot=True)
                 # skip only if the last comment isn't a trigger phrase
-                if last_comment and not re.fullmatch(
-                    trigger_phrases_regex, last_comment["body"]
+                if (
+                    last_comment
+                    and trigger_phrases_regex
+                    and not re.fullmatch(trigger_phrases_regex, last_comment["body"])
                 ):
                     continue
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1188,9 +1188,9 @@ def app_interface_review_queue(ctx):
             queue_data.append(item)
         return queue_data
 
-    queue_data = get_mrs("app-interface", settings["repoUrl"])
+    queue_data = list()
 
-    review_repos = settings["reviewRepos"]
+    review_repos = queries.get_review_repos()
     if review_repos:
         for repo in review_repos:
             queue_data.extend(get_mrs(repo["name"], repo["url"]))

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1115,7 +1115,7 @@ def app_interface_review_queue(ctx):
         "labels",
     ]
 
-    def get_mrs(repo, url) -> list:
+    def get_mrs(repo, url) -> list[dict[str, str]]:
         gl = GitLabApi(instance, project_url=url, settings=settings)
         merge_requests = gl.get_merge_requests(state=MRState.OPENED)
         job = jjb.get_job_by_repo_url(url, job_type="gl-pr-check")
@@ -1190,10 +1190,8 @@ def app_interface_review_queue(ctx):
 
     queue_data = []
 
-    review_repos = queries.get_review_repos()
-    if review_repos:
-        for repo in review_repos:
-            queue_data.extend(get_mrs(repo["name"], repo["url"]))
+    for repo in queries.get_review_repos():
+        queue_data.extend(get_mrs(repo["name"], repo["url"]))
 
     queue_data.sort(key=itemgetter("updated_at"))
     ctx.obj["options"]["sort"] = False  # do not sort

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1188,7 +1188,7 @@ def app_interface_review_queue(ctx):
             queue_data.append(item)
         return queue_data
 
-    queue_data = list()
+    queue_data = []
 
     review_repos = queries.get_review_repos()
     if review_repos:


### PR DESCRIPTION
[APPSRE-6355](https://issues.redhat.com/browse/APPSRE-6355)

* To increase visibility of MRs for ICs in AppSRE, this allows us to define repos to watch for MRs within the codeComponents section of an app file (app interface appfile will have to be updated to add this flag as well)
* The watched repos must be on GitLab.cee and [managed by the AppSRE Bot](https://gitlab.cee.redhat.com/service/app-interface#enable-gitlab-features-on-an-app-interface-controlled-gitlab-repository) as well as have a PR check job setup
* Schemas change here: https://github.com/app-sre/qontract-schemas/pull/271
* Tested with [infra repo](https://gitlab.cee.redhat.com/app-sre/infra) and [managed tenants repo](https://gitlab.cee.redhat.com/service/managed-tenants/) to ensure that MRs show up as expected

Example of an updated app file:
```yaml
codeComponents:
- name: infra
  resource: other
  url: https://gitlab.cee.redhat.com/app-sre/infra
  showInReviewQueue: true
  gitlabHousekeeping:
    enabled: true
    rebase: false
  jira:
    $ref: /dependencies/jira/issues-redhat-com.yaml
```