### PR TITLE
[terraform-resources] add ability to set ip_address_type to ipv4/dualstack for alb

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -280,6 +280,7 @@ provider
   certificate_arn
   ingress_cidr_blocks
   idle_timeout
+  ip_address_type
   targets {
     name
     default

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4637,7 +4637,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             "provider": provider,
             "name": identifier,
             "internal": False,
-            "ip_address_type": "dualstack",
+            "ip_address_type": resource.get("ip_address_type", "ipv4"),
             "load_balancer_type": "application",
             "security_groups": [f"${{{sg_tf_resource.id}}}"],
             "subnets": [s["id"] for s in vpc["subnets"]],


### PR DESCRIPTION
Allow configuring ip_address_type for ALB resources

This is an optional parameter as per the [terraform aws provider docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb#ip_address_type) and neither the terraform aws provider or aws api docs document a default. The AWS console defaults to `ipv4` so we set that as a default here to be more consistent/explicit

part of https://issues.redhat.com/browse/APPSRE-7044

depends on https://github.com/app-sre/qontract-schemas/pull/381
