### PR TITLE
integration runner refactor + sharded dry-runs

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -9061,6 +9061,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "addonManagedUpgrades",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "addonUpgradeTests",
                             "description": null,
                             "args": [],
@@ -22262,6 +22274,18 @@
                         },
                         {
                             "name": "early_exit",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "check_only_affected_shards",
                             "description": null,
                             "args": [],
                             "type": {

--- a/reconcile/test/runtime/demo_integration.py
+++ b/reconcile/test/runtime/demo_integration.py
@@ -1,0 +1,12 @@
+QONTRACT_INTEGRATION = "demo-integration"
+
+run_calls = []
+
+
+def run(dry_run: bool, some_arg: int) -> None:
+    run_calls.append(
+        {
+            "some_arg": some_arg,
+            "dry_run": dry_run,
+        }
+    )

--- a/reconcile/test/runtime/demo_integration_early_exit.py
+++ b/reconcile/test/runtime/demo_integration_early_exit.py
@@ -1,0 +1,14 @@
+from typing import Any
+
+QONTRACT_INTEGRATION = "demo-integration-early-exit"
+
+
+def run(dry_run: bool, some_arg: int) -> None:
+    pass
+
+
+def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
+    return {
+        "args": args,
+        "kwargs": kwargs,
+    }

--- a/reconcile/test/runtime/demo_integration_no_run_func.py
+++ b/reconcile/test/runtime/demo_integration_no_run_func.py
@@ -1,0 +1,1 @@
+QONTRACT_INTEGRATION = "demo-integration-no-run-func"

--- a/reconcile/test/runtime/demo_integration_shard_config.py
+++ b/reconcile/test/runtime/demo_integration_shard_config.py
@@ -1,0 +1,16 @@
+from reconcile.utils.runtime.integration import DesiredStateShardConfig
+
+QONTRACT_INTEGRATION = "demo-integration-sharded"
+SHARD_ARG_NAME = "shard"
+
+
+def run(dry_run: bool, some_arg: int, shard: str) -> None:
+    pass
+
+
+def desired_state_shard_config() -> DesiredStateShardConfig:
+    return DesiredStateShardConfig(
+        shard_arg_name=SHARD_ARG_NAME,
+        shard_path_selectors={"shard[*].name"},
+        sharded_run_review=lambda _: True,
+    )

--- a/reconcile/test/runtime/fixtures.py
+++ b/reconcile/test/runtime/fixtures.py
@@ -1,0 +1,61 @@
+from typing import (
+    Any,
+    Optional,
+)
+
+import pytest
+
+from reconcile.utils.runtime.integration import (
+    DesiredStateShardConfig,
+    QontractReconcileIntegration,
+)
+
+
+class SimpleTestIntegration(QontractReconcileIntegration):
+    def __init__(self):
+        self.desired_state_data = {}
+
+    @property
+    def name(self) -> str:
+        return "test-integration"
+
+    def get_early_exit_desired_state(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return self.desired_state_data
+
+    def get_desired_state_shard_config(self) -> Optional[DesiredStateShardConfig]:
+        return None
+
+    def run(self, dry_run: bool, *args, **kwargs) -> None:
+        pass
+
+
+@pytest.fixture
+def simple_test_integration() -> SimpleTestIntegration:
+    return SimpleTestIntegration()
+
+
+class ShardableTestIntegration(QontractReconcileIntegration):
+    def __init__(self):
+        self.desired_state_data = {}
+
+    @property
+    def name(self) -> str:
+        return "shardable-test-integration"
+
+    def get_early_exit_desired_state(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return self.desired_state_data
+
+    def get_desired_state_shard_config(self) -> Optional[DesiredStateShardConfig]:
+        return DesiredStateShardConfig(
+            shard_arg_name="shard",
+            shard_path_selectors={"shards[*].shard"},
+            sharded_run_review=lambda srp: True,
+        )
+
+    def run(self, dry_run: bool, *args, **kwargs) -> None:
+        pass
+
+
+@pytest.fixture
+def shardable_test_integration() -> ShardableTestIntegration:
+    return ShardableTestIntegration()

--- a/reconcile/test/runtime/test_utils_desired_state_diff.py
+++ b/reconcile/test/runtime/test_utils_desired_state_diff.py
@@ -1,0 +1,165 @@
+from time import sleep
+from typing import Any
+
+import jsonpath_ng
+import pytest
+from pytest_mock.plugin import MockerFixture
+
+from reconcile.change_owners.diff import (
+    Diff,
+    DiffType,
+)
+from reconcile.test.runtime.fixtures import (
+    ShardableTestIntegration,
+    SimpleTestIntegration,
+)
+from reconcile.utils.runtime import desired_state_diff
+from reconcile.utils.runtime.desired_state_diff import (
+    DiffDetectionTimeout,
+    build_desired_state_diff,
+    extract_diffs_with_timeout,
+)
+
+pytest_plugins = [
+    "reconcile.test.runtime.fixtures",
+]
+
+
+def test_desired_state_diff_building(simple_test_integration: SimpleTestIntegration):
+    desired_state_diff = build_desired_state_diff(
+        simple_test_integration.get_desired_state_shard_config(),
+        previous_desired_state={"data": "old"},
+        current_desired_state={"data": "new"},
+    )
+    assert desired_state_diff.affected_shards == set()
+    assert not desired_state_diff.can_exit_early()
+
+
+def test_desired_state_diff_building_no_diffs(
+    simple_test_integration: SimpleTestIntegration,
+):
+    desired_state_diff = build_desired_state_diff(
+        simple_test_integration.get_desired_state_shard_config(),
+        previous_desired_state={"data": [{"name": "a"}, {"name": "b"}]},
+        current_desired_state={"data": [{"name": "a"}, {"name": "b"}]},
+    )
+    assert desired_state_diff.affected_shards == set()
+    assert desired_state_diff.can_exit_early()
+
+
+def test_desired_state_diff_building_unshardable_integration(
+    simple_test_integration: SimpleTestIntegration,
+):
+    desired_state_diff = build_desired_state_diff(
+        simple_test_integration.get_desired_state_shard_config(),
+        previous_desired_state={
+            "shards": [
+                {"shard": "a", "value": "old"},
+                {"shard": "b", "value": "old"},
+            ]
+        },
+        current_desired_state={
+            "shards": [
+                {"shard": "a", "value": "old"},
+                {"shard": "b", "value": "new"},
+            ]
+        },
+    )
+    assert desired_state_diff.affected_shards == set()
+
+
+def test_desired_state_diff_building_shardable_integration(
+    shardable_test_integration: ShardableTestIntegration,
+):
+    desired_state_diff = build_desired_state_diff(
+        shardable_test_integration.get_desired_state_shard_config(),
+        previous_desired_state={
+            "shards": [
+                {"shard": "a", "value": "old"},
+                {"shard": "b", "value": "old"},
+            ]
+        },
+        current_desired_state={
+            "shards": [
+                {"shard": "a", "value": "old"},
+                {"shard": "b", "value": "new"},
+            ]
+        },
+    )
+    assert desired_state_diff.affected_shards == {"b"}
+
+
+def diff_extration_with_3_second_sleep(
+    old_file_content: Any, new_file_content: Any
+) -> list[Diff]:
+    sleep(3)
+    return [
+        Diff(
+            diff_type=DiffType.CHANGED,
+            path=jsonpath_ng.parse("shards[1].value"),
+            old="old",
+            new="new",
+        )
+    ]
+
+
+def test_desired_state_diff_building_time(
+    mocker: MockerFixture, shardable_test_integration: ShardableTestIntegration
+):
+    extract_diffs_with_timeout_mock = mocker.patch.object(
+        desired_state_diff, "extract_diffs_with_timeout"
+    )
+    extract_diffs_with_timeout_mock.side_effect = DiffDetectionTimeout()
+    diff = build_desired_state_diff(
+        shardable_test_integration.get_desired_state_shard_config(),
+        previous_desired_state={
+            "shards": [
+                {"shard": "a", "value": "old"},
+                {"shard": "b", "value": "old"},
+            ]
+        },
+        current_desired_state={
+            "shards": [
+                {"shard": "a", "value": "old"},
+                {"shard": "b", "value": "new"},
+            ]
+        },
+    )
+    assert diff.affected_shards == set()
+
+
+def test_extract_diffs_with_timeout():
+    """
+    test timeout behaviour of diff extraction
+    """
+    previous_desired_state = {
+        "shards": [
+            {"shard": "a", "value": "old"},
+            {"shard": "b", "value": "old"},
+        ]
+    }
+    current_desired_state = {
+        "shards": [
+            {"shard": "a", "value": "old"},
+            {"shard": "b", "value": "new"},
+        ]
+    }
+
+    # the timeout is lower than the extraction duration -> TIMEOUT
+    with pytest.raises(DiffDetectionTimeout):
+        extract_diffs_with_timeout(
+            diff_extration_with_3_second_sleep,
+            previous_desired_state=previous_desired_state,
+            current_desired_state=current_desired_state,
+            timeout_seconds=1,
+        )
+
+    # the timeout is higher than the extraction duration -> NO TIMEOUT
+    diffs = extract_diffs_with_timeout(
+        diff_extration_with_3_second_sleep,
+        previous_desired_state=previous_desired_state,
+        current_desired_state=current_desired_state,
+        timeout_seconds=5,
+    )
+    assert diffs
+    assert isinstance(diffs[0], Diff)

--- a/reconcile/test/runtime/test_utils_integration.py
+++ b/reconcile/test/runtime/test_utils_integration.py
@@ -1,0 +1,73 @@
+import pytest
+
+from reconcile.test.runtime import (
+    demo_integration,
+    demo_integration_early_exit,
+    demo_integration_no_name,
+    demo_integration_no_run_func,
+    demo_integration_shard_config,
+)
+from reconcile.utils.runtime.integration import ModuleBasedQontractReconcileIntegration
+
+
+def test_module_integration_no_name():
+    """
+    an integration with no QONTRACT_INTEGRATION name variable
+    """
+    with pytest.raises(NotImplementedError):
+        ModuleBasedQontractReconcileIntegration(demo_integration_no_name)
+
+
+def test_module_integration_no_run_func():
+    """
+    an integration with no run function
+    """
+    with pytest.raises(NotImplementedError):
+        ModuleBasedQontractReconcileIntegration(demo_integration_no_run_func)
+
+
+def test_module_integration_run():
+    demo_integration.run_calls = []
+    integration = ModuleBasedQontractReconcileIntegration(demo_integration)
+    integration.run(dry_run=True, some_arg=1)
+
+    assert {
+        "some_arg": 1,
+        "dry_run": True,
+    } in demo_integration.run_calls
+    demo_integration.run_calls = []
+
+
+def test_demo_integration_no_early_exit_desired_state():
+    integration = ModuleBasedQontractReconcileIntegration(demo_integration)
+    assert not integration.get_early_exit_desired_state(some_arg=1)
+
+
+def test_demo_integration_early_exit_desired_state():
+    integration = ModuleBasedQontractReconcileIntegration(demo_integration_early_exit)
+    data = integration.get_early_exit_desired_state("arg", some_kw_arg="kwarg")
+
+    assert data == {"args": ("arg",), "kwargs": {"some_kw_arg": "kwarg"}}
+
+
+def test_demo_integration_no_shard_config():
+    integration = ModuleBasedQontractReconcileIntegration(demo_integration)
+    assert not integration.get_desired_state_shard_config()
+
+
+def test_demo_integration_shard_config():
+    integration = ModuleBasedQontractReconcileIntegration(demo_integration_shard_config)
+    assert integration.get_desired_state_shard_config()
+
+
+def test_demo_integration_kwargs_have_shard_info():
+    integration = ModuleBasedQontractReconcileIntegration(demo_integration_shard_config)
+    assert integration.kwargs_have_shard_info(
+        **{demo_integration_shard_config.SHARD_ARG_NAME: "shard1"}
+    )
+
+    assert not integration.kwargs_have_shard_info(
+        **{demo_integration_shard_config.SHARD_ARG_NAME: None}
+    )
+
+    assert not integration.kwargs_have_shard_info(**{})

--- a/reconcile/test/runtime/test_utils_runtime_runner.py
+++ b/reconcile/test/runtime/test_utils_runtime_runner.py
@@ -1,0 +1,442 @@
+import sys
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Optional,
+)
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock.plugin import MockerFixture
+
+from reconcile.test.runtime.fixtures import (
+    ShardableTestIntegration,
+    SimpleTestIntegration,
+)
+from reconcile.utils import gql
+from reconcile.utils.runtime import runner
+from reconcile.utils.runtime.desired_state_diff import DesiredStateDiff
+from reconcile.utils.runtime.runner import (
+    IntegrationRunConfiguration,
+    _integration_dry_run,
+    _integration_wet_run,
+    get_desired_state_diff,
+    run_integration_cfg,
+)
+
+pytest_plugins = [
+    "reconcile.test.runtime.fixtures",
+]
+
+
+@dataclass
+class MockIntegrationRunConfiguration(IntegrationRunConfiguration):
+
+    main_data: dict[str, Any]
+    comparison_data: dict[str, Any]
+
+    def main_bundle_desired_state(self) -> dict[str, Any]:
+        return self.main_data
+
+    def comparison_bundle_desired_state(self) -> dict[str, Any]:
+        return self.comparison_data
+
+    def switch_to_main_bundle(self, validate_schemas: Optional[bool] = None) -> None:
+        pass
+
+    def switch_to_comparison_bundle(
+        self, validate_schemas: Optional[bool] = None
+    ) -> None:
+        pass
+
+
+@pytest.fixture
+def dry_run_test_integration_cfg(
+    simple_test_integration: SimpleTestIntegration,
+) -> IntegrationRunConfiguration:
+    return MockIntegrationRunConfiguration(
+        integration=simple_test_integration,
+        valdiate_schemas=False,
+        dry_run=True,
+        early_exit_compare_sha="abc",
+        check_only_affected_shards=True,
+        gql_sha_url=False,
+        print_url=True,
+        run_args=(),
+        run_kwargs={},
+        main_data={"data": "a"},
+        comparison_data={"data": "b"},
+    )
+
+
+@pytest.fixture
+def wet_run_test_integration_cfg(
+    simple_test_integration: SimpleTestIntegration,
+) -> IntegrationRunConfiguration:
+    return MockIntegrationRunConfiguration(
+        integration=simple_test_integration,
+        valdiate_schemas=False,
+        dry_run=False,
+        early_exit_compare_sha="abc",
+        check_only_affected_shards=True,
+        gql_sha_url=False,
+        print_url=True,
+        run_args=(),
+        run_kwargs={},
+        main_data={"data": "a"},
+        comparison_data={"data": "b"},
+    )
+
+
+def test_run_configuration_switch_to_main_bundle(
+    mocker,
+    simple_test_integration: SimpleTestIntegration,
+):
+    gql_init_from_config = mocker.patch.object(gql, "init_from_config")
+    cfg = IntegrationRunConfiguration(
+        integration=simple_test_integration,
+        valdiate_schemas=False,
+        dry_run=True,
+        early_exit_compare_sha="abc",
+        check_only_affected_shards=False,
+        gql_sha_url=False,
+        print_url=True,
+        run_args=None,
+        run_kwargs=None,
+    )
+    cfg.switch_to_main_bundle()
+    gql_init_from_config.assert_called_with(
+        autodetect_sha=False,
+        integration=simple_test_integration.name,
+        validate_schemas=False,
+        print_url=True,
+    )
+
+
+def test_run_configuration_switch_to_comparison_bundle(
+    mocker,
+    simple_test_integration: SimpleTestIntegration,
+):
+    gql_init_from_config = mocker.patch.object(gql, "init_from_config")
+    gql_init_from_config.return_value = "a"
+    cfg = IntegrationRunConfiguration(
+        integration=simple_test_integration,
+        valdiate_schemas=False,
+        dry_run=True,
+        early_exit_compare_sha="abc",
+        check_only_affected_shards=False,
+        gql_sha_url=False,
+        print_url=True,
+        run_args=None,
+        run_kwargs=None,
+    )
+    cfg.switch_to_comparison_bundle()
+    gql_init_from_config.assert_called_with(
+        sha=cfg.early_exit_compare_sha,
+        integration=simple_test_integration.name,
+        validate_schemas=False,
+        print_url=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "check_only_affected_shards,early_exit_sha,previous_data,current_data,desired_state_diff_found,early_exitable,affected_shards",
+    [
+        # no comparison bundle available, so no early exit and no sharding
+        (False, None, {"data": "a"}, {"data": "b"}, False, False, set()),
+        # no desired state diff found, so early exit available but no sharding
+        (True, "some_sha", {"data": "a"}, {"data": "a"}, True, True, set()),
+        # no desired state diff found, so early exit available but no sharding
+        (False, "some_sha", {"data": "a"}, {"data": "a"}, True, True, set()),
+        # desired state diff found, so no early exit available and also no sharding
+        (True, "some_sha", {"data": "a"}, {"data": "b"}, True, False, set()),
+        (False, "some_sha", {"data": "a"}, {"data": "b"}, True, False, set()),
+        # desired state diff found, so no early exit BUT sharding available
+        (
+            True,
+            "some_sha",
+            {"shards": [{"shard": "a", "data": "a"}, {"shard": "b", "data": "b"}]},
+            {"shards": [{"shard": "a", "data": "c"}, {"shard": "b", "data": "b"}]},
+            True,
+            False,
+            set("a"),
+        ),
+        # ... but when check_only_affected_shards is not set, then no sharding
+        (
+            False,
+            "some_sha",
+            {"shards": [{"shard": "a", "data": "a"}, {"shard": "b", "data": "b"}]},
+            {"shards": [{"shard": "a", "data": "c"}, {"shard": "b", "data": "b"}]},
+            True,
+            False,
+            set(),
+        ),
+    ],
+)
+def test_get_desired_state_diff(
+    check_only_affected_shards: bool,
+    early_exit_sha: Optional[str],
+    previous_data: dict[str, Any],
+    current_data: dict[str, Any],
+    desired_state_diff_found: bool,
+    early_exitable: bool,
+    affected_shards: set[str],
+    shardable_test_integration: ShardableTestIntegration,
+):
+    cfg = MockIntegrationRunConfiguration(
+        integration=shardable_test_integration,
+        valdiate_schemas=False,
+        dry_run=True,
+        early_exit_compare_sha=early_exit_sha,
+        check_only_affected_shards=check_only_affected_shards,
+        gql_sha_url=False,
+        print_url=True,
+        run_args=(),
+        run_kwargs={},
+        main_data=current_data,
+        comparison_data=previous_data,
+    )
+    desired_state_diff = get_desired_state_diff(cfg)
+    assert (desired_state_diff is not None) == desired_state_diff_found
+    if desired_state_diff:
+        assert desired_state_diff.can_exit_early() == early_exitable
+        assert desired_state_diff.affected_shards == affected_shards
+
+
+def test_run_configuration_dispatch_dry_run(
+    mocker: MockerFixture,
+    simple_test_integration: SimpleTestIntegration,
+):
+    """
+    making sure, the dry run mode is called
+    """
+    cfg = MockIntegrationRunConfiguration(
+        integration=simple_test_integration,
+        valdiate_schemas=False,
+        dry_run=True,
+        early_exit_compare_sha="abc",
+        check_only_affected_shards=False,
+        gql_sha_url=False,
+        print_url=True,
+        run_args=(),
+        run_kwargs={},
+        main_data={"data": "a"},
+        comparison_data={"data": "b"},
+    )
+    integration_wet_run_mock = mocker.patch.object(runner, "_integration_wet_run")
+    integration_dry_run_mock = mocker.patch.object(runner, "_integration_dry_run")
+
+    run_integration_cfg(cfg)
+
+    assert not integration_wet_run_mock.called
+    assert integration_dry_run_mock.called
+
+
+def test_run_configuration_dispatch_wet_run(
+    mocker: MockerFixture,
+    simple_test_integration: SimpleTestIntegration,
+):
+    """
+    making sure, the wet run mode is called
+    """
+    cfg = MockIntegrationRunConfiguration(
+        integration=simple_test_integration,
+        valdiate_schemas=False,
+        dry_run=False,
+        early_exit_compare_sha="abc",
+        check_only_affected_shards=False,
+        gql_sha_url=False,
+        print_url=True,
+        run_args=(),
+        run_kwargs={},
+        main_data={"data": "a"},
+        comparison_data={"data": "b"},
+    )
+    integration_wet_run_mock = mocker.patch.object(runner, "_integration_wet_run")
+    integration_dry_run_mock = mocker.patch.object(runner, "_integration_dry_run")
+
+    run_integration_cfg(cfg)
+
+    assert integration_wet_run_mock.called
+    assert not integration_dry_run_mock.called
+
+
+def test_run_configuration_dry_run(
+    simple_test_integration: SimpleTestIntegration,
+):
+    """
+    if there is no desired state diff object, we can't say anything about
+    early exit or sharding, so the run function of the integration is called
+    with dry_run=True
+    """
+    simple_test_integration.run = MagicMock()  # type: ignore
+    args = (1,)
+    kwargs = {"a_string": "s"}
+    _integration_dry_run(
+        simple_test_integration,
+        None,
+        *args,
+        **kwargs,
+    )
+
+    simple_test_integration.run.assert_called_once_with(True, *args, **kwargs)
+
+
+def test_run_configuration_dry_run_diff_no_early_exit(
+    simple_test_integration: SimpleTestIntegration,
+):
+    """
+    when there is not diff, we don't do early exit but run the integration
+    """
+    simple_test_integration.run = MagicMock()  # type: ignore
+    args = (1,)
+    kwargs = {"a_string": "s"}
+    _integration_dry_run(
+        simple_test_integration,
+        DesiredStateDiff(
+            current_desired_state={},
+            previous_desired_state={},
+            diff_found=True,
+            affected_shards=set(),
+        ),
+        *args,
+        **kwargs,
+    )
+
+    simple_test_integration.run.assert_called_once_with(True, *args, **kwargs)
+
+
+def test_run_configuration_dry_run_no_diff_early_exit(
+    simple_test_integration: SimpleTestIntegration,
+):
+    """
+    when there is no difference in the desired state, exit early.
+    """
+    simple_test_integration.run = MagicMock()  # type: ignore
+    args = (1,)
+    kwargs = {"a_string": "s"}
+    _integration_dry_run(
+        simple_test_integration,
+        DesiredStateDiff(
+            current_desired_state={},
+            previous_desired_state={},
+            diff_found=False,
+            affected_shards=set(),
+        ),
+        *args,
+        **kwargs,
+    )
+
+    assert not simple_test_integration.run.called
+
+
+def test_run_configuration_dry_run_diff_no_early_exit_sharding(
+    shardable_test_integration: ShardableTestIntegration,
+):
+    """
+    when there is not diff, we don't do early exit. since the integration supports
+    sharding, and affected shards have been detected, we run the integration once
+    per shard.
+    """
+    shardable_test_integration.run = MagicMock()  # type: ignore
+    affected_shards = {"a", "b"}
+    args = ()
+    kwargs = {"an_arg": "arg"}
+    _integration_dry_run(
+        shardable_test_integration,
+        DesiredStateDiff(
+            current_desired_state={},
+            previous_desired_state={},
+            diff_found=True,
+            affected_shards=affected_shards,
+        ),
+        *args,
+        **kwargs,
+    )
+
+    # make sure the run method has been called once per shard
+    assert shardable_test_integration.run.call_count == len(affected_shards)
+    for shard in affected_shards:
+        shard_kwargs = kwargs.copy()
+        shard_kwargs["shard"] = shard
+        shardable_test_integration.run.assert_any_call(True, *args, **shard_kwargs)
+
+
+def test_run_configuration_dry_run_diff_no_early_exit_shard_err(
+    shardable_test_integration: ShardableTestIntegration,
+):
+    """
+    if a shard fails during dry-run, we expect exit with an error
+    """
+    succeeding_shard = "succeed"  # success
+    another_succeeding_shard = "succeed as well"  # success
+    failing_shard = "fail"  # fail
+    sys_exit_1_shard = "sys-exit-1"  # fail
+    sys_exit_true_shard = "sys-exit-true"  # fail
+    sys_exit_0_shard = "sys-exit-0"  # success
+    sys_exit_false_shard = "sys-exit-false"  # success
+
+    def integration_run_func(
+        dry_run: bool, an_arg: str, shard: Optional[str] = None
+    ) -> None:
+        if shard == failing_shard:
+            raise Exception(f"shard {shard} failed")
+        if shard == sys_exit_1_shard:
+            sys.exit(1)
+        if shard == sys_exit_false_shard:
+            sys.exit(False)
+        if shard == sys_exit_0_shard:
+            sys.exit(0)
+        if shard == sys_exit_true_shard:
+            sys.exit(True)
+
+    shardable_test_integration.run = MagicMock(side_effect=integration_run_func)  # type: ignore
+    affected_shards = {
+        succeeding_shard,
+        another_succeeding_shard,
+        failing_shard,
+        sys_exit_1_shard,
+        sys_exit_false_shard,
+        sys_exit_0_shard,
+        sys_exit_true_shard,
+    }
+    args = ()
+    kwargs = {"an_arg": "arg"}
+
+    with pytest.raises(SystemExit) as e:
+        _integration_dry_run(
+            shardable_test_integration,
+            DesiredStateDiff(
+                current_desired_state={},
+                previous_desired_state={},
+                diff_found=True,
+                affected_shards=affected_shards,
+            ),
+            *args,
+            **kwargs,
+        )
+
+    # the SystemExit exception contains the nr of failed shards as code
+    assert e.value.code == 3
+
+    # make sure the run method has been called once per shard
+    assert shardable_test_integration.run.call_count == len(affected_shards)
+    for shard in affected_shards:
+        shard_kwargs = kwargs.copy()
+        shard_kwargs["shard"] = shard
+        shardable_test_integration.run.assert_any_call(True, *args, **shard_kwargs)
+
+
+def test_run_configuration_wet_run(simple_test_integration: SimpleTestIntegration):
+    simple_test_integration.run = MagicMock()  # type: ignore
+    args = (1,)
+    kwargs = {"a_string": "s"}
+    _integration_wet_run(
+        simple_test_integration,
+        *args,
+        **kwargs,
+    )
+
+    assert not simple_test_integration.run.assert_called_once_with(  # type: ignore
+        False, *args, **kwargs
+    )

--- a/reconcile/test/test_utils_jsonpath.py
+++ b/reconcile/test/test_utils_jsonpath.py
@@ -1,0 +1,198 @@
+from jsonpath_ng import (
+    Child,
+    Fields,
+    Index,
+    Slice,
+    This,
+)
+from jsonpath_ng.ext import parse
+from jsonpath_ng.ext.filter import (
+    Expression,
+    Filter,
+)
+
+from reconcile.utils.jsonpath import (
+    apply_constraint_to_path,
+    jsonpath_parts,
+    narrow_jsonpath_node,
+)
+
+#
+# test jsonpath splitting
+#
+
+
+def test_jsonpath_parts():
+    path = parse("$.a.b.c")
+    assert jsonpath_parts(path) == [parse("$"), parse("a"), parse("b"), parse("c")]
+
+
+def test_jsonpath_parts_root_only():
+    path = parse("$")
+    assert jsonpath_parts(path) == [parse("$")]
+
+
+def test_jsonpath_parts_with_index():
+    path = parse("a[0]")
+    assert jsonpath_parts(path) == [parse("a"), Index(0)]
+
+
+def test_jsonpath_parts_with_slice_all():
+    path = parse("a[*]")
+    assert jsonpath_parts(path) == [parse("a"), Slice(None, None, None)]
+
+
+def test_jsonpath_parts_with_filter():
+    path = parse("a.b[?(@.c=='c')].d")
+    assert jsonpath_parts(path) == [
+        parse("a"),
+        parse("b"),
+        Filter(expressions=[Expression(Child(This(), Fields("c")), "==", "c")]),
+        parse("d"),
+    ]
+
+
+def test_jsonpath_parts_with_filter_ignore():
+    path = parse("a.b[?(@.c=='c')].d")
+    assert jsonpath_parts(path, ignore_filter=True) == [
+        parse("a"),
+        parse("b"),
+        parse("d"),
+    ]
+
+
+#
+# test narrow jsonpath node
+#
+
+
+def test_narrow_jsonpath_node_field_equal():
+    assert narrow_jsonpath_node(parse("a"), parse("a")) == parse("a")
+
+
+def test_narrow_jsonpath_node_field_not_equal():
+    assert not narrow_jsonpath_node(parse("a"), parse("b"))
+
+
+def testnarrow_jsonpath_node_index_equal():
+    assert narrow_jsonpath_node(Index(0), Index(0)) == Index(0)
+
+
+def test_narrow_jsonpath_node_index_slice():
+    assert narrow_jsonpath_node(Index(0), Slice(None, None, None)) == Index(0)
+
+
+def test_narrow_jsonpath_node_slice_index():
+    assert narrow_jsonpath_node(Slice(None, None, None), Index(0)) == Index(0)
+
+
+def test_narrow_jsonpath_node_slice_slice():
+    assert narrow_jsonpath_node(
+        Slice(None, None, None), Slice(None, None, None)
+    ) == Slice(None, None, None)
+
+
+def test_narrow_jsonpath_node_filter_equal():
+    assert narrow_jsonpath_node(
+        Filter(expressions=[Expression(Child(This(), Fields("c")), "==", "c")]),
+        Filter(expressions=[Expression(Child(This(), Fields("c")), "==", "c")]),
+    ) == Filter(expressions=[Expression(Child(This(), Fields("c")), "==", "c")])
+
+
+def test_narrow_jsonpath_node_filter_not_equal():
+    assert (
+        narrow_jsonpath_node(
+            Filter(expressions=[Expression(Child(This(), Fields("c")), "==", "c")]),
+            Filter(expressions=[Expression(Child(This(), Fields("d")), "==", "d")]),
+        )
+        is None
+    )
+
+
+def test_narrow_jsonpath_node_filter_slice():
+    filter = Filter(expressions=[Expression(Child(This(), Fields("c")), "==", "c")])
+    assert (
+        narrow_jsonpath_node(
+            filter,
+            Slice(None, None, None),
+        )
+        == filter
+    )
+
+
+def test_narrow_jsonpath_node_silce_filter():
+    filter = Filter(expressions=[Expression(Child(This(), Fields("c")), "==", "c")])
+    assert (
+        narrow_jsonpath_node(
+            Slice(None, None, None),
+            filter,
+        )
+        == filter
+    )
+
+
+def test_narrow_jsonpath_node_index_filter():
+    assert narrow_jsonpath_node(
+        Index(0),
+        Filter(expressions=[Expression(Child(This(), Fields("c")), "==", "c")]),
+    ) == Index(0)
+
+
+def test_narrow_jsonpath_node_filter_index():
+    assert narrow_jsonpath_node(
+        Filter(expressions=[Expression(Child(This(), Fields("c")), "==", "c")]),
+        Index(0),
+    ) == Index(0)
+
+
+def test_narrow_jsonpath_node_field_wildcard():
+    assert narrow_jsonpath_node(parse("a"), parse("*")) == parse("a")
+
+
+def test_narrow_jsonpath_node_wildcard_field():
+    assert narrow_jsonpath_node(parse("*"), parse("a")) == parse("a")
+
+
+def test_narrow_jsonpath_node_wildcard_wildcard():
+    assert narrow_jsonpath_node(parse("*"), parse("*")) == parse("*")
+
+
+#
+# narrow jsonpath expression
+#
+
+
+def test_apply_constraint_to_path_equal():
+    assert apply_constraint_to_path(parse("a.b.c"), parse("a.b.c")) == parse("a.b.c")
+
+
+def test_apply_constraint_to_longer_path():
+    assert apply_constraint_to_path(parse("a.b[*].c.f"), parse("a.b[0].c")) == parse(
+        "a.b[0].c.f"
+    )
+
+
+def test_apply_constraint_to_shorter_path():
+    assert apply_constraint_to_path(parse("a.b[*]"), parse("a.b[0].c")) == parse(
+        "a.b[0]"
+    )
+
+
+def test_apply_constraint_to_unrelated_path():
+    assert not apply_constraint_to_path(parse("a.b[*]"), parse("d.e[0].f"))
+
+
+def test_apply_incompatible_constraint_to_path():
+    assert apply_constraint_to_path(parse("a.b[0].f"), parse("a.b[1].c")) == parse(
+        "a.b[0].f"
+    )
+
+
+def test_apply_partially_incompatible_constraint_to_path():
+    assert apply_constraint_to_path(
+        parse("a.b[*].c[0].d"), parse("a.b[1].c[1]")
+    ) == parse("a.b[1].c[0].d")
+
+
+def test_apply_field_constraint_to_wildcard_path():
+    assert apply_constraint_to_path(parse("a.*.c"), parse("a.b.c.d")) == parse("a.b.c")

--- a/reconcile/utils/jsonpath.py
+++ b/reconcile/utils/jsonpath.py
@@ -1,0 +1,94 @@
+from itertools import zip_longest
+from typing import Optional
+
+import jsonpath_ng
+import jsonpath_ng.ext.filter
+
+
+def narrow_jsonpath_node(
+    path_1: jsonpath_ng.JSONPath, path_2: jsonpath_ng.JSONPath
+) -> jsonpath_ng.JSONPath:
+    """
+    given two jsonpath nodes, return the most specific and narrow one
+    e.g. an index is more specific than a slice, a filter is more specific than
+    a slice, etc.
+
+    if the two nodes are not compatible, return None. e.g. a filter and an index
+    might cover different sets of data, so not compatible
+    """
+    if path_1 == path_2:
+        return path_1
+    elif isinstance(path_1, jsonpath_ng.Fields) and isinstance(
+        path_2, jsonpath_ng.Fields
+    ):
+        if path_1.fields == ("*",):
+            return path_2
+        elif path_2.fields == ("*",):
+            return path_1
+    elif isinstance(path_1, jsonpath_ng.Index) and isinstance(
+        path_2, (jsonpath_ng.Slice, jsonpath_ng.ext.filter.Filter)
+    ):
+        return path_1
+    elif isinstance(
+        path_1, (jsonpath_ng.Slice, jsonpath_ng.ext.filter.Filter)
+    ) and isinstance(path_2, jsonpath_ng.Index):
+        return path_2
+    elif isinstance(path_1, jsonpath_ng.ext.filter.Filter) and isinstance(
+        path_2, jsonpath_ng.Slice
+    ):
+        return path_1
+    elif isinstance(path_1, jsonpath_ng.Slice) and isinstance(
+        path_2, jsonpath_ng.ext.filter.Filter
+    ):
+        return path_2
+
+    return None
+
+
+def jsonpath_parts(
+    path: jsonpath_ng.JSONPath, ignore_filter: Optional[bool] = False
+) -> list[jsonpath_ng.JSONPath]:
+    """
+    Return a list of JSONPath nodes that make up the given path.
+    """
+    parts: list[jsonpath_ng.JSONPath] = []
+    while isinstance(path, jsonpath_ng.Child):
+        current = path.right
+        path = path.left
+        if isinstance(current, jsonpath_ng.ext.filter.Filter) and ignore_filter:
+            continue
+        parts.insert(0, current)
+    parts.insert(0, path)
+    return parts
+
+
+def apply_constraint_to_path(
+    path: jsonpath_ng.JSONPath,
+    path_constraint: jsonpath_ng.JSONPath,
+    min_common_prefix_length: int = 1,
+) -> Optional[jsonpath_ng.JSONPath]:
+    """
+    Narrow the `path` with a more specific `path_constraint`.
+    e.g. if the path constraints a slice `[*]` and the constraints a
+    specific index `[0]`, the `path` will be narrowed down to `[0]`.
+    """
+    prefix_path = jsonpath_ng.Root()
+    common = True
+    common_prefix_length = 0
+    for p1, p2 in zip_longest(
+        jsonpath_parts(path_constraint),
+        jsonpath_parts(path),
+    ):
+        if common and (n := narrow_jsonpath_node(p1, p2)):
+            prefix_path = prefix_path.child(n)
+            common_prefix_length += 1
+        else:
+            common = False
+            if p2:
+                prefix_path = prefix_path.child(p2)
+            else:
+                break
+    if common_prefix_length < min_common_prefix_length:
+        return None
+    else:
+        return prefix_path

--- a/reconcile/utils/runtime/desired_state_diff.py
+++ b/reconcile/utils/runtime/desired_state_diff.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from typing import (
+    Any,
+)
+
+from deepdiff import DeepHash
+
+
+@dataclass
+class DesiredStateDiff:
+
+    previous_desired_state: Any
+    current_desired_state: Any
+    diff_found: bool
+
+    def can_exit_early(self) -> bool:
+        return not self.diff_found
+
+
+def build_desired_state_diff(
+    previous_desired_state: dict[str, Any],
+    current_desired_state: dict[str, Any],
+) -> DesiredStateDiff:
+    # is there a difference?
+    previous_hash = DeepHash(previous_desired_state)
+    current_hash = DeepHash(current_desired_state)
+    desired_state_diff_found = previous_hash.get(
+        previous_desired_state
+    ) != current_hash.get(current_desired_state)
+    return DesiredStateDiff(
+        previous_desired_state=previous_desired_state,
+        current_desired_state=current_desired_state,
+        diff_found=desired_state_diff_found,
+    )

--- a/reconcile/utils/runtime/desired_state_diff.py
+++ b/reconcile/utils/runtime/desired_state_diff.py
@@ -1,34 +1,212 @@
+import logging
+import multiprocessing
 from dataclasses import dataclass
 from typing import (
     Any,
+    Callable,
+    Iterable,
+    Mapping,
+    Optional,
 )
 
 from deepdiff import DeepHash
+from jsonpath_ng.ext.parser import parse
+
+from reconcile.change_owners.diff import (
+    Diff,
+    DiffType,
+    extract_diffs,
+)
+from reconcile.utils.jsonpath import apply_constraint_to_path
+from reconcile.utils.runtime.integration import (
+    DesiredStateShardConfig,
+    ShardedRunProposal,
+)
 
 
 @dataclass
 class DesiredStateDiff:
+    """
+    Describes the diff between two desired states and potentially the affected
+    shards.
+    """
 
-    previous_desired_state: Any
-    current_desired_state: Any
+    previous_desired_state: Mapping[str, Any]
+    """
+    The desired state of an integration before the change.
+    """
+    current_desired_state: Mapping[str, Any]
+    """
+    The desired state of an integration after the change.
+    """
     diff_found: bool
+    """
+    Whether there are any differences between the two states
+    """
+    affected_shards: set[str]
+    """
+    The shards affected by the change.
+    """
 
     def can_exit_early(self) -> bool:
         return not self.diff_found
 
 
+def find_changed_shards(
+    diffs: Iterable[Diff],
+    previous_desired_state: Mapping[str, Any],
+    current_desired_state: Mapping[str, Any],
+    sharding_config: DesiredStateShardConfig,
+) -> set[str]:
+    """
+    Finds the affected desired state shards introduced by a set of diffs. The
+    affected shards are determined by the shard path selectors from the
+    provided `DesiredStateShardConfig`.
+    """
+    affected_shards = set()
+    for d in diffs:
+        for shard_path_spec in sharding_config.shard_path_selectors:
+            shard_path = apply_constraint_to_path(parse(shard_path_spec), d.path)
+            if shard_path:
+                if d.diff_type == DiffType.CHANGED or d.diff_type.REMOVED:
+                    affected_shards.update(
+                        {
+                            shard.value
+                            for shard in shard_path.find(previous_desired_state)
+                        }
+                    )
+                if d.diff_type == DiffType.CHANGED or d.diff_type.ADDED:
+                    affected_shards.update(
+                        {
+                            shard.value
+                            for shard in shard_path.find(current_desired_state)
+                        }
+                    )
+    return affected_shards
+
+
+def _extract_diffs_task(
+    extraction_function: Callable[
+        [Mapping[str, Any], Mapping[str, Any]], Iterable[Diff]
+    ],
+    previous_desired_state: Mapping[str, Any],
+    current_desired_state: Mapping[str, Any],
+    return_value: dict,
+) -> None:
+    """
+    A multiprocessing task that extracts diffs from two desired states
+    and stores them in a return value dictionary.
+    """
+    diffs = extraction_function(previous_desired_state, current_desired_state)
+    return_value["diffs"] = diffs
+
+
+class DiffDetectionTimeout(Exception):
+    """
+    Raised when the fine grained diff detection takes too long.
+    """
+
+
+def extract_diffs_with_timeout(
+    extraction_function: Callable[
+        [Mapping[str, Any], Mapping[str, Any]], Iterable[Diff]
+    ],
+    previous_desired_state: Mapping[str, Any],
+    current_desired_state: Mapping[str, Any],
+    timeout_seconds: int,
+) -> list[Diff]:
+    """
+    Extracts diffs from two desired states using a dedicated extraction function.
+    If the timeout is reached, a `DiffDetectionTimeout` exception is raised.
+
+    The diff extraction is performed in a separate process for the sole purpose
+    to be able to enforce a timeout. This is necessary because the diff extraction
+    can take a long time for large desired states. Stoping the process is reasonable
+    for multiple reasons:
+        * the process can potentially take minutes to complete. that would deminish
+          the value derived from the detected diffs (e.g. sharded runs)
+        * the process can potentially take a lot of memory the longer it runs,
+          which would put more pressure on the system executing the process, e.g.
+          Jenkins
+        * experience has shown that the diff extraction process yields the most
+          valueable results when it is fast. if it takes too long, the results
+          yield contain too many diffs to be meaningful for followup processing
+    """
+    m = multiprocessing.Manager()
+    result_value = m.dict()
+
+    process = multiprocessing.Process(
+        target=_extract_diffs_task,
+        args=(
+            extraction_function,
+            previous_desired_state,
+            current_desired_state,
+            result_value,
+        ),
+    )
+    process.start()
+    process.join(timeout_seconds)
+    if process.is_alive():
+        logging.info(
+            f"timeout {timeout_seconds}s reached to find fine grained diffs. "
+            "no shard detection or sharded runs will be performed."
+        )
+        process.terminate()
+        process.join()
+        raise DiffDetectionTimeout()
+    else:
+        return result_value["diffs"]
+
+
 def build_desired_state_diff(
-    previous_desired_state: dict[str, Any],
-    current_desired_state: dict[str, Any],
+    sharding_config: Optional[DesiredStateShardConfig],
+    previous_desired_state: Mapping[str, Any],
+    current_desired_state: Mapping[str, Any],
 ) -> DesiredStateDiff:
-    # is there a difference?
+    """
+    Builds a `DesiredStateDiff` object based on the provided desired states.
+    If sharding config is provided, the diff will also contain the affected
+    shards introduced by the change between the two desired states.
+    """
+    # is there even a difference?
     previous_hash = DeepHash(previous_desired_state)
     current_hash = DeepHash(current_desired_state)
     desired_state_diff_found = previous_hash.get(
         previous_desired_state
     ) != current_hash.get(current_desired_state)
+
+    shards = set()
+    exract_diff_timeout_seconds = 10
+    try:
+        if desired_state_diff_found and sharding_config:
+            # detect shards based on fine grained diffs
+            diffs = extract_diffs_with_timeout(
+                extraction_function=extract_diffs,
+                previous_desired_state=previous_desired_state,
+                current_desired_state=current_desired_state,
+                timeout_seconds=exract_diff_timeout_seconds,
+            )
+            changed_shards = find_changed_shards(
+                diffs=diffs,
+                previous_desired_state=previous_desired_state,
+                current_desired_state=current_desired_state,
+                sharding_config=sharding_config,
+            )
+            if changed_shards:
+                # let the integration decide if the sharding proposal is fine
+                if sharding_config.sharded_run_review(
+                    ShardedRunProposal(proposed_shards=changed_shards)
+                ):
+                    shards = changed_shards
+    except DiffDetectionTimeout:
+        logging.warning(
+            f"unable to extract fine grained diffs for shard extraction "
+            f"within {exract_diff_timeout_seconds} seconds. continue without sharding"
+        )
+
     return DesiredStateDiff(
         previous_desired_state=previous_desired_state,
         current_desired_state=current_desired_state,
         diff_found=desired_state_diff_found,
+        affected_shards=shards,
     )

--- a/reconcile/utils/runtime/integration.py
+++ b/reconcile/utils/runtime/integration.py
@@ -2,33 +2,175 @@ from abc import (
     ABC,
     abstractmethod,
 )
+from dataclasses import dataclass
 from types import ModuleType
 from typing import (
     Any,
+    Callable,
     Optional,
 )
 
 
+@dataclass
+class ShardedRunProposal:
+    """
+    A `ShardedRunProposal` represents the a proposal how a sharded integration
+    run should be executed. It is passed to the `sharded_run_review` callback
+    an integration can register in its `DesiredStateShardConfig` instance.
+    The integration uses an instance of `ShardedRunProposal` to decide if sharded
+    run should be executed or not.
+
+    Right now, a `ShardedRunProposal` only contains the affected shards extracted
+    from the diffs in desired state. If additional information is needed to make
+    the decision, it can be added to this class.
+    """
+
+    proposed_shards: set[str]
+    """
+    The shards that are affected by the current change. This is the set of shards
+    that will be passed to the integration's `run` function individually, if the
+    integration decides to execute a sharded run.
+    """
+
+
+@dataclass
+class DesiredStateShardConfig:
+    """
+    A `DesiredStateShardConfig` instance describes how a `QontractReconcileIntegration`
+    wants to execute sharded dry-runs on its desired state. It contains the
+    information needed to extract the shards from the desired state, and to
+    pass them to the integration `run` function. It also contains a callback
+    function that allows the integration to review the proposed shards and
+    decide if they should be processed with sharded runs or not.
+    """
+
+    sharded_run_review: Callable[[ShardedRunProposal], bool]
+    """
+    A callback function that allows the integration to review the proposed
+    shards and decide if they should be processed with sharded runs or not
+    """
+
+    shard_path_selectors: set[str]
+    """
+    A set of JSONPath selectors defining where to find the shards in the desired
+    state offered by `QontractReconcileIntegration.get_early_exit_desired_state`
+    function.
+    """
+
+    shard_arg_name: str
+    """
+    The name of the argument that the integration's `run` function expects to
+    receive the shards in.
+    """
+
+    shard_arg_is_collection: bool = False
+    """
+    Some integration's `run` functions expect the shards to be passed as a
+    collection. In that case, this flag should be set to `True`.
+    """
+
+
 class QontractReconcileIntegration(ABC):
+    """
+    The base class for all integrations. It defines the basic interface to interact
+    with an integration and offers hook methods that allow the integration to opt
+    into optional functionality like early-exit or sharded dry-runs.
+    """
+
     @property
     @abstractmethod
     def name(self) -> str:
         ...
 
-    @abstractmethod
-    def get_early_exit_desired_state(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        ...
+    def get_early_exit_desired_state(
+        self, *args: Any, **kwargs: Any
+    ) -> Optional[dict[str, Any]]:
+        """
+        An integration that wants to support early exit on its desired state
+        must implement this method and return the desired state as a dictionary.
+        The dictionary can be nested and can contain any data type that can be
+        serialized to JSON.
+
+        If `None` is returned, the integration will not be able to opt into
+        early exit.
+        """
+        return None
+
+    def get_desired_state_shard_config(self) -> Optional["DesiredStateShardConfig"]:
+        """
+        An integration that wants to support sharded dry-runs on its desired state
+        must implement this method and return a `DesiredStateShardConfig` instance.
+
+        If `None` is returned, the integration will not be able to opt into
+        sharded dry-runs.
+        """
+        return None
 
     @abstractmethod
     def run(self, dry_run: bool, *args: Any, **kwargs: Any) -> None:
-        ...
+        """
+        The `run` function of a QontractReconcileIntegration is the entry point to
+        its actual functionality. It is obliged to honor the `dry_run` argument and not
+        perform any changes to the system if it is set to `True`. At the same time
+        the integration should progress as far as possible in the dry-run mode to
+        highlight any issues that would have prevented it from running in non-dry-run
+        mode.
+        """
+
+    def supports_sharded_dry_run_mode(self) -> bool:
+        """
+        Returns `True` if the integration supports sharded dry-runs.
+        """
+        return self.get_desired_state_shard_config() is not None
+
+    def kwargs_have_shard_info(self, **kwargs: Any) -> bool:
+        """
+        Returns `True` if the args and kwargs already contain sharding information.
+        """
+        sharding_config = (  # pylint: disable=assignment-from-none
+            self.get_desired_state_shard_config()
+        )
+        if sharding_config:
+            return kwargs.get(sharding_config.shard_arg_name) is not None
+        else:
+            return False
+
+    def run_for_shard(
+        self, dry_run: bool, shard: str, *run_args: Any, **run_kwargs: Any
+    ) -> None:
+        """
+        Runs the integration for a specific shard, by patching the `run_kwargs`.
+        If the integration does not support sharded runs, it raises an exception.
+        """
+        sharding_config = (  # pylint: disable=assignment-from-none
+            self.get_desired_state_shard_config()
+        )
+        if sharding_config:
+            shard_kwargs = run_kwargs.copy()
+            if sharding_config.shard_arg_is_collection:
+                shard_kwargs[sharding_config.shard_arg_name] = [shard]
+            else:
+                shard_kwargs[sharding_config.shard_arg_name] = shard
+            self.run(dry_run, *run_args, **shard_kwargs)
+        else:
+            raise NotImplementedError(
+                "The integration does not support run in sharded mode."
+            )
 
 
 RUN_FUNCTION = "run"
 EARLY_EXIT_DESIRED_STATE_FUNCTION = "early_exit_desired_state"
+DESIRED_STATE_SHARD_CONFIG_FUNCTION = "desired_state_shard_config"
 
 
 class ModuleBasedQontractReconcileIntegration(QontractReconcileIntegration):
+    """
+    Since most integrations are implemented as modules, this class provides a
+    wrapper around a module that implements the `QontractReconcileIntegration`
+    interface. This way such module based integrations can be used as if they
+    were instances of the `QontractReconcileIntegration` class.
+    """
+
     def __init__(self, module: ModuleType):
         self._module = module
         self.name  # run to check if the name can be extracted from the module
@@ -36,6 +178,10 @@ class ModuleBasedQontractReconcileIntegration(QontractReconcileIntegration):
             raise NotImplementedError(f"Integration has no {RUN_FUNCTION}() function")
 
     def _integration_supports(self, func_name: str) -> bool:
+        """
+        Verifies, that an integration supports a specific function.
+        todo: more thorough verification of the functions signature would be required.
+        """
         return func_name in dir(self._module)
 
     @property
@@ -45,11 +191,18 @@ class ModuleBasedQontractReconcileIntegration(QontractReconcileIntegration):
         except AttributeError:
             raise NotImplementedError("Integration missing QONTRACT_INTEGRATION.")
 
-    def get_early_exit_desired_state(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def get_early_exit_desired_state(
+        self, *args: Any, **kwargs: Any
+    ) -> Optional[dict[str, Any]]:
         if self._integration_supports(EARLY_EXIT_DESIRED_STATE_FUNCTION):
             return self._module.early_exit_desired_state(*args, **kwargs)
         else:
-            raise NotImplementedError("Integration does not support early exit.")
+            return None
+
+    def get_desired_state_shard_config(self) -> Optional["DesiredStateShardConfig"]:
+        if self._integration_supports(DESIRED_STATE_SHARD_CONFIG_FUNCTION):
+            return self._module.desired_state_shard_config()
+        return None
 
     def run(self, dry_run: bool, *args: Any, **kwargs: Any) -> None:
         self._module.run(dry_run, *args, **kwargs)

--- a/reconcile/utils/runtime/integration.py
+++ b/reconcile/utils/runtime/integration.py
@@ -1,0 +1,55 @@
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from types import ModuleType
+from typing import (
+    Any,
+    Optional,
+)
+
+
+class QontractReconcileIntegration(ABC):
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        ...
+
+    @abstractmethod
+    def get_early_exit_desired_state(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        ...
+
+    @abstractmethod
+    def run(self, dry_run: bool, *args: Any, **kwargs: Any) -> None:
+        ...
+
+
+RUN_FUNCTION = "run"
+EARLY_EXIT_DESIRED_STATE_FUNCTION = "early_exit_desired_state"
+
+
+class ModuleBasedQontractReconcileIntegration(QontractReconcileIntegration):
+    def __init__(self, module: ModuleType):
+        self._module = module
+        self.name  # run to check if the name can be extracted from the module
+        if not self._integration_supports(RUN_FUNCTION):
+            raise NotImplementedError(f"Integration has no {RUN_FUNCTION}() function")
+
+    def _integration_supports(self, func_name: str) -> bool:
+        return func_name in dir(self._module)
+
+    @property
+    def name(self) -> str:
+        try:
+            return self._module.QONTRACT_INTEGRATION.replace("_", "-")
+        except AttributeError:
+            raise NotImplementedError("Integration missing QONTRACT_INTEGRATION.")
+
+    def get_early_exit_desired_state(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        if self._integration_supports(EARLY_EXIT_DESIRED_STATE_FUNCTION):
+            return self._module.early_exit_desired_state(*args, **kwargs)
+        else:
+            raise NotImplementedError("Integration does not support early exit.")
+
+    def run(self, dry_run: bool, *args: Any, **kwargs: Any) -> None:
+        self._module.run(dry_run, *args, **kwargs)

--- a/reconcile/utils/runtime/runner.py
+++ b/reconcile/utils/runtime/runner.py
@@ -1,10 +1,12 @@
 import logging
+import sys
 from dataclasses import dataclass
 from typing import (
     Any,
     Optional,
-    Protocol,
 )
+
+from sretoolbox.utils import threaded as sretoolbox_threaded
 
 from reconcile.utils import gql
 from reconcile.utils.runtime.desired_state_diff import (
@@ -14,34 +16,60 @@ from reconcile.utils.runtime.desired_state_diff import (
 from reconcile.utils.runtime.integration import QontractReconcileIntegration
 
 
-class DesiredStateProvider(Protocol):
-    def current_desired_state(self) -> dict[str, Any]:
-        ...
-
-    def previous_desired_state(self) -> dict[str, Any]:
-        ...
-
-
 @dataclass
 class IntegrationRunConfiguration:
+    """
+    Holds all required context and configuration for an integration run.
+    """
+
     integration: QontractReconcileIntegration
-    valdiate_schemas: bool
-    dry_run: bool
-    early_exit_compare_sha: Optional[str]
-    gql_sha_url: bool
-    print_url: bool
     run_args: Any
     run_kwargs: Any
+    valdiate_schemas: bool
+    """
+    Wheter to fail an integration if it queries schemas it is not allowed to.
+    Allowed schemas are listed in the `/app-sre/integration-1.yml` files.
+    """
 
-    def main_bundle_desired_state(self) -> dict[str, Any]:
+    dry_run: bool
+    """
+    Whether to run the integration in dry-run mode.
+    An integration running dry-run mode should not take any actions but should
+    progress through the integration run as far and deep as possible to highlight
+    potential problems with the integration or the configuration data from app-interface.
+    """
+
+    early_exit_compare_sha: Optional[str]
+    """
+    The SHA of the bundle to compare the current desired state against.
+    """
+
+    check_only_affected_shards: bool
+    """
+    Whether to only dry-run the integration on shards that are affected by the
+    change in desired state.
+    """
+
+    gql_sha_url: bool
+    """
+    If `False`, it will not use the sha_url endpoint
+    of graphql (prevent stopping execution on data reload).
+    """
+
+    print_url: bool
+    """
+    A debug flag to control wheter the URL of the GraphQL endpoint in use is printed.
+    """
+
+    def main_bundle_desired_state(self) -> Optional[dict[str, Any]]:
         self.switch_to_main_bundle()
         return self.integration.get_early_exit_desired_state(
             *self.run_args, **self.run_kwargs
         )
 
-    def comparison_bundle_desired_state(self) -> dict[str, Any]:
+    def comparison_bundle_desired_state(self) -> Optional[dict[str, Any]]:
         self.switch_to_comparison_bundle()
-        data = self.integration.get_early_exit_desired_state(
+        data = self.integration.get_early_exit_desired_state(  # pylint: disable=assignment-from-none
             *self.run_args, **self.run_kwargs
         )
         self.switch_to_main_bundle()
@@ -75,15 +103,22 @@ class IntegrationRunConfiguration:
 def get_desired_state_diff(
     run_cfg: IntegrationRunConfiguration,
 ) -> Optional[DesiredStateDiff]:
+    """
+    Calculates the desired state diff between the current bundle and the
+    comparison bundle for an integration. If the integration does not support
+    early exit, or if no comparison bundle is set, returns None.
+
+    The desired state diff contains information about the early-exit eligibility
+    of the integration run, and the affected shards.
+    """
     if not run_cfg.early_exit_compare_sha:
         return None
 
     # get desired state from comparison bundle
     try:
         previous_desired_state = run_cfg.comparison_bundle_desired_state()
-    except NotImplementedError:
-        logging.warning(f"{run_cfg.integration.name} does not support early exit.")
-        return None
+        if previous_desired_state is None:
+            return None
     except Exception as e:
         logging.exception(
             f"Failed to fetch desired state for comparison bundle {run_cfg.early_exit_compare_sha}",
@@ -94,18 +129,26 @@ def get_desired_state_diff(
     # get desired state from current bundle
     try:
         current_desired_state = run_cfg.main_bundle_desired_state()
+        if current_desired_state is None:
+            return None
     except Exception:
         logging.exception("Failed to fetch desired state for current bundle")
         return None
 
     return build_desired_state_diff(
-        run_cfg.integration.get_desired_state_shard_config(),
+        run_cfg.integration.get_desired_state_shard_config()
+        if run_cfg.check_only_affected_shards
+        else None,
         previous_desired_state,
         current_desired_state,
     )
 
 
 def run_integration_cfg(run_cfg: IntegrationRunConfiguration) -> None:
+    """
+    Runs an integration with the given configuration, making sure to run it
+    in the right mode accoring to `run.cfg.dry_run`.
+    """
     if run_cfg.dry_run:
         desired_state_diff = get_desired_state_diff(run_cfg)
         run_cfg.switch_to_main_bundle()
@@ -125,6 +168,9 @@ def run_integration_cfg(run_cfg: IntegrationRunConfiguration) -> None:
 def _integration_wet_run(
     integration: QontractReconcileIntegration, *run_args: Any, **run_kwargs: Any
 ) -> None:
+    """
+    Runs an integration in wet mode, i.e. not in dry-run mode.
+    """
     integration.run(False, *run_args, **run_kwargs)
 
 
@@ -134,11 +180,55 @@ def _integration_dry_run(
     *run_args: Any,
     **run_kwargs: Any,
 ) -> None:
+    """
+    Runs an integration in dry-run mode, i.e. not actually making any changes
+    but only logging what would have been done.
+
+    Additionally, if the integration supports early exit, and the desired state
+    has not changed, the integration will exit early.
+
+    If the integration supports sharded mode, and the desired state has changed
+    only on a subset of shards, the integration will dry-run only on those shards
+    only.
+    """
 
     # if the integration can exit early, do so ...
     if desired_state_diff and desired_state_diff.can_exit_early():
         logging.debug("No changes in desired state. Exit PR check early.")
         return
+
+    # we can still try to run the integration in sharded mode on the
+    # affected shards only
+    if (
+        integration.supports_sharded_dry_run_mode()
+        and not integration.kwargs_have_shard_info(
+            **run_kwargs
+        )  # already running in sharded mode?
+        and desired_state_diff
+        and desired_state_diff.affected_shards
+    ):
+        affected_shard_list = list(desired_state_diff.affected_shards)
+        logging.info(f"run {integration.name} for shards {affected_shard_list}")
+
+        def run_integration_shard(shard: str) -> None:
+            integration.run_for_shard(True, shard, *run_args, **run_kwargs)
+
+        # run all shards
+        exceptions = sretoolbox_threaded.run(
+            run_integration_shard,
+            affected_shard_list,
+            thread_pool_size=min(len(affected_shard_list), 10),
+            return_exceptions=True,
+        )
+
+        for shard, ex in zip(affected_shard_list, exceptions):
+            if ex:
+                logging.error(f"Failed to run integration shard {shard}: {ex}")
+        failed_shards_count = sum(1 for _ in filter(None.__ne__, exceptions))
+        if failed_shards_count > 0:
+            sys.exit(failed_shards_count)
+        else:
+            return
 
     # if not, we run the integration in full
     integration.run(True, *run_args, **run_kwargs)

--- a/reconcile/utils/runtime/runner.py
+++ b/reconcile/utils/runtime/runner.py
@@ -1,0 +1,144 @@
+import logging
+from dataclasses import dataclass
+from typing import (
+    Any,
+    Optional,
+    Protocol,
+)
+
+from reconcile.utils import gql
+from reconcile.utils.runtime.desired_state_diff import (
+    DesiredStateDiff,
+    build_desired_state_diff,
+)
+from reconcile.utils.runtime.integration import QontractReconcileIntegration
+
+
+class DesiredStateProvider(Protocol):
+    def current_desired_state(self) -> dict[str, Any]:
+        ...
+
+    def previous_desired_state(self) -> dict[str, Any]:
+        ...
+
+
+@dataclass
+class IntegrationRunConfiguration:
+    integration: QontractReconcileIntegration
+    valdiate_schemas: bool
+    dry_run: bool
+    early_exit_compare_sha: Optional[str]
+    gql_sha_url: bool
+    print_url: bool
+    run_args: Any
+    run_kwargs: Any
+
+    def main_bundle_desired_state(self) -> dict[str, Any]:
+        self.switch_to_main_bundle()
+        return self.integration.get_early_exit_desired_state(
+            *self.run_args, **self.run_kwargs
+        )
+
+    def comparison_bundle_desired_state(self) -> dict[str, Any]:
+        self.switch_to_comparison_bundle()
+        data = self.integration.get_early_exit_desired_state(
+            *self.run_args, **self.run_kwargs
+        )
+        self.switch_to_main_bundle()
+        return data
+
+    def switch_to_main_bundle(self, validate_schemas: Optional[bool] = None) -> None:
+        final_validate_schemas = (
+            validate_schemas if validate_schemas is not None else self.valdiate_schemas
+        )
+        gql.init_from_config(
+            autodetect_sha=self.gql_sha_url,
+            integration=self.integration.name,
+            validate_schemas=final_validate_schemas,
+            print_url=self.print_url,
+        )
+
+    def switch_to_comparison_bundle(
+        self, validate_schemas: Optional[bool] = None
+    ) -> None:
+        final_validate_schemas = (
+            validate_schemas if validate_schemas is not None else self.valdiate_schemas
+        )
+        gql.init_from_config(
+            sha=self.early_exit_compare_sha,
+            integration=self.integration.name,
+            validate_schemas=final_validate_schemas,
+            print_url=self.print_url,
+        )
+
+
+def get_desired_state_diff(
+    run_cfg: IntegrationRunConfiguration,
+) -> Optional[DesiredStateDiff]:
+    if not run_cfg.early_exit_compare_sha:
+        return None
+
+    # get desired state from comparison bundle
+    try:
+        previous_desired_state = run_cfg.comparison_bundle_desired_state()
+    except NotImplementedError:
+        logging.warning(f"{run_cfg.integration.name} does not support early exit.")
+        return None
+    except Exception as e:
+        logging.exception(
+            f"Failed to fetch desired state for comparison bundle {run_cfg.early_exit_compare_sha}",
+            e,
+        )
+        return None
+
+    # get desired state from current bundle
+    try:
+        current_desired_state = run_cfg.main_bundle_desired_state()
+    except Exception:
+        logging.exception("Failed to fetch desired state for current bundle")
+        return None
+
+    return build_desired_state_diff(
+        run_cfg.integration.get_desired_state_shard_config(),
+        previous_desired_state,
+        current_desired_state,
+    )
+
+
+def run_integration_cfg(run_cfg: IntegrationRunConfiguration) -> None:
+    if run_cfg.dry_run:
+        desired_state_diff = get_desired_state_diff(run_cfg)
+        run_cfg.switch_to_main_bundle()
+        _integration_dry_run(
+            run_cfg.integration,
+            desired_state_diff,
+            *run_cfg.run_args,
+            **run_cfg.run_kwargs,
+        )
+    else:
+        run_cfg.switch_to_main_bundle()
+        _integration_wet_run(
+            run_cfg.integration, *run_cfg.run_args, **run_cfg.run_kwargs
+        )
+
+
+def _integration_wet_run(
+    integration: QontractReconcileIntegration, *run_args: Any, **run_kwargs: Any
+) -> None:
+    integration.run(False, *run_args, **run_kwargs)
+
+
+def _integration_dry_run(
+    integration: QontractReconcileIntegration,
+    desired_state_diff: Optional[DesiredStateDiff],
+    *run_args: Any,
+    **run_kwargs: Any,
+) -> None:
+
+    # if the integration can exit early, do so ...
+    if desired_state_diff and desired_state_diff.can_exit_early():
+        logging.debug("No changes in desired state. Exit PR check early.")
+        return
+
+    # if not, we run the integration in full
+    integration.run(True, *run_args, **run_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(exclude=("tests",)),
     package_data={"reconcile": ["templates/*.j2", "gql_queries/*/*.gql"]},
     install_requires=[
-        "sretoolbox~=2.2.0",
+        "sretoolbox~=2.2.1",
         "Click>=7.0,<9.0",
         "gql==3.1.0",
         "toml>=0.10.0,<0.11.0",


### PR DESCRIPTION
This PR refactors the current `cli.py` based integration startup function and enhances it with `sharded` dry-runs.

REVIEW COMMIT BY COMMIT

# Part 1 - Refactor
commit 1

The main logic for integration running has been moved to the `reconcile.utils.runtime` module. An integration and the required callback hooks `run` and `get_early_exit_desired_state` are now part of a class `QontractReconcileIntegration`. New integrations can subclass this one directly and implement the hook methods. Existing integrations are wrapped during startup into an `ModuleBasedQontractReconcileIntegration`. This way the code in `reconcile.utils.runtime.runner` deal only with `QontractReconcileIntegration` and can rely on a typed interface.

And integration can be executed by constructing a `IntegrationRunConfiguration` object which contains all the relevant generic qontract-reconcile runtime infos (`dry_run`, `validate_schema`, ...)

# Part 2 - Detect affected shards
commit 2+3

the difference in desired state state is used to find to find the affected shards for an integration. an integration can use the `get_desired_state_shard_config` function to return a `DesiredStateShardConfig` object that defines where to find the affected shards in the desired state.

the `DesiredStateShardConfig` object can contain a callback function where the integration can decide, if sharded run should be tried based on the detected shards, e.g. this can be used to not run in sharded mode if too many shards have been detected.

Sharded dry-runs are opt-int in many levels: 
* an integration must provide early-exit functionality and a `DesiredStateShardConfig` configuration
* an integration must be started with the `--check-only-affected-shards` CLI flag. This flag can be controlled via app-interface hack scripts (through data in the `/app-sre/integration-1.yml` [schema](https://github.com/app-sre/qontract-schemas/pull/373)) to activate/deactivate the functionality on demand

# Part 3 - Enable `terraform-resources` for sharded dry-runs

(!) this part will be split out into a dedicated PR - i left it here for now to show how the `desired_state_shard_config` hook works.

by implementing the `desired_state_shard_config` function, the `terraform-resources` integrations opts into the sharded integration dry-run mechanism.

the desired state returned by `early_exit_desired_state` has been enhanced by adding `IDENTIFIER_FIELD_NAME` fields to establish identifies for objects in lists, which speeds up the difference finding procedure. `IDENTIFIER_FIELD_NAME` is not something new but is populated in `bundles` by `qontract-validator` when a schema defines `uniqe` or `context-unique` fields.

this is not really necessary but helps in speeding up the diffing process so it does not run into timeouts, which would prevent sharded dry-runs.

Jira: https://issues.redhat.com/browse/APPSRE-6785
Schema change for activation flag: https://github.com/app-sre/qontract-schemas/pull/373

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>