### PR TITLE
do not skip ci on clusters updates MRs

### DIFF
--- a/reconcile/utils/mr/clusters_updates.py
+++ b/reconcile/utils/mr/clusters_updates.py
@@ -2,7 +2,6 @@ from ruamel import yaml
 
 from reconcile.utils.mr.base import MergeRequestBase
 from reconcile.utils.mr.labels import AUTO_MERGE
-from reconcile.utils.mr.labels import SKIP_CI
 
 
 class CreateClustersUpdates(MergeRequestBase):
@@ -14,7 +13,7 @@ class CreateClustersUpdates(MergeRequestBase):
 
         super().__init__()
 
-        self.labels = [AUTO_MERGE, SKIP_CI]
+        self.labels = [AUTO_MERGE]
 
     @property
     def title(self):


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6532

this is a small piece of #2923, to allow for more review time while not skipping CI on cluster updates.