### PR TITLE
Add cli command user-credentials-migrate-output

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -918,7 +918,7 @@ def terraform_users_credentials(ctx) -> None:
 def user_credentials_migrate_output(ctx, account_name, output_path) -> None:
     vc = cast(_VaultClient, VaultClient())
 
-    skip_accounts, appsre_pgp_key, reencrypt_settings = tfu.get_reencrypt_settings()
+    skip_accounts, appsre_pgp_key, _ = tfu.get_reencrypt_settings()
 
     accounts, working_dirs, _, aws_api = tfu.setup(
         False,


### PR DESCRIPTION
Adds a CLI command to copy aws credentials from terraform output to vault. These credentials need to be migrated, cause the get terraform-users-credentials reads these from vault

Related issue: [APPSRE-4706](https://issues.redhat.com/browse/APPSRE-4706)