### PR TITLE
do not check for AZ count to equal number of subnet if zone awareness is disabled

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4184,7 +4184,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 f" resource {values['identifier']}"
             )
 
-        if availability_zone_count != len(subnet_ids):
+        if zone_awareness_enabled and availability_zone_count != len(subnet_ids):
             raise ElasticSearchResourceZoneAwareSubnetInvalidError(
                 f"[{account}] Subnet ids count does not match "
                 + f" availability_zone_count for"


### PR DESCRIPTION
At the moment is not possible to run a single node instance of opensearch, as if we try to turn off zone awareness this check will fire.
If we try to work around it, schema validation will block it.
