### PR TITLE
[change-owners] ignore leading/trailing spaces in approval comments

### DIFF
--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -33,6 +33,7 @@ def get_approver_decisions_from_mr_comments(
         commenter = c["username"]
         comment_body = c.get("body")
         for line in comment_body.split("\n") if comment_body else []:
+            line = line.strip()
             if line == DecisionCommand.APPROVED.value:
                 decisions_by_users[commenter].approve = True
             if line == DecisionCommand.CANCEL_APPROVED.value:

--- a/reconcile/test/change_owners/test_change_type_decision.py
+++ b/reconcile/test/change_owners/test_change_type_decision.py
@@ -115,6 +115,25 @@ def test_approval_comments_none_body():
     assert not get_approver_decisions_from_mr_comments(comments)
 
 
+def test_approver_decision_leading_trailing_spaces():
+    comments = [
+        {
+            "username": "user-1",
+            "body": ("nice\n" f" {DecisionCommand.APPROVED.value}"),
+            "created_at": "2020-01-01T00:00:00Z",
+        },
+        {
+            "username": "user-2",
+            "body": (f"{DecisionCommand.HOLD.value} \n" "oh wait... big problems"),
+            "created_at": "2020-01-02T00:00:00Z",
+        },
+    ]
+    assert get_approver_decisions_from_mr_comments(comments) == {
+        "user-1": Decision(approve=True, hold=False),
+        "user-2": Decision(approve=False, hold=True),
+    }
+
+
 #
 # test decide on changes
 #


### PR DESCRIPTION
leading or trailing spaces in approval rendered the approval comment invalid. this fix ignores such spaces

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>