### PR TITLE
override cronjob deprecated api version

### DIFF
--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -501,6 +501,10 @@ class OpenshiftResource:
             if spec.get("type") == "ClusterIP":
                 spec.pop("clusterIP", None)
 
+        if body["kind"] == "CronJob":
+            if body["apiVersion"] == "batch/v1beta1":
+                body["apiVersion"] = "batch/v1"
+
         # remove qontract specific params
         annotations.pop("qontract.integration", None)
         annotations.pop("qontract.integration_version", None)


### PR DESCRIPTION
not all cronjobs were migrated to `v1`. this is a fix that will override `v1beta1`.