### PR TITLE
[WIP][integration-runtime] parameter class for class based integrations

### DIFF
--- a/reconcile/test/runtime/fixtures.py
+++ b/reconcile/test/runtime/fixtures.py
@@ -7,11 +7,17 @@ import pytest
 
 from reconcile.utils.runtime.integration import (
     DesiredStateShardConfig,
+    PydanticRunParams,
     QontractReconcileIntegration,
 )
 
 
-class SimpleTestIntegration(QontractReconcileIntegration):
+class SimpleTestIntegrationParams(PydanticRunParams):
+    int_arg: int
+    opt_str_arg: Optional[str] = None
+
+
+class SimpleTestIntegration(QontractReconcileIntegration[SimpleTestIntegrationParams]):
     def __init__(self):
         self.desired_state_data = {}
 
@@ -19,13 +25,15 @@ class SimpleTestIntegration(QontractReconcileIntegration):
     def name(self) -> str:
         return "test-integration"
 
-    def get_early_exit_desired_state(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def get_early_exit_desired_state(
+        self, params: SimpleTestIntegrationParams
+    ) -> dict[str, Any]:
         return self.desired_state_data
 
     def get_desired_state_shard_config(self) -> Optional[DesiredStateShardConfig]:
         return None
 
-    def run(self, dry_run: bool, *args, **kwargs) -> None:
+    def run(self, dry_run: bool, params: SimpleTestIntegrationParams) -> None:
         pass
 
 
@@ -34,7 +42,13 @@ def simple_test_integration() -> SimpleTestIntegration:
     return SimpleTestIntegration()
 
 
-class ShardableTestIntegration(QontractReconcileIntegration):
+class ShardableTestIntegrationParams(PydanticRunParams):
+    shard: Optional[str] = None
+
+
+class ShardableTestIntegration(
+    QontractReconcileIntegration[ShardableTestIntegrationParams]
+):
     def __init__(self):
         self.desired_state_data = {}
 
@@ -42,7 +56,9 @@ class ShardableTestIntegration(QontractReconcileIntegration):
     def name(self) -> str:
         return "shardable-test-integration"
 
-    def get_early_exit_desired_state(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def get_early_exit_desired_state(
+        self, params: ShardableTestIntegrationParams
+    ) -> dict[str, Any]:
         return self.desired_state_data
 
     def get_desired_state_shard_config(self) -> Optional[DesiredStateShardConfig]:
@@ -52,7 +68,7 @@ class ShardableTestIntegration(QontractReconcileIntegration):
             sharded_run_review=lambda srp: True,
         )
 
-    def run(self, dry_run: bool, *args, **kwargs) -> None:
+    def run(self, dry_run: bool, params: ShardableTestIntegrationParams) -> None:
         pass
 
 

--- a/reconcile/test/runtime/test_utils_integration.py
+++ b/reconcile/test/runtime/test_utils_integration.py
@@ -7,7 +7,10 @@ from reconcile.test.runtime import (
     demo_integration_no_run_func,
     demo_integration_shard_config,
 )
-from reconcile.utils.runtime.integration import ModuleBasedQontractReconcileIntegration
+from reconcile.utils.runtime.integration import (
+    ArgsKwargsRunParams,
+    ModuleBasedQontractReconcileIntegration,
+)
 
 
 def test_module_integration_no_name():
@@ -29,7 +32,8 @@ def test_module_integration_no_run_func():
 def test_module_integration_run():
     demo_integration.run_calls = []
     integration = ModuleBasedQontractReconcileIntegration(demo_integration)
-    integration.run(dry_run=True, some_arg=1)
+    params = ArgsKwargsRunParams(some_arg=1)
+    integration.run(dry_run=True, params=params)
 
     assert {
         "some_arg": 1,
@@ -40,12 +44,14 @@ def test_module_integration_run():
 
 def test_demo_integration_no_early_exit_desired_state():
     integration = ModuleBasedQontractReconcileIntegration(demo_integration)
-    assert not integration.get_early_exit_desired_state(some_arg=1)
+    assert not integration.get_early_exit_desired_state(ArgsKwargsRunParams(1))
 
 
 def test_demo_integration_early_exit_desired_state():
     integration = ModuleBasedQontractReconcileIntegration(demo_integration_early_exit)
-    data = integration.get_early_exit_desired_state("arg", some_kw_arg="kwarg")
+    data = integration.get_early_exit_desired_state(
+        ArgsKwargsRunParams("arg", some_kw_arg="kwarg")
+    )
 
     assert data == {"args": ("arg",), "kwargs": {"some_kw_arg": "kwarg"}}
 
@@ -62,24 +68,26 @@ def test_demo_integration_shard_config():
 
 def test_demo_integration_kwargs_have_shard_info():
     integration = ModuleBasedQontractReconcileIntegration(demo_integration_shard_config)
-    assert integration.kwargs_have_shard_info(
-        **{demo_integration_shard_config.SHARD_ARG_NAME: "shard1"}
+    assert integration.params_have_shard_info(
+        ArgsKwargsRunParams(**{demo_integration_shard_config.SHARD_ARG_NAME: "shard1"})
     )
 
-    assert integration.kwargs_have_shard_info(
-        **{demo_integration_shard_config.SHARD_ARG_NAME: ["shard1"]}
+    assert integration.params_have_shard_info(
+        ArgsKwargsRunParams(
+            **{demo_integration_shard_config.SHARD_ARG_NAME: ["shard1"]}
+        )
     )
 
-    assert not integration.kwargs_have_shard_info(
-        **{demo_integration_shard_config.SHARD_ARG_NAME: None}
+    assert not integration.params_have_shard_info(
+        ArgsKwargsRunParams(**{demo_integration_shard_config.SHARD_ARG_NAME: None})
     )
 
-    assert not integration.kwargs_have_shard_info(
-        **{demo_integration_shard_config.SHARD_ARG_NAME: ()}
+    assert not integration.params_have_shard_info(
+        ArgsKwargsRunParams(**{demo_integration_shard_config.SHARD_ARG_NAME: ()})
     )
 
-    assert not integration.kwargs_have_shard_info(
-        **{demo_integration_shard_config.SHARD_ARG_NAME: []}
+    assert not integration.params_have_shard_info(
+        ArgsKwargsRunParams(**{demo_integration_shard_config.SHARD_ARG_NAME: []})
     )
 
-    assert not integration.kwargs_have_shard_info(**{})
+    assert not integration.params_have_shard_info(ArgsKwargsRunParams(**{}))


### PR DESCRIPTION
# What
replace the generic `*args: Any, **kwargs: Any` parameterlist for class based integrations. to allow each integration to have their parameters passed in as verifiable as possible and typesafe as possible, each integration can define the dedicated class for the params wrapper as a generic type, e.g.

```python
class SimpleTestIntegrationParams(PydanticRunParams):
    int_arg: int
    opt_str_arg: Optional[str] = None

class SimpleTestIntegration(QontractReconcileIntegration[SimpleTestIntegrationParams]):
    ...

    def run(self, dry_run: bool, params: SimpleTestIntegrationParams) -> None:
        params.int_arg
	params.opt_str_arg
```

in cli.py, the integration is hooked up like this:

```python
@integration.command()
@click.pass_context
def simple_integration(ctx, int_param: int):
    from reconcile import simple_integration

    run_class_integration(
        integration=simple_integration.SimpleIntegration(),
        params=SimpleTestIntegrationParams(int_arg=int_param),
        ctx=ctx.obj,
    )
```

in this example, a pydantic based `RunParams` class is used to wrap the parameters. this way the entire parameter validation process can be covered by having type hints in place. pydantic drives the validation and allows for additional validation functions within the class itself.

for the module based integrations, the generic wrapper class `ArgsKwargsRunParams` is available, that makes sure the custom `run` functions in the modules do not need to change. all the wrapping happens in `reconcile.cli`.

# Why

The very generic `*args, **kwargs` does not play well with subclassing the class based integrations. Mypy complaints if we would go more specific.

# Alternatives considered

Use the init function of the class to pass accept parameters and keep the run function free of params except for maybe the `dry_run`. I will open another PR so both approaches can be compared.

https://issues.redhat.com/browse/APPSRE-7023


Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>