### PR TITLE
Revert "OC client: only use Project kind if it is supported"

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 import tempfile
-import threading
 import time
 from contextlib import suppress
 from datetime import datetime
@@ -261,21 +260,17 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
         # calling get_version to check if cluster is reachable
         if not local:
             self.get_version()
-
-        self.api_resources_lock = threading.RLock()
+        self.init_projects = init_projects
+        if self.init_projects:
+            self.projects = [
+                p["metadata"]["name"]
+                for p in self.get_all("Project.project.openshift.io")["items"]
+            ]
         self.init_api_resources = init_api_resources
         if self.init_api_resources:
             self.api_resources = self.get_api_resources()
         else:
             self.api_resources = None
-
-        self.init_projects = init_projects
-        if self.init_projects:
-            if self.is_kind_supported("Project"):
-                kind = "Project.project.openshift.io"
-            else:
-                kind = "Namespace"
-            self.projects = [p["metadata"]["name"] for p in self.get_all(kind)["items"]]
 
         self.slow_oc_reconcile_threshold = float(
             os.environ.get("SLOW_OC_RECONCILE_THRESHOLD", 600)
@@ -459,10 +454,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
             return name in self.projects
 
         try:
-            if self.is_kind_supported("Project"):
-                self.get(None, "Project.project.openshift.io", name)
-            else:
-                self.get(None, "Namespace", name)
+            self.get(None, "Project.project.openshift.io", name)
         except StatusCodeError as e:
             if "NotFound" in str(e):
                 return False
@@ -472,10 +464,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
 
     @OCDecorators.process_reconcile_time
     def new_project(self, namespace):
-        if self.is_kind_supported("Project"):
-            cmd = ["new-project", namespace]
-        else:
-            cmd = ["create", "namespace", namespace]
+        cmd = ["new-project", namespace]
         try:
             self._run(cmd)
         except StatusCodeError as e:
@@ -488,10 +477,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
 
     @OCDecorators.process_reconcile_time
     def delete_project(self, namespace):
-        if self.is_kind_supported("Project"):
-            cmd = ["delete", "project", namespace]
-        else:
-            cmd = ["delete", "namespace", namespace]
+        cmd = ["delete", "project", namespace]
         self._run(cmd)
 
         # This return will be removed by the last decorator
@@ -543,12 +529,9 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
     def get_api_resources(self):
         # oc api-resources only has name or wide output
         # and we need to get the KIND, which is the last column
-        with self.api_resources_lock:
-            if not self.api_resources:
-                cmd = ["api-resources", "--no-headers"]
-                results = self._run(cmd).decode("utf-8").split("\n")
-                self.api_resources = [r.split()[-1] for r in results]
-        return self.api_resources
+        cmd = ["api-resources", "--no-headers"]
+        results = self._run(cmd).decode("utf-8").split("\n")
+        return [r.split()[-1] for r in results]
 
     def get_version(self):
         # this is actually a 10 second timeout, because: oc reasons
@@ -957,7 +940,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
         if "." in kind:
             # self.api_resources contains only the short kind names
             kind = kind.split(".", 1)[0]
-        return self.get_api_resources() and kind in self.get_api_resources()
+        return self.api_resources and kind in self.api_resources
 
 
 class OCNative(OCDeprecated):
@@ -987,26 +970,22 @@ class OCNative(OCDeprecated):
 
         if server:
             self.client = self._get_client(server, token)
-            self.api_kind_version = self.get_api_kind_version()
+            self.api_kind_version = self.get_api_resources()
         else:
             raise Exception("A method relies on client/api_kind_version to be set")
 
         self.object_clients = {}
-
+        self.init_projects = init_projects
+        if self.init_projects:
+            self.projects = [
+                p["metadata"]["name"]
+                for p in self.get_all("Project.project.openshift.io")["items"]
+            ]
         self.init_api_resources = init_api_resources
-        self.api_resources_lock = threading.RLock()
         if self.init_api_resources:
             self.api_resources = self.api_kind_version.keys()
         else:
             self.api_resources = None
-
-        self.init_projects = init_projects
-        if self.init_projects:
-            if self.is_kind_supported("Project"):
-                kind = "Project.project.openshift.io"
-            else:
-                kind = "Namespace"
-            self.projects = [p["metadata"]["name"] for p in self.get_all(kind)["items"]]
 
     @retry(exceptions=(ServerTimeoutError, InternalServerError, ForbiddenError))
     def _get_client(self, server, token):
@@ -1074,7 +1053,7 @@ class OCNative(OCDeprecated):
 
     # this function returns a kind:apigroup/version map for each kind on the
     # cluster
-    def get_api_kind_version(self):
+    def get_api_resources(self):
         c_res = self.client.resources
         # this returns a prefix:apis map
         api_prefix = c_res.parse_api_groups(request_resources=False, update=True)
@@ -1113,12 +1092,6 @@ class OCNative(OCDeprecated):
                                 kind, kind_groupversion, r.group_version, obj.preferred
                             )
         return kind_groupversion
-
-    def get_api_resources(self):
-        with self.api_resources_lock:
-            if not self.api_resources:
-                self.api_resources = self.get_api_kind_version().keys()
-        return self.api_resources
 
     @retry(max_attempts=5, exceptions=(ServerTimeoutError))
     def get_items(self, kind, **kwargs):
@@ -1220,7 +1193,7 @@ class OCNative(OCDeprecated):
             except StatusCodeError:
                 return False
         else:
-            return kind in self.get_api_resources()
+            return kind in self.api_resources
 
 
 OCClient = Union[OCNative, OCDeprecated]


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#2866

The thread locks that were introduces seem to be causing issues with the kubernetes client, used by the OCNative client. The kubernetes client creates cache files in /tmp that contains the resource kinds, verbs and versions that are available on clusters. Right when these changes were introduced we began seeing errors such as

```
[openshift-serviceaccount-tokens] load cache error: Expecting ',' delimiter: line 1 column 40958 (char 40957)
```

Upon closer inspection the json files are sometimes getting corrupted. This happens almost on every run, in at least one cache file (there is one per cluster targetted during the run)

I'm hoping reverting this MR will clear the errors. If not we can re-introduce the changes

ref.: https://coreos.slack.com/archives/GGC2A0MS8/p1666118145834499?thread_ts=1666113582.323259&cid=GGC2A0MS8