### PR TITLE
Require Python type hints for all new code

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,206 +27,206 @@ disallow_incomplete_defs = True
 ; enabling the checking of untyped defs. We can work on reducing this list by removing an item from the list and fixing
 ; the issues to make CI pass.
 
-[mypy-e2e_tests.network_policy_test_base.*]
+[mypy-e2e_tests.network_policy_test_base]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-e2e_tests.cli.*]
+[mypy-e2e_tests.cli]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-e2e_tests.create_namespace.*]
+[mypy-e2e_tests.create_namespace]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-e2e_tests.dedicated_admin_rolebindings.*]
+[mypy-e2e_tests.dedicated_admin_rolebindings]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-e2e_tests.dedicated_admin_test_base.*]
+[mypy-e2e_tests.dedicated_admin_test_base]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-e2e_tests.default_network_policies.*]
+[mypy-e2e_tests.default_network_policies]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-e2e_tests.default_project_labels.*]
+[mypy-e2e_tests.default_project_labels]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-e2e_tests.test_base.*]
+[mypy-e2e_tests.test_base]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.aws_ami_share.*]
+[mypy-reconcile.aws_ami_share]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.aws_ecr_image_pull_secrets.*]
+[mypy-reconcile.aws_ecr_image_pull_secrets]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.aws_garbage_collector.*]
+[mypy-reconcile.aws_garbage_collector]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.aws_iam_keys.*]
+[mypy-reconcile.aws_iam_keys]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.aws_iam_password_reset.*]
+[mypy-reconcile.aws_iam_password_reset]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.aws_support_cases_sos.*]
+[mypy-reconcile.aws_support_cases_sos]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.change_owners.change_owners.*]
+[mypy-reconcile.change_owners.change_owners]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.change_owners.change_types.*]
+[mypy-reconcile.change_owners.change_types]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.change_owners.tester.*]
+[mypy-reconcile.change_owners.tester]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.cli.*]
+[mypy-reconcile.cli]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.closedbox_endpoint_monitoring_base.*]
+[mypy-reconcile.closedbox_endpoint_monitoring_base]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.cluster_deployment_mapper.*]
+[mypy-reconcile.cluster_deployment_mapper]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.cna.client.*]
+[mypy-reconcile.cna.client]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.cna.integration.*]
+[mypy-reconcile.cna.integration]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.cna.state.*]
+[mypy-reconcile.cna.state]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.dashdotdb_base.*]
+[mypy-reconcile.dashdotdb_base]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.dashdotdb_cso.*]
+[mypy-reconcile.dashdotdb_cso]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.dashdotdb_dvo.*]
+[mypy-reconcile.dashdotdb_dvo]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.dashdotdb_slo.*]
+[mypy-reconcile.dashdotdb_slo]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.dyn_traffic_director.*]
+[mypy-reconcile.dyn_traffic_director]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ecr_mirror.*]
+[mypy-reconcile.ecr_mirror]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.email_sender.*]
+[mypy-reconcile.email_sender]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.gabi_authorized_users.*]
+[mypy-reconcile.gabi_authorized_users]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.gcr_mirror.*]
+[mypy-reconcile.gcr_mirror]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.github_org.*]
+[mypy-reconcile.github_org]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.github_owners.*]
+[mypy-reconcile.github_owners]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.github_repo_invites.*]
+[mypy-reconcile.github_repo_invites]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.github_repo_permissions_validator.*]
+[mypy-reconcile.github_repo_permissions_validator]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.github_scanner.*]
+[mypy-reconcile.github_scanner]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.github_users.*]
+[mypy-reconcile.github_users]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.github_validator.*]
+[mypy-reconcile.github_validator]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.gitlab_fork_compliance.*]
+[mypy-reconcile.gitlab_fork_compliance]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.gitlab_housekeeping.*]
+[mypy-reconcile.gitlab_housekeeping]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.gitlab_integrations.*]
+[mypy-reconcile.gitlab_integrations]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.gitlab_labeler.*]
+[mypy-reconcile.gitlab_labeler]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.gitlab_members.*]
+[mypy-reconcile.gitlab_members]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.gitlab_mr_sqs_consumer.*]
+[mypy-reconcile.gitlab_mr_sqs_consumer]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.gitlab_owners.*]
+[mypy-reconcile.gitlab_owners]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.gitlab_permissions.*]
+[mypy-reconcile.gitlab_permissions]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.gitlab_projects.*]
+[mypy-reconcile.gitlab_projects]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.glitchtip.integration.*]
+[mypy-reconcile.glitchtip.integration]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
@@ -235,355 +235,355 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.integrations_manager.*]
+[mypy-reconcile.integrations_manager]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.integrations_validator.*]
+[mypy-reconcile.integrations_validator]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.jenkins_job_builder.*]
+[mypy-reconcile.jenkins_job_builder]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.jenkins_job_builds_cleaner.*]
+[mypy-reconcile.jenkins_job_builds_cleaner]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.jenkins_job_cleaner.*]
+[mypy-reconcile.jenkins_job_cleaner]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.jenkins_plugins.*]
+[mypy-reconcile.jenkins_plugins]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.jenkins_roles.*]
+[mypy-reconcile.jenkins_roles]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.jenkins_webhooks_cleaner.*]
+[mypy-reconcile.jenkins_webhooks_cleaner]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.jenkins_webhooks.*]
+[mypy-reconcile.jenkins_webhooks]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.jira_watcher.*]
+[mypy-reconcile.jira_watcher]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.kafka_clusters.*]
+[mypy-reconcile.kafka_clusters]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ldap_users.*]
+[mypy-reconcile.ldap_users]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.mr_client_gateway.*]
+[mypy-reconcile.mr_client_gateway]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ocm_additional_routers.*]
+[mypy-reconcile.ocm_additional_routers]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ocm_addons.*]
+[mypy-reconcile.ocm_addons]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ocm_aws_infrastructure_access.*]
+[mypy-reconcile.ocm_aws_infrastructure_access]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ocm_clusters.*]
+[mypy-reconcile.ocm_clusters]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ocm_external_configuration_labels.*]
+[mypy-reconcile.ocm_external_configuration_labels]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ocm_github_idp.*]
+[mypy-reconcile.ocm_github_idp]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ocm_groups.*]
+[mypy-reconcile.ocm_groups]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ocm_machine_pools.*]
+[mypy-reconcile.ocm_machine_pools]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ocm_upgrade_scheduler.*]
+[mypy-reconcile.ocm_upgrade_scheduler]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ocm_upgrade_scheduler_org.*]
+[mypy-reconcile.ocm_upgrade_scheduler_org]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ocm_upgrade_scheduler_org_updater.*]
+[mypy-reconcile.ocm_upgrade_scheduler_org_updater]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.ocp_release_mirror.*]
+[mypy-reconcile.ocp_release_mirror]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_base.*]
+[mypy-reconcile.openshift_base]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_clusterrolebindings.*]
+[mypy-reconcile.openshift_clusterrolebindings]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_groups.*]
+[mypy-reconcile.openshift_groups]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_limitranges.*]
+[mypy-reconcile.openshift_limitranges]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_namespace_labels.*]
+[mypy-reconcile.openshift_namespace_labels]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_namespaces.*]
+[mypy-reconcile.openshift_namespaces]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_network_policies.*]
+[mypy-reconcile.openshift_network_policies]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_resourcequotas.*]
+[mypy-reconcile.openshift_resourcequotas]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_resources_base.*]
+[mypy-reconcile.openshift_resources_base]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_resources.*]
+[mypy-reconcile.openshift_resources]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_rolebindings.*]
+[mypy-reconcile.openshift_rolebindings]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_routes.*]
+[mypy-reconcile.openshift_routes]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_saas_deploy_change_tester.*]
+[mypy-reconcile.openshift_saas_deploy_change_tester]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_saas_deploy.*]
+[mypy-reconcile.openshift_saas_deploy]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_saas_deploy_trigger_base.*]
+[mypy-reconcile.openshift_saas_deploy_trigger_base]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_saas_deploy_trigger_cleaner.*]
+[mypy-reconcile.openshift_saas_deploy_trigger_cleaner]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_saas_deploy_trigger_configs.*]
+[mypy-reconcile.openshift_saas_deploy_trigger_configs]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_saas_deploy_trigger_images.*]
+[mypy-reconcile.openshift_saas_deploy_trigger_images]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_saas_deploy_trigger_moving_commits.*]
+[mypy-reconcile.openshift_saas_deploy_trigger_moving_commits]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_saas_deploy_trigger_upstream_jobs.*]
+[mypy-reconcile.openshift_saas_deploy_trigger_upstream_jobs]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_saas_deploy_wrapper.*]
+[mypy-reconcile.openshift_saas_deploy_wrapper]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_serviceaccount_tokens.*]
+[mypy-reconcile.openshift_serviceaccount_tokens]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_upgrade_watcher.*]
+[mypy-reconcile.openshift_upgrade_watcher]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_users.*]
+[mypy-reconcile.openshift_users]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.openshift_vault_secrets.*]
+[mypy-reconcile.openshift_vault_secrets]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.prometheus_rules_tester.*]
+[mypy-reconcile.prometheus_rules_tester]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.quay_base.*]
+[mypy-reconcile.quay_base]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.quay_membership.*]
+[mypy-reconcile.quay_membership]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.quay_mirror_org.*]
+[mypy-reconcile.quay_mirror_org]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.quay_mirror.*]
+[mypy-reconcile.quay_mirror]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.quay_permissions.*]
+[mypy-reconcile.quay_permissions]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.quay_repos.*]
+[mypy-reconcile.quay_repos]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.queries.*]
+[mypy-reconcile.queries]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.query_validator.*]
+[mypy-reconcile.query_validator]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.requests_sender.*]
+[mypy-reconcile.requests_sender]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.resource_scraper.*]
+[mypy-reconcile.resource_scraper]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.saas_file_owners.*]
+[mypy-reconcile.saas_file_owners]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.saas_file_validator.*]
+[mypy-reconcile.saas_file_validator]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.sendgrid_teammates.*]
+[mypy-reconcile.sendgrid_teammates]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.sentry_config.*]
+[mypy-reconcile.sentry_config]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.sentry_helper.*]
+[mypy-reconcile.sentry_helper]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.service_dependencies.*]
+[mypy-reconcile.service_dependencies]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.slack_cluster_usergroups.*]
+[mypy-reconcile.slack_cluster_usergroups]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.slack_usergroups.*]
+[mypy-reconcile.slack_usergroups]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.sql_query.*]
+[mypy-reconcile.sql_query]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.statuspage.atlassian.*]
+[mypy-reconcile.statuspage.atlassian]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.status_page_components.*]
+[mypy-reconcile.status_page_components]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.status.*]
+[mypy-reconcile.status]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.template_tester.*]
+[mypy-reconcile.template_tester]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.terraform_aws_route53.*]
+[mypy-reconcile.terraform_aws_route53]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.terraform_cloudflare_resources.*]
+[mypy-reconcile.terraform_cloudflare_resources]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.terraform_resources.*]
+[mypy-reconcile.terraform_resources]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.terraform_tgw_attachments.*]
+[mypy-reconcile.terraform_tgw_attachments]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.terraform_users.*]
+[mypy-reconcile.terraform_users]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.terraform_vpc_peerings.*]
+[mypy-reconcile.terraform_vpc_peerings]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.unleash_watcher.*]
+[mypy-reconcile.unleash_watcher]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
@@ -592,389 +592,389 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.test.test_aggregated_list.*]
+[mypy-reconcile.test.test_aggregated_list]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_auto_promoter.*]
+[mypy-reconcile.test.test_auto_promoter]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_blackbox_exporter_endpoint_monitoring.*]
+[mypy-reconcile.test.test_blackbox_exporter_endpoint_monitoring]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_checkpoint.*]
+[mypy-reconcile.test.test_checkpoint]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_gabi_authorized_users.*]
+[mypy-reconcile.test.test_gabi_authorized_users]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_gitlab_housekeeping.*]
+[mypy-reconcile.test.test_gitlab_housekeeping]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_ocm_upgrade_scheduler.*]
+[mypy-reconcile.test.test_ocm_upgrade_scheduler]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_openshift_namespace_labels.*]
+[mypy-reconcile.test.test_openshift_namespace_labels]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_openshift_resources_base.*]
+[mypy-reconcile.test.test_openshift_resources_base]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_quay_repos.*]
+[mypy-reconcile.test.test_quay_repos]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_saasherder.*]
+[mypy-reconcile.test.test_saasherder]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_slack_usergroups.*]
+[mypy-reconcile.test.test_slack_usergroups]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_status_page_components.*]
+[mypy-reconcile.test.test_status_page_components]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_terraform_vpc_peerings_build_desired_state.*]
+[mypy-reconcile.test.test_terraform_vpc_peerings_build_desired_state]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_utils_data_structures.*]
+[mypy-reconcile.test.test_utils_data_structures]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_utils_expiration.*]
+[mypy-reconcile.test.test_utils_expiration]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_utils_ocm.*]
+[mypy-reconcile.test.test_utils_ocm]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_utils_oc_native.*]
+[mypy-reconcile.test.test_utils_oc_native]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_utils_oc.*]
+[mypy-reconcile.test.test_utils_oc]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_utils_state.*]
+[mypy-reconcile.test.test_utils_state]
 check_untyped_defs = False
 
-[mypy-reconcile.test.test_vault_utils.*]
+[mypy-reconcile.test.test_vault_utils]
 check_untyped_defs = False
 
-[mypy-reconcile.user_validator.*]
+[mypy-reconcile.user_validator]
 check_untyped_defs = False
 
-[mypy-reconcile.utils.aggregated_list.*]
+[mypy-reconcile.utils.aggregated_list]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.amtool.*]
+[mypy-reconcile.utils.amtool]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.aws_api.*]
-check_untyped_defs = False
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.aws_helper.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.binary.*]
+[mypy-reconcile.utils.aws_api]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.config.*]
+[mypy-reconcile.utils.aws_helper]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.data_structures.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.defer.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.dnsutils.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.elasticsearch_exceptions.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.environ.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.exceptions.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.github_api.*]
+[mypy-reconcile.utils.binary]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.gitlab_api.*]
+[mypy-reconcile.utils.config]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.git.*]
+[mypy-reconcile.utils.data_structures]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.git_secrets.*]
+[mypy-reconcile.utils.defer]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.glitchtip.models.*]
+[mypy-reconcile.utils.dnsutils]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.gpg.*]
+[mypy-reconcile.utils.elasticsearch_exceptions]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.environ]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.exceptions]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.github_api]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.gql.*]
+[mypy-reconcile.utils.gitlab_api]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.git]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.git_secrets]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.glitchtip.models]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.gpg]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.helpers.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.imap_client.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.instrumented_wrappers.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.jenkins_api.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.jinja2_ext.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.jjb_client.*]
+[mypy-reconcile.utils.gql]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.jump_host.*]
+[mypy-reconcile.utils.helpers]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.imap_client]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.instrumented_wrappers]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.jenkins_api]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.jinja2_ext]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.jjb_client]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.ldap_client.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.lean_terraform_client.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.mr.app_interface_reporter.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.mr.auto_promoter.*]
+[mypy-reconcile.utils.jump_host]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.mr.aws_access.*]
+[mypy-reconcile.utils.ldap_client]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.lean_terraform_client]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.mr.app_interface_reporter]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.mr.auto_promoter]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.mr.base.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.mr.cluster_service_install_config.*]
-check_untyped_defs = False
-
-[mypy-reconcile.utils.mr.clusters_updates.*]
+[mypy-reconcile.utils.mr.aws_access]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.mr.__init__.*]
+[mypy-reconcile.utils.mr.base]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.mr.notificator.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
+[mypy-reconcile.utils.mr.cluster_service_install_config]
+check_untyped_defs = False
 
-[mypy-reconcile.utils.mr.ocm_upgrade_scheduler_org_updates.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.mr.user_maintenance.*]
+[mypy-reconcile.utils.mr.clusters_updates]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.ocm_base_client.*]
+[mypy-reconcile.utils.mr]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.ocm.*]
+[mypy-reconcile.utils.mr.notificator]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.mr.ocm_upgrade_scheduler_org_updates]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.mr.user_maintenance]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.oc.*]
+[mypy-reconcile.utils.ocm_base_client]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.ocm]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.openshift_resource.*]
+[mypy-reconcile.utils.oc]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.openssl.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.output.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.pagerduty_api.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.password_validator.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.promtool.*]
+[mypy-reconcile.utils.openshift_resource]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.quay_api.*]
+[mypy-reconcile.utils.openssl]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.raw_github_api.*]
+[mypy-reconcile.utils.output]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.repo_owners.*]
+[mypy-reconcile.utils.pagerduty_api]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.password_validator]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.promtool]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.runtime.meta.*]
+[mypy-reconcile.utils.quay_api]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.saasherder.*]
+[mypy-reconcile.utils.raw_github_api]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.repo_owners]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.secret_reader.*]
+[mypy-reconcile.utils.runtime.meta]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.sentry_client.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.sharding.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.slack_api.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.smtp_client.*]
-check_untyped_defs = False
-
-[mypy-reconcile.utils.sqs_gateway.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.state.*]
+[mypy-reconcile.utils.saasherder]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.statuspage.atlassian.*]
+[mypy-reconcile.utils.secret_reader]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.statuspage.models.*]
+[mypy-reconcile.utils.sentry_client]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.structs.*]
+[mypy-reconcile.utils.sharding]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.template.*]
+[mypy-reconcile.utils.slack_api]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.terraform_client.*]
+[mypy-reconcile.utils.smtp_client]
+check_untyped_defs = False
+
+[mypy-reconcile.utils.sqs_gateway]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.state]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.terrascript_aws_client.*]
+[mypy-reconcile.utils.statuspage.atlassian]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.statuspage.models]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.structs]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.template]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.terraform_client]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.throughput.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.unleash.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.vault.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.utils.vaultsecretref.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-reconcile.vpc_peerings_validator.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
-[mypy-tools.app_interface_reporter.*]
+[mypy-reconcile.utils.terrascript_aws_client]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-tools.cli_commands.gpg_encrypt.*]
+[mypy-reconcile.utils.throughput]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-tools.cli_commands.test.test_gpg_encrypt.*]
+[mypy-reconcile.utils.unleash]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-tools.qontract_cli.*]
+[mypy-reconcile.utils.vault]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.vaultsecretref]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.vpc_peerings_validator]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-tools.app_interface_reporter]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-tools.sre_checkpoints.util.*]
+[mypy-tools.cli_commands.gpg_encrypt]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-tools.cli_commands.test.test_gpg_encrypt]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-tools.qontract_cli]
+check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-tools.sre_checkpoints.util]
 check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
@@ -984,7 +984,7 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-tools.test.test_sre_checkpoints.*]
+[mypy-tools.test.test_sre_checkpoints]
 check_untyped_defs = False
 
 ; Below are all of the packages that don't implement stub packages. Mypy will throw an error if we don't ignore the

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,19 +18,7 @@ warn_unused_ignores = True
 ; Enable error codes in Mypy so that specific error codes can be ignored if needed
 show_error_codes = True
 
-; STRICT MODULES
-; As we continue to improve our usage of Mypy and write new code, we can make the modules enforce stricter criteria to
-; make it easier to ensure that we've not missed anything.
-
-[mypy-reconcile.utils.external_resources.*]
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-
-[mypy-reconcile.utils.terraform.*]
-disallow_untyped_defs = True
-disallow_incomplete_defs = True
-
-[mypy-reconcile.utils.terrascript.*]
+; Ensure that Python type hints have been defined
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 
@@ -39,110 +27,570 @@ disallow_incomplete_defs = True
 ; enabling the checking of untyped defs. We can work on reducing this list by removing an item from the list and fixing
 ; the issues to make CI pass.
 
+[mypy-e2e_tests.network_policy_test_base.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-e2e_tests.cli.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-e2e_tests.create_namespace.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-e2e_tests.dedicated_admin_rolebindings.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-e2e_tests.dedicated_admin_test_base.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-e2e_tests.default_network_policies.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-e2e_tests.default_project_labels.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-e2e_tests.test_base.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.aws_ami_share.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
 [mypy-reconcile.aws_ecr_image_pull_secrets.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.aws_garbage_collector.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.aws_iam_keys.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.aws_iam_password_reset.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.aws_support_cases_sos.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.change_owners.change_owners.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.change_owners.change_types.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.change_owners.tester.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.cli.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.closedbox_endpoint_monitoring_base.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.cluster_deployment_mapper.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.cna.client.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.cna.integration.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.cna.state.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.dashdotdb_base.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.dashdotdb_cso.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.dashdotdb_dvo.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.dashdotdb_slo.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.dyn_traffic_director.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.ecr_mirror.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.email_sender.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.gabi_authorized_users.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.gcr_mirror.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.github_org.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.github_owners.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.github_repo_invites.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.github_repo_permissions_validator.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.github_scanner.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.github_users.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.github_validator.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.gitlab_fork_compliance.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.gitlab_housekeeping.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.gitlab_integrations.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.gitlab_labeler.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.gitlab_members.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.gitlab_mr_sqs_consumer.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.gitlab_owners.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.gitlab_permissions.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.gitlab_projects.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.glitchtip.integration.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+; TODO: this is generated code, can probably treat this as one?
+[mypy-reconcile.gql_definitions.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.integrations_manager.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.integrations_validator.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.jenkins_job_builder.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.jenkins_job_builds_cleaner.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.jenkins_job_cleaner.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.jenkins_plugins.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.jenkins_roles.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.jenkins_webhooks_cleaner.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.jenkins_webhooks.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.jira_watcher.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.kafka_clusters.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.ldap_users.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.mr_client_gateway.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.ocm_additional_routers.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.ocm_addons.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.ocm_aws_infrastructure_access.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.ocm_clusters.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.ocm_external_configuration_labels.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.ocm_github_idp.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.ocm_groups.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.ocm_machine_pools.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.ocm_upgrade_scheduler.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.ocm_upgrade_scheduler_org.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.ocm_upgrade_scheduler_org_updater.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.ocp_release_mirror.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_base.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_clusterrolebindings.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.openshift_groups.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.openshift_limitranges.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.openshift_namespace_labels.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_namespaces.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_network_policies.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.openshift_resourcequotas.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.openshift_resources_base.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_resources.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_rolebindings.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_routes.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_saas_deploy_change_tester.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_saas_deploy.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.openshift_saas_deploy_trigger_base.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_saas_deploy_trigger_cleaner.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_saas_deploy_trigger_configs.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_saas_deploy_trigger_images.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_saas_deploy_trigger_moving_commits.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_saas_deploy_trigger_upstream_jobs.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_saas_deploy_wrapper.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.openshift_serviceaccount_tokens.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_upgrade_watcher.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_users.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.openshift_vault_secrets.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.prometheus_rules_tester.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.quay_base.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.quay_membership.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.quay_mirror_org.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.quay_mirror.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.quay_permissions.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.quay_repos.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.queries.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.query_validator.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.requests_sender.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.resource_scraper.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.saas_file_owners.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.saas_file_validator.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.sendgrid_teammates.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.sentry_config.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.sentry_helper.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.service_dependencies.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.slack_cluster_usergroups.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.slack_usergroups.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.sql_query.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.statuspage.atlassian.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.status_page_components.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.status.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.template_tester.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.terraform_aws_route53.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.terraform_cloudflare_resources.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.terraform_resources.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.terraform_tgw_attachments.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.terraform_users.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.terraform_vpc_peerings.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.unleash_watcher.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+; Skip strict type hints in tests for now
+[mypy-reconcile.test.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.test.test_aggregated_list.*]
 check_untyped_defs = False
@@ -210,80 +658,331 @@ check_untyped_defs = False
 [mypy-reconcile.user_validator.*]
 check_untyped_defs = False
 
+[mypy-reconcile.utils.aggregated_list.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.amtool.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
 [mypy-reconcile.utils.aws_api.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.aws_helper.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.binary.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.config.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.data_structures.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.defer.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.dnsutils.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.elasticsearch_exceptions.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.environ.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.exceptions.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.github_api.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.gitlab_api.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.git.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.git_secrets.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.glitchtip.models.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.gpg.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.gql.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.helpers.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.imap_client.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.instrumented_wrappers.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.jenkins_api.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.jinja2_ext.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.jjb_client.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.jump_host.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.ldap_client.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.lean_terraform_client.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.mr.app_interface_reporter.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.mr.auto_promoter.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.mr.aws_access.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.mr.base.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.mr.cluster_service_install_config.*]
 check_untyped_defs = False
 
 [mypy-reconcile.utils.mr.clusters_updates.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.mr.__init__.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.mr.notificator.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.mr.ocm_upgrade_scheduler_org_updates.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.mr.user_maintenance.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.ocm_base_client.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.ocm.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.oc.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.openshift_resource.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.openssl.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.output.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.pagerduty_api.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.password_validator.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.promtool.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.quay_api.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.raw_github_api.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.repo_owners.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.runtime.meta.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.saasherder.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.secret_reader.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.sentry_client.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.sharding.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.slack_api.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.smtp_client.*]
 check_untyped_defs = False
 
+[mypy-reconcile.utils.sqs_gateway.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
 [mypy-reconcile.utils.state.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.statuspage.atlassian.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.statuspage.models.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.structs.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.template.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.terraform_client.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-reconcile.utils.terrascript_aws_client.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.throughput.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.unleash.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.vault.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.utils.vaultsecretref.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-reconcile.vpc_peerings_validator.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-tools.app_interface_reporter.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-tools.cli_commands.gpg_encrypt.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+[mypy-tools.cli_commands.test.test_gpg_encrypt.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-tools.qontract_cli.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-tools.sre_checkpoints.util.*]
 check_untyped_defs = False
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
+
+; Skip strict type hints in tests for now
+[mypy-tools.test.*]
+disallow_untyped_defs = False
+disallow_incomplete_defs = False
 
 [mypy-tools.test.test_sre_checkpoints.*]
 check_untyped_defs = False


### PR DESCRIPTION
A little while back a `STRICT MODULES` section was introduced into `setup.cfg` to ensure that new code had full coverage for type definitions. This was underutilized, probably in part because it wasn't shared well enough. I've taken a new approach here where I've permitted existing modules to ignoring missing type definitions, but anything not matching those existing modules will require type definitions to be defined.

This change will make it much simpler to enforce type hints for all new modules being added to this project.