### PR TITLE
[integration-runtime] fix extraction of affected shards from PR

### DIFF
--- a/reconcile/utils/runtime/desired_state_diff.py
+++ b/reconcile/utils/runtime/desired_state_diff.py
@@ -68,14 +68,14 @@ def find_changed_shards(
         for shard_path_spec in sharding_config.shard_path_selectors:
             shard_path = apply_constraint_to_path(parse(shard_path_spec), d.path)
             if shard_path:
-                if d.diff_type == DiffType.CHANGED or d.diff_type.REMOVED:
+                if d.diff_type in {DiffType.CHANGED, d.diff_type.REMOVED}:
                     affected_shards.update(
                         {
                             shard.value
                             for shard in shard_path.find(previous_desired_state)
                         }
                     )
-                if d.diff_type == DiffType.CHANGED or d.diff_type.ADDED:
+                if d.diff_type in {d.diff_type.ADDED}:
                     affected_shards.update(
                         {
                             shard.value


### PR DESCRIPTION
due to a bug, too many affected shards were extracted from desired state diff, which prevented some sharded dry-runs due to the shard-maximum integrations can opt-in (tf-resources, tf-users, openshift-resources, ...).

this part of the code was not properly tested before. this PR therefore also adds test coverage.

https://issues.redhat.com/browse/APPSRE-6972

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>