### PR TITLE
APPSRE-6609 fix OCMap connections

### DIFF
--- a/reconcile/test/fixtures/oc_connection_parameters/namespace_no_admin_token.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/namespace_no_admin_token.yml
@@ -9,18 +9,24 @@ cluster:
     format: null
     path: path/to/automation_token
     version: null
-  clusterAdminAutomationToken:
-    field: token
-    format: null
-    path: path/to/admin_token
-    version: null
+  clusterAdminAutomationToken: null
   disable: null
   insecureSkipTLSVerify: null
   internal: false
-  jumpHost: null
+  jumpHost:
+    hostname: jumphost
+    identity:
+      field: identity
+      format: base64
+      path: jumphost-secret
+      version: null
+    knownHosts: /path/to/file
+    port: null
+    remotePort: null
+    user: jumphost-user
   name: cluster-without-admin
   serverUrl: server-url
-clusterAdmin: null
+clusterAdmin: true
 delete: null
 externalResources: []
 labels: null

--- a/reconcile/test/fixtures/oc_connection_parameters/namespace_no_tokens.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/namespace_no_tokens.yml
@@ -4,23 +4,25 @@ app:
   - email: owner@owner
     name: owner
 cluster:
-  automationToken:
-    field: token
-    format: null
-    path: path/to/automation_token
-    version: null
-  clusterAdminAutomationToken:
-    field: token
-    format: null
-    path: path/to/admin_token
-    version: null
+  automationToken: null
+  clusterAdminAutomationToken: null
   disable: null
   insecureSkipTLSVerify: null
   internal: false
-  jumpHost: null
+  jumpHost:
+    hostname: jumphost
+    identity:
+      field: identity
+      format: base64
+      path: jumphost-secret
+      version: null
+    knownHosts: /path/to/file
+    port: null
+    remotePort: null
+    user: jumphost-user
   name: cluster-without-admin
   serverUrl: server-url
-clusterAdmin: null
+clusterAdmin: false
 delete: null
 externalResources: []
 labels: null

--- a/reconcile/test/fixtures/oc_connection_parameters/namespace_with_admin.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/namespace_with_admin.yml
@@ -28,41 +28,13 @@ cluster:
     port: null
     remotePort: null
     user: jumphost-user
-  name: test-cluster
+  name: cluster-with-admin
   serverUrl: server-url
 clusterAdmin: true
 delete: null
 externalResources: []
 labels: null
-limitRanges:
-  limits:
-  - default:
-      cpu: '1'
-      memory: 512Mi
-    defaultRequest:
-      cpu: 100m
-      memory: 256Mi
-    max:
-      cpu: '3'
-      memory: 8Gi
-    maxLimitRequestRatio:
-      cpu: '20'
-      memory: '4'
-    min:
-      cpu: 10m
-      memory: 20Mi
-    type: Container
-  - default: null
-    defaultRequest: null
-    max:
-      cpu: '3'
-      memory: 8Gi
-    maxLimitRequestRatio: null
-    min:
-      cpu: 10m
-      memory: 20Mi
-    type: Pod
-  name: resource-limits
+limitRanges: null
 managedExternalResources: true
 managedResourceNames: null
 managedRoles: true

--- a/reconcile/test/oc/test_oc_connection_parameters.py
+++ b/reconcile/test/oc/test_oc_connection_parameters.py
@@ -280,7 +280,7 @@ def test_from_namespaces(
     is_cluster_admin: bool,
     expected_parameters: list[ExpectedConnection],
 ):
-    namespaces = [
+    parsed_namespaces = [
         load_namespace_for_connection_parameters(f"{ns}.yml") for ns in namespaces
     ]
     secret_reader = create_autospec(SecretReaderBase)
@@ -291,7 +291,7 @@ def test_from_namespaces(
 
     parameters = get_oc_connection_parameters_from_namespaces(
         secret_reader=secret_reader,
-        namespaces=namespaces,
+        namespaces=parsed_namespaces,
         cluster_admin=is_cluster_admin,
         use_jump_host=False,
         thread_pool_size=1,

--- a/reconcile/test/oc/test_oc_connection_parameters.py
+++ b/reconcile/test/oc/test_oc_connection_parameters.py
@@ -1,3 +1,6 @@
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Optional
 from unittest.mock import create_autospec
 
 import pytest
@@ -6,7 +9,10 @@ from reconcile.test.oc.fixtures import (
     load_cluster_for_connection_parameters,
     load_namespace_for_connection_parameters,
 )
-from reconcile.utils.oc_connection_parameters import OCConnectionParameters
+from reconcile.utils.oc_connection_parameters import (
+    OCConnectionParameters,
+    get_oc_connection_parameters_from_namespaces,
+)
 from reconcile.utils.secret_reader import SecretReaderBase
 
 
@@ -31,7 +37,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
                 jumphost_user=None,
                 jumphost_remote_port=None,
                 jumphost_local_port=None,
-                is_cluster_admin=None,
+                is_cluster_admin=False,
                 is_internal=False,
                 skip_tls_verify=None,
             ),
@@ -54,7 +60,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
                 jumphost_user=None,
                 jumphost_remote_port=None,
                 jumphost_local_port=None,
-                is_cluster_admin=None,
+                is_cluster_admin=False,
                 is_internal=False,
                 skip_tls_verify=None,
             ),
@@ -77,7 +83,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
                 jumphost_user="jumphost-user",
                 jumphost_remote_port=8888,
                 jumphost_local_port=None,
-                is_cluster_admin=None,
+                is_cluster_admin=False,
                 is_internal=True,
                 skip_tls_verify=None,
             ),
@@ -100,7 +106,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
                 jumphost_user=None,
                 jumphost_remote_port=None,
                 jumphost_local_port=None,
-                is_cluster_admin=None,
+                is_cluster_admin=False,
                 is_internal=True,
                 skip_tls_verify=None,
             ),
@@ -116,119 +122,184 @@ def test_from_cluster(
     parameters = OCConnectionParameters.from_cluster(
         secret_reader=secret_reader,
         cluster=test_cluster,
+        cluster_admin=False,
         use_jump_host=use_jump_host,
     )
 
     assert parameters == expected_parameters
+
+
+@dataclass
+class ExpectedConnection:
+    cluster_name: str
+    automation_token: Optional[str]
+    cluster_admin_automation_token: Optional[str]
+    is_cluster_admin: bool
+
+    def to_parameters(self) -> OCConnectionParameters:
+        return OCConnectionParameters(
+            cluster_name=self.cluster_name,
+            server_url="server-url",
+            automation_token=self.automation_token,
+            cluster_admin_automation_token=self.cluster_admin_automation_token,
+            disabled_e2e_tests=[],
+            disabled_integrations=[],
+            jumphost_port=None,
+            jumphost_hostname=None,
+            jumphost_key=None,
+            jumphost_known_hosts=None,
+            jumphost_user=None,
+            jumphost_remote_port=None,
+            jumphost_local_port=None,
+            is_cluster_admin=self.is_cluster_admin,
+            is_internal=False,
+            skip_tls_verify=None,
+        )
 
 
 @pytest.mark.parametrize(
-    "namespace, use_jump_host, expected_parameters",
+    "namespaces, is_cluster_admin, expected_parameters",
     [
-        # No jumphost settings and --no-jump-host flag
         (
-            "namespace_no_admin",
+            # No duplicated namespaces
+            ["namespace_with_admin", "namespace_no_admin"],
             False,
-            OCConnectionParameters(
-                cluster_name="test-cluster",
-                server_url="server-url",
-                automation_token="secret1",
-                cluster_admin_automation_token=None,
-                disabled_e2e_tests=[],
-                disabled_integrations=[],
-                jumphost_port=None,
-                jumphost_hostname=None,
-                jumphost_key=None,
-                jumphost_known_hosts=None,
-                jumphost_user=None,
-                jumphost_remote_port=None,
-                jumphost_local_port=None,
-                is_cluster_admin=None,
-                is_internal=False,
-                skip_tls_verify=None,
-            ),
+            [
+                ExpectedConnection(
+                    cluster_name="cluster-with-admin",
+                    automation_token=None,
+                    cluster_admin_automation_token="secret",
+                    is_cluster_admin=True,
+                ),
+                ExpectedConnection(
+                    cluster_name="cluster-without-admin",
+                    automation_token="secret",
+                    cluster_admin_automation_token=None,
+                    is_cluster_admin=False,
+                ),
+                ExpectedConnection(
+                    cluster_name="cluster-with-admin",
+                    automation_token="secret",
+                    cluster_admin_automation_token=None,
+                    is_cluster_admin=False,
+                ),
+            ],
         ),
-        # No jumphost settings and --use-jump-host flag
         (
-            "namespace_no_admin",
-            True,
-            OCConnectionParameters(
-                cluster_name="test-cluster",
-                server_url="server-url",
-                automation_token="secret1",
-                cluster_admin_automation_token=None,
-                disabled_e2e_tests=[],
-                disabled_integrations=[],
-                jumphost_port=None,
-                jumphost_hostname=None,
-                jumphost_key=None,
-                jumphost_known_hosts=None,
-                jumphost_user=None,
-                jumphost_remote_port=None,
-                jumphost_local_port=None,
-                is_cluster_admin=None,
-                is_internal=False,
-                skip_tls_verify=None,
-            ),
-        ),
-        # Jumphost settings and --use-jump-host flag
-        (
-            "namespace_with_admin",
-            True,
-            OCConnectionParameters(
-                cluster_name="test-cluster",
-                server_url="server-url",
-                automation_token="secret1",
-                cluster_admin_automation_token="secret3",
-                disabled_e2e_tests=[],
-                disabled_integrations=[],
-                jumphost_port=None,
-                jumphost_hostname="jumphost",
-                jumphost_key="secret2",
-                jumphost_known_hosts="/path/to/file",
-                jumphost_user="jumphost-user",
-                jumphost_remote_port=None,
-                jumphost_local_port=None,
-                is_cluster_admin=True,
-                is_internal=False,
-                skip_tls_verify=None,
-            ),
-        ),
-        # Jumphost settings and --no-jump-host flag
-        (
-            "namespace_with_admin",
+            # Duplicated namespace
+            ["namespace_with_admin", "namespace_with_admin", "namespace_no_admin"],
             False,
-            OCConnectionParameters(
-                cluster_name="test-cluster",
-                server_url="server-url",
-                automation_token="secret1",
-                cluster_admin_automation_token="secret2",
-                disabled_e2e_tests=[],
-                disabled_integrations=[],
-                jumphost_port=None,
-                jumphost_hostname=None,
-                jumphost_key=None,
-                jumphost_known_hosts=None,
-                jumphost_user=None,
-                jumphost_remote_port=None,
-                jumphost_local_port=None,
-                is_cluster_admin=True,
-                is_internal=False,
-                skip_tls_verify=None,
-            ),
+            [
+                ExpectedConnection(
+                    cluster_name="cluster-with-admin",
+                    automation_token=None,
+                    cluster_admin_automation_token="secret",
+                    is_cluster_admin=True,
+                ),
+                ExpectedConnection(
+                    cluster_name="cluster-with-admin",
+                    automation_token="secret",
+                    cluster_admin_automation_token=None,
+                    is_cluster_admin=False,
+                ),
+                ExpectedConnection(
+                    cluster_name="cluster-without-admin",
+                    automation_token="secret",
+                    cluster_admin_automation_token=None,
+                    is_cluster_admin=False,
+                ),
+            ],
+        ),
+        (
+            # Enforce admin
+            ["namespace_with_admin", "namespace_no_admin"],
+            True,
+            [
+                ExpectedConnection(
+                    cluster_name="cluster-with-admin",
+                    automation_token=None,
+                    cluster_admin_automation_token="secret",
+                    is_cluster_admin=True,
+                ),
+                ExpectedConnection(
+                    cluster_name="cluster-without-admin",
+                    automation_token=None,
+                    cluster_admin_automation_token="secret",
+                    is_cluster_admin=True,
+                ),
+                ExpectedConnection(
+                    cluster_name="cluster-with-admin",
+                    automation_token="secret",
+                    cluster_admin_automation_token=None,
+                    is_cluster_admin=False,
+                ),
+                ExpectedConnection(
+                    cluster_name="cluster-without-admin",
+                    automation_token="secret",
+                    cluster_admin_automation_token=None,
+                    is_cluster_admin=False,
+                ),
+            ],
+        ),
+        (
+            # Enforce admin on namespace w/o token
+            ["namespace_no_admin_token"],
+            True,
+            [
+                ExpectedConnection(
+                    cluster_name="cluster-without-admin",
+                    automation_token="secret",
+                    cluster_admin_automation_token=None,
+                    is_cluster_admin=False,
+                ),
+                ExpectedConnection(
+                    cluster_name="cluster-without-admin",
+                    automation_token=None,
+                    cluster_admin_automation_token=None,
+                    is_cluster_admin=True,
+                ),
+            ],
+        ),
+        (
+            # Missing automation token
+            ["namespace_no_tokens"],
+            False,
+            [
+                ExpectedConnection(
+                    cluster_name="cluster-without-admin",
+                    automation_token=None,
+                    cluster_admin_automation_token=None,
+                    is_cluster_admin=False,
+                ),
+            ],
         ),
     ],
 )
-def test_from_namespace(
-    namespace: str, expected_parameters: OCConnectionParameters, use_jump_host: bool
+def test_from_namespaces(
+    namespaces: list[str],
+    is_cluster_admin: bool,
+    expected_parameters: list[ExpectedConnection],
 ):
-    test_namespace = load_namespace_for_connection_parameters(f"{namespace}.yml")
+    namespaces = [
+        load_namespace_for_connection_parameters(f"{ns}.yml") for ns in namespaces
+    ]
     secret_reader = create_autospec(SecretReaderBase)
-    secret_reader.read_secret.side_effect = ["secret1", "secret2", "secret3"]
-    parameters = OCConnectionParameters.from_namespace(
+    secret_reader.read_secret.side_effect = ["secret"] * 100
+
+    def _sort(items: Iterable[OCConnectionParameters]) -> list[OCConnectionParameters]:
+        return sorted(items, key=lambda x: (x.cluster_name, str(x.automation_token)))
+
+    parameters = get_oc_connection_parameters_from_namespaces(
         secret_reader=secret_reader,
-        namespace=test_namespace,
-        use_jump_host=use_jump_host,
+        namespaces=namespaces,
+        cluster_admin=is_cluster_admin,
+        use_jump_host=False,
+        thread_pool_size=1,
     )
 
-    assert parameters == expected_parameters
+    expected = [param.to_parameters() for param in expected_parameters]
+
+    # This line is nice for debugging output
+    sorted_parameters, sorted_expected = _sort(parameters), _sort(expected)
+
+    assert sorted_parameters == sorted_expected

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import (
     Optional,
     Protocol,
+    Union,
 )
 
 from sretoolbox.utils import threaded
@@ -77,7 +78,7 @@ class OCConnectionParameters:
     cluster_name: str
     server_url: str
     is_internal: Optional[bool]
-    is_cluster_admin: Optional[bool]
+    is_cluster_admin: bool
     skip_tls_verify: Optional[bool]
     automation_token: Optional[str]
     cluster_admin_automation_token: Optional[str]
@@ -96,17 +97,40 @@ class OCConnectionParameters:
     def from_cluster(
         cluster: Cluster,
         secret_reader: SecretReaderBase,
+        cluster_admin: bool,
         use_jump_host: bool = True,
     ) -> OCConnectionParameters:
         automation_token: Optional[str] = None
-        if cluster.automation_token:
-            try:
-                automation_token = secret_reader.read_secret(cluster.automation_token)
-            except SecretNotFound as e:
+        cluster_admin_automation_token: Optional[str] = None
+
+        # Note, that currently OCMap uses OCLogMsg if a token is missing, i.e.,
+        # for now we must not fail hard.
+        if cluster_admin:
+            if cluster.cluster_admin_automation_token:
+                try:
+                    cluster_admin_automation_token = secret_reader.read_secret(
+                        cluster.cluster_admin_automation_token
+                    )
+                except SecretNotFound as e:
+                    logging.error(
+                        f"[{cluster.name}] secret {cluster.automation_token} not found"
+                    )
+            else:
                 logging.error(
-                    f"[{cluster.name}] secret {cluster.automation_token} not found"
+                    f"No admin automation token set for cluster '{cluster.name}', but privileged access requested."
                 )
-                raise e
+        else:
+            if cluster.automation_token:
+                try:
+                    automation_token = secret_reader.read_secret(
+                        cluster.automation_token
+                    )
+                except SecretNotFound as e:
+                    logging.error(
+                        f"[{cluster.name}] secret {cluster.automation_token} not found"
+                    )
+            else:
+                logging.error(f"No automation token for cluster '{cluster.name}'.")
 
         disabled_integrations = []
         disabled_e2e_tests = []
@@ -151,60 +175,16 @@ class OCConnectionParameters:
             jumphost_port=jumphost_port,
             jumphost_remote_port=jumphost_remote_port,
             jumphost_local_port=jumphost_local_port,
-            # is_cluster_admin only possible for namespace queries
-            is_cluster_admin=None,
-            cluster_admin_automation_token=None,
-        )
-
-    @staticmethod
-    def from_namespace(
-        namespace: Namespace,
-        secret_reader: SecretReaderBase,
-        use_jump_host: bool = True,
-    ) -> OCConnectionParameters:
-        """
-        This does the same as from_cluster(), but additionally checks
-        for cluster_admin credentials.
-        """
-        cluster = namespace.cluster
-        parameter = OCConnectionParameters.from_cluster(
-            cluster=cluster,
-            secret_reader=secret_reader,
-            use_jump_host=use_jump_host,
-        )
-        if namespace.cluster_admin is None:
-            return parameter
-
-        cluster_admin_automation_token = None
-        if cluster.cluster_admin_automation_token and namespace.cluster_admin:
-            try:
-                cluster_admin_automation_token = secret_reader.read_secret(
-                    cluster.cluster_admin_automation_token
-                )
-            except SecretNotFound as e:
-                logging.error(
-                    f"[{cluster.name}] secret {cluster.automation_token} not found"
-                )
-                raise e
-
-        return OCConnectionParameters(
-            cluster_name=parameter.cluster_name,
-            server_url=parameter.server_url,
-            is_internal=parameter.is_internal,
-            skip_tls_verify=parameter.skip_tls_verify,
-            disabled_e2e_tests=parameter.disabled_e2e_tests,
-            disabled_integrations=parameter.disabled_integrations,
-            automation_token=parameter.automation_token,
-            is_cluster_admin=namespace.cluster_admin,
-            jumphost_hostname=parameter.jumphost_hostname,
-            jumphost_key=parameter.jumphost_key,
-            jumphost_known_hosts=parameter.jumphost_known_hosts,
-            jumphost_user=parameter.jumphost_user,
-            jumphost_port=parameter.jumphost_port,
-            jumphost_local_port=parameter.jumphost_local_port,
-            jumphost_remote_port=parameter.jumphost_remote_port,
             cluster_admin_automation_token=cluster_admin_automation_token,
+            is_cluster_admin=cluster_admin,
         )
+
+
+def _filter_unique_clusters_from_namespace(
+    namespaces: Iterable[Namespace],
+) -> list[Cluster]:
+    unique_by_cluster_name = {ns.cluster.name: ns.cluster for ns in namespaces}
+    return list(unique_by_cluster_name.values())
 
 
 def get_oc_connection_parameters_from_clusters(
@@ -218,12 +198,14 @@ def get_oc_connection_parameters_from_clusters(
     Also fetch required ClusterParameter secrets from vault with multiple threads.
     ClusterParameter objects are used to initialize an OCMap.
     """
+    unique_clusers = list({c.name: c for c in clusters}.values())
     parameters: list[OCConnectionParameters] = threaded.run(
         OCConnectionParameters.from_cluster,
-        clusters,
+        unique_clusers,
         thread_pool_size,
         secret_reader=secret_reader,
         use_jump_host=use_jump_host,
+        cluster_admin=False,
     )
     return parameters
 
@@ -233,17 +215,47 @@ def get_oc_connection_parameters_from_namespaces(
     namespaces: Iterable[Namespace],
     thread_pool_size: int = 1,
     use_jump_host: bool = True,
+    cluster_admin: bool = False,
 ) -> list[OCConnectionParameters]:
     """
     Convert nested generated namespace classes from queries into flat ClusterParameter objects.
     Also fetch required ClusterParameter secrets from vault with multiple threads.
     ClusterParameter objects are used to initialize an OCMap.
     """
-    parameters: list[OCConnectionParameters] = threaded.run(
-        OCConnectionParameters.from_namespace,
-        namespaces,
+
+    # init a namespace with clusterAdmin with both auth tokens
+    # OC_Map is used in various places and even when a namespace
+    # declares clusterAdmin token usage, many of those places are
+    # happy with regular dedicated-admin and will request a cluster
+    # with oc_map.get(cluster) without specifying privileged access
+    # specifically
+    all_unique_clusters = _filter_unique_clusters_from_namespace(namespaces=namespaces)
+    unique_privileged_clusters = _filter_unique_clusters_from_namespace(
+        namespaces=(ns for ns in namespaces if (ns.cluster_admin or cluster_admin))
+    )
+
+    unprivileged_connections: list[
+        Union[OCConnectionParameters, Exception]
+    ] = threaded.run(
+        OCConnectionParameters.from_cluster,
+        all_unique_clusters,
         thread_pool_size,
         secret_reader=secret_reader,
         use_jump_host=use_jump_host,
+        cluster_admin=False,
+        return_exceptions=True,
     )
-    return parameters
+
+    privileged_connections: list[
+        Union[OCConnectionParameters, Exception]
+    ] = threaded.run(
+        OCConnectionParameters.from_cluster,
+        unique_privileged_clusters,
+        thread_pool_size,
+        secret_reader=secret_reader,
+        use_jump_host=use_jump_host,
+        cluster_admin=True,
+        return_exceptions=True,
+    )
+
+    return unprivileged_connections + privileged_connections

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -103,8 +103,6 @@ class OCConnectionParameters:
         automation_token: Optional[str] = None
         cluster_admin_automation_token: Optional[str] = None
 
-        # Note, that currently OCMap uses OCLogMsg if a token is missing, i.e.,
-        # for now we must not fail hard.
         if cluster_admin:
             if cluster.cluster_admin_automation_token:
                 try:
@@ -116,7 +114,9 @@ class OCConnectionParameters:
                         f"[{cluster.name}] secret {cluster.automation_token} not found"
                     )
             else:
-                logging.error(
+                # Note, that currently OCMap uses OCLogMsg if a token is missing, i.e.,
+                # for now this is valid behavior.
+                logging.debug(
                     f"No admin automation token set for cluster '{cluster.name}', but privileged access requested."
                 )
         else:
@@ -130,7 +130,9 @@ class OCConnectionParameters:
                         f"[{cluster.name}] secret {cluster.automation_token} not found"
                     )
             else:
-                logging.error(f"No automation token for cluster '{cluster.name}'.")
+                # Note, that currently OCMap uses OCLogMsg if a token is missing, i.e.,
+                # for now this is valid behavior.
+                logging.debug(f"No automation token for cluster '{cluster.name}'.")
 
         disabled_integrations = []
         disabled_e2e_tests = []

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -6,7 +6,6 @@ from dataclasses import dataclass
 from typing import (
     Optional,
     Protocol,
-    Union,
 )
 
 from sretoolbox.utils import threaded
@@ -236,9 +235,7 @@ def get_oc_connection_parameters_from_namespaces(
         namespaces=(ns for ns in namespaces if (ns.cluster_admin or cluster_admin))
     )
 
-    unprivileged_connections: list[
-        Union[OCConnectionParameters, Exception]
-    ] = threaded.run(
+    unprivileged_connections: list[OCConnectionParameters] = threaded.run(
         OCConnectionParameters.from_cluster,
         all_unique_clusters,
         thread_pool_size,
@@ -248,9 +245,7 @@ def get_oc_connection_parameters_from_namespaces(
         return_exceptions=True,
     )
 
-    privileged_connections: list[
-        Union[OCConnectionParameters, Exception]
-    ] = threaded.run(
+    privileged_connections: list[OCConnectionParameters] = threaded.run(
         OCConnectionParameters.from_cluster,
         unique_privileged_clusters,
         thread_pool_size,

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -110,7 +110,7 @@ class OCConnectionParameters:
                     )
                 except SecretNotFound:
                     logging.error(
-                        f"[{cluster.name}] secret {cluster.automation_token} not found"
+                        f"[{cluster.name}] admin token {cluster.cluster_admin_automation_token} not found"
                     )
             else:
                 # Note, that currently OCMap uses OCLogMsg if a token is missing, i.e.,
@@ -126,7 +126,7 @@ class OCConnectionParameters:
                     )
                 except SecretNotFound:
                     logging.error(
-                        f"[{cluster.name}] secret {cluster.automation_token} not found"
+                        f"[{cluster.name}] automation token {cluster.automation_token} not found"
                     )
             else:
                 # Note, that currently OCMap uses OCLogMsg if a token is missing, i.e.,

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -108,7 +108,7 @@ class OCConnectionParameters:
                     cluster_admin_automation_token = secret_reader.read_secret(
                         cluster.cluster_admin_automation_token
                     )
-                except SecretNotFound as e:
+                except SecretNotFound:
                     logging.error(
                         f"[{cluster.name}] secret {cluster.automation_token} not found"
                     )
@@ -124,7 +124,7 @@ class OCConnectionParameters:
                     automation_token = secret_reader.read_secret(
                         cluster.automation_token
                     )
-                except SecretNotFound as e:
+                except SecretNotFound:
                     logging.error(
                         f"[{cluster.name}] secret {cluster.automation_token} not found"
                     )

--- a/reconcile/utils/oc_map.py
+++ b/reconcile/utils/oc_map.py
@@ -67,7 +67,9 @@ class OCMap:
         # happy with regular dedicated-admin and will request a cluster
         # with oc_map.get(cluster) without specifying privileged access
         # specifically
-        def filter_unique_connection_parameters(connection_parameters: Iterable[OCConnectionParameters]) -> list[OCConnectionParameters]:
+        def filter_unique_connection_parameters(
+            connection_parameters: Iterable[OCConnectionParameters],
+        ) -> list[OCConnectionParameters]:
             unique_by_cluster_name = {c.cluster_name: c for c in connection_parameters}
             return list(unique_by_cluster_name.values())
 

--- a/reconcile/utils/oc_map.py
+++ b/reconcile/utils/oc_map.py
@@ -67,24 +67,22 @@ class OCMap:
         # happy with regular dedicated-admin and will request a cluster
         # with oc_map.get(cluster) without specifying privileged access
         # specifically
-        privileged_clusters: list[OCConnectionParameters] = [
-            c for c in connection_parameters if (c.is_cluster_admin or cluster_admin)
-        ]
-        unprivileged_clusters: list[OCConnectionParameters] = [
-            c
+        all_clusters = {c.cluster_name: c for c in connection_parameters}
+        privileged_clusters = {
+            c.cluster_name: c
             for c in connection_parameters
-            if not (c.is_cluster_admin or cluster_admin)
-        ]
+            if (c.is_cluster_admin or cluster_admin)
+        }
 
         threaded.run(
             self._init_oc_client,
-            unprivileged_clusters,
+            list(all_clusters.values()),
             self._thread_pool_size,
             privileged=False,
         )
         threaded.run(
             self._init_oc_client,
-            privileged_clusters,
+            list(privileged_clusters.values()),
             self._thread_pool_size,
             privileged=True,
         )

--- a/reconcile/utils/oc_map.py
+++ b/reconcile/utils/oc_map.py
@@ -67,8 +67,10 @@ class OCMap:
         # happy with regular dedicated-admin and will request a cluster
         # with oc_map.get(cluster) without specifying privileged access
         # specifically
-        all_clusters = {c.cluster_name: c for c in connection_parameters}
-        privileged_clusters = {
+        all_unique_clusters = {c.cluster_name: c for c in connection_parameters}
+
+        # Note, that we must iterate over all given parameters in order to catch is_cluster_admin
+        unique_privileged_clusters = {
             c.cluster_name: c
             for c in connection_parameters
             if (c.is_cluster_admin or cluster_admin)
@@ -76,13 +78,13 @@ class OCMap:
 
         threaded.run(
             self._init_oc_client,
-            list(all_clusters.values()),
+            list(all_unique_clusters.values()),
             self._thread_pool_size,
             privileged=False,
         )
         threaded.run(
             self._init_oc_client,
-            list(privileged_clusters.values()),
+            list(unique_privileged_clusters.values()),
             self._thread_pool_size,
             privileged=True,
         )

--- a/reconcile/utils/oc_map.py
+++ b/reconcile/utils/oc_map.py
@@ -67,24 +67,24 @@ class OCMap:
         # happy with regular dedicated-admin and will request a cluster
         # with oc_map.get(cluster) without specifying privileged access
         # specifically
-        all_unique_clusters = {c.cluster_name: c for c in connection_parameters}
+        def filter_unique_connection_parameters(connection_parameters: Iterable[OCConnectionParameters]) -> list[OCConnectionParameters]:
+            unique_by_cluster_name = {c.cluster_name: c for c in connection_parameters}
+            return list(unique_by_cluster_name.values())
 
-        # Note, that we must iterate over all given parameters in order to catch is_cluster_admin
-        unique_privileged_clusters = {
-            c.cluster_name: c
-            for c in connection_parameters
-            if (c.is_cluster_admin or cluster_admin)
-        }
+        all_unique_clusters = filter_unique_connection_parameters(connection_parameters)
+        unique_privileged_clusters = filter_unique_connection_parameters(
+            (c for c in connection_parameters if (c.is_cluster_admin or cluster_admin))
+        )
 
         threaded.run(
             self._init_oc_client,
-            list(all_unique_clusters.values()),
+            all_unique_clusters,
             self._thread_pool_size,
             privileged=False,
         )
         threaded.run(
             self._init_oc_client,
-            list(unique_privileged_clusters.values()),
+            unique_privileged_clusters,
             self._thread_pool_size,
             privileged=True,
         )


### PR DESCRIPTION
The current `OCMap` has a crucial bug: it does not create an unprivileged client if there is a privileged client available. This does not comply with how the original `OC_Map` behaves and leads to issues with namespace initialized `OCMap`s.

This overall aligns `OCMap` closer to the behavior of the old `OC_Map`.

This PR:

- fixes the bug: OCMap must hold a non-privileged client for **EVERY** cluster, also the ones that have a privileged connection established.
- reduces the number of vault requests on namespace queries by grouping clusters from namespaces.
- shifts all logic about how to group OC connections away from `OCMap`. `OCMap` is only concerned about creating and holding clients based on the given connection parameters.

**Test**

- ran `skupper-network` locally
- ran `openshift-groups` locally
- added unit tests which cover the above bugs