### PR TITLE
bug fix: version_data does not report any histiry on new versions

### DIFF
--- a/reconcile/utils/cluster_version_data.py
+++ b/reconcile/utils/cluster_version_data.py
@@ -97,7 +97,7 @@ class VersionData(BaseModel):
     stats: Optional[Stats]
 
     def jsondict(self) -> dict[str, Any]:
-        return json.loads(self.json(exclude_unset=True))
+        return json.loads(self.json(exclude_none=True))
 
     def save(self, state: State, ocm_name: str) -> None:
         state.add(ocm_name, self.jsondict(), force=True)


### PR DESCRIPTION
with `exclude_unset` the `Workload` we're adding for new versions (such as `4.12`) are considered unset as their `soak_days` remain `0`. this means new versions don't get reported (and accumulated) anymore in the state.

We keep `exclude_none` to not store `inherited` data when there are none..