### PR TITLE
PoC: Make Integrations Manager reusable

### DIFF
--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -177,6 +177,8 @@ objects:
             value: "${INTERNAL_CERTIFICATES_IMAGE_TAG}"
           - name: INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY
             value: "${INTERNAL_CERTIFICATES_IMAGE_PULL_POLICY}"
+          - name: INTEGRATIONS_MANAGER_IMAGE_TAG_FROM_REF
+            value: "${INTEGRATIONS_MANAGER_IMAGE_TAG_FROM_REF}"
           resources:
             limits:
               cpu: ${INTEGRATIONS_MANAGER_CPU_LIMIT}
@@ -295,3 +297,5 @@ parameters:
   value: 200m
 - name: INTEGRATIONS_MANAGER_MEMORY_REQUEST
   value: 300Mi
+- name: INTEGRATIONS_MANAGER_IMAGE_TAG_FROM_REF
+  value: ""

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2400,6 +2400,12 @@ def vault_replication(ctx):
     help="git ref to use as IMAGE_TAG for given environment. example: '--image-tag-from-ref app-interface-dev=master'.",
     multiple=True,
     callback=parse_image_tag_from_ref,
+    envvar="INTEGRATIONS_MANAGER_IMAGE_TAG_FROM_REF"
+)
+@click.option(
+    "--upstream",
+    "-u",
+    help="specify upstream of managed integrations",
 )
 @click.pass_context
 def integrations_manager(
@@ -2409,6 +2415,7 @@ def integrations_manager(
     internal,
     use_jump_host,
     image_tag_from_ref,
+    upstream,
 ):
     import reconcile.integrations_manager
 
@@ -2421,6 +2428,7 @@ def integrations_manager(
         internal,
         use_jump_host,
         image_tag_from_ref,
+        upstream,
     )
 
 

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -285,6 +285,7 @@ def populate_current_state(
     ri: ResourceInventory,
     integration: str,
     integration_version: str,
+    caller: Optional[str] = None,
 ):
     # if spec.oc is None: - oc can't be none because init_namespace_specs_to_fetch does not create specs if oc is none
     #    return
@@ -297,6 +298,9 @@ def populate_current_state(
             spec.kind, namespace=spec.namespace, resource_names=spec.resource_names
         ):
             openshift_resource = OR(item, integration, integration_version)
+            if caller and openshift_resource.caller != caller:
+                continue
+
             ri.add_current(
                 spec.cluster,
                 spec.namespace,
@@ -320,6 +324,7 @@ def fetch_current_state(
     use_jump_host=True,
     init_api_resources=False,
     cluster_admin=False,
+    caller=None,
 ):
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
@@ -348,6 +353,7 @@ def fetch_current_state(
         ri=ri,
         integration=integration,
         integration_version=integration_version,
+        caller=caller,
     )
 
     return ri, oc_map

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -204,6 +204,7 @@ INTEGRATIONS_QUERY = """
 {
   integrations: integrations_v1 {
     name
+    upstream
     managed {
       namespace {
         path


### PR DESCRIPTION
Making integrations manager reusable:

- add upstream as parameter to filter out integrations and fetch ref from repo
- add caller to populate_current_state to filter resource inventory on caller. makes it possible to deploy multiple upstream in one namespace

Missing: setting image location, either pass in environment variable or add it to the integration schema

@geoberle & @maorfr 