### PR TITLE
[app-interface state] initialize via builder function

### DIFF
--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -5,7 +5,10 @@ import sys
 from reconcile import queries
 from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.defer import defer
-from reconcile.utils.state import State
+from reconcile.utils.state import (
+    State,
+    init_state,
+)
 from reconcile.utils.terrascript_aws_client import TerrascriptClient as Terrascript
 
 QONTRACT_INTEGRATION = "aws-iam-keys"
@@ -83,11 +86,7 @@ def run(
         return
 
     settings = queries.get_app_interface_settings()
-    state = State(
-        integration=QONTRACT_INTEGRATION,
-        accounts=queries.get_state_aws_accounts(),
-        settings=settings,
-    )
+    state = init_state(integration=QONTRACT_INTEGRATION)
     keys_to_delete = get_keys_to_delete(accounts)
     if not should_run(state, keys_to_delete):
         logging.debug("nothing to do here")

--- a/reconcile/aws_iam_password_reset.py
+++ b/reconcile/aws_iam_password_reset.py
@@ -11,7 +11,7 @@ from typing import (
 
 from reconcile import queries
 from reconcile.utils.aws_api import AWSApi
-from reconcile.utils.state import State
+from reconcile.utils.state import init_state
 
 QONTRACT_INTEGRATION = "aws-iam-password-reset"
 
@@ -37,9 +37,7 @@ def run(dry_run):
     accounts = queries.get_aws_accounts(reset_passwords=True)
     settings = queries.get_app_interface_settings()
     roles = queries.get_roles(aws=True)
-    state = State(
-        integration=QONTRACT_INTEGRATION, accounts=accounts, settings=settings
-    )
+    state = init_state(integration=QONTRACT_INTEGRATION)
 
     for a in accounts:
         aws_api = None

--- a/reconcile/jira_watcher.py
+++ b/reconcile/jira_watcher.py
@@ -5,7 +5,10 @@ from reconcile.slack_base import slackapi_from_slack_workspace
 from reconcile.utils.jira_client import JiraClient
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.sharding import is_in_shard_round_robin
-from reconcile.utils.state import State
+from reconcile.utils.state import (
+    State,
+    init_state,
+)
 
 QONTRACT_INTEGRATION = "jira-watcher"
 
@@ -85,17 +88,14 @@ def act(dry_run, jira_board, diffs):
             slack.chat_post_message(diff)
 
 
-def write_state(state, project, state_to_write):
+def write_state(state: State, project, state_to_write):
     state.add(project, value=state_to_write, force=True)
 
 
 def run(dry_run):
     jira_boards = [j for j in queries.get_jira_boards() if j.get("slack")]
-    accounts = queries.get_state_aws_accounts()
     settings = queries.get_app_interface_settings()
-    state = State(
-        integration=QONTRACT_INTEGRATION, accounts=accounts, settings=settings
-    )
+    state = init_state(integration=QONTRACT_INTEGRATION)
     for index, jira_board in enumerate(jira_boards):
         if not is_in_shard_round_robin(jira_board["name"], index):
             continue

--- a/reconcile/ocm_addons_upgrade_tests_trigger.py
+++ b/reconcile/ocm_addons_upgrade_tests_trigger.py
@@ -2,21 +2,22 @@ import logging
 from typing import Optional
 
 from reconcile import queries
+from reconcile.typed_queries.app_interface_vault_settings import (
+    get_app_interface_vault_settings,
+)
 from reconcile.utils.jenkins_api import JenkinsApi
 from reconcile.utils.ocm import OCMMap
-from reconcile.utils.secret_reader import SecretReader
-from reconcile.utils.state import State
+from reconcile.utils.secret_reader import create_secret_reader
+from reconcile.utils.state import init_state
 
 QONTRACT_INTEGRATION = "ocm-addons-upgrade-tests-trigger"
 
 
 def run(dry_run: bool) -> None:
     settings = queries.get_app_interface_settings()
-    secret_reader = SecretReader(queries.get_secret_reader_settings())
-    accounts = queries.get_state_aws_accounts()
-    state = State(
-        integration=QONTRACT_INTEGRATION, accounts=accounts, settings=settings
-    )
+    vault_settings = get_app_interface_vault_settings()
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+    state = init_state(integration=QONTRACT_INTEGRATION, secret_reader=secret_reader)
     ocms = queries.get_openshift_cluster_managers()
     for ocm_info in ocms:
         ocm_name = ocm_info["name"]

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -29,7 +29,7 @@ from reconcile.utils.semver_helper import (
     parse_semver,
     sort_versions,
 )
-from reconcile.utils.state import State
+from reconcile.utils.state import init_state
 
 QONTRACT_INTEGRATION = "ocm-upgrade-scheduler"
 
@@ -150,11 +150,7 @@ def get_version_data_map(
     Returns:
         dict: version data per OCM instance
     """
-    settings = queries.get_app_interface_settings()
-    accounts = queries.get_state_aws_accounts()
-    state = State(
-        integration=QONTRACT_INTEGRATION, accounts=accounts, settings=settings
-    )
+    state = init_state(integration=QONTRACT_INTEGRATION)
     results: dict[str, VersionData] = {}
     # we keep a remote state per OCM instance
     for ocm_name in ocm_map.instances():

--- a/reconcile/openshift_namespace_labels.py
+++ b/reconcile/openshift_namespace_labels.py
@@ -33,7 +33,10 @@ from reconcile.utils.oc_map import (
 )
 from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.sharding import is_in_shard
-from reconcile.utils.state import State
+from reconcile.utils.state import (
+    State,
+    init_state,
+)
 
 _LOG = logging.getLogger(__name__)
 
@@ -437,10 +440,7 @@ def run(
     _LOG.debug("Collecting desired state ...")
     get_desired(inventory, oc_map, namespaces)
 
-    accounts = queries.get_state_aws_accounts()
-    state = State(
-        integration=QONTRACT_INTEGRATION, accounts=accounts, secret_reader=secret_reader
-    )
+    state = init_state(integration=QONTRACT_INTEGRATION)
     _LOG.debug("Collecting managed state ...")
     get_managed(inventory, state)
 

--- a/reconcile/openshift_namespace_labels.py
+++ b/reconcile/openshift_namespace_labels.py
@@ -15,7 +15,6 @@ from kubernetes.client.exceptions import ApiException
 from sretoolbox.utils import threaded
 
 import reconcile.openshift_base as ob
-from reconcile import queries
 from reconcile.gql_definitions.common.namespaces import NamespaceV1
 from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -132,7 +132,6 @@ def run(
         desired_instances=desired_jenkins_instances
     )
     settings = queries.get_app_interface_settings()
-    accounts = queries.get_aws_accounts()
     try:
         instance = queries.get_gitlab_instance()
         gl = GitLabApi(instance, settings=settings)
@@ -149,7 +148,7 @@ def run(
         integration_version=QONTRACT_INTEGRATION_VERSION,
         settings=settings,
         jenkins_map=jenkins_map,
-        accounts=accounts,
+        initialise_state=True,
     )
     if len(saasherder.namespaces) == 0:
         logging.warning("no targets found")

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -131,7 +131,6 @@ def setup(
 
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()
-    accounts = queries.get_state_aws_accounts()
     gl = GitLabApi(instance, settings=settings)
     jenkins_map = jenkins_base.get_jenkins_map()
     pipelines_providers = queries.get_pipelines_providers()
@@ -156,7 +155,7 @@ def setup(
         integration_version=integration_version,
         settings=settings,
         jenkins_map=jenkins_map,
-        accounts=accounts,
+        initialise_state=True,
         include_trigger_trace=include_trigger_trace,
     )
 

--- a/reconcile/openshift_upgrade_watcher.py
+++ b/reconcile/openshift_upgrade_watcher.py
@@ -6,7 +6,6 @@ from collections.abc import (
 from datetime import datetime
 from typing import Optional
 
-from reconcile import queries
 from reconcile.gql_definitions.common.clusters import ClusterV1
 from reconcile.slack_base import slackapi_from_queries
 from reconcile.typed_queries.app_interface_vault_settings import (
@@ -21,7 +20,10 @@ from reconcile.utils.oc_map import (
 )
 from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.slack_api import SlackApi
-from reconcile.utils.state import State
+from reconcile.utils.state import (
+    State,
+    init_state,
+)
 
 QONTRACT_INTEGRATION = "openshift-upgrade-watcher"
 
@@ -121,12 +123,7 @@ def run(
 ) -> None:
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-    accounts = queries.get_state_aws_accounts()
-    state = State(
-        integration=QONTRACT_INTEGRATION,
-        accounts=accounts,
-        secret_reader=secret_reader,
-    )
+    state = init_state(integration=QONTRACT_INTEGRATION, secret_reader=secret_reader)
 
     clusters = [
         c for c in get_clusters() if c.ocm and not (c.spec and c.spec.hypershift)

--- a/reconcile/requests_sender.py
+++ b/reconcile/requests_sender.py
@@ -10,7 +10,10 @@ from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,
 )
 from reconcile.utils.gpg import gpg_encrypt
-from reconcile.utils.secret_reader import SecretReader, create_secret_reader
+from reconcile.utils.secret_reader import (
+    SecretReader,
+    create_secret_reader,
+)
 from reconcile.utils.smtp_client import (
     DEFAULT_SMTP_TIMEOUT,
     SmtpClient,

--- a/reconcile/sentry_helper.py
+++ b/reconcile/sentry_helper.py
@@ -3,7 +3,7 @@ import logging
 from reconcile import queries
 from reconcile.slack_base import slackapi_from_queries
 from reconcile.utils.imap_client import ImapClient
-from reconcile.utils.state import State
+from reconcile.utils.state import init_state
 
 QONTRACT_INTEGRATION = "sentry-helper"
 
@@ -35,11 +35,8 @@ def get_sentry_users_from_mails(mails):
 
 def run(dry_run):
     settings = queries.get_app_interface_settings()
-    accounts = queries.get_state_aws_accounts()
     users = queries.get_users()
-    state = State(
-        integration=QONTRACT_INTEGRATION, accounts=accounts, settings=settings
-    )
+    state = init_state(integration=QONTRACT_INTEGRATION)
     with ImapClient(settings=settings) as imap_client:
         mails = imap_client.get_mails(
             folder="[Gmail]/Sent Mail", criteria='SUBJECT "Sentry Access Request"'

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -35,7 +35,7 @@ from reconcile.utils.smtp_client import (
     SmtpClient,
     get_smtp_server_connection,
 )
-from reconcile.utils.state import State
+from reconcile.utils.state import init_state
 from reconcile.utils.terrascript_aws_client import TerrascriptClient as Terrascript
 
 QONTRACT_INTEGRATION = "sql-query"
@@ -557,10 +557,7 @@ def openshift_delete_by_label(
 
 def run(dry_run: bool, enable_deletion: bool = False) -> None:
     settings = queries.get_app_interface_settings()
-    accounts = queries.get_state_aws_accounts()
-    state = State(
-        integration=QONTRACT_INTEGRATION, accounts=accounts, settings=settings
-    )
+    state = init_state(integration=QONTRACT_INTEGRATION)
     smtp_settings = typed_queries.smtp.settings()
     smtp_client = SmtpClient(
         server=get_smtp_server_connection(

--- a/reconcile/statuspage/integration.py
+++ b/reconcile/statuspage/integration.py
@@ -2,7 +2,6 @@ import logging
 import sys
 from collections.abc import Callable
 
-from reconcile import queries
 from reconcile.gql_definitions.statuspage import statuspages
 from reconcile.gql_definitions.statuspage.statuspages import StatusPageV1
 from reconcile.statuspage.page import (
@@ -25,7 +24,10 @@ from reconcile.utils.secret_reader import (
     create_secret_reader,
 )
 from reconcile.utils.semver_helper import make_semver
-from reconcile.utils.state import State
+from reconcile.utils.state import (
+    State,
+    init_state,
+)
 
 QONTRACT_INTEGRATION = "status-page-components"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
@@ -36,9 +38,9 @@ def get_status_pages(query_func: Callable) -> list[StatusPageV1]:
 
 
 def get_state(secret_reader: SecretReaderBase) -> State:
-    accounts = queries.get_state_aws_accounts()
-    return State(
-        integration=QONTRACT_INTEGRATION, accounts=accounts, secret_reader=secret_reader
+    return init_state(
+        integration=QONTRACT_INTEGRATION,
+        secret_reader=secret_reader,
     )
 
 

--- a/reconcile/test/test_openshift_namespace_labels.py
+++ b/reconcile/test/test_openshift_namespace_labels.py
@@ -171,12 +171,10 @@ class TestOpenshiftNamespaceLabels(TestCase):
         self.oc_map = create_autospec(spec=OCMap)
         self.oc_map.clusters.side_effect = self._oc_map_clusters
         self.oc_map.get.side_effect = self._oc_map_get
-
         self.init_oc_map_patcher = patch(f"{module}.init_oc_map_from_namespaces")
         self.init_oc_map = self.init_oc_map_patcher.start()
         self.init_oc_map.side_effect = [self.oc_map]
-
-        self.state_patcher = patch(f"{module}.State")
+        self.state_patcher = patch(f"{module}.init_state")
         self.state = self.state_patcher.start().return_value
         self.state.ls.side_effect = self._state_ls
         self.state.get.side_effect = self._state_get

--- a/reconcile/test/test_openshift_namespace_labels.py
+++ b/reconcile/test/test_openshift_namespace_labels.py
@@ -150,7 +150,7 @@ class TestOpenshiftNamespaceLabels(TestCase):
 
         module = "reconcile.openshift_namespace_labels"
 
-        self.queries_patcher = patch(f"{module}.queries")
+        self.queries_patcher = patch("reconcile.queries")
         self.queries = self.queries_patcher.start()
 
         self.namespaces_patcher = patch(f"{module}.get_namespaces")

--- a/reconcile/test/test_requests_sender.py
+++ b/reconcile/test/test_requests_sender.py
@@ -47,7 +47,7 @@ class TestRunInteg(TestCase):
         self.get_credentials_requests_patcher = patch.object(
             queries, "get_credentials_requests", autospec=True
         )
-        self.state_patcher = patch.object(integ, "State", autospec=True)
+        self.state_patcher = patch.object(integ, "init_state", autospec=True)
 
         self.do_exit = self.exit_patcher.start()
         self.get_encrypted_credentials = self.get_encrypted_creds_patcher.start()

--- a/reconcile/test/test_requests_sender.py
+++ b/reconcile/test/test_requests_sender.py
@@ -48,6 +48,11 @@ class TestRunInteg(TestCase):
             queries, "get_credentials_requests", autospec=True
         )
         self.state_patcher = patch.object(integ, "init_state", autospec=True)
+        self.vault_settings_patcher = patch.object(
+            integ,
+            "get_app_interface_vault_settings",
+            autospec=True,
+        )
 
         self.do_exit = self.exit_patcher.start()
         self.get_encrypted_credentials = self.get_encrypted_creds_patcher.start()
@@ -60,6 +65,7 @@ class TestRunInteg(TestCase):
         self.get_credentials_requests.return_value = self.requests
         self.get_encrypted_credentials.return_value = "anencryptedcred"
         self.state = self.state_patcher.start()
+        self.vault_settings_patcher.start()
         self.settings = {
             "smtp": {
                 "secret_path": "asecretpath",
@@ -84,6 +90,7 @@ class TestRunInteg(TestCase):
             self.get_credentials_requests_patcher,
             self.get_aws_accounts_patcher,
             self.state_patcher,
+            self.vault_settings_patcher,
         ):
             p.stop()
 

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -797,7 +797,9 @@ class TestConfigHashPromotionsValidation(TestCase):
     def setUp(self) -> None:
         self.all_saas_files = [self.fxt.get_anymarkup("saas.gql.yml")]
 
-        self.state_patcher = patch("reconcile.utils.saasherder.State", autospec=True)
+        self.state_patcher = patch(
+            "reconcile.utils.saasherder.init_state", autospec=True
+        )
         self.state_mock = self.state_patcher.start().return_value
 
         self.ig_patcher = patch.object(SaasHerder, "_initiate_github", autospec=True)
@@ -827,7 +829,7 @@ class TestConfigHashPromotionsValidation(TestCase):
             gitlab=None,
             integration="",
             integration_version="",
-            accounts={"name": "test-account"},  # Initiates State in SaasHerder
+            initialise_state=True,
             settings={"hashLength": 24},
         )
 
@@ -938,7 +940,9 @@ class TestConfigHashTrigger(TestCase):
     def setUp(self) -> None:
         self.all_saas_files = [self.fxt.get_anymarkup("saas.gql.yml")]
 
-        self.state_patcher = patch("reconcile.utils.saasherder.State", autospec=True)
+        self.state_patcher = patch(
+            "reconcile.utils.saasherder.init_state", autospec=True
+        )
         self.state_mock = self.state_patcher.start().return_value
 
         self.saas_file = self.fxt.get_anymarkup("saas.gql.yml")
@@ -962,7 +966,7 @@ class TestConfigHashTrigger(TestCase):
             gitlab=None,
             integration="",
             integration_version="",
-            accounts={"name": "test-account"},  # Initiates State in SaasHerder
+            initialise_state=True,
             settings={"hashLength": 24},
         )
 

--- a/reconcile/utils/jenkins_api.py
+++ b/reconcile/utils/jenkins_api.py
@@ -6,7 +6,7 @@ import toml
 import yaml
 from sretoolbox.utils import retry
 
-from reconcile.utils.secret_reader import SecretReader
+from reconcile.utils.secret_reader import SecretReaderBase
 
 
 class JenkinsApi:
@@ -14,7 +14,7 @@ class JenkinsApi:
 
     @staticmethod
     def init_jenkins_from_secret(
-        secret_reader: SecretReader, secret, ssl_verify=True
+        secret_reader: SecretReaderBase, secret, ssl_verify=True
     ) -> "JenkinsApi":
         token_config = secret_reader.read(secret)
         config = toml.loads(token_config)

--- a/reconcile/utils/saasherder.py
+++ b/reconcile/utils/saasherder.py
@@ -49,7 +49,7 @@ from reconcile.utils.openshift_resource import (
     fully_qualified_kind,
 )
 from reconcile.utils.secret_reader import SecretReader
-from reconcile.utils.state import State
+from reconcile.utils.state import init_state
 
 TARGET_CONFIG_HASH = "target_config_hash"
 
@@ -174,7 +174,7 @@ class SaasHerder:
         integration_version,
         settings,
         jenkins_map=None,
-        accounts=None,
+        initialise_state=False,
         validate=False,
         include_trigger_trace=False,
     ):
@@ -206,8 +206,8 @@ class SaasHerder:
         self.compare = self._get_saas_file_feature_enabled("compare", default=True)
         self.publish_job_logs = self._get_saas_file_feature_enabled("publishJobLogs")
         self.cluster_admin = self._get_saas_file_feature_enabled("clusterAdmin")
-        if accounts:
-            self._initiate_state(accounts)
+        if initialise_state:
+            self.state = init_state(integration=self.integration)
 
     def _register_error(self):
         self.error_registered = True
@@ -703,11 +703,6 @@ class SaasHerder:
             for rt in resource_templates:
                 repo_urls.add(rt["url"])
         return repo_urls
-
-    def _initiate_state(self, accounts):
-        self.state = State(
-            integration=self.integration, accounts=accounts, settings=self.settings
-        )
 
     @staticmethod
     def _collect_parameters(container):

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         "deepdiff6==6.2.0",
         "jsonpath-ng~=1.5",
         "networkx~=2.8",
+        "mypy-boto3-s3~=1.24.94",
     ],
     test_suite="tests",
     classifiers=[

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -67,7 +67,10 @@ from reconcile.utils.ocm import (
     OCMMap,
 )
 from reconcile.utils.output import print_output
-from reconcile.utils.secret_reader import SecretReader, create_secret_reader
+from reconcile.utils.secret_reader import (
+    SecretReader,
+    create_secret_reader,
+)
 from reconcile.utils.semver_helper import parse_semver
 from reconcile.utils.state import init_state
 from reconcile.utils.terraform_client import TerraformClient as Terraform

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -877,9 +877,8 @@ def clusters_aws_account_ids(ctx):
 @get.command()
 @click.pass_context
 def terraform_users_credentials(ctx) -> None:
-    settings = queries.get_app_interface_settings()
     accounts = queries.get_state_aws_accounts()
-    state = State("account-notifier", accounts, settings=settings)
+    state = init_state(integration="account-notifier")
 
     skip_accounts, appsre_pgp_key, _ = tfu.get_reencrypt_settings()
 
@@ -942,10 +941,8 @@ def terraform_users_credentials(ctx) -> None:
 @click.argument("account_name")
 @click.pass_context
 def user_credentials_migrate_output(ctx, account_name) -> None:
-    settings = queries.get_app_interface_settings()
     accounts = queries.get_state_aws_accounts()
-    state = State("account-notifier", accounts, settings=settings)
-
+    state = init_state(integration="account-notifier")
     skip_accounts, appsre_pgp_key, _ = tfu.get_reencrypt_settings()
 
     accounts, working_dirs, _, aws_api = tfu.setup(

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -33,9 +33,6 @@ from reconcile.cli import config_file
 from reconcile.jenkins_job_builder import init_jjb
 from reconcile.prometheus_rules_tester import get_data_from_jinja_test_template
 from reconcile.slack_base import slackapi_from_queries
-from reconcile.typed_queries.app_interface_vault_settings import (
-    get_app_interface_vault_settings,
-)
 from reconcile.utils import (
     amtool,
     config,
@@ -69,7 +66,6 @@ from reconcile.utils.ocm import (
 from reconcile.utils.output import print_output
 from reconcile.utils.secret_reader import (
     SecretReader,
-    create_secret_reader,
 )
 from reconcile.utils.semver_helper import parse_semver
 from reconcile.utils.state import init_state
@@ -1824,9 +1820,7 @@ def state(ctx):
 @click.argument("integration", default="")
 @click.pass_context
 def ls(ctx, integration):
-    vault_settings = get_app_interface_vault_settings()
-    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-    state = init_state(integration=integration, secret_reader=secret_reader)
+    state = init_state(integration=integration)
     keys = state.ls()
     # if integration in not defined the 2th token will be the integration name
     key_index = 1 if integration else 2
@@ -1847,9 +1841,7 @@ def ls(ctx, integration):
 @click.argument("key")
 @click.pass_context
 def get(ctx, integration, key):
-    vault_settings = get_app_interface_vault_settings()
-    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-    state = init_state(integration=integration, secret_reader=secret_reader)
+    state = init_state(integration=integration)
     value = state.get(key)
     print(value)
 
@@ -1859,9 +1851,7 @@ def get(ctx, integration, key):
 @click.argument("key")
 @click.pass_context
 def add(ctx, integration, key):
-    vault_settings = get_app_interface_vault_settings()
-    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-    state = init_state(integration=integration, secret_reader=secret_reader)
+    state = init_state(integration=integration)
     state.add(key)
 
 
@@ -1871,9 +1861,7 @@ def add(ctx, integration, key):
 @click.argument("value")
 @click.pass_context
 def set(ctx, integration, key, value):
-    vault_settings = get_app_interface_vault_settings()
-    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-    state = init_state(integration=integration, secret_reader=secret_reader)
+    state = init_state(integration=integration)
     state.add(key, value=value, force=True)
 
 
@@ -1882,9 +1870,7 @@ def set(ctx, integration, key, value):
 @click.argument("key")
 @click.pass_context
 def rm(ctx, integration, key):
-    vault_settings = get_app_interface_vault_settings()
-    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-    state = init_state(integration=integration, secret_reader=secret_reader)
+    state = init_state(integration=integration)
     state.rm(key)
 
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -33,6 +33,9 @@ from reconcile.cli import config_file
 from reconcile.jenkins_job_builder import init_jjb
 from reconcile.prometheus_rules_tester import get_data_from_jinja_test_template
 from reconcile.slack_base import slackapi_from_queries
+from reconcile.typed_queries.app_interface_vault_settings import (
+    get_app_interface_vault_settings,
+)
 from reconcile.utils import (
     amtool,
     config,
@@ -64,9 +67,9 @@ from reconcile.utils.ocm import (
     OCMMap,
 )
 from reconcile.utils.output import print_output
-from reconcile.utils.secret_reader import SecretReader
+from reconcile.utils.secret_reader import SecretReader, create_secret_reader
 from reconcile.utils.semver_helper import parse_semver
-from reconcile.utils.state import State
+from reconcile.utils.state import init_state
 from reconcile.utils.terraform_client import TerraformClient as Terraform
 from tools.cli_commands.gpg_encrypt import (
     GPGEncryptCommand,
@@ -1818,9 +1821,9 @@ def state(ctx):
 @click.argument("integration", default="")
 @click.pass_context
 def ls(ctx, integration):
-    settings = queries.get_app_interface_settings()
-    accounts = queries.get_state_aws_accounts()
-    state = State(integration, accounts, settings=settings)
+    vault_settings = get_app_interface_vault_settings()
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+    state = init_state(integration=integration, secret_reader=secret_reader)
     keys = state.ls()
     # if integration in not defined the 2th token will be the integration name
     key_index = 1 if integration else 2
@@ -1841,9 +1844,9 @@ def ls(ctx, integration):
 @click.argument("key")
 @click.pass_context
 def get(ctx, integration, key):
-    settings = queries.get_app_interface_settings()
-    accounts = queries.get_state_aws_accounts()
-    state = State(integration, accounts, settings=settings)
+    vault_settings = get_app_interface_vault_settings()
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+    state = init_state(integration=integration, secret_reader=secret_reader)
     value = state.get(key)
     print(value)
 
@@ -1853,9 +1856,9 @@ def get(ctx, integration, key):
 @click.argument("key")
 @click.pass_context
 def add(ctx, integration, key):
-    settings = queries.get_app_interface_settings()
-    accounts = queries.get_state_aws_accounts()
-    state = State(integration, accounts, settings=settings)
+    vault_settings = get_app_interface_vault_settings()
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+    state = init_state(integration=integration, secret_reader=secret_reader)
     state.add(key)
 
 
@@ -1865,9 +1868,9 @@ def add(ctx, integration, key):
 @click.argument("value")
 @click.pass_context
 def set(ctx, integration, key, value):
-    settings = queries.get_app_interface_settings()
-    accounts = queries.get_state_aws_accounts()
-    state = State(integration, accounts, settings=settings)
+    vault_settings = get_app_interface_vault_settings()
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+    state = init_state(integration=integration, secret_reader=secret_reader)
     state.add(key, value=value, force=True)
 
 
@@ -1876,9 +1879,9 @@ def set(ctx, integration, key, value):
 @click.argument("key")
 @click.pass_context
 def rm(ctx, integration, key):
-    settings = queries.get_app_interface_settings()
-    accounts = queries.get_state_aws_accounts()
-    state = State(integration, accounts, settings=settings)
+    vault_settings = get_app_interface_vault_settings()
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+    state = init_state(integration=integration, secret_reader=secret_reader)
     state.rm(key)
 
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -64,9 +64,7 @@ from reconcile.utils.ocm import (
     OCMMap,
 )
 from reconcile.utils.output import print_output
-from reconcile.utils.secret_reader import (
-    SecretReader,
-)
+from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.semver_helper import parse_semver
 from reconcile.utils.state import init_state
 from reconcile.utils.terraform_client import TerraformClient as Terraform

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -17,7 +17,7 @@ def mock_queries(mocker):
 
 @pytest.fixture
 def mock_state(mocker):
-    return mocker.patch("tools.qontract_cli.State", autospec=True)
+    return mocker.patch("tools.qontract_cli.init_state", autospec=True)
 
 
 def test_state_ls_with_integration(env_vars, mock_queries, mock_state):


### PR DESCRIPTION
change all initialization of the `reconcile.utils.state.State` class to be handled via the `init_state` function. this is a small minimal preparational step to make additional improvements in upcoming PRs easier where we will fully inject all dependencies to the `init_state` function (e.g. `SecretReader`) while getting  rid of other dependencies (e.g. `accounts`) and add other means of providing configuration data for state bucket initialization.

This change could have been bigger, touching `SecretReader` initializiation in various places, but the scope of this PR has been kept small on purpose.

https://issues.redhat.com/browse/APPSRE-7226