### PR TITLE
Revert "[gitlab-housekeeping] retest approved failed MRs"

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -491,7 +491,6 @@ def merge_merge_requests(
 
         last_pipeline_result = pipelines[0]["status"]
         if last_pipeline_result != "success":
-            gl.add_comment_to_merge_request(mr.iid, "/retest")
             continue
 
         logging.info(["merge", gl.project.name, mr.iid])


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#3159

There is no upper bound on how many types `/retest` is triggered so an MR can end up blocking the merge queue.

See: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/59447