### PR TITLE
Move to list for namespace gathering in monitoring

### DIFF
--- a/reconcile/closedbox_endpoint_monitoring_base.py
+++ b/reconcile/closedbox_endpoint_monitoring_base.py
@@ -147,13 +147,11 @@ def run_for_provider(
 ) -> None:
     # prepare
     desired_endpoints = get_endpoints(provider)
-    namespaces = {
-        p.namespace.get("name"): p.namespace for p in desired_endpoints if p.namespace
-    }
+    namespaces = [p.namespace for p in desired_endpoints if p.namespace]
 
     if namespaces:
         ri, oc_map = ob.fetch_current_state(
-            namespaces.values(),
+            namespaces,
             thread_pool_size=thread_pool_size,
             internal=internal,
             use_jump_host=use_jump_host,


### PR DESCRIPTION
We currently only allow for monitoring from one cluster, as we can have multiple openshift-customer-monitoring namespaces in different clusters.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>