### PR TITLE
[Draft] Add support for vault auth using kubernetes

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -276,6 +276,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           {{- if $integration.environmentAware }}
           - name: ENVIRONMENT_NAME
             value: "${ENVIRONMENT_NAME}"
@@ -303,8 +305,6 @@ objects:
             value: "${INTERNAL_CERTIFICATES_IMAGE_TAG}"
           - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
             value: "${INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY}"
-          - name: KUBE_SA_TOKEN_PATH
-            value: "${KUBE_SA_TOKEN_PATH}/token"
           {{- end }}
           {{- with $integration.extraEnv }}
           {{- range $i, $env := . }}

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -303,6 +303,8 @@ objects:
             value: "${INTERNAL_CERTIFICATES_IMAGE_TAG}"
           - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
             value: "${INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           {{- end }}
           {{- with $integration.extraEnv }}
           {{- range $i, $env := . }}
@@ -354,7 +356,7 @@ objects:
           - name: logs
             mountPath: /fluentd/log/
           - name: qontract-reconcile-sa-token
-            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -599,6 +601,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -276,8 +276,6 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
-          - name: KUBE_SA_TOKEN_PATH
-            value: "${KUBE_SA_TOKEN_PATH}/token"
           {{- if $integration.environmentAware }}
           - name: ENVIRONMENT_NAME
             value: "${ENVIRONMENT_NAME}"
@@ -305,6 +303,8 @@ objects:
             value: "${INTERNAL_CERTIFICATES_IMAGE_TAG}"
           - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
             value: "${INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           {{- end }}
           {{- with $integration.extraEnv }}
           {{- range $i, $env := . }}

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -353,6 +353,8 @@ objects:
           {{- end }}
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -411,6 +413,12 @@ objects:
             mountPath: /fluentd/buffer
           {{- end }}
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -177,6 +177,8 @@ objects:
             value: "${INTERNAL_CERTIFICATES_IMAGE_TAG}"
           - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
             value: "${INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEGRATIONS_MANAGER_CPU_LIMIT}
@@ -190,7 +192,7 @@ objects:
           - name: logs
             mountPath: /fluentd/log/
           - name: qontract-reconcile-sa-token
-            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -273,6 +275,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -189,6 +189,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -223,6 +225,12 @@ objects:
           - name: buffer
             mountPath: /fluentd/buffer
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -151,8 +151,6 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
-          - name: KUBE_SA_TOKEN_PATH
-            value: "${KUBE_SA_TOKEN_PATH}/token"
           - name: ENVIRONMENT_NAME
             value: "${ENVIRONMENT_NAME}"
           - name: IMAGE
@@ -179,6 +177,8 @@ objects:
             value: "${INTERNAL_CERTIFICATES_IMAGE_TAG}"
           - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
             value: "${INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEGRATIONS_MANAGER_CPU_LIMIT}

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -151,6 +151,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           - name: ENVIRONMENT_NAME
             value: "${ENVIRONMENT_NAME}"
           - name: IMAGE
@@ -177,8 +179,6 @@ objects:
             value: "${INTERNAL_CERTIFICATES_IMAGE_TAG}"
           - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
             value: "${INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY}"
-          - name: KUBE_SA_TOKEN_PATH
-            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEGRATIONS_MANAGER_CPU_LIMIT}

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -177,6 +177,8 @@ objects:
             value: "${INTERNAL_CERTIFICATES_IMAGE_TAG}"
           - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
             value: "${INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEGRATIONS_MANAGER_CPU_LIMIT}
@@ -190,7 +192,7 @@ objects:
           - name: logs
             mountPath: /fluentd/log/
           - name: qontract-reconcile-sa-token
-            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -269,6 +271,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -151,8 +151,6 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
-          - name: KUBE_SA_TOKEN_PATH
-            value: "${KUBE_SA_TOKEN_PATH}/token"
           - name: ENVIRONMENT_NAME
             value: "${ENVIRONMENT_NAME}"
           - name: IMAGE
@@ -179,6 +177,8 @@ objects:
             value: "${INTERNAL_CERTIFICATES_IMAGE_TAG}"
           - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
             value: "${INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEGRATIONS_MANAGER_CPU_LIMIT}

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -189,6 +189,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: /var/run/secrets/kubernetes.io/serviceaccount
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -221,6 +223,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -151,6 +151,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           - name: ENVIRONMENT_NAME
             value: "${ENVIRONMENT_NAME}"
           - name: IMAGE
@@ -177,8 +179,6 @@ objects:
             value: "${INTERNAL_CERTIFICATES_IMAGE_TAG}"
           - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
             value: "${INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY}"
-          - name: KUBE_SA_TOKEN_PATH
-            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEGRATIONS_MANAGER_CPU_LIMIT}

--- a/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
@@ -137,6 +137,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -149,6 +151,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -181,6 +185,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -320,6 +330,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -332,6 +344,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -364,6 +378,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -418,6 +438,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/aws_account_shards.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shards.yml
@@ -137,6 +137,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -149,6 +151,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -181,6 +185,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -320,6 +330,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -332,6 +344,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -364,6 +378,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -418,6 +438,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/basic.yml
+++ b/reconcile/test/fixtures/helm/basic.yml
@@ -135,6 +135,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -147,6 +149,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -179,6 +183,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -233,6 +243,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/cache.yml
+++ b/reconcile/test/fixtures/helm/cache.yml
@@ -144,6 +144,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -158,6 +160,8 @@ objects:
             mountPath: /.cache
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -190,6 +194,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -244,6 +254,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/command.yml
+++ b/reconcile/test/fixtures/helm/command.yml
@@ -135,6 +135,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -147,6 +149,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -179,6 +183,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -233,6 +243,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/disable_unleash.yml
+++ b/reconcile/test/fixtures/helm/disable_unleash.yml
@@ -125,6 +125,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -137,6 +139,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -169,6 +173,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -163,6 +163,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -175,6 +177,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -209,6 +213,12 @@ objects:
           - name: buffer
             mountPath: /fluentd/buffer
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -265,6 +275,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/environment_aware.yml
+++ b/reconcile/test/fixtures/helm/environment_aware.yml
@@ -161,6 +161,8 @@ objects:
             value: "${INTERNAL_CERTIFICATES_IMAGE_TAG}"
           - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
             value: "${INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -173,6 +175,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -205,6 +209,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -259,6 +269,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/exclude_service.yml
+++ b/reconcile/test/fixtures/helm/exclude_service.yml
@@ -135,6 +135,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -147,6 +149,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -179,6 +183,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -219,6 +229,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/extra_args.yml
+++ b/reconcile/test/fixtures/helm/extra_args.yml
@@ -137,6 +137,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -149,6 +151,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -181,6 +185,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -235,6 +245,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/extra_env.yml
+++ b/reconcile/test/fixtures/helm/extra_env.yml
@@ -135,6 +135,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           - name: key
             valueFrom:
               secretKeyRef:
@@ -154,6 +156,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -186,6 +190,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -240,6 +250,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/integrations_manager.yml
+++ b/reconcile/test/fixtures/helm/integrations_manager.yml
@@ -137,6 +137,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEGRATIONS_MANAGER_CPU_LIMIT}
@@ -149,6 +151,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -181,6 +185,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -235,6 +245,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/internal_certificates.yml
+++ b/reconcile/test/fixtures/helm/internal_certificates.yml
@@ -145,6 +145,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -159,6 +161,8 @@ objects:
             mountPath: /etc/pki/
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -191,6 +195,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -247,6 +257,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/logs_slack.yml
+++ b/reconcile/test/fixtures/helm/logs_slack.yml
@@ -153,6 +153,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -165,6 +167,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -197,6 +201,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -251,6 +261,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/shards.yml
+++ b/reconcile/test/fixtures/helm/shards.yml
@@ -135,6 +135,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -147,6 +149,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -179,6 +183,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -316,6 +326,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -328,6 +340,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -360,6 +374,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -414,6 +434,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/sleep_duration.yml
+++ b/reconcile/test/fixtures/helm/sleep_duration.yml
@@ -135,6 +135,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -147,6 +149,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -179,6 +183,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -233,6 +243,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/state.yml
+++ b/reconcile/test/fixtures/helm/state.yml
@@ -142,6 +142,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -154,6 +156,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -186,6 +190,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -240,6 +250,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/storage.yml
+++ b/reconcile/test/fixtures/helm/storage.yml
@@ -135,6 +135,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -147,6 +149,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -179,6 +183,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -233,6 +243,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/test/fixtures/helm/trigger.yml
+++ b/reconcile/test/fixtures/helm/trigger.yml
@@ -135,6 +135,8 @@ objects:
             value: "${LOG_SLOW_OC_RECONCILE}"
           - name: USE_NATIVE_CLIENT
             value: "${USE_NATIVE_CLIENT}"
+          - name: KUBE_SA_TOKEN_PATH
+            value: "${KUBE_SA_TOKEN_PATH}/token"
           resources:
             limits:
               cpu: ${INTEG_CPU_LIMIT}
@@ -147,6 +149,8 @@ objects:
             mountPath: /config
           - name: logs
             mountPath: /fluentd/log/
+          - name: qontract-reconcile-sa-token
+            mountPath: ${KUBE_SA_TOKEN_PATH}
         - name: fluentd
           image: ${FLUENTD_IMAGE}:${FLUENTD_IMAGE_TAG}
           imagePullPolicy: ${FLUENTD_IMAGE_PULL_POLICY}
@@ -179,6 +183,12 @@ objects:
           - name: fluentd-config
             mountPath: /fluentd/etc/
         volumes:
+        - name: qontract-reconcile-sa-token
+          projected: 
+            sources:
+            - serviceAccountToken:
+                expirationSeconds: 1800
+                path: token
         - name: qontract-reconcile-toml
           secret:
             secretName: qontract-reconcile-toml
@@ -233,6 +243,8 @@ parameters:
   value: "0"
 - name: USER_ID
   value: dummy
+- name: KUBE_SA_TOKEN_PATH
+  value: '/var/run/secrets/kubernetes.io/serviceaccount'
 - name: LOG_FILE
   value: "/fluentd/log/integration.log"
 - name: SLACK_CHANNEL

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -129,12 +129,14 @@ class _VaultClient:
         if self.kube_auth_role:
             # must read each time to account for sa token refresh
             with open(self.kube_sa_token_path) as f:
-                self._client.auth_kubernetes(
-                    role=self.kube_auth_role,
-                    jwt=f.read(),
-                    mount_point=self.kube_auth_mount,
-                )
-                print("WE MADE IT")
+                try:
+                    self._client.auth_kubernetes(
+                        role=self.kube_auth_role,
+                        jwt=f.read(),
+                        mount_point=self.kube_auth_mount,
+                    )
+                except Exception as e:
+                    LOG.error(e)
         else:
             self._client.auth_approle(self.role_id, self.secret_id)
 

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -63,15 +63,33 @@ class _VaultClient:
         server: Optional[str] = None,
         role_id: Optional[str] = None,
         secret_id: Optional[str] = None,
+        kube_auth_role: Optional[str] = None,
+        kube_auth_mount: Optional[str] = None,
         auto_refresh: bool = True,
     ):
         config = get_config()
 
         server = config["vault"]["server"] if server is None else server
-        self.role_id = config["vault"]["role_id"] if role_id is None else role_id
-        self.secret_id = (
-            config["vault"]["secret_id"] if secret_id is None else secret_id
-        )
+        if "kube_auth_role" in config["vault"] or kube_auth_role is not None:
+            self.kube_auth_role = (
+                config["vault"]["kube_auth_role"]
+                if kube_auth_role is None
+                else kube_auth_role
+            )
+            self.kube_auth_mount = (
+                config["vault"]["kube_auth_mount"]
+                if kube_auth_mount is None
+                else kube_auth_mount
+            )
+            self.kube_sa_token_path = os.environ.get(
+                "KUBE_SA_TOKEN_PATH",
+                "/var/run/secrets/kubernetes.io/serviceaccount/token",
+            )
+        else:
+            self.role_id = config["vault"]["role_id"] if role_id is None else role_id
+            self.secret_id = (
+                config["vault"]["secret_id"] if secret_id is None else secret_id
+            )
 
         # This is a threaded world. Let's define a big
         # connections pool to live in that world
@@ -108,7 +126,17 @@ class _VaultClient:
             self._refresh_client_auth()
 
     def _refresh_client_auth(self):
-        self._client.auth_approle(self.role_id, self.secret_id)
+        if self.kube_auth_role:
+            # must read each time to account for sa token refresh
+            with open(self.kube_sa_token_path) as f:
+                self._client.auth_kubernetes(
+                    role=self.kube_auth_role,
+                    jwt=f.read(),
+                    mount_point=self.kube_auth_mount,
+                )
+                print("WE MADE IT")
+        else:
+            self._client.auth_approle(self.role_id, self.secret_id)
 
     @retry()
     def read_all_with_version(self, secret: Mapping) -> tuple[Mapping, Optional[str]]:


### PR DESCRIPTION
APPSRE-7074
SDE-2558

**Summary:** adds support for kubernetes auth option within vault client and explicitly defines service account volume projection in order to overwrite default expiration.

**Changes:**
* Adds option for kubernetes auth to be utilized by the Vault client
  * Defaults to approle when specific kubernetes auth attributes are not set within toml or passed as arguments when initializing `VaultClient`
* Adds environment variable and explicit service account volume projection
  * this is enabled by default but set to expiry of `3607`. This equates to `1 year`. 