### PR TITLE
Update queries.py to add googleChat logging parameter for integrations

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -250,6 +250,7 @@ INTEGRATIONS_QUERY = """
         internalCertificates
         logs {
           slack
+          googleChat
         }
         resources {
           requests {


### PR DESCRIPTION
See https://github.com/app-sre/qontract-schemas/pull/315

This fix will allow integrations manager to spawn new pods in FedRamp with Google Chat logging. Tested locally in dry run and saw the expected Fluentd config.

https://issues.redhat.com/browse/APPSRE-6564