### PR TITLE
Define Cluster-Scoped resources in app-interface

### DIFF
--- a/reconcile/dashdotdb_cso.py
+++ b/reconcile/dashdotdb_cso.py
@@ -19,10 +19,7 @@ from reconcile.utils.oc import (
     OCLogMsg,
     StatusCodeError,
 )
-from reconcile.utils.oc_map import (
-    OCMap,
-    init_oc_map_from_clusters,
-)
+from reconcile.utils.oc_map import OCMap
 from reconcile.utils.secret_reader import (
     SecretReaderBase,
     create_secret_reader,
@@ -93,9 +90,11 @@ class DashdotdbCSO(DashdotdbBase):
 
     def run(self) -> None:
         clusters: list[ClusterV1] = get_clusters()
-        oc_map = init_oc_map_from_clusters(
-            clusters=clusters,
-            secret_reader=self.secret_reader,
+        oc_map_parameters = get_oc_connection_parameters_from_clusters(
+            secret_reader=self.secret_reader, clusters=clusters
+        )
+        oc_map = OCMap(
+            connection_parameters=oc_map_parameters,
             integration=QONTRACT_INTEGRATION,
             use_jump_host=True,
             thread_pool_size=self.thread_pool_size,

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1066,3 +1066,53 @@ def user_has_cluster_access(
     """Check user has access to cluster."""
     userkeys = determine_user_keys_for_access(cluster.name, cluster.auth)
     return any((getattr(user, userkey) in cluster_users for userkey in userkeys))
+
+
+def get_namespace_type_overrides(namespace: Mapping) -> dict[str, str]:
+    """Returns a dict with the type overrides defined in a namespace
+
+    :param namespace: the namespace
+    :return: dict with the the type overrides
+    """
+    return {
+        o["resource"]: o["override"]
+        for o in namespace.get("managedResourceTypeOverrides") or []
+    }
+
+
+def get_namespace_resource_types(
+    namespace: Mapping, type_overrides: Optional[dict[str, str]] = None
+) -> list[str]:
+    """Returns a list with the namespace ResourceTypes, with the overrides in place
+
+    :param namespace: the namespace
+    :param type_overrides: dict with the namespace type overrides
+    :return: Definitive managed resource TYPES for a namespace
+    """
+    if not type_overrides:
+        type_overrides = get_namespace_type_overrides(namespace)
+
+    return [
+        type_overrides.get(t, t) for t in namespace.get("managedResourceTypes") or []
+    ]
+
+
+def get_namespace_resource_names(
+    namespace: Mapping, type_overrides: Optional[dict[str, str]] = None
+) -> dict[str, list[str]]:
+    """Returns a list with the namespace ResourceTypeNames, with the overrides in place
+
+    :param namespace: the namespace
+    :param type_overrides: dict with the namespace type overrides
+    :return: Definitive managed resource NAMES for a namespace
+    """
+    if not type_overrides:
+        type_overrides = get_namespace_type_overrides(namespace)
+    rnames: dict[str, list[str]] = {}
+
+    for item in namespace.get("managedResourceNames") or []:
+        kind = type_overrides.get(item["resource"], item["resource"])
+        ref = rnames.setdefault(kind, [])
+        ref += item["resourceNames"]
+
+    return rnames

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -2,6 +2,7 @@ import base64
 import hashlib
 import itertools
 import hashlib
+import itertools
 import json
 import logging
 import sys

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -2,7 +2,6 @@ import base64
 import hashlib
 import itertools
 import hashlib
-import itertools
 import json
 import logging
 import sys

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -1,6 +1,7 @@
 import base64
 import hashlib
 import itertools
+import hashlib
 import json
 import logging
 import sys
@@ -1180,15 +1181,12 @@ def early_exit_desired_state(
             settings=settings,
         )
 
-    def post_process_ns(ns):
+    def add_ns_identify(ns):
         ns[IDENTIFIER_FIELD_NAME] = f"{ns['cluster']['name']}/{ns['name']}"
-        # the sharedResources have been aggreated into the openshiftResources
-        # and are no longer needed - speeds up diffing process
-        del ns["sharedResources"]
         return ns
 
     return {
-        "namespaces": [post_process_ns(ns) for ns in namespaces],
+        "namespaces": [add_ns_identify(ns) for ns in namespaces],
         "resources": resources,
     }
 
@@ -1211,7 +1209,6 @@ def _early_exit_fetch_resource(spec, settings):
         # detect changes in desired state
         c = resource["resource"].get("content")
     del resource["resource"]
-    resource[IDENTIFIER_FIELD_NAME] = id
     content_sha = hashlib.md5(c.encode("utf-8")).hexdigest()
     return {
         IDENTIFIER_FIELD_NAME: id,

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -1087,7 +1087,7 @@ def check_cluster_scoped_resources(
 
     checks = [
         CheckClusterScopedResourceNames(oc_map, ri, namespaces),
-        CheckClusterScopedResourceDuplicates(oc_map, all_namespaces, thread_pool_size),
+        CheckClusterScopedResourceDuplicates(oc_map, all_namespaces),
     ]
 
     results = threaded.run(

--- a/reconcile/test/fixtures/namespaces/ns-overrides-cluster-resources.yml
+++ b/reconcile/test/fixtures/namespaces/ns-overrides-cluster-resources.yml
@@ -1,0 +1,26 @@
+---
+name: ns1
+cluster:
+  name: cs1
+managedResourceTypes:
+  - ClusterRole
+  - Project
+  - Deployment
+managedResourceTypeOverrides:
+- resource: Project
+  override: Project.config.openshift.io
+managedResourceNames:
+  - resource: ClusterRole
+    resourceNames:
+      - cr1
+  - resource: Project
+    resourceNames:
+      - pr1
+      - pr2
+  - resource: Deployment
+    resourceNames:
+      - d1
+
+openshiftResources:
+  - provider: resource
+    path: /some/path.yml

--- a/reconcile/test/oc/test_oc_connection_parameters.py
+++ b/reconcile/test/oc/test_oc_connection_parameters.py
@@ -48,7 +48,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
                 jumphost_key="secret2",
                 jumphost_known_hosts="/path/to/file",
                 jumphost_user="jumphost-user",
-                jumphost_remote_port=8888,
+                jumphost_remote_port=None,
                 jumphost_local_port=None,
                 is_cluster_admin=None,
                 is_internal=True,

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from kubernetes.dynamic import Resource
 from pydantic import BaseModel
 from pytest_mock import MockerFixture
 
@@ -523,15 +524,34 @@ def test_namespaces_managed_mixed_qualified_types_with_resource_names(
 #
 
 
+@pytest.fixture
+def api_resources():
+    r1 = Resource(
+        prefix="",
+        kind="Kind",
+        group="fully.qualified",
+        api_version="v1",
+        namespaced=True,
+    )
+    r2 = Resource(
+        prefix="",
+        kind="Kind",
+        group="another.group",
+        api_version="v1",
+        namespaced=True,
+    )
+    return {"Kind": [r1, r2]}
+
+
 def test_populate_current_state(
-    resource_inventory: resource.ResourceInventory, oc_cs1: oc.OCNative
+    api_resources, resource_inventory: resource.ResourceInventory, oc_cs1: oc.OCNative
 ):
     """
     test that populate_current_state properly populates the resource inventory
     """
     # prepare client and resource inventory
     oc_cs1.init_api_resources = True
-    oc_cs1.api_kind_version = {"Kind": ["fully.qualified/v1", "another.group/v1"]}
+    oc_cs1.api_resources = api_resources
     oc_cs1.get_items = lambda kind, **kwargs: [
         build_resource("Kind", "fully.qualified/v1", "name")
     ]
@@ -562,7 +582,8 @@ def test_populate_current_state_unknown_kind(
     test that a missing kind in the cluster is catched early on
     """
     oc_cs1.init_api_resources = True
-    oc_cs1.api_kind_version = {"Kind": ["some.other.group/v1"]}
+    k1 = Resource(prefix="", group="some.other.group", api_version="v1", kind="Kind")
+    oc_cs1.api_resources = {"Kind": [k1]}
     get_item_mock = mocker.patch.object(oc.OCNative, "get_items", autospec=True)
 
     spec = sut.CurrentStateSpec(

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -1,3 +1,4 @@
+import copy
 from typing import Any
 from unittest.mock import (
     Mock,
@@ -5,10 +6,12 @@ from unittest.mock import (
 )
 
 import pytest
+from kubernetes.dynamic import Resource
 
 from reconcile import openshift_resources_base as orb
 from reconcile.openshift_base import CurrentStateSpec
 from reconcile.openshift_resources_base import (
+    CheckClusterScopedResourceDuplicates,
     canonicalize_namespaces,
     ob,
 )
@@ -29,11 +32,10 @@ def namespaces() -> list[dict[str, Any]]:
 def oc_cs1(self) -> oc.OCClient:
     client = oc.OCNative(cluster_name="cs1", server="s", token="t", local=True)
     client.init_api_resources = True
-    client.api_kind_version = {
+    client.api_resources = {
         "Template": ["template.openshift.io/v1"],
         "Subscription": ["apps.open-cluster-management.io/v1", "operators.coreos.com"],
     }
-    client.api_resources = client.api_kind_version.keys()
     client.get_items = lambda kind, **kwargs: []
     return client
 
@@ -250,3 +252,177 @@ def test_fetch_states_oc_error(current_state_spec: CurrentStateSpec):
     assert ri.has_error_registered("cs1")
     _, _, _, resource = list(ri)[0]
     assert len(resource["current"]) == 0
+
+
+@pytest.fixture
+def nss_csr_overrides() -> list[dict[str, Any]]:
+    return [fxt.get_anymarkup("ns-overrides-cluster-resources.yml")]
+
+
+@pytest.fixture
+def api_resources():
+    p1 = Resource(
+        prefix="",
+        kind="Project",
+        group="project.openshift.io",
+        api_version="v1",
+        namespaced=False,
+    )
+    p2 = Resource(
+        prefix="",
+        kind="Project",
+        group="config.openshift.io",
+        api_version="v1",
+        namespaced=False,
+    )
+    cr = Resource(
+        prefix="",
+        kind="ClusterRole",
+        group="rbac.authorization.k8s.io",
+        api_version="v1",
+        namespaced=False,
+    )
+    d1 = Resource(
+        prefix="",
+        kind="Deployment",
+        group="apps",
+        api_version="v1",
+        namespaced=True,
+    )
+    return {"Project": [p1, p2], "ClusterRole": [cr], "Deployment": [d1]}
+
+
+@pytest.fixture
+def oc_api_resources(mocker, api_resources):
+    mock = mocker.patch("reconcile.utils.oc.OCNative", autospec=True).return_value
+    mock.get_api_resources.return_value = api_resources
+    mock.is_kind_namespaced.side_effect = lambda k: k == "Deployment"
+    return oc.OCNative("cluster", "server", "token", local=True)
+
+
+@pytest.fixture
+def oc_map_api_resources(mocker, oc_api_resources):
+    ocmap = mocker.patch("reconcile.utils.oc.OC_Map", autospec=True).return_value
+    ocmap.get_cluster.return_value = oc_api_resources
+    ocmap.clusters.side_effect = (
+        lambda include_errors=False, privileged=False: ["cs1"] if not privileged else []
+    )
+    return oc.OC_Map(clusters=["cs1"])
+
+
+def test_get_namespace_cluster_scoped_resources(
+    oc_map_api_resources, nss_csr_overrides
+):
+    expected = (
+        "cs1",
+        "ns1",
+        {
+            "ClusterRole": ["cr1"],
+            "Project.config.openshift.io": ["pr1", "pr2"],
+        },
+    )
+
+    result = orb._get_namespace_cluster_scoped_resources(
+        nss_csr_overrides[0],
+        oc_map_api_resources,
+    )
+    assert result == expected
+
+
+def test_get_cluster_scoped_resources(oc_map_api_resources, nss_csr_overrides):
+    expected = {
+        "cs1": {
+            "ns1": {
+                "ClusterRole": ["cr1"],
+                "Project.config.openshift.io": ["pr1", "pr2"],
+            }
+        }
+    }
+    result = orb.get_cluster_scoped_resources(
+        oc_map_api_resources, clusters=["cs1"], namespaces=nss_csr_overrides
+    )
+    assert result == expected
+
+
+def test_find_resource_duplicates(oc_map_api_resources):
+    input = {
+        "ns1": {
+            "ClusterRole": ["cr1"],
+            "Project.config.openshift.io": ["pr1", "pr2"],
+        },
+        "ns2": {
+            "ClusterRole": ["cr1"],
+        },
+    }
+
+    expected = ("cs1", {("ClusterRole", "cr1"): ["ns1", "ns2"]})
+
+    c = CheckClusterScopedResourceDuplicates(oc_map_api_resources)
+    result = c._find_resource_duplicates(("cs1", input))
+    assert result == expected
+
+
+@pytest.fixture
+def resource_inventory_csr_tests():
+    ri = ResourceInventory()
+    ri.initialize_resource_type("cs1", "ns1", "ClusterRole")
+    ri.initialize_resource_type("cs1", "ns1", "Project.config.openshift.io")
+    ri.add_desired("cs1", "ns1", "ClusterRole", "cr1", "dummy_values", True)
+    ri.add_desired(
+        "cs1", "ns1", "Project.config.openshift.io", "pr1", "dummy_values", True
+    )
+    ri.add_desired(
+        "cs1", "ns1", "Project.config.openshift.io", "pr2", "dummy_values", True
+    )
+    return ri
+
+
+def test_check_cluster_scoped_resources_ok(
+    oc_map_api_resources, resource_inventory_csr_tests, nss_csr_overrides
+):
+    error = orb.check_cluster_scoped_resources(
+        oc_map_api_resources,
+        resource_inventory_csr_tests,
+        nss_csr_overrides,
+        nss_csr_overrides,
+    )
+
+    assert error is False
+
+
+def test_check_cluster_scoper_resources_non_declared(
+    oc_map_api_resources, resource_inventory_csr_tests, nss_csr_overrides
+):
+    resource_inventory_csr_tests.add_desired(
+        "cs1", "ns1", "ClusterRole", "cr3", "dummy_value", True
+    )
+    error = orb.check_cluster_scoped_resources(
+        oc_map_api_resources,
+        resource_inventory_csr_tests,
+        nss_csr_overrides,
+        nss_csr_overrides,
+    )
+
+    assert error is True
+
+
+def test_check_cluster_scoped_resources_duplicated(
+    oc_map_api_resources, resource_inventory_csr_tests, nss_csr_overrides
+):
+    ns2 = copy.deepcopy(nss_csr_overrides[0])
+    ns2["name"] = "ns3"
+
+    all_namespaces = [nss_csr_overrides[0], ns2]
+    error = orb.check_cluster_scoped_resources(
+        oc_map_api_resources,
+        resource_inventory_csr_tests,
+        nss_csr_overrides,
+        all_namespaces,
+    )
+
+    assert error is True
+
+
+def test_check_error():
+    e = orb.CheckError("message")
+    print(e)

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -346,19 +346,31 @@ def test_get_cluster_scoped_resources(oc_map_api_resources, nss_csr_overrides):
 
 def test_find_resource_duplicates(oc_map_api_resources):
     input = {
-        "ns1": {
-            "ClusterRole": ["cr1"],
-            "Project.config.openshift.io": ["pr1", "pr2"],
+        "cs1": {
+            "ns1": {
+                "ClusterRole": ["cr1"],
+                "Project.config.openshift.io": ["pr1", "pr2"],
+            },
+            "ns2": {
+                "ClusterRole": ["cr1"],
+            },
         },
-        "ns2": {
-            "ClusterRole": ["cr1"],
+        "cs2": {
+            "ns3": {
+                "ClusterRole": ["cr1"],
+                "ClusterRoleBinding": ["crb1"],
+            },
+            "ns4": {
+                "ClusterRoleBinding": ["crb1"],
+            },
         },
     }
-
-    expected = ("cs1", {("ClusterRole", "cr1"): ["ns1", "ns2"]})
-
+    expected = {
+        ("cs1", "ClusterRole", "cr1"): ["ns1", "ns2"],
+        ("cs2", "ClusterRoleBinding", "crb1"): ["ns3", "ns4"],
+    }
     c = CheckClusterScopedResourceDuplicates(oc_map_api_resources)
-    result = c._find_resource_duplicates(("cs1", input))
+    result = c._find_resource_duplicates(input)
     assert result == expected
 
 

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -365,10 +365,10 @@ def test_find_resource_duplicates(oc_map_api_resources):
             },
         },
     }
-    expected = {
-        ("cs1", "ClusterRole", "cr1"): ["ns1", "ns2"],
-        ("cs2", "ClusterRoleBinding", "crb1"): ["ns3", "ns4"],
-    }
+    expected = [
+        ("cs1", "ClusterRole", "cr1", ["ns1", "ns2"]),
+        ("cs2", "ClusterRoleBinding", "crb1", ["ns3", "ns4"]),
+    ]
     c = CheckClusterScopedResourceDuplicates(oc_map_api_resources)
     result = c._find_resource_duplicates(input)
     assert result == expected

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -4,8 +4,8 @@ from unittest import TestCase
 from unittest.mock import patch
 
 import pytest
-from kubernetes.dynamic.exceptions import ResourceNotFoundError
 from kubernetes.dynamic import Resource
+from kubernetes.dynamic.exceptions import ResourceNotFoundError
 
 import reconcile.utils.oc
 from reconcile.utils.oc import (

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 import pytest
 from kubernetes.dynamic import Resource
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
-from kubernetes.dynamic import Resource
 
 import reconcile.utils.oc
 from reconcile.utils.oc import (

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 import pytest
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
+from kubernetes.dynamic import Resource
 
 import reconcile.utils.oc
 from reconcile.utils.oc import (
@@ -891,3 +892,42 @@ def test_get_replicaset_allow_empty(patch_sleep, mocker, oc: OCNative, deploymen
     )
     oc__get_owned_replicasets.return_value = []
     assert oc.get_replicaset("namespace", deployment, allow_empty=True) == {}
+
+
+@pytest.fixture
+def api_resources():
+    k1_g1 = Resource(
+        prefix="", kind="kind1", group="group1", api_version="v1", namespaced=True
+    )
+    k1_g11 = Resource(
+        prefix="", kind="kind1", group="group11", api_version="v1", namespaced=True
+    )
+    k2_g2 = Resource(
+        prefix="", kind="kind2", group="group2", api_version="v2", namespaced=False
+    )
+    return {"kind1": [k1_g1, k1_g11], "kind2": [k2_g2]}
+
+
+@pytest.fixture
+def oc_api_resources(mocker, api_resources):
+    get_api_resources = mocker.patch.object(
+        OCNative, "get_api_resources", autospec=True
+    )
+    get_api_resources.return_value = api_resources
+    return OC("cluster", "server", "token", local=True)
+
+
+def test_is_kind_namespaced(oc_api_resources):
+    assert oc_api_resources.is_kind_namespaced("kind1")
+
+
+def test_is_kind_namespaced_full_name(oc_api_resources):
+    assert oc_api_resources.is_kind_namespaced("kind1.group11")
+
+
+def test_is_kind_not_namespaced(oc_api_resources):
+    assert not oc_api_resources.is_kind_namespaced("kind2")
+
+
+def test_is_kind_not_namespaced_full_name(oc_api_resources):
+    assert not oc_api_resources.is_kind_namespaced("kind2.group2")

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 from kubernetes.dynamic import Resource
 from kubernetes.dynamic.exceptions import ResourceNotFoundError
+from kubernetes.dynamic import Resource
 
 import reconcile.utils.oc
 from reconcile.utils.oc import (

--- a/reconcile/test/test_utils_oc_native.py
+++ b/reconcile/test/test_utils_oc_native.py
@@ -41,8 +41,6 @@ class TestOCNative(TestCase):
         mock_request.side_effect = request
 
         oc = OC("cluster", "server", "token", init_projects=True, local=True)
-        expected = fixture["api_kind_version"]
-        self.assertEqual(oc.api_kind_version, expected)
 
         expected = fixture["projects"]
         self.assertEqual(oc.projects, expected)

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1254,7 +1254,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
 
         # Same Kinds might exist in different api groups
         kind_resources = self.api_resources.get(kind)
-        if not kind:
+        if not kind_resources:
             raise StatusCodeError(f"Kind {kind} does not exist in the ApiServer")
 
         if len(kg) > 1:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -63,6 +63,8 @@ from reconcile.utils.secret_reader import (
 )
 from reconcile.utils.unleash import get_feature_toggle_state
 
+from dataclasses import dataclass
+
 urllib3.disable_warnings()
 
 GET_REPLICASET_MAX_ATTEMPTS = 20
@@ -243,6 +245,23 @@ def equal_spec_template(t1: dict, t2: dict) -> bool:
     return t1_copy == t2_copy
 
 
+@dataclass
+class OCDeprecatedApiResource:
+    """This class mimics kubernetes.dynamic.resource.Resource and it's used
+    To get Api Resources with the OCDeprecated client"""
+
+    kind: str
+    group: str
+    api_version: str
+    namespaced: bool
+
+    @property
+    def group_version(self):
+        if self.group:
+            return "{}/{}".format(self.group, self.api_version)
+        return self.api_version
+
+
 class OCDeprecated:  # pylint: disable=too-many-public-methods
     def __init__(
         self,
@@ -416,7 +435,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
 
         self.api_resources_lock = threading.RLock()
         self.init_api_resources = init_api_resources
-        self.api_resources = None
+        self.api_resources = {}
         if self.init_api_resources:
             self.api_resources = self.get_api_resources()
 
@@ -692,12 +711,26 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
         return self._run(cmd)
 
     def get_api_resources(self):
-        # oc api-resources only has name or wide output
-        # and we need to get the KIND, which is the last column
         with self.api_resources_lock:
             if not self.api_resources:
                 cmd = ["api-resources", "--no-headers"]
                 results = self._run(cmd).decode("utf-8").split("\n")
+                for line in results:
+                    r = line.split()
+                    kind = r[-1]
+                    namespaced = r[-2].lower() == "true"
+                    group_version = r[-3].split("/", 1)
+                    # Core group (v1)
+                    group = ""
+                    api_version = group_version
+                    if len(group_version) > 1:
+                        # group/version
+                        group = group_version[0]
+                        api_version = group_version[1]
+                    obj = OCDeprecatedApiResource(kind, group, api_version, namespaced)
+                    d = self.api_resources.setdefault(kind, [])
+                    d.append(obj)
+
                 self.api_resources = [r.split()[-1] for r in results]
         return self.api_resources
 
@@ -1104,11 +1137,63 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
 
         return out_json
 
+    def _parse_kind(self, kind_name):
+        kind_group = kind_name.split(".", 1)
+        kind = kind_group[0]
+        # if kind in self.api_kind_version:
+        if kind in self.api_resources:
+            group_version = self.api_resources[kind][0].group_version
+        else:
+            raise StatusCodeError(f"{self.server}: {kind} does not exist")
+
+        # if a kind_group has more than 1 entry than the kind_name is in
+        # the format kind.apigroup.  Find the apigroup/version that matches
+        # the apigroup passed with the kind_name
+        if len(kind_group) > 1:
+            apigroup_override = kind_group[1]
+            find = False
+            for gv in self.api_resources[kind]:
+                if apigroup_override == gv.group:
+                    if gv.group == "":
+                        group_version = gv.api_version
+                    else:
+                        group_version = f"{gv.group}/{gv.api_version}"
+                    find = True
+                    break
+
+            if not find:
+                raise StatusCodeError(
+                    f"{self.server}: {apigroup_override}" f" does not have kind {kind}"
+                )
+        return (kind, group_version)
+
     def is_kind_supported(self, kind: str) -> bool:
         if "." in kind:
-            # self.api_resources contains only the short kind names
-            kind = kind.split(".", 1)[0]
-        return kind in self.get_api_resources()
+            try:
+                self._parse_kind(kind)
+                return True
+            except StatusCodeError:
+                return False
+        else:
+            return kind in self.api_resources
+
+    def is_kind_namespaced(self, kind: str) -> bool:
+        kg = kind.split(".", 1)
+        kind = kg[0]
+
+        # Same Kinds might exist in different api groups
+        kind_resources = self.api_resources.get(kind)
+        if not kind:
+            raise StatusCodeError(f"Kind {kind} does not exist in the ApiServer")
+
+        if len(kg) > 1:
+            group = kg[1]
+            for r in kind_resources:
+                if group == r.group:
+                    return r.namespaced
+            raise StatusCodeError(f"Kind: {kind} does nod exist in the ApiServer")
+        else:
+            return kind_resources[0].namespaced
 
 
 class OCNative(OCDeprecated):
@@ -1146,8 +1231,8 @@ class OCNative(OCDeprecated):
 
         if server:
             self.client = self._get_client(server, token)
-            self.api_kind_version = self.get_api_resources()
-            self.api_resources = self.api_kind_version.keys()
+            self.api_resources = self.get_api_resources()
+
         else:
             raise Exception("A method relies on client/api_kind_version to be set")
 
@@ -1200,38 +1285,13 @@ class OCNative(OCDeprecated):
             )
         return self.object_clients[key]
 
-    def _parse_kind(self, kind_name):
-        kind_group = kind_name.split(".", 1)
-        kind = kind_group[0]
-        if kind in self.api_kind_version:
-            group_version = self.api_kind_version[kind][0]
-        else:
-            raise StatusCodeError(f"{self.server}: {kind} does not exist")
-
-        # if a kind_group has more than 1 entry than the kind_name is in
-        # the format kind.apigroup.  Find the apigroup/version that matches
-        # the apigroup passed with the kind_name
-        if len(kind_group) > 1:
-            apigroup_override = kind_group[1]
-            find = False
-            for gv in self.api_kind_version[kind]:
-                if apigroup_override in gv:
-                    group_version = gv
-                    find = True
-                    break
-            if not find:
-                raise StatusCodeError(
-                    f"{self.server}: {apigroup_override}" f" does not have kind {kind}"
-                )
-        return (kind, group_version)
-
-    # this function returns a kind:apigroup/version map for each kind on the
+    # this function returns a kind:Resource for each kind on the
     # cluster
     def get_api_resources(self):
         c_res = self.client.resources
         # this returns a prefix:apis map
         api_prefix = c_res.parse_api_groups(request_resources=False, update=True)
-        kind_groupversion = {}
+        api_resources = {}
         for prefix, apis in api_prefix.items():
             # each api prefix consists of api:versions map
             for apigroup, versions in apis.items():
@@ -1260,12 +1320,10 @@ class OCNative(OCDeprecated):
                         for r in res:
                             if isinstance(r, ResourceList):
                                 continue
-                            # add the kind and apigroup/version to the set
-                            # of api kinds
-                            kind_groupversion = self.add_group_kind(
-                                kind, kind_groupversion, r.group_version, obj.preferred
+                            api_resources = self.add_api_resource(
+                                kind, api_resources, obj.preferred, r
                             )
-        return kind_groupversion
+        return api_resources
 
     @retry(max_attempts=5, exceptions=(ServerTimeoutError))
     def get_items(self, kind, **kwargs):
@@ -1335,28 +1393,29 @@ class OCNative(OCDeprecated):
             raise StatusCodeError(f"[{self.server}]: {e}")
 
     @staticmethod
-    def add_group_kind(kind, kgv, new, preferred):
+    def add_api_resource(kind, kgv, preferred, resource):
         updated_kgv = copy.copy(kgv)
+
         if kind not in kgv:
             # this is a new kind so add it
-            updated_kgv[kind] = [new]
+            updated_kgv[kind] = [resource]
         else:
             # this kind already exists, so check if this apigroup has
             # already been added as an option.  If this apigroup/version is the
             # preferred one, then replace the apigroup/version so that the
             # preferred apigroup/version is used instead of a non-preferred one
-            group = new.split("/", 1)[0]
+            # group = resource.group_version.split("/", 1)[0]
             new_group = True
             for pos in range(len(kgv[kind])):
-                if group in kgv[kind][pos]:
+                if resource.group == kgv[kind][pos].group:
                     new_group = False
                     if preferred:
-                        updated_kgv[kind][pos] = new
+                        updated_kgv[kind][pos] = resource
                     break
 
             if new_group:
                 # this is a new apigroup
-                updated_kgv[kind].append(new)
+                updated_kgv[kind].append(resource)
         return updated_kgv
 
     def is_kind_supported(self, kind: str) -> bool:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -11,6 +11,7 @@ from collections.abc import (
     Mapping,
 )
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import datetime
 from functools import wraps
 from subprocess import (
@@ -62,8 +63,6 @@ from reconcile.utils.secret_reader import (
     SecretReader,
 )
 from reconcile.utils.unleash import get_feature_toggle_state
-
-from dataclasses import dataclass
 
 urllib3.disable_warnings()
 

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -64,8 +64,6 @@ from reconcile.utils.secret_reader import (
 )
 from reconcile.utils.unleash import get_feature_toggle_state
 
-from dataclasses import dataclass
-
 urllib3.disable_warnings()
 
 GET_REPLICASET_MAX_ATTEMPTS = 20

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -64,6 +64,8 @@ from reconcile.utils.secret_reader import (
 )
 from reconcile.utils.unleash import get_feature_toggle_state
 
+from dataclasses import dataclass
+
 urllib3.disable_warnings()
 
 GET_REPLICASET_MAX_ATTEMPTS = 20
@@ -506,7 +508,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
 
         self.api_resources_lock = threading.RLock()
         self.init_api_resources = init_api_resources
-        self.api_resources = None
+        self.api_resources = {}
         if self.init_api_resources:
             self.api_resources = self.get_api_resources()
 

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -88,9 +88,9 @@ class OCConnectionParameters:
     jumphost_user: Optional[str]
     jumphost_port: Optional[int]
     jumphost_key: Optional[str]
-    jumphost_remote_port: Optional[int]
-    # The local port is currently calculated and set outside of this class
+    # These tunneling ports are currently calculated and set outside of this class
     jumphost_local_port: Optional[int]
+    jumphost_remote_port: Optional[int]
 
     @staticmethod
     def from_cluster(

--- a/reconcile/utils/oc_map.py
+++ b/reconcile/utils/oc_map.py
@@ -92,6 +92,9 @@ class OCMap:
     def _set_jumphost_tunnel_ports(
         self, connection_parameters: OCConnectionParameters
     ) -> None:
+        # This will be replaced with getting the data from app-interface in
+        # a future PR.
+        connection_parameters.jumphost_remote_port = 8888
         key = f"{connection_parameters.jumphost_hostname}:{connection_parameters.jumphost_remote_port}"
         with self._lock:
             if key not in self._jh_ports:

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -591,6 +591,12 @@ class ResourceInventory:
         except KeyError:
             return None
 
+    def get_desired_by_type(self, cluster, namespace, resource_type):
+        try:
+            return self._clusters[cluster][namespace][resource_type]["desired"]
+        except KeyError:
+            return None
+
     def get_current(self, cluster, namespace, resource_type, name):
         try:
             return self._clusters[cluster][namespace][resource_type]["current"][name]


### PR DESCRIPTION
## Overview

This PR introduces a validation to ensure that cluster-scoped resources managed by App-Interface are not duplicated. 

With our current approach, multiple namespace files can define the same cluster-scoped resource using `openshiftResources`. That has happened sometimes and ends up with a clash of the reconciliation loop trying to reconcile the same resource from multiple locations. 

This change forces the cluster-scoped defined in `openshiftResoures` to be defined under `ManagedResourceNames` within the service namespace files. This allows a validation at PR-check to ensure that newly introduced cluster-scoped resources are not duplicated in the same cluster.

There are two checks: 
* CheckClusterScopedResourceNames: Ensures that all cluster-scoped resources in the desired state of a namespace are defined in the `ManagedResourceNames` list.
* CheckClusterScopedResourceDuplicates: Ensures that no cluster-scoped resource duplications exist in a cluster

**Note**: Before introducing this, all existent cluster-scoped resources should be defined in their namespace files

APPSRE-2935
