### PR TITLE
[skupper-network] k8s labels have a 63 characters limit

### DIFF
--- a/reconcile/skupper_network/models.py
+++ b/reconcile/skupper_network/models.py
@@ -305,4 +305,8 @@ class SkupperSite(BaseModel):
     @property
     def token_labels(self) -> dict[str, str]:
         """Get the token labels."""
-        return {"token-receiver": self.name}
+        # This label is used to identify the site in the `skupper link status` command
+        # self.name ({skupper_network.identifier}-{ns.cluster.name}-{ns.name}) can be longer than 63 characters
+        # so use cluster.name-namespaced.name instead and trim it to 63 characters
+        # a namespace can't be in more than one skupper network, so it's safe to omit the skupper network identifier
+        return {"token-receiver": f"{self.cluster.name}-{self.namespace.name}"[0:63]}

--- a/reconcile/test/skupper_network/test_skupper_network_models.py
+++ b/reconcile/test/skupper_network/test_skupper_network_models.py
@@ -300,3 +300,22 @@ def test_skupper_network_model_skupper_site_properties(
         namespace_factory("internal01", private=False), edge=True
     )
     assert internal01.is_edge_site is True
+
+
+def test_skupper_network_model_skupper_site_token_labels(
+    skupper_site_factory: SkupperSiteFactory, namespace_factory: NamespaceFactory
+) -> None:
+    # very long name
+    long01 = skupper_site_factory(
+        namespace_factory(
+            "this-is-a-very-long-namespace-name-and-clearly-exceeds-some-kubernetes-limits",
+            private=False,
+        ),
+        edge=False,
+    )
+    # https://issues.redhat.com/browse/APPSRE-6993
+    assert (
+        long01.token_labels["token-receiver"]
+        == "cluster-this-is-a-very-long-namespace-name-and-clearly-exceeds-"
+    )
+    assert len(long01.token_labels["token-receiver"]) <= 63


### PR DESCRIPTION
Shrink the connection-token `token-receiver` label to an upper limit of 63 characters.

[APPSRE-6993](https://issues.redhat.com/browse/APPSRE-6993)