### PR TITLE
Fluentd memory limit increase

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -362,7 +362,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -198,7 +198,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -212,7 +212,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
@@ -172,7 +172,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs
@@ -354,7 +354,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/aws_account_shards.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shards.yml
@@ -172,7 +172,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs
@@ -354,7 +354,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/basic.yml
+++ b/reconcile/test/fixtures/helm/basic.yml
@@ -170,7 +170,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/cache.yml
+++ b/reconcile/test/fixtures/helm/cache.yml
@@ -181,7 +181,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/command.yml
+++ b/reconcile/test/fixtures/helm/command.yml
@@ -170,7 +170,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/disable_unleash.yml
+++ b/reconcile/test/fixtures/helm/disable_unleash.yml
@@ -160,7 +160,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -184,7 +184,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/environment_aware.yml
+++ b/reconcile/test/fixtures/helm/environment_aware.yml
@@ -196,7 +196,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/exclude_service.yml
+++ b/reconcile/test/fixtures/helm/exclude_service.yml
@@ -170,7 +170,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/extra_args.yml
+++ b/reconcile/test/fixtures/helm/extra_args.yml
@@ -172,7 +172,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/extra_env.yml
+++ b/reconcile/test/fixtures/helm/extra_env.yml
@@ -177,7 +177,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/integrations_manager.yml
+++ b/reconcile/test/fixtures/helm/integrations_manager.yml
@@ -172,7 +172,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/internal_certificates.yml
+++ b/reconcile/test/fixtures/helm/internal_certificates.yml
@@ -182,7 +182,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/logs_slack.yml
+++ b/reconcile/test/fixtures/helm/logs_slack.yml
@@ -188,7 +188,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/shards.yml
+++ b/reconcile/test/fixtures/helm/shards.yml
@@ -170,7 +170,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs
@@ -350,7 +350,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/sleep_duration.yml
+++ b/reconcile/test/fixtures/helm/sleep_duration.yml
@@ -170,7 +170,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/state.yml
+++ b/reconcile/test/fixtures/helm/state.yml
@@ -177,7 +177,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/storage.yml
+++ b/reconcile/test/fixtures/helm/storage.yml
@@ -170,7 +170,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs

--- a/reconcile/test/fixtures/helm/trigger.yml
+++ b/reconcile/test/fixtures/helm/trigger.yml
@@ -170,7 +170,7 @@ objects:
               memory: 30Mi
               cpu: 15m
             limits:
-              memory: 120Mi
+              memory: 130Mi
               cpu: 25m
           volumeMounts:
           - name: logs


### PR DESCRIPTION
[APPSRE-6600](https://issues.redhat.com/browse/APPSRE-6600)

With Fluentd -> GChat logging now deployed in FedRamp, we have noted the Fluentd containers consistently running over the existing memory limit of 120Mi to around 125Mi. Thus, this MR increases the limit to 130Mi to reduce the amount of SIGKILL errors in Fluentd and prevent issues such as repeating logs into Google Chat.