### PR TITLE
[ocm-oidc-idp] use standard OIDC claim names

### DIFF
--- a/reconcile/ocm_oidc_idp.py
+++ b/reconcile/ocm_oidc_idp.py
@@ -24,7 +24,7 @@ QONTRACT_INTEGRATION = "ocm-oidc-idp"
 
 DEFAULT_EMAIL_CLAIMS: list[str] = ["email"]
 DEFAULT_NAME_CLAIMS: list[str] = ["name"]
-DEFAULT_USERNAME_CLAIMS: list[str] = ["username"]
+DEFAULT_USERNAME_CLAIMS: list[str] = ["preferred_username"]
 DEFAULT_GROUPS_CLAIMS: list[str] = []
 
 


### PR DESCRIPTION
Using the standard OIDC claims avoids additional user-defined claims and setup errors for all OIDC clients.

APPSRE-6795
