### PR TITLE
Add filtering capabilities to quay-mirror-org

### DIFF
--- a/reconcile/quay_base.py
+++ b/reconcile/quay_base.py
@@ -31,6 +31,14 @@ def get_quay_api_store():
         else:
             mirror = None
 
+        mirror_filters = {}
+        if org_data.get("mirrorFilters"):
+            for repo in org_data["mirrorFilters"]:
+                mirror_filters[repo["name"]] = {
+                    "tags": repo.get("tags"),
+                    "tags_exclude": repo.get("tagsExclude"),
+                }
+
         if org_data.get("pushCredentials"):
             push_token = secret_reader.read_all(org_data["pushCredentials"])
         else:
@@ -43,6 +51,7 @@ def get_quay_api_store():
             "teams": org_data.get("managedTeams"),
             "managedRepos": org_data.get("managedRepos"),
             "mirror": mirror,
+            "mirror_filters": mirror_filters,
         }
 
     return store

--- a/reconcile/quay_mirror_org.py
+++ b/reconcile/quay_mirror_org.py
@@ -118,6 +118,9 @@ class QuayMirrorOrg:
                         "username": username,
                         "token": token,
                     },
+                    "mirror_filters": org_info.get("mirror_filters").get(
+                        repo["name"], {}
+                    ),
                 }
                 summary[org_key].append(data)
 
@@ -158,9 +161,22 @@ class QuayMirrorOrg:
                     mirror_url, username=mirror_username, password=mirror_password
                 )
 
+                tags = item["mirror_filters"].get("tags")
+                tags_exclude = item["mirror_filters"].get("tags_exclude")
+
                 for tag in image_mirror:
                     upstream = image_mirror[tag]
                     downstream = image[tag]
+
+                    if not QuayMirror.sync_tag(
+                        tags=tags, tags_exclude=tags_exclude, candidate=tag
+                    ):
+                        _LOG.debug(
+                            "Image %s excluded through a mirror filter",
+                            upstream,
+                        )
+                        continue
+
                     if tag not in image:
                         _LOG.debug(
                             "Image %s and mirror %s are out of sync",

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1728,6 +1728,13 @@ QUAY_ORGS_QUERY = """
         name
       }
     }
+    mirrorFilters {
+      ... on QuayOrgMirrorFilter_v1 {
+        name
+        tags
+        tagsExclude
+      }
+    }
   }
 }
 """

--- a/reconcile/test/test_quay_mirror.py
+++ b/reconcile/test/test_quay_mirror.py
@@ -78,3 +78,29 @@ class TestIsCompareTags:
             compare_tags=True,
         )
         assert qm.is_compare_tags
+
+
+@pytest.mark.parametrize(
+    "tags, tags_exclude, candidate, result",
+    [
+        (["^sha256-.+sig$", "^main-.+"], None, "main-755781cc", True),
+        (["^sha256-.+sig$", "^main-.+"], None, "sha256-8b5.sig", True),
+        (["^sha256-.+sig$", "^main-.+"], None, "1.2.3", False),
+        (None, ["^sha256-.+sig$", "^main-.+"], "main-755781cc", False),
+        (None, ["^sha256-.+sig$", "^main-.+"], "sha256-8b5.sig", False),
+        (
+            ["^sha256-.+sig$", "^main-.+"],
+            ["^sha256-.+sig$", "^main-.+"],
+            "main-755781cc",
+            True,
+        ),
+        (
+            ["^sha256-.+sig$", "^main-.+"],
+            ["^sha256-.+sig$", "^main-.+"],
+            "sha256-8b5.sig",
+            True,
+        ),
+    ],
+)
+def test_sync_tag(tags, tags_exclude, candidate, result):
+    assert QuayMirror.sync_tag(tags, tags_exclude, candidate) == result

--- a/reconcile/test/test_quay_mirror.py
+++ b/reconcile/test/test_quay_mirror.py
@@ -83,11 +83,14 @@ class TestIsCompareTags:
 @pytest.mark.parametrize(
     "tags, tags_exclude, candidate, result",
     [
+        # Tags include tests.
         (["^sha256-.+sig$", "^main-.+"], None, "main-755781cc", True),
         (["^sha256-.+sig$", "^main-.+"], None, "sha256-8b5.sig", True),
         (["^sha256-.+sig$", "^main-.+"], None, "1.2.3", False),
+        # Tags exclude tests.
         (None, ["^sha256-.+sig$", "^main-.+"], "main-755781cc", False),
         (None, ["^sha256-.+sig$", "^main-.+"], "sha256-8b5.sig", False),
+        # When both includes and excludes are explicitly given, includes take precedence.
         (
             ["^sha256-.+sig$", "^main-.+"],
             ["^sha256-.+sig$", "^main-.+"],


### PR DESCRIPTION
This mimics how we include/exclude tags in quay-mirror.

part of APPSRE-6916

depends on schema changes in https://github.com/app-sre/qontract-schemas/pull/374

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>