### PR TITLE
manage route53 vpc associations on tgw peerings

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1072,6 +1072,7 @@ CLUSTER_PEERING_QUERY = """
           tags
           cidrBlock
           manageSecurityGroups
+          manageRoute53Associations
           assumeRole
         }
         ... on ClusterPeeringConnectionClusterRequester_v1 {

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -81,6 +81,7 @@ def build_desired_state_tgw_attachments(clusters, ocm_map: OCMMap, awsapi: AWSAp
                 tags=json.loads(peer_connection.get("tags") or "{}"),
                 route_tables=peer_connection.get("manageRoutes"),
                 security_groups=peer_connection.get("manageSecurityGroups"),
+                route53_associations=peer_connection.get("manageRoute53Associations"),
             )
             for tgw in account_tgws:
                 tgw_id = tgw["tgw_id"]
@@ -93,6 +94,7 @@ def build_desired_state_tgw_attachments(clusters, ocm_map: OCMMap, awsapi: AWSAp
                     "region": tgw["region"],
                     "routes": tgw.get("routes"),
                     "rules": tgw.get("rules"),
+                    "hostedzones": tgw.get("hostedzones"),
                     "cidr_block": peer_connection.get("cidrBlock"),
                     "account": account,
                 }

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1098,13 +1098,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
                 zones = []
                 for page in paginator.paginate():
                     for zone in page["HostedZones"]:
-                        if zone["Config"]["PrivateZone"]:  # TODO: add filter on tags?
-                            zone_name = zone["Name"]
-                            # ignore high-level zone names, like p1.openshiftapps.com.
-                            # since zone names end with a dot, we get a length of 4
-                            zone_name_labels = zone_name.split(".")
-                            if len(zone_name_labels) <= 4:
-                                continue
+                        if zone["Config"]["PrivateZone"]:
                             zone_id = self._get_hosted_zone_id(zone)
                             zones.append(zone_id)
                 item["hostedzones"] = zones


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-7273

On TGW attachments to non-hive transit accounts, we may want to associate Private Hostedzones to our cluster VPC in order to resolve hostnames.

This is especially the case of the hypershift "service-transit-account", which contains private hosted zones for hypershift service clusters VPCE interfaces (privatelink endpoints).

Depends on https://github.com/app-sre/qontract-schemas/pull/408