### PR TITLE
gql_class_factory and data_factory pytest fixtures

### DIFF
--- a/reconcile/test/conftest.py
+++ b/reconcile/test/conftest.py
@@ -75,14 +75,14 @@ def data_default_none(
 
 @pytest.fixture
 def data_factory() -> Callable[
-    [type[BaseModel], MutableMapping[str, Any]], MutableMapping[str, Any]
+    [type[BaseModel], Optional[MutableMapping[str, Any]]], MutableMapping[str, Any]
 ]:
     """Set default values to None."""
 
     def _data_factory(
-        klass: type[BaseModel], data: MutableMapping[str, Any] = {}
+        klass: type[BaseModel], data: Optional[MutableMapping[str, Any]] = None
     ) -> MutableMapping[str, Any]:
-        return data_default_none(klass, data)
+        return data_default_none(klass, data or {})
 
     return _data_factory
 

--- a/reconcile/test/conftest.py
+++ b/reconcile/test/conftest.py
@@ -89,7 +89,7 @@ def data_factory() -> Callable[
 
 @pytest.fixture
 def gql_class_factory() -> Callable[
-    [type[BaseModel], MutableMapping[str, Any]], BaseModel
+    [type[BaseModel], Optional[MutableMapping[str, Any]]], BaseModel
 ]:
     """Create a GQL class from a fixture and set default values to None."""
 

--- a/reconcile/test/conftest.py
+++ b/reconcile/test/conftest.py
@@ -1,7 +1,13 @@
 import time
+from collections.abc import (
+    Callable,
+    MutableMapping,
+)
+from typing import Any
 
 import httpretty as _httpretty
 import pytest
+from pydantic import BaseModel
 
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 
@@ -36,3 +42,57 @@ def vault_secret():
         format=None,
         version=None,
     )
+
+
+def data_default_none(
+    klass: type[BaseModel], data: MutableMapping[str, Any]
+) -> MutableMapping[str, Any]:
+    """Set default values to None for required but optional fields."""
+    for field in klass.__fields__.values():
+        if not field.required:
+            continue
+
+        if field.alias not in data:
+            if field.allow_none:
+                data[field.alias] = None
+        else:
+            if isinstance(field.type_, type) and issubclass(field.type_, BaseModel):
+                if isinstance(data[field.alias], dict):
+                    data[field.alias] = data_default_none(
+                        field.type_, data[field.alias]
+                    )
+                if isinstance(data[field.alias], list):
+                    data[field.alias] = [
+                        data_default_none(field.type_, item)
+                        for item in data[field.alias]
+                    ]
+
+    return data
+
+
+@pytest.fixture
+def data_factory() -> Callable[
+    [type[BaseModel], MutableMapping[str, Any]], MutableMapping[str, Any]
+]:
+    """Set default values to None."""
+
+    def _data_factory(
+        klass: type[BaseModel], data: MutableMapping[str, Any] = {}
+    ) -> MutableMapping[str, Any]:
+        return data_default_none(klass, data)
+
+    return _data_factory
+
+
+@pytest.fixture
+def gql_class_factory() -> Callable[
+    [type[BaseModel], MutableMapping[str, Any]], BaseModel
+]:
+    """Create a GQL class from a fixture and set default values to None."""
+
+    def _gql_class_factory(
+        klass: type[BaseModel], data: MutableMapping[str, Any] = {}
+    ) -> BaseModel:
+        return klass(**data_default_none(klass, data))
+
+    return _gql_class_factory

--- a/reconcile/test/conftest.py
+++ b/reconcile/test/conftest.py
@@ -3,7 +3,10 @@ from collections.abc import (
     Callable,
     MutableMapping,
 )
-from typing import Any
+from typing import (
+    Any,
+    Optional,
+)
 
 import httpretty as _httpretty
 import pytest
@@ -91,8 +94,8 @@ def gql_class_factory() -> Callable[
     """Create a GQL class from a fixture and set default values to None."""
 
     def _gql_class_factory(
-        klass: type[BaseModel], data: MutableMapping[str, Any] = {}
+        klass: type[BaseModel], data: Optional[MutableMapping[str, Any]] = None
     ) -> BaseModel:
-        return klass(**data_default_none(klass, data))
+        return klass(**data_default_none(klass, data or {}))
 
     return _gql_class_factory

--- a/reconcile/test/fixtures/glitchtip/dsn_projects.yml
+++ b/reconcile/test/fixtures/glitchtip/dsn_projects.yml
@@ -12,26 +12,15 @@ glitchtip_projects:
   platform: python
   namespaces:
   - name: namespace-1
-    delete: null
-    clusterAdmin: null
     cluster:
       name: cluster-1
       serverUrl: "https://api.cluster-1"
-      insecureSkipTLSVerify: null
-      jumpHost: null
       spec:
         private: false
-      automationToken:
-        path: creds/kube-configs/small-1
-        field: token
-        version: null
-        format: null
-      clusterAdminAutomationToken: null
       internal: false
       disable:
         integrations:
         - glitchtip-project-dsn
-        e2eTests: null
   teams: []
   organization:
     name: NASA
@@ -42,22 +31,12 @@ glitchtip_projects:
   namespaces:
   - name: namespace-1
     delete: true
-    clusterAdmin: null
     cluster:
       name: cluster-1
       serverUrl: "https://api.cluster-1"
-      insecureSkipTLSVerify: null
-      jumpHost: null
       spec:
         private: false
-      automationToken:
-        path: creds/kube-configs/small-1
-        field: token
-        version: null
-        format: null
-      clusterAdminAutomationToken: null
       internal: false
-      disable: null
   teams: []
   organization:
     name: NASA
@@ -72,77 +51,34 @@ glitchtip_projects:
       name: glitchtip-dev
   namespaces:
   - name: namespace-1
-    delete: null
-    clusterAdmin: null
     cluster:
       name: cluster-1
       serverUrl: "https://api.cluster-1"
-      insecureSkipTLSVerify: null
-      jumpHost: null
       spec:
         private: false
-      automationToken:
-        path: creds/kube-configs/small-1
-        field: token
-        version: null
-        format: null
-      clusterAdminAutomationToken: null
       internal: false
-      disable: null
   - name: namespace-1
-    delete: null
-    clusterAdmin: null
     cluster:
       name: cluster-2
       serverUrl: "https://api.cluster-2"
-      insecureSkipTLSVerify: null
-      jumpHost: null
       spec:
         private: false
-      automationToken:
-        path: creds/kube-configs/small-1
-        field: token
-        version: null
-        format: null
-      clusterAdminAutomationToken: null
       internal: false
-      disable: null
   - name: namespace-delete
     delete: true
-    clusterAdmin: null
     cluster:
       name: cluster-2
       serverUrl: "https://api.cluster-2"
-      insecureSkipTLSVerify: null
-      jumpHost: null
       spec:
         private: false
-      automationToken:
-        path: creds/kube-configs/small-1
-        field: token
-        version: null
-        format: null
-      clusterAdminAutomationToken: null
       internal: false
-      disable: null
   - name: cluster-integration-disabled
-    delete: null
-    clusterAdmin: null
     cluster:
       name: cluster-1
       serverUrl: "https://api.cluster-1"
-      insecureSkipTLSVerify: null
-      jumpHost: null
       spec:
         private: false
-      automationToken:
-        path: creds/kube-configs/small-1
-        field: token
-        version: null
-        format: null
-      clusterAdminAutomationToken: null
       internal: false
       disable:
         integrations:
         - glitchtip-project-dsn
-        e2eTests: null

--- a/reconcile/test/fixtures/skupper_network/skupper_networks.yml
+++ b/reconcile/test/fixtures/skupper_network/skupper_networks.yml
@@ -1,437 +1,131 @@
 skupper_networks:
   - identifier: small
     siteConfigDefaults:
-      clusterLocal: null
-      console: null
-      consoleAuthentication: null
-      consoleIngress: null
-      controllerCpuLimit: null
-      controllerCpu: null
-      controllerMemoryLimit: null
-      controllerMemory: null
-      controllerPodAntiaffinity: null
-      controllerServiceAnnotations: null
-      edge: null
-      ingress: null
-      routerConsole: null
-      routerCpuLimit: null
-      routerCpu: null
       routerMemoryLimit: "1Gi"
-      routerMemory: null
-      routerLogging: null
-      routerPodAntiaffinity: null
-      routerServiceAnnotations: null
-      routers: null
-      serviceController: null
-      serviceSync: null
       skupperSiteController: "quay.io/skupper/site-controller:1.2.0"
     namespaces:
       - name: site-1
-        delete: null
         skupperSite:
-          delete: null
           config:
-            clusterLocal: null
-            console: null
-            consoleAuthentication: null
-            consoleIngress: null
-            controllerCpuLimit: null
-            controllerCpu: null
-            controllerMemoryLimit: null
-            controllerMemory: null
-            controllerPodAntiaffinity: null
-            controllerServiceAnnotations: null
-            edge: null
-            ingress: null
-            routerConsole: null
-            routerCpuLimit: null
-            routerCpu: null
             routerMemoryLimit: "1Gi"
-            routerMemory: null
-            routerLogging: null
-            routerPodAntiaffinity: null
-            routerServiceAnnotations: null
             routers: 1
-            serviceController: null
-            serviceSync: null
-        clusterAdmin: null
         cluster:
           name: small-1
           serverUrl: "https://api.small-1"
-          insecureSkipTLSVerify: null
-          jumpHost: null
           spec:
             private: false
-          automationToken:
-            path: creds/kube-configs/small-1
-            field: token
-            version: null
-            format: null
-          clusterAdminAutomationToken: null
           internal: false
-          disable: null
           peering:
             connections:
               - provider: account-vpc-mesh
       - name: site-2
-        delete: null
         skupperSite:
-          delete: null
           config:
-            clusterLocal: null
-            console: null
-            consoleAuthentication: null
-            consoleIngress: null
-            controllerCpuLimit: null
-            controllerCpu: null
-            controllerMemoryLimit: null
-            controllerMemory: null
-            controllerPodAntiaffinity: null
-            controllerServiceAnnotations: null
-            edge: null
-            ingress: null
-            routerConsole: null
-            routerCpuLimit: null
-            routerCpu: null
             routerMemoryLimit: "1Gi"
-            routerMemory: null
-            routerLogging: null
-            routerPodAntiaffinity: null
-            routerServiceAnnotations: null
             routers: 1
-            serviceController: null
-            serviceSync: null
-        clusterAdmin: null
         cluster:
           name: small-2
           serverUrl: "https://api.small-2"
-          insecureSkipTLSVerify: null
-          jumpHost: null
           spec:
             private: false
-          automationToken:
-            path: creds/kube-configs/small-2
-            field: token
-            version: null
-            format: null
-          clusterAdminAutomationToken: null
           internal: false
-          disable: null
           peering:
             connections:
               - provider: account-vpc-mesh
 
   - identifier: advanced
     siteConfigDefaults:
-      clusterLocal: null
-      console: null
-      consoleAuthentication: null
-      consoleIngress: null
-      controllerCpuLimit: null
-      controllerCpu: null
-      controllerMemoryLimit: null
-      controllerMemory: null
-      controllerPodAntiaffinity: null
-      controllerServiceAnnotations: null
-      edge: null
-      ingress: null
-      routerConsole: null
-      routerCpuLimit: null
-      routerCpu: null
       routerMemoryLimit: "1Gi"
-      routerMemory: null
-      routerLogging: null
-      routerPodAntiaffinity: null
-      routerServiceAnnotations: null
-      routers: null
-      serviceController: null
-      serviceSync: null
       skupperSiteController: "quay.io/skupper/site-controller:1.2.0"
     namespaces:
       - name: public-1
-        delete: null
         skupperSite:
-          delete: null
           config:
-            clusterLocal: null
-            console: null
-            consoleAuthentication: null
-            consoleIngress: null
-            controllerCpuLimit: null
-            controllerCpu: null
-            controllerMemoryLimit: null
-            controllerMemory: null
-            controllerPodAntiaffinity: null
-            controllerServiceAnnotations: null
-            edge: null
-            ingress: null
-            routerConsole: null
-            routerCpuLimit: null
-            routerCpu: null
             routerMemoryLimit: "1Gi"
-            routerMemory: null
-            routerLogging: null
-            routerPodAntiaffinity: null
-            routerServiceAnnotations: null
             routers: 1
-            serviceController: null
-            serviceSync: null
-        clusterAdmin: null
         cluster:
           name: public-1
           serverUrl: "https://api.public-1"
-          insecureSkipTLSVerify: null
-          jumpHost: null
           spec:
             private: false
-          automationToken:
-            path: creds/kube-configs/public-1
-            field: token
-            version: null
-            format: null
-          clusterAdminAutomationToken: null
           internal: false
-          disable: null
           peering:
             connections:
               - provider: account-vpc-mesh
 
       - name: public-2
-        delete: null
         skupperSite:
-          delete: null
           config:
-            clusterLocal: null
-            console: null
-            consoleAuthentication: null
-            consoleIngress: null
-            controllerCpuLimit: null
-            controllerCpu: null
-            controllerMemoryLimit: null
-            controllerMemory: null
-            controllerPodAntiaffinity: null
-            controllerServiceAnnotations: null
-            edge: null
-            ingress: null
-            routerConsole: null
-            routerCpuLimit: null
-            routerCpu: null
             routerMemoryLimit: "1Gi"
-            routerMemory: null
-            routerLogging: null
-            routerPodAntiaffinity: null
-            routerServiceAnnotations: null
             routers: 1
-            serviceController: null
-            serviceSync: null
-        clusterAdmin: null
         cluster:
           name: public-2
           serverUrl: "https://api.public-2"
-          insecureSkipTLSVerify: null
-          jumpHost: null
           spec:
             private: false
-          automationToken:
-            path: creds/kube-configs/public-2
-            field: token
-            version: null
-            format: null
-          clusterAdminAutomationToken: null
           internal: false
-          disable: null
           peering:
             connections:
               - provider: account-vpc-mesh
 
       - name: edge-1
-        delete: null
         skupperSite:
-          delete: null
           config:
-            clusterLocal: null
-            console: null
-            consoleAuthentication: null
-            consoleIngress: null
-            controllerCpuLimit: null
-            controllerCpu: null
-            controllerMemoryLimit: null
-            controllerMemory: null
-            controllerPodAntiaffinity: null
-            controllerServiceAnnotations: null
             edge: true
-            ingress: null
-            routerConsole: null
-            routerCpuLimit: null
-            routerCpu: null
             routerMemoryLimit: "1Gi"
-            routerMemory: null
-            routerLogging: null
-            routerPodAntiaffinity: null
-            routerServiceAnnotations: null
             routers: 2
-            serviceController: null
-            serviceSync: null
-        clusterAdmin: null
         cluster:
           name: internal-1
           serverUrl: "https://api.internal-1"
-          insecureSkipTLSVerify: null
-          jumpHost: null
           spec:
             private: false
-          automationToken:
-            path: creds/kube-configs/internal-1
-            field: token
-            version: null
-            format: null
-          clusterAdminAutomationToken: null
           internal: true
-          disable: null
           peering:
             connections:
               - provider: account-vpc-mesh
 
       - name: edge-2
-        delete: null
         skupperSite:
-          delete: null
           config:
-            clusterLocal: null
-            console: null
-            consoleAuthentication: null
-            consoleIngress: null
-            controllerCpuLimit: null
-            controllerCpu: null
-            controllerMemoryLimit: null
-            controllerMemory: null
-            controllerPodAntiaffinity: null
-            controllerServiceAnnotations: null
             edge: true
-            ingress: null
-            routerConsole: null
-            routerCpuLimit: null
-            routerCpu: null
             routerMemoryLimit: "1Gi"
-            routerMemory: null
-            routerLogging: null
-            routerPodAntiaffinity: null
-            routerServiceAnnotations: null
             routers: 1
-            serviceController: null
-            serviceSync: null
-        clusterAdmin: null
         cluster:
           name: internal-2
           serverUrl: "https://api.internal-2"
-          insecureSkipTLSVerify: null
-          jumpHost: null
           spec:
             private: false
-          automationToken:
-            path: creds/kube-configs/internal-2
-            field: token
-            version: null
-            format: null
-          clusterAdminAutomationToken: null
           internal: true
-          disable: null
           peering:
             connections:
               - provider: account-vpc-mesh
 
       - name: private-1
-        delete: null
         skupperSite:
-          delete: null
           config:
-            clusterLocal: null
-            console: null
-            consoleAuthentication: null
-            consoleIngress: null
-            controllerCpuLimit: null
-            controllerCpu: null
-            controllerMemoryLimit: null
-            controllerMemory: null
-            controllerPodAntiaffinity: null
-            controllerServiceAnnotations: null
-            edge: null
-            ingress: null
-            routerConsole: null
-            routerCpuLimit: null
-            routerCpu: null
             routerMemoryLimit: "1Gi"
-            routerMemory: null
-            routerLogging: null
-            routerPodAntiaffinity: null
-            routerServiceAnnotations: null
             routers: 1
-            serviceController: null
-            serviceSync: null
-        clusterAdmin: null
         cluster:
           name: private-1
           serverUrl: "https://api.private-1"
-          insecureSkipTLSVerify: null
-          jumpHost: null
           spec:
             private: true
-          automationToken:
-            path: creds/kube-configs/private-1
-            field: token
-            version: null
-            format: null
-          clusterAdminAutomationToken: null
           internal: false
-          disable: null
           peering:
             connections:
               - provider: account-vpc-mesh
 
       - name: private-2
-        delete: null
         skupperSite:
-          delete: null
           config:
-            clusterLocal: null
-            console: null
-            consoleAuthentication: null
-            consoleIngress: null
-            controllerCpuLimit: null
-            controllerCpu: null
-            controllerMemoryLimit: null
-            controllerMemory: null
-            controllerPodAntiaffinity: null
-            controllerServiceAnnotations: null
-            edge: null
-            ingress: null
-            routerConsole: null
-            routerCpuLimit: null
-            routerCpu: null
             routerMemoryLimit: "1Gi"
-            routerMemory: null
-            routerLogging: null
-            routerPodAntiaffinity: null
-            routerServiceAnnotations: null
             routers: 1
-            serviceController: null
-            serviceSync: null
-        clusterAdmin: null
         cluster:
           name: private-2
           serverUrl: "https://api.private-2"
-          insecureSkipTLSVerify: null
-          jumpHost: null
           spec:
             private: false
-          automationToken:
-            path: creds/kube-configs/private-2
-            field: token
-            version: null
-            format: null
-          clusterAdminAutomationToken: null
           internal: false
-          disable: null
           peering:
             connections:
               - provider: account-vpc-mesh
@@ -442,146 +136,49 @@ skupper_networks:
       - name: delete-1
         delete: true
         skupperSite:
-          delete: null
           config:
-            clusterLocal: null
-            console: null
-            consoleAuthentication: null
-            consoleIngress: null
-            controllerCpuLimit: null
-            controllerCpu: null
-            controllerMemoryLimit: null
-            controllerMemory: null
-            controllerPodAntiaffinity: null
-            controllerServiceAnnotations: null
-            edge: null
-            ingress: null
-            routerConsole: null
-            routerCpuLimit: null
-            routerCpu: null
             routerMemoryLimit: "1Gi"
-            routerMemory: null
-            routerLogging: null
-            routerPodAntiaffinity: null
-            routerServiceAnnotations: null
             routers: 1
-            serviceController: null
-            serviceSync: null
-        clusterAdmin: null
         cluster:
           name: public-1
           serverUrl: "https://api.public-1"
-          insecureSkipTLSVerify: null
-          jumpHost: null
           spec:
             private: false
-          automationToken:
-            path: creds/kube-configs/public-1
-            field: token
-            version: null
-            format: null
-          clusterAdminAutomationToken: null
           internal: false
-          disable: null
           peering:
             connections:
               - provider: account-vpc-mesh
 
       - name: delete-2
-        delete: null
         skupperSite:
           delete: true
           config:
-            clusterLocal: null
-            console: null
-            consoleAuthentication: null
-            consoleIngress: null
-            controllerCpuLimit: null
-            controllerCpu: null
-            controllerMemoryLimit: null
-            controllerMemory: null
-            controllerPodAntiaffinity: null
-            controllerServiceAnnotations: null
-            edge: null
-            ingress: null
-            routerConsole: null
-            routerCpuLimit: null
-            routerCpu: null
             routerMemoryLimit: "1Gi"
-            routerMemory: null
-            routerLogging: null
-            routerPodAntiaffinity: null
-            routerServiceAnnotations: null
             routers: 1
-            serviceController: null
-            serviceSync: null
-        clusterAdmin: null
         cluster:
           name: public-1
           serverUrl: "https://api.public-1"
-          insecureSkipTLSVerify: null
-          jumpHost: null
           spec:
             private: false
-          automationToken:
-            path: creds/kube-configs/public-1
-            field: token
-            version: null
-            format: null
-          clusterAdminAutomationToken: null
           internal: false
-          disable: null
           peering:
             connections:
               - provider: account-vpc-mesh
 
       - name: disabled-1
-        delete: null
         skupperSite:
-          delete: null
           config:
-            clusterLocal: null
-            console: null
-            consoleAuthentication: null
-            consoleIngress: null
-            controllerCpuLimit: null
-            controllerCpu: null
-            controllerMemoryLimit: null
-            controllerMemory: null
-            controllerPodAntiaffinity: null
-            controllerServiceAnnotations: null
-            edge: null
-            ingress: null
-            routerConsole: null
-            routerCpuLimit: null
-            routerCpu: null
             routerMemoryLimit: "1Gi"
-            routerMemory: null
-            routerLogging: null
-            routerPodAntiaffinity: null
-            routerServiceAnnotations: null
             routers: 1
-            serviceController: null
-            serviceSync: null
-        clusterAdmin: null
         cluster:
           name: disabled-1
           serverUrl: "https://api.disabled-1"
-          insecureSkipTLSVerify: null
-          jumpHost: null
           spec:
             private: false
-          automationToken:
-            path: creds/kube-configs/disabled-1
-            field: token
-            version: null
-            format: null
-          clusterAdminAutomationToken: null
           internal: false
           disable:
             integrations:
               - skupper-network
-            e2eTests: null
           peering:
             connections:
               - provider: account-vpc-mesh

--- a/reconcile/test/glitchtip/test_glitchtip_project_dsn.py
+++ b/reconcile/test/glitchtip/test_glitchtip_project_dsn.py
@@ -1,4 +1,8 @@
-from collections.abc import Sequence
+from collections.abc import (
+    Callable,
+    MutableMapping,
+    Sequence,
+)
 from typing import Any
 
 import pytest
@@ -17,9 +21,20 @@ from reconcile.utils.openshift_resource import ResourceInventory
 
 
 @pytest.fixture
-def projects(fx: Fixtures) -> list[GlitchtipProjectsV1]:
+def projects(
+    fx: Fixtures,
+    data_factory: Callable[
+        [type[GlitchtipProjectsV1], MutableMapping[str, Any]], MutableMapping[str, Any]
+    ],
+) -> list[GlitchtipProjectsV1]:
     def q(*args: Any, **kwargs: Any) -> dict:
-        return fx.get_anymarkup("dsn_projects.yml")
+        raw_data = fx.get_anymarkup("dsn_projects.yml")
+        return {
+            "glitchtip_projects": [
+                data_factory(GlitchtipProjectsV1, item)
+                for item in raw_data["glitchtip_projects"]
+            ]
+        }
 
     return projects_query(q)
 

--- a/reconcile/test/skupper_network/conftest.py
+++ b/reconcile/test/skupper_network/conftest.py
@@ -1,3 +1,7 @@
+from collections.abc import (
+    Callable,
+    MutableMapping,
+)
 from typing import Any
 
 import pytest
@@ -18,9 +22,20 @@ def fx() -> Fixtures:
 
 
 @pytest.fixture
-def skupper_networks(fx: Fixtures) -> list[SkupperNetworkV1]:
+def skupper_networks(
+    fx: Fixtures,
+    data_factory: Callable[
+        [type[SkupperNetworkV1], MutableMapping[str, Any]], MutableMapping[str, Any]
+    ],
+) -> list[SkupperNetworkV1]:
     def q(*args: Any, **kwargs: Any) -> dict[Any, Any]:
-        return fx.get_anymarkup("skupper_networks.yml")
+        raw_data = fx.get_anymarkup("skupper_networks.yml")
+        return {
+            "skupper_networks": [
+                data_factory(SkupperNetworkV1, item)
+                for item in raw_data["skupper_networks"]
+            ]
+        }
 
     return intg.get_skupper_networks(q)
 


### PR DESCRIPTION
Introduce `gql_class_factory` and `data_factory` pytest fixtures.

**gql_class_factory**

This pytest fixture helps you to create GQL classes from test fixtures without worrying about `Optional` fields. Just specify all required and non-optional fields, and you're done.

**data_factory**

This fixture does the same as `gql_class_factory` but returns a data dictionary instead of a GQL class. Very handy to test and re-use the GQL `query` methods. 


Hints for the reviewer: This affects just tests; no prod code has been touched
