### PR TITLE
[skupper-network] internal clusters don't need a peering to reach each other

### DIFF
--- a/reconcile/skupper_network/integration.py
+++ b/reconcile/skupper_network/integration.py
@@ -226,6 +226,9 @@ def run(
         logging.debug("No skupper networks found. Exiting...")
         return
     skupper_sites = compile_skupper_sites(skupper_networks)
+    if not skupper_sites:
+        logging.debug("No skupper sites found. Exiting...")
+        return
 
     # APIs
     oc_map = OC_Map(

--- a/reconcile/skupper_network/models.py
+++ b/reconcile/skupper_network/models.py
@@ -199,7 +199,7 @@ class SkupperSite(BaseModel):
     @property
     def on_internal_cluster(self) -> bool:
         """Return True if the skupper site is hosted on an internal cluster."""
-        return self.cluster.internal if self.cluster.internal else False
+        return self.cluster.internal or False
 
     def is_peered_with(self, other: SkupperSite) -> bool:
         """Return True if the involved skupper site clusters are peered."""


### PR DESCRIPTION
Spawn skupper networks between sites on internal clusters because all internal clusters can reach each other without peerings.

[APPSRE-6997](https://issues.redhat.com/browse/APPSRE-6997)