### PR TITLE
Revert "[gabi-authorized-users] OIDC support"

### DIFF
--- a/reconcile/gabi_authorized_users.py
+++ b/reconcile/gabi_authorized_users.py
@@ -8,10 +8,7 @@ from datetime import (
     date,
     datetime,
 )
-from typing import (
-    Any,
-    Optional,
-)
+from typing import Optional
 
 import reconcile.openshift_base as ob
 from reconcile import queries
@@ -42,24 +39,20 @@ def construct_gabi_oc_resource(name: str, users: Iterable[str]) -> OpenshiftReso
     )
 
 
-def get_usernames(
-    users: Iterable[Mapping[str, Any]], cluster: Mapping[str, Any]
-) -> list[str]:
-    """Extract usernames from objects based on used cluster authentication methods."""
-    user_keys = ob.determine_user_keys_for_access(cluster["name"], cluster["auth"])
-    return [u[key] for u in users for key in user_keys]
-
-
 def fetch_desired_state(
     gabi_instances: Iterable[Mapping], ri: ResourceInventory
 ) -> None:
     for g in gabi_instances:
         exp_date = datetime.strptime(g["expirationDate"], "%Y-%m-%d").date()
-        if (exp_date - date.today()).days > EXPIRATION_MAX:
+        users = [u["github_username"] for u in g["users"]]
+        if exp_date < date.today():
+            users = []
+        elif (exp_date - date.today()).days > EXPIRATION_MAX:
             raise RunnerException(
                 f'The maximum expiration date of {g["name"]} '
                 f"shall not exceed {EXPIRATION_MAX} days form today"
             )
+        resource = construct_gabi_oc_resource(g["name"], users)
         for i in g["instances"]:
             namespace = i["namespace"]
             account = i["account"]
@@ -78,12 +71,6 @@ def fetch_desired_state(
                     f'for account {account} in namespace {namespace["name"]}'
                 )
             cluster = namespace["cluster"]["name"]
-            users = (
-                get_usernames(g["users"], namespace["cluster"])
-                if exp_date >= date.today()
-                else []
-            )
-            resource = construct_gabi_oc_resource(g["name"], users)
             ri.add_desired(cluster, namespace["name"], "ConfigMap", g["name"], resource)
 
 

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2884,9 +2884,6 @@ GABI_INSTANCES_QUERY = """
           disable {
             integrations
           }
-          auth {
-            service
-          }
         }
       }
     }

--- a/reconcile/test/fixtures/gabi_authorized_users/apply.yml
+++ b/reconcile/test/fixtures/gabi_authorized_users/apply.yml
@@ -22,8 +22,6 @@ gql_response:
           automationToken:
             path: token
             field: token
-          auth:
-            - service: github-org-team
 
 server:
   version:


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#3046

The OIDC related changes in qontract-reconcile and qontract-schemas break FedRAMP environment authentication. We have to revert and align on a strategy that can exist in parallel.

re: https://coreos.slack.com/archives/GGC2A0MS8/p1670432900179959