### PR TITLE
openshift resource processing fix for Service with `null` annotations

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -780,7 +780,7 @@ def _validate_resources_used_exist(
             # Check serving-cert-secret-name annotation on every considered resource
             for service in service_resources:
                 metadata = service.body.get("metadata", {})
-                annotations = metadata.get("annotations", {})
+                annotations = metadata.get("annotations") or {}
                 serving_cert_alpha_secret_name = annotations.get(
                     "service.alpha.openshift.io/serving-cert-secret-name", False
                 )


### PR DESCRIPTION
if a `kind: Service` has `metadata.annotations` explicitely set to `null` in desired state, processing can fail under certain circumstances (related to serving-cert Secrets).

https://issues.redhat.com/browse/APPSRE-6965

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>