### PR TITLE
[terraform-users] sharded pr-checks on affected accounts

### DIFF
--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -212,6 +212,17 @@ def run(
 
 
 def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
+
+    """
+    Finding diffs in deeply nested structures is time/resource consuming.
+    Having a unique known property to identify objects makes it easier to match
+    the same object in different states. This speeds up the diffing process
+    A LOT!
+
+    The IDENTIFIER_FIELD_NAME is added for that purpose. It is a well known field
+    for the DeepDiff library used in qontract-reconcile.
+    """
+
     def add_account_identity(acc):
         acc[IDENTIFIER_FIELD_NAME] = acc["path"]
         return acc
@@ -237,5 +248,6 @@ def desired_state_shard_config() -> DesiredStateShardConfig:
             "roles[*].aws_groups[*].account.name",
             "roles[*].user_policies[*].account.name",
         },
+        # Only run shard if less than 2 shards are affected. Else it is not worth the effort -> run everything.
         sharded_run_review=lambda proposal: len(proposal.proposed_shards) <= 2,
     )


### PR DESCRIPTION
terraform-users is an integration that runs very long if it has to process all aws accounts. by running it only on affected aws-accounts, the dry-run runtime is a fraction of what it is when it runs in full.

like in https://github.com/app-sre/qontract-reconcile/pull/3149, the `IDENTIFIER_FIELD_NAME` field is introduced to speed up the fine grained diff extraction between the involved desired states.

https://issues.redhat.com/browse/APPSRE-6967

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>