### PR TITLE
APPSRE-7067 containerize pypi publish

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -2,10 +2,11 @@
 
 DOCKER_CONF="$PWD/.docker"
 mkdir -p "$DOCKER_CONF"
+PYPI_PUSH_IMAGE=quay.io/app-sre/qontract-reconcile-builder:0.3.8
 docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 
 # build images
 make test build push
 
 # publish to pypi
-./build_tag.sh
+docker run -e TWINE_USERNAME -e TWINE_PASSWORD -v $(pwd):/work --rm $PYPI_PUSH_IMAGE ./build_tag.sh

--- a/build_tag.sh
+++ b/build_tag.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-set -e
-
 python3 -m pip install --user twine wheel
 python3 setup.py bdist_wheel
 python3 -m twine upload dist/*


### PR DESCRIPTION
`build_tag.sh` is executed on builder node. We want to have it containerized to isolate build environment.