### PR TITLE
add support to manage routes in account-vpc on the aws side

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1005,6 +1005,7 @@ CLUSTER_PEERING_QUERY = """
             region
           }
           assumeRole
+          manageAccountRoutes
         }
         ... on ClusterPeeringConnectionAccountVPCMesh_v1 {
           account {

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -390,6 +390,10 @@ def build_desired_state_vpc_single_cluster(
             "cidr_block": peer_vpc["cidr_block"],
             "region": peer_vpc["region"],
         }
+        if peer_connection.get("manageAccountRoutes"):
+            accepter["route_table_ids"] = awsapi.get_vpc_route_table_ids(
+                account, peer_vpc["vpc_id"], peer_vpc["region"]
+            )
 
         # assume_role is the role to assume to provision the peering
         # connection request, through the accepter AWS account.

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -935,6 +935,13 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
         return results
 
+    def get_vpc_route_table_ids(
+        self, account: dict[str, Any], vpc_id: str, region_name: str
+    ) -> list[str]:
+        ec2 = self._account_ec2_client(account["name"], region_name)
+        vpc_route_tables = self.get_vpc_route_tables(vpc_id, ec2)
+        return [rt["RouteTableId"] for rt in vpc_route_tables]
+
     @staticmethod
     def _filter_amis(
         images: Iterable[ImageTypeDef], regex: str


### PR DESCRIPTION
probably the oldest tech debt around vpc peerings.

when we started out, we only had `account-vpc`. it could mostly manage the peering connection, and that's it. no route management support.

until today!

depends on https://github.com/app-sre/qontract-schemas/pull/347

`manageRoutes` currently exists on `account-vpc` connections to say "manage routes on the cluster side". we are adding a new field for backwards compatibility, and to allow a migration from routes managed elsewhere to being managed via app-interface.

once all `account-vpc` connections have both `manageRoutes` and `manageAccountRoutes`, we can refactor this PR and remove `manageAccountRoutes` altogether.