### PR TITLE
tf-cloudflare: add cloudflare account 2fa enforcement

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -19261,6 +19261,30 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "enforceTwofactor",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_accounts.gql
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_accounts.gql
@@ -29,5 +29,7 @@ query TerraformCloudflareAccounts {
       name
       type
     }
+    enforceTwofactor
+    type
   }
 }

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_accounts.py
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_accounts.py
@@ -47,6 +47,8 @@ query TerraformCloudflareAccounts {
       name
       type
     }
+    enforceTwofactor
+    type
   }
 }
 """
@@ -120,6 +122,8 @@ class CloudflareAccountV1(BaseModel):
     deletion_approvals: Optional[list[DeletionApprovalV1]] = Field(
         ..., alias="deletionApprovals"
     )
+    enforce_twofactor: Optional[bool] = Field(..., alias="enforceTwofactor")
+    q_type: Optional[str] = Field(..., alias="type")
 
     class Config:
         smart_union = True

--- a/reconcile/terraform_cloudflare_resources.py
+++ b/reconcile/terraform_cloudflare_resources.py
@@ -12,6 +12,7 @@ from reconcile.gql_definitions.terraform_cloudflare_resources.terraform_cloudfla
     CloudflareAccountV1,
     TerraformCloudflareAccountsQueryData,
 )
+from reconcile.status import ExitCodes
 from reconcile.utils import gql
 from reconcile.utils.defer import defer
 from reconcile.utils.external_resources import (
@@ -23,12 +24,13 @@ from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.terraform.config_client import TerraformConfigClientCollection
 from reconcile.utils.terraform_client import TerraformClient
 from reconcile.utils.terrascript.cloudflare_client import (
+    DEFAULT_CLOUDFLARE_ACCOUNT_TYPE,
+    DEFAULT_CLOUDFLARE_ACCOUNT_2FA,
     CloudflareAccountConfig,
     TerraformS3BackendConfig,
     TerrascriptCloudflareClient,
     create_cloudflare_terrascript,
 )
-from reconcile.status import ExitCodes
 
 QONTRACT_INTEGRATION = "terraform_cloudflare_resources"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
@@ -89,6 +91,8 @@ def build_clients(
             cf_acct.name,
             cf_acct_creds.get("api_token"),
             cf_acct_creds.get("account_id"),
+            cf_acct.enforce_twofactor or DEFAULT_CLOUDFLARE_ACCOUNT_2FA,
+            cf_acct.q_type or DEFAULT_CLOUDFLARE_ACCOUNT_TYPE,
         )
 
         aws_acct = cf_acct.terraform_state_account

--- a/reconcile/test/test_utils_terrascript_cloudflare_client.py
+++ b/reconcile/test/test_utils_terrascript_cloudflare_client.py
@@ -97,6 +97,13 @@ def test_create_cloudflare_resources_terraform_json(account_config, backend_conf
         },
         "variable": {"account_id": {"default": "account_id", "type": "string"}},
         "resource": {
+            "cloudflare_account": {
+                "account-name": {
+                    "name": "account-name",
+                    "enforce_twofactor": False,
+                    "type": "standard",
+                }
+            },
             "cloudflare_zone": {
                 "domain-com": {
                     "account_id": "${var.account_id}",

--- a/reconcile/utils/terrascript/cloudflare_client.py
+++ b/reconcile/utils/terrascript/cloudflare_client.py
@@ -14,10 +14,14 @@ from reconcile.utils.terraform.config_client import (
     TerraformConfigClient,
 )
 from reconcile.utils.terrascript.cloudflare_resources import (
+    cloudflare_account,
     create_cloudflare_terrascript_resource,
 )
 
 TMP_DIR_PREFIX = "terrascript-cloudflare-"
+
+DEFAULT_CLOUDFLARE_ACCOUNT_TYPE = "standard"
+DEFAULT_CLOUDFLARE_ACCOUNT_2FA = False
 
 
 @dataclass
@@ -27,6 +31,8 @@ class CloudflareAccountConfig:
     name: str
     api_token: str
     account_id: str
+    enforce_twofactor: bool = DEFAULT_CLOUDFLARE_ACCOUNT_2FA
+    type: str = DEFAULT_CLOUDFLARE_ACCOUNT_TYPE
 
 
 def create_cloudflare_terrascript(
@@ -62,6 +68,16 @@ def create_cloudflare_terrascript(
     terrascript += provider.cloudflare(
         api_token=account_config.api_token,
         account_id=account_config.account_id,  # needed for some resources, see note below
+    )
+
+    cloudflare_account_values = {
+        "name": account_config.name,
+        "enforce_twofactor": account_config.enforce_twofactor,
+        "type": account_config.type,
+    }
+    terrascript += cloudflare_account(
+        account_config.name,
+        **cloudflare_account_values,
     )
 
     # Some resources need "account_id" to be set at the resource level

--- a/reconcile/utils/terrascript/cloudflare_resources.py
+++ b/reconcile/utils/terrascript/cloudflare_resources.py
@@ -21,6 +21,14 @@ class UnsupportedCloudflareResourceError(Exception):
     pass
 
 
+class cloudflare_account(Resource):
+    """
+    https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/account
+    This resource isn't supported directly by Terrascript, which is why it needs to be
+    defined like this as a Resource.
+    """
+
+
 class cloudflare_certificate_pack(Resource):
     """
     https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/certificate_pack


### PR DESCRIPTION
Rework of #2964 to include fields which were missing and causing issues

Ref.: [APPSRE-6571](https://issues.redhat.com/browse/APPSRE-6571)

This adds a `cloudflare_account` definition which allows setting 2FA enforcement on accounts. The plan type also needs to be defined on that resource otherwise it default to "standard"

Depends on
* https://github.com/app-sre/qontract-schemas/pull/321