### PR TITLE
Move terraform_cloudflare_users import to local scope

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -16,7 +16,6 @@ from reconcile.status import (
     ExitCodes,
     RunningState,
 )
-from reconcile.terraform_cloudflare_users import TerraformCloudflareUsersParams
 from reconcile.utils import gql
 from reconcile.utils.aggregated_list import RunnerException
 from reconcile.utils.binary import (
@@ -1721,11 +1720,13 @@ def terraform_cloudflare_dns(
 def terraform_cloudflare_users(
     ctx, print_to_file, account_name, thread_pool_size, enable_deletion
 ):
-
-    import reconcile.terraform_cloudflare_users
+    from reconcile.terraform_cloudflare_users import (
+        TerraformCloudflareUsers,
+        TerraformCloudflareUsersParams,
+    )
 
     run_class_integration(
-        reconcile.terraform_cloudflare_users.TerraformCloudflareUsers(
+        TerraformCloudflareUsers(
             TerraformCloudflareUsersParams(
                 print_to_file=print_to_file,
                 account_name=account_name,


### PR DESCRIPTION
Based on https://github.com/app-sre/qontract-reconcile/pull/2573, we should try to put import in local scope to save memory.

`reconcile.terraform_cloudflare_users` is using about 70M on my machine.