### PR TITLE
[slack-usergroups] do not init pagerduty users if usergroup name is defined

### DIFF
--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -65,10 +65,10 @@ def get_slack_map(
     return slack_map
 
 
-def get_pagerduty_map():
+def get_pagerduty_map(init_users: bool = True):
     instances = queries.get_pagerduty_instances()
     settings = queries.get_app_interface_settings()
-    return PagerDutyMap(instances, settings)
+    return PagerDutyMap(instances, init_users=init_users, settings=settings)
 
 
 def get_current_state(
@@ -514,7 +514,8 @@ def run(
 ):
     secret_reader = SecretReader(queries.get_secret_reader_settings())
     slack_map = get_slack_map(secret_reader, workspace_name)
-    pagerduty_map = get_pagerduty_map()
+    init_users = False if usergroup_name else True
+    pagerduty_map = get_pagerduty_map(init_users=init_users)
     desired_state = get_desired_state(
         slack_map, pagerduty_map, workspace_name, usergroup_name
     )

--- a/reconcile/utils/pagerduty_api.py
+++ b/reconcile/utils/pagerduty_api.py
@@ -40,7 +40,9 @@ class PagerDutyApi:
                 return user.email.split("@")[0]
 
         # handle for users not initiated
-        return pypd.User.fetch(user_id).email.split("@")[0]
+        user = pypd.User.fetch(user_id).email.split("@")[0]
+        self.users.append(user)
+        return user
 
     def get_schedule_users(self, schedule_id, now):
         s = pypd.Schedule.fetch(id=schedule_id, since=now, until=now, time_zone="UTC")

--- a/reconcile/utils/pagerduty_api.py
+++ b/reconcile/utils/pagerduty_api.py
@@ -40,9 +40,9 @@ class PagerDutyApi:
                 return user.email.split("@")[0]
 
         # handle for users not initiated
-        user = pypd.User.fetch(user_id).email.split("@")[0]
+        user = pypd.User.fetch(user_id)
         self.users.append(user)
-        return user
+        return user.email.split("@")[0]
 
     def get_schedule_users(self, schedule_id, now):
         s = pypd.Schedule.fetch(id=schedule_id, since=now, until=now, time_zone="UTC")

--- a/reconcile/utils/pagerduty_api.py
+++ b/reconcile/utils/pagerduty_api.py
@@ -6,18 +6,17 @@ import pypd
 from reconcile.utils.secret_reader import SecretReader
 
 
-class PagerDutyUserNotFoundException(Exception):
-    pass
-
-
 class PagerDutyApi:
     """Wrapper around PagerDuty API calls"""
 
-    def __init__(self, token, settings=None):
+    def __init__(self, token, init_users=True, settings=None):
         secret_reader = SecretReader(settings=settings)
         pd_api_key = secret_reader.read(token)
         pypd.api_key = pd_api_key
-        self.init_users()
+        if init_users:
+            self.init_users()
+        else:
+            self.users = []
 
     def init_users(self):
         self.users = pypd.User.find()
@@ -40,8 +39,8 @@ class PagerDutyApi:
             if user.id == user_id:
                 return user.email.split("@")[0]
 
-        # should never be reached as user_id comes from PagerDuty API itself
-        raise PagerDutyUserNotFoundException(user_id)
+        # handle for users not initiated
+        return pypd.User.fetch(user_id).email.split("@")[0]
 
     def get_schedule_users(self, schedule_id, now):
         s = pypd.Schedule.fetch(id=schedule_id, since=now, until=now, time_zone="UTC")
@@ -78,12 +77,12 @@ class PagerDutyApi:
 class PagerDutyMap:
     """A collection of PagerDutyApi instances per PagerDuty instance"""
 
-    def __init__(self, instances, settings=None):
+    def __init__(self, instances, init_users: bool = True, settings=None):
         self.pd_apis = {}
         for i in instances:
             name = i["name"]
             token = i["token"]
-            pd_api = PagerDutyApi(token, settings=settings)
+            pd_api = PagerDutyApi(token, init_users=init_users, settings=settings)
             self.pd_apis[name] = pd_api
 
     def get(self, name):


### PR DESCRIPTION
when a single usergroup is defined, it is likely more performant to avoid initiating all users in a pagerduty instance, and instead search for a user when needed.

follows up on the introduction of `usergroup-name` in #2882