### PR TITLE
Fluentd buffering for GChat

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -168,6 +168,19 @@ objects:
                 @type teams
                 webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=${POD_NAME}"
                 text "<%= Time.at(time) %> [${POD_NAME}] <%= record['message'] %>\n\n"
+                buffered true
+                <buffer>
+                  @type file
+                  path /fluentd/buffer
+
+                  flush_mode interval
+                  flush_interval 15s
+                  flush_at_shutdown true
+
+                  retry_max_times 3
+
+                  disable_chunk_backup true
+                </buffer>
               </store>
               {{- end }}
               <store>
@@ -391,6 +404,10 @@ objects:
             mountPath: /fluentd/log/
           - name: fluentd-config
             mountPath: /fluentd/etc/
+          {{- if $logs.googleChat }}
+          - name: buffer
+            mountPath: /fluentd/buffer
+          {{- end }}
         volumes:
         - name: qontract-reconcile-toml
           secret:
@@ -399,6 +416,10 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
+        {{- if $logs.googleChat }}
+        - name: buffer
+          emptyDir: {}
+        {{- end }}
         {{- if $integration.internalCertificates }}
         - name: internal-certificates
           emptyDir: {}

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -91,6 +91,19 @@ objects:
                 @type teams
                 webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=${POD_NAME}"
                 text "<%= Time.at(time) %> [${POD_NAME}] <%= record['message'] %>\n\n"
+                buffered true
+                <buffer>
+                  @type file
+                  path /fluentd/buffer
+
+                  flush_mode interval
+                  flush_interval 15s
+                  flush_at_shutdown true
+
+                  retry_max_times 3
+
+                  disable_chunk_backup true
+                </buffer>
               </store>
               <store>
                 @type cloudwatch_logs
@@ -205,6 +218,8 @@ objects:
             mountPath: /fluentd/log/
           - name: fluentd-config
             mountPath: /fluentd/etc/
+          - name: buffer
+            mountPath: /fluentd/buffer
         volumes:
         - name: qontract-reconcile-toml
           secret:
@@ -212,6 +227,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: buffer
           emptyDir: {}
 parameters:
 - name: IMAGE

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -91,6 +91,19 @@ objects:
                 @type teams
                 webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=${POD_NAME}"
                 text "<%= Time.at(time) %> [${POD_NAME}] <%= record['message'] %>\n\n"
+                buffered true
+                <buffer>
+                  @type file
+                  path /fluentd/buffer
+
+                  flush_mode interval
+                  flush_interval 15s
+                  flush_at_shutdown true
+
+                  retry_max_times 3
+
+                  disable_chunk_backup true
+                </buffer>
               </store>
               <store>
                 @type cloudwatch_logs
@@ -191,6 +204,8 @@ objects:
             mountPath: /fluentd/log/
           - name: fluentd-config
             mountPath: /fluentd/etc/
+          - name: buffer
+            mountPath: /fluentd/buffer
         volumes:
         - name: qontract-reconcile-toml
           secret:
@@ -198,6 +213,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: buffer
           emptyDir: {}
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION
[APPSRE-6696](https://issues.redhat.com/browse/APPSRE-6696)

Fluentd in FedRamp often runs into rate-limiting 429 errors when trying to post logs to Google Chat. This MR adds [buffering](https://docs.fluentd.org/configuration/buffer-section) to a file with Fluentd, meaning that a buffer volume will be created and logs will be written to there prior to being posted to GChat. Every 15 seconds these buffers will be emptied and the messages will be posted. 

Retry logic will allow Fluentd to retry posting logs if it runs into rate limits.