### PR TITLE
[change-owners] validate context schema for role assignments

### DIFF
--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -109,7 +109,7 @@ class BundleFileChange:
             $schema: /app-interface/change-type-1.yml
 
             contextType: datafile
-            contextSchema: /access/roles-1.yml
+            contextSchema: /access/role-1.yml
 
             changes:
             - provider: jsonPath

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
@@ -7,6 +7,7 @@ query SelfServiceRolesQuery($name: String) {
     self_service {
       change_type {
         name
+        contextSchema
       }
       datafiles {
         datafileSchema: schema

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
@@ -25,6 +25,7 @@ query SelfServiceRolesQuery($name: String) {
     self_service {
       change_type {
         name
+        contextSchema
       }
       datafiles {
         datafileSchema: schema
@@ -46,6 +47,7 @@ query SelfServiceRolesQuery($name: String) {
 
 class ChangeTypeV1(BaseModel):
     name: str = Field(..., alias="name")
+    context_schema: Optional[str] = Field(..., alias="contextSchema")
 
     class Config:
         smart_union = True

--- a/reconcile/test/fixtures/change_owners/changetype_role_member.yaml
+++ b/reconcile/test/fixtures/change_owners/changetype_role_member.yaml
@@ -3,7 +3,7 @@ description: change-role-member
 
 # this change type can be used on owned role-1 datafiles
 contextType: datafile
-contextSchema: /access/roles-1.yml
+contextSchema: /access/role-1.yml
 
 disabled: false
 

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -277,7 +277,7 @@ def test_extract_context_file_refs_in_list_added_selector(
     assert file_refs == [
         FileRef(
             file_type=BundleFileType.DATAFILE,
-            schema="/access/roles-1.yml",
+            schema="/access/role-1.yml",
             path=new_role,
         )
     ]
@@ -311,7 +311,7 @@ def test_extract_context_file_refs_in_list_removed_selector(
     assert file_refs == [
         FileRef(
             file_type=BundleFileType.DATAFILE,
-            schema="/access/roles-1.yml",
+            schema="/access/role-1.yml",
             path=existing_role,
         )
     ]

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -9,6 +9,7 @@ from reconcile.change_owners.diff import (
 )
 from reconcile.change_owners.change_owners import (
     manage_conditional_label,
+    validate_self_service_role,
 )
 from reconcile.change_owners.self_service_roles import (
     cover_changes_with_self_service_roles,
@@ -113,7 +114,7 @@ def build_role(
         self_service=[
             SelfServiceConfigV1(
                 change_type=self_service_roles.ChangeTypeV1(
-                    name=change_type_name,
+                    name=change_type_name, contextSchema=None
                 ),
                 datafiles=datafiles,
                 resources=None,
@@ -1846,3 +1847,59 @@ def test_parse_resource_file_content_none():
     content, schema = parse_resource_file_content(None)
     assert schema is None
     assert content is None
+
+
+#
+# test self-service role validation
+#
+
+
+def test_valid_self_service_role():
+    role = RoleV1(
+        name="role",
+        path="/role.yaml",
+        self_service=[
+            SelfServiceConfigV1(
+                change_type=self_service_roles.ChangeTypeV1(
+                    name="change-type",
+                    contextSchema="schema-1.yml",
+                ),
+                datafiles=[
+                    DatafileObjectV1(
+                        datafileSchema="schema-1.yml",
+                        path="datafile.yaml",
+                    )
+                ],
+                resources=None,
+            )
+        ],
+        users=[],
+        bots=[],
+    )
+    validate_self_service_role(role)
+
+
+def test_invalid_self_service_role():
+    role = RoleV1(
+        name="role",
+        path="/role.yaml",
+        self_service=[
+            SelfServiceConfigV1(
+                change_type=self_service_roles.ChangeTypeV1(
+                    name="change-type",
+                    contextSchema="schema-1.yml",
+                ),
+                datafiles=[
+                    DatafileObjectV1(
+                        datafileSchema="another-schema-1.yml",
+                        path="datafile.yaml",
+                    )
+                ],
+                resources=None,
+            )
+        ],
+        users=[],
+        bots=[],
+    )
+    with pytest.raises(ValueError):
+        validate_self_service_role(role)


### PR DESCRIPTION
verify that the datafiles referenced in `Role_v1.self_service` together with a `change-type` match the `contextSchema` of that `change-type`. fail the integration if they don't match

ref https://issues.redhat.com/browse/APPSRE-6628