### PR TITLE
[ocm-addons-upgrade-tests-trigger] introduce new integration

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1848,6 +1848,14 @@ def ocm_cluster_admin(ctx):
     run_integration(reconcile.ocm_cluster_admin, ctx.obj)
 
 
+@integration.command(short_help="Trigger jenkins jobs following Addon upgrades.")
+@click.pass_context
+def ocm_addons_upgrade_tests_trigger(ctx):
+    import reconcile.ocm_addons_upgrade_tests_trigger
+
+    run_integration(reconcile.ocm_addons_upgrade_tests_trigger, ctx.obj)
+
+
 @integration.command(short_help="Manage Machine Pools in OCM.")
 @threaded()
 @click.pass_context

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1849,6 +1849,7 @@ def ocm_cluster_admin(ctx):
 
 
 @integration.command(short_help="Trigger jenkins jobs following Addon upgrades.")
+@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def ocm_addons_upgrade_tests_trigger(ctx):
     import reconcile.ocm_addons_upgrade_tests_trigger

--- a/reconcile/ocm_addons_upgrade_tests_trigger.py
+++ b/reconcile/ocm_addons_upgrade_tests_trigger.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Optional
+
 from reconcile import queries
 from reconcile.utils.jenkins_api import JenkinsApi
 from reconcile.utils.ocm import OCMMap

--- a/reconcile/ocm_addons_upgrade_tests_trigger.py
+++ b/reconcile/ocm_addons_upgrade_tests_trigger.py
@@ -1,13 +1,24 @@
+import logging
+from typing import Optional
 from reconcile import queries
+from reconcile.utils.jenkins_api import JenkinsApi
 from reconcile.utils.ocm import OCMMap
+from reconcile.utils.secret_reader import SecretReader
+from reconcile.utils.state import State
 
 QONTRACT_INTEGRATION = "ocm-addons-upgrade-tests-trigger"
 
 
-def run(dry_run):
+def run(dry_run: bool) -> None:
     settings = queries.get_app_interface_settings()
+    secret_reader = SecretReader(queries.get_secret_reader_settings())
+    accounts = queries.get_state_aws_accounts()
+    state = State(
+        integration=QONTRACT_INTEGRATION, accounts=accounts, settings=settings
+    )
     ocms = queries.get_openshift_cluster_managers()
     for ocm_info in ocms:
+        ocm_name = ocm_info["name"]
         addon_upgrade_tests = ocm_info.get("addonUpgradeTests")
         if not addon_upgrade_tests:
             continue
@@ -19,9 +30,62 @@ def run(dry_run):
             init_addons=True,
         )
 
-        ocm = ocm_map[ocm_info["name"]]
-        print(ocm_info["name"])
-        for cluster in ocm.clusters:
-            print(cluster)
-            cluster_addons = ocm.get_cluster_addons(cluster, with_version=True)
-            print(cluster_addons)
+        ocm = ocm_map[ocm_name]
+        state_updates: dict[str, Optional[str]] = {}
+        for aut in addon_upgrade_tests:
+            addon_name = aut["addon"]["name"]
+            addon_org_version = None
+            should_trigger = True
+            state_key = f"{ocm_name}/{addon_name}"
+            last_known_version = state.get(state_key, None)
+
+            for cluster in ocm.clusters:
+                if not should_trigger:
+                    break
+                cluster_addons = ocm.get_cluster_addons(cluster, with_version=True)
+                for ca in cluster_addons:
+                    if ca["id"] != addon_name:
+                        continue
+                    ca_version = ca["version"]
+                    # all clusters should be in the same version to trigger a job
+                    # store the version in addon_org_version
+                    if not addon_org_version:
+                        addon_org_version = ca_version
+                    # is cluster addon version different from the rest of the clusters?
+                    # this means that an upgrade is progressing through the clusters.
+                    if addon_org_version != ca_version:
+                        should_trigger = False
+                        break
+                    # is cluster addon version the same as the last known version?
+                    # this means no upgrade has happened.
+                    if ca_version == last_known_version:
+                        should_trigger = False
+                        break
+
+            if should_trigger:
+                # store state updates because the list of addons and jobs to trigger
+                # may reference the same addon multiple times in order to trigger
+                # multiple jobs. update the state only when we are done with this org.
+                state_updates[addon_name] = addon_org_version
+                # now trigger the job already, people are waiting!
+                instance = aut["instance"]
+                job_name = aut["name"]
+                logging.info(
+                    [
+                        "trigger_job",
+                        instance["name"],
+                        job_name,
+                        addon_name,
+                        addon_org_version,
+                    ]
+                )
+                if not dry_run:
+                    jenkins = JenkinsApi.init_jenkins_from_secret(
+                        secret_reader, instance["token"], ssl_verify=False
+                    )
+                    jenkins.trigger_job(job_name)
+
+        if not dry_run:
+            for addon_name, addon_version in state_updates.items():
+                state_key = f"{ocm_name}/{addon_name}"
+                state.add(state_key, addon_version, force=True)

--- a/reconcile/ocm_addons_upgrade_tests_trigger.py
+++ b/reconcile/ocm_addons_upgrade_tests_trigger.py
@@ -1,0 +1,34 @@
+import reconcile.ocm_upgrade_scheduler as ous
+from reconcile import queries
+from reconcile.utils.ocm import OCMMap
+
+QONTRACT_INTEGRATION = "ocm-addons-upgrade-tests-trigger"
+
+
+def run(dry_run):
+    # patch integration name for state usage
+    ous.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION
+    settings = queries.get_app_interface_settings()
+    ocms = queries.get_openshift_cluster_managers()
+    for ocm in ocms:
+        upgrade_policy_clusters = ocm.get("upgradePolicyClusters")
+        if not upgrade_policy_clusters:
+            continue
+
+        # patch cluster items with ocm instance
+        for c in upgrade_policy_clusters:
+            c["ocm"] = ocm
+        ocm_map = OCMMap(
+            clusters=upgrade_policy_clusters,
+            integration=QONTRACT_INTEGRATION,
+            settings=settings,
+            init_version_gates=True,
+        )
+
+        current_state = ous.fetch_current_state(upgrade_policy_clusters, ocm_map)
+        desired_state = ous.fetch_desired_state(upgrade_policy_clusters, ocm_map)
+        version_history = ous.get_version_data_map(dry_run, desired_state, ocm_map)
+        diffs = ous.calculate_diff(
+            current_state, desired_state, ocm_map, version_history
+        )
+        ous.act(dry_run, diffs, ocm_map)

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1145,7 +1145,21 @@ OCM_QUERY = """
       format
       version
     }
-    
+    addonUpgradeTests {
+      addon {
+        name
+      }
+      instance {
+        name
+        token {
+          path
+          field
+          version
+          format
+        }
+      }
+      name
+    }
     inheritVersionData {
       name
       publishVersionData {

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1145,6 +1145,7 @@ OCM_QUERY = """
       format
       version
     }
+    
     inheritVersionData {
       name
       publishVersionData {

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1461,14 +1461,16 @@ class OCM:  # pylint: disable=too-many-public-methods
         api = f"{CS_API_BASE}/v1/clusters/{cluster_id}/gate_agreements"
         return self._post(api, {"version_gate": {"id": gate_id}})
 
-    def get_cluster_addons(self, cluster, with_version: bool = False):
+    def get_cluster_addons(
+        self, cluster: str, with_version: bool = False
+    ) -> list[dict[str, str]]:
         """Returns a list of Addons installed on a cluster
 
         :param cluster: cluster name
 
         :type cluster: string
         """
-        results = []
+        results: list[dict[str, str]] = []
         cluster_id = self.cluster_ids.get(cluster)
         if not cluster_id:
             return results

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1461,7 +1461,7 @@ class OCM:  # pylint: disable=too-many-public-methods
         api = f"{CS_API_BASE}/v1/clusters/{cluster_id}/gate_agreements"
         return self._post(api, {"version_gate": {"id": gate_id}})
 
-    def get_cluster_addons(self, cluster):
+    def get_cluster_addons(self, cluster, with_version: bool = False):
         """Returns a list of Addons installed on a cluster
 
         :param cluster: cluster name
@@ -1482,6 +1482,8 @@ class OCM:  # pylint: disable=too-many-public-methods
             parameters = result.pop("parameters", None)
             if parameters is not None:
                 result["parameters"] = parameters["items"]
+            if with_version:
+                result["version"] = item["addon_version"]["id"]
             results.append(result)
 
         return results


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-6756

depends on https://github.com/app-sre/qontract-schemas/pull/363

this integration will trigger jobs in jenkins following an upgrade of an addon for all clusters within an OCM org.
