### PR TITLE
Revert "allow disable per cluster for route53 (#3233)"

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2627,9 +2627,6 @@ DNS_ZONES_QUERY = """
       _target_cluster {
         name
         elbFQDN
-        disable {
-          integrations
-        }
       }
       _target_namespace_zone {
         namespace {

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -11,7 +11,6 @@ from reconcile.status import ExitCodes
 from reconcile.utils import dnsutils
 from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.defer import defer
-from reconcile.utils.disabled_integrations import integration_is_enabled
 from reconcile.utils.external_resources import (
     PROVIDER_AWS,
     get_external_resource_specs,
@@ -76,12 +75,6 @@ def build_desired_state(
             # Process '_target_cluster'
             target_cluster = record.pop("_target_cluster", None)
             if target_cluster:
-                if not integration_is_enabled(
-                    integration=QONTRACT_INTEGRATION.replace("_", "-"),
-                    disable_obj=target_cluster,
-                ):
-                    logging.info("Skipping cluster '%s'", target_cluster["name"])
-                    continue
                 target_cluster_elb = target_cluster["elbFQDN"]
 
                 # get_a_record is used here to validate the record and reused later


### PR DESCRIPTION
This reverts commit 0c2558a321c5966632bd382e525e0c56bf910d39.

disabling on per-cluster basis is not a safe operation because tf state is on per-account basis.