### PR TITLE
support for the usage of multiple cluster authentication backends at the same time

### DIFF
--- a/reconcile/gql_definitions/common/clusters_minimal.py
+++ b/reconcile/gql_definitions/common/clusters_minimal.py
@@ -145,7 +145,7 @@ class ClusterV1(BaseModel):
     automation_token: Optional[VaultSecret] = Field(..., alias="automationToken")
     internal: Optional[bool] = Field(..., alias="internal")
     disable: Optional[DisableClusterAutomationsV1] = Field(..., alias="disable")
-    auth: Optional[
+    auth: list[
         Union[ClusterAuthGithubOrgTeamV1, ClusterAuthGithubOrgV1, ClusterAuthV1]
     ] = Field(..., alias="auth")
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -3447,9 +3447,21 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "INTERFACE",
-                                "name": "ClusterAuth_v1",
-                                "ofType": null
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "INTERFACE",
+                                            "name": "ClusterAuth_v1",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -3973,6 +3985,11 @@
                         },
                         {
                             "kind": "OBJECT",
+                            "name": "OpenShiftClusterManager_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
                             "name": "JiraBoard_v1",
                             "ofType": null
                         },
@@ -3989,11 +4006,6 @@
                         {
                             "kind": "OBJECT",
                             "name": "SharedResources_v1",
-                            "ofType": null
-                        },
-                        {
-                            "kind": "OBJECT",
-                            "name": "OpenShiftClusterManager_v1",
                             "ofType": null
                         },
                         {
@@ -7282,7 +7294,7 @@
                             "args": [],
                             "type": {
                                 "kind": "OBJECT",
-                                "name": "RosaAWSSpec_v1",
+                                "name": "RosaOcmSpec_v1",
                                 "ofType": null
                             },
                             "isDeprecated": false,
@@ -8612,9 +8624,56 @@
                 },
                 {
                     "kind": "OBJECT",
-                    "name": "RosaAWSSpec_v1",
+                    "name": "RosaOcmSpec_v1",
                     "description": null,
                     "fields": [
+                        {
+                            "name": "ocm_environments",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "RosaOcmAwsSpec_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "RosaOcmAwsSpec_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "ocm",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "OpenShiftClusterManager_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
                         {
                             "name": "creator_role_arn",
                             "description": null,
@@ -8636,9 +8695,13 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -8648,9 +8711,13 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -8660,9 +8727,13 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -8672,9 +8743,616 @@
                             "description": null,
                             "args": [],
                             "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "OpenShiftClusterManager_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "labels",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
                                 "kind": "SCALAR",
                                 "name": "String",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "url",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "accessTokenClientId",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "accessTokenUrl",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "accessTokenClientSecret",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "VaultSecret_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "recommendedVersions",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "OpenShiftClusterManagerRecommendedVersions_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "recommendedVersionWeight",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "OpenShiftClusterManagerRecommendedVersionsWeight_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "blockedVersions",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "upgradePolicyAllowedWorkloads",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "upgradePolicyAllowedMutexes",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "upgradePolicyDefaults",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "OpenShiftClusterManagerUpgradePolicyDefault_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "upgradePolicyClusters",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "OpenShiftClusterManagerUpgradePolicyCluster_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "clusters",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "Cluster_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "OpenShiftClusterManagerRecommendedVersions_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "recommendedVersion",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "workload",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "OpenShiftClusterManagerRecommendedVersionsWeight_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "majority",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "highest",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "OpenShiftClusterManagerUpgradePolicyDefault_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "matchLabels",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "JSON",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "upgradePolicy",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "ClusterUpgradePolicy_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "ClusterUpgradePolicy_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schedule_type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "schedule",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "workloads",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "SCALAR",
+                                            "name": "String",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "conditions",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "ClusterUpgradePolicyConditions_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "ClusterUpgradePolicyConditions_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "soakDays",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "mutexes",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "OpenShiftClusterManagerUpgradePolicyCluster_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "upgradePolicy",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "ClusterUpgradePolicy_v1",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -12421,6 +13099,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "gitlabSync",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "CodeComponentGitlabSync_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "showInReviewQueue",
                             "description": null,
                             "args": [],
@@ -12476,6 +13166,108 @@
                                 "kind": "SCALAR",
                                 "name": "String",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "CodeComponentGitlabSync_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "sourceProject",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "CodeComponentGitlabSyncProject_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "destinationProject",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "CodeComponentGitlabSyncProject_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "CodeComponentGitlabSyncProject_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "group",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "branch",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -14223,6 +15015,18 @@
                             "type": {
                                 "kind": "SCALAR",
                                 "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "timeout",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
                                 "ofType": null
                             },
                             "isDeprecated": false,
@@ -16740,499 +17544,6 @@
                                         "name": "Namespace_v1",
                                         "ofType": null
                                     }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "OpenShiftClusterManager_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "schema",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "path",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "labels",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "JSON",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "name",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "description",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "url",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "accessTokenClientId",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "accessTokenUrl",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "accessTokenClientSecret",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "OBJECT",
-                                "name": "VaultSecret_v1",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "blockedVersions",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "SCALAR",
-                                        "name": "String",
-                                        "ofType": null
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "upgradePolicyAllowedWorkloads",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "SCALAR",
-                                        "name": "String",
-                                        "ofType": null
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "upgradePolicyAllowedMutexes",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "SCALAR",
-                                        "name": "String",
-                                        "ofType": null
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "upgradePolicyDefaults",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "OBJECT",
-                                        "name": "OpenShiftClusterManagerUpgradePolicyDefault_v1",
-                                        "ofType": null
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "upgradePolicyClusters",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "OBJECT",
-                                        "name": "OpenShiftClusterManagerUpgradePolicyCluster_v1",
-                                        "ofType": null
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "clusters",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "OBJECT",
-                                        "name": "Cluster_v1",
-                                        "ofType": null
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [
-                        {
-                            "kind": "INTERFACE",
-                            "name": "DatafileObject_v1",
-                            "ofType": null
-                        }
-                    ],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "OpenShiftClusterManagerUpgradePolicyDefault_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "name",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "matchLabels",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "JSON",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "upgradePolicy",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "ClusterUpgradePolicy_v1",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "ClusterUpgradePolicy_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "schedule_type",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "schedule",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "workloads",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "LIST",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "NON_NULL",
-                                        "name": null,
-                                        "ofType": {
-                                            "kind": "SCALAR",
-                                            "name": "String",
-                                            "ofType": null
-                                        }
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "conditions",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "ClusterUpgradePolicyConditions_v1",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "ClusterUpgradePolicyConditions_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "soakDays",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "Int",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "mutexes",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "SCALAR",
-                                        "name": "String",
-                                        "ofType": null
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "OpenShiftClusterManagerUpgradePolicyCluster_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "name",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "upgradePolicy",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "ClusterUpgradePolicy_v1",
-                                    "ofType": null
                                 }
                             },
                             "isDeprecated": false,
@@ -21514,6 +21825,18 @@
                     "fields": [
                         {
                             "name": "slack",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "googleChat",
                             "description": null,
                             "args": [],
                             "type": {
@@ -28862,6 +29185,30 @@
                         },
                         {
                             "name": "variables",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "overrides",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "extra_tags",
                             "description": null,
                             "args": [],
                             "type": {

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -19572,6 +19572,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "enforceTwofactor",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,

--- a/reconcile/ocm_github_idp.py
+++ b/reconcile/ocm_github_idp.py
@@ -33,33 +33,31 @@ def fetch_desired_state(clusters, vault_input_path, settings):
     secret_reader = SecretReader(settings=settings)
     for cluster_info in clusters:
         cluster = cluster_info["name"]
-        auth = cluster_info["auth"]
-        service = auth["service"]
-        if service != "github-org-team":
-            # currently not supported
-            continue
-        org = auth["org"]
-        team = auth["team"]
-        secret_path = (
-            f"{vault_input_path}/{QONTRACT_INTEGRATION}/" + f"{service}/{org}/{team}"
-        )
-        secret = {"path": secret_path}
-        try:
-            oauth_data = secret_reader.read_all(secret)
-            client_id = oauth_data["client-id"]
-            client_secret = oauth_data["client-secret"]
-        except Exception:
-            logging.error(f"unable to read secret in path {secret['path']}")
-            error = True
-            continue
-        item = {
-            "cluster": cluster,
-            "name": f"github-{org}",
-            "client_id": client_id,
-            "client_secret": client_secret,
-            "teams": [f"{org}/{team}"],
-        }
-        desired_state.append(item)
+        for auth in cluster_info["auth"]:
+            if auth["service"] != "github-org-team":
+                continue
+
+            org = auth["org"]
+            team = auth["team"]
+            secret = {
+                "path": f"{vault_input_path}/{QONTRACT_INTEGRATION}/{auth['service']}/{org}/{team}"
+            }
+            try:
+                oauth_data = secret_reader.read_all(secret)
+                client_id = oauth_data["client-id"]
+                client_secret = oauth_data["client-secret"]
+            except Exception:
+                logging.error(f"unable to read secret in path {secret['path']}")
+                error = True
+                continue
+            item = {
+                "cluster": cluster,
+                "name": f"github-{org}",
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "teams": [f"{org}/{team}"],
+            }
+            desired_state.append(item)
 
     return desired_state, error
 

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -979,25 +979,16 @@ def aggregate_shared_resources(namespace_info, shared_resources_type):
             namespace_info[shared_resources_type] = namespace_type_resources
 
 
-def determine_user_key_for_access(cluster_info: dict) -> str:
-    DEFAULT = "github_username"
+def determine_user_key_for_access(cluster_name: str, cluster_auth: dict) -> str:
     AUTH_METHOD_USER_KEY = {
         "github-org": "github_username",
         "github-org-team": "github_username",
         "oidc": "org_username",
     }
-    cluster_auth = cluster_info["auth"]
-    if not cluster_auth:
-        # for backwards compatibility
-        logging.debug(
-            f"[{cluster_info['name']}] auth section missing, defaulting to: {DEFAULT}"
-        )
-        return DEFAULT
-
     service = cluster_auth["service"]
     try:
         return AUTH_METHOD_USER_KEY[service]
     except KeyError:
         raise NotImplementedError(
-            f"[{cluster_info['name']}] auth service not implemented: {service}"
+            f"[{cluster_name}] auth service not implemented: {service}"
         )

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -87,7 +87,7 @@ def fetch_desired_state(ri, oc_map):
     roles: list[dict] = expiration.filter(gqlapi.query(ROLES_QUERY)["roles"])
     users_desired_state = []
     # set namespace to something indicative
-    namepsace = "cluster"
+    namespace = "cluster"
     for role in roles:
         permissions = [
             {"cluster": a["cluster"], "cluster_role": a["clusterRole"]}
@@ -124,7 +124,7 @@ def fetch_desired_state(ri, oc_map):
                     try:
                         ri.add_desired(
                             cluster,
-                            namepsace,
+                            namespace,
                             "ClusterRoleBinding",
                             resource_name,
                             oc_resource,
@@ -143,7 +143,7 @@ def fetch_desired_state(ri, oc_map):
                 try:
                     ri.add_desired(
                         cluster,
-                        namepsace,
+                        namespace,
                         "ClusterRoleBinding",
                         resource_name,
                         oc_resource,

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -108,28 +108,31 @@ def fetch_desired_state(ri, oc_map):
             cluster = cluster_info["name"]
             if not oc_map.get(cluster):
                 continue
-            user_key = ob.determine_user_key_for_access(cluster_info)
-            for user in role["users"]:
-                # used by openshift-users and github integrations
-                # this is just to simplify things a bit on the their side
-                users_desired_state.append({"cluster": cluster, "user": user[user_key]})
-                if ri is None:
-                    continue
-                oc_resource, resource_name = construct_user_oc_resource(
-                    permission["cluster_role"], user[user_key]
-                )
-                try:
-                    ri.add_desired(
-                        cluster,
-                        namepsace,
-                        "ClusterRoleBinding",
-                        resource_name,
-                        oc_resource,
+            for auth in cluster_info["auth"]:
+                user_key = ob.determine_user_key_for_access(cluster, auth)
+                for user in role["users"]:
+                    # used by openshift-users and github integrations
+                    # this is just to simplify things a bit on the their side
+                    users_desired_state.append(
+                        {"cluster": cluster, "user": user[user_key]}
                     )
-                except ResourceKeyExistsError:
-                    # a user may have a Role assigned to them
-                    # from multiple app-interface roles
-                    pass
+                    if ri is None:
+                        continue
+                    oc_resource, resource_name = construct_user_oc_resource(
+                        permission["cluster_role"], user[user_key]
+                    )
+                    try:
+                        ri.add_desired(
+                            cluster,
+                            namepsace,
+                            "ClusterRoleBinding",
+                            resource_name,
+                            oc_resource,
+                        )
+                    except ResourceKeyExistsError:
+                        # a user may have a Role assigned to them
+                        # from multiple app-interface roles
+                        pass
             for sa in service_accounts:
                 if ri is None:
                     continue

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -124,18 +124,19 @@ def fetch_desired_state(oc_map):
             if oc_map and a["cluster"]["name"] not in oc_map.clusters():
                 continue
 
-            user_key = ob.determine_user_key_for_access(a["cluster"])
-            for u in r["users"]:
-                if u[user_key] is None:
-                    continue
+            for auth in a["cluster"]["auth"]:
+                user_key = ob.determine_user_key_for_access(a["cluster"]["name"], auth)
+                for u in r["users"]:
+                    if u[user_key] is None:
+                        continue
 
-                desired_state.append(
-                    {
-                        "cluster": a["cluster"]["name"],
-                        "group": a["group"],
-                        "user": u[user_key],
-                    }
-                )
+                    desired_state.append(
+                        {
+                            "cluster": a["cluster"]["name"],
+                            "group": a["group"],
+                            "user": u[user_key],
+                        }
+                    )
 
     return desired_state
 

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -117,28 +117,31 @@ def fetch_desired_state(ri, oc_map):
                 continue
             if oc_map and not oc_map.get(cluster):
                 continue
-            user_key = ob.determine_user_key_for_access(cluster_info)
-            for user in role["users"]:
-                # used by openshift-users and github integrations
-                # this is just to simplify things a bit on the their side
-                users_desired_state.append({"cluster": cluster, "user": user[user_key]})
-                if ri is None:
-                    continue
-                oc_resource, resource_name = construct_user_oc_resource(
-                    permission["role"], user[user_key]
-                )
-                try:
-                    ri.add_desired(
-                        cluster,
-                        permission["namespace"],
-                        "RoleBinding.authorization.openshift.io",
-                        resource_name,
-                        oc_resource,
+            for auth in cluster_info["auth"]:
+                user_key = ob.determine_user_key_for_access(cluster, auth)
+                for user in role["users"]:
+                    # used by openshift-users and github integrations
+                    # this is just to simplify things a bit on the their side
+                    users_desired_state.append(
+                        {"cluster": cluster, "user": user[user_key]}
                     )
-                except ResourceKeyExistsError:
-                    # a user may have a Role assigned to them
-                    # from multiple app-interface roles
-                    pass
+                    if ri is None:
+                        continue
+                    oc_resource, resource_name = construct_user_oc_resource(
+                        permission["role"], user[user_key]
+                    )
+                    try:
+                        ri.add_desired(
+                            cluster,
+                            permission["namespace"],
+                            "RoleBinding.authorization.openshift.io",
+                            resource_name,
+                            oc_resource,
+                        )
+                    except ResourceKeyExistsError:
+                        # a user may have a Role assigned to them
+                        # from multiple app-interface roles
+                        pass
             for sa in service_accounts:
                 if ri is None:
                     continue

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -607,24 +607,24 @@ def test_populate_current_state_resource_name_filtering(
 
 
 def test_determine_user_key_for_access_github_org():
-    cluster_info = {"auth": {"service": "github-org"}}
-    user_key = sut.determine_user_key_for_access(cluster_info)
+    auth = {"service": "github-org"}
+    user_key = sut.determine_user_key_for_access("cluster-name", auth)
     assert user_key == "github_username"
 
 
 def test_determine_user_key_for_access_github_org_team():
-    cluster_info = {"auth": {"service": "github-org-team"}}
-    user_key = sut.determine_user_key_for_access(cluster_info)
+    auth = {"service": "github-org-team"}
+    user_key = sut.determine_user_key_for_access("cluster-name", auth)
     assert user_key == "github_username"
 
 
 def test_determine_user_key_for_access_oidc():
-    cluster_info = {"auth": {"service": "oidc"}}
-    user_key = sut.determine_user_key_for_access(cluster_info)
+    auth = {"service": "oidc"}
+    user_key = sut.determine_user_key_for_access("cluster-name", auth)
     assert user_key == "org_username"
 
 
 def test_determine_user_key_for_access_not_implemented():
-    cluster_info = {"auth": {"service": "not-implemented"}, "name": "c"}
+    auth = {"service": "not-implemented"}
     with pytest.raises(NotImplementedError):
-        sut.determine_user_key_for_access(cluster_info)
+        sut.determine_user_key_for_access("cluster-name", auth)

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -157,9 +157,7 @@ def cluster_upgrades(ctx, name):
 
     clusters = queries.get_clusters()
 
-    clusters_ocm = [
-        c for c in clusters if c.get("ocm") is not None and c.get("auth") is not None
-    ]
+    clusters_ocm = [c for c in clusters if c.get("ocm") is not None and c.get("auth")]
 
     ocm_map = OCMMap(clusters=clusters_ocm, settings=settings)
 


### PR DESCRIPTION
In preparation for [cluster logins via RedHat SSO](https://issues.redhat.com/browse/APPSRE-6374),
the `/openshift/cluster-1.yml.auth` attribute needs to be a list of auth objects. This PR adapts all integrations and utils.

* [APPSRE-6374](https://issues.redhat.com/browse/APPSRE-6374)
* [APPSRE-6554](https://issues.redhat.com/browse/APPSRE-6554)

Depends on https://github.com/app-sre/qontract-schemas/pull/317