### PR TITLE
Add integration-specific metrics for gitlab-housekeeping

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -15,6 +15,11 @@ from gitlab.v4.objects import (
     ProjectIssue,
     ProjectMergeRequest,
 )
+from prometheus_client import (
+    Counter,
+    Gauge,
+    Histogram,
+)
 from sretoolbox.utils import retry
 
 from reconcile import queries
@@ -57,6 +62,40 @@ HOLD_LABELS = [
 
 QONTRACT_INTEGRATION = "gitlab-housekeeping"
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+merged_merge_requests = Counter(
+    name="qontract_reconcile_merged_merge_requests",
+    documentation="Number of merge requests that have been successfully merged in a repository",
+    labelnames=["project_id"],
+)
+
+rebased_merge_requests = Counter(
+    name="qontract_reconcile_rebased_merge_requests",
+    documentation="Number of merge requests that have been successfully rebased in a repository",
+    labelnames=["project_id"],
+)
+
+time_to_merge = Histogram(
+    name="qontract_reconcile_time_to_merge_merge_request",
+    documentation="The number of minutes it takes from when a merge request is mergeable until it is actually merged. This is an indicator of how busy the merge queue is.",
+    labelnames=["project_id"],
+    buckets=(5.0, 10.0, 20.0, 40.0, 60.0, float("inf")),
+)
+
+merge_requests_waiting = Gauge(
+    name="qontract_reconcile_merge_requests_waiting",
+    documentation="Number of merge requests that are in the queue waiting to be merged.",
+    labelnames=["project_id"],
+)
+
+
+def calculate_time_since_approval(mr: ProjectMergeRequest) -> float:
+    """Returns the number of minutes since a MR has been approved."""
+    time_since_approval = datetime.utcnow() - datetime.strptime(
+        mr.attributes["approved_at"], DATE_FORMAT
+    )
+    return time_since_approval.total_seconds() / 60
 
 
 def get_timed_out_pipelines(
@@ -357,6 +396,7 @@ def rebase_merge_requests(
                 if not dry_run:
                     mr.rebase()
                     rebases += 1
+                    rebased_merge_requests.labels(mr.source_project_id).inc()
             except gitlab.exceptions.GitlabMRRebaseError as e:
                 logging.error("unable to rebase {}: {}".format(mr.iid, e))
         else:
@@ -387,6 +427,9 @@ def merge_merge_requests(
     merge_requests = [
         item["mr"] for item in get_merge_requests(dry_run, gl, users_allowed_to_label)
     ]
+
+    merge_requests_waiting.labels(gl.project.id).set(len(merge_requests))
+
     for mr in merge_requests:
         if rebase and not is_rebased(mr, gl):
             continue
@@ -425,6 +468,10 @@ def merge_merge_requests(
         if not dry_run and merges < merge_limit:
             try:
                 mr.merge()
+                merged_merge_requests.labels(mr.source_project_id).inc()
+                time_to_merge.labels(mr.source_project_id).observe(
+                    calculate_time_since_approval(mr)
+                )
                 if rebase:
                     return
                 merges += 1

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -77,7 +77,7 @@ rebased_merge_requests = Counter(
 )
 
 time_to_merge = Histogram(
-    name="qontract_reconcile_time_to_merge_merge_request",
+    name="qontract_reconcile_time_to_merge_merge_request_minutes",
     documentation="The number of minutes it takes from when a merge request is mergeable until it is actually merged. This is an indicator of how busy the merge queue is.",
     labelnames=["project_id"],
     buckets=(5.0, 10.0, 20.0, 40.0, 60.0, float("inf")),

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -2,9 +2,13 @@ from datetime import (
     datetime,
     timedelta,
 )
-from unittest.mock import patch
+from unittest.mock import (
+    create_autospec,
+    patch,
+)
 
 from gitlab import Gitlab
+from gitlab.v4.objects import ProjectMergeRequest
 
 import reconcile.gitlab_housekeeping as gl_h
 from reconcile.test.fixtures import Fixtures
@@ -78,3 +82,13 @@ class TestGitLabHousekeeping:
 
         # Test if mock have this exact calls
         http_post.assert_called_once_with("/projects/1/pipelines/47/cancel")
+
+
+def test_calculate_time_since_approval():
+    mock_merge_request = create_autospec(ProjectMergeRequest)
+    one_hour_ago = datetime.utcnow() - timedelta(minutes=60)
+    mock_merge_request.attributes = {"approved_at": one_hour_ago.strftime(DATE_FORMAT)}
+
+    time_since_merge = gl_h.calculate_time_since_approval(mock_merge_request)
+
+    assert round(time_since_merge) == 60


### PR DESCRIPTION
These metrics should provide more data for guiding future enhancements related to speeding up gitlab-housekeeping, and improving the throughput of the integration.

I tested this manually as well by running the integration and ensuring that the metric calls returned proper data with the `collect()` method call. Any metrics that didn't run in dry-run mode were moved out of the conditional to make sure that they still work as expected.

Related: https://issues.redhat.com/browse/APPSRE-6653