### PR TITLE
Use new implementation of Image response cache

### DIFF
--- a/reconcile/test/test_instrumented_wrappers.py
+++ b/reconcile/test/test_instrumented_wrappers.py
@@ -16,23 +16,3 @@ class TestInstrumentedImage(TestCase):
         getter.assert_called_once_with()
         counter.assert_called_once()
         counter.return_value.inc.assert_called_once()
-
-
-class TestInstrumentedCache(TestCase):
-    def test_get_set(self):
-        c = instrumented.InstrumentedCache("aninteg", 2, 0)
-        c["lifeuniverseandeverything"] = 42
-        self.assertEqual(c["lifeuniverseandeverything"], 42)
-
-    def test_get_not_exists(self):
-        c = instrumented.InstrumentedCache("aninteg", 2, 0)
-        with self.assertRaises(KeyError):
-            c["akeythatdoesnotexist"]
-
-    def test_del(self):
-        c = instrumented.InstrumentedCache("aninteg", 2, 0)
-        c["todelete"] = 42
-        self.assertEqual(c["todelete"], 42)
-        del c["todelete"]
-        with self.assertRaises(KeyError):
-            c["todelete"]

--- a/reconcile/utils/instrumented_wrappers.py
+++ b/reconcile/utils/instrumented_wrappers.py
@@ -31,40 +31,6 @@ class InstrumentedImage(Image):
         super()._get_manifest()
 
 
-class InstrumentedCache:
-    def __init__(self, integration_name, shards, shard_id):
-        self.integraton_name = integration_name
-        self.shards = shards
-        self.shard_id = shard_id
-
-        self._hits = metrics.cache_hits.labels(
-            integration=integration_name, shards=shards, shard_id=shard_id
-        )
-        self._misses = metrics.cache_misses.labels(
-            integration=integration_name, shards=shards, shard_id=shard_id
-        )
-        self._size = metrics.cache_size.labels(
-            integration=integration_name, shards=shards, shard_id=shard_id
-        )
-
-        self._cache = {}
-
-    def __getitem__(self, item):
-        if item in self._cache:
-            self._hits.inc()
-        else:
-            self._misses.inc()
-        return self._cache[item]
-
-    def __setitem__(self, key, value):
-        self._cache[key] = value
-        self._size.inc()
-
-    def __delitem__(self, key):
-        del self._cache[key]
-        self._size.dec(1)
-
-
 class InstrumentedSkopeo(Skopeo):
     def copy(self, *args, **kwargs):
         # pylint: disable=signature-differs

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(exclude=("tests",)),
     package_data={"reconcile": ["templates/*.j2", "gql_queries/*/*.gql"]},
     install_requires=[
-        "sretoolbox~=1.6.0",
+        "sretoolbox~=2.1.0",
         "Click>=7.0,<9.0",
         "gql==3.1.0",
         "toml>=0.10.0,<0.11.0",


### PR DESCRIPTION
The former implementation of the Image class had a few problems (and was broken for registries not returning `Docker-Content-Digest` header on manifest retrieval). A new implementation has been written and we have used the cache stats provided by it instead of rolling our own InstrumentedCache that was highly dependent of the previous implementation.

See the following PRs for more context on the Image change:

* https://github.com/app-sre/sretoolbox/pull/80
* https://github.com/app-sre/sretoolbox/pull/82

Signed-off-by: Rafael Porres Molina <rporres@gmail.com>