### PR TITLE
APPSRE-6609 obey to use_jump_host setting

### DIFF
--- a/reconcile/test/oc/test_oc_connection_parameters.py
+++ b/reconcile/test/oc/test_oc_connection_parameters.py
@@ -13,7 +13,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
 @pytest.mark.parametrize(
     "cluster, use_jump_host, expected_parameters",
     [
-        ### No jumphost settings and --no-jump-host flag
+        # No jumphost settings and --no-jump-host flag
         (
             "cluster_no_jumphost",
             False,
@@ -36,7 +36,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
                 skip_tls_verify=None,
             ),
         ),
-        ### No jumphost settings and --use-jump-host flag
+        # No jumphost settings and --use-jump-host flag
         (
             "cluster_no_jumphost",
             True,
@@ -59,7 +59,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
                 skip_tls_verify=None,
             ),
         ),
-        ### Jumphost settings and --use-jump-host flag
+        # Jumphost settings and --use-jump-host flag
         (
             "cluster_with_jumphost",
             True,
@@ -82,7 +82,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
                 skip_tls_verify=None,
             ),
         ),
-        ### Jumphost settings, but --no-jump-host flag given
+        # Jumphost settings, but --no-jump-host flag given
         (
             "cluster_with_jumphost",
             False,
@@ -125,7 +125,7 @@ def test_from_cluster(
 @pytest.mark.parametrize(
     "namespace, use_jump_host, expected_parameters",
     [
-        ### No jumphost settings and --no-jump-host flag
+        # No jumphost settings and --no-jump-host flag
         (
             "namespace_no_admin",
             False,
@@ -148,7 +148,7 @@ def test_from_cluster(
                 skip_tls_verify=None,
             ),
         ),
-        ### No jumphost settings and --use-jump-host flag
+        # No jumphost settings and --use-jump-host flag
         (
             "namespace_no_admin",
             True,
@@ -171,7 +171,7 @@ def test_from_cluster(
                 skip_tls_verify=None,
             ),
         ),
-        ### Jumphost settings and --use-jump-host flag
+        # Jumphost settings and --use-jump-host flag
         (
             "namespace_with_admin",
             True,
@@ -194,7 +194,7 @@ def test_from_cluster(
                 skip_tls_verify=None,
             ),
         ),
-        ### Jumphost settings and --no-jump-host flag
+        # Jumphost settings and --no-jump-host flag
         (
             "namespace_with_admin",
             False,

--- a/reconcile/test/oc/test_oc_connection_parameters.py
+++ b/reconcile/test/oc/test_oc_connection_parameters.py
@@ -13,6 +13,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
 @pytest.mark.parametrize(
     "cluster, use_jump_host, expected_parameters",
     [
+        ### No jumphost settings and --no-jump-host flag
         (
             "cluster_no_jumphost",
             False,
@@ -35,6 +36,30 @@ from reconcile.utils.secret_reader import SecretReaderBase
                 skip_tls_verify=None,
             ),
         ),
+        ### No jumphost settings and --use-jump-host flag
+        (
+            "cluster_no_jumphost",
+            True,
+            OCConnectionParameters(
+                cluster_name="test-cluster",
+                server_url="server-url",
+                automation_token="secret1",
+                cluster_admin_automation_token=None,
+                disabled_e2e_tests=[],
+                disabled_integrations=[],
+                jumphost_port=None,
+                jumphost_hostname=None,
+                jumphost_key=None,
+                jumphost_known_hosts=None,
+                jumphost_user=None,
+                jumphost_remote_port=None,
+                jumphost_local_port=None,
+                is_cluster_admin=None,
+                is_internal=False,
+                skip_tls_verify=None,
+            ),
+        ),
+        ### Jumphost settings and --use-jump-host flag
         (
             "cluster_with_jumphost",
             True,
@@ -51,6 +76,29 @@ from reconcile.utils.secret_reader import SecretReaderBase
                 jumphost_known_hosts="/path/to/file",
                 jumphost_user="jumphost-user",
                 jumphost_remote_port=8888,
+                jumphost_local_port=None,
+                is_cluster_admin=None,
+                is_internal=True,
+                skip_tls_verify=None,
+            ),
+        ),
+        ### Jumphost settings, but --no-jump-host flag given
+        (
+            "cluster_with_jumphost",
+            False,
+            OCConnectionParameters(
+                cluster_name="test-cluster",
+                server_url="server-url",
+                automation_token="secret1",
+                cluster_admin_automation_token=None,
+                disabled_e2e_tests=[],
+                disabled_integrations=[],
+                jumphost_port=None,
+                jumphost_hostname=None,
+                jumphost_key=None,
+                jumphost_known_hosts=None,
+                jumphost_user=None,
+                jumphost_remote_port=None,
                 jumphost_local_port=None,
                 is_cluster_admin=None,
                 is_internal=True,
@@ -77,6 +125,7 @@ def test_from_cluster(
 @pytest.mark.parametrize(
     "namespace, use_jump_host, expected_parameters",
     [
+        ### No jumphost settings and --no-jump-host flag
         (
             "namespace_no_admin",
             False,
@@ -99,6 +148,30 @@ def test_from_cluster(
                 skip_tls_verify=None,
             ),
         ),
+        ### No jumphost settings and --use-jump-host flag
+        (
+            "namespace_no_admin",
+            True,
+            OCConnectionParameters(
+                cluster_name="test-cluster",
+                server_url="server-url",
+                automation_token="secret1",
+                cluster_admin_automation_token=None,
+                disabled_e2e_tests=[],
+                disabled_integrations=[],
+                jumphost_port=None,
+                jumphost_hostname=None,
+                jumphost_key=None,
+                jumphost_known_hosts=None,
+                jumphost_user=None,
+                jumphost_remote_port=None,
+                jumphost_local_port=None,
+                is_cluster_admin=None,
+                is_internal=False,
+                skip_tls_verify=None,
+            ),
+        ),
+        ### Jumphost settings and --use-jump-host flag
         (
             "namespace_with_admin",
             True,
@@ -121,6 +194,29 @@ def test_from_cluster(
                 skip_tls_verify=None,
             ),
         ),
+        ### Jumphost settings and --no-jump-host flag
+        (
+            "namespace_with_admin",
+            False,
+            OCConnectionParameters(
+                cluster_name="test-cluster",
+                server_url="server-url",
+                automation_token="secret1",
+                cluster_admin_automation_token="secret2",
+                disabled_e2e_tests=[],
+                disabled_integrations=[],
+                jumphost_port=None,
+                jumphost_hostname=None,
+                jumphost_key=None,
+                jumphost_known_hosts=None,
+                jumphost_user=None,
+                jumphost_remote_port=None,
+                jumphost_local_port=None,
+                is_cluster_admin=True,
+                is_internal=False,
+                skip_tls_verify=None,
+            ),
+        ),
     ],
 )
 def test_from_namespace(
@@ -136,33 +232,3 @@ def test_from_namespace(
     )
 
     assert parameters == expected_parameters
-
-
-def test_missing_jumphost_settings_cluster():
-    test_cluster = load_cluster_for_connection_parameters("cluster_no_jumphost.yml")
-    secret_reader = create_autospec(SecretReaderBase)
-    with pytest.raises(RuntimeError) as e:
-        OCConnectionParameters.from_cluster(
-            secret_reader=secret_reader,
-            cluster=test_cluster,
-            use_jump_host=True,
-        )
-    assert (
-        str(e.value)
-        == "Cannot use jumphost. Cluster test-cluster does not have any jumphost settings."
-    )
-
-
-def test_missing_jumphost_settings_namespace():
-    test_namespace = load_namespace_for_connection_parameters("namespace_no_admin.yml")
-    secret_reader = create_autospec(SecretReaderBase)
-    with pytest.raises(RuntimeError) as e:
-        OCConnectionParameters.from_namespace(
-            secret_reader=secret_reader,
-            namespace=test_namespace,
-            use_jump_host=True,
-        )
-    assert (
-        str(e.value)
-        == "Cannot use jumphost. Cluster test-cluster does not have any jumphost settings."
-    )

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -121,11 +121,7 @@ class OCConnectionParameters:
         jumphost_key = None
         jumphost_remote_port = None
         jumphost_local_port = None
-        if use_jump_host:
-            if not cluster.jump_host:
-                raise RuntimeError(
-                    f"Cannot use jumphost. Cluster {cluster.name} does not have any jumphost settings."
-                )
+        if use_jump_host and cluster.jump_host:
             jumphost_hostname = cluster.jump_host.hostname
             jumphost_known_hosts = cluster.jump_host.known_hosts
             jumphost_user = cluster.jump_host.user

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -172,7 +172,9 @@ class OCConnectionParameters:
         """
         cluster = namespace.cluster
         parameter = OCConnectionParameters.from_cluster(
-            cluster=cluster, secret_reader=secret_reader
+            cluster=cluster,
+            secret_reader=secret_reader,
+            use_jump_host=use_jump_host,
         )
         if namespace.cluster_admin is None:
             return parameter

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -94,7 +94,9 @@ class OCConnectionParameters:
 
     @staticmethod
     def from_cluster(
-        cluster: Cluster, secret_reader: SecretReaderBase
+        cluster: Cluster,
+        secret_reader: SecretReaderBase,
+        use_jump_host: bool = True,
     ) -> OCConnectionParameters:
         automation_token: Optional[str] = None
         if cluster.automation_token:
@@ -119,18 +121,22 @@ class OCConnectionParameters:
         jumphost_key = None
         jumphost_remote_port = None
         jumphost_local_port = None
-        if jh := cluster.jump_host:
-            jumphost_hostname = jh.hostname
-            jumphost_known_hosts = jh.known_hosts
-            jumphost_user = jh.user
-            jumphost_port = jh.port
-            jumphost_remote_port = jh.remote_port
+        if use_jump_host:
+            if not cluster.jump_host:
+                raise RuntimeError(
+                    f"Cannot use jumphost. Cluster {cluster.name} does not have any jumphost settings."
+                )
+            jumphost_hostname = cluster.jump_host.hostname
+            jumphost_known_hosts = cluster.jump_host.known_hosts
+            jumphost_user = cluster.jump_host.user
+            jumphost_port = cluster.jump_host.port
+            jumphost_remote_port = cluster.jump_host.remote_port
 
             try:
-                jumphost_key = secret_reader.read_secret(jh.identity)
+                jumphost_key = secret_reader.read_secret(cluster.jump_host.identity)
             except SecretNotFound as e:
                 logging.error(
-                    f"[{cluster.name}] jumphost secret {jh.identity} not found"
+                    f"[{cluster.name}] jumphost secret {cluster.jump_host.identity} not found"
                 )
                 raise e
 
@@ -156,7 +162,9 @@ class OCConnectionParameters:
 
     @staticmethod
     def from_namespace(
-        namespace: Namespace, secret_reader: SecretReaderBase
+        namespace: Namespace,
+        secret_reader: SecretReaderBase,
+        use_jump_host: bool = True,
     ) -> OCConnectionParameters:
         """
         This does the same as from_cluster(), but additionally checks
@@ -205,6 +213,7 @@ def get_oc_connection_parameters_from_clusters(
     secret_reader: SecretReaderBase,
     clusters: Iterable[Cluster],
     thread_pool_size: int = 1,
+    use_jump_host: bool = True,
 ) -> list[OCConnectionParameters]:
     """
     Convert nested generated cluster classes from queries into flat ClusterParameter objects.
@@ -216,6 +225,7 @@ def get_oc_connection_parameters_from_clusters(
         clusters,
         thread_pool_size,
         secret_reader=secret_reader,
+        use_jump_host=use_jump_host,
     )
     return parameters
 
@@ -224,6 +234,7 @@ def get_oc_connection_parameters_from_namespaces(
     secret_reader: SecretReaderBase,
     namespaces: Iterable[Namespace],
     thread_pool_size: int = 1,
+    use_jump_host: bool = True,
 ) -> list[OCConnectionParameters]:
     """
     Convert nested generated namespace classes from queries into flat ClusterParameter objects.
@@ -235,5 +246,6 @@ def get_oc_connection_parameters_from_namespaces(
         namespaces,
         thread_pool_size,
         secret_reader=secret_reader,
+        use_jump_host=use_jump_host,
     )
     return parameters

--- a/reconcile/utils/oc_map.py
+++ b/reconcile/utils/oc_map.py
@@ -249,6 +249,7 @@ def init_oc_map_from_clusters(
         clusters=clusters,
         secret_reader=secret_reader,
         thread_pool_size=2,
+        use_jump_host=use_jump_host,
     )
     return OCMap(
         connection_parameters=connection_parameters,
@@ -283,6 +284,7 @@ def init_oc_map_from_namespaces(
         namespaces=namespaces,
         secret_reader=secret_reader,
         thread_pool_size=2,
+        use_jump_host=use_jump_host,
     )
     return OCMap(
         connection_parameters=connection_parameters,


### PR DESCRIPTION
At the moment we use a jumphost whenever we find a configuration for it. However, we should obey to the `use_jump_host` variable on whether to use a jumphost or not.