### PR TITLE
APPSRE-6609 cluster-deployment-mapper uses OCMap

### DIFF
--- a/reconcile/cluster_deployment_mapper.py
+++ b/reconcile/cluster_deployment_mapper.py
@@ -1,36 +1,49 @@
 import logging
 import sys
+from typing import (
+    Any,
+    Optional,
+)
 
-from reconcile import queries
 from reconcile.status import ExitCodes
-from reconcile.utils.oc import OC_Map
+from reconcile.typed_queries.app_interface_vault_settings import (
+    get_app_interface_vault_settings,
+)
+from reconcile.typed_queries.clusters import get_clusters
+from reconcile.utils.oc import OCLogMsg
+from reconcile.utils.oc_map import init_oc_map_from_clusters
+from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.vault import VaultClient
 
 QONTRACT_INTEGRATION = "cluster-deployment-mapper"
 
 
-def run(dry_run, vault_output_path):
+def run(dry_run: bool, vault_output_path: Optional[str]) -> None:
     """Get Hive ClusterDeployments from clusters and save mapping to Vault"""
     if not vault_output_path:
         logging.error("must supply vault output path")
         sys.exit(ExitCodes.ERROR)
 
-    clusters = queries.get_clusters()
-    settings = queries.get_app_interface_settings()
-    oc_map = OC_Map(
+    vault_settings = get_app_interface_vault_settings()
+    if not vault_settings:
+        logging.error("Missing app-interface vault_settings")
+        sys.exit(ExitCodes.ERROR)
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+    clusters = get_clusters()
+    oc_map = init_oc_map_from_clusters(
         clusters=clusters,
+        secret_reader=secret_reader,
         integration=QONTRACT_INTEGRATION,
         thread_pool_size=1,
-        settings=settings,
         init_api_resources=True,
     )
-    results = []
+    results: list[dict[str, Any]] = []
     for c in clusters:
-        name = c["name"]
+        name = c.name
         oc = oc_map.get(name)
-        if not oc:
+        if not oc or isinstance(oc, OCLogMsg):
             continue
-        if "ClusterDeployment" not in oc.api_resources:
+        if "ClusterDeployment" not in (oc.api_resources or []):
             continue
         logging.info(f"[{name}] getting ClusterDeployments")
         cds = oc.get_all("ClusterDeployment", all_namespaces=True)["items"]
@@ -53,4 +66,5 @@ def run(dry_run, vault_output_path):
                 "map": "\n".join(f"{item['id']}: {item['cluster']}" for item in results)
             },
         }
-        vault_client.write(secret, decode_base64=False)
+        # mypy doesn't like our fancy way of creating a VaultClient
+        vault_client.write(secret, decode_base64=False)  # type: ignore[attr-defined]

--- a/reconcile/dashdotdb_cso.py
+++ b/reconcile/dashdotdb_cso.py
@@ -15,7 +15,10 @@ from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,
 )
 from reconcile.typed_queries.clusters import get_clusters
-from reconcile.utils.oc import StatusCodeError, OCLogMsg
+from reconcile.utils.oc import (
+    OCLogMsg,
+    StatusCodeError,
+)
 from reconcile.utils.oc_map import (
     OCMap,
     init_oc_map_from_clusters,

--- a/reconcile/dashdotdb_cso.py
+++ b/reconcile/dashdotdb_cso.py
@@ -15,14 +15,11 @@ from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,
 )
 from reconcile.typed_queries.clusters import get_clusters
-from reconcile.utils.oc import (
-    OC_Map,
-    StatusCodeError,
+from reconcile.utils.oc import StatusCodeError, OCLogMsg
+from reconcile.utils.oc_map import (
+    OCMap,
+    init_oc_map_from_clusters,
 )
-from reconcile.utils.oc_connection_parameters import (
-    get_oc_connection_parameters_from_clusters,
-)
-from reconcile.utils.oc_map import OCMap
 from reconcile.utils.secret_reader import (
     SecretReaderBase,
     create_secret_reader,
@@ -70,13 +67,14 @@ class DashdotdbCSO(DashdotdbBase):
         return response
 
     @staticmethod
-    def _get_imagemanifestvuln(
-        cluster: str, oc_map: OC_Map
-    ) -> Optional[dict[str, Any]]:
+    def _get_imagemanifestvuln(cluster: str, oc_map: OCMap) -> Optional[dict[str, Any]]:
         LOG.info("%s processing %s", LOGMARKER, cluster)
         oc = oc_map.get(cluster)
-        if not oc:
+        if isinstance(oc, OCLogMsg):
             LOG.log(level=oc.log_level, msg=oc.message)
+            return None
+        if not oc:
+            LOG.error("No OC client for cluster %s", cluster)
             return None
 
         try:
@@ -92,11 +90,9 @@ class DashdotdbCSO(DashdotdbBase):
 
     def run(self) -> None:
         clusters: list[ClusterV1] = get_clusters()
-        oc_map_parameters = get_oc_connection_parameters_from_clusters(
-            secret_reader=self.secret_reader, clusters=clusters
-        )
-        oc_map = OCMap(
-            connection_parameters=oc_map_parameters,
+        oc_map = init_oc_map_from_clusters(
+            clusters=clusters,
+            secret_reader=self.secret_reader,
             integration=QONTRACT_INTEGRATION,
             use_jump_host=True,
             thread_pool_size=self.thread_pool_size,

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1454,7 +1454,10 @@ class OC:
 
 
 class OC_Map:
-    """OC_Map gets a GraphQL query results list as input
+    """
+    DEPRECATED! Use reconcile.utils.oc_map.OCMap instead.
+
+    OC_Map gets a GraphQL query results list as input
     and initiates a dictionary of OC clients per cluster.
 
     The input must contain either 'clusters' or 'namespaces', but not both.

--- a/reconcile/utils/oc_map.py
+++ b/reconcile/utils/oc_map.py
@@ -15,19 +15,26 @@ from reconcile.utils.oc import (
     OCLogMsg,
     StatusCodeError,
 )
-from reconcile.utils.oc_connection_parameters import OCConnectionParameters
+from reconcile.utils.oc_connection_parameters import (
+    Cluster,
+    Namespace,
+    OCConnectionParameters,
+    get_oc_connection_parameters_from_clusters,
+    get_oc_connection_parameters_from_namespaces,
+)
+from reconcile.utils.secret_reader import SecretReaderBase
 
 
 class OCMap:
     """
-    DO NOT USE YET! This class is still in refactoring state.
-    Only selected integrations are using this class for now.
-
     OCMap takes a list of OCConnectionParameters as input
     and initializes a dictionary of Openshift Clients (OC) per cluster.
 
     In case a connection parameter does not have an automation token
     the OC client will be initiated with a OCLogMessage.
+
+    For convenience, use init_oc_map_from_clusters() or
+    init_oc_map_from_namespaces() to initiate an OCMap object.
     """
 
     def __init__(
@@ -222,3 +229,71 @@ class OCMap:
         for oc in self._privileged_oc_map.values():
             if oc and isinstance(oc, OCDeprecated):
                 oc.cleanup()
+
+
+def init_oc_map_from_clusters(
+    clusters: Iterable[Cluster],
+    secret_reader: SecretReaderBase,
+    integration: str = "",
+    e2e_test: str = "",
+    internal: Optional[bool] = None,
+    use_jump_host: bool = True,
+    thread_pool_size: int = 1,
+    init_projects: bool = False,
+    init_api_resources: bool = False,
+    cluster_admin: bool = False,
+) -> OCMap:
+    """
+    Convenience function to hide connection_parameters implementation
+    from caller.
+    """
+    connection_parameters = get_oc_connection_parameters_from_clusters(
+        clusters=clusters,
+        secret_reader=secret_reader,
+        thread_pool_size=2,
+    )
+    return OCMap(
+        connection_parameters=connection_parameters,
+        integration=integration,
+        e2e_test=e2e_test,
+        internal=internal,
+        use_jump_host=use_jump_host,
+        thread_pool_size=thread_pool_size,
+        init_projects=init_projects,
+        init_api_resources=init_api_resources,
+        cluster_admin=cluster_admin,
+    )
+
+
+def init_oc_map_from_namespaces(
+    namespaces: Iterable[Namespace],
+    secret_reader: SecretReaderBase,
+    integration: str = "",
+    e2e_test: str = "",
+    internal: Optional[bool] = None,
+    use_jump_host: bool = True,
+    thread_pool_size: int = 1,
+    init_projects: bool = False,
+    init_api_resources: bool = False,
+    cluster_admin: bool = False,
+) -> OCMap:
+    """
+    Convenience function to hide connection_parameters implementation
+    from caller.
+    """
+    connection_parameters = get_oc_connection_parameters_from_namespaces(
+        namespaces=namespaces,
+        secret_reader=secret_reader,
+        thread_pool_size=2,
+    )
+    return OCMap(
+        connection_parameters=connection_parameters,
+        integration=integration,
+        e2e_test=e2e_test,
+        internal=internal,
+        use_jump_host=use_jump_host,
+        thread_pool_size=thread_pool_size,
+        init_projects=init_projects,
+        init_api_resources=init_api_resources,
+        cluster_admin=cluster_admin,
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -105,11 +105,6 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.cluster_deployment_mapper]
-check_untyped_defs = False
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
 [mypy-reconcile.cna.client]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False


### PR DESCRIPTION
Integration `cluster-deployment-mapper` should use the new typed `OCMap` class.
This is part of the `OC_Map` refactor attempt. See https://github.com/app-sre/qontract-reconcile/pull/3176

This also adds convenience functions to init an `OCMap` object. Goal of the convenience function is to hide the underlying `OCConnectionParameter` class.