### PR TITLE
Fix case where there are no secrets in a path

### DIFF
--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -343,7 +343,7 @@ class _VaultClient:
         else:
             path_list = self._list(path)
 
-        return path_list["data"]["keys"]
+        return path_list["data"]["keys"] or []
 
     def list_all(self, path):
         """Returns a list of secrets in a given path and


### PR DESCRIPTION
This change is related to a proposal in a Slack thread. The list capability was added for VaultReplication and it's only used there for now. 

The problem that we found is that if there was a path in the replication list without secrets the integration fails as there are no keys, a temporal solution was adding a dummy secret on the path to ensure that there is at least one secret to be listed. Adding this change we are making sure that in the case that there are no secrets we return an empty list.

Tested by running the vault replication integration locally, and everything working as expected.