### PR TITLE
fix ocm cluster upgrade-policy deletion

### DIFF
--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -57,9 +57,10 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
                 ]
                 if not found:
                     continue
-                upgrade_policy_clusters = [
+                content["upgradePolicyClusters"] = [
                     c for c in upgrade_policy_clusters if c["name"] != cluster_name
                 ]
+                upgrade_policy_clusters = content["upgradePolicyClusters"]
                 changes = True
             else:
                 raise NotImplementedError(action)


### PR DESCRIPTION
Setting `upgrade_policy_clusters` was not actually deleting items from the initial `upgradePolicyClusters` list.