### PR TITLE
APPSRE-6295 add OCMBaseClient

### DIFF
--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -217,7 +217,7 @@ def ocm_secrets_reader():
 def ocm_mock(ocm_secrets_reader):
     with patch.object(OCM, "_post", autospec=True) as _post:
         with patch.object(OCM, "_patch", autospec=True) as _patch:
-            with patch.object(OCM, "_init_access_token", autospec=True):
+            with patch.object(OCM, "_init_ocm_client", autospec=True):
                 with patch.object(OCM, "get_provision_shard", autospec=True) as gps:
                     gps.return_value = {"id": "provision_shard_id"}
                     yield _post, _patch

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -8,8 +8,8 @@ from reconcile.utils.ocm import OCM
 
 @pytest.fixture
 def ocm(mocker):
-    mocker.patch("reconcile.utils.ocm.OCM._init_access_token")
-    mocker.patch("reconcile.utils.ocm.OCM._init_request_headers")
+    mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient._init_access_token")
+    mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient._init_request_headers")
     mocker.patch("reconcile.utils.ocm.OCM._init_clusters")
     mocker.patch("reconcile.utils.ocm.OCM._init_blocked_versions")
     mocker.patch("reconcile.utils.ocm.OCM._init_version_gates")
@@ -92,7 +92,7 @@ def test_get_version_gate(ocm):
 
 
 def test__get_json_pagination(ocm):
-    ocm.url = "http://ocm.test"
+    ocm._ocm_client._url = "http://ocm.test"
     call_cnt = 0
 
     def paginated_response(request: HTTPrettyRequest, url, response_headers):
@@ -132,7 +132,7 @@ def test__get_json_pagination(ocm):
 
 
 def test__get_json_empty_list(ocm: OCM):
-    ocm.url = "http://ocm.test"
+    ocm._ocm_client._url = "http://ocm.test"
     httpretty.enable()
     httpretty.register_uri(
         httpretty.GET,
@@ -147,7 +147,7 @@ def test__get_json_empty_list(ocm: OCM):
 
 
 def test__get_json_simple_list(ocm: OCM):
-    ocm.url = "http://ocm.test"
+    ocm._ocm_client._url = "http://ocm.test"
     httpretty.enable()
     httpretty.register_uri(
         httpretty.GET,
@@ -161,7 +161,7 @@ def test__get_json_simple_list(ocm: OCM):
 
 
 def test__get_json(ocm):
-    ocm.url = "http://ocm.test"
+    ocm._ocm_client._url = "http://ocm.test"
 
     httpretty.enable()
     httpretty.register_uri(

--- a/reconcile/test/test_utils_ocm_versions.py
+++ b/reconcile/test/test_utils_ocm_versions.py
@@ -4,8 +4,8 @@ from reconcile.utils.ocm import OCM
 
 @pytest.fixture
 def ocm(mocker):
-    mocker.patch("reconcile.utils.ocm.OCM._init_access_token")
-    mocker.patch("reconcile.utils.ocm.OCM._init_request_headers")
+    mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient._init_access_token")
+    mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient._init_request_headers")
     mocker.patch("reconcile.utils.ocm.OCM._init_clusters")
     mocker.patch("reconcile.utils.ocm.OCM._init_version_gates")
     return OCM("name", "url", "tid", "turl", "ot")

--- a/reconcile/utils/ocm_base_client.py
+++ b/reconcile/utils/ocm_base_client.py
@@ -1,0 +1,104 @@
+import logging
+from typing import Any, Mapping, Optional
+from requests import Session, codes
+
+from sretoolbox.utils import retry
+
+
+REQUEST_TIMEOUT_SEC = 60
+
+
+class OCMBaseClient:
+    """
+    Thin client for OCM. This class takes care of authentication
+    and provides methods for GET, POST, PATCH, DELETE to interact with ocm API.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        offline_token: str,
+        access_token_url: str,
+        access_token_client_id: str,
+        session: Optional[Session] = None,
+    ):
+        self._offline_token = offline_token
+        self._access_token_client_id = access_token_client_id
+        self._access_token_url = access_token_url
+        self._url = url
+        self._session = session if session else Session()
+        self._init_access_token()
+        self._init_request_headers()
+
+    @retry()
+    def _init_access_token(self):
+        data = {
+            "grant_type": "refresh_token",
+            "client_id": self._access_token_client_id,
+            "refresh_token": self._offline_token,
+        }
+        r = self._session.post(
+            self._access_token_url, data=data, timeout=REQUEST_TIMEOUT_SEC
+        )
+        r.raise_for_status()
+        self._access_token = r.json().get("access_token")
+
+    def _init_request_headers(self):
+        self._session.headers.update(
+            {
+                "Authorization": f"Bearer {self._access_token}",
+                "accept": "application/json",
+            }
+        )
+
+    def get(self, api_path: str, params: Optional[Mapping[str, str]] = None) -> Any:
+        r = self._session.get(
+            f"{self._url}{api_path}",
+            params=params,
+            timeout=REQUEST_TIMEOUT_SEC,
+        )
+        r.raise_for_status()
+        return r.json()
+
+    def post(
+        self,
+        api_path: str,
+        data: Optional[Mapping[str, Any]] = None,
+        params: Optional[Mapping[str, str]] = None,
+    ) -> Any:
+        r = self._session.post(
+            f"{self._url}{api_path}",
+            json=data,
+            params=params,
+            timeout=REQUEST_TIMEOUT_SEC,
+        )
+        try:
+            r.raise_for_status()
+        except Exception as e:
+            logging.error(r.text)
+            raise e
+        if r.status_code == codes.no_content:
+            return {}
+        return r.json()
+
+    def patch(
+        self,
+        api_path: str,
+        data: Mapping[str, Any],
+        params: Optional[Mapping[str, str]] = None,
+    ):
+        r = self._session.patch(
+            f"{self._url}{api_path}",
+            json=data,
+            params=params,
+            timeout=REQUEST_TIMEOUT_SEC,
+        )
+        try:
+            r.raise_for_status()
+        except Exception as e:
+            logging.error(r.text)
+            raise e
+
+    def delete(self, api_path: str):
+        r = self._session.delete(f"{self._url}{api_path}", timeout=REQUEST_TIMEOUT_SEC)
+        r.raise_for_status()


### PR DESCRIPTION
`OCMBaseClient` is a thin layer between the OCM API and more complex OCM clients (e.g., `OCMClient` or `CNAClient`). `OCMBaseClient` can be used by more sophisticated clients to interact with the OCM API. It takes care of authentication and provides basic API operations GET, POST, PATCH, DELETE.

Using `OCMBaseClient` will also ease testing, as it can easily be mocked and passed to the sophisticated client as an input parameter.