### PR TITLE
Bugfix for gitlab for compliance

### DIFF
--- a/reconcile/gitlab_fork_compliance.py
+++ b/reconcile/gitlab_fork_compliance.py
@@ -2,7 +2,6 @@ import logging
 import sys
 
 from gitlab import MAINTAINER_ACCESS
-from gitlab.exceptions import GitlabGetError
 
 from reconcile import queries
 from reconcile.utils.gitlab_api import GitLabApi

--- a/reconcile/gitlab_fork_compliance.py
+++ b/reconcile/gitlab_fork_compliance.py
@@ -84,20 +84,12 @@ class GitlabForkCompliance:
         return self.OK
 
     def check_bot_access(self):
-        # The bot needs access to the fork project
-        try:
-            self.src = GitLabApi(
-                self.instance,
-                project_id=self.mr.source_project_id,
-                settings=self.settings,
-            )
-            project_bot = self.src.project.members.get(self.gl_cli.user.id)
-        except GitlabGetError:
-            self.handle_error("access denied for user {bot}", MSG_ACCESS)
-            return self.ERR_NOT_A_MEMBER
-
-        # The bot has to be a maintainer of the fork project
-        if not project_bot or project_bot.access_level != MAINTAINER_ACCESS:
+        self.src = GitLabApi(
+            self.instance,
+            project_id=self.mr.source_project_id,
+            settings=self.settings,
+        )
+        if self.gl_cli.user.username not in self.src.get_project_maintainers():
             self.handle_error(
                 "{bot} is not a maintainer in the fork project", MSG_ACCESS
             )

--- a/reconcile/gitlab_fork_compliance.py
+++ b/reconcile/gitlab_fork_compliance.py
@@ -1,7 +1,10 @@
 import logging
 import sys
 
-from gitlab import MAINTAINER_ACCESS, GitlabGetError
+from gitlab import (
+    MAINTAINER_ACCESS,
+    GitlabGetError,
+)
 
 from reconcile import queries
 from reconcile.utils.gitlab_api import GitLabApi


### PR DESCRIPTION
This fixes a bug in gitlab fork compliance that will falsely report devtools-bot missing in cases where the user was not added to the repository directly but got permission by adding the grup instead. Prominent case for this is when devtools bot itself is creating MRs directly on the repository in question, this is common for automated MRs.

Required for: https://issues.redhat.com/browse/APPSRE-6369