### PR TITLE
reusable change-types through composition

### DIFF
--- a/reconcile/change_owners/bundle.py
+++ b/reconcile/change_owners/bundle.py
@@ -1,6 +1,14 @@
+from abc import abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import (
+    Any,
+    Optional,
+    Protocol,
+    Tuple,
+)
+
+from reconcile.utils.gql import get_diff
 
 
 class BundleFileType(Enum):
@@ -16,3 +24,50 @@ class FileRef:
 
     def __str__(self) -> str:
         return f"{self.file_type.value}:{self.path}"
+
+
+class FileDiffResolver(Protocol):
+    """
+    A protocol to lookup the diff of a file given its FileRef.
+    """
+
+    @abstractmethod
+    def lookup_file_diff(
+        self, file_ref: FileRef
+    ) -> Tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+        ...
+
+
+@dataclass
+class QontractServerFileDiffResolver:
+    """
+    An implementation of the FileDiffResolver protocol that uses the comparison
+    SHA from a qontract-server to lookup the diff of a file.
+    """
+
+    comparison_sha: str
+
+    def lookup_file_diff(
+        self, file_ref: FileRef
+    ) -> Tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+        data = get_diff(
+            old_sha=self.comparison_sha,
+            file_type=file_ref.file_type.value,
+            file_path=file_ref.path,
+        )
+        return data["old"], data["new"]
+
+
+class NoOpFileDiffResolver:
+    """
+    A resolver that is used in contexts where it is required from a typing
+    perspective, but where the actual lookup is not needed.
+    """
+
+    def lookup_file_diff(
+        self, file_ref: FileRef
+    ) -> Tuple[Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+        raise Exception(
+            "NoOpFileDiffResolver is not supposed to be used in "
+            "runtime contexts where lookups are needed"
+        )

--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -53,6 +53,13 @@ class ChangeDecision:
     coverage: list[ChangeTypeContext]
     decision: Decision
 
+    def deduped_coverage(self) -> list[ChangeTypeContext]:
+        unique_coverage = {}
+        for ctx in self.coverage:
+            key = f"{ctx.change_type_processor.name}:{ctx.context}"
+            unique_coverage[key] = ctx
+        return list(unique_coverage.values())
+
 
 def apply_decisions_to_changes(
     changes: list[BundleFileChange],

--- a/reconcile/change_owners/implicit_ownership.py
+++ b/reconcile/change_owners/implicit_ownership.py
@@ -37,7 +37,9 @@ def change_type_contexts_for_implicit_ownership(
     ]
     for ctp in processors_with_implicit_ownership:
         for bc in bundle_changes:
-            for context_file_ref in bc.extract_context_file_refs(ctp):
+            for context_file_ref in ctp.find_context_file_refs(
+                bc.fileref, bc.old, bc.new
+            ):
                 for io in ctp.implicit_ownership:
                     if isinstance(io, ChangeTypeImplicitOwnershipJsonPathProviderV1):
                         if context_file_ref != bc.fileref:

--- a/reconcile/change_owners/implicit_ownership.py
+++ b/reconcile/change_owners/implicit_ownership.py
@@ -37,12 +37,10 @@ def change_type_contexts_for_implicit_ownership(
     ]
     for ctp in processors_with_implicit_ownership:
         for bc in bundle_changes:
-            for context_file_ref in ctp.find_context_file_refs(
-                bc.fileref, bc.old, bc.new
-            ):
+            for ownership in ctp.find_context_file_refs(bc.fileref, bc.old, bc.new):
                 for io in ctp.implicit_ownership:
                     if isinstance(io, ChangeTypeImplicitOwnershipJsonPathProviderV1):
-                        if context_file_ref != bc.fileref:
+                        if ownership.context_file_ref != bc.fileref:
                             logging.warning(
                                 f"{io.provider} provider based implicit ownership is not supported for ownership context files that are not the changed file."
                             )
@@ -72,9 +70,10 @@ def change_type_contexts_for_implicit_ownership(
                                 bc,
                                 ChangeTypeContext(
                                     change_type_processor=ctp,
-                                    context=f"implicit ownership - { ','.join(a.org_username for a in implicit_approvers ) }",
+                                    context=f"implicit ownership - (via {ownership.change_type.name}))",
+                                    origin=ownership.change_type.name,
                                     approvers=implicit_approvers,
-                                    context_file=context_file_ref,
+                                    context_file=ownership.context_file_ref,
                                 ),
                             )
                         )

--- a/reconcile/change_owners/self_service_roles.py
+++ b/reconcile/change_owners/self_service_roles.py
@@ -54,7 +54,7 @@ def change_type_contexts_for_self_service_roles(
     change_type_contexts = []
     for bc in bundle_changes:
         for ctp in change_type_processors:
-            datafile_refs = bc.extract_context_file_refs(ctp)
+            datafile_refs = ctp.find_context_file_refs(bc.fileref, bc.old, bc.new)
             for df_ref in datafile_refs:
                 # if the context file is bound with the change type in
                 # a role, build a changetypecontext

--- a/reconcile/change_owners/self_service_roles.py
+++ b/reconcile/change_owners/self_service_roles.py
@@ -54,11 +54,16 @@ def change_type_contexts_for_self_service_roles(
     change_type_contexts = []
     for bc in bundle_changes:
         for ctp in change_type_processors:
-            datafile_refs = ctp.find_context_file_refs(bc.fileref, bc.old, bc.new)
-            for df_ref in datafile_refs:
+            for ownership in ctp.find_context_file_refs(bc.fileref, bc.old, bc.new):
                 # if the context file is bound with the change type in
                 # a role, build a changetypecontext
-                for role in role_lookup[(df_ref.file_type, df_ref.path, ctp.name)]:
+                for role in role_lookup[
+                    (
+                        ownership.owned_file_ref.file_type,
+                        ownership.owned_file_ref.path,
+                        ownership.change_type.name,
+                    )
+                ]:
                     approvers = [
                         Approver(u.org_username, u.tag_on_merge_requests)
                         for u in role.users or []
@@ -76,8 +81,9 @@ def change_type_contexts_for_self_service_roles(
                             ChangeTypeContext(
                                 change_type_processor=ctp,
                                 context=f"RoleV1 - {role.name}",
+                                origin=ownership.change_type.name,
                                 approvers=approvers,
-                                context_file=df_ref,
+                                context_file=ownership.context_file_ref,
                             ),
                         )
                     )

--- a/reconcile/gql_definitions/change_owners/queries/change_types.gql
+++ b/reconcile/gql_definitions/change_owners/queries/change_types.gql
@@ -11,12 +11,22 @@ query ChangeTypes($name: String) {
     changes {
       provider
       changeSchema
-      context {
-        selector
-        when
-      }
       ... on ChangeTypeChangeDetectorJsonPathProvider_v1 {
         jsonPathSelectors
+        context {
+          selector
+          when
+        }
+      }
+      ... on ChangeTypeChangeDetectorChangeTypeProvider_v1 {
+        changeTypes {
+          name
+          contextSchema
+        }
+        ownership_context: context {
+          selector
+          when
+        }
       }
     }
     implicitOwnership {

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -11754,6 +11754,11 @@
                             "kind": "OBJECT",
                             "name": "ChangeTypeChangeDetectorJsonPathProvider_v1",
                             "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "ChangeTypeChangeDetectorChangeTypeProvider_v1",
+                            "ofType": null
                         }
                     ]
                 },
@@ -36962,6 +36967,91 @@
                                 "kind": "OBJECT",
                                 "name": "ChangeTypeChangeDetectorContextSelector_v1",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "ChangeTypeChangeDetector_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "ChangeTypeChangeDetectorChangeTypeProvider_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "provider",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "changeSchema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "changeTypes",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "ChangeType_v1",
+                                            "ofType": null
+                                        }
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "context",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "ChangeTypeChangeDetectorContextSelector_v1",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/test/change_owners/test_change_type_coverage.py
+++ b/reconcile/test/change_owners/test_change_type_coverage.py
@@ -5,7 +5,6 @@ from reconcile.change_owners.change_types import (
     Approver,
     ChangeTypeContext,
     DiffCoverage,
-    build_change_type_processor,
     create_bundle_file_change,
 )
 from reconcile.change_owners.diff import (
@@ -13,7 +12,10 @@ from reconcile.change_owners.diff import (
     DiffType,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
-from reconcile.test.change_owners.fixtures import TestFile
+from reconcile.test.change_owners.fixtures import (
+    TestFile,
+    change_type_to_processor,
+)
 
 pytest_plugins = [
     "reconcile.test.change_owners.fixtures",
@@ -31,8 +33,9 @@ def test_cover_changes_one_file(
         {"resourceTemplates[0].targets[0].ref": "new-ref"}
     )
     ctx = ChangeTypeContext(
-        change_type_processor=build_change_type_processor(saas_file_changetype),
+        change_type_processor=change_type_to_processor(saas_file_changetype),
         context="RoleV1 - some-role",
+        origin="",
         approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
         context_file=saas_file.file_ref(),
     )
@@ -51,8 +54,9 @@ def test_uncovered_change_because_change_type_is_disabled(
         {"resourceTemplates[0].targets[0].ref": "new-ref"}
     )
     ctx = ChangeTypeContext(
-        change_type_processor=build_change_type_processor(saas_file_changetype),
+        change_type_processor=change_type_to_processor(saas_file_changetype),
         context="RoleV1 - some-role",
+        origin="",
         approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
         context_file=saas_file.file_ref(),
     )
@@ -68,8 +72,9 @@ def test_uncovered_change_one_file(
 ):
     saas_file_change = saas_file.create_bundle_change({"name": "new-name"})
     ctx = ChangeTypeContext(
-        change_type_processor=build_change_type_processor(saas_file_changetype),
+        change_type_processor=change_type_to_processor(saas_file_changetype),
         context="RoleV1 - some-role",
+        origin="",
         approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
         context_file=saas_file.file_ref(),
     )
@@ -88,8 +93,9 @@ def test_partially_covered_change_one_file(
         d for d in saas_file_change.diff_coverage if str(d.diff.path) == ref_update_path
     )
     ctx = ChangeTypeContext(
-        change_type_processor=build_change_type_processor(saas_file_changetype),
+        change_type_processor=change_type_to_processor(saas_file_changetype),
         context="RoleV1 - some-role",
+        origin="",
         approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
         context_file=saas_file.file_ref(),
     )
@@ -123,8 +129,9 @@ def test_root_change_type(cluster_owner_change_type: ChangeTypeV1, saas_file: Te
     )
     assert namespace_change
     ctx = ChangeTypeContext(
-        change_type_processor=build_change_type_processor(cluster_owner_change_type),
+        change_type_processor=change_type_to_processor(cluster_owner_change_type),
         context="RoleV1 - some-role",
+        origin="",
         approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
         context_file=saas_file.file_ref(),
     )
@@ -150,8 +157,9 @@ def test_diff_covered(saas_file_changetype: ChangeTypeV1):
         ),
         coverage=[
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(saas_file_changetype),
+                change_type_processor=change_type_to_processor(saas_file_changetype),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),
@@ -169,16 +177,16 @@ def test_diff_covered_many(
         ),
         coverage=[
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(saas_file_changetype),
+                change_type_processor=change_type_to_processor(saas_file_changetype),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(
-                    role_member_change_type
-                ),
+                change_type_processor=change_type_to_processor(role_member_change_type),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),
@@ -197,16 +205,16 @@ def test_diff_covered_partially_disabled(
         ),
         coverage=[
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(saas_file_changetype),
+                change_type_processor=change_type_to_processor(saas_file_changetype),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(
-                    role_member_change_type
-                ),
+                change_type_processor=change_type_to_processor(role_member_change_type),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),
@@ -226,16 +234,16 @@ def test_diff_no_coverage_all_disabled(
         ),
         coverage=[
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(saas_file_changetype),
+                change_type_processor=change_type_to_processor(saas_file_changetype),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),
             ChangeTypeContext(
-                change_type_processor=build_change_type_processor(
-                    role_member_change_type
-                ),
+                change_type_processor=change_type_to_processor(role_member_change_type),
                 context="RoleV1 - some-role",
+                origin="",
                 approvers=[],
                 context_file=None,  # type: ignore
             ),

--- a/reconcile/test/change_owners/test_change_type_decision.py
+++ b/reconcile/test/change_owners/test_change_type_decision.py
@@ -4,7 +4,6 @@ from reconcile.change_owners.bundle import BundleFileType
 from reconcile.change_owners.change_types import (
     Approver,
     ChangeTypeContext,
-    build_change_type_processor,
     create_bundle_file_change,
 )
 from reconcile.change_owners.decision import (
@@ -14,6 +13,7 @@ from reconcile.change_owners.decision import (
     get_approver_decisions_from_mr_comments,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
+from reconcile.test.change_owners.fixtures import change_type_to_processor
 
 pytest_plugins = [
     "reconcile.test.change_owners.fixtures",
@@ -167,8 +167,9 @@ def test_change_decision(
     assert change and len(change.diff_coverage) == 1
     change.diff_coverage[0].coverage = [
         ChangeTypeContext(
-            change_type_processor=build_change_type_processor(saas_file_changetype),
+            change_type_processor=change_type_to_processor(saas_file_changetype),
             context="something-something",
+            origin="",
             approvers=[
                 Approver(org_username=yea_user, tag_on_merge_requests=False),
                 Approver(org_username=nay_sayer, tag_on_merge_requests=False),
@@ -204,8 +205,9 @@ def test_change_decision_auto_approve_only_approver(saas_file_changetype: Change
     assert change and len(change.diff_coverage) == 1
     change.diff_coverage[0].coverage = [
         ChangeTypeContext(
-            change_type_processor=build_change_type_processor(saas_file_changetype),
+            change_type_processor=change_type_to_processor(saas_file_changetype),
             context="something-something",
+            origin="",
             approvers=[
                 Approver(org_username=bot_user, tag_on_merge_requests=False),
             ],
@@ -237,8 +239,9 @@ def test_change_decision_auto_approve_not_only_approver(
     assert change and len(change.diff_coverage) == 1
     change.diff_coverage[0].coverage = [
         ChangeTypeContext(
-            change_type_processor=build_change_type_processor(saas_file_changetype),
+            change_type_processor=change_type_to_processor(saas_file_changetype),
             context="something-something",
+            origin="",
             approvers=[
                 Approver(org_username=nothing_sayer, tag_on_merge_requests=False),
                 Approver(org_username=bot_user, tag_on_merge_requests=False),
@@ -271,8 +274,9 @@ def test_change_decision_auto_approve_with_approval(
     assert change and len(change.diff_coverage) == 1
     change.diff_coverage[0].coverage = [
         ChangeTypeContext(
-            change_type_processor=build_change_type_processor(saas_file_changetype),
+            change_type_processor=change_type_to_processor(saas_file_changetype),
             context="something-something",
+            origin="",
             approvers=[
                 Approver(org_username=nothing_sayer, tag_on_merge_requests=False),
                 Approver(org_username=bot_user, tag_on_merge_requests=False),

--- a/reconcile/test/change_owners/test_change_type_diff_splitting.py
+++ b/reconcile/test/change_owners/test_change_type_diff_splitting.py
@@ -34,6 +34,7 @@ def test_root_diff_fully_covered_by_splits():
     split_a = ChangeTypeContext(
         change_type_processor=build_change_type("split-a", ["split-a"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -43,6 +44,7 @@ def test_root_diff_fully_covered_by_splits():
     split_b = ChangeTypeContext(
         change_type_processor=build_change_type("split-b", ["split-b"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -75,6 +77,7 @@ def test_root_diff_uncovered_fully_covered_by_splits():
     split_a = ChangeTypeContext(
         change_type_processor=build_change_type("split-a", ["split-a"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -84,6 +87,7 @@ def test_root_diff_uncovered_fully_covered_by_splits():
     split_b = ChangeTypeContext(
         change_type_processor=build_change_type("split-b", ["split-b"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -117,6 +121,7 @@ def test_root_diff_uncovered():
     split_a = ChangeTypeContext(
         change_type_processor=build_change_type("split-a", ["split-a"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -126,6 +131,7 @@ def test_root_diff_uncovered():
     split_b = ChangeTypeContext(
         change_type_processor=build_change_type("split-b", ["split-b"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -166,6 +172,7 @@ def test_nested_splits():
     top = ChangeTypeContext(
         change_type_processor=build_change_type("top", ["top"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -175,6 +182,7 @@ def test_nested_splits():
     sub = ChangeTypeContext(
         change_type_processor=build_change_type("sub", ["top.sub"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -184,6 +192,7 @@ def test_nested_splits():
     sub_sub = ChangeTypeContext(
         change_type_processor=build_change_type("sub-sub", ["top.sub.sub-sub"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -260,6 +269,7 @@ def test_diff_splitting_empty_parent_coverage():
     role_change_type = ChangeTypeContext(
         change_type_processor=build_change_type("roles", ["roles[*]"]),
         context="context",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -294,6 +304,7 @@ def test_diff_splitting_two_contexts_on_same_split():
     ctx_1 = ChangeTypeContext(
         change_type_processor=build_change_type("roles", ["roles[*]"]),
         context="context-1",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
@@ -302,6 +313,7 @@ def test_diff_splitting_two_contexts_on_same_split():
     ctx_2 = ChangeTypeContext(
         change_type_processor=build_change_type("roles", ["roles[*]"]),
         context="context-2",
+        origin="",
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),

--- a/reconcile/test/change_owners/test_change_type_implicit_ownership.py
+++ b/reconcile/test/change_owners/test_change_type_implicit_ownership.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+import jsonpath_ng.ext
 import pytest
 
 from reconcile.change_owners.approver import Approver
@@ -10,13 +11,13 @@ from reconcile.change_owners.bundle import (
 from reconcile.change_owners.change_types import (
     BundleFileChange,
     ChangeTypeProcessor,
+    OwnershipContext,
 )
 from reconcile.change_owners.implicit_ownership import (
     change_type_contexts_for_implicit_ownership,
     find_approvers_with_implicit_ownership_jsonpath_selector,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import (
-    ChangeTypeChangeDetectorContextSelectorV1,
     ChangeTypeImplicitOwnershipJsonPathProviderV1,
     ChangeTypeImplicitOwnershipV1,
 )
@@ -174,9 +175,9 @@ def test_find_implict_change_type_context_jsonpath_provider_invalid_context_file
     approver = Approver("approver", False)
     change_schema = "change-schema-1.yml"
 
-    change_type.changes[0].change_schema = change_schema
-    change_type.changes[0].context = ChangeTypeChangeDetectorContextSelectorV1(
-        selector="$.approver", when=None
+    change_type.change_detectors[0].change_schema = change_schema
+    change_type.change_detectors[0].context = OwnershipContext(
+        selector=jsonpath_ng.ext.parse("$.approver"), when=None
     )
 
     bc = build_test_datafile(

--- a/reconcile/test/change_owners/test_change_type_inheritance.py
+++ b/reconcile/test/change_owners/test_change_type_inheritance.py
@@ -1,21 +1,30 @@
 from collections.abc import Sequence
-from typing import Optional
+from typing import (
+    Any,
+    Optional,
+)
 
 import pytest
 
 from reconcile.change_owners.bundle import BundleFileType
 from reconcile.change_owners.change_types import (
+    ChangeDetector,
+    ChangeTypeCycleError,
     ChangeTypeIncompatibleInheritanceError,
-    ChangeTypeInheritanceCycleError,
     ChangeTypePriority,
+    JsonPathChangeDetector,
     init_change_type_processors,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import (
+    ChangeTypeChangeDetectorJsonPathProviderV1,
     ChangeTypeChangeDetectorV1,
     ChangeTypeV1,
     ChangeTypeV1_ChangeTypeV1,
 )
-from reconcile.test.change_owners.fixtures import build_jsonpath_change
+from reconcile.test.change_owners.fixtures import (
+    MockFileDiffResolver,
+    build_jsonpath_change,
+)
 
 
 def build_def_change_type(
@@ -43,7 +52,10 @@ def test_change_type_no_inheritance():
     ct_1 = build_def_change_type("change-type-1")
     ct_2 = build_def_change_type("change-type-2")
 
-    processors = init_change_type_processors([ct_1, ct_2])
+    processors = init_change_type_processors(
+        [ct_1, ct_2],
+        MockFileDiffResolver(fail_on_unknown_path=False),
+    )
     assert len(processors) == 2
 
 
@@ -52,8 +64,11 @@ def test_change_type_inheritance_cycle():
     ct_2 = build_def_change_type("change-type-2", inherit=["change-type-3"])
     ct_3 = build_def_change_type("change-type-3", inherit=["change-type-1"])
 
-    with pytest.raises(ChangeTypeInheritanceCycleError) as e:
-        init_change_type_processors([ct_1, ct_2, ct_3])
+    with pytest.raises(ChangeTypeCycleError) as e:
+        init_change_type_processors(
+            [ct_1, ct_2, ct_3],
+            MockFileDiffResolver(fail_on_unknown_path=False),
+        )
     assert e.value.args[0] == "Cycles detected in change-type inheritance"
     assert set(e.value.args[1][0]) == {ct_1.name, ct_2.name, ct_3.name}
 
@@ -68,7 +83,10 @@ def test_change_type_inheritance_context_schema_mismatch():
     ct_2.context_schema = "schema-2"
 
     with pytest.raises(ChangeTypeIncompatibleInheritanceError):
-        init_change_type_processors([ct_1, ct_2])
+        init_change_type_processors(
+            [ct_1, ct_2],
+            MockFileDiffResolver(fail_on_unknown_path=False),
+        )
 
 
 def test_change_type_inhertiance_no_context_schema():
@@ -81,7 +99,10 @@ def test_change_type_inhertiance_no_context_schema():
     ct_2 = build_def_change_type("change-type-2")
     ct_2.context_schema = None
 
-    init_change_type_processors([ct_1, ct_2])
+    init_change_type_processors(
+        [ct_1, ct_2],
+        MockFileDiffResolver(fail_on_unknown_path=False),
+    )
 
 
 def test_change_type_inheritance_context_type_mismatch():
@@ -93,7 +114,10 @@ def test_change_type_inheritance_context_type_mismatch():
     ct_2.context_type = BundleFileType.RESOURCEFILE.value
 
     with pytest.raises(ChangeTypeIncompatibleInheritanceError):
-        init_change_type_processors([ct_1, ct_2])
+        init_change_type_processors(
+            [ct_1, ct_2],
+            MockFileDiffResolver(fail_on_unknown_path=False),
+        )
 
 
 def test_change_type_single_level_inheritance():
@@ -103,14 +127,22 @@ def test_change_type_single_level_inheritance():
     ct_2 = build_def_change_type("change-type-2")
     ct_3 = build_def_change_type("change-type-3")
 
-    processors = init_change_type_processors([ct_1, ct_2, ct_3])
+    processors = init_change_type_processors(
+        [ct_1, ct_2, ct_3],
+        MockFileDiffResolver(fail_on_unknown_path=False),
+    )
     assert len(processors) == 3
 
     assert change_list_equals(
-        processors["change-type-1"].changes, ct_1.changes + ct_2.changes + ct_3.changes
+        processors["change-type-1"].change_detectors,
+        ct_1.changes + ct_2.changes + ct_3.changes,
     )
-    assert change_list_equals(processors["change-type-2"].changes, ct_2.changes)
-    assert change_list_equals(processors["change-type-3"].changes, ct_3.changes)
+    assert change_list_equals(
+        processors["change-type-2"].change_detectors, ct_2.changes
+    )
+    assert change_list_equals(
+        processors["change-type-3"].change_detectors, ct_3.changes
+    )
 
 
 def test_change_type_multi_level_inheritance():
@@ -118,16 +150,22 @@ def test_change_type_multi_level_inheritance():
     ct_2 = build_def_change_type("change-type-2", inherit=["change-type-3"])
     ct_3 = build_def_change_type("change-type-3")
 
-    processors = init_change_type_processors([ct_1, ct_2, ct_3])
+    processors = init_change_type_processors(
+        [ct_1, ct_2, ct_3],
+        MockFileDiffResolver(fail_on_unknown_path=False),
+    )
     assert len(processors) == 3
 
     assert change_list_equals(
-        processors["change-type-1"].changes, ct_1.changes + ct_2.changes + ct_3.changes
+        processors["change-type-1"].change_detectors,
+        ct_1.changes + ct_2.changes + ct_3.changes,
     )
     assert change_list_equals(
-        processors["change-type-2"].changes, ct_2.changes + ct_3.changes
+        processors["change-type-2"].change_detectors, ct_2.changes + ct_3.changes
     )
-    assert change_list_equals(processors["change-type-3"].changes, ct_3.changes)
+    assert change_list_equals(
+        processors["change-type-3"].change_detectors, ct_3.changes
+    )
 
 
 def test_change_type_multi_level_inheritance_multiple_paths():
@@ -137,16 +175,22 @@ def test_change_type_multi_level_inheritance_multiple_paths():
     ct_2 = build_def_change_type("change-type-2", inherit=["change-type-3"])
     ct_3 = build_def_change_type("change-type-3")
 
-    processors = init_change_type_processors([ct_1, ct_2, ct_3])
+    processors = init_change_type_processors(
+        [ct_1, ct_2, ct_3],
+        MockFileDiffResolver(fail_on_unknown_path=False),
+    )
     assert len(processors) == 3
 
     assert change_list_equals(
-        processors["change-type-1"].changes, ct_1.changes + ct_2.changes + ct_3.changes
+        processors["change-type-1"].change_detectors,
+        ct_1.changes + ct_2.changes + ct_3.changes,
     )
     assert change_list_equals(
-        processors["change-type-2"].changes, ct_2.changes + ct_3.changes
+        processors["change-type-2"].change_detectors, ct_2.changes + ct_3.changes
     )
-    assert change_list_equals(processors["change-type-3"].changes, ct_3.changes)
+    assert change_list_equals(
+        processors["change-type-3"].change_detectors, ct_3.changes
+    )
 
 
 # todo - write a test to check that the same change will not land
@@ -154,7 +198,21 @@ def test_change_type_multi_level_inheritance_multiple_paths():
 
 
 def change_list_equals(
-    a: Sequence[ChangeTypeChangeDetectorV1],
+    a: Sequence[ChangeDetector],
     b: Sequence[ChangeTypeChangeDetectorV1],
 ) -> bool:
+    def detector_to_tuple(d: ChangeDetector) -> Any:
+        if isinstance(d, JsonPathChangeDetector):
+            return (d.change_schema, d.json_path_selectors)
+        else:
+            raise ValueError(f"unknown change detector type: {type(d)}")
+
+    def change_to_tuple(c: ChangeTypeChangeDetectorV1) -> Any:
+        if isinstance(c, ChangeTypeChangeDetectorJsonPathProviderV1):
+            return (c.change_schema, c.json_path_selectors)
+        else:
+            raise ValueError(f"unknown change type change: {type(c)}")
+
+    a = [detector_to_tuple(d) for d in a]
+    b = [change_to_tuple(d) for d in b]
     return len(a) == len(b) and all(a_item in b for a_item in a)

--- a/reconcile/test/change_owners/test_change_type_integration.py
+++ b/reconcile/test/change_owners/test_change_type_integration.py
@@ -1,6 +1,5 @@
 import pytest
 
-from reconcile.change_owners.change_types import build_change_type_processor
 from reconcile.change_owners.self_service_roles import (
     cover_changes_with_self_service_roles,
 )
@@ -11,6 +10,7 @@ from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
 from reconcile.test.change_owners.fixtures import (
     TestFile,
     build_role,
+    change_type_to_processor,
 )
 
 pytest_plugins = [
@@ -58,8 +58,8 @@ def test_change_coverage(
     cover_changes_with_self_service_roles(
         roles=[role_approval_role, secret_promoter_role],
         change_type_processors=[
-            build_change_type_processor(role_member_change_type),
-            build_change_type_processor(secret_promoter_change_type),
+            change_type_to_processor(role_member_change_type),
+            change_type_to_processor(secret_promoter_change_type),
         ],
         bundle_changes=bundle_changes,
     )

--- a/reconcile/test/change_owners/test_change_type_ownership_expansion.py
+++ b/reconcile/test/change_owners/test_change_type_ownership_expansion.py
@@ -1,0 +1,101 @@
+import pytest
+
+from reconcile.change_owners.bundle import BundleFileType
+from reconcile.change_owners.change_types import (
+    ChangeTypeCycleError,
+    ChangeTypePriority,
+    init_change_type_processors,
+)
+from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
+from reconcile.test.change_owners.fixtures import (
+    MockFileDiffResolver,
+    build_change_type_change,
+    build_jsonpath_change,
+    build_test_datafile,
+)
+
+
+@pytest.fixture
+def namespace_change_type() -> ChangeTypeV1:
+    return ChangeTypeV1(
+        name="namespace",
+        description="namespace",
+        contextType=BundleFileType.DATAFILE.value,
+        contextSchema="namespace-1.yml",
+        disabled=False,
+        priority=ChangeTypePriority.HIGH.value,
+        changes=[
+            build_jsonpath_change(
+                schema="namespace-1.yml",
+                selectors=["description"],
+            )
+        ],
+        inherit=None,
+        implicitOwnership=[],
+    )
+
+
+@pytest.fixture
+def app_change_type() -> ChangeTypeV1:
+    return ChangeTypeV1(
+        name="app",
+        description="app",
+        contextType=BundleFileType.DATAFILE.value,
+        contextSchema="app-1.yml",
+        disabled=False,
+        priority=ChangeTypePriority.HIGH.value,
+        changes=[
+            build_change_type_change(
+                schema="app-1.yml",
+                change_type_names=["namespace"],
+                context_selector="app",
+                context_when=None,
+            )
+        ],
+        inherit=None,
+        implicitOwnership=[],
+    )
+
+
+def test_change_type_ownership_resolve(
+    namespace_change_type: ChangeTypeV1, app_change_type: ChangeTypeV1
+):
+    namespace_change = build_test_datafile(
+        filepath="my-namespace.yml",
+        schema=namespace_change_type.context_schema,
+        content={"app": "my-app.yml", "description": "my-description"},
+    ).create_bundle_change(jsonpath_patches={"$.description": "updated-description"})
+
+    processors = init_change_type_processors(
+        [namespace_change_type, app_change_type],
+        MockFileDiffResolver(fail_on_unknown_path=False),
+    )
+
+    namespace_change_type_processor = processors[namespace_change_type.name]
+    contexts = namespace_change_type_processor.find_context_file_refs(
+        namespace_change.fileref, namespace_change.old, namespace_change.new
+    )
+    ownership_dict = {ro.owned_file_ref.path: ro for ro in contexts}
+    assert len(ownership_dict) == 2
+
+    # verify that the regular context for the changed file is present
+    assert "my-namespace.yml" in ownership_dict
+    assert ownership_dict["my-namespace.yml"].change_type.name == "namespace"
+
+    # then verify that a context for the app of the namespace has been derived
+    # from the ownership expansion
+    assert "my-app.yml" in ownership_dict
+    assert ownership_dict["my-app.yml"].change_type.name == "app"
+
+
+def test_change_type_expansion_cycle(
+    namespace_change_type: ChangeTypeV1, app_change_type: ChangeTypeV1
+):
+    namespace_change_type.changes = app_change_type.changes
+    namespace_change_type.changes[0].change_types[0].name = "app"  # type: ignore
+
+    with pytest.raises(ChangeTypeCycleError):
+        init_change_type_processors(
+            [namespace_change_type, app_change_type],
+            MockFileDiffResolver(fail_on_unknown_path=False),
+        )

--- a/reconcile/test/change_owners/test_change_type_priorities.py
+++ b/reconcile/test/change_owners/test_change_type_priorities.py
@@ -3,10 +3,10 @@ from unittest.mock import MagicMock
 from reconcile.change_owners.change_types import (
     BundleFileChange,
     ChangeTypePriority,
-    build_change_type_processor,
     get_priority_for_changes,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
+from reconcile.test.change_owners.fixtures import change_type_to_processor
 
 pytest_plugins = [
     "reconcile.test.change_owners.fixtures",
@@ -29,7 +29,7 @@ def test_priority_for_changes(
         diffs=[],
     )
     c1.involved_change_types = MagicMock(  # type: ignore
-        return_value=[build_change_type_processor(saas_file_changetype)]
+        return_value=[change_type_to_processor(saas_file_changetype)]
     )
     c2 = BundleFileChange(
         fileref=None,  # type: ignore
@@ -38,7 +38,7 @@ def test_priority_for_changes(
         diffs=[],
     )
     c2.involved_change_types = MagicMock(  # type: ignore
-        return_value=[build_change_type_processor(secret_promoter_change_type)]
+        return_value=[change_type_to_processor(secret_promoter_change_type)]
     )
 
     assert ChangeTypePriority.MEDIUM == get_priority_for_changes([c1, c2])

--- a/reconcile/test/change_owners/test_change_type_processor.py
+++ b/reconcile/test/change_owners/test_change_type_processor.py
@@ -1,15 +1,12 @@
 import pytest
 from jsonpath_ng.exceptions import JsonPathParserError
 
-from reconcile.change_owners.change_types import (
-    ChangeTypeContext,
-    build_change_type_processor,
+from reconcile.change_owners.change_types import ChangeTypeContext
+from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
+from reconcile.test.change_owners.fixtures import (
+    TestFile,
+    change_type_to_processor,
 )
-from reconcile.gql_definitions.change_owners.queries.change_types import (
-    ChangeTypeChangeDetectorV1,
-    ChangeTypeV1,
-)
-from reconcile.test.change_owners.fixtures import TestFile
 
 pytest_plugins = [
     "reconcile.test.change_owners.fixtures",
@@ -21,16 +18,6 @@ pytest_plugins = [
 #
 
 
-def test_change_type_processor_building_unsupported_provider(
-    secret_promoter_change_type: ChangeTypeV1,
-):
-    secret_promoter_change_type.changes[0] = ChangeTypeChangeDetectorV1(
-        provider="unsupported-provider", changeSchema=None, context=None
-    )
-    with pytest.raises(ValueError):
-        build_change_type_processor(secret_promoter_change_type)
-
-
 def test_change_type_processor_building_invalid_jsonpaths(
     secret_promoter_change_type: ChangeTypeV1,
 ):
@@ -38,7 +25,7 @@ def test_change_type_processor_building_invalid_jsonpaths(
         0
     ] = "invalid-jsonpath/selector"
     with pytest.raises(JsonPathParserError):
-        build_change_type_processor(secret_promoter_change_type)
+        change_type_to_processor(secret_promoter_change_type)
 
 
 #
@@ -52,13 +39,14 @@ def test_change_type_processor_allowed_paths_simple(
     changed_user_file = user_file.create_bundle_change(
         {"roles[0]": {"$ref": "some-role"}}
     )
-    processor = build_change_type_processor(role_member_change_type)
+    processor = change_type_to_processor(role_member_change_type)
     paths = processor.allowed_changed_paths(
         file_ref=changed_user_file.fileref,
         file_content=changed_user_file.new,
         ctx=ChangeTypeContext(
             change_type_processor=processor,
             context="RoleV1 - some role",
+            origin="",
             approvers=[],
             context_file=user_file.file_ref(),
         ),
@@ -73,13 +61,14 @@ def test_change_type_processor_allowed_paths_conditions(
     changed_namespace_file = namespace_file.create_bundle_change(
         {"openshiftResources[1].version": 2}
     )
-    processor = build_change_type_processor(secret_promoter_change_type)
+    processor = change_type_to_processor(secret_promoter_change_type)
     paths = processor.allowed_changed_paths(
         file_ref=changed_namespace_file.fileref,
         file_content=changed_namespace_file.new,
         ctx=ChangeTypeContext(
             change_type_processor=processor,
             context="RoleV1 - some role",
+            origin="",
             approvers=[],
             context_file=namespace_file.file_ref(),
         ),

--- a/reconcile/test/change_owners/test_change_type_various.py
+++ b/reconcile/test/change_owners/test_change_type_various.py
@@ -93,6 +93,7 @@ def test_normal_path_expression():
         ChangeTypeContext(
             change_type_processor=None,  # type: ignore
             context="RoleV1 - some-role",
+            origin="",
             approvers=[],
             context_file=FileRef(
                 BundleFileType.DATAFILE, "some-file.yaml", "schema-1.yml"
@@ -111,6 +112,7 @@ def test_templated_path_expression():
         ChangeTypeContext(
             change_type_processor=None,  # type: ignore
             context="RoleV1 - some-role",
+            origin="",
             approvers=[],
             context_file=FileRef(
                 BundleFileType.DATAFILE, "some-file.yaml", "schema-1.yml"

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -21,6 +21,7 @@ import reconcile.terraform_resources as tfr
 import reconcile.terraform_users as tfu
 import reconcile.terraform_vpc_peerings as tfvpc
 from reconcile import queries
+from reconcile.change_owners.bundle import NoOpFileDiffResolver
 from reconcile.change_owners.change_owners import (
     fetch_change_type_processors,
     fetch_self_service_roles,
@@ -1456,7 +1457,7 @@ def app_interface_open_selfserviceable_mr_queue(ctx):
 @click.pass_context
 def change_types(ctx):
     """List all change types."""
-    change_types = fetch_change_type_processors(gql.get_api())
+    change_types = fetch_change_type_processors(gql.get_api(), NoOpFileDiffResolver())
 
     usage_statistics: dict[str, int] = defaultdict(int)
     roles = fetch_self_service_roles(gql.get_api())


### PR DESCRIPTION
# What changed

Add a new change provider named change-type to /app-interface/change-type-1.yml#changes.provider that can reference an existing change-type and put it into the context of changes.context.

```yaml
name: app-owner
...
changes:
- provider: change-type         <-- new provider
  changeTypes:
  - $ref: namespace-owner.yml   <-- puts the existing change-type ...
  context:                      <-- ... into a new context
    selector: app.'$ref'
```

This makes the referenced change-type usable in the ownership context of the referencing change-type. It redurced ownership management toil and makes the change-types reusable. It also enables the definition of higher level concepts for ownership, e.g. the owned entity is an app and by putting existing change-types into the context of the app change-type, ownership is dynamically expanded to other entities.

# How to review

*The commits prefixed with `refactor` do not change anything on the logic but restructure the code in preparation for the actual changes. Review optional.*

*The commit prefixed with `query` changes the qenerate query for change-types. Review optional.*

The commit  "add context-expansion" contains the actual changes for change-type reusability. This is the one you should review. ⚠️ 

# References

Jira ticket: https://issues.redhat.com/browse/APPSRE-6651
Design document: https://gitlab.cee.redhat.com/service/app-interface/-/blob/27228c461e545826779911d55a5c7d1784d4da78/docs/app-sre/design-docs/change-type-reusability.md
schema-change: https://github.com/app-sre/qontract-schemas/pull/365

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>