### PR TITLE
upgrade sretoolbox to 2.3.0 and adapt exception handling for tasks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(exclude=("tests",)),
     package_data={"reconcile": ["templates/*.j2", "gql_queries/*/*.gql"]},
     install_requires=[
-        "sretoolbox~=2.2.1",
+        "sretoolbox~=2.3.0",
         "Click>=7.0,<9.0",
         "gql==3.1.0",
         "toml>=0.10.0,<0.11.0",


### PR DESCRIPTION
sretoolbox 2.3.0 is not hiding `sys.exit` exceptions anymore from the caller of `threaded.run(return_exceptions=True)`. therefore we need to adapt our interpretation of exception results.

e.g. in the case of running integration shards threaded, a `sys.exit(0)` is still fine and not an error.

additionally, the process based parallelisation that is part of this sretoolbox release is prepwork for https://issues.redhat.com/browse/APPSRE-7040