### PR TITLE
allowedSecretParameterPaths prefix but not parent of secretParameters

### DIFF
--- a/reconcile/test/test_saasherder_allowed_secret_paths.py
+++ b/reconcile/test/test_saasherder_allowed_secret_paths.py
@@ -1,0 +1,57 @@
+from reconcile.utils.saasherder import SaasHerder
+
+def test_saasherder_allowed_secret_paths():
+    saas_files = [
+            {
+                "path": "path1",
+                "name": "a1",
+                "managedResourceTypes": [],
+                "allowedSecretParameterPaths": [
+                    "foo",
+                ],
+                "resourceTemplates": [
+                    {
+                        "name": "test",
+                        "url": "url",
+                        "targets": [
+                            {
+                                "namespace": {
+                                    "name": "ns",
+                                    "environment": {"name": "env1", "parameters": "{}"},
+                                    "cluster": {"name": "cluster"},
+                                },
+                                "ref": "main",
+                                "upstream": {"instance": {"name": "ci"}, "name": "job"},
+                                "parameters": {},
+                                "secretParameters": [
+                                    {
+                                        "name": "secret",
+                                        "secret": {
+                                            "path": "foobar/baz",
+                                            "field": "db.endpoint"
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+                "selfServiceRoles": [
+                    {"users": [{"org_username": "theirname"}], "bots": []}
+                ],
+            },
+        ]
+
+    saasherder = SaasHerder(
+        saas_files,
+        thread_pool_size=1,
+        gitlab=None,
+        integration="",
+        integration_version="",
+        settings={},
+        validate=True,
+    )
+
+    assert not saasherder.valid
+
+

--- a/reconcile/test/test_saasherder_allowed_secret_paths.py
+++ b/reconcile/test/test_saasherder_allowed_secret_paths.py
@@ -1,7 +1,68 @@
 from reconcile.utils.saasherder import SaasHerder
 
 
-def test_saasherder_allowed_secret_paths():
+def test_saasherder_allowed_secret_paths_parent_directory():
+    """
+    ensure a parent directory in allowed_secret_parameter_paths matches correctly
+    """
+    saas_files = [
+        {
+            "path": "path1",
+            "name": "a1",
+            "managedResourceTypes": [],
+            "allowedSecretParameterPaths": [
+                "foobar",
+            ],
+            "resourceTemplates": [
+                {
+                    "name": "test",
+                    "url": "url",
+                    "targets": [
+                        {
+                            "namespace": {
+                                "name": "ns",
+                                "environment": {"name": "env1", "parameters": "{}"},
+                                "cluster": {"name": "cluster"},
+                            },
+                            "ref": "main",
+                            "upstream": {"instance": {"name": "ci"}, "name": "job"},
+                            "parameters": {},
+                            "secretParameters": [
+                                {
+                                    "name": "secret",
+                                    "secret": {
+                                        "path": "foobar/baz",
+                                        "field": "db.endpoint",
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            "selfServiceRoles": [
+                {"users": [{"org_username": "theirname"}], "bots": []}
+            ],
+        },
+    ]
+
+    saasherder = SaasHerder(
+        saas_files,
+        thread_pool_size=1,
+        gitlab=None,
+        integration="",
+        integration_version="",
+        settings={},
+        validate=True,
+    )
+
+    assert saasherder.valid
+
+
+def test_saasherder_allowed_secret_paths_invalid_parent_directory():
+    """
+    ensure a prefix directory allowed_secret_parameter_paths is not incorrectly identified as a parent
+    """
     saas_files = [
         {
             "path": "path1",

--- a/reconcile/test/test_saasherder_allowed_secret_paths.py
+++ b/reconcile/test/test_saasherder_allowed_secret_paths.py
@@ -1,46 +1,47 @@
 from reconcile.utils.saasherder import SaasHerder
 
+
 def test_saasherder_allowed_secret_paths():
     saas_files = [
-            {
-                "path": "path1",
-                "name": "a1",
-                "managedResourceTypes": [],
-                "allowedSecretParameterPaths": [
-                    "foo",
-                ],
-                "resourceTemplates": [
-                    {
-                        "name": "test",
-                        "url": "url",
-                        "targets": [
-                            {
-                                "namespace": {
-                                    "name": "ns",
-                                    "environment": {"name": "env1", "parameters": "{}"},
-                                    "cluster": {"name": "cluster"},
-                                },
-                                "ref": "main",
-                                "upstream": {"instance": {"name": "ci"}, "name": "job"},
-                                "parameters": {},
-                                "secretParameters": [
-                                    {
-                                        "name": "secret",
-                                        "secret": {
-                                            "path": "foobar/baz",
-                                            "field": "db.endpoint"
-                                        },
-                                    },
-                                ],
+        {
+            "path": "path1",
+            "name": "a1",
+            "managedResourceTypes": [],
+            "allowedSecretParameterPaths": [
+                "foo",
+            ],
+            "resourceTemplates": [
+                {
+                    "name": "test",
+                    "url": "url",
+                    "targets": [
+                        {
+                            "namespace": {
+                                "name": "ns",
+                                "environment": {"name": "env1", "parameters": "{}"},
+                                "cluster": {"name": "cluster"},
                             },
-                        ],
-                    },
-                ],
-                "selfServiceRoles": [
-                    {"users": [{"org_username": "theirname"}], "bots": []}
-                ],
-            },
-        ]
+                            "ref": "main",
+                            "upstream": {"instance": {"name": "ci"}, "name": "job"},
+                            "parameters": {},
+                            "secretParameters": [
+                                {
+                                    "name": "secret",
+                                    "secret": {
+                                        "path": "foobar/baz",
+                                        "field": "db.endpoint",
+                                    },
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            "selfServiceRoles": [
+                {"users": [{"org_username": "theirname"}], "bots": []}
+            ],
+        },
+    ]
 
     saasherder = SaasHerder(
         saas_files,
@@ -53,5 +54,3 @@ def test_saasherder_allowed_secret_paths():
     )
 
     assert not saasherder.valid
-
-

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -249,7 +249,11 @@ class SaasHerder:
             return
         for sp in secret_parameters:
             path = sp["secret"]["path"]
-            match = [a for a in allowed_secret_parameter_paths if (os.path.commonpath([path, a]) == a)]
+            match = [
+                a
+                for a in allowed_secret_parameter_paths
+                if (os.path.commonpath([path, a]) == a)
+            ]
             if not match:
                 self.valid = False
                 logging.error(
@@ -465,7 +469,7 @@ class SaasHerder:
             else:
                 (pub_saas, pub_rt_name, pub_rt_url) = pub_channel_ref
 
-            for (sub_saas, sub_rt_name, sub_rt_url) in sub_targets:
+            for sub_saas, sub_rt_name, sub_rt_url in sub_targets:
                 if not pub_channel_ref:
                     logging.error(
                         "Channel is not published by any target\n"

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -249,7 +249,7 @@ class SaasHerder:
             return
         for sp in secret_parameters:
             path = sp["secret"]["path"]
-            match = [a for a in allowed_secret_parameter_paths if path.startswith(a)]
+            match = [a for a in allowed_secret_parameter_paths if (os.path.commonpath([path, a]) == a)]
             if not match:
                 self.valid = False
                 logging.error(


### PR DESCRIPTION
trying to make a test for another example of #3227.  In this test, we have `foo` in `allowedSecretParameterPaths` but the `secretParameters` has `path = "foobar/baz"`.

I think this means validation should fail in `_validate_allowed_secret_parameter_paths` with the log message `secret parameter path 'foobar/baz' does not match any of allowedSecretParameterPaths`.

But this is based on a naive reading of the code + test cases, and I could be wrong.  Somebody who uses this function should review.

https://issues.redhat.com/browse/APPSRE-7196