### PR TITLE
Jira + Gitlab Client Improvements for change-control-automation

### DIFF
--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -329,7 +329,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
 
     def get_merge_requests(self, state):
         return self.get_items(self.project.mergerequests.list, state=state)
-    
+
     def get_merge_request_first_commit_hash(self, mr_id: int) -> str:
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         merge_request = self.project.mergerequests.get(mr_id)

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -329,6 +329,13 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
 
     def get_merge_requests(self, state):
         return self.get_items(self.project.mergerequests.list, state=state)
+    
+    def get_merge_request_first_commit_hash(self, mr_id: int) -> str:
+        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
+        merge_request = self.project.mergerequests.get(mr_id)
+        commits = mr.commits()
+        first = commits.next()
+        return first_commit_hash.id
 
     def get_merge_request_label_events(self, mr: ProjectMergeRequest):
         return self.get_items(mr.resourcelabelevents.list)

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -330,7 +330,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
     def get_merge_requests(self, state):
         return self.get_items(self.project.mergerequests.list, state=state)
 
-    def get_merge_request_first_commit_hash(self, mr_id: int) -> str:
+    def get_merge_request_first_commit_hash(self, mr_id: int) -> Optional[str]:
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         merge_request = self.project.mergerequests.get(mr_id)
         commits = merge_request.commits()

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -335,7 +335,8 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         merge_request = self.project.mergerequests.get(mr_id)
         commits = merge_request.commits()
         first = commits.next()
-        return first.id
+        first_commit_sha = None if not first.id else first.id
+        return first_commit_sha
 
     def get_merge_request_label_events(self, mr: ProjectMergeRequest):
         return self.get_items(mr.resourcelabelevents.list)

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -333,9 +333,9 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
     def get_merge_request_first_commit_hash(self, mr_id: int) -> str:
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         merge_request = self.project.mergerequests.get(mr_id)
-        commits = mr.commits()
+        commits = merge_request.commits()
         first = commits.next()
-        return first_commit_hash.id
+        return first.id
 
     def get_merge_request_label_events(self, mr: ProjectMergeRequest):
         return self.get_items(mr.resourcelabelevents.list)

--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -39,12 +39,16 @@ class JiraClient:
             self.server, token_auth=token_auth, timeout=(read_timeout, connect_timeout)
         )
 
-    def get_issues(self, fields: Optional[Mapping] = None) -> list[Issue]:
+    def get_issues(self, fields: Optional[Mapping] = None, custom_jql: Optional[str, Any] = None) -> list[Issue]:
         block_size = 100
         block_num = 0
 
         all_issues: list[Issue] = []
-        jql = "project={}".format(self.project)
+
+        jql = f"project={self.project}"
+        if custom_jql:
+            jql = f"{jql} and {custom_jql}"
+        
         kwargs: dict[str, Any] = {}
         if fields:
             kwargs["fields"] = ",".join(fields)

--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -40,7 +40,7 @@ class JiraClient:
         )
 
     def get_issues(
-        self, fields: Optional[Mapping] = None, custom_jql: Optional[str, Any] = None
+        self, fields: Optional[Mapping] = None, custom_jql: Optional[str] = None
     ) -> list[Issue]:
         block_size = 100
         block_num = 0
@@ -81,7 +81,7 @@ class JiraClient:
         labels: Optional[Iterable[str]] = None,
         links: Iterable[str] = (),
         issueType: Optional[Mapping[str, str]] = {"name": "Task"},
-        assignee: Optional[str, Any] = None,
+        assignee: Optional[str] = None,
     ) -> Issue:
         """Create an issue in our project with the given labels."""
         issue = self.jira.create_issue(

--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -99,3 +99,15 @@ class JiraClient:
                 type="is caused by", inwardIssue=issue.key, outwardIssue=ln
             )
         return issue
+
+    def delete_issue(
+        self,
+        issue: Issue,
+    ) -> bool:
+        """Delete an issue in a project by object reference"""
+        try:
+            issue.delete()
+            return True
+        except Exception as err:
+            logging.exception("Error in deleting issue.")
+            return False

--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -39,7 +39,9 @@ class JiraClient:
             self.server, token_auth=token_auth, timeout=(read_timeout, connect_timeout)
         )
 
-    def get_issues(self, fields: Optional[Mapping] = None, custom_jql: Optional[str, Any] = None) -> list[Issue]:
+    def get_issues(
+        self, fields: Optional[Mapping] = None, custom_jql: Optional[str, Any] = None
+    ) -> list[Issue]:
         block_size = 100
         block_num = 0
 
@@ -48,7 +50,7 @@ class JiraClient:
         jql = f"project={self.project}"
         if custom_jql:
             jql = f"{jql} and {custom_jql}"
-        
+
         kwargs: dict[str, Any] = {}
         if fields:
             kwargs["fields"] = ",".join(fields)
@@ -79,7 +81,7 @@ class JiraClient:
         labels: Optional[Iterable[str]] = None,
         links: Iterable[str] = (),
         issueType: Optional[Mapping[str, str]] = {"name": "Task"},
-        assignee: Optional[str, Any] = None
+        assignee: Optional[str, Any] = None,
     ) -> Issue:
         """Create an issue in our project with the given labels."""
         issue = self.jira.create_issue(

--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -78,6 +78,8 @@ class JiraClient:
         body: str,
         labels: Optional[Iterable[str]] = None,
         links: Iterable[str] = (),
+        issueType: Optional[Mapping[str, str]] = {"name": "Task"},
+        assignee: Optional[str, Any] = None
     ) -> Issue:
         """Create an issue in our project with the given labels."""
         issue = self.jira.create_issue(
@@ -85,7 +87,8 @@ class JiraClient:
             summary=summary,
             description=body,
             labels=labels,
-            issuetype={"name": "Task"},
+            issuetype=issueType,
+            assignee=assignee,
         )
         for ln in links:
             self.jira.create_issue_link(

--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -80,18 +80,18 @@ class JiraClient:
         body: str,
         labels: Optional[Iterable[str]] = None,
         links: Iterable[str] = (),
-        issueType: Optional[Mapping[str, str]] = None,
+        issuetype: Optional[Mapping[str, str]] = None,
         assignee: Optional[Mapping[str, str]] = None,
     ) -> Issue:
         """Create an issue in our project with the given labels."""
-        if not issueType:
-            issueType = {"name": "Task"}
+        if not issuetype:
+            issuetype = {"name": "Task"}
         issue = self.jira.create_issue(
             project=self.project,
             summary=summary,
             description=body,
             labels=labels,
-            issuetype=issueType,
+            issuetype=issuetype,
             assignee=assignee,
         )
         for ln in links:

--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -80,10 +80,12 @@ class JiraClient:
         body: str,
         labels: Optional[Iterable[str]] = None,
         links: Iterable[str] = (),
-        issueType: Optional[Mapping[str, str]] = {"name": "Task"},
+        issueType: Optional[Mapping[str, str]] = None,
         assignee: Optional[str] = None,
     ) -> Issue:
         """Create an issue in our project with the given labels."""
+        if not issueType:
+            issueType = {"name": "Task"}
         issue = self.jira.create_issue(
             project=self.project,
             summary=summary,

--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -81,7 +81,7 @@ class JiraClient:
         labels: Optional[Iterable[str]] = None,
         links: Iterable[str] = (),
         issueType: Optional[Mapping[str, str]] = None,
-        assignee: Optional[str] = None,
+        assignee: Optional[Mapping[str, str]] = None,
     ) -> Issue:
         """Create an issue in our project with the given labels."""
         if not issueType:


### PR DESCRIPTION
This MR improves GitLab and Jira Clients in qontract-reconcile to support features needed by change-control-automation.

Jira client:

* adds custom JQL query support to get_issues
* adds ability to specify assignee in create_issue
* add delete_issue method (use case is deleting tickets for MRs that no longer exist)

GitLab client:

* adds get_merge_request_first_commit_hash method

https://issues.redhat.com/browse/APPSRE-6934

