### PR TITLE
introduce ocm-upgrade-scheduler-org

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Additional tools that use the libraries created by the reconciliations are also 
                                   OCM.
   ocm-machine-pools               Manage Machine Pools in OCM.
   ocm-upgrade-scheduler           Manage Upgrade Policy schedules in OCM.
+  ocm-upgrade-scheduler-org       Manage Upgrade Policy schedules in OCM organizations.
   ocp-release-mirror              Mirrors OCP release images.
   openshift-clusterrolebindings   Configures ClusterRolebindings in OpenShift
                                   clusters.

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1843,6 +1843,15 @@ def ocm_upgrade_scheduler(ctx):
     run_integration(reconcile.ocm_upgrade_scheduler, ctx.obj)
 
 
+@integration.command(short_help="Manage Upgrade Policy schedules in OCM organizations.")
+@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
+@click.pass_context
+def ocm_upgrade_scheduler_org(ctx):
+    import reconcile.ocm_upgrade_scheduler_org
+
+    run_integration(reconcile.ocm_upgrade_scheduler_org, ctx.obj)
+
+
 @integration.command(short_help="Manages cluster Addons in OCM.")
 @threaded()
 @click.pass_context

--- a/reconcile/ocm_upgrade_scheduler_org.py
+++ b/reconcile/ocm_upgrade_scheduler_org.py
@@ -1,0 +1,37 @@
+from reconcile import queries
+
+import reconcile.ocm_upgrade_scheduler as ous
+
+from reconcile.utils.ocm import OCMMap
+
+
+QONTRACT_INTEGRATION = "ocm-upgrade-scheduler-org"
+
+
+def run(dry_run):
+    # patch integration name for state usage
+    ous.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION
+    settings = queries.get_app_interface_settings()
+    ocms = queries.get_openshift_cluster_managers()
+    for ocm in ocms:
+        upgrade_policy_clusters = ocm.get("upgradePolicyClusters")
+        if not upgrade_policy_clusters:
+            continue
+
+        # patch cluster items with ocm instance
+        for c in upgrade_policy_clusters:
+            c["ocm"] = ocm
+        ocm_map = OCMMap(
+            clusters=upgrade_policy_clusters,
+            integration=QONTRACT_INTEGRATION,
+            settings=settings,
+            init_version_gates=True,
+        )
+
+        current_state = ous.fetch_current_state(upgrade_policy_clusters, ocm_map)
+        desired_state = ous.fetch_desired_state(upgrade_policy_clusters)
+        version_history = ous.get_version_history(dry_run, desired_state, ocm_map)
+        diffs = ous.calculate_diff(
+            current_state, desired_state, ocm_map, version_history
+        )
+        ous.act(dry_run, diffs, ocm_map)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1096,6 +1096,23 @@ OCM_QUERY = """
       format
       version
     }
+    upgradePolicyClusters {
+      name
+      spec {
+        id
+        product
+        version
+        channel
+      }
+      upgradePolicy {
+        workloads
+        schedule
+        conditions {
+          soakDays
+          mutexes
+        }
+      }
+    }
   }
 }
 """


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6517

depends on https://github.com/app-sre/qontract-schemas/pull/294

this PR introduces a new integration - `ocm-upgrade-scheduler-org`.

this integration managed upgrades in the exact same way as `ocm-upgrade-scheduler`, but it works for OCM orgs defined in app-interface, while the clusters themselves are not managed via app-interface.

this allows external groups to submit MRs to app-interface adding their OCM org with a list of clusters and upgrade policies, and poof! it works.