### PR TITLE
gitlab-housekeeping are accidentally using source_project_id instead …

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -396,7 +396,7 @@ def rebase_merge_requests(
                 if not dry_run:
                     mr.rebase()
                     rebases += 1
-                    rebased_merge_requests.labels(mr.source_project_id).inc()
+                    rebased_merge_requests.labels(mr.target_project_id).inc()
             except gitlab.exceptions.GitlabMRRebaseError as e:
                 logging.error("unable to rebase {}: {}".format(mr.iid, e))
         else:
@@ -468,8 +468,8 @@ def merge_merge_requests(
         if not dry_run and merges < merge_limit:
             try:
                 mr.merge()
-                merged_merge_requests.labels(mr.source_project_id).inc()
-                time_to_merge.labels(mr.source_project_id).observe(
+                merged_merge_requests.labels(mr.target_project_id).inc()
+                time_to_merge.labels(mr.target_project_id).observe(
                     calculate_time_since_approval(mr)
                 )
                 if rebase:


### PR DESCRIPTION
…of target_project_id

I accidentally used source (the users' fork) project id instead of the destination. As per GitLab docs:

> project_id represents the ID of the project where the merge request resides. project_id always equals target_project_id.

https://docs.gitlab.com/ee/api/merge_requests.html