### PR TITLE
[cna] revert externalresourcespec

### DIFF
--- a/reconcile/cna/assets/asset.py
+++ b/reconcile/cna/assets/asset.py
@@ -7,7 +7,6 @@ from typing import Any, Generic, Mapping, Optional, Type, TypeVar, get_args
 import copy
 
 from reconcile.gql_definitions.cna.queries.cna_resources import CNAssetV1
-from reconcile.utils.external_resource_spec import TypedExternalResourceSpec
 
 
 ASSET_ID_FIELD = "id"
@@ -135,11 +134,11 @@ class Asset(ABC, Generic[AssetQueryClass, ConfigClass]):
     @classmethod
     def from_external_resources(
         cls,
-        external_resource: TypedExternalResourceSpec[CNAssetV1],
+        external_resource: CNAssetV1,
     ) -> "Asset":
         query_class = cls._get_query_class_type()
-        if isinstance(external_resource.spec, query_class):
-            return cls.from_query_class(external_resource.spec)
+        if isinstance(external_resource, query_class):
+            return cls.from_query_class(external_resource)
         else:
             raise AssetError(
                 f"CNA type {query_class} does not match "

--- a/reconcile/cna/assets/asset_factory.py
+++ b/reconcile/cna/assets/asset_factory.py
@@ -12,7 +12,6 @@ from reconcile.cna.assets.asset import (
     ASSET_HREF_FIELD,
     ASSET_NAME_FIELD,
 )
-from reconcile.utils.external_resource_spec import TypedExternalResourceSpec
 
 
 _ASSET_TYPE_SCHEME: dict[AssetType, Type[Asset]] = {}
@@ -39,7 +38,7 @@ def asset_type_for_provider(provider: str) -> AssetType:
 
 
 def asset_factory_from_schema(
-    external_resource_spec: TypedExternalResourceSpec[CNAssetV1],
+    external_resource_spec: CNAssetV1,
 ) -> Asset:
     cna_dataclass = _dataclass_for_provider(external_resource_spec.provider)
     return cna_dataclass.from_external_resources(external_resource_spec)

--- a/reconcile/cna/integration.py
+++ b/reconcile/cna/integration.py
@@ -9,7 +9,6 @@ from reconcile.cna.state import State
 
 from reconcile.utils import gql
 from reconcile.utils.external_resources import (
-    get_external_resource_specs_for_namespace,
     PROVIDER_CNA_EXPERIMENTAL,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
@@ -18,8 +17,8 @@ from reconcile.gql_definitions.cna.queries.cna_provisioners import (
     query as cna_provisioners_query,
 )
 from reconcile.gql_definitions.cna.queries.cna_resources import (
-    CNAssetV1,
     NamespaceV1,
+    NamespaceCNAssetV1,
     query as namespaces_query,
 )
 from reconcile.typed_queries.app_interface_vault_settings import (
@@ -58,33 +57,36 @@ class CNAIntegration:
     def assemble_desired_states(self):
         self._desired_states = defaultdict(State)
         for namespace in self._namespaces:
-            for spec in get_external_resource_specs_for_namespace(
-                namespace, CNAssetV1, PROVIDER_CNA_EXPERIMENTAL
-            ):
-                asset = asset_factory_from_schema(spec)
-                self._desired_states[spec.provisioner_name].add_asset(asset)
+            for provider in namespace.external_resources or []:
+                if provider.provider != PROVIDER_CNA_EXPERIMENTAL:
+                    continue
+                if not isinstance(provider, NamespaceCNAssetV1):
+                    continue
+                for resource in provider.resources or []:
+                    asset = asset_factory_from_schema(resource)
+                    self._desired_states[provider.provisioner.name].add_asset(asset)
 
-                # For now we assume that if an asset is bindable, then it
-                # always binds to its defining namespace
-                # TODO: probably this should also be done by passing the required namespace vars
-                #       to the factory method.
-                if not asset.bindable():
-                    continue
-                if not (namespace.cluster.spec and namespace.cluster.spec.q_id):
-                    logging.warning(
-                        "cannot bind asset %s because namespace %s does not have a cluster spec with a cluster id.",
-                        asset,
-                        namespace.name,
+                    # For now we assume that if an asset is bindable, then it
+                    # always binds to its defining namespace
+                    # TODO: probably this should also be done by passing the required namespace vars
+                    #       to the factory method.
+                    if not asset.bindable():
+                        continue
+                    if not (namespace.cluster.spec and namespace.cluster.spec.q_id):
+                        logging.warning(
+                            "cannot bind asset %s because namespace %s does not have a cluster spec with a cluster id.",
+                            asset,
+                            namespace.name,
+                        )
+                        continue
+                    asset.bindings.add(
+                        Binding(
+                            cluster_id=namespace.cluster.spec.q_id,
+                            namespace=namespace.name,
+                            # For now secret_name is implicit.
+                            secret_name=f"{asset.asset_type()}-{asset.name}",
+                        )
                     )
-                    continue
-                asset.bindings.add(
-                    Binding(
-                        cluster_id=namespace.cluster.spec.q_id,
-                        namespace=namespace.name,
-                        # For now secret_name is implicit.
-                        secret_name=f"{asset.asset_type()}-{asset.name}",
-                    )
-                )
 
     def assemble_current_states(self):
         self._current_states = defaultdict(State)

--- a/reconcile/test/cna/test_asset.py
+++ b/reconcile/test/cna/test_asset.py
@@ -17,13 +17,7 @@ from reconcile.cna.assets.null import NullAsset
 from reconcile.gql_definitions.cna.queries.cna_resources import (
     CNAAssumeRoleAssetV1,
     CNAssetV1,
-    NamespaceV1,
-    NamespaceCNAssetV1,
 )
-from reconcile.utils.external_resource_spec import (
-    TypedExternalResourceSpec,
-)
-from reconcile.utils.external_resources import PROVIDER_CNA_EXPERIMENTAL
 
 import pytest
 
@@ -238,7 +232,7 @@ def build_assume_role_typed_external_resource(
     role_arn: str,
     verify_slug_override: Optional[str],
     verify_slug_default: Optional[str],
-) -> TypedExternalResourceSpec[CNAssetV1]:
+) -> CNAssetV1:
     resource = {
         "provider": AWSAssumeRoleAsset.provider(),
         "identifier": identifier,
@@ -255,24 +249,7 @@ def build_assume_role_typed_external_resource(
             "slug": verify_slug_default,
         },
     }
-    namespace_resource = {
-        "provider": PROVIDER_CNA_EXPERIMENTAL,
-        "provisioner": {"name": "some-ocm-org"},
-        "resources": [resource],
-    }
-    namespace = {
-        "name": "ns-name",
-        "managedExternalResources": True,
-        "cluster": {
-            "spec": None,
-        },
-        "externalResources": [namespace_resource],
-    }
-    return TypedExternalResourceSpec[CNAssetV1](
-        namespace_spec=NamespaceV1(**namespace),
-        namespace_external_resource=NamespaceCNAssetV1(**namespace_resource),
-        spec=CNAAssumeRoleAssetV1(**resource),
-    )
+    return CNAAssumeRoleAssetV1(**resource)
 
 
 def test_from_external_resources_with_default():

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -2,19 +2,8 @@ from abc import abstractmethod
 from dataclasses import field
 from pydantic.dataclasses import dataclass
 import json
-from typing import (
-    Any,
-    Generic,
-    Optional,
-    Protocol,
-    TypeVar,
-    runtime_checkable,
-    Union,
-    cast,
-    get_args,
-    get_origin,
-)
-from collections.abc import Mapping, MutableMapping, Sequence
+from typing import Any, Optional, cast
+from collections.abc import Mapping, MutableMapping
 
 import yaml
 from reconcile.utils.openshift_resource import (
@@ -86,89 +75,6 @@ class OutputFormat:
 
     def render(self, vars: Mapping[str, str]) -> dict[str, str]:
         return self._formatter.render(vars)
-
-
-class ExternalResourceProvisioner(Protocol):
-    @property
-    def name(self) -> str:
-        ...
-
-    @abstractmethod
-    def dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        ...
-
-
-@runtime_checkable
-class ExternalResource(Protocol):
-    @property
-    def provider(self) -> str:
-        ...
-
-    @property
-    def identifier(self) -> str:
-        ...
-
-    @abstractmethod
-    def dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        ...
-
-
-@runtime_checkable
-class OverridableExternalResource(ExternalResource, Protocol):
-    @property
-    def overrides(self) -> Optional[Any]:
-        ...
-
-    @abstractmethod
-    def dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        ...
-
-
-@runtime_checkable
-class DefaultableExternalResource(ExternalResource, Protocol):
-    @property
-    def defaults(self) -> Optional[Any]:
-        ...
-
-    @abstractmethod
-    def dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        ...
-
-
-@runtime_checkable
-class NamespaceExternalResource(Protocol):
-    @property
-    def provider(self) -> str:
-        ...
-
-    @property
-    def provisioner(self) -> ExternalResourceProvisioner:
-        ...
-
-    @property
-    def resources(self) -> Sequence[ExternalResource]:
-        ...
-
-
-@runtime_checkable
-class Namespace(Protocol):
-    @property
-    def name(self) -> str:
-        ...
-
-    @property
-    def managed_external_resources(self) -> Optional[bool]:
-        ...
-
-    @property
-    def external_resources(
-        self,
-    ) -> Optional[Sequence[Union[NamespaceExternalResource, Any]]]:
-        ...
-
-    @abstractmethod
-    def dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        ...
 
 
 @dataclass
@@ -278,71 +184,3 @@ class ExternalResourceUniqueKey:
 ExternalResourceSpecInventory = MutableMapping[
     ExternalResourceUniqueKey, ExternalResourceSpec
 ]
-
-
-T = TypeVar("T", bound=ExternalResource)
-
-
-class MyConfig:
-    arbitrary_types_allowed = True
-
-
-EXTERNAL_RESOURCE_SPEC_DEFAULTS_PROPERTY = "defaults"
-EXTERNAL_RESOURCE_SPEC_OVERRIDES_PROPERTY = "overrides"
-
-
-@dataclass(config=MyConfig)
-class TypedExternalResourceSpec(ExternalResourceSpec, Generic[T]):
-
-    namespace_spec: Namespace
-    namespace_external_resource: NamespaceExternalResource
-    spec: T
-
-    def __init__(
-        self,
-        namespace_spec: Namespace,
-        namespace_external_resource: NamespaceExternalResource,
-        spec: T,
-    ):
-        self.namespace_spec = namespace_spec
-        self.namespace_external_resource = namespace_external_resource
-        self.spec = spec
-        super().__init__(
-            provision_provider=self.namespace_external_resource.provider,
-            provisioner=self.namespace_external_resource.provisioner.dict(
-                by_alias=True
-            ),
-            resource=self.spec.dict(by_alias=True),
-            namespace=self.namespace_spec.dict(by_alias=True),
-        )
-
-    def get_defaults_data(self) -> dict[str, Any]:
-        if not isinstance(self.spec, DefaultableExternalResource):
-            return {}
-        if self.spec.defaults is None:
-            return {}
-        return self.spec.defaults.dict(by_alias=True)
-
-    def get_overrides_data(self) -> dict[str, Any]:
-        if not isinstance(self.spec, OverridableExternalResource):
-            return {}
-        if self.spec.overrides is None:
-            return {}
-        return self.spec.overrides.dict(by_alias=True)
-
-    def is_overridable(self) -> bool:
-        return isinstance(self.spec, OverridableExternalResource)
-
-    def get_overridable_fields(self) -> Sequence[str]:
-        if isinstance(self.spec, OverridableExternalResource):
-            overrides_class = self.spec.__annotations__[
-                EXTERNAL_RESOURCE_SPEC_OVERRIDES_PROPERTY
-            ]
-            is_optional = get_origin(overrides_class) is Union and type(
-                None
-            ) in get_args(overrides_class)
-            if is_optional:
-                overrides_class = get_args(overrides_class)[0]
-            return overrides_class.__annotations__.keys()
-        else:
-            raise ValueError("resource is not overridable")

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -1,64 +1,17 @@
 import json
-from typing import (
-    Any,
-    Optional,
-    Type,
-    TypeVar,
-)
+from typing import Any, Optional
 from collections.abc import Mapping, MutableMapping
 
 import anymarkup
 
 from reconcile.utils import gql
 from reconcile.utils.exceptions import FetchResourceError
-from reconcile.utils.external_resource_spec import (
-    ExternalResourceSpec,
-    TypedExternalResourceSpec,
-    ExternalResource,
-    Namespace,
-    NamespaceExternalResource,
-)
+from reconcile.utils.external_resource_spec import ExternalResourceSpec
 
 
 PROVIDER_AWS = "aws"
 PROVIDER_CLOUDFLARE = "cloudflare"
 PROVIDER_CNA_EXPERIMENTAL = "cna-experimental"
-
-T = TypeVar("T", bound=ExternalResource)
-
-
-def get_external_resource_specs_for_namespace(
-    namespace: Namespace,
-    resource_type: Type[T],
-    provision_provider: Optional[str] = None,
-) -> list[TypedExternalResourceSpec[T]]:
-    if not namespace.managed_external_resources:
-        return []
-    specs: list[TypedExternalResourceSpec[T]] = []
-    for e in namespace.external_resources or []:
-        if isinstance(e, NamespaceExternalResource):
-            for r in e.resources:
-                if isinstance(r, resource_type):
-                    specs.append(
-                        TypedExternalResourceSpec[T](
-                            namespace_spec=namespace,
-                            namespace_external_resource=e,
-                            spec=r,
-                        )
-                    )
-                else:
-                    raise ValueError(
-                        f"expected resource of type {resource_type}, got {type(r)}"
-                    )
-
-    if provision_provider:
-        specs = [
-            s
-            for s in specs
-            if s.namespace_external_resource.provider == provision_provider
-        ]
-
-    return specs
 
 
 def get_external_resource_specs(


### PR DESCRIPTION
the downsides of using untyped external-resource specs just for the sake of it is unwise

if #2990 gets revived one day we can reintroduce it. until then the CNA code works just fine without.