### PR TITLE
[change-owners] auto approve when author is the only approver

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -397,7 +397,12 @@ def run(
             )
         )
         change_decisions = apply_decisions_to_changes(
-            changes, approver_decisions, {gl.user.username}
+            changes,
+            approver_decisions,
+            {
+                gl.user.username,
+                gl.get_merge_request_author_username(gitlab_merge_request_id),
+            },
         )
         hold = any(d.decision.hold for d in change_decisions)
         approved = all(

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -397,7 +397,7 @@ def run(
             )
         )
         change_decisions = apply_decisions_to_changes(
-            changes, approver_decisions, gl.user.username
+            changes, approver_decisions, {gl.user.username}
         )
         hold = any(d.decision.hold for d in change_decisions)
         approved = all(

--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -64,7 +64,7 @@ class ChangeDecision:
 def apply_decisions_to_changes(
     changes: list[BundleFileChange],
     approver_decisions: dict[str, Decision],
-    auto_approver_bot_username: str,
+    auto_approver_usernames: set[str],
 ) -> list[ChangeDecision]:
     """
     Apply and aggregate approver decisions to changes. Each diff of a
@@ -87,7 +87,7 @@ def apply_decisions_to_changes(
                 if (
                     len(change_type_context.approvers) == 1
                     and change_type_context.approvers[0].org_username
-                    == auto_approver_bot_username
+                    in auto_approver_usernames
                 ):
                     change_decision.decision.approve |= True
                     continue

--- a/reconcile/test/change_owners/test_change_type_decision.py
+++ b/reconcile/test/change_owners/test_change_type_decision.py
@@ -184,7 +184,7 @@ def test_change_decision(
             nay_sayer: Decision(approve=False, hold=True),
         },
         changes=[change],
-        auto_approver_bot_username=bot_user,
+        auto_approver_usernames={bot_user},
     )
 
     assert change_decision[0].decision.approve == expected_approve
@@ -218,7 +218,7 @@ def test_change_decision_auto_approve_only_approver(saas_file_changetype: Change
     change_decision = apply_decisions_to_changes(
         approver_decisions={},
         changes=[change],
-        auto_approver_bot_username=bot_user,
+        auto_approver_usernames={bot_user},
     )
 
     assert change_decision[0].decision.approve is True
@@ -253,7 +253,7 @@ def test_change_decision_auto_approve_not_only_approver(
     change_decision = apply_decisions_to_changes(
         approver_decisions={},
         changes=[change],
-        auto_approver_bot_username=bot_user,
+        auto_approver_usernames={bot_user},
     )
 
     assert change_decision[0].decision.approve is False
@@ -290,7 +290,7 @@ def test_change_decision_auto_approve_with_approval(
             bot_user: Decision(approve=True, hold=False),
         },
         changes=[change],
-        auto_approver_bot_username=bot_user,
+        auto_approver_usernames={bot_user},
     )
 
     assert change_decision[0].decision.approve is True

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -350,6 +350,11 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             changed_paths.add(new_path)
         return list(changed_paths)
 
+    def get_merge_request_author_username(self, mr_id: int) -> str:
+        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
+        merge_request = self.project.mergerequests.get(mr_id)
+        return merge_request.author["username"]
+
     def get_merge_request_comments(
         self, mr_id: int, include_description: bool = False
     ) -> list[dict[str, Any]]:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6786

similar to #3028

when the author is the only approver - it's approved. tests will block merges if something is wrong. the user can only `/hold`.