### PR TITLE
[autopromoter] ignore null elements in the promotions list

### DIFF
--- a/reconcile/utils/mr/auto_promoter.py
+++ b/reconcile/utils/mr/auto_promoter.py
@@ -33,7 +33,7 @@ class AutoPromoter(MergeRequestBase):
     name = "auto_promoter"
 
     def __init__(self, promotions):
-        self.promotions = promotions
+        self.promotions = [p for p in promotions if p]
         super().__init__()
 
         self.labels = [AUTO_MERGE]


### PR DESCRIPTION
if a null element makes it into the promotions list of an `AutoPromoter` message, the processing fails with an error. ignore those elmenets is a quick fix to resolve the issue.

a proper solution would prevent such elements from being produced. right now we don't know yet how they come into existence.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>