### PR TITLE
Fix missing path excpt in q-cli template command

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1659,7 +1659,7 @@ def template(ctx, cluster, namespace, kind, name, path, secret_reader):
     settings = queries.get_app_interface_settings()
     settings["vault"] = secret_reader == "vault"
 
-    if path.startswith("resources"):
+    if path and path.startswith("resources"):
         path = path.replace("resources", "", 1)
 
     [namespace_info] = namespace_info


### PR DESCRIPTION
Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>