### PR TITLE
[OCDeprecated] fix is_kind_supported

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1174,7 +1174,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
             except StatusCodeError:
                 return False
         else:
-            return kind in self.api_resources
+            return kind in self.get_api_resources()
 
     def is_kind_namespaced(self, kind: str) -> bool:
         kg = kind.split(".", 1)


### PR DESCRIPTION
a change made in #3206 assumes that `self.api_resources` will be initialized in advance. most integrations do not set `init_api_resources`, hence when using OCDeprecated they will all face `cluster has no API resource`.