### PR TITLE
Add call to get_a_records for cluster CNAMES

### DIFF
--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -73,6 +73,9 @@ def build_desired_state(
             if target_cluster:
                 target_cluster_elb = target_cluster["elbFQDN"]
 
+                # get_a_record is used here to validate the record and reused later
+                target_cluster_elb_value = dnsutils.get_a_records(target_cluster_elb)
+
                 if target_cluster_elb is None or target_cluster_elb == "":
                     msg = (
                         f"{zone_name}: field `_target_cluster` for record "
@@ -84,10 +87,8 @@ def build_desired_state(
 
                 record_values = []
                 if record_type == "A":
-                    record_values = dnsutils.get_a_records(target_cluster_elb)
+                    record_values = target_cluster_elb_value
                 elif record_type == "CNAME":
-                    # just call get_a_record for validation
-                    dnsutils.get_a_records(target_cluster_elb)
                     record_values = [target_cluster_elb]
                 else:
                     msg = (

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -86,6 +86,8 @@ def build_desired_state(
                 if record_type == "A":
                     record_values = dnsutils.get_a_records(target_cluster_elb)
                 elif record_type == "CNAME":
+                    # just call get_a_record for validation
+                    dnsutils.get_a_records(target_cluster_elb)
                     record_values = [target_cluster_elb]
                 else:
                     msg = (


### PR DESCRIPTION
Verify CNAME records by resolving the target cluster elb record. This will crash the integration on failures in DNS resolution