### PR TITLE
introduce ocm orgId as mandatory field

### DIFF
--- a/reconcile/gql_definitions/cna/queries/cna_provisioners.gql
+++ b/reconcile/gql_definitions/cna/queries/cna_provisioners.gql
@@ -6,6 +6,7 @@ query CNAProvisioners {
     description
     ocm {
       name
+      orgId
       accessTokenUrl
       accessTokenClientId
       accessTokenClientSecret {

--- a/reconcile/gql_definitions/cna/queries/cna_provisioners.py
+++ b/reconcile/gql_definitions/cna/queries/cna_provisioners.py
@@ -34,6 +34,7 @@ query CNAProvisioners {
     description
     ocm {
       name
+      orgId
       accessTokenUrl
       accessTokenClientId
       accessTokenClientSecret {
@@ -54,6 +55,7 @@ class ConfiguredBaseModel(BaseModel):
 
 class OpenShiftClusterManagerV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+    org_id: str = Field(..., alias="orgId")
     access_token_url: str = Field(..., alias="accessTokenUrl")
     access_token_client_id: str = Field(..., alias="accessTokenClientId")
     access_token_client_secret: Optional[VaultSecret] = Field(

--- a/reconcile/gql_definitions/common/clusters.gql
+++ b/reconcile/gql_definitions/common/clusters.gql
@@ -30,6 +30,7 @@ query Clusters($name: String) {
     ocm {
       name
       url
+      orgId
       accessTokenClientId
       accessTokenUrl
       accessTokenClientSecret {

--- a/reconcile/gql_definitions/common/clusters.py
+++ b/reconcile/gql_definitions/common/clusters.py
@@ -89,6 +89,7 @@ query Clusters($name: String) {
     ocm {
       name
       url
+      orgId
       accessTokenClientId
       accessTokenUrl
       accessTokenClientSecret {
@@ -387,6 +388,7 @@ class OpenShiftClusterManagerSectorV1(ConfiguredBaseModel):
 class OpenShiftClusterManagerV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     url: str = Field(..., alias="url")
+    org_id: str = Field(..., alias="orgId")
     access_token_client_id: str = Field(..., alias="accessTokenClientId")
     access_token_url: str = Field(..., alias="accessTokenUrl")
     access_token_client_secret: Optional[VaultSecret] = Field(

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -2808,6 +2808,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "state",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "INTERFACE",
+                                "name": "AppInterfaceStateConfiguration_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -9255,6 +9267,22 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "orgId",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "url",
                             "description": null,
                             "args": [],
@@ -10418,12 +10446,28 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "NON_NULL",
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "matchName",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
                                 "name": null,
                                 "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "JSON",
-                                    "ofType": null
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
                                 }
                             },
                             "isDeprecated": false,
@@ -21189,6 +21233,39 @@
                     "possibleTypes": null
                 },
                 {
+                    "kind": "INTERFACE",
+                    "name": "AppInterfaceStateConfiguration_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "provider",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": null,
+                    "enumValues": null,
+                    "possibleTypes": [
+                        {
+                            "kind": "OBJECT",
+                            "name": "AppInterfaceStateConfigurationS3_v1",
+                            "ofType": null
+                        }
+                    ]
+                },
+                {
                     "kind": "OBJECT",
                     "name": "AppInterfaceEmail_v1",
                     "description": null,
@@ -27366,6 +27443,87 @@
                 },
                 {
                     "kind": "OBJECT",
+                    "name": "AppInterfaceStateConfigurationS3_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "provider",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "bucket",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "region",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "credentials",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "VaultSecret_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "AppInterfaceStateConfiguration_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
                     "name": "VaultAuditOptionsFile_v1",
                     "description": null,
                     "fields": [
@@ -27742,6 +27900,18 @@
                         },
                         {
                             "name": "kubernetes_ca_cert",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "VaultSecret_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "kubernetes_ca_cert_kv_version",
                             "description": null,
                             "args": [],
                             "type": {

--- a/reconcile/gql_definitions/ocm_oidc_idp/clusters.gql
+++ b/reconcile/gql_definitions/ocm_oidc_idp/clusters.gql
@@ -6,6 +6,7 @@ query OidcClusters($name: String) {
     ocm {
       name
       url
+      orgId
       accessTokenClientId
       accessTokenUrl
       accessTokenClientSecret {

--- a/reconcile/gql_definitions/ocm_oidc_idp/clusters.py
+++ b/reconcile/gql_definitions/ocm_oidc_idp/clusters.py
@@ -34,6 +34,7 @@ query OidcClusters($name: String) {
     ocm {
       name
       url
+      orgId
       accessTokenClientId
       accessTokenUrl
       accessTokenClientSecret {
@@ -107,6 +108,7 @@ class OpenShiftClusterManagerSectorV1(ConfiguredBaseModel):
 class OpenShiftClusterManagerV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     url: str = Field(..., alias="url")
+    org_id: str = Field(..., alias="orgId")
     access_token_client_id: str = Field(..., alias="accessTokenClientId")
     access_token_url: str = Field(..., alias="accessTokenUrl")
     access_token_client_secret: Optional[VaultSecret] = Field(

--- a/reconcile/gql_definitions/ocp_release_mirror/ocp_release_mirror.gql
+++ b/reconcile/gql_definitions/ocp_release_mirror/ocp_release_mirror.gql
@@ -13,6 +13,7 @@ query OCPReleaseMirror {
       ocm {
         name
         url
+        orgId
         accessTokenClientId
         accessTokenUrl
         accessTokenClientSecret {

--- a/reconcile/gql_definitions/ocp_release_mirror/ocp_release_mirror.py
+++ b/reconcile/gql_definitions/ocp_release_mirror/ocp_release_mirror.py
@@ -55,6 +55,7 @@ query OCPReleaseMirror {
       ocm {
         name
         url
+        orgId
         accessTokenClientId
         accessTokenUrl
         accessTokenClientSecret {
@@ -140,6 +141,7 @@ class ConfiguredBaseModel(BaseModel):
 class OpenShiftClusterManagerV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     url: str = Field(..., alias="url")
+    org_id: str = Field(..., alias="orgId")
     access_token_client_id: str = Field(..., alias="accessTokenClientId")
     access_token_url: str = Field(..., alias="accessTokenUrl")
     access_token_client_secret: Optional[VaultSecret] = Field(

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -650,6 +650,7 @@ CLUSTERS_QUERY = """
     ocm {
       name
       url
+      orgId
       accessTokenClientId
       accessTokenUrl
       accessTokenClientSecret {
@@ -980,6 +981,7 @@ CLUSTER_PEERING_QUERY = """
     ocm {
       name
       url
+      orgId
       accessTokenClientId
       accessTokenUrl
       accessTokenClientSecret {
@@ -1158,6 +1160,7 @@ OCM_QUERY = """
     path
     name
     url
+    orgId
     blockedVersions
     recommendedVersions {
       recommendedVersion
@@ -1258,6 +1261,7 @@ KAFKA_CLUSTERS_QUERY = """
     ocm {
       name
       url
+      orgId
       accessTokenClientId
       accessTokenUrl
       accessTokenClientSecret {
@@ -2724,6 +2728,7 @@ OCP_RELEASE_ECR_MIRROR_QUERY = """
       ocm {
         name
         url
+        orgId
         accessTokenClientId
         accessTokenUrl
         accessTokenClientSecret {

--- a/reconcile/test/fixtures/clusters/osd_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/osd_spec_ai.yml
@@ -13,6 +13,7 @@ elbFQDN: "elb.test-cluster.0000.p1.openshiftapps.com"
 ocm:
   name: non-existent-ocm
   url: non-existent-ocm-url
+  orgId: org-id
   accessTokenClientId: cloud-services
   accessTokenClientSecret:
     path: "client-secret-path"

--- a/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
@@ -13,6 +13,7 @@ elbFQDN: "elb.tst-jpr-rosa.0000.p1.openshiftapps.com"
 ocm:
   name: ocm-stage
   url: non-existent-ocm-url
+  orgId: org-id
   accessTokenClientId: cloud-services
   accessTokenClientSecret:
     path: "client-secret-path"

--- a/reconcile/test/fixtures/oc_connection_parameters/cluster_no_jumphost.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/cluster_no_jumphost.yml
@@ -47,6 +47,7 @@ ocm:
   name: ocm-production
   sectors: null
   url: ocm-url
+  orgId: org-id
 peering:
   connections: []
 prometheusUrl: prom-url

--- a/reconcile/test/fixtures/oc_connection_parameters/cluster_with_jumphost.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/cluster_with_jumphost.yml
@@ -57,6 +57,7 @@ ocm:
   name: ocm-production
   sectors: null
   url: ocm-url
+  orgId: org-id
 peering:
   connections: []
 prometheusUrl: prom-url

--- a/reconcile/test/fixtures/ocm_oidc_idp/clusters.yml
+++ b/reconcile/test/fixtures/ocm_oidc_idp/clusters.yml
@@ -4,6 +4,7 @@ clusters:
     ocm:
       name: ocm-production
       url: "https://api.openshift.com"
+      orgId: "org-id"
       accessTokenClientId: "access-token-client-id"
       accessTokenUrl: "http://token-url.com"
       accessTokenClientSecret: null
@@ -27,6 +28,7 @@ clusters:
     ocm:
       name: ocm-production
       url: "https://api.openshift.com"
+      orgId: "org-id"
       accessTokenClientId: "access-token-client-id"
       accessTokenUrl: "http://token-url.com"
       accessTokenClientSecret: null
@@ -52,6 +54,7 @@ clusters:
     ocm:
       name: ocm-production
       url: "https://api.openshift.com"
+      orgId: "org-id"
       accessTokenClientId: "access-token-client-id"
       accessTokenUrl: "http://token-url.com"
       accessTokenClientSecret: null
@@ -83,6 +86,7 @@ clusters:
     ocm:
       name: ocm-production
       url: "https://api.openshift.com"
+      orgId: "org-id"
       accessTokenClientId: "access-token-client-id"
       accessTokenUrl: "http://token-url.com"
       accessTokenClientSecret: null

--- a/reconcile/test/fixtures/openshift_upgrade_watcher/cluster1.yml
+++ b/reconcile/test/fixtures/openshift_upgrade_watcher/cluster1.yml
@@ -47,6 +47,7 @@ ocm:
   name: ocm-production
   sectors: null
   url: ocm-url
+  orgId: org-id
 peering:
   connections: []
 prometheusUrl: prom-url

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -115,6 +115,7 @@ def osd_cluster_fxt():
         "ocm": {
             "name": "non-existent-ocm",
             "url": "https://api.non-existent-ocm.com",
+            "orgId": "org_id",
             "accessTokenClientId": "cloud-services",
             "accessTokenUrl": "https://sso.blah.com/token",
             "accessTokenClientSecret": {
@@ -174,6 +175,7 @@ def rosa_cluster_fxt():
         "ocm": {
             "name": "non-existent-ocm",
             "url": "https://api.non-existent-ocm.com",
+            "orgId": "org_id",
             "accessTokenClientId": "cloud-services",
             "accessTokenUrl": "https://sso.blah.com/token",
             "accessTokenClientSecret": {
@@ -234,6 +236,7 @@ def rosa_hosted_cp_cluster_fxt():
         "ocm": {
             "name": "non-existent-ocm",
             "url": "https://api.non-existent-ocm.com",
+            "orgId": "org_id",
             "accessTokenClientId": "cloud-services",
             "accessTokenUrl": "https://sso.blah.com/token",
             "offlineToken": {

--- a/reconcile/test/test_ocm_oidc_idp.py
+++ b/reconcile/test/test_ocm_oidc_idp.py
@@ -52,6 +52,7 @@ def test_ocm_oidc_idp_get_clusters(clusters: Sequence[ClusterV1]):
             ocm=OpenShiftClusterManagerV1(
                 name="ocm-production",
                 url="https://api.openshift.com",
+                orgId="org-id",
                 accessTokenClientId="access-token-client-id",
                 accessTokenUrl="http://token-url.com",
                 accessTokenClientSecret=None,
@@ -79,6 +80,7 @@ def test_ocm_oidc_idp_get_clusters(clusters: Sequence[ClusterV1]):
             ocm=OpenShiftClusterManagerV1(
                 name="ocm-production",
                 url="https://api.openshift.com",
+                orgId="org-id",
                 accessTokenClientId="access-token-client-id",
                 accessTokenUrl="http://token-url.com",
                 accessTokenClientSecret=None,
@@ -107,6 +109,7 @@ def test_ocm_oidc_idp_get_clusters(clusters: Sequence[ClusterV1]):
             ocm=OpenShiftClusterManagerV1(
                 name="ocm-production",
                 url="https://api.openshift.com",
+                orgId="org-id",
                 accessTokenClientId="access-token-client-id",
                 accessTokenUrl="http://token-url.com",
                 accessTokenClientSecret=None,

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -91,7 +91,7 @@ def ocm(mocker: MockerFixture, ocm_url: str, cluster: str, cluster_id: str) -> O
     mocker.patch("reconcile.utils.ocm.OCM._init_clusters")
     mocker.patch("reconcile.utils.ocm.OCM._init_blocked_versions")
     mocker.patch("reconcile.utils.ocm.OCM._init_version_gates")
-    ocm = OCM("name", "url", "tid", "turl", "ot")
+    ocm = OCM("name", "url", "org_id", "tid", "turl", "ot")
     ocm._ocm_client._url = ocm_url
     ocm.cluster_ids = {cluster: cluster_id}
     return ocm
@@ -292,6 +292,7 @@ def test_ocm_map_upgrade_policies_sector(ocm, mocker):
     ocm1_info = {
         "name": "ocm1",
         "sectors": sectors,
+        "orgId": "orgId1",
         "accessTokenClientId": "atci",
         "accessTokenUrl": "atu",
         "accessTokenClientSecret": "atcs",
@@ -311,6 +312,7 @@ def test_ocm_map_upgrade_policies_sector(ocm, mocker):
     # second org, using the same sector names
     ocm2_info = deepcopy(ocm1_info)
     ocm2_info["name"] = "ocm2"
+    ocm2_info["orgId"] = ("orgId2",)
     c3 = {
         "name": "c3",
         "ocm": ocm2_info,

--- a/reconcile/test/test_utils_ocm_versions.py
+++ b/reconcile/test/test_utils_ocm_versions.py
@@ -10,7 +10,7 @@ def ocm(mocker):
     mocker.patch("reconcile.utils.ocm.OCM.whoami")
     mocker.patch("reconcile.utils.ocm.OCM._init_clusters")
     mocker.patch("reconcile.utils.ocm.OCM._init_version_gates")
-    return OCM("name", "url", "tid", "turl", "ot")
+    return OCM("name", "url", "org_id", "tid", "turl", "ot")
 
 
 def test_no_blocked_versions(ocm):
@@ -62,4 +62,4 @@ def test_version_not_blocked_regex(ocm):
 
 def test_version_invalid_regex(ocm):
     with pytest.raises(TypeError):
-        OCM("name", "url", "tid", "turl", "ot", blocked_versions=["["])
+        OCM("name", "url", "org_id", "tid", "turl", "ot", blocked_versions=["["])

--- a/reconcile/utils/ocm.py
+++ b/reconcile/utils/ocm.py
@@ -522,10 +522,6 @@ OCM_PRODUCTS_IMPL = {
 }
 
 
-class OCMServiceAccountNotAssociatedToOrg(Exception):
-    pass
-
-
 class SectorConfigError(Exception):
     pass
 
@@ -579,6 +575,7 @@ class OCM:  # pylint: disable=too-many-public-methods
 
     :param name: OCM instance name
     :param url: OCM instance URL
+    :param org_id: OCM org ID
     :param access_token_client_id: client-id to get access token
     :param access_token_url: URL to get access token from
     :param access_token_client_secret: client-secret to get access token
@@ -599,6 +596,7 @@ class OCM:  # pylint: disable=too-many-public-methods
         self,
         name,
         url,
+        org_id,
         access_token_client_id,
         access_token_url,
         access_token_client_secret,
@@ -621,10 +619,7 @@ class OCM:  # pylint: disable=too-many-public-methods
             )
         else:
             self._ocm_client = ocm_client
-        try:
-            self.org_id = self.whoami()["organization"]["id"]
-        except KeyError:
-            raise OCMServiceAccountNotAssociatedToOrg(access_token_client_id)
+        self.org_id = org_id
         self._init_clusters(init_provision_shards=init_provision_shards)
 
         if init_addons:
@@ -1778,12 +1773,14 @@ class OCMMap:  # pylint: disable=too-many-public-methods
             self.ocm_map[ocm_name] = False
         else:
             url = ocm_info["url"]
+            org_id = ocm_info["orgId"]
             name = ocm_info["name"]
             secret_reader = SecretReader(settings=self.settings)
             token = secret_reader.read(access_token_client_secret)
             self.ocm_map[ocm_name] = OCM(
                 name,
                 url,
+                org_id,
                 access_token_client_id,
                 access_token_url,
                 token,


### PR DESCRIPTION
the new `ocmId` field will be used for cluster filtering within an OCM org instead of relying on the `ocm whoami` detected org id of the used SA. this enables us to use OCM SAs that are not bound to an org (which is a very common thing anyways) and that can act within multiple orgs.

schema change: https://github.com/app-sre/qontract-schemas/pull/404
part of https://issues.redhat.com/browse/APPSRE-7252