### PR TITLE
[terraform-resources] don't filter disabled accounts in terrascript during dry-runs

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -538,6 +538,7 @@ def fetch_current_state(
 
 def init_working_dirs(
     accounts: list[dict[str, Any]],
+    filter_disabled_accounts: bool,
     thread_pool_size: int,
     settings: Optional[Mapping[str, Any]] = None,
 ) -> tuple[Terrascript, dict[str, str]]:
@@ -547,6 +548,7 @@ def init_working_dirs(
         thread_pool_size,
         accounts,
         settings=settings,
+        filter_disabled_accounts=filter_disabled_accounts,
     )
     working_dirs = ts.dump()
     return ts, working_dirs
@@ -583,7 +585,12 @@ def setup(
     )
 
     # initialize terrascript (scripting engine to generate terraform manifests)
-    ts, working_dirs = init_working_dirs(accounts, thread_pool_size, settings=settings)
+    ts, working_dirs = init_working_dirs(
+        accounts=accounts,
+        filter_disabled_accounts=not dry_run,
+        thread_pool_size=thread_pool_size,
+        settings=settings,
+    )
 
     # initialize terraform client
     # it is used to plan and apply according to the output of terrascript

--- a/reconcile/test/test_terrascript_account_filtering.py
+++ b/reconcile/test/test_terrascript_account_filtering.py
@@ -1,0 +1,92 @@
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.utils.secret_reader import SecretReader
+from reconcile.utils.terrascript_aws_client import TerrascriptClient
+
+
+@pytest.fixture
+def accounts() -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "acc-with-another-integration-disabled",
+            "automationToken": {
+                "path": "path",
+            },
+            "resourcesDefaultRegion": "us-east-1",
+            "supportedDeploymentRegions": ["us-east-1"],
+            "providerVersion": "1.2.3",
+            "uid": "123",
+            "terraformState": {
+                "provider": "s3",
+                "bucket": "the-bucket",
+                "region": "us-east-1",
+                "integrations": [
+                    {
+                        "integration": "terraform-resources",
+                        "key": "the-state.tfstate",
+                    }
+                ],
+            },
+            "disable": {"integrations": ["another-integration"]},
+        },
+        {
+            "name": "acc-with-terraform-resource-disabled",
+            "automationToken": {
+                "path": "path",
+            },
+            "resourcesDefaultRegion": "us-east-1",
+            "supportedDeploymentRegions": ["us-east-1"],
+            "providerVersion": "1.2.3",
+            "uid": "123",
+            "terraformState": {
+                "provider": "s3",
+                "bucket": "another-bucket",
+                "region": "us-east-1",
+                "integrations": [
+                    {
+                        "integration": "terraform-resources",
+                        "key": "another-state.tfstate",
+                    }
+                ],
+            },
+            "disable": {"integrations": ["terraform-resources"]},
+        },
+    ]
+
+
+@pytest.fixture
+def secret_reader(mocker: MockerFixture) -> SecretReader:
+    mock_secret_reader = mocker.patch(
+        "reconcile.utils.terrascript_aws_client.SecretReader", autospec=True
+    )
+    mock_secret_reader.return_value.read_all.return_value = {
+        "aws_access_key_id": "key_id",
+        "aws_secret_access_key": "access_key",
+        "region": "us-east-1",
+        "bucket": "tf-bucket-name",
+        "_key": "tf_key.tfstate",
+    }
+    return mock_secret_reader
+
+
+def test_filter_disabled_accounts_for_integration(
+    accounts: list[dict[str, Any]], secret_reader: SecretReader
+) -> None:
+    ts = TerrascriptClient(
+        "terraform_resources", "", 1, accounts, filter_disabled_accounts=True
+    )
+    assert "acc-with-another-integration-disabled" in ts.accounts
+    assert "acc-with-terraform-resource-disabled" not in ts.accounts
+
+
+def test_dont_filter_disabled_accounts_for_integration(
+    accounts: list[dict[str, Any]], secret_reader: SecretReader
+) -> None:
+    ts = TerrascriptClient(
+        "terraform_resources", "", 1, accounts, filter_disabled_accounts=False
+    )
+    assert "acc-with-another-integration-disabled" in ts.accounts
+    assert "acc-with-terraform-resource-disabled" in ts.accounts

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -318,12 +318,17 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         accounts: list[dict[str, Any]],
         settings: Optional[Mapping[str, Any]] = None,
         prefetch_resources_by_schemas: Optional[list[str]] = None,
+        filter_disabled_accounts: Optional[bool] = True,
     ) -> None:
         self.integration = integration
         self.integration_prefix = integration_prefix
         self.settings = settings
         self.thread_pool_size = thread_pool_size
-        filtered_accounts = self.filter_disabled_accounts(accounts)
+        filtered_accounts = (
+            self.filter_disabled_accounts(accounts)
+            if filter_disabled_accounts
+            else accounts
+        )
         self.secret_reader = SecretReader(settings=settings)
         self.populate_configs(filtered_accounts)
         self.versions = {a["name"]: a["providerVersion"] for a in filtered_accounts}


### PR DESCRIPTION
filtering disabled accounts during dry-runs can lead to potential errors during excution, especially since terraform-resources itself does not filter disabled accounts. we need to make this consistent:

* during dry-runs terraform-resources runs for all accounts (or at least all affected accounts) and therefore TerrascriptClient needs to initialize those accounts as well
* during wet-runs terraform-resources does not run for disabled accounts (integrations-manager removed the shard deployment) and therefore TerrascriptClient needs to filter as well

this is merely a quick fix rather a long-term solution.