### PR TITLE
don't print GQL SHA during dry-runs

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -538,7 +538,13 @@ def integration(
 ):
     ctx.ensure_object(dict)
 
-    init_env(log_level=log_level, config_file=configfile)
+    init_env(
+        log_level=log_level,
+        config_file=configfile,
+        # don't print gql url in dry-run mode - less noisy PR check logs and
+        # the actual SHA is not that important during PR checks
+        print_gql_url=(not dry_run and bool(gql_url_print)),
+    )
 
     ctx.obj["dry_run"] = dry_run
     ctx.obj["early_exit_compare_sha"] = early_exit_compare_sha

--- a/reconcile/utils/runtime/environment.py
+++ b/reconcile/utils/runtime/environment.py
@@ -19,7 +19,9 @@ LOG_DATEFMT = "%Y-%m-%d %H:%M:%S"
 
 
 def init_env(
-    log_level: Optional[str] = None, config_file: Optional[str] = None
+    log_level: Optional[str] = None,
+    config_file: Optional[str] = None,
+    print_gql_url: Optional[bool] = True,
 ) -> None:
     # store env configs in environment variables. this way child processes
     # will inherit them and a compatible environment can be setup in a child
@@ -44,4 +46,4 @@ def init_env(
     config.init_from_toml(config_file)
 
     # init basic gql connection
-    gql.init_from_config()
+    gql.init_from_config(print_url=print_gql_url)


### PR DESCRIPTION
the actual SHA used during PR checks is not important. hence lets not print it to keep the PR check logs easier to read