### PR TITLE
[openshift-resources] no namespaces left after cluster-filtering

### DIFF
--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -35,7 +35,8 @@ def run(
 
     # check for unused resources types
     # listed under `managedResourceTypes`
-    ob.check_unused_resource_types(ri)
+    if ri:
+        ob.check_unused_resource_types(ri)
 
 
 def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -929,6 +929,13 @@ def run(
     namespaces, overrides = get_namespaces(
         providers=providers, cluster_name=cluster_name, namespace_name=namespace_name
     )
+    if not namespaces:
+        logging.info(
+            "No namespaces found when filtering for "
+            f"cluster={cluster_name}, namespace={namespace_name}. "
+            "Exiting."
+        )
+        return
     oc_map, ri = fetch_data(
         namespaces,
         thread_pool_size,

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -935,7 +935,7 @@ def run(
             f"cluster={cluster_name}, namespace={namespace_name}. "
             "Exiting."
         )
-        return
+        return None
     oc_map, ri = fetch_data(
         namespaces,
         thread_pool_size,


### PR DESCRIPTION
when openshift-resources-base (so openshift-resource, vaults-secrets, etc) are executed with cluster or namespace filtering, there might be no namespace left after filtering. this does not necessarily indicate a usage issue but can happen during cluster deprovisioning.

this fix prevents those integrations to fail in such scenarios, but gracefully exits with a log message.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>