### PR TITLE
Fix: Rollback OCM cluster attribute updates

### DIFF
--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -98,13 +98,10 @@ def get_app_interface_spec_updates(
         logging.error(cve)
         error = True
 
-    if current_spec.spec.id and desired_spec.spec.id != current_spec.spec.id:
+    if not desired_spec.spec.id:
         ocm_spec_updates[ocmmod.SPEC_ATTR_ID] = current_spec.spec.id
 
-    if (
-        current_spec.spec.external_id
-        and desired_spec.spec.external_id != current_spec.spec.external_id
-    ):
+    if not desired_spec.spec.external_id:
         ocm_spec_updates[ocmmod.SPEC_ATTR_EXTERNAL_ID] = current_spec.spec.external_id
 
     if (
@@ -115,27 +112,21 @@ def get_app_interface_spec_updates(
             ocmmod.SPEC_ATTR_DISABLE_UWM
         ] = current_spec.spec.disable_user_workload_monitoring
 
-    if (
-        current_spec.spec.provision_shard_id is not None
-        and desired_spec.spec.provision_shard_id != current_spec.spec.provision_shard_id
-    ):
+    if desired_spec.spec.provision_shard_id != current_spec.spec.provision_shard_id:
         ocm_spec_updates[
             ocmmod.SPEC_ATTR_PROVISION_SHARD_ID
         ] = current_spec.spec.provision_shard_id
 
-    if (
-        current_spec.console_url
-        and desired_spec.console_url != current_spec.console_url
-    ):
+    if not desired_spec.console_url:
         root_updates[ocmmod.SPEC_ATTR_CONSOLE_URL] = current_spec.console_url
 
-    if current_spec.server_url and desired_spec.server_url != current_spec.server_url:
+    if not desired_spec.server_url:
         root_updates[ocmmod.SPEC_ATTR_SERVER_URL] = current_spec.server_url
 
-    if (
-        current_spec.domain
-        and desired_spec.elb_fqdn != f"elb.apps.{cluster}.{current_spec.domain}"
-    ):
+    if not desired_spec.elb_fqdn:
+        # There is Bug Here. elb.apps.{cluster} might be longer than the allowed lenght.
+        # In those cases OCM truncates the string in front of {current_spec.domain}
+        # Check app-sre-stage-01 as an example.
         root_updates[
             ocmmod.SPEC_ATTR_ELBFQDN
         ] = f"elb.apps.{cluster}.{current_spec.domain}"

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -558,4 +558,4 @@ def test_console_url_changes_ai(
     _post, _patch = ocm_mock
     assert _patch.call_count == 0
     assert _post.call_count == 0
-    assert cluster_updates_mr_mock.call_count == 1
+    assert cluster_updates_mr_mock.call_count == 0


### PR DESCRIPTION
This change reverts cluster manifest updates from the OCM API. There was a problem updating the cluster's elbFQDN due to DNS record length. 

The changes introduced here will be managed separately from the ROSA/Hypershift initiative. 