### PR TITLE
APPSRE-6295 typed secret-reader for CNA

### DIFF
--- a/reconcile/gql_definitions/common/app_interface_vault_settings.gql
+++ b/reconcile/gql_definitions/common/app_interface_vault_settings.gql
@@ -1,0 +1,7 @@
+# qenerate: plugin=pydantic_v1
+
+query AppInterfaceVaultSettings {
+  vault_settings: app_interface_settings_v1 {
+    vault
+  }
+}

--- a/reconcile/gql_definitions/common/app_interface_vault_settings.py
+++ b/reconcile/gql_definitions/common/app_interface_vault_settings.py
@@ -15,58 +15,35 @@ from pydantic import (  # noqa: F401 # pylint: disable=W0611
     Json,
 )
 
-from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
-
 
 DEFINITION = """
-fragment VaultSecret on VaultSecret_v1 {
-    path
-    field
-    version
-    format
+query AppInterfaceVaultSettings {
+  vault_settings: app_interface_settings_v1 {
+    vault
+  }
 }
-
-query AppInterfaceSmtpSettings {
-   settings: app_interface_settings_v1 {
-     smtp {
-       mailAddress
-       timeout
-       credentials {
-         ... VaultSecret
-       }
-     }
-   }
- }
 """
 
 
-class SmtpSettingsV1(BaseModel):
-    mail_address: str = Field(..., alias="mailAddress")
-    timeout: Optional[int] = Field(..., alias="timeout")
-    credentials: VaultSecret = Field(..., alias="credentials")
-
-    class Config:
-        smart_union = True
-        extra = Extra.forbid
-
-
 class AppInterfaceSettingsV1(BaseModel):
-    smtp: Optional[SmtpSettingsV1] = Field(..., alias="smtp")
+    vault: bool = Field(..., alias="vault")
 
     class Config:
         smart_union = True
         extra = Extra.forbid
 
 
-class AppInterfaceSmtpSettingsQueryData(BaseModel):
-    settings: Optional[list[AppInterfaceSettingsV1]] = Field(..., alias="settings")
+class AppInterfaceVaultSettingsQueryData(BaseModel):
+    vault_settings: Optional[list[AppInterfaceSettingsV1]] = Field(
+        ..., alias="vault_settings"
+    )
 
     class Config:
         smart_union = True
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> AppInterfaceSmtpSettingsQueryData:
+def query(query_func: Callable, **kwargs) -> AppInterfaceVaultSettingsQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.
@@ -79,7 +56,7 @@ def query(query_func: Callable, **kwargs) -> AppInterfaceSmtpSettingsQueryData:
         kwargs: optional arguments that will be passed to the query function
 
     Returns:
-        AppInterfaceSmtpSettingsQueryData: queried data parsed into generated classes
+        AppInterfaceVaultSettingsQueryData: queried data parsed into generated classes
     """
     raw_data: dict[Any, Any] = query_func(DEFINITION, **kwargs)
-    return AppInterfaceSmtpSettingsQueryData(**raw_data)
+    return AppInterfaceVaultSettingsQueryData(**raw_data)

--- a/reconcile/gql_definitions/common/smtp_client_settings.gql
+++ b/reconcile/gql_definitions/common/smtp_client_settings.gql
@@ -1,6 +1,6 @@
 # qenerate: plugin=pydantic_v1
 
- query AppInterfaceSettings {
+ query AppInterfaceSmtpSettings {
    settings: app_interface_settings_v1 {
      smtp {
        mailAddress

--- a/reconcile/test/test_secret_reader.py
+++ b/reconcile/test/test_secret_reader.py
@@ -1,9 +1,115 @@
+from unittest.mock import MagicMock
 import pytest
 
 import reconcile.utils.secret_reader
 from reconcile.utils import vault
-from reconcile.utils.secret_reader import SecretReader, SecretNotFound
+from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
+from reconcile.utils.secret_reader import (
+    ConfigSecretReader,
+    SecretReader,
+    SecretNotFound,
+    VaultSecretReader,
+)
 from reconcile.utils.vault import _VaultClient
+
+
+VAULT_READ_EXPECTED = {"key": "value"}
+VAULT_READ_ALL_EXPECTED = {"key2": "value2"}
+
+
+@pytest.fixture
+def vault_mock():
+    read_mock = MagicMock()
+    read_mock.side_effect = [VAULT_READ_EXPECTED] * 100
+    read_all_mock = MagicMock()
+    read_all_mock.side_effect = [VAULT_READ_ALL_EXPECTED] * 100
+    vault_mock = MagicMock(spec=_VaultClient)
+    vault_mock.read = read_mock
+    vault_mock.read_all = read_all_mock
+    return vault_mock
+
+
+@pytest.fixture
+def vault_secret():
+    return VaultSecret(
+        path="path/test",
+        field="key",
+        format=None,
+        version=None,
+    )
+
+
+def to_dict(secret):
+    return {
+        "path": secret.path,
+        "field": secret.field,
+        "format": secret.q_format,
+        "version": secret.version,
+    }
+
+
+def test_vault_secret_reader_typed_read(vault_mock, vault_secret):
+    vault_secret_reader = VaultSecretReader(vault_client=vault_mock)
+    result = vault_secret_reader.typed_read(vault_secret)
+
+    assert result == VAULT_READ_EXPECTED
+    vault_mock.read.assert_called_once_with(to_dict(vault_secret))
+    vault_mock.read_all.assert_not_called()
+
+
+def test_vault_secret_reader_typed_read_all(vault_mock, vault_secret):
+    vault_secret_reader = VaultSecretReader(vault_client=vault_mock)
+    result = vault_secret_reader.typed_read_all(vault_secret)
+
+    assert result == VAULT_READ_ALL_EXPECTED
+    vault_mock.read_all.assert_called_once_with(to_dict(vault_secret))
+    vault_mock.read.assert_not_called()
+
+
+def test_vault_secret_reader_parameters_read(vault_mock, vault_secret):
+    vault_secret_reader = VaultSecretReader(vault_client=vault_mock)
+    result = vault_secret_reader.read_with_parameters(
+        path=vault_secret.path,
+        field=vault_secret.field,
+        format=vault_secret.q_format,
+        version=vault_secret.version,
+    )
+
+    assert result == VAULT_READ_EXPECTED
+    vault_mock.read.assert_called_once_with(to_dict(vault_secret))
+    vault_mock.read_all.assert_not_called()
+
+
+def test_vault_secret_reader_parameters_read_all(vault_mock, vault_secret):
+    vault_secret_reader = VaultSecretReader(vault_client=vault_mock)
+    result = vault_secret_reader.read_all_with_parameters(
+        path=vault_secret.path,
+        field=vault_secret.field,
+        format=vault_secret.q_format,
+        version=vault_secret.version,
+    )
+
+    assert result == VAULT_READ_ALL_EXPECTED
+    vault_mock.read_all.assert_called_once_with(to_dict(vault_secret))
+    vault_mock.read.assert_not_called()
+
+
+def test_vault_secret_reader_raises(vault_mock, vault_secret, patch_sleep):
+    vault_mock.read.side_effect = [vault.SecretNotFound] * 100
+    vault_secret_reader = VaultSecretReader(vault_client=vault_mock)
+
+    with pytest.raises(SecretNotFound):
+        vault_secret_reader.typed_read(vault_secret)
+
+    vault_mock.read.assert_called_with(to_dict(vault_secret))
+    vault_mock.read_all.assert_not_called()
+
+
+def test_config_secret_reader_raises(vault_secret, patch_sleep):
+    config_secret_reader = ConfigSecretReader()
+
+    with pytest.raises(SecretNotFound):
+        config_secret_reader.typed_read(vault_secret)
 
 
 def test_read_vault_raises(mocker, patch_sleep):

--- a/reconcile/typed_queries/app_interface_vault_settings.py
+++ b/reconcile/typed_queries/app_interface_vault_settings.py
@@ -1,0 +1,17 @@
+from typing import Optional
+
+from reconcile.utils import gql
+from reconcile.gql_definitions.common.app_interface_vault_settings import (
+    query,
+    AppInterfaceSettingsV1,
+)
+
+
+def get_app_interface_vault_settings() -> Optional[AppInterfaceSettingsV1]:
+    """Returns App Interface Settings"""
+    gqlapi = gql.get_api()
+    data = query(gqlapi.query)
+    if data.vault_settings:
+        # assuming a single settings file for now
+        return data.vault_settings[0]
+    return None

--- a/reconcile/utils/secret_reader.py
+++ b/reconcile/utils/secret_reader.py
@@ -41,28 +41,28 @@ class TypedSecretReader(ABC):
     ) -> dict[str, str]:
         raise NotImplementedError()
 
-    def read(self, secret: Mapping[str, Any]) -> dict[str, str]:
+    def read(self, secret: Mapping[str, Any]):
         """
         Kept to stay backwards compatible with to-be deprecated
         SecretReader. Once SecretReader is not used, we can
         remove this.
         """
         return self._read(
-            path=secret.get("path"),
-            field=secret.get("field"),
+            path=secret.get("path", ""),
+            field=secret.get("field", ""),
             format=secret.get("format"),
             version=secret.get("version"),
         )
 
-    def read_all(self, secret: Mapping[str, Any]) -> dict[str, str]:
+    def read_all(self, secret: Mapping[str, Any]):
         """
         Kept to stay backwards compatible with to-be deprecated
         SecretReader. Once SecretReader is not used, we can
         remove this.
         """
         return self._read_all(
-            path=secret.get("path"),
-            field=secret.get("field"),
+            path=secret.get("path", ""),
+            field=secret.get("field", ""),
             format=secret.get("format"),
             version=secret.get("version"),
         )

--- a/reconcile/utils/secret_reader.py
+++ b/reconcile/utils/secret_reader.py
@@ -28,15 +28,6 @@ class SupportsSecret(Protocol):
     q_format: Optional[str]
 
 
-class SupportsVaultSettings(Protocol):
-    """
-    SupportsVaultSettings defines all attributes needed from app-interface-settings
-    to instantiate a SecretReader
-    """
-
-    vault: bool
-
-
 class TypedSecretReader(ABC):
     @abstractmethod
     def read(self, secret: Mapping[str, Any]) -> dict[str, str]:
@@ -230,14 +221,12 @@ class ConfigSecretReader(TypedSecretReader):
         return data
 
 
-def create_secret_reader(
-    settings: Optional[SupportsVaultSettings],
-) -> TypedSecretReader:
+def create_secret_reader(use_vault: bool) -> TypedSecretReader:
     """
     This function could be used in an integrations run() function to instantiate a
     TypedSecretReader.
     """
-    return VaultSecretReader() if settings and settings.vault else ConfigSecretReader()
+    return VaultSecretReader() if use_vault else ConfigSecretReader()
 
 
 class SecretReader(TypedSecretReader):

--- a/reconcile/utils/secret_reader.py
+++ b/reconcile/utils/secret_reader.py
@@ -28,7 +28,7 @@ class SupportsSecret(Protocol):
     q_format: Optional[str]
 
 
-class TypedSecretReader(ABC):
+class SecretReaderBase(ABC):
     @abstractmethod
     def _read(
         self, path: str, field: str, format: Optional[str], version: Optional[int]
@@ -67,7 +67,7 @@ class TypedSecretReader(ABC):
             version=secret.get("version"),
         )
 
-    def typed_read(self, secret: SupportsSecret) -> dict[str, str]:
+    def read_secret(self, secret: SupportsSecret) -> dict[str, str]:
         return self._read(
             path=secret.path,
             field=secret.field,
@@ -75,7 +75,7 @@ class TypedSecretReader(ABC):
             version=secret.version,
         )
 
-    def typed_read_all(self, secret: SupportsSecret) -> dict[str, str]:
+    def read_all_secret(self, secret: SupportsSecret) -> dict[str, str]:
         return self._read_all(
             path=secret.path,
             field=secret.field,
@@ -114,7 +114,7 @@ class TypedSecretReader(ABC):
         }
 
 
-class VaultSecretReader(TypedSecretReader):
+class VaultSecretReader(SecretReaderBase):
     """
     Read secrets from vault via a vault_client
     """
@@ -167,7 +167,7 @@ class VaultSecretReader(TypedSecretReader):
         return data
 
 
-class ConfigSecretReader(TypedSecretReader):
+class ConfigSecretReader(SecretReaderBase):
     """
     Read secrets from a config file
     """
@@ -205,7 +205,7 @@ class ConfigSecretReader(TypedSecretReader):
         return data
 
 
-def create_secret_reader(use_vault: bool) -> TypedSecretReader:
+def create_secret_reader(use_vault: bool) -> SecretReaderBase:
     """
     This function could be used in an integrations run() function to instantiate a
     TypedSecretReader.
@@ -213,7 +213,7 @@ def create_secret_reader(use_vault: bool) -> TypedSecretReader:
     return VaultSecretReader() if use_vault else ConfigSecretReader()
 
 
-class SecretReader(TypedSecretReader):
+class SecretReader(SecretReaderBase):
     """
     Read secrets from either Vault or a config file.
 

--- a/reconcile/utils/secret_reader.py
+++ b/reconcile/utils/secret_reader.py
@@ -1,4 +1,4 @@
-from typing import Mapping, Optional, Protocol
+from typing import Any, Mapping, Optional, Protocol
 
 from hvac.exceptions import Forbidden
 from sretoolbox.utils import retry
@@ -27,15 +27,19 @@ class SupportsSecret(Protocol):
     q_format: Optional[str]
 
 
-class SecretReader:
+class SupportsVaultSettings(Protocol):
+    """
+    SupportsVaultSettings defines all attributes needed from app-interface-settings
+    to instantiate a SecretReader
+    """
+
+    vault: bool
+
+
+class SecretReaderBase:
     """Read secrets from either Vault or a config file."""
 
-    def __init__(self, settings: Optional[Mapping] = None) -> None:
-        """
-        :param settings: app-interface-settings object. It is a dictionary
-        containing `value: true` if Vault is to be used as the secret backend.
-        """
-        self.settings = settings
+    def __init__(self) -> None:
         self._vault_client: Optional[VaultClient] = None
 
     @property
@@ -45,7 +49,7 @@ class SecretReader:
         return self._vault_client
 
     @retry()
-    def read(self, secret: Mapping[str, str]):
+    def _read_base(self, secret: Mapping[str, Any], use_vault: bool) -> dict[str, str]:
         """Returns a value of a key from Vault secret or configuration file.
 
         The input secret is a dictionary which contains the following fields:
@@ -61,7 +65,7 @@ class SecretReader:
         :raises secret_reader.SecretNotFound:
         """
 
-        if self.settings and self.settings.get("vault"):
+        if use_vault:
             try:
                 data = self.vault_client.read(secret)
             except vault.SecretNotFound as e:
@@ -75,7 +79,9 @@ class SecretReader:
         return data
 
     @retry()
-    def read_all(self, secret: Mapping[str, str]):
+    def _read_all_base(
+        self, secret: Mapping[str, Any], use_vault: bool
+    ) -> dict[str, str]:
         """Returns a dictionary of keys and values
         from Vault secret or configuration file.
 
@@ -90,7 +96,7 @@ class SecretReader:
         :raises secret_reader.SecretNotFound:
         """
 
-        if self.settings and self.settings.get("vault"):
+        if use_vault:
             try:
                 data = self.vault_client.read_all(secret)
             except Forbidden:
@@ -106,3 +112,62 @@ class SecretReader:
                 raise SecretNotFound(*e.args) from e
 
         return data
+
+
+class TypedSecretReader(SecretReaderBase):
+    """
+    Typed version of SecretReader. Once all references to the
+    untyped version are removed, we can merge this fully with
+    the SecretReaderBase class.
+    """
+
+    def __init__(self, settings: Optional[SupportsVaultSettings]):
+        super().__init__()
+        self._use_vault = settings and settings.vault
+
+    def _to_secret_dict(self, secret: SupportsSecret) -> dict[str, Any]:
+        """
+        VaultClient currently works with dictionaries. Once we got a typed
+        version of VaultClient, we could remove this
+        """
+        return {
+            "path": secret.path,
+            "field": secret.field,
+            "version": secret.version,
+            "format": secret.q_format,
+        }
+
+    def read(self, secret: SupportsSecret) -> dict[str, str]:
+        return self._read_base(
+            secret=self._to_secret_dict(secret),
+            use_vault=self._use_vault,
+        )
+
+    def read_all(self, secret: SupportsSecret) -> dict[str, str]:
+        return self._read_all_base(
+            secret=self._to_secret_dict(secret),
+            use_vault=self._use_vault,
+        )
+
+
+class SecretReader(SecretReaderBase):
+    """
+    Untyped version of SecretReader.
+    Once all references are cleared, this can be removed
+    """
+
+    def __init__(self, settings: Optional[Mapping] = None) -> None:
+        super().__init__()
+        self.settings = settings
+
+    def read(self, secret: Mapping[str, Any]):
+        return self._read_base(
+            secret=secret,
+            use_vault=self.settings and self.settings.get("vault"),
+        )
+
+    def read_all(self, secret: Mapping[str, Any]):
+        return self._read_all_base(
+            secret=secret,
+            use_vault=self.settings and self.settings.get("vault"),
+        )

--- a/reconcile/utils/secret_reader.py
+++ b/reconcile/utils/secret_reader.py
@@ -36,7 +36,7 @@ class SupportsVaultSettings(Protocol):
     vault: bool
 
 
-class TypedSecretReader():
+class TypedSecretReader:
     def read(self, secret: SupportsSecret) -> dict[str, str]:
         raise NotImplementedError()
 
@@ -60,6 +60,7 @@ class VaultSecretReader(TypedSecretReader):
     """
     Read secrets from vault via a vault_client
     """
+
     def __init__(self, vault_client: Optional[VaultClient] = None):
         self._vault_client = vault_client
 
@@ -83,7 +84,7 @@ class VaultSecretReader(TypedSecretReader):
             data = self.vault_client.read_all(self._secret_to_dict(secret))
         except Forbidden:
             raise VaultForbidden(
-                f"permission denied reading vault secret " f'at {secret.path}'
+                f"permission denied reading vault secret " f"at {secret.path}"
             )
         except vault.SecretNotFound as e:
             raise SecretNotFound(*e.args) from e
@@ -94,6 +95,7 @@ class ConfigSecretReader(TypedSecretReader):
     """
     Read secrets from a config file
     """
+
     def read(self, secret: SupportsSecret) -> dict[str, str]:
         try:
             data = config.read(self._secret_to_dict(secret))
@@ -109,7 +111,9 @@ class ConfigSecretReader(TypedSecretReader):
         return data
 
 
-def create_secret_reader(settings: Optional[SupportsVaultSettings]) -> TypedSecretReader:
+def create_secret_reader(
+    settings: Optional[SupportsVaultSettings],
+) -> TypedSecretReader:
     """
     This function could be used in an integrations run() function to instantiate a
     TypedSecretReader.
@@ -120,7 +124,7 @@ def create_secret_reader(settings: Optional[SupportsVaultSettings]) -> TypedSecr
 class SecretReader:
     """
     Read secrets from either Vault or a config file.
-    
+
     This class is untyped and we try to eliminate it across our codebase.
     Consider using create_secret_reader() instead.
     """

--- a/reconcile/utils/secret_reader.py
+++ b/reconcile/utils/secret_reader.py
@@ -30,24 +30,6 @@ class SupportsSecret(Protocol):
 
 class TypedSecretReader(ABC):
     @abstractmethod
-    def read(self, secret: Mapping[str, Any]) -> dict[str, str]:
-        """
-        Kept to stay backwards compatible with to-be deprecated
-        SecretReader. Once SecretReader is not used, we can
-        remove this.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def read_all(self, secret: Mapping[str, Any]) -> dict[str, str]:
-        """
-        Kept to stay backwards compatible with to-be deprecated
-        SecretReader. Once SecretReader is not used, we can
-        remove this.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
     def _read(
         self, path: str, field: str, format: Optional[str], version: Optional[int]
     ) -> dict[str, str]:
@@ -58,6 +40,32 @@ class TypedSecretReader(ABC):
         self, path: str, field: str, format: Optional[str], version: Optional[int]
     ) -> dict[str, str]:
         raise NotImplementedError()
+
+    def read(self, secret: Mapping[str, Any]) -> dict[str, str]:
+        """
+        Kept to stay backwards compatible with to-be deprecated
+        SecretReader. Once SecretReader is not used, we can
+        remove this.
+        """
+        return self._read(
+            path=secret.get("path"),
+            field=secret.get("field"),
+            format=secret.get("format"),
+            version=secret.get("version"),
+        )
+
+    def read_all(self, secret: Mapping[str, Any]) -> dict[str, str]:
+        """
+        Kept to stay backwards compatible with to-be deprecated
+        SecretReader. Once SecretReader is not used, we can
+        remove this.
+        """
+        return self._read_all(
+            path=secret.get("path"),
+            field=secret.get("field"),
+            format=secret.get("format"),
+            version=secret.get("version"),
+        )
 
     def typed_read(self, secret: SupportsSecret) -> dict[str, str]:
         return self._read(
@@ -120,18 +128,6 @@ class VaultSecretReader(TypedSecretReader):
             self._vault_client = VaultClient()
         return self._vault_client
 
-    def read(self, secret: Mapping[str, Any]) -> dict[str, str]:
-        """
-        This method is to be deprecated and will not be implemented.
-        """
-        raise NotImplementedError()
-
-    def read_all(self, secret: Mapping[str, Any]) -> dict[str, str]:
-        """
-        This method is to be deprecated and will not be implemented.
-        """
-        raise NotImplementedError()
-
     @retry()
     def _read_all(
         self, path: str, field: str, format: Optional[str], version: Optional[int]
@@ -175,18 +171,6 @@ class ConfigSecretReader(TypedSecretReader):
     """
     Read secrets from a config file
     """
-
-    def read(self, secret: Mapping[str, Any]) -> dict[str, str]:
-        """
-        This method is to be deprecated and will not be implemented.
-        """
-        raise NotImplementedError()
-
-    def read_all(self, secret: Mapping[str, Any]) -> dict[str, str]:
-        """
-        This method is to be deprecated and will not be implemented.
-        """
-        raise NotImplementedError()
 
     def _read(
         self, path: str, field: str, format: Optional[str], version: Optional[int]
@@ -325,19 +309,3 @@ class SecretReader(TypedSecretReader):
                 raise SecretNotFound(*e.args) from e
 
         return data
-
-    def read(self, secret: Mapping[str, Any]):
-        return self._read(
-            path=secret.get("path"),
-            field=secret.get("field"),
-            format=secret.get("format"),
-            version=secret.get("version"),
-        )
-
-    def read_all(self, secret: Mapping[str, Any]):
-        return self._read_all(
-            path=secret.get("path"),
-            field=secret.get("field"),
-            format=secret.get("format"),
-            version=secret.get("version"),
-        )

--- a/reconcile/utils/secret_reader.py
+++ b/reconcile/utils/secret_reader.py
@@ -1,3 +1,4 @@
+from abc import ABC, abstractmethod
 from typing import Any, Mapping, Optional, Protocol
 
 from hvac.exceptions import Forbidden
@@ -36,10 +37,12 @@ class SupportsVaultSettings(Protocol):
     vault: bool
 
 
-class TypedSecretReader:
+class TypedSecretReader(ABC):
+    @abstractmethod
     def read(self, secret: SupportsSecret) -> dict[str, str]:
         raise NotImplementedError()
 
+    @abstractmethod
     def read_all(self, secret: SupportsSecret) -> dict[str, str]:
         raise NotImplementedError()
 

--- a/reconcile/utils/secret_reader.py
+++ b/reconcile/utils/secret_reader.py
@@ -39,8 +39,8 @@ class SupportsVaultSettings(Protocol):
 class SecretReaderBase:
     """Read secrets from either Vault or a config file."""
 
-    def __init__(self) -> None:
-        self._vault_client: Optional[VaultClient] = None
+    def __init__(self, vault_client: Optional[VaultClient] = None) -> None:
+        self._vault_client: Optional[VaultClient] = vault_client
 
     @property
     def vault_client(self):
@@ -121,8 +121,12 @@ class TypedSecretReader(SecretReaderBase):
     the SecretReaderBase class.
     """
 
-    def __init__(self, settings: Optional[SupportsVaultSettings]):
-        super().__init__()
+    def __init__(
+        self,
+        settings: Optional[SupportsVaultSettings],
+        vault_client: Optional[VaultClient] = None,
+    ):
+        super().__init__(vault_client=vault_client)
         self._use_vault = settings and settings.vault
 
     def _to_secret_dict(self, secret: SupportsSecret) -> dict[str, Any]:

--- a/tools/cli_commands/test/test_gpg_encrypt.py
+++ b/tools/cli_commands/test/test_gpg_encrypt.py
@@ -13,9 +13,7 @@ from tools.cli_commands.gpg_encrypt import (
 )
 
 
-def craft_command(
-    command_data: GPGEncryptCommandData, secret: Mapping[str, str]
-) -> GPGEncryptCommand:
+def craft_command(command_data: GPGEncryptCommandData, secret: Mapping[str, str]):
     secret_reader = MagicMock(spec=SecretReader)
     secret_reader.read_all = MagicMock()
     secret_reader.read_all.side_effect = [secret]


### PR DESCRIPTION
New integration for CNA should be fully typed. To achieve this, we must have a fully typed version of `SecretReader`.
This PR:

- Adds `TypedSecretReader`
- Adds `AppInterfaceSettings` query for vault settings for `TypedSecretReader`.
- Renames SMPT Settings, because a query name must be unique across our codebase.

The core idea is that `SecretReader` and `TypedSecretReader` both have the same base class. The base class is compatible with untyped `VaultClient`. The new `TypedSecretReader` abides to dependency inversion as agreed in recent discussions for new library components.

The new `SecretReader` is to be instantiated at integration `run()` level and injected into any sub-functions / classes, e.g.:

```python
from reconcile.typed_queries.app_interface_vault_settings import query as get_app_interface_vault_settings
from reconcile.utils.secret_reader import create_secret_reader

def run():
    settings = get_app_interface_vault_settings()
    secret_reader = create_secret_reader(settings=settings)
    ...
```

**Test**

- running dashdotdb-dvo locally (as an example that uses the untyped `SecretReader`)
- running new CNA integration locally with `TypedSecretReader` (new integration not part of this PR)