### PR TITLE
Add exclude account parameter

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -351,7 +351,7 @@ def account_name_multiple(function):
     return function
 
 
-def exclude_accounts(function):
+def exclude_aws_accounts(function):
     function = click.option(
         "--exclude-accounts",
         multiple=True,
@@ -1612,7 +1612,7 @@ def ldap_users(ctx, gitlab_project_id):
 @use_jump_host()
 @enable_deletion(default=False)
 @account_name_multiple
-@exclude_accounts
+@exclude_aws_accounts
 @click.option(
     "--light/--full",
     default=False,

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -351,6 +351,17 @@ def account_name_multiple(function):
     return function
 
 
+def exclude_accounts(function):
+    function = click.option(
+        "--exclude-accounts",
+        multiple=True,
+        help="aws account name to remove from execution when in dry-run",
+        default=[],
+    )(function)
+
+    return function
+
+
 def workspace_name(function):
     function = click.option(
         "--workspace-name", help="slack workspace name to act on.", default=None
@@ -1601,6 +1612,7 @@ def ldap_users(ctx, gitlab_project_id):
 @use_jump_host()
 @enable_deletion(default=False)
 @account_name_multiple
+@exclude_accounts
 @click.option(
     "--light/--full",
     default=False,
@@ -1617,6 +1629,7 @@ def terraform_resources(
     light,
     vault_output_path,
     account_name,
+    exclude_accounts,
 ):
     import reconcile.terraform_resources
 
@@ -1633,6 +1646,7 @@ def terraform_resources(
         light,
         vault_output_path,
         account_name=account_name,
+        exclude_accounts=exclude_accounts,
     )
 
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -711,6 +711,18 @@ def populate_desired_state(
             )
 
 
+class ExcludeAccountsAndDryRunException(Exception):
+    pass
+
+
+class ExcludeAccountsAndAccountNameException(Exception):
+    pass
+
+
+class MultipleAccountNamesInDryRunException(Exception):
+    pass
+
+
 @defer
 def run(
     dry_run,
@@ -728,12 +740,12 @@ def run(
     if exclude_accounts and not dry_run:
         message = "--exclude-accounts is only supported in dry-run mode"
         logging.error(message)
-        raise RuntimeError(message)
+        raise ExcludeAccountsAndDryRunException(message)
 
     if exclude_accounts and account_name:
         message = "Using --exclude-accounts and --account-name at the same time is not allowed"
         logging.error(message)
-        raise RuntimeError(message)
+        raise ExcludeAccountsAndAccountNameException(message)
 
     # account_name is a tuple of account names for more detail go to
     # https://click.palletsprojects.com/en/8.1.x/options/#multiple-options
@@ -746,7 +758,7 @@ def run(
     if account_names and len(account_names) > 1 and not dry_run:
         message = "Running with multiple accounts is only supported in dry-run mode"
         logging.error(message)
-        raise RuntimeError(message)
+        raise MultipleAccountNamesInDryRunException(message)
 
     ri, oc_map, tf, resource_specs = setup(
         dry_run,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -560,8 +560,11 @@ def setup(
     internal: str,
     use_jump_host: bool,
     account_names: Optional[Collection[str]],
+    exclude_accounts: Optional[Collection[str]],
 ) -> tuple[ResourceInventory, OC_Map, Terraform, ExternalResourceSpecInventory]:
     accounts = queries.get_aws_accounts(terraform_state=True)
+    if not account_names and exclude_accounts:
+        accounts = [ac for ac in accounts if ac["name"] not in exclude_accounts]
     if account_names:
         accounts = [n for n in accounts if n["name"] in account_names]
         if len(accounts) != len(account_names):
@@ -700,6 +703,7 @@ def run(
     light=False,
     vault_output_path="",
     account_name: Optional[Sequence[str]] = None,
+    exclude_accounts: Optional[Sequence[str]] = None,
     defer=None,
 ) -> None:
     # account_name is a tuple of account names for more detail go to
@@ -722,6 +726,7 @@ def run(
         internal,
         use_jump_host,
         account_names,
+        exclude_accounts,
     )
 
     if not dry_run:

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -587,26 +587,15 @@ def setup(
     accounts = queries.get_aws_accounts(terraform_state=True)
     if not include_accounts and exclude_accounts:
         excluding = filter_accounts_by_name(accounts, exclude_accounts)
-        if len(excluding) != len(exclude_accounts):
-            raise ValueError(
-                f"Accounts {exclude_accounts} were provided as arguments, but not found in app-interface. Check your input for typos or for missing AWS account definitions."
-            )
+        validate_account_names(excluding, exclude_accounts)
         accounts = exclude_accounts_by_name(accounts, exclude_accounts)
         if len(accounts) == 0:
             raise ValueError("You have excluded all aws accounts, verify your input")
         account_names = tuple(ac["name"] for ac in accounts)
     elif include_accounts:
-        accounts = filter_accounts_by_name(accounts, account_names)
-        if len(accounts) != len(account_names):
-            # Some of the passed account names don't exist in app-interface
-            acc_names = tuple(
-                a
-                for a in account_names
-                if a not in tuple(account["name"] for account in accounts)
-            )
-            raise ValueError(
-                f"Accounts {acc_names} were provided as arguments, but not found in app-interface. Check your input for typos or for missing AWS account definitions."
-            )
+        accounts = filter_accounts_by_name(accounts, include_accounts)
+        validate_account_names(accounts, include_accounts)
+    account_names = tuple(a["name"] for a in accounts)
     settings = queries.get_app_interface_settings()
 
     # build a resource inventory for all the kube secrets managed by the

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -565,6 +565,16 @@ def exclude_accounts_by_name(
     return [ac for ac in accounts if ac["name"] not in filter]
 
 
+def validate_account_names(
+    accounts: Collection[Mapping[str, Any]], names: Collection[str]
+) -> None:
+    if len(accounts) != len(names):
+        missing_names = set(names) - {a["name"] for a in accounts}
+        raise ValueError(
+            f"Accounts {missing_names} were provided as arguments, but not found in app-interface. Check your input for typos or for missing AWS account definitions."
+        )
+
+
 def setup(
     dry_run: bool,
     print_to_file: str,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -726,14 +726,12 @@ def run(
     defer=None,
 ) -> None:
     if exclude_accounts and not dry_run:
-        message = "Exclude accounts is only supported in dry-run mode"
+        message = "--exclude-accounts is only supported in dry-run mode"
         logging.error(message)
         raise RuntimeError(message)
 
     if exclude_accounts and account_name:
-        message = (
-            "Using exclude account and account name at the same time is not allowed"
-        )
+        message = "Using --exclude-accounts and --account-name at the same time is not allowed"
         logging.error(message)
         raise RuntimeError(message)
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -706,6 +706,11 @@ def run(
     exclude_accounts: Optional[Sequence[str]] = None,
     defer=None,
 ) -> None:
+    if exclude_accounts and not dry_run:
+        message = "Exclude accounts is only supported in dry-run mode"
+        logging.error(message)
+        raise RuntimeError(message)
+
     # account_name is a tuple of account names for more detail go to
     # https://click.palletsprojects.com/en/8.1.x/options/#multiple-options
     account_names = account_name

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -581,11 +581,11 @@ def setup(
     thread_pool_size: int,
     internal: str,
     use_jump_host: bool,
-    account_names: Optional[Collection[str]],
+    include_accounts: Optional[Collection[str]],
     exclude_accounts: Optional[Collection[str]],
 ) -> tuple[ResourceInventory, OC_Map, Terraform, ExternalResourceSpecInventory]:
     accounts = queries.get_aws_accounts(terraform_state=True)
-    if not account_names and exclude_accounts:
+    if not include_accounts and exclude_accounts:
         excluding = filter_accounts_by_name(accounts, exclude_accounts)
         if len(excluding) != len(exclude_accounts):
             raise ValueError(
@@ -595,7 +595,7 @@ def setup(
         if len(accounts) == 0:
             raise ValueError("You have excluded all aws accounts, verify your input")
         account_names = tuple(ac["name"] for ac in accounts)
-    if account_names:
+    elif include_accounts:
         accounts = filter_accounts_by_name(accounts, account_names)
         if len(accounts) != len(account_names):
             # Some of the passed account names don't exist in app-interface

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -576,6 +576,11 @@ def setup(
 ) -> tuple[ResourceInventory, OC_Map, Terraform, ExternalResourceSpecInventory]:
     accounts = queries.get_aws_accounts(terraform_state=True)
     if not account_names and exclude_accounts:
+        excluding = filter_accounts_by_name(accounts, exclude_accounts)
+        if len(excluding) != len(exclude_accounts):
+            raise ValueError(
+                f"Accounts {exclude_accounts} were provided as arguments, but not found in app-interface. Check your input for typos or for missing AWS account definitions."
+            )
         accounts = exclude_accounts_by_name(accounts, exclude_accounts)
         if len(accounts) == 0:
             raise ValueError("You have excluded all aws accounts, verify your input")

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -711,6 +711,13 @@ def run(
         logging.error(message)
         raise RuntimeError(message)
 
+    if exclude_accounts and account_name:
+        message = (
+            "Using exclude account and account name at the same time is not allowed"
+        )
+        logging.error(message)
+        raise RuntimeError(message)
+
     # account_name is a tuple of account names for more detail go to
     # https://click.palletsprojects.com/en/8.1.x/options/#multiple-options
     account_names = account_name

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -20,6 +20,21 @@ def test_cannot_use_exclude_account_with_account_name():
     )
 
 
+def test_cannot_exclude_invalid_aws_account(mocker):
+    mocker.patch(
+        "reconcile.queries.get_aws_accounts",
+        return_value=[{"name": "a"}],
+        autospec=True,
+    )
+    with pytest.raises(ValueError) as excinfo:
+        integ.run(True, exclude_accounts=("b"))
+
+    assert (
+        "Accounts b were provided as arguments, but not found in app-interface. Check your input for typos or for missing AWS account definitions."
+        in str(excinfo.value)
+    )
+
+
 def test_cannot_exclude_all_accounts(mocker):
     mocker.patch(
         "reconcile.queries.get_aws_accounts",

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -20,6 +20,19 @@ def test_cannot_use_exclude_account_with_account_name():
     )
 
 
+def test_cannot_exclude_all_accounts(mocker):
+    mocker.patch(
+        "reconcile.queries.get_aws_accounts",
+        return_value=[{"name": "a"}, {"name": "b"}],
+        autospec=True,
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        integ.run(True, exclude_accounts=("a", "b"))
+
+    assert "You have excluded all aws accounts, verify your input" in str(excinfo.value)
+
+
 def test_cannot_pass_two_aws_account_if_not_dry_run():
     with pytest.raises(RuntimeError) as excinfo:
         integ.run(False, account_name=("a", "b"))

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -29,6 +29,22 @@ def test_cannot_pass_two_aws_account_if_not_dry_run():
     )
 
 
+def test_filter_accounts_by_name():
+    accounts = [{"name": "a"}, {"name": "b"}, {"name": "c"}]
+
+    filtered = integ.filter_accounts_by_name(accounts, filter=("a", "b"))
+
+    assert filtered == [{"name": "a"}, {"name": "b"}]
+
+
+def test_exclude_accounts_by_name():
+    accounts = [{"name": "a"}, {"name": "b"}, {"name": "c"}]
+
+    filtered = integ.exclude_accounts_by_name(accounts, filter=("a", "b"))
+
+    assert filtered == [{"name": "c"}]
+
+
 def test_cannot_pass_invalid_aws_account(mocker):
     mocker.patch(
         "reconcile.queries.get_aws_accounts",

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -7,7 +7,7 @@ def test_cannot_use_exclude_accounts_if_not_dry_run():
     with pytest.raises(RuntimeError) as excinfo:
         integ.run(False, exclude_accounts=("a", "b"))
 
-    assert "Exclude accounts is only supported in dry-run mode" in str(excinfo.value)
+    assert "--exclude-accounts is only supported in dry-run mode" in str(excinfo.value)
 
 
 def test_cannot_use_exclude_account_with_account_name():
@@ -15,7 +15,7 @@ def test_cannot_use_exclude_account_with_account_name():
         integ.run(True, exclude_accounts=("a", "b"), account_name=("c", "d"))
 
     assert (
-        "Using exclude account and account name at the same time is not allowed"
+        "Using --exclude-accounts and --account-name at the same time is not allowed"
         in str(excinfo.value)
     )
 

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -4,14 +4,14 @@ import reconcile.terraform_resources as integ
 
 
 def test_cannot_use_exclude_accounts_if_not_dry_run():
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(integ.ExcludeAccountsAndDryRunException) as excinfo:
         integ.run(False, exclude_accounts=("a", "b"))
 
     assert "--exclude-accounts is only supported in dry-run mode" in str(excinfo.value)
 
 
 def test_cannot_use_exclude_account_with_account_name():
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(integ.ExcludeAccountsAndAccountNameException) as excinfo:
         integ.run(True, exclude_accounts=("a", "b"), account_name=("c", "d"))
 
     assert (
@@ -49,7 +49,7 @@ def test_cannot_exclude_all_accounts(mocker):
 
 
 def test_cannot_pass_two_aws_account_if_not_dry_run():
-    with pytest.raises(RuntimeError) as excinfo:
+    with pytest.raises(integ.MultipleAccountNamesInDryRunException) as excinfo:
         integ.run(False, account_name=("a", "b"))
 
     assert "Running with multiple accounts is only supported in dry-run mode" in str(

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -3,6 +3,13 @@ import pytest
 import reconcile.terraform_resources as integ
 
 
+def test_cannot_use_exclude_accounts_if_not_dry_run():
+    with pytest.raises(RuntimeError) as excinfo:
+        integ.run(False, exclude_accounts=("a", "b"))
+
+    assert "Exclude accounts is only supported in dry-run mode" in str(excinfo.value)
+
+
 def test_cannot_pass_two_aws_account_if_not_dry_run():
     with pytest.raises(RuntimeError) as excinfo:
         integ.run(False, account_name=("a", "b"))

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -10,6 +10,16 @@ def test_cannot_use_exclude_accounts_if_not_dry_run():
     assert "Exclude accounts is only supported in dry-run mode" in str(excinfo.value)
 
 
+def test_cannot_use_exclude_account_with_account_name():
+    with pytest.raises(RuntimeError) as excinfo:
+        integ.run(True, exclude_accounts=("a", "b"), account_name=("c", "d"))
+
+    assert (
+        "Using exclude account and account name at the same time is not allowed"
+        in str(excinfo.value)
+    )
+
+
 def test_cannot_pass_two_aws_account_if_not_dry_run():
     with pytest.raises(RuntimeError) as excinfo:
         integ.run(False, account_name=("a", "b"))

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -30,7 +30,7 @@ def test_cannot_exclude_invalid_aws_account(mocker):
         integ.run(True, exclude_accounts=("b"))
 
     assert (
-        "Accounts b were provided as arguments, but not found in app-interface. Check your input for typos or for missing AWS account definitions."
+        "Accounts {'b'} were provided as arguments, but not found in app-interface. Check your input for typos or for missing AWS account definitions."
         in str(excinfo.value)
     )
 
@@ -83,7 +83,7 @@ def test_cannot_pass_invalid_aws_account(mocker):
         integ.run(True, account_name=("a", "b"))
 
     assert (
-        "Accounts ('b',) were provided as arguments, but not found in app-interface. Check your input for typos or for missing AWS account definitions."
+        "Accounts {'b'} were provided as arguments, but not found in app-interface. Check your input for typos or for missing AWS account definitions."
         in str(excinfo.value)
     )
 


### PR DESCRIPTION
Related to  [APPSRE-6586](https://issues.redhat.com/browse/APPSRE-6586) 

Things to teste here:

* Running `terraform-resources` with `--dry-run` show the changes in resources for all accounts;
* Running `terraform-resources` with `--dry-run`, `--account-name` and `--exclude-accounts` gives the user an error;
* Running `terraform-resources` with  `--exclude-accounts` and not `--dry-run` gives the user an error;
* RUnning `terraform-resources` excluding an account that doesn't exist gives the user an error; 
* Running `terraform-resources` excluding all accounts gives the user an error;
* Running `terraform-resouces` with `--exclude-account=a --exclude-account=b` show the changes in resources for all accounts except `a` and `b`.

This is testable by using `app-interface-dev-data`.