### PR TITLE
[OCM] add support for CCS clusters

### DIFF
--- a/reconcile/ocm/types.py
+++ b/reconcile/ocm/types.py
@@ -96,7 +96,7 @@ class ROSAClusterSpec(OCMClusterSpec):
 
 class OCMSpec(BaseModel):
     path: Optional[str]
-    spec: Union[OSDClusterSpec, ROSAClusterSpec]
+    spec: Union[OSDClusterSpec, ROSAClusterSpec, OCMClusterSpec]
     network: OCMClusterNetwork
     domain: Optional[str]
     server_url: str = Field(None, alias="serverUrl")

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -168,7 +168,9 @@ class OCMProductOsd(OCMProduct):
 
         if not cluster["ccs"]["enabled"]:
             cluster_spec_data = spec.dict()
-            cluster_spec_data["storage"] = cluster["storage_quota"]["value"] // BYTES_IN_GIGABYTE
+            cluster_spec_data["storage"] = (
+                cluster["storage_quota"]["value"] // BYTES_IN_GIGABYTE
+            )
             cluster_spec_data["load_balancers"] = cluster["load_balancer_quota"]
             spec = OSDClusterSpec(**cluster_spec_data)
 


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-6517

CCS clusters are OSD clusters created within a customer's AWS account. As such, they do not have storage/LB quota.

This PR adds a handle for a CCS cluster so we can work with such clusters.