### PR TITLE
Bump sretoolbox to 2.0.0

### DIFF
--- a/reconcile/utils/instrumented_wrappers.py
+++ b/reconcile/utils/instrumented_wrappers.py
@@ -50,10 +50,6 @@ class InstrumentedCache:
         self._cache = {}
 
     def __getitem__(self, item):
-        if item in self._cache:
-            self._hits.inc()
-        else:
-            self._misses.inc()
         return self._cache[item]
 
     def __setitem__(self, key, value):
@@ -63,6 +59,14 @@ class InstrumentedCache:
     def __delitem__(self, key):
         del self._cache[key]
         self._size.dec(1)
+
+    def __contains__(self, item):
+        if item in self._cache:
+            self._hits.inc()
+            return True
+        else:
+            self._misses.inc()
+            return False
 
 
 class InstrumentedSkopeo(Skopeo):

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(exclude=("tests",)),
     package_data={"reconcile": ["templates/*.j2", "gql_queries/*/*.gql"]},
     install_requires=[
-        "sretoolbox~=1.6.0",
+        "sretoolbox~=2.0.0",
         "Click>=7.0,<9.0",
         "gql==3.1.0",
         "toml>=0.10.0,<0.11.0",


### PR DESCRIPTION
sretoolbox 2.0.0 contains a refactored implementation of the responses cache. Instrumented cache was not implementing all the needed methods for it to work. This patch solves this.

See https://github.com/app-sre/sretoolbox/pull/80

Signed-off-by: Rafael Porres Molina <rporres@gmail.com>