### PR TITLE
[integration-manager] sharding labels for integration workload (2nd try)

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -39,14 +39,14 @@ objects:
       matchLabels:
         app: qontract-reconcile-{{ $integration.name }}
         {{- if $shard.shard_name }}
-        qontract_reconcile_integration_shard: {{ $shard.shard_name }}
+        qontract_reconcile_integration_shard: "{{ $shard.shard_name }}"
         {{- end }}
     template:
       metadata:
         labels:
           app: qontract-reconcile-{{ $integration.name }}
           {{- if $shard.shard_name }}
-          qontract_reconcile_integration_shard: {{ $shard.shard_name }}
+          qontract_reconcile_integration_shard: "{{ $shard.shard_name }}"
           {{- end }}
           component: qontract-reconcile
       spec:

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -38,10 +38,16 @@ objects:
     selector:
       matchLabels:
         app: qontract-reconcile-{{ $integration.name }}
+        {{- if $shard.shard_name }}
+        qontract_reconcile_integration_shard: {{ $shard.shard_name }}
+        {{- end }}
     template:
       metadata:
         labels:
           app: qontract-reconcile-{{ $integration.name }}
+          {{- if $shard.shard_name }}
+          qontract_reconcile_integration_shard: {{ $shard.shard_name }}
+          {{- end }}
           component: qontract-reconcile
       spec:
         serviceAccountName: qontract-reconcile

--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -88,6 +88,7 @@ class StaticShardingStrategy(ShardingStrategy):
             {
                 "shard_id": str(s),
                 "shards": str(shards),
+                "shard_name": str(s) if shards > 1 else "",
                 "shard_name_suffix": f"-{s}" if shards > 1 else "",
                 "extra_args": "",
             }
@@ -109,6 +110,7 @@ class AWSAccountShardManager(ShardingStrategy):
             return [
                 {
                     "shard_key": account["name"],
+                    "shard_name": account["name"] if len(filtered_accounts) > 1 else "",
                     "shard_name_suffix": f"-{account['name']}"
                     if len(filtered_accounts) > 1
                     else "",

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -384,7 +384,13 @@ def test_initialize_shard_specs_no_shards(
     """
     intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
     expected = [
-        {"shard_id": "0", "shards": "1", "shard_name_suffix": "", "extra_args": ""}
+        {
+            "shard_id": "0",
+            "shards": "1",
+            "shard_name": "",
+            "shard_name_suffix": "",
+            "extra_args": "",
+        }
     ]
     assert (
         expected
@@ -402,8 +408,20 @@ def test_initialize_shard_specs_two_shards(
     collected_namespaces_env_test1[0]["integration_specs"][0]["shards"] = 2
     intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
     expected = [
-        {"shard_id": "0", "shards": "2", "shard_name_suffix": "-0", "extra_args": ""},
-        {"shard_id": "1", "shards": "2", "shard_name_suffix": "-1", "extra_args": ""},
+        {
+            "shard_id": "0",
+            "shards": "2",
+            "shard_name": "0",
+            "shard_name_suffix": "-0",
+            "extra_args": "",
+        },
+        {
+            "shard_id": "1",
+            "shards": "2",
+            "shard_name": "1",
+            "shard_name_suffix": "-1",
+            "extra_args": "",
+        },
     ]
     assert (
         expected
@@ -424,8 +442,20 @@ def test_initialize_shard_specs_two_shards_explicit(
     collected_namespaces_env_test1[0]["integration_specs"][0]["shards"] = 2
     intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
     expected = [
-        {"shard_id": "0", "shards": "2", "shard_name_suffix": "-0", "extra_args": ""},
-        {"shard_id": "1", "shards": "2", "shard_name_suffix": "-1", "extra_args": ""},
+        {
+            "shard_id": "0",
+            "shards": "2",
+            "shard_name": "0",
+            "shard_name_suffix": "-0",
+            "extra_args": "",
+        },
+        {
+            "shard_id": "1",
+            "shards": "2",
+            "shard_name": "1",
+            "shard_name_suffix": "-1",
+            "extra_args": "",
+        },
     ]
     assert (
         expected
@@ -447,16 +477,19 @@ def test_initialize_shard_specs_aws_account_shards(
     intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
     expected = [
         {
+            "shard_name": "acc-1",
             "shard_name_suffix": "-acc-1",
             "shard_key": "acc-1",
             "extra_args": "--account-name acc-1",
         },
         {
+            "shard_name": "acc-2",
             "shard_name_suffix": "-acc-2",
             "shard_key": "acc-2",
             "extra_args": "--account-name acc-2",
         },
         {
+            "shard_name": "acc-3",
             "shard_name_suffix": "-acc-3",
             "shard_key": "acc-3",
             "extra_args": "--account-name acc-3",
@@ -482,16 +515,19 @@ def test_initialize_shard_specs_extra_arg_agregation(
     intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
     expected = [
         {
+            "shard_name": "acc-1",
             "shard_name_suffix": "-acc-1",
             "shard_key": "acc-1",
             "extra_args": "--arg --account-name acc-1",
         },
         {
+            "shard_name": "acc-2",
             "shard_name_suffix": "-acc-2",
             "shard_key": "acc-2",
             "extra_args": "--arg --account-name acc-2",
         },
         {
+            "shard_name": "acc-3",
             "shard_name_suffix": "-acc-3",
             "shard_key": "acc-3",
             "extra_args": "--arg --account-name acc-3",
@@ -617,3 +653,70 @@ def test_collect_managed_integrations_all(integrations):
     assert "integ3" in found
 
     assert len([i for i in found if i == "integ2"]) == 2
+
+
+def test_match_labels_for_workloads(
+    collected_namespaces_env_test1: list[dict[str, Any]],
+    shard_manager: intop.IntegrationShardManager,
+):
+    intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
+    ri = ResourceInventory()
+    ri.initialize_resource_type("cl1", "ns1", "Deployment")
+    ri.initialize_resource_type("cl1", "ns1", "Service")
+    intop.fetch_desired_state(
+        namespaces=collected_namespaces_env_test1,
+        ri=ri,
+        image_tag_from_ref=None,
+        environment_override_mapping={"test1": {}},
+    )
+
+    deployment = ri.get_desired("cl1", "ns1", "Deployment", "qontract-reconcile-integ1")
+    assert deployment
+    match_labels = deployment.body["spec"]["selector"]["matchLabels"]
+    assert match_labels.keys() == {"app"}
+    assert match_labels["app"] == "qontract-reconcile-integ1"
+    pod_template_labels = deployment.body["spec"]["template"]["metadata"]["labels"]
+    assert pod_template_labels.keys() == {
+        "app",
+        "component",
+    }
+    assert pod_template_labels["app"] == "qontract-reconcile-integ1"
+    assert pod_template_labels["component"] == "qontract-reconcile"
+
+
+def test_match_labels_for_sharded_workloads(
+    collected_namespaces_env_test1: list[dict[str, Any]],
+    shard_manager: intop.IntegrationShardManager,
+):
+    collected_namespaces_env_test1[0]["integration_specs"][0][
+        "shardingStrategy"
+    ] = "per-aws-account"
+    intop.initialize_shard_specs(collected_namespaces_env_test1, shard_manager)
+    ri = ResourceInventory()
+    ri.initialize_resource_type("cl1", "ns1", "Deployment")
+    ri.initialize_resource_type("cl1", "ns1", "Service")
+    intop.fetch_desired_state(
+        namespaces=collected_namespaces_env_test1,
+        ri=ri,
+        image_tag_from_ref=None,
+        environment_override_mapping={"test1": {}},
+    )
+
+    for acc in ["acc-1", "acc-2", "acc-3"]:
+        deployment = ri.get_desired(
+            "cl1", "ns1", "Deployment", f"qontract-reconcile-integ1-{acc}"
+        )
+        assert deployment
+        match_labels = deployment.body["spec"]["selector"]["matchLabels"]
+        assert match_labels.keys() == {"app", "qontract_reconcile_integration_shard"}
+        assert match_labels["app"] == "qontract-reconcile-integ1"
+        assert match_labels["qontract_reconcile_integration_shard"] == acc
+        pod_template_labels = deployment.body["spec"]["template"]["metadata"]["labels"]
+        assert pod_template_labels.keys() == {
+            "app",
+            "qontract_reconcile_integration_shard",
+            "component",
+        }
+        assert pod_template_labels["app"] == "qontract-reconcile-integ1"
+        assert pod_template_labels["component"] == "qontract-reconcile"
+        assert pod_template_labels["qontract_reconcile_integration_shard"] == acc


### PR DESCRIPTION
the current matchLabels on a Deployment are not sufficient to catch only the pods spawned by ReplicaSets of the deployment itself, because the app label alone is the same for all potential shards of an integration.

this has no negative effect because the ReplicaSets still handle pod creation/termination correctly. the only downside is the incorrect pod filtering within the openshift UI within Deployment/Pods.

to fix this, we will add a shard label qontract_reconcile_integration_shard to both the pod template and the matchLabels of the deployment if applicable.

the first attempt of this PR failed because number based shard labels have not been cast to strings and the resulting `Deployment` manifest was invalid. this has been addressed in this PR and specifically covered by a test

Signed-off-by: Gerd Oberlechner [goberlec@redhat.com](mailto:goberlec@redhat.com)