### PR TITLE
qontract-cli output for ocm addon upgrade policies

### DIFF
--- a/reconcile/ocm_addons_upgrade_scheduler_org.py
+++ b/reconcile/ocm_addons_upgrade_scheduler_org.py
@@ -5,6 +5,7 @@ import reconcile.ocm_upgrade_scheduler as ous
 from reconcile import queries
 from reconcile.utils.cluster_version_data import VersionData
 from reconcile.utils.ocm import OCMMap
+
 QONTRACT_INTEGRATION = "ocm-addons-upgrade-scheduler-org"
 
 
@@ -36,20 +37,22 @@ def calculate_diff(
 
 
 @dataclasses.dataclass(unsafe_hash=True)
-class ResultKey():
+class ResultKey:
     ocm_map: OCMMap
     ocm_name: str
     addon_id: str
 
 
 @dataclasses.dataclass
-class Result():
+class Result:
     current_state: list[dict[str, Any]]
     desired_state: list[dict[str, Any]]
     diffs: list[dict[str, str]]
 
 
-def compute(settings: dict, ocms: list[dict[str, Any]], dry_run: bool) -> dict[ResultKey, Result]:
+def compute(
+    settings: dict, ocms: list[dict[str, Any]], dry_run: bool
+) -> dict[ResultKey, Result]:
     ocms = [o for o in ocms if o.get("addonManagedUpgrades")]
     results: dict[ResultKey, Result] = {}
     for ocm in ocms:

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1193,7 +1193,7 @@ class OCM:  # pylint: disable=too-many-public-methods
         )
         self._delete(api)
 
-    def addon_version_blocked(self, version: str, addon_id: str = "") -> bool:
+    def addon_version_blocked(self, version: str, addon_id: str) -> bool:
         """Check if an addon version is blocked
 
         Args:

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -1434,6 +1434,13 @@ class OCM:  # pylint: disable=too-many-public-methods
                 return addon
         return None
 
+    def get_addon_version(self, id):
+        for addon in self.addons:
+            addon_id = addon["id"]
+            if id == addon_id:
+                return addon["version"]["id"]
+        return None
+
     def get_addon_upgrade_policies(
         self, cluster_name: str, addon_id: str = ""
     ) -> list[dict[str, Any]]:

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -581,10 +581,11 @@ def ocm_fleet_upgrade_policies(
 @click.pass_context
 def ocm_addon_upgrade_policies(ctx):
     import reconcile.ocm_addons_upgrade_scheduler_org as oauso
+
     md_output = ctx.obj["options"]["output"] == "md"
     if not md_output:
         print("We only support md output for now")
-        exit(1)
+        sys.exit(1)
     ous.QONTRACT_INTEGRATION = oauso.QONTRACT_INTEGRATION
 
     settings = queries.get_app_interface_settings()
@@ -602,17 +603,19 @@ def ocm_addon_upgrade_policies(ctx):
             if d.get("conditions", {}).get("sector"):
                 sector = d["conditions"]["sector"].name
             version = d["current_version"]
-            ocm_output.append({
-                "cluster": d["cluster"],
-                "addon_id": addon_id,
-                "current_version": version,
-                "schedule": d["schedule"],
-                "sector": sector,
-                "mutexes": ", ".join(d.get("conditions", {}).get("mutexes", [])),
-                "soak_days": d.get("conditions", {}).get("soakDays"),
-                "workloads": ", ".join(d["workloads"]),
-                "next_version": next_version if next_version != version else ""
-            })
+            ocm_output.append(
+                {
+                    "cluster": d["cluster"],
+                    "addon_id": addon_id,
+                    "current_version": version,
+                    "schedule": d["schedule"],
+                    "sector": sector,
+                    "mutexes": ", ".join(d.get("conditions", {}).get("mutexes", [])),
+                    "soak_days": d.get("conditions", {}).get("soakDays"),
+                    "workloads": ", ".join(d["workloads"]),
+                    "next_version": next_version if next_version != version else "",
+                }
+            )
     fields = [
         {"key": "cluster", "sortable": True},
         {"key": "addon_id", "sortable": True},
@@ -632,7 +635,15 @@ def ocm_addon_upgrade_policies(ctx):
 ```
     """
     for ocm_name in sorted(output.keys()):
-        json_data = json.dumps({"fields": fields, "items": output[ocm_name], "filter": True, "caption": ""}, indent=1)
+        json_data = json.dumps(
+            {
+                "fields": fields,
+                "items": output[ocm_name],
+                "filter": True,
+                "caption": "",
+            },
+            indent=1,
+        )
         print(section.format(ocm_name, json_data))
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-6809

This is a bit more simple than clusters' output as addons can be upgraded to only one version. We can review later if more fancy display is deemed necessary (🎉 )

Example output:
https://gitlab.cee.redhat.com/-/snippets/6206