### PR TITLE
rely on asset field metadata for CNA API and asset class conversion

### DIFF
--- a/reconcile/cna/assets/__init__.py
+++ b/reconcile/cna/assets/__init__.py
@@ -1,0 +1,8 @@
+from reconcile.cna.assets.asset_factory import register_asset_dataclass
+
+from reconcile.cna.assets.null import NullAsset
+
+from reconcile.cna.assets.aws_assume_role import AWSAssumeRoleAsset
+
+register_asset_dataclass(NullAsset)
+register_asset_dataclass(AWSAssumeRoleAsset)

--- a/reconcile/cna/assets/__init__.py
+++ b/reconcile/cna/assets/__init__.py
@@ -1,8 +1,7 @@
 from reconcile.cna.assets.asset_factory import register_asset_dataclass
-
 from reconcile.cna.assets.null import NullAsset
-
 from reconcile.cna.assets.aws_assume_role import AWSAssumeRoleAsset
+
 
 register_asset_dataclass(NullAsset)
 register_asset_dataclass(AWSAssumeRoleAsset)

--- a/reconcile/cna/assets/asset.py
+++ b/reconcile/cna/assets/asset.py
@@ -1,38 +1,222 @@
 from __future__ import annotations
 from abc import ABC, abstractmethod
-from dataclasses import dataclass, field
+
+from pydantic.dataclasses import dataclass
+from pydantic.fields import FieldInfo
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Mapping, Optional, Type
+
+from reconcile.gql_definitions.cna.queries.cna_resources import CNAssetV1
+
+
+ASSET_TYPE_FIELD = "asset_type"
+ASSET_PARAMETERS_FIELD = "parameters"
 
 
 class AssetError(Exception):
     pass
 
 
-class AssetType(Enum):
+class UnknownAssetTypeError(Exception):
+    pass
+
+
+class AssetType(str, Enum):
     NULL = "null"
     EXAMPLE_AWS_ASSUMEROLE = "example-aws-assumerole"
 
 
+def asset_type_by_id(asset_type_id: str) -> Optional[AssetType]:
+    try:
+        return AssetType(asset_type_id)
+    except ValueError:
+        return None
+
+
+def asset_type_from_raw_asset(raw_assset: Mapping[str, Any]) -> Optional[AssetType]:
+    return asset_type_by_id(raw_assset.get(ASSET_TYPE_FIELD, ""))
+
+
+class AssetTypeVariableType(Enum):
+    STRING = "${string}"
+    NUMBER = "${number}"
+    LIST_STRING = "${list(string)}"
+    LIST_NUMBER = "${list(number)}"
+
+
+@dataclass(frozen=True)
+class AssetTypeVariable:
+    name: str
+    type: AssetTypeVariableType
+    optional: bool = False
+    default: Optional[str] = None
+
+
+@dataclass
+class AssetTypeMetadata:
+    id: AssetType
+    bindable: bool
+    variables: set[AssetTypeVariable]
+
+
 class AssetStatus(Enum):
+    UNKNOWN = None
     READY = "Ready"
     TERMINATED = "Terminated"
     PENDING = "Pending"
     RUNNING = "Running"
 
 
-@dataclass(frozen=True)
+class AssetModelConfig:
+    allow_population_by_field_name = True
+    extra = "forbid"
+
+
+@dataclass(frozen=True, config=AssetModelConfig)
 class Asset(ABC):
-    uuid: Optional[str] = field(compare=False, hash=True)
-    href: Optional[str] = field(compare=False, hash=True)
-    status: Optional[AssetStatus] = field(compare=False, hash=True)
     name: str
-    kind: AssetType
+    id: Optional[str]
+    href: Optional[str]
+    status: Optional[AssetStatus]
 
+    @staticmethod
+    def bindable() -> bool:
+        return True
+
+    @classmethod
+    def type_metadata(cls) -> AssetTypeMetadata:
+        return asset_type_metadata_from_asset_dataclass(cls)
+
+    @staticmethod
     @abstractmethod
+    def asset_type() -> AssetType:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def provider() -> str:
+        ...
+
+    @staticmethod
+    @abstractmethod
+    def from_query_class(asset: CNAssetV1) -> Asset:
+        ...
+
+    @staticmethod
+    def asset_type_from_raw_asset(raw_asset: Mapping[str, Any]) -> Optional[AssetType]:
+        asset_type_value = raw_asset[ASSET_TYPE_FIELD]
+        return asset_type_by_id(asset_type_value)
+
+    def asset_metadata(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "href": self.href,
+            "status": self.status.value if self.status else None,
+            "name": self.name,
+            ASSET_TYPE_FIELD: self.asset_type().value,
+        }
+
     def api_payload(self) -> dict[str, Any]:
-        raise NotImplementedError()
+        return {
+            ASSET_TYPE_FIELD: self.asset_type().value,
+            "name": self.name,
+            ASSET_PARAMETERS_FIELD: self.raw_asset_parameters(omit_empty=False),
+        }
 
-    @abstractmethod
-    def update_from(self, asset: Asset) -> Asset:
-        raise NotImplementedError()
+    def raw_asset_parameters(self, omit_empty: bool) -> dict[str, Any]:
+        raw_asset_params = {}
+        for var in self.type_metadata().variables:
+            python_property_name = _property_for_asset_parameter_alias(
+                type(self), var.name
+            )
+            var_value = getattr(self, python_property_name)
+            if not var.optional and var_value is None:
+                raise AssetError(
+                    f"Required variable {var.name} not set for asset {self.name}"
+                )
+            if var_value is not None or not omit_empty:
+                raw_asset_params[var.name] = var_value
+        return raw_asset_params
+
+    def update_from(
+        self,
+        asset: Asset,
+    ) -> Asset:
+        assert isinstance(asset, type(self))
+        return type(asset)(
+            id=self.id,
+            href=self.href,
+            status=self.status,
+            name=self.name,
+            **asset.asset_properties(),
+        )
+
+    def asset_properties(self) -> dict[str, Any]:
+        return {p: getattr(self, p) for p in self.__annotations__.keys()}
+
+    @staticmethod
+    def from_api_mapping(
+        raw_asset: Mapping[str, Any],
+        cna_dataclass: Type[Asset],
+    ) -> Asset:
+        params = {}
+        raw_asset_params = raw_asset.get(ASSET_PARAMETERS_FIELD) or {}
+        for var in cna_dataclass.type_metadata().variables:
+            var_value = raw_asset_params.get(var.name)
+            if not var.optional and not var_value:
+                raise AssetError(
+                    f"Inconsistent asset from CNA API {raw_asset}: required parameter {var.name} is missing in CNA"
+                )
+            property_name = _property_for_asset_parameter_alias(cna_dataclass, var.name)
+            params[property_name] = var_value
+
+        return cna_dataclass(
+            id=raw_asset.get("id"),
+            href=raw_asset.get("href"),
+            status=AssetStatus(raw_asset.get("status")),
+            name=raw_asset.get("name", ""),
+            **params,
+        )
+
+
+def asset_type_metadata_from_asset_dataclass(
+    asset_dataclass: Type[Asset],
+) -> AssetTypeMetadata:
+    variables = {
+        _asset_type_metadata_variable_from_type_annotation(
+            property_name, type_hint, getattr(asset_dataclass, property_name)
+        )
+        for property_name, type_hint in asset_dataclass.__annotations__.items()
+    }
+    return AssetTypeMetadata(
+        id=asset_dataclass.asset_type(),
+        bindable=asset_dataclass.bindable(),
+        variables=variables,
+    )
+
+
+def _asset_type_metadata_variable_from_type_annotation(
+    property_name: str,
+    type_hint: str,
+    field_info: FieldInfo,
+) -> AssetTypeVariable:
+    optional = type_hint.startswith("Optional[")
+    if type_hint == "str" or type_hint.endswith("[str]"):
+        asset_type = AssetTypeVariableType.STRING
+    elif type_hint == "int" or type_hint.endswith("[int]"):
+        asset_type = AssetTypeVariableType.NUMBER
+    else:
+        raise AssetError(f"Unsupported type hint {type_hint} for {property_name}")
+        # TODO handle list types
+    return AssetTypeVariable(
+        name=field_info.alias or property_name,
+        optional=optional,
+        type=asset_type,
+    )
+
+
+def _property_for_asset_parameter_alias(cna_dataclass: Type[Asset], alias: str) -> str:
+    for property_name in cna_dataclass.__annotations__.keys():
+        if alias in (getattr(cna_dataclass, property_name).alias, property_name):
+            return property_name
+    raise AssetError(f"Cannot find property for alias {alias} in {cna_dataclass}")

--- a/reconcile/cna/assets/asset_factory.py
+++ b/reconcile/cna/assets/asset_factory.py
@@ -1,34 +1,47 @@
-from typing import Any, Mapping, Optional
-import logging
+from typing import Any, Mapping, Type
 
 from reconcile.gql_definitions.cna.queries.cna_resources import (
-    CNANullAssetV1,
-    CNAAssumeRoleAssetV1,
     CNAssetV1,
 )
-from reconcile.cna.assets.null import NullAsset
-from reconcile.cna.assets.aws_assume_role import AWSAssumeRoleAsset
-from reconcile.cna.assets.asset import Asset, AssetError, AssetType
+from reconcile.cna.assets.asset import (
+    Asset,
+    AssetType,
+    UnknownAssetTypeError,
+    asset_type_from_raw_asset,
+)
+
+
+_ASSET_TYPE_SCHEME: dict[AssetType, Type[Asset]] = {}
+_PROVIDER_SCHEME: dict[str, Type[Asset]] = {}
+
+
+def register_asset_dataclass(asset_dataclass: Type[Asset]) -> None:
+    _ASSET_TYPE_SCHEME[asset_dataclass.asset_type()] = asset_dataclass
+    _PROVIDER_SCHEME[asset_dataclass.provider()] = asset_dataclass
+
+
+def _dataclass_for_asset_type(asset_type: AssetType) -> Type[Asset]:
+    if asset_type in _ASSET_TYPE_SCHEME:
+        return _ASSET_TYPE_SCHEME[asset_type]
+    raise UnknownAssetTypeError(f"Unknown asset type {asset_type}")
+
+
+def _dataclass_for_provider(provider: str) -> Type[Asset]:
+    return _PROVIDER_SCHEME[provider]
+
+
+def asset_type_for_provider(provider: str) -> AssetType:
+    return _dataclass_for_provider(provider).asset_type()
 
 
 def asset_factory_from_schema(schema_asset: CNAssetV1) -> Asset:
-    if isinstance(schema_asset, CNANullAssetV1):
-        return NullAsset.from_query_class(schema_asset)
-    elif isinstance(schema_asset, CNAAssumeRoleAssetV1):
-        return AWSAssumeRoleAsset.from_query_class(schema_asset)
-    else:
-        raise AssetError(f"Unknown schema asset type {schema_asset}")
+    cna_dataclass = _dataclass_for_provider(schema_asset.provider)
+    return cna_dataclass.from_query_class(schema_asset)
 
 
-def asset_factory_from_raw_data(data_asset: Mapping[str, Any]) -> Optional[Asset]:
-    asset_type = data_asset.get("asset_type")
-    if asset_type == AssetType.NULL.value:
-        return NullAsset.from_api_mapping(data_asset)
-    elif asset_type == AssetType.EXAMPLE_AWS_ASSUMEROLE.value:
-        return AWSAssumeRoleAsset.from_api_mapping(data_asset)
-    else:
-        href = data_asset.get("href")
-        logging.warning(
-            f"Ignoring unknown data asset type '{asset_type}' - href: {href}"
-        )
-        return None
+def asset_factory_from_raw_data(raw_asset: Mapping[str, Any]) -> Asset:
+    asset_type = asset_type_from_raw_asset(raw_asset)
+    if asset_type:
+        cna_dataclass = _dataclass_for_asset_type(asset_type)
+        return Asset.from_api_mapping(raw_asset, cna_dataclass)
+    raise UnknownAssetTypeError(f"Unknown asset type found in {raw_asset}")

--- a/reconcile/cna/assets/aws_utils.py
+++ b/reconcile/cna/assets/aws_utils.py
@@ -1,0 +1,15 @@
+from typing import Optional
+from reconcile.gql_definitions.cna.queries.aws_account_fragment import CNAAWSSpecV1
+
+
+def aws_role_arn_for_module(
+    aws_cna_cfg: Optional[CNAAWSSpecV1], module: str
+) -> Optional[str]:
+    if aws_cna_cfg is None:
+        return None
+    role_arn = aws_cna_cfg.default_role_arn
+    for module_config in aws_cna_cfg.module_role_arns or []:
+        if module_config.module == module:
+            role_arn = module_config.arn
+            break
+    return role_arn

--- a/reconcile/cna/assets/null.py
+++ b/reconcile/cna/assets/null.py
@@ -1,54 +1,39 @@
 from __future__ import annotations
-from dataclasses import dataclass
-from typing import Any, Mapping, Optional
+from pydantic.dataclasses import dataclass
+from pydantic import Field
+from typing import Optional
 
-from reconcile.cna.assets.asset import Asset, AssetError, AssetStatus, AssetType
-from reconcile.gql_definitions.cna.queries.cna_resources import CNANullAssetV1
+from reconcile.cna.assets.asset import (
+    Asset,
+    AssetType,
+    AssetStatus,
+    AssetModelConfig,
+)
+from reconcile.gql_definitions.cna.queries.cna_resources import (
+    CNANullAssetV1,
+    CNAssetV1,
+)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, config=AssetModelConfig)
 class NullAsset(Asset):
-    addr_block: Optional[str]
-
-    def api_payload(self) -> dict[str, Any]:
-        return {
-            "asset_type": "null",
-            "name": self.name,
-            "parameters": {
-                "addr_block": self.addr_block,
-            },
-        }
-
-    def update_from(self, asset: Asset) -> Asset:
-        if not isinstance(asset, NullAsset):
-            raise AssetError(f"Cannot create NullAsset from {asset}")
-        return NullAsset(
-            uuid=self.uuid,
-            href=self.href,
-            status=self.status,
-            name=self.name,
-            kind=self.kind,
-            addr_block=asset.addr_block,
-        )
+    addr_block: Optional[str] = Field(None, alias="AddrBlock")
 
     @staticmethod
-    def from_query_class(asset: CNANullAssetV1) -> NullAsset:
+    def provider() -> str:
+        return "null-asset"
+
+    @staticmethod
+    def asset_type() -> AssetType:
+        return AssetType.NULL
+
+    @staticmethod
+    def from_query_class(asset: CNAssetV1) -> Asset:
+        assert isinstance(asset, CNANullAssetV1)
         return NullAsset(
-            uuid=None,
+            id=None,
             href=None,
-            status=None,
-            kind=AssetType.NULL,
+            status=AssetStatus.UNKNOWN,
             name=asset.name,
             addr_block=asset.addr_block,
-        )
-
-    @staticmethod
-    def from_api_mapping(asset: Mapping[str, Any]) -> NullAsset:
-        return NullAsset(
-            uuid=asset.get("id"),
-            href=asset.get("href"),
-            status=AssetStatus(asset.get("status")),
-            kind=AssetType.NULL,
-            name=asset.get("name", ""),
-            addr_block=asset.get("addr_block"),
         )

--- a/reconcile/cna/client.py
+++ b/reconcile/cna/client.py
@@ -17,9 +17,9 @@ class CNAClient:
     https://gitlab.cee.redhat.com/service/cna-management/-/blob/main/openapi/openapi.yaml#/
     """
 
-    def __init__(self, ocm_client: OCMBaseClient):
+    def __init__(self, ocm_client: OCMBaseClient, init_metadata: bool = False):
         self._ocm_client = ocm_client
-        self._metadata = self._init_metadata()
+        self._metadata = self._init_metadata() if init_metadata else None
 
     def _init_metadata(self) -> dict[AssetType, AssetTypeMetadata]:
         asset_types_metadata: dict[AssetType, AssetTypeMetadata] = {}
@@ -47,8 +47,16 @@ class CNAClient:
 
         return asset_types_metadata
 
-    def get_asset_type_metadata(self, asset_type: AssetType) -> AssetTypeMetadata:
-        return self._metadata[asset_type]
+    def service_account_name(self) -> str:
+        account = self._ocm_client.get(api_path="/api/accounts_mgmt/v1/current_account")
+        return account["username"]
+
+    def list_assets_for_creator(self, creator_username: str) -> list[dict[str, Any]]:
+        return [
+            c
+            for c in self.list_assets()
+            if c.get("creator", {}).get("username") == creator_username
+        ]
 
     def list_assets(self) -> list[dict[str, Any]]:
         """

--- a/reconcile/cna/client.py
+++ b/reconcile/cna/client.py
@@ -1,6 +1,13 @@
 import logging
 from typing import Any
-from reconcile.cna.assets.asset import Asset
+from reconcile.cna.assets.asset import (
+    Asset,
+    AssetType,
+    AssetTypeMetadata,
+    AssetTypeVariable,
+    AssetTypeVariableType,
+    asset_type_by_id,
+)
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
@@ -12,6 +19,36 @@ class CNAClient:
 
     def __init__(self, ocm_client: OCMBaseClient):
         self._ocm_client = ocm_client
+        self._metadata = self._init_metadata()
+
+    def _init_metadata(self) -> dict[AssetType, AssetTypeMetadata]:
+        asset_types_metadata: dict[AssetType, AssetTypeMetadata] = {}
+        for asset_type_ref in self._ocm_client.get(
+            api_path="/api/cna-management/v1/asset_types"
+        )["items"]:
+            raw_asset_type_metadata = self._ocm_client.get(
+                api_path=asset_type_ref["href"]
+            )
+            asset_type = asset_type_by_id(raw_asset_type_metadata["id"])
+            if asset_type:
+                asset_types_metadata[asset_type] = AssetTypeMetadata(
+                    id=asset_type,
+                    bindable=raw_asset_type_metadata.get("bindable", False),
+                    variables={
+                        AssetTypeVariable(
+                            name=var["name"],
+                            optional=var.get("default") is not None,
+                            type=AssetTypeVariableType(var["type"]),
+                            default=var.get("default"),
+                        )
+                        for var in raw_asset_type_metadata.get("variables", [])
+                    },
+                )
+
+        return asset_types_metadata
+
+    def get_asset_type_metadata(self, asset_type: AssetType) -> AssetTypeMetadata:
+        return self._metadata[asset_type]
 
     def list_assets(self) -> list[dict[str, Any]]:
         """
@@ -24,7 +61,12 @@ class CNAClient:
 
     def create(self, asset: Asset, dry_run: bool = False):
         if dry_run:
-            logging.info("CREATE %s", asset)
+            logging.info(
+                "CREATE %s %s %s",
+                asset.asset_type().value,
+                asset.name,
+                asset.raw_asset_parameters(True),
+            )
             return
         self._ocm_client.post(
             api_path="/api/cna-management/v1/cnas",

--- a/reconcile/cna/integration.py
+++ b/reconcile/cna/integration.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import logging
 from typing import Iterable, Mapping, Optional
 from reconcile.cna.client import CNAClient
 from reconcile.cna.state import State
@@ -19,7 +20,11 @@ from reconcile.typed_queries.app_interface_vault_settings import (
 )
 from reconcile.utils.secret_reader import SecretReaderBase, create_secret_reader
 from reconcile.utils.semver_helper import make_semver
-from reconcile.cna.assets.asset_factory import asset_factory_from_schema
+from reconcile.cna.assets.asset import UnknownAssetTypeError
+from reconcile.cna.assets.asset_factory import (
+    asset_factory_from_schema,
+    asset_factory_from_raw_data,
+)
 
 
 QONTRACT_INTEGRATION = "cna_resources"
@@ -58,9 +63,16 @@ class CNAIntegration:
     def assemble_current_states(self):
         self._current_states = defaultdict(State)
         for name, client in self._cna_clients.items():
-            cnas = client.list_assets()
             state = State()
-            state.add_raw_data(cnas)
+            for raw_asset in client.list_assets():
+                try:
+                    state.add_asset(
+                        asset_factory_from_raw_data(
+                            raw_asset,
+                        )
+                    )
+                except UnknownAssetTypeError as e:
+                    logging.warning(e)
             self._current_states[name] = state
 
     def provision(self, dry_run: bool = False):
@@ -94,6 +106,7 @@ def build_cna_clients(
         secret_data = secret_reader.read_all_secret(
             provisioner.ocm.access_token_client_secret
         )
+        # todo verify schema compatibility
         ocm_client = OCMBaseClient(
             url=provisioner.ocm.url,
             access_token_client_secret=secret_data["client_secret"],

--- a/reconcile/cna/integration.py
+++ b/reconcile/cna/integration.py
@@ -64,7 +64,9 @@ class CNAIntegration:
         self._current_states = defaultdict(State)
         for name, client in self._cna_clients.items():
             state = State()
-            for raw_asset in client.list_assets():
+            for raw_asset in client.list_assets_for_creator(
+                client.service_account_name()
+            ):
                 try:
                     state.add_asset(
                         asset_factory_from_raw_data(

--- a/reconcile/cna/state.py
+++ b/reconcile/cna/state.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
-from typing import Any, Iterable, Mapping, Optional
+from typing import Optional
 from reconcile.cna.assets.asset import Asset, AssetStatus, AssetType
-from reconcile.cna.assets.asset_factory import asset_factory_from_raw_data
 
 
 class CNAStateError(Exception):
@@ -18,21 +17,27 @@ class State:
 
     def __init__(self, assets: Optional[dict[AssetType, dict[str, Asset]]] = None):
         self._assets: dict[AssetType, dict[str, Asset]] = {}
-        for kind in AssetType:
-            self._assets[kind] = {}
         if assets:
             self._assets = assets
+        for asset_type in AssetType:
+            if asset_type not in self._assets:
+                self._assets[asset_type] = {}
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, State):
             return False
         if not set(list(self._assets.keys())) == set(list(other._assets.keys())):
             return False
-        for kind in list(self._assets.keys()):
-            if not set(list(self._assets[kind])) == set(list(other._assets[kind])):
+        for asset_type in list(self._assets.keys()):
+            if not set(list(self._assets[asset_type])) == set(
+                list(other._assets[asset_type])
+            ):
                 return False
-            for name, asset in self._assets[kind].items():
-                if asset != other._assets[kind][name]:
+            for name, asset in self._assets[asset_type].items():
+                if (
+                    asset.asset_properties()
+                    != other._assets[asset_type][name].asset_properties()
+                ):
                     return False
         return True
 
@@ -41,23 +46,17 @@ class State:
         return str(self._assets)
 
     def _validate_addition(self, asset: Asset):
-        if asset.kind not in self._assets:
-            raise CNAStateError(f"State doesn't know asset_kind {asset.kind}")
-        if asset.name in self._assets[asset.kind]:
+        asset_type = asset.asset_type()
+        if asset_type not in self._assets:
+            raise CNAStateError(f"State doesn't know asset_type {asset_type}")
+        if asset.name in self._assets[asset_type]:
             raise CNAStateError(
-                f"Duplicate asset name found in state: kind={asset.kind}, name={asset.name}"
+                f"Duplicate asset name found in state: asset_type={asset_type}, name={asset.name}"
             )
 
     def add_asset(self, asset: Asset):
         self._validate_addition(asset=asset)
-        self._assets[asset.kind][asset.name] = asset
-
-    def add_raw_data(self, data: Iterable[Mapping[str, Any]]):
-        for cna in data:
-            asset = asset_factory_from_raw_data(cna)
-            if asset:
-                self._validate_addition(asset=asset)
-                self._assets[asset.kind][asset.name] = asset
+        self._assets[asset.asset_type()][asset.name] = asset
 
     def required_updates_to_reach(self, other: State) -> State:
         """
@@ -68,14 +67,14 @@ class State:
         I.e., actual.required_updates_to_reach(desired)
         """
         ans = State()
-        for kind in AssetType:
-            for asset_name, other_asset in other._assets[kind].items():
-                if asset_name not in self._assets[kind]:
+        for asset_type in AssetType:
+            for asset_name, other_asset in other._assets[asset_type].items():
+                if asset_name not in self._assets[asset_type]:
                     continue
-                asset = self._assets[kind][asset_name]
+                asset = self._assets[asset_type][asset_name]
                 if asset.status in (AssetStatus.TERMINATED, AssetStatus.PENDING):
                     continue
-                if asset == other_asset:
+                if asset.asset_properties() == other_asset.asset_properties():
                     # There is no diff - no need to update
                     continue
                 ans.add_asset(asset=asset.update_from(other_asset))
@@ -92,11 +91,11 @@ class State:
         deletions = other - self
         """
         ans = State()
-        for kind in AssetType:
-            for asset_name, asset in self._assets[kind].items():
+        for asset_type in AssetType:
+            for asset_name, asset in self._assets[asset_type].items():
                 if asset.status in (AssetStatus.TERMINATED, AssetStatus.PENDING):
                     continue
-                if other_asset := other._assets[kind].get(asset_name):
+                if other_asset := other._assets[asset_type].get(asset_name):
                     if other_asset.status == AssetStatus.TERMINATED:
                         raise CNAStateError(
                             f"Trying to create/update terminated asset {asset}. Currently not possible."
@@ -108,8 +107,8 @@ class State:
     def __iter__(self) -> State:
         self._i = 0
         self._assets_list: list[Asset] = []
-        for kind in AssetType:
-            self._assets_list += list(self._assets[kind].values())
+        for asset_type in AssetType:
+            self._assets_list += list(self._assets[asset_type].values())
         return self
 
     def __next__(self) -> Asset:

--- a/reconcile/test/cna/test_asset.py
+++ b/reconcile/test/cna/test_asset.py
@@ -1,0 +1,214 @@
+from typing import Any, Mapping
+from reconcile.cna.assets.asset import (
+    Asset,
+    AssetStatus,
+    AssetType,
+    AssetTypeMetadata,
+    AssetTypeVariable,
+    AssetTypeVariableType,
+    AssetError,
+    asset_type_metadata_from_asset_dataclass,
+)
+from reconcile.cna.assets.aws_assume_role import AWSAssumeRoleAsset
+
+import pytest
+
+
+@pytest.fixture
+def aws_assumerole_asset_type_metadata() -> AssetTypeMetadata:
+    return AssetTypeMetadata(
+        id=AssetType.EXAMPLE_AWS_ASSUMEROLE,
+        bindable=True,
+        variables={
+            AssetTypeVariable(
+                name="role_arn",
+                type=AssetTypeVariableType.STRING,
+            ),
+            AssetTypeVariable(
+                name="verify-slug",
+                type=AssetTypeVariableType.STRING,
+                default="verify-slug",
+            ),
+        },
+    )
+
+
+def raw_asset(
+    id: str,
+    name: str,
+    asset_type: AssetType,
+    status: AssetStatus,
+    parameters: dict[str, str],
+) -> dict[str, Any]:
+    return {
+        "id": id,
+        "kind": "CNA",
+        "href": f"/api/cna-management/v1/cnas/{id}",
+        "asset_type": asset_type.value,
+        "name": name,
+        "status": status.value,
+        "parameters": parameters,
+        "creator": {
+            "name": "App SRE OCM bot",
+            "email": "sd-app-sre+ocm@redhat.com",
+            "username": "sd-app-sre-ocm-bot",
+        },
+        "created_at": "2022-10-27T12:08:27.98559Z",
+        "updated_at": "2022-10-27T12:08:27.98559Z",
+    }
+
+
+@pytest.fixture
+def raw_aws_assumerole_asset() -> dict[str, Any]:
+    return raw_asset(
+        "123",
+        "test",
+        AssetType.EXAMPLE_AWS_ASSUMEROLE,
+        AssetStatus.READY,
+        {"role_arn": "1234", "verify-slug": "verify-slug"},
+    )
+
+
+@pytest.fixture
+def aws_assumerole_asset(
+    raw_aws_assumerole_asset: Mapping[str, Any],
+) -> AWSAssumeRoleAsset:
+    asset = Asset.from_api_mapping(
+        raw_aws_assumerole_asset,
+        AWSAssumeRoleAsset,
+    )
+    assert isinstance(asset, AWSAssumeRoleAsset)
+    return asset
+
+
+def test_asset_type_extraction_from_raw(raw_aws_assumerole_asset: Mapping[str, Any]):
+    assert AssetType.EXAMPLE_AWS_ASSUMEROLE == Asset.asset_type_from_raw_asset(
+        raw_aws_assumerole_asset
+    )
+
+
+def test_from_api_mapping(
+    raw_aws_assumerole_asset: Mapping[str, Any],
+):
+    asset = Asset.from_api_mapping(raw_aws_assumerole_asset, AWSAssumeRoleAsset)
+    assert isinstance(asset, AWSAssumeRoleAsset)
+    assert asset.id == raw_aws_assumerole_asset["id"]
+    assert asset.href == raw_aws_assumerole_asset["href"]
+    assert asset.name == raw_aws_assumerole_asset["name"]
+    assert asset.status == AssetStatus(raw_aws_assumerole_asset["status"])
+    assert asset.role_arn == raw_aws_assumerole_asset["parameters"]["role_arn"]
+    assert asset.verify_slug == raw_aws_assumerole_asset["parameters"]["verify-slug"]
+
+
+def test_from_api_mapping_required_parameter_missing(
+    raw_aws_assumerole_asset: Mapping[str, Any],
+):
+    raw_aws_assumerole_asset["parameters"].pop("role_arn")
+    with pytest.raises(AssetError) as e:
+        Asset.from_api_mapping(
+            raw_aws_assumerole_asset,
+            AWSAssumeRoleAsset,
+        )
+    assert str(e.value).startswith("Inconsistent asset from CNA API")
+
+
+def test_api_payload(aws_assumerole_asset: AWSAssumeRoleAsset):
+    assert aws_assumerole_asset.api_payload() == {
+        "asset_type": aws_assumerole_asset.asset_type().value,
+        "name": aws_assumerole_asset.name,
+        "parameters": {
+            "role_arn": aws_assumerole_asset.role_arn,
+            "verify-slug": aws_assumerole_asset.verify_slug,
+        },
+    }
+
+
+def test_asset_type_metadata_from_asset_dataclass():
+    expected = AssetTypeMetadata(
+        id=AssetType.EXAMPLE_AWS_ASSUMEROLE,
+        bindable=True,
+        variables={
+            AssetTypeVariable(
+                name="role_arn",
+                type=AssetTypeVariableType.STRING,
+            ),
+            AssetTypeVariable(
+                name="verify-slug", type=AssetTypeVariableType.STRING, optional=True
+            ),
+        },
+    )
+    actual = asset_type_metadata_from_asset_dataclass(AWSAssumeRoleAsset)
+    assert expected == actual
+
+
+def test_update_from():
+    id = "1234"
+    name = "name"
+    href = "href"
+    status = AssetStatus.READY
+
+    desired_asset = AWSAssumeRoleAsset(
+        id=None,
+        href=None,
+        status=None,
+        name=name,
+        role_arn="new_arn",
+        verify_slug="new_verify_slug",
+    )
+
+    current_asset = AWSAssumeRoleAsset(
+        id=id,
+        href=href,
+        name=name,
+        status=status,
+        role_arn="old_arn",
+        verify_slug="old_verify_slug",
+    )
+
+    update_asset = current_asset.update_from(desired_asset)
+    assert isinstance(update_asset, AWSAssumeRoleAsset)
+    assert update_asset.id == id
+    assert update_asset.href == href
+    assert update_asset.name == name
+    assert update_asset.status == status
+    assert update_asset.role_arn == "new_arn"
+    assert update_asset.verify_slug == "new_verify_slug"
+
+
+def test_asset_comparion_ignorable_fields():
+    name = "name"
+    arn = "arn"
+    verify_slug = "verify-slug"
+    asset_1 = AWSAssumeRoleAsset(
+        id="id",
+        href="href",
+        status=AssetStatus.READY,
+        name=name,
+        role_arn=arn,
+        verify_slug=verify_slug,
+    )
+
+    asset_2 = AWSAssumeRoleAsset(
+        id=None,
+        href=None,
+        status=AssetStatus.TERMINATED,
+        name=name,
+        role_arn=arn,
+        verify_slug=verify_slug,
+    )
+
+    assert asset_1.asset_properties() == asset_2.asset_properties()
+
+
+def test_asset_properties_extration():
+    AWSAssumeRoleAsset(
+        id=None,
+        href=None,
+        status=AssetStatus.TERMINATED,
+        name="name",
+        role_arn="arn",
+        verify_slug="slug",
+    ).asset_properties() == {
+        "role_arn": "arn",
+        "verify_slug": "slug",
+    }

--- a/reconcile/test/cna/test_aws_assume_role.py
+++ b/reconcile/test/cna/test_aws_assume_role.py
@@ -1,0 +1,31 @@
+from reconcile.cna.assets.aws_assume_role import AWSAssumeRoleAsset
+from reconcile.gql_definitions.cna.queries.cna_resources import (
+    CNAAssumeRoleAssetV1,
+    CNAAssumeRoleAssetConfigV1,
+)
+from reconcile.gql_definitions.cna.queries.aws_account_fragment import (
+    CNAAWSAccountRoleARNs,
+    CNAAWSSpecV1,
+)
+
+
+def test_from_query_class():
+    name = "name"
+    slug = "slug"
+    arn = "arn"
+    query_asset = CNAAssumeRoleAssetV1(
+        provider=AWSAssumeRoleAsset.provider(),
+        name=name,
+        aws_assume_role=CNAAssumeRoleAssetConfigV1(
+            slug=slug,
+            account=CNAAWSAccountRoleARNs(
+                name="acc",
+                cna=CNAAWSSpecV1(defaultRoleARN=arn, moduleRoleARNS=None),
+            ),
+        ),
+    )
+    asset = AWSAssumeRoleAsset.from_query_class(query_asset)
+    assert isinstance(asset, AWSAssumeRoleAsset)
+    assert asset.name == name
+    assert asset.verify_slug == slug
+    assert asset.role_arn == arn

--- a/reconcile/test/cna/test_client.py
+++ b/reconcile/test/cna/test_client.py
@@ -1,0 +1,45 @@
+from reconcile.cna.client import CNAClient
+
+
+def test_client_asset_type_metadata_init():
+    pass
+
+
+def test_client_list_assets_for_creator(mocker):
+    creator = "creator"
+    listed_assets = [
+        {
+            "asset_type": "null",
+            "id": "123",
+            "href": "url/123",
+            "status": "Running",
+            "creator": {"username": creator},
+        },
+        {
+            "asset_type": "null",
+            "id": "456",
+            "href": "url/456",
+            "status": "Running",
+            "creator": {},
+        },
+        {
+            "asset_type": "null",
+            "id": "789",
+            "href": "url/789",
+            "status": "Running",
+        },
+        {
+            "asset_type": "null",
+            "id": "000",
+            "href": "url/000",
+            "status": "Running",
+            "creator": {"username": "another_user"},
+        },
+    ]
+
+    mocker.patch.object(CNAClient, "list_assets", return_value=listed_assets)
+    cna_client = CNAClient(None)  # type: ignore
+
+    creator_assets = cna_client.list_assets_for_creator(creator)
+    for asset in creator_assets:
+        assert asset["creator"]["username"] == creator

--- a/reconcile/test/cna/test_integration.py
+++ b/reconcile/test/cna/test_integration.py
@@ -4,7 +4,10 @@ from pytest import fixture
 import pytest
 from reconcile.cna.client import CNAClient
 from reconcile.cna.integration import CNAIntegration
-from reconcile.cna.assets.asset import AssetStatus, AssetType
+from reconcile.cna.assets.asset import (
+    AssetStatus,
+    AssetType,
+)
 from reconcile.cna.assets.null import NullAsset
 from reconcile.cna.state import State
 from reconcile.gql_definitions.cna.queries.cna_resources import (
@@ -40,11 +43,10 @@ def namespace(assets: list[CNANullAssetV1]) -> NamespaceV1:
 
 def null_asset(name: str, addr_block: Optional[str]) -> NullAsset:
     return NullAsset(
-        uuid=None,
+        id=None,
         href=None,
         status=None,
         name=name,
-        kind=AssetType.NULL,
         addr_block=addr_block,
     )
 
@@ -55,7 +57,7 @@ def null_asset(name: str, addr_block: Optional[str]) -> NullAsset:
         (
             # Empty state
             [],
-            State(assets={AssetType.NULL: {}}),
+            State(),
         ),
         (
             # Single asset
@@ -66,16 +68,16 @@ def null_asset(name: str, addr_block: Optional[str]) -> NullAsset:
                     "href": "url/123",
                     "status": "Running",
                     "name": "null-test",
+                    "parameters": {},
                 }
             ],
             State(
                 assets={
                     AssetType.NULL: {
                         "null-test": NullAsset(
-                            uuid="123",
+                            id="123",
                             status=AssetStatus.RUNNING,
                             name="null-test",
-                            kind=AssetType.NULL,
                             href="url/123",
                             addr_block=None,
                         )
@@ -105,18 +107,16 @@ def null_asset(name: str, addr_block: Optional[str]) -> NullAsset:
                 assets={
                     AssetType.NULL: {
                         "null-test": NullAsset(
-                            uuid="123",
+                            id="123",
                             status=AssetStatus.RUNNING,
                             name="null-test",
-                            kind=AssetType.NULL,
                             href="url/123",
                             addr_block=None,
                         ),
                         "null-test2": NullAsset(
-                            uuid="456",
+                            id="456",
                             status=AssetStatus.RUNNING,
                             name="null-test2",
-                            kind=AssetType.NULL,
                             href="url/456",
                             addr_block=None,
                         ),
@@ -198,8 +198,10 @@ def test_integration_assemble_current_states(
     ],
 )
 def test_integration_assemble_desired_states(
-    namespaces: list[NamespaceV1], expected_state: State
+    cna_clients: Mapping[str, CNAClient],
+    namespaces: list[NamespaceV1],
+    expected_state: State,
 ):
-    integration = CNAIntegration(cna_clients={}, namespaces=namespaces)
+    integration = CNAIntegration(cna_clients=cna_clients, namespaces=namespaces)
     integration.assemble_desired_states()
     assert integration._desired_states == {"test": expected_state}

--- a/reconcile/test/cna/test_integration.py
+++ b/reconcile/test/cna/test_integration.py
@@ -69,6 +69,7 @@ def null_asset(name: str, addr_block: Optional[str]) -> NullAsset:
                     "status": "Running",
                     "name": "null-test",
                     "parameters": {},
+                    "creator": {"username": "creator"},
                 }
             ],
             State(
@@ -94,6 +95,7 @@ def null_asset(name: str, addr_block: Optional[str]) -> NullAsset:
                     "href": "url/123",
                     "status": "Running",
                     "name": "null-test",
+                    "creator": {"username": "creator"},
                 },
                 {
                     "asset_type": "null",
@@ -101,6 +103,7 @@ def null_asset(name: str, addr_block: Optional[str]) -> NullAsset:
                     "href": "url/456",
                     "status": "Running",
                     "name": "null-test2",
+                    "creator": {"username": "creator"},
                 },
             ],
             State(
@@ -132,12 +135,17 @@ def null_asset(name: str, addr_block: Optional[str]) -> NullAsset:
     ],
 )
 def test_integration_assemble_current_states(
-    cna_clients: Mapping[str, CNAClient],
+    mocker,
     listed_assets: Iterable[Mapping[str, Any]],
     expected_state: State,
 ):
-    cna_clients["test"].list_assets.side_effect = [listed_assets]  # type: ignore
-    integration = CNAIntegration(cna_clients=cna_clients, namespaces=[])
+    mocker.patch.object(
+        CNAClient, "list_assets", create_autospec=True, return_value=listed_assets
+    )
+    mocker.patch.object(
+        CNAClient, "service_account_name", create_autospec=True, return_value="creator"
+    )
+    integration = CNAIntegration(cna_clients={"test": CNAClient(None)}, namespaces=[])
     integration.assemble_current_states()
     assert integration._current_states == {"test": expected_state}
 

--- a/reconcile/test/cna/test_null.py
+++ b/reconcile/test/cna/test_null.py
@@ -1,0 +1,16 @@
+from reconcile.cna.assets.null import NullAsset
+from reconcile.gql_definitions.cna.queries.cna_resources import (
+    CNANullAssetV1,
+)
+
+
+def test_from_query_class():
+    name = "name"
+    addr_block = "addr_block"
+    query_asset = CNANullAssetV1(
+        provider=NullAsset.provider(), name=name, addr_block=addr_block
+    )
+    asset = NullAsset.from_query_class(query_asset)
+    assert isinstance(asset, NullAsset)
+    assert asset.name == name
+    assert asset.addr_block == addr_block

--- a/reconcile/test/cna/test_state_assembly.py
+++ b/reconcile/test/cna/test_state_assembly.py
@@ -1,16 +1,20 @@
 from typing import Optional, cast
 import pytest
 
-from reconcile.cna.assets.asset import Asset, AssetStatus, AssetType
+from reconcile.cna.assets.asset import (
+    Asset,
+    AssetStatus,
+    AssetType,
+)
+from reconcile.cna.assets.asset_factory import asset_factory_from_raw_data
 from reconcile.cna.assets.null import NullAsset
 from reconcile.cna.state import CNAStateError, State
 
 
 def null_asset(name: str, addr_block: Optional[str] = None) -> NullAsset:
     return NullAsset(
-        uuid=None,
+        id=None,
         href=None,
-        kind=AssetType.NULL,
         status=AssetStatus.RUNNING,
         name=name,
         addr_block=addr_block,
@@ -29,7 +33,6 @@ def test_assemble_state_with_assets():
     }
     for asset in list(assets.values()):
         state.add_asset(asset)
-    state.add_raw_data([])
 
     assert state == State(
         assets=cast(dict[AssetType, dict[str, Asset]], {AssetType.NULL: assets})
@@ -55,13 +58,19 @@ def test_assemble_state_raw_data():
             "addr_block": "1234",
         },
     ]
-    assets = {
+    assets: dict[AssetType, dict[str, Asset]] = {
         AssetType.NULL: {
-            asset.get("name", ""): NullAsset.from_api_mapping(asset) for asset in data
+            raw_asset.get("name", ""): Asset.from_api_mapping(
+                raw_asset,
+                NullAsset,
+            )
+            for raw_asset in data
         }
     }
-    state.add_raw_data(data)
+    for raw_asset in data:
+        state.add_asset(asset_factory_from_raw_data(raw_asset))
 
+    # todo check if cast is needed
     assert state == State(assets=cast(dict[AssetType, dict[str, Asset]], assets))
 
 
@@ -77,5 +86,5 @@ def test_assemble_raises_duplicate_error():
 
     assert (
         str(err.value)
-        == "Duplicate asset name found in state: kind=AssetType.NULL, name=test"
+        == "Duplicate asset name found in state: asset_type=null, name=test"
     )

--- a/reconcile/test/cna/test_state_overrides.py
+++ b/reconcile/test/cna/test_state_overrides.py
@@ -1,7 +1,10 @@
 from typing import Optional
 import pytest
 
-from reconcile.cna.assets.asset import AssetStatus, AssetType
+from reconcile.cna.assets.asset import (
+    AssetStatus,
+    AssetType,
+)
 from reconcile.cna.assets.null import NullAsset
 from reconcile.cna.state import State
 
@@ -9,14 +12,13 @@ from reconcile.cna.state import State
 def null_asset(
     name: str,
     href: Optional[str] = None,
-    uuid: Optional[str] = None,
+    id: Optional[str] = None,
     addr_block: Optional[str] = None,
     status: Optional[AssetStatus] = None,
 ) -> NullAsset:
     return NullAsset(
-        uuid=uuid,
+        id=id,
         href=href,
-        kind=AssetType.NULL,
         status=status,
         name=name,
         addr_block=addr_block,
@@ -61,7 +63,7 @@ def null_asset(
             ),
         ),
         (
-            # uuid and href do not count towards equality
+            # id and href do not count towards equality
             State(
                 assets={
                     AssetType.NULL: {
@@ -83,7 +85,7 @@ def null_asset(
                         ),
                         "test2": null_asset(
                             name="test2",
-                            uuid="123",
+                            id="123",
                             href="/123",
                         ),
                     }
@@ -94,7 +96,7 @@ def null_asset(
     ids=[
         "Empty states are equal",
         "Status does not count towards equality",
-        "uuid and href do not count towards equality",
+        "id and href do not count towards equality",
     ],
 )
 def test_state_eq(a: State, b: State):
@@ -149,7 +151,7 @@ def test_state_eq(a: State, b: State):
                     AssetType.NULL: {
                         "test2": null_asset(
                             name="test2",
-                            uuid="123",
+                            id="123",
                             href="/123",
                         ),
                     }


### PR DESCRIPTION
* use registration process to make asset classes, their provider and CNA kind known to the integration
* use pydantic `alias` fields to map the difference from CNA api and python dataclasses
* drive dataclass<->API conversion through this metadata
* load CNA metadata into the client so we can test for dataclass<->API compatibility
* renamed kind to asset_type (kind means something different in the CNA API)
* creator filtering

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>