### PR TITLE
APPSRE-6665: Add urlescape and urlunescape to Jinja2

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -278,7 +278,6 @@ def json_to_dict(input):
 
 def urlescape(
     string: str,
-    quote_plus: bool = False,
     safe: str = "/",
     encoding: Optional[str] = None,
 ) -> str:
@@ -288,7 +287,6 @@ def urlescape(
     urllib.parse.quote() and urllib.parse.quote_plus() for reference.
 
     :param str string: String value to escape.
-    :param bool quote_plus: Replace spaces with plus signs.
     :param str safe: Optional characters that should not be escaped.
     :param encoding: Encoding to apply to the string to be escaped. Defaults
         to UTF-8. Unsupported characters raise a UnicodeEncodeError error.
@@ -296,21 +294,16 @@ def urlescape(
     :returns: A string with reserved characters escaped.
     :rtype: str
     """
-    if quote_plus:
-        return parse.quote_plus(string, safe="", encoding=encoding)
     return parse.quote(string, safe=safe, encoding=encoding)
 
 
-def urlunescape(
-    string: str, unquote_plus: bool = False, encoding: Optional[str] = None
-) -> str:
+def urlunescape(string: str, encoding: Optional[str] = None) -> str:
     """Jinja2 filter that is a simple wrapper around urllib's URL unquoting
     functions that takes an URL-encoded string value and unescapes it
     replacing any URL-encoded values with their character equivalent. See:
     urllib.parse.unquote() and urllib.parse.unquote_plus() for reference.
 
     :param str string: String value to unescape.
-    :param bool quote_plus: Replace plus signs with spaces.
     :param encoding: Encoding to apply to the string to be unescaped. Defaults
         to UTF-8. Unsupported characters are replaced by placeholder values.
     :type encoding: typing.Optional[str]
@@ -319,8 +312,6 @@ def urlunescape(
     """
     if encoding is None:
         encoding = "utf-8"
-    if unquote_plus:
-        return parse.unquote_plus(string, encoding=encoding)
     return parse.unquote(string, encoding=encoding)
 
 
@@ -364,12 +355,10 @@ def process_jinja2_template(body, vars=None, extra_curly: bool = False, settings
             "github": lambda u, p, r, v=None: lookup_github_file_content(
                 repo=u, path=p, ref=r, tvars=vars, settings=settings
             ),
-            "urlescape": lambda u, p=False, s="/", e=None: urlescape(
-                string=u, quote_plus=p, safe=s, encoding=e
+            "urlescape": lambda u, s="/", e=None: urlescape(
+                string=u, safe=s, encoding=e
             ),
-            "urlunescape": lambda u, p=False, e=None: urlunescape(
-                string=u, unquote_plus=p, encoding=e
-            ),
+            "urlunescape": lambda u, e=None: urlunescape(string=u, encoding=e),
             "query": lookup_graphql_query_results,
             "url": url_makes_sense,
         }

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -14,6 +14,7 @@ from typing import (
     Any,
     Optional,
 )
+from urllib import parse
 
 import anymarkup
 import jinja2
@@ -275,6 +276,54 @@ def json_to_dict(input):
     return data
 
 
+def urlescape(
+    string: str,
+    quote_plus: bool = False,
+    safe: str = "/",
+    encoding: Optional[str] = None,
+) -> str:
+    """Jinja2 filter that is a simple wrapper around urllib's URL quoting
+    functions that takes a string value and makes it safe for use as URL
+    components escaping any reserved characters using URL encoding. See:
+    urllib.parse.quote() and urllib.parse.quote_plus() for reference.
+
+    :param str string: String value to escape.
+    :param bool quote_plus: Replace spaces with plus signs.
+    :param str safe: Optional characters that should not be escaped.
+    :param encoding: Encoding to apply to the string to be escaped. Defaults
+        to UTF-8. Unsupported characters raise a UnicodeEncodeError error.
+    :type encoding: typing.Optional[str]
+    :returns: A string with reserved characters escaped.
+    :rtype: str
+    """
+    if quote_plus:
+        return parse.quote_plus(string, safe="", encoding=encoding)
+    return parse.quote(string, safe=safe, encoding=encoding)
+
+
+def urlunescape(
+    string: str, unquote_plus: bool = False, encoding: Optional[str] = None
+) -> str:
+    """Jinja2 filter that is a simple wrapper around urllib's URL unquoting
+    functions that takes an URL-encoded string value and unescapes it
+    replacing any URL-encoded values with their character equivalent. See:
+    urllib.parse.unquote() and urllib.parse.unquote_plus() for reference.
+
+    :param str string: String value to unescape.
+    :param bool quote_plus: Replace plus signs with spaces.
+    :param encoding: Encoding to apply to the string to be unescaped. Defaults
+        to UTF-8. Unsupported characters are replaced by placeholder values.
+    :type encoding: typing.Optional[str]
+    :returns: A string with URL-encoded sequences unescaped.
+    :rtype: str
+    """
+    if encoding is None:
+        encoding = "utf-8"
+    if unquote_plus:
+        return parse.unquote_plus(string, encoding=encoding)
+    return parse.unquote(string, encoding=encoding)
+
+
 @cache
 def compile_jinja2_template(body, extra_curly: bool = False):
     env: dict = {}
@@ -293,8 +342,13 @@ def compile_jinja2_template(body, extra_curly: bool = False):
         undefined=jinja2.StrictUndefined,
         **env,
     )
-    # Register Custom filters
-    jinja_env.filters["json_to_dict"] = json_to_dict
+    jinja_env.filters.update(
+        {
+            "json_to_dict": json_to_dict,
+            "urlescape": urlescape,
+            "urlunescape": urlunescape,
+        }
+    )
 
     return jinja_env.from_string(body)
 
@@ -306,18 +360,20 @@ def process_jinja2_template(body, vars=None, extra_curly: bool = False, settings
         {
             "vault": lambda p, k, v=None: lookup_secret(
                 path=p, key=k, version=v, tvars=vars, settings=settings
-            )
-        }
-    )
-    vars.update(
-        {
+            ),
             "github": lambda u, p, r, v=None: lookup_github_file_content(
                 repo=u, path=p, ref=r, tvars=vars, settings=settings
-            )
+            ),
+            "urlescape": lambda u, p=False, s="/", e=None: urlescape(
+                string=u, quote_plus=p, safe=s, encoding=e
+            ),
+            "urlunescape": lambda u, p=False, e=None: urlunescape(
+                string=u, unquote_plus=p, encoding=e
+            ),
+            "query": lookup_graphql_query_results,
+            "url": url_makes_sense,
         }
     )
-    vars.update({"query": lookup_graphql_query_results})
-    vars.update({"url": url_makes_sense})
     try:
         template = compile_jinja2_template(body, extra_curly)
         r = template.render(vars)


### PR DESCRIPTION
Add `urlescape` and `urlunescape` to Jinja2 for use in resource templates either as a filter or as a function to be run directly. Both additions are simple wrappers that expose `urllib.parse.quote()` and `urllib.parse.quote_plus()` to the template engine.

This change enables users to escape and unescape reserved characters using URL encoding, making a string value safe to use as URL components or turning it back into a raw string should it be currently URL-encoded.

Since both additions are wrappers around the standard library functions, the approach to handling character encoding during escaping and unescaping would be the same as what the library functions currently offer - there is a strong bias towards supporting UTF-8 as the default encoding that has also been preserved.

Related: [APPSRE-6665](https://issues.redhat.com/browse/APPSRE-6665)

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>