### PR TITLE
sort ocm org by names in q-cli ocm-fleet-upgrade-policies

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -501,7 +501,7 @@ def ocm_fleet_upgrade_policies(
             {"key": "workload"},
             {"key": "soaking_upgrades"},
         ]
-        ocm_orgs = {o["ocm"] for o in results}
+        ocm_orgs = sorted({o["ocm"] for o in results})
         ocm_org_section = """
 # {}
 


### PR DESCRIPTION
This ensures we keep the same OCM org display order in https://gitlab.cee.redhat.com/service/app-interface-output/-/blob/master/ocm-fleet-upgrade-policies.md