### PR TITLE
adds insights service account oauth scope to ocm resource server

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5345,6 +5345,10 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     "scope_name": "BackplaneService",
                     "scope_description": "Backplane API service account",
                 },
+                {
+                    "scope_name": "InsightsServiceAccount",
+                    "scope_description": "Insights service account",
+                },                
             ],
             **cognito_resource_server_args,
         )

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5418,6 +5418,17 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         )
         tf_resources.append(backplane_api_service_account_pool_client_resource)
 
+        # INSIGHTS
+        insights_service_account_pool_client_resource = aws_cognito_user_pool_client(
+            "ocm_ams_service_account",
+            name=f"ocm-{identifier}-insights-service-account",
+            user_pool_id=f"${{{cognito_user_pool_resource.id}}}",
+            allowed_oauth_scopes=["ocm/InsightsServiceAccount"],
+            depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
+            **pool_client_service_account_common_args,
+        )
+        tf_resources.append(ams_service_account_pool_client_resource)
+
         # USER POOL COMPLETE
 
         # rosa-authenticator-vpce provider OR pre-created vpce resources are required for this

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5348,7 +5348,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 {
                     "scope_name": "InsightsServiceAccount",
                     "scope_description": "Insights service account",
-                },                
+                },
             ],
             **cognito_resource_server_args,
         )
@@ -5420,14 +5420,14 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         # INSIGHTS
         insights_service_account_pool_client_resource = aws_cognito_user_pool_client(
-            "ocm_ams_service_account",
+            "ocm_insights_service_account",
             name=f"ocm-{identifier}-insights-service-account",
             user_pool_id=f"${{{cognito_user_pool_resource.id}}}",
             allowed_oauth_scopes=["ocm/InsightsServiceAccount"],
             depends_on=["aws_cognito_resource_server.userpool_service_resource_server"],
             **pool_client_service_account_common_args,
         )
-        tf_resources.append(ams_service_account_pool_client_resource)
+        tf_resources.append(insights_service_account_pool_client_resource)
 
         # USER POOL COMPLETE
 


### PR DESCRIPTION
FedRAMP Insights initiative needs to leverage AMS and a new oauth scope which does not currently exist. This PR is to add the scope to Cognito in FedRAMP so a service account can be created with this new scope.

@aleccohan can address any questions for more details as the originator of the request