### PR TITLE
cluster upgrade cross org sector dependencies

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -634,9 +634,6 @@ CLUSTERS_QUERY = """
         name
         dependencies {
           name
-          ocm {
-            name
-          }
         }
       }
     }

--- a/reconcile/test/test_utils_cluster_version_data.py
+++ b/reconcile/test/test_utils_cluster_version_data.py
@@ -6,13 +6,16 @@ import pytest
 
 from reconcile.utils import cluster_version_data as cvd
 
+LOW_VERSION = "4.12.1"
+HIGH_VERSION = "4.12.2"
+
 
 @pytest.fixture
 def ocm1_state():
     return {
         "check_in": "2021-08-29T18:00:00",
         "versions": {
-            "version1": {
+            LOW_VERSION: {
                 "workloads": {
                     "workload1": {
                         "soak_days": 21.0,
@@ -22,6 +25,12 @@ def ocm1_state():
                 }
             }
         },
+        "stats": {
+            "min_version": LOW_VERSION,
+            "min_version_per_workload": {
+                "workload1": LOW_VERSION,
+            },
+        },
     }
 
 
@@ -30,7 +39,7 @@ def ocm2_state():
     return {
         "check_in": "2021-08-29T18:00:00",
         "versions": {
-            "version1": {
+            LOW_VERSION: {
                 "workloads": {
                     "workload1": {
                         "soak_days": 3.0,
@@ -39,7 +48,7 @@ def ocm2_state():
                     "workload3": {"soak_days": 10.0, "reporting": ["cluster6"]},
                 }
             },
-            "version2": {
+            HIGH_VERSION: {
                 "workloads": {
                     "workload1": {
                         "soak_days": 13.0,
@@ -47,6 +56,13 @@ def ocm2_state():
                     },
                     "workload3": {"soak_days": 20.0, "reporting": ["cluster6"]},
                 }
+            },
+        },
+        "stats": {
+            "min_version": LOW_VERSION,
+            "min_version_per_workload": {
+                "workload1": LOW_VERSION,
+                "workload3": HIGH_VERSION,
             },
         },
     }
@@ -95,30 +111,30 @@ def test_version_data_old_style_check_in(state, ocm1_state):
 def test_version_data_load_update_save(state, ocm1_state):
     version_data = cvd.get_version_data(state, "ocm1")
     new_ocm1_state = deepcopy(ocm1_state)
-    get_data(new_ocm1_state, "version1", "workload1")["soak_days"] = 100.0
-    version_data.versions["version1"].workloads["workload1"].soak_days = 100.0
+    get_data(new_ocm1_state, LOW_VERSION, "workload1")["soak_days"] = 100.0
+    version_data.versions[LOW_VERSION].workloads["workload1"].soak_days = 100.0
     version_data.save(state, "ocm1")
     state.add.assert_called_once_with("ocm1", new_ocm1_state, force=True)
 
 
-def test_version_data_workload_history(state, ocm1_state, ocm2_state):
+def test_version_data_workload_history(state, ocm1_state):
     default_wh = cvd.WorkloadHistory()
     version_data = cvd.get_version_data(state, "ocm1")
 
-    wh = version_data.workload_history("version1", "workload1")
-    assert wh == get_data(ocm1_state, "version1", "workload1")
+    wh = version_data.workload_history(LOW_VERSION, "workload1")
+    assert wh == get_data(ocm1_state, LOW_VERSION, "workload1")
 
-    wh = version_data.workload_history("version1", "workload1", default_wh)
-    assert wh == get_data(ocm1_state, "version1", "workload1")
+    wh = version_data.workload_history(LOW_VERSION, "workload1", default_wh)
+    assert wh == get_data(ocm1_state, LOW_VERSION, "workload1")
 
-    wh = version_data.workload_history("version1", "does-not-exist")
+    wh = version_data.workload_history(LOW_VERSION, "does-not-exist")
     assert wh == default_wh
 
     default_wh.soak_days = 5.0
-    wh = version_data.workload_history("version1", "does-not-exist", default_wh)
+    wh = version_data.workload_history(LOW_VERSION, "does-not-exist", default_wh)
     assert wh == default_wh
     # ensure our new default has been set
-    wh = version_data.workload_history("version1", "does-not-exist")
+    wh = version_data.workload_history(LOW_VERSION, "does-not-exist")
     assert wh == default_wh
 
 
@@ -127,24 +143,35 @@ def test_version_data_aggregate(state, ocm1_state, ocm2_state):
     version_data_ocm2 = cvd.get_version_data(state, "ocm2")
     version_data.aggregate(version_data_ocm2, "ocm2")
 
-    assert set(version_data.versions.keys()) == {"version1", "version2"}
+    assert set(version_data.versions.keys()) == {LOW_VERSION, HIGH_VERSION}
 
-    v1_workloads = version_data.versions["version1"].workloads
+    v1_workloads = version_data.versions[LOW_VERSION].workloads
     # unkwown workloads are not aggregated
     assert "workload3" not in v1_workloads
     # nothing to aggregate
-    assert v1_workloads["workload2"] == get_data(ocm1_state, "version1", "workload2")
-    # aggregation fo version1/woarkload1
-    ocm1_v1_w1 = get_data(ocm1_state, "version1", "workload1")
-    ocm2_v1_w1 = get_data(ocm2_state, "version1", "workload1")
+    assert v1_workloads["workload2"] == get_data(ocm1_state, LOW_VERSION, "workload2")
+    # aggregation of LOW_VERSION/workload1
+    ocm1_v1_w1 = get_data(ocm1_state, LOW_VERSION, "workload1")
+    ocm2_v1_w1 = get_data(ocm2_state, LOW_VERSION, "workload1")
     assert v1_workloads["workload1"] == {
         "soak_days": ocm1_v1_w1["soak_days"] + ocm2_v1_w1["soak_days"],
         "reporting": ocm1_v1_w1["reporting"]
         + [f"ocm2/{r}" for r in ocm2_v1_w1["reporting"]],
     }
 
-    v2_workloads = version_data.versions["version2"].workloads
-    aggregated = get_data(ocm2_state, "version2", "workload1")
+    v2_workloads = version_data.versions[HIGH_VERSION].workloads
+    aggregated = get_data(ocm2_state, HIGH_VERSION, "workload1")
     aggregated["reporting"] = [f"ocm2/{r}" for r in aggregated["reporting"]]
-    # new version version2 for workload1 aggregated
+    # new version HIGH_VERSION for workload1 aggregated
     assert v2_workloads == {"workload1": aggregated}
+
+    assert version_data.stats is not None
+    assert version_data.stats.inherited == version_data_ocm2.stats
+
+
+def test_update_stats():
+    pass
+
+
+def test_validate_against_inherited():
+    pass

--- a/reconcile/utils/cluster_version_data.py
+++ b/reconcile/utils/cluster_version_data.py
@@ -11,6 +11,7 @@ from pydantic import (
     Field,
 )
 
+from reconcile.utils.semver_helper import parse_semver
 from reconcile.utils.state import State
 
 
@@ -23,12 +24,58 @@ class VersionHistory(BaseModel):
     workloads: dict[str, WorkloadHistory] = Field(default_factory=dict)
 
 
+class Stats(BaseModel):
+    min_version: str
+    min_version_per_workload: dict[str, str] = Field(default_factory=dict)
+    inherited: Optional["Stats"]
+
+    def inherit(self, added: "Stats") -> None:
+        if not self.inherited:
+            self.inherited = added
+            return
+        self.inherited.min_version = min(
+            self.inherited.min_version, added.min_version, key=parse_semver
+        )
+        for workload, added_version in added.min_version_per_workload.items():
+            v = self.inherited.min_version_per_workload.get(workload, added_version)
+            self.inherited.min_version_per_workload[workload] = min(
+                v, added_version, key=parse_semver
+            )
+
+    def validate_against_inherited(self, version: str, workloads: list[str]) -> bool:
+        """Returns True only if version is less than any of the inherited version for these workloads
+        If one of the worloads is not part of the inherited stats, we will check against the global
+        minimum version
+        """
+        if not self.inherited:
+            return True
+        semver = parse_semver(version)
+        all_workloads_found = True
+        all_workload_ok = True
+        # check that inherited orgs run at least that version for our workloads
+        for w in workloads:
+            all_workloads_found = w in self.inherited.min_version_per_workload
+            if not all_workloads_found:
+                break
+            if semver > parse_semver(self.inherited.min_version_per_workload[w]):
+                all_workload_ok = False
+        if all_workloads_found and not all_workload_ok:
+            return False
+        if not all_workloads_found:
+            # if some of our workload is not inherited, check the global min_version
+            # from the other orgs
+            if semver > parse_semver(self.inherited.min_version):
+                return False
+        return True
+
+
 class VersionData(BaseModel):
     check_in: Optional[datetime]
     versions: dict[str, VersionHistory] = Field(default_factory=dict)
+    stats: Optional[Stats]
 
     def jsondict(self) -> dict[str, Any]:
-        return json.loads(self.json())
+        return json.loads(self.json(exclude_unset=True))
 
     def save(self, state: State, ocm_name: str) -> None:
         state.add(ocm_name, self.jsondict(), force=True)
@@ -48,6 +95,22 @@ class VersionData(BaseModel):
             workloads.update(v.workloads.keys())
         return workloads
 
+    def update_stats(self, upgrade_policies: list[dict[str, str]]) -> None:
+        min_version_per_workload: dict[str, str] = {}
+        for item in upgrade_policies:
+            current_version = item["current_version"]
+            for w in item["workloads"]:
+                min_ver = min_version_per_workload.setdefault(w, current_version)
+                if parse_semver(current_version) < parse_semver(min_ver):
+                    min_version_per_workload[w] = current_version
+
+        if min_version_per_workload:
+            min_version = min(min_version_per_workload.values(), key=parse_semver)
+            self.stats = Stats(
+                min_version=min_version,
+                min_version_per_workload=min_version_per_workload,
+            )
+
     def aggregate(self, added: "VersionData", added_org_name: str) -> None:
         known_workloads = self.workloads()
         for version, version_data in added.versions.items():
@@ -61,6 +124,13 @@ class VersionData(BaseModel):
                     f"{added_org_name}/{cluster}" for cluster in workload_data.reporting
                 ]
                 w.reporting += ocm_clusters
+        if self.stats and added.stats:
+            self.stats.inherit(added.stats)
+
+    def validate_against_inherited(self, version: str, workloads: list[str]) -> bool:
+        if not self.stats:
+            return True
+        return self.stats.validate_against_inherited(version, workloads)
 
 
 def get_version_data(state: State, ocm_name: str) -> VersionData:


### PR DESCRIPTION
[APPSRE-6675](https://issues.redhat.com/browse/APPSRE-6675)

The first implementation of cluster upgrade sectors ([APPSRE-6545](https://issues.redhat.com/browse/APPSRE-6545)) allowed to reference sectors cross orgs. This implementation has several drawbacks:
- knowledge of sectors from one org to the other, which may not be the case/needed/wanted and makes changes to sector list more complex.
- complex code where a sector map needs to be global. It also forbids (or make complex) sharding of integrations that use this feature.

This PR changes this by relying on the `inheritVersionData` flag in the ocm org schema:

if `sector` is defined in the cluster upgradepolicy and the cluster org inherits from an other one, we will allow an upgrade to a version if either:
- all the cluster `workloads` exist on the inherited org, and they all run at least that version
- all `workloads` are not existing in the inherited org and all cluster in that org run at least that version

Review will be easier 1 commit at a time