### PR TITLE
[glitchtip] get automation user email from vault secret

### DIFF
--- a/reconcile/glitchtip/integration.py
+++ b/reconcile/glitchtip/integration.py
@@ -153,10 +153,18 @@ def run(dry_run: bool, instance: Optional[str] = None) -> None:
             read_timeout=read_timeout,
             max_retries=max_retries,
         )
+        automation_user_email = secret_reader.read(
+            {
+                "path": glitchtip_instance.automation_user_email.path,
+                "field": glitchtip_instance.automation_user_email.field,
+                "format": glitchtip_instance.automation_user_email.q_format,
+                "version": glitchtip_instance.automation_user_email.version,
+            }
+        )
         current_state = fetch_current_state(
             glitchtip_client=glitchtip_client,
             # the automation user isn't managed by app-interface (chicken - egg problem), so just ignore it
-            ignore_users=[glitchtip_instance.automation_user_email],
+            ignore_users=[automation_user_email],
         )
         desired_state = fetch_desired_state(
             glitchtip_projects=[

--- a/reconcile/glitchtip/integration.py
+++ b/reconcile/glitchtip/integration.py
@@ -142,29 +142,16 @@ def run(dry_run: bool, instance: Optional[str] = None) -> None:
 
         glitchtip_client = GlitchtipClient(
             host=glitchtip_instance.console_url,
-            token=secret_reader.read(
-                {
-                    "path": glitchtip_instance.automation_token.path,
-                    "field": glitchtip_instance.automation_token.field,
-                    "format": glitchtip_instance.automation_token.q_format,
-                    "version": glitchtip_instance.automation_token.version,
-                }
-            ),
+            token=secret_reader.read_secret(glitchtip_instance.automation_token),
             read_timeout=read_timeout,
             max_retries=max_retries,
-        )
-        automation_user_email = secret_reader.read(
-            {
-                "path": glitchtip_instance.automation_user_email.path,
-                "field": glitchtip_instance.automation_user_email.field,
-                "format": glitchtip_instance.automation_user_email.q_format,
-                "version": glitchtip_instance.automation_user_email.version,
-            }
         )
         current_state = fetch_current_state(
             glitchtip_client=glitchtip_client,
             # the automation user isn't managed by app-interface (chicken - egg problem), so just ignore it
-            ignore_users=[automation_user_email],
+            ignore_users=[
+                secret_reader.read_secret(glitchtip_instance.automation_user_email)
+            ],
         )
         desired_state = fetch_desired_state(
             glitchtip_projects=[

--- a/reconcile/gql_definitions/glitchtip/glitchtip_instance.gql
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_instance.gql
@@ -4,7 +4,9 @@ query GlitchtipInstance {
   instances: glitchtip_instances_v1 {
     name
     consoleUrl
-    automationUserEmail
+    automationUserEmail {
+      ...VaultSecret
+    }
     automationToken {
       ...VaultSecret
     }

--- a/reconcile/gql_definitions/glitchtip/glitchtip_instance.py
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_instance.py
@@ -31,7 +31,9 @@ query GlitchtipInstance {
   instances: glitchtip_instances_v1 {
     name
     consoleUrl
-    automationUserEmail
+    automationUserEmail {
+      ...VaultSecret
+    }
     automationToken {
       ...VaultSecret
     }
@@ -43,7 +45,7 @@ query GlitchtipInstance {
 class GlitchtipInstanceV1(BaseModel):
     name: str = Field(..., alias="name")
     console_url: str = Field(..., alias="consoleUrl")
-    automation_user_email: str = Field(..., alias="automationUserEmail")
+    automation_user_email: VaultSecret = Field(..., alias="automationUserEmail")
     automation_token: VaultSecret = Field(..., alias="automationToken")
 
     class Config:

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -5878,6 +5878,26 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "mirrorFilters",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "QuayOrgMirrorFilter_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "managedRepos",
                             "description": null,
                             "args": [],
@@ -5978,6 +5998,73 @@
                             "ofType": null
                         }
                     ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "QuayOrgMirrorFilter_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tags",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "tagsExclude",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
                 },
@@ -11317,8 +11404,8 @@
                                 "kind": "NON_NULL",
                                 "name": null,
                                 "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
+                                    "kind": "OBJECT",
+                                    "name": "VaultSecret_v1",
                                     "ofType": null
                                 }
                             },
@@ -32217,6 +32304,18 @@
                         },
                         {
                             "name": "enhanced_monitoring",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "grafana_datasource",
                             "description": null,
                             "args": [],
                             "type": {


### PR DESCRIPTION
Refactor `glitchtip-instance-1` and get the automation user email address from a vault secret instead of specifying it manually. The vault secret is used by the glitchtip application during the startup to create/reconcile the API users.
This avoids glitchtip instance misconfigurations.

Ticket: [APPSRE-6904](https://issues.redhat.com/browse/APPSRE-6904)

Hint for the reviewer:
I've tested the glitchtip integration locally against a local glitchtip instance.