### PR TITLE
[change-owners] fix jsonpath sorting

### DIFF
--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -48,6 +48,7 @@ from reconcile.gql_definitions.change_owners.queries.change_types import (
     ChangeTypeImplicitOwnershipV1,
     ChangeTypeV1,
 )
+from reconcile.utils.jsonpath import sortable_jsonpath_string_repr
 
 
 class ChangeTypePriority(Enum):
@@ -103,7 +104,9 @@ class DiffCoverage:
         if uncovered_data and isinstance(uncovered_data, MutableMapping):
             # sort splits so that later indices are always removed before earlier ones
             sorted_splits = sorted(
-                self._split_into, key=lambda x: str(x.diff.path), reverse=True
+                self._split_into,
+                key=lambda x: sortable_jsonpath_string_repr(x.diff.path, 5),
+                reverse=True,
             )
             for s in sorted_splits:
                 if s.is_covered():

--- a/reconcile/test/test_utils_jsonpath.py
+++ b/reconcile/test/test_utils_jsonpath.py
@@ -1,3 +1,4 @@
+import pytest
 from jsonpath_ng import (
     Child,
     Fields,
@@ -15,6 +16,7 @@ from reconcile.utils.jsonpath import (
     apply_constraint_to_path,
     jsonpath_parts,
     narrow_jsonpath_node,
+    sortable_jsonpath_string_repr,
 )
 
 #
@@ -196,3 +198,21 @@ def test_apply_partially_incompatible_constraint_to_path():
 
 def test_apply_field_constraint_to_wildcard_path():
     assert apply_constraint_to_path(parse("a.*.c"), parse("a.b.c.d")) == parse("a.b.c")
+
+
+#
+# test sortable jsonpath representation
+#
+
+
+@pytest.mark.parametrize(
+    "jsonpath, sortable_jsonpath",
+    [
+        ("a.b[0].c", "a.b.[00000].c"),
+        ("a.b[10].c", "a.b.[00010].c"),
+        ("[10]", "[00010]"),
+        ("a.[10][*]", "a.[00010].*"),
+    ],
+)
+def test_sortable_jsonpath_string_repr(jsonpath: str, sortable_jsonpath: str):
+    assert sortable_jsonpath_string_repr(parse(jsonpath), 5) == sortable_jsonpath

--- a/reconcile/utils/jsonpath.py
+++ b/reconcile/utils/jsonpath.py
@@ -45,6 +45,29 @@ def narrow_jsonpath_node(
     return None
 
 
+def sortable_jsonpath_string_repr(
+    path: jsonpath_ng.JSONPath, index_padding: int = 5
+) -> str:
+    """
+    Return a string representation of the JSONPath that can be used for sorting.
+    The relevant thing is the reprsentation of an Index, which needs to be left
+    padded with zeros to ensure comparability of the string representation.
+
+    Please be aware that the resulting string representation is not necessarily
+    a valid JSONPath expression, even though it might look like one occasionally.
+    The only purpose of this function is to produce sortable strings.
+    """
+    sortable_parts = []
+    for p in jsonpath_parts(path, ignore_filter=True):
+        if isinstance(p, jsonpath_ng.Fields):
+            sortable_parts.append(p.fields[0])
+        elif isinstance(p, jsonpath_ng.Index):
+            sortable_parts.append(f"[{str(p.index).zfill(index_padding)}]")
+        elif isinstance(p, jsonpath_ng.Slice):
+            sortable_parts.append("*")
+    return ".".join(sortable_parts)
+
+
 def jsonpath_parts(
     path: jsonpath_ng.JSONPath, ignore_filter: Optional[bool] = False
 ) -> list[jsonpath_ng.JSONPath]:

--- a/reconcile/utils/jsonpath.py
+++ b/reconcile/utils/jsonpath.py
@@ -50,7 +50,7 @@ def sortable_jsonpath_string_repr(
 ) -> str:
     """
     Return a string representation of the JSONPath that can be used for sorting.
-    The relevant thing is the reprsentation of an Index, which needs to be left
+    The relevant aspect is the representation of an Index, which needs to be left
     padded with zeros to ensure comparability of the string representation.
 
     Please be aware that the resulting string representation is not necessarily


### PR DESCRIPTION
for certain operations, jsonpaths need to be sorted. the currently used naive approach simply compared the jsonpath strings, which starts to fail when double digit indices are involved.

e.g. `a.b.[10] comes before a.b.[9]` in a pure string comparison

this PR introduces a function that creates a sortable string representation of jsonpaths that takes care of those index numbers by padding with zeros.

https://issues.redhat.com/browse/APPSRE-7197