### PR TITLE
allow bots to own saas files

### DIFF
--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -97,7 +97,9 @@ class TestSaasFileValid(TestCase):
                     }
                 ],
                 "roles": [{"users": [{"org_username": "myname"}]}],
-                "selfServiceRoles": [{"users": [{"org_username": "theirname"}]}],
+                "selfServiceRoles": [
+                    {"users": [{"org_username": "theirname"}], "bots": []}
+                ],
             }
         ]
         jjb_mock_data = {

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -266,7 +266,7 @@ class SaasHerder:
             saas_file_owners = [
                 u["org_username"]
                 for r in saas_file["selfServiceRoles"]
-                for u in r["users"]
+                for u in r["users"] + r["bots"]
             ]
             if not saas_file_owners:
                 msg = "saas file {} has no owners: {}"


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6638

follows up on #3028

saas-file-validator is failing due to https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/53099