### PR TITLE
Add channel and initialversion

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1129,6 +1129,8 @@ OCM_QUERY = """
     recommendedVersions {
       recommendedVersion
       workload
+      channel
+      initialVersion
     }
     recommendedVersionWeight {
       highest


### PR DESCRIPTION
Adds missing query fields, right now ocm-update-recommended-version creates a new MR all the time, cause the fields are not set and thus it shows a diff. 

