### PR TITLE
APPSRE-4645: Add more RDS pending modifications for which to skip Terraform apply

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 
 .vscode
 .tox
-.pytest_cache
+.*_cache
 .eggs
 .coverage
 build


### PR DESCRIPTION
The Pull Request https://github.com/app-sre/qontract-reconcile/pull/2254 brought about an ability to _skip_ an attempt to perform a Terraform **apply** when the RDS database settings had been modified, and the `apply_immediately` property had not been set to `true`.

The initial implementation took care of cases where the underlying database version (the engine) had been changed, for example, as part of routine maintenance or needing a specific version.

This change expands the current implementation beyond only detecting that there has been a change to **`engine_version`** resource attribute on the Terraform's side (or **EngineVersion** as per the AWS' API) and adds several commonly changed [settings](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.DBInstance.Modifying.html#USER_ModifyInstance.Settings) that can be deferred to be applied only during the next maintenance window.

Related: [APPSRE-4645](https://issues.redhat.com/browse/APPSRE-4645)

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>