### PR TITLE
Include fluentdResources in queries.py

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -262,6 +262,16 @@ INTEGRATIONS_QUERY = """
             memory
           }
         }
+        fluentdResources {
+          requests {
+            cpu
+            memory
+          }
+          limits {
+            cpu
+            memory
+          }
+        }
         shards
         shardingStrategy
         sleepDurationSecs


### PR DESCRIPTION
Follow-up to #2996 to update queries.py to include the new `fluentdResources` part of the Integration Spec query so that integrations manager can properly update new pods.