### PR TITLE
[change-types] implicit ownership for change-types

### DIFF
--- a/reconcile/change_owners/approver.py
+++ b/reconcile/change_owners/approver.py
@@ -1,0 +1,62 @@
+from dataclasses import dataclass
+from typing import (
+    Optional,
+    Protocol,
+)
+
+from reconcile.utils.gql import GqlApi
+
+
+@dataclass
+class Approver:
+    """
+    Minimalistic wrapper for approver sources to be used in ChangeTypeContexts.
+    Since we might load different approver contexts via GraphQL query classes,
+    a wrapper enables us to deal with different dataclasses representing an
+    approver.
+    """
+
+    org_username: str
+    tag_on_merge_requests: Optional[bool] = False
+
+
+class ApproverResolver(Protocol):
+    def lookup_approver_by_path(self, path: str) -> Optional[Approver]:
+        ...
+
+
+class GqlApproverResolver:
+    def __init__(self, gqlapis: list[GqlApi]):
+        self.gqlapis = gqlapis
+
+    def lookup_approver_by_path(self, path: str) -> Optional[Approver]:
+        for gqlapi in self.gqlapis:
+            approver = self._lookup_approver_by_path(gqlapi, path)
+            if approver:
+                return approver
+        return None
+
+    def _lookup_approver_by_path(self, gqlapi: GqlApi, path: str) -> Optional[Approver]:
+        approvers = gqlapi.query(
+            """
+            query Approvers($path: String) {
+                user: users_v1(path: $path) {
+                    org_username
+                    tag_on_merge_requests
+                }
+                bot: bots_v1(path: $path) {
+                    org_username
+                }
+            }
+            """,
+            {"path": path},
+        )
+        if approvers.get("user"):
+            return Approver(
+                approvers["user"][0]["org_username"],
+                approvers["user"][0]["tag_on_merge_requests"],
+            )
+        elif approvers.get("bot"):
+            return Approver(approvers["bot"][0]["org_username"], False)
+        else:
+            return None

--- a/reconcile/change_owners/bundle.py
+++ b/reconcile/change_owners/bundle.py
@@ -1,16 +1,6 @@
 from dataclasses import dataclass
 from enum import Enum
-from typing import (
-    Optional,
-)
-
-COMPARISON_BUNDLE = "comparison_bundle"
-TARGET_BUNDLE = "target_bundle"
-
-
-class Bundle(Enum):
-    COMPARISON = "comparison"
-    TARGET = "target"
+from typing import Optional
 
 
 class BundleFileType(Enum):

--- a/reconcile/change_owners/bundle.py
+++ b/reconcile/change_owners/bundle.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import (
+    Optional,
+)
+
+COMPARISON_BUNDLE = "comparison_bundle"
+TARGET_BUNDLE = "target_bundle"
+
+
+class Bundle(Enum):
+    COMPARISON = "comparison"
+    TARGET = "target"
+
+
+class BundleFileType(Enum):
+    DATAFILE = "datafile"
+    RESOURCEFILE = "resourcefile"
+
+
+@dataclass(frozen=True)
+class FileRef:
+    file_type: BundleFileType
+    path: str
+    schema: Optional[str]
+
+    def __str__(self) -> str:
+        return f"{self.file_type.value}:{self.path}"

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -3,9 +3,11 @@ import sys
 import traceback
 
 from reconcile import queries
+from reconcile.change_owners.bundle import (
+    BundleFileType,
+)
 from reconcile.change_owners.change_types import (
     BundleFileChange,
-    BundleFileType,
     ChangeTypePriority,
     ChangeTypeProcessor,
     create_bundle_file_change,

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -3,9 +3,8 @@ import sys
 import traceback
 
 from reconcile import queries
-from reconcile.change_owners.bundle import (
-    BundleFileType,
-)
+from reconcile.change_owners.approver import GqlApproverResolver
+from reconcile.change_owners.bundle import BundleFileType
 from reconcile.change_owners.change_types import (
     BundleFileChange,
     ChangeTypePriority,
@@ -19,6 +18,9 @@ from reconcile.change_owners.decision import (
     DecisionCommand,
     apply_decisions_to_changes,
     get_approver_decisions_from_mr_comments,
+)
+from reconcile.change_owners.implicit_ownership import (
+    cover_changes_with_implicit_ownership,
 )
 from reconcile.change_owners.self_service_roles import (
     cover_changes_with_self_service_roles,
@@ -61,11 +63,14 @@ def cover_changes(
         roles=roles,
     )
 
-    # ... add more cover_* functions to cover more changes based on dynamic
-    # or static contexts. some ideas:
-    # - users should be able to change certain things in their user file without
-    #   explicit configuration in app-interface
-    # - ...
+    # implicit ownership coverage
+    cover_changes_with_implicit_ownership(
+        bundle_changes=changes,
+        change_type_processors=[
+            ct for ct in change_type_processors if ct.implicit_ownership
+        ],
+        approver_resolver=GqlApproverResolver([comparision_gql_api, gql.get_api()]),
+    )
 
 
 def validate_self_service_role(role: RoleV1) -> None:

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -20,6 +20,10 @@ import jsonpath_ng
 import jsonpath_ng.ext
 import networkx
 
+from reconcile.change_owners.bundle import (
+    BundleFileType,
+    FileRef,
+)
 from reconcile.change_owners.diff import (
     SHA256SUM_FIELD_NAME,
     SHA256SUM_PATH,
@@ -34,11 +38,6 @@ from reconcile.gql_definitions.change_owners.queries.change_types import (
 )
 
 
-class BundleFileType(Enum):
-    DATAFILE = "datafile"
-    RESOURCEFILE = "resourcefile"
-
-
 class ChangeTypePriority(Enum):
     """
     The order of the priorities is important. They are listed in decreasing priority.
@@ -49,17 +48,6 @@ class ChangeTypePriority(Enum):
     HIGH = "high"
     MEDIUM = "medium"
     LOW = "low"
-
-
-@dataclass(frozen=True)
-class FileRef:
-    file_type: BundleFileType
-    path: str
-    schema: Optional[str]
-
-    def __str__(self) -> str:
-        return f"{self.file_type.value}:{self.path}"
-
 
 @dataclass
 class DiffCoverage:

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -34,6 +34,7 @@ from reconcile.change_owners.diff import (
 from reconcile.gql_definitions.change_owners.queries.change_types import (
     ChangeTypeChangeDetectorJsonPathProviderV1,
     ChangeTypeChangeDetectorV1,
+    ChangeTypeImplicitOwnershipV1,
     ChangeTypeV1,
 )
 
@@ -486,6 +487,7 @@ class ChangeTypeProcessor:
     context_type: BundleFileType
     context_schema: Optional[str]
     disabled: bool
+    implicit_ownership: list[ChangeTypeImplicitOwnershipV1]
 
     def __post_init__(self):
         self._expressions_by_file_type_schema: dict[
@@ -550,6 +552,7 @@ def build_change_type_processor(change_type: ChangeTypeV1) -> ChangeTypeProcesso
         context_type=BundleFileType[change_type.context_type.upper()],
         context_schema=change_type.context_schema,
         disabled=bool(change_type.disabled),
+        implicit_ownership=change_type.implicit_ownership or [],
     )
     for change in change_type.changes:
         ctp.add_change(change)

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -20,6 +20,7 @@ import jsonpath_ng
 import jsonpath_ng.ext
 import networkx
 
+from reconcile.change_owners.approver import Approver
 from reconcile.change_owners.bundle import (
     BundleFileType,
     FileRef,
@@ -601,19 +602,6 @@ class ChangeTypeIncompatibleInheritanceError(ValueError):
 
 class ChangeTypeInheritanceCycleError(ValueError):
     pass
-
-
-@dataclass
-class Approver:
-    """
-    Minimalistic wrapper for approver sources to be used in ChangeTypeContexts.
-    Since we might load different approver contexts via GraphQL query classes,
-    a wrapper enables us to deal with different dataclasses representing an
-    approver.
-    """
-
-    org_username: str
-    tag_on_merge_requests: Optional[bool] = False
 
 
 @dataclass

--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -3,10 +3,10 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+from reconcile.change_owners.bundle import FileRef
 from reconcile.change_owners.change_types import (
     BundleFileChange,
     ChangeTypeContext,
-    FileRef,
 )
 from reconcile.change_owners.diff import Diff
 

--- a/reconcile/change_owners/implicit_ownership.py
+++ b/reconcile/change_owners/implicit_ownership.py
@@ -1,0 +1,99 @@
+import logging
+
+import jsonpath_ng.ext
+
+from reconcile.change_owners.approver import ApproverResolver
+from reconcile.change_owners.change_types import (
+    BundleFileChange,
+    ChangeTypeContext,
+    ChangeTypeProcessor,
+)
+from reconcile.gql_definitions.change_owners.queries.change_types import (
+    ChangeTypeImplicitOwnershipJsonPathProviderV1,
+)
+
+
+def cover_changes_with_implicit_ownership(
+    change_type_processors: list[ChangeTypeProcessor],
+    bundle_changes: list[BundleFileChange],
+    approver_resolver: ApproverResolver,
+) -> None:
+    for bc, ctx in change_type_contexts_for_implicit_ownership(
+        change_type_processors=change_type_processors,
+        bundle_changes=bundle_changes,
+        approver_resolver=approver_resolver,
+    ):
+        bc.cover_changes(ctx)
+
+
+def change_type_contexts_for_implicit_ownership(
+    change_type_processors: list[ChangeTypeProcessor],
+    bundle_changes: list[BundleFileChange],
+    approver_resolver: ApproverResolver,
+) -> list[tuple[BundleFileChange, ChangeTypeContext]]:
+    change_type_contexts: list[tuple[BundleFileChange, ChangeTypeContext]] = []
+    processors_with_implicit_ownership = [
+        ctp for ctp in change_type_processors if ctp.implicit_ownership
+    ]
+    for ctp in processors_with_implicit_ownership:
+        for bc in bundle_changes:
+            for context_file_ref in bc.extract_context_file_refs(ctp):
+                for io in ctp.implicit_ownership:
+                    if isinstance(io, ChangeTypeImplicitOwnershipJsonPathProviderV1):
+                        if context_file_ref != bc.fileref:
+                            logging.warning(
+                                f"{io.provider} provider based implicit ownership is not supported for ownership context files that are not the changed file."
+                            )
+                            continue
+                        implicit_owner_refs = (
+                            find_approvers_with_implicit_ownership_jsonpath_selector(
+                                bc=bc,
+                                implicit_ownership=io,
+                            )
+                        )
+                    else:
+                        raise NotImplementedError(
+                            f"unsupported implicit ownership provider: {io}"
+                        )
+                    implicit_approvers = list(
+                        filter(
+                            None,
+                            [
+                                approver_resolver.lookup_approver_by_path(owner_path)
+                                for owner_path in implicit_owner_refs
+                            ],
+                        )
+                    )
+                    if implicit_approvers:
+                        change_type_contexts.append(
+                            (
+                                bc,
+                                ChangeTypeContext(
+                                    change_type_processor=ctp,
+                                    context=f"implicit ownership - { ','.join(a.org_username for a in implicit_approvers ) }",
+                                    approvers=implicit_approvers,
+                                    context_file=context_file_ref,
+                                ),
+                            )
+                        )
+
+    return change_type_contexts
+
+
+def find_approvers_with_implicit_ownership_jsonpath_selector(
+    bc: BundleFileChange,
+    implicit_ownership: ChangeTypeImplicitOwnershipJsonPathProviderV1,
+) -> set[str]:
+
+    context_file_content = bc.old or bc.new
+    if context_file_content is None:
+        # this can't happen. either bc.old or bc.new is set
+        # but to make mypy happy, we need to check for None
+        return set()
+
+    return {
+        owner_ref.value
+        for owner_ref in jsonpath_ng.ext.parse(
+            implicit_ownership.json_path_selector
+        ).find(context_file_content)
+    }

--- a/reconcile/change_owners/self_service_roles.py
+++ b/reconcile/change_owners/self_service_roles.py
@@ -1,9 +1,9 @@
 from collections import defaultdict
 
+from reconcile.change_owners.bundle import BundleFileType
 from reconcile.change_owners.change_types import (
     Approver,
     BundleFileChange,
-    BundleFileType,
     ChangeTypeContext,
     ChangeTypeProcessor,
 )

--- a/reconcile/gql_definitions/change_owners/queries/change_types.gql
+++ b/reconcile/gql_definitions/change_owners/queries/change_types.gql
@@ -19,6 +19,12 @@ query ChangeTypes($name: String) {
         jsonPathSelectors
       }
     }
+    implicitOwnership {
+      provider
+      ... on ChangeTypeImplicitOwnershipJsonPathProvider_v1 {
+        jsonPathSelector
+      }
+    }
     inherit {
       name
     }

--- a/reconcile/gql_definitions/change_owners/queries/change_types.py
+++ b/reconcile/gql_definitions/change_owners/queries/change_types.py
@@ -37,6 +37,12 @@ query ChangeTypes($name: String) {
         jsonPathSelectors
       }
     }
+    implicitOwnership {
+      provider
+      ... on ChangeTypeImplicitOwnershipJsonPathProvider_v1 {
+        jsonPathSelector
+      }
+    }
     inherit {
       name
     }
@@ -74,6 +80,22 @@ class ChangeTypeChangeDetectorJsonPathProviderV1(ChangeTypeChangeDetectorV1):
         extra = Extra.forbid
 
 
+class ChangeTypeImplicitOwnershipV1(BaseModel):
+    provider: str = Field(..., alias="provider")
+
+    class Config:
+        smart_union = True
+        extra = Extra.forbid
+
+
+class ChangeTypeImplicitOwnershipJsonPathProviderV1(ChangeTypeImplicitOwnershipV1):
+    json_path_selector: str = Field(..., alias="jsonPathSelector")
+
+    class Config:
+        smart_union = True
+        extra = Extra.forbid
+
+
 class ChangeTypeV1_ChangeTypeV1(BaseModel):
     name: str = Field(..., alias="name")
 
@@ -92,6 +114,14 @@ class ChangeTypeV1(BaseModel):
     changes: list[
         Union[ChangeTypeChangeDetectorJsonPathProviderV1, ChangeTypeChangeDetectorV1]
     ] = Field(..., alias="changes")
+    implicit_ownership: Optional[
+        list[
+            Union[
+                ChangeTypeImplicitOwnershipJsonPathProviderV1,
+                ChangeTypeImplicitOwnershipV1,
+            ]
+        ]
+    ] = Field(..., alias="implicitOwnership")
     inherit: Optional[list[ChangeTypeV1_ChangeTypeV1]] = Field(..., alias="inherit")
 
     class Config:

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -2299,6 +2299,37 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "pgp_reencrypt_settings_v1",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "path",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "PgpReencryptSettings_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -9250,6 +9281,22 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "initialVersion",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "workload",
                             "description": null,
                             "args": [],
@@ -9261,6 +9308,18 @@
                                     "name": "String",
                                     "ofType": null
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "channel",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -11110,6 +11169,26 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "implicitOwnership",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "INTERFACE",
+                                        "name": "ChangeTypeImplicitOwnership_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -11212,6 +11291,39 @@
                     "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
+                },
+                {
+                    "kind": "INTERFACE",
+                    "name": "ChangeTypeImplicitOwnership_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "provider",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": [
+                        {
+                            "kind": "OBJECT",
+                            "name": "ChangeTypeImplicitOwnershipJsonPathProvider_v1",
+                            "ofType": null
+                        }
+                    ]
                 },
                 {
                     "kind": "OBJECT",
@@ -22209,7 +22321,7 @@
                             "args": [],
                             "type": {
                                 "kind": "SCALAR",
-                                "name": "Int",
+                                "name": "String",
                                 "ofType": null
                             },
                             "isDeprecated": false,
@@ -24265,6 +24377,117 @@
                                 "kind": "SCALAR",
                                 "name": "String",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "PgpReencryptSettings_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "public_gpg_key",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "private_pgp_key_vault_path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "reencrypt_vault_path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "aws_account_output_vault_path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "skip_aws_accounts",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "AWSAccount_v1",
+                                        "ofType": null
+                                    }
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -36250,6 +36473,55 @@
                     ],
                     "inputFields": null,
                     "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "ChangeTypeImplicitOwnershipJsonPathProvider_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "provider",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "jsonPathSelector",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "ChangeTypeImplicitOwnership_v1",
+                            "ofType": null
+                        }
+                    ],
                     "enumValues": null,
                     "possibleTypes": null
                 },

--- a/reconcile/test/change_owners/fixtures.py
+++ b/reconcile/test/change_owners/fixtures.py
@@ -15,6 +15,8 @@ from reconcile.change_owners.bundle import (
 )
 from reconcile.change_owners.change_types import (
     BundleFileChange,
+    ChangeTypeProcessor,
+    build_change_type_processor,
     create_bundle_file_change,
 )
 from reconcile.gql_definitions.change_owners.queries import self_service_roles
@@ -66,6 +68,19 @@ class TestFile:
         )
         assert bundle_file_change
         return bundle_file_change
+
+
+def build_test_datafile(
+    content: dict[str, Any],
+    filepath: Optional[str] = None,
+    schema: Optional[str] = None,
+) -> TestFile:
+    return TestFile(
+        filepath=filepath or "datafile.yaml",
+        fileschema=schema or "schema-1.yml",
+        filetype=BundleFileType.DATAFILE.value,
+        content=content,
+    )
 
 
 def build_role(
@@ -166,4 +181,30 @@ def build_jsonpath_change(
         changeSchema=schema,
         jsonPathSelectors=selectors,
         context=context,
+    )
+
+
+def build_change_type(
+    name: str,
+    change_selectors: list[str],
+    change_schema: Optional[str] = None,
+    context_schema: Optional[str] = None,
+) -> ChangeTypeProcessor:
+    return build_change_type_processor(
+        ChangeTypeV1(
+            name=name,
+            description=name,
+            contextType=BundleFileType.DATAFILE.value,
+            contextSchema=context_schema,
+            changes=[
+                build_jsonpath_change(
+                    schema=change_schema,
+                    selectors=change_selectors,
+                )
+            ],
+            disabled=False,
+            priority="urgent",
+            inherit=[],
+            implicitOwnership=[],
+        )
     )

--- a/reconcile/test/change_owners/fixtures.py
+++ b/reconcile/test/change_owners/fixtures.py
@@ -9,10 +9,12 @@ import jsonpath_ng
 import jsonpath_ng.ext
 import pytest
 
-from reconcile.change_owners.change_types import (
-    BundleFileChange,
+from reconcile.change_owners.bundle import (
     BundleFileType,
     FileRef,
+)
+from reconcile.change_owners.change_types import (
+    BundleFileChange,
     create_bundle_file_change,
 )
 from reconcile.gql_definitions.change_owners.queries import self_service_roles

--- a/reconcile/test/change_owners/test_change_type_context.py
+++ b/reconcile/test/change_owners/test_change_type_context.py
@@ -1,6 +1,8 @@
-from reconcile.change_owners.change_types import (
+from reconcile.change_owners.bundle import (
     BundleFileType,
     FileRef,
+)
+from reconcile.change_owners.change_types import (
     build_change_type_processor,
     create_bundle_file_change,
 )

--- a/reconcile/test/change_owners/test_change_type_coverage.py
+++ b/reconcile/test/change_owners/test_change_type_coverage.py
@@ -1,8 +1,8 @@
 import jsonpath_ng
 
+from reconcile.change_owners.bundle import BundleFileType
 from reconcile.change_owners.change_types import (
     Approver,
-    BundleFileType,
     ChangeTypeContext,
     DiffCoverage,
     build_change_type_processor,

--- a/reconcile/test/change_owners/test_change_type_decision.py
+++ b/reconcile/test/change_owners/test_change_type_decision.py
@@ -1,8 +1,8 @@
 import pytest
 
+from reconcile.change_owners.bundle import BundleFileType
 from reconcile.change_owners.change_types import (
     Approver,
-    BundleFileType,
     ChangeTypeContext,
     build_change_type_processor,
     create_bundle_file_change,

--- a/reconcile/test/change_owners/test_change_type_diff.py
+++ b/reconcile/test/change_owners/test_change_type_diff.py
@@ -2,8 +2,8 @@ import jsonpath_ng
 import jsonpath_ng.ext
 import pytest
 
+from reconcile.change_owners.bundle import BundleFileType
 from reconcile.change_owners.change_types import (
-    BundleFileType,
     DiffCoverage,
     create_bundle_file_change,
 )

--- a/reconcile/test/change_owners/test_change_type_diff_splitting.py
+++ b/reconcile/test/change_owners/test_change_type_diff_splitting.py
@@ -4,34 +4,10 @@ from reconcile.change_owners.bundle import (
 )
 from reconcile.change_owners.change_types import (
     ChangeTypeContext,
-    ChangeTypeProcessor,
-    build_change_type_processor,
     create_bundle_file_change,
 )
 from reconcile.change_owners.diff import DiffType
-from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
-from reconcile.test.change_owners.fixtures import build_jsonpath_change
-
-
-def build_change_type(name: str, change_selectors: list[str]) -> ChangeTypeProcessor:
-    return build_change_type_processor(
-        ChangeTypeV1(
-            name=name,
-            description=name,
-            contextType=BundleFileType.DATAFILE.value,
-            contextSchema=None,
-            changes=[
-                build_jsonpath_change(
-                    schema=None,
-                    selectors=change_selectors,
-                )
-            ],
-            disabled=False,
-            priority="urgent",
-            inherit=[],
-            implicitOwnership=[],
-        )
-    )
+from reconcile.test.change_owners.fixtures import build_change_type
 
 
 def test_root_diff_fully_covered_by_splits():

--- a/reconcile/test/change_owners/test_change_type_diff_splitting.py
+++ b/reconcile/test/change_owners/test_change_type_diff_splitting.py
@@ -1,8 +1,10 @@
-from reconcile.change_owners.change_types import (
+from reconcile.change_owners.bundle import (
     BundleFileType,
+    FileRef,
+)
+from reconcile.change_owners.change_types import (
     ChangeTypeContext,
     ChangeTypeProcessor,
-    FileRef,
     build_change_type_processor,
     create_bundle_file_change,
 )

--- a/reconcile/test/change_owners/test_change_type_diff_splitting.py
+++ b/reconcile/test/change_owners/test_change_type_diff_splitting.py
@@ -29,6 +29,7 @@ def build_change_type(name: str, change_selectors: list[str]) -> ChangeTypeProce
             disabled=False,
             priority="urgent",
             inherit=[],
+            implicitOwnership=[],
         )
     )
 

--- a/reconcile/test/change_owners/test_change_type_implicit_ownership.py
+++ b/reconcile/test/change_owners/test_change_type_implicit_ownership.py
@@ -1,0 +1,231 @@
+from typing import Optional
+
+import pytest
+
+from reconcile.change_owners.approver import Approver
+from reconcile.change_owners.bundle import (
+    BundleFileType,
+    FileRef,
+)
+from reconcile.change_owners.change_types import (
+    BundleFileChange,
+    ChangeTypeProcessor,
+)
+from reconcile.change_owners.implicit_ownership import (
+    change_type_contexts_for_implicit_ownership,
+    find_approvers_with_implicit_ownership_jsonpath_selector,
+)
+from reconcile.gql_definitions.change_owners.queries.change_types import (
+    ChangeTypeChangeDetectorContextSelectorV1,
+    ChangeTypeImplicitOwnershipJsonPathProviderV1,
+    ChangeTypeImplicitOwnershipV1,
+)
+from reconcile.test.change_owners.fixtures import (
+    build_change_type,
+    build_test_datafile,
+)
+
+pytest_plugins = [
+    "reconcile.test.change_owners.fixtures",
+]
+
+
+#
+# test finding implicit approver in bundle change
+#
+
+
+def test_find_implict_single_approver_with_jsonpath():
+    bc = BundleFileChange(
+        fileref=FileRef(
+            file_type=BundleFileType.DATAFILE,
+            path="/file.yml",
+            schema="some-schema",
+        ),
+        old=None,
+        new={"approver": "/user/approver.yml"},
+        diffs=[],
+    )
+    approver = find_approvers_with_implicit_ownership_jsonpath_selector(
+        bc=bc,
+        implicit_ownership=ChangeTypeImplicitOwnershipJsonPathProviderV1(
+            provider="jsonPath",
+            jsonPathSelector="$.approver",
+        ),
+    )
+
+    assert approver == {"/user/approver.yml"}
+
+
+def test_find_implict_multiple_approvers_with_jsonpath():
+    bc = BundleFileChange(
+        fileref=FileRef(
+            file_type=BundleFileType.DATAFILE,
+            path="/file.yml",
+            schema="some-schema",
+        ),
+        old=None,
+        new={"approvers": ["/user/approver-1.yml", "/user/approver-2.yml"]},
+        diffs=[],
+    )
+    approvers = find_approvers_with_implicit_ownership_jsonpath_selector(
+        bc=bc,
+        implicit_ownership=ChangeTypeImplicitOwnershipJsonPathProviderV1(
+            provider="jsonPath",
+            jsonPathSelector="$.approvers[*]",
+        ),
+    )
+
+    assert approvers == {"/user/approver-1.yml", "/user/approver-2.yml"}
+
+
+def test_find_implict_approver_with_jsonpath_no_data():
+    """
+    in this test, no approvers should be found because no data is provided
+    """
+    bc = BundleFileChange(
+        fileref=FileRef(
+            file_type=BundleFileType.DATAFILE,
+            path="/file.yml",
+            schema="some-schema",
+        ),
+        old=None,
+        new=None,
+        diffs=[],
+    )
+    approver = find_approvers_with_implicit_ownership_jsonpath_selector(
+        bc=bc,
+        implicit_ownership=ChangeTypeImplicitOwnershipJsonPathProviderV1(
+            provider="jsonPath",
+            jsonPathSelector="$.approver",
+        ),
+    )
+
+    assert not approver
+
+
+#
+# test finding change type contexts for implicit ownership
+#
+
+
+class MockApproverResolver:
+    def __init__(self, approvers: dict[str, Approver]):
+        self.approvers = approvers
+
+    def lookup_approver_by_path(self, path: str) -> Optional[Approver]:
+        return self.approvers.get(path)
+
+
+@pytest.fixture
+def change_type() -> ChangeTypeProcessor:
+    ct = build_change_type("change-type", [], context_schema="schame-1.yml")
+    ct.implicit_ownership = [
+        ChangeTypeImplicitOwnershipJsonPathProviderV1(
+            provider="jsonPath",
+            jsonPathSelector="$.approver",
+        )
+    ]
+    return ct
+
+
+def test_find_implict_change_type_context_jsonpath_provider(
+    change_type: ChangeTypeProcessor,
+):
+    approver_path = "/user/approver.yml"
+    approver = Approver("approver", False)
+
+    bc = build_test_datafile(
+        filepath="file.yml",
+        schema=change_type.context_schema,
+        content={"some": "data", "approver": approver_path},
+    ).create_bundle_change(jsonpath_patches={"$.some": "new-data"})
+
+    result = change_type_contexts_for_implicit_ownership(
+        change_type_processors=[change_type],
+        bundle_changes=[bc],
+        approver_resolver=MockApproverResolver(approvers={approver_path: approver}),
+    )
+
+    assert result[0][0] == bc
+
+    ctx = result[0][1]
+
+    assert ctx.approvers == [approver]
+    assert ctx.change_type_processor.name == change_type.name
+    assert ctx.context_file == bc.fileref
+
+
+def test_find_implict_change_type_context_jsonpath_provider_invalid_context_file(
+    change_type: ChangeTypeProcessor,
+):
+    """
+    the jsonpath provider for implicit ownership only supports change-types
+    that don't try to find the ownership context in a datafile different from
+    the one that contains the changes to cover.
+    this test makes sure we handle that correctly at the level of extracting the
+    approvers from the changed file.
+    note: there is another test about validating change-types so that such a
+    situation is already prevented at the level of loading the change-types, hence
+    failing the PR check that would introduce such a change-type.
+    """
+
+    approver_path = "/user/approver.yml"
+    approver = Approver("approver", False)
+    change_schema = "change-schema-1.yml"
+
+    change_type.changes[0].change_schema = change_schema
+    change_type.changes[0].context = ChangeTypeChangeDetectorContextSelectorV1(
+        selector="$.approver", when=None
+    )
+
+    bc = build_test_datafile(
+        filepath="file.yml",
+        schema=change_schema,
+        content={"some": "data", "approver": approver_path},
+    ).create_bundle_change(jsonpath_patches={"$.some": "new-data"})
+
+    assert not change_type_contexts_for_implicit_ownership(
+        change_type_processors=[change_type],
+        bundle_changes=[bc],
+        approver_resolver=MockApproverResolver(approvers={approver_path: approver}),
+    )
+
+
+def test_find_implict_change_type_context_unknown_provider(
+    change_type: ChangeTypeProcessor,
+):
+    change_type.implicit_ownership = [
+        ChangeTypeImplicitOwnershipV1(
+            provider="unknown-provider",
+        )
+    ]
+
+    bc = build_test_datafile(
+        filepath="file.yml",
+        schema=change_type.context_schema,
+        content={"some": "data", "approver": "/user/approver.yml"},
+    ).create_bundle_change(jsonpath_patches={"$.some": "new-data"})
+
+    with pytest.raises(NotImplementedError):
+        change_type_contexts_for_implicit_ownership(
+            change_type_processors=[change_type],
+            bundle_changes=[bc],
+            approver_resolver=MockApproverResolver(approvers={}),
+        )
+
+
+def test_find_implict_change_type_context_jsonpath_provider_unresolvable_approvers(
+    change_type: ChangeTypeProcessor,
+):
+    bc = build_test_datafile(
+        filepath="file.yml",
+        schema=change_type.context_schema,
+        content={"some": "data", "approver": "/user/approver.yml"},
+    ).create_bundle_change(jsonpath_patches={"$.some": "new-data"})
+
+    assert not change_type_contexts_for_implicit_ownership(
+        change_type_processors=[change_type],
+        bundle_changes=[bc],
+        approver_resolver=MockApproverResolver(approvers={}),
+    )

--- a/reconcile/test/change_owners/test_change_type_inheritance.py
+++ b/reconcile/test/change_owners/test_change_type_inheritance.py
@@ -3,8 +3,8 @@ from typing import Optional
 
 import pytest
 
+from reconcile.change_owners.bundle import BundleFileType
 from reconcile.change_owners.change_types import (
-    BundleFileType,
     ChangeTypeIncompatibleInheritanceError,
     ChangeTypeInheritanceCycleError,
     ChangeTypePriority,
@@ -35,6 +35,7 @@ def build_def_change_type(
             )
         ],
         inherit=[ChangeTypeV1_ChangeTypeV1(name=i) for i in inherit or []],
+        implicitOwnership=[],
     )
 
 

--- a/reconcile/test/change_owners/test_change_type_various.py
+++ b/reconcile/test/change_owners/test_change_type_various.py
@@ -1,11 +1,13 @@
 import pytest
 import yaml
 
+from reconcile.change_owners.bundle import (
+    BundleFileType,
+    FileRef,
+)
 from reconcile.change_owners.change_owners import manage_conditional_label
 from reconcile.change_owners.change_types import (
-    BundleFileType,
     ChangeTypeContext,
-    FileRef,
     PathExpression,
     parse_resource_file_content,
 )

--- a/reconcile/test/fixtures/change_owners/changetype_cluster_owner.yml
+++ b/reconcile/test/fixtures/change_owners/changetype_cluster_owner.yml
@@ -7,6 +7,7 @@ contextSchema: /openshift/cluster-1.yml
 disabled: false
 
 inherit: null
+implicitOwnership: null
 
 priority: high
 

--- a/reconcile/test/fixtures/change_owners/changetype_role_member.yaml
+++ b/reconcile/test/fixtures/change_owners/changetype_role_member.yaml
@@ -8,6 +8,7 @@ contextSchema: /access/role-1.yml
 disabled: false
 
 inherit: null
+implicitOwnership: null
 
 priority: high
 

--- a/reconcile/test/fixtures/change_owners/changetype_saas_file.yaml
+++ b/reconcile/test/fixtures/change_owners/changetype_saas_file.yaml
@@ -7,6 +7,7 @@ contextSchema: /app-sre/saas-file-2.yml
 disabled: false
 
 inherit: null
+implicitOwnership: null
 
 priority: high
 

--- a/reconcile/test/fixtures/change_owners/changetype_secret_promoter.yaml
+++ b/reconcile/test/fixtures/change_owners/changetype_secret_promoter.yaml
@@ -7,6 +7,7 @@ contextSchema: /openshift/namespace-1.yml
 disabled: false
 
 inherit: null
+implicitOwnership: null
 
 priority: high
 


### PR DESCRIPTION
For certain changes, the natural approvers can be found in the datafiles themselves and would not require explicit ownership via roles. To reduce the need for such explicit ownership, we can make change-types implicitly applicable on changes.

# Example

The following example enables users to approve updates on their `public_gpg_key`s. The `jsonPathSelector` is the mechanism to find a reference to an approver, either a `/access/user-1.yml` or `/access/bot-1.yml` object. In this example the selector is `$.path` which finds the approver in the changed file itself.

```yaml
$schema: /app-interface/change-type-1.yml
...
contextSchema: /access/user-1.yml
changes:
- public_gpg_key

implicitOwnership:
- provider: jsonPath
  jsonPathSelector: $.path
```

# How to review

the only commit introducing actual changes is https://github.com/app-sre/qontract-reconcile/pull/3075/commits/0b450a672f08e4732f0b668a5d07bc4e7c417ea6 - all the others are neutral refactors or tests

https://issues.redhat.com/browse/APPSRE-6629

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>