### PR TITLE
Fix: elasticsearch log group identifier

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -3816,7 +3816,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         domain_identifier: str, log_type: ElasticSearchLogGroupType
     ) -> str:
         log_type_name = log_type.value.lower()
-        return f"OpenSearchService/{domain_identifier}/{log_type_name}"
+        return f"OpenSearchService-{domain_identifier}-{log_type_name}"
 
     def _elasticsearch_get_all_log_group_infos(
         self, account: str
@@ -3940,7 +3940,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             log_type_identifier = TerrascriptClient.elasticsearch_log_group_identifier(
                 domain_identifier=identifier,
                 log_type=t,
-            ).replace("/", "-")
+            )
             log_group_values = {
                 "name": log_type_identifier,
                 "tags": values["tags"],


### PR DESCRIPTION
Found this while working in the app-interface-dev-data.

If we try to run `terraform-resources` it fails with the following error message:

```
aws_elasticsearch_domain.app-int-example-01-es2: Creating...
aws_elasticsearch_domain.app-int-example-01-es1: Creating...

Error: Error creating Elasticsearch domain: ValidationException: The Resource Access Policy specified for the CloudWatch Logs log group OpenSearchService-app-int-example-01-es1-search_slow_logs does not grant sufficient permissions for Amazon OpenSearch Service to create a log stream. Please check the Resource Access Policy.

  on config.tf.json line 363, in resource.aws_elasticsearch_domain.app-int-example-01-es1:
 363:       },



Error: Error creating Elasticsearch domain: ValidationException: The Resource Access Policy specified for the CloudWatch Logs log group OpenSearchService-app-int-example-01-es2-es_application_logs does not grant sufficient permissions for Amazon OpenSearch Service to create a log stream. Please check the Resource Access Policy.

  on config.tf.json line 449, in resource.aws_elasticsearch_domain.app-int-example-01-es2:
 449:       }
```

Investigating the code I founded that the policy beeing atached was this:

```JSON
{
   "Statement":[
      {
         "Action":[
            "logs:PutLogEvents",
            "logs:CreateLogStream"
         ],
         "Effect":"Allow",
         "Principal":{
            "Service":"es.amazonaws.com"
         },
         "Resource":[
            "arn:aws:logs:us-east-1:<account_id>:log-group:OpenSearchService/app-int-example-01-es1/index_slow_logs:*",
            "arn:aws:logs:us-east-1:<account_id>:log-group:OpenSearchService/app-int-example-01-es1/search_slow_logs:*",
            "arn:aws:logs:us-east-1:<account_id>:log-group:OpenSearchService/app-int-example-01-es1/es_application_logs:*",
            "arn:aws:logs:us-east-1:<account_id>:log-group:OpenSearchService/app-int-example-01-es2/es_application_logs:*"
         ]
      }
   ],
   "Version":"2012-10-17"
}
```

Then I found the typo. The `/` character.

Also the only other place where `elasticsearch_log_group_identifier` was doing a `replace("/", "-")`