### PR TITLE
sql-query: performance improvements by reducing http calls

### DIFF
--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -189,6 +189,7 @@ class GqlApi:
         return resources[0]
 
     def get_resources_by_schema(self, schema: str) -> list[dict[str, str]]:
+        """Return all resources (resources_v1) filtered by given schema."""
         query = """
         query Resource($schema: String) {
             resources: resources_v1 (schema: $schema) {

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -188,6 +188,22 @@ class GqlApi:
 
         return resources[0]
 
+    def get_resources_by_schema(self, schema: str) -> list[dict[str, str]]:
+        query = """
+        query Resource($schema: String) {
+            resources: resources_v1 (schema: $schema) {
+                path
+                content
+                sha256sum
+            }
+        }
+        """
+
+        # Do not validate schema in resources since schema support in the
+        # resources is not complete.
+        resources = self.query(query, {"schema": schema}, skip_validation=True)
+        return resources["resources"]
+
     def get_queried_schemas(self):
         return list(self._queried_schemas)
 


### PR DESCRIPTION
* use bulk request to fetch "/aws/rds-defaults-1.yml" resources all at once
* use state.ls instead of state.exists for query states

## old
QUERY_COUNT * "get rds default resource" + QUERY_COUNT * (state.exists + state.get)

674 + 674 * 2 = 2022 http calls

## new
"get all rds default resources" + QUERY_COUNT * state.get + state.ls

1 + 674 + 1 = 676 http calls

APPSRE-6546
