### PR TITLE
glitchtip: remove github support - glitchtip uses auth.redhat.com as IdP

### DIFF
--- a/reconcile/test/glitchtip/test_glitchtip.py
+++ b/reconcile/test/glitchtip/test_glitchtip.py
@@ -1,4 +1,3 @@
-from github import UnknownObjectException
 from reconcile.glitchtip.integration import fetch_current_state, fetch_desired_state
 from reconcile.utils.glitchtip import GlitchtipClient, Organization
 from reconcile.gql_definitions.glitchtip.glitchtip_project import GlitchtipProjectsV1
@@ -34,13 +33,11 @@ def test_fetch_current_state(
 
 
 def test_desire_state(mocker, fx):
-    gh = mocker.patch("github.Github")
-    gh.get_user.side_effect = UnknownObjectException(status=404, data="", headers={})
     projects = [
         GlitchtipProjectsV1(**i) for i in fx.get_anymarkup("desire_state_projects.yml")
     ]
     desired_state = fetch_desired_state(
-        glitchtip_projects=projects, gh=gh, mail_domain="nasa.com"
+        glitchtip_projects=projects, mail_domain="nasa.com"
     )
     expected_desire_state = [
         Organization(**i) for i in fx.get_anymarkup("desire_state_expected.yml")


### PR DESCRIPTION
Glitchtip switches to auth.redhat.com as IdP therefore the GitHub email lookup code isn't required anymore.

Ticket: https://issues.redhat.com/browse/APPSRE-6553