### PR TITLE
use smtp settings in glitchtip and qcli

### DIFF
--- a/reconcile/glitchtip/integration.py
+++ b/reconcile/glitchtip/integration.py
@@ -1,6 +1,6 @@
 from typing import Any, Iterable, Optional, Sequence
 
-from reconcile import queries
+from reconcile import queries, typed_queries
 
 from reconcile.glitchtip.reconciler import GlitchtipReconciler
 from reconcile.gql_definitions.glitchtip.glitchtip_instance import (
@@ -107,9 +107,10 @@ def fetch_desired_state(
 def run(dry_run: bool, instance: Optional[str] = None) -> None:
     gqlapi = gql.get_api()
     secret_reader = SecretReader(queries.get_secret_reader_settings())
-    read_timeout = 30
+    smtp_settings = typed_queries.smtp.settings()
+    read_timeout = smtp_settings.timeout
     max_retries = 3
-    mail_domain = "redhat.com"
+    mail_domain = smtp_settings.mail_address
     if _s := glitchtip_settings_query(query_func=gqlapi.query).settings:
         if _gs := _s[0].glitchtip:
             if _gs.read_timeout is not None:

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -19,7 +19,7 @@ import reconcile.terraform_users as tfu
 import reconcile.terraform_vpc_peerings as tfvpc
 import requests
 import yaml
-from reconcile import queries
+from reconcile import queries, typed_queries
 from reconcile.checkpoint import report_invalid_metadata
 from reconcile.cli import config_file
 from reconcile.slack_base import slackapi_from_queries
@@ -1499,11 +1499,10 @@ def slack_usergroup(ctx, workspace, usergroup, username):
     Use an org_username as the username.
     To empty a slack usergroup, pass '' (empty string) as the username.
     """
-    settings = queries.get_app_interface_settings()
     slack = slackapi_from_queries("qontract-cli")
     ugid = slack.get_usergroup_id(usergroup)
     if username:
-        mail_address = settings["smtp"]["mailAddress"]
+        mail_address = typed_queries.smtp.settings().mail_address
         users = [slack.get_user_id_by_name(username, mail_address)]
     else:
         users = [slack.get_random_deleted_user()]


### PR DESCRIPTION
in glitchtip we replace the hard coded value "redhat.com" with a value coming from settings. this is more "open source".
in qontract-cli we replace the usage of queries with typed_queries (super nice!)