### PR TITLE
APPSRE-6535 Return empty array if job dosen't return allBuilds key

### DIFF
--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -86,7 +86,7 @@ def run(dry_run):
         token = instance["token"]
         instance_name = instance["name"]
         jenkins = JenkinsApi.init_jenkins_from_secret(
-            secret_reader, token, ssl_verify=True
+            secret_reader, token
         )
         all_job_names = jenkins.get_job_names()
 

--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -85,9 +85,7 @@ def run(dry_run):
 
         token = instance["token"]
         instance_name = instance["name"]
-        jenkins = JenkinsApi.init_jenkins_from_secret(
-            secret_reader, token
-        )
+        jenkins = JenkinsApi.init_jenkins_from_secret(secret_reader, token)
         all_job_names = jenkins.get_job_names()
 
         builds_todel = find_builds(jenkins, all_job_names, cleanup_rules)

--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -86,7 +86,7 @@ def run(dry_run):
         token = instance["token"]
         instance_name = instance["name"]
         jenkins = JenkinsApi.init_jenkins_from_secret(
-            secret_reader, token, ssl_verify=False
+            secret_reader, token, ssl_verify=True
         )
         all_job_names = jenkins.get_job_names()
 

--- a/reconcile/utils/jenkins_api.py
+++ b/reconcile/utils/jenkins_api.py
@@ -162,7 +162,11 @@ class JenkinsApi:
             url, verify=self.ssl_verify, auth=(self.user, self.password), timeout=60
         )
         res.raise_for_status()
-        return res.json()["allBuilds"]
+        logging.debug(f"Job: {job_name} Builds: {res.json()}")
+        try:
+            return res.json()["allBuilds"]
+        except KeyError:
+            return []
 
     def get_build_history(self, job_name, time_limit):
         return [


### PR DESCRIPTION
Fixing:

```
Traceback (most recent call last):
 File "/run-integration.py", line 164, in main 
   command.invoke(ctx) 
 File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1657, in invoke 
   return _process_result(sub_ctx.command.invoke(sub_ctx)) 
 File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1404, in invoke 
   return ctx.invoke(self.callback, **ctx.params) 
 File "/usr/local/lib/python3.9/site-packages/click/core.py", line 760, in invoke 
   return __callback(*args, **kwargs) 
 File "/usr/local/lib/python3.9/site-packages/click/decorators.py", line 26, in new_func 
   return f(get_current_context(), *args, **kwargs) 
 File "/usr/local/lib/python3.9/site-packages/reconcile/cli.py", line 780, in jenkins_job_builds_cleaner 
   run_integration(reconcile.jenkins_job_builds_cleaner, ctx.obj) 
 File "/usr/local/lib/python3.9/site-packages/reconcile/cli.py", line 457, in run_integration 
   func_container.run(dry_run, *args, **kwargs) 
 File "/usr/local/lib/python3.9/site-packages/reconcile/jenkins_job_builds_cleaner.py", line 93, in run 
   builds_todel = find_builds(jenkins, all_job_names, cleanup_rules) 
 File "/usr/local/lib/python3.9/site-packages/reconcile/jenkins_job_builds_cleaner.py", line 48, in find_builds 
   builds = jenkins.get_builds(job_name) 
 File "/usr/local/lib/python3.9/site-packages/reconcile/utils/jenkins_api.py", line 165, in get_builds 
   return res.json()["allBuilds"] 
KeyError: 'allBuilds'
```