### PR TITLE
[openshift-upgrade-watcher] ignore hypershift clusters

### DIFF
--- a/reconcile/openshift_upgrade_watcher.py
+++ b/reconcile/openshift_upgrade_watcher.py
@@ -128,7 +128,9 @@ def run(
         secret_reader=secret_reader,
     )
 
-    clusters = [c for c in get_clusters() if c.ocm and not c.spec.hypershift]
+    clusters = [
+        c for c in get_clusters() if c.ocm and not (c.spec and c.spec.hypershift)
+    ]
 
     slack: Optional[SlackApi] = None
     if not dry_run:

--- a/reconcile/openshift_upgrade_watcher.py
+++ b/reconcile/openshift_upgrade_watcher.py
@@ -128,7 +128,7 @@ def run(
         secret_reader=secret_reader,
     )
 
-    clusters = [c for c in get_clusters() if c.ocm]
+    clusters = [c for c in get_clusters() if c.ocm and not c.spec.hypershift]
 
     slack: Optional[SlackApi] = None
     if not dry_run:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-7182

UpgradeConfig is not found.