### PR TITLE
increase quay-mirror verbosity

### DIFF
--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -196,6 +196,8 @@ class QuayMirror:
         return True
 
     def process_sync_tasks(self):
+        if self.is_compare_tags:
+            _LOG.warning("Making a compare-tags run. This is a slow operation.")
         summary = self.process_repos_query(self.images)
         sync_tasks = defaultdict(list)
         for org_key, data in summary.items():


### PR DESCRIPTION
When looking at `quay-mirror` logs, it is not clear in which mode it is running. The `compare-tags` mode is very slow and should only run once daily -> this extra log line gives more insights on what's happening.