### PR TITLE
[change-owners] MR with no changes is not self-serviceable + more logs

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -336,7 +336,7 @@ def run(
         #
         changes = fetch_bundle_changes(comparison_sha)
         logging.info(
-            f"detected {len(changes)} changed bundle files with {sum(len(c.diff_coverage) for c in changes)} differences"
+            f"detected {len(changes)} changed files with {sum(len(c.diff_coverage) for c in changes)} differences"
         )
         cover_changes(
             changes,

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -53,6 +53,9 @@ class FileRef:
     path: str
     schema: Optional[str]
 
+    def __str__(self) -> str:
+        return f"{self.file_type.value}:{self.path}"
+
 
 @dataclass
 class DiffCoverage:

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -356,6 +356,7 @@ def get_diff(old_sha: str):
     server_url = urlparse(config["graphql"]["server"])
     token = config["graphql"].get("token")
     current_sha = get_sha(server_url, token)
+    logging.debug(f"get bundle diffs between {old_sha} and {current_sha}...")
     diff_endpoint = server_url._replace(path=f"/diff/{old_sha}/{current_sha}")
     headers = {"Authorization": token} if token else None
     response = requests.get(diff_endpoint.geturl(), headers=headers, timeout=30)


### PR DESCRIPTION
an MR that has no detected changes, will not be marked as self-serviceable anymore. additonally, several log statements for info and debug loglevel have been introduce to make it easier to figure out why no changes were detected on an MR

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>