### PR TITLE
[openshift-resources] remove sharedResources from desired state

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -970,12 +970,15 @@ def early_exit_desired_state(
             settings=settings,
         )
 
-    def add_ns_identify(ns):
+    def post_process_ns(ns):
         ns[IDENTIFIER_FIELD_NAME] = f"{ns['cluster']['name']}/{ns['name']}"
+        # the sharedResources have been aggreated into the openshiftResources
+        # and are no longer needed - speeds up diffing process
+        del ns["sharedResources"]
         return ns
 
     return {
-        "namespaces": [add_ns_identify(ns) for ns in namespaces],
+        "namespaces": [post_process_ns(ns) for ns in namespaces],
         "resources": resources,
     }
 
@@ -998,6 +1001,7 @@ def _early_exit_fetch_resource(spec, settings):
         # detect changes in desired state
         c = resource["resource"].get("content")
     del resource["resource"]
+    resource[IDENTIFIER_FIELD_NAME] = id
     content_sha = hashlib.md5(c.encode("utf-8")).hexdigest()
     return {
         IDENTIFIER_FIELD_NAME: id,


### PR DESCRIPTION
the `sharedResources` field of a namespaces desired state gets aggreated into the `openshiftResources` fields during desired state loading. after that, the `sharedResources` field itself it not required anymore. removing it has positive effects on the diffing process between desired states.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>