### PR TITLE
ocm initiate clusters from own org only

### DIFF
--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -277,10 +277,11 @@ def ocm_secrets_reader():
 def ocm_mock(ocm_secrets_reader):
     with patch.object(OCM, "_post", autospec=True) as _post:
         with patch.object(OCM, "_patch", autospec=True) as _patch:
-            with patch.object(OCM, "_init_ocm_client", autospec=True):
-                with patch.object(OCM, "get_provision_shard", autospec=True) as gps:
-                    gps.return_value = {"id": "provision_shard_id"}
-                    yield _post, _patch
+            with patch.object(OCM, "whoami", autospec=True):
+                with patch.object(OCM, "_init_ocm_client", autospec=True):
+                    with patch.object(OCM, "get_provision_shard", autospec=True) as gps:
+                        gps.return_value = {"id": "provision_shard_id"}
+                        yield _post, _patch
 
 
 @pytest.fixture

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -10,6 +10,7 @@ from reconcile.utils.ocm import OCM
 def ocm(mocker):
     mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient._init_access_token")
     mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient._init_request_headers")
+    mocker.patch("reconcile.utils.ocm.OCM.whoami")
     mocker.patch("reconcile.utils.ocm.OCM._init_clusters")
     mocker.patch("reconcile.utils.ocm.OCM._init_blocked_versions")
     mocker.patch("reconcile.utils.ocm.OCM._init_version_gates")

--- a/reconcile/test/test_utils_ocm_versions.py
+++ b/reconcile/test/test_utils_ocm_versions.py
@@ -6,6 +6,7 @@ from reconcile.utils.ocm import OCM
 def ocm(mocker):
     mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient._init_access_token")
     mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient._init_request_headers")
+    mocker.patch("reconcile.utils.ocm.OCM.whoami")
     mocker.patch("reconcile.utils.ocm.OCM._init_clusters")
     mocker.patch("reconcile.utils.ocm.OCM._init_version_gates")
     return OCM("name", "url", "tid", "turl", "ot")

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1310,8 +1310,12 @@ class OCM:  # pylint: disable=too-many-public-methods
     def _response_is_list(rs: Mapping[str, Any]) -> bool:
         return rs["kind"].endswith("List")
 
-    def _get_json(self, api: str, params: dict[str, Any] = {}) -> dict[str, Any]:
+    def _get_json(
+        self, api: str, params: Optional[dict[str, Any]] = None
+    ) -> dict[str, Any]:
         responses = []
+        if not params:
+            params = {}
         params["size"] = 100
         while True:
             rs = self._do_get_request(api, params=params)

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1310,7 +1310,7 @@ class OCM:  # pylint: disable=too-many-public-methods
     def _response_is_list(rs: Mapping[str, Any]) -> bool:
         return rs["kind"].endswith("List")
 
-    def _get_json(self, api: str, params: Mapping[str, str] = {}) -> dict[str, Any]:
+    def _get_json(self, api: str, params: dict[str, Any] = {}) -> dict[str, Any]:
         responses = []
         params["size"] = 100
         while True:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6526

some SAs may have non-org scoped permissions. in such cases, using a SA may mean we are a danger to the entire fleet.

this PR makes initiating clusters only consider clusters within the SA's org.