### PR TITLE
[terraform-resources] fix sharded dry-runs

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1620,7 +1620,7 @@ def terraform_resources(
         use_jump_host,
         light,
         vault_output_path,
-        account_name,
+        account_name=account_name,
     )
 
 

--- a/reconcile/test/runtime/test_utils_integration.py
+++ b/reconcile/test/runtime/test_utils_integration.py
@@ -66,8 +66,20 @@ def test_demo_integration_kwargs_have_shard_info():
         **{demo_integration_shard_config.SHARD_ARG_NAME: "shard1"}
     )
 
+    assert integration.kwargs_have_shard_info(
+        **{demo_integration_shard_config.SHARD_ARG_NAME: ["shard1"]}
+    )
+
     assert not integration.kwargs_have_shard_info(
         **{demo_integration_shard_config.SHARD_ARG_NAME: None}
+    )
+
+    assert not integration.kwargs_have_shard_info(
+        **{demo_integration_shard_config.SHARD_ARG_NAME: ()}
+    )
+
+    assert not integration.kwargs_have_shard_info(
+        **{demo_integration_shard_config.SHARD_ARG_NAME: []}
     )
 
     assert not integration.kwargs_have_shard_info(**{})

--- a/reconcile/utils/runtime/integration.py
+++ b/reconcile/utils/runtime/integration.py
@@ -131,7 +131,8 @@ class QontractReconcileIntegration(ABC):
             self.get_desired_state_shard_config()
         )
         if sharding_config:
-            return kwargs.get(sharding_config.shard_arg_name) is not None
+            shard_arg_value = kwargs.get(sharding_config.shard_arg_name)
+            return shard_arg_value is not None and shard_arg_value
         else:
             return False
 


### PR DESCRIPTION
tf-resources got passed the shard arg multiple times to the run function: once as arg, once as kwarg

right now, sharded dry-runs rely on the shard arg to be passed exclusively as kwarg

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>