### PR TITLE
Fluentd Customizable Resource Limits and Requests 

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -23,30 +23,31 @@ https://github.com/helm/helm/releases
 
 ### Integration spec configuration
 
-| Parameter                   | Description                                                              | Default                            |
-|-----------------------------|--------------------------------------------------------------------------|------------------------------------|
-| cache                       | integration requires cache                                               | false                              |
-| command                     | command to run                                                           | qontract-reconcile                 |
-| disableUnleash              | disable integration interaction with unleash instance                    | false                              |
-| environmentAware            | integration requires environment awareness (env vars and env name)       | false                              |
-| extraArgs                   | additional arguments to pass to integration                              | []                                 |
-| extraEnv                    | additional environment variables to set for the integration              | []                                 |
-| internalCertificates        | integration requires internal certificates to execute                    | false                              |
-| logs                        | ship logs to providers                                                   | cloudwatch is enabled by default   |
-| logs.slack                  | ship logs to slack                                                       | false                              |
-| logs.googleChat             | ship logs to google chat                                                 | false                              |
-| resources                   | CPU/Memory resource requests/limits                                      |                                    |
-| shards                      | number of shards to run integration with                                 | 1                                  |
-| sleepDurationSecs           | time to sleep in seconds between integration executions                  | 600s                               |
-| state                       | integration is stateful                                                  | false                              |
-| storage                     | size of cache storage                                                    | 1Gi                                |
-| trigger                     | integration is an openshift-saas-deploy trigger                          | false                              |
-| cron                        | cron expression for integration execution                                | nil                                |
-| dashdotdb                   | integration interacts with dashdotdb                                     | false                              |
-| concurrencyPolicy           | how to treat concurrent executions of the integration                    | Allow                              |
-| restartPolicy               | restarts of the integration                                              | OnFailure                          |
-| successfulJobHistoryLimit   | number of history records reserved for successful integration executions | 3                                  |
-| failedJobHistoryLimit       | number of history records reserved for failed integration executions     | 1                                  |
+| Parameter                 | Description                                                              | Default                                                                 |
+|---------------------------|--------------------------------------------------------------------------|-------------------------------------------------------------------------|
+| cache                     | integration requires cache                                               | false                                                                   |
+| command                   | command to run                                                           | qontract-reconcile                                                      |
+| disableUnleash            | disable integration interaction with unleash instance                    | false                                                                   |
+| environmentAware          | integration requires environment awareness (env vars and env name)       | false                                                                   |
+| extraArgs                 | additional arguments to pass to integration                              | []                                                                      |
+| extraEnv                  | additional environment variables to set for the integration              | []                                                                      |
+| internalCertificates      | integration requires internal certificates to execute                    | false                                                                   |
+| logs                      | ship logs to providers                                                   | cloudwatch is enabled by default                                        |
+| logs.slack                | ship logs to slack                                                       | false                                                                   |
+| logs.googleChat           | ship logs to google chat                                                 | false                                                                   |
+| resources                 | CPU/Memory resource requests/limits                                      |                                                                         |
+| fluentdResources          | CPU/Memory resource requests/limits for Fluentd                          | {requests: {memory: 30Mi, cpu: 15m}, limits: {memory: 120Mi, cpu: 25m}} |
+| shards                    | number of shards to run integration with                                 | 1                                                                       |
+| sleepDurationSecs         | time to sleep in seconds between integration executions                  | 600s                                                                    |
+| state                     | integration is stateful                                                  | false                                                                   |
+| storage                   | size of cache storage                                                    | 1Gi                                                                     |
+| trigger                   | integration is an openshift-saas-deploy trigger                          | false                                                                   |
+| cron                      | cron expression for integration execution                                | nil                                                                     |
+| dashdotdb                 | integration interacts with dashdotdb                                     | false                                                                   |
+| concurrencyPolicy         | how to treat concurrent executions of the integration                    | Allow                                                                   |
+| restartPolicy             | restarts of the integration                                              | OnFailure                                                               |
+| successfulJobHistoryLimit | number of history records reserved for successful integration executions | 3                                                                       |
+| failedJobHistoryLimit     | number of history records reserved for failed integration executions     | 1                                                                       |
 
 ## Logging
 

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -357,6 +357,27 @@ objects:
               secretKeyRef:
                 name: ${CLOUDWATCH_SECRET}
                 key: aws_secret_access_key
+          {{- if $integration.fluentdResources }}
+          resources:
+            {{- if $integration.fluentdResources.limits }}
+            limits:
+              {{- if $integration.fluentdResources.limits.cpu }}
+              cpu: {{ "${" }}{{ $integration.name | upper | replace "-" "_" }}FLUENTD_CPU_LIMIT{{ "}" }}
+              {{- end }}
+              {{- if $integration.fluentdResources.limits.memory }}
+              memory: {{ "${" }}{{ $integration.name | upper | replace "-" "_" }}FLUENTD_MEMORY_LIMIT{{ "}" }}
+              {{- end }}
+            {{- end }}
+            {{- if $integration.fluentdResources.requests }}
+            requests:
+              {{- if $integration.fluentdResources.requests.cpu }}
+              cpu: {{ "${" }}{{ $integration.name | upper | replace "-" "_" }}FLUENTD_CPU_REQUEST{{ "}" }}
+              {{- end }}
+              {{- if $integration.fluentdResources.requests.memory }}
+              memory: {{ "${" }}{{ $integration.name | upper | replace "-" "_" }}FLUENTD_MEMORY_REQUEST{{ "}" }}
+              {{- end }}
+            {{- end }}
+          {{- else }}
           resources:
             requests:
               memory: 30Mi
@@ -364,6 +385,7 @@ objects:
             limits:
               memory: 120Mi
               cpu: 25m
+          {{- end }}
           volumeMounts:
           - name: logs
             mountPath: /fluentd/log/
@@ -596,6 +618,28 @@ parameters:
 {{- if $integration.resources.requests.memory }}
 - name: {{ $integration.name | upper | replace "-" "_" }}_MEMORY_REQUEST
   value: {{ $integration.resources.requests.memory }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $integration.fluentdResources }}
+{{- if $integration.fluentdResources.limits }}
+{{- if $integration.fluentdResources.limits.cpu }}
+- name: {{ $integration.name | upper | replace "-" "_"}}_FLUENTD_CPU_LIMIT
+  value: {{ $integration.fluentdResources.limits.cpu }}
+{{- end }}
+{{- if $integration.fluentdResources.limits.memory }}
+- name: {{ $integration.name | upper | replace "-" "_" }}_FLUENTD_MEMORY_LIMIT
+  value: {{ $integration.fluentdResources.limits.memory }}
+{{- end }}
+{{- end }}
+{{- if $integration.fluentdResources.requests }}
+{{- if $integration.fluentdResources.requests.cpu }}
+- name: {{ $integration.name | upper | replace "-" "_" }}_FLUENTD_CPU_REQUEST
+  value: {{ $integration.fluentdResources.requests.cpu }}
+{{- end }}
+{{- if $integration.fluentdResources.requests.memory }}
+- name: {{ $integration.name | upper | replace "-" "_" }}_FLUENTD_MEMORY_REQUEST
+  value: {{ $integration.fluentdResources.requests.memory }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -362,19 +362,19 @@ objects:
             {{- if $integration.fluentdResources.limits }}
             limits:
               {{- if $integration.fluentdResources.limits.cpu }}
-              cpu: {{ "${" }}{{ $integration.name | upper | replace "-" "_" }}FLUENTD_CPU_LIMIT{{ "}" }}
+              cpu: {{ "${" }}{{ $integration.name | upper | replace "-" "_" }}_FLUENTD_CPU_LIMIT{{ "}" }}
               {{- end }}
               {{- if $integration.fluentdResources.limits.memory }}
-              memory: {{ "${" }}{{ $integration.name | upper | replace "-" "_" }}FLUENTD_MEMORY_LIMIT{{ "}" }}
+              memory: {{ "${" }}{{ $integration.name | upper | replace "-" "_" }}_FLUENTD_MEMORY_LIMIT{{ "}" }}
               {{- end }}
             {{- end }}
             {{- if $integration.fluentdResources.requests }}
             requests:
               {{- if $integration.fluentdResources.requests.cpu }}
-              cpu: {{ "${" }}{{ $integration.name | upper | replace "-" "_" }}FLUENTD_CPU_REQUEST{{ "}" }}
+              cpu: {{ "${" }}{{ $integration.name | upper | replace "-" "_" }}_FLUENTD_CPU_REQUEST{{ "}" }}
               {{- end }}
               {{- if $integration.fluentdResources.requests.memory }}
-              memory: {{ "${" }}{{ $integration.name | upper | replace "-" "_" }}FLUENTD_MEMORY_REQUEST{{ "}" }}
+              memory: {{ "${" }}{{ $integration.name | upper | replace "-" "_" }}_FLUENTD_MEMORY_REQUEST{{ "}" }}
               {{- end }}
             {{- end }}
           {{- else }}

--- a/helm/qontract-reconcile/values-manager-fedramp.yaml
+++ b/helm/qontract-reconcile/values-manager-fedramp.yaml
@@ -8,6 +8,13 @@ integrations:
     limits:
       memory: 600Mi
       cpu: 400m
+  fluentdResources:
+    requests:
+      memory: 60Mi
+      cpu: 15m
+    limits:
+      memory: 240Mi
+      cpu: 25m
   environmentAware: true
   logs:
     slack: false

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -194,12 +194,12 @@ objects:
                 name: ${CLOUDWATCH_SECRET}
                 key: aws_secret_access_key
           resources:
-            requests:
-              memory: 30Mi
-              cpu: 15m
             limits:
-              memory: 120Mi
-              cpu: 25m
+              cpu: ${INTEGRATIONS_MANAGER_FLUENTD_CPU_LIMIT}
+              memory: ${INTEGRATIONS_MANAGER_FLUENTD_MEMORY_LIMIT}
+            requests:
+              cpu: ${INTEGRATIONS_MANAGER_FLUENTD_CPU_REQUEST}
+              memory: ${INTEGRATIONS_MANAGER_FLUENTD_MEMORY_REQUEST}
           volumeMounts:
           - name: logs
             mountPath: /fluentd/log/
@@ -280,3 +280,11 @@ parameters:
   value: 200m
 - name: INTEGRATIONS_MANAGER_MEMORY_REQUEST
   value: 300Mi
+- name: INTEGRATIONS_MANAGER_FLUENTD_CPU_LIMIT
+  value: 25m
+- name: INTEGRATIONS_MANAGER_FLUENTD_MEMORY_LIMIT
+  value: 240Mi
+- name: INTEGRATIONS_MANAGER_FLUENTD_CPU_REQUEST
+  value: 15m
+- name: INTEGRATIONS_MANAGER_FLUENTD_MEMORY_REQUEST
+  value: 60Mi


### PR DESCRIPTION
Take 2 at https://github.com/app-sre/qontract-reconcile/pull/2992 using Helm templating.

[APPSRE-6600](https://issues.redhat.com/browse/APPSRE-6600)

With Fluentd -> GChat logging now deployed in FedRamp, we have noted the Fluentd containers consistently running over the existing memory limit of 120Mi. This MR allows users to specify on an integration level the Fluentd resource limits/requests, similar to what we can currently do with the QR pod.