### PR TITLE
invalid pagerduty IDs

### DIFF
--- a/reconcile/utils/pagerduty_api.py
+++ b/reconcile/utils/pagerduty_api.py
@@ -21,7 +21,11 @@ from reconcile.utils.secret_reader import (
 
 
 class PagerDutyTargetException(Exception):
-    pass
+    """This exception is raised when PagerDutyTarget is not configured correctly."""
+
+
+class PagerDutyApiException(Exception):
+    """This exception is raised when PagerDuty API call fails."""
 
 
 class PagerDutyInstance(Protocol):
@@ -84,8 +88,8 @@ class PagerDutyApi:
             elif resource_type == "escalationPolicy":
                 users = self.get_escalation_policy_users(resource_id, now)
         except requests.exceptions.HTTPError as e:
-            logging.warning(str(e))
-            return []
+            logging.error(str(e))
+            raise PagerDutyApiException(str(e)) from e
 
         return users
 


### PR DESCRIPTION
pagerduty raises an exception for invalid resource_ids, slack-usergroups reconciles all user groups but exits with exit code 1 when an error occurs.

Ticket: [APPSRE-6621](https://issues.redhat.com/browse/APPSRE-6621)