### PR TITLE
make RDS work

### DIFF
--- a/reconcile/cna/state.py
+++ b/reconcile/cna/state.py
@@ -76,7 +76,7 @@ class State:
                 if asset_name not in self._assets[asset_type]:
                     continue
                 asset = self._assets[asset_type][asset_name]
-                if asset.status in (AssetStatus.TERMINATED, AssetStatus.PENDING):
+                if asset.status in (AssetStatus.TERMINATED, AssetStatus.PENDING, AssetStatus.ERROR):
                     continue
                 required_bindings: set[Binding] = set()
                 if compare_bindings:


### PR DESCRIPTION
- username is required and cannot be optional
- is_production is implicitly set
- family is implicitly calculated (postgres only)

Corresponding schema change https://github.com/app-sre/qontract-schemas/pull/338