### PR TITLE
allow access cluster region in resource-templates

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -146,6 +146,7 @@ NAMESPACES_QUERY = """
       }
       spec {
         version
+        region
       }
       network {
         pod


### PR DESCRIPTION
This allows to get the cluster region in jinja2 resource templates:
```
{{ REGION | default(resource.namespace.cluster.spec.region) }}
```