### PR TITLE
add delete to namespaces query for openshift-resources

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -108,6 +108,7 @@ NAMESPACES_QUERY = """
 {
   namespaces: namespaces_v1 {
     name
+    delete
     clusterAdmin
     managedResourceTypes
     managedResourceTypeOverrides {


### PR DESCRIPTION
without querying this field, openshift-resources based integrations can not ignore deleted namespaces.

another fix on top of #2942