### PR TITLE
Fix race condition in tox

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# We want jenkins to fail hard
+set -e
+
 DOCKER_CONF="$PWD/.docker"
 mkdir -p "$DOCKER_CONF"
 docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,8 @@ deps = -r{toxinidir}/requirements/requirements-type.txt
 [testenv:generate]
 # We want to ensure that there is no drift between introspection.json
 # and generated classes.
+# Note, that this must not run parallel with the pytests generate test case.
+depends = py39
 allowlist_externals = git
 commands =
     qenerate code -i reconcile/gql_definitions/introspection.json reconcile/gql_definitions


### PR DESCRIPTION
- `py39` and `generate` test envs have a race condition when executed in parallel
- `set -e` is required for CI to fail