### PR TITLE
APPSRE-6609 typed jumphost (OC_Map refactor Part 2)

### DIFF
--- a/reconcile/test/fixtures/oc_connection_parameters/namespace_with_admin.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/namespace_with_admin.yml
@@ -17,7 +17,16 @@ cluster:
   disable: null
   insecureSkipTLSVerify: null
   internal: false
-  jumpHost: null
+  jumpHost:
+    hostname: jumphost
+    identity:
+      field: identity
+      format: base64
+      path: jumphost-secret
+      version: null
+    knownHosts: /path/to/file
+    port: null
+    user: jumphost-user
   name: test-cluster
   serverUrl: server-url
 clusterAdmin: true

--- a/reconcile/test/oc/test_oc_connection_parameters.py
+++ b/reconcile/test/oc/test_oc_connection_parameters.py
@@ -11,7 +11,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
 
 
 @pytest.mark.parametrize(
-    "cluster,expected_parameters",
+    "cluster, expected_parameters",
     [
         (
             "cluster_no_jumphost",
@@ -65,7 +65,7 @@ def test_from_cluster(cluster: str, expected_parameters: OCConnectionParameters)
 
 
 @pytest.mark.parametrize(
-    "namespace,expected_parameters",
+    "namespace, expected_parameters",
     [
         (
             "namespace_no_admin",

--- a/reconcile/test/oc/test_oc_connection_parameters.py
+++ b/reconcile/test/oc/test_oc_connection_parameters.py
@@ -18,10 +18,15 @@ from reconcile.utils.secret_reader import SecretReaderBase
             OCConnectionParameters(
                 cluster_name="test-cluster",
                 server_url="server-url",
-                automation_token="secret",
+                automation_token="secret1",
                 cluster_admin_automation_token=None,
                 disabled_e2e_tests=[],
                 disabled_integrations=[],
+                jumphost_port=None,
+                jumphost_hostname=None,
+                jumphost_key=None,
+                jumphost_known_hosts=None,
+                jumphost_user=None,
                 is_cluster_admin=None,
                 is_internal=False,
                 skip_tls_verify=None,
@@ -32,10 +37,15 @@ from reconcile.utils.secret_reader import SecretReaderBase
             OCConnectionParameters(
                 cluster_name="test-cluster",
                 server_url="server-url",
-                automation_token="secret",
+                automation_token="secret1",
                 cluster_admin_automation_token=None,
                 disabled_e2e_tests=[],
                 disabled_integrations=[],
+                jumphost_port=None,
+                jumphost_hostname="jumphost",
+                jumphost_key="secret2",
+                jumphost_known_hosts="/path/to/file",
+                jumphost_user="jumphost-user",
                 is_cluster_admin=None,
                 is_internal=True,
                 skip_tls_verify=None,
@@ -46,7 +56,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
 def test_from_cluster(cluster: str, expected_parameters: OCConnectionParameters):
     test_cluster = load_cluster_for_connection_parameters(f"{cluster}.yml")
     secret_reader = create_autospec(SecretReaderBase)
-    secret_reader.read_secret.side_effect = ["secret"]
+    secret_reader.read_secret.side_effect = ["secret1", "secret2"]
     parameters = OCConnectionParameters.from_cluster(
         secret_reader=secret_reader, cluster=test_cluster
     )
@@ -62,10 +72,15 @@ def test_from_cluster(cluster: str, expected_parameters: OCConnectionParameters)
             OCConnectionParameters(
                 cluster_name="test-cluster",
                 server_url="server-url",
-                automation_token="secret",
+                automation_token="secret1",
                 cluster_admin_automation_token=None,
                 disabled_e2e_tests=[],
                 disabled_integrations=[],
+                jumphost_port=None,
+                jumphost_hostname=None,
+                jumphost_key=None,
+                jumphost_known_hosts=None,
+                jumphost_user=None,
                 is_cluster_admin=None,
                 is_internal=False,
                 skip_tls_verify=None,
@@ -76,10 +91,15 @@ def test_from_cluster(cluster: str, expected_parameters: OCConnectionParameters)
             OCConnectionParameters(
                 cluster_name="test-cluster",
                 server_url="server-url",
-                automation_token="secret",
-                cluster_admin_automation_token="admin-token",
+                automation_token="secret1",
+                cluster_admin_automation_token="secret3",
                 disabled_e2e_tests=[],
                 disabled_integrations=[],
+                jumphost_port=None,
+                jumphost_hostname="jumphost",
+                jumphost_key="secret2",
+                jumphost_known_hosts="/path/to/file",
+                jumphost_user="jumphost-user",
                 is_cluster_admin=True,
                 is_internal=False,
                 skip_tls_verify=None,
@@ -90,7 +110,7 @@ def test_from_cluster(cluster: str, expected_parameters: OCConnectionParameters)
 def test_from_namespace(namespace: str, expected_parameters: OCConnectionParameters):
     test_namespace = load_namespace_for_connection_parameters(f"{namespace}.yml")
     secret_reader = create_autospec(SecretReaderBase)
-    secret_reader.read_secret.side_effect = ["secret", "admin-token"]
+    secret_reader.read_secret.side_effect = ["secret1", "secret2", "secret3"]
     parameters = OCConnectionParameters.from_namespace(
         secret_reader=secret_reader, namespace=test_namespace
     )

--- a/reconcile/test/test_jump_host.py
+++ b/reconcile/test/test_jump_host.py
@@ -21,7 +21,7 @@ EXPECTED_KNOWN_HOSTS_CONTENT = "known-hosts-file-content"
 
 
 @pytest.mark.parametrize(
-    "parameters,expected_port",
+    "parameters, expected_port",
     [
         (
             # Jumphost with default port
@@ -64,7 +64,7 @@ def test_base_jumphost(fs: Any, parameters: JumphostParameters, expected_port: i
 
 
 @pytest.mark.parametrize(
-    "parameters,local_port,remote_port",
+    "parameters, local_port, remote_port",
     [
         (
             # Jumphost without remote or local port set

--- a/reconcile/test/test_jump_host.py
+++ b/reconcile/test/test_jump_host.py
@@ -1,0 +1,117 @@
+import os
+from typing import (
+    Any,
+    Optional,
+)
+from unittest.mock import create_autospec
+
+import pytest
+
+from reconcile.utils import gql
+from reconcile.utils.jump_host import (
+    JumpHostBase,
+    JumphostParameters,
+    JumpHostSSH,
+)
+
+EXPECTED_USER = "test-user"
+EXPECTED_HOSTNAME = "test"
+EXPECTED_KNOWN_HOSTS_PATH = "path/to/known-hosts"
+EXPECTED_KNOWN_HOSTS_CONTENT = "known-hosts-file-content"
+
+
+@pytest.mark.parametrize(
+    "parameters,expected_port",
+    [
+        (
+            # Jumphost with default port
+            JumphostParameters(
+                hostname=EXPECTED_HOSTNAME,
+                key="ABC",
+                known_hosts=EXPECTED_KNOWN_HOSTS_PATH,
+                local_port=None,
+                port=None,
+                remote_port=None,
+                user=EXPECTED_USER,
+            ),
+            22,
+        ),
+        (
+            # Jumphost with non-default port
+            JumphostParameters(
+                hostname=EXPECTED_HOSTNAME,
+                key="ABC",
+                known_hosts=EXPECTED_KNOWN_HOSTS_PATH,
+                local_port=None,
+                port=25,
+                remote_port=None,
+                user=EXPECTED_USER,
+            ),
+            25,
+        ),
+    ],
+)
+def test_base_jumphost(fs: Any, parameters: JumphostParameters, expected_port: int):
+    jumphost = JumpHostBase(parameters=parameters)
+    assert os.path.exists(jumphost._identity_file)
+
+    with open(jumphost._identity_file, "r") as f:
+        assert f.read() == parameters.key
+
+    assert jumphost._port == expected_port
+    assert jumphost._user == EXPECTED_USER
+    assert jumphost._hostname == EXPECTED_HOSTNAME
+
+
+@pytest.mark.parametrize(
+    "parameters,local_port,remote_port",
+    [
+        (
+            # Jumphost without remote or local port set
+            JumphostParameters(
+                hostname=EXPECTED_HOSTNAME,
+                key="ABC",
+                known_hosts=EXPECTED_KNOWN_HOSTS_PATH,
+                local_port=None,
+                port=None,
+                remote_port=None,
+                user=EXPECTED_USER,
+            ),
+            None,
+            None,
+        ),
+        (
+            # Jumphost with remote and local port
+            JumphostParameters(
+                hostname=EXPECTED_HOSTNAME,
+                key="ABC",
+                known_hosts=EXPECTED_KNOWN_HOSTS_PATH,
+                local_port=25,
+                port=None,
+                remote_port=30,
+                user=EXPECTED_USER,
+            ),
+            25,
+            30,
+        ),
+    ],
+)
+def test_ssh_jumphost(
+    fs: Any,
+    parameters: JumphostParameters,
+    local_port: Optional[int],
+    remote_port: Optional[int],
+):
+    gql_mock = create_autospec(spec=gql.GqlApi)
+    gql_mock.get_resource.side_effect = [{"content": EXPECTED_KNOWN_HOSTS_CONTENT}]
+    jumphost = JumpHostSSH(parameters=parameters, gql_api=gql_mock)
+    known_hosts_file = jumphost._identity_dir + "/known_hosts"
+
+    assert os.path.exists(known_hosts_file)
+    assert jumphost._remote_port == remote_port
+    assert isinstance(jumphost._local_port, int)
+    if local_port:
+        assert jumphost._local_port == local_port
+
+    with open(known_hosts_file, "r") as f:
+        assert f.read() == EXPECTED_KNOWN_HOSTS_CONTENT

--- a/reconcile/utils/jump_host.py
+++ b/reconcile/utils/jump_host.py
@@ -3,13 +3,14 @@ import random
 import shutil
 import tempfile
 import threading
+from typing import Optional
+from dataclasses import dataclass
 
 from sshtunnel import SSHTunnelForwarder
 
 from reconcile.utils import gql
 from reconcile.utils.exceptions import FetchResourceError
 from reconcile.utils.helpers import toggle_logger
-from reconcile.utils.secret_reader import SecretReader
 
 # https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml
 DYNAMIC_PORT_MIN = 49152
@@ -21,23 +22,33 @@ class HTTPStatusCodeError(Exception):
         super().__init__("HTTP status code error: " + str(msg))
 
 
-class JumpHostBase:
-    def __init__(self, jh, settings=None):
-        self.hostname = jh["hostname"]
-        self.user = jh["user"]
-        self.port = 22 if jh["port"] is None else jh["port"]
-        secret_reader = SecretReader(settings=settings)
-        self.identity = secret_reader.read(jh["identity"])
-        self.init_identity_file()
+@dataclass
+class JumphostParameters:
+    hostname: str
+    known_hosts: str
+    user: str
+    port: Optional[int]
+    remote_port: Optional[int]
+    local_port: Optional[int]
+    key: str
 
-    def init_identity_file(self):
+
+class JumpHostBase:
+    def __init__(self, parameters: JumphostParameters):
+        self._hostname = parameters.hostname
+        self._user = parameters.user
+        self._port = parameters.port if parameters.port else 22
+        self._identity = parameters.key
+        self._init_identity_file()
+
+    def _init_identity_file(self):
         self._identity_dir = tempfile.mkdtemp()
 
         identity_file = self._identity_dir + "/id"
         with open(identity_file, "w") as f:
-            f.write(self.identity.decode("utf-8"))
+            f.write(self._identity.decode("utf-8"))
         os.chmod(identity_file, 0o600)
-        self.identity_file = identity_file
+        self._identity_file = identity_file
 
     def cleanup(self):
         shutil.rmtree(self._identity_dir)
@@ -48,17 +59,17 @@ class JumpHostSSH(JumpHostBase):
     local_ports: list[int] = []
     tunnel_lock = threading.Lock()
 
-    def __init__(self, jh, settings=None):
-        JumpHostBase.__init__(self, jh, settings=settings)
+    def __init__(self, parameters: JumphostParameters):
+        JumpHostBase.__init__(self, parameters=parameters)
 
-        self.known_hosts = self.get_known_hosts(jh)
-        self.init_known_hosts_file()
-        self.local_port = (
-            self.get_random_port()
-            if jh.get("localPort") is None
-            else jh.get("localPort")
+        self._known_hosts = self._get_known_hosts(parameters.known_hosts)
+        self._init_known_hosts_file()
+        self._local_port = (
+            self.get_unique_random_port()
+            if parameters.local_port is None
+            else parameters.local_port
         )
-        self.remote_port = jh["remotePort"]
+        self._remote_port = parameters.remote_port
 
     @staticmethod
     def get_unique_random_port():
@@ -69,9 +80,7 @@ class JumpHostSSH(JumpHostBase):
             JumpHostSSH.local_ports.append(port)
             return port
 
-    @staticmethod
-    def get_known_hosts(jh):
-        known_hosts_path = jh["knownHosts"]
+    def _get_known_hosts(known_hosts_path: str) -> str:
         gqlapi = gql.get_api()
 
         try:
@@ -80,15 +89,15 @@ class JumpHostSSH(JumpHostBase):
             raise FetchResourceError(str(e))
         return known_hosts["content"]
 
-    def init_known_hosts_file(self):
+    def _init_known_hosts_file(self):
         known_hosts_file = self._identity_dir + "/known_hosts"
         with open(known_hosts_file, "w") as f:
-            f.write(self.known_hosts)
+            f.write(self._known_hosts)
         os.chmod(known_hosts_file, 0o600)
         self.known_hosts_file = known_hosts_file
 
     def get_ssh_base_cmd(self):
-        user_host = "{}@{}".format(self.user, self.hostname)
+        user_host = "{}@{}".format(self._user, self._hostname)
 
         return [
             "ssh",
@@ -103,33 +112,33 @@ class JumpHostSSH(JumpHostBase):
             "-o",
             "UserKnownHostsFile={}".format(self.known_hosts_file),
             "-i",
-            self.identity_file,
+            self._identity_file,
             "-p",
-            str(self.port),
+            str(self._port),
             user_host,
         ]
 
     def create_ssh_tunnel(self):
         with JumpHostSSH.tunnel_lock:
-            if self.local_port not in JumpHostSSH.bastion_tunnel:
+            if self._local_port not in JumpHostSSH.bastion_tunnel:
                 # Hide connect messages from sshtunnel
                 with toggle_logger():
                     tunnel = SSHTunnelForwarder(
-                        ssh_address_or_host=self.hostname,
-                        ssh_port=self.port,
-                        ssh_username=self.user,
-                        ssh_pkey=self.identity_file,
-                        remote_bind_address=(self.hostname, self.remote_port),
-                        local_bind_address=("localhost", self.local_port),
+                        ssh_address_or_host=self._hostname,
+                        ssh_port=self._port,
+                        ssh_username=self._user,
+                        ssh_pkey=self._identity_file,
+                        remote_bind_address=(self._hostname, self._remote_port),
+                        local_bind_address=("localhost", self._local_port),
                     )
                     tunnel.start()
-                JumpHostSSH.bastion_tunnel[self.local_port] = tunnel
+                JumpHostSSH.bastion_tunnel[self._local_port] = tunnel
 
     def cleanup(self):
         JumpHostBase.cleanup(self)
         with JumpHostSSH.tunnel_lock:
             tunnels = JumpHostSSH.bastion_tunnel
-            if self.local_port in tunnels:
-                tunnel = tunnels.pop(self.local_port)
+            if self._local_port in tunnels:
+                tunnel = tunnels.pop(self._local_port)
                 tunnel.close()
-                JumpHostSSH.local_ports.remove(self.local_port)
+                JumpHostSSH.local_ports.remove(self._local_port)

--- a/reconcile/utils/jump_host.py
+++ b/reconcile/utils/jump_host.py
@@ -3,8 +3,8 @@ import random
 import shutil
 import tempfile
 import threading
-from typing import Optional
 from dataclasses import dataclass
+from typing import Optional
 
 from sshtunnel import SSHTunnelForwarder
 
@@ -71,6 +71,10 @@ class JumpHostSSH(JumpHostBase):
         )
         self._remote_port = parameters.remote_port
 
+    @property
+    def local_port(self) -> Optional[int]:
+        return self._local_port
+
     @staticmethod
     def get_unique_random_port():
         with JumpHostSSH.tunnel_lock:
@@ -80,7 +84,7 @@ class JumpHostSSH(JumpHostBase):
             JumpHostSSH.local_ports.append(port)
             return port
 
-    def _get_known_hosts(known_hosts_path: str) -> str:
+    def _get_known_hosts(self, known_hosts_path: str) -> str:
         gqlapi = gql.get_api()
 
         try:

--- a/reconcile/utils/jump_host.py
+++ b/reconcile/utils/jump_host.py
@@ -18,8 +18,8 @@ DYNAMIC_PORT_MAX = 65535
 
 
 class HTTPStatusCodeError(Exception):
-    def __init__(self, msg):
-        super().__init__("HTTP status code error: " + str(msg))
+    def __init__(self, msg: str):
+        super().__init__("HTTP status code error: " + msg)
 
 
 @dataclass
@@ -41,16 +41,16 @@ class JumpHostBase:
         self._identity = parameters.key
         self._init_identity_file()
 
-    def _init_identity_file(self):
+    def _init_identity_file(self) -> None:
         self._identity_dir = tempfile.mkdtemp()
 
         identity_file = self._identity_dir + "/id"
         with open(identity_file, "w") as f:
-            f.write(self._identity.decode("utf-8"))
+            f.write(self._identity)
         os.chmod(identity_file, 0o600)
         self._identity_file = identity_file
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         shutil.rmtree(self._identity_dir)
 
 
@@ -59,9 +59,12 @@ class JumpHostSSH(JumpHostBase):
     local_ports: list[int] = []
     tunnel_lock = threading.Lock()
 
-    def __init__(self, parameters: JumphostParameters):
+    def __init__(
+        self, parameters: JumphostParameters, gql_api: Optional[gql.GqlApi] = None
+    ):
         JumpHostBase.__init__(self, parameters=parameters)
 
+        self._gql_api = gql.get_api() if gql_api is None else gql_api
         self._known_hosts = self._get_known_hosts(parameters.known_hosts)
         self._init_known_hosts_file()
         self._local_port = (
@@ -76,7 +79,7 @@ class JumpHostSSH(JumpHostBase):
         return self._local_port
 
     @staticmethod
-    def get_unique_random_port():
+    def get_unique_random_port() -> int:
         with JumpHostSSH.tunnel_lock:
             port = random.randint(DYNAMIC_PORT_MIN, DYNAMIC_PORT_MAX)
             while port in JumpHostSSH.local_ports:
@@ -85,22 +88,20 @@ class JumpHostSSH(JumpHostBase):
             return port
 
     def _get_known_hosts(self, known_hosts_path: str) -> str:
-        gqlapi = gql.get_api()
-
         try:
-            known_hosts = gqlapi.get_resource(known_hosts_path)
+            known_hosts = self._gql_api.get_resource(known_hosts_path)
         except gql.GqlGetResourceError as e:
             raise FetchResourceError(str(e))
         return known_hosts["content"]
 
-    def _init_known_hosts_file(self):
+    def _init_known_hosts_file(self) -> None:
         known_hosts_file = self._identity_dir + "/known_hosts"
         with open(known_hosts_file, "w") as f:
             f.write(self._known_hosts)
         os.chmod(known_hosts_file, 0o600)
         self.known_hosts_file = known_hosts_file
 
-    def get_ssh_base_cmd(self):
+    def get_ssh_base_cmd(self) -> list[str]:
         user_host = "{}@{}".format(self._user, self._hostname)
 
         return [
@@ -122,7 +123,7 @@ class JumpHostSSH(JumpHostBase):
             user_host,
         ]
 
-    def create_ssh_tunnel(self):
+    def create_ssh_tunnel(self) -> None:
         with JumpHostSSH.tunnel_lock:
             if self._local_port not in JumpHostSSH.bastion_tunnel:
                 # Hide connect messages from sshtunnel
@@ -138,7 +139,7 @@ class JumpHostSSH(JumpHostBase):
                     tunnel.start()
                 JumpHostSSH.bastion_tunnel[self._local_port] = tunnel
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         JumpHostBase.cleanup(self)
         with JumpHostSSH.tunnel_lock:
             tunnels = JumpHostSSH.bastion_tunnel

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -277,10 +277,11 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
         self.jump_host = None
         if jh is not None:
             secret_reader = SecretReader(settings=settings)
-            key = secret_reader.read(jh["identity"])
+            key: bytes = secret_reader.read(jh["identity"])
+            decoded_key = key.decode("utf-8")
             jumphost_parameters = JumphostParameters(
                 hostname=jh["hostname"],
-                key=key,
+                key=decoded_key,
                 known_hosts=jh["knownHosts"],
                 local_port=jh.get("localPort"),
                 port=jh.get("port"),

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -48,6 +48,7 @@ from sretoolbox.utils import (
 
 from reconcile.status import RunningState
 from reconcile.utils.jump_host import JumpHostSSH
+from reconcile.utils.jump_host import JumphostParameters, JumpHostSSH
 from reconcile.utils.metrics import reconcile_time
 from reconcile.utils.secret_reader import (
     SecretNotFound,
@@ -273,7 +274,18 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
 
         self.jump_host = None
         if jh is not None:
-            self.jump_host = JumpHostSSH(jh, settings=settings)
+            secret_reader = SecretReader(settings=settings)
+            key = secret_reader.read(jh["identity"])
+            jumphost_parameters = JumphostParameters(
+                hostname=jh["hostname"],
+                key=key,
+                known_hosts=jh["knownHosts"],
+                local_port=jh.get("localPort"),
+                port=jh.get("port"),
+                remote_port=jh.get("remotePort"),
+                user=jh["user"],
+            )
+            self.jump_host = JumpHostSSH(parameters=jumphost_parameters)
             oc_base_cmd = self.jump_host.get_ssh_base_cmd() + oc_base_cmd
 
         self.oc_base_cmd = oc_base_cmd

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -47,8 +47,10 @@ from sretoolbox.utils import (
 )
 
 from reconcile.status import RunningState
-from reconcile.utils.jump_host import JumpHostSSH
-from reconcile.utils.jump_host import JumphostParameters, JumpHostSSH
+from reconcile.utils.jump_host import (
+    JumphostParameters,
+    JumpHostSSH,
+)
 from reconcile.utils.metrics import reconcile_time
 from reconcile.utils.secret_reader import (
     SecretNotFound,

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -27,7 +27,7 @@ class Jumphost(Protocol):
     port: Optional[int]
     known_hosts: str
     user: str
-    
+
     @property
     def identity(self) -> HasSecret:
         ...
@@ -126,7 +126,6 @@ class OCConnectionParameters:
                     f"[{cluster.name}] jumphost secret {jh.identity} not found"
                 )
                 raise e
-
 
         return OCConnectionParameters(
             cluster_name=cluster.name,

--- a/reconcile/utils/oc_map.py
+++ b/reconcile/utils/oc_map.py
@@ -13,9 +13,9 @@ from typing import (
 
 from sretoolbox.utils import threaded
 
+from reconcile.utils.jump_host import JumpHostSSH
 from reconcile.utils.oc import (
     OC,
-    JumpHostSSH,
     OCDeprecated,
     OCLogMsg,
     StatusCodeError,

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -13,3 +13,4 @@ moto~=2.2
 MarkupSafe==2.1.1
 smtpdfix==0.3.3
 isort~=5.10
+pyfakefs~=5.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -723,11 +723,6 @@ check_untyped_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.utils.jump_host]
-check_untyped_defs = False
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
 [mypy-reconcile.utils.ldap_client]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False


### PR DESCRIPTION
Add types and tests for jumphost implementation. This is required to have a typed `OCMap` class.

Follow-up of `OC_Map` refactor https://github.com/app-sre/qontract-reconcile/pull/3154

After this is merged, another PR will be opened to make `OCDeprecated` and `OCNative` fully compatible with new `OCMap` (in a backwards-compatible manner).

**Test**

- Tested with new `OCMap` class (dashdotdb-cso integration)
- Tested with old `OC_Map` class (openshift-users integration)