### PR TITLE
fluentd read_from_head

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -123,6 +123,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -62,6 +62,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -62,6 +62,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>
@@ -235,6 +236,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/aws_account_shards.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shards.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>
@@ -235,6 +236,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/basic.yml
+++ b/reconcile/test/fixtures/helm/basic.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/cache.yml
+++ b/reconcile/test/fixtures/helm/cache.yml
@@ -62,6 +62,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/command.yml
+++ b/reconcile/test/fixtures/helm/command.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/disable_unleash.yml
+++ b/reconcile/test/fixtures/helm/disable_unleash.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -62,6 +62,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/environment_aware.yml
+++ b/reconcile/test/fixtures/helm/environment_aware.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/exclude_service.yml
+++ b/reconcile/test/fixtures/helm/exclude_service.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/extra_args.yml
+++ b/reconcile/test/fixtures/helm/extra_args.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/extra_env.yml
+++ b/reconcile/test/fixtures/helm/extra_env.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/integrations_manager.yml
+++ b/reconcile/test/fixtures/helm/integrations_manager.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/internal_certificates.yml
+++ b/reconcile/test/fixtures/helm/internal_certificates.yml
@@ -63,6 +63,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/logs_slack.yml
+++ b/reconcile/test/fixtures/helm/logs_slack.yml
@@ -62,6 +62,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/shards.yml
+++ b/reconcile/test/fixtures/helm/shards.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>
@@ -233,6 +234,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/sleep_duration.yml
+++ b/reconcile/test/fixtures/helm/sleep_duration.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/state.yml
+++ b/reconcile/test/fixtures/helm/state.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/storage.yml
+++ b/reconcile/test/fixtures/helm/storage.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>

--- a/reconcile/test/fixtures/helm/trigger.yml
+++ b/reconcile/test/fixtures/helm/trigger.yml
@@ -53,6 +53,7 @@ objects:
             <source>
               @type tail
               path /fluentd/log/integration.log
+              read_from_head true
               pos_file /fluentd/log/integration.log.pos
               tag integration
               <parse>


### PR DESCRIPTION
Use [fluentd read_from_head](https://docs.fluentd.org/input/tail#read_from_head) to log all integration output from the start, even if fluentd takes more time than the integration to start.

This should avoid missing early logs on pod startup.

I will check on stage once merged if fluentd starts correctly.