### PR TITLE
ocm-upgrade-scheduler-org-updater

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Additional tools that use the libraries created by the reconciliations are also 
   ocm-machine-pools               Manage Machine Pools in OCM.
   ocm-upgrade-scheduler           Manage Upgrade Policy schedules in OCM.
   ocm-upgrade-scheduler-org       Manage Upgrade Policy schedules in OCM organizations.
+  ocm-upgrade-scheduler-org-updater
+                                  Update Upgrade Policy schedules in OCM organizations.
   ocp-release-mirror              Mirrors OCP release images.
   openshift-clusterrolebindings   Configures ClusterRolebindings in OpenShift
                                   clusters.

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1875,11 +1875,14 @@ def ocm_upgrade_scheduler_org(ctx):
 
 @integration.command(short_help="Update Upgrade Policy schedules in OCM organizations.")
 @environ(["gitlab_pr_submitter_queue_url"])
+@gitlab_project_id
 @click.pass_context
-def ocm_upgrade_scheduler_org_updater(ctx):
+def ocm_upgrade_scheduler_org_updater(ctx, gitlab_project_id):
     import reconcile.ocm_upgrade_scheduler_org_updater
 
-    run_integration(reconcile.ocm_upgrade_scheduler_org_updater, ctx.obj)
+    run_integration(
+        reconcile.ocm_upgrade_scheduler_org_updater, ctx.obj, gitlab_project_id
+    )
 
 
 @integration.command(short_help="Manages cluster Addons in OCM.")

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1873,6 +1873,15 @@ def ocm_upgrade_scheduler_org(ctx):
     run_integration(reconcile.ocm_upgrade_scheduler_org, ctx.obj)
 
 
+@integration.command(short_help="Update Upgrade Policy schedules in OCM organizations.")
+@environ(["gitlab_pr_submitter_queue_url"])
+@click.pass_context
+def ocm_upgrade_scheduler_org_updater(ctx):
+    import reconcile.ocm_upgrade_scheduler_org_updater
+
+    run_integration(reconcile.ocm_upgrade_scheduler_org_updater, ctx.obj)
+
+
 @integration.command(short_help="Manages cluster Addons in OCM.")
 @threaded()
 @click.pass_context

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -1,6 +1,9 @@
 import json
 import logging
 
+import reconcile.utils.mr.ocm_upgrade_scheduler_org_updates as ousou
+
+from reconcile import mr_client_gateway
 from reconcile import queries
 from reconcile.utils.ocm import OCMMap
 
@@ -8,10 +11,12 @@ from reconcile.utils.ocm import OCMMap
 QONTRACT_INTEGRATION = "ocm-upgrade-scheduler-org-updater"
 
 
-def run(dry_run):
+def run(dry_run, gitlab_project_id):
     settings = queries.get_app_interface_settings()
     ocms = queries.get_openshift_cluster_managers()
     for ocm_info in ocms:
+        updates = {}
+        create_update_mr = False
         upgrade_policy_defaults = ocm_info.get("upgradePolicyDefaults")
         if not upgrade_policy_defaults:
             continue
@@ -38,6 +43,7 @@ def run(dry_run):
                     default_name = default["name"]
                     match_labels: dict[str, str] = json.loads(default["matchLabels"])
                     if match_labels.items() <= ocm_cluster_labels.items():
+                        create_update_mr = True
                         logging.info(
                             ["add_cluster", ocm_name, ocm_cluster_name, default_name]
                         )
@@ -46,4 +52,10 @@ def run(dry_run):
             up_cluster_name = up_cluster["name"]
             found = [c for c in ocm.clusters if c == up_cluster_name]
             if not found:
+                create_update_mr = True
                 logging.info(["delete_cluster", ocm_name, up_cluster_name])
+
+        if create_update_mr and not dry_run:
+            mr_cli = mr_client_gateway.init(gitlab_project_id=gitlab_project_id)
+            mr = ousou.CreateOCMUpgradeSchedulerOrgUpdates(updates)
+            mr.submit(cli=mr_cli)

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -51,7 +51,7 @@ def run(dry_run, gitlab_project_id):
                         item = {
                             "action": "add",
                             "cluster": ocm_cluster_name,
-                            "policy": default_name,
+                            "policy": default["upgradePolicy"],
                         }
                         updates.append(item)
 

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -1,0 +1,30 @@
+from reconcile import queries
+
+import reconcile.ocm_upgrade_scheduler as ous
+
+from reconcile.utils.ocm import OCMMap
+
+
+QONTRACT_INTEGRATION = "ocm-upgrade-scheduler-org-updater"
+
+
+def run(dry_run):
+    settings = queries.get_app_interface_settings()
+    ocms = queries.get_openshift_cluster_managers()
+    for ocm in ocms:
+        upgrade_policy_defaults = ocm.get("upgradePolicyDefaults")
+        if not upgrade_policy_defaults:
+            continue
+
+        upgrade_policy_clusters = upgrade_policy_defaults = (
+            ocm.get("upgradePolicyClusters") or []
+        )
+        ocm_map = OCMMap(
+            ocm=ocm,
+            integration=QONTRACT_INTEGRATION,
+            settings=settings,
+            init_version_gates=True,
+        )
+        ocm_name = ocm["name"]
+        ocm = ocm_map[ocm_name]
+        print(ocm.name)

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -54,6 +54,7 @@ def run(dry_run, gitlab_project_id):
                             "policy": default["upgradePolicy"],
                         }
                         updates.append(item)
+                        break
 
         for up_cluster in upgrade_policy_clusters:
             up_cluster_name = up_cluster["name"]

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -1,7 +1,6 @@
+import logging
+
 from reconcile import queries
-
-import reconcile.ocm_upgrade_scheduler as ous
-
 from reconcile.utils.ocm import OCMMap
 
 
@@ -27,4 +26,16 @@ def run(dry_run):
         )
         ocm_name = ocm["name"]
         ocm = ocm_map[ocm_name]
-        print(ocm.name)
+
+        for ocm_cluster_name in ocm.clusters:
+            found = [
+                c for c in upgrade_policy_clusters if c["name"] == ocm_cluster_name
+            ]
+            if not found:
+                logging.info(["add_cluster", ocm_cluster_name])
+
+        for up_cluster in upgrade_policy_clusters:
+            up_cluster_name = up_cluster["name"]
+            found = [c for c in ocm.clusters if c == up_cluster_name]
+            if not found:
+                logging.info(["delete_cluster", up_cluster_name])

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -15,9 +15,7 @@ def run(dry_run):
         if not upgrade_policy_defaults:
             continue
 
-        upgrade_policy_clusters = upgrade_policy_defaults = (
-            ocm.get("upgradePolicyClusters") or []
-        )
+        upgrade_policy_clusters = ocm.get("upgradePolicyClusters") or []
         ocm_map = OCMMap(
             ocms=[ocm],
             integration=QONTRACT_INTEGRATION,

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -69,6 +69,10 @@ def run(dry_run, gitlab_project_id):
 
         if create_update_mr and not dry_run:
             mr_cli = mr_client_gateway.init(gitlab_project_id=gitlab_project_id)
-            updates_info = {"path": ocm_path, "name": ocm_name, "updates": updates}
+            updates_info = {
+                "path": "data" + ocm_path,
+                "name": ocm_name,
+                "updates": updates,
+            }
             mr = ousou.CreateOCMUpgradeSchedulerOrgUpdates(updates_info)
             mr.submit(cli=mr_cli)

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -32,10 +32,10 @@ def run(dry_run):
                 c for c in upgrade_policy_clusters if c["name"] == ocm_cluster_name
             ]
             if not found:
-                logging.info(["add_cluster", ocm_cluster_name])
+                logging.info(["add_cluster", ocm_name, ocm_cluster_name])
 
         for up_cluster in upgrade_policy_clusters:
             up_cluster_name = up_cluster["name"]
             found = [c for c in ocm.clusters if c == up_cluster_name]
             if not found:
-                logging.info(["delete_cluster", up_cluster_name])
+                logging.info(["delete_cluster", ocm_name, up_cluster_name])

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -50,7 +50,6 @@ def run(dry_run, gitlab_project_id):
                         )
                         item = {
                             "action": "add",
-                            "path": ocm_path,
                             "cluster": ocm_cluster_name,
                             "policy": default_name,
                         }
@@ -64,12 +63,12 @@ def run(dry_run, gitlab_project_id):
                 logging.info(["delete_cluster", ocm_name, up_cluster_name])
                 item = {
                     "action": "delete",
-                    "path": ocm_path,
                     "cluster": up_cluster_name,
                 }
                 updates.append(item)
 
         if create_update_mr and not dry_run:
             mr_cli = mr_client_gateway.init(gitlab_project_id=gitlab_project_id)
-            mr = ousou.CreateOCMUpgradeSchedulerOrgUpdates(updates)
+            updates_info = {"path": ocm_path, "name": ocm_name, "updates": updates}
+            mr = ousou.CreateOCMUpgradeSchedulerOrgUpdates(updates_info)
             mr.submit(cli=mr_cli)

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from reconcile import queries
@@ -30,7 +31,16 @@ def run(dry_run):
                 c for c in upgrade_policy_clusters if c["name"] == ocm_cluster_name
             ]
             if not found:
-                logging.info(["add_cluster", ocm_name, ocm_cluster_name])
+                ocm_cluster_labels = ocm.get_external_configuration_labels(
+                    ocm_cluster_name
+                )
+                for default in upgrade_policy_defaults:
+                    default_name = default["name"]
+                    match_labels = json.loads(default["matchLabels"])
+                    if match_labels.items() <= ocm_cluster_labels.items():
+                        logging.info(
+                            ["add_cluster", ocm_name, ocm_cluster_name, default_name]
+                        )
 
         for up_cluster in upgrade_policy_clusters:
             up_cluster_name = up_cluster["name"]

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -11,19 +11,19 @@ QONTRACT_INTEGRATION = "ocm-upgrade-scheduler-org-updater"
 def run(dry_run):
     settings = queries.get_app_interface_settings()
     ocms = queries.get_openshift_cluster_managers()
-    for ocm in ocms:
-        upgrade_policy_defaults = ocm.get("upgradePolicyDefaults")
+    for ocm_info in ocms:
+        upgrade_policy_defaults = ocm_info.get("upgradePolicyDefaults")
         if not upgrade_policy_defaults:
             continue
 
-        upgrade_policy_clusters = ocm.get("upgradePolicyClusters") or []
+        upgrade_policy_clusters = ocm_info.get("upgradePolicyClusters") or []
         ocm_map = OCMMap(
-            ocms=[ocm],
+            ocms=[ocm_info],
             integration=QONTRACT_INTEGRATION,
             settings=settings,
             init_version_gates=True,
         )
-        ocm_name = ocm["name"]
+        ocm_name = ocm_info["name"]
         ocm = ocm_map[ocm_name]
 
         for ocm_cluster_name in ocm.clusters:
@@ -36,7 +36,7 @@ def run(dry_run):
                 )
                 for default in upgrade_policy_defaults:
                     default_name = default["name"]
-                    match_labels = json.loads(default["matchLabels"])
+                    match_labels: dict[str, str] = json.loads(default["matchLabels"])
                     if match_labels.items() <= ocm_cluster_labels.items():
                         logging.info(
                             ["add_cluster", ocm_name, ocm_cluster_name, default_name]

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -20,7 +20,7 @@ def run(dry_run):
             ocm.get("upgradePolicyClusters") or []
         )
         ocm_map = OCMMap(
-            ocm=ocm,
+            ocms=[ocm],
             integration=QONTRACT_INTEGRATION,
             settings=settings,
             init_version_gates=True,

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1089,6 +1089,7 @@ def get_clusters_by(filter: ClusterFilter, minimal: bool = False) -> list[dict]:
 OCM_QUERY = """
 {
   instances: ocm_instances_v1 {
+    path
     name
     url
     accessTokenClientId

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1099,6 +1099,18 @@ OCM_QUERY = """
       format
       version
     }
+    upgradePolicyDefaults {
+      name
+      matchLabels
+      upgradePolicy {
+        workloads
+        schedule
+        conditions {
+          soakDays
+          mutexes
+        }
+      }
+    }
     upgradePolicyClusters {
       name
       upgradePolicy {

--- a/reconcile/test/test_ocm_additional_routers.py
+++ b/reconcile/test/test_ocm_additional_routers.py
@@ -28,10 +28,14 @@ class TestOCMAdditionalRouters(TestCase):
 
     @patch.object(queries, "get_app_interface_settings")
     @patch.object(queries, "get_clusters")
-    @patch.object(OCMMap, "init_ocm_client")
+    @patch.object(OCMMap, "init_ocm_client_from_cluster")
     @patch.object(OCMMap, "get")
     def test_integ(
-        self, get, init_ocm_client, get_clusters, get_app_interface_settings
+        self,
+        get,
+        init_ocm_client_from_cluster,
+        get_clusters,
+        get_app_interface_settings,
     ):
         fixture = fxt.get_anymarkup("state.yml")
 
@@ -59,9 +63,11 @@ class TestOCMAdditionalRouters(TestCase):
 
     # unit test
     @patch.object(queries, "get_app_interface_settings")
-    @patch.object(OCMMap, "init_ocm_client")
+    @patch.object(OCMMap, "init_ocm_client_from_cluster")
     @patch.object(OCMMap, "get")
-    def test_current_state(self, get, init_ocm_client, get_app_interface_settings):
+    def test_current_state(
+        self, get, init_ocm_client_from_cluster, get_app_interface_settings
+    ):
         fixture = fxt.get_anymarkup("state.yml")
 
         ocm_api = fixture["ocm_api"]
@@ -94,9 +100,9 @@ class TestOCMAdditionalRouters(TestCase):
         expected = fixture["diffs"]
         self.assertEqual(diffs, expected)
 
-    @patch.object(OCMMap, "init_ocm_client")
+    @patch.object(OCMMap, "init_ocm_client_from_cluster")
     @patch.object(OCMMap, "get")
-    def test_act(self, get, init_ocm_client):
+    def test_act(self, get, init_ocm_client_from_cluster):
         fixture = fxt.get_anymarkup("state.yml")
 
         ocm_api = fixture["ocm_api"]

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -260,7 +260,7 @@ def queries_mock(osd_cluster_fxt):
 @pytest.fixture
 def ocmmap_mock(ocm_osd_cluster_spec, ocm_mock):
     with patch.object(OCMMap, "get", autospec=True) as get:
-        with patch.object(OCMMap, "init_ocm_client", autospec=True):
+        with patch.object(OCMMap, "init_ocm_client_from_cluster", autospec=True):
             with patch.object(OCMMap, "cluster_specs", autospec=True) as cs:
                 get.return_value = ocm_mock
                 cs.return_value = ({"cluster1": ocm_osd_cluster_spec}, {})

--- a/reconcile/utils/mr/__init__.py
+++ b/reconcile/utils/mr/__init__.py
@@ -4,6 +4,9 @@ from reconcile.utils.mr.base import MergeRequestProcessingError
 from reconcile.utils.mr.app_interface_reporter import CreateAppInterfaceReporter
 from reconcile.utils.mr.aws_access import CreateDeleteAwsAccessKey
 from reconcile.utils.mr.clusters_updates import CreateClustersUpdates
+from reconcile.utils.mr.ocm_upgrade_scheduler_org_updates import (
+    CreateOCMUpgradeSchedulerOrgUpdates,
+)
 from reconcile.utils.mr.notificator import CreateAppInterfaceNotificator
 from reconcile.utils.mr.user_maintenance import CreateDeleteUser
 from reconcile.utils.mr.auto_promoter import AutoPromoter
@@ -17,6 +20,7 @@ __all__ = [
     "CreateAppInterfaceReporter",
     "CreateDeleteAwsAccessKey",
     "CreateClustersUpdates",
+    "CreateOCMUpgradeSchedulerOrgUpdates",
     "CreateAppInterfaceNotificator",
     "CreateDeleteUser",
     "AutoPromoter",

--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -9,8 +9,8 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
 
     name = "create_ocm_upgrade_scheduler_org_updates_mr"
 
-    def __init__(self, updates):
-        self.updates = updates
+    def __init__(self, updates_info):
+        self.updates_info = updates_info
 
         super().__init__()
 

--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -1,0 +1,65 @@
+from ruamel import yaml
+
+from reconcile.utils.mr.base import MergeRequestBase
+
+# from reconcile.utils.mr.labels import AUTO_MERGE
+
+
+class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
+
+    name = "create_ocm_upgrade_scheduler_org_updates_mr"
+
+    def __init__(self, updates):
+        self.updates = updates
+
+        super().__init__()
+
+        # self.labels = [AUTO_MERGE]
+        self.labels = []
+
+    @property
+    def title(self):
+        return f"[{self.name}] ocm upgrade scheduler org updates"
+
+    def process(self, gitlab_cli):
+        changes = False
+        # for cluster_name, cluster_updates in self.clusters_updates.items():
+        #     if not cluster_updates:
+        #         continue
+
+        #     cluster_path = cluster_updates.pop("path")
+        #     raw_file = gitlab_cli.project.files.get(
+        #         file_path=cluster_path, ref=self.main_branch
+        #     )
+        #     content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+        #     if "spec" not in content:
+        #         self.cancel("Spec missing. Nothing to do.")
+
+        #     # check that there are updates to be made
+        #     if (
+        #         cluster_updates["spec"].items() <= content["spec"].items()
+        #         and cluster_updates["root"].items() <= content.items()
+        #     ):
+        #         continue
+        #     changes = True
+
+        #     content["spec"].update(cluster_updates["spec"])
+        #     # Since spec is a dictionary we can't simply do
+        #     # content.update(cluster_updates) :(
+        #     content.update(cluster_updates["root"])
+
+        #     yaml.explicit_start = True
+        #     new_content = yaml.dump(
+        #         content, Dumper=yaml.RoundTripDumper, explicit_start=True
+        #     )
+
+        #     msg = f"update cluster {cluster_name} spec fields"
+        #     gitlab_cli.update_file(
+        #         branch_name=self.branch,
+        #         file_path=cluster_path,
+        #         commit_message=msg,
+        #         content=new_content,
+        #     )
+
+        if not changes:
+            self.cancel("OCM Upgrade schedules are up to date. Nothing to do.")

--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -60,6 +60,9 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
             else:
                 raise NotImplementedError(action)
 
+        if not changes:
+            self.cancel("OCM Upgrade schedules are up to date. Nothing to do.")
+
         yaml.explicit_start = True  # type: ignore[attr-defined]
         new_content = yaml.dump(
             content, Dumper=yaml.RoundTripDumper, explicit_start=True
@@ -72,6 +75,3 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
             commit_message=msg,
             content=new_content,
         )
-
-        if not changes:
-            self.cancel("OCM Upgrade schedules are up to date. Nothing to do.")

--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -62,7 +62,7 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
             else:
                 raise NotImplementedError(action)
 
-        yaml.explicit_start = True
+        yaml.explicit_start = True  # type: ignore[attr-defined]
         new_content = yaml.dump(
             content, Dumper=yaml.RoundTripDumper, explicit_start=True
         )

--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -1,8 +1,7 @@
 from ruamel import yaml
 
 from reconcile.utils.mr.base import MergeRequestBase
-
-# from reconcile.utils.mr.labels import AUTO_MERGE
+from reconcile.utils.mr.labels import AUTO_MERGE
 
 
 class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
@@ -14,8 +13,7 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
 
         super().__init__()
 
-        # self.labels = [AUTO_MERGE]
-        self.labels = []
+        self.labels = [AUTO_MERGE]
 
     @property
     def title(self):

--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -30,13 +30,12 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
             file_path=ocm_path, ref=self.main_branch
         )
         content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
-        upgrade_policy_defaults = content["upgradePolicyDefaults"]
         upgrade_policy_clusters = content["upgradePolicyClusters"]
 
         for update in self.updates_info["updates"]:
             action = update["action"]
             cluster_name = update["cluster"]
-            default_upgrade_policy_name = update.get("policy")
+            upgrade_policy = update.get("policy")
 
             if action == "add":
                 found = [
@@ -44,14 +43,6 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
                 ]
                 if found:
                     continue
-                upgrade_policy = [
-                    p["upgradePolicy"]
-                    for p in upgrade_policy_defaults
-                    if p["name"] == default_upgrade_policy_name
-                ]
-                if not upgrade_policy:
-                    continue
-                [upgrade_policy] = upgrade_policy
                 item = {
                     "name": cluster_name,
                     "upgradePolicy": upgrade_policy,

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -852,7 +852,7 @@ class OCM:  # pylint: disable=too-many-public-methods
 
         :type cluster: string
         """
-        results = {}
+        results: dict[str, str] = {}
         cluster_id = self.cluster_ids.get(cluster)
         if not cluster_id:
             return results

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1376,7 +1376,7 @@ class OCMMap:  # pylint: disable=too-many-public-methods
         self,
         clusters=None,
         namespaces=None,
-        ocm=None,
+        ocms=None,
         integration="",
         settings=None,
         init_provision_shards=False,
@@ -1389,7 +1389,7 @@ class OCMMap:  # pylint: disable=too-many-public-methods
         self.calling_integration = integration
         self.settings = settings
 
-        inputs = [i for i in [clusters, namespaces, ocm] if i]
+        inputs = [i for i in [clusters, namespaces, ocms] if i]
         if len(inputs) > 1:
             raise KeyError("expected only one of clusters, namespaces or ocm.")
         elif clusters:
@@ -1409,13 +1409,14 @@ class OCMMap:  # pylint: disable=too-many-public-methods
                     init_addons,
                     init_version_gates=init_version_gates,
                 )
-        elif ocm:
-            self.init_ocm_client(
-                ocm,
-                init_provision_shards,
-                init_addons,
-                init_version_gates=init_version_gates,
-            )
+        elif ocms:
+            for ocm in ocms:
+                self.init_ocm_client(
+                    ocm,
+                    init_provision_shards,
+                    init_addons,
+                    init_version_gates=init_version_gates,
+                )
         else:
             raise KeyError("expected one of clusters, namespaces or ocm.")
 

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1376,6 +1376,7 @@ class OCMMap:  # pylint: disable=too-many-public-methods
         self,
         clusters=None,
         namespaces=None,
+        ocm=None,
         integration="",
         settings=None,
         init_provision_shards=False,
@@ -1388,11 +1389,11 @@ class OCMMap:  # pylint: disable=too-many-public-methods
         self.calling_integration = integration
         self.settings = settings
 
-        if clusters and namespaces:
-            raise KeyError("expected only one of clusters or namespaces.")
+        if len([clusters, namespaces, ocm]) > 1:
+            raise KeyError("expected only one of clusters, namespaces or ocm.")
         elif clusters:
             for cluster_info in clusters:
-                self.init_ocm_client(
+                self.init_ocm_client_from_cluster(
                     cluster_info,
                     init_provision_shards,
                     init_addons,
@@ -1401,30 +1402,23 @@ class OCMMap:  # pylint: disable=too-many-public-methods
         elif namespaces:
             for namespace_info in namespaces:
                 cluster_info = namespace_info["cluster"]
-                self.init_ocm_client(
+                self.init_ocm_client_from_cluster(
                     cluster_info,
                     init_provision_shards,
                     init_addons,
                     init_version_gates=init_version_gates,
                 )
+        elif ocm:
+            self.init_ocm_client()
         else:
-            raise KeyError("expected one of clusters or namespaces.")
+            raise KeyError("expected one of clusters, namespaces or ocm.")
 
-    def init_ocm_client(
+    def __getitem__(self, ocm_name) -> OCM:
+        return self.ocm_map[ocm_name]
+
+    def init_ocm_client_from_cluster(
         self, cluster_info, init_provision_shards, init_addons, init_version_gates
     ):
-        """
-        Initiate OCM client.
-        Gets the OCM information and initiates an OCM client.
-        Skip initiating OCM if it has already been initialized or if
-        the current integration is disabled on it.
-
-        :param cluster_info: Graphql cluster query result
-        :param init_provision_shards: should initiate provision shards
-        :param init_addons: should initiate addons
-
-        :type cluster_info: dict
-        """
         if self.cluster_disabled(cluster_info):
             return
         cluster_name = cluster_info["name"]
@@ -1435,6 +1429,26 @@ class OCMMap:  # pylint: disable=too-many-public-methods
         if self.ocm_map.get(ocm_name):
             return
 
+        self.init_ocm_client(
+            ocm_info, init_provision_shards, init_addons, init_version_gates
+        )
+
+    def init_ocm_client(
+        self, ocm_info, init_provision_shards, init_addons, init_version_gates
+    ):
+        """
+        Initiate OCM client.
+        Gets the OCM information and initiates an OCM client.
+        Skip initiating OCM if it has already been initialized or if
+        the current integration is disabled on it.
+
+        :param ocm_info: Graphql ocm query result
+        :param init_provision_shards: should initiate provision shards
+        :param init_addons: should initiate addons
+
+        :type cluster_info: dict
+        """
+        ocm_name = ocm_info["name"]
         access_token_client_id = ocm_info.get("accessTokenClientId")
         access_token_url = ocm_info.get("accessTokenUrl")
         access_token_client_secret = ocm_info.get("accessTokenClientSecret")

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1389,7 +1389,8 @@ class OCMMap:  # pylint: disable=too-many-public-methods
         self.calling_integration = integration
         self.settings = settings
 
-        if len([clusters, namespaces, ocm]) > 1:
+        inputs = [i for i in [clusters, namespaces, ocm] if i]
+        if len(inputs) > 1:
             raise KeyError("expected only one of clusters, namespaces or ocm.")
         elif clusters:
             for cluster_info in clusters:

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -845,7 +845,7 @@ class OCM:  # pylint: disable=too-many-public-methods
         }
         self._post(api, payload)
 
-    def get_external_configuration_labels(self, cluster):
+    def get_external_configuration_labels(self, cluster: str) -> dict[str, str]:
         """Returns details of External Configurations
 
         :param cluster: cluster name

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1409,7 +1409,12 @@ class OCMMap:  # pylint: disable=too-many-public-methods
                     init_version_gates=init_version_gates,
                 )
         elif ocm:
-            self.init_ocm_client()
+            self.init_ocm_client(
+                ocm,
+                init_provision_shards,
+                init_addons,
+                init_version_gates=init_version_gates,
+            )
         else:
             raise KeyError("expected one of clusters, namespaces or ocm.")
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6517

depends on https://github.com/app-sre/qontract-schemas/pull/302

in order to keep `upgradePolicyClusters` up-to-date with clusters being created/deleted, we need to define conditions of clusters (ClusterDeployment labels a.k.a external configuration labels) based on which we select an upgrade policy for a discovered cluster.

this PR creates a separate integration that will submit MRs to app-interface to update `upgradePolicyClusters`, so we can keep the logic of `ocm-upgrade-scheduler-org` unchanged. the reason is that the current "static" nature of defining clusters is a no-go for management of OSD-FM fleets.

the OSD FM requirements are more complex compared to a regular customer, which usually has a single OCM org in a single OCM environment with a `statically managed set of clusters.