### PR TITLE
[WIP] typed externalresource spec

### DIFF
--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.gql
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.gql
@@ -2,6 +2,9 @@
 query TerraformCloudflareResources {
   namespaces: namespaces_v1 {
     name
+    cluster {
+      name
+    }
     managedExternalResources
     externalResources {
       ... on NamespaceTerraformProviderResourceCloudflare_v1 {
@@ -11,9 +14,9 @@ query TerraformCloudflareResources {
         }
         resources {
           provider
+          identifier
           ... on NamespaceTerraformResourceCloudflareWorkerScript_v1
           {
-            identifier
             name
             content_from_github {
               repo
@@ -27,7 +30,6 @@ query TerraformCloudflareResources {
           }
           ... on NamespaceTerraformResourceCloudflareZone_v1
           {
-            identifier
             zone
             plan
             type

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.py
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.py
@@ -21,6 +21,9 @@ DEFINITION = """
 query TerraformCloudflareResources {
   namespaces: namespaces_v1 {
     name
+    cluster {
+      name
+    }
     managedExternalResources
     externalResources {
       ... on NamespaceTerraformProviderResourceCloudflare_v1 {
@@ -30,9 +33,9 @@ query TerraformCloudflareResources {
         }
         resources {
           provider
+          identifier
           ... on NamespaceTerraformResourceCloudflareWorkerScript_v1
           {
-            identifier
             name
             content_from_github {
               repo
@@ -46,7 +49,6 @@ query TerraformCloudflareResources {
           }
           ... on NamespaceTerraformResourceCloudflareZone_v1
           {
-            identifier
             zone
             plan
             type
@@ -86,6 +88,14 @@ query TerraformCloudflareResources {
 """
 
 
+class ClusterV1(BaseModel):
+    name: str = Field(..., alias="name")
+
+    class Config:
+        smart_union = True
+        extra = Extra.forbid
+
+
 class NamespaceExternalResourceV1(BaseModel):
     class Config:
         smart_union = True
@@ -102,6 +112,7 @@ class CloudflareAccountV1(BaseModel):
 
 class NamespaceTerraformResourceCloudflareV1(BaseModel):
     provider: str = Field(..., alias="provider")
+    identifier: str = Field(..., alias="identifier")
 
     class Config:
         smart_union = True
@@ -130,7 +141,6 @@ class CloudflareZoneWorkerScriptVarsV1(BaseModel):
 class NamespaceTerraformResourceCloudflareWorkerScriptV1(
     NamespaceTerraformResourceCloudflareV1
 ):
-    identifier: str = Field(..., alias="identifier")
     name: str = Field(..., alias="name")
     content_from_github: Optional[
         CloudflareZoneWorkerScriptContentFromGithubV1
@@ -191,7 +201,6 @@ class CloudflareZoneCertificateV1(BaseModel):
 class NamespaceTerraformResourceCloudflareZoneV1(
     NamespaceTerraformResourceCloudflareV1
 ):
-    identifier: str = Field(..., alias="identifier")
     zone: str = Field(..., alias="zone")
     plan: Optional[str] = Field(..., alias="plan")
     q_type: Optional[str] = Field(..., alias="type")
@@ -226,6 +235,7 @@ class NamespaceTerraformProviderResourceCloudflareV1(NamespaceExternalResourceV1
 
 class NamespaceV1(BaseModel):
     name: str = Field(..., alias="name")
+    cluster: ClusterV1 = Field(..., alias="cluster")
     managed_external_resources: Optional[bool] = Field(
         ..., alias="managedExternalResources"
     )

--- a/reconcile/terraform_cloudflare_resources.py
+++ b/reconcile/terraform_cloudflare_resources.py
@@ -7,6 +7,9 @@ from reconcile.gql_definitions.terraform_cloudflare_resources import (
     terraform_cloudflare_accounts,
     terraform_cloudflare_resources,
 )
+from reconcile.gql_definitions.terraform_cloudflare_resources.terraform_cloudflare_resources import (
+    NamespaceTerraformResourceCloudflareV1,
+)
 from reconcile.gql_definitions.terraform_cloudflare_resources.terraform_cloudflare_accounts import (
     AWSAccountV1,
     CloudflareAccountV1,
@@ -18,8 +21,9 @@ from reconcile.utils.defer import defer
 from reconcile.utils.exceptions import SecretIncompleteError
 from reconcile.utils.external_resources import (
     PROVIDER_CLOUDFLARE,
-    get_external_resource_specs,
+    get_external_resource_specs_for_namespace,
 )
+from reconcile.utils.external_resource_spec import TypedExternalResourceSpec
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.terraform.config_client import TerraformConfigClientCollection
@@ -129,7 +133,9 @@ def run(
 
     # Build Cloudflare clients
     query_accounts = terraform_cloudflare_accounts.query(query_func=gql.get_api().query)
-    cf_clients = TerraformConfigClientCollection()
+    cf_clients = TerraformConfigClientCollection[
+        TypedExternalResourceSpec[NamespaceTerraformResourceCloudflareV1]
+    ]()
     for client in build_clients(secret_reader, query_accounts, selected_account):
         cf_clients.register_client(*client)
 
@@ -137,11 +143,13 @@ def run(
     query_resources = terraform_cloudflare_resources.query(
         query_func=gql.get_api().query
     )
-    cf_specs = [
+    cf_specs: list[
+        TypedExternalResourceSpec[NamespaceTerraformResourceCloudflareV1]
+    ] = [
         spec
         for namespace in query_resources.namespaces or []
-        for spec in get_external_resource_specs(
-            namespace.dict(by_alias=True), PROVIDER_CLOUDFLARE
+        for spec in get_external_resource_specs_for_namespace(
+            namespace, NamespaceTerraformResourceCloudflareV1, PROVIDER_CLOUDFLARE
         )
         if not selected_account or spec.provisioner_name == selected_account
     ]

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -16,7 +16,7 @@ from reconcile.utils.external_resources import (
 import reconcile.openshift_base as ob
 
 from reconcile import queries
-from reconcile.utils.external_resource_spec import ExternalResourceSpecInventory
+from reconcile.utils.external_resource_spec import DictExternalResourceSpecInventory
 from reconcile.utils import gql
 from reconcile.aws_iam_keys import run as disable_keys
 from reconcile.utils.aws_api import AWSApi
@@ -532,7 +532,7 @@ def setup(
     internal: str,
     use_jump_host: bool,
     account_name: Optional[str],
-) -> Tuple[ResourceInventory, OC_Map, Terraform, ExternalResourceSpecInventory]:
+) -> Tuple[ResourceInventory, OC_Map, Terraform, DictExternalResourceSpecInventory]:
     accounts = queries.get_aws_accounts(terraform_state=True)
     if account_name:
         accounts = [n for n in accounts if n["name"] == account_name]
@@ -616,7 +616,7 @@ def cleanup_and_exit(tf=None, status=False, working_dirs=None):
 
 
 def write_outputs_to_vault(
-    vault_path: str, resource_specs: ExternalResourceSpecInventory
+    vault_path: str, resource_specs: DictExternalResourceSpecInventory
 ) -> None:
     integration_name = QONTRACT_INTEGRATION.replace("_", "-")
     vault_client = cast(_VaultClient, VaultClient())
@@ -634,7 +634,7 @@ def write_outputs_to_vault(
 
 
 def populate_desired_state(
-    ri: ResourceInventory, resource_specs: ExternalResourceSpecInventory
+    ri: ResourceInventory, resource_specs: DictExternalResourceSpecInventory
 ) -> None:
     for spec in resource_specs.values():
         if ri.is_cluster_present(spec.cluster_name):

--- a/reconcile/test/test_terraform_cloudflare_resources.py
+++ b/reconcile/test/test_terraform_cloudflare_resources.py
@@ -6,6 +6,7 @@ from reconcile.gql_definitions.terraform_cloudflare_resources.terraform_cloudfla
     NamespaceTerraformProviderResourceCloudflareV1,
     NamespaceTerraformResourceCloudflareZoneV1,
     NamespaceV1,
+    ClusterV1,
     TerraformCloudflareResourcesQueryData,
     CloudflareZoneCertificateV1,
 )
@@ -18,6 +19,7 @@ def query_data(external_resources):
             NamespaceV1(
                 name="namespace1",
                 managedExternalResources=True,
+                cluster=ClusterV1(name="cluster1"),
                 externalResources=[external_resources],
             )
         ],

--- a/reconcile/test/test_utils_external_resource_spec.py
+++ b/reconcile/test/test_utils_external_resource_spec.py
@@ -7,15 +7,15 @@ from reconcile.utils.openshift_resource import (
 )
 from reconcile.utils.external_resource_spec import (
     ExternalResourceUniqueKey,
-    ExternalResourceSpec,
+    DictExternalResourceSpec,
 )
 
 
 def test_identifier_creation_from_spec():
     id = ExternalResourceUniqueKey.from_spec(
-        ExternalResourceSpec(
+        DictExternalResourceSpec(
             provision_provider="p",
-            provisioner={"name": "a"},
+            provisioner_name="a",
             resource={
                 "identifier": "i",
                 "provider": "p",
@@ -31,9 +31,9 @@ def test_identifier_creation_from_spec():
 def test_identifier_missing():
     with pytest.raises(ValidationError):
         ExternalResourceUniqueKey.from_spec(
-            ExternalResourceSpec(
+            DictExternalResourceSpec(
                 provision_provider="p",
-                provisioner={"name": "a"},
+                provisioner_name="a",
                 resource={
                     "identifier": None,
                     "provider": "p",
@@ -43,37 +43,10 @@ def test_identifier_missing():
         )
     with pytest.raises(KeyError):
         ExternalResourceUniqueKey.from_spec(
-            ExternalResourceSpec(
+            DictExternalResourceSpec(
                 provision_provider="p",
-                provisioner={"name": "a"},
+                provisioner_name="a",
                 resource={
-                    "provider": "p",
-                },
-                namespace={},
-            )
-        )
-
-
-def test_identifier_account_missing():
-    with pytest.raises(ValidationError):
-        ExternalResourceUniqueKey.from_spec(
-            ExternalResourceSpec(
-                provision_provider="p",
-                provisioner={"name": None},
-                resource={
-                    "identifier": "i",
-                    "provider": "p",
-                },
-                namespace={},
-            )
-        )
-    with pytest.raises(KeyError):
-        ExternalResourceUniqueKey.from_spec(
-            ExternalResourceSpec(
-                provision_provider="p",
-                provisioner={},
-                resource={
-                    "identifier": "i",
                     "provider": "p",
                 },
                 namespace={},
@@ -84,9 +57,9 @@ def test_identifier_account_missing():
 def test_identifier_provider_missing():
     with pytest.raises(ValidationError):
         ExternalResourceUniqueKey.from_spec(
-            ExternalResourceSpec(
+            DictExternalResourceSpec(
                 provision_provider="p",
-                provisioner={"name": "a"},
+                provisioner_name="a",
                 resource={
                     "identifier": "i",
                     "provider": None,
@@ -96,9 +69,9 @@ def test_identifier_provider_missing():
         )
     with pytest.raises(KeyError):
         ExternalResourceUniqueKey.from_spec(
-            ExternalResourceSpec(
+            DictExternalResourceSpec(
                 provision_provider="p",
-                provisioner={"name": "a"},
+                provisioner_name="a",
                 resource={
                     "identifier": "i",
                 },
@@ -108,9 +81,9 @@ def test_identifier_provider_missing():
 
 
 def test_spec_output_prefix():
-    s = ExternalResourceSpec(
+    s = DictExternalResourceSpec(
         provision_provider="aws",
-        provisioner={"name": "a"},
+        provisioner_name="a",
         resource={"identifier": "i", "provider": "p"},
         namespace={},
     )
@@ -118,9 +91,9 @@ def test_spec_output_prefix():
 
 
 def test_spec_implicit_output_resource_name():
-    s = ExternalResourceSpec(
+    s = DictExternalResourceSpec(
         provision_provider="aws",
-        provisioner={"name": "a"},
+        provisioner_name="a",
         resource={"identifier": "i", "provider": "p"},
         namespace={},
     )
@@ -128,9 +101,9 @@ def test_spec_implicit_output_resource_name():
 
 
 def test_spec_explicit_output_resource_name():
-    s = ExternalResourceSpec(
+    s = DictExternalResourceSpec(
         provision_provider="aws",
-        provisioner={"name": "a"},
+        provisioner_name="a",
         resource={
             "identifier": "i",
             "provider": "p",
@@ -142,9 +115,9 @@ def test_spec_explicit_output_resource_name():
 
 
 def test_spec_annotation_parsing():
-    s = ExternalResourceSpec(
+    s = DictExternalResourceSpec(
         provision_provider="aws",
-        provisioner={"name": "a"},
+        provisioner_name="a",
         resource={
             "identifier": "i",
             "provider": "p",
@@ -156,9 +129,9 @@ def test_spec_annotation_parsing():
 
 
 def test_spec_annotation_parsing_none_present():
-    s = ExternalResourceSpec(
+    s = DictExternalResourceSpec(
         provision_provider="aws",
-        provisioner={"name": "a"},
+        provisioner_name="a",
         resource={
             "identifier": "i",
             "provider": "p",
@@ -169,9 +142,9 @@ def test_spec_annotation_parsing_none_present():
 
 
 def test_spec_tags():
-    s = ExternalResourceSpec(
+    s = DictExternalResourceSpec(
         provision_provider="aws",
-        provisioner={"name": "a"},
+        provisioner_name="a",
         resource={
             "identifier": "i",
             "provider": "p",
@@ -205,10 +178,10 @@ def resource_secret() -> dict[str, Any]:
 
 
 @pytest.fixture
-def spec() -> ExternalResourceSpec:
-    return ExternalResourceSpec(
+def spec() -> DictExternalResourceSpec:
+    return DictExternalResourceSpec(
         provision_provider="aws",
-        provisioner={"name": "a"},
+        provisioner_name="a",
         resource={
             "identifier": "i",
             "provider": "p",
@@ -222,13 +195,13 @@ def spec() -> ExternalResourceSpec:
 #
 
 
-def test_terraform_output_with_when_no_secret(spec: ExternalResourceSpec):
+def test_terraform_output_with_when_no_secret(spec: DictExternalResourceSpec):
     output_secret = spec.build_oc_secret("int", "1.0")
     assert output_secret.body["data"] == {}
 
 
 def test_terraform_generic_secret_output_format(
-    spec: ExternalResourceSpec, resource_secret: dict[str, Any]
+    spec: DictExternalResourceSpec, resource_secret: dict[str, Any]
 ):
     spec.resource["output_format"] = {
         "provider": "generic-secret",
@@ -245,7 +218,7 @@ def test_terraform_generic_secret_output_format(
 
 
 def test_terraform_generic_secret_output_format_no_data(
-    spec: ExternalResourceSpec, resource_secret: dict[str, Any]
+    spec: DictExternalResourceSpec, resource_secret: dict[str, Any]
 ):
     """
     this test shows backwards compatibility with the simple dict output when
@@ -263,7 +236,7 @@ def test_terraform_generic_secret_output_format_no_data(
 
 
 def test_terraform_no_output_format_provider(
-    spec: ExternalResourceSpec, resource_secret: dict[str, Any]
+    spec: DictExternalResourceSpec, resource_secret: dict[str, Any]
 ):
     """
     this test shows full backwards compatibility when no provider has been specified
@@ -276,7 +249,7 @@ def test_terraform_no_output_format_provider(
         assert output_secret.body["data"][k] == base64_encode_secret_field_value(v)
 
 
-def test_terraform_unknown_output_format_provider(spec: ExternalResourceSpec):
+def test_terraform_unknown_output_format_provider(spec: DictExternalResourceSpec):
     """
     this test expects the secret generation to fail when an unknown provider is
     given. while the schema usually protects against such cases, additional protection
@@ -288,7 +261,7 @@ def test_terraform_unknown_output_format_provider(spec: ExternalResourceSpec):
 
 
 def test_terraform_generic_secret_output_format_not_a_dict(
-    spec: ExternalResourceSpec, resource_secret: dict[str, Any]
+    spec: DictExternalResourceSpec, resource_secret: dict[str, Any]
 ):
     """
     this test shows how a data template for a generic-secret provider must result
@@ -305,7 +278,7 @@ def test_terraform_generic_secret_output_format_not_a_dict(
 
 
 def test_terraform_generic_secret_output_format_not_str_keys(
-    spec: ExternalResourceSpec, resource_secret: dict[str, Any]
+    spec: DictExternalResourceSpec, resource_secret: dict[str, Any]
 ):
     """
     this test shows how a data template for a generic-secret provider must produce
@@ -322,7 +295,7 @@ def test_terraform_generic_secret_output_format_not_str_keys(
 
 
 def test_terraform_generic_secret_output_format_not_str_val(
-    spec: ExternalResourceSpec, resource_secret: dict[str, Any]
+    spec: DictExternalResourceSpec, resource_secret: dict[str, Any]
 ):
     """
     this test shows how a data template for a generic-secret provider must produce
@@ -339,7 +312,7 @@ def test_terraform_generic_secret_output_format_not_str_val(
 
 
 def test_terraform_generic_secret_output_key_too_long(
-    spec: ExternalResourceSpec, resource_secret: dict[str, Any]
+    spec: DictExternalResourceSpec, resource_secret: dict[str, Any]
 ):
     """
     tests for too long secret keys (max length in kubernetes is 253 characters )

--- a/reconcile/test/test_utils_external_resources.py
+++ b/reconcile/test/test_utils_external_resources.py
@@ -1,8 +1,12 @@
 import json
+from typing import Optional, Union
 
 import pytest
-from reconcile.utils.external_resource_spec import ExternalResourceSpec
+from pydantic import BaseModel
 
+from reconcile.utils.external_resource_spec import (
+    DictExternalResourceSpec,
+)
 import reconcile.utils.external_resources as uer
 
 
@@ -51,16 +55,16 @@ def namespace_info():
 @pytest.fixture
 def expected(namespace_info):
     return [
-        ExternalResourceSpec(
+        DictExternalResourceSpec(
             provision_provider=uer.PROVIDER_AWS,
             resource={"provider": "rds"},
-            provisioner={"name": "acc1"},
+            provisioner_name="acc1",
             namespace=namespace_info,
         ),
-        ExternalResourceSpec(
+        DictExternalResourceSpec(
             provision_provider=uer.PROVIDER_AWS,
             resource={"provider": "rds"},
-            provisioner={"name": "acc2"},
+            provisioner_name="acc2",
             namespace=namespace_info,
         ),
     ]
@@ -76,10 +80,10 @@ def test_get_external_resource_specs(namespace_info, expected):
 @pytest.fixture
 def expected_other(namespace_info):
     return [
-        ExternalResourceSpec(
+        DictExternalResourceSpec(
             provision_provider="other",
             resource={"provider": "other"},
-            provisioner={"name": "acc3"},
+            provisioner_name="acc3",
             namespace=namespace_info,
         ),
     ]
@@ -122,9 +126,9 @@ def test_managed_external_resources_none():
 
 def test_resource_value_resolver_no_defaults_or_overrides():
     """Values are resolved properly when defaults and overrides are omitted."""
-    spec = ExternalResourceSpec(
+    spec = DictExternalResourceSpec(
         provision_provider="other",
-        provisioner={"name": "some_account"},
+        provisioner_name="some_account",
         resource={
             "provider": "other",
             "identifier": "some-id",
@@ -147,9 +151,9 @@ def test_resource_value_resolver_identifier_as_value():
     is for compatibility when both our schemas and a Terraform provider both expect
     `identifier` to be present (so it must be in the resolved values).
     """
-    spec = ExternalResourceSpec(
+    spec = DictExternalResourceSpec(
         provision_provider="other",
-        provisioner={"name": "some_account"},
+        provisioner_name="some_account",
         resource={
             "provider": "other",
             "identifier": "some-id",
@@ -173,9 +177,9 @@ def test_resource_value_resolver_identifier_as_value():
 
 def test_resource_value_resolver_tags():
     """`tags` is added to the resolved values if `integration_tag` is set."""
-    spec = ExternalResourceSpec(
+    spec = DictExternalResourceSpec(
         provision_provider="other",
-        provisioner={"name": "some_account"},
+        provisioner_name="some_account",
         resource={
             "provider": "other",
             "identifier": "some-id",
@@ -219,9 +223,9 @@ def test_resource_value_resolver_overrides_and_defaults(mocker):
         "default_3": "default_data3",
     }
 
-    spec = ExternalResourceSpec(
+    spec = DictExternalResourceSpec(
         provision_provider="other",
-        provisioner={"name": "some_account"},
+        provisioner_name="some_account",
         resource={
             "provider": "other",
             "identifier": "some-id",
@@ -245,3 +249,90 @@ def test_resource_value_resolver_overrides_and_defaults(mocker):
         "default_2": "override_data2",
         "default_3": "default_data3",
     }
+
+
+class TestProvisionier(BaseModel):
+    name: str
+
+
+class MyResource(BaseModel):
+    provider: str
+    identifier: str
+
+
+class ResourceConfig(BaseModel):
+    field_1: Optional[str]
+    field_2: Optional[str]
+
+
+class OverrideableResource(BaseModel):
+    provider: str
+    identifier: str
+    overrides: Optional[ResourceConfig]
+    defaults: Optional[ResourceConfig]
+
+
+class TestNamespaceExternalResource(BaseModel):
+    provider: str
+    provisioner: TestProvisionier
+    resources: list[Union[MyResource, OverrideableResource]]
+
+
+class TestCluster(BaseModel):
+    name: str
+
+
+class TestNamespace(BaseModel):
+    name: str
+    managed_external_resources: bool
+    cluster: TestCluster
+    external_resources: Optional[list[TestNamespaceExternalResource]]
+
+
+@pytest.fixture
+def namespace() -> TestNamespace:
+    return TestNamespace(
+        name="ns",
+        managed_external_resources=True,
+        cluster=TestCluster(name="cluster"),
+        external_resources=[
+            TestNamespaceExternalResource(
+                provider="pp",
+                provisioner=TestProvisionier(name="pn"),
+                resources=[
+                    MyResource(provider="rp", identifier="ri"),
+                ],
+            )
+        ],
+    )
+
+
+def test_get_external_resource_specs_for_namespace(
+    namespace: TestNamespace,
+):
+    external_resources = uer.get_external_resource_specs_for_namespace(
+        namespace, MyResource, None
+    )
+    assert len(external_resources) == 1
+
+    assert external_resources[0].provision_provider == "pp"
+    assert external_resources[0].provisioner_name == "pn"
+    assert external_resources[0].namespace_name == "ns"
+    assert external_resources[0].provider == "rp"
+    assert external_resources[0].identifier == "ri"
+
+
+def test_get_external_resource_specs_for_namespace_provisioning_provider_filter(
+    namespace: TestNamespace,
+):
+    external_resources = uer.get_external_resource_specs_for_namespace(
+        namespace, MyResource, "another-provisioning-provider"
+    )
+    assert len(external_resources) == 0
+
+
+def test_get_external_resource_specs_for_namespace_wrong_type(namespace: TestNamespace):
+    with pytest.raises(ValueError):
+        uer.get_external_resource_specs_for_namespace(
+            namespace, OverrideableResource, None
+        )

--- a/reconcile/test/test_utils_terraform_client.py
+++ b/reconcile/test/test_utils_terraform_client.py
@@ -3,7 +3,7 @@ from unittest.mock import create_autospec
 import pytest
 
 from reconcile.utils.external_resource_spec import (
-    ExternalResourceSpec,
+    DictExternalResourceSpec,
     ExternalResourceUniqueKey,
 )
 import reconcile.utils.terraform_client as tfclient
@@ -76,9 +76,9 @@ def test_expiration_value_error(aws_api):
 
 def test_get_replicas_info_via_replica_source():
     resource_specs = [
-        ExternalResourceSpec(
+        DictExternalResourceSpec(
             provision_provider="aws",
-            provisioner={"name": "acc"},
+            provisioner_name="acc",
             resource={
                 "identifier": "replica-id",
                 "provider": "rds",
@@ -98,9 +98,9 @@ def test_build_oc_secret():
     integration_version = "v1"
     account = "account"
 
-    spec = ExternalResourceSpec(
+    spec = DictExternalResourceSpec(
         provision_provider="aws",
-        provisioner={"name": account},
+        provisioner_name=account,
         resource={
             "identifier": "replica-id",
             "provider": "rds",
@@ -145,9 +145,9 @@ def test_populate_terraform_output_secret():
     integration_prefix = "integ_pfx"
     account = "account"
     resource_specs = [
-        ExternalResourceSpec(
+        DictExternalResourceSpec(
             provision_provider="aws",
-            provisioner={"name": account},
+            provisioner_name=account,
             resource={
                 "identifier": "id",
                 "provider": "provider",
@@ -179,18 +179,18 @@ def test_populate_terraform_output_secret():
 def test_populate_terraform_output_secret_with_replica_credentials():
     integration_prefix = "integ_pfx"
     account = "account"
-    replica = ExternalResourceSpec(
+    replica = DictExternalResourceSpec(
         provision_provider="aws",
-        provisioner={"name": account},
+        provisioner_name=account,
         resource={
             "identifier": "replica-db",
             "provider": "rds",
         },
         namespace={},
     )
-    replica_source = ExternalResourceSpec(
+    replica_source = DictExternalResourceSpec(
         provision_provider="aws",
-        provisioner={"name": account},
+        provisioner_name=account,
         resource={
             "identifier": "main-db",
             "provider": "rds",

--- a/reconcile/test/test_utils_terraform_config_client.py
+++ b/reconcile/test/test_utils_terraform_config_client.py
@@ -5,7 +5,7 @@ from unittest.mock import create_autospec, MagicMock, call, mock_open
 import pytest
 
 from reconcile.utils.exceptions import PrintToFileInGitRepositoryError
-from reconcile.utils.external_resource_spec import ExternalResourceSpec
+from reconcile.utils.external_resource_spec import DictExternalResourceSpec
 from reconcile.utils.terraform.config_client import (
     TerraformConfigClientCollection,
     TerraformConfigClient,
@@ -22,9 +22,9 @@ def empty_git_repo(tmp_path_factory) -> Path:
 
 
 def create_external_resource_spec(provisioner_name, identifier):
-    return ExternalResourceSpec(
+    return DictExternalResourceSpec(
         "cloudflare_zone",
-        {"name": provisioner_name, "automationToken": {}},
+        provisioner_name,
         {
             "provider": "cloudflare_zone",
             "identifier": f"{identifier}-com",
@@ -38,11 +38,17 @@ def create_external_resource_spec(provisioner_name, identifier):
 
 def test_terraform_config_client_collection_populate_resources():
     """populate_resources() is called on all registered clients."""
-    client_1: MagicMock = create_autospec(TerraformConfigClient)
-    client_2: MagicMock = create_autospec(TerraformConfigClient)
-    client_3: MagicMock = create_autospec(TerraformConfigClient)
+    client_1: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
+    client_2: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
+    client_3: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
 
-    terraform_configs = TerraformConfigClientCollection()
+    terraform_configs = TerraformConfigClientCollection[DictExternalResourceSpec]()
     terraform_configs.register_client("acct_1", client_1)
     terraform_configs.register_client("acct_2", client_2)
     terraform_configs.register_client("acct_3", client_3)
@@ -56,11 +62,17 @@ def test_terraform_config_client_collection_populate_resources():
 
 def test_terraform_config_client_collection_add_specs():
     """add_specs() is called on the correct client."""
-    client_1: MagicMock = create_autospec(TerraformConfigClient)
-    client_2: MagicMock = create_autospec(TerraformConfigClient)
-    client_3: MagicMock = create_autospec(TerraformConfigClient)
+    client_1: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
+    client_2: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
+    client_3: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
 
-    terraform_configs = TerraformConfigClientCollection()
+    terraform_configs = TerraformConfigClientCollection[DictExternalResourceSpec]()
     terraform_configs.register_client("acct_1", client_1)
     terraform_configs.register_client("acct_2", client_2)
     terraform_configs.register_client("acct_3", client_3)
@@ -80,11 +92,17 @@ def test_terraform_config_client_collection_add_specs():
 
 def test_terraform_config_client_collection_add_specs_with_filter():
     """add_specs() is called on the correct client when a filter is set."""
-    client_1: MagicMock = create_autospec(TerraformConfigClient)
-    client_2: MagicMock = create_autospec(TerraformConfigClient)
-    client_3: MagicMock = create_autospec(TerraformConfigClient)
+    client_1: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
+    client_2: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
+    client_3: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
 
-    terraform_configs = TerraformConfigClientCollection()
+    terraform_configs = TerraformConfigClientCollection[DictExternalResourceSpec]()
     terraform_configs.register_client("acct_1", client_1)
     terraform_configs.register_client("acct_2", client_2)
     terraform_configs.register_client("acct_3", client_3)
@@ -106,14 +124,20 @@ def test_terraform_config_client_collection_add_specs_with_filter():
 
 def test_terraform_config_client_collection_dump():
     """The working directories return by clients are aggregated properly in dump()."""
-    client_1: MagicMock = create_autospec(TerraformConfigClient)
+    client_1: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
     client_1.dump.return_value = {"acct_1": "/tmp/acct_1"}
-    client_2: MagicMock = create_autospec(TerraformConfigClient)
+    client_2: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
     client_2.dump.return_value = {"acct_2": "/tmp/acct_2"}
-    client_3: MagicMock = create_autospec(TerraformConfigClient)
+    client_3: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
     client_3.dump.return_value = {"acct_3": "/tmp/acct_3"}
 
-    terraform_configs = TerraformConfigClientCollection()
+    terraform_configs = TerraformConfigClientCollection[DictExternalResourceSpec]()
     terraform_configs.register_client("acct_1", client_1)
     terraform_configs.register_client("acct_2", client_2)
     terraform_configs.register_client("acct_3", client_3)
@@ -135,14 +159,20 @@ def test_terraform_config_client_collection_print_to_file(mocker):
     mock_builtins_open = mock_open()
     mocker.patch("builtins.open", mock_builtins_open)
 
-    client_1: MagicMock = create_autospec(TerraformConfigClient)
+    client_1: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
     client_1.dumps.return_value = {"acct_1": "data"}
-    client_2: MagicMock = create_autospec(TerraformConfigClient)
+    client_2: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
     client_2.dumps.return_value = {"acct_2": "data"}
-    client_3: MagicMock = create_autospec(TerraformConfigClient)
+    client_3: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
     client_3.dumps.return_value = {"acct_3": "data"}
 
-    terraform_configs = TerraformConfigClientCollection()
+    terraform_configs = TerraformConfigClientCollection[DictExternalResourceSpec]()
     terraform_configs.register_client("acct_1", client_1)
     terraform_configs.register_client("acct_2", client_2)
     terraform_configs.register_client("acct_3", client_3)
@@ -171,10 +201,12 @@ def test_terraform_config_client_collection_print_to_file(mocker):
 
 def test_terraform_config_client_collection_dump_print_file_git(empty_git_repo):
     """Using print_to_file in a git repo should result in an exception."""
-    client_1: MagicMock = create_autospec(TerraformConfigClient)
+    client_1: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
     client_1.dump.return_value = {"acct_1": "/tmp/acct_1"}
 
-    terraform_configs = TerraformConfigClientCollection()
+    terraform_configs = TerraformConfigClientCollection[DictExternalResourceSpec]()
     terraform_configs.register_client("acct_1", client_1)
 
     with pytest.raises(PrintToFileInGitRepositoryError):
@@ -185,10 +217,14 @@ def test_terraform_config_client_collection_dump_print_file_git(empty_git_repo):
 
 def test_terraform_config_client_collection_raise_on_duplicate():
     """Client names must be unique."""
-    client_1: MagicMock = create_autospec(TerraformConfigClient)
-    client_2: MagicMock = create_autospec(TerraformConfigClient)
+    client_1: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
+    client_2: MagicMock = create_autospec(
+        TerraformConfigClient[DictExternalResourceSpec]
+    )
 
-    terraform_configs = TerraformConfigClientCollection()
+    terraform_configs = TerraformConfigClientCollection[DictExternalResourceSpec]()
     terraform_configs.register_client("duplicate", client_1)
 
     with pytest.raises(ClientAlreadyRegisteredError):
@@ -197,7 +233,7 @@ def test_terraform_config_client_collection_raise_on_duplicate():
 
 def test_terraform_config_client_collection_raise_on_missing():
     """Specs cannot be added to clients that don't exist."""
-    terraform_configs = TerraformConfigClientCollection()
+    terraform_configs = TerraformConfigClientCollection[DictExternalResourceSpec]()
     spec_1 = create_external_resource_spec("acct_1", "dev-1")
 
     with pytest.raises(ClientNotRegisteredError):

--- a/reconcile/test/test_utils_terrascript_aws_client.py
+++ b/reconcile/test/test_utils_terrascript_aws_client.py
@@ -3,7 +3,7 @@ from reconcile.utils.aws_api import AmiTag
 
 import reconcile.utils.terrascript_aws_client as tsclient
 from reconcile.utils.external_resource_spec import (
-    ExternalResourceSpec,
+    DictExternalResourceSpec,
     ExternalResourceUniqueKey,
 )
 
@@ -172,7 +172,7 @@ def test_resource_specs_without_account_filter(ts):
     namespaces = [ns1]
     ts.init_populate_specs(namespaces, None)
     specs = ts.resource_spec_inventory
-    spec = ExternalResourceSpec(p, pa, ra, ns1)
+    spec = DictExternalResourceSpec(p, pa["name"], ra, ns1)
     assert specs == {ExternalResourceUniqueKey.from_spec(spec): spec}
 
 
@@ -198,7 +198,7 @@ def test_resource_specs_with_account_filter(ts):
     namespaces = [ns1]
     ts.init_populate_specs(namespaces, "a")
     specs = ts.resource_spec_inventory
-    spec = ExternalResourceSpec(p, pa, ra, ns1)
+    spec = DictExternalResourceSpec(p, pa["name"], ra, ns1)
     assert specs == {ExternalResourceUniqueKey.from_spec(spec): spec}
 
 

--- a/reconcile/test/test_utils_terrascript_cloudflare_resources.py
+++ b/reconcile/test/test_utils_terrascript_cloudflare_resources.py
@@ -1,6 +1,6 @@
 import pytest
 
-from reconcile.utils.external_resource_spec import ExternalResourceSpec
+from reconcile.utils.external_resource_spec import DictExternalResourceSpec
 from reconcile.utils.terrascript.cloudflare_resources import (
     create_cloudflare_terrascript_resource,
     UnsupportedCloudflareResourceError,
@@ -8,9 +8,9 @@ from reconcile.utils.terrascript.cloudflare_resources import (
 
 
 def create_external_resource_spec(provision_provider):
-    return ExternalResourceSpec(
+    return DictExternalResourceSpec(
         provision_provider,
-        {"name": "dev", "automationToken": {}},
+        "dev",
         {
             "provider": provision_provider,
             "identifier": "test",

--- a/reconcile/utils/terraform/config_client.py
+++ b/reconcile/utils/terraform/config_client.py
@@ -1,20 +1,22 @@
 import os
 from abc import ABC, abstractmethod
-from typing import Iterable, Optional
+from typing import Generic, Iterable, Optional, TypeVar
 
 from reconcile.utils.exceptions import PrintToFileInGitRepositoryError
 from reconcile.utils.external_resource_spec import ExternalResourceSpec
 from reconcile.utils.git import is_file_in_git_repo
 
+T = TypeVar("T", bound=ExternalResourceSpec)
 
-class TerraformConfigClient(ABC):
+
+class TerraformConfigClient(ABC, Generic[T]):
     """
     Clients that are responsible for collecting external resource specs and returning
     Terraform JSON configuration.
     """
 
     @abstractmethod
-    def add_spec(self, spec: ExternalResourceSpec) -> None:
+    def add_spec(self, spec: T) -> None:
         """
         Add external resource specs that will be used to populate a Terraform JSON
         config.
@@ -36,16 +38,18 @@ class TerraformConfigClient(ABC):
         """Return the Terraform JSON configuration as a string."""
 
 
-class TerraformConfigClientCollection:
+class TerraformConfigClientCollection(Generic[T]):
     """
     Collection of TerraformConfigClient for consolidating logic related collecting the
     clients and iterating through them, optionally concurrency as needed.
     """
 
     def __init__(self) -> None:
-        self._clients: dict[str, TerraformConfigClient] = {}
+        self._clients: dict[str, TerraformConfigClient[T]] = {}
 
-    def register_client(self, account_name: str, client: TerraformConfigClient) -> None:
+    def register_client(
+        self, account_name: str, client: TerraformConfigClient[T]
+    ) -> None:
         if account_name in self._clients:
             raise ClientAlreadyRegisteredError(
                 f"Client already registered with the name: {account_name}"
@@ -55,7 +59,7 @@ class TerraformConfigClientCollection:
 
     def add_specs(
         self,
-        specs: Iterable[ExternalResourceSpec],
+        specs: Iterable[T],
         account_filter: Optional[str] = None,
     ) -> None:
         """

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -15,7 +15,7 @@ from sretoolbox.utils import threaded
 from reconcile.utils.aws_helper import get_region_from_availability_zone
 from reconcile.utils.external_resource_spec import (
     ExternalResourceSpec,
-    ExternalResourceSpecInventory,
+    DictExternalResourceSpecInventory,
 )
 
 import reconcile.utils.lean_terraform_client as lean_tf
@@ -471,7 +471,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
 
     def populate_terraform_output_secrets(
         self,
-        resource_specs: ExternalResourceSpecInventory,
+        resource_specs: DictExternalResourceSpecInventory,
         init_rds_replica_source: bool = False,
     ) -> None:
         """
@@ -495,7 +495,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     def _populate_terraform_output_secrets(
-        resource_specs: ExternalResourceSpecInventory,
+        resource_specs: DictExternalResourceSpecInventory,
         terraform_output_secrets: Mapping[str, Mapping[str, Mapping[str, str]]],
         integration_prefix: str,
         replica_sources: Mapping[str, Mapping[str, str]],

--- a/reconcile/utils/terrascript/cloudflare_client.py
+++ b/reconcile/utils/terrascript/cloudflare_client.py
@@ -1,13 +1,13 @@
 import tempfile
 from dataclasses import dataclass
-from typing import Iterable, Optional, Union
+from typing import Iterable, MutableMapping, Optional, Union
 
 from terrascript import Terrascript, Terraform, Resource, Output, Backend, Variable
 from terrascript import provider
 
 from reconcile.utils.external_resource_spec import (
-    ExternalResourceSpec,
-    ExternalResourceSpecInventory,
+    ExternalResourceUniqueKey,
+    TypedExternalResourceSpec,
 )
 from reconcile.utils.terraform.config import TerraformS3BackendConfig
 from reconcile.utils.terraform.config_client import (
@@ -16,6 +16,9 @@ from reconcile.utils.terraform.config_client import (
 from reconcile.utils.terrascript.cloudflare_resources import (
     cloudflare_account,
     create_cloudflare_terrascript_resource,
+)
+from reconcile.gql_definitions.terraform_cloudflare_resources.terraform_cloudflare_resources import (
+    NamespaceTerraformResourceCloudflareV1,
 )
 
 TMP_DIR_PREFIX = "terrascript-cloudflare-"
@@ -92,7 +95,10 @@ def create_cloudflare_terrascript(
     return terrascript
 
 
-class TerrascriptCloudflareClient(TerraformConfigClient):
+T = TypedExternalResourceSpec[NamespaceTerraformResourceCloudflareV1]
+
+
+class TerrascriptCloudflareClient(TerraformConfigClient[T]):
     """
     Build the Terrascript configuration, collect resources, and return Terraform JSON
     configuration.
@@ -108,9 +114,9 @@ class TerrascriptCloudflareClient(TerraformConfigClient):
         ts_client: Terrascript,
     ) -> None:
         self._terrascript = ts_client
-        self._resource_specs: ExternalResourceSpecInventory = {}
+        self._resource_specs: MutableMapping[ExternalResourceUniqueKey, T] = {}
 
-    def add_spec(self, spec: ExternalResourceSpec) -> None:
+    def add_spec(self, spec: T) -> None:
         self._resource_specs[spec.id_object()] = spec
 
     def populate_resources(self) -> None:

--- a/reconcile/utils/terrascript/cloudflare_resources.py
+++ b/reconcile/utils/terrascript/cloudflare_resources.py
@@ -1,4 +1,11 @@
-from typing import Union, Iterable, Any, MutableMapping
+from typing import (
+    Type,
+    Union,
+    Iterable,
+    Any,
+    MutableMapping,
+    get_args,
+)
 
 from terrascript import Resource, Output, Variable
 from terrascript.resource import (
@@ -10,8 +17,15 @@ from terrascript.resource import (
     cloudflare_worker_script,
 )
 from reconcile import queries
-from reconcile.utils.external_resource_spec import ExternalResourceSpec
-from reconcile.utils.external_resources import ResourceValueResolver
+from reconcile.gql_definitions.terraform_cloudflare_resources.terraform_cloudflare_resources import (
+    NamespaceTerraformResourceCloudflareWorkerScriptV1,
+    NamespaceTerraformResourceCloudflareZoneV1,
+    NamespaceTerraformResourceCloudflareV1,
+)
+from reconcile.utils.external_resource_spec import TypedExternalResourceSpec
+from reconcile.utils.external_resources import (
+    ResourceValueResolver,
+)
 from reconcile.utils.github_api import GithubApi
 from reconcile.utils.terrascript.resources import TerrascriptResource
 from reconcile.utils.terraform import safe_resource_id
@@ -39,7 +53,7 @@ class cloudflare_certificate_pack(Resource):
 
 
 def create_cloudflare_terrascript_resource(
-    spec: ExternalResourceSpec,
+    spec: TypedExternalResourceSpec[NamespaceTerraformResourceCloudflareV1],
 ) -> list[Union[Resource, Output]]:
     """
     Create the required Cloudflare Terrascript resources as defined by the external
@@ -47,17 +61,21 @@ def create_cloudflare_terrascript_resource(
     """
     resource_type = spec.provider
 
-    if resource_type == "worker_script":
-        return CloudflareWorkerScriptTerrascriptResource(spec).populate()
-    elif resource_type == "zone":
-        return CloudflareZoneTerrascriptResource(spec).populate()
-    else:
-        raise UnsupportedCloudflareResourceError(
-            f"The resource type {resource_type} is not supported"
-        )
+    for cf_resource_type in _cloudflare_resource_types:
+        (external_resource_type,) = get_args(cf_resource_type.__orig_bases__[0])  # type: ignore
+        (spec_type,) = get_args(external_resource_type)
+        if isinstance(spec.resource, spec_type):
+            return cf_resource_type(spec).populate()
+    raise UnsupportedCloudflareResourceError(
+        f"The resource type {resource_type} is not supported"
+    )
 
 
-class CloudflareWorkerScriptTerrascriptResource(TerrascriptResource):
+class CloudflareWorkerScriptTerrascriptResource(
+    TerrascriptResource[
+        TypedExternalResourceSpec[NamespaceTerraformResourceCloudflareWorkerScriptV1]
+    ]
+):
     """Generate a cloudflare_worker_script resource"""
 
     def populate(self) -> list[Union[Resource, Output]]:
@@ -98,7 +116,11 @@ class CloudflareWorkerScriptTerrascriptResource(TerrascriptResource):
         ]
 
 
-class CloudflareZoneTerrascriptResource(TerrascriptResource):
+class CloudflareZoneTerrascriptResource(
+    TerrascriptResource[
+        TypedExternalResourceSpec[NamespaceTerraformResourceCloudflareZoneV1]
+    ]
+):
     """Generate a cloudflare_zone and related resources."""
 
     def _create_cloudflare_certificate_pack(
@@ -120,7 +142,6 @@ class CloudflareZoneTerrascriptResource(TerrascriptResource):
 
     def populate(self) -> list[Union[Resource, Output]]:
         resources = []
-
         values = ResourceValueResolver(self._spec).resolve()
 
         zone_settings = values.pop("settings", {})
@@ -184,3 +205,9 @@ class CloudflareZoneTerrascriptResource(TerrascriptResource):
         resources.extend(self._create_cloudflare_certificate_pack(zone, zone_certs))
 
         return resources
+
+
+_cloudflare_resource_types: list[Type[TerrascriptResource]] = [
+    CloudflareWorkerScriptTerrascriptResource,
+    CloudflareZoneTerrascriptResource,
+]

--- a/reconcile/utils/terrascript/resources.py
+++ b/reconcile/utils/terrascript/resources.py
@@ -1,12 +1,12 @@
 from abc import ABC, abstractmethod
-from typing import Iterable, Union
+from typing import Generic, Iterable, Union
 
 from terrascript import Resource, Output
 
-from reconcile.utils.external_resource_spec import ExternalResourceSpec
+from reconcile.utils.terraform.config_client import T
 
 
-class TerrascriptResource(ABC):
+class TerrascriptResource(ABC, Generic[T]):
     """
     Base class for creating Terrascript resources. New resources are added by
     subclassing this class and implementing the logic to return the required Terrascript
@@ -18,8 +18,8 @@ class TerrascriptResource(ABC):
     implicitly created certain resources.
     """
 
-    def __init__(self, spec: ExternalResourceSpec) -> None:
-        self._spec = spec
+    def __init__(self, spec: T) -> None:
+        self._spec: T = spec
 
     @staticmethod
     def _get_dependencies(tf_resources: Iterable[Resource]) -> list[str]:

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -142,7 +142,7 @@ from reconcile.utils import gql
 from reconcile.utils.aws_api import AWSApi, AmiTag
 from reconcile.utils.external_resource_spec import (
     ExternalResourceSpec,
-    ExternalResourceSpecInventory,
+    DictExternalResourceSpecInventory,
 )
 from reconcile.utils.external_resources import PROVIDER_AWS, get_external_resource_specs
 from reconcile.utils.gitlab_api import GitLabApi
@@ -1153,7 +1153,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         :param account_name: AWS account name
         """
         self.account_resource_specs: dict[str, list[ExternalResourceSpec]] = {}
-        self.resource_spec_inventory: ExternalResourceSpecInventory = {}
+        self.resource_spec_inventory: DictExternalResourceSpecInventory = {}
 
         for namespace_info in namespaces:
             specs = get_external_resource_specs(


### PR DESCRIPTION
`ExternalResourceSpec` serves well as streamlined way to load external resources. sadly it operators only on `dict` data. especially for cloudflare and the upcoming CNA integratioln, it means leaving the typehinted dataclasses behind when transforming query results into `ExternalResourceSpec`.

this PR makes `ExternalResourceSpec` a base type and introduces two subtypes:

* `DictExternalResourceSpec` which represents the dict based approach to keep compatibility with the classic `terraform-resources` integrations
* `TypedExternalResourceSpec` for cloudflare and CNA, which keeps the dataclasses alive.

both types leverage python generics (typevars) to be able to store the resource and namespaces with different types and compensate their differences with customer property getters.

the loading mechanism from dataclasses to `TypedExternalResourceSpec` is done via `get_external_resource_specs_for_namespace` and leverages `Protocols` so that various namespaces, provisioners and actual resources provided by different qenerate queries can be passed.


the first commit introduces the to `ExternalResourceSpec` subtypes and adapt `terraform-resources` to use the `dict` version of it.

the second commit adapts the cloudflare integration to use `TypedExternalResourceSpec`. by that, the dataclasses survive through all layers of code into `cloudflare_resources.py`. the transition is not executed in full, because the`populate` functions have not been adapted yet to `self._spec` being a proper dataclass.

the resolver has also not been touched yet.