### PR TITLE
[integration-runtime] replace integration args, kwargs run parameters with class

### DIFF
--- a/reconcile/test/runtime/fixtures.py
+++ b/reconcile/test/runtime/fixtures.py
@@ -7,42 +7,56 @@ import pytest
 
 from reconcile.utils.runtime.integration import (
     DesiredStateShardConfig,
+    PydanticRunParams,
     QontractReconcileIntegration,
 )
 
 
-class SimpleTestIntegration(QontractReconcileIntegration):
-    def __init__(self):
-        self.desired_state_data = {}
+class SimpleTestIntegrationParams(PydanticRunParams):
+    int_arg: int
+    opt_str_arg: Optional[str] = None
+
+
+class SimpleTestIntegration(QontractReconcileIntegration[SimpleTestIntegrationParams]):
+    def __init__(self, params: SimpleTestIntegrationParams):
+        super().__init__(params)
+        self.desired_state_data: dict[str, Any] = {}
 
     @property
     def name(self) -> str:
         return "test-integration"
 
-    def get_early_exit_desired_state(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def get_early_exit_desired_state(self) -> dict[str, Any]:
         return self.desired_state_data
 
     def get_desired_state_shard_config(self) -> Optional[DesiredStateShardConfig]:
         return None
 
-    def run(self, dry_run: bool, *args, **kwargs) -> None:
-        pass
+    def run(self, dry_run: bool) -> None:
+        print(self.params.int_arg)
 
 
 @pytest.fixture
 def simple_test_integration() -> SimpleTestIntegration:
-    return SimpleTestIntegration()
+    return SimpleTestIntegration(params=SimpleTestIntegrationParams(int_arg=1))
 
 
-class ShardableTestIntegration(QontractReconcileIntegration):
-    def __init__(self):
-        self.desired_state_data = {}
+class ShardableTestIntegrationParams(PydanticRunParams):
+    shard: Optional[str] = None
+
+
+class ShardableTestIntegration(
+    QontractReconcileIntegration[ShardableTestIntegrationParams]
+):
+    def __init__(self, params: ShardableTestIntegrationParams):
+        super().__init__(params)
+        self.desired_state_data: dict[str, Any] = {}
 
     @property
     def name(self) -> str:
         return "shardable-test-integration"
 
-    def get_early_exit_desired_state(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    def get_early_exit_desired_state(self) -> dict[str, Any]:
         return self.desired_state_data
 
     def get_desired_state_shard_config(self) -> Optional[DesiredStateShardConfig]:
@@ -52,10 +66,10 @@ class ShardableTestIntegration(QontractReconcileIntegration):
             sharded_run_review=lambda srp: True,
         )
 
-    def run(self, dry_run: bool, *args, **kwargs) -> None:
+    def run(self, dry_run: bool) -> None:
         pass
 
 
 @pytest.fixture
 def shardable_test_integration() -> ShardableTestIntegration:
-    return ShardableTestIntegration()
+    return ShardableTestIntegration(params=ShardableTestIntegrationParams())

--- a/reconcile/test/runtime/test_utils_integration.py
+++ b/reconcile/test/runtime/test_utils_integration.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 
 from reconcile.test.runtime import (
@@ -7,7 +9,10 @@ from reconcile.test.runtime import (
     demo_integration_no_run_func,
     demo_integration_shard_config,
 )
-from reconcile.utils.runtime.integration import ModuleBasedQontractReconcileIntegration
+from reconcile.utils.runtime.integration import (
+    ModuleArgsKwargsRunParams,
+    ModuleBasedQontractReconcileIntegration,
+)
 
 
 def test_module_integration_no_name():
@@ -15,7 +20,9 @@ def test_module_integration_no_name():
     an integration with no QONTRACT_INTEGRATION name variable
     """
     with pytest.raises(NotImplementedError):
-        ModuleBasedQontractReconcileIntegration(demo_integration_no_name)
+        ModuleBasedQontractReconcileIntegration(
+            ModuleArgsKwargsRunParams(module=demo_integration_no_name)
+        )
 
 
 def test_module_integration_no_run_func():
@@ -23,13 +30,17 @@ def test_module_integration_no_run_func():
     an integration with no run function
     """
     with pytest.raises(NotImplementedError):
-        ModuleBasedQontractReconcileIntegration(demo_integration_no_run_func)
+        ModuleBasedQontractReconcileIntegration(
+            ModuleArgsKwargsRunParams(module=demo_integration_no_run_func)
+        )
 
 
 def test_module_integration_run():
     demo_integration.run_calls = []
-    integration = ModuleBasedQontractReconcileIntegration(demo_integration)
-    integration.run(dry_run=True, some_arg=1)
+    integration = ModuleBasedQontractReconcileIntegration(
+        ModuleArgsKwargsRunParams(module=demo_integration, some_arg=1)
+    )
+    integration.run(dry_run=True)
 
     assert {
         "some_arg": 1,
@@ -39,47 +50,54 @@ def test_module_integration_run():
 
 
 def test_demo_integration_no_early_exit_desired_state():
-    integration = ModuleBasedQontractReconcileIntegration(demo_integration)
-    assert not integration.get_early_exit_desired_state(some_arg=1)
+    integration = ModuleBasedQontractReconcileIntegration(
+        ModuleArgsKwargsRunParams(module=demo_integration, some_arg=1)
+    )
+    assert not integration.get_early_exit_desired_state()
 
 
 def test_demo_integration_early_exit_desired_state():
-    integration = ModuleBasedQontractReconcileIntegration(demo_integration_early_exit)
-    data = integration.get_early_exit_desired_state("arg", some_kw_arg="kwarg")
+    integration = ModuleBasedQontractReconcileIntegration(
+        ModuleArgsKwargsRunParams(
+            demo_integration_early_exit, "arg", some_kw_arg="kwarg"
+        )
+    )
+    data = integration.get_early_exit_desired_state()
 
     assert data == {"args": ("arg",), "kwargs": {"some_kw_arg": "kwarg"}}
 
 
 def test_demo_integration_no_shard_config():
-    integration = ModuleBasedQontractReconcileIntegration(demo_integration)
+    integration = ModuleBasedQontractReconcileIntegration(
+        ModuleArgsKwargsRunParams(module=demo_integration, some_arg=1)
+    )
     assert not integration.get_desired_state_shard_config()
 
 
 def test_demo_integration_shard_config():
-    integration = ModuleBasedQontractReconcileIntegration(demo_integration_shard_config)
+    integration = ModuleBasedQontractReconcileIntegration(
+        ModuleArgsKwargsRunParams(demo_integration_shard_config)
+    )
     assert integration.get_desired_state_shard_config()
 
 
-def test_demo_integration_kwargs_have_shard_info():
-    integration = ModuleBasedQontractReconcileIntegration(demo_integration_shard_config)
-    assert integration.kwargs_have_shard_info(
-        **{demo_integration_shard_config.SHARD_ARG_NAME: "shard1"}
+@pytest.mark.parametrize(
+    "kwargs,expected_result",
+    [
+        # no comparison bundle available, so no early exit and no sharding
+        ({demo_integration_shard_config.SHARD_ARG_NAME: "shard1"}, True),
+        ({demo_integration_shard_config.SHARD_ARG_NAME: ["shard1"]}, True),
+        ({demo_integration_shard_config.SHARD_ARG_NAME: None}, False),
+        ({demo_integration_shard_config.SHARD_ARG_NAME: ()}, False),
+        ({demo_integration_shard_config.SHARD_ARG_NAME: []}, False),
+        ({}, False),
+    ],
+)
+def test_demo_integration_params_have_shard_info(kwargs: Any, expected_result: bool):
+    integration = ModuleBasedQontractReconcileIntegration(
+        ModuleArgsKwargsRunParams(
+            demo_integration_shard_config,
+            **kwargs,
+        )
     )
-
-    assert integration.kwargs_have_shard_info(
-        **{demo_integration_shard_config.SHARD_ARG_NAME: ["shard1"]}
-    )
-
-    assert not integration.kwargs_have_shard_info(
-        **{demo_integration_shard_config.SHARD_ARG_NAME: None}
-    )
-
-    assert not integration.kwargs_have_shard_info(
-        **{demo_integration_shard_config.SHARD_ARG_NAME: ()}
-    )
-
-    assert not integration.kwargs_have_shard_info(
-        **{demo_integration_shard_config.SHARD_ARG_NAME: []}
-    )
-
-    assert not integration.kwargs_have_shard_info(**{})
+    assert integration.params_have_shard_info() == expected_result

--- a/reconcile/test/runtime/test_utils_runtime_runner.py
+++ b/reconcile/test/runtime/test_utils_runtime_runner.py
@@ -11,6 +11,7 @@ from pytest_mock.plugin import MockerFixture
 
 from reconcile.test.runtime.fixtures import (
     ShardableTestIntegration,
+    ShardableTestIntegrationParams,
     SimpleTestIntegration,
 )
 from reconcile.utils import gql
@@ -62,8 +63,6 @@ def dry_run_test_integration_cfg(
         check_only_affected_shards=True,
         gql_sha_url=False,
         print_url=True,
-        run_args=(),
-        run_kwargs={},
         main_data={"data": "a"},
         comparison_data={"data": "b"},
     )
@@ -81,8 +80,6 @@ def wet_run_test_integration_cfg(
         check_only_affected_shards=True,
         gql_sha_url=False,
         print_url=True,
-        run_args=(),
-        run_kwargs={},
         main_data={"data": "a"},
         comparison_data={"data": "b"},
     )
@@ -101,8 +98,6 @@ def test_run_configuration_switch_to_main_bundle(
         check_only_affected_shards=False,
         gql_sha_url=False,
         print_url=True,
-        run_args=None,
-        run_kwargs=None,
     )
     cfg.switch_to_main_bundle()
     gql_init_from_config.assert_called_with(
@@ -127,8 +122,6 @@ def test_run_configuration_switch_to_comparison_bundle(
         check_only_affected_shards=False,
         gql_sha_url=False,
         print_url=True,
-        run_args=None,
-        run_kwargs=None,
     )
     cfg.switch_to_comparison_bundle()
     gql_init_from_config.assert_called_with(
@@ -191,8 +184,6 @@ def test_get_desired_state_diff(
         check_only_affected_shards=check_only_affected_shards,
         gql_sha_url=False,
         print_url=True,
-        run_args=(),
-        run_kwargs={},
         main_data=current_data,
         comparison_data=previous_data,
     )
@@ -218,8 +209,6 @@ def test_run_configuration_dispatch_dry_run(
         check_only_affected_shards=False,
         gql_sha_url=False,
         print_url=True,
-        run_args=(),
-        run_kwargs={},
         main_data={"data": "a"},
         comparison_data={"data": "b"},
     )
@@ -247,8 +236,6 @@ def test_run_configuration_dispatch_wet_run(
         check_only_affected_shards=False,
         gql_sha_url=False,
         print_url=True,
-        run_args=(),
-        run_kwargs={},
         main_data={"data": "a"},
         comparison_data={"data": "b"},
     )
@@ -270,16 +257,12 @@ def test_run_configuration_dry_run(
     with dry_run=True
     """
     simple_test_integration.run = MagicMock()  # type: ignore
-    args = (1,)
-    kwargs = {"a_string": "s"}
     _integration_dry_run(
         simple_test_integration,
         None,
-        *args,
-        **kwargs,
     )
 
-    simple_test_integration.run.assert_called_once_with(True, *args, **kwargs)
+    simple_test_integration.run.assert_called_once_with(True)
 
 
 def test_run_configuration_dry_run_diff_no_early_exit(
@@ -289,8 +272,6 @@ def test_run_configuration_dry_run_diff_no_early_exit(
     when there is not diff, we don't do early exit but run the integration
     """
     simple_test_integration.run = MagicMock()  # type: ignore
-    args = (1,)
-    kwargs = {"a_string": "s"}
     _integration_dry_run(
         simple_test_integration,
         DesiredStateDiff(
@@ -299,11 +280,9 @@ def test_run_configuration_dry_run_diff_no_early_exit(
             diff_found=True,
             affected_shards=set(),
         ),
-        *args,
-        **kwargs,
     )
 
-    simple_test_integration.run.assert_called_once_with(True, *args, **kwargs)
+    simple_test_integration.run.assert_called_once_with(True)
 
 
 def test_run_configuration_dry_run_no_diff_early_exit(
@@ -313,8 +292,6 @@ def test_run_configuration_dry_run_no_diff_early_exit(
     when there is no difference in the desired state, exit early.
     """
     simple_test_integration.run = MagicMock()  # type: ignore
-    args = (1,)
-    kwargs = {"a_string": "s"}
     _integration_dry_run(
         simple_test_integration,
         DesiredStateDiff(
@@ -323,25 +300,26 @@ def test_run_configuration_dry_run_no_diff_early_exit(
             diff_found=False,
             affected_shards=set(),
         ),
-        *args,
-        **kwargs,
     )
 
     assert not simple_test_integration.run.called
 
 
 def test_run_configuration_dry_run_diff_no_early_exit_sharding(
-    shardable_test_integration: ShardableTestIntegration,
+    mocker: MockerFixture,
 ):
     """
     when there is not diff, we don't do early exit. since the integration supports
     sharding, and affected shards have been detected, we run the integration once
     per shard.
     """
-    shardable_test_integration.run = MagicMock()  # type: ignore
+    integration_run_func = mocker.patch.object(
+        ShardableTestIntegration, "run", autospec=True
+    )
+    shardable_test_integration = ShardableTestIntegration(
+        params=ShardableTestIntegrationParams()
+    )
     affected_shards = {"a", "b"}
-    args = ()
-    kwargs = {"an_arg": "arg"}
     _integration_dry_run(
         shardable_test_integration,
         DesiredStateDiff(
@@ -350,21 +328,21 @@ def test_run_configuration_dry_run_diff_no_early_exit_sharding(
             diff_found=True,
             affected_shards=affected_shards,
         ),
-        *args,
-        **kwargs,
     )
 
     # make sure the run method has been called once per shard
-    assert shardable_test_integration.run.call_count == len(affected_shards)
+    assert integration_run_func.call_count == len(affected_shards)
+    called_sharded_params = [
+        c[0][0].params for c in integration_run_func.call_args_list
+    ]
     for shard in affected_shards:
-        shard_kwargs = kwargs.copy()
-        shard_kwargs["shard"] = shard
-        shardable_test_integration.run.assert_any_call(True, *args, **shard_kwargs)
+        sharded_params = shardable_test_integration.params.copy_and_update(
+            {"shard": shard}
+        )
+        assert sharded_params in called_sharded_params
 
 
-def test_run_configuration_dry_run_diff_no_early_exit_shard_err(
-    shardable_test_integration: ShardableTestIntegration,
-):
+def test_run_configuration_dry_run_diff_no_early_exit_shard_err(mocker: MockerFixture):
     """
     if a shard fails during dry-run, we expect exit with an error
     """
@@ -376,21 +354,26 @@ def test_run_configuration_dry_run_diff_no_early_exit_shard_err(
     sys_exit_0_shard = "sys-exit-0"  # success
     sys_exit_false_shard = "sys-exit-false"  # success
 
-    def integration_run_func(
-        dry_run: bool, an_arg: str, shard: Optional[str] = None
-    ) -> None:
-        if shard == failing_shard:
-            raise Exception(f"shard {shard} failed")
-        if shard == sys_exit_1_shard:
+    def integration_run_func(self: ShardableTestIntegration, dry_run: bool) -> None:
+        if self.params.shard == failing_shard:
+            raise Exception(f"shard {self.params.shard} failed")
+        if self.params.shard == sys_exit_1_shard:
             sys.exit(1)
-        if shard == sys_exit_false_shard:
+        if self.params.shard == sys_exit_false_shard:
             sys.exit(False)
-        if shard == sys_exit_0_shard:
+        if self.params.shard == sys_exit_0_shard:
             sys.exit(0)
-        if shard == sys_exit_true_shard:
+        if self.params.shard == sys_exit_true_shard:
             sys.exit(True)
 
-    shardable_test_integration.run = MagicMock(side_effect=integration_run_func)  # type: ignore
+    integration_run_func_mock = mocker.patch.object(
+        ShardableTestIntegration, "run", side_effect=integration_run_func, autospec=True
+    )
+
+    shardable_test_integration = ShardableTestIntegration(
+        params=ShardableTestIntegrationParams()
+    )
+
     affected_shards = {
         succeeding_shard,
         another_succeeding_shard,
@@ -400,8 +383,6 @@ def test_run_configuration_dry_run_diff_no_early_exit_shard_err(
         sys_exit_0_shard,
         sys_exit_true_shard,
     }
-    args = ()
-    kwargs = {"an_arg": "arg"}
 
     with pytest.raises(SystemExit) as e:
         _integration_dry_run(
@@ -412,31 +393,29 @@ def test_run_configuration_dry_run_diff_no_early_exit_shard_err(
                 diff_found=True,
                 affected_shards=affected_shards,
             ),
-            *args,
-            **kwargs,
         )
 
     # the SystemExit exception contains the nr of failed shards as code
     assert e.value.code == 3
 
     # make sure the run method has been called once per shard
-    assert shardable_test_integration.run.call_count == len(affected_shards)
+    assert integration_run_func_mock.call_count == len(affected_shards)
+    called_sharded_params = [
+        c[0][0].params for c in integration_run_func_mock.call_args_list
+    ]
     for shard in affected_shards:
-        shard_kwargs = kwargs.copy()
-        shard_kwargs["shard"] = shard
-        shardable_test_integration.run.assert_any_call(True, *args, **shard_kwargs)
+        sharded_params = shardable_test_integration.params.copy_and_update(
+            {"shard": shard}
+        )
+        assert sharded_params in called_sharded_params
 
 
 def test_run_configuration_wet_run(simple_test_integration: SimpleTestIntegration):
     simple_test_integration.run = MagicMock()  # type: ignore
-    args = (1,)
-    kwargs = {"a_string": "s"}
     _integration_wet_run(
         simple_test_integration,
-        *args,
-        **kwargs,
     )
 
     assert not simple_test_integration.run.assert_called_once_with(  # type: ignore
-        False, *args, **kwargs
+        False
     )

--- a/reconcile/utils/runtime/runner.py
+++ b/reconcile/utils/runtime/runner.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import (
     Any,
     Optional,
+    TypeVar,
 )
 
 from sretoolbox.utils import threaded as sretoolbox_threaded
@@ -13,7 +14,12 @@ from reconcile.utils.runtime.desired_state_diff import (
     DesiredStateDiff,
     build_desired_state_diff,
 )
-from reconcile.utils.runtime.integration import QontractReconcileIntegration
+from reconcile.utils.runtime.integration import (
+    QontractReconcileIntegration,
+    RunParams,
+)
+
+RunParamsTypeVar = TypeVar("RunParamsTypeVar", bound=RunParams)
 
 
 @dataclass
@@ -23,8 +29,6 @@ class IntegrationRunConfiguration:
     """
 
     integration: QontractReconcileIntegration
-    run_args: Any
-    run_kwargs: Any
     valdiate_schemas: bool
     """
     Wheter to fail an integration if it queries schemas it is not allowed to.
@@ -63,14 +67,12 @@ class IntegrationRunConfiguration:
 
     def main_bundle_desired_state(self) -> Optional[dict[str, Any]]:
         self.switch_to_main_bundle()
-        return self.integration.get_early_exit_desired_state(
-            *self.run_args, **self.run_kwargs
-        )
+        return self.integration.get_early_exit_desired_state()
 
     def comparison_bundle_desired_state(self) -> Optional[dict[str, Any]]:
         self.switch_to_comparison_bundle()
-        data = self.integration.get_early_exit_desired_state(  # pylint: disable=assignment-from-none
-            *self.run_args, **self.run_kwargs
+        data = (  # pylint: disable=assignment-from-none
+            self.integration.get_early_exit_desired_state()
         )
         self.switch_to_main_bundle()
         return data
@@ -152,33 +154,24 @@ def run_integration_cfg(run_cfg: IntegrationRunConfiguration) -> None:
     if run_cfg.dry_run:
         desired_state_diff = get_desired_state_diff(run_cfg)
         run_cfg.switch_to_main_bundle()
-        _integration_dry_run(
-            run_cfg.integration,
-            desired_state_diff,
-            *run_cfg.run_args,
-            **run_cfg.run_kwargs,
-        )
+        _integration_dry_run(run_cfg.integration, desired_state_diff)
     else:
         run_cfg.switch_to_main_bundle()
-        _integration_wet_run(
-            run_cfg.integration, *run_cfg.run_args, **run_cfg.run_kwargs
-        )
+        _integration_wet_run(run_cfg.integration)
 
 
 def _integration_wet_run(
-    integration: QontractReconcileIntegration, *run_args: Any, **run_kwargs: Any
+    integration: QontractReconcileIntegration[RunParamsTypeVar],
 ) -> None:
     """
     Runs an integration in wet mode, i.e. not in dry-run mode.
     """
-    integration.run(False, *run_args, **run_kwargs)
+    integration.run(False)
 
 
 def _integration_dry_run(
-    integration: QontractReconcileIntegration,
+    integration: QontractReconcileIntegration[RunParamsTypeVar],
     desired_state_diff: Optional[DesiredStateDiff],
-    *run_args: Any,
-    **run_kwargs: Any,
 ) -> None:
     """
     Runs an integration in dry-run mode, i.e. not actually making any changes
@@ -201,9 +194,7 @@ def _integration_dry_run(
     # affected shards only
     if (
         integration.supports_sharded_dry_run_mode()
-        and not integration.kwargs_have_shard_info(
-            **run_kwargs
-        )  # already running in sharded mode?
+        and not integration.params_have_shard_info()  # already running in sharded mode?
         and desired_state_diff
         and desired_state_diff.affected_shards
     ):
@@ -211,7 +202,10 @@ def _integration_dry_run(
         logging.info(f"run {integration.name} for shards {affected_shard_list}")
 
         def run_integration_shard(shard: str) -> None:
-            integration.run_for_shard(True, shard, *run_args, **run_kwargs)
+            sharded_integration = integration.build_integration_instance_for_shard(
+                shard
+            )
+            sharded_integration.run(True)
 
         # run all shards
         exceptions = sretoolbox_threaded.run(
@@ -231,4 +225,4 @@ def _integration_dry_run(
             return
 
     # if not, we run the integration in full
-    integration.run(True, *run_args, **run_kwargs)
+    integration.run(True)


### PR DESCRIPTION
### What
replace the generic `*args: Any, **kwargs: Any` parameterlist on the `run` function of class based integrations with a dedicated parameter class on an integrations `__init__` function. wrapping parameters in a dataclass enables validations at runtime (e.g. pydantic) but also at static code analysis (e.g. mypy).

### How
to leverage type safety all the way, the type of the parameter class can be defined as type hint when inheriting from `QontractReconcileIntegration`. the `__init__` function will then accept that type and the `param` property of the class will have that as a verifable type as well.

```python
class SimpleTestIntegrationParams(PydanticRunParams):
    int_arg: int
    opt_str_arg: Optional[str] = None

class SimpleTestIntegration(QontractReconcileIntegration[SimpleTestIntegrationParams]):
    def __init__(self, params: SimpleTestIntegrationParams):
        super().__init__(params)

    ...

    def run(self, dry_run: bool) -> None:
        print(self.params.int_arg)
```

in this example, the `print(self.params.int_arg)` statement is completely verifiable with mypy and also VSCode yields proper autocompletion.

in cli.py, the integration is hooked up like this:

```python
@integration.command()
@click.pass_context
def simple_integration(ctx, int_param: int):
    from reconcile import simple_integration

    run_class_integration(
        integration=simple_integration.SimpleIntegration(SimpleTestIntegrationParams(int_arg=int_param)),
        ctx=ctx.obj,
    )
```

Wrapping all parameters in a single object makes it easier to pass them around. This comes in handy when sharded integration runs are spawned off into threads or processes.

for the module based integrations, the generic wrapper class `ModuleArgsKwargsRunParams` is available, that makes sure the custom `run` functions in the modules do not need to change. all the wrapping happens in `reconcile.cli` so module integrations do not need to adapt because of this change.

### Alternatives considered

Another option would have been to make the integration a dataclass and defining all parameters as properties. That would make it harder to distinguish between run parameters passed into the integration and potential object properties that are just there to hold some values for the integration run.

Yet another approach was experimented with in https://github.com/app-sre/qontract-reconcile/pull/3191 where the parameter class was passed to the run function instead to the init function.