### PR TITLE
[change-owners] auto approve when bot is the only approver

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -316,7 +316,9 @@ def run(
                 gitlab_merge_request_id, include_description=True
             )
         )
-        change_decisions = apply_decisions_to_changes(changes, approver_decisions)
+        change_decisions = apply_decisions_to_changes(
+            changes, approver_decisions, gl.user.username
+        )
         hold = any(d.decision.hold for d in change_decisions)
         approved = all(
             d.decision.approve and not d.decision.hold for d in change_decisions

--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -54,7 +54,9 @@ class ChangeDecision:
 
 
 def apply_decisions_to_changes(
-    changes: list[BundleFileChange], approver_decisions: dict[str, Decision]
+    changes: list[BundleFileChange],
+    approver_decisions: dict[str, Decision],
+    auto_approver_bot_username: str,
 ) -> list[ChangeDecision]:
     """
     Apply and aggregate approver decisions to changes. Each diff of a
@@ -73,6 +75,13 @@ def apply_decisions_to_changes(
             for change_type_context in change_decision.coverage:
                 if change_type_context.disabled:
                     # approvers of a disabled change-type are ignored
+                    continue
+                if (
+                    len(change_type_context.approvers) == 1
+                    and change_type_context.approvers[0].org_username
+                    == auto_approver_bot_username
+                ):
+                    change_decision.decision.approve |= True
                     continue
                 for approver in change_type_context.approvers:
                     if approver.org_username in approver_decisions:

--- a/reconcile/test/test_change_owners.py
+++ b/reconcile/test/test_change_owners.py
@@ -1481,7 +1481,7 @@ def test_change_decision_auto_approve(saas_file_changetype: ChangeTypeV1):
         auto_approver_bot_username=bot_user,
     )
 
-    assert change_decision[0].decision.approve == True
+    assert change_decision[0].decision.approve is True
 
 
 #


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6638

in some cases, we want changes to be automatically accepted and merged. such cases do not require a human review.

to define such cases, we can use the bot user behind our automations as an approver. if the bot is the only approver for a change - consider the change approved.

app-interface implementation: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/52773