### PR TITLE
APPSRE-6609 OCMap for namespace-labels

### DIFF
--- a/reconcile/openshift_namespace_labels.py
+++ b/reconcile/openshift_namespace_labels.py
@@ -1,7 +1,10 @@
 import json
 import logging
 import sys
-from collections.abc import Generator
+from collections.abc import (
+    Callable,
+    Generator,
+)
 from threading import Lock
 from typing import (
     Any,
@@ -14,13 +17,22 @@ from sretoolbox.utils import threaded
 
 import reconcile.openshift_base as ob
 from reconcile import queries
+from reconcile.gql_definitions.common.namespaces import NamespaceV1
+from reconcile.typed_queries.app_interface_vault_settings import (
+    get_app_interface_vault_settings,
+)
+from reconcile.typed_queries.namespaces import get_namespaces
 from reconcile.utils.defer import defer
 from reconcile.utils.oc import (
-    OC_Map,
-    OCNative,
     StatusCodeError,
     validate_labels,
 )
+from reconcile.utils.oc_map import (
+    OCLogMsg,
+    OCMap,
+    init_oc_map_from_namespaces,
+)
+from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.sharding import is_in_shard
 from reconcile.utils.state import State
 
@@ -68,7 +80,7 @@ class LabelInventory:
         Defaults to []"""
         return self._errors.setdefault(cluster, {}).setdefault(namespace, [])
 
-    def add_error(self, cluster: str, namespace: str, err: str):
+    def add_error(self, cluster: str, namespace: str, err: str) -> None:
         """Add an error to the given cluster / namespace"""
         self.errors(cluster, namespace).append(err)
 
@@ -110,7 +122,7 @@ class LabelInventory:
             self._ns(cluster, namespace)[type] = labels
             return labels
 
-    def delete(self, cluster: str, namespace: str):
+    def delete(self, cluster: str, namespace: str) -> None:
         """Delete the given cluster / namespace from the inventory"""
         with self._lock:
             self._inv.get(cluster, {}).pop(namespace, None)
@@ -122,7 +134,7 @@ class LabelInventory:
             for namespace, types in namespaces.items():
                 yield cluster, namespace, types
 
-    def update_managed_keys(self, cluster: str, namespace: str, key: str):
+    def update_managed_keys(self, cluster: str, namespace: str, key: str) -> None:
         """
         Add or remove a key from the managed key list.
         This actually handles a copy of the managed keys dict and updates it.
@@ -188,52 +200,31 @@ class LabelInventory:
                     changed[k] = None
 
 
-def get_names_for_namespace(namespace: dict[str, Any]) -> tuple[str, str]:
+def get_names_for_namespace(namespace: NamespaceV1) -> tuple[str, str]:
     """
     Get the cluster and namespace names from the provided
     namespace qontract info
     """
-    return namespace["cluster"]["name"], namespace["name"]
+    return namespace.cluster.name, namespace.name
 
 
-def get_gql_namespaces_in_shard() -> list[Any]:
+def get_gql_namespaces_in_shard() -> list[NamespaceV1]:
     """
     Get all namespaces from qontract-server and filter those which are in
     our shard
     """
-    all_namespaces = queries.get_namespaces()
+    all_namespaces = get_namespaces()
 
     return [
         ns
         for ns in all_namespaces
-        if not ob.is_namespace_deleted(ns)
-        and is_in_shard(f"{ns['cluster']['name']}/{ns['name']}")
+        if not ob.is_namespace_deleted(ns.dict(by_alias=True))
+        and is_in_shard(f"{ns.cluster.name}/{ns.name}")
     ]
 
 
-def get_oc_map(
-    namespaces: list[Any],
-    internal: Optional[bool],
-    use_jump_host: bool,
-    thread_pool_size: int,
-) -> OC_Map:
-    """
-    Get an OC_Map for our namespaces
-    """
-    settings = queries.get_app_interface_settings()
-    return OC_Map(
-        namespaces=namespaces,
-        integration=QONTRACT_INTEGRATION,
-        settings=settings,
-        internal=internal,
-        use_jump_host=use_jump_host,
-        thread_pool_size=thread_pool_size,
-        init_projects=True,
-    )
-
-
 def get_desired(
-    inventory: LabelInventory, oc_map: OC_Map, namespaces: list[Any]
+    inventory: LabelInventory, oc_map: OCMap, namespaces: list[NamespaceV1]
 ) -> None:
     """
     Fill the provided label inventory with every desired info from the
@@ -242,7 +233,7 @@ def get_desired(
     """
     to_be_ignored = []
     for ns in namespaces:
-        if "labels" not in ns:
+        if not ns.labels:
             continue
 
         cluster, ns_name = get_names_for_namespace(ns)
@@ -250,21 +241,21 @@ def get_desired(
         # eg: internal settings may not match --internal / --external param
         if cluster not in oc_map.clusters():
             continue
-        labels = json.loads(ns["labels"])
+        labels = json.loads(ns.labels)
 
         validation_errors = validate_labels(labels)
         for err in validation_errors:
-            inventory.add_error(cluster, ns_name, err)
-        if inventory.errors(cluster, ns_name):
+            inventory.add_error(cluster=cluster, namespace=ns_name, err=err)
+        if inventory.errors(cluster=cluster, namespace=ns_name):
             continue
 
-        if inventory.get(cluster, ns_name, DESIRED) is not None:
+        if inventory.get(cluster=cluster, namespace=ns_name, type=DESIRED) is not None:
             # delete at the end of the loop to avoid having a reinsertion at
             # the third/fifth/.. occurrences
             to_be_ignored.append((cluster, ns_name))
             continue
 
-        inventory.set(cluster, ns_name, DESIRED, labels)
+        inventory.set(cluster=cluster, namespace=ns_name, type=DESIRED, labels=labels)
 
     for cluster, ns_name in to_be_ignored:
         # Log only a warning here and do not report errors nor fail the
@@ -274,10 +265,10 @@ def get_desired(
         _LOG.debug(
             f"Found several namespace definitions for " f"{cluster}/{ns_name}. Ignoring"
         )
-        inventory.delete(cluster, ns_name)
+        inventory.delete(cluster=cluster, namespace=ns_name)
 
 
-def state_key(cluster: str, namespace: str):
+def state_key(cluster: str, namespace: str) -> str:
     return f"{cluster}/{namespace}-managed-labels"
 
 
@@ -297,18 +288,21 @@ def get_managed(inventory: LabelInventory, state: State) -> None:
         if f"/{key}" not in keys:
             continue
         managed = state.get(key, [])
-        inventory.set(cluster, ns_name, MANAGED, managed)
+        inventory.set(cluster=cluster, namespace=ns_name, type=MANAGED, labels=managed)
 
 
-def lookup_namespaces(cluster: str, oc_map: OC_Map):
+def lookup_namespaces(
+    cluster: str, oc_map: OCMap
+) -> tuple[str, Optional[dict[str, Any]]]:
     """
     Retrieve all namespaces from the given cluster
     """
     try:
         oc = oc_map.get(cluster)
-        if not oc:
+        if isinstance(oc, OCLogMsg):
             # cluster is not reachable (may be used --internal / --external ?)
             _LOG.debug(f"Skipping not-handled cluster: {cluster}")
+            logging.debug(msg=oc.message)
             return cluster, None
         _LOG.debug(f"Looking up namespaces on {cluster}")
         namespaces = oc.get_all("Namespace")
@@ -328,7 +322,7 @@ def lookup_namespaces(cluster: str, oc_map: OC_Map):
 
 
 def get_current(
-    inventory: LabelInventory, oc_map: OC_Map, thread_pool_size: int
+    inventory: LabelInventory, oc_map: OCMap, thread_pool_size: int
 ) -> None:
     """
     Fill the provided label inventory with every current info from the
@@ -349,15 +343,17 @@ def get_current(
             if inventory.get(cluster, ns_name, DESIRED) is None:
                 continue
             labels = ns_meta.get("labels", {})
-            inventory.set(cluster, ns_name, CURRENT, labels)
+            inventory.set(
+                cluster=cluster, namespace=ns_name, type=CURRENT, labels=labels
+            )
 
 
 def label(
     inv_item: tuple[str, str, Types],
-    oc_map: OC_Map,
+    oc_map: OCMap,
     dry_run: bool,
     inventory: LabelInventory,
-):
+) -> None:
     cluster, namespace, types = inv_item
     if inventory.errors(cluster, namespace):
         return
@@ -366,14 +362,17 @@ def label(
         prefix = "[dry-run] " if dry_run else ""
         _LOG.info(prefix + f"Updating labels on {cluster}/{namespace}: {changed}")
         if not dry_run:
-            oc: OCNative = oc_map.get(cluster)
+            oc = oc_map.get(cluster)
+            if isinstance(oc, OCLogMsg):
+                logging.log(level=oc.log_level, msg=oc.message)
+                return
             oc.label(None, "Namespace", namespace, changed, overwrite=True)
 
 
 def realize(
     inventory: LabelInventory,
     state: State,
-    oc_map: OC_Map,
+    oc_map: OCMap,
     dry_run: bool,
     thread_pool_size: int,
 ) -> None:
@@ -411,25 +410,36 @@ def run(
     thread_pool_size: int = 10,
     internal: Optional[bool] = None,
     use_jump_host: bool = True,
-    defer=None,
-    raise_errors=False,
-):
+    defer: Optional[Callable] = None,
+    raise_errors: bool = False,
+) -> None:
     _LOG.debug("Collecting GQL data ...")
     namespaces = get_gql_namespaces_in_shard()
 
     inventory = LabelInventory()
 
     _LOG.debug("Initializing OC_Map ...")
-    oc_map = get_oc_map(namespaces, internal, use_jump_host, thread_pool_size)
-    defer(oc_map.cleanup)
+    vault_settings = get_app_interface_vault_settings()
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+    oc_map = init_oc_map_from_namespaces(
+        namespaces=namespaces,
+        integration=QONTRACT_INTEGRATION,
+        secret_reader=secret_reader,
+        internal=internal,
+        use_jump_host=use_jump_host,
+        thread_pool_size=thread_pool_size,
+        init_projects=True,
+    )
+
+    if defer:
+        defer(oc_map.cleanup)
 
     _LOG.debug("Collecting desired state ...")
     get_desired(inventory, oc_map, namespaces)
 
-    settings = queries.get_app_interface_settings()
     accounts = queries.get_state_aws_accounts()
     state = State(
-        integration=QONTRACT_INTEGRATION, accounts=accounts, settings=settings
+        integration=QONTRACT_INTEGRATION, accounts=accounts, secret_reader=secret_reader
     )
     _LOG.debug("Collecting managed state ...")
     get_managed(inventory, state)

--- a/reconcile/test/fixtures/openshift_namespace_labels/namespace.yml
+++ b/reconcile/test/fixtures/openshift_namespace_labels/namespace.yml
@@ -1,0 +1,60 @@
+app:
+  name: test-app
+  serviceOwners:
+  - email: owner@owner
+    name: owner
+cluster:
+  automationToken:
+    field: token
+    format: null
+    path: path/to/automation_token
+    version: null
+  clusterAdminAutomationToken:
+    field: token
+    format: null
+    path: path/to/admin_token
+    version: null
+  disable: null
+  insecureSkipTLSVerify: null
+  internal: false
+  jumpHost: null
+  name: test-cluster
+  serverUrl: server-url
+clusterAdmin: null
+delete: null
+externalResources: []
+labels: null
+limitRanges:
+  limits:
+  - default:
+      cpu: '1'
+      memory: 512Mi
+    defaultRequest:
+      cpu: 100m
+      memory: 256Mi
+    max:
+      cpu: '3'
+      memory: 8Gi
+    maxLimitRequestRatio:
+      cpu: '20'
+      memory: '4'
+    min:
+      cpu: 10m
+      memory: 20Mi
+    type: Container
+  - default: null
+    defaultRequest: null
+    max:
+      cpu: '3'
+      memory: 8Gi
+    maxLimitRequestRatio: null
+    min:
+      cpu: 10m
+      memory: 20Mi
+    type: Pod
+  name: resource-limits
+managedExternalResources: true
+managedResourceNames: null
+managedRoles: true
+name: name
+quota: null

--- a/reconcile/test/test_openshift_namespace_labels.py
+++ b/reconcile/test/test_openshift_namespace_labels.py
@@ -1,17 +1,33 @@
 import json
+from dataclasses import dataclass
 from typing import Optional
 from unittest import TestCase
 from unittest.mock import (
     Mock,
     call,
+    create_autospec,
     patch,
 )
 
 from reconcile import openshift_namespace_labels
+from reconcile.gql_definitions.common.app_interface_vault_settings import (
+    AppInterfaceSettingsV1,
+)
+from reconcile.gql_definitions.common.namespaces import NamespaceV1
 from reconcile.openshift_namespace_labels import state_key
+from reconcile.test.fixtures import Fixtures
+from reconcile.utils.oc_map import OCMap
+from reconcile.utils.secret_reader import SecretReaderBase
+
+fxt = Fixtures("openshift_namespace_labels")
 
 
-# TODO: use a dataclass when python > 3.6
+def load_namespace(name: str) -> NamespaceV1:
+    content = fxt.get_anymarkup(name)
+    return NamespaceV1(**content)
+
+
+@dataclass
 class NS:
     """
     Simple utility class holding test information about current,
@@ -20,28 +36,21 @@ class NS:
     Some methods are there to convert this data into GQL, State or OC outputs.
     """
 
-    def __init__(
-        self,
-        cluster: str,
-        name: str,
-        current: Optional[dict[str, str]],
-        managed: Optional[list[str]],
-        desired: dict[str, str],
-        exists: bool = True,
-    ):
-        self.cluster = cluster
-        self.name = name
-        self.current = current
-        self.managed = managed
-        self.desired = desired
-        self.exists = exists
+    cluster: str
+    name: str
+    current: Optional[dict[str, str]]
+    managed: Optional[list[str]]
+    desired: dict[str, str]
+    exists: bool = True
 
-    def gql(self):
-        """Get this namespace as an output of GQL"""
-        d = {"name": self.name, "cluster": {"name": self.cluster}}
+    def data(self):
+        """Get typed namespace data"""
+        namespace = load_namespace(f"{self.name}.yml")
+        namespace.name = self.name
+        namespace.cluster.name = self.cluster
         if self.desired is not None:
-            d["labels"] = json.dumps(self.desired)
-        return d
+            namespace.labels = json.dumps(self.desired)
+        return namespace
 
     def oc_get_all(self):
         """Get this namespace as an output of oc get namespace"""
@@ -90,16 +99,16 @@ class TestOpenshiftNamespaceLabels(TestCase):
     This allows to code teh mock logic only once.
     """
 
-    def _queries_get_namespaces(self):
-        """Mock queries.get_namespaces() by returning our test data"""
-        return [ns.gql() for ns in self.test_ns]
+    def _get_namespaces(self):
+        """Mock get_namespaces() by returning our test data"""
+        return [ns.data() for ns in self.test_ns]
 
     def _oc_map_clusters(self):
-        """Mock OCM_Map.clusters() by listing clusters in our test data"""
+        """Mock OCMap.clusters() by listing clusters in our test data"""
         return list({ns.cluster for ns in self.test_ns if ns.exists})
 
     def _oc_map_get(self, cluster):
-        """Mock OCM_Map.get() by getting namespaces from our test data"""
+        """Mock OCMap.get() by getting namespaces from our test data"""
         oc = self.oc_clients.setdefault(cluster, Mock(name=f"oc_{cluster}"))
         ns = [
             ns.oc_get_all()
@@ -142,16 +151,31 @@ class TestOpenshiftNamespaceLabels(TestCase):
 
         module = "reconcile.openshift_namespace_labels"
 
-        # mock all {module}.queries functions
-        # with a side_effect on get_namespaces only
         self.queries_patcher = patch(f"{module}.queries")
         self.queries = self.queries_patcher.start()
-        self.queries.get_namespaces.side_effect = self._queries_get_namespaces
 
-        self.oc_map_patcher = patch(f"{module}.OC_Map")
-        self.oc_map = self.oc_map_patcher.start().return_value
+        self.namespaces_patcher = patch(f"{module}.get_namespaces")
+        self.namespaces = self.namespaces_patcher.start()
+        self.namespaces.side_effect = self._get_namespaces
+
+        vault_settings = AppInterfaceSettingsV1(vault=False)
+        self.get_vault_settings_patcher = patch(
+            f"{module}.get_app_interface_vault_settings"
+        )
+        self.get_vault_settings = self.get_vault_settings_patcher.start()
+        self.get_vault_settings.side_effect = [vault_settings]
+
+        self.create_secret_reader_patcher = patch(f"{module}.create_secret_reader")
+        self.create_secret_reader = self.create_secret_reader_patcher.start()
+        self.create_secret_reader.side_effect = [create_autospec(spec=SecretReaderBase)]
+
+        self.oc_map = create_autospec(spec=OCMap)
         self.oc_map.clusters.side_effect = self._oc_map_clusters
         self.oc_map.get.side_effect = self._oc_map_get
+
+        self.init_oc_map_patcher = patch(f"{module}.init_oc_map_from_namespaces")
+        self.init_oc_map = self.init_oc_map_patcher.start()
+        self.init_oc_map.side_effect = [self.oc_map]
 
         self.state_patcher = patch(f"{module}.State")
         self.state = self.state_patcher.start().return_value
@@ -161,14 +185,16 @@ class TestOpenshiftNamespaceLabels(TestCase):
 
     def tearDown(self) -> None:
         """cleanup patches created in self.setUp"""
-        self.oc_map_patcher.stop()
+        self.init_oc_map_patcher.stop()
         self.queries_patcher.stop()
         self.state_patcher.stop()
+        self.create_secret_reader_patcher.stop()
+        self.namespaces_patcher.stop()
 
     def test_no_change(self):
         """No label change: nothing should be done"""
         self.test_ns = [
-            NS(c1, "no-change", k1v1, k1, k1v1),
+            NS(c1, "namespace", k1v1, k1, k1v1),
         ]
         run_integration()
         self.state.add.assert_not_called()
@@ -178,59 +204,65 @@ class TestOpenshiftNamespaceLabels(TestCase):
     def test_update(self):
         """single label value change"""
         self.test_ns = [
-            NS(c1, "update", k1v1, k1, k1v2),
+            NS(c1, "namespace", k1v1, k1, k1v2),
         ]
         run_integration()
         # no change in the managed key store: we have the same keys than before
         self.state.add.assert_not_called()
         oc = self.oc_clients[c1]
         oc.label.assert_called_once_with(
-            None, "Namespace", "update", k1v2, overwrite=True
+            None, "Namespace", "namespace", k1v2, overwrite=True
         )
 
     def test_add(self):
         """addition of a label"""
         self.test_ns = [
-            NS(c1, "add", k1v1, k1, k1v1_k2v2),
+            NS(c1, "namespace", k1v1, k1, k1v1_k2v2),
         ]
         run_integration()
-        self.state.add.assert_called_once_with(state_key(c1, "add"), k1_k2, force=True)
+        self.state.add.assert_called_once_with(
+            state_key(c1, "namespace"), k1_k2, force=True
+        )
         oc = self.oc_clients[c1]
-        oc.label.assert_called_once_with(None, "Namespace", "add", k2v2, overwrite=True)
+        oc.label.assert_called_once_with(
+            None, "Namespace", "namespace", k2v2, overwrite=True
+        )
 
     def test_add_from_none(self):
         """addition of a label from none on the current namespace"""
         self.test_ns = [
-            NS(c1, "add-from-none", {}, None, k1v1),
+            NS(c1, "namespace", {}, None, k1v1),
         ]
         run_integration()
         self.state.add.assert_called_once_with(
-            state_key(c1, "add-from-none"), k1, force=True
+            state_key(c1, "namespace"), k1, force=True
         )
         oc = self.oc_clients[c1]
         oc.label.assert_called_once_with(
-            None, "Namespace", "add-from-none", k1v1, overwrite=True
+            None, "Namespace", "namespace", k1v1, overwrite=True
         )
 
     def test_remove_step1(self):
         """removal of a label step 1: remove label"""
         self.test_ns = [
-            NS(c1, "remove", k1v1_k2v2, k1_k2, k1v1),
+            NS(c1, "namespace", k1v1_k2v2, k1_k2, k1v1),
         ]
         run_integration()
         self.state.add.assert_not_called()
         oc = self.oc_clients[c1]
         oc.label.assert_called_once_with(
-            None, "Namespace", "remove", {"k2": None}, overwrite=True
+            None, "Namespace", "namespace", {"k2": None}, overwrite=True
         )
 
     def test_remove_step2(self):
         """removal of a label step 2: remove key from managed state"""
         self.test_ns = [
-            NS(c1, "remove", k1v1, k1_k2, k1v1),
+            NS(c1, "namespace", k1v1, k1_k2, k1v1),
         ]
         run_integration()
-        self.state.add.assert_called_once_with(state_key(c1, "remove"), k1, force=True)
+        self.state.add.assert_called_once_with(
+            state_key(c1, "namespace"), k1, force=True
+        )
         oc = self.oc_clients[c1]
         oc.label.assert_not_called()
 
@@ -238,27 +270,27 @@ class TestOpenshiftNamespaceLabels(TestCase):
         """Remove, add and modify labels all at once, step 1 (removals are in
         two steps)"""
         self.test_ns = [
-            NS(c1, "all-in-one", k1v1_k2v2, k1_k2, k2v3_k3v3),
+            NS(c1, "namespace", k1v1_k2v2, k1_k2, k2v3_k3v3),
         ]
         run_integration()
         self.state.add.assert_called_once_with(
-            state_key(c1, "all-in-one"), k1_k2_k3, force=True
+            state_key(c1, "namespace"), k1_k2_k3, force=True
         )
         oc = self.oc_clients[c1]
         labels = {"k1": None, "k2": "v3", "k3": "v3"}
         oc.label.assert_called_once_with(
-            None, "Namespace", "all-in-one", labels, overwrite=True
+            None, "Namespace", "namespace", labels, overwrite=True
         )
 
     def test_remove_add_modify_step2(self):
         """Remove, add and modify labels all at once, step 2 (removals are in
         two steps)"""
         self.test_ns = [
-            NS(c1, "all-in-one", k2v3_k3v3, k1_k2_k3, k2v3_k3v3),
+            NS(c1, "namespace", k2v3_k3v3, k1_k2_k3, k2v3_k3v3),
         ]
         run_integration()
         self.state.add.assert_called_once_with(
-            state_key(c1, "all-in-one"), k2_k3, force=True
+            state_key(c1, "namespace"), k2_k3, force=True
         )
         oc = self.oc_clients[c1]
         oc.label.assert_not_called()
@@ -266,7 +298,7 @@ class TestOpenshiftNamespaceLabels(TestCase):
     def test_namespace_not_exists(self):
         """namespace does not exist (yet)"""
         self.test_ns = [
-            NS(c1, "not-exists", None, None, k1v1, exists=False),
+            NS(c1, "namespace", None, None, k1v1, exists=False),
         ]
         run_integration()
         self.state.add.assert_not_called()
@@ -275,9 +307,9 @@ class TestOpenshiftNamespaceLabels(TestCase):
     def test_duplicate_namespace(self):
         """Namespace declared several times in a single cluster: ignored"""
         self.test_ns = [
-            NS(c1, "no-change", k1v1, k1, k1v1),
-            NS(c1, "no-change", k1v1, k1, k2v2),
-            NS(c1, "no-change", k1v1, k1, k1v2),
+            NS(c1, "namespace", k1v1, k1, k1v1),
+            NS(c1, "namespace", k1v1, k1, k2v2),
+            NS(c1, "namespace", k1v1, k1, k1v2),
         ]
         run_integration()
         self.state.add.assert_not_called()
@@ -287,14 +319,14 @@ class TestOpenshiftNamespaceLabels(TestCase):
     def test_multi_cluster(self):
         """Namespace declared in several clusters. All get updated"""
         self.test_ns = [
-            NS(c1, "multi-cluster", k1v1, k1, k1v1_k2v2),
-            NS(c2, "multi-cluster", k1v1, k1, k1v1_k2v2),
+            NS(c1, "namespace", k1v1, k1, k1v1_k2v2),
+            NS(c2, "namespace", k1v1, k1, k1v1_k2v2),
         ]
         run_integration()
         self.assertEqual(self.state.add.call_count, 2)
         calls = [
-            call(state_key(c1, "multi-cluster"), k1_k2, force=True),
-            call(state_key(c2, "multi-cluster"), k1_k2, force=True),
+            call(state_key(c1, "namespace"), k1_k2, force=True),
+            call(state_key(c2, "namespace"), k1_k2, force=True),
         ]
         self.state.add.assert_has_calls(calls)
 
@@ -302,13 +334,13 @@ class TestOpenshiftNamespaceLabels(TestCase):
         self.assertIn(c2, self.oc_clients)
         for oc in self.oc_clients.values():
             oc.label.assert_called_once_with(
-                None, "Namespace", "multi-cluster", k2v2, overwrite=True
+                None, "Namespace", "namespace", k2v2, overwrite=True
             )
 
     def test_dry_run(self):
         """Ensures nothing is done in dry_run mode"""
         self.test_ns = [
-            NS(c1, "many-changes", k1v1_k2v2, k1_k2, k2v3_k3v3),
+            NS(c1, "namespace", k1v1_k2v2, k1_k2, k2v3_k3v3),
         ]
         run_integration(dry_run=True)
         self.state.add.assert_not_called()

--- a/reconcile/typed_queries/namespaces.py
+++ b/reconcile/typed_queries/namespaces.py
@@ -1,0 +1,11 @@
+from reconcile.gql_definitions.common.namespaces import (
+    NamespaceV1,
+    query,
+)
+from reconcile.utils import gql
+
+
+def get_namespaces() -> list[NamespaceV1]:
+    gqlapi = gql.get_api()
+    data = query(gqlapi.query)
+    return list(data.namespaces or [])


### PR DESCRIPTION
Introducing new `OCMap` for `openshift-namespace-labels` integration.

Note, that the `reconcile` method has a complicated typing situation using `LabelsOrKeys`, which introduces a dict/list ambiguity. I do not dare to solve that in this PR as I do not know the full context behind it. So the integration is not fully typed now.