### PR TITLE
[integration-runtime] detect new shard when moving config from shard to shard

### DIFF
--- a/reconcile/utils/runtime/desired_state_diff.py
+++ b/reconcile/utils/runtime/desired_state_diff.py
@@ -75,7 +75,7 @@ def find_changed_shards(
                             for shard in shard_path.find(previous_desired_state)
                         }
                     )
-                if d.diff_type in {d.diff_type.ADDED}:
+                if d.diff_type in {DiffType.CHANGED, d.diff_type.ADDED}:
                     affected_shards.update(
                         {
                             shard.value


### PR DESCRIPTION
when a configuration items is moved from one shard to another one, the integration runtime only detects the old shard as the affected one, instead of detecting both.

https://issues.redhat.com/browse/APPSRE-7204