### PR TITLE
Remove unmanaged_record_names field from terraform-aws-route53

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2457,7 +2457,6 @@ DNS_ZONES_QUERY = """
       vpc_id
       region
     }
-    unmanaged_record_names
     records {
       name
       type

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -60,30 +60,9 @@ def build_desired_state(
         if vpc:
             zone_values["vpc"] = {"vpc_id": vpc["vpc_id"], "vpc_region": vpc["region"]}
 
-        # Check if we have unmanaged_record_names (urn) and compile them
-        # all as regular expressions
-        urn_compiled = []
-        for urn in zone.get("unmanaged_record_names", []):
-            urn_compiled.append(re.compile(urn))
-
         for record in zone["records"]:
             record_name = record["name"]
             record_type = record["type"]
-
-            # Check if this record should be ignored
-            # as per 'unmanaged_record_names'
-            ignored = False
-            for regex in urn_compiled:
-                if regex.fullmatch(record["name"]):
-                    logging.debug(
-                        f"{zone_name}: excluding unmanaged "
-                        f"record {record_name} because it matched "
-                        f"unmanaged_record_names pattern "
-                        f"'{regex.pattern}'"
-                    )
-                    ignored = True
-            if ignored:
-                continue
 
             # We use the record object as-is from the list as the terraform
             # data to apply. This makes things simpler and map 1-to-1 with

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -1,5 +1,4 @@
 import logging
-import re
 import sys
 from typing import Any, Iterable, Mapping
 


### PR DESCRIPTION
[APPSRE-6393](https://issues.redhat.com/browse/APPSRE-6393)

`unmanaged_record_names` in the `dns-zone-1.yml` schema is no longer needed as Terraform won't overwrite existing DNS records and only modifies records explicitly outlined in DNS zone files. Removed from schemas in https://github.com/app-sre/qontract-schemas/pull/296

Here we remove the corresponding logic from the terraform-aws-route53 integration