### PR TITLE
[change-owners] change-type inheritance

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -22,7 +22,7 @@ from reconcile.change_owners.change_types import (
     BundleFileType,
     ChangeTypeProcessor,
     create_bundle_file_change,
-    build_change_type_processor,
+    init_change_type_processors,
 )
 from reconcile.change_owners.self_service_roles import (
     cover_changes_with_self_service_roles,
@@ -75,7 +75,7 @@ def fetch_self_service_roles(gql_api: gql.GqlApi) -> list[RoleV1]:
 
 def fetch_change_type_processors(gql_api: gql.GqlApi) -> list[ChangeTypeProcessor]:
     change_type_list = change_types.query(gql_api.query).change_types or []
-    return [build_change_type_processor(ct) for ct in change_type_list]
+    return list(init_change_type_processors(change_type_list).values())
 
 
 def fetch_bundle_changes(comparison_sha: str) -> list[BundleFileChange]:

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -214,7 +214,7 @@ def write_coverage_report_to_stdout(change_decisions: list[ChangeDecision]) -> N
                         "file": d.file.path,
                         "schema": d.file.schema,
                         "changed path": d.diff.path,
-                        "change type": ctx.change_type_processor.change_type.name,
+                        "change type": ctx.change_type_processor.name,
                         "context": ctx.context,
                         "disabled": str(ctx.disabled),
                     }

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -401,8 +401,7 @@ def init_change_type_processors(
         processors[change_type.name] = build_change_type_processor(change_type)
 
     # detect cycles
-    cycles = list(networkx.simple_cycles(change_type_graph))
-    if cycles:
+    if cycles := list(networkx.simple_cycles(change_type_graph)):
         raise ChangeTypeInheritanceCycleError(
             "Cycles detected in change-type inheritance", cycles
         )

--- a/reconcile/change_owners/self_service_roles.py
+++ b/reconcile/change_owners/self_service_roles.py
@@ -56,13 +56,11 @@ def change_type_contexts_for_self_service_roles(
     change_type_contexts = []
     for bc in bundle_changes:
         for ctp in change_type_processors:
-            datafile_refs = bc.extract_context_file_refs(ctp.change_type)
+            datafile_refs = bc.extract_context_file_refs(ctp)
             for df_ref in datafile_refs:
                 # if the context file is bound with the change type in
                 # a role, build a changetypecontext
-                for role in role_lookup[
-                    (df_ref.file_type, df_ref.path, ctp.change_type.name)
-                ]:
+                for role in role_lookup[(df_ref.file_type, df_ref.path, ctp.name)]:
                     approvers = [
                         Approver(u.org_username, u.tag_on_merge_requests)
                         for u in role.users or []

--- a/reconcile/change_owners/tester.py
+++ b/reconcile/change_owners/tester.py
@@ -118,20 +118,17 @@ class AppInterfaceRepo:
     ) -> list[BundleFileChange]:
         bundle_files = []
         processed_schemas = set()
-        for c in ctp.change_type.changes:
+        for c in ctp.changes:
             if (
                 c.change_schema
-                and c.change_schema != ctp.change_type.context_schema
+                and c.change_schema != ctp.context_schema
                 and c.change_schema not in processed_schemas
             ):
                 # the changes can happen in other files, not the one related
                 # under RoleV1.self_service
                 bundle_files.extend(self.bundle_files_with_schemas(c.change_schema))
                 processed_schemas.add(c.change_schema)
-            elif (
-                c.change_schema is None
-                or c.change_schema == ctp.change_type.context_schema
-            ):
+            elif c.change_schema is None or c.change_schema == ctp.context_schema:
                 # the change happens in the self_service related files
                 for ssc in role.self_service or []:
                     for df in ssc.datafiles or []:

--- a/reconcile/change_owners/tester.py
+++ b/reconcile/change_owners/tester.py
@@ -13,10 +13,10 @@ from pygments.formatters.terminal256 import (
 )
 import jsonpath_ng
 
+from reconcile.change_owners.change_owners import fetch_change_type_processors
 from reconcile.change_owners.change_types import (
     BundleFileChange,
     ChangeTypeProcessor,
-    build_change_type_processor,
     parse_resource_file_content,
     FileRef,
     BundleFileType,
@@ -26,7 +26,6 @@ from reconcile.change_owners.self_service_roles import (
 )
 from reconcile.gql_definitions.change_owners.queries.self_service_roles import RoleV1
 from reconcile.gql_definitions.change_owners.queries import (
-    change_types,
     self_service_roles,
 )
 
@@ -214,13 +213,8 @@ class SelfServiceableHighlighter(Filter):
 def get_changetype_processor_by_name(
     change_type_name: str,
 ) -> Optional[ChangeTypeProcessor]:
-    result = change_types.query(
-        gql.get_api().query, variables={"name": change_type_name}
-    ).change_types
-    if result:
-        return build_change_type_processor(result[0])
-    else:
-        return None
+    processors = fetch_change_type_processors(gql.get_api())
+    return next((p for p in processors if p.name == change_type_name), None)
 
 
 def get_self_service_role_by_name(

--- a/reconcile/gql_definitions/change_owners/queries/change_types.gql
+++ b/reconcile/gql_definitions/change_owners/queries/change_types.gql
@@ -17,5 +17,8 @@ query ChangeTypes($name: String) {
         jsonPathSelectors
       }
     }
+    inherit {
+      name
+    }
   }
 }

--- a/reconcile/gql_definitions/change_owners/queries/change_types.py
+++ b/reconcile/gql_definitions/change_owners/queries/change_types.py
@@ -34,6 +34,9 @@ query ChangeTypes($name: String) {
         jsonPathSelectors
       }
     }
+    inherit {
+      name
+    }
   }
 }
 """
@@ -68,6 +71,14 @@ class ChangeTypeChangeDetectorJsonPathProviderV1(ChangeTypeChangeDetectorV1):
         extra = Extra.forbid
 
 
+class ChangeTypeV1_ChangeTypeV1(BaseModel):
+    name: str = Field(..., alias="name")
+
+    class Config:
+        smart_union = True
+        extra = Extra.forbid
+
+
 class ChangeTypeV1(BaseModel):
     name: str = Field(..., alias="name")
     context_type: str = Field(..., alias="contextType")
@@ -76,6 +87,7 @@ class ChangeTypeV1(BaseModel):
     changes: list[
         Union[ChangeTypeChangeDetectorJsonPathProviderV1, ChangeTypeChangeDetectorV1]
     ] = Field(..., alias="changes")
+    inherit: Optional[list[ChangeTypeV1_ChangeTypeV1]] = Field(..., alias="inherit")
 
     class Config:
         smart_union = True

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -3881,6 +3881,11 @@
                         },
                         {
                             "kind": "OBJECT",
+                            "name": "GabiInstance_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
                             "name": "SaasFile_v2",
                             "ofType": null
                         },
@@ -8198,7 +8203,13 @@
                         }
                     ],
                     "inputFields": null,
-                    "interfaces": [],
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
                     "enumValues": null,
                     "possibleTypes": null
                 },
@@ -9744,6 +9755,26 @@
                                 "kind": "SCALAR",
                                 "name": "Boolean",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "inherit",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "ChangeType_v1",
+                                        "ofType": null
+                                    }
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/test/fixtures/change_owners/changetype_cluster_owner.yml
+++ b/reconcile/test/fixtures/change_owners/changetype_cluster_owner.yml
@@ -5,6 +5,8 @@ contextSchema: /openshift/cluster-1.yml
 
 disabled: false
 
+inherit: null
+
 changes:
 - provider: jsonPath
   changeSchema: /openshift/namespace-1.yml

--- a/reconcile/test/fixtures/change_owners/changetype_role_member.yaml
+++ b/reconcile/test/fixtures/change_owners/changetype_role_member.yaml
@@ -6,6 +6,8 @@ contextSchema: /access/roles-1.yml
 
 disabled: false
 
+inherit: null
+
 changes:
 # this changetype covers changes on roles within a user-1 but since it can only
 # be used in the context of role-1 datafiles, we need to declare how to find the

--- a/reconcile/test/fixtures/change_owners/changetype_saas_file.yaml
+++ b/reconcile/test/fixtures/change_owners/changetype_saas_file.yaml
@@ -5,6 +5,8 @@ contextSchema: /app-sre/saas-file-2.yml
 
 disabled: false
 
+inherit: null
+
 changes:
 - provider: jsonPath
   jsonPathSelectors:

--- a/reconcile/test/fixtures/change_owners/changetype_secret_promoter.yaml
+++ b/reconcile/test/fixtures/change_owners/changetype_secret_promoter.yaml
@@ -5,6 +5,8 @@ contextSchema: /openshift/namespace-1.yml
 
 disabled: false
 
+inherit: null
+
 changes:
 - provider: jsonPath
   jsonPathSelectors:

--- a/reconcile/test/test_change_owners_inheritance.py
+++ b/reconcile/test/test_change_owners_inheritance.py
@@ -1,0 +1,177 @@
+from typing import Optional, Sequence
+
+import pytest
+
+from reconcile.gql_definitions.change_owners.queries.change_types import (
+    ChangeTypeChangeDetectorContextSelectorV1,
+    ChangeTypeChangeDetectorJsonPathProviderV1,
+    ChangeTypeChangeDetectorV1,
+    ChangeTypeV1,
+    ChangeTypeV1_ChangeTypeV1,
+)
+
+from reconcile.change_owners.change_types import (
+    BundleFileType,
+    init_change_type_processors,
+    ChangeTypeInheritanceCycleError,
+    ChangeTypeIncompatibleInheritanceError,
+)
+
+
+def build_jsonpath_change(
+    selectors: list[str],
+    schema: Optional[str] = None,
+    context_selector: Optional[str] = None,
+    context_when: Optional[str] = None,
+) -> ChangeTypeChangeDetectorJsonPathProviderV1:
+    if context_selector:
+        context = ChangeTypeChangeDetectorContextSelectorV1(
+            selector=context_selector, when=context_when
+        )
+    else:
+        context = None
+    return ChangeTypeChangeDetectorJsonPathProviderV1(
+        provider="jsonPath",
+        changeSchema=schema,
+        jsonPathSelectors=selectors,
+        context=context,
+    )
+
+
+def build_def_change_type(
+    name: str, inherit: Optional[list[str]] = None
+) -> ChangeTypeV1:
+    return ChangeTypeV1(
+        name=name,
+        contextType=BundleFileType.DATAFILE.value,
+        contextSchema="context-schema",
+        disabled=False,
+        changes=[
+            build_jsonpath_change(
+                schema=f"/schema/change-schema-{name}",
+                selectors=[f"selector.{name}"],
+            )
+        ],
+        inherit=[ChangeTypeV1_ChangeTypeV1(name=i) for i in inherit or []],
+    )
+
+
+def test_change_type_no_inheritance():
+    ct_1 = build_def_change_type("change-type-1")
+    ct_2 = build_def_change_type("change-type-2")
+
+    processors = init_change_type_processors([ct_1, ct_2])
+    assert len(processors) == 2
+
+
+def test_change_type_inheritance_cycle():
+    ct_1 = build_def_change_type("change-type-1", inherit=["change-type-2"])
+    ct_2 = build_def_change_type("change-type-2", inherit=["change-type-3"])
+    ct_3 = build_def_change_type("change-type-3", inherit=["change-type-1"])
+
+    with pytest.raises(ChangeTypeInheritanceCycleError) as e:
+        init_change_type_processors([ct_1, ct_2, ct_3])
+    assert e.value.args[0] == "Cycles detected in change-type inheritance"
+    assert set(e.value.args[1][0]) == {ct_1.name, ct_2.name, ct_3.name}
+
+
+def test_change_type_inheritance_context_schema_mismatch():
+    """
+    a mismatch in context schema in an inheritance chain should be detected
+    """
+    ct_1 = build_def_change_type("change-type-1", inherit=["change-type-2"])
+    ct_1.context_schema = "schema-1"
+    ct_2 = build_def_change_type("change-type-2")
+    ct_2.context_schema = "schema-2"
+
+    with pytest.raises(ChangeTypeIncompatibleInheritanceError):
+        init_change_type_processors([ct_1, ct_2])
+
+
+def test_change_type_inhertiance_no_context_schema():
+    """
+    missing context schema is ok as long as both change types
+    in an inheritance chain miss it
+    """
+    ct_1 = build_def_change_type("change-type-1", inherit=["change-type-2"])
+    ct_1.context_schema = None
+    ct_2 = build_def_change_type("change-type-2")
+    ct_2.context_schema = None
+
+    init_change_type_processors([ct_1, ct_2])
+
+
+def test_change_type_inheritance_context_type_mismatch():
+    """
+    all change types in an inheritance chain must have the same context type
+    """
+    ct_1 = build_def_change_type("change-type-1", inherit=["change-type-2"])
+    ct_2 = build_def_change_type("change-type-2")
+    ct_2.context_type = BundleFileType.RESOURCEFILE.value
+
+    with pytest.raises(ChangeTypeIncompatibleInheritanceError):
+        init_change_type_processors([ct_1, ct_2])
+
+
+def test_change_type_single_level_inheritance():
+    ct_1 = build_def_change_type(
+        "change-type-1", inherit=["change-type-2", "change-type-3"]
+    )
+    ct_2 = build_def_change_type("change-type-2")
+    ct_3 = build_def_change_type("change-type-3")
+
+    processors = init_change_type_processors([ct_1, ct_2, ct_3])
+    assert len(processors) == 3
+
+    assert change_list_equals(
+        processors["change-type-1"].changes, ct_1.changes + ct_2.changes + ct_3.changes
+    )
+    assert change_list_equals(processors["change-type-2"].changes, ct_2.changes)
+    assert change_list_equals(processors["change-type-3"].changes, ct_3.changes)
+
+
+def test_change_type_multi_level_inheritance():
+    ct_1 = build_def_change_type("change-type-1", inherit=["change-type-2"])
+    ct_2 = build_def_change_type("change-type-2", inherit=["change-type-3"])
+    ct_3 = build_def_change_type("change-type-3")
+
+    processors = init_change_type_processors([ct_1, ct_2, ct_3])
+    assert len(processors) == 3
+
+    assert change_list_equals(
+        processors["change-type-1"].changes, ct_1.changes + ct_2.changes + ct_3.changes
+    )
+    assert change_list_equals(
+        processors["change-type-2"].changes, ct_2.changes + ct_3.changes
+    )
+    assert change_list_equals(processors["change-type-3"].changes, ct_3.changes)
+
+
+def test_change_type_multi_level_inheritance_multiple_paths():
+    ct_1 = build_def_change_type(
+        "change-type-1", inherit=["change-type-2", "change-type-3"]
+    )
+    ct_2 = build_def_change_type("change-type-2", inherit=["change-type-3"])
+    ct_3 = build_def_change_type("change-type-3")
+
+    processors = init_change_type_processors([ct_1, ct_2, ct_3])
+    assert len(processors) == 3
+
+    assert change_list_equals(
+        processors["change-type-1"].changes, ct_1.changes + ct_2.changes + ct_3.changes
+    )
+    assert change_list_equals(
+        processors["change-type-2"].changes, ct_2.changes + ct_3.changes
+    )
+    assert change_list_equals(processors["change-type-3"].changes, ct_3.changes)
+
+
+# todo - write a test to check that the same change will not land
+# multiple times in a changetype processor
+
+
+def change_list_equals(
+    a: Sequence[ChangeTypeChangeDetectorV1],
+    b: Sequence[ChangeTypeChangeDetectorV1],
+) -> bool:
+    return len(a) == len(b) and all(a_item in b for a_item in a)

--- a/setup.cfg
+++ b/setup.cfg
@@ -398,3 +398,6 @@ ignore_missing_imports = True
 
 [mypy-pygments.*]
 ignore_missing_imports = True
+
+[mypy-networkx.*]
+ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
         "cryptography==36.0.2",
         "deepdiff6==6.2.0",
         "jsonpath-ng~=1.5",
+        "networkx~=2.8",
     ],
     test_suite="tests",
     classifiers=[


### PR DESCRIPTION
# What changes?

The granular permission model based on `change-types` allows fine grained control of what is self serviceable but to really allow the right amount of change for the right people, we would need to define a lot of change-types for individual aspects. Having a lot of similar `change-types` eventually leads to duplication. `change-type` inheritance is an approach to keep duplication at bay.

A `change-type` can inherit change detector configurations (jsonpaths, etc.) from other `change-types`

```yaml
$schema: "/app-interface/change-type-1.yml"

name: a-change-type

inherit:
- $ref: "/another-change-type.yml"
- ...
```

All changes along the inheritance paths will be aggregated into the `ChangeTypeProcessor` representing a `change-type`. The rest of the code is unaware this aggregation happens.

During `change-type` loading, the following conditions are checked

* there are not cycles within the `change-type` inheritance tree
* a `change-type` can only inherit from a `change-type` with the same `context-schema`, or both have no `context-schema`

If any of these conditions are not met, `change-owners` will fail. this serves as a quality gate during PR checks introducing changes to `change-types`.

# How to review

Review commit by commit. The first one does not change anything functionally but refactors the `ChangeTypeProcessor` to keep its inner state more isolated and less dependant on the actual `change-type` representation within `qontract-server`. Feel free to ignore this commit during review.

The second commit 79b84d371d64caf41a19fedd38e923817c9c6615 adapts the `ChangeTypeProcessor` loading process to aggregate inherited change detector configurations. The magic happens here. The hard part of building the graph, finding cycles and finding inheritance linages is offloaded to the amazing https://networkx.org/ library. 

All commits following from here on are tests or minor improvements.

# References

Part of: https://issues.redhat.com/browse/APPSRE-6473
Depends on schema: https://github.com/app-sre/qontract-schemas/pull/278