### PR TITLE
use skupper to access internal integrations prometheus

### DIFF
--- a/grafana-dashboards/grafana-dashboard-integrations.configmap.yaml
+++ b/grafana-dashboards/grafana-dashboard-integrations.configmap.yaml
@@ -933,8 +933,8 @@ data:
           {
             "current": {
               "selected": true,
-              "text": "app-sre-prod-01-prometheus",
-              "value": "app-sre-prod-01-prometheus"
+              "text": "appsrep05ue1-prometheus-skupper",
+              "value": "appsrep05ue1-prometheus-skupper"
             },
             "hide": 0,
             "includeAll": false,
@@ -944,7 +944,7 @@ data:
             "query": "prometheus",
             "queryValue": "",
             "refresh": 1,
-            "regex": "/app-sre-prod-01-prometheus/",
+            "regex": "/appsrep05ue1-prometheus/",
             "skipUrlSync": false,
             "type": "datasource"
           }


### PR DESCRIPTION
Grafana is on a public cluster while integrations run on an internal cluster. We can use skupper to access metrics.