### PR TITLE
Update vault query to use fragment so it can get all the fields, and …

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -21983,6 +21983,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "kubeRoleName",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -25309,6 +25321,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "geolocation_routing_policy",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "DnsRecordGeolocationRoutingPolicy_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "set_identifier",
                             "description": null,
                             "args": [],
@@ -25453,6 +25477,53 @@
                             "type": {
                                 "kind": "SCALAR",
                                 "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "DnsRecordGeolocationRoutingPolicy_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "continent",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "country",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "subdivision",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
                                 "ofType": null
                             },
                             "isDeprecated": false,
@@ -27665,6 +27736,30 @@
                                     "name": "String",
                                     "ofType": null
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "kubernetes_ca_cert",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "disable_local_ca_jwt",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -36412,6 +36507,26 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "insights_callback_urls",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "defaults",
                             "description": null,
                             "args": [],
@@ -37403,6 +37518,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "kubeRoleName",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -37465,6 +37592,18 @@
                                     "name": "VaultSecret_v1",
                                     "ofType": null
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "kubeRoleName",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_accounts.gql
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_accounts.gql
@@ -5,14 +5,12 @@ query TerraformCloudflareAccounts {
     name
     providerVersion
     apiCredentials {
-      path
-      field
+      ... VaultSecret
     }
     terraformStateAccount {
       name
       automationToken {
-        path
-        field
+        ... VaultSecret
       }
       terraformState {
         provider

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_accounts.py
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_accounts.py
@@ -16,21 +16,28 @@ from pydantic import (  # noqa: F401 # pylint: disable=W0611
     Json,
 )
 
+from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
+
 
 DEFINITION = """
+fragment VaultSecret on VaultSecret_v1 {
+    path
+    field
+    version
+    format
+}
+
 query TerraformCloudflareAccounts {
   accounts: cloudflare_accounts_v1 {
     name
     providerVersion
     apiCredentials {
-      path
-      field
+      ... VaultSecret
     }
     terraformStateAccount {
       name
       automationToken {
-        path
-        field
+        ... VaultSecret
       }
       terraformState {
         provider
@@ -52,24 +59,6 @@ query TerraformCloudflareAccounts {
   }
 }
 """
-
-
-class VaultSecretV1(BaseModel):
-    path: str = Field(..., alias="path")
-    field: str = Field(..., alias="field")
-
-    class Config:
-        smart_union = True
-        extra = Extra.forbid
-
-
-class AWSAccountV1_VaultSecretV1(BaseModel):
-    path: str = Field(..., alias="path")
-    field: str = Field(..., alias="field")
-
-    class Config:
-        smart_union = True
-        extra = Extra.forbid
 
 
 class AWSTerraformStateIntegrationsV1(BaseModel):
@@ -96,7 +85,7 @@ class TerraformStateAWSV1(BaseModel):
 
 class AWSAccountV1(BaseModel):
     name: str = Field(..., alias="name")
-    automation_token: AWSAccountV1_VaultSecretV1 = Field(..., alias="automationToken")
+    automation_token: VaultSecret = Field(..., alias="automationToken")
     terraform_state: Optional[TerraformStateAWSV1] = Field(..., alias="terraformState")
 
     class Config:
@@ -117,7 +106,7 @@ class DeletionApprovalV1(BaseModel):
 class CloudflareAccountV1(BaseModel):
     name: str = Field(..., alias="name")
     provider_version: str = Field(..., alias="providerVersion")
-    api_credentials: VaultSecretV1 = Field(..., alias="apiCredentials")
+    api_credentials: VaultSecret = Field(..., alias="apiCredentials")
     terraform_state_account: AWSAccountV1 = Field(..., alias="terraformStateAccount")
     deletion_approvals: Optional[list[DeletionApprovalV1]] = Field(
         ..., alias="deletionApprovals"


### PR DESCRIPTION
#### What:
* Update vault query to use fragment so it can get all the fields
* Use typed new method to get vault secret.
#### Why:
Fixing the [error](https://ci.int.devshift.net/job/service-app-interface-gl-pr-check/211799/artifact/temp/reports/index.html) from this [MR](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/60450/diffs).

#### Validation:
Local dry run with a new Cloudflare account that referencing a new versioned vault secret as apiCredentials.