### PR TITLE
fix expiration date test data to UTC

### DIFF
--- a/reconcile/test/test_utils_expiration.py
+++ b/reconcile/test/test_utils_expiration.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta, datetime
+from datetime import timedelta, datetime
 from typing import Optional
 from pydantic import BaseModel
 

--- a/reconcile/test/test_utils_expiration.py
+++ b/reconcile/test/test_utils_expiration.py
@@ -1,4 +1,4 @@
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 from typing import Optional
 from pydantic import BaseModel
 
@@ -7,7 +7,7 @@ import pytest
 from reconcile.utils import expiration
 
 
-TODAY = date.today()
+TODAY = datetime.utcnow().date()
 YESTERDAY = TODAY - timedelta(days=1)
 TOMORROW = TODAY + timedelta(days=1)
 NEXT_WEEK = TODAY + timedelta(days=7)


### PR DESCRIPTION
the test data for `reconcile.utils.expiration` was defined in local time but the expiration lib itself operates on UTC. the result is failing tests every day around day change.

this is one of those rare occasions where coding around day change provides value... for when we need to hot fix something around day change ¯\\_(ツ)_/¯

i'm a bit afraid though that i [verschlimmbessert](https://en.wiktionary.org/wiki/verschlimmbessern) the situation and that tests might start to fail outside of day change, which would provide evidence that coding around day change does not provide value.

but it is late and i can't do timezone math when it is late and i don't want to argue with myself when it is late so here we go -> "Create pull request". future me will take care i guess

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>