### PR TITLE
APPSRE-6609 add remotePort to schema

### DIFF
--- a/reconcile/gql_definitions/common/clusters.py
+++ b/reconcile/gql_definitions/common/clusters.py
@@ -45,6 +45,7 @@ fragment CommonJumphostFields on ClusterJumpHost_v1 {
   knownHosts
   user
   port
+  remotePort
   identity {
     ... VaultSecret
   }

--- a/reconcile/gql_definitions/common/clusters_minimal.py
+++ b/reconcile/gql_definitions/common/clusters_minimal.py
@@ -28,6 +28,7 @@ fragment CommonJumphostFields on ClusterJumpHost_v1 {
   knownHosts
   user
   port
+  remotePort
   identity {
     ... VaultSecret
   }

--- a/reconcile/gql_definitions/common/namespaces.py
+++ b/reconcile/gql_definitions/common/namespaces.py
@@ -28,6 +28,7 @@ fragment CommonJumphostFields on ClusterJumpHost_v1 {
   knownHosts
   user
   port
+  remotePort
   identity {
     ... VaultSecret
   }

--- a/reconcile/gql_definitions/fragments/jumphost_common_fields.gql
+++ b/reconcile/gql_definitions/fragments/jumphost_common_fields.gql
@@ -5,6 +5,7 @@ fragment CommonJumphostFields on ClusterJumpHost_v1 {
   knownHosts
   user
   port
+  remotePort
   identity {
     ... VaultSecret
   }

--- a/reconcile/gql_definitions/fragments/jumphost_common_fields.py
+++ b/reconcile/gql_definitions/fragments/jumphost_common_fields.py
@@ -24,6 +24,7 @@ class CommonJumphostFields(BaseModel):
     known_hosts: str = Field(..., alias="knownHosts")
     user: str = Field(..., alias="user")
     port: Optional[int] = Field(..., alias="port")
+    remote_port: Optional[int] = Field(..., alias="remotePort")
     identity: VaultSecret = Field(..., alias="identity")
 
     class Config:

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -9860,6 +9860,26 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "workerFleets",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "JenkinsWorkerFleets_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -9900,6 +9920,157 @@
                                     "name": "Int",
                                     "ofType": null
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "JenkinsWorkerFleets_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "account",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "identifier",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "namespace",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "Namespace_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "credentialsId",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "fsRoot",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "labelString",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "numExecutors",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "idleMinutes",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "minSpareSize",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "noDelayProvision",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -20200,6 +20371,18 @@
                         },
                         {
                             "name": "port",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "remotePort",
                             "description": null,
                             "args": [],
                             "type": {

--- a/reconcile/gql_definitions/jumphosts/jumphosts.py
+++ b/reconcile/gql_definitions/jumphosts/jumphosts.py
@@ -27,6 +27,7 @@ fragment CommonJumphostFields on ClusterJumpHost_v1 {
   knownHosts
   user
   port
+  remotePort
   identity {
     ... VaultSecret
   }

--- a/reconcile/gql_definitions/skupper_network/skupper_networks.py
+++ b/reconcile/gql_definitions/skupper_network/skupper_networks.py
@@ -28,6 +28,7 @@ fragment CommonJumphostFields on ClusterJumpHost_v1 {
   knownHosts
   user
   port
+  remotePort
   identity {
     ... VaultSecret
   }

--- a/reconcile/test/fixtures/oc_connection_parameters/cluster_with_jumphost.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/cluster_with_jumphost.yml
@@ -32,6 +32,7 @@ jumpHost:
     version: null
   knownHosts: /path/to/file
   port: null
+  remotePort: 8888
   user: jumphost-user
 kibanaUrl: ''
 machinePools: null

--- a/reconcile/test/fixtures/oc_connection_parameters/namespace_with_admin.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/namespace_with_admin.yml
@@ -26,6 +26,7 @@ cluster:
       version: null
     knownHosts: /path/to/file
     port: null
+    remotePort: null
     user: jumphost-user
   name: test-cluster
   serverUrl: server-url

--- a/reconcile/test/oc/test_oc_connection_parameters.py
+++ b/reconcile/test/oc/test_oc_connection_parameters.py
@@ -48,7 +48,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
                 jumphost_key="secret2",
                 jumphost_known_hosts="/path/to/file",
                 jumphost_user="jumphost-user",
-                jumphost_remote_port=None,
+                jumphost_remote_port=8888,
                 jumphost_local_port=None,
                 is_cluster_admin=None,
                 is_internal=True,

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -25,6 +25,7 @@ class Disable(Protocol):
 class Jumphost(Protocol):
     hostname: str
     port: Optional[int]
+    remote_port: Optional[int]
     known_hosts: str
     user: str
 
@@ -87,9 +88,9 @@ class OCConnectionParameters:
     jumphost_user: Optional[str]
     jumphost_port: Optional[int]
     jumphost_key: Optional[str]
-    # These tunneling ports are currently calculated and set outside of this class
-    jumphost_local_port: Optional[int]
     jumphost_remote_port: Optional[int]
+    # These local port is currently calculated and set outside of this class
+    jumphost_local_port: Optional[int]
 
     @staticmethod
     def from_cluster(
@@ -123,6 +124,7 @@ class OCConnectionParameters:
             jumphost_known_hosts = jh.known_hosts
             jumphost_user = jh.user
             jumphost_port = jh.port
+            jumphost_remote_port = jh.remote_port
 
             try:
                 jumphost_key = secret_reader.read_secret(jh.identity)

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -89,7 +89,7 @@ class OCConnectionParameters:
     jumphost_port: Optional[int]
     jumphost_key: Optional[str]
     jumphost_remote_port: Optional[int]
-    # These local port is currently calculated and set outside of this class
+    # The local port is currently calculated and set outside of this class
     jumphost_local_port: Optional[int]
 
     @staticmethod

--- a/reconcile/utils/oc_map.py
+++ b/reconcile/utils/oc_map.py
@@ -85,9 +85,6 @@ class OCMap:
     def _set_jumphost_tunnel_ports(
         self, connection_parameters: OCConnectionParameters
     ) -> None:
-        # This will be replaced with getting the data from app-interface in
-        # a future PR.
-        connection_parameters.jumphost_remote_port = 8888
         key = f"{connection_parameters.jumphost_hostname}:{connection_parameters.jumphost_remote_port}"
         with self._lock:
             if key not in self._jh_ports:


### PR DESCRIPTION
Introduce `remotePort` to jumphost fragment.

This is a result of a discussion in https://github.com/app-sre/qontract-reconcile/pull/3176

Relies on schema change: https://github.com/app-sre/qontract-schemas/pull/378