### PR TITLE
[change-owners] reusable change-types through composition

### DIFF
--- a/reconcile/change_owners/bundle.py
+++ b/reconcile/change_owners/bundle.py
@@ -1,6 +1,14 @@
+from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import (
+    Any,
+    Optional,
+    Protocol,
+    Tuple,
+)
+
+from reconcile.utils.gql import get_diff
 
 
 class BundleFileType(Enum):
@@ -16,3 +24,36 @@ class FileRef:
 
     def __str__(self) -> str:
         return f"{self.file_type.value}:{self.path}"
+
+
+class FileDiffResolver(Protocol):
+    @abstractmethod
+    def lookup_file_diff(
+        self, file_ref: FileRef
+    ) -> Tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+        ...
+
+
+@dataclass
+class QontractServerFileDiffResolver:
+    comparison_sha: str
+
+    def lookup_file_diff(
+        self, file_ref: FileRef
+    ) -> Tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+        data = get_diff(
+            old_sha=self.comparison_sha,
+            file_type=file_ref.file_type.value,
+            file_path=file_ref.path,
+        )
+        return data["old"], data["new"]
+
+
+class NoOpFileDiffResolver:
+    def lookup_file_diff(
+        self, file_ref: FileRef
+    ) -> Tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+        raise Exception(
+            "NoOpFileDiffResolver is not supposed to be used in "
+            "runtime contexts where lookups are needed"
+        )

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -4,7 +4,11 @@ import traceback
 
 from reconcile import queries
 from reconcile.change_owners.approver import GqlApproverResolver
-from reconcile.change_owners.bundle import BundleFileType
+from reconcile.change_owners.bundle import (
+    BundleFileType,
+    FileDiffResolver,
+    QontractServerFileDiffResolver,
+)
 from reconcile.change_owners.change_types import (
     BundleFileChange,
     ChangeTypePriority,
@@ -56,7 +60,7 @@ def cover_changes(
     """
 
     # self service roles coverage
-    roles = fetch_self_service_roles(comparision_gql_api)
+    roles = fetch_self_service_roles(gql.get_api())
     cover_changes_with_self_service_roles(
         bundle_changes=changes,
         change_type_processors=change_type_processors,
@@ -100,9 +104,13 @@ def fetch_self_service_roles(gql_api: gql.GqlApi) -> list[RoleV1]:
     return roles
 
 
-def fetch_change_type_processors(gql_api: gql.GqlApi) -> list[ChangeTypeProcessor]:
+def fetch_change_type_processors(
+    gql_api: gql.GqlApi, file_diff_resolver: FileDiffResolver
+) -> list[ChangeTypeProcessor]:
     change_type_list = change_types.query(gql_api.query).change_types or []
-    return list(init_change_type_processors(change_type_list).values())
+    return list(
+        init_change_type_processors(change_type_list, file_diff_resolver).values()
+    )
 
 
 def fetch_bundle_changes(comparison_sha: str) -> list[BundleFileChange]:
@@ -249,6 +257,7 @@ def write_coverage_report_to_stdout(change_decisions: list[ChangeDecision]) -> N
                         "schema": d.file.schema,
                         "changed path": d.diff.path,
                         "change type": ctx.change_type_processor.name,
+                        "origin": ctx.origin,
                         "context": ctx.context,
                         "disabled": str(ctx.disabled),
                     }
@@ -269,6 +278,7 @@ def write_coverage_report_to_stdout(change_decisions: list[ChangeDecision]) -> N
                 "file",
                 "changed path",
                 "change type",
+                "origin",
                 "disabled",
                 "context",
             ],
@@ -313,11 +323,13 @@ def run(
         )
         return
 
+    file_diff_resolver = QontractServerFileDiffResolver(comparison_sha=comparison_sha)
+
     try:
         # fetch change-types from current bundle to verify they are syntactically correct.
         # this is a cheap way to figure out if a newly introduced change-type works.
         # needs a lot of improvements!
-        fetch_change_type_processors(gql.get_api())
+        fetch_change_type_processors(gql.get_api(), file_diff_resolver)
         # also verify that self service roles are configured correctly, e.g. if change-types
         # are brought together only with compatible schema files
         fetch_self_service_roles(gql.get_api())
@@ -331,7 +343,9 @@ def run(
         f"(sha={comparison_sha}, commit_id={comparison_gql_api.commit}, "
         f"build_time {comparison_gql_api.commit_timestamp_utc})"
     )
-    change_type_processors = fetch_change_type_processors(comparison_gql_api)
+    change_type_processors = fetch_change_type_processors(
+        comparison_gql_api, file_diff_resolver
+    )
 
     # an error while trying to cover changes will not fail the integration
     # and the PR check - self service merges will not be available though

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -1,3 +1,7 @@
+from abc import (
+    ABC,
+    abstractmethod,
+)
 from collections import defaultdict
 from collections.abc import (
     MutableMapping,
@@ -23,6 +27,7 @@ import networkx
 from reconcile.change_owners.approver import Approver
 from reconcile.change_owners.bundle import (
     BundleFileType,
+    FileDiffResolver,
     FileRef,
 )
 from reconcile.change_owners.diff import (
@@ -33,8 +38,8 @@ from reconcile.change_owners.diff import (
     extract_diffs,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import (
+    ChangeTypeChangeDetectorChangeTypeProviderV1,
     ChangeTypeChangeDetectorJsonPathProviderV1,
-    ChangeTypeChangeDetectorV1,
     ChangeTypeImplicitOwnershipV1,
     ChangeTypeV1,
 )
@@ -189,103 +194,6 @@ class BundleFileChange:
 
     def __post_init__(self) -> None:
         self._diff_coverage = {d.path_str(): DiffCoverage(d, []) for d in self.diffs}
-
-    def extract_context_file_refs(
-        self, change_type: "ChangeTypeProcessor"
-    ) -> list[FileRef]:
-        """
-        ChangeTypeV1 are attached to bundle files, react to changes within
-        them and use their context to derive who can approve those changes.
-        Extracting this context can be done in two ways depending on the configuration
-        of the ChangeTypeV1.
-
-        direct context extraction
-          If a ChangeTypeV1 defines a `context_schema`, it can be attached to files
-          of that schema. If such a file changes, the ChangeTypeV1 feels responsible
-          for it in subsequent diff coverage calculations and will use the approvers
-          that exist in the context of that changed file. This is the default
-          mode almost all ChangeTypeV1 operate in.
-
-          Example: a ChangeTypeV1 defines `/openshift/namespace-1.yml` as the
-          context_schema and can cover certain changes in it. If this ChangeTypeV1
-          is attached to certain namespace files (potential BundleChanges) and
-          a Role (context), changes in those namespace files can be approved by
-          members of the role.
-
-        context detection
-          If a ChangeTypeV1 additionally defines change_schemas and context selectors,
-          it has the capability to differentiate between reacting to changes
-          (and trying to cover them) and finding the context where approvers are
-          defined.
-
-          Example: Consider the following ChangeTypeV1 granting permissions to
-          approve on new members wanting to join a role.
-          ```
-            $schema: /app-interface/change-type-1.yml
-
-            contextType: datafile
-            contextSchema: /access/role-1.yml
-
-            changes:
-            - provider: jsonPath
-              changeSchema: /access/user-1.yml
-              jsonPathSelectors:
-              - roles[*]
-              context:
-                selector: roles[*].'$ref'
-                when: added
-          ```
-
-          Users join a role by adding the role to the user. This means that it
-          is a /access/user-1.yml file that changes in this situation. But permissions
-          to approve changes should be attached to the role not the user. This
-          ChangeTypeV1 takes care of that differentiation by defining /access/role-1.yml
-          as the context schema (making the ChangeTypeV1 assignable to a role)
-          but defining change detection on /access/user-1.yml via the `changeSchema`.
-          The actual role can be found within the userfile by looking for `added`
-          entries under `roles[*].$ref` (this is a jsonpath expression) as defined
-          under `context.selector`.
-        """
-        if not change_type.changes:
-            return []
-
-        # direct context extraction
-        # the changed file itself is giving the context for approver extraction
-        # see doc string for more details
-        if change_type.context_schema == self.fileref.schema:
-            return [self.fileref]
-
-        # context detection
-        # the context for approver extraction can be found within the changed
-        # file with a `context.selector`
-        # see doc string for more details
-        contexts: list[FileRef] = []
-        for c in change_type.changes:
-            if c.change_schema == self.fileref.schema and c.context:
-                context_selector = jsonpath_ng.ext.parse(c.context.selector)
-                old_contexts = {e.value for e in context_selector.find(self.old)}
-                new_contexts = {e.value for e in context_selector.find(self.new)}
-                if c.context.when == "added":
-                    affected_context_paths = new_contexts - old_contexts
-                elif c.context.when == "removed":
-                    affected_context_paths = old_contexts - new_contexts
-                elif c.context.when is None and old_contexts == new_contexts:
-                    affected_context_paths = old_contexts
-                else:
-                    affected_context_paths = None
-
-                if affected_context_paths:
-                    contexts.extend(
-                        [
-                            FileRef(
-                                schema=change_type.context_schema,
-                                path=path,
-                                file_type=BundleFileType.DATAFILE,
-                            )
-                            for path in affected_context_paths
-                        ]
-                    )
-        return contexts
 
     def cover_changes(self, change_type_context: "ChangeTypeContext") -> list[Diff]:
         """
@@ -475,6 +383,122 @@ class PathExpression:
 
 
 @dataclass
+class OwnershipContext:
+    selector: jsonpath_ng.JSONPath
+    when: Optional[str]
+
+    def find_ownership_context(
+        self,
+        context_schema: Optional[str],
+        old_data: Optional[dict[str, Any]] = None,
+        new_data: Optional[dict[str, Any]] = None,
+    ) -> list[FileRef]:
+
+        # extract contexts
+        old_contexts = {e.value for e in self.selector.find(old_data)}
+        new_contexts = {e.value for e in self.selector.find(new_data)}
+
+        # apply conditions
+        if self.when == "added":
+            affected_context_paths = new_contexts - old_contexts
+        elif self.when == "removed":
+            affected_context_paths = old_contexts - new_contexts
+        elif self.when is None and old_contexts == new_contexts:
+            affected_context_paths = old_contexts
+        else:
+            affected_context_paths = set()
+
+        return [
+            FileRef(
+                schema=context_schema,
+                path=path,
+                file_type=BundleFileType.DATAFILE,
+            )
+            for path in affected_context_paths
+        ]
+
+
+@dataclass
+class OwnershipExpansion:
+    context: OwnershipContext
+    change_type: "ChangeTypeProcessor"
+    file_diff_resolver: FileDiffResolver
+
+    def resolve_ownership_expansion(
+        self,
+        old_data: Optional[dict[str, Any]] = None,
+        new_data: Optional[dict[str, Any]] = None,
+    ) -> list["ResolvedOwnership"]:
+        context_file_refs = self.context.find_ownership_context(
+            context_schema=self.change_type.context_schema,
+            old_data=old_data,
+            new_data=new_data,
+        )
+        expaned_context_file_refs: list["ResolvedOwnership"] = []
+        for ref in context_file_refs:
+            ref_old_data, ref_new_data = self.file_diff_resolver.lookup_file_diff(ref)
+            expaned_context_file_refs.extend(
+                self.change_type.find_context_file_refs(
+                    ref,
+                    old_data=ref_old_data,
+                    new_data=ref_new_data,
+                )
+            )
+        return expaned_context_file_refs
+
+
+@dataclass
+class ResolvedOwnership:
+
+    owned_file_ref: FileRef
+    context_file_ref: FileRef
+    change_type: "ChangeTypeProcessor"
+
+
+@dataclass
+class ChangeDetector(ABC):
+    context_schema: Optional[str]
+    change_schema: Optional[str]
+    context: Optional[OwnershipContext]
+
+    @abstractmethod
+    def find_context_file_refs(
+        self,
+        old_data: Optional[dict[str, Any]] = None,
+        new_data: Optional[dict[str, Any]] = None,
+    ) -> list[FileRef]:
+        ...
+
+
+@dataclass
+class JsonPathChangeDetector(ChangeDetector):
+    json_path_selectors: list[str]
+
+    def __post_init__(self):
+        self._json_path_expressions = [
+            PathExpression(jsonpath_expression)
+            for jsonpath_expression in self.json_path_selectors
+            + [f"'{SHA256SUM_FIELD_NAME}'"]
+        ]
+
+    @property
+    def json_path_expressions(self) -> list[PathExpression]:
+        return self._json_path_expressions
+
+    def find_context_file_refs(
+        self,
+        old_data: Optional[dict[str, Any]] = None,
+        new_data: Optional[dict[str, Any]] = None,
+    ) -> list[FileRef]:
+        if self.context:
+            return self.context.find_ownership_context(
+                self.context_schema, old_data, new_data
+            )
+        else:
+            return []
+
+
+@dataclass
 class ChangeTypeProcessor:
     """
     ChangeTypeProcessor wraps the generated GQL class ChangeTypeV1 and adds
@@ -494,11 +518,127 @@ class ChangeTypeProcessor:
         self._expressions_by_file_type_schema: dict[
             tuple[BundleFileType, Optional[str]], list[PathExpression]
         ] = defaultdict(list)
-        self._changes: list[ChangeTypeChangeDetectorV1] = []
+        self._change_detectors: list[ChangeDetector] = []
+        self._ownership_expansions: list[OwnershipExpansion] = []
 
     @property
-    def changes(self) -> Sequence[ChangeTypeChangeDetectorV1]:
-        return self._changes
+    def change_detectors(self) -> Sequence[ChangeDetector]:
+        return self._change_detectors
+
+    def find_context_file_refs(
+        self,
+        file_ref: FileRef,
+        old_data: Optional[dict[str, Any]],
+        new_data: Optional[dict[str, Any]],
+    ) -> list[ResolvedOwnership]:
+        """
+        ChangeTypeV1 are attached to bundle files, react to changes within
+        them and use their context to derive who can approve those changes.
+        Extracting this context can be done in two ways depending on the configuration
+        of the ChangeTypeV1.
+
+        direct context extraction
+          If a ChangeTypeV1 defines a `context_schema`, it can be attached to files
+          of that schema. If such a file changes, the ChangeTypeV1 feels responsible
+          for it in subsequent diff coverage calculations and will use the approvers
+          that exist in the context of that changed file. This is the default
+          mode almost all ChangeTypeV1 operate in.
+
+          Example: a ChangeTypeV1 defines `/openshift/namespace-1.yml` as the
+          context_schema and can cover certain changes in it. If this ChangeTypeV1
+          is attached to certain namespace files (potential BundleChanges) and
+          a Role (context), changes in those namespace files can be approved by
+          members of the role.
+
+        context detection
+          If a ChangeTypeV1 additionally defines change_schemas and context selectors,
+          it has the capability to differentiate between reacting to changes
+          (and trying to cover them) and finding the context where approvers are
+          defined.
+
+          Example: Consider the following ChangeTypeV1 granting permissions to
+          approve on new members wanting to join a role.
+          ```
+            $schema: /app-interface/change-type-1.yml
+
+            contextType: datafile
+            contextSchema: /access/role-1.yml
+
+            changes:
+            - provider: jsonPath
+              changeSchema: /access/user-1.yml
+              jsonPathSelectors:
+              - roles[*]
+              context:
+                selector: roles[*].'$ref'
+                when: added
+          ```
+
+          Users join a role by adding the role to the user. This means that it
+          is a /access/user-1.yml file that changes in this situation. But permissions
+          to approve changes should be attached to the role not the user. This
+          ChangeTypeV1 takes care of that differentiation by defining /access/role-1.yml
+          as the context schema (making the ChangeTypeV1 assignable to a role)
+          but defining change detection on /access/user-1.yml via the `changeSchema`.
+          The actual role can be found within the userfile by looking for `added`
+          entries under `roles[*].$ref` (this is a jsonpath expression) as defined
+          under `context.selector`.
+        """
+        contexts: list[ResolvedOwnership] = []
+
+        # expand ownership based on change-type composition
+        expanded_ownership: list[ResolvedOwnership] = []
+        for oe in self._ownership_expansions:
+            expanded_ownership.extend(
+                oe.resolve_ownership_expansion(old_data, new_data)
+            )
+
+        # direct context extraction
+        # the changed file itself is giving the context for approver extraction
+        # see doc string for more details
+        if self.context_schema == file_ref.schema:
+            contexts.append(
+                ResolvedOwnership(
+                    owned_file_ref=file_ref,
+                    context_file_ref=file_ref,
+                    change_type=self,
+                )
+            )
+
+            for eo in expanded_ownership:
+                contexts.append(
+                    ResolvedOwnership(
+                        owned_file_ref=eo.owned_file_ref,
+                        context_file_ref=file_ref,
+                        change_type=eo.change_type,
+                    )
+                )
+
+        # context detection
+        # the context for approver extraction can be found within the changed
+        # file with a `context.selector`
+        # see doc string for more details
+        for c in self.change_detectors:
+            if c.change_schema == file_ref.schema:
+                for ctx_file_ref in c.find_context_file_refs(old_data, new_data):
+                    contexts.append(
+                        ResolvedOwnership(
+                            owned_file_ref=ctx_file_ref,
+                            context_file_ref=ctx_file_ref,
+                            change_type=self,
+                        )
+                    )
+
+                    for eo in expanded_ownership:
+                        contexts.append(
+                            ResolvedOwnership(
+                                owned_file_ref=eo.owned_file_ref,
+                                context_file_ref=ctx_file_ref,
+                                change_type=eo.change_type,
+                            )
+                        )
+
+        return contexts
 
     def allowed_changed_paths(
         self, file_ref: FileRef, file_content: Any, ctx: "ChangeTypeContext"
@@ -526,60 +666,111 @@ class ChangeTypeProcessor:
                 )
         return paths
 
-    def add_change(self, change: ChangeTypeChangeDetectorV1) -> None:
-        self._changes.append(change)
-        if isinstance(change, ChangeTypeChangeDetectorJsonPathProviderV1):
-            change_schema = change.change_schema or self.context_schema
-            for jsonpath_expression in change.json_path_selectors + [
-                f"'{SHA256SUM_FIELD_NAME}'"
-            ]:
+    def add_change_detector(
+        self,
+        detector: ChangeDetector,
+    ) -> None:
+        if isinstance(detector, JsonPathChangeDetector):
+            self._change_detectors.append(detector)
+            change_schema = detector.change_schema or self.context_schema
+            for path_expression in detector.json_path_expressions:
                 self._expressions_by_file_type_schema[
                     (self.context_type, change_schema)
-                ].append(PathExpression(jsonpath_expression))
+                ].append(path_expression)
         else:
             raise ValueError(
-                f"{change.provider} is not a supported change detection provider within ChangeTypes"
+                f"{type(detector)} is not a supported change detection provider within ChangeTypes"
             )
 
-
-def build_change_type_processor(change_type: ChangeTypeV1) -> ChangeTypeProcessor:
-    """
-    Build a ChangeTypeProcessor from a ChangeTypeV1 and pre-initializing jsonpaths.
-    """
-    ctp = ChangeTypeProcessor(
-        name=change_type.name,
-        description=change_type.description,
-        priority=ChangeTypePriority(change_type.priority),
-        context_type=BundleFileType[change_type.context_type.upper()],
-        context_schema=change_type.context_schema,
-        disabled=bool(change_type.disabled),
-        implicit_ownership=change_type.implicit_ownership or [],
-    )
-    for change in change_type.changes:
-        ctp.add_change(change)
-    return ctp
+    def add_ownership_expansion(self, ownership_expansion: OwnershipExpansion):
+        self._ownership_expansions.append(ownership_expansion)
 
 
 def init_change_type_processors(
-    change_types: Sequence[ChangeTypeV1],
+    change_types: Sequence[ChangeTypeV1], file_diff_resolver: FileDiffResolver
 ) -> dict[str, ChangeTypeProcessor]:
-    processors = {}
-    change_type_graph = networkx.DiGraph()
-    for change_type in change_types:
-        change_type_graph.add_node(change_type.name)
-        for i in change_type.inherit or []:
-            change_type_graph.add_edge(change_type.name, i.name)
-        processors[change_type.name] = build_change_type_processor(change_type)
+    processors: dict[str, ChangeTypeProcessor] = {}
 
-    # detect cycles
-    if cycles := list(networkx.simple_cycles(change_type_graph)):
-        raise ChangeTypeInheritanceCycleError(
-            "Cycles detected in change-type inheritance", cycles
+    change_type_inheritance_graph = networkx.DiGraph()
+    change_type_composition_graph = networkx.DiGraph()
+
+    for change_type in change_types:
+        # build raw change-type-processor
+        processors[change_type.name] = ChangeTypeProcessor(
+            name=change_type.name,
+            description=change_type.description,
+            priority=ChangeTypePriority(change_type.priority),
+            context_type=BundleFileType[change_type.context_type.upper()],
+            context_schema=change_type.context_schema,
+            disabled=bool(change_type.disabled),
+            implicit_ownership=change_type.implicit_ownership or [],
         )
+        # register inheritance edges
+        change_type_inheritance_graph.add_node(change_type.name)
+        for i in change_type.inherit or []:
+            change_type_inheritance_graph.add_edge(change_type.name, i.name)
+
+    # register change detectors
+    for change_type in change_types:
+        processor = processors[change_type.name]
+        for change_detector in change_type.changes or []:
+            if isinstance(change_detector, ChangeTypeChangeDetectorJsonPathProviderV1):
+                ownership_context = None
+                if change_detector.context:
+                    ownership_context = OwnershipContext(
+                        selector=jsonpath_ng.ext.parse(
+                            change_detector.context.selector
+                        ),
+                        when=change_detector.context.when,
+                    )
+                processor.add_change_detector(
+                    JsonPathChangeDetector(
+                        context_schema=processor.context_schema,
+                        change_schema=change_detector.change_schema
+                        or processor.context_schema,
+                        json_path_selectors=change_detector.json_path_selectors,
+                        context=ownership_context,
+                    )
+                )
+            elif isinstance(
+                change_detector, ChangeTypeChangeDetectorChangeTypeProviderV1
+            ):
+                for ct in change_detector.change_types:
+                    # todo - schema validation?
+                    processors[ct.name].add_ownership_expansion(
+                        OwnershipExpansion(
+                            change_type=processor,
+                            context=OwnershipContext(
+                                selector=jsonpath_ng.ext.parse(
+                                    change_detector.ownership_context.selector
+                                ),
+                                when=change_detector.ownership_context.when,
+                            ),
+                            file_diff_resolver=file_diff_resolver,
+                        )
+                    )
+                    # register dependency in graph
+                    change_type_composition_graph.add_edge(change_type.name, ct.name)
+
+    #
+    # V A L I D A T E
+    #
+
+    # detect inheritance cycles
+    if cycles := list(networkx.simple_cycles(change_type_inheritance_graph)):
+        raise ChangeTypeCycleError("Cycles detected in change-type inheritance", cycles)
+
+    # detect composition cycles
+    if cycles := list(networkx.simple_cycles(change_type_composition_graph)):
+        raise ChangeTypeCycleError("Cycles detected in change-type composition", cycles)
+
+    #
+    # A G G R E G A T I O N
+    #
 
     # aggregate inherited changes
     for ctp in processors.values():
-        for d in networkx.descendants(change_type_graph, ctp.name):
+        for d in networkx.descendants(change_type_inheritance_graph, ctp.name):
             if ctp.context_type != processors[d].context_type:
                 raise ChangeTypeIncompatibleInheritanceError(
                     f"change-type '{ctp.name}' inherits from '{d}' "
@@ -590,8 +781,9 @@ def init_change_type_processors(
                     f"change-type '{ctp.name}' inherits from '{d}' "
                     "but has a different context_schema"
                 )
-            for change in processors[d].changes:
-                ctp.add_change(change)
+            for detector in processors[d].change_detectors:
+                ctp.add_change_detector(detector)
+            # todo - what about ownership expansions?
 
     return processors
 
@@ -600,7 +792,7 @@ class ChangeTypeIncompatibleInheritanceError(ValueError):
     pass
 
 
-class ChangeTypeInheritanceCycleError(ValueError):
+class ChangeTypeCycleError(ValueError):
     pass
 
 
@@ -621,6 +813,7 @@ class ChangeTypeContext:
 
     change_type_processor: ChangeTypeProcessor
     context: str
+    origin: str
     approvers: list[Approver]
     context_file: FileRef
 

--- a/reconcile/change_owners/implicit_ownership.py
+++ b/reconcile/change_owners/implicit_ownership.py
@@ -37,10 +37,10 @@ def change_type_contexts_for_implicit_ownership(
     ]
     for ctp in processors_with_implicit_ownership:
         for bc in bundle_changes:
-            for context_file_ref in bc.extract_context_file_refs(ctp):
+            for ownership in ctp.find_context_file_refs(bc.fileref, bc.old, bc.new):
                 for io in ctp.implicit_ownership:
                     if isinstance(io, ChangeTypeImplicitOwnershipJsonPathProviderV1):
-                        if context_file_ref != bc.fileref:
+                        if ownership.context_file_ref != bc.fileref:
                             logging.warning(
                                 f"{io.provider} provider based implicit ownership is not supported for ownership context files that are not the changed file."
                             )
@@ -70,9 +70,10 @@ def change_type_contexts_for_implicit_ownership(
                                 bc,
                                 ChangeTypeContext(
                                     change_type_processor=ctp,
-                                    context=f"implicit ownership - { ','.join(a.org_username for a in implicit_approvers ) }",
+                                    context=f"implicit ownership - (via {ownership.change_type.name}))",
+                                    origin=ownership.change_type.name,
                                     approvers=implicit_approvers,
-                                    context_file=context_file_ref,
+                                    context_file=ownership.context_file_ref,
                                 ),
                             )
                         )

--- a/reconcile/change_owners/tester.py
+++ b/reconcile/change_owners/tester.py
@@ -1,7 +1,11 @@
 import os
 import sys
 from dataclasses import dataclass
-from typing import Any, Optional, Tuple
+from typing import (
+    Any,
+    Optional,
+    Tuple,
+)
 
 import jsonpath_ng
 import pygments

--- a/reconcile/change_owners/tester.py
+++ b/reconcile/change_owners/tester.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional, Tuple
 
 import jsonpath_ng
 import pygments
@@ -114,7 +114,7 @@ class AppInterfaceRepo:
     ) -> list[BundleFileChange]:
         bundle_files = []
         processed_schemas = set()
-        for c in ctp.changes:
+        for c in ctp.change_detectors:
             if (
                 c.change_schema
                 and c.change_schema != ctp.context_schema
@@ -207,10 +207,19 @@ class SelfServiceableHighlighter(Filter):
             yield ttype, value
 
 
+class FilesystemFileDiffResolver:
+    def lookup_file_diff(
+        self, file_ref: FileRef
+    ) -> Tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+        return None, None
+
+
 def get_changetype_processor_by_name(
     change_type_name: str,
 ) -> Optional[ChangeTypeProcessor]:
-    processors = fetch_change_type_processors(gql.get_api())
+    processors = fetch_change_type_processors(
+        gql.get_api(), FilesystemFileDiffResolver()
+    )
     return next((p for p in processors if p.name == change_type_name), None)
 
 

--- a/reconcile/gql_definitions/change_owners/queries/change_types.gql
+++ b/reconcile/gql_definitions/change_owners/queries/change_types.gql
@@ -11,12 +11,22 @@ query ChangeTypes($name: String) {
     changes {
       provider
       changeSchema
-      context {
-        selector
-        when
-      }
       ... on ChangeTypeChangeDetectorJsonPathProvider_v1 {
         jsonPathSelectors
+        context {
+          selector
+          when
+        }
+      }
+      ... on ChangeTypeChangeDetectorChangeTypeProvider_v1 {
+        changeTypes {
+          name
+          contextSchema
+        }
+        ownership_context: context {
+          selector
+          when
+        }
       }
     }
     implicitOwnership {

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -11250,6 +11250,11 @@
                             "kind": "OBJECT",
                             "name": "ChangeTypeChangeDetectorJsonPathProvider_v1",
                             "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "ChangeTypeChangeDetectorChangeTypeProvider_v1",
+                            "ofType": null
                         }
                     ]
                 },
@@ -36783,6 +36788,91 @@
                                 "kind": "OBJECT",
                                 "name": "ChangeTypeChangeDetectorContextSelector_v1",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "ChangeTypeChangeDetector_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "ChangeTypeChangeDetectorChangeTypeProvider_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "provider",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "changeSchema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "changeTypes",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "ChangeType_v1",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "context",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "ChangeTypeChangeDetectorContextSelector_v1",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/test/change_owners/test_change_type_coverage.py
+++ b/reconcile/test/change_owners/test_change_type_coverage.py
@@ -5,7 +5,6 @@ from reconcile.change_owners.change_types import (
     Approver,
     ChangeTypeContext,
     DiffCoverage,
-    build_change_type_processor,
     create_bundle_file_change,
 )
 from reconcile.change_owners.diff import (
@@ -13,7 +12,10 @@ from reconcile.change_owners.diff import (
     DiffType,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
-from reconcile.test.change_owners.fixtures import TestFile
+from reconcile.test.change_owners.fixtures import (
+    TestFile,
+    change_type_to_processor,
+)
 
 pytest_plugins = [
     "reconcile.test.change_owners.fixtures",
@@ -31,8 +33,9 @@ def test_cover_changes_one_file(
         {"resourceTemplates[0].targets[0].ref": "new-ref"}
     )
     ctx = ChangeTypeContext(
-        change_type_processor=build_change_type_processor(saas_file_changetype),
+        change_type_processor=change_type_to_processor(saas_file_changetype),
         context="RoleV1 - some-role",
+        origin="",
         approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
         context_file=saas_file.file_ref(),
     )
@@ -51,8 +54,9 @@ def test_uncovered_change_because_change_type_is_disabled(
         {"resourceTemplates[0].targets[0].ref": "new-ref"}
     )
     ctx = ChangeTypeContext(
-        change_type_processor=build_change_type_processor(saas_file_changetype),
+        change_type_processor=change_type_to_processor(saas_file_changetype),
         context="RoleV1 - some-role",
+        origin="",
         approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
         context_file=saas_file.file_ref(),
     )
@@ -68,8 +72,9 @@ def test_uncovered_change_one_file(
 ):
     saas_file_change = saas_file.create_bundle_change({"name": "new-name"})
     ctx = ChangeTypeContext(
-        change_type_processor=build_change_type_processor(saas_file_changetype),
+        change_type_processor=change_type_to_processor(saas_file_changetype),
         context="RoleV1 - some-role",
+        origin="",
         approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
         context_file=saas_file.file_ref(),
     )
@@ -88,8 +93,9 @@ def test_partially_covered_change_one_file(
         d for d in saas_file_change.diff_coverage if str(d.diff.path) == ref_update_path
     )
     ctx = ChangeTypeContext(
-        change_type_processor=build_change_type_processor(saas_file_changetype),
+        change_type_processor=change_type_to_processor(saas_file_changetype),
         context="RoleV1 - some-role",
+        origin="",
         approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
         context_file=saas_file.file_ref(),
     )
@@ -123,8 +129,9 @@ def test_root_change_type(cluster_owner_change_type: ChangeTypeV1, saas_file: Te
     )
     assert namespace_change
     ctx = ChangeTypeContext(
-        change_type_processor=build_change_type_processor(cluster_owner_change_type),
+        change_type_processor=change_type_to_processor(cluster_owner_change_type),
         context="RoleV1 - some-role",
+        origin="",
         approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
         context_file=saas_file.file_ref(),
     )
@@ -150,8 +157,9 @@ def test_diff_covered(saas_file_changetype: ChangeTypeV1):
         ),
         coverage=[
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(saas_file_changetype),
+                change_type_processor=change_type_to_processor(saas_file_changetype),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),
@@ -169,16 +177,16 @@ def test_diff_covered_many(
         ),
         coverage=[
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(saas_file_changetype),
+                change_type_processor=change_type_to_processor(saas_file_changetype),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(
-                    role_member_change_type
-                ),
+                change_type_processor=change_type_to_processor(role_member_change_type),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),
@@ -197,16 +205,16 @@ def test_diff_covered_partially_disabled(
         ),
         coverage=[
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(saas_file_changetype),
+                change_type_processor=change_type_to_processor(saas_file_changetype),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(
-                    role_member_change_type
-                ),
+                change_type_processor=change_type_to_processor(role_member_change_type),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),
@@ -226,16 +234,16 @@ def test_diff_no_coverage_all_disabled(
         ),
         coverage=[
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(saas_file_changetype),
+                change_type_processor=change_type_to_processor(saas_file_changetype),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(
-                    role_member_change_type
-                ),
+                change_type_processor=change_type_to_processor(role_member_change_type),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),

--- a/reconcile/test/change_owners/test_change_type_decision.py
+++ b/reconcile/test/change_owners/test_change_type_decision.py
@@ -4,7 +4,6 @@ from reconcile.change_owners.bundle import BundleFileType
 from reconcile.change_owners.change_types import (
     Approver,
     ChangeTypeContext,
-    build_change_type_processor,
     create_bundle_file_change,
 )
 from reconcile.change_owners.decision import (
@@ -14,6 +13,9 @@ from reconcile.change_owners.decision import (
     get_approver_decisions_from_mr_comments,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
+from reconcile.test.change_owners.fixtures import (
+    change_type_to_processor,
+)
 
 pytest_plugins = [
     "reconcile.test.change_owners.fixtures",
@@ -148,8 +150,9 @@ def test_change_decision(
     assert change and len(change.diff_coverage) == 1
     change.diff_coverage[0].coverage = [
         ChangeTypeContext(
-            change_type_processor=build_change_type_processor(saas_file_changetype),
+            change_type_processor=change_type_to_processor(saas_file_changetype),
             context="something-something",
+            origin="",
             approvers=[
                 Approver(org_username=yea_user, tag_on_merge_requests=False),
                 Approver(org_username=nay_sayer, tag_on_merge_requests=False),
@@ -185,8 +188,9 @@ def test_change_decision_auto_approve_only_approver(saas_file_changetype: Change
     assert change and len(change.diff_coverage) == 1
     change.diff_coverage[0].coverage = [
         ChangeTypeContext(
-            change_type_processor=build_change_type_processor(saas_file_changetype),
+            change_type_processor=change_type_to_processor(saas_file_changetype),
             context="something-something",
+            origin="",
             approvers=[
                 Approver(org_username=bot_user, tag_on_merge_requests=False),
             ],
@@ -218,8 +222,9 @@ def test_change_decision_auto_approve_not_only_approver(
     assert change and len(change.diff_coverage) == 1
     change.diff_coverage[0].coverage = [
         ChangeTypeContext(
-            change_type_processor=build_change_type_processor(saas_file_changetype),
+            change_type_processor=change_type_to_processor(saas_file_changetype),
             context="something-something",
+            origin="",
             approvers=[
                 Approver(org_username=nothing_sayer, tag_on_merge_requests=False),
                 Approver(org_username=bot_user, tag_on_merge_requests=False),
@@ -252,8 +257,9 @@ def test_change_decision_auto_approve_with_approval(
     assert change and len(change.diff_coverage) == 1
     change.diff_coverage[0].coverage = [
         ChangeTypeContext(
-            change_type_processor=build_change_type_processor(saas_file_changetype),
+            change_type_processor=change_type_to_processor(saas_file_changetype),
             context="something-something",
+            origin="",
             approvers=[
                 Approver(org_username=nothing_sayer, tag_on_merge_requests=False),
                 Approver(org_username=bot_user, tag_on_merge_requests=False),

--- a/reconcile/test/change_owners/test_change_type_decision.py
+++ b/reconcile/test/change_owners/test_change_type_decision.py
@@ -13,9 +13,7 @@ from reconcile.change_owners.decision import (
     get_approver_decisions_from_mr_comments,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
-from reconcile.test.change_owners.fixtures import (
-    change_type_to_processor,
-)
+from reconcile.test.change_owners.fixtures import change_type_to_processor
 
 pytest_plugins = [
     "reconcile.test.change_owners.fixtures",

--- a/reconcile/test/change_owners/test_change_type_diff_splitting.py
+++ b/reconcile/test/change_owners/test_change_type_diff_splitting.py
@@ -28,6 +28,7 @@ def test_root_diff_fully_covered_by_splits():
     split_a = ChangeTypeContext(
         change_type_processor=build_change_type("split-a", ["split-a"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -37,6 +38,7 @@ def test_root_diff_fully_covered_by_splits():
     split_b = ChangeTypeContext(
         change_type_processor=build_change_type("split-b", ["split-b"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -69,6 +71,7 @@ def test_root_diff_uncovered_fully_covered_by_splits():
     split_a = ChangeTypeContext(
         change_type_processor=build_change_type("split-a", ["split-a"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -78,6 +81,7 @@ def test_root_diff_uncovered_fully_covered_by_splits():
     split_b = ChangeTypeContext(
         change_type_processor=build_change_type("split-b", ["split-b"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -111,6 +115,7 @@ def test_root_diff_uncovered():
     split_a = ChangeTypeContext(
         change_type_processor=build_change_type("split-a", ["split-a"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -120,6 +125,7 @@ def test_root_diff_uncovered():
     split_b = ChangeTypeContext(
         change_type_processor=build_change_type("split-b", ["split-b"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -160,6 +166,7 @@ def test_nested_splits():
     top = ChangeTypeContext(
         change_type_processor=build_change_type("top", ["top"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -169,6 +176,7 @@ def test_nested_splits():
     sub = ChangeTypeContext(
         change_type_processor=build_change_type("sub", ["top.sub"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -178,6 +186,7 @@ def test_nested_splits():
     sub_sub = ChangeTypeContext(
         change_type_processor=build_change_type("sub-sub", ["top.sub.sub-sub"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -254,6 +263,7 @@ def test_diff_splitting_empty_parent_coverage():
     role_change_type = ChangeTypeContext(
         change_type_processor=build_change_type("roles", ["roles[*]"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),

--- a/reconcile/test/change_owners/test_change_type_implicit_ownership.py
+++ b/reconcile/test/change_owners/test_change_type_implicit_ownership.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import jsonpath_ng.ext
 import pytest
 
 from reconcile.change_owners.approver import Approver
@@ -10,13 +11,13 @@ from reconcile.change_owners.bundle import (
 from reconcile.change_owners.change_types import (
     BundleFileChange,
     ChangeTypeProcessor,
+    OwnershipContext,
 )
 from reconcile.change_owners.implicit_ownership import (
     change_type_contexts_for_implicit_ownership,
     find_approvers_with_implicit_ownership_jsonpath_selector,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import (
-    ChangeTypeChangeDetectorContextSelectorV1,
     ChangeTypeImplicitOwnershipJsonPathProviderV1,
     ChangeTypeImplicitOwnershipV1,
 )
@@ -174,9 +175,9 @@ def test_find_implict_change_type_context_jsonpath_provider_invalid_context_file
     approver = Approver("approver", False)
     change_schema = "change-schema-1.yml"
 
-    change_type.changes[0].change_schema = change_schema
-    change_type.changes[0].context = ChangeTypeChangeDetectorContextSelectorV1(
-        selector="$.approver", when=None
+    change_type.change_detectors[0].change_schema = change_schema
+    change_type.change_detectors[0].context = OwnershipContext(
+        selector=jsonpath_ng.ext.parse("$.approver"), when=None
     )
 
     bc = build_test_datafile(

--- a/reconcile/test/change_owners/test_change_type_inheritance.py
+++ b/reconcile/test/change_owners/test_change_type_inheritance.py
@@ -1,21 +1,30 @@
 from collections.abc import Sequence
-from typing import Optional
+from typing import (
+    Any,
+    Optional,
+)
 
 import pytest
 
 from reconcile.change_owners.bundle import BundleFileType
 from reconcile.change_owners.change_types import (
+    ChangeDetector,
+    ChangeTypeCycleError,
     ChangeTypeIncompatibleInheritanceError,
-    ChangeTypeInheritanceCycleError,
     ChangeTypePriority,
+    JsonPathChangeDetector,
     init_change_type_processors,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import (
+    ChangeTypeChangeDetectorJsonPathProviderV1,
     ChangeTypeChangeDetectorV1,
     ChangeTypeV1,
     ChangeTypeV1_ChangeTypeV1,
 )
-from reconcile.test.change_owners.fixtures import build_jsonpath_change
+from reconcile.test.change_owners.fixtures import (
+    MockFileDiffResolver,
+    build_jsonpath_change,
+)
 
 
 def build_def_change_type(
@@ -43,7 +52,10 @@ def test_change_type_no_inheritance():
     ct_1 = build_def_change_type("change-type-1")
     ct_2 = build_def_change_type("change-type-2")
 
-    processors = init_change_type_processors([ct_1, ct_2])
+    processors = init_change_type_processors(
+        [ct_1, ct_2],
+        MockFileDiffResolver(fail_on_unknown_path=False),
+    )
     assert len(processors) == 2
 
 
@@ -52,8 +64,11 @@ def test_change_type_inheritance_cycle():
     ct_2 = build_def_change_type("change-type-2", inherit=["change-type-3"])
     ct_3 = build_def_change_type("change-type-3", inherit=["change-type-1"])
 
-    with pytest.raises(ChangeTypeInheritanceCycleError) as e:
-        init_change_type_processors([ct_1, ct_2, ct_3])
+    with pytest.raises(ChangeTypeCycleError) as e:
+        init_change_type_processors(
+            [ct_1, ct_2, ct_3],
+            MockFileDiffResolver(fail_on_unknown_path=False),
+        )
     assert e.value.args[0] == "Cycles detected in change-type inheritance"
     assert set(e.value.args[1][0]) == {ct_1.name, ct_2.name, ct_3.name}
 
@@ -68,7 +83,10 @@ def test_change_type_inheritance_context_schema_mismatch():
     ct_2.context_schema = "schema-2"
 
     with pytest.raises(ChangeTypeIncompatibleInheritanceError):
-        init_change_type_processors([ct_1, ct_2])
+        init_change_type_processors(
+            [ct_1, ct_2],
+            MockFileDiffResolver(fail_on_unknown_path=False),
+        )
 
 
 def test_change_type_inhertiance_no_context_schema():
@@ -81,7 +99,10 @@ def test_change_type_inhertiance_no_context_schema():
     ct_2 = build_def_change_type("change-type-2")
     ct_2.context_schema = None
 
-    init_change_type_processors([ct_1, ct_2])
+    init_change_type_processors(
+        [ct_1, ct_2],
+        MockFileDiffResolver(fail_on_unknown_path=False),
+    )
 
 
 def test_change_type_inheritance_context_type_mismatch():
@@ -93,7 +114,10 @@ def test_change_type_inheritance_context_type_mismatch():
     ct_2.context_type = BundleFileType.RESOURCEFILE.value
 
     with pytest.raises(ChangeTypeIncompatibleInheritanceError):
-        init_change_type_processors([ct_1, ct_2])
+        init_change_type_processors(
+            [ct_1, ct_2],
+            MockFileDiffResolver(fail_on_unknown_path=False),
+        )
 
 
 def test_change_type_single_level_inheritance():
@@ -103,14 +127,22 @@ def test_change_type_single_level_inheritance():
     ct_2 = build_def_change_type("change-type-2")
     ct_3 = build_def_change_type("change-type-3")
 
-    processors = init_change_type_processors([ct_1, ct_2, ct_3])
+    processors = init_change_type_processors(
+        [ct_1, ct_2, ct_3],
+        MockFileDiffResolver(fail_on_unknown_path=False),
+    )
     assert len(processors) == 3
 
     assert change_list_equals(
-        processors["change-type-1"].changes, ct_1.changes + ct_2.changes + ct_3.changes
+        processors["change-type-1"].change_detectors,
+        ct_1.changes + ct_2.changes + ct_3.changes,
     )
-    assert change_list_equals(processors["change-type-2"].changes, ct_2.changes)
-    assert change_list_equals(processors["change-type-3"].changes, ct_3.changes)
+    assert change_list_equals(
+        processors["change-type-2"].change_detectors, ct_2.changes
+    )
+    assert change_list_equals(
+        processors["change-type-3"].change_detectors, ct_3.changes
+    )
 
 
 def test_change_type_multi_level_inheritance():
@@ -118,16 +150,22 @@ def test_change_type_multi_level_inheritance():
     ct_2 = build_def_change_type("change-type-2", inherit=["change-type-3"])
     ct_3 = build_def_change_type("change-type-3")
 
-    processors = init_change_type_processors([ct_1, ct_2, ct_3])
+    processors = init_change_type_processors(
+        [ct_1, ct_2, ct_3],
+        MockFileDiffResolver(fail_on_unknown_path=False),
+    )
     assert len(processors) == 3
 
     assert change_list_equals(
-        processors["change-type-1"].changes, ct_1.changes + ct_2.changes + ct_3.changes
+        processors["change-type-1"].change_detectors,
+        ct_1.changes + ct_2.changes + ct_3.changes,
     )
     assert change_list_equals(
-        processors["change-type-2"].changes, ct_2.changes + ct_3.changes
+        processors["change-type-2"].change_detectors, ct_2.changes + ct_3.changes
     )
-    assert change_list_equals(processors["change-type-3"].changes, ct_3.changes)
+    assert change_list_equals(
+        processors["change-type-3"].change_detectors, ct_3.changes
+    )
 
 
 def test_change_type_multi_level_inheritance_multiple_paths():
@@ -137,16 +175,22 @@ def test_change_type_multi_level_inheritance_multiple_paths():
     ct_2 = build_def_change_type("change-type-2", inherit=["change-type-3"])
     ct_3 = build_def_change_type("change-type-3")
 
-    processors = init_change_type_processors([ct_1, ct_2, ct_3])
+    processors = init_change_type_processors(
+        [ct_1, ct_2, ct_3],
+        MockFileDiffResolver(fail_on_unknown_path=False),
+    )
     assert len(processors) == 3
 
     assert change_list_equals(
-        processors["change-type-1"].changes, ct_1.changes + ct_2.changes + ct_3.changes
+        processors["change-type-1"].change_detectors,
+        ct_1.changes + ct_2.changes + ct_3.changes,
     )
     assert change_list_equals(
-        processors["change-type-2"].changes, ct_2.changes + ct_3.changes
+        processors["change-type-2"].change_detectors, ct_2.changes + ct_3.changes
     )
-    assert change_list_equals(processors["change-type-3"].changes, ct_3.changes)
+    assert change_list_equals(
+        processors["change-type-3"].change_detectors, ct_3.changes
+    )
 
 
 # todo - write a test to check that the same change will not land
@@ -154,7 +198,21 @@ def test_change_type_multi_level_inheritance_multiple_paths():
 
 
 def change_list_equals(
-    a: Sequence[ChangeTypeChangeDetectorV1],
+    a: Sequence[ChangeDetector],
     b: Sequence[ChangeTypeChangeDetectorV1],
 ) -> bool:
+    def detector_to_tuple(d: ChangeDetector) -> Any:
+        if isinstance(d, JsonPathChangeDetector):
+            return (d.change_schema, d.json_path_selectors)
+        else:
+            raise ValueError(f"unknown change detector type: {type(d)}")
+
+    def change_to_tuple(c: ChangeTypeChangeDetectorV1) -> Any:
+        if isinstance(c, ChangeTypeChangeDetectorJsonPathProviderV1):
+            return (c.change_schema, c.json_path_selectors)
+        else:
+            raise ValueError(f"unknown change type change: {type(c)}")
+
+    a = [detector_to_tuple(d) for d in a]
+    b = [change_to_tuple(d) for d in b]
     return len(a) == len(b) and all(a_item in b for a_item in a)

--- a/reconcile/test/change_owners/test_change_type_integration.py
+++ b/reconcile/test/change_owners/test_change_type_integration.py
@@ -1,6 +1,5 @@
 import pytest
 
-from reconcile.change_owners.change_types import build_change_type_processor
 from reconcile.change_owners.self_service_roles import (
     cover_changes_with_self_service_roles,
 )
@@ -11,6 +10,7 @@ from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
 from reconcile.test.change_owners.fixtures import (
     TestFile,
     build_role,
+    change_type_to_processor,
 )
 
 pytest_plugins = [
@@ -58,8 +58,8 @@ def test_change_coverage(
     cover_changes_with_self_service_roles(
         roles=[role_approval_role, secret_promoter_role],
         change_type_processors=[
-            build_change_type_processor(role_member_change_type),
-            build_change_type_processor(secret_promoter_change_type),
+            change_type_to_processor(role_member_change_type),
+            change_type_to_processor(secret_promoter_change_type),
         ],
         bundle_changes=bundle_changes,
     )

--- a/reconcile/test/change_owners/test_change_type_ownership_expansion.py
+++ b/reconcile/test/change_owners/test_change_type_ownership_expansion.py
@@ -1,0 +1,101 @@
+import pytest
+
+from reconcile.change_owners.bundle import BundleFileType
+from reconcile.change_owners.change_types import (
+    ChangeTypeCycleError,
+    ChangeTypePriority,
+    init_change_type_processors,
+)
+from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
+from reconcile.test.change_owners.fixtures import (
+    MockFileDiffResolver,
+    build_change_type_change,
+    build_jsonpath_change,
+    build_test_datafile,
+)
+
+
+@pytest.fixture
+def namespace_change_type() -> ChangeTypeV1:
+    return ChangeTypeV1(
+        name="namespace",
+        description="namespace",
+        contextType=BundleFileType.DATAFILE.value,
+        contextSchema="namespace-1.yml",
+        disabled=False,
+        priority=ChangeTypePriority.HIGH.value,
+        changes=[
+            build_jsonpath_change(
+                schema="namespace-1.yml",
+                selectors=["description"],
+            )
+        ],
+        inherit=None,
+        implicitOwnership=[],
+    )
+
+
+@pytest.fixture
+def app_change_type() -> ChangeTypeV1:
+    return ChangeTypeV1(
+        name="app",
+        description="app",
+        contextType=BundleFileType.DATAFILE.value,
+        contextSchema="app-1.yml",
+        disabled=False,
+        priority=ChangeTypePriority.HIGH.value,
+        changes=[
+            build_change_type_change(
+                schema="app-1.yml",
+                change_type_names=["namespace"],
+                context_selector="app",
+                context_when=None,
+            )
+        ],
+        inherit=None,
+        implicitOwnership=[],
+    )
+
+
+def test_change_type_ownership_resolve(
+    namespace_change_type: ChangeTypeV1, app_change_type: ChangeTypeV1
+):
+    namespace_change = build_test_datafile(
+        filepath="my-namespace.yml",
+        schema=namespace_change_type.context_schema,
+        content={"app": "my-app.yml", "description": "my-description"},
+    ).create_bundle_change(jsonpath_patches={"$.description": "updated-description"})
+
+    processors = init_change_type_processors(
+        [namespace_change_type, app_change_type],
+        MockFileDiffResolver(fail_on_unknown_path=False),
+    )
+
+    namespace_change_type_processor = processors[namespace_change_type.name]
+    contexts = namespace_change_type_processor.find_context_file_refs(
+        namespace_change.fileref, namespace_change.old, namespace_change.new
+    )
+    ownership_dict = {ro.owned_file_ref.path: ro for ro in contexts}
+    assert len(ownership_dict) == 2
+
+    # verify that the regular context for the changed file is present
+    assert "my-namespace.yml" in ownership_dict
+    assert ownership_dict["my-namespace.yml"].change_type.name == "namespace"
+
+    # then verify that a context for the app of the namespace has been derived
+    # from the ownership expansion
+    assert "my-app.yml" in ownership_dict
+    assert ownership_dict["my-app.yml"].change_type.name == "app"
+
+
+def test_change_type_expansion_cycle(
+    namespace_change_type: ChangeTypeV1, app_change_type: ChangeTypeV1
+):
+    namespace_change_type.changes = app_change_type.changes
+    namespace_change_type.changes[0].change_types[0].name = "app"  # type: ignore
+
+    with pytest.raises(ChangeTypeCycleError):
+        init_change_type_processors(
+            [namespace_change_type, app_change_type],
+            MockFileDiffResolver(fail_on_unknown_path=False),
+        )

--- a/reconcile/test/change_owners/test_change_type_priorities.py
+++ b/reconcile/test/change_owners/test_change_type_priorities.py
@@ -3,10 +3,10 @@ from unittest.mock import MagicMock
 from reconcile.change_owners.change_types import (
     BundleFileChange,
     ChangeTypePriority,
-    build_change_type_processor,
     get_priority_for_changes,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
+from reconcile.test.change_owners.fixtures import change_type_to_processor
 
 pytest_plugins = [
     "reconcile.test.change_owners.fixtures",
@@ -29,7 +29,7 @@ def test_priority_for_changes(
         diffs=[],
     )
     c1.involved_change_types = MagicMock(  # type: ignore
-        return_value=[build_change_type_processor(saas_file_changetype)]
+        return_value=[change_type_to_processor(saas_file_changetype)]
     )
     c2 = BundleFileChange(
         fileref=None,  # type: ignore
@@ -38,7 +38,7 @@ def test_priority_for_changes(
         diffs=[],
     )
     c2.involved_change_types = MagicMock(  # type: ignore
-        return_value=[build_change_type_processor(secret_promoter_change_type)]
+        return_value=[change_type_to_processor(secret_promoter_change_type)]
     )
 
     assert ChangeTypePriority.MEDIUM == get_priority_for_changes([c1, c2])

--- a/reconcile/test/change_owners/test_change_type_processor.py
+++ b/reconcile/test/change_owners/test_change_type_processor.py
@@ -1,15 +1,12 @@
 import pytest
 from jsonpath_ng.exceptions import JsonPathParserError
 
-from reconcile.change_owners.change_types import (
-    ChangeTypeContext,
-    build_change_type_processor,
+from reconcile.change_owners.change_types import ChangeTypeContext
+from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
+from reconcile.test.change_owners.fixtures import (
+    TestFile,
+    change_type_to_processor,
 )
-from reconcile.gql_definitions.change_owners.queries.change_types import (
-    ChangeTypeChangeDetectorV1,
-    ChangeTypeV1,
-)
-from reconcile.test.change_owners.fixtures import TestFile
 
 pytest_plugins = [
     "reconcile.test.change_owners.fixtures",
@@ -21,16 +18,6 @@ pytest_plugins = [
 #
 
 
-def test_change_type_processor_building_unsupported_provider(
-    secret_promoter_change_type: ChangeTypeV1,
-):
-    secret_promoter_change_type.changes[0] = ChangeTypeChangeDetectorV1(
-        provider="unsupported-provider", changeSchema=None, context=None
-    )
-    with pytest.raises(ValueError):
-        build_change_type_processor(secret_promoter_change_type)
-
-
 def test_change_type_processor_building_invalid_jsonpaths(
     secret_promoter_change_type: ChangeTypeV1,
 ):
@@ -38,7 +25,7 @@ def test_change_type_processor_building_invalid_jsonpaths(
         0
     ] = "invalid-jsonpath/selector"
     with pytest.raises(JsonPathParserError):
-        build_change_type_processor(secret_promoter_change_type)
+        change_type_to_processor(secret_promoter_change_type)
 
 
 #
@@ -52,13 +39,14 @@ def test_change_type_processor_allowed_paths_simple(
     changed_user_file = user_file.create_bundle_change(
         {"roles[0]": {"$ref": "some-role"}}
     )
-    processor = build_change_type_processor(role_member_change_type)
+    processor = change_type_to_processor(role_member_change_type)
     paths = processor.allowed_changed_paths(
         file_ref=changed_user_file.fileref,
         file_content=changed_user_file.new,
         ctx=ChangeTypeContext(
             change_type_processor=processor,
             context="RoleV1 - some role",
+            origin="",
             approvers=[],
             context_file=user_file.file_ref(),
         ),
@@ -73,13 +61,14 @@ def test_change_type_processor_allowed_paths_conditions(
     changed_namespace_file = namespace_file.create_bundle_change(
         {"openshiftResources[1].version": 2}
     )
-    processor = build_change_type_processor(secret_promoter_change_type)
+    processor = change_type_to_processor(secret_promoter_change_type)
     paths = processor.allowed_changed_paths(
         file_ref=changed_namespace_file.fileref,
         file_content=changed_namespace_file.new,
         ctx=ChangeTypeContext(
             change_type_processor=processor,
             context="RoleV1 - some role",
+            origin="",
             approvers=[],
             context_file=namespace_file.file_ref(),
         ),

--- a/reconcile/test/change_owners/test_change_type_various.py
+++ b/reconcile/test/change_owners/test_change_type_various.py
@@ -93,6 +93,7 @@ def test_normal_path_expression():
         ChangeTypeContext(
             change_type_processor=None,  # type: ignore
             context="RoleV1 - some-role",
+            origin="",
             approvers=[],
             context_file=FileRef(
                 BundleFileType.DATAFILE, "some-file.yaml", "schema-1.yml"
@@ -111,6 +112,7 @@ def test_templated_path_expression():
         ChangeTypeContext(
             change_type_processor=None,  # type: ignore
             context="RoleV1 - some-role",
+            origin="",
             approvers=[],
             context_file=FileRef(
                 BundleFileType.DATAFILE, "some-file.yaml", "schema-1.yml"

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -12,7 +12,6 @@ from typing import Optional
 import click
 import requests
 import yaml
-from reconcile.change_owners.bundle import NoOpFileDiffResolver
 
 import reconcile.gitlab_housekeeping as glhk
 import reconcile.ocm_upgrade_scheduler as ous
@@ -22,6 +21,7 @@ import reconcile.terraform_resources as tfr
 import reconcile.terraform_users as tfu
 import reconcile.terraform_vpc_peerings as tfvpc
 from reconcile import queries
+from reconcile.change_owners.bundle import NoOpFileDiffResolver
 from reconcile.change_owners.change_owners import (
     fetch_change_type_processors,
     fetch_self_service_roles,

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -12,6 +12,7 @@ from typing import Optional
 import click
 import requests
 import yaml
+from reconcile.change_owners.bundle import NoOpFileDiffResolver
 
 import reconcile.gitlab_housekeeping as glhk
 import reconcile.ocm_upgrade_scheduler as ous
@@ -1456,7 +1457,7 @@ def app_interface_open_selfserviceable_mr_queue(ctx):
 @click.pass_context
 def change_types(ctx):
     """List all change types."""
-    change_types = fetch_change_type_processors(gql.get_api())
+    change_types = fetch_change_type_processors(gql.get_api(), NoOpFileDiffResolver())
 
     usage_statistics: dict[str, int] = defaultdict(int)
     roles = fetch_self_service_roles(gql.get_api())


### PR DESCRIPTION
Add a new change provider named change-type to /app-interface/change-type-1.yml#changes.provider that can reference an existing change-type and put it into the context of changes.context.

```yaml
- provider: change-type         <-- new provider
  changeTypes:
  - $ref: namespace-owner.yml   <-- puts the existing change-type ...
  context:                      <-- ... into a new context
    selector: app.'$ref'
```

This makes the referenced change-type usable in the ownership context of the referencing change-type. It redurced ownership management toil and makes the change-types reusable. It also enables the definition of higher level concepts for ownership, e.g. the owned entity is an app and by putting existing change-types into the context of the app change-type, ownership is dynamically expanded to other entities.

Ref: https://issues.redhat.com/browse/APPSRE-6651
schema-change: https://github.com/app-sre/qontract-schemas/pull/365

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>