### PR TITLE
smtp-client secret_reader new function

### DIFF
--- a/reconcile/utils/smtp_client.py
+++ b/reconcile/utils/smtp_client.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 
 from sretoolbox.utils import retry
 
-from reconcile.utils.secret_reader import SecretReader, SupportsSecret
+from reconcile.utils.secret_reader import SecretReaderBase, SupportsSecret
 
 DEFAULT_SMTP_TIMEOUT = 30
 
@@ -22,7 +22,7 @@ class SmtpServerConnectionInfo(BaseModel):
 
 
 def get_smtp_server_connection(
-    secret_reader: SecretReader, secret: SupportsSecret
+    secret_reader: SecretReaderBase, secret: SupportsSecret
 ) -> SmtpServerConnectionInfo:
     """Retrieve SMTP credentials from config or vault.
 
@@ -30,15 +30,7 @@ def get_smtp_server_connection(
     - secret_reader: a SecretReader instance
     - secret: a 'secret' class instance which implements the SupportsSecret protocol. E.g. VaultSecret (reconcile.gql_definitions.common.smtp_client_settings.SmtpSettingsV1.credentials)
     """
-    # This will change later when SecretReader fully supports 'SupportsSecret'
-    data = secret_reader.read_all(
-        {
-            "path": secret.path,
-            "field": secret.field,
-            "format": secret.q_format,
-            "version": secret.version,
-        }
-    )
+    data = secret_reader.read_all_secret(secret)
     return SmtpServerConnectionInfo(**data)
 
 


### PR DESCRIPTION
`SecretReader` now supports `SupportsSecret` -> we can use that in smtp-client.