### PR TITLE
[slack-usergroups] slack <-> pagerduty source of truth is email

### DIFF
--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -294,11 +294,11 @@ def get_desired_state(
 
         slack_users_pagerduty = get_users_from_pagerduty(
             p["pagerduty"],
-            usergroup,
             pagerduty_map,
             get_user_method=slack.get_user_by_email,
         )
-        users.update({u["id"]: u for u in slack_users_pagerduty})
+        for u in slack_users_pagerduty:
+            users[u["id"]] = u["name"]
 
         channel_names = [] if p["channels"] is None else p["channels"]
         channels = slack.get_channels_by_names(channel_names)

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -293,14 +293,6 @@ def get_desired_state(
         ugid = slack.get_usergroup_id(usergroup)
 
         all_user_names = [get_slack_username(u) for r in p["roles"] for u in r["users"]]
-        slack_usernames_pagerduty = get_usernames_from_pagerduty(
-            p["pagerduty"],
-            all_users,
-            usergroup,
-            pagerduty_map,
-            get_username_method=get_slack_username,
-        )
-        all_user_names.extend(slack_usernames_pagerduty)
 
         slack_usernames_repo = get_slack_usernames_from_owners(
             p["ownersFromRepos"], all_users, usergroup
@@ -309,6 +301,15 @@ def get_desired_state(
 
         slack_usernames_schedule = get_slack_usernames_from_schedule(p["schedule"])
         all_user_names.extend(slack_usernames_schedule)
+
+        slack_usernames_pagerduty = get_usernames_from_pagerduty(
+            p["pagerduty"],
+            all_users,
+            usergroup,
+            pagerduty_map,
+            get_username_method=get_slack_username,
+        )
+        all_user_names.extend(slack_usernames_pagerduty)
 
         user_names = list(set(all_user_names))
         users = slack.get_users_by_names(user_names)

--- a/reconcile/utils/pagerduty_api.py
+++ b/reconcile/utils/pagerduty_api.py
@@ -42,7 +42,7 @@ class PagerDutyApi:
         # handle for users not initiated
         user = pypd.User.fetch(user_id)
         self.users.append(user)
-        return user.email.split("@")[0]
+        return user.email
 
     def get_schedule_user_emails(self, schedule_id, now):
         s = pypd.Schedule.fetch(id=schedule_id, since=now, until=now, time_zone="UTC")

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -303,8 +303,11 @@ class SlackApi:
         return ""
 
     def get_user_id_by_name(self, user_name: str, mail_address: str) -> str:
+        return self.get_user_by_email(f"{user_name}@{mail_address}")["id"]
+
+    def get_user_by_email(self, email: str) -> Any:
         """
-        Get user id from their username.
+        Get user from their username.
 
         :param user_name: Slack user name
         :return: encoded user ID (ex. W012A3CDE)
@@ -313,14 +316,14 @@ class SlackApi:
         :raises UserNotFoundException: if the Slack user is not found
         """
         try:
-            result = self._sc.users_lookupByEmail(email=f"{user_name}@{mail_address}")
+            result = self._sc.users_lookupByEmail(email=email)
         except SlackApiError as e:
             if e.response["error"] == "users_not_found":
                 raise UserNotFoundException(e.response["error"])
             else:
                 raise
 
-        return result["user"]["id"]
+        return result["user"]
 
     def get_channels_by_names(self, channels_names):
         return {


### PR DESCRIPTION
we assume that the email is identical between pagerduty users and slack users, instead of matching using `pagerduty_username`.