### PR TITLE
Cluster upgrade shared version data

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,6 @@
+[MAIN]
+extension-pkg-allow-list=pydantic
+
 [MESSAGES CONTROL]
 disable = attribute-defined-outside-init,
           broad-except,

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import sys
 from collections.abc import Mapping
@@ -13,8 +12,12 @@ from dateutil import parser
 from semver import VersionInfo
 
 from reconcile import queries
-
 from reconcile.ocm.utils import cluster_disabled_integrations
+from reconcile.utils.cluster_version_data import (
+    VersionData,
+    WorkloadHistory,
+    get_version_data,
+)
 from reconcile.utils.ocm import (
     OCM,
     OCM_PRODUCT_OSD,
@@ -81,55 +84,15 @@ def fetch_desired_state(
     return sorted_desired_state
 
 
-def default_workload_history():
-    return copy.deepcopy(
-        {
-            "soak_days": 0.0,
-            "reporting": [],
-        }
-    )
-
-
-def get_version_workload(
-    h: dict[str, dict], version: str, workload: str
-) -> dict[str, Any]:
-    v = h.setdefault("versions", {}).setdefault(version, {})
-    w = v.setdefault("workloads", {}).setdefault(workload, default_workload_history())
-    return w
-
-
-def update_history(history, upgrade_policies):
-    """Update history with information from clusters
-    with upgrade policies.
+def update_history(version_data: VersionData, upgrade_policies: list[dict[str, Any]]):
+    """Update history with information from clusters with upgrade policies.
 
     Args:
-        history (dict): history in the following format:
-        {
-          "check_in": "2021-08-29 18:01:27.730441",
-          "versions": {
-            "version1": {
-                "workloads": {
-                    "workload1": {
-                        "soak_days": 21,
-                        "reporting": [
-                            "cluster1",
-                            "cluster2"
-                        ]
-                    },
-                        "workload2": {
-                        "soak_days": 6,
-                        "reporting": [
-                            "cluster3"
-                        ]
-                    }
-                }
-            }
-          }
-        }
+        history (VersionData): version data, including history of soakdays
         upgrade_policies (list): query results of clusters upgrade policies
     """
     now = datetime.utcnow()
-    check_in = parser.parse(history.setdefault("check_in", str(now)))
+    check_in = parser.parse(version_data.check_in or str(now))
 
     # we iterate over clusters upgrade policies and update the version history
     for item in upgrade_policies:
@@ -138,43 +101,42 @@ def update_history(history, upgrade_policies):
         workloads = item["workloads"]
         # we keep the version history per workload
         for w in workloads:
-            workload_history = get_version_workload(history, current_version, w)
+            workload_history = version_data.workload_history(
+                current_version, w, WorkloadHistory()
+            )
 
-            reporting = workload_history["reporting"]
             # if the cluster is already reporting - accumulate it.
             # if not - add it to the reporting list (first report)
-            if cluster in reporting:
-                workload_history["soak_days"] += (
+            if cluster in workload_history.reporting:
+                workload_history.soak_days += (
                     now - check_in
                 ).total_seconds() / 86400  # seconds in day
             else:
-                workload_history["reporting"].append(cluster)
+                workload_history.reporting.append(cluster)
 
-    history["check_in"] = str(now)
+    version_data.check_in = str(now)
 
 
-def aggregateVersionData(
-    data: dict[str, Any], added: dict[str, Any], added_org_name: str
-):
-    known_workloads = set()
-    for v in data.get("versions", {}).values():
-        known_workloads.update(v.get("workloads", {}).keys())
-    for version, version_data in added.get("versions", {}).items():
-        for workload, workload_data in version_data.get("workloads", {}).items():
-            # skip if our current history data does not contain this remote workload
+def aggregateVersionData(data: VersionData, added: VersionData, added_org_name: str):
+    known_workloads: set[str] = set()
+    for v in data.versions.values():
+        known_workloads.update(v.workloads.keys())
+    for version, version_data in added.versions.items():
+        for workload, workload_data in version_data.workloads.items():
+            # skip if our current version data does not contain this remote workload
             if workload not in known_workloads:
                 continue
-            w = get_version_workload(data, version, workload)
-            w["soak_days"] += workload_data["soak_days"]
+            w = data.workload_history(version, workload)
+            w.soak_days += workload_data.soak_days
             ocm_clusters = [
-                f"{added_org_name}/{cluster}" for cluster in workload_data["reporting"]
+                f"{added_org_name}/{cluster}" for cluster in workload_data.reporting
             ]
-            w["reporting"] += ocm_clusters
+            w.reporting += ocm_clusters
 
 
-def get_version_history(
+def get_version_data_map(
     dry_run: bool, upgrade_policies: list[dict[str, Any]], ocm_map: OCMMap
-) -> dict:
+) -> dict[str, VersionData]:
     """Get a summary of versions history per OCM instance
 
     Args:
@@ -183,21 +145,21 @@ def get_version_history(
         ocm_map (OCMMap): OCM clients per OCM instance
 
     Returns:
-        dict: version history per OCM instance
+        dict: version data per OCM instance
     """
     settings = queries.get_app_interface_settings()
     accounts = queries.get_state_aws_accounts()
     state = State(
         integration=QONTRACT_INTEGRATION, accounts=accounts, settings=settings
     )
-    results = {}
+    results: dict[str, VersionData] = {}
     # we keep a remote state per OCM instance
     for ocm_name in ocm_map.instances():
-        history = state.get(ocm_name, {})
-        update_history(history, upgrade_policies)
-        results[ocm_name] = history
+        version_data = get_version_data(state, ocm_name)
+        update_history(version_data, upgrade_policies)
+        results[ocm_name] = version_data
         if not dry_run:
-            state.add(ocm_name, history, force=True)
+            version_data.save(state, ocm_name)
 
     # inherit data from other ocm orgs
     for ocm_name in ocm_map.instances():
@@ -253,7 +215,7 @@ def workload_sector_dependencies(sector: Sector, workload: str) -> set[Sector]:
 
 def version_conditions_met(
     version: str,
-    history: Mapping[Any, Any],
+    version_data_map: dict[str, VersionData],
     ocm_name: str,
     workloads: list[str],
     upgrade_conditions: dict[str, Any],
@@ -286,11 +248,10 @@ def version_conditions_met(
     # check soak days condition is met for this version
     soak_days = upgrade_conditions.get("soakDays", None)
     if soak_days is not None:
-        ocm_history = history[ocm_name]
-        version_history = ocm_history["versions"].get(version, {})
+        version_data = version_data_map[ocm_name]
         for w in workloads:
-            workload_history = version_history.get("workloads", {}).get(w, {})
-            if soak_days > workload_history.get("soak_days", 0.0):
+            workload_history = version_data.workload_history(version, w)
+            if soak_days > workload_history.soak_days:
                 return False
 
     return True
@@ -324,7 +285,9 @@ def get_version_prefix(version: str) -> str:
     return f"{semver.major}.{semver.minor}"
 
 
-def upgradeable_version(policy: Mapping, history: Mapping, ocm: OCM) -> Optional[str]:
+def upgradeable_version(
+    policy: Mapping, version_data_map: dict[str, VersionData], ocm: OCM
+) -> Optional[str]:
     """Get the highest next version we can upgrade to, fulfilling all conditions"""
     upgrades = ocm.get_available_upgrades(policy["current_version"], policy["channel"])
     for version in reversed(sort_versions(upgrades)):
@@ -332,7 +295,7 @@ def upgradeable_version(policy: Mapping, history: Mapping, ocm: OCM) -> Optional
             continue
         if version_conditions_met(
             version,
-            history,
+            version_data_map,
             ocm.name,
             policy["workloads"],
             policy["conditions"],
@@ -346,7 +309,12 @@ def cluster_mutexes(policy: dict) -> list[str]:
     return (policy.get("conditions") or {}).get("mutexes") or []
 
 
-def calculate_diff(current_state, desired_state, ocm_map, version_history):
+def calculate_diff(
+    current_state: list[dict[str, Any]],
+    desired_state: list[dict[str, Any]],
+    ocm_map: OCMMap,
+    version_data_map: dict[str, VersionData],
+) -> list[Any]:
     """Check available upgrades for each cluster in the desired state
     according to upgrade conditions
 
@@ -354,7 +322,7 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
         current_state (list): current state of upgrade policies
         desired_state (list): desired state of upgrade policies
         ocm_map (OCMMap): OCM clients per OCM instance
-        version_history (dict): version history per OCM instance
+        version_data_map (dict): version data history per OCM instance
 
     Returns:
         list: upgrade policies to be applied
@@ -378,10 +346,10 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
             # there can only be one upgrade policy per cluster
             if len(c) != 1:
                 raise ValueError(f"[{cluster}] expected only one upgrade policy")
-            [c] = c
-            version = c.get("version")  # may not exist in automatic upgrades
+            current = c[0]
+            version = current.get("version")  # may not exist in automatic upgrades
             if version and ocm.version_blocked(version):
-                next_run = c.get("next_run")
+                next_run = current.get("next_run")
                 if next_run and datetime.strptime(next_run, "%Y-%m-%dT%H:%M:%SZ") < now:
                     logging.warning(
                         f"[{cluster}] currently upgrading to blocked version '{version}'"
@@ -395,7 +363,7 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
                     "action": "delete",
                     "cluster": cluster,
                     "version": version,
-                    "id": c["id"],
+                    "id": current["id"],
                 }
                 diffs.append(item)
             else:
@@ -431,7 +399,7 @@ def calculate_diff(current_state, desired_state, ocm_map, version_history):
             continue
 
         # choose version that meets the conditions and add it to the diffs
-        version = upgradeable_version(d, version_history, ocm)
+        version = upgradeable_version(d, version_data_map, ocm)
         if version:
             item = {
                 "action": "create",
@@ -520,6 +488,6 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
     )
     current_state = fetch_current_state(clusters, ocm_map)
     desired_state = fetch_desired_state(clusters, ocm_map)
-    version_history = get_version_history(dry_run, desired_state, ocm_map)
-    diffs = calculate_diff(current_state, desired_state, ocm_map, version_history)
+    version_data_map = get_version_data_map(dry_run, desired_state, ocm_map)
+    diffs = calculate_diff(current_state, desired_state, ocm_map, version_data_map)
     act(dry_run, diffs, ocm_map)

--- a/reconcile/ocm_upgrade_scheduler_org.py
+++ b/reconcile/ocm_upgrade_scheduler_org.py
@@ -27,7 +27,7 @@ def run(dry_run):
 
         current_state = ous.fetch_current_state(upgrade_policy_clusters, ocm_map)
         desired_state = ous.fetch_desired_state(upgrade_policy_clusters, ocm_map)
-        version_history = ous.get_version_history(dry_run, desired_state, ocm_map)
+        version_history = ous.get_version_data_map(dry_run, desired_state, ocm_map)
         diffs = ous.calculate_diff(
             current_state, desired_state, ocm_map, version_history
         )

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -624,6 +624,12 @@ CLUSTERS_QUERY = """
         version
       }
       blockedVersions
+      inheritVersionData {
+        name
+        publishVersionData {
+          name
+        }
+      }
       sectors {
         name
         dependencies {
@@ -1133,6 +1139,12 @@ OCM_QUERY = """
       field
       format
       version
+    }
+    inheritVersionData {
+      name
+      publishVersionData {
+        name
+      }
     }
     sectors {
       name

--- a/reconcile/test/test_ocm_upgrade_scheduler.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler.py
@@ -11,7 +11,7 @@ from croniter import croniter
 from dateutil import parser
 
 import reconcile.ocm_upgrade_scheduler as ous
-from reconcile.utils.cluster_version_data import version_data_from_dict
+from reconcile.utils.cluster_version_data import VersionData
 from reconcile.utils.ocm import Sector
 
 
@@ -19,7 +19,7 @@ class TestUpdateHistory(TestCase):
     @patch.object(ous, "datetime", Mock(wraps=datetime))
     def test_update_history(self):
         history = {
-            "check_in": "2021-08-29 18:00:00",
+            "check_in": "2021-08-29T18:00:00",
             "versions": {
                 "version1": {
                     "workloads": {
@@ -32,7 +32,7 @@ class TestUpdateHistory(TestCase):
                 }
             },
         }
-        ous.datetime.utcnow.return_value = parser.parse("2021-08-30 18:00:00.00000")
+        ous.datetime.utcnow.return_value = parser.parse("2021-08-30T18:00:00.00000")
         upgrade_policies = [
             {
                 "workloads": ["workload1"],
@@ -50,10 +50,10 @@ class TestUpdateHistory(TestCase):
                 "current_version": "version1",
             },
         ]
-        version_data = version_data_from_dict(history)
+        version_data = VersionData(**history)
         ous.update_history(version_data, upgrade_policies)
         expected = {
-            "check_in": "2021-08-30 18:00:00",
+            "check_in": "2021-08-30T18:00:00",
             "versions": {
                 "version1": {
                     "workloads": {
@@ -66,7 +66,7 @@ class TestUpdateHistory(TestCase):
                 }
             },
         }
-        self.assertEqual(expected, version_data.asdict())
+        self.assertEqual(expected, version_data.jsondict())
 
 
 class TestVersionConditionsMetSoakDays(TestCase):
@@ -87,7 +87,7 @@ class TestVersionConditionsMetSoakDays(TestCase):
                 }
             },
         }
-        version_data = version_data_from_dict(version_data_dict)
+        version_data = VersionData(**version_data_dict)
         self.version_data_map = {self.ocm_name: version_data}
 
     def test_conditions_met_larger(self):
@@ -153,9 +153,9 @@ class TestUpgradeLock:
     @staticmethod
     def set_upgradeable():
         ous.version_conditions_met.return_value = True
-        ous.datetime.utcnow.return_value = parser.parse("2021-08-30 18:00:00.00000")
+        ous.datetime.utcnow.return_value = parser.parse("2021-08-30T18:00:00.00000")
         schedule = ous.croniter.return_value
-        schedule.get_next.return_value = parser.parse("2021-08-30 19:00:00.00000")
+        schedule.get_next.return_value = parser.parse("2021-08-30T19:00:00.00000")
         return True
 
     current_cluster1 = {

--- a/reconcile/test/test_utils_cluster_version_data.py
+++ b/reconcile/test/test_utils_cluster_version_data.py
@@ -1,0 +1,150 @@
+from copy import deepcopy
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from reconcile.utils import cluster_version_data as cvd
+
+
+@pytest.fixture
+def ocm1_state():
+    return {
+        "check_in": "2021-08-29T18:00:00",
+        "versions": {
+            "version1": {
+                "workloads": {
+                    "workload1": {
+                        "soak_days": 21.0,
+                        "reporting": ["cluster1", "cluster2"],
+                    },
+                    "workload2": {"soak_days": 6.0, "reporting": ["cluster3"]},
+                }
+            }
+        },
+    }
+
+
+@pytest.fixture
+def ocm2_state():
+    return {
+        "check_in": "2021-08-29T18:00:00",
+        "versions": {
+            "version1": {
+                "workloads": {
+                    "workload1": {
+                        "soak_days": 3.0,
+                        "reporting": ["cluster4", "cluster5"],
+                    },
+                    "workload3": {"soak_days": 10.0, "reporting": ["cluster6"]},
+                }
+            },
+            "version2": {
+                "workloads": {
+                    "workload1": {
+                        "soak_days": 13.0,
+                        "reporting": ["cluster4", "cluster5"],
+                    },
+                    "workload3": {"soak_days": 20.0, "reporting": ["cluster6"]},
+                }
+            },
+        },
+    }
+
+
+def get_data(
+    version_data_dict: dict[str, Any], version: str, workload: str
+) -> dict[str, Any]:
+    return version_data_dict["versions"][version]["workloads"][workload]
+
+
+@pytest.fixture
+def state(mocker: Mock, ocm1_state, ocm2_state):
+    s = mocker.patch(
+        "reconcile.utils.cluster_version_data.State", autospec=True
+    ).return_value
+    data = {"ocm1": ocm1_state, "ocm2": ocm2_state}
+    s.get.side_effect = data.get
+    return s
+
+
+def test_version_data_load(state, ocm1_state):
+    version_data = cvd.get_version_data(state, "ocm1")
+    assert version_data.jsondict() == ocm1_state
+
+
+def test_version_data_save(state, ocm1_state):
+    version_data = cvd.get_version_data(state, "ocm1")
+    version_data.save(state, "ocm1")
+    state.add.assert_called_once_with("ocm1", ocm1_state, force=True)
+
+
+def test_version_data_old_style_check_in(state, ocm1_state):
+    # the check_in datetime used to not be using the iso format
+    # let's check we can load the old format and still save the new one..
+    # this test can be removed once deployed in production since the check_in
+    # format will then become the standard ISO
+    new_ocm1_state = deepcopy(ocm1_state)
+    ocm1_state["check_in"] = "2021-08-29 18:00:00"
+    version_data = cvd.get_version_data(state, "ocm1")
+    assert version_data.jsondict() == new_ocm1_state
+    version_data.save(state, "ocm1")
+    state.add.assert_called_once_with("ocm1", new_ocm1_state, force=True)
+
+
+def test_version_data_load_update_save(state, ocm1_state):
+    version_data = cvd.get_version_data(state, "ocm1")
+    new_ocm1_state = deepcopy(ocm1_state)
+    get_data(new_ocm1_state, "version1", "workload1")["soak_days"] = 100.0
+    version_data.versions["version1"].workloads["workload1"].soak_days = 100.0
+    version_data.save(state, "ocm1")
+    state.add.assert_called_once_with("ocm1", new_ocm1_state, force=True)
+
+
+def test_version_data_workload_history(state, ocm1_state, ocm2_state):
+    default_wh = cvd.WorkloadHistory()
+    version_data = cvd.get_version_data(state, "ocm1")
+
+    wh = version_data.workload_history("version1", "workload1")
+    assert wh == get_data(ocm1_state, "version1", "workload1")
+
+    wh = version_data.workload_history("version1", "workload1", default_wh)
+    assert wh == get_data(ocm1_state, "version1", "workload1")
+
+    wh = version_data.workload_history("version1", "does-not-exist")
+    assert wh == default_wh
+
+    default_wh.soak_days = 5.0
+    wh = version_data.workload_history("version1", "does-not-exist", default_wh)
+    assert wh == default_wh
+    # ensure our new default has been set
+    wh = version_data.workload_history("version1", "does-not-exist")
+    assert wh == default_wh
+
+
+def test_version_data_aggregate(state, ocm1_state, ocm2_state):
+    version_data = cvd.get_version_data(state, "ocm1")
+    version_data_ocm2 = cvd.get_version_data(state, "ocm2")
+    version_data.aggregate(version_data_ocm2, "ocm2")
+
+    assert set(version_data.versions.keys()) == {"version1", "version2"}
+
+    v1_workloads = version_data.versions["version1"].workloads
+    # unkwown workloads are not aggregated
+    assert "workload3" not in v1_workloads
+    # nothing to aggregate
+    assert v1_workloads["workload2"] == get_data(ocm1_state, "version1", "workload2")
+    # aggregation fo version1/woarkload1
+    ocm1_v1_w1 = get_data(ocm1_state, "version1", "workload1")
+    ocm2_v1_w1 = get_data(ocm2_state, "version1", "workload1")
+    assert v1_workloads["workload1"] == {
+        "soak_days": ocm1_v1_w1["soak_days"] + ocm2_v1_w1["soak_days"],
+        "reporting": ocm1_v1_w1["reporting"]
+        + [f"ocm2/{r}" for r in ocm2_v1_w1["reporting"]],
+    }
+
+    v2_workloads = version_data.versions["version2"].workloads
+    aggregated = get_data(ocm2_state, "version2", "workload1")
+    aggregated["reporting"] = [f"ocm2/{r}" for r in aggregated["reporting"]]
+    # new version version2 for workload1 aggregated
+    assert v2_workloads == {"workload1": aggregated}

--- a/reconcile/utils/cluster_version_data.py
+++ b/reconcile/utils/cluster_version_data.py
@@ -1,0 +1,61 @@
+from dataclasses import (
+    asdict,
+    dataclass,
+    field,
+)
+from typing import (
+    Any,
+    Optional,
+)
+
+from reconcile.utils.state import State
+
+
+@dataclass
+class WorkloadHistory:
+    soak_days: float = 0.0
+    reporting: list[str] = field(default_factory=list)
+
+
+@dataclass
+class VersionHistory:
+    workloads: dict[str, WorkloadHistory]
+
+
+@dataclass
+class VersionData:
+    check_in: str
+    versions: dict[str, VersionHistory]
+
+    def workload_history(
+        self, version: str, workload: str, default: Optional[WorkloadHistory] = None
+    ) -> WorkloadHistory:
+        if not default:
+            vh = self.versions.get(version, VersionHistory({}))
+            return vh.workloads.get(workload, WorkloadHistory())
+        vh = self.versions.setdefault(version, VersionHistory({}))
+        return vh.workloads.setdefault(workload, default)
+
+    def asdict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def save(self, state: State, ocm_name: str) -> None:
+        state.add(ocm_name, asdict(self), force=True)
+
+
+def version_data_from_dict(d: dict[str, Any]) -> VersionData:
+    ret = VersionData(d["check_in"], {})
+    for version, version_data in d.setdefault("versions", {}).items():
+        for workload, workload_data in version_data["workloads"].items():
+            wh = WorkloadHistory(workload_data["soak_days"], workload_data["reporting"])
+            ret.workload_history(version, workload, wh)
+    return ret
+
+
+def get_version_data(state: State, ocm_name: str) -> VersionData:
+    vd = state.get(ocm_name, {})
+    return version_data_from_dict(vd)
+
+
+def default_workload_history() -> WorkloadHistory:
+    return WorkloadHistory()

--- a/reconcile/utils/cluster_version_data.py
+++ b/reconcile/utils/cluster_version_data.py
@@ -1,61 +1,68 @@
-from dataclasses import (
-    asdict,
-    dataclass,
-    field,
-)
+import json
+from datetime import datetime
 from typing import (
     Any,
+    Iterable,
     Optional,
+)
+
+from pydantic import (
+    BaseModel,
+    Field,
 )
 
 from reconcile.utils.state import State
 
 
-@dataclass
-class WorkloadHistory:
+class WorkloadHistory(BaseModel):
     soak_days: float = 0.0
-    reporting: list[str] = field(default_factory=list)
+    reporting: list[str] = Field(default_factory=list)
 
 
-@dataclass
-class VersionHistory:
-    workloads: dict[str, WorkloadHistory]
+class VersionHistory(BaseModel):
+    workloads: dict[str, WorkloadHistory] = Field(default_factory=dict)
 
 
-@dataclass
-class VersionData:
-    check_in: str
-    versions: dict[str, VersionHistory]
+class VersionData(BaseModel):
+    check_in: Optional[datetime]
+    versions: dict[str, VersionHistory] = Field(default_factory=dict)
+
+    def jsondict(self) -> dict[str, Any]:
+        return json.loads(self.json())
+
+    def save(self, state: State, ocm_name: str) -> None:
+        state.add(ocm_name, self.jsondict(), force=True)
 
     def workload_history(
         self, version: str, workload: str, default: Optional[WorkloadHistory] = None
     ) -> WorkloadHistory:
         if not default:
-            vh = self.versions.get(version, VersionHistory({}))
+            vh = self.versions.get(version, VersionHistory())
             return vh.workloads.get(workload, WorkloadHistory())
-        vh = self.versions.setdefault(version, VersionHistory({}))
+        vh = self.versions.setdefault(version, VersionHistory())
         return vh.workloads.setdefault(workload, default)
 
-    def asdict(self) -> dict[str, Any]:
-        return asdict(self)
+    def workloads(self) -> Iterable[str]:
+        workloads: set[str] = set()
+        for v in self.versions.values():
+            workloads.update(v.workloads.keys())
+        return workloads
 
-    def save(self, state: State, ocm_name: str) -> None:
-        state.add(ocm_name, asdict(self), force=True)
-
-
-def version_data_from_dict(d: dict[str, Any]) -> VersionData:
-    ret = VersionData(d["check_in"], {})
-    for version, version_data in d.setdefault("versions", {}).items():
-        for workload, workload_data in version_data["workloads"].items():
-            wh = WorkloadHistory(workload_data["soak_days"], workload_data["reporting"])
-            ret.workload_history(version, workload, wh)
-    return ret
+    def aggregate(self, added: "VersionData", added_org_name: str) -> None:
+        known_workloads = self.workloads()
+        for version, version_data in added.versions.items():
+            for workload, workload_data in version_data.workloads.items():
+                # skip if our current version data does not contain this remote workload
+                if workload not in known_workloads:
+                    continue
+                w = self.workload_history(version, workload, WorkloadHistory())
+                w.soak_days += workload_data.soak_days
+                ocm_clusters = [
+                    f"{added_org_name}/{cluster}" for cluster in workload_data.reporting
+                ]
+                w.reporting += ocm_clusters
 
 
 def get_version_data(state: State, ocm_name: str) -> VersionData:
     vd = state.get(ocm_name, {})
-    return version_data_from_dict(vd)
-
-
-def default_workload_history() -> WorkloadHistory:
-    return WorkloadHistory()
+    return VersionData(**vd)

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -610,6 +610,8 @@ class OCM:  # pylint: disable=too-many-public-methods
         blocked_versions=None,
         ocm_client: Optional[OCMBaseClient] = None,
         sectors: Optional[list[dict[str, Any]]] = None,
+        inheritVersionData: Optional[list[dict[str, Any]]] = None,
+        publishVersionData: Optional[list[dict[str, Any]]] = None,
     ):
         """Initiates access token and gets clusters information."""
         self.name = name
@@ -632,6 +634,9 @@ class OCM:  # pylint: disable=too-many-public-methods
             self._init_addons()
 
         self._init_blocked_versions(blocked_versions)
+
+        self.inheritVersionData = inheritVersionData or []
+        self.publishVersionData = publishVersionData or []
 
         self.init_version_gates = init_version_gates
         self.version_gates: list[Any] = []
@@ -1612,6 +1617,8 @@ class OCMMap:  # pylint: disable=too-many-public-methods
                 blocked_versions=ocm_info.get("blockedVersions"),
                 init_version_gates=init_version_gates,
                 sectors=ocm_info.get("sectors"),
+                inheritVersionData=ocm_info.get("inheritVersionData"),
+                publishVersionData=ocm_info.get("publishVersionData"),
             )
 
     def instances(self) -> list[str]:

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -5,7 +5,6 @@ import os
 import re
 import sys
 from collections import defaultdict
-from contextlib import suppress
 from datetime import datetime
 from operator import itemgetter
 from typing import Optional

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -39,6 +39,7 @@ from reconcile.utils import (
     promtool,
 )
 from reconcile.utils.aws_api import AWSApi
+from reconcile.utils.cluster_version_data import VersionData
 from reconcile.utils.environ import environ
 from reconcile.utils.external_resources import (
     PROVIDER_AWS,
@@ -224,22 +225,22 @@ def version_history(ctx):
     clusters = [c for c in clusters if c.get("upgradePolicy") is not None]
     ocm_map = OCMMap(clusters=clusters, settings=settings)
 
-    history = ous.get_version_history(
+    version_data_map = ous.get_version_data_map(
         dry_run=True, upgrade_policies=[], ocm_map=ocm_map
     )
 
     results = []
-    for ocm_name, history_data in history.items():
-        for version, version_data in history_data["versions"].items():
+    for ocm_name, version_data in version_data_map.items():
+        for version, version_history in version_data.versions.items():
             if not version:
                 continue
-            for workload, workload_data in version_data["workloads"].items():
+            for workload, workload_data in version_history.workloads.items():
                 item = {
                     "ocm": ocm_name,
                     "version": parse_semver(version),
                     "workload": workload,
-                    "soak_days": round(workload_data["soak_days"], 2),
-                    "clusters": ", ".join(workload_data["reporting"]),
+                    "soak_days": round(workload_data.soak_days, 2),
+                    "clusters": ", ".join(workload_data.reporting),
                 }
                 results.append(item)
     columns = ["ocm", "version", "workload", "soak_days", "clusters"]
@@ -247,13 +248,17 @@ def version_history(ctx):
     print_output(ctx.obj["options"], results, columns)
 
 
-def soaking_days(history, upgrades, workload, only_soaking):
+def soaking_days(
+    version_data_map: dict[str, VersionData],
+    upgrades: list[str],
+    workload: str,
+    only_soaking: bool,
+) -> dict[str, float]:
     soaking = {}
     for version in upgrades:
-        for h in history.values():
-            with suppress(KeyError):
-                workload_data = h["versions"][version]["workloads"][workload]
-                soaking[version] = round(workload_data["soak_days"], 2)
+        for h in version_data_map.values():
+            workload_history = h.workload_history(version, workload)
+            soaking[version] = round(workload_history.soak_days, 2)
         if not only_soaking and version not in soaking:
             soaking[version] = 0
     return soaking
@@ -275,7 +280,7 @@ def get_upgrade_policies_data(
     current_state = ous.fetch_current_state(clusters, ocm_map)
     desired_state = ous.fetch_desired_state(clusters, ocm_map)
 
-    history = ous.get_version_history(
+    version_data_map = ous.get_version_data_map(
         dry_run=True, upgrade_policies=[], ocm_map=ocm_map
     )
 
@@ -339,12 +344,14 @@ def get_upgrade_policies_data(
         if current and current[0]["schedule_type"] == "manual":
             upgrade_policy = current[0]
 
-        upgradeable_version = ous.upgradeable_version(c, history, ocm_org)
+        upgradeable_version = ous.upgradeable_version(c, version_data_map, ocm_org)
 
         workload_soaking_upgrades = {}
         for w in c.get("workloads", []):
             if not workload or workload == w:
-                s = soaking_days(history, upgrades, w, show_only_soaking_upgrades)
+                s = soaking_days(
+                    version_data_map, upgrades, w, show_only_soaking_upgrades
+                )
                 workload_soaking_upgrades[w] = s
 
         if by_workload:


### PR DESCRIPTION
[APPSRE-6549](https://issues.redhat.com/browse/APPSRE-6549)

Allow to inherit cluster version data information from one org to an other. Currently, this is limited to soak days. We will add current version stats (lowest current version, ...) in a subsequent PR.

The first commit is the implementation. The second one is a refactor of the version history deep-dict into a set of dataclasses.

Depends on https://github.com/app-sre/qontract-schemas/pull/330
