### PR TITLE
Remove broken time-to-merge metric in gitlab-housekeeping

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -469,9 +469,6 @@ def merge_merge_requests(
             try:
                 mr.merge()
                 merged_merge_requests.labels(mr.target_project_id).inc()
-                time_to_merge.labels(mr.target_project_id).observe(
-                    calculate_time_since_approval(mr)
-                )
                 if rebase:
                     return
                 merges += 1


### PR DESCRIPTION
It looks like the exception wasn't being bubbled up properly, but data was trying to be accessed that didn't exist. I'll look to replace this shortly with some improvements to type hints to catch this in the future.