### PR TITLE
qontract-cli/get/clusters-egress-ips aws no init users

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -665,7 +665,7 @@ def clusters_egress_ips(ctx):
         if not account:
             continue
         account["resourcesDefaultRegion"] = management_account["resourcesDefaultRegion"]
-        aws_api = AWSApi(1, [account], settings=settings)
+        aws_api = AWSApi(1, [account], settings=settings, init_users=False)
         egress_ips = aws_api.get_cluster_nat_gateways_egress_ips(account)
         item = {"cluster": cluster_name, "egress_ips": ", ".join(sorted(egress_ips))}
         results.append(item)


### PR DESCRIPTION
https://redhat.pagerduty.com/incidents/Q3PTYHHQPPS51L

```
Traceback (most recent call last):
  File "/usr/local/bin/qontract-cli", line 8, in <module>
    sys.exit(root())
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/tools/qontract_cli.py", line 668, in clusters_egress_ips
    aws_api = AWSApi(1, [account], settings=settings)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/aws_api.py", line 127, in __init__
    self.init_users()
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/aws_api.py", line 216, in init_users
    users = self.paginate(iam, "list_users", "Users")
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/aws_api.py", line 339, in paginate
    return [
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/aws_api.py", line 339, in <listcomp>
    return [
  File "/usr/local/lib/python3.9/site-packages/botocore/paginate.py", line 255, in __iter__
    response = self._make_request(current_kwargs)
  File "/usr/local/lib/python3.9/site-packages/botocore/paginate.py", line 332, in _make_request
    return self._method(**current_kwargs)
  File "/usr/local/lib/python3.9/site-packages/botocore/client.py", line 386, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.9/site-packages/botocore/client.py", line 705, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (Throttling) when calling the ListUsers operation (reached max retries: 4): Rate exceeded
```