### PR TITLE
Add triggers channel for GChat in FedRamp

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -86,11 +86,19 @@ objects:
             value: ${SLACK_ICON_EMOJI}
           {{- end }}
           {{- if $logs.googleChat }}
+          {{- if $integration.trigger }}
+          - name: GOOGLE_CHAT_WEBHOOK_URL
+            valueFrom:
+              secretKeyRef:
+                key: google_chat.triggers_url
+                name: app-interface
+          {{- else }}
           - name: GOOGLE_CHAT_WEBHOOK_URL
             valueFrom:
               secretKeyRef:
                 key: google_chat.webhook_url
                 name: app-interface
+          {{- end }}
           - name: POD_NAME
             valueFrom:
               fieldRef:

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -86,6 +86,12 @@ objects:
             value: ${SLACK_ICON_EMOJI}
           {{- end }}
           {{- if $logs.googleChat }}
+
+          {{- /*
+          "*-triggers" integrations will be sent to a seperate GChat channel as
+          they are much noisier than other integrations
+          */}}
+
           {{- if $integration.trigger }}
           - name: GOOGLE_CHAT_WEBHOOK_URL
             valueFrom:


### PR DESCRIPTION
[APPSRE-6480](https://issues.redhat.com/browse/APPSRE-6480)

In FedRamp, ship logs from *-trigger integration to a separate channel to avoid spamming the main reconcile channel with messages. 