### PR TITLE
Adjust GChat Rate Limit Settings 

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -177,7 +177,8 @@ objects:
                   flush_interval 15s
                   flush_at_shutdown true
 
-                  retry_max_times 3
+                  retry_max_times 5
+                  retry_wait 30
 
                   disable_chunk_backup true
                 </buffer>

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -100,7 +100,8 @@ objects:
                   flush_interval 15s
                   flush_at_shutdown true
 
-                  retry_max_times 3
+                  retry_max_times 5
+                  retry_wait 30
 
                   disable_chunk_backup true
                 </buffer>

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -100,7 +100,8 @@ objects:
                   flush_interval 15s
                   flush_at_shutdown true
 
-                  retry_max_times 3
+                  retry_max_times 5
+                  retry_wait 30
 
                   disable_chunk_backup true
                 </buffer>


### PR DESCRIPTION
Related to #3085. After monitoring the changes in FedRamp over the past week, noticed that sometimes chunks don't get correctly sent and are dropped. 

This change updates buffering settings to set a default wait time of 30 seconds before a retry and then increase the max number of retries to 5 to decrease the likelihood that chunks are dropped.

See https://docs.fluentd.org/configuration/buffer-section for documentation.

Current errors:
```
2022-12-26 11:33:59 +0000 [warn]: #0 buffer flush took longer time than slow_flush_log_threshold: elapsed_time=81.73582330183126 slow_flush_log_threshold=20.0 plugin_id="object:c2d8"
2022-12-27 09:12:50 +0000 [warn]: #0 failed to flush the buffer. retry_times=0 next_retry_time=2022-12-27 09:12:51 +0000 chunk="5f0cba6ec3cd3fc6354c1ff5f47ee147" error_class=RestClient::TooManyRequests error="429 Too Many Requests"
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/rest-client-2.1.0/lib/restclient/abstract_response.rb:249:in `exception_with_response'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/rest-client-2.1.0/lib/restclient/abstract_response.rb:129:in `return!'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/rest-client-2.1.0/lib/restclient/request.rb:836:in `process_result'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/rest-client-2.1.0/lib/restclient/request.rb:743:in `block in transmit'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/3.1.0/net/http.rb:966:in `start'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/rest-client-2.1.0/lib/restclient/request.rb:727:in `transmit'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/rest-client-2.1.0/lib/restclient/request.rb:163:in `execute'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/rest-client-2.1.0/lib/restclient/request.rb:63:in `execute'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/rest-client-2.1.0/lib/restclient.rb:70:in `post'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/fluent-plugin-teams-1.1.0/lib/fluent/plugin/out_teams.rb:68:in `post_message'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/fluent-plugin-teams-1.1.0/lib/fluent/plugin/out_teams.rb:62:in `block in write'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/fluentd-1.15.2/lib/fluent/event.rb:315:in `each'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/fluentd-1.15.2/lib/fluent/event.rb:315:in `block in each'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/fluentd-1.15.2/lib/fluent/plugin/buffer/file_chunk.rb:171:in `open'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/fluentd-1.15.2/lib/fluent/event.rb:314:in `each'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/fluent-plugin-teams-1.1.0/lib/fluent/plugin/out_teams.rb:61:in `write'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/fluentd-1.15.2/lib/fluent/plugin/output.rb:1180:in `try_flush'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/fluentd-1.15.2/lib/fluent/plugin/output.rb:1501:in `flush_thread_run'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/fluentd-1.15.2/lib/fluent/plugin/output.rb:501:in `block (2 levels) in start'
  2022-12-27 09:12:50 +0000 [warn]: #0 /usr/lib/ruby/gems/3.1.0/gems/fluentd-1.15.2/lib/fluent/plugin_helper/thread.rb:78:in `block in thread_create'
2022-12-27 09:12:52 +0000 [warn]: #0 failed to flush the buffer. retry_times=1 next_retry_time=2022-12-27 09:12:54 +0000 chunk="5f0cba6ec3cd3fc6354c1ff5f47ee147" error_class=RestClient::TooManyRequests error="429 Too Many Requests"
  2022-12-27 09:12:52 +0000 [warn]: #0 suppressed same stacktrace
2022-12-27 09:12:55 +0000 [warn]: #0 failed to flush the buffer. retry_times=2 next_retry_time=2022-12-27 09:12:59 +0000 chunk="5f0cba6ec3cd3fc6354c1ff5f47ee147" error_class=RestClient::TooManyRequests error="429 Too Many Requests"
  2022-12-27 09:12:55 +0000 [warn]: #0 suppressed same stacktrace
2022-12-27 09:13:00 +0000 [error]: #0 Hit limit for retries. dropping all chunks in the buffer queue. retry_times=3 records=8 error_class=RestClient::TooManyRequests error="429 Too Many Requests"
  2022-12-27 09:13:00 +0000 [error]: #0 suppressed same stacktrace
2022-12-27 09:32:56 +0000 [warn]: #0 failed to flush the buffer. retry_times=0 next_retry_time=2022-12-27 09:32:57 +0000 chunk="5f0cbeece56256f9c3b67b4baeeb0f0f" error_class=RestClient::TooManyRequests error="429 Too Many Requests"
  2022-12-27 09:32:56 +0000 [warn]: #0 suppressed same stacktrace
2022-12-27 09:32:57 +0000 [warn]: #0 failed to flush the buffer. retry_times=1 next_retry_time=2022-12-27 09:33:00 +0000 chunk="5f0cbeece56256f9c3b67b4baeeb0f0f" error_class=RestClient::TooManyRequests error="429 Too Many Requests"
  2022-12-27 09:32:57 +0000 [warn]: #0 suppressed same stacktrace
2022-12-27 09:33:00 +0000 [warn]: #0 failed to flush the buffer. retry_times=2 next_retry_time=2022-12-27 09:33:05 +0000 chunk="5f0cbeece56256f9c3b67b4baeeb0f0f" error_class=RestClient::TooManyRequests error="429 Too Many Requests"
  2022-12-27 09:33:00 +0000 [warn]: #0 suppressed same stacktrace
2022-12-27 09:33:06 +0000 [error]: #0 Hit limit for retries. dropping all chunks in the buffer queue. retry_times=3 records=8 error_class=RestClient::TooManyRequests error="429 Too Many Requests"
  2022-12-27 09:33:06 +0000 [error]: #0 suppressed same stacktrace
```