### PR TITLE
APPSRE-7138: Support default Server Side Encryption (SSE) setting for S3 buckets

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1666,8 +1666,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             values.setdefault("lifecycle", {}).setdefault("ignore_changes", []).append(
                 "grant"
             )
-        server_side_encryption_configuration = common_values.get(
-            "server_side_encryption_configuration", DEFAULT_S3_SSE_CONFIGURATION
+        server_side_encryption_configuration = (
+            common_values.get("server_side_encryption_configuration")
+            or DEFAULT_S3_SSE_CONFIGURATION
         )
         values[
             "server_side_encryption_configuration"

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -234,6 +234,10 @@ EMAIL_REGEX = re.compile(r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$")
 
 TMP_DIR_PREFIX = "terrascript-aws-"
 
+DEFAULT_S3_SSE_CONFIGURATION = {
+    "rule": {"apply_server_side_encryption_by_default": {"sse_algorithm": "AES256"}}
+}
+
 
 class StateInaccessibleException(Exception):
     pass
@@ -1663,12 +1667,11 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 "grant"
             )
         server_side_encryption_configuration = common_values.get(
-            "server_side_encryption_configuration"
+            "server_side_encryption_configuration", DEFAULT_S3_SSE_CONFIGURATION
         )
-        if server_side_encryption_configuration:
-            values[
-                "server_side_encryption_configuration"
-            ] = server_side_encryption_configuration
+        values[
+            "server_side_encryption_configuration"
+        ] = server_side_encryption_configuration
         # Support static website hosting [rosa-authenticator]
         website = common_values.get("website")
         if website:


### PR DESCRIPTION
AWS has been rolling out their new approach to enabling a default S3 Bucket encryption policy.

Many of the old S3 Buckets did not have the SSE (Server Side Encryption) encryption enabled in the past, and there was also no default, or rather the default was no encryption of the objects stored at rest. This rollout of new settings and policies will result in the Terraform detecting drift perpetually where the SSE wasn't previously enabled.

Thus, add a new default SEE setting that will be applied where the configuration was not explicitly added to stop the problem with the state drift and align with the new recommendation from AWS per:

- [Setting default server-side encryption behavior for Amazon S3 buckets](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-encryption.html)
- [Amazon S3 now automatically encrypts all new objects](https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-encryption-faq.html)

Related: [APPSRE-7138](https://issues.redhat.com/browse/APPSRE-7138)

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>