### PR TITLE
APPSRE-6175: Retire legacy users file support

### DIFF
--- a/reconcile/gabi_authorized_users.py
+++ b/reconcile/gabi_authorized_users.py
@@ -35,14 +35,11 @@ EXPIRATION_DAYS_MAX = 90
 def construct_gabi_oc_resource(
     name: str, expiration_date: date, users: Iterable[str]
 ) -> OpenshiftResource:
-    # Support the legacy users file. To be removed in the future.
-    _users = users if expiration_date >= date.today() else []
     body = {
         "apiVersion": "v1",
         "kind": "ConfigMap",
         "metadata": {"name": name, "annotations": {"qontract.recycle": "true"}},
         "data": {
-            "authorized-users.yaml": "\n".join(_users),
             "config.json": json.dumps(
                 {
                     "expiration": str(expiration_date),

--- a/reconcile/test/fixtures/gabi_authorized_users/apply.yml
+++ b/reconcile/test/fixtures/gabi_authorized_users/apply.yml
@@ -64,8 +64,5 @@ desired:
     annotations:
       qontract.recycle: 'true'
   data:
-    authorized-users.yaml: |-
-      user1
-      user2
     config.json: |-
       {"expiration":"2023-01-01","users":["user1","user2"]}

--- a/reconcile/test/fixtures/gabi_authorized_users/delete.yml
+++ b/reconcile/test/fixtures/gabi_authorized_users/delete.yml
@@ -18,9 +18,6 @@ server:
           qontract.recycle: 'true'
           qontract.sha256sum: abc
       data:
-        authorized-users.yaml: |-
-           user1
-           user2
         config.json: |-
           {"expiration":"2023-01-01","users":["user1","user2"]}
   apis:
@@ -50,6 +47,5 @@ desired:
     annotations:
       qontract.recycle: 'true'
   data:
-    authorized-users.yaml: ''
     config.json: |-
       {"expiration":"2022-12-31","users":["user1","user2"]}

--- a/reconcile/test/test_gabi_authorized_users.py
+++ b/reconcile/test/test_gabi_authorized_users.py
@@ -2,14 +2,10 @@ import json
 import os
 from datetime import (
     date,
-    datetime,
     timedelta,
 )
 from unittest import TestCase
-from unittest.mock import (
-    Mock,
-    patch,
-)
+from unittest.mock import patch
 
 import reconcile.gabi_authorized_users as gabi_u
 import reconcile.openshift_base as ob
@@ -88,7 +84,6 @@ class TestGabiAuthorizedUser(TestCase):
         with self.assertRaises(RunnerException):
             gabi_u.run(dry_run=False)
 
-    @patch.object(gabi_u, "date", Mock(wraps=datetime))
     @patch.object(ob, "apply", autospec=True)
     def test_gabi_authorized_users_apply(
         self,
@@ -102,7 +97,6 @@ class TestGabiAuthorizedUser(TestCase):
         expiration_date = date(2023, 1, 1)
         get_gabi_instances.return_value = mock_get_gabi_instances(expiration_date)
         mock_request.side_effect = apply_request
-        gabi_u.date.today.return_value = expiration_date
         gabi_u.run(dry_run=False)
         expected = OR(
             apply["desired"],


### PR DESCRIPTION
Currently, both the legacy users file and the new configuration file are supported.  However, the old legacy support is no longer needed after the AppInterface integration has been updated to create the new style configuration file.

Thus, remove the old legacy users file support, as it's no longer needed.

Related: [APPSRE-6175](https://issues.redhat.com/browse/APPSRE-6175)

Depends on:

- https://github.com/app-sre/gabi/pull/54

Related to:

- https://github.com/app-sre/gabi/pull/46
- https://github.com/app-sre/qontract-reconcile/pull/3219

Signed-off-by: Krzysztof Wilczyński <kwilczynski@redhat.com>