### PR TITLE
[skupper-network] use typed OCMap

### DIFF
--- a/reconcile/dashdotdb_cso.py
+++ b/reconcile/dashdotdb_cso.py
@@ -76,9 +76,6 @@ class DashdotdbCSO(DashdotdbBase):
         if isinstance(oc, OCLogMsg):
             LOG.log(level=oc.log_level, msg=oc.message)
             return None
-        if not oc:
-            LOG.error("No OC client for cluster %s", cluster)
-            return None
 
         try:
             imagemanifestvuln = oc.get_all("ImageManifestVuln", all_namespaces=True)

--- a/reconcile/gql_definitions/skupper_network/skupper_networks.gql
+++ b/reconcile/gql_definitions/skupper_network/skupper_networks.gql
@@ -60,6 +60,7 @@ query SkupperNetworks {
           serviceSync
         }
       }
+      clusterAdmin
       cluster {
         name
         serverUrl
@@ -73,9 +74,13 @@ query SkupperNetworks {
         automationToken {
           ...VaultSecret
         }
+        clusterAdminAutomationToken {
+          ...VaultSecret
+        }
         internal
         disable {
           integrations
+          e2eTests
         }
         peering {
           connections {

--- a/reconcile/gql_definitions/skupper_network/skupper_networks.py
+++ b/reconcile/gql_definitions/skupper_network/skupper_networks.py
@@ -101,6 +101,7 @@ query SkupperNetworks {
           serviceSync
         }
       }
+      clusterAdmin
       cluster {
         name
         serverUrl
@@ -114,9 +115,13 @@ query SkupperNetworks {
         automationToken {
           ...VaultSecret
         }
+        clusterAdminAutomationToken {
+          ...VaultSecret
+        }
         internal
         disable {
           integrations
+          e2eTests
         }
         peering {
           connections {
@@ -232,6 +237,7 @@ class ClusterSpecV1(BaseModel):
 
 class DisableClusterAutomationsV1(BaseModel):
     integrations: Optional[list[str]] = Field(..., alias="integrations")
+    e2e_tests: Optional[list[str]] = Field(..., alias="e2eTests")
 
     class Config:
         smart_union = True
@@ -303,6 +309,9 @@ class ClusterV1(BaseModel):
     jump_host: Optional[CommonJumphostFields] = Field(..., alias="jumpHost")
     spec: Optional[ClusterSpecV1] = Field(..., alias="spec")
     automation_token: Optional[VaultSecret] = Field(..., alias="automationToken")
+    cluster_admin_automation_token: Optional[VaultSecret] = Field(
+        ..., alias="clusterAdminAutomationToken"
+    )
     internal: Optional[bool] = Field(..., alias="internal")
     disable: Optional[DisableClusterAutomationsV1] = Field(..., alias="disable")
     peering: Optional[ClusterPeeringV1] = Field(..., alias="peering")
@@ -318,6 +327,7 @@ class NamespaceV1(BaseModel):
     skupper_site: Optional[NamespaceSkupperSiteConfigV1] = Field(
         ..., alias="skupperSite"
     )
+    cluster_admin: Optional[bool] = Field(..., alias="clusterAdmin")
     cluster: ClusterV1 = Field(..., alias="cluster")
 
     class Config:

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -104,7 +104,7 @@ class HasOrgAndGithubUsername(Protocol):
     github_username: str
 
 
-class HasOCMap(Protocol):
+class ClusterMap(Protocol):
     """An OCMap protocol."""
 
     def get(
@@ -118,7 +118,7 @@ class HasOCMap(Protocol):
 
 def init_specs_to_fetch(
     ri: ResourceInventory,
-    oc_map: HasOCMap,
+    oc_map: ClusterMap,
     namespaces: Optional[Iterable[Mapping]] = None,
     clusters: Optional[Iterable[Mapping]] = None,
     override_managed_types: Optional[Iterable[str]] = None,
@@ -356,7 +356,7 @@ def wait_for_namespace_exists(oc, namespace):
 
 def apply(
     dry_run: bool,
-    oc_map: HasOCMap,
+    oc_map: ClusterMap,
     cluster: str,
     namespace: str,
     resource_type: str,
@@ -513,7 +513,7 @@ def create(dry_run, oc_map, cluster, namespace, resource_type, resource):
 
 def delete(
     dry_run: bool,
-    oc_map: HasOCMap,
+    oc_map: ClusterMap,
     cluster: str,
     namespace: str,
     resource_type: str,
@@ -550,7 +550,7 @@ def check_unused_resource_types(ri):
 def _realize_resource_data(
     unpacked_ri_item,
     dry_run,
-    oc_map: HasOCMap,
+    oc_map: ClusterMap,
     ri: ResourceInventory,
     take_over,
     caller,
@@ -729,7 +729,7 @@ def _realize_resource_data(
 
 def realize_data(
     dry_run,
-    oc_map: HasOCMap,
+    oc_map: ClusterMap,
     ri: ResourceInventory,
     thread_pool_size,
     take_over=False,
@@ -836,7 +836,7 @@ def _validate_resources_used_exist(
             continue
 
 
-def validate_planned_data(ri: ResourceInventory, oc_map: HasOCMap) -> None:
+def validate_planned_data(ri: ResourceInventory, oc_map: ClusterMap) -> None:
     for cluster, namespace, kind, data in ri:
         oc = oc_map.get_cluster(cluster)
 
@@ -852,7 +852,7 @@ def validate_planned_data(ri: ResourceInventory, oc_map: HasOCMap) -> None:
 
 
 @retry(exceptions=(ValidationError), max_attempts=100)
-def validate_realized_data(actions: Iterable[dict[str, str]], oc_map: HasOCMap):
+def validate_realized_data(actions: Iterable[dict[str, str]], oc_map: ClusterMap):
     """
     Validate the realized desired state.
 

--- a/reconcile/openshift_users.py
+++ b/reconcile/openshift_users.py
@@ -42,9 +42,6 @@ def get_cluster_users(
     if isinstance(oc, OCLogMsg):
         logging.log(level=oc.log_level, msg=oc.message)
         return []
-    if not oc:
-        logging.error("No OC client for cluster %s", cluster)
-        return []
     users: list[str] = []
 
     # get cluster info for current cluster name from clusters list

--- a/reconcile/skupper_network/reconciler.py
+++ b/reconcile/skupper_network/reconciler.py
@@ -8,14 +8,14 @@ import reconcile.openshift_base as ob
 from reconcile.skupper_network.models import SkupperSite
 from reconcile.skupper_network.site_controller import LABELS as SITE_CONTROLLER_LABELS
 from reconcile.skupper_network.site_controller import get_site_controller
-from reconcile.utils.oc import OC_Map
+from reconcile.utils.oc_map import OCMap
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.openshift_resource import ResourceInventory
 
 
 def delete_skupper_site(
     site: SkupperSite,
-    oc_map: OC_Map,
+    oc_map: OCMap,
     dry_run: bool,
     integration_managed_kinds: Iterable[str],
 ) -> None:
@@ -62,14 +62,14 @@ def delete_skupper_site(
             oc.delete(site.namespace.name, item["kind"], item["metadata"]["name"])
 
 
-def _get_token(oc_map: OC_Map, site: SkupperSite, name: str) -> dict[str, Any]:
+def _get_token(oc_map: OCMap, site: SkupperSite, name: str) -> dict[str, Any]:
     """Get a connection token secret from the site's namespace."""
     oc = oc_map.get_cluster(site.cluster.name)
     return oc.get(site.namespace.name, "Secret", name, allow_not_found=True)
 
 
 def _create_token(
-    oc_map: OC_Map,
+    oc_map: OCMap,
     site: SkupperSite,
     connected_site: SkupperSite,
     dry_run: bool,
@@ -94,7 +94,7 @@ def _create_token(
 
 
 def _transfer_token(
-    oc_map: OC_Map,
+    oc_map: OCMap,
     site: SkupperSite,
     connected_site: SkupperSite,
     dry_run: bool,
@@ -145,7 +145,7 @@ def _transfer_token(
 
 def connect_sites(
     site: SkupperSite,
-    oc_map: OC_Map,
+    oc_map: OCMap,
     dry_run: bool,
     integration: str,
     integration_version: str,
@@ -209,7 +209,7 @@ def connect_sites(
                 )
 
 
-def delete_unused_tokens(site: SkupperSite, oc_map: OC_Map, dry_run: bool) -> None:
+def delete_unused_tokens(site: SkupperSite, oc_map: OCMap, dry_run: bool) -> None:
     """Delete any other connection tokens that are no longer needed."""
     oc = oc_map.get_cluster(site.cluster.name)
     for item in oc.get_items(
@@ -228,7 +228,7 @@ def delete_unused_tokens(site: SkupperSite, oc_map: OC_Map, dry_run: bool) -> No
 
 
 def reconcile(
-    oc_map: OC_Map,
+    oc_map: OCMap,
     ri: ResourceInventory,
     dry_run: bool,
     thread_pool_size: int,

--- a/reconcile/test/fixtures/skupper_network/skupper_networks-island.yml
+++ b/reconcile/test/fixtures/skupper_network/skupper_networks-island.yml
@@ -54,6 +54,7 @@ skupper_networks:
             routers: 1
             serviceController: null
             serviceSync: null
+        clusterAdmin: null
         cluster:
           name: small-1
           serverUrl: "https://api.small-1"
@@ -66,6 +67,7 @@ skupper_networks:
             field: token
             version: null
             format: null
+          clusterAdminAutomationToken: null
           internal: false
           disable: null
           peering:

--- a/reconcile/test/fixtures/skupper_network/skupper_networks.yml
+++ b/reconcile/test/fixtures/skupper_network/skupper_networks.yml
@@ -54,6 +54,7 @@ skupper_networks:
             routers: 1
             serviceController: null
             serviceSync: null
+        clusterAdmin: null
         cluster:
           name: small-1
           serverUrl: "https://api.small-1"
@@ -66,6 +67,7 @@ skupper_networks:
             field: token
             version: null
             format: null
+          clusterAdminAutomationToken: null
           internal: false
           disable: null
           peering:
@@ -99,6 +101,7 @@ skupper_networks:
             routers: 1
             serviceController: null
             serviceSync: null
+        clusterAdmin: null
         cluster:
           name: small-2
           serverUrl: "https://api.small-2"
@@ -111,6 +114,7 @@ skupper_networks:
             field: token
             version: null
             format: null
+          clusterAdminAutomationToken: null
           internal: false
           disable: null
           peering:
@@ -172,6 +176,7 @@ skupper_networks:
             routers: 1
             serviceController: null
             serviceSync: null
+        clusterAdmin: null
         cluster:
           name: public-1
           serverUrl: "https://api.public-1"
@@ -184,6 +189,7 @@ skupper_networks:
             field: token
             version: null
             format: null
+          clusterAdminAutomationToken: null
           internal: false
           disable: null
           peering:
@@ -218,6 +224,7 @@ skupper_networks:
             routers: 1
             serviceController: null
             serviceSync: null
+        clusterAdmin: null
         cluster:
           name: public-2
           serverUrl: "https://api.public-2"
@@ -230,6 +237,7 @@ skupper_networks:
             field: token
             version: null
             format: null
+          clusterAdminAutomationToken: null
           internal: false
           disable: null
           peering:
@@ -264,6 +272,7 @@ skupper_networks:
             routers: 2
             serviceController: null
             serviceSync: null
+        clusterAdmin: null
         cluster:
           name: internal-1
           serverUrl: "https://api.internal-1"
@@ -276,6 +285,7 @@ skupper_networks:
             field: token
             version: null
             format: null
+          clusterAdminAutomationToken: null
           internal: true
           disable: null
           peering:
@@ -310,6 +320,7 @@ skupper_networks:
             routers: 1
             serviceController: null
             serviceSync: null
+        clusterAdmin: null
         cluster:
           name: internal-2
           serverUrl: "https://api.internal-2"
@@ -322,6 +333,7 @@ skupper_networks:
             field: token
             version: null
             format: null
+          clusterAdminAutomationToken: null
           internal: true
           disable: null
           peering:
@@ -356,6 +368,7 @@ skupper_networks:
             routers: 1
             serviceController: null
             serviceSync: null
+        clusterAdmin: null
         cluster:
           name: private-1
           serverUrl: "https://api.private-1"
@@ -368,6 +381,7 @@ skupper_networks:
             field: token
             version: null
             format: null
+          clusterAdminAutomationToken: null
           internal: false
           disable: null
           peering:
@@ -402,6 +416,7 @@ skupper_networks:
             routers: 1
             serviceController: null
             serviceSync: null
+        clusterAdmin: null
         cluster:
           name: private-2
           serverUrl: "https://api.private-2"
@@ -414,6 +429,7 @@ skupper_networks:
             field: token
             version: null
             format: null
+          clusterAdminAutomationToken: null
           internal: false
           disable: null
           peering:
@@ -451,6 +467,7 @@ skupper_networks:
             routers: 1
             serviceController: null
             serviceSync: null
+        clusterAdmin: null
         cluster:
           name: public-1
           serverUrl: "https://api.public-1"
@@ -463,6 +480,7 @@ skupper_networks:
             field: token
             version: null
             format: null
+          clusterAdminAutomationToken: null
           internal: false
           disable: null
           peering:
@@ -497,6 +515,7 @@ skupper_networks:
             routers: 1
             serviceController: null
             serviceSync: null
+        clusterAdmin: null
         cluster:
           name: public-1
           serverUrl: "https://api.public-1"
@@ -509,6 +528,7 @@ skupper_networks:
             field: token
             version: null
             format: null
+          clusterAdminAutomationToken: null
           internal: false
           disable: null
           peering:
@@ -543,6 +563,7 @@ skupper_networks:
             routers: 1
             serviceController: null
             serviceSync: null
+        clusterAdmin: null
         cluster:
           name: disabled-1
           serverUrl: "https://api.disabled-1"
@@ -555,10 +576,12 @@ skupper_networks:
             field: token
             version: null
             format: null
+          clusterAdminAutomationToken: null
           internal: false
           disable:
             integrations:
               - skupper-network
+            e2eTests: null
           peering:
             connections:
               - provider: account-vpc-mesh

--- a/reconcile/test/skupper_network/conftest.py
+++ b/reconcile/test/skupper_network/conftest.py
@@ -8,10 +8,8 @@ from reconcile.skupper_network import integration as intg
 from reconcile.skupper_network.models import SkupperSite
 from reconcile.skupper_network.site_controller import CONFIG_NAME
 from reconcile.test.fixtures import Fixtures
-from reconcile.utils.oc import (
-    OC_Map,
-    OCNative,
-)
+from reconcile.utils.oc import OCNative
+from reconcile.utils.oc_map import OCMap
 
 
 @pytest.fixture
@@ -58,7 +56,7 @@ def oc(mocker: MockerFixture, fake_site_configmap: dict[str, Any]) -> OCNative:
 
 
 @pytest.fixture
-def oc_map(mocker: MockerFixture, oc: OCNative) -> OC_Map:
-    oc_map = mocker.patch("reconcile.utils.oc.OC_Map", autospec=True)
+def oc_map(mocker: MockerFixture, oc: OCNative) -> OCMap:
+    oc_map = mocker.patch("reconcile.utils.oc_map.OCMap", autospec=True)
     oc_map.get_cluster.return_value = oc
     return oc_map

--- a/reconcile/test/skupper_network/test_skupper_network_integration.py
+++ b/reconcile/test/skupper_network/test_skupper_network_integration.py
@@ -11,7 +11,7 @@ from reconcile.skupper_network.models import (
 )
 from reconcile.skupper_network.site_controller import CONFIG_NAME
 from reconcile.test.fixtures import Fixtures
-from reconcile.utils.oc import OC_Map
+from reconcile.utils.oc_map import OCMap
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.openshift_resource import ResourceInventory
 
@@ -130,7 +130,7 @@ def test_skupper_network_intg_fetch_desired_state(
 
 
 def test_skupper_network_intg_fetch_current_state(
-    oc_map: OC_Map,
+    oc_map: OCMap,
     skupper_sites: list[SkupperSite],
     fake_site_configmap: dict[str, Any],
 ) -> None:

--- a/reconcile/test/skupper_network/test_skupper_network_models.py
+++ b/reconcile/test/skupper_network/test_skupper_network_models.py
@@ -119,6 +119,7 @@ def namespace_factory() -> NamespaceFactory:
     ) -> NamespaceV1:
         return NamespaceV1(
             name=name,
+            clusterAdmin=None,
             cluster=ClusterV1(
                 name=f"cluster-{name}",
                 serverUrl="https://api.example.com:6443",
@@ -126,6 +127,7 @@ def namespace_factory() -> NamespaceFactory:
                 jumpHost=None,
                 spec=ClusterSpecV1(private=private),
                 automationToken=None,
+                clusterAdminAutomationToken=None,
                 internal=internal,
                 disable=None,
                 peering=ClusterPeeringV1(

--- a/reconcile/test/skupper_network/test_skupper_network_reconciler.py
+++ b/reconcile/test/skupper_network/test_skupper_network_reconciler.py
@@ -10,16 +10,14 @@ from pytest_mock import MockerFixture
 
 from reconcile.skupper_network import reconciler
 from reconcile.skupper_network.models import SkupperSite
-from reconcile.utils.oc import (
-    OC_Map,
-    OCNative,
-)
+from reconcile.utils.oc import OCNative
+from reconcile.utils.oc_map import OCMap
 
 
 @pytest.mark.parametrize("dry_run", [True, False])
 def test_skupper_network_reconciler_delete_skupper_resources(
     dry_run: bool,
-    oc_map: OC_Map,
+    oc_map: OCMap,
     oc: OCNative,
     skupper_sites: list[SkupperSite],
     fake_site_configmap: dict[str, Any],
@@ -60,7 +58,7 @@ def test_skupper_network_reconciler_delete_skupper_resources(
 
 
 def test_skupper_network_reconciler_get_token(
-    oc_map: OC_Map,
+    oc_map: OCMap,
     oc: OCNative,
     skupper_sites: list[SkupperSite],
     fake_site_configmap: dict[str, Any],
@@ -74,7 +72,7 @@ def test_skupper_network_reconciler_get_token(
 @pytest.mark.parametrize("dry_run", [True, False])
 def test_skupper_network_reconciler_create_token(
     dry_run: bool,
-    oc_map: OC_Map,
+    oc_map: OCMap,
     oc: OCNative,
     skupper_sites: list[SkupperSite],
 ) -> None:
@@ -119,7 +117,7 @@ def test_skupper_network_reconciler_transfer_token(
     dry_run: bool,
     is_usable_connection_token: bool,
     mocker: MockerFixture,
-    oc_map: OC_Map,
+    oc_map: OCMap,
     oc: OCNative,
     skupper_sites: list[SkupperSite],
     fake_token: dict[str, Any],
@@ -177,7 +175,7 @@ def test_skupper_network_reconciler_connect_sites(
     local_token: dict[str, Any],
     remote_token: dict[str, Any],
     mocker: MockerFixture,
-    oc_map: OC_Map,
+    oc_map: OCMap,
     oc: OCNative,
     skupper_sites: list[SkupperSite],
 ) -> None:
@@ -265,7 +263,7 @@ def test_skupper_network_reconciler_delete_unused_tokens(
     dry_run: bool,
     token_secrets: list[dict[str, Any]],
     expected_deletion_count: int,
-    oc_map: OC_Map,
+    oc_map: OCMap,
     oc: OCNative,
     skupper_sites: list[SkupperSite],
 ) -> None:

--- a/reconcile/utils/oc_map.py
+++ b/reconcile/utils/oc_map.py
@@ -192,16 +192,14 @@ class OCMap:
 
     def get(
         self, cluster: str, privileged: bool = False
-    ) -> Optional[Union[OCDeprecated, OCLogMsg]]:
+    ) -> Union[OCDeprecated, OCLogMsg]:
         cluster_map = self._privileged_oc_map if privileged else self._oc_map
         return cluster_map.get(
             cluster,
             OCLogMsg(log_level=logging.DEBUG, message=f"[{cluster}] cluster skipped"),
         )
 
-    def get_cluster(
-        self, cluster: str, privileged: bool = False
-    ) -> Optional[Union[OCDeprecated, OCLogMsg]]:
+    def get_cluster(self, cluster: str, privileged: bool = False) -> OCDeprecated:
         result = self.get(cluster, privileged)
         if isinstance(result, OCLogMsg):
             raise result


### PR DESCRIPTION
Refactor `skupper-network` to use the new typed `OCMap` class. 

* improve `openshift_base` to support old `OC_Map` and new `OCMap`
* improve `OCMap.get()` and `OCMap.get_cluster()` returned types
* remove unneeded `oc` checks in `openshift_users` and `dashdotdb_cso`

Ticket: [APPSRE-7033](https://issues.redhat.com/browse/APPSRE-7033)