### PR TITLE
Add cluster_name and namespace_name args to openshift_namespaces

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1325,8 +1325,12 @@ def openshift_namespace_labels(ctx, thread_pool_size, internal, use_jump_host):
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
 @internal()
 @use_jump_host()
+@cluster_name
+@namespace_name
 @click.pass_context
-def openshift_namespaces(ctx, thread_pool_size, internal, use_jump_host):
+def openshift_namespaces(
+    ctx, thread_pool_size, internal, use_jump_host, cluster_name, namespace_name
+):
     import reconcile.openshift_namespaces
 
     run_integration(
@@ -1335,6 +1339,8 @@ def openshift_namespaces(ctx, thread_pool_size, internal, use_jump_host):
         thread_pool_size,
         internal,
         use_jump_host,
+        cluster_name=cluster_name,
+        namespace_name=namespace_name,
     )
 
 

--- a/reconcile/openshift_namespaces.py
+++ b/reconcile/openshift_namespaces.py
@@ -13,6 +13,7 @@ from typing import (
 from sretoolbox.utils import threaded
 
 import reconcile.openshift_base as ob
+import reconcile.openshift_resources_base as orb
 from reconcile import queries
 from reconcile.status import ExitCodes
 from reconcile.utils.defer import defer
@@ -136,17 +137,22 @@ def run(
     thread_pool_size=10,
     internal: Optional[bool] = None,
     use_jump_host=True,
+    cluster_name=None,
+    namespace_name=None,
     defer=None,
 ):
 
     all_namespaces = queries.get_namespaces(minimal=True)
     shard_namespaces, duplicates = get_shard_namespaces(all_namespaces)
+    namespaces = orb.filter_namespaces_by_cluster_and_namespace(
+        shard_namespaces, cluster_name, namespace_name
+    )
 
-    desired_state = get_desired_state(shard_namespaces)
+    desired_state = get_desired_state(namespaces)
 
     settings = queries.get_app_interface_settings()
     oc_map = OC_Map(
-        namespaces=shard_namespaces,
+        namespaces=namespaces,
         integration=QONTRACT_INTEGRATION,
         settings=settings,
         internal=internal,

--- a/reconcile/test/test_openshift_namespaces.py
+++ b/reconcile/test/test_openshift_namespaces.py
@@ -201,3 +201,25 @@ class TestOpenshiftNamespaces(TestCase):
         with self.assertRaises(SystemExit), contextlib.redirect_stderr(f):
             openshift_namespaces.run(False, thread_pool_size=1)
             self.assertIn("SomeError", f.getvalue())
+
+    def test_run_with_cluster_name(self):
+        self.test_ns = [
+            NS(c1, n1, delete=False, exists=False),
+            NS(c2, n2, delete=False, exists=False),
+        ]
+
+        openshift_namespaces.run(False, thread_pool_size=1, cluster_name=c1)
+
+        self.oc_clients[c1].new_project.assert_called_with(n1)
+        self.assertNotIn(c2, self.oc_clients)
+
+    def test_run_with_namespace_name(self):
+        self.test_ns = [
+            NS(c1, n1, delete=False, exists=False),
+            NS(c2, n2, delete=False, exists=False),
+        ]
+
+        openshift_namespaces.run(False, thread_pool_size=1, namespace_name=n1)
+
+        self.oc_clients[c1].new_project.assert_called_with(n1)
+        self.assertNotIn(c2, self.oc_clients)

--- a/reconcile/test/test_openshift_namespaces.py
+++ b/reconcile/test/test_openshift_namespaces.py
@@ -85,22 +85,28 @@ class TestOpenshiftNamespaces(TestCase):
     def test_create_namespace(self):
         self.test_ns = [
             NS(c1, n1, delete=False, exists=False),
+            NS(c2, n2, delete=False, exists=False),
         ]
 
         openshift_namespaces.run(False, thread_pool_size=1)
-        oc = self.oc_clients[c1]
-        oc.new_project.assert_called_with(n1)
-        oc.delete_project.assert_not_called()
+
+        for ns in self.test_ns:
+            oc = self.oc_clients[ns.cluster]
+            oc.new_project.assert_called_with(ns.name)
+            oc.delete_project.assert_not_called()
 
     def test_delete_namespace(self):
         self.test_ns = [
             NS(c1, n1, delete=True, exists=True),
+            NS(c2, n2, delete=True, exists=True),
         ]
 
         openshift_namespaces.run(False, thread_pool_size=1)
-        oc = self.oc_clients[c1]
-        oc.delete_project.assert_called_with(n1)
-        oc.new_project.assert_not_called()
+
+        for ns in self.test_ns:
+            oc = self.oc_clients[ns.cluster]
+            oc.delete_project.assert_called_with(ns.name)
+            oc.new_project.assert_not_called()
 
     def test_dup_present_namespace_no_deletes_should_do_nothing(self):
         self.test_ns = [


### PR DESCRIPTION
`cluster_name` and `namespace_name` args make it easy debug

example:

```
qontract-reconcile \
  --config config.debug.toml \
  --dry-run \
  --log-level DEBUG \
  openshift-namespaces \
  --cluster-name some-cluster \
  --namespace-name some-namespace
```