### PR TITLE
[terraform-resources] ignore deleted namespaces

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -585,8 +585,7 @@ def filter_tf_namespaces(
 ) -> list[Mapping[str, Any]]:
     tf_namespaces = []
     for namespace_info in namespaces:
-        # TODO: ob.is_namespace_deleted(namespace_info) [#3010]
-        if namespace_info.get("delete"):
+        if ob.is_namespace_deleted(namespace_info):
             continue
         if not managed_external_resources(namespace_info):
             continue

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -372,6 +372,7 @@ TF_NAMESPACES_QUERY = """
 {
   namespaces: namespaces_v1 {
     name
+    delete
     clusterAdmin
     managedExternalResources
     externalResources {
@@ -584,6 +585,9 @@ def filter_tf_namespaces(
 ) -> list[Mapping[str, Any]]:
     tf_namespaces = []
     for namespace_info in namespaces:
+        # TODO: ob.is_namespace_deleted(namespace_info) [#3010]
+        if namespace_info.get("delete"):
+            continue
         if not managed_external_resources(namespace_info):
             continue
 

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -121,3 +121,31 @@ def test_filter_tf_namespaces_no_tf_resources_with_account_filter():
     namespaces = [ns1, ns2]
     filtered = integ.filter_tf_namespaces(namespaces, "b")
     assert filtered == [ns1]
+
+
+def test_filter_tf_namespaces_namespace_deleted():
+    """
+    test that a deleted namespace is not returned
+    """
+    ra = {"identifier": "a", "provider": "p"}
+    rb = {"identifier": "b", "provider": "p"}
+    ns1 = {
+        "name": "ns1",
+        "managedExternalResources": True,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "a"}, "resources": [ra]}
+        ],
+        "cluster": {"name": "c"},
+        "delete": True,
+    }
+    ns2 = {
+        "name": "ns2",
+        "managedExternalResources": True,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "b"}, "resources": [rb]}
+        ],
+        "cluster": {"name": "c"},
+    }
+    namespaces = [ns1, ns2]
+    filtered = integ.filter_tf_namespaces(namespaces, None)
+    assert filtered == [ns2]


### PR DESCRIPTION
similar to #2942, but for terraform-resources.

this means that when a namespace is marked as `delete: true`, the cloud resources will be deleted (and will need `deleteionApproval` if account is deleteion protected).