### PR TITLE
[openshift-resources-*] dry-run on affected clusters only

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -2,6 +2,7 @@ from typing import Any
 
 import reconcile.openshift_base as ob
 import reconcile.openshift_resources_base as orb
+from reconcile.utils.runtime.integration import DesiredStateShardConfig
 from reconcile.utils.semver_helper import make_semver
 
 QONTRACT_INTEGRATION = "openshift_resources"
@@ -39,3 +40,7 @@ def run(
 
 def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
     return orb.early_exit_desired_state(PROVIDERS)
+
+
+def desired_state_shard_config() -> DesiredStateShardConfig:
+    return orb.desired_state_shard_config()

--- a/reconcile/openshift_routes.py
+++ b/reconcile/openshift_routes.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import reconcile.openshift_resources_base as orb
+from reconcile.utils.runtime.integration import DesiredStateShardConfig
 from reconcile.utils.semver_helper import make_semver
 
 QONTRACT_INTEGRATION = "openshift-routes"
@@ -33,3 +34,7 @@ def run(
 
 def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
     return orb.early_exit_desired_state(PROVIDERS)
+
+
+def desired_state_shard_config() -> DesiredStateShardConfig:
+    return orb.desired_state_shard_config()


### PR DESCRIPTION
enables `openshift-resources`, `openshift-routes` and `openshift-vault-secrets` to run their dry-run operations on affected clusters only for more performance and cluster isolation.

https://issues.redhat.com/browse/APPSRE-6785

this is just temporary work to benefit from PR check speed and isolation until @lechuk47 s work on partitioning/sharding has been implemented - https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/55171

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>