### PR TITLE
Switch OCM auth from offline token to client secret

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -16812,6 +16812,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "accessTokenClientSecret",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "VaultSecret_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "blockedVersions",
                             "description": null,
                             "args": [],

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1083,6 +1083,28 @@ def get_clusters_by(filter: ClusterFilter, minimal: bool = False) -> list[dict]:
     return gqlapi.query(query)["clusters"]
 
 
+OCM_QUERY = """
+{
+  instances: ocm_instances_v1 {
+    name
+    url
+    accessTokenClientId
+    accessTokenUrl
+    accessTokenClientSecret {
+      path
+      field
+      format
+      version
+    }
+  }
+}
+"""
+
+
+def get_openshift_cluster_managers() -> list[dict[str, Any]]:
+    return gql.get_api().query(OCM_QUERY)["instances"]
+
+
 KAFKA_CLUSTERS_QUERY = """
 {
   clusters: kafka_clusters_v1 {

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -613,12 +613,6 @@ CLUSTERS_QUERY = """
         format
         version
       }
-      offlineToken {
-        path
-        field
-        format
-        version
-      }
       blockedVersions
     }
     awsInfrastructureAccess {
@@ -926,12 +920,6 @@ CLUSTER_PEERING_QUERY = """
         format
         version
       }
-      offlineToken {
-        path
-        field
-        format
-        version
-      }
       blockedVersions
     }
     awsInfrastructureManagementAccounts {
@@ -1105,12 +1093,6 @@ KAFKA_CLUSTERS_QUERY = """
       accessTokenClientId
       accessTokenUrl
       accessTokenClientSecret {
-        path
-        field
-        format
-        version
-      }
-      offlineToken {
         path
         field
         format
@@ -2558,12 +2540,6 @@ OCP_RELEASE_ECR_MIRROR_QUERY = """
         accessTokenClientId
         accessTokenUrl
         accessTokenClientSecret {
-          path
-          field
-          format
-          version
-        }
-        offlineToken {
           path
           field
           format

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -607,6 +607,12 @@ CLUSTERS_QUERY = """
       url
       accessTokenClientId
       accessTokenUrl
+      accessTokenClientSecret {
+        path
+        field
+        format
+        version
+      }
       offlineToken {
         path
         field
@@ -914,6 +920,12 @@ CLUSTER_PEERING_QUERY = """
       url
       accessTokenClientId
       accessTokenUrl
+      accessTokenClientSecret {
+        path
+        field
+        format
+        version
+      }
       offlineToken {
         path
         field
@@ -1092,6 +1104,12 @@ KAFKA_CLUSTERS_QUERY = """
       url
       accessTokenClientId
       accessTokenUrl
+      accessTokenClientSecret {
+        path
+        field
+        format
+        version
+      }
       offlineToken {
         path
         field
@@ -2539,6 +2557,12 @@ OCP_RELEASE_ECR_MIRROR_QUERY = """
         url
         accessTokenClientId
         accessTokenUrl
+        accessTokenClientSecret {
+          path
+          field
+          format
+          version
+        }
         offlineToken {
           path
           field

--- a/reconcile/test/fixtures/clusters/osd_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/osd_spec_ai.yml
@@ -14,9 +14,9 @@ ocm:
   name: non-existent-ocm
   url: non-existent-ocm-url
   accessTokenClientId: cloud-services
-  offlineToken:
-    path: "offline-token-secret-path"
-    field: "offline-token"
+  accessTokenClientSecret:
+    path: "client-secret-path"
+    field: "client_secret"
 spec:
   product: osd
   id: "osd-cluster-id"

--- a/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
@@ -14,9 +14,9 @@ ocm:
   name: non-existent-ocm
   url: non-existent-ocm-url
   accessTokenClientId: cloud-services
-  offlineToken:
-    path: "offline-token-secret-path"
-    field: "offline-token"
+  accessTokenClientSecret:
+    path: "client-secret-path"
+    field: "client_secret"
 spec:
   product: rosa
   account:

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -110,9 +110,9 @@ def osd_cluster_fxt():
             "url": "https://api.non-existent-ocm.com",
             "accessTokenClientId": "cloud-services",
             "accessTokenUrl": "https://sso.blah.com/token",
-            "offlineToken": {
+            "accessTokenClientSecret": {
                 "path": "a-secret-path",
-                "field": "offline_token",
+                "field": "client_secret",
                 "format": None,
                 "version": None,
             },
@@ -169,9 +169,9 @@ def rosa_cluster_fxt():
             "url": "https://api.non-existent-ocm.com",
             "accessTokenClientId": "cloud-services",
             "accessTokenUrl": "https://sso.blah.com/token",
-            "offlineToken": {
+            "accessTokenClientSecret": {
                 "path": "a-secret-path",
-                "field": "offline_token",
+                "field": "client_secret",
                 "format": None,
                 "version": None,
             },

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -471,14 +471,14 @@ class OCM:  # pylint: disable=too-many-public-methods
     :param url: OCM instance URL
     :param access_token_client_id: client-id to get access token
     :param access_token_url: URL to get access token from
-    :param offline_token: Long lived offline token used to get access token
+    :param access_token_client_secret: client-secret to get access token
     :param init_provision_shards: should initiate provision shards
     :param init_addons: should initiate addons
     :param blocked_versions: versions to block upgrades for
     :type url: string
     :type access_token_client_id: string
     :type access_token_url: string
-    :type offline_token: string
+    :type access_token_client_secret: string
     :type init_provision_shards: bool
     :type init_addons: bool
     :type init_version_gates: bool
@@ -491,7 +491,7 @@ class OCM:  # pylint: disable=too-many-public-methods
         url,
         access_token_client_id,
         access_token_url,
-        offline_token,
+        access_token_client_secret,
         init_provision_shards=False,
         init_addons=False,
         init_version_gates=False,
@@ -503,7 +503,7 @@ class OCM:  # pylint: disable=too-many-public-methods
         if not ocm_client:
             self._init_ocm_client(
                 url=url,
-                offline_token=offline_token,
+                access_token_client_secret=access_token_client_secret,
                 access_token_client_id=access_token_client_id,
                 access_token_url=access_token_url,
             )
@@ -532,13 +532,13 @@ class OCM:  # pylint: disable=too-many-public-methods
     def _init_ocm_client(
         self,
         url: str,
-        offline_token: str,
+        access_token_client_secret: str,
         access_token_url: str,
         access_token_client_id: str,
     ):
         self._ocm_client = OCMBaseClient(
             url=url,
-            offline_token=offline_token,
+            access_token_client_secret=access_token_client_secret,
             access_token_url=access_token_url,
             access_token_client_id=access_token_client_id,
         )
@@ -1394,14 +1394,14 @@ class OCMMap:  # pylint: disable=too-many-public-methods
 
         access_token_client_id = ocm_info.get("accessTokenClientId")
         access_token_url = ocm_info.get("accessTokenUrl")
-        ocm_offline_token = ocm_info.get("offlineToken")
-        if ocm_offline_token is None:
+        access_token_client_secret = ocm_info.get("accessTokenClientSecret")
+        if access_token_client_secret is None:
             self.ocm_map[ocm_name] = False
         else:
             url = ocm_info["url"]
             name = ocm_info["name"]
             secret_reader = SecretReader(settings=self.settings)
-            token = secret_reader.read(ocm_offline_token)
+            token = secret_reader.read(access_token_client_secret)
             self.ocm_map[ocm_name] = OCM(
                 name,
                 url,

--- a/reconcile/utils/ocm_base_client.py
+++ b/reconcile/utils/ocm_base_client.py
@@ -17,12 +17,12 @@ class OCMBaseClient:
     def __init__(
         self,
         url: str,
-        offline_token: str,
+        access_token_client_secret: str,
         access_token_url: str,
         access_token_client_id: str,
         session: Optional[Session] = None,
     ):
-        self._offline_token = offline_token
+        self._access_token_client_secret = access_token_client_secret
         self._access_token_client_id = access_token_client_id
         self._access_token_url = access_token_url
         self._url = url
@@ -33,9 +33,9 @@ class OCMBaseClient:
     @retry()
     def _init_access_token(self):
         data = {
-            "grant_type": "refresh_token",
+            "grant_type": "client_credentials",
             "client_id": self._access_token_client_id,
-            "refresh_token": self._offline_token,
+            "client_secret": self._access_token_client_secret,
         }
         r = self._session.post(
             self._access_token_url, data=data, timeout=REQUEST_TIMEOUT_SEC

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -632,6 +632,26 @@ def bot_login(ctx, cluster_name):
     print(f"oc login --server {server} --token {token}")
 
 
+@get.command()
+@click.argument("org_name")
+@click.pass_context
+def ocm_login(ctx, org_name):
+    settings = queries.get_app_interface_settings()
+    secret_reader = SecretReader(settings=settings)
+    ocms = [
+        o for o in queries.get_openshift_cluster_managers() if o["name"] == org_name
+    ]
+    try:
+        ocm = ocms[0]
+    except IndexError:
+        print(f"{org_name} not found.")
+        sys.exit(1)
+
+    client_secret = secret_reader.read(ocm["accessTokenClientSecret"])
+    access_token_command = f'curl -s -X POST {ocm["accessTokenUrl"]} -d "grant_type=client_credentials" -d "client_id={ocm["accessTokenClientId"]}" -d "client_secret={client_secret}" | jq -r .access_token'
+    print(f'ocm login --url {ocm["url"]} --token $({access_token_command})')
+
+
 @get.command(
     short_help="obtain automation credentials for "
     "aws account by name. executing this "

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -632,7 +632,9 @@ def bot_login(ctx, cluster_name):
     print(f"oc login --server {server} --token {token}")
 
 
-@get.command()
+@get.command(
+    short_help="obtain automation credentials for ocm organization by org name"
+)
 @click.argument("org_name")
 @click.pass_context
 def ocm_login(ctx, org_name):


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2494

depends on https://github.com/app-sre/qontract-schemas/pull/292

docs: https://www.appsdeveloperblog.com/keycloak-client-credentials-grant-example/