### PR TITLE
Skip extra GitLab labels API calls in gitlab-housekeeping

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -202,18 +202,18 @@ def is_rebased(mr, gl: GitLabApi) -> bool:
 
 
 def get_labels(mr: ProjectMergeRequest, gl: GitLabApi) -> list[str]:
-    labels = mr.attributes.get("labels")
-    if not labels:
-        # Sometimes the label attribute is empty but shouldn't. Try it again by fetching this MR separately
-        labels = gl.get_merge_request_labels(mr.iid)
-        # This log is being added to get more data about how often GitLab doesn't return
-        # labels to see if we can remove the extra GitLab API call above.
-        if labels:
-            logging.info(
-                "Found a MR with missing labels, but successfully obtained labels on second call - %s",
-                mr.attributes["web_url"],
-            )
-    return labels
+    """
+    This function used to contain logic for checking if labels were empty and calling
+    gl.get_merge_request_labels() if they were missing because there were reports of the
+    label attribute being empty sometimes when it shouldn't be. This was an expensive
+    approach, increasing the runtime of the integration by something around 20-30%.
+    Through investigation in APPSRE-6653 it was determined this no longer appears to be
+    an issue.
+
+    This is being left to continue to abstract the way that labels are pulled in case
+    this becomes an issue again in the future.
+    """
+    return mr.attributes.get("labels")
 
 
 def get_merge_requests(


### PR DESCRIPTION
Related: https://issues.redhat.com/browse/APPSRE-6653

Also, related to draft PR #3050 which introduced multiple ideas for improving the performance of gitlab-housekeeping, that are now being addressed as separate MRs.

After a week of data, we only found 3 instances where labels were empty, but after calling the GitLab API again, labels were returned. All of these cases appear to be related to timing because the log entries matched when the first label was added to the MR, to the minute. In these cases, `gitlab-housekeeping` would have ignored these MRs for the first run, and then found them on the next run.

The performance improvements are 10-30 second reduction is run time of the integration (close to 20% reduction) and 80 fewer API calls to GitLab (>10% reduction). These performance improvements would be even clearer for cases where there are a larger number of MRs because the calls and runtime effectively grow linearly with the number of MRs.