### PR TITLE
[qontract-cli] get\app-interface-review-queue handle no pr-check job

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1303,7 +1303,7 @@ def app_interface_review_queue(ctx):
         try:
             job = jjb.get_job_by_repo_url(url, job_type="gl-pr-check")
             trigger_phrases_regex = jjb.get_trigger_phrases_regex(job)
-        except Exception:
+        except ValueError:
             trigger_phrases_regex = None
 
         queue_data = []

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1300,8 +1300,11 @@ def app_interface_review_queue(ctx):
     def get_mrs(repo, url) -> list[dict[str, str]]:
         gl = GitLabApi(instance, project_url=url, settings=settings)
         merge_requests = gl.get_merge_requests(state=MRState.OPENED)
-        job = jjb.get_job_by_repo_url(url, job_type="gl-pr-check")
-        trigger_phrases_regex = jjb.get_trigger_phrases_regex(job)
+        try:
+            job = jjb.get_job_by_repo_url(url, job_type="gl-pr-check")
+            trigger_phrases_regex = jjb.get_trigger_phrases_regex(job)
+        except Exception:
+            trigger_phrases_regex = None
 
         queue_data = []
         for mr in merge_requests:


### PR DESCRIPTION
the code currently assumes that a repo has a `pr-check` job to determine what is the regex expression of the job that indicates `/retest`. but what if the repo doesn't have a pr-check job?

this PR handles that case.