### PR TITLE
[ocm-upgrade-scheduler] rely on spec from ocm

### DIFF
--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -20,7 +20,9 @@ QONTRACT_INTEGRATION = "ocm-upgrade-scheduler"
 SUPPORTED_OCM_PRODUCTS = [OCM_PRODUCT_OSD]
 
 
-def fetch_current_state(clusters, ocm_map):
+def fetch_current_state(
+    clusters: list[dict[str, Any]], ocm_map: OCMMap
+) -> list[dict[str, Any]]:
     current_state = []
     for cluster in clusters:
         cluster_name = cluster["name"]
@@ -33,7 +35,9 @@ def fetch_current_state(clusters, ocm_map):
     return current_state
 
 
-def fetch_desired_state(clusters):
+def fetch_desired_state(
+    clusters: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
     desired_state = []
     for cluster in clusters:
         cluster_name = cluster["name"]

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -20,6 +20,14 @@ QONTRACT_INTEGRATION = "ocm-upgrade-scheduler"
 SUPPORTED_OCM_PRODUCTS = [OCM_PRODUCT_OSD]
 
 
+# consider first lower versions and lower soakdays (when versions are equal)
+def sort_key(d: dict) -> tuple:
+    return (
+        parse_semver(d["current_version"]),
+        d["conditions"].get("soakDays") or 0,
+    )
+
+
 def fetch_current_state(
     clusters: list[dict[str, Any]], ocm_map: OCMMap
 ) -> list[dict[str, Any]]:
@@ -46,13 +54,6 @@ def fetch_desired_state(
         upgrade_policy["current_version"] = cluster["spec"]["version"]
         upgrade_policy["channel"] = cluster["spec"]["channel"]
         desired_state.append(upgrade_policy)
-
-    # consider first lower versions and lower soakdays (when versions are equal)
-    def sort_key(d: dict) -> tuple:
-        return (
-            parse_semver(d["current_version"]),
-            d["conditions"].get("soakDays") or 0,
-        )
 
     sorted_desired_state = sorted(desired_state, key=sort_key)
 

--- a/reconcile/ocm_upgrade_scheduler_org.py
+++ b/reconcile/ocm_upgrade_scheduler_org.py
@@ -29,7 +29,7 @@ def run(dry_run):
         )
 
         current_state = ous.fetch_current_state(upgrade_policy_clusters, ocm_map)
-        desired_state = ous.fetch_desired_state(upgrade_policy_clusters)
+        desired_state = ous.fetch_desired_state(upgrade_policy_clusters, ocm_map)
         version_history = ous.get_version_history(dry_run, desired_state, ocm_map)
         diffs = ous.calculate_diff(
             current_state, desired_state, ocm_map, version_history

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1101,12 +1101,6 @@ OCM_QUERY = """
     }
     upgradePolicyClusters {
       name
-      spec {
-        id
-        product
-        version
-        channel
-      }
       upgradePolicy {
         workloads
         schedule

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -277,7 +277,7 @@ def cluster_upgrade_policies(
         init_version_gates=True,
     )
     current_state = ous.fetch_current_state(clusters, ocm_map)
-    desired_state = ous.fetch_desired_state(clusters)
+    desired_state = ous.fetch_desired_state(clusters, ocm_map)
 
     history = ous.get_version_history(
         dry_run=True, upgrade_policies=[], ocm_map=ocm_map


### PR DESCRIPTION
with this PR, the upgrade scheduler will not rely on the data found in app-interface for `version` and `channel`, but on the same information returned from the OCM API.

this makes the integration more resilient, in case the version has not been updated (we currently rely on an automation to update the field).