### PR TITLE
[gabi-authorized-users] OIDC support

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2884,6 +2884,9 @@ GABI_INSTANCES_QUERY = """
           disable {
             integrations
           }
+          auth {
+            service
+          }
         }
       }
     }

--- a/reconcile/test/fixtures/gabi_authorized_users/apply.yml
+++ b/reconcile/test/fixtures/gabi_authorized_users/apply.yml
@@ -22,6 +22,8 @@ gql_response:
           automationToken:
             path: token
             field: token
+          auth:
+            - service: github-org-team
 
 server:
   version:


### PR DESCRIPTION
Use usernames for Gabi authentication based on configured cluster authentication methods.

[APPSRE-6612](https://issues.redhat.com/browse/APPSRE-6612)

Reapply reverted:
* https://github.com/app-sre/qontract-reconcile/pull/3046