### PR TITLE
Add missing type hint to generated files

### DIFF
--- a/reconcile/gql_definitions/change_owners/queries/change_types.py
+++ b/reconcile/gql_definitions/change_owners/queries/change_types.py
@@ -107,7 +107,7 @@ class ChangeTypesQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> ChangeTypesQueryData:
+def query(query_func: Callable, **kwargs: Any) -> ChangeTypesQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
@@ -108,7 +108,7 @@ class SelfServiceRolesQueryQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> SelfServiceRolesQueryQueryData:
+def query(query_func: Callable, **kwargs: Any) -> SelfServiceRolesQueryQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/cna/queries/cna_provisioners.py
+++ b/reconcile/gql_definitions/cna/queries/cna_provisioners.py
@@ -79,7 +79,7 @@ class CNAProvisionersQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> CNAProvisionersQueryData:
+def query(query_func: Callable, **kwargs: Any) -> CNAProvisionersQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/cna/queries/cna_resources.py
+++ b/reconcile/gql_definitions/cna/queries/cna_resources.py
@@ -102,7 +102,7 @@ class CNAssetsQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> CNAssetsQueryData:
+def query(query_func: Callable, **kwargs: Any) -> CNAssetsQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/common/app_interface_vault_settings.py
+++ b/reconcile/gql_definitions/common/app_interface_vault_settings.py
@@ -44,7 +44,7 @@ class AppInterfaceVaultSettingsQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> AppInterfaceVaultSettingsQueryData:
+def query(query_func: Callable, **kwargs: Any) -> AppInterfaceVaultSettingsQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/common/clusters_minimal.py
+++ b/reconcile/gql_definitions/common/clusters_minimal.py
@@ -162,7 +162,7 @@ class ClustersMinimalQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> ClustersMinimalQueryData:
+def query(query_func: Callable, **kwargs: Any) -> ClustersMinimalQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/common/smtp_client_settings.py
+++ b/reconcile/gql_definitions/common/smtp_client_settings.py
@@ -67,7 +67,7 @@ class AppInterfaceSmtpSettingsQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> AppInterfaceSmtpSettingsQueryData:
+def query(query_func: Callable, **kwargs: Any) -> AppInterfaceSmtpSettingsQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.py
+++ b/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.py
@@ -137,7 +137,7 @@ class SLODocumentsQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> SLODocumentsQueryData:
+def query(query_func: Callable, **kwargs: Any) -> SLODocumentsQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/glitchtip/glitchtip_instance.py
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_instance.py
@@ -107,7 +107,7 @@ class GlitchtipInstanceQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> GlitchtipInstanceQueryData:
+def query(query_func: Callable, **kwargs: Any) -> GlitchtipInstanceQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/glitchtip/glitchtip_project.py
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_project.py
@@ -144,7 +144,7 @@ class ProjectsQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> ProjectsQueryData:
+def query(query_func: Callable, **kwargs: Any) -> ProjectsQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/glitchtip/glitchtip_settings.py
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_settings.py
@@ -56,7 +56,7 @@ class GlitchtipSettingsQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> GlitchtipSettingsQueryData:
+def query(query_func: Callable, **kwargs: Any) -> GlitchtipSettingsQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/jumphosts/jumphosts.py
+++ b/reconcile/gql_definitions/jumphosts/jumphosts.py
@@ -86,7 +86,7 @@ class JumphostsQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> JumphostsQueryData:
+def query(query_func: Callable, **kwargs: Any) -> JumphostsQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/quay_membership/quay_membership.py
+++ b/reconcile/gql_definitions/quay_membership/quay_membership.py
@@ -115,7 +115,7 @@ class QuayMembershipQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> QuayMembershipQueryData:
+def query(query_func: Callable, **kwargs: Any) -> QuayMembershipQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/service_dependencies/service_dependencies.py
+++ b/reconcile/gql_definitions/service_dependencies/service_dependencies.py
@@ -226,7 +226,7 @@ class ServiceDependenciesQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> ServiceDependenciesQueryData:
+def query(query_func: Callable, **kwargs: Any) -> ServiceDependenciesQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_accounts.py
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_accounts.py
@@ -138,7 +138,7 @@ class TerraformCloudflareAccountsQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> TerraformCloudflareAccountsQueryData:
+def query(query_func: Callable, **kwargs: Any) -> TerraformCloudflareAccountsQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.py
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.py
@@ -251,7 +251,7 @@ class TerraformCloudflareResourcesQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> TerraformCloudflareResourcesQueryData:
+def query(query_func: Callable, **kwargs: Any) -> TerraformCloudflareResourcesQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/reconcile/gql_definitions/vpc_peerings_validator/vpc_peerings_validator.py
+++ b/reconcile/gql_definitions/vpc_peerings_validator/vpc_peerings_validator.py
@@ -122,7 +122,7 @@ class VpcPeeringsValidatorQueryData(BaseModel):
         extra = Extra.forbid
 
 
-def query(query_func: Callable, **kwargs) -> VpcPeeringsValidatorQueryData:
+def query(query_func: Callable, **kwargs: Any) -> VpcPeeringsValidatorQueryData:
     """
     This is a convenience function which queries and parses the data into
     concrete types. It should be compatible with most GQL clients.

--- a/requirements/requirements-type.txt
+++ b/requirements/requirements-type.txt
@@ -11,4 +11,4 @@ types-setuptools
 types-tabulate
 types-toml
 boto3-stubs[ec2,s3,rds,iam,route53]==1.24.29
-qenerate==0.4.1
+qenerate==0.4.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -230,11 +230,6 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-; TODO: this is generated code, can probably treat this as one?
-[mypy-reconcile.gql_definitions.*]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
 [mypy-reconcile.integrations_manager]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False


### PR DESCRIPTION
Apply latest qenerate upgrade https://github.com/app-sre/qenerate/pull/60

There was a type-hint missing for `**kwargs` for `query` convenience function.