### PR TITLE
show diffs when modified files are present during build

### DIFF
--- a/reconcile/test/test_make.py
+++ b/reconcile/test/test_make.py
@@ -2,7 +2,10 @@ import os
 
 import pytest
 
-from reconcile.utils.git import has_uncommited_changes
+from reconcile.utils.git import (
+    has_uncommited_changes,
+    show_uncommited_changes,
+)
 from reconcile.utils.make import generate
 
 
@@ -11,12 +14,15 @@ from reconcile.utils.make import generate
     reason="This test is only for CI environments",
 )
 def test_make_generate():
-    assert not has_uncommited_changes(), "No uncommited changes must " "exists"
+    assert not has_uncommited_changes(), (
+        "No uncommited changes must " "exists\n" + show_uncommited_changes()
+    )
 
     result = generate()
     # Just to make sure the command does not fail
     assert not result.returncode
 
     assert not has_uncommited_changes(), (
-        "No uncommited changes must " 'exists after "make generate"'
+        "No uncommited changes must "
+        'exists after "make generate"\n' + show_uncommited_changes()
     )

--- a/reconcile/utils/git.py
+++ b/reconcile/utils/git.py
@@ -41,3 +41,11 @@ def has_uncommited_changes() -> bool:
     if result.stdout:
         return True
     return False
+
+
+def show_uncommited_changes() -> str:
+    cmd = ["git", "diff"]
+    result = subprocess.run(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True
+    )
+    return result.stdout.decode("utf-8")


### PR DESCRIPTION
our ci pipelines fails if there are modified files in the work dir after certain generational tasks (helm chart, qenerate files, file reformats). if that happens, it is quite hard/annoying to debug and to find the affected files.

this PR prints those changes to ease the debug process.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>