### PR TITLE
Disable ssl verification for jenkins job builds cleaner

### DIFF
--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -84,7 +84,7 @@ def run(dry_run):
 
         token = instance["token"]
         instance_name = instance["name"]
-        jenkins = JenkinsApi.init_jenkins_from_secret(secret_reader, token)
+        jenkins = JenkinsApi.init_jenkins_from_secret(secret_reader, token, ssl_verify=False)
         all_job_names = jenkins.get_job_names()
 
         builds_todel = find_builds(jenkins, all_job_names, cleanup_rules)

--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -84,7 +84,9 @@ def run(dry_run):
 
         token = instance["token"]
         instance_name = instance["name"]
-        jenkins = JenkinsApi.init_jenkins_from_secret(secret_reader, token, ssl_verify=False)
+        jenkins = JenkinsApi.init_jenkins_from_secret(
+            secret_reader, token, ssl_verify=False
+        )
         all_job_names = jenkins.get_job_names()
 
         builds_todel = find_builds(jenkins, all_job_names, cleanup_rules)


### PR DESCRIPTION
Many Jenkins integrations disable SSL verification. 

![Screenshot_20221209_154604](https://user-images.githubusercontent.com/4098927/206793387-5c731b33-0bd0-4205-90af-5b8db5fa7611.png)

With us using this integration now in FedRamp, we need to disable verification for the CronJob to run as we are using a DigiCert certificate tied with a private Route53 DNS name for our Jenkins instance.

[APPSRE-6691](https://issues.redhat.com/browse/APPSRE-6691)