### PR TITLE
[slack-usergroups] add option to run per workspace and usergroup

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -310,6 +310,22 @@ def account_name(function):
     return function
 
 
+def workspace_name(function):
+    function = click.option(
+        "--workspace-name", help="slack workspace name to act on.", default=None
+    )(function)
+
+    return function
+
+
+def usergroup_name(function):
+    function = click.option(
+        "--usergroup-name", help="slack usergroup name to act on.", default=None
+    )(function)
+
+    return function
+
+
 def gitlab_project_id(function):
     function = click.option(
         "--gitlab-project-id",
@@ -831,11 +847,18 @@ def openshift_upgrade_watcher(ctx, thread_pool_size, internal, use_jump_host):
 
 
 @integration.command(short_help="Manage Slack User Groups (channels and users).")
+@workspace_name
+@usergroup_name
 @click.pass_context
-def slack_usergroups(ctx):
+def slack_usergroups(ctx, workspace_name, usergroup_name):
     import reconcile.slack_usergroups
 
-    run_integration(reconcile.slack_usergroups, ctx.obj)
+    run_integration(
+        reconcile.slack_usergroups,
+        ctx.obj,
+        workspace_name,
+        usergroup_name,
+    )
 
 
 @integration.command(

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -40,6 +40,7 @@ class GitApi:
         raise ValueError(f"Unable to handle URL: {url}")
 
 
+SlackState = dict[str, dict[str, dict[str, Any]]]
 SlackMap = dict[str, dict[str, Any]]
 
 
@@ -74,7 +75,7 @@ def get_current_state(
     slack_map: SlackMap,
     desired_workspace_name: Optional[str],
     desired_usergroup_name: Optional[str],
-):
+) -> SlackState:
     """
     Get the current state of Slack usergroups.
 
@@ -85,7 +86,7 @@ def get_current_state(
                 (ex. state['coreos']['app-sre-ic']
     :rtype: dict
     """
-    current_state = {}
+    current_state: SlackState = {}
 
     for workspace, spec in slack_map.items():
         if desired_workspace_name and desired_workspace_name != workspace:
@@ -246,7 +247,7 @@ def get_desired_state(
     pagerduty_map: PagerDutyMap,
     desired_workspace_name: Optional[str],
     desired_usergroup_name: Optional[str],
-):
+) -> SlackState:
     """
     Get the desired state of Slack usergroups.
 
@@ -263,7 +264,7 @@ def get_desired_state(
     permissions = queries.get_permissions_for_slack_usergroup()
     all_users = queries.get_users()
 
-    desired_state = {}
+    desired_state: SlackState = {}
     for p in permissions:
         if p["service"] != "slack-usergroup":
             continue

--- a/reconcile/test/test_slack_usergroups.py
+++ b/reconcile/test/test_slack_usergroups.py
@@ -98,7 +98,7 @@ class TestSupportFunctions(TestCase):
                 "managed_usergroups": ["app-sre-team", "app-sre-ic"],
             }
         }
-        result = integ.get_slack_map(SecretReader())
+        result = integ.get_slack_map(SecretReader(), None)
         mock_slack_api.assert_called_once()
         self.assertEqual(
             result["coreos"]["managed_usergroups"],


### PR DESCRIPTION
with this PR, we can run the integration with the following options: `--workspace-name coreos --usergroup-name app-sre-ic`.

currently meant only for local execution, but there is a bigger plan behind this :magic_wand: 