### PR TITLE
route53 geolocation records

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2613,6 +2613,11 @@ DNS_ZONES_QUERY = """
       weighted_routing_policy {
         weight
       }
+      geolocation_routing_policy {
+        continent
+        country
+        subdivision
+      }
       set_identifier
       records
       _healthcheck {


### PR DESCRIPTION
APPSRE-7222

Allow to create AWS Route53 geolocation records

See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record#geolocation-routing-policy and https://docs.aws.amazon.com/Route53/latest/APIReference/API_GetGeoLocation.html

Depends on https://github.com/app-sre/qontract-schemas/pull/401

Doc and example: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/60318