### PR TITLE
Bugfix for gitlab for compliance

### DIFF
--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -223,6 +223,15 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             for m in self.get_items(group.members.list)
         ]
 
+    def get_group_member_object(self, group_name, member_id):
+        if not self.check_group_exists(group_name):
+            logging.error(group_name + " group not found")
+            return []
+        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
+        group = self.gl.groups.get(group_name)
+        members = [m for m in self.get_items(group.members.list) if m.id == member_id]
+        return members[0] if members else None
+
     def add_project_member(self, repo_url, user, access="maintainer"):
         project = self.get_project(repo_url)
         if project is None:
@@ -301,6 +310,16 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         group = self.gl.groups.get(group_name)
         return group.id, [p.name for p in self.get_items(group.projects.list)]
+
+    def get_group_id(self, group_name):
+        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
+        group = self.gl.groups.get(group_name)
+        return group.id
+
+    def is_group_in_project(self, group_id, project_id):
+        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
+        projects = self.gl.groups.get(group_id).projects.list(all=True)
+        return project_id in [p.id for p in projects]
 
     def create_project(self, group_id, project):
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()


### PR DESCRIPTION
This fixes a bug in gitlab fork compliance that will falsely report devtools-bot missing in cases where the user was not added to the repository directly but got permission by adding the group instead. A prominent case for this is when devtools bot itself is creating MRs directly on the repository in question, this is common for automated MRs.

Discovered while working on: [APPSRE-6369](https://issues.redhat.com/browse/APPSRE-6369)