### PR TITLE
Fix exception for missing resources

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -233,7 +233,7 @@ def populate_current_state(
 ):
     # if spec.oc is None: - oc can't be none because init_namespace_specs_to_fetch does not create specs if oc is none
     #    return
-    if spec.oc.init_api_resources and not spec.oc.is_kind_supported(spec.kind):
+    if not spec.oc.is_kind_supported(spec.kind):
         msg = f"[{spec.cluster}] cluster has no API resource {spec.kind}."
         logging.warning(msg)
         return


### PR DESCRIPTION
`is_kind_supported` works even if `init_api_resources` is false. So remove the condition