### PR TITLE
refactor slack-api

### DIFF
--- a/reconcile/slack_base.py
+++ b/reconcile/slack_base.py
@@ -1,4 +1,5 @@
-from typing import Mapping, Any, Optional
+from typing import Any, Optional
+from collections.abc import Mapping
 
 from reconcile import queries
 from reconcile.utils.secret_reader import SecretReader

--- a/reconcile/slack_base.py
+++ b/reconcile/slack_base.py
@@ -2,12 +2,12 @@ from typing import Mapping, Any, Optional
 
 from reconcile import queries
 from reconcile.utils.secret_reader import SecretReader
-
 from reconcile.utils.slack_api import SlackApi, SlackApiConfig
+from reconcile.utils.slack_api import SupportsClientConfig
 
 
 def slackapi_from_queries(
-    integration_name: str, init_usergroups: Optional[bool] = True
+    integration_name: str, init_usergroups: bool = True
 ) -> SlackApi:
     secret_reader = SecretReader(queries.get_secret_reader_settings())
     slack_workspace = {"workspace": queries.get_slack_workspace()}
@@ -20,7 +20,7 @@ def slackapi_from_slack_workspace(
     slack_workspace: Mapping[str, Any],
     secret_reader: SecretReader,
     integration_name: str,
-    init_usergroups: Optional[bool] = True,
+    init_usergroups: bool = True,
     channel: Optional[str] = None,
 ) -> SlackApi:
     if "workspace" not in slack_workspace:
@@ -53,8 +53,7 @@ def slackapi_from_slack_workspace(
 
     api = SlackApi(
         workspace_name,
-        token,
-        secret_reader,
+        token=secret_reader.read(token),
         channel=channel,
         api_config=api_config,
         init_usergroups=init_usergroups,
@@ -68,7 +67,7 @@ def slackapi_from_slack_workspace(
 def slackapi_from_permissions(
     permissions: Mapping[str, Any],
     secret_reader: SecretReader,
-    init_usergroups: Optional[bool] = True,
+    init_usergroups: bool = True,
 ) -> SlackApi:
     if "workspace" not in permissions:
         raise ValueError('Slack workspace not containing keyword "workspace"')
@@ -84,10 +83,29 @@ def slackapi_from_permissions(
 
     api = SlackApi(
         workspace_name,
-        token,
-        secret_reader,
+        token=secret_reader.read(token),
         init_usergroups=init_usergroups,
         api_config=api_config,
     )
 
+    return api
+
+
+def get_slackapi(
+    workspace_name: str,
+    token: str,
+    client_config: Optional[SupportsClientConfig] = None,
+    init_usergroups: bool = True,
+) -> SlackApi:
+    if client_config:
+        api_config = SlackApiConfig.from_client_config(client_config)
+    else:
+        api_config = SlackApiConfig()
+
+    api = SlackApi(
+        workspace_name,
+        token,
+        init_usergroups=init_usergroups,
+        api_config=api_config,
+    )
     return api

--- a/reconcile/slack_base.py
+++ b/reconcile/slack_base.py
@@ -97,6 +97,7 @@ def get_slackapi(
     client_config: Optional[SupportsClientConfig] = None,
     init_usergroups: bool = True,
 ) -> SlackApi:
+    """Initiate a SlackApi instance."""
     if client_config:
         api_config = SlackApiConfig.from_client_config(client_config)
     else:

--- a/reconcile/slack_cluster_usergroups.py
+++ b/reconcile/slack_cluster_usergroups.py
@@ -98,7 +98,7 @@ def get_desired_state(slack: SlackApi) -> dict[str, Any]:
             if include_user(u, cluster_name, cluster_users)
         ]
         users = slack.get_users_by_names(user_names)
-        channels = slack.get_channels_by_names([slack.channel])
+        channels = slack.get_channels_by_names([slack.channel])  # type: ignore[list-item] # will be refactored later
         desired_state.setdefault(slack.workspace_name, {})[usergroup] = {
             "workspace": slack.workspace_name,
             "usergroup": usergroup,

--- a/reconcile/test/test_slack_usergroups.py
+++ b/reconcile/test/test_slack_usergroups.py
@@ -87,9 +87,15 @@ class TestSupportFunctions(TestCase):
     @patch.object(slackbase, "SlackApi", autospec=True)
     @patch.object(queries, "get_app_interface_settings", autospec=True)
     @patch.object(queries, "get_permissions_for_slack_usergroup", autospec=True)
+    @patch.object(SecretReader, "read", autospec=True)
     def test_get_slack_map_return_expected(
-        self, mock_get_permissions, mock_get_app_interface_settings, mock_slack_api
+        self,
+        mock_secret_reader_read,
+        mock_get_permissions,
+        mock_get_app_interface_settings,
+        mock_slack_api,
     ):
+        mock_secret_reader_read.return_value = "secret"
         mock_get_permissions.return_value = self.get_permissions_fixture()
         slack_api_mock = create_autospec(SlackApi)
         expected_slack_map = {

--- a/reconcile/test/test_utils_slack_api.py
+++ b/reconcile/test/test_utils_slack_api.py
@@ -1,6 +1,6 @@
 import json
 from collections import namedtuple
-from typing import Union, Dict
+from typing import Union
 from unittest.mock import call, patch, MagicMock
 
 import httpretty
@@ -62,7 +62,7 @@ def test_slack_api_config_from_dict():
     assert slack_api_config.timeout == 5
 
 
-def new_slack_response(data: Dict[str, Union[bool, str]]):
+def new_slack_response(data: dict[str, Union[bool, str]]):
     return SlackResponse(
         client="",
         http_verb="",

--- a/reconcile/test/test_utils_slack_api.py
+++ b/reconcile/test/test_utils_slack_api.py
@@ -20,10 +20,6 @@ from reconcile.utils.slack_api import (
 
 @pytest.fixture
 def slack_api(mocker):
-    mock_secret_reader = mocker.patch.object(
-        reconcile.utils.slack_api, "SecretReader", autospec=True
-    )
-
     mock_slack_client = mocker.patch.object(
         reconcile.utils.slack_api, "WebClient", autospec=True
     )
@@ -31,16 +27,11 @@ def slack_api(mocker):
     # autospec doesn't know about instance attributes
     mock_slack_client.return_value.retry_handlers = []
 
-    token = {"path": "some/path", "field": "some-field"}
-    slack_api = SlackApi(
-        "some-workspace", token, reconcile.utils.slack_api.SecretReader()
-    )
+    slack_api = SlackApi("some-workspace", "token")
 
-    SlackApiMock = namedtuple(
-        "SlackApiMock", "client mock_secret_reader " "mock_slack_client"
-    )
+    SlackApiMock = namedtuple("SlackApiMock", "client mock_slack_client")
 
-    return SlackApiMock(slack_api, mock_secret_reader, mock_slack_client)
+    return SlackApiMock(slack_api, mock_slack_client)
 
 
 def test_slack_api_config_defaults():
@@ -88,8 +79,6 @@ def test_instantiate_slack_api_with_config(mocker):
     When SlackApiConfig is passed into SlackApi, the constructor shouldn't
     create a default configuration object.
     """
-    mocker.patch.object(reconcile.utils.slack_api, "SecretReader", autospec=True)
-
     mock_slack_client = mocker.patch.object(
         reconcile.utils.slack_api, "WebClient", autospec=True
     )
@@ -99,10 +88,7 @@ def test_instantiate_slack_api_with_config(mocker):
 
     config = SlackApiConfig()
 
-    token = {"path": "some/path", "field": "some-field"}
-    slack_api = SlackApi(
-        "some-workspace", token, reconcile.utils.slack_api.SecretReader(), config
-    )
+    slack_api = SlackApi("some-workspace", "token", config)
 
     assert slack_api.config is config
 
@@ -343,9 +329,8 @@ def test_update_usergroups_users_raise(slack_api):
 
 
 @httpretty.activate(allow_net_connect=False)
-@patch("reconcile.utils.slack_api.SecretReader", autospec=True)
 @patch("time.sleep", autospec=True)
-def test_slack_api__client_throttle_raise(mock_sleep, mock_secret_reader):
+def test_slack_api__client_throttle_raise(mock_sleep):
     """Raise an exception if the max retries is exceeded."""
     httpretty.register_uri(
         httpretty.POST,
@@ -355,12 +340,7 @@ def test_slack_api__client_throttle_raise(mock_sleep, mock_secret_reader):
         status=429,
     )
 
-    slack_client = SlackApi(
-        "workspace",
-        {"path": "some/path", "field": "some-field"},
-        reconcile.utils.slack_api.SecretReader(),
-        init_usergroups=False,
-    )
+    slack_client = SlackApi("workspace", "token", init_usergroups=False)
 
     with pytest.raises(SlackApiError):
         slack_client._sc.api_call("users.list")
@@ -369,9 +349,8 @@ def test_slack_api__client_throttle_raise(mock_sleep, mock_secret_reader):
 
 
 @httpretty.activate(allow_net_connect=False)
-@patch("reconcile.utils.slack_api.SecretReader", autospec=True)
 @patch("time.sleep", autospec=True)
-def test_slack_api__client_throttle_doesnt_raise(mock_sleep, mock_secret_reader):
+def test_slack_api__client_throttle_doesnt_raise(mock_sleep):
     """Don't raise an exception if the max retries aren't reached."""
     uri_args = (httpretty.POST, "https://www.slack.com/api/users.list")
     uri_kwargs_failure = {
@@ -387,12 +366,7 @@ def test_slack_api__client_throttle_doesnt_raise(mock_sleep, mock_secret_reader)
     httpretty.register_uri(*uri_args, **uri_kwargs_failure)
     httpretty.register_uri(*uri_args, **uri_kwargs_failure)
 
-    slack_client = SlackApi(
-        "workspace",
-        {"path": "some/path", "field": "some-field"},
-        reconcile.utils.slack_api.SecretReader(),
-        init_usergroups=False,
-    )
+    slack_client = SlackApi("workspace", "token", init_usergroups=False)
 
     slack_client._sc.api_call("users.list")
 
@@ -400,9 +374,8 @@ def test_slack_api__client_throttle_doesnt_raise(mock_sleep, mock_secret_reader)
 
 
 @httpretty.activate(allow_net_connect=False)
-@patch("reconcile.utils.slack_api.SecretReader", autospec=True)
 @patch("time.sleep", autospec=True)
-def test_slack_api__client_5xx_raise(mock_sleep, mock_secret_reader):
+def test_slack_api__client_5xx_raise(mock_sleep):
     """Raise an exception if the max retries is exceeded."""
     httpretty.register_uri(
         httpretty.POST,
@@ -411,12 +384,7 @@ def test_slack_api__client_5xx_raise(mock_sleep, mock_secret_reader):
         status=500,
     )
 
-    slack_client = SlackApi(
-        "workspace",
-        {"path": "some/path", "field": "some-field"},
-        reconcile.utils.slack_api.SecretReader(),
-        init_usergroups=False,
-    )
+    slack_client = SlackApi("workspace", "token", init_usergroups=False)
 
     with pytest.raises(SlackApiError):
         slack_client._sc.api_call("users.list")
@@ -425,9 +393,8 @@ def test_slack_api__client_5xx_raise(mock_sleep, mock_secret_reader):
 
 
 @httpretty.activate(allow_net_connect=False)
-@patch("reconcile.utils.slack_api.SecretReader", autospec=True)
 @patch("time.sleep", autospec=True)
-def test_slack_api__client_5xx_doesnt_raise(mock_sleep, mock_secret_reader):
+def test_slack_api__client_5xx_doesnt_raise(mock_sleep):
     """Don't raise an exception if the max retries aren't reached."""
     uri_args = (httpretty.POST, "https://www.slack.com/api/users.list")
     uri_kwargs_failure = {
@@ -442,12 +409,7 @@ def test_slack_api__client_5xx_doesnt_raise(mock_sleep, mock_secret_reader):
     httpretty.register_uri(*uri_args, **uri_kwargs_failure)
     httpretty.register_uri(*uri_args, **uri_kwargs_failure)
 
-    slack_client = SlackApi(
-        "workspace",
-        {"path": "some/path", "field": "some-field"},
-        reconcile.utils.slack_api.SecretReader(),
-        init_usergroups=False,
-    )
+    slack_client = SlackApi("workspace", "token", init_usergroups=False)
 
     slack_client._sc.api_call("users.list")
 
@@ -455,9 +417,8 @@ def test_slack_api__client_5xx_doesnt_raise(mock_sleep, mock_secret_reader):
 
 
 @httpretty.activate(allow_net_connect=False)
-@patch("reconcile.utils.slack_api.SecretReader", autospec=True)
 @patch("time.sleep", autospec=True)
-def test_slack_api__client_dont_retry(mock_sleep, mock_secret_reader):
+def test_slack_api__client_dont_retry(mock_sleep):
     """Don't retry client-side errors that aren't 429s."""
     httpretty.register_uri(
         httpretty.POST,
@@ -466,12 +427,7 @@ def test_slack_api__client_dont_retry(mock_sleep, mock_secret_reader):
         status=401,
     )
 
-    slack_client = SlackApi(
-        "workspace",
-        {"path": "some/path", "field": "some-field"},
-        reconcile.utils.slack_api.SecretReader(),
-        init_usergroups=False,
-    )
+    slack_client = SlackApi("workspace", "token", init_usergroups=False)
 
     with pytest.raises(SlackApiError):
         slack_client._sc.api_call("users.list")

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -134,6 +134,10 @@ class SlackApiConfig:
 
     @classmethod
     def from_client_config(cls, config_data: SupportsClientConfig) -> SlackApiConfig:
+        """Initiate a SlackApiConfig instance via user-defined config class (e.g. GQL class).
+
+        The config class must implement the `SupportsClientConfig` protocol.
+        """
         config: dict[str, Union[list[dict[str, str]], dict[str, Optional[int]]]] = {}
         if config_data.q_global:
             config["global"] = config_data.q_global.dict()

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 import json
 import logging
-from typing import Iterable, Protocol, Sequence, Any, Mapping, Optional, Union
+from typing import Any, Optional, Union, Protocol
+from collections.abc import Iterable, Sequence, Mapping
 
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from functools import cache
+from functools import lru_cache
 import json
 import logging
 from typing import Iterable, Protocol, Sequence, Any, Mapping, Optional, Union
@@ -378,7 +378,7 @@ class SlackApi:
     def get_users_by_ids(self, users_ids: Iterable[str]) -> dict[str, str]:
         return {k: v["name"] for k, v in self._get("users").items() if k in users_ids}
 
-    @cache
+    @lru_cache(maxsize=10)
     def _get(self, resource: str) -> dict[str, Any]:
         """
         Get Slack resources by type. This method uses a cache to ensure that

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
 import json
 import logging
-from typing import Sequence, Dict, Any, Mapping, Optional, Union
+from typing import Iterable, Protocol, Sequence, Any, Mapping, Optional, Union
 
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
@@ -12,7 +13,6 @@ from slack_sdk.http_retry import (
     HttpResponse,
 )
 
-from reconcile.utils.secret_reader import SecretReader
 
 MAX_RETRIES = 5
 TIMEOUT = 30
@@ -40,6 +40,32 @@ class ServerErrorRetryHandler(RetryHandler):
         return response is not None and response.status_code >= 500
 
 
+class SupportsClientGlobalConfig(Protocol):
+    max_retries: Optional[int]
+    timeout: Optional[int]
+
+    def dict(self) -> dict[str, Optional[int]]:
+        ...
+
+
+class SupportsClientMethodConfig(Protocol):
+    name: str
+    args: str  # Json
+
+    def dict(self) -> dict[str, str]:
+        ...
+
+
+class SupportsClientConfig(Protocol):
+    @property
+    def q_global(self) -> Optional[SupportsClientGlobalConfig]:
+        ...
+
+    @property
+    def methods(self) -> Optional[Sequence[SupportsClientMethodConfig]]:
+        ...
+
+
 class SlackApiConfig:
     """
     Aggregates Slack API configuration objects to be used passed to a
@@ -50,7 +76,7 @@ class SlackApiConfig:
 
         self.timeout = timeout
         self.max_retries = max_retries
-        self._methods: Dict[str, Any] = {}
+        self._methods: dict[str, Any] = {}
 
     def set_method_config(
         self, method_name: str, method_config: Mapping[str, Any]
@@ -62,7 +88,7 @@ class SlackApiConfig:
         """
         self._methods[method_name] = method_config
 
-    def get_method_config(self, method_name: str) -> Optional[Dict[str, Any]]:
+    def get_method_config(self, method_name: str) -> Optional[dict[str, Any]]:
         """
         Get Slack method configuration.
         :param method_name: the name of a method (ex. users.list)
@@ -70,7 +96,7 @@ class SlackApiConfig:
         return self._methods.get(method_name)
 
     @classmethod
-    def from_dict(cls, config_data: Mapping[str, Any]) -> "SlackApiConfig":
+    def from_dict(cls, config_data: Mapping[str, Any]) -> SlackApiConfig:
         """
         Build a SlackApiConfig object from a mapping object.
 
@@ -106,6 +132,15 @@ class SlackApiConfig:
 
         return config
 
+    @classmethod
+    def from_client_config(cls, config_data: SupportsClientConfig) -> SlackApiConfig:
+        config: dict[str, Union[list[dict[str, str]], dict[str, Optional[int]]]] = {}
+        if config_data.q_global:
+            config["global"] = config_data.q_global.dict()
+        if config_data.methods:
+            config["methods"] = [m.dict() for m in config_data.methods]
+        return cls.from_dict(config)
+
 
 class SlackApi:
     """Wrapper around Slack API calls"""
@@ -113,12 +148,11 @@ class SlackApi:
     def __init__(
         self,
         workspace_name: str,
-        token: Mapping[str, str],
-        secret_reader: SecretReader,
+        token: str,
         api_config: Optional[SlackApiConfig] = None,
-        init_usergroups=True,
+        init_usergroups: bool = True,
         channel: Optional[str] = None,
-        **chat_kwargs,
+        **chat_kwargs: Any,
     ) -> None:
         """
         :param workspace_name: Slack workspace name (ex. coreos)
@@ -139,12 +173,10 @@ class SlackApi:
         else:
             self.config = SlackApiConfig()
 
-        slack_token = secret_reader.read(token)
-
-        self._sc = WebClient(token=slack_token, timeout=self.config.timeout)
+        self._sc = WebClient(token=token, timeout=self.config.timeout)
         self._configure_client_retry()
 
-        self._results: Dict[str, Any] = {}
+        self._results: dict[str, Any] = {}
 
         self.channel = channel
         self.chat_kwargs = chat_kwargs
@@ -179,10 +211,10 @@ class SlackApi:
         """
         if not self.channel:
             raise ValueError(
-                "Slack channel name must be provided when " "posting messages."
+                "Slack channel name must be provided when posting messages."
             )
 
-        def do_send(c: str, t: str):
+        def do_send(c: str, t: str) -> None:
             self._sc.chat_postMessage(channel=c, text=t, **self.chat_kwargs)
 
         try:
@@ -194,11 +226,13 @@ class SlackApi:
             else:
                 raise e
 
-    def describe_usergroup(self, handle):
+    def describe_usergroup(
+        self, handle: str
+    ) -> tuple[dict[str, str], dict[str, str], str]:
         usergroup = self.get_usergroup(handle)
         description = usergroup["description"]
 
-        user_ids = usergroup.get("users", [])
+        user_ids: list[str] = usergroup.get("users", [])
         users = self.get_users_by_ids(user_ids)
 
         channel_ids = usergroup["prefs"]["channels"]
@@ -206,7 +240,7 @@ class SlackApi:
 
         return users, channels, description
 
-    def join_channel(self):
+    def join_channel(self) -> None:
         """
         Join a given channel if not already a member, will join self.channel
 
@@ -216,7 +250,7 @@ class SlackApi:
         """
         if not self.channel:
             raise ValueError(
-                "Slack channel name must be provided when " "joining a channel."
+                "Slack channel name must be provided when joining a channel."
             )
 
         channels_found = self.get_channels_by_names(self.channel)
@@ -241,12 +275,11 @@ class SlackApi:
         result = self._sc.usergroups_list(include_users=True)
         self.usergroups = result["usergroups"]
 
-    def get_usergroup(self, handle):
+    def get_usergroup(self, handle: str) -> dict[str, Any]:
         usergroup = [g for g in self.usergroups if g["handle"] == handle]
         if len(usergroup) != 1:
             raise UsergroupNotFoundException(handle)
-        [usergroup] = usergroup
-        return usergroup
+        return usergroup[0]
 
     def create_usergroup(self, handle: str) -> str:
         response = self._sc.usergroups_create(name=handle, handle=handle)
@@ -292,7 +325,7 @@ class SlackApi:
             if e.response["error"] != "invalid_users":
                 raise
 
-    def get_random_deleted_user(self):
+    def get_random_deleted_user(self) -> str:
         for user_id, user_data in self._get("users").items():
             if user_data["deleted"] is True:
                 return user_id
@@ -322,29 +355,29 @@ class SlackApi:
 
         return result["user"]["id"]
 
-    def get_channels_by_names(self, channels_names):
+    def get_channels_by_names(self, channels_names: Iterable[str]) -> dict[str, str]:
         return {
             k: v["name"]
             for k, v in self._get("channels").items()
             if v["name"] in channels_names
         }
 
-    def get_channels_by_ids(self, channels_ids):
+    def get_channels_by_ids(self, channels_ids: Iterable[str]) -> dict[str, str]:
         return {
             k: v["name"] for k, v in self._get("channels").items() if k in channels_ids
         }
 
-    def get_users_by_names(self, user_names):
+    def get_users_by_names(self, user_names: Iterable[str]) -> dict[str, str]:
         return {
             k: v["name"]
             for k, v in self._get("users").items()
             if v["name"] in user_names
         }
 
-    def get_users_by_ids(self, users_ids):
+    def get_users_by_ids(self, users_ids: Iterable[str]) -> dict[str, str]:
         return {k: v["name"] for k, v in self._get("users").items() if k in users_ids}
 
-    def _get(self, resource: str) -> Dict[str, Any]:
+    def _get(self, resource: str) -> dict[str, Any]:
         """
         Get Slack resources by type. This method uses a cache to ensure that
         each resource type is only fetched once.
@@ -355,7 +388,7 @@ class SlackApi:
         result_key = "members" if resource == "users" else resource
         api_key = "conversations" if resource == "channels" else resource
         results = {}
-        additional_kwargs: Dict[str, Union[str, int]] = {"cursor": ""}
+        additional_kwargs: dict[str, Union[str, int]] = {"cursor": ""}
 
         if resource in self._results:
             return self._results[resource]

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from functools import lru_cache
 import json
 import logging
 from typing import Iterable, Protocol, Sequence, Any, Mapping, Optional, Union
@@ -378,7 +377,6 @@ class SlackApi:
     def get_users_by_ids(self, users_ids: Iterable[str]) -> dict[str, str]:
         return {k: v["name"] for k, v in self._get("users").items() if k in users_ids}
 
-    @lru_cache(maxsize=10)
     def _get(self, resource: str) -> dict[str, Any]:
         """
         Get Slack resources by type. This method uses a cache to ensure that

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from functools import cache
 import json
 import logging
 from typing import Iterable, Protocol, Sequence, Any, Mapping, Optional, Union
@@ -377,6 +378,7 @@ class SlackApi:
     def get_users_by_ids(self, users_ids: Iterable[str]) -> dict[str, str]:
         return {k: v["name"] for k, v in self._get("users").items() if k in users_ids}
 
+    @cache
     def _get(self, resource: str) -> dict[str, Any]:
         """
         Get Slack resources by type. This method uses a cache to ensure that

--- a/setup.cfg
+++ b/setup.cfg
@@ -868,10 +868,6 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.slack_api]
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
 [mypy-reconcile.utils.smtp_client]
 check_untyped_defs = False
 


### PR DESCRIPTION
Refactor `SlackApi` ([APPSRE-6594](https://issues.redhat.com/browse/APPSRE-6594)):

* remove `SecretReader` dependency
* full type hints support
* prepare it to be used/configured via GQL classes

This is some preparation work for
* [APPSRE-6592 - refactor slack-usergroups](https://issues.redhat.com/browse/APPSRE-6592)
* [APPSRE-6593 - merge slack integrations](https://issues.redhat.com/browse/APPSRE-6593)
* and finally [APPSRE-6374 - slack-cluster-usergroups OIDC support](https://issues.redhat.com/browse/APPSRE-6575)

Hints for the reviewer:
* I ran `slack-usergroups` and `slack-cluster-usergroups` locally with `dry-run`
* `slack_base.get_slackapi` will be used with [APPSRE-6592](https://issues.redhat.com/browse/APPSRE-6592) and replaces `slack_base.slackapi_from_permissions`
