### PR TITLE
Add support for aws gov partition within `populate_tf_resource_cloudwatch`

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -3079,7 +3079,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                         ],
                         "Resource": "*",
                     },
-                    {"Effect": "Allow", "Action": "es:*", "Resource": "arn:aws:es:*"},
+                    {
+                        "Effect": "Allow",
+                        "Action": "es:*",
+                        "Resource": f"arn:{self._get_partition(account)}:es:*",
+                    },
                 ],
             }
 


### PR DESCRIPTION
Addresses error encountered when attempting to provision supporting role for cloudwatch within FR