### PR TITLE
[change-owners] role members can cancel /lgtm and /hold from role peers

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -229,9 +229,9 @@ def write_coverage_report_to_mr(
             "schema": d.file.schema,
             "change": d.diff.path,
         }
-        if d.decision.hold:
+        if d.is_held():
             item["status"] = "hold"
-        elif d.decision.approve:
+        elif d.is_approved():
             item["status"] = "approved"
         item["approvers"] = approvers
         results.append(item)
@@ -404,10 +404,8 @@ def run(
                 gl.get_merge_request_author_username(gitlab_merge_request_id),
             },
         )
-        hold = any(d.decision.hold for d in change_decisions)
-        approved = all(
-            d.decision.approve and not d.decision.hold for d in change_decisions
-        )
+        hold = any(d.is_held() for d in change_decisions)
+        approved = all(d.is_approved() and not d.is_held() for d in change_decisions)
 
         #
         #   R E P O R T I N G

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -861,6 +861,12 @@ class ChangeTypeContext:
     def disabled(self) -> bool:
         return self.change_type_processor.disabled
 
+    def includes_approver(self, approver_name: str) -> bool:
+        return (
+            next((a for a in self.approvers if a.org_username == approver_name), None)
+            is not None
+        )
+
 
 JSON_PATH_ROOT = "$"
 

--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -1,7 +1,10 @@
 from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
+from typing import (
+    Any,
+    Iterable,
+)
 
 from reconcile.change_owners.bundle import FileRef
 from reconcile.change_owners.change_types import (
@@ -11,13 +14,6 @@ from reconcile.change_owners.change_types import (
 from reconcile.change_owners.diff import Diff
 
 
-@dataclass
-class Decision:
-
-    approve: bool = False
-    hold: bool = False
-
-
 class DecisionCommand(Enum):
     APPROVED = "/lgtm"
     CANCEL_APPROVED = "/lgtm cancel"
@@ -25,24 +21,43 @@ class DecisionCommand(Enum):
     CANCEL_HOLD = "/hold cancel"
 
 
+@dataclass
+class Decision:
+
+    approver_name: str
+    command: DecisionCommand
+
+
 def get_approver_decisions_from_mr_comments(
-    comments: list[dict[str, Any]]
-) -> dict[str, Decision]:
-    decisions_by_users: dict[str, Decision] = defaultdict(Decision)
+    comments: Iterable[dict[str, Any]]
+) -> list[Decision]:
+    decisions: list[Decision] = []
     for c in sorted(comments, key=lambda k: k["created_at"]):
         commenter = c["username"]
         comment_body = c.get("body")
         for line in comment_body.split("\n") if comment_body else []:
             line = line.strip()
             if line == DecisionCommand.APPROVED.value:
-                decisions_by_users[commenter].approve = True
+                decisions.append(
+                    Decision(approver_name=commenter, command=DecisionCommand.APPROVED)
+                )
             if line == DecisionCommand.CANCEL_APPROVED.value:
-                decisions_by_users[commenter].approve = False
+                decisions.append(
+                    Decision(
+                        approver_name=commenter, command=DecisionCommand.CANCEL_APPROVED
+                    )
+                )
             if line == DecisionCommand.HOLD.value:
-                decisions_by_users[commenter].hold = True
+                decisions.append(
+                    Decision(approver_name=commenter, command=DecisionCommand.HOLD)
+                )
             if line == DecisionCommand.CANCEL_HOLD.value:
-                decisions_by_users[commenter].hold = False
-    return decisions_by_users
+                decisions.append(
+                    Decision(
+                        approver_name=commenter, command=DecisionCommand.CANCEL_HOLD
+                    )
+                )
+    return decisions
 
 
 @dataclass
@@ -51,7 +66,28 @@ class ChangeDecision:
     file: FileRef
     diff: Diff
     coverage: list[ChangeTypeContext]
-    decision: Decision
+
+    def __post_init__(self) -> None:
+        self.approve: dict[str, bool] = defaultdict(bool)
+        self.hold: dict[str, bool] = defaultdict(bool)
+
+    def apply_decision(
+        self, ctx: ChangeTypeContext, decision_cmd: DecisionCommand
+    ) -> None:
+        if decision_cmd == DecisionCommand.APPROVED:
+            self.approve[ctx.context] = True
+        elif decision_cmd == DecisionCommand.CANCEL_APPROVED:
+            self.approve[ctx.context] = False
+        elif decision_cmd == DecisionCommand.HOLD:
+            self.hold[ctx.context] = True
+        elif decision_cmd == DecisionCommand.CANCEL_HOLD:
+            self.hold[ctx.context] = False
+
+    def is_approved(self) -> bool:
+        return any(self.approve.values())
+
+    def is_held(self) -> bool:
+        return any(self.hold.values())
 
     def deduped_coverage(self) -> list[ChangeTypeContext]:
         unique_coverage = {}
@@ -63,7 +99,7 @@ class ChangeDecision:
 
 def apply_decisions_to_changes(
     changes: list[BundleFileChange],
-    approver_decisions: dict[str, Decision],
+    approver_decisions: Iterable[Decision],
     auto_approver_usernames: set[str],
 ) -> list[ChangeDecision]:
     """
@@ -77,24 +113,28 @@ def apply_decisions_to_changes(
     for c in changes:
         for d in c.diff_coverage:
             change_decision = ChangeDecision(
-                file=c.fileref, diff=d.diff, coverage=d.coverage, decision=Decision()
+                file=c.fileref, diff=d.diff, coverage=d.coverage
             )
             diff_decisions.append(change_decision)
             for change_type_context in change_decision.coverage:
+                # approvers of a disabled change-type are ignored
                 if change_type_context.disabled:
-                    # approvers of a disabled change-type are ignored
                     continue
+
+                # autoapproval authors
                 if (
                     len(change_type_context.approvers) == 1
                     and change_type_context.approvers[0].org_username
                     in auto_approver_usernames
                 ):
-                    change_decision.decision.approve |= True
+                    change_decision.apply_decision(
+                        change_type_context, DecisionCommand.APPROVED
+                    )
                     continue
-                for approver in change_type_context.approvers:
-                    if approver.org_username in approver_decisions:
-                        if approver_decisions[approver.org_username].approve:
-                            change_decision.decision.approve |= True
-                        if approver_decisions[approver.org_username].hold:
-                            change_decision.decision.hold |= True
+
+                for decision in approver_decisions:
+                    if change_type_context.includes_approver(decision.approver_name):
+                        change_decision.apply_decision(
+                            change_type_context, decision.command
+                        )
     return diff_decisions

--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -1,10 +1,11 @@
 from collections import defaultdict
+from collections.abc import (
+    Iterable,
+    Mapping,
+)
 from dataclasses import dataclass
 from enum import Enum
-from typing import (
-    Any,
-    Iterable,
-)
+from typing import Any
 
 from reconcile.change_owners.bundle import FileRef
 from reconcile.change_owners.change_types import (
@@ -29,7 +30,7 @@ class Decision:
 
 
 def get_approver_decisions_from_mr_comments(
-    comments: Iterable[dict[str, Any]]
+    comments: Iterable[Mapping[str, Any]]
 ) -> list[Decision]:
     decisions: list[Decision] = []
     for c in sorted(comments, key=lambda k: k["created_at"]):
@@ -98,7 +99,7 @@ class ChangeDecision:
 
 
 def apply_decisions_to_changes(
-    changes: list[BundleFileChange],
+    changes: Iterable[BundleFileChange],
     approver_decisions: Iterable[Decision],
     auto_approver_usernames: set[str],
 ) -> list[ChangeDecision]:

--- a/reconcile/test/change_owners/test_change_type_decision.py
+++ b/reconcile/test/change_owners/test_change_type_decision.py
@@ -24,7 +24,7 @@ pytest_plugins = [
 #
 
 
-def test_approver_decision_approve_and_hold():
+def test_get_approver_decisions_from_mr_comments():
     comments = [
         {
             "username": "user-1",
@@ -34,74 +34,44 @@ def test_approver_decision_approve_and_hold():
         {
             "username": "user-2",
             "body": (f"{DecisionCommand.HOLD.value}\n" "oh wait... big problems"),
-            "created_at": "2020-01-02T00:00:00Z",
+            "created_at": "2020-01-03T00:00:00Z",
+        },
+        {
+            "username": "user-2",
+            "body": (f"{DecisionCommand.CANCEL_HOLD.value}\n" "never mind... all good"),
+            "created_at": "2020-01-04T00:00:00Z",
+        },
+        {
+            "username": "user-1",
+            "body": (f"{DecisionCommand.CANCEL_APPROVED.value}"),
+            "created_at": "2020-01-05T00:00:00Z",
         },
     ]
-    assert get_approver_decisions_from_mr_comments(comments) == {
-        "user-1": Decision(approve=True, hold=False),
-        "user-2": Decision(approve=False, hold=True),
-    }
+    assert get_approver_decisions_from_mr_comments(comments) == [
+        Decision(approver_name="user-1", command=DecisionCommand.APPROVED),
+        Decision(approver_name="user-2", command=DecisionCommand.HOLD),
+        Decision(approver_name="user-2", command=DecisionCommand.CANCEL_HOLD),
+        Decision(approver_name="user-1", command=DecisionCommand.CANCEL_APPROVED),
+    ]
 
 
-def test_approver_approve_and_cancel():
+def test_get_approver_decisions_from_mr_comments_unordered():
     comments = [
         {
             "username": "user-1",
             "body": ("nice\n" f"{DecisionCommand.APPROVED.value}"),
-            "created_at": "2020-01-01T00:00:00Z",
+            "created_at": "2020-01-02T00:00:00Z",  # this date is later then the next comment
         },
         {
-            "username": "user-1",
-            "body": (
-                f"{DecisionCommand.CANCEL_APPROVED.value}\n"
-                "oh wait... changed my mind"
-            ),
-            "created_at": "2020-01-02T00:00:00Z",
-        },
-    ]
-    assert get_approver_decisions_from_mr_comments(comments) == {
-        "user-1": Decision(approve=False, hold=False),
-    }
-
-
-def test_approver_hold_and_unhold():
-    comments = [
-        {
-            "username": "user-1",
-            "body": ("wait...\n" f"{DecisionCommand.HOLD.value}"),
-            "created_at": "2020-01-01T00:00:00Z",
-        },
-        {
-            "username": "user-1",
-            "body": (
-                f"{DecisionCommand.CANCEL_HOLD.value}\n" "oh never mind... keep going"
-            ),
-            "created_at": "2020-01-02T00:00:00Z",
-        },
-    ]
-    assert get_approver_decisions_from_mr_comments(comments) == {
-        "user-1": Decision(approve=False, hold=False),
-    }
-
-
-def test_unordered_approval_comments():
-    comments = [
-        {
-            "username": "user-1",
-            "body": (
-                f"{DecisionCommand.CANCEL_HOLD.value}\n" "oh never mind... keep going"
-            ),
-            "created_at": "2020-01-02T00:00:00Z",
-        },
-        {
-            "username": "user-1",
-            "body": ("wait...\n" f"{DecisionCommand.HOLD.value}"),
+            "username": "user-2",
+            "body": (f"{DecisionCommand.HOLD.value}\n" "oh wait... big problems"),
             "created_at": "2020-01-01T00:00:00Z",
         },
     ]
-    assert get_approver_decisions_from_mr_comments(comments) == {
-        "user-1": Decision(approve=False, hold=False),
-    }
+    assert get_approver_decisions_from_mr_comments(comments) == [
+        Decision(approver_name="user-2", command=DecisionCommand.HOLD),
+        Decision(approver_name="user-1", command=DecisionCommand.APPROVED),
+    ]
 
 
 def test_approval_comments_none_body():
@@ -128,10 +98,10 @@ def test_approver_decision_leading_trailing_spaces():
             "created_at": "2020-01-02T00:00:00Z",
         },
     ]
-    assert get_approver_decisions_from_mr_comments(comments) == {
-        "user-1": Decision(approve=True, hold=False),
-        "user-2": Decision(approve=False, hold=True),
-    }
+    assert get_approver_decisions_from_mr_comments(comments) == [
+        Decision(approver_name="user-1", command=DecisionCommand.APPROVED),
+        Decision(approver_name="user-2", command=DecisionCommand.HOLD),
+    ]
 
 
 #
@@ -179,16 +149,124 @@ def test_change_decision(
     ]
 
     change_decision = apply_decisions_to_changes(
-        approver_decisions={
-            yea_user: Decision(approve=True, hold=False),
-            nay_sayer: Decision(approve=False, hold=True),
-        },
+        approver_decisions=[
+            Decision(approver_name=yea_user, command=DecisionCommand.APPROVED),
+            Decision(approver_name=nay_sayer, command=DecisionCommand.HOLD),
+        ],
         changes=[change],
         auto_approver_usernames={bot_user},
     )
 
-    assert change_decision[0].decision.approve == expected_approve
-    assert change_decision[0].decision.hold == expected_hold
+    assert change_decision[0].is_approved() == expected_approve
+    assert change_decision[0].is_held() == expected_hold
+    assert change_decision[0].diff == change.diff_coverage[0].diff
+    assert change_decision[0].file == change.fileref
+
+
+GROUP_A_USER_1 = "group-a-user-1"
+GROUP_A_USER_2 = "group-a-user-2"
+GROUP_B_USER_1 = "group-b-user-1"
+GROUP_B_USER_2 = "group-b-user-2"
+GROUP_AB_USER = "group-a-and-b-user"
+
+
+@pytest.mark.parametrize(
+    "decisions,expected_approve,expected_hold",
+    [
+        # group A holds, group A cancels hold - not on hold anymore
+        (
+            [
+                Decision(GROUP_A_USER_1, DecisionCommand.HOLD),
+                Decision(GROUP_A_USER_2, DecisionCommand.CANCEL_HOLD),
+            ],
+            False,
+            False,
+        ),
+        # group A holds, group B cancels hold - still hold because group A would need to cancel the hold
+        (
+            [
+                Decision(GROUP_A_USER_1, DecisionCommand.HOLD),
+                Decision(GROUP_B_USER_1, DecisionCommand.CANCEL_HOLD),
+            ],
+            False,
+            True,
+        ),
+        # group A approves, group A cancels approval - not approved anymore
+        (
+            [
+                Decision(GROUP_A_USER_1, DecisionCommand.APPROVED),
+                Decision(GROUP_A_USER_2, DecisionCommand.CANCEL_APPROVED),
+            ],
+            False,
+            False,
+        ),
+        # group A approves, group B cancels approval - still approved because group A would need to cancel the approval
+        (
+            [
+                Decision(GROUP_A_USER_1, DecisionCommand.APPROVED),
+                Decision(GROUP_B_USER_1, DecisionCommand.CANCEL_APPROVED),
+            ],
+            True,
+            False,
+        ),
+        # group A approves, user from group A and B cancels approval - not approved anymore
+        (
+            [
+                Decision(GROUP_A_USER_1, DecisionCommand.APPROVED),
+                Decision(GROUP_AB_USER, DecisionCommand.CANCEL_APPROVED),
+            ],
+            False,
+            False,
+        ),
+    ],
+)
+def test_change_decision_one_change_multiple_groups(
+    saas_file_changetype: ChangeTypeV1,
+    decisions: list[Decision],
+    expected_approve: bool,
+    expected_hold: bool,
+):
+    change = create_bundle_file_change(
+        file_type=BundleFileType.DATAFILE,
+        path="/my/file.yml",
+        schema="/my/schema.yml",
+        old_file_content={"foo": "bar"},
+        new_file_content={"foo": "baz"},
+    )
+    assert change and len(change.diff_coverage) == 1
+    change.diff_coverage[0].coverage = [
+        ChangeTypeContext(
+            change_type_processor=change_type_to_processor(saas_file_changetype),
+            context="team-a-context",
+            origin="",
+            approvers=[
+                Approver(org_username=GROUP_A_USER_1, tag_on_merge_requests=False),
+                Approver(org_username=GROUP_A_USER_2, tag_on_merge_requests=False),
+                Approver(org_username=GROUP_AB_USER, tag_on_merge_requests=False),
+            ],
+            context_file=change.fileref,
+        ),
+        ChangeTypeContext(
+            change_type_processor=change_type_to_processor(saas_file_changetype),
+            context="team-b-context",
+            origin="",
+            approvers=[
+                Approver(org_username=GROUP_B_USER_1, tag_on_merge_requests=False),
+                Approver(org_username=GROUP_B_USER_2, tag_on_merge_requests=False),
+                Approver(org_username=GROUP_AB_USER, tag_on_merge_requests=False),
+            ],
+            context_file=change.fileref,
+        ),
+    ]
+
+    change_decision = apply_decisions_to_changes(
+        approver_decisions=decisions,
+        changes=[change],
+        auto_approver_usernames=set(),
+    )
+
+    assert change_decision[0].is_approved() == expected_approve
+    assert change_decision[0].is_held() == expected_hold
     assert change_decision[0].diff == change.diff_coverage[0].diff
     assert change_decision[0].file == change.fileref
 
@@ -221,7 +299,7 @@ def test_change_decision_auto_approve_only_approver(saas_file_changetype: Change
         auto_approver_usernames={bot_user},
     )
 
-    assert change_decision[0].decision.approve is True
+    assert change_decision[0].is_approved()
 
 
 def test_change_decision_auto_approve_not_only_approver(
@@ -256,7 +334,7 @@ def test_change_decision_auto_approve_not_only_approver(
         auto_approver_usernames={bot_user},
     )
 
-    assert change_decision[0].decision.approve is False
+    assert not change_decision[0].is_approved()
 
 
 def test_change_decision_auto_approve_with_approval(
@@ -286,11 +364,11 @@ def test_change_decision_auto_approve_with_approval(
     ]
 
     change_decision = apply_decisions_to_changes(
-        approver_decisions={
-            bot_user: Decision(approve=True, hold=False),
-        },
+        approver_decisions=[
+            Decision(approver_name=bot_user, command=DecisionCommand.APPROVED),
+        ],
         changes=[change],
         auto_approver_usernames={bot_user},
     )
 
-    assert change_decision[0].decision.approve is True
+    assert change_decision[0].is_approved()


### PR DESCRIPTION
Currently, a user adding a hold on an MR is the only one able to remove that hold with `/hold cancel`. this might block the MR from being merged even if another role member decides that it is now good to proceed.

this change fixes the situation while still making sure that a person from another team can't cancel another persons hold.

```
user 1 from role A: /hold
user 2 from role A: /hold cancel

result: hold is canceled
```

```
user 1 from role A: /hold
user 2 from role B: /hold cancel

result: MR is still on hold
```

https://issues.redhat.com/browse/APPSRE-6942

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>