### PR TITLE
APPSRE-6175: Update instance expiration management

### DIFF
--- a/reconcile/gabi_authorized_users.py
+++ b/reconcile/gabi_authorized_users.py
@@ -128,4 +128,4 @@ def run(
     ob.realize_data(dry_run, oc_map, ri, thread_pool_size)
 
     if ri.has_error_registered():
-        sys.exit(1)
+        sys.exit(ExitCodes.ERROR)

--- a/reconcile/gabi_authorized_users.py
+++ b/reconcile/gabi_authorized_users.py
@@ -88,10 +88,15 @@ def fetch_desired_state(
                     f"Could not find RDS identifier {identifier} "
                     f'for account {account} in namespace {namespace["name"]}'
                 )
-            cluster = namespace["cluster"]["name"]
             users = get_usernames(g["users"], namespace["cluster"])
             resource = construct_gabi_oc_resource(g["name"], expiration_date, users)
-            ri.add_desired(cluster, namespace["name"], "ConfigMap", g["name"], resource)
+            ri.add_desired(
+                namespace["cluster"]["name"],
+                namespace["name"],
+                resource.kind,
+                resource.name,
+                resource,
+            )
 
 
 @defer

--- a/reconcile/gabi_authorized_users.py
+++ b/reconcile/gabi_authorized_users.py
@@ -35,18 +35,21 @@ EXPIRATION_DAYS_MAX = 90
 def construct_gabi_oc_resource(
     name: str, expiration_date: date, users: Iterable[str]
 ) -> OpenshiftResource:
+    # Support the legacy users file. To be removed in the future.
+    _users = users if expiration_date >= date.today() else []
     body = {
         "apiVersion": "v1",
         "kind": "ConfigMap",
         "metadata": {"name": name, "annotations": {"qontract.recycle": "true"}},
         "data": {
+            "authorized-users.yaml": "\n".join(_users),
             "config.json": json.dumps(
                 {
                     "expiration": str(expiration_date),
                     "users": users,
                 },
                 separators=(",", ":"),
-            )
+            ),
         },
     }
     return OpenshiftResource(

--- a/reconcile/gabi_authorized_users.py
+++ b/reconcile/gabi_authorized_users.py
@@ -2,6 +2,7 @@ import json
 import logging
 import sys
 from collections.abc import (
+    Callable,
     Iterable,
     Mapping,
 )
@@ -11,7 +12,6 @@ from datetime import (
 )
 from typing import (
     Any,
-    Callable,
     Optional,
 )
 

--- a/reconcile/gabi_authorized_users.py
+++ b/reconcile/gabi_authorized_users.py
@@ -11,6 +11,7 @@ from datetime import (
 )
 from typing import (
     Any,
+    Callable,
     Optional,
 )
 
@@ -104,9 +105,9 @@ def run(
     dry_run: bool,
     thread_pool_size: int = 10,
     internal: Optional[bool] = None,
-    use_jump_host=True,
-    defer=None,
-):
+    use_jump_host: bool = True,
+    defer: Optional[Callable] = None,
+) -> None:
     gabi_instances = queries.get_gabi_instances()
     if not gabi_instances:
         logging.debug("No GABI instances found in app-interface")
@@ -123,7 +124,8 @@ def run(
         internal=internal,
         use_jump_host=use_jump_host,
     )
-    defer(oc_map.cleanup)
+    if defer:
+        defer(oc_map.cleanup)
     fetch_desired_state(gabi_instances, ri)
     ob.realize_data(dry_run, oc_map, ri, thread_pool_size)
 

--- a/reconcile/gabi_authorized_users.py
+++ b/reconcile/gabi_authorized_users.py
@@ -28,7 +28,7 @@ from reconcile.utils.semver_helper import make_semver
 
 QONTRACT_INTEGRATION = "gabi-authorized-users"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
-EXPIRATION_MAX = 90
+EXPIRATION_DAYS_MAX = 90
 
 
 def construct_gabi_oc_resource(
@@ -66,10 +66,10 @@ def fetch_desired_state(
 ) -> None:
     for g in gabi_instances:
         expiration_date = datetime.strptime(g["expirationDate"], "%Y-%m-%d").date()
-        if (expiration_date - date.today()).days > EXPIRATION_MAX:
+        if (expiration_date - date.today()).days > EXPIRATION_DAYS_MAX:
             raise RunnerException(
-                f'The maximum expiration date of {g["name"]} '
-                f"shall not exceed {EXPIRATION_MAX} days form today"
+                f'The maximum expiration date of {g["name"]} shall not '
+                f"exceed {EXPIRATION_DAYS_MAX} days from today"
             )
         for i in g["instances"]:
             namespace = i["namespace"]
@@ -85,7 +85,7 @@ def fetch_desired_state(
                     break
             if not found:
                 raise RunnerException(
-                    f"Could not find rds identifier {identifier} "
+                    f"Could not find RDS identifier {identifier} "
                     f'for account {account} in namespace {namespace["name"]}'
                 )
             cluster = namespace["cluster"]["name"]
@@ -104,7 +104,7 @@ def run(
 ):
     gabi_instances = queries.get_gabi_instances()
     if not gabi_instances:
-        logging.debug("No gabi instances found in app-interface")
+        logging.debug("No GABI instances found in app-interface")
         sys.exit(ExitCodes.SUCCESS)
 
     gabi_namespaces = [i["namespace"] for g in gabi_instances for i in g["instances"]]

--- a/reconcile/test/fixtures/gabi_authorized_users/apply.yml
+++ b/reconcile/test/fixtures/gabi_authorized_users/apply.yml
@@ -64,5 +64,8 @@ desired:
     annotations:
       qontract.recycle: 'true'
   data:
+    authorized-users.yaml: |-
+      user1
+      user2
     config.json: |-
       {"expiration":"2023-01-01","users":["user1","user2"]}

--- a/reconcile/test/fixtures/gabi_authorized_users/apply.yml
+++ b/reconcile/test/fixtures/gabi_authorized_users/apply.yml
@@ -64,6 +64,5 @@ desired:
     annotations:
       qontract.recycle: 'true'
   data:
-    authorized-users.yaml: |-
-      user1
-      user2
+    config.json: |-
+      {"expiration":"2023-01-01","users":["user1","user2"]}

--- a/reconcile/test/fixtures/gabi_authorized_users/delete.yml
+++ b/reconcile/test/fixtures/gabi_authorized_users/delete.yml
@@ -18,6 +18,9 @@ server:
           qontract.recycle: 'true'
           qontract.sha256sum: abc
       data:
+        authorized-users.yaml: |-
+           user1
+           user2
         config.json: |-
           {"expiration":"2023-01-01","users":["user1","user2"]}
   apis:
@@ -47,5 +50,6 @@ desired:
     annotations:
       qontract.recycle: 'true'
   data:
+    authorized-users.yaml: ''
     config.json: |-
       {"expiration":"2022-12-31","users":["user1","user2"]}

--- a/reconcile/test/fixtures/gabi_authorized_users/delete.yml
+++ b/reconcile/test/fixtures/gabi_authorized_users/delete.yml
@@ -18,9 +18,8 @@ server:
           qontract.recycle: 'true'
           qontract.sha256sum: abc
       data:
-        authorized-users.yaml: |-
-          user1
-          user2
+        config.json: |-
+          {"expiration":"2023-01-01","users":["user1","user2"]}
   apis:
     kind: APIGroupList
     groups:
@@ -48,4 +47,5 @@ desired:
     annotations:
       qontract.recycle: 'true'
   data:
-    authorized-users.yaml: ''
+    config.json: |-
+      {"expiration":"2022-12-31","users":["user1","user2"]}

--- a/reconcile/test/test_gabi_authorized_users.py
+++ b/reconcile/test/test_gabi_authorized_users.py
@@ -2,10 +2,14 @@ import json
 import os
 from datetime import (
     date,
+    datetime,
     timedelta,
 )
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import (
+    Mock,
+    patch,
+)
 
 import reconcile.gabi_authorized_users as gabi_u
 import reconcile.openshift_base as ob
@@ -82,6 +86,7 @@ class TestGabiAuthorizedUser(TestCase):
         with self.assertRaises(RunnerException):
             gabi_u.run(dry_run=False)
 
+    @patch.object(gabi_u, "date", Mock(wraps=datetime))
     @patch.object(ob, "apply", autospec=True)
     def test_gabi_authorized_users_apply(
         self,
@@ -95,6 +100,7 @@ class TestGabiAuthorizedUser(TestCase):
         expirationDate = date(2023, 1, 1)
         get_gabi_instances.return_value = mock_get_gabi_instances(expirationDate)
         mock_request.side_effect = apply_request
+        gabi_u.date.today.return_value = expirationDate
         gabi_u.run(dry_run=False)
         expected = OR(
             apply["desired"],

--- a/reconcile/test/test_gabi_authorized_users.py
+++ b/reconcile/test/test_gabi_authorized_users.py
@@ -92,7 +92,7 @@ class TestGabiAuthorizedUser(TestCase):
         secret_read,
         get_settings,
     ):
-        expirationDate = date.today()
+        expirationDate = date(2023, 1, 1)
         get_gabi_instances.return_value = mock_get_gabi_instances(expirationDate)
         mock_request.side_effect = apply_request
         gabi_u.run(dry_run=False)
@@ -133,7 +133,7 @@ class TestGabiAuthorizedUser(TestCase):
         secret_read,
         get_settings,
     ):
-        expirationDate = date.today() - timedelta(days=1)
+        expirationDate = date(2023, 1, 1) - timedelta(days=1)
         get_gabi_instances.return_value = mock_get_gabi_instances(expirationDate)
         mock_request.side_effect = delete_request
         gabi_u.run(dry_run=False)

--- a/reconcile/test/test_gabi_authorized_users.py
+++ b/reconcile/test/test_gabi_authorized_users.py
@@ -76,7 +76,7 @@ class TestGabiAuthorizedUser(TestCase):
     def test_gabi_authorized_users_exceed(
         self, mock_request, get_gabi_instances, oc_version, secret_read, get_settings
     ):
-        expirationDate = date.today() + timedelta(days=(gabi_u.EXPIRATION_MAX + 1))
+        expirationDate = date.today() + timedelta(days=(gabi_u.EXPIRATION_DAYS_MAX + 1))
         get_gabi_instances.return_value = mock_get_gabi_instances(expirationDate)
         mock_request.side_effect = apply_request
         with self.assertRaises(RunnerException):

--- a/reconcile/test/test_gabi_authorized_users.py
+++ b/reconcile/test/test_gabi_authorized_users.py
@@ -64,9 +64,9 @@ def delete_request(
     return RespMock(data)
 
 
-def mock_get_gabi_instances(expirationDate: str) -> list[dict]:
+def mock_get_gabi_instances(expiration_date: str) -> list[dict]:
     gabi_instances = apply["gql_response"]
-    gabi_instances[0]["expirationDate"] = str(expirationDate)
+    gabi_instances[0]["expirationDate"] = str(expiration_date)
     return gabi_instances
 
 
@@ -80,8 +80,10 @@ class TestGabiAuthorizedUser(TestCase):
     def test_gabi_authorized_users_exceed(
         self, mock_request, get_gabi_instances, oc_version, secret_read, get_settings
     ):
-        expirationDate = date.today() + timedelta(days=(gabi_u.EXPIRATION_DAYS_MAX + 1))
-        get_gabi_instances.return_value = mock_get_gabi_instances(expirationDate)
+        expiration_date = date.today() + timedelta(
+            days=(gabi_u.EXPIRATION_DAYS_MAX + 1)
+        )
+        get_gabi_instances.return_value = mock_get_gabi_instances(expiration_date)
         mock_request.side_effect = apply_request
         with self.assertRaises(RunnerException):
             gabi_u.run(dry_run=False)
@@ -97,10 +99,10 @@ class TestGabiAuthorizedUser(TestCase):
         secret_read,
         get_settings,
     ):
-        expirationDate = date(2023, 1, 1)
-        get_gabi_instances.return_value = mock_get_gabi_instances(expirationDate)
+        expiration_date = date(2023, 1, 1)
+        get_gabi_instances.return_value = mock_get_gabi_instances(expiration_date)
         mock_request.side_effect = apply_request
-        gabi_u.date.today.return_value = expirationDate
+        gabi_u.date.today.return_value = expiration_date
         gabi_u.run(dry_run=False)
         expected = OR(
             apply["desired"],
@@ -122,8 +124,8 @@ class TestGabiAuthorizedUser(TestCase):
         secret_read,
         get_settings,
     ):
-        expirationDate = date.today()
-        get_gabi_instances.return_value = mock_get_gabi_instances(expirationDate)
+        expiration_date = date.today()
+        get_gabi_instances.return_value = mock_get_gabi_instances(expiration_date)
         mock_request.side_effect = delete_request
         sha.return_value = "abc"
         gabi_u.run(dry_run=False)
@@ -139,8 +141,8 @@ class TestGabiAuthorizedUser(TestCase):
         secret_read,
         get_settings,
     ):
-        expirationDate = date(2023, 1, 1) - timedelta(days=1)
-        get_gabi_instances.return_value = mock_get_gabi_instances(expirationDate)
+        expiration_date = date(2023, 1, 1) - timedelta(days=1)
+        get_gabi_instances.return_value = mock_get_gabi_instances(expiration_date)
         mock_request.side_effect = delete_request
         gabi_u.run(dry_run=False)
         expected = OR(


### PR DESCRIPTION
Currently, the file this integration manages via a ConfigMap object for the GABI service only includes a simple new line delimited list of users allowed to use a particular GABI instance. There is no notion of the expiration date conveyed there in any shape or form. The only way an instance would currently "expire" is when it reaches the expiration date upon which the authorised users list is emptied, and the Deployment recycled to allow new Pods to load updated file content.

Thus, this change moves the expiration date forward into the GABI instance itself so that it can be verified locally, allowing one to distinguish between an instance that has expired or lacks user access permissions from now on with a different set of HTTP response codes.

To achieve this, the configuration file format has been changed to a JSON-based to allow for the inclusion of the expiration date and the user's lists simultaneously.

Note that the old legacy users file is still supported for backward compatibility, and it's to be removed in the near future.

Related: [APPSRE-6175](https://issues.redhat.com/browse/APPSRE-6175)

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>