### PR TITLE
Add ROSA/Hypershift clusters support

### DIFF
--- a/reconcile/ocm/types.py
+++ b/reconcile/ocm/types.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel, Field, Extra, validator
+from pydantic import BaseModel, Field, Extra
 from typing import Optional, Union
 
 
@@ -30,6 +30,7 @@ class OCMClusterSpec(BaseModel):
     region: str
     initial_version: Optional[str]
     version: str
+    hypershift: Optional[bool]
 
     class Config:
         extra = Extra.forbid
@@ -45,10 +46,10 @@ class OSDClusterSpec(OCMClusterSpec):
 
 class ROSAAWSAttrs(BaseModel):
     creator_role_arn: str
-    installer_role_arn: Optional[str]
-    support_role_arn: Optional[str]
-    controlplane_role_arn: Optional[str]
-    worker_role_arn: Optional[str]
+    installer_role_arn: str
+    support_role_arn: str
+    controlplane_role_arn: str
+    worker_role_arn: str
 
     class Config:
         extra = Extra.forbid
@@ -58,37 +59,14 @@ class ROSAClusterAWSAccount(BaseModel):
     uid: str
     rosa: ROSAAWSAttrs
 
-    @validator("rosa", always=True)
-    @classmethod
-    def set_rosa(cls, rosa: ROSAAWSAttrs, values):
-        if not rosa.installer_role_arn:
-            rosa.installer_role_arn = (
-                f"arn:aws:iam::{values['uid']}:role/ManagedOpenShift-Installer-Role"
-            )
-
-        if not rosa.support_role_arn:
-            rosa.support_role_arn = (
-                f"arn:aws:iam::{values['uid']}:role/ManagedOpenShift-Support-Role"
-            )
-
-        if not rosa.controlplane_role_arn:
-            rosa.controlplane_role_arn = (
-                f"arn:aws:iam::{values['uid']}:role/ManagedOpenShift-ControlPlane-Role"
-            )
-
-        if not rosa.worker_role_arn:
-            rosa.worker_role_arn = (
-                f"arn:aws:iam::{values['uid']}:role/ManagedOpenShift-Worker-Role"
-            )
-
-        return rosa
-
     class Config:
         extra = Extra.forbid
 
 
 class ROSAClusterSpec(OCMClusterSpec):
     account: ROSAClusterAWSAccount
+    subnet_ids: Optional[list[str]]
+    availability_zones: Optional[list[str]]
 
     class Config:
         extra = Extra.forbid

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -98,10 +98,13 @@ def get_app_interface_spec_updates(
         logging.error(cve)
         error = True
 
-    if not desired_spec.spec.id:
+    if current_spec.spec.id and desired_spec.spec.id != current_spec.spec.id:
         ocm_spec_updates[ocmmod.SPEC_ATTR_ID] = current_spec.spec.id
 
-    if not desired_spec.spec.external_id:
+    if (
+        current_spec.spec.external_id
+        and desired_spec.spec.external_id != current_spec.spec.external_id
+    ):
         ocm_spec_updates[ocmmod.SPEC_ATTR_EXTERNAL_ID] = current_spec.spec.external_id
 
     if (
@@ -112,18 +115,27 @@ def get_app_interface_spec_updates(
             ocmmod.SPEC_ATTR_DISABLE_UWM
         ] = current_spec.spec.disable_user_workload_monitoring
 
-    if desired_spec.spec.provision_shard_id != current_spec.spec.provision_shard_id:
+    if (
+        current_spec.spec.provision_shard_id is not None
+        and desired_spec.spec.provision_shard_id != current_spec.spec.provision_shard_id
+    ):
         ocm_spec_updates[
             ocmmod.SPEC_ATTR_PROVISION_SHARD_ID
         ] = current_spec.spec.provision_shard_id
 
-    if not desired_spec.console_url:
+    if (
+        current_spec.console_url
+        and desired_spec.console_url != current_spec.console_url
+    ):
         root_updates[ocmmod.SPEC_ATTR_CONSOLE_URL] = current_spec.console_url
 
-    if not desired_spec.server_url:
+    if current_spec.server_url and desired_spec.server_url != current_spec.server_url:
         root_updates[ocmmod.SPEC_ATTR_SERVER_URL] = current_spec.server_url
 
-    if not desired_spec.elb_fqdn:
+    if (
+        current_spec.domain
+        and desired_spec.elb_fqdn != f"elb.apps.{cluster}.{current_spec.domain}"
+    ):
         root_updates[
             ocmmod.SPEC_ATTR_ELBFQDN
         ] = f"elb.apps.{cluster}.{current_spec.domain}"

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -639,11 +639,14 @@ CLUSTERS_QUERY = """
     %s
     spec {
       product
+      hypershift
       ... on ClusterSpecOSD_v1 {
         storage
         load_balancers
       }
       ... on ClusterSpecROSA_v1 {
+        subnet_ids
+        availability_zones
         account {
           uid
           rosa {

--- a/reconcile/test/fixtures/clusters/osd_spec.json
+++ b/reconcile/test/fixtures/clusters/osd_spec.json
@@ -145,5 +145,8 @@
   "disable_user_workload_monitoring": true,
   "managed_service": {
     "enabled": false
+  },
+  "hypershift": {
+    "enabled": false
   }
 }

--- a/reconcile/test/fixtures/clusters/osd_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/osd_spec_ai.yml
@@ -24,7 +24,7 @@ spec:
   provider: aws
   region: us-east-1
   channel: candidate
-  version: 4.10.16
+  version: 4.10.6
   initial_version: 4.8.10
   multi_az: true
   instance_type: m5.2xlarge
@@ -36,6 +36,7 @@ spec:
     min_replicas: 21
     max_replicas: 30
   disable_user_workload_monitoring: true
+  hypershift: null
 network:
   type: OpenShiftSDN
   vpc: 10.112.0.0/16

--- a/reconcile/test/fixtures/clusters/rosa_spec.json
+++ b/reconcile/test/fixtures/clusters/rosa_spec.json
@@ -3,7 +3,7 @@
   "id": "rosa-cluster-id",
   "href": "/api/clusters_mgmt/v1/clusters/rosa-cluster-id",
   "name": "tst-jpr-rosa",
-  "external_id": "53c15df9-92e3-4ed6-9945-b37025d0b63d",
+  "external_id": "external-id",
   "infra_id": "tst-jpr-rosa-hzwts",
   "display_name": "tst-jpr-rosa",
   "creation_timestamp": "2022-04-01T09:46:33.71918Z",
@@ -202,6 +202,9 @@
   "billing_model": "standard",
   "disable_user_workload_monitoring": false,
   "managed_service": {
+    "enabled": false
+  },
+  "hypershift": {
     "enabled": false
   }
 }

--- a/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
@@ -9,7 +9,7 @@ kibanaUrl: ""
 prometheusUrl: ""
 alertmanagerUrl: ""
 serverUrl: "https://api-url"
-elbFQDN: "elb.apps.an-osd-test-cluster.k3s7.p1.openshiftapps.com"
+elbFQDN: "elb.apps.tst-jpr-rosa.wrr0.p1.openshiftapps.com"
 ocm:
   name: non-existent-ocm
   url: non-existent-ocm-url

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -120,7 +120,7 @@ def osd_cluster_fxt():
         },
         "consoleUrl": "the-cluster-console_url",
         "serverUrl": "the-cluster-server_url",
-        "elbFQDN": "the-cluster-elbFQDN",
+        "elbFQDN": "elb.apps.cluster1.devshift.net",
         "path": "the-cluster-path",
         "name": "cluster1",
         "id": "anid",
@@ -189,6 +189,66 @@ def rosa_cluster_fxt():
 
 
 @pytest.fixture
+def rosa_hosted_cp_cluster_fxt():
+    return {
+        "spec": {
+            "product": "rosa",
+            "account": {
+                "uid": "123123123",
+                "rosa": {
+                    "creator_role_arn": "creator_role",
+                    "installer_role_arn": "installer_role",
+                    "support_role_arn": " support_role",
+                    "controlplane_role_arn": "controlplane_role",
+                    "worker_role_arn": "worker_role",
+                },
+            },
+            "id": "the-cluster-id",
+            "external_id": "the-cluster-external_id",
+            "provider": "aws",
+            "region": "us-east-1",
+            "channel": "stable",
+            "version": "4.10.0",
+            "initial_version": "4.9.0-candidate",
+            "multi_az": False,
+            "nodes": 5,
+            "instance_type": "m5.xlarge",
+            "private": False,
+            "provision_shard_id": "the-cluster-provision_shard_id",
+            "disable_user_workload_monitoring": True,
+            "hypershift": True,
+        },
+        "network": {
+            "type": None,
+            "vpc": "10.112.0.0/16",
+            "service": "10.120.0.0/16",
+            "pod": "10.128.0.0/14",
+        },
+        "ocm": {
+            "name": "non-existent-ocm",
+            "url": "https://api.non-existent-ocm.com",
+            "accessTokenClientId": "cloud-services",
+            "accessTokenUrl": "https://sso.blah.com/token",
+            "offlineToken": {
+                "path": "a-secret-path",
+                "field": "offline_token",
+                "format": None,
+                "version": None,
+            },
+            "blockedVersions": ["^.*-fc\\..*$"],
+        },
+        "consoleUrl": "the-cluster-console_url",
+        "serverUrl": "the-cluster-server_url",
+        "elbFQDN": "the-cluster-elbFQDN",
+        "path": "the-cluster-path",
+        "name": "cluster1",
+        "id": "anid",
+        "managed": True,
+        "state": "ready",
+    }
+
+
+@pytest.fixture
 def queries_mock(osd_cluster_fxt):
     with patch.object(queries, "get_app_interface_settings", autospec=True) as s:
         with patch.object(queries, "get_clusters", autospec=True) as gc:
@@ -239,32 +299,6 @@ def get_json_mock():
 def test_ocm_spec_population_rosa(rosa_cluster_fxt):
     n = OCMSpec(**rosa_cluster_fxt)
     assert isinstance(n.spec, ROSAClusterSpec)
-
-
-def test_ocm_spec_population_rosa_default_roles(rosa_cluster_fxt):
-    rosa = rosa_cluster_fxt["spec"]["account"]["rosa"]
-    rosa["installer_role_arn"] = None
-    rosa["support_role_arn"] = None
-    rosa["controlplane_role_arn"] = None
-    rosa["worker_role_arn"] = None
-    n = OCMSpec(**rosa_cluster_fxt)
-    assert isinstance(n.spec, ROSAClusterSpec)
-    assert (
-        n.spec.account.rosa.installer_role_arn
-        == "arn:aws:iam::123123123:role/ManagedOpenShift-Installer-Role"
-    )
-    assert (
-        n.spec.account.rosa.support_role_arn
-        == "arn:aws:iam::123123123:role/ManagedOpenShift-Support-Role"
-    )
-    assert (
-        n.spec.account.rosa.controlplane_role_arn
-        == "arn:aws:iam::123123123:role/ManagedOpenShift-ControlPlane-Role"
-    )
-    assert (
-        n.spec.account.rosa.worker_role_arn
-        == "arn:aws:iam::123123123:role/ManagedOpenShift-Worker-Role"
-    )
 
 
 def test_ocm_spec_population_osd(osd_cluster_fxt):
@@ -502,3 +536,26 @@ def test_changed_ocm_spec_disable_uwm(
     assert _patch.call_count == 1
     assert _post.call_count == 0
     assert cluster_updates_mr_mock.call_count == 0
+
+
+def test_console_url_changes_ai(
+    get_json_mock,
+    queries_mock,
+    ocm_mock,
+    ocm_osd_cluster_raw_spec,
+    ocm_osd_cluster_ai_spec,
+    cluster_updates_mr_mock,
+):
+
+    ocm_osd_cluster_ai_spec["consoleUrl"] = "old-console-url"
+
+    get_json_mock.return_value = {"items": [ocm_osd_cluster_raw_spec]}
+    queries_mock[1].return_value = [ocm_osd_cluster_ai_spec]
+
+    with pytest.raises(SystemExit):
+        occ.run(dry_run=False)
+
+    _post, _patch = ocm_mock
+    assert _patch.call_count == 0
+    assert _post.call_count == 0
+    assert cluster_updates_mr_mock.call_count == 1


### PR DESCRIPTION
# Overview 
* Introduce ROSA hosted-cp clusters creation 
* OCM-clusters app-interface updates will now update values when they differ, not only when the AI values are missing. This is needed to recreate clusters automatically when they got deleted by OCM (clusters in ocm-staging are ephemeral) 
* Removed the pydantic validator to set default Rosa AWS role ARN's. Roles must be set. 
* Changed ocm-clusters updates conditions: Rosa hosted-CP clusters do not inform provision_shard nor external_id
 
Requires: https://github.com/app-sre/qontract-schemas/pull/291