### PR TITLE
[terraform-resources] add support for ingress cidr blocks for alb provider

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -278,6 +278,7 @@ provider
     }
   }
   certificate_arn
+  ingress_cidr_blocks
   idle_timeout
   targets {
     name

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -220,7 +220,6 @@ VARIABLE_KEYS = [
     "openshift_ingress_load_balancer_arn",
     "domain_name",
     "certificate_arn",
-    "ingress_cidr_blocks",
     "vpc_id",
     "subnet_ids",
     "network_interface_ids",

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -220,6 +220,7 @@ VARIABLE_KEYS = [
     "openshift_ingress_load_balancer_arn",
     "domain_name",
     "certificate_arn",
+    "ingress_cidr_blocks",
     "vpc_id",
     "subnet_ids",
     "network_interface_ids",
@@ -4583,6 +4584,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "security_groups": None,
             "self": None,
         }
+        ingress_cidr_blocks = resource["ingress_cidr_blocks"]
         values = {
             "provider": provider,
             "vpc_id": vpc_id,
@@ -4593,7 +4595,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     "from_port": 80,
                     "to_port": 80,
                     "protocol": "tcp",
-                    "cidr_blocks": ["0.0.0.0/0"],
+                    "cidr_blocks": ingress_cidr_blocks,
                     "ipv6_cidr_blocks": ["::/0"],
                     **empty_required_sg_values,
                 },
@@ -4602,7 +4604,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     "from_port": 443,
                     "to_port": 443,
                     "protocol": "tcp",
-                    "cidr_blocks": ["0.0.0.0/0"],
+                    "cidr_blocks": ingress_cidr_blocks,
                     "ipv6_cidr_blocks": ["::/0"],
                     **empty_required_sg_values,
                 },


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-7044

depends on https://github.com/app-sre/qontract-schemas/pull/380

this will enable the ingress cidr blocks to be configurable (and self-serviceable).