### PR TITLE
[change-type] qontract-cli change-type tester

### DIFF
--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -219,15 +219,16 @@ class BundleFileChange:
         return not any(self.uncovered_changes())
 
 
-def parse_resource_file_content(content: Optional[Any]) -> Any:
+def parse_resource_file_content(content: Optional[Any]) -> Tuple[Any, Optional[str]]:
     if content:
         try:
-            return anymarkup.parse(content, force_types=None)
+            data = anymarkup.parse(content, force_types=None)
+            return data, data.get("$schema")
         except Exception:
             # not parsable content - we will just deal with the plain content
-            return content
+            return content, None
     else:
-        return None
+        return None, None
 
 
 def create_bundle_file_change(
@@ -248,8 +249,8 @@ def create_bundle_file_change(
 
     # try to parse the content if a resourcefile has a schema
     if file_type == BundleFileType.RESOURCEFILE and schema:
-        old_file_content = parse_resource_file_content(old_file_content)
-        new_file_content = parse_resource_file_content(new_file_content)
+        old_file_content, _ = parse_resource_file_content(old_file_content)
+        new_file_content, _ = parse_resource_file_content(new_file_content)
     diffs = extract_diffs(
         schema=schema,
         old_file_content=old_file_content,

--- a/reconcile/change_owners/tester.py
+++ b/reconcile/change_owners/tester.py
@@ -1,0 +1,238 @@
+from dataclasses import dataclass
+from typing import Optional
+import os
+import sys
+
+import yaml
+import pygments
+import pygments.lexers
+from pygments.token import Name
+from pygments.filter import Filter
+from pygments.formatters.terminal256 import (
+    TerminalTrueColorFormatter,
+)
+import jsonpath_ng
+
+from reconcile.change_owners.change_types import (
+    BundleFileChange,
+    ChangeTypeProcessor,
+    build_change_type_processor,
+    parse_resource_file_content,
+    FileRef,
+    BundleFileType,
+)
+from reconcile.change_owners.self_service_roles import (
+    change_type_contexts_for_self_service_roles,
+)
+from reconcile.gql_definitions.change_owners.queries.self_service_roles import RoleV1
+from reconcile.gql_definitions.change_owners.queries import (
+    change_types,
+    self_service_roles,
+)
+
+from reconcile.utils import gql
+
+
+def test_change_type_in_context(
+    change_type_name: str, role_name: str, app_interface_path: str
+):
+    print(f"Sections marked with '{SELF_SERVICABLE_MARKER}' are self serviceable\n\n")
+    change_type_processor = get_changetype_processor_by_name(change_type_name)
+    if change_type_processor is None:
+        print(f"Change type {change_type_name} not found")
+        sys.exit(1)
+
+    role = get_self_service_role_by_name(role_name)
+    if role is None:
+        print(f"Role {role_name} not found")
+        sys.exit(1)
+
+    app_interface_path = os.path.expanduser(app_interface_path)
+    if not os.path.isdir(app_interface_path):
+        print(f"app-interface directory {app_interface_path} not found")
+        sys.exit(1)
+    if not os.path.isfile(f"{app_interface_path}/.env"):
+        print(
+            f"app-interface directory {app_interface_path} does not contain a .env file. "
+            "maybe not an app-interface dir?"
+        )
+        sys.exit(1)
+    ai_repo = AppInterfaceRepo(app_interface_path)
+
+    bundle_files = ai_repo.relevant_bundle_files_for_change_type(
+        role, change_type_processor
+    )
+
+    change_type_contexts = change_type_contexts_for_self_service_roles(
+        roles=[role],
+        change_type_processors=[change_type_processor],
+        bundle_changes=bundle_files,
+    )
+
+    for file, ctx in change_type_contexts:
+        self_serviceable_paths = change_type_processor.allowed_changed_paths(
+            file_ref=file.fileref, file_content=file.new, ctx=ctx
+        )
+        if self_serviceable_paths:
+            print_annotated_file(file, self_serviceable_paths)
+
+
+SELF_SERVICABLE_MARKER = "self-serviceable"
+
+
+def print_annotated_file(file: BundleFileChange, self_serviceable_paths: list[str]):
+    # add a markers to the data to indicate which parts are self serviceable
+    for path_expression in [jsonpath_ng.parse(p) for p in self_serviceable_paths]:
+        for self_serviceable_data in path_expression.find(file.new):
+            self_serviceable_data.full_path.update(
+                file.new, {SELF_SERVICABLE_MARKER: self_serviceable_data.value}
+            )
+
+    print(f"File - {file.fileref.path}\n")
+    lexer = pygments.lexers.YamlLexer()
+    lexer.add_filter(SelfServiceableHighlighter(SELF_SERVICABLE_MARKER))
+    pygments.highlight(
+        yaml.dump(file.new, sort_keys=False),
+        lexer,
+        TerminalTrueColorFormatter(),
+        sys.stdout,
+    )
+    print("\n=======================================\n\n")
+
+
+@dataclass
+class AppInterfaceRepo:
+
+    root_dir: str
+
+    def data_dir(self) -> str:
+        return f"{self.root_dir}/data"
+
+    def resource_dir(self) -> str:
+        return f"{self.root_dir}/resources"
+
+    def relevant_bundle_files_for_change_type(
+        self,
+        role: RoleV1,
+        ctp: ChangeTypeProcessor,
+    ) -> list[BundleFileChange]:
+        bundle_files = []
+        processed_schemas = set()
+        for c in ctp.change_type.changes:
+            if (
+                c.change_schema
+                and c.change_schema != ctp.change_type.context_schema
+                and c.change_schema not in processed_schemas
+            ):
+                # the changes can happen in other files, not the one related
+                # under RoleV1.self_service
+                bundle_files.extend(self.bundle_files_with_schemas(c.change_schema))
+                processed_schemas.add(c.change_schema)
+            elif (
+                c.change_schema is None
+                or c.change_schema == ctp.change_type.context_schema
+            ):
+                # the change happens in the self_service related files
+                for ssc in role.self_service or []:
+                    for df in ssc.datafiles or []:
+                        bundle_files.append(
+                            self.bundle_file_for_path(BundleFileType.DATAFILE, df.path)
+                        )
+                    for rf_path in ssc.resources or []:
+                        bundle_files.append(
+                            self.bundle_file_for_path(
+                                BundleFileType.RESOURCEFILE, rf_path
+                            )
+                        )
+        return bundle_files
+
+    def bundle_files_with_schemas(self, schema: str) -> list[BundleFileChange]:
+        datafiles = []
+        for root, _, files in os.walk(self.data_dir()):
+            for file in files:
+                if file.endswith(".yml") or file.endswith(".yaml"):
+                    filepath = os.path.join(root, file)
+                    with open(filepath, "r") as f:
+                        parsed_yaml = yaml.safe_load(f)
+                        if parsed_yaml.get("$schema") == schema:
+                            relative_path = filepath[len(self.data_dir()) :]
+                            datafiles.append(
+                                self.bundle_file_for_path(
+                                    BundleFileType.DATAFILE, relative_path
+                                )
+                            )
+        return datafiles
+
+    def bundle_file_for_path(
+        self, file_type: BundleFileType, path: str
+    ) -> BundleFileChange:
+        if file_type == BundleFileType.DATAFILE:
+            with open(f"{self.data_dir()}{path}", "r") as f:
+                parsed_yaml = yaml.safe_load(f)
+                return BundleFileChange(
+                    fileref=FileRef(
+                        path=path,
+                        file_type=file_type,
+                        schema=parsed_yaml.get("$schema"),
+                    ),
+                    old=parsed_yaml,
+                    new=parsed_yaml,
+                    diff_coverage=[],
+                )
+        elif file_type == BundleFileType.RESOURCEFILE:
+            with open(f"{self.resource_dir()}{path}", "r") as f:
+                content = f.read()
+                parsed_content, schema = parse_resource_file_content(content)
+                return BundleFileChange(
+                    fileref=FileRef(
+                        path=path,
+                        file_type=file_type,
+                        schema=schema,
+                    ),
+                    old=parsed_content,
+                    new=parsed_content,
+                    diff_coverage=[],
+                )
+        else:
+            raise ValueError(f"Unknown file type {file_type}")
+
+
+class SelfServiceableHighlighter(Filter):
+    """
+    This pygments filter is used to highlight the self service marker
+    in a structured file.
+    """
+
+    def __init__(self, self_serviceable_marker: str):
+        Filter.__init__(self)
+        self.self_serviceable_marker = self_serviceable_marker
+
+    def filter(self, _, stream):
+        for ttype, value in stream:
+            if value != self.self_serviceable_marker:
+                ttype = Name
+            yield ttype, value
+
+
+def get_changetype_processor_by_name(
+    change_type_name: str,
+) -> Optional[ChangeTypeProcessor]:
+    result = change_types.query(
+        gql.get_api().query, variables={"name": change_type_name}
+    ).change_types
+    if result:
+        return build_change_type_processor(result[0])
+    else:
+        return None
+
+
+def get_self_service_role_by_name(
+    role_name: str,
+) -> Optional[RoleV1]:
+    result = self_service_roles.query(
+        gql.get_api().query, variables={"name": role_name}
+    ).roles
+    if result:
+        return result[0]
+    else:
+        return None

--- a/reconcile/gql_definitions/change_owners/queries/change_types.gql
+++ b/reconcile/gql_definitions/change_owners/queries/change_types.gql
@@ -1,7 +1,7 @@
 # qenerate: plugin=pydantic_v1
 
-query ChangeTypes {
-  change_types: change_types_v1 {
+query ChangeTypes($name: String) {
+  change_types: change_types_v1(name: $name) {
     name
     contextType
     contextSchema

--- a/reconcile/gql_definitions/change_owners/queries/change_types.py
+++ b/reconcile/gql_definitions/change_owners/queries/change_types.py
@@ -17,8 +17,8 @@ from pydantic import (  # noqa: F401 # pylint: disable=W0611
 
 
 DEFINITION = """
-query ChangeTypes {
-  change_types: change_types_v1 {
+query ChangeTypes($name: String) {
+  change_types: change_types_v1(name: $name) {
     name
     contextType
     contextSchema

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
@@ -1,7 +1,7 @@
 # qenerate: plugin=pydantic_v1
 
-query SelfServiceRolesQuery {
-  roles: roles_v1 {
+query SelfServiceRolesQuery($name: String) {
+  roles: roles_v1(name: $name) {
     name
     path
     self_service {

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
@@ -17,8 +17,8 @@ from pydantic import (  # noqa: F401 # pylint: disable=W0611
 
 
 DEFINITION = """
-query SelfServiceRolesQuery {
-  roles: roles_v1 {
+query SelfServiceRolesQuery($name: String) {
+  roles: roles_v1(name: $name) {
     name
     path
     self_service {

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -2054,6 +2054,16 @@
                                         "ofType": null
                                     },
                                     "defaultValue": null
+                                },
+                                {
+                                    "name": "name",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
                                 }
                             ],
                             "type": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -395,3 +395,6 @@ ignore_missing_imports = True
 
 [mypy-jsonpath_ng.*]
 ignore_missing_imports = True
+
+[mypy-pygments.*]
+ignore_missing_imports = True

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2,6 +2,7 @@ import base64
 import json
 from operator import itemgetter
 import re
+import os
 import sys
 from contextlib import suppress
 from datetime import datetime
@@ -1919,6 +1920,21 @@ def gpg_encrypt(
             target_user=for_user,
         ),
     ).execute()
+
+
+@root.command()
+@click.option("--change-type-name")
+@click.option("--role-name")
+@click.option(
+    "--app-interface-path",
+    help="filesystem path to a local app-interface repo",
+    default=os.environ.get("APP_INTERFACE_PATH", None),
+)
+def test_change_type(change_type_name: str, role_name: str, app_interface_path: str):
+    from reconcile.change_owners import tester
+
+    # tester.test_change_type(change_type_name, datafile_path)
+    tester.test_change_type_in_context(change_type_name, role_name, app_interface_path)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
adds a qontract-cli command for change-type testing

```
qontract-cli test-change-type --change-type-name aws-account-owner --role-name app-sre --app-interface-path ~/dev/service/app-interface
```

role and change-type are loaded from a qontract-server. datafiles and resources are loaded from disk right now because we don't have a way to load those files in full from qontract-server

part of: https://issues.redhat.com/browse/APPSRE-6460
depends on: https://github.com/app-sre/qontract-schemas/pull/276