### PR TITLE
[change-owners] split high level changes into fine grained diffs

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -112,8 +112,6 @@ def _parse_bundle_changes(bundle_changes) -> list[BundleFileChange]:
     """
     parses the output of the qontract-server /diff endpoint
     """
-
-    # todo - add some logging to remove BundleFileChange file with no changes
     datafiles = bundle_changes["datafiles"].values()
     resourcefiles = bundle_changes["resources"].values()
     logging.debug(
@@ -336,15 +334,12 @@ def run(
         #
         changes = fetch_bundle_changes(comparison_sha)
         logging.info(
-            f"detected {len(changes)} changed files with {sum(len(c.diff_coverage) for c in changes)} differences"
+            f"detected {len(changes)} changed files with {sum(c.raw_diff_count() for c in changes)} differences"
         )
         cover_changes(
             changes,
             change_type_processors,
             comparison_gql_api,
-        )
-        logging.debug(
-            f"bundle files with changes uncovered by change-types: {', '.join([str(c.fileref) for c in changes if not c.all_changes_covered()])}"
         )
         self_serviceable = (
             len(changes) > 0

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -121,7 +121,9 @@ class DiffCoverage:
                     return sub_cov
 
             # no suitable existing split found, create a new one
-            split_sub_coverage = DiffCoverage(self.diff.create_subdiff(path), [ctx])
+            split_sub_coverage = DiffCoverage(
+                self.diff.create_subdiff(path), self.coverage + [ctx]
+            )
 
             # consolidate existing splits. maybe they should go under the newly created one?
             consolidated_splits = [split_sub_coverage]

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -122,7 +122,7 @@ class DiffCoverage:
 
             # no suitable existing split found, create a new one
             split_sub_coverage = DiffCoverage(
-                self.diff.create_subdiff(path), self.coverage + [ctx]
+                self.diff.create_subdiff(path), self.coverage.copy()
             )
 
             # consolidate existing splits. maybe they should go under the newly created one?
@@ -133,12 +133,20 @@ class DiffCoverage:
                 else:
                     consolidated_splits.append(s)
 
+            # add the covering context to the new split and all its child splits
+            split_sub_coverage.add_covering_context(ctx)
+
             self._split_into = consolidated_splits
             return split_sub_coverage
         if self.diff.path == path:
             return self
         else:
             return None
+
+    def add_covering_context(self, ctx: "ChangeTypeContext"):
+        self.coverage.append(ctx)
+        for s in self._split_into:
+            s.add_covering_context(ctx)
 
     def fine_grained_diff_coverages(self) -> dict[str, "DiffCoverage"]:
         coverages = {}

--- a/reconcile/change_owners/tester.py
+++ b/reconcile/change_owners/tester.py
@@ -168,7 +168,7 @@ class AppInterfaceRepo:
                     ),
                     old=parsed_yaml,
                     new=parsed_yaml,
-                    diff_coverage=[],
+                    diffs=[],
                 )
         elif file_type == BundleFileType.RESOURCEFILE:
             with open(f"{self.resource_dir()}{path}", "r") as f:
@@ -182,7 +182,7 @@ class AppInterfaceRepo:
                     ),
                     old=parsed_content,
                     new=parsed_content,
-                    diff_coverage=[],
+                    diffs=[],
                 )
         else:
             raise ValueError(f"Unknown file type {file_type}")

--- a/reconcile/test/change_owners/fixtures.py
+++ b/reconcile/test/change_owners/fixtures.py
@@ -16,7 +16,11 @@ from reconcile.change_owners.change_types import (
     create_bundle_file_change,
 )
 from reconcile.gql_definitions.change_owners.queries import self_service_roles
-from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
+from reconcile.gql_definitions.change_owners.queries.change_types import (
+    ChangeTypeChangeDetectorContextSelectorV1,
+    ChangeTypeChangeDetectorJsonPathProviderV1,
+    ChangeTypeV1,
+)
 from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
     BotV1,
     DatafileObjectV1,
@@ -141,3 +145,23 @@ def namespace_file() -> TestFile:
 @pytest.fixture
 def rds_defaults_file() -> TestFile:
     return TestFile(**fxt.get_anymarkup("resourcefile_rds_defaults.yaml"))
+
+
+def build_jsonpath_change(
+    selectors: list[str],
+    schema: Optional[str] = None,
+    context_selector: Optional[str] = None,
+    context_when: Optional[str] = None,
+) -> ChangeTypeChangeDetectorJsonPathProviderV1:
+    if context_selector:
+        context = ChangeTypeChangeDetectorContextSelectorV1(
+            selector=context_selector, when=context_when
+        )
+    else:
+        context = None
+    return ChangeTypeChangeDetectorJsonPathProviderV1(
+        provider="jsonPath",
+        changeSchema=schema,
+        jsonPathSelectors=selectors,
+        context=context,
+    )

--- a/reconcile/test/change_owners/test_change_type_diff.py
+++ b/reconcile/test/change_owners/test_change_type_diff.py
@@ -52,6 +52,9 @@ def test_deepdiff_path_element_with_dot():
 
 
 def test_bundle_change_diff_value_changed():
+    """
+    detect a change on a top level field
+    """
     bundle_change = create_bundle_file_change(
         path="path",
         schema="schema",
@@ -69,6 +72,9 @@ def test_bundle_change_diff_value_changed():
 
 
 def test_bundle_change_diff_value_changed_deep():
+    """
+    detect a change deeper in the object tree
+    """
     bundle_change = create_bundle_file_change(
         path="path",
         schema="schema",
@@ -87,7 +93,7 @@ def test_bundle_change_diff_value_changed_deep():
 
 def test_bundle_change_diff_value_changed_multiple_in_iterable():
     """
-    this testscenario searches shows how changes can be detected in a list,
+    this testscenario shows how changes can be detected in a list,
     when objects with identifiers and objects without are mixed and shuffled
     """
     bundle_change = create_bundle_file_change(
@@ -184,6 +190,10 @@ def test_bundle_change_diff_value_changed_multiple_in_iterable():
 
 
 def test_bundle_change_diff_property_added():
+    """
+    this test scenario show how a newly added property is correctly
+    detected if the containing object has a clear identity.
+    """
     bundle_change = create_bundle_file_change(
         path="path",
         schema="/openshift/namespace-1.yml",
@@ -229,6 +239,10 @@ def test_bundle_change_diff_property_added():
 
 
 def test_bundle_change_diff_property_removed():
+    """
+    this test scenario show how a removed property is correctly
+    detected if the containing object has a clear identity.
+    """
     bundle_change = create_bundle_file_change(
         path="path",
         schema="/openshift/namespace-1.yml",

--- a/reconcile/test/change_owners/test_change_type_diff_splitting.py
+++ b/reconcile/test/change_owners/test_change_type_diff_splitting.py
@@ -219,8 +219,34 @@ def test_nested_splits():
 
     diffs = {d.diff.path_str(): d for d in bundle_change.diff_coverage}
 
+    # check that the `top` field has a split for `top.sub` and is covered
+    # by the `top` change-type
     assert ["top.sub"] == [s.diff.path_str() for s in diffs["top"]._split_into]
+    assert diffs["top"].is_directly_covered()
+    assert {ctx.change_type_processor.name for ctx in diffs["top"].coverage} == {
+        top.change_type_processor.name
+    }
+
+    # check that the `top.sub` field has a split for `top.sub.sub-sub` and is covered
+    # by the `sub` and `top` change-types
     assert ["top.sub.sub-sub"] == [
         s.diff.path_str() for s in diffs["top.sub"]._split_into
     ]
+    assert diffs["top.sub"].is_directly_covered()
+    assert {ctx.change_type_processor.name for ctx in diffs["top.sub"].coverage} == {
+        top.change_type_processor.name,
+        sub.change_type_processor.name,
+    }
+
+    # check that the `top.sub.sub-sub` field is not split and is covered
+    # by the `sub-sub`, `sub` and `top` change-types
     assert [] == [s.diff.path_str() for s in diffs["top.sub.sub-sub"]._split_into]
+    assert diffs["top.sub.sub-sub"].is_directly_covered()
+    assert not diffs["top.sub.sub-sub"].is_covered_by_splits()
+    assert {
+        ctx.change_type_processor.name for ctx in diffs["top.sub.sub-sub"].coverage
+    } == {
+        top.change_type_processor.name,
+        sub.change_type_processor.name,
+        sub_sub.change_type_processor.name,
+    }

--- a/reconcile/test/change_owners/test_change_type_diff_splitting.py
+++ b/reconcile/test/change_owners/test_change_type_diff_splitting.py
@@ -1,0 +1,226 @@
+from reconcile.change_owners.change_types import (
+    BundleFileType,
+    ChangeTypeContext,
+    ChangeTypeProcessor,
+    FileRef,
+    build_change_type_processor,
+    create_bundle_file_change,
+)
+from reconcile.change_owners.diff import DiffType
+from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
+from reconcile.test.change_owners.fixtures import build_jsonpath_change
+
+
+def build_change_type(name: str, change_selectors: list[str]) -> ChangeTypeProcessor:
+    return build_change_type_processor(
+        ChangeTypeV1(
+            name=name,
+            description=name,
+            contextType=BundleFileType.DATAFILE.value,
+            contextSchema=None,
+            changes=[
+                build_jsonpath_change(
+                    schema=None,
+                    selectors=change_selectors,
+                )
+            ],
+            disabled=False,
+            priority="urgent",
+            inherit=[],
+        )
+    )
+
+
+def test_root_diff_fully_covered_by_splits():
+    bundle_change = create_bundle_file_change(
+        path="path",
+        schema=None,
+        file_type=BundleFileType.DATAFILE,
+        old_file_content=None,
+        new_file_content={"split-a": "a", "split-b": "b"},
+    )
+
+    assert bundle_change
+    # only the root diff is present
+    assert len(bundle_change.diff_coverage) == 1
+    assert bundle_change.diff_coverage[0].diff.path_str() == "$"
+    assert bundle_change.diff_coverage[0].diff.diff_type == DiffType.ADDED
+
+    split_a = ChangeTypeContext(
+        change_type_processor=build_change_type("split-a", ["split-a"]),
+        context="context",
+        context_file=FileRef(
+            path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
+        ),
+        approvers=[],
+    )
+
+    split_b = ChangeTypeContext(
+        change_type_processor=build_change_type("split-b", ["split-b"]),
+        context="context",
+        context_file=FileRef(
+            path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
+        ),
+        approvers=[],
+    )
+
+    bundle_change.cover_changes(split_a)
+    bundle_change.cover_changes(split_b)
+    # after consolidation, the root diff is gone and only two splits are present
+    diffs = bundle_change.diff_coverage
+    assert len(diffs) == 2
+
+    for d in diffs:
+        assert d.is_covered()
+
+
+def test_root_diff_uncovered_fully_covered_by_splits():
+    bundle_change = create_bundle_file_change(
+        path="path",
+        schema=None,
+        file_type=BundleFileType.DATAFILE,
+        old_file_content=None,
+        new_file_content={"split-a": "a", "split-b": "b"},
+    )
+
+    assert bundle_change
+    # only the root diff is present
+    assert len(bundle_change.diff_coverage) == 1
+
+    split_a = ChangeTypeContext(
+        change_type_processor=build_change_type("split-a", ["split-a"]),
+        context="context",
+        context_file=FileRef(
+            path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
+        ),
+        approvers=[],
+    )
+
+    split_b = ChangeTypeContext(
+        change_type_processor=build_change_type("split-b", ["split-b"]),
+        context="context",
+        context_file=FileRef(
+            path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
+        ),
+        approvers=[],
+    )
+
+    bundle_change.cover_changes(split_a)
+    bundle_change.cover_changes(split_b)
+
+    # after consolidation, the root diff is gone and only two splits are present
+    diffs = bundle_change.diff_coverage
+    assert len(diffs) == 2
+
+    for d in diffs:
+        assert d.is_covered()
+
+
+def test_root_diff_uncovered():
+    bundle_change = create_bundle_file_change(
+        path="path",
+        schema=None,
+        file_type=BundleFileType.DATAFILE,
+        old_file_content=None,
+        new_file_content={"split-a": "a", "split-b": "b", "split-c": "c"},
+    )
+
+    assert bundle_change
+    # only the root diff is present
+    assert len(bundle_change.diff_coverage) == 1
+
+    split_a = ChangeTypeContext(
+        change_type_processor=build_change_type("split-a", ["split-a"]),
+        context="context",
+        context_file=FileRef(
+            path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
+        ),
+        approvers=[],
+    )
+
+    split_b = ChangeTypeContext(
+        change_type_processor=build_change_type("split-b", ["split-b"]),
+        context="context",
+        context_file=FileRef(
+            path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
+        ),
+        approvers=[],
+    )
+
+    bundle_change.cover_changes(split_a)
+    bundle_change.cover_changes(split_b)
+
+    diffs = {d.diff.path_str(): d for d in bundle_change.diff_coverage}
+    # the root split is not covered in full by the other change-types
+    # so it must remain, next to the two splits
+    assert len(diffs) == 3
+
+    # the root diff remains uncovered (directly and indirectly)
+    assert not diffs["$"].is_directly_covered()
+    assert not diffs["$"].is_covered_by_splits()
+    assert not diffs["$"].is_covered()
+    assert {"split-a", "split-b"} == {s.diff.path_str() for s in diffs["$"]._split_into}
+
+    assert diffs["split-a"].is_covered()
+    assert diffs["split-b"].is_covered()
+
+
+def test_nested_splits():
+    bundle_change = create_bundle_file_change(
+        path="path",
+        schema=None,
+        file_type=BundleFileType.DATAFILE,
+        old_file_content=None,
+        new_file_content={"top": {"sub": {"sub-sub": "value"}}},
+    )
+
+    assert bundle_change
+    # only the root diff is present
+    assert len(bundle_change.diff_coverage) == 1
+
+    top = ChangeTypeContext(
+        change_type_processor=build_change_type("top", ["top"]),
+        context="context",
+        context_file=FileRef(
+            path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
+        ),
+        approvers=[],
+    )
+
+    sub = ChangeTypeContext(
+        change_type_processor=build_change_type("sub", ["top.sub"]),
+        context="context",
+        context_file=FileRef(
+            path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
+        ),
+        approvers=[],
+    )
+
+    sub_sub = ChangeTypeContext(
+        change_type_processor=build_change_type("sub-sub", ["top.sub.sub-sub"]),
+        context="context",
+        context_file=FileRef(
+            path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
+        ),
+        approvers=[],
+    )
+
+    # call the coverage function in this order is on purpose
+
+    # so that the split functionality must reconsolidate the diff split tree
+    # first add a split for top.sub.sub-sub
+    bundle_change.cover_changes(sub_sub)
+    # then add a split for root, which means that top.sub.sub-sub needs to be
+    # placed under the split for top
+    bundle_change.cover_changes(top)
+    # then add the split for top.sub that goes between the top and top.sub.sub-sub
+    # split within the split tree
+    bundle_change.cover_changes(sub)
+
+    diffs = {d.diff.path_str(): d for d in bundle_change.diff_coverage}
+
+    assert ["top.sub"] == [s.diff.path_str() for s in diffs["top"]._split_into]
+    assert ["top.sub.sub-sub"] == [
+        s.diff.path_str() for s in diffs["top.sub"]._split_into
+    ]
+    assert [] == [s.diff.path_str() for s in diffs["top.sub.sub-sub"]._split_into]

--- a/reconcile/test/change_owners/test_change_type_inheritance.py
+++ b/reconcile/test/change_owners/test_change_type_inheritance.py
@@ -11,32 +11,11 @@ from reconcile.change_owners.change_types import (
     init_change_type_processors,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import (
-    ChangeTypeChangeDetectorContextSelectorV1,
-    ChangeTypeChangeDetectorJsonPathProviderV1,
     ChangeTypeChangeDetectorV1,
     ChangeTypeV1,
     ChangeTypeV1_ChangeTypeV1,
 )
-
-
-def build_jsonpath_change(
-    selectors: list[str],
-    schema: Optional[str] = None,
-    context_selector: Optional[str] = None,
-    context_when: Optional[str] = None,
-) -> ChangeTypeChangeDetectorJsonPathProviderV1:
-    if context_selector:
-        context = ChangeTypeChangeDetectorContextSelectorV1(
-            selector=context_selector, when=context_when
-        )
-    else:
-        context = None
-    return ChangeTypeChangeDetectorJsonPathProviderV1(
-        provider="jsonPath",
-        changeSchema=schema,
-        jsonPathSelectors=selectors,
-        context=context,
-    )
+from reconcile.test.change_owners.fixtures import build_jsonpath_change
 
 
 def build_def_change_type(

--- a/reconcile/test/change_owners/test_change_type_priorities.py
+++ b/reconcile/test/change_owners/test_change_type_priorities.py
@@ -1,8 +1,8 @@
+from unittest.mock import MagicMock
+
 from reconcile.change_owners.change_types import (
     BundleFileChange,
-    ChangeTypeContext,
     ChangeTypePriority,
-    DiffCoverage,
     build_change_type_processor,
     get_priority_for_changes,
 )
@@ -22,28 +22,26 @@ def test_priority_for_changes(
 ):
     saas_file_changetype.priority = ChangeTypePriority.HIGH.value
     secret_promoter_change_type.priority = ChangeTypePriority.MEDIUM.value
-    changes = [
-        BundleFileChange(
-            fileref=None,  # type: ignore
-            old=None,
-            new=None,
-            diff_coverage=[
-                DiffCoverage(
-                    diff=None,  # type: ignore
-                    coverage=[
-                        ChangeTypeContext(
-                            change_type_processor=build_change_type_processor(ct),
-                            context="RoleV1 - some-role",
-                            approvers=[],
-                            context_file=None,  # type: ignore
-                        ),
-                    ],
-                )
-            ],
-        )
-        for ct in [saas_file_changetype, secret_promoter_change_type]
-    ]
-    assert ChangeTypePriority.MEDIUM == get_priority_for_changes(changes)
+    c1 = BundleFileChange(
+        fileref=None,  # type: ignore
+        old=None,
+        new=None,
+        diffs=[],
+    )
+    c1.involved_change_types = MagicMock(  # type: ignore
+        return_value=[build_change_type_processor(saas_file_changetype)]
+    )
+    c2 = BundleFileChange(
+        fileref=None,  # type: ignore
+        old=None,
+        new=None,
+        diffs=[],
+    )
+    c2.involved_change_types = MagicMock(  # type: ignore
+        return_value=[build_change_type_processor(secret_promoter_change_type)]
+    )
+
+    assert ChangeTypePriority.MEDIUM == get_priority_for_changes([c1, c2])
 
 
 def test_priorty_for_changes_no_coverage():
@@ -52,7 +50,7 @@ def test_priorty_for_changes_no_coverage():
             fileref=None,  # type: ignore
             old=None,
             new=None,
-            diff_coverage=[],
+            diffs=[],
         )
     ]
     assert get_priority_for_changes(changes) is None

--- a/reconcile/test/change_owners/test_change_type_processor.py
+++ b/reconcile/test/change_owners/test_change_type_processor.py
@@ -64,7 +64,7 @@ def test_change_type_processor_allowed_paths_simple(
         ),
     )
 
-    assert paths == ["roles"]
+    assert [str(p) for p in paths] == ["roles"]
 
 
 def test_change_type_processor_allowed_paths_conditions(
@@ -85,4 +85,4 @@ def test_change_type_processor_allowed_paths_conditions(
         ),
     )
 
-    assert paths == ["openshiftResources.[1].version"]
+    assert [str(p) for p in paths] == ["openshiftResources.[1].version"]


### PR DESCRIPTION
# Problem statement

When the detected changes within a file are too rough/high level, only high level `change-types` would be able to cover them. e.g. if a new file is introduced, the detected change would be the entire file, only coverable by the top-level JSONPath placeholder for the file-root '$'. Such `change-types` are the opposite of what we intend to do with `fine-grained` permissions.

# Idea

Split high level changes in smaller changes so they can be covered by `change-types`. The process of splitting is driven by the involved change-types, so that the resulting splits are as fine as they are required to allow the change-types to have effect, but not finer than required in order to keep the list of changes as concise as possible.

The center-piece of this change is the list of splits (`_split_into`) within the `DiffCoverage` dataclass which are `DiffCoverage` objects themselves. This forms a tree-like structure of diffs/sub-diffs, with the most fine grained splits represented as leaves. A diff is considered covered, if it is directly covered by a `change-type` or if all the splits of the diff are covered.

The approval process does not know anything about this process since it will operate on a flattened and consolidated list of diffs as if they would have been detected that way to begin with.

Imagine you add a new namespace file on a cluster you have permissions on. Before diff splitting, a single diff would have been detected

```
/services/mysvc/namespaces/test-ns.yml      $
```

With diff splitting, the diffs would look like this, depending on the involved change-types.

```
/services/mysvc/namespaces/test-ns.yml      cluster
/services/mysvc/namespaces/test-ns.yml      managedRoles
/services/mysvc/namespaces/test-ns.yml      environment
/services/mysvc/namespaces/test-ns.yml      app
/services/mysvc/namespaces/test-ns.yml      description
/services/mysvc/namespaces/test-ns.yml      name
/services/mysvc/namespaces/test-ns.yml      labels
```

Ref: https://issues.redhat.com/browse/APPSRE-6606