### PR TITLE
replace cluster updates auto MR automerge label with /lgtm comment

### DIFF
--- a/reconcile/test/test_utils_mr.py
+++ b/reconcile/test/test_utils_mr.py
@@ -17,6 +17,9 @@ class DummyMergeRequest(MergeRequestBase):
     def title(self):
         return "xxx"
 
+    def description(self):
+        return "xxx"
+
     def process(self, gitlab_cli):
         if self.process_error:
             raise self.process_error

--- a/reconcile/utils/mr/README.md
+++ b/reconcile/utils/mr/README.md
@@ -30,6 +30,7 @@ The minimum methods that have to be defined are:
 * `title`: a property that is used to give the Gitlab Merge Request a title.
   It can also be used for building commit messages or as content to committed
   files.
+* `description`: a description for the Merge Request.
 * `process`: this method is called when submitting the Merge Request to gitlab.
   it's the place for the merge request changes, like creating, updating and
   deleting files. The `process` method is called after the local branch is
@@ -60,6 +61,10 @@ class CreateDeleteUser(MergeRequestBase):
     @property
     def title(self):
         return f'[{self.name}] delete user {self.username}'
+
+    @property
+    def description(self):
+        return f'delete user {self.username}'
 
     def process(self, gitlab_cli):
         for path in self.paths:

--- a/reconcile/utils/mr/README.md
+++ b/reconcile/utils/mr/README.md
@@ -59,11 +59,11 @@ class CreateDeleteUser(MergeRequestBase):
         super().__init__()
 
     @property
-    def title(self):
+    def title(self) -> str:
         return f'[{self.name}] delete user {self.username}'
 
     @property
-    def description(self):
+    def description(self) -> str:
         return f'delete user {self.username}'
 
     def process(self, gitlab_cli):

--- a/reconcile/utils/mr/app_interface_reporter.py
+++ b/reconcile/utils/mr/app_interface_reporter.py
@@ -29,11 +29,11 @@ class CreateAppInterfaceReporter(MergeRequestBase):
         self.ts = now.strftime("%Y%m%d%H%M%S")
 
     @property
-    def title(self):
+    def title(self) -> str:
         return f"[{self.name}] reports for {self.isodate}"
 
     @property
-    def description(self):
+    def description(self) -> str:
         return f"reports for {self.isodate}"
 
     def process(self, gitlab_cli):

--- a/reconcile/utils/mr/app_interface_reporter.py
+++ b/reconcile/utils/mr/app_interface_reporter.py
@@ -32,6 +32,10 @@ class CreateAppInterfaceReporter(MergeRequestBase):
     def title(self):
         return f"[{self.name}] reports for {self.isodate}"
 
+    @property
+    def description(self):
+        return f"reports for {self.isodate}"
+
     def process(self, gitlab_cli):
         actions = [
             {

--- a/reconcile/utils/mr/auto_promoter.py
+++ b/reconcile/utils/mr/auto_promoter.py
@@ -43,6 +43,10 @@ class AutoPromoter(MergeRequestBase):
         digest = m.hexdigest()[:6]
         return f"[{self.name}] openshift-saas-deploy automated " f"promotion {digest}"
 
+    @property
+    def description(self):
+        return "openshift-saas-deploy automated promotion"
+
     @staticmethod
     def init_promotion_data(
         channel: str, promotion: Mapping[str, Any]

--- a/reconcile/utils/mr/auto_promoter.py
+++ b/reconcile/utils/mr/auto_promoter.py
@@ -32,7 +32,7 @@ class AutoPromoter(MergeRequestBase):
         self.labels = [AUTO_MERGE]
 
     @property
-    def title(self):
+    def title(self) -> str:
         """
         to make the MR title unique, add a sha256sum of the promotions to it
         TODO: while adding a digest ensures uniqueness, this title is
@@ -44,7 +44,7 @@ class AutoPromoter(MergeRequestBase):
         return f"[{self.name}] openshift-saas-deploy automated " f"promotion {digest}"
 
     @property
-    def description(self):
+    def description(self) -> str:
         return "openshift-saas-deploy automated promotion"
 
     @staticmethod

--- a/reconcile/utils/mr/aws_access.py
+++ b/reconcile/utils/mr/aws_access.py
@@ -31,6 +31,10 @@ class CreateDeleteAwsAccessKey(MergeRequestBase):
     def title(self):
         return f"[{self.name}] delete {self.account} access key {self.key}"
 
+    @property
+    def description(self):
+        return f"delete {self.account} access key {self.key}"
+
     def process(self, gitlab_cli):
         # add key to deleteKeys list to be picked up by aws-iam-keys
         raw_file = gitlab_cli.project.files.get(

--- a/reconcile/utils/mr/aws_access.py
+++ b/reconcile/utils/mr/aws_access.py
@@ -28,11 +28,11 @@ class CreateDeleteAwsAccessKey(MergeRequestBase):
         self.labels = [AUTO_MERGE]
 
     @property
-    def title(self):
+    def title(self) -> str:
         return f"[{self.name}] delete {self.account} access key {self.key}"
 
     @property
-    def description(self):
+    def description(self) -> str:
         return f"delete {self.account} access key {self.key}"
 
     def process(self, gitlab_cli):

--- a/reconcile/utils/mr/base.py
+++ b/reconcile/utils/mr/base.py
@@ -72,6 +72,15 @@ class MergeRequestBase(metaclass=ABCMeta):
         """
 
     @abstractmethod
+    def description(self):
+        """
+        Description of the Merge Request.
+
+        :return: Merge Request description as seen in the Gitlab Web UI
+        :rtype: str
+        """
+
+    @abstractmethod
     def process(self, gitlab_cli):
         """
         Called by `submit_to_gitlab`, this method is the place for
@@ -110,6 +119,7 @@ class MergeRequestBase(metaclass=ABCMeta):
             "source_branch": self.branch,
             "target_branch": self.main_branch,
             "title": self.title,
+            "description": self.description,
             "remove_source_branch": self.remove_source_branch,
             "labels": self.labels,
         }

--- a/reconcile/utils/mr/base.py
+++ b/reconcile/utils/mr/base.py
@@ -63,7 +63,7 @@ class MergeRequestBase(metaclass=ABCMeta):
         )
 
     @abstractmethod
-    def title(self):
+    def title(self) -> str:
         """
         Title of the Merge Request.
 
@@ -72,7 +72,7 @@ class MergeRequestBase(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def description(self):
+    def description(self) -> str:
         """
         Description of the Merge Request.
 

--- a/reconcile/utils/mr/cluster_service_install_config.py
+++ b/reconcile/utils/mr/cluster_service_install_config.py
@@ -34,6 +34,10 @@ class CSInstallConfig(MergeRequestBase):
     def title(self):
         return f"[{self.name}] Clusters Service install-config ConfigMap"
 
+    @property
+    def description(self):
+        return "Clusters Service install-config ConfigMap"
+
     def process(self, gitlab_cli):
         install_config = {}
         install_config["apiVersion"] = "v1"

--- a/reconcile/utils/mr/cluster_service_install_config.py
+++ b/reconcile/utils/mr/cluster_service_install_config.py
@@ -31,11 +31,11 @@ class CSInstallConfig(MergeRequestBase):
         self.labels = [AUTO_MERGE, SKIP_CI]
 
     @property
-    def title(self):
+    def title(self) -> str:
         return f"[{self.name}] Clusters Service install-config ConfigMap"
 
     @property
-    def description(self):
+    def description(self) -> str:
         return "Clusters Service install-config ConfigMap"
 
     def process(self, gitlab_cli):

--- a/reconcile/utils/mr/clusters_updates.py
+++ b/reconcile/utils/mr/clusters_updates.py
@@ -16,11 +16,11 @@ class CreateClustersUpdates(MergeRequestBase):
         self.labels = []
 
     @property
-    def title(self):
+    def title(self) -> str:
         return f"[{self.name}] clusters updates"
 
     @property
-    def description(self):
+    def description(self) -> str:
         return DecisionCommand.APPROVED.value
 
     def process(self, gitlab_cli):

--- a/reconcile/utils/mr/clusters_updates.py
+++ b/reconcile/utils/mr/clusters_updates.py
@@ -1,7 +1,7 @@
 from ruamel import yaml
 
+from reconcile.change_owners.decision import DecisionCommand
 from reconcile.utils.mr.base import MergeRequestBase
-from reconcile.utils.mr.labels import AUTO_MERGE
 
 
 class CreateClustersUpdates(MergeRequestBase):
@@ -13,7 +13,7 @@ class CreateClustersUpdates(MergeRequestBase):
 
         super().__init__()
 
-        self.labels = [AUTO_MERGE]
+        self.labels = []
 
     @property
     def title(self):
@@ -21,7 +21,7 @@ class CreateClustersUpdates(MergeRequestBase):
 
     @property
     def description(self):
-        return "clusters updates"
+        return DecisionCommand.APPROVED
 
     def process(self, gitlab_cli):
         changes = False

--- a/reconcile/utils/mr/clusters_updates.py
+++ b/reconcile/utils/mr/clusters_updates.py
@@ -21,7 +21,7 @@ class CreateClustersUpdates(MergeRequestBase):
 
     @property
     def description(self):
-        return DecisionCommand.APPROVED
+        return DecisionCommand.APPROVED.value
 
     def process(self, gitlab_cli):
         changes = False

--- a/reconcile/utils/mr/clusters_updates.py
+++ b/reconcile/utils/mr/clusters_updates.py
@@ -19,6 +19,10 @@ class CreateClustersUpdates(MergeRequestBase):
     def title(self):
         return f"[{self.name}] clusters updates"
 
+    @property
+    def description(self):
+        return "clusters updates"
+
     def process(self, gitlab_cli):
         changes = False
         for cluster_name, cluster_updates in self.clusters_updates.items():

--- a/reconcile/utils/mr/notificator.py
+++ b/reconcile/utils/mr/notificator.py
@@ -43,6 +43,13 @@ class CreateAppInterfaceNotificator(MergeRequestBase):
             f"{self.notification['short_description']}"
         )
 
+    @property
+    def description(self):
+        return (
+            f"{self.notification['notification_type']}: "
+            f"{self.notification['short_description']}"
+        )
+
     def process(self, gitlab_cli):
         now = datetime.now()
         ts = now.strftime("%Y%m%d%H%M%S")

--- a/reconcile/utils/mr/notificator.py
+++ b/reconcile/utils/mr/notificator.py
@@ -36,7 +36,7 @@ class CreateAppInterfaceNotificator(MergeRequestBase):
         self.labels = [DO_NOT_MERGE_HOLD]
 
     @property
-    def title(self):
+    def title(self) -> str:
         return (
             f"[{self.name}] "
             f"{self.notification['notification_type']}: "
@@ -44,7 +44,7 @@ class CreateAppInterfaceNotificator(MergeRequestBase):
         )
 
     @property
-    def description(self):
+    def description(self) -> str:
         return (
             f"{self.notification['notification_type']}: "
             f"{self.notification['short_description']}"

--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -19,6 +19,10 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
     def title(self):
         return f"[{self.name}] ocm upgrade scheduler org updates"
 
+    @property
+    def description(self):
+        return f'ocm upgrade scheduler org updates for {self.updates_info["name"]}'
+
     def process(self, gitlab_cli):
         changes = False
         ocm_path = self.updates_info["path"]

--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -16,11 +16,11 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
         self.labels = [AUTO_MERGE]
 
     @property
-    def title(self):
+    def title(self) -> str:
         return f"[{self.name}] ocm upgrade scheduler org updates"
 
     @property
-    def description(self):
+    def description(self) -> str:
         return f'ocm upgrade scheduler org updates for {self.updates_info["name"]}'
 
     def process(self, gitlab_cli):

--- a/reconcile/utils/mr/user_maintenance.py
+++ b/reconcile/utils/mr/user_maintenance.py
@@ -24,11 +24,11 @@ class CreateDeleteUser(MergeRequestBase):
         self.labels = [AUTO_MERGE]
 
     @property
-    def title(self):
+    def title(self) -> str:
         return f"[{self.name}] delete user {self.username}"
 
     @property
-    def description(self):
+    def description(self) -> str:
         return f"delete user {self.username}"
 
     def process(self, gitlab_cli):

--- a/reconcile/utils/mr/user_maintenance.py
+++ b/reconcile/utils/mr/user_maintenance.py
@@ -27,6 +27,10 @@ class CreateDeleteUser(MergeRequestBase):
     def title(self):
         return f"[{self.name}] delete user {self.username}"
 
+    @property
+    def description(self):
+        return f"delete user {self.username}"
+
     def process(self, gitlab_cli):
         for path_spec in self.paths:
             path_type = path_spec["type"]


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6532

follows up on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/51044

in this MR we granted our bot self-service permissions over *some* cluster updates, excluding `elbFQDN` for example.

this PR adds a `description` field when submitting automated MRs. the clusters updates automated MR, which used to contain a `bot/automerge` and a `bot/skip-ci` labels will now contain a `/lgtm` in the MR description. this will lead to an automated merge, if the updates are within the self-service role.