### PR TITLE
[change-owners] show approver groups on merge requests

### DIFF
--- a/reconcile/change_owners/approver.py
+++ b/reconcile/change_owners/approver.py
@@ -60,3 +60,25 @@ class GqlApproverResolver:
             return Approver(approvers["bot"][0]["org_username"], False)
         else:
             return None
+
+
+class ApproverReachability(Protocol):
+    def render_for_mr_report(self) -> str:
+        ...
+
+
+@dataclass
+class SlackGroupApproverReachability:
+    slack_group: str
+    workspace: str
+
+    def render_for_mr_report(self) -> str:
+        return f"Slack group {self.slack_group}/{self.workspace}"
+
+
+@dataclass
+class GitlabGroupApproverReachability:
+    gitlab_group: str
+
+    def render_for_mr_report(self) -> str:
+        return f"GitLab group {self.gitlab_group}"

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -24,7 +24,10 @@ import jsonpath_ng
 import jsonpath_ng.ext
 import networkx
 
-from reconcile.change_owners.approver import Approver
+from reconcile.change_owners.approver import (
+    Approver,
+    ApproverReachability,
+)
 from reconcile.change_owners.bundle import (
     BundleFileType,
     FileDiffResolver,
@@ -850,8 +853,9 @@ class ChangeTypeContext:
     change_type_processor: ChangeTypeProcessor
     context: str
     origin: str
-    approvers: list[Approver]
     context_file: FileRef
+    approvers: list[Approver]
+    approver_reachability: Optional[list[ApproverReachability]] = None
 
     @property
     def disabled(self) -> bool:

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
@@ -22,5 +22,16 @@ query SelfServiceRolesQuery($name: String) {
     bots {
       org_username
     }
+    permissions {
+      ... on PermissionSlackUsergroup_v1 {
+        handle
+        workspace {
+          name
+        }
+      }
+      ... on PermissionGitlabGroupMembership_v1 {
+        group
+      }
+    }
   }
 }

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
@@ -40,6 +40,17 @@ query SelfServiceRolesQuery($name: String) {
     bots {
       org_username
     }
+    permissions {
+      ... on PermissionSlackUsergroup_v1 {
+        handle
+        workspace {
+          name
+        }
+      }
+      ... on PermissionGitlabGroupMembership_v1 {
+        group
+      }
+    }
   }
 }
 """
@@ -90,12 +101,52 @@ class BotV1(BaseModel):
         extra = Extra.forbid
 
 
+class PermissionV1(BaseModel):
+    class Config:
+        smart_union = True
+        extra = Extra.forbid
+
+
+class SlackWorkspaceV1(BaseModel):
+    name: str = Field(..., alias="name")
+
+    class Config:
+        smart_union = True
+        extra = Extra.forbid
+
+
+class PermissionSlackUsergroupV1(PermissionV1):
+    handle: str = Field(..., alias="handle")
+    workspace: SlackWorkspaceV1 = Field(..., alias="workspace")
+
+    class Config:
+        smart_union = True
+        extra = Extra.forbid
+
+
+class PermissionGitlabGroupMembershipV1(PermissionV1):
+    group: str = Field(..., alias="group")
+
+    class Config:
+        smart_union = True
+        extra = Extra.forbid
+
+
 class RoleV1(BaseModel):
     name: str = Field(..., alias="name")
     path: str = Field(..., alias="path")
     self_service: Optional[list[SelfServiceConfigV1]] = Field(..., alias="self_service")
     users: list[UserV1] = Field(..., alias="users")
     bots: list[BotV1] = Field(..., alias="bots")
+    permissions: Optional[
+        list[
+            Union[
+                PermissionSlackUsergroupV1,
+                PermissionGitlabGroupMembershipV1,
+                PermissionV1,
+            ]
+        ]
+    ] = Field(..., alias="permissions")
 
     class Config:
         smart_union = True

--- a/reconcile/test/change_owners/fixtures.py
+++ b/reconcile/test/change_owners/fixtures.py
@@ -33,8 +33,12 @@ from reconcile.gql_definitions.change_owners.queries.change_types import (
 from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
     BotV1,
     DatafileObjectV1,
+    PermissionGitlabGroupMembershipV1,
+    PermissionSlackUsergroupV1,
+    PermissionV1,
     RoleV1,
     SelfServiceConfigV1,
+    SlackWorkspaceV1,
     UserV1,
 )
 from reconcile.test.fixtures import Fixtures
@@ -94,7 +98,16 @@ def build_role(
     datafiles: Optional[list[DatafileObjectV1]],
     users: Optional[list[str]] = None,
     bots: Optional[list[str]] = None,
+    slack_groups: Optional[list[str]] = None,
+    slack_workspace: Optional[str] = "workspace",
+    gitlab_groups: Optional[list[str]] = None,
 ) -> self_service_roles.RoleV1:
+    permissions: list[PermissionV1] = [
+        PermissionSlackUsergroupV1(
+            handle=g, workspace=SlackWorkspaceV1(name=slack_workspace)
+        )
+        for g in slack_groups or []
+    ] + [PermissionGitlabGroupMembershipV1(group=g) for g in gitlab_groups or []]
     return self_service_roles.RoleV1(
         name=name,
         path=f"/role/{name}.yaml",
@@ -111,6 +124,7 @@ def build_role(
             UserV1(org_username=u, tag_on_merge_requests=False) for u in users or []
         ],
         bots=[BotV1(org_username=b) for b in bots or []],
+        permissions=permissions,
     )
 
 

--- a/reconcile/test/change_owners/test_change_type_self_service_roles.py
+++ b/reconcile/test/change_owners/test_change_type_self_service_roles.py
@@ -1,12 +1,18 @@
 import pytest
 
+from reconcile.change_owners.approver import (
+    GitlabGroupApproverReachability,
+    SlackGroupApproverReachability,
+)
 from reconcile.change_owners.change_owners import validate_self_service_role
+from reconcile.change_owners.self_service_roles import approver_reachability_from_role
 from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
     ChangeTypeV1,
     DatafileObjectV1,
     RoleV1,
     SelfServiceConfigV1,
 )
+from reconcile.test.change_owners.fixtures import build_role
 
 #
 # test self-service role validation
@@ -34,11 +40,12 @@ def test_valid_self_service_role():
         ],
         users=[],
         bots=[],
+        permissions=[],
     )
     validate_self_service_role(role)
 
 
-def test_invalid_self_service_role():
+def test_invalid_self_service_role_schema_mismatch():
     role = RoleV1(
         name="role",
         path="/role.yaml",
@@ -59,6 +66,43 @@ def test_invalid_self_service_role():
         ],
         users=[],
         bots=[],
+        permissions=[],
     )
     with pytest.raises(ValueError):
         validate_self_service_role(role)
+
+
+#
+# test self-service role approver-reachability
+#
+
+
+def test_self_service_role_slack_user_group_approver_reachability():
+    slack_groups = ["slack-group-1", "slack-group-2"]
+    slack_workspace = "slack-workspace"
+    role = build_role(
+        name="role",
+        datafiles=None,
+        change_type_name="change-type-name",
+        slack_groups=slack_groups,
+        slack_workspace=slack_workspace,
+    )
+    reachability = approver_reachability_from_role(role)
+    assert reachability == [
+        SlackGroupApproverReachability(slack_group=g, workspace=slack_workspace)
+        for g in slack_groups
+    ]
+
+
+def test_self_service_role_gitlab_user_group_approver_reachability():
+    gitlab_groups = ["slack-group-1", "slack-group-2"]
+    role = build_role(
+        name="role",
+        datafiles=None,
+        change_type_name="change-type-name",
+        gitlab_groups=gitlab_groups,
+    )
+    reachability = approver_reachability_from_role(role)
+    assert reachability == [
+        GitlabGroupApproverReachability(gitlab_group=g) for g in gitlab_groups
+    ]


### PR DESCRIPTION
this change lists approver group contact information as part of the MR change report. this way, MR authors have an easier time identifying a communication channel to approach the approver group as a whole instead of reaching out to individuals.

the slack user groups and gitlab user groups of a `RoleV1` are the relevant group communication information used for this feature.

e.g. the following message will be available within an MR

```
Reach out to approvers for reviews on
* Slack group abc
* GitLab group def
```

Ref: https://issues.redhat.com/browse/APPSRE-6847

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>