### PR TITLE
alert-to-receiver: ignore rules with no alerts/labels

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2075,12 +2075,15 @@ def alert_to_receiver(
     alert_labels: list[dict] = []
     for group in rule_spec["groups"]:
         for rule in group["rules"]:
-            alert_labels.append(
-                {
-                    "name": rule["alert"],
-                    "labels": rule["labels"] | additional_labels,
-                }
-            )
+            try:
+                alert_labels.append(
+                    {
+                        "name": rule["alert"],
+                        "labels": rule["labels"] | additional_labels,
+                    }
+                )
+            except KeyError:
+                print("Skipping rule with no alert and/or labels", file=sys.stderr)
 
     if alert_name:
         alert_labels = [al for al in alert_labels if al["name"] == alert_name]


### PR DESCRIPTION
Attempting to use alert-to-receiver on [this rules file](https://gitlab.cee.redhat.com/service/app-interface/-/blob/f5595a956235d08e6e807cb8d0f159e87c38a9ae/resources/observability/prometheusrules/hive-production-capacity.prometheusrules.yaml) resulted in an exception:

```
Traceback (most recent call last):
  File "/home/mold/gitwork/qontract-reconcile/venv/bin/qontract-cli", line 33, in <module>
    sys.exit(load_entry_point('qontract-reconcile', 'console_scripts', 'qontract-cli')())
  File "/home/mold/gitwork/qontract-reconcile/venv/lib64/python3.9/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/home/mold/gitwork/qontract-reconcile/venv/lib64/python3.9/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/mold/gitwork/qontract-reconcile/venv/lib64/python3.9/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/mold/gitwork/qontract-reconcile/venv/lib64/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/mold/gitwork/qontract-reconcile/venv/lib64/python3.9/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/home/mold/gitwork/qontract-reconcile/venv/lib64/python3.9/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/mold/gitwork/qontract-reconcile/tools/qontract_cli.py", line 1677, in alert_to_receiver
    "name": rule["alert"],
KeyError: 'alert'
```

This is due to the fact that the first two rules do not define an `alert`.

This commit adds a safeguard to ignore such rules.

Part of [APPSRE-6850](https://issues.redhat.com/browse/APPSRE-6850)