### PR TITLE
[gitlab-owners] detect and log basic OWNER file format

### DIFF
--- a/reconcile/utils/repo_owners.py
+++ b/reconcile/utils/repo_owners.py
@@ -134,7 +134,16 @@ class RepoOwners:
             except yaml.parser.ParserError:
                 owners = None
             if owners is None:
-                _LOG.warning("Non-parsable OWNERS file")
+                _LOG.warning(
+                    "Non-parsable OWNERS file "
+                    f"{self._git_cli.project.web_url}:{owner_file.get('path')}"
+                )
+                continue
+            if not isinstance(owners, dict):
+                _LOG.warning(
+                    f"owner file {self._git_cli.project.web_url}:{owner_file.get('path')} "
+                    "content is not a dictionary"
+                )
                 continue
 
             approvers = owners.get("approvers") or set()


### PR DESCRIPTION
gitlab-owners expects a dictionary like structure in an OWNERS file. this fix makes sure that the integration does not fail if that is not the case and logs the repo and owner file that makes troubles.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>