### PR TITLE
[slack-usergroups] reset error flag at startup

### DIFF
--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -733,6 +733,9 @@ def run(
     workspace_name: Optional[str] = None,
     usergroup_name: Optional[str] = None,
 ) -> None:
+    global error_occurred
+    error_occurred = False
+
     gqlapi = gql.get_api()
     secret_reader = SecretReader(queries.get_secret_reader_settings())
     init_users = False if usergroup_name else True


### PR DESCRIPTION
After an error occurred, the global `error_occurred` flag was still set. Reset it on each integration run to avoid that.

[APPSRE-6818](https://issues.redhat.com/browse/APPSRE-6818)