### PR TITLE
Revert "[openshift-users] OIDC support"

### DIFF
--- a/reconcile/openshift_users.py
+++ b/reconcile/openshift_users.py
@@ -14,36 +14,21 @@ from reconcile.utils.oc import OC_Map
 QONTRACT_INTEGRATION = "openshift-users"
 
 
-def get_cluster_users(cluster, oc_map, clusters):
+def get_cluster_users(cluster, oc_map):
     oc = oc_map.get(cluster)
     if not oc:
         logging.log(level=oc.log_level, msg=oc.message)
         return []
-    users: list[str] = []
+    users = [
+        u["metadata"]["name"]
+        for u in oc.get_users()
+        if u.get("identities", None) is not None
+        and len(u["identities"]) == 1
+        and u["identities"][0].startswith("github")
+        and not u["metadata"].get("labels", {}).get("admin", "")
+    ]
 
-    # get cluster info for current cluster name from clusters list
-    cluster_info = next((cl for cl in clusters if cl["name"] == cluster))
-
-    # backwarts compatibiltiy for clusters w/o auth
-    identity_prefixes = ["github"]
-
-    for auth in cluster_info["auth"]:
-        if auth["service"] == "oidc":
-            identity_prefixes.append(auth["name"])
-
-    for u in oc.get_users():
-        if u["metadata"].get("labels", {}).get("admin", ""):
-            # ignore admins
-            continue
-        if any(
-            identity.startswith(identity_prefix)
-            for identity in u.get("identities", [])
-            for identity_prefix in identity_prefixes
-        ):
-            # the user has at least one identitiy which is managed by app-interface
-            users.append(u["metadata"]["name"])
-
-    return [{"cluster": cluster, "user": user} for user in users]
+    return [{"cluster": cluster, "user": user} for user in users or []]
 
 
 def fetch_current_state(thread_pool_size, internal, use_jump_host):
@@ -62,7 +47,6 @@ def fetch_current_state(thread_pool_size, internal, use_jump_host):
         oc_map.clusters(include_errors=True),
         thread_pool_size,
         oc_map=oc_map,
-        clusters=clusters,
     )
     current_state = list(itertools.chain.from_iterable(results))
     return oc_map, current_state

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -917,9 +917,8 @@ CLUSTERS_MINIMAL_QUERY = """
         org
         team
       }
-      ... on ClusterAuthOIDC_v1 {
-        name
-      }
+      # ... on ClusterAuthOIDC_v1 {
+      # }
     }
   }
 }


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#3032

The OIDC related changes in qontract-reconcile and qontract-schemas break FedRAMP environment authentication. We have to revert and align on a strategy that can exist in parallel.

re: https://coreos.slack.com/archives/GGC2A0MS8/p1670432900179959