### PR TITLE
Add DCV validation_records output to terraform-cloudflare-resources

### DIFF
--- a/reconcile/test/test_utils_terrascript_cloudflare_client.py
+++ b/reconcile/test/test_utils_terrascript_cloudflare_client.py
@@ -184,6 +184,11 @@ def test_create_cloudflare_resources_terraform_json(account_config, backend_conf
                 }
             },
         },
+        "output": {
+            "domain-com-zone__validation_records": {
+                "value": "${{ for value in cloudflare_certificate_pack.some-cert.validation_records: value.txt_name => value.txt_value }}"
+            }
+        },
     }
 
     assert json.loads(cloudflare_client.dumps()) == expected_dict

--- a/reconcile/utils/terrascript/cloudflare_resources.py
+++ b/reconcile/utils/terrascript/cloudflare_resources.py
@@ -124,8 +124,17 @@ class CloudflareZoneTerrascriptResource(TerrascriptResource):
                 "depends_on": self._get_dependencies([zone]),
                 **cert_values,
             }
+
+            cert_pack = cloudflare_certificate_pack(identifier, **zone_cert_values)
+
+            resources.append(cert_pack)
+
+            output_name = f"{self._spec.output_prefix}__validation_records"
             resources.append(
-                cloudflare_certificate_pack(identifier, **zone_cert_values)
+                Output(
+                    output_name,
+                    value=f"${{{{ for value in {cert_pack.validation_records}: value.txt_name => value.txt_value }}}}",
+                )
             )
 
         return resources


### PR DESCRIPTION
The terraform-cloudflare-resources integration is responsible for creating certificate packs (automatic renewing Let's Encrypt certificate), but the integration doesn't create the DNS records required for validation. This change will make these records available as an output so that another integration can be responsible for creating the DNS records.

Related: [APPSRE-6695](https://issues.redhat.com/browse/APPSRE-6695)

I'm still working through which integration would consume this, so leaving this in draft status for now.

## Testing

### Terraform plan

The `terraform plan` produces the expected outputs:

```
Changes to Outputs:
  + cloudflare-<account_name>-zone__validation_records = {
      + _acme-challenge.somedomain.local = "<TXT record value>"
      + _acme-challenge.subdomain.somedomain.local       = "<TXT record value>"
    }
```

### Running integration

Running the integration correctly identifies a change to the output:

```
[2022-12-19 13:56:30] [INFO] [terraform_client.py:log_plan_diff:247] - ['update', '<account>', 'output', 'cloudflare-<account>-zone__validation_records']
```