### PR TITLE
Fix cluster_is_compatible method in some ocm integrations

### DIFF
--- a/reconcile/ocm_additional_routers.py
+++ b/reconcile/ocm_additional_routers.py
@@ -89,7 +89,8 @@ def act(dry_run, diffs, ocm_map):
 def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
 
     return (
-        cluster["spec"]["product"] in SUPPORTED_OCM_PRODUCTS
+        cluster.get("ocm") is not None
+        and cluster["spec"]["product"] in SUPPORTED_OCM_PRODUCTS
         and cluster.get("additionalRouters") is not None
     )
 

--- a/reconcile/ocm_addons.py
+++ b/reconcile/ocm_addons.py
@@ -94,7 +94,7 @@ def act(dry_run, diffs, ocm_map):
 
 
 def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
-    return cluster.get("addons") is not None
+    return cluster.get("ocm") is not None and cluster.get("addons") is not None
 
 
 def run(dry_run, gitlab_project_id=None, thread_pool_size=10):

--- a/reconcile/test/fixtures/ocm_additional_routers/state.yml
+++ b/reconcile/test/fixtures/ocm_additional_routers/state.yml
@@ -1,15 +1,21 @@
 gql_response:
   - name: cluster1
+    ocm:
+      name: ocm-production
     spec:
       product: osd
     additionalRouters:
     - private: True
   - name: cluster2
+    ocm:
+      name: ocm-production
     spec:
       product: osd
     additionalRouters:
     - private: False
   - name: cluster3
+    ocm:
+      name: ocm-production
     spec:
       product: osd
     additionalRouters:
@@ -18,6 +24,8 @@ gql_response:
   - name: cluster4
     spec:
       product: osd
+    ocm:
+      name: ocm-production
     additionalRouters: []
 
 desired_state:


### PR DESCRIPTION
- Standardize OCM integrations and allow its disablement at cluster level
- Fix cluster_is_compatible methods
