### PR TITLE
create orgs first and delete orgs afterward

### DIFF
--- a/reconcile/glitchtip/reconciler.py
+++ b/reconcile/glitchtip/reconciler.py
@@ -240,11 +240,6 @@ class GlitchtipReconciler:
         current: Sequence[Organization],
         desired: Iterable[Organization],
     ) -> None:
-        for org in set(current).difference(desired):
-            logging.info(["delete_organization", org.name, self.client.host])
-            if not self.dry_run:
-                self.client.delete_organization(slug=org.slug)
-
         for desired_org in desired:
             if desired_org not in current:
                 logging.info(
@@ -276,3 +271,10 @@ class GlitchtipReconciler:
                 current_projects=current_org.projects,
                 desired_projects=desired_org.projects,
             )
+
+        # remove obsolete organizations after creating/updating other ones. this avoids a chicken-egg problem when onboarding a new glitchtip instance.
+        # the automation user must have the owner role in an existing organization (bootstrap organization) but this one is maybe not app-interface managed
+        for org in set(current).difference(desired):
+            logging.info(["delete_organization", org.name, self.client.host])
+            if not self.dry_run:
+                self.client.delete_organization(slug=org.slug)


### PR DESCRIPTION
Avoid a chicken-egg problem. See https://ci.int.devshift.net/job/service-app-interface-gl-pr-check/173519/app-interface_20JSON_20validation/

To grant the automation user proper glitchtip permission, during the onboarding of a new glitchtip instance, the automation user must be added to a bootstrap organization manually (`app-sre` in this example). But this organization is maybe not app-interface managed and therefore we have to remove it after creating other ones.

```
[2022-10-20 14:05:33] [INFO] [reconciler.py:reconcile:244] - ['delete_organization', 'app-sre', 'https://glitchtip.stage.devshift.net']
[2022-10-20 14:05:33] [INFO] [reconciler.py:reconcile:250] - ['create_organization', 'app-sre-stage', 'https://glitchtip.stage.devshift.net']
```