### PR TITLE
[glitchtip] cleanup

### DIFF
--- a/reconcile/gql_definitions/glitchtip/glitchtip_instance.gql
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_instance.gql
@@ -5,17 +5,14 @@ query GlitchtipInstance {
     name
     consoleUrl
     automationUserEmail
-    automationToken{
-      ... VaultSecret
+    automationToken {
+      ...VaultSecret
     }
     organizations {
       name
-      roles{
+      roles {
         glitchtip_roles {
           role
-        }
-        users {
-          github_username
         }
       }
     }

--- a/reconcile/gql_definitions/glitchtip/glitchtip_instance.gql
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_instance.gql
@@ -8,13 +8,5 @@ query GlitchtipInstance {
     automationToken {
       ...VaultSecret
     }
-    organizations {
-      name
-      roles {
-        glitchtip_roles {
-          role
-        }
-      }
-    }
   }
 }

--- a/reconcile/gql_definitions/glitchtip/glitchtip_instance.py
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_instance.py
@@ -35,44 +35,9 @@ query GlitchtipInstance {
     automationToken {
       ...VaultSecret
     }
-    organizations {
-      name
-      roles {
-        glitchtip_roles {
-          role
-        }
-      }
-    }
   }
 }
 """
-
-
-class GlitchtipRoleV1(BaseModel):
-    role: str = Field(..., alias="role")
-
-    class Config:
-        smart_union = True
-        extra = Extra.forbid
-
-
-class RoleV1(BaseModel):
-    glitchtip_roles: Optional[list[GlitchtipRoleV1]] = Field(
-        ..., alias="glitchtip_roles"
-    )
-
-    class Config:
-        smart_union = True
-        extra = Extra.forbid
-
-
-class GlitchtipOrganizationV1(BaseModel):
-    name: str = Field(..., alias="name")
-    roles: list[RoleV1] = Field(..., alias="roles")
-
-    class Config:
-        smart_union = True
-        extra = Extra.forbid
 
 
 class GlitchtipInstanceV1(BaseModel):
@@ -80,7 +45,6 @@ class GlitchtipInstanceV1(BaseModel):
     console_url: str = Field(..., alias="consoleUrl")
     automation_user_email: str = Field(..., alias="automationUserEmail")
     automation_token: VaultSecret = Field(..., alias="automationToken")
-    organizations: list[GlitchtipOrganizationV1] = Field(..., alias="organizations")
 
     class Config:
         smart_union = True

--- a/reconcile/gql_definitions/glitchtip/glitchtip_instance.py
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_instance.py
@@ -32,17 +32,14 @@ query GlitchtipInstance {
     name
     consoleUrl
     automationUserEmail
-    automationToken{
-      ... VaultSecret
+    automationToken {
+      ...VaultSecret
     }
     organizations {
       name
-      roles{
+      roles {
         glitchtip_roles {
           role
-        }
-        users {
-          github_username
         }
       }
     }
@@ -59,19 +56,10 @@ class GlitchtipRoleV1(BaseModel):
         extra = Extra.forbid
 
 
-class UserV1(BaseModel):
-    github_username: str = Field(..., alias="github_username")
-
-    class Config:
-        smart_union = True
-        extra = Extra.forbid
-
-
 class RoleV1(BaseModel):
     glitchtip_roles: Optional[list[GlitchtipRoleV1]] = Field(
         ..., alias="glitchtip_roles"
     )
-    users: list[UserV1] = Field(..., alias="users")
 
     class Config:
         smart_union = True

--- a/reconcile/gql_definitions/glitchtip/glitchtip_project.gql
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_project.gql
@@ -15,7 +15,6 @@ query Projects {
         }
         users {
           org_username
-          github_username
         }
       }
     }

--- a/reconcile/gql_definitions/glitchtip/glitchtip_project.py
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_project.py
@@ -33,7 +33,6 @@ query Projects {
         }
         users {
           org_username
-          github_username
         }
       }
     }
@@ -67,7 +66,6 @@ class GlitchtipRoleV1(BaseModel):
 
 class UserV1(BaseModel):
     org_username: str = Field(..., alias="org_username")
-    github_username: str = Field(..., alias="github_username")
 
     class Config:
         smart_union = True

--- a/reconcile/test/fixtures/glitchtip/desire_state_projects.yml
+++ b/reconcile/test/fixtures/glitchtip/desire_state_projects.yml
@@ -10,7 +10,6 @@
               role: member
           users:
             - org_username: SamanthaCristoforetti
-              github_username: SamanthaCristoforetti
     - name: esa-flight-control
       roles:
         - glitchtip_roles:
@@ -22,16 +21,13 @@
               role: owner
           users:
             - org_username: GlobalFlightDirector
-              github_username: GlobalFlightDirector
         - glitchtip_roles:
             - organization:
                 name: ESA
               role: member
           users:
             - org_username: MatthiasMaurer
-              github_username: MatthiasMaurer
             - org_username: TimPeake
-              github_username: TimPeake
   organization:
     name: ESA
     instance:
@@ -50,16 +46,13 @@
               role: owner
           users:
             - org_username: GlobalFlightDirector
-              github_username: GlobalFlightDirector
         - glitchtip_roles:
             - organization:
                 name: ESA
               role: member
           users:
             - org_username: MatthiasMaurer
-              github_username: MatthiasMaurer
             - org_username: TimPeake
-              github_username: TimPeake
   organization:
     name: ESA
     instance:
@@ -75,9 +68,7 @@
               role: member
           users:
             - org_username: NeilArmstrong
-              github_username: NeilArmstrong
             - org_username: BuzzAldrin
-              github_username: BuzzAldrin
     - name: nasa-flight-control
       roles:
         - glitchtip_roles:
@@ -89,14 +80,12 @@
               role: owner
           users:
             - org_username: GlobalFlightDirector
-              github_username: GlobalFlightDirector
         - glitchtip_roles:
             - organization:
                 name: NASA
               role: member
           users:
             - org_username: MichaelCollins
-              github_username: MichaelCollins
   organization:
     name: NASA
     instance:
@@ -115,14 +104,12 @@
               role: owner
           users:
             - org_username: GlobalFlightDirector
-              github_username: GlobalFlightDirector
         - glitchtip_roles:
             - organization:
                 name: NASA
               role: member
           users:
             - org_username: MichaelCollins
-              github_username: MichaelCollins
   organization:
     name: NASA
     instance:


### PR DESCRIPTION
* Glitchtip switched to Red Hat SSO as IDP, therefore the `github_username` attribute is obsolete.
* Remove unused `organizations` attribute from `glitchtip.instance` object

[APPSRE-6615](https://issues.redhat.com/browse/APPSRE-6615)