### PR TITLE
Support multiple aws accounts to act in terraform resources

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -344,7 +344,7 @@ def account_name_multiple(function):
         "--account-name",
         default=None,
         multiple=True,
-        help="aws account names to act on comma separated i.e.: --account-name aws-account-1 --account-name aws-account-2",
+        help="aws account names to act on i.e.: --account-name aws-account-1 --account-name aws-account-2",
     )(function)
 
     return function

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -337,6 +337,7 @@ def account_name(function):
 
     return function
 
+
 def account_name_multiple(function):
     """This option can be used when more than one account needs to be passed as argument"""
     function = click.option(
@@ -347,6 +348,7 @@ def account_name_multiple(function):
     )(function)
 
     return function
+
 
 def workspace_name(function):
     function = click.option(

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -337,6 +337,16 @@ def account_name(function):
 
     return function
 
+def account_name_multiple(function):
+    """This option can be used when more than one account needs to be passed as argument"""
+    function = click.option(
+        "--account-name",
+        default=None,
+        multiple=True,
+        help="aws account names to act on comma separated i.e.: --account-name aws-account-1 --account-name aws-account-2",
+    )(function)
+
+    return function
 
 def workspace_name(function):
     function = click.option(
@@ -1571,12 +1581,7 @@ def ldap_users(ctx, gitlab_project_id):
 @internal()
 @use_jump_host()
 @enable_deletion(default=False)
-@click.option(
-    "--account-name",
-    default=None,
-    multiple=True,
-    help="aws account names to act on comma separated i.e.: aws-account-1,aws-account-2",
-)
+@account_name_multiple
 @click.option(
     "--light/--full",
     default=False,

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1613,7 +1613,7 @@ def terraform_resources(
         use_jump_host,
         light,
         vault_output_path,
-        account_name=account_name,
+        account_name,
     )
 
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1571,7 +1571,11 @@ def ldap_users(ctx, gitlab_project_id):
 @internal()
 @use_jump_host()
 @enable_deletion(default=False)
-@account_name
+@click.option(
+    "--account-names",
+    default=None,
+    help="aws account names to act on comma separated i.e.: aws-account-1,aws-account-2",
+)
 @click.option(
     "--light/--full",
     default=False,
@@ -1587,7 +1591,7 @@ def terraform_resources(
     use_jump_host,
     light,
     vault_output_path,
-    account_name,
+    account_names,
 ):
     import reconcile.terraform_resources
 
@@ -1603,7 +1607,7 @@ def terraform_resources(
         use_jump_host,
         light,
         vault_output_path,
-        account_name=account_name,
+        account_names=account_names,
     )
 
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1572,8 +1572,9 @@ def ldap_users(ctx, gitlab_project_id):
 @use_jump_host()
 @enable_deletion(default=False)
 @click.option(
-    "--account-names",
+    "--account-name",
     default=None,
+    multiple=True,
     help="aws account names to act on comma separated i.e.: aws-account-1,aws-account-2",
 )
 @click.option(
@@ -1591,7 +1592,7 @@ def terraform_resources(
     use_jump_host,
     light,
     vault_output_path,
-    account_names,
+    account_name,
 ):
     import reconcile.terraform_resources
 
@@ -1607,7 +1608,7 @@ def terraform_resources(
         use_jump_host,
         light,
         vault_output_path,
-        account_names=account_names,
+        account_name=account_name,
     )
 
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -689,14 +689,14 @@ def run(
     defer=None,
 ):
     # If we are not running in dry run we don't want to run with more than one account
-    if account_name and len(account_name) > 1 and not dry_run:
+    account_names = account_name
+    if account_names and len(account_names) > 1 and not dry_run:
         logging.error(
             "Running with multiple accounts is only supported in dry-run mode"
         )
         sys.exit(1)
-    elif account_name:
-        account_names = account_name
-        account_name = account_name[0]
+    elif account_names:
+        account_name = account_names[0]
 
     ri, oc_map, tf, resource_specs = setup(
         dry_run,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -691,10 +691,9 @@ def run(
     # If we are not running in dry run we don't want to run with more than one account
     account_names = account_name
     if account_names and len(account_names) > 1 and not dry_run:
-        logging.error(
-            "Running with multiple accounts is only supported in dry-run mode"
-        )
-        sys.exit(1)
+        message = "Running with multiple accounts is only supported in dry-run mode"
+        logging.error(message)
+        raise RuntimeError(message)
     elif account_names:
         account_name = account_names[0]
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -558,8 +558,16 @@ def setup(
     accounts = queries.get_aws_accounts(terraform_state=True)
     if account_names:
         accounts = [n for n in accounts if n["name"] in account_names]
-        if not accounts:
-            raise ValueError(f"aws accounts {account_names} where not found")
+        if len(accounts) < len(account_names):
+            # Some of the passed account names don't exist in app-interface
+            acc_names = tuple(
+                a
+                for a in account_names
+                if a not in tuple(account["name"] for account in accounts)
+            )
+            raise ValueError(
+                f"Accounts {acc_names} where not found in account names, check your input"
+            )
     settings = queries.get_app_interface_settings()
 
     # build a resource inventory for all the kube secrets managed by the

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -8,6 +8,7 @@ from collections.abc import (
 from textwrap import indent
 from typing import (
     Any,
+    Collection,
     Optional,
     cast,
 )
@@ -553,7 +554,7 @@ def setup(
     thread_pool_size: int,
     internal: str,
     use_jump_host: bool,
-    account_names: Optional[tuple[str]],
+    account_names: Optional[Collection[str]],
 ) -> tuple[ResourceInventory, OC_Map, Terraform, ExternalResourceSpecInventory]:
     accounts = queries.get_aws_accounts(terraform_state=True)
     if account_names:

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -694,7 +694,7 @@ def run(
     use_jump_host=True,
     light=False,
     vault_output_path="",
-    account_name: Optional[tuple[str]] = None,
+    account_name: Optional[Collection[str]] = None,
     defer=None,
 ) -> None:
     # account_name is a tuple of account names for more detail go to
@@ -812,6 +812,7 @@ def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
 def desired_state_shard_config() -> DesiredStateShardConfig:
     return DesiredStateShardConfig(
         shard_arg_name="account_name",
+        shard_arg_is_collection=True,
         shard_path_selectors={
             "accounts[*].name",
             "namespaces[*].externalResources[*].provisioner.name",

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -558,7 +558,7 @@ def setup(
     accounts = queries.get_aws_accounts(terraform_state=True)
     if account_names:
         accounts = [n for n in accounts if n["name"] in account_names]
-        if len(accounts) < len(account_names):
+        if len(accounts) != len(account_names):
             # Some of the passed account names don't exist in app-interface
             acc_names = tuple(
                 a

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -685,11 +685,18 @@ def run(
     use_jump_host=True,
     light=False,
     vault_output_path="",
-    account_names=None,
+    account_name=None,
     defer=None,
 ):
-    if account_names:
-        account_names = account_names.split(",")
+    # If we are not running in dry run we don't want to run with more than one account
+    if account_name and len(account_name) > 1 and not dry_run:
+        logging.error(
+            "You can only pass two account names when running in dry-run mode"
+        )
+        sys.exit(1)
+    elif account_name:
+        account_names = account_name
+        account_name = account_name[0]
 
     ri, oc_map, tf, resource_specs = setup(
         dry_run,
@@ -732,7 +739,7 @@ def run(
     populate_desired_state(ri, resource_specs)
 
     actions = ob.realize_data(
-        dry_run, oc_map, ri, thread_pool_size, caller=account_names
+        dry_run, oc_map, ri, thread_pool_size, caller=account_name
     )
 
     if not light and tf.should_apply:
@@ -740,7 +747,7 @@ def run(
             dry_run,
             thread_pool_size,
             disable_service_account_keys=True,
-            account_names=account_names,
+            account_name=account_name,
         )
 
     if actions and vault_output_path:

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -553,7 +553,7 @@ def setup(
     thread_pool_size: int,
     internal: str,
     use_jump_host: bool,
-    account_names: Optional[str],
+    account_names: Optional[tuple[str]],
 ) -> tuple[ResourceInventory, OC_Map, Terraform, ExternalResourceSpecInventory]:
     accounts = queries.get_aws_accounts(terraform_state=True)
     if account_names:
@@ -685,7 +685,7 @@ def run(
     use_jump_host=True,
     light=False,
     vault_output_path="",
-    account_name=None,
+    account_name: Optional[tuple[str]] = None,
     defer=None,
 ):
     # If we are not running in dry run we don't want to run with more than one account

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -10,6 +10,7 @@ from typing import (
     Any,
     Collection,
     Optional,
+    Sequence,
     cast,
 )
 
@@ -694,7 +695,7 @@ def run(
     use_jump_host=True,
     light=False,
     vault_output_path="",
-    account_name: Optional[Collection[str]] = None,
+    account_name: Optional[Sequence[str]] = None,
     defer=None,
 ) -> None:
     # account_name is a tuple of account names for more detail go to

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -566,7 +566,7 @@ def setup(
                 if a not in tuple(account["name"] for account in accounts)
             )
             raise ValueError(
-                f"Accounts {acc_names} where not found in account names, check your input"
+                f"Accounts {acc_names} were provided as arguments, but not found in app-interface. Check your input for typos or for missing AWS account definitions."
             )
     settings = queries.get_app_interface_settings()
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -695,7 +695,7 @@ def run(
     vault_output_path="",
     account_name: Optional[tuple[str]] = None,
     defer=None,
-):
+) -> None:
     # account_name is a tuple of account names for more detail go to
     # https://click.palletsprojects.com/en/8.1.x/options/#multiple-options
     account_names = account_name

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -691,7 +691,7 @@ def run(
     # If we are not running in dry run we don't want to run with more than one account
     if account_name and len(account_name) > 1 and not dry_run:
         logging.error(
-            "You can only pass two account names when running in dry-run mode"
+            "Running with multiple accounts is only supported in dry-run mode"
         )
         sys.exit(1)
     elif account_name:

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -1,4 +1,15 @@
+import pytest
+
 import reconcile.terraform_resources as integ
+
+
+def test_cannot_pass_two_aws_account_if_not_dry_run():
+    with pytest.raises(RuntimeError) as excinfo:
+        integ.run(False, account_name=("a", "b"))
+
+    assert "Running with multiple accounts is only supported in dry-run mode" in str(
+        excinfo.value
+    )
 
 
 def test_filter_namespaces_no_managed_tf_resources():

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -12,6 +12,16 @@ def test_cannot_pass_two_aws_account_if_not_dry_run():
     )
 
 
+def test_cannot_pass_invalid_aws_account(mocker):
+    mocker.patch("reconcile.queries.get_aws_accounts", return_value=[{"name": "a"}])
+    with pytest.raises(ValueError) as excinfo:
+        integ.run(True, account_name=("a", "b"))
+
+    assert "Accounts ('b',) where not found in account names, check your input" in str(
+        excinfo.value
+    )
+
+
 def test_filter_namespaces_no_managed_tf_resources():
     ra = {"identifier": "a", "provider": "p"}
     ns1 = {

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -13,7 +13,11 @@ def test_cannot_pass_two_aws_account_if_not_dry_run():
 
 
 def test_cannot_pass_invalid_aws_account(mocker):
-    mocker.patch("reconcile.queries.get_aws_accounts", return_value=[{"name": "a"}])
+    mocker.patch(
+        "reconcile.queries.get_aws_accounts",
+        return_value=[{"name": "a"}],
+        autospec=True,
+    )
     with pytest.raises(ValueError) as excinfo:
         integ.run(True, account_name=("a", "b"))
 

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -17,8 +17,9 @@ def test_cannot_pass_invalid_aws_account(mocker):
     with pytest.raises(ValueError) as excinfo:
         integ.run(True, account_name=("a", "b"))
 
-    assert "Accounts ('b',) where not found in account names, check your input" in str(
-        excinfo.value
+    assert (
+        "Accounts ('b',) were provided as arguments, but not found in app-interface. Check your input for typos or for missing AWS account definitions."
+        in str(excinfo.value)
     )
 
 

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -22,9 +22,10 @@ def test_filter_namespaces_no_managed_tf_resources():
     assert filtered == [ns2]
 
 
-def test_filter_namespaces_with_account_filter():
+def test_filter_namespaces_with_accounts_filter():
     ra = {"identifier": "a", "provider": "p"}
     rb = {"identifier": "b", "provider": "p"}
+    rc = {"identifier": "c", "provider": "p"}
     ns1 = {
         "name": "ns1",
         "managedExternalResources": True,
@@ -41,12 +42,20 @@ def test_filter_namespaces_with_account_filter():
         ],
         "cluster": {"name": "c"},
     }
-    namespaces = [ns1, ns2]
-    filtered = integ.filter_tf_namespaces(namespaces, "a")
-    assert filtered == [ns1]
+    ns3 = {
+        "name": "ns3",
+        "managedExternalResources": True,
+        "externalResources": [
+            {"provider": "aws", "provisioner": {"name": "c"}, "resources": [rc]}
+        ],
+        "cluster": {"name": "c"},
+    }
+    namespaces = [ns1, ns2, ns3]
+    filtered = integ.filter_tf_namespaces(namespaces, ("a", "b"))
+    assert filtered == [ns1, ns2]
 
 
-def test_filter_namespaces_no_account_filter():
+def test_filter_namespaces_no_accounts_filter():
     ra = {"identifier": "a", "provider": "p"}
     rb = {"identifier": "b", "provider": "p"}
     ns1 = {
@@ -70,7 +79,7 @@ def test_filter_namespaces_no_account_filter():
     assert filtered == namespaces
 
 
-def test_filter_namespaces_no_tf_resources_no_account_filter():
+def test_filter_namespaces_no_tf_resources_no_accounts_filter():
     """
     this test makes sure that a namespace is returned even if it has no resources
     attached. this way we can delete the last terraform resources that might have been
@@ -97,7 +106,7 @@ def test_filter_namespaces_no_tf_resources_no_account_filter():
     assert filtered == [ns1, ns2]
 
 
-def test_filter_tf_namespaces_no_tf_resources_with_account_filter():
+def test_filter_tf_namespaces_no_tf_resources_with_accounts_filter():
     """
     even if an account filter is defined, a namespace without resources is returned
     to enable terraform resource deletion. in contrast to that, a namespace with a resource
@@ -119,7 +128,7 @@ def test_filter_tf_namespaces_no_tf_resources_with_account_filter():
         "cluster": {"name": "c"},
     }
     namespaces = [ns1, ns2]
-    filtered = integ.filter_tf_namespaces(namespaces, "b")
+    filtered = integ.filter_tf_namespaces(namespaces, ["b"])
     assert filtered == [ns1]
 
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1147,7 +1147,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 self.populate_tf_resources(spec, ocm_map=ocm_map)
 
     def init_populate_specs(
-        self, namespaces: Iterable[Mapping[str, Any]], account_name: Optional[str]
+        self,
+        namespaces: Iterable[Mapping[str, Any]],
+        account_names: Optional[Iterable[str]],
     ) -> None:
         """
         Initiates resource specs from the definitions in app-interface
@@ -1163,7 +1165,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 namespace_info, provision_provider=PROVIDER_AWS
             )
             for spec in specs:
-                if account_name and spec.provisioner_name != account_name:
+                if account_names and spec.provisioner_name not in account_names:
                     continue
                 self.account_resource_specs.setdefault(
                     spec.provisioner_name, []


### PR DESCRIPTION
JIRA: [APPSRE-6586]( https://issues.redhat.com/browse/APPSRE-6586)

## Testing
With `qontract-server` configured with `app-interface-dev-data` do the following.
Run `terraform-resources` without any account filter in dry-run mode:
```
APP_INTERFACE_STATE_BUCKET="a" APP_INTERFACE_STATE_BUCKET_ACCOUNT="a" qontract-reconcile --config config.dev.toml --log-level INFO --dry-run terraform-resources
```

Run `terraform-resources` passing one account name filter in dry-run mode:
```
 APP_INTERFACE_STATE_BUCKET="a" APP_INTERFACE_STATE_BUCKET_ACCOUNT="a" qontract-reconcile --config config.dev.toml --log-level INFO --dry-run terraform-resources --account-name=app-int-example-01
```

Verify that the resources belonging to account `app-int-example-01` appears in the second output are the same that appear in the first output.
You can do the same with `app-int-example-02` account.

Run `terraform-resources` passing two account names filter in dry-run mode:
```
APP_INTERFACE_STATE_BUCKET="a" APP_INTERFACE_STATE_BUCKET_ACCOUNT="a" qontract-reconcile --config config.dev.toml --log-level INFO --dry-run terraform-resources --account-name=app-int-example-01 --account-name=app-int-example-02
```

Verify that the output is the same for running without filters, since in `app-interface-dev-data` there are only two accounts setup.

Now, to verify that we can only run with more than one `--ccount-name` in dry run:
```
APP_INTERFACE_STATE_BUCKET="a" APP_INTERFACE_STATE_BUCKET_ACCOUNT="a" qontract-reconcile --config config.dev.toml --log-level INFO terraform-resources --account-name=app-int-example-01 --account-name=app-int-example-02
```

This should give a `RuntimeError`.

To verify that we catch typos or passing a account that doesn't exists:
```
APP_INTERFACE_STATE_BUCKET="a" APP_INTERFACE_STATE_BUCKET_ACCOUNT="a" qontract-reconcile --config config.dev.toml --log-level INFO --dry-run terraform-resources --account-name=app-int-example-01 --account-name=app-int-example
```

This should give a `ValueError`.
