### PR TITLE
pylint complains about broad exceptions

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -3,7 +3,6 @@ extension-pkg-allow-list=pydantic
 
 [MESSAGES CONTROL]
 disable = attribute-defined-outside-init,
-          broad-except,
           duplicate-code,
           expression-not-assigned,
           fixme,
@@ -56,4 +55,10 @@ disable = attribute-defined-outside-init,
           # global and multi-threading locks          
           global-variable-not-assigned,
           # This one is inconsistent between isort and pylint
-          wrong-import-order
+          wrong-import-order,
+          # since v2.16
+          use-dict-literal,
+          broad-exception-raised,
+          broad-exception-caught,
+          pointless-exception-statement,
+          superfluous-parens,

--- a/reconcile/test/test_status_page_components.py
+++ b/reconcile/test/test_status_page_components.py
@@ -74,10 +74,10 @@ def component_to_dict(
     group_id: Optional[str] = None,
     status: Optional[str] = None,
 ) -> dict[str, Optional[str]]:
-    data = dict(
-        name=component.display_name,
-        description=component.description,
-    )
+    data = {
+        "name": component.display_name,
+        "description": component.description,
+    }
     if group_id:
         data["group_id"] = group_id
     if status:

--- a/reconcile/utils/statuspage/atlassian.py
+++ b/reconcile/utils/statuspage/atlassian.py
@@ -96,9 +96,10 @@ class AtlassianStatusPage(StatusPageProvider):
                 f"{desired.group_name} is currently unsupported"
             )
 
-        component_update = dict(
-            name=desired.display_name, description=desired.description
-        )
+        component_update = {
+            "name": desired.display_name,
+            "description": desired.description,
+        }
         if group_id:
             component_update["group_id"] = group_id
 


### PR DESCRIPTION
Pylint recently started complaining about `broad-exception-raised` in multiple modules.

The errors seem to come from the latest pylint release https://github.com/PyCQA/pylint/releases/tag/v2.16.0

Since we explicitly do not want to pin mypy, I guess the same should hold true for pylint.