### PR TITLE
[terraform-resources] support records for route53-zone provider

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2440,6 +2440,57 @@ def get_unleash_instances():
     return gqlapi.query(UNLEASH_INSTANCES_QUERY)["unleash_instances"]
 
 
+DNS_RECORD = """
+name
+type
+ttl
+alias {
+  name
+  zone_id
+  evaluate_target_health
+}
+weighted_routing_policy {
+  weight
+}
+set_identifier
+records
+_healthcheck {
+  fqdn
+  port
+  type
+  resource_path
+  failure_threshold
+  request_interval
+  search_string
+}
+_target_cluster {
+  name
+  elbFQDN
+}
+_target_namespace_zone {
+  namespace {
+    managedExternalResources
+    externalResources {
+      provider
+      provisioner {
+        name
+      }
+      ... on NamespaceTerraformProviderResourceAWS_v1 {
+        resources {
+          provider
+          ... on NamespaceTerraformResourceRoute53Zone_v1 {
+            region
+            name
+          }
+        }
+      }
+    }
+  }
+  name
+}
+"""
+
+
 DNS_ZONES_QUERY = """
 {
   zones: dns_zone_v1 {
@@ -2461,57 +2512,13 @@ DNS_ZONES_QUERY = """
       region
     }
     records {
-      name
-      type
-      ttl
-      alias {
-        name
-        zone_id
-        evaluate_target_health
-      }
-      weighted_routing_policy {
-        weight
-      }
-      set_identifier
-      records
-      _healthcheck {
-        fqdn
-        port
-        type
-        resource_path
-        failure_threshold
-        request_interval
-        search_string
-      }
-      _target_cluster {
-        name
-        elbFQDN
-      }
-      _target_namespace_zone {
-        namespace {
-          managedExternalResources
-          externalResources {
-            provider
-            provisioner {
-              name
-            }
-            ... on NamespaceTerraformProviderResourceAWS_v1 {
-              resources {
-                provider
-                ... on NamespaceTerraformResourceRoute53Zone_v1 {
-                  region
-                  name
-                }
-              }
-            }
-          }
-        }
-        name
-      }
+      %s
     }
   }
 }
-"""
+""" % (
+    indent(DNS_RECORD, 6 * " "),
+)
 
 
 def get_dns_zones(account_name=None):

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -335,6 +335,9 @@ provider
   region
   identifier
   name
+  records {
+    %s
+  }
   output_resource_name
   annotations
 }
@@ -363,7 +366,9 @@ provider
   annotations
   defaults
 }
-"""
+""" % (
+    indent(queries.DNS_RECORD, 4 * " "),
+)
 
 
 TF_NAMESPACES_QUERY = """

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5048,6 +5048,12 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         zone_tf_resource = aws_route53_zone(zone_id, **values)
         tf_resources.append(zone_tf_resource)
 
+        counts = {}
+        for record in common_values.get("records") or []:
+            self.populate_route53_record(
+                account, values, record, counts, zone_tf_resource
+            )
+
         policy = {
             "Version": "2012-10-17",
             "Statement": [

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -800,9 +800,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 )
 
     def populate_route53_record(
-        self, zone, record, counts, zone_resource, default_ttl=300
+        self, account_name, zone, record, counts, zone_resource, default_ttl=300
     ):
-        acct_name = zone["account_name"]
         record_fqdn = f"{record['name']}.{zone['name']}"
         record_id = safe_resource_id(f"{record_fqdn}_{record['type'].upper()}")
 
@@ -829,17 +828,17 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             healthcheck_resource = aws_route53_health_check(
                 healthcheck_id, **healthcheck_values
             )
-            self.add_resource(acct_name, healthcheck_resource)
+            self.add_resource(account_name, healthcheck_resource)
             # Assign the healthcheck resource ID to the record
             record["health_check_id"] = f"${{{healthcheck_resource.id}}}"
 
         record_values = {"zone_id": f"${{{zone_resource.id}}}", **record}
         record_resource = aws_route53_record(record_id, **record_values)
-        self.add_resource(acct_name, record_resource)
+        self.add_resource(account_name, record_resource)
 
     def populate_route53(self, desired_state, default_ttl=300):
         for zone in desired_state:
-            acct_name = zone["account_name"]
+            account_name = zone["account_name"]
 
             zone_res_name = safe_resource_id(f"{zone['resource_name']}")
             zone_values = {
@@ -848,12 +847,12 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 "comment": "Managed by Terraform",
             }
             zone_resource = aws_route53_zone(zone_res_name, **zone_values)
-            self.add_resource(acct_name, zone_resource)
+            self.add_resource(account_name, zone_resource)
 
             counts = {}
             for record in zone["records"]:
                 self.populate_route53_record(
-                    zone, record, counts, zone_resource, default_ttl
+                    account_name, zone, record, counts, zone_resource, default_ttl
                 )
 
     def populate_vpc_peerings(self, desired_state):

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -799,7 +799,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     assume_role={"role_arn": assume_role},
                 )
 
-    def populate_route53_record(self, zone, record, counts, default_ttl, zone_resource):
+    def populate_route53_record(
+        self, zone, record, counts, zone_resource, default_ttl=300
+    ):
         acct_name = zone["account_name"]
         record_fqdn = f"{record['name']}.{zone['name']}"
         record_id = safe_resource_id(f"{record_fqdn}_{record['type'].upper()}")
@@ -851,7 +853,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             counts = {}
             for record in zone["records"]:
                 self.populate_route53_record(
-                    zone, record, counts, default_ttl, zone_resource
+                    zone, record, counts, zone_resource, default_ttl
                 )
 
     def populate_vpc_peerings(self, desired_state):


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-5707

depends on https://github.com/app-sre/qontract-schemas/pull/299

this PR adds support to specify records on a `route53-zone` provider. these records will be added to the zone.