### PR TITLE
APPSRE-6545 upgrade policy sector

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -615,6 +615,15 @@ CLUSTERS_QUERY = """
         version
       }
       blockedVersions
+      sectors {
+        name
+        dependencies {
+          name
+          ocm {
+            name
+          }
+        }
+      }
     }
     awsInfrastructureAccess {
       awsGroup {
@@ -691,6 +700,7 @@ CLUSTERS_QUERY = """
       conditions {
         soakDays
         mutexes
+        sector
       }
     }
     additionalRouters {
@@ -1106,6 +1116,15 @@ OCM_QUERY = """
       format
       version
     }
+    sectors {
+      name
+      dependencies {
+        name
+        ocm {
+          name
+        }
+      }
+    }
     upgradePolicyDefaults {
       name
       matchLabels
@@ -1126,6 +1145,7 @@ OCM_QUERY = """
         conditions {
           soakDays
           mutexes
+          sector
         }
       }
     }

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -2,6 +2,7 @@ import json
 import pytest
 import httpretty
 from httpretty.core import HTTPrettyRequest
+from copy import deepcopy
 
 from reconcile.utils.ocm import (
     OCMMap,
@@ -246,14 +247,15 @@ def test_sector_validate_dependencies(ocm):
         sector3.validate_dependencies()
 
 
-def test_ocm_map_upgrade_policies(ocm, mocker):
+def test_ocm_map_upgrade_policies_sector(ocm, mocker):
     mocker.patch("reconcile.utils.ocm.SecretReader")
     sectors = [
         {"name": "s1"},
         {"name": "s2", "dependencies": [{"name": "s1"}]},
         {"name": "s3", "dependencies": [{"ocm": {"name": "ocm1"}, "name": "s1"}]},
+        {"name": "s4", "dependencies": [{"ocm": {"name": "ocm1"}, "name": "*"}]},
     ]
-    ocm_info = {
+    ocm1_info = {
         "name": "ocm1",
         "sectors": sectors,
         "accessTokenClientId": "atci",
@@ -261,24 +263,44 @@ def test_ocm_map_upgrade_policies(ocm, mocker):
         "accessTokenClientSecret": "atcs",
         "url": "u",
     }
-    c1 = {"name": "c1", "ocm": ocm_info, "upgradePolicy": {"workload": "w1"}}
+    c1 = {
+        "name": "c1",
+        "ocm": ocm1_info,
+        "upgradePolicy": {"workload": "w1"},
+    }
     c2 = {
         "name": "c2",
-        "ocm": ocm_info,
+        "ocm": ocm1_info,
         "upgradePolicy": {"workload": "w1", "conditions": {"sector": "s2"}},
     }
 
-    ocm_map = OCMMap(clusters=[c1, c2])
+    # second org, using the same sector names
+    ocm2_info = deepcopy(ocm1_info)
+    ocm2_info["name"] = "ocm2"
+    c3 = {
+        "name": "c3",
+        "ocm": ocm2_info,
+        "upgradePolicy": {"workload": "w1", "conditions": {"sector": "s3"}},
+    }
+
+    ocm_map = OCMMap(clusters=[c1, c2, c3])
     assert "ocm1" in ocm_map.ocm_map
+    assert "ocm2" in ocm_map.ocm_map
 
+    # all sectors are reported, even the ones without clusters
     ocm1 = ocm_map["ocm1"]
-    assert len(ocm1.sectors) == 3
+    assert len(ocm1.sectors) == 4
 
+    ocm2 = ocm_map["ocm2"]
+    assert len(ocm2.sectors) == 4
+
+    # no dependencies
     s1 = Sector(
         name="s1", ocm=ocm1, dependencies=[], dependencies_refs=[], cluster_infos=[]
     )
     assert ocm1.sectors["s1"] == s1
 
+    # partial dependency definition, without ocm org. defaulting to sector's org
     s1_weak = SectorWeakReference(ocm_org_name="ocm1", sector_name="s1")
     s2 = Sector(
         name="s2",
@@ -289,6 +311,7 @@ def test_ocm_map_upgrade_policies(ocm, mocker):
     )
     assert ocm1.sectors["s2"] == s2
 
+    # full dependency definition, including ocm org
     s3 = Sector(
         name="s3",
         ocm=ocm1,
@@ -297,3 +320,20 @@ def test_ocm_map_upgrade_policies(ocm, mocker):
         cluster_infos=[],
     )
     assert ocm1.sectors["s3"] == s3
+
+    # wildcard dependencies report all other sectors
+    wildcard_dep_ref = SectorWeakReference(ocm_org_name="ocm1", sector_name="*")
+    s4 = Sector(
+        name="s4",
+        ocm=ocm1,
+        dependencies=[s1, s2, s3],
+        dependencies_refs=[wildcard_dep_ref],
+        cluster_infos=[],
+    )
+    assert ocm1.sectors["s4"] == s4
+
+    # cross-orgs dependency
+    assert ocm2.sectors["s3"].dependencies == [s1]
+
+    # cross-orgs wildcard dependencies
+    assert ocm2.sectors["s4"].dependencies == [s1, s2, s3, s4]

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1519,10 +1519,15 @@ class OCMMap:  # pylint: disable=too-many-public-methods
         # link sectors across OCM orgs
         for ocm in self.ocm_map.values():
             for sector in ocm.sectors.values():
-                sector.dependencies = []
                 for dep_refs in sector.dependencies_refs:
                     other_ocm = self.ocm_map[dep_refs.ocm_org_name]
-                    sector.dependencies.append(other_ocm.sectors[dep_refs.sector_name])
+                    other_sector_names = [dep_refs.sector_name]
+                    if dep_refs.sector_name == "*":
+                        other_sector_names = list(other_ocm.sectors.keys())
+                        if ocm.name == other_ocm.name:  # do not depend on ourself
+                            other_sector_names.remove(sector.name)
+                    for name in other_sector_names:
+                        sector.dependencies.append(other_ocm.sectors[name])
 
         # check sectors dependencies loop
         for ocm in self.ocm_map.values():

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -292,6 +292,9 @@ def get_upgrade_policies_data(
         channel, schedule = c["channel"], c.get("schedule")
         soakdays = c.get("conditions", {}).get("soakDays")
         mutexes = c.get("conditions", {}).get("mutexes") or []
+        sector = ""
+        if c.get("conditions", {}).get("sector"):
+            sector = c["condition"]["sector"].name
         ocm_org = ocm_map.get(cluster_name)
         ocm_spec = ocm_org.clusters[cluster_name]
         item = {
@@ -304,6 +307,7 @@ def get_upgrade_policies_data(
             "version": version,
             "channel": channel,
             "schedule": schedule,
+            "sector": sector,
             "soak_days": soakdays,
             "mutexes": ", ".join(mutexes),
         }
@@ -430,6 +434,7 @@ def cluster_upgrade_policies(
             {"key": "version", "sortable": True},
             {"key": "channel", "sortable": True},
             {"key": "schedule"},
+            {"key": "sector", "sortable": True},
             {"key": "mutexes", "sortable": True},
             {"key": "soak_days", "sortable": True},
             {"key": "workload"},
@@ -456,6 +461,7 @@ def cluster_upgrade_policies(
             "version",
             "channel",
             "schedule",
+            "sector",
             "mutexes",
             "soak_days",
             "workload",
@@ -500,6 +506,7 @@ def ocm_fleet_upgrade_policies(
             {"key": "version", "sortable": True},
             {"key": "channel", "sortable": True},
             {"key": "schedule"},
+            {"key": "sector", "sortable": True},
             {"key": "mutexes", "sortable": True},
             {"key": "soak_days", "sortable": True},
             {"key": "workload"},
@@ -528,6 +535,7 @@ def ocm_fleet_upgrade_policies(
             "version",
             "channel",
             "schedule",
+            "sector",
             "mutexes",
             "soak_days",
             "workload",


### PR DESCRIPTION
Depends on https://github.com/app-sre/qontract-schemas/pull/314

See [APPSRE-6545](https://issues.redhat.com/browse/APPSRE-6545) and [ADR 0032](https://docs.google.com/document/d/1_aRuF_Owlryo50mycbS7E0m9I6pzE_KPNUnLp7nQaXE/edit)

This pull request introduces the notion of OCM sectors. A sector regroups a set of clusters. Sectors are enablers for progressive rollout of versions across a fleet of clusters. In the context of this PR, only cluster versions are considered, but sectors could be later used for component (applications, resources, ...) progressive rollouts.

* An OCM organization can define a set of sectors by naming them
  * A sector name is unique within the OCM organization
  * Sectors can depend on each other, creating one or multiple dependency chains.
    * loops are being detected and the integration will fail in those cases
    * it is also possible to create sector dependency trees or even graphs for more complex scenarios (e.g. "production rollout start after stage `sector3` is done, while there are still more stage sectors to be deployed")
    * a sector can depend on a sector in an other OCM organization. This allows to use an OCM organization for each environment (integration/stage/production) and ensure a version is deployed on stage before being rolled out on production for example.
    * sector dependency name can be a `*` wildcard.
      * If it is in the same organization, all other sectors will be selected as dependencies
      * If is is referring to an other organization, all sectors of that organization will be selected as dependencies.
* A cluster in this org can then be part of a sector by configuring the sector name in its `upgradePolicy.conditions`
  * This cluster can then be upgraded to a version only if previous sector clusters running the same `workload` all run at least that version
  * If there are no previous sectors, the cluster can upgrade
  * If the previous sector does not include any cluster running the workload, we will
    * lookup recursively the sector chain to find matching `workload` clusters
    * if none is found, we will allow the upgrade.

Note: this might be easier to review commit by commit