### PR TITLE
[change-owners] best effort parse resource files without schema

### DIFF
--- a/reconcile/change_owners/diff.py
+++ b/reconcile/change_owners/diff.py
@@ -100,9 +100,7 @@ def compare_object_ctx_identifier(
 SHA256SUM_FIELD_NAME = "$file_sha256sum"
 
 
-def extract_diffs(
-    schema: Optional[str], old_file_content: Any, new_file_content: Any
-) -> list[Diff]:
+def extract_diffs(old_file_content: Any, new_file_content: Any) -> list[Diff]:
     diffs: list[Diff] = []
     if old_file_content and new_file_content:
         deep_diff = DeepDiff(
@@ -224,7 +222,10 @@ def deepdiff_path_to_jsonpath(deep_diff_path: str) -> jsonpath_ng.JSONPath:
         if element.isdigit():
             return jsonpath_ng.Index(int(element))
         else:
-            return jsonpath_ng.Fields(element)
+            if "." in element:
+                return jsonpath_ng.Fields(f"'{element}'")
+            else:
+                return jsonpath_ng.Fields(element)
 
     path_parts = [
         build_jsonpath_part(p) for p in DEEP_DIFF_RE.findall(deep_diff_path[4:])


### PR DESCRIPTION
resource files without schema are not parsed right now, which means that fine jsonpath expressions to pinpoint the change in a file will not work in those situations.

a lot of resource files are parsable though even without a schema, e.g. ConfigMaps while at the same time not all resource files with a schema are parsable when they include jinja2 templating.

this change will try to best-effort parse resource files and falls back to handling the file content as clob if not parsable.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>