### PR TITLE
Condense GChat logs to single 'thread'

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -152,7 +152,7 @@ objects:
               {{- if $logs.googleChat }}
               <store>
                 @type teams
-                webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=${POD_NAME}"
+                webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=app-sre"
                 text "<%= Time.at(time) %> [${POD_NAME}] <%= record['message'] %>\n\n"
               </store>
               {{- end }}

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -89,7 +89,7 @@ objects:
               @type copy
               <store>
                 @type teams
-                webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=${POD_NAME}"
+                webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=app-sre"
                 text "<%= Time.at(time) %> [${POD_NAME}] <%= record['message'] %>\n\n"
               </store>
               <store>

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -89,7 +89,7 @@ objects:
               @type copy
               <store>
                 @type teams
-                webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=${POD_NAME}"
+                webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=app-sre"
                 text "<%= Time.at(time) %> [${POD_NAME}] <%= record['message'] %>\n\n"
               </store>
               <store>


### PR DESCRIPTION
Navigating Google Chat threads is very slow and requires a lot of scrolling. This MR just changes the webhook to post log messages from all pods to a single "thread" so you can easily see sequential log messages.

https://developers.google.com/chat/how-tos/webhooks#start_or_reply_to_a_message_thread