### PR TITLE
Fix issues when a cluster is deleted in OCM

### DIFF
--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -64,6 +64,9 @@ def fetch_desired_state(
         upgrade_policy = cluster["upgradePolicy"]
         upgrade_policy["cluster"] = cluster_name
         ocm: OCM = ocm_map.get(cluster_name)
+        if cluster_name not in ocm.clusters:
+            # cluster has been deleted in OCM
+            continue
         spec = ocm.clusters[cluster_name].spec
         upgrade_policy["current_version"] = spec.version
         upgrade_policy["channel"] = spec.channel

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -64,8 +64,8 @@ def fetch_desired_state(
         upgrade_policy = cluster["upgradePolicy"]
         upgrade_policy["cluster"] = cluster_name
         ocm: OCM = ocm_map.get(cluster_name)
-        if cluster_name not in ocm.clusters:
-            # cluster has been deleted in OCM
+        if not ocm.is_ready(cluster_name):
+            # cluster has been deleted in OCM or is not ready yet
             continue
         spec = ocm.clusters[cluster_name].spec
         upgrade_policy["current_version"] = spec.version

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -284,6 +284,7 @@ def test_ocm_map_upgrade_policies_sector(ocm, mocker):
         "upgradePolicy": {"workload": "w1", "conditions": {"sector": "s3"}},
     }
 
+    mocker.patch("reconcile.utils.ocm.OCM.is_ready").return_value = True
     ocm_map = OCMMap(clusters=[c1, c2, c3])
     assert "ocm1" in ocm_map.ocm_map
     assert "ocm2" in ocm_map.ocm_map

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -703,6 +703,9 @@ class OCM:  # pylint: disable=too-many-public-methods
             else:
                 self.not_ready_clusters.add(cluster_name)
 
+    def is_ready(self, cluster):
+        return cluster in self.clusters
+
     def _get_ocm_impl(self, product: str):
         return OCM_PRODUCTS_IMPL[product]
 
@@ -1569,7 +1572,7 @@ class OCMMap:  # pylint: disable=too-many-public-methods
             if sector_name:
                 ocm = self.ocm_map.get(ocm_name)
                 # ensure our cluster actually runs in an OCM org we have access to
-                if ocm and cluster_name in ocm.clusters:
+                if ocm and ocm.is_ready(cluster_name):
                     ocm.sectors[sector_name].cluster_infos.append(cluster_info)
 
     def init_ocm_client(

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1568,7 +1568,8 @@ class OCMMap:  # pylint: disable=too-many-public-methods
             sector_name = cluster_info["upgradePolicy"]["conditions"].get("sector")
             if sector_name:
                 ocm = self.ocm_map.get(ocm_name)
-                if ocm:
+                # ensure our cluster actually runs in an OCM org we have access to
+                if ocm and cluster_name in ocm.clusters:
                     ocm.sectors[sector_name].cluster_infos.append(cluster_info)
 
     def init_ocm_client(


### PR DESCRIPTION
This fixes the case where a cluster is removed from OCM but remains in the ocm schema definition.
However, there seem to be other subsequent issues in this case. I will need to dig more.