### PR TITLE
extract runtime environment config

### DIFF
--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -10,15 +10,15 @@ from typing import Optional
 import click
 from prometheus_client import start_http_server
 
-from reconcile.cli import (
-    LOG_DATEFMT,
-    LOG_FMT,
-)
 from reconcile.status import ExitCodes
 from reconcile.utils.metrics import (
     execution_counter,
     run_status,
     run_time,
+)
+from reconcile.utils.runtime.environment import (
+    LOG_DATEFMT,
+    LOG_FMT,
 )
 
 SHARDS = int(os.environ.get("SHARDS", 1))

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -15,10 +15,7 @@ from reconcile.status import (
     ExitCodes,
     RunningState,
 )
-from reconcile.utils import (
-    config,
-    gql,
-)
+from reconcile.utils import gql
 from reconcile.utils.aggregated_list import RunnerException
 from reconcile.utils.binary import (
     binary,
@@ -27,6 +24,7 @@ from reconcile.utils.binary import (
 from reconcile.utils.environ import environ
 from reconcile.utils.exceptions import PrintToFileInGitRepositoryError
 from reconcile.utils.git import is_file_in_git_repo
+from reconcile.utils.runtime.environment import init_env
 from reconcile.utils.runtime.integration import (
     ModuleArgsKwargsRunParams,
     ModuleBasedQontractReconcileIntegration,
@@ -44,12 +42,6 @@ TERRAFORM_VERSION_REGEX = r"^Terraform\sv([\d]+\.[\d]+\.[\d]+)$"
 
 OC_VERSION = "4.10.15"
 OC_VERSION_REGEX = r"^Client\sVersion:\s([\d]+\.[\d]+\.[\d]+)$"
-
-LOG_FMT = (
-    "[%(asctime)s] [%(levelname)s] "
-    "[%(filename)s:%(funcName)s:%(lineno)d] - %(message)s"
-)
-LOG_DATEFMT = "%Y-%m-%d %H:%M:%S"
 
 
 def before_breadcrumb(crumb, hint):
@@ -521,11 +513,6 @@ def run_class_integration(
                 f.write(json.dumps(gqlapi.get_queried_schemas()))
 
 
-def init_log_level(log_level):
-    level = getattr(logging, log_level) if log_level else logging.INFO
-    logging.basicConfig(format=LOG_FMT, datefmt=LOG_DATEFMT, level=level)
-
-
 @click.group()
 @config_file
 @dry_run
@@ -551,8 +538,8 @@ def integration(
 ):
     ctx.ensure_object(dict)
 
-    init_log_level(log_level)
-    config.init_from_toml(configfile)
+    init_env(log_level=log_level, config_file=configfile)
+
     ctx.obj["dry_run"] = dry_run
     ctx.obj["early_exit_compare_sha"] = early_exit_compare_sha
     ctx.obj["check_only_affected_shards"] = check_only_affected_shards

--- a/reconcile/utils/runtime/environment.py
+++ b/reconcile/utils/runtime/environment.py
@@ -1,0 +1,47 @@
+import logging
+import os
+import sys
+from typing import Optional
+
+from reconcile.utils import (
+    config,
+    gql,
+)
+
+QONTRACT_CONFIG = "QONTRACT_CONFIG"
+QONTRACT_LOG_LEVEL = "QONTRACT_LOG_LEVEL"
+
+LOG_FMT = (
+    "[%(asctime)s] [%(levelname)s] "
+    "[%(filename)s:%(funcName)s:%(lineno)d] - %(message)s"
+)
+LOG_DATEFMT = "%Y-%m-%d %H:%M:%S"
+
+
+def init_env(
+    log_level: Optional[str] = None, config_file: Optional[str] = None
+) -> None:
+    # store env configs in environment variables. this way child processes
+    # will inherit them and a compatible environment can be setup in a child
+    # process easily by running `init_env()` with no parameters.
+    if log_level:
+        os.environ[QONTRACT_LOG_LEVEL] = log_level
+    if config_file:
+        os.environ[QONTRACT_CONFIG] = config_file
+
+    # init loglevel
+    logging.basicConfig(
+        format=LOG_FMT,
+        datefmt=LOG_DATEFMT,
+        level=getattr(logging, os.environ.get(QONTRACT_LOG_LEVEL, "INFO")),
+    )
+
+    # init basic config
+    config_file = os.environ.get(QONTRACT_CONFIG)
+    if not config_file:
+        logging.fatal("no config file for qontract-reconcile specified")
+        sys.exit(1)
+    config.init_from_toml(config_file)
+
+    # init basic gql connection
+    gql.init_from_config()

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -22,7 +22,6 @@ from reconcile.cli import (
     config_file,
     dry_run,
     gitlab_project_id,
-    init_log_level,
     log_level,
     threaded,
 )
@@ -30,12 +29,9 @@ from reconcile.jenkins_job_builder import (
     get_openshift_saas_deploy_job_name,
     init_jjb,
 )
-from reconcile.utils import (
-    config,
-    gql,
-)
 from reconcile.utils.jjb_client import JJB
 from reconcile.utils.mr import CreateAppInterfaceReporter
+from reconcile.utils.runtime.environment import init_env
 from reconcile.utils.secret_reader import SecretReader
 
 CONTENT_FORMAT_VERSION = "1.0.0"
@@ -537,10 +533,8 @@ def get_repo_url(job):
 def main(
     configfile, dry_run, log_level, gitlab_project_id, reports_path, thread_pool_size
 ):
-    config.init_from_toml(configfile)
-    init_log_level(log_level)
-    config.init_from_toml(configfile)
-    gql.init_from_config()
+
+    init_env(log_level=log_level, config_file=configfile)
 
     now = datetime.now()
     apps = get_apps_data(now, thread_pool_size=thread_pool_size)


### PR DESCRIPTION
# What
extract the configuration and setup of the qontract-reconcile environment to a dedicated module. the `init_env` function sets up logging, initializes the config and sets up GQL connectivity to the `qontract-server`.

`init_env` can be called with or without parameters about loglevel and config. if no parameters are passed, their values are extracted from env variables.

if it is called with parameters, their values are stored in env variables. this way, if a child process is spawned, it can call `init_env` without parameters and a log + config + GQL environment compatible with the parent process is established.

the intended way to use `init_env` is with parameter from the main entry point of q-r (cli.py). this sets up env vars to allow child processes to use `init_var` without parameters to replicate the same environment.

# Why
the current way to set up the q-r env was implemented multiple times. this change unifies the process.

this is prepwork to optionally run integration shards during dry-runs with `multiprocessing.Process` instead of threading. this makes sense for certain integrations that are CPU bound and not so much I/O bound because python threading is not really allowing CPU bound tasks to benefit a lot.

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>