### PR TITLE
Standardize OCM integrations

### DIFF
--- a/reconcile/ocm/utils.py
+++ b/reconcile/ocm/utils.py
@@ -1,0 +1,9 @@
+from typing import Mapping, Any
+
+
+def cluster_disabled_integrations(cluster: Mapping[str, Any]) -> list[str]:
+    disabled_ints: list[str] = []
+    disable = cluster.get("disable")
+    if disable:
+        disabled_ints = disable.get("integrations") or []
+    return disabled_ints

--- a/reconcile/ocm_additional_routers.py
+++ b/reconcile/ocm_additional_routers.py
@@ -1,11 +1,13 @@
 import sys
 import logging
 import json
+from typing import Any, Mapping
 
 from reconcile import queries
 
 from reconcile.status import ExitCodes
 from reconcile.utils.ocm import OCM_PRODUCT_OSD, OCMMap
+from reconcile.ocm.utils import cluster_disabled_integrations
 
 QONTRACT_INTEGRATION = "ocm-additional-routers"
 
@@ -84,13 +86,21 @@ def act(dry_run, diffs, ocm_map):
                 ocm.delete_additional_router(cluster, diff)
 
 
+def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
+
+    return (
+        cluster["spec"]["product"] in SUPPORTED_OCM_PRODUCTS
+        and cluster.get("additionalRouters") is not None
+    )
+
+
 def run(dry_run):
     clusters = queries.get_clusters()
     clusters = [
         c
         for c in clusters
-        if c.get("additionalRouters") is not None
-        and c["spec"]["product"] in SUPPORTED_OCM_PRODUCTS
+        if QONTRACT_INTEGRATION not in cluster_disabled_integrations(c)
+        and _cluster_is_compatible(c)
     ]
     if not clusters:
         logging.debug("No additionalRouters definitions found in app-interface")

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -1,10 +1,13 @@
 import sys
 import logging
 import json
+from typing import Any, Mapping
 
 from reconcile import queries
 
 from reconcile.utils.ocm import OCMMap
+from reconcile.ocm.utils import cluster_disabled_integrations
+
 
 QONTRACT_INTEGRATION = "ocm-machine-pools"
 
@@ -111,9 +114,18 @@ def act(dry_run, diffs, ocm_map):
                 ocm.delete_machine_pool(cluster, diff)
 
 
+def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
+    return cluster.get("ocm") is not None and cluster.get("machinePools") is not None
+
+
 def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
     clusters = queries.get_clusters()
-    clusters = [c for c in clusters if c.get("machinePools") is not None]
+    clusters = [
+        c
+        for c in clusters
+        if QONTRACT_INTEGRATION not in cluster_disabled_integrations(c)
+        and _cluster_is_compatible(c)
+    ]
     if not clusters:
         logging.debug("No machinePools definitions found in app-interface")
         sys.exit(0)


### PR DESCRIPTION
## Overview 

* Standardize all the OCM integrations to get clusters the same way. Clusters suitability is now checked in a `_cluster_is_compatible` method in all the integrations. Also, cluster filtering is now made within the `run` method in all cases. 

* Enable integration disablement at the cluster level. This is required to early support Hypershift clusters where a lot of OCM administration tasks are not yet in place and will be disabled in the cluster spec.  

Requires: https://github.com/app-sre/qontract-schemas/pull/282