### PR TITLE
[ocm-cluster-admin] introduce integration

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1840,6 +1840,15 @@ def ocm_external_configuration_labels(ctx, thread_pool_size):
     )
 
 
+@integration.command(short_help="Manage Cluster Admin in OCM.")
+@threaded()
+@click.pass_context
+def ocm_cluster_admin(ctx, thread_pool_size):
+    import reconcile.ocm_cluster_admin
+
+    run_integration(reconcile.ocm_cluster_admin, ctx.obj, thread_pool_size)
+
+
 @integration.command(short_help="Manage Machine Pools in OCM.")
 @threaded()
 @click.pass_context

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1841,12 +1841,11 @@ def ocm_external_configuration_labels(ctx, thread_pool_size):
 
 
 @integration.command(short_help="Manage Cluster Admin in OCM.")
-@threaded()
 @click.pass_context
-def ocm_cluster_admin(ctx, thread_pool_size):
+def ocm_cluster_admin(ctx):
     import reconcile.ocm_cluster_admin
 
-    run_integration(reconcile.ocm_cluster_admin, ctx.obj, thread_pool_size)
+    run_integration(reconcile.ocm_cluster_admin, ctx.obj)
 
 
 @integration.command(short_help="Manage Machine Pools in OCM.")

--- a/reconcile/ocm_cluster_admin.py
+++ b/reconcile/ocm_cluster_admin.py
@@ -17,7 +17,7 @@ def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
     )
 
 
-def run(dry_run, thread_pool_size=10):
+def run(dry_run):
     settings = queries.get_app_interface_settings()
     clusters = queries.get_clusters()
     clusters = [

--- a/reconcile/ocm_cluster_admin.py
+++ b/reconcile/ocm_cluster_admin.py
@@ -1,11 +1,14 @@
-import sys
 import logging
-from typing import Any, Mapping
+import sys
+from typing import (
+    Any,
+    Mapping,
+)
 
 from reconcile import queries
+from reconcile.ocm.utils import cluster_disabled_integrations
 from reconcile.status import ExitCodes
 from reconcile.utils.ocm import OCMMap
-from reconcile.ocm.utils import cluster_disabled_integrations
 
 QONTRACT_INTEGRATION = "ocm-cluster-admin"
 

--- a/reconcile/ocm_cluster_admin.py
+++ b/reconcile/ocm_cluster_admin.py
@@ -1,0 +1,43 @@
+import sys
+import logging
+from typing import Any, Mapping
+
+from reconcile import queries
+from reconcile.status import ExitCodes
+from reconcile.utils.ocm import OCMMap
+from reconcile.ocm.utils import cluster_disabled_integrations
+
+QONTRACT_INTEGRATION = "ocm-cluster-admin"
+
+
+def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
+    return (
+        cluster.get("ocm") is not None
+        and cluster.get("clusterAdminAutomationToken") is not None
+    )
+
+
+def run(dry_run, thread_pool_size=10):
+    settings = queries.get_app_interface_settings()
+    clusters = queries.get_clusters()
+    clusters = [
+        c
+        for c in clusters
+        if QONTRACT_INTEGRATION not in cluster_disabled_integrations(c)
+        and _cluster_is_compatible(c)
+    ]
+
+    if not clusters:
+        logging.debug("No cluster admin definitions found in app-interface")
+        sys.exit(ExitCodes.SUCCESS)
+
+    ocm_map = OCMMap(
+        clusters=clusters, integration=QONTRACT_INTEGRATION, settings=settings
+    )
+    for cluster in clusters:
+        cluster_name = cluster["name"]
+        ocm = ocm_map.get(cluster_name)
+        if not ocm.is_cluster_admin_enabled(cluster_name):
+            logging.info(["enable_cluster_admin", cluster_name])
+            if not dry_run:
+                raise NotImplementedError()

--- a/reconcile/ocm_cluster_admin.py
+++ b/reconcile/ocm_cluster_admin.py
@@ -11,10 +11,7 @@ QONTRACT_INTEGRATION = "ocm-cluster-admin"
 
 
 def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
-    return (
-        cluster.get("ocm") is not None
-        and cluster.get("clusterAdminAutomationToken") is not None
-    )
+    return cluster.get("ocm") is not None and cluster.get("clusterAdmin")
 
 
 def run(dry_run: bool) -> None:

--- a/reconcile/ocm_cluster_admin.py
+++ b/reconcile/ocm_cluster_admin.py
@@ -14,7 +14,7 @@ QONTRACT_INTEGRATION = "ocm-cluster-admin"
 
 
 def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
-    return cluster.get("ocm") is not None and cluster.get("clusterAdmin")
+    return bool(cluster.get("ocm") is not None and cluster.get("clusterAdmin"))
 
 
 def run(dry_run: bool) -> None:

--- a/reconcile/ocm_cluster_admin.py
+++ b/reconcile/ocm_cluster_admin.py
@@ -17,7 +17,7 @@ def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
     )
 
 
-def run(dry_run):
+def run(dry_run: bool) -> None:
     settings = queries.get_app_interface_settings()
     clusters = queries.get_clusters()
     clusters = [

--- a/reconcile/ocm_cluster_admin.py
+++ b/reconcile/ocm_cluster_admin.py
@@ -40,4 +40,4 @@ def run(dry_run, thread_pool_size=10):
         if not ocm.is_cluster_admin_enabled(cluster_name):
             logging.info(["enable_cluster_admin", cluster_name])
             if not dry_run:
-                raise NotImplementedError()
+                ocm.enable_cluster_admin(cluster_name)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -862,6 +862,12 @@ CLUSTERS_QUERY = """
       version
       format
     }
+    clusterAdminAutomationToken {
+      path
+      field
+      version
+      format
+    }
     internal
     disable {
       integrations

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -862,12 +862,7 @@ CLUSTERS_QUERY = """
       version
       format
     }
-    clusterAdminAutomationToken {
-      path
-      field
-      version
-      format
-    }
+    clusterAdmin
     internal
     disable {
       integrations

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1023,7 +1023,7 @@ class OCM:  # pylint: disable=too-many-public-methods
         api = self._get_subscription_labels_api(cluster)
         subcription_labels = self._get_json(api).get("items")
 
-        for sl in subcription_labels:
+        for sl in subcription_labels or []:
             if sl["key"] == CLUSTER_ADMIN_LABEL_KEY and sl["value"] == "true":
                 return True
 

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -52,6 +52,7 @@ AUTOSCALE_DESIRED_KEYS = {"min_replicas", "max_replicas"}
 CLUSTER_ADDON_DESIRED_KEYS = {"id", "parameters"}
 
 DISABLE_UWM_ATTR = "disable_user_workload_monitoring"
+CLUSTER_ADMIN_LABEL_KEY = "capability.cluster.manage_cluster_admin"
 BYTES_IN_GIGABYTE = 1024**3
 REQUEST_TIMEOUT_SEC = 60
 
@@ -1023,10 +1024,7 @@ class OCM:  # pylint: disable=too-many-public-methods
         subcription_labels = self._get_json(api).get("items")
 
         for sl in subcription_labels:
-            if (
-                sl["key"] == "capability.cluster.manage_cluster_admin"
-                and sl["value"] == "true"
-            ):
+            if sl["key"] == CLUSTER_ADMIN_LABEL_KEY and sl["value"] == "true":
                 return True
 
         return False
@@ -1034,7 +1032,7 @@ class OCM:  # pylint: disable=too-many-public-methods
     def enable_cluster_admin(self, cluster: str):
         api = self._get_subscription_labels_api(cluster)
         data = {
-            "key": "capability.cluster.manage_cluster_admin",
+            "key": CLUSTER_ADMIN_LABEL_KEY,
             "value": "true",
             "internal": "true",
         }

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1015,8 +1015,8 @@ class OCM:  # pylint: disable=too-many-public-methods
     def _get_subscription_labels_api(self, cluster: str) -> str:
         cluster_id = self.cluster_ids[cluster]
         api = f"{CS_API_BASE}/v1/clusters/{cluster_id}"
-        subscription_id = self._get_json(api)["subscription"]["id"]
-        return f"{AMS_API_BASE}/v1/subscriptions/{subscription_id}/labels"
+        subscription_api = self._get_json(api)["subscription"]["href"]
+        return f"{subscription_api}/labels"
 
     def is_cluster_admin_enabled(self, cluster: str) -> bool:
         api = self._get_subscription_labels_api(cluster)

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1028,6 +1028,19 @@ class OCM:  # pylint: disable=too-many-public-methods
 
         return False
 
+    def enable_cluster_admin(self, cluster: str):
+        cluster_id = self.cluster_ids[cluster]
+        api = f"{CS_API_BASE}/v1/clusters/{cluster_id}"
+        subscription_id = self._get_json(api)["subscription"]["id"]
+        api = f"{AMS_API_BASE}/v1/subscriptions/{subscription_id}/labels"
+
+        data = {
+            "key": "capability.cluster.manage_cluster_admin",
+            "value": "true",
+            "internal": "true",
+        }
+        self._post(api, data)
+
     def get_machine_pools(self, cluster):
         """Returns a list of details of Machine Pools
 

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1034,7 +1034,7 @@ class OCM:  # pylint: disable=too-many-public-methods
         data = {
             "key": CLUSTER_ADMIN_LABEL_KEY,
             "value": "true",
-            "internal": "true",
+            "internal": True,
         }
 
         self._post(api, data)

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1012,6 +1012,22 @@ class OCM:  # pylint: disable=too-many-public-methods
         )
         self._delete(api)
 
+    def is_cluster_admin_enabled(self, cluster: str) -> bool:
+        cluster_id = self.cluster_ids[cluster]
+        api = f"{CS_API_BASE}/v1/clusters/{cluster_id}"
+        subscription_id = self._get_json(api)["subscription"]["id"]
+        api = f"{AMS_API_BASE}/v1/subscriptions/{subscription_id}/labels"
+        subcription_labels = self._get_json(api).get("items")
+
+        for sl in subcription_labels:
+            if (
+                sl["key"] == "capability.cluster.manage_cluster_admin"
+                and sl["value"] == "true"
+            ):
+                return True
+
+        return False
+
     def get_machine_pools(self, cluster):
         """Returns a list of details of Machine Pools
 

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1012,11 +1012,14 @@ class OCM:  # pylint: disable=too-many-public-methods
         )
         self._delete(api)
 
-    def is_cluster_admin_enabled(self, cluster: str) -> bool:
+    def _get_subscription_labels_api(self, cluster: str) -> str:
         cluster_id = self.cluster_ids[cluster]
         api = f"{CS_API_BASE}/v1/clusters/{cluster_id}"
         subscription_id = self._get_json(api)["subscription"]["id"]
-        api = f"{AMS_API_BASE}/v1/subscriptions/{subscription_id}/labels"
+        return f"{AMS_API_BASE}/v1/subscriptions/{subscription_id}/labels"
+
+    def is_cluster_admin_enabled(self, cluster: str) -> bool:
+        api = self._get_subscription_labels_api(cluster)
         subcription_labels = self._get_json(api).get("items")
 
         for sl in subcription_labels:
@@ -1029,16 +1032,13 @@ class OCM:  # pylint: disable=too-many-public-methods
         return False
 
     def enable_cluster_admin(self, cluster: str):
-        cluster_id = self.cluster_ids[cluster]
-        api = f"{CS_API_BASE}/v1/clusters/{cluster_id}"
-        subscription_id = self._get_json(api)["subscription"]["id"]
-        api = f"{AMS_API_BASE}/v1/subscriptions/{subscription_id}/labels"
-
+        api = self._get_subscription_labels_api(cluster)
         data = {
             "key": "capability.cluster.manage_cluster_admin",
             "value": "true",
             "internal": "true",
         }
+
         self._post(api, data)
 
     def get_machine_pools(self, cluster):

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1535,6 +1535,22 @@ def slack_usergroup(ctx, workspace, usergroup, username):
     slack.update_usergroup_users(ugid, users)
 
 
+@set.command()
+@click.argument("org_name")
+@click.argument("cluster_name")
+@click.pass_context
+def cluster_admin(ctx, org_name, cluster_name):
+    settings = queries.get_app_interface_settings()
+    ocms = [
+        o for o in queries.get_openshift_cluster_managers() if o["name"] == org_name
+    ]
+    ocm_map = OCMMap(ocms=ocms, settings=settings)
+    ocm = ocm_map[org_name]
+    enabled = ocm.is_cluster_admin_enabled(cluster_name)
+    if not enabled:
+        ocm.enable_cluster_admin(cluster_name)
+
+
 @root.group()
 @environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context


### PR DESCRIPTION
this integration enables `cluster-admin` via OCM API.

this will prevent us from requesting this for every cluster we create. this integration will act once a `clusterAdminAutomationToken` is added to a cluster file.

automating based on this SOP: https://github.com/openshift/ops-sop/blob/master/v4/utils/cluster-admin

app-interface counterpart: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/52546