### PR TITLE
Set Cloudflare provider rps based on zone

### DIFF
--- a/reconcile/terraform_cloudflare_resources.py
+++ b/reconcile/terraform_cloudflare_resources.py
@@ -66,6 +66,7 @@ def create_backend_config(
         )
 
     integrations = tf_state.integrations or []
+    bucket_key = bucket_name = bucket_region = None
     for i in integrations or []:
         name = i.integration
         if name.replace("-", "_") == QONTRACT_INTEGRATION:

--- a/reconcile/test/test_utils_terrascript_cloudflare_client.py
+++ b/reconcile/test/test_utils_terrascript_cloudflare_client.py
@@ -141,7 +141,11 @@ def test_create_cloudflare_resources_terraform_json(account_config, backend_conf
     expected_dict = {
         "terraform": {
             "required_providers": {
-                "cloudflare": {"source": "cloudflare/cloudflare", "version": "3.18"}
+                "cloudflare": {
+                    "source": "cloudflare/cloudflare",
+                    "version": "3.18",
+                    "rps": 4,
+                }
             },
             "backend": {
                 "s3": {

--- a/reconcile/utils/terrascript/cloudflare_client.py
+++ b/reconcile/utils/terrascript/cloudflare_client.py
@@ -44,6 +44,7 @@ TMP_DIR_PREFIX = "terrascript-cloudflare-"
 DEFAULT_CLOUDFLARE_ACCOUNT_TYPE = "standard"
 DEFAULT_CLOUDFLARE_ACCOUNT_2FA = False
 DEFAULT_IS_MANAGED_CLOUDFLARE_ACCOUNT = True
+DEFAULT_PROVIDER_RPS = 4
 
 
 @dataclass
@@ -62,6 +63,7 @@ def create_cloudflare_terrascript(
     account_config: CloudflareAccountConfig,
     backend_config: TerraformS3BackendConfig,
     provider_version: str,
+    provider_rps: int = DEFAULT_PROVIDER_RPS,
     is_managed_account: bool = True,
 ) -> Terrascript:
     """
@@ -98,6 +100,7 @@ def create_cloudflare_terrascript(
         "cloudflare": {
             "source": "cloudflare/cloudflare",
             "version": provider_version,
+            "rps": provider_rps,
         }
     }
 
@@ -259,7 +262,10 @@ class TerrascriptCloudflareClientFactory:
         backend_config = cls._create_backend_config(tf_state_s3, key, secret_reader)
         cf_acct_config = cls._create_cloudflare_account_config(cf_acct, secret_reader)
         ts_config = create_cloudflare_terrascript(
-            cf_acct_config, backend_config, cf_acct.provider_version, is_managed_account
+            cf_acct_config,
+            backend_config,
+            cf_acct.provider_version,
+            is_managed_account=is_managed_account,
         )
         client = TerrascriptCloudflareClient(ts_config)
         return client


### PR DESCRIPTION
#### What
*  Adjust Cloudflare terraform provider's rps based on the number of records in the zone.
* Catch the 'referenced before assignment' error with a better error message.
#### Validation:
Ran the terraform-cloudflare-dns locally against dev-data and was able to see the provider setting in the state file, and was able to `terraform apply`
Dry ran terraform-cloudflare-resources locally against dev-data.