### PR TITLE
[change-owners] improve diff detection when values repeat in lists

### DIFF
--- a/reconcile/change_owners/diff.py
+++ b/reconcile/change_owners/diff.py
@@ -163,6 +163,7 @@ def extract_diffs(old_file_content: Any, new_file_content: Any) -> list[Diff]:
             old_file_content,
             new_file_content,
             ignore_order=True,
+            report_repetition=True,
             iterable_compare_func=compare_object_ctx_identifier,
             cutoff_intersection_for_pairs=1,
         )
@@ -227,6 +228,25 @@ def extract_diffs(old_file_content: Any, new_file_content: Any) -> list[Diff]:
                     new=None,
                 )
                 for path, change in deep_diff.get("iterable_item_removed", {}).items()
+            ]
+        )
+
+        # handle repetition change
+        diffs.extend(
+            [
+                Diff(
+                    path=deepdiff_path_to_jsonpath(path),
+                    diff_type=DiffType.ADDED
+                    if change["old_repeat"] < change["new_repeat"]
+                    else DiffType.REMOVED,
+                    old=None
+                    if change["old_repeat"] < change["new_repeat"]
+                    else change["value"],
+                    new=change["value"]
+                    if change["old_repeat"] < change["new_repeat"]
+                    else None,
+                )
+                for path, change in deep_diff.get("repetition_change", {}).items()
             ]
         )
 

--- a/reconcile/test/change_owners/test_change_type_diff.py
+++ b/reconcile/test/change_owners/test_change_type_diff.py
@@ -573,6 +573,82 @@ def test_bundle_change_diff_item_reorder():
     assert not bundle_change
 
 
+def test_bundle_change_diff_item_repeat_increase():
+    bundle_change = create_bundle_file_change(
+        path="path",
+        schema="/access/user-1.yml",
+        file_type=BundleFileType.DATAFILE,
+        old_file_content={
+            "$schema": "/access/user-1.yml",
+            "roles": [
+                {"$ref": "an_item"},
+                {"$ref": "another_item"},
+            ],
+        },
+        new_file_content={
+            "$schema": "/access/user-1.yml",
+            "roles": [
+                {"$ref": "an_item"},
+                {"$ref": "an_item"},
+                {"$ref": "another_item"},
+            ],
+        },
+    )
+    assert bundle_change
+
+    expected = [
+        DiffCoverage(
+            diff=Diff(
+                path=jsonpath_ng.parse("roles.[0]"),
+                diff_type=DiffType.ADDED,
+                old=None,
+                new={"$ref": "an_item"},
+            ),
+            coverage=[],
+        ),
+    ]
+    diffs = sorted(bundle_change.diff_coverage, key=lambda d: str(d.diff.path))
+    assert diffs == expected
+
+
+def test_bundle_change_diff_item_repeat_decrease():
+    bundle_change = create_bundle_file_change(
+        path="path",
+        schema="/access/user-1.yml",
+        file_type=BundleFileType.DATAFILE,
+        old_file_content={
+            "$schema": "/access/user-1.yml",
+            "roles": [
+                {"$ref": "an_item"},
+                {"$ref": "an_item"},
+                {"$ref": "another_item"},
+            ],
+        },
+        new_file_content={
+            "$schema": "/access/user-1.yml",
+            "roles": [
+                {"$ref": "an_item"},
+                {"$ref": "another_item"},
+            ],
+        },
+    )
+    assert bundle_change
+
+    expected = [
+        DiffCoverage(
+            diff=Diff(
+                path=jsonpath_ng.parse("roles.[0]"),
+                diff_type=DiffType.REMOVED,
+                old={"$ref": "an_item"},
+                new=None,
+            ),
+            coverage=[],
+        ),
+    ]
+    diffs = sorted(bundle_change.diff_coverage, key=lambda d: str(d.diff.path))
+    assert diffs == expected
+
+
 def test_bundle_change_diff_resourcefile_without_schema_unparsable():
     bundle_change = create_bundle_file_change(
         path="path",


### PR DESCRIPTION
this might be an edge case but currently change-owners is unaware of certain changes. if a value in a list is duplicated, such duplicate values will not be reported as diff if they are next to each other in the list.

fixed in this PR

https://issues.redhat.com/browse/APPSRE-6889

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>