### PR TITLE
enable blacks' truthy-bool and redundant-expr checks

### DIFF
--- a/reconcile/change_owners/self_service_roles.py
+++ b/reconcile/change_owners/self_service_roles.py
@@ -64,13 +64,12 @@ def change_type_contexts_for_self_service_roles(
                     approvers = [
                         Approver(u.org_username, u.tag_on_merge_requests)
                         for u in role.users or []
-                        if u
                     ]
                     approvers.extend(
                         [
                             Approver(b.org_username, False)
                             for b in role.bots or []
-                            if b and b.org_username
+                            if b.org_username
                         ]
                     )
                     change_type_contexts.append(

--- a/reconcile/closedbox_endpoint_monitoring_base.py
+++ b/reconcile/closedbox_endpoint_monitoring_base.py
@@ -114,7 +114,7 @@ def fill_desired_state(
     probe: OpenshiftResource,
     ri: ResourceInventory,
 ) -> None:
-    if probe and provider.namespace:
+    if provider.namespace:
         ri.add_desired(
             cluster=provider.namespace["cluster"]["name"],
             namespace=provider.namespace["name"],

--- a/reconcile/dashdotdb_dvo.py
+++ b/reconcile/dashdotdb_dvo.py
@@ -206,7 +206,7 @@ class DashdotdbDVO(DashdotdbBase):
         validation_metrics_by_cluster: dict[str, list[str]] = {}
         if validation_list:
             validation_metrics_by_cluster = {
-                v.cluster_name: v.metrics for v in validation_list if v
+                v.cluster_name: v.metrics for v in validation_list
             }
         self._get_token()
         for cluster in clusters:

--- a/reconcile/service_dependencies.py
+++ b/reconcile/service_dependencies.py
@@ -84,7 +84,7 @@ def get_desired_dependency_names(
         for ern in er_namespaces:
             providers: set[str] = set()
             if ern.managed_external_resources and ern.external_resources:
-                providers = {res.provider for res in ern.external_resources if res}
+                providers = {res.provider for res in ern.external_resources}
             for p in providers:
                 required_dep_names.update(get_dependency_names(dependency_map, p))
         kafka_namespaces = [n for n in namespaces if n.kafka_cluster]

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -541,7 +541,7 @@ def run(
         awsapi,
     )
 
-    if tf is None or any(errors):
+    if any(errors):
         sys.exit(1)
 
     defer(tf.cleanup)

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -1397,7 +1397,7 @@ def test_change_decision(
         old_file_content={"foo": "bar"},
         new_file_content={"foo": "baz"},
     )
-    assert change and len(change.diff_coverage) == 1 and change.diff_coverage[0]
+    assert change and len(change.diff_coverage) == 1
     change.diff_coverage[0].coverage = [
         ChangeTypeContext(
             change_type_processor=build_change_type_processor(saas_file_changetype),

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -14,6 +14,7 @@ from typing import (
     Any,
     MutableMapping,
     Optional,
+    Sequence,
     Set,
     Tuple,
     Union,
@@ -221,8 +222,8 @@ class SaasHerder:
     def _validate_allowed_secret_parameter_paths(
         self,
         saas_file_name: str,
-        secret_parameters: Iterable[Mapping[str, Any]],
-        allowed_secret_parameter_paths: Iterable[str],
+        secret_parameters: Sequence[Mapping[str, Any]],
+        allowed_secret_parameter_paths: Sequence[str],
     ) -> None:
         if not secret_parameters:
             return

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -360,10 +360,9 @@ class SlackApi:
         if resource in self._results:
             return self._results[resource]
 
-        if self.config:
-            method_config = self.config.get_method_config(f"{api_key}.list")
-            if method_config:
-                additional_kwargs.update(method_config)
+        method_config = self.config.get_method_config(f"{api_key}.list")
+        if method_config:
+            additional_kwargs.update(method_config)
 
         while True:
             result = self._sc.api_call(

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ extend-ignore = E203,E501,W503
 [mypy]
 files = reconcile,tools,e2e_tests
 plugins = pydantic.mypy
+enable_error_code = truthy-bool, redundant-expr
 
 ; More context here: https://github.com/python/mypy/issues/9091
 no_implicit_optional = True


### PR DESCRIPTION
This enables blacks' `truthy-bool` and `redundant-expr` checks.

* for a detailed explanation of `truthy-bool` see this [blog post](https://adamj.eu/tech/2022/10/24/python-type-hints-truthy-bool/)
* and for `redundant-expr` see the [official one](https://mypy.readthedocs.io/en/stable/error_code_list2.html#check-that-expression-is-redundant-redundant-expr)