### PR TITLE
[change-owners] prevent cycles in ownership expansion on data level

### DIFF
--- a/reconcile/change_owners/implicit_ownership.py
+++ b/reconcile/change_owners/implicit_ownership.py
@@ -37,7 +37,9 @@ def change_type_contexts_for_implicit_ownership(
     ]
     for ctp in processors_with_implicit_ownership:
         for bc in bundle_changes:
-            for ownership in ctp.find_context_file_refs(bc.fileref, bc.old, bc.new):
+            for ownership in ctp.find_context_file_refs(
+                bc.fileref, bc.old, bc.new, set()
+            ):
                 for io in ctp.implicit_ownership:
                     if isinstance(io, ChangeTypeImplicitOwnershipJsonPathProviderV1):
                         if ownership.context_file_ref != bc.fileref:

--- a/reconcile/change_owners/self_service_roles.py
+++ b/reconcile/change_owners/self_service_roles.py
@@ -63,7 +63,9 @@ def change_type_contexts_for_self_service_roles(
     change_type_contexts = []
     for bc in bundle_changes:
         for ctp in change_type_processors:
-            for ownership in ctp.find_context_file_refs(bc.fileref, bc.old, bc.new):
+            for ownership in ctp.find_context_file_refs(
+                bc.fileref, bc.old, bc.new, set()
+            ):
                 # if the context file is bound with the change type in
                 # a role, build a changetypecontext
                 for role in role_lookup[

--- a/reconcile/test/change_owners/test_change_type_context.py
+++ b/reconcile/test/change_owners/test_change_type_context.py
@@ -31,7 +31,7 @@ def test_extract_context_file_refs_from_bundle_change(
     )
     ctp = change_type_to_processor(saas_file_changetype)
     file_refs = ctp.find_context_file_refs(
-        bundle_change.fileref, bundle_change.old, bundle_change.new
+        bundle_change.fileref, bundle_change.old, bundle_change.new, set()
     )
     assert [o.context_file_ref for o in file_refs] == [saas_file.file_ref()]
 
@@ -49,7 +49,7 @@ def test_extract_context_file_refs_from_bundle_change_schema_mismatch(
     )
     ctp = change_type_to_processor(saas_file_changetype)
     file_refs = ctp.find_context_file_refs(
-        bundle_change.fileref, bundle_change.old, bundle_change.new
+        bundle_change.fileref, bundle_change.old, bundle_change.new, set()
     )
     assert not file_refs
 
@@ -81,7 +81,7 @@ def test_extract_context_file_refs_selector(
     assert namespace_change
     ctp = change_type_to_processor(cluster_owner_change_type)
     file_refs = ctp.find_context_file_refs(
-        namespace_change.fileref, namespace_change.old, namespace_change.new
+        namespace_change.fileref, namespace_change.old, namespace_change.new, set()
     )
     assert [o.context_file_ref for o in file_refs] == [
         FileRef(
@@ -118,7 +118,7 @@ def test_extract_context_file_refs_in_list_added_selector(
     assert user_change
     ctp = change_type_to_processor(role_member_change_type)
     file_refs = ctp.find_context_file_refs(
-        user_change.fileref, user_change.old, user_change.new
+        user_change.fileref, user_change.old, user_change.new, set()
     )
     assert [o.context_file_ref for o in file_refs] == [
         FileRef(
@@ -153,7 +153,7 @@ def test_extract_context_file_refs_in_list_removed_selector(
     assert user_change
     ctp = change_type_to_processor(role_member_change_type)
     file_refs = ctp.find_context_file_refs(
-        user_change.fileref, user_change.old, user_change.new
+        user_change.fileref, user_change.old, user_change.new, set()
     )
     assert [o.context_file_ref for o in file_refs] == [
         FileRef(
@@ -181,6 +181,6 @@ def test_extract_context_file_refs_in_list_selector_change_schema_mismatch(
     assert datafile_change
     ctp = change_type_to_processor(role_member_change_type)
     file_refs = ctp.find_context_file_refs(
-        datafile_change.fileref, datafile_change.old, datafile_change.new
+        datafile_change.fileref, datafile_change.old, datafile_change.new, set()
     )
     assert not file_refs


### PR DESCRIPTION
right now, change-type ownership expansion forbids cycles to protect against endless loops during the expansion process.

but still, there are some legitimate usecases where self-referencing change-types are meaningful (self-reference == shortest cycle possible), e.g. ownership of an app grants ownership on child-apps.

such a cycle is not automatically problematic, it depends on the actual data, e.g. is there something like `app A -parent-> app B -parent-> app A`.

the protective means against such situations can be at ownership expansion runtime instead of change-type declaration loading/verification.

this change replaces the static configuration verification against cycle detection during runtime.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>