### PR TITLE
Allow tekton timeouts bigger than 60 minutes

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -21,6 +21,7 @@ from reconcile.utils.saasherder import (
 from reconcile.utils.sharding import is_in_shard
 from reconcile.utils.defer import defer
 from reconcile.openshift_tekton_resources import build_one_per_saas_file_tkn_object_name
+from reconcile.utils.parse_dhms_duration import dhms_to_seconds
 
 _trigger_lock = Lock()
 
@@ -361,13 +362,13 @@ def _construct_tekton_trigger_resource(
     }
 
     if timeout:
-        if timeout < 60:
+        seconds = dhms_to_seconds(timeout)
+        if seconds < 3600:  # 1 hour
             raise TektonTimeoutBadValueError(
                 f"timeout {timeout} is smaller than 60 minutes"
             )
 
-        # conforming to Go’s ParseDuration format
-        body["spec"]["timeout"] = f"{timeout}m"
+        body["spec"]["timeout"] = timeout
 
     return OR(body, integration, integration_version, error_details=name), long_name
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1997,6 +1997,7 @@ SAAS_FILES_QUERY_V2 = """
     takeover
     deprecated
     compare
+    timeout
     publishJobLogs
     clusterAdmin
     imagePatterns

--- a/reconcile/test/test_utils_parse_dhms_duration.py
+++ b/reconcile/test/test_utils_parse_dhms_duration.py
@@ -1,0 +1,30 @@
+import pytest
+from reconcile.utils.parse_dhms_duration import dhms_to_seconds, BadHDMSDurationError
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        ("3s", 3),
+        ("1h30m", 5400),
+        ("2m", 120),
+        ("2h", 7200),
+        ("1d", 86400),
+        ("1m1s", 61),
+        ("2h1m1s", 7261),
+        ("2d1h1m2s", 176462),
+        ("1s2h", 7201),
+        ("1s1m1s", 62),
+    ],
+)
+def test_valid_duration(test_input: str, expected: int) -> None:
+    assert dhms_to_seconds(test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "bad_input",
+    ["2", "35", "1d1", "1d1j", "2hh", "ms"],
+)
+def test_invalid_duration(bad_input: str):
+    with pytest.raises(BadHDMSDurationError):
+        dhms_to_seconds(bad_input)

--- a/reconcile/utils/parse_dhms_duration.py
+++ b/reconcile/utils/parse_dhms_duration.py
@@ -1,0 +1,63 @@
+DAY_TO_SECONDS = 24 * 3600
+HOUR_TO_SECONDS = 3600
+MINUTE_TO_SECONDS = 60
+
+
+class BadHDMSDurationError(Exception):
+    pass
+
+
+def _days_to_seconds(days: int) -> int:
+    return days * DAY_TO_SECONDS
+
+
+def _hours_to_seconds(hours: int) -> int:
+    return hours * HOUR_TO_SECONDS
+
+
+def _minutes_to_seconds(minutes: int) -> int:
+    return minutes * MINUTE_TO_SECONDS
+
+
+def _seconds_to_seconds(seconds: int) -> int:
+    return seconds
+
+
+HANDLE_UNIT_MAP = {
+    "d": _days_to_seconds,
+    "h": _hours_to_seconds,
+    "m": _minutes_to_seconds,
+    "s": _seconds_to_seconds,
+}
+
+
+def dhms_to_seconds(time_str: str) -> int:
+    """Parses durations and returns seconds. The format is a subset of Go's
+    ParseDuration format, only allowing from days to seconds in resolution,
+    e.g. "1h", "1d1h1m2s", ...
+    """
+    total_seconds = 0
+    s = previous_number = time_str[0]
+
+    if not previous_number.isnumeric():
+        raise BadHDMSDurationError(f"Invalid time duration {time_str}")
+
+    for s in time_str[1:]:
+        if s.isnumeric():
+            previous_number += s
+        else:
+            if previous_number == "":
+                raise BadHDMSDurationError(f"Invalid time duration {time_str}")
+
+            if s in HANDLE_UNIT_MAP:
+                total_seconds += HANDLE_UNIT_MAP[s](int(previous_number))
+                previous_number = ""
+            else:
+                raise BadHDMSDurationError(
+                    f"Invalid unit {s} in time duration {time_str}"
+                )
+
+    if s.isnumeric():
+        raise BadHDMSDurationError(f"Invalid time duration {time_str}")
+
+    return total_seconds


### PR DESCRIPTION
Tekton default timeout for PipelineRuns are 60 minutes. We may need to allow for larger timeouts for certain jobs, but we don't want to allow for smaller timeouts since the current implementation is to delete the underlying pods, which gets us without logs.

schema: https://github.com/app-sre/qontract-schemas/pull/312

Part of APPSRE-4670

Signed-off-by: Rafael Porres Molina <rporres@gmail.com>