### PR TITLE
change-owners fix MR priority for uncovered changes

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -338,12 +338,15 @@ def run(
 
         labels = gl.get_merge_request_labels(gitlab_merge_request_id)
 
-        mr_priority = get_priority_for_changes(changes)
+        # base labels
         conditional_labels = {
             SELF_SERVICEABLE: self_serviceable,
             NOT_SELF_SERVICEABLE: not self_serviceable,
             HOLD: self_serviceable and hold,
         }
+
+        # priority labels
+        mr_priority = get_priority_for_changes(changes)
         conditional_labels.update(
             {
                 prioritized_approval_label(p.value): self_serviceable

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -494,7 +494,7 @@ def change_path_covered_by_allowed_path(changed_path: str, allowed_path: str) ->
 
 def get_priority_for_changes(
     bundle_file_changes: list[BundleFileChange],
-) -> ChangeTypePriority:
+) -> Optional[ChangeTypePriority]:
     """
     Finds the lowest priority of all change types involved in the provided bundle file changes.
     """
@@ -507,8 +507,4 @@ def get_priority_for_changes(
     for p in reversed(ChangeTypePriority):
         if p in prorities:
             return p
-    raise ValueError(
-        "The priorities of the involved change types are not compatible with the supported priorities \n"
-        f"change-type priorities: {[p.value for p in prorities]} \n"
-        f"supported priorities: {[p.value for p in ChangeTypePriority]}"
-    )
+    return None

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -1548,6 +1548,18 @@ def test_priority_for_changes(
     assert ChangeTypePriority.MEDIUM == get_priority_for_changes(changes)
 
 
+def test_priorty_for_changes_no_coverage():
+    changes = [
+        BundleFileChange(
+            fileref=None,  # type: ignore
+            old=None,
+            new=None,
+            diff_coverage=[],
+        )
+    ]
+    assert get_priority_for_changes(changes) is None
+
+
 #
 # DiffCoverage tests
 #


### PR DESCRIPTION
this fixes a bug in the priority calculation logic for non-self-serviceable MR.

an MR that has only uncovered changed, will not yield any priority for self-service merges because it can't be self-service merged anways.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>