### PR TITLE
Draft: Reduce the number of calls made to the GitLab API by gitlab-housekeeping

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -449,6 +449,13 @@ def merge_merge_requests(
 
 
 def run(dry_run, wait_for_pipeline):
+    # Invalidate the cache each time the integration starts to run. We only wish to
+    # cache data within each integration run, not to the next integration run. There is
+    # probably a better way to do this.
+    _get_merge_requests.cache_clear()
+    _get_merge_request_commits.cache_clear()
+    _get_merge_requst_label_events.cache_clear()
+
     default_days_interval = 15
     default_limit = 8
     default_enable_closing = False

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -134,7 +134,7 @@ def handle_stale_items(dry_run, gl, days_interval, enable_closing, item_type):
     if item_type == "issue":
         items = gl.get_issues(state=MRState.OPENED)
     elif item_type == "merge-request":
-        items = gl.get_merge_requests(state=MRState.OPENED)
+        items = _get_merge_requests(gl)
 
     now = datetime.utcnow()
     for item in items:
@@ -223,12 +223,12 @@ def _get_merge_requests(gl: GitLabApi):
 
 
 @cache
-def _get_merge_request_commits(mr):
+def _get_merge_request_commits(mr: ProjectMergeRequest):
     return mr.commits()
 
 
 @cache
-def _get_merge_requst_label_events(gl, mr):
+def _get_merge_requst_label_events(gl: GitLabApi, mr: ProjectMergeRequest):
     return gl.get_merge_request_label_events(mr)
 
 


### PR DESCRIPTION
The gitlab-housekeeping integration is one factor that affects MR merge throughput in app-interface. From looking at metrics, it appears that this integration can sometimes take up to 5 minutes to run. It appears that most of the work being done is calling the GitLab API. From investigating debug logs, it appears that we were making calls for the same resources multiple times in a single integration run.

The initial proposal is a pretty quick and dirty fix leveraging caching and removing calls to get labels from the GitLab API if they're empty. From my investigation, 100% of the cases where the API didn't return labels were because there weren't any, so we wasted many API calls there.

I still need to look into:
* take a closer look to see whether each set of data can be pulled only once, or whether something could be updated by another part of gitlab-housekeeping, so we need fresh data

Before:
* Runtime: 1m37.549s
* 648 API calls

After:
* Runtime: 57.062s
* 390 API calls

Note that the runtimes on my laptop are significantly faster than the worst-case where we can see 5 minute spikes. We can see what impact this MR makes in real world execution.

A more thorough refactoring might be appropriate, but this is if nothing else a POC for the performance improvements that can be had in gitlab-housekeeping.