### PR TITLE
allow disable per cluster for route53

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2627,6 +2627,9 @@ DNS_ZONES_QUERY = """
       _target_cluster {
         name
         elbFQDN
+        disable {
+          integrations
+        }
       }
       _target_namespace_zone {
         namespace {

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -78,7 +78,7 @@ def build_desired_state(
             if target_cluster:
                 if not integration_is_enabled(
                     integration=QONTRACT_INTEGRATION.replace("_", "-"),
-                    disable_obj=target_cluster["disable"],
+                    disable_obj=target_cluster,
                 ):
                     continue
                 target_cluster_elb = target_cluster["elbFQDN"]

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -75,6 +75,10 @@ def build_desired_state(
             # Process '_target_cluster'
             target_cluster = record.pop("_target_cluster", None)
             if target_cluster:
+                if target_cluster["disable"]:
+                    if QONTRACT_INTEGRATION.replace("_", "-") in target_cluster["disable"]["integrations"] or []:
+                        # The integration is marked as disabled for this cluster -> skip
+                        continue
                 target_cluster_elb = target_cluster["elbFQDN"]
 
                 # get_a_record is used here to validate the record and reused later

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -11,6 +11,7 @@ from reconcile.status import ExitCodes
 from reconcile.utils import dnsutils
 from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.defer import defer
+from reconcile.utils.disabled_integrations import integration_is_enabled
 from reconcile.utils.external_resources import (
     PROVIDER_AWS,
     get_external_resource_specs,
@@ -75,10 +76,11 @@ def build_desired_state(
             # Process '_target_cluster'
             target_cluster = record.pop("_target_cluster", None)
             if target_cluster:
-                if target_cluster["disable"]:
-                    if QONTRACT_INTEGRATION.replace("_", "-") in target_cluster["disable"]["integrations"] or []:
-                        # The integration is marked as disabled for this cluster -> skip
-                        continue
+                if not integration_is_enabled(
+                    integration=QONTRACT_INTEGRATION.replace("_", "-"),
+                    disable_obj=target_cluster["disable"],
+                ):
+                    continue
                 target_cluster_elb = target_cluster["elbFQDN"]
 
                 # get_a_record is used here to validate the record and reused later

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -80,6 +80,7 @@ def build_desired_state(
                     integration=QONTRACT_INTEGRATION.replace("_", "-"),
                     disable_obj=target_cluster,
                 ):
+                    logging.info("Skipping cluster '%s'", target_cluster["name"])
                     continue
                 target_cluster_elb = target_cluster["elbFQDN"]
 


### PR DESCRIPTION
elbFQDNs are used in a zone in our `app-sre` account. Having a bad FQDN in a single cluster can block this integration for other clusters too, so we should have a way to disable it on a per cluster base.

Schema: https://github.com/app-sre/qontract-schemas/pull/393