### PR TITLE
[qontract-cli/get/selectorsyncset-managed-resources] fix bug

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1820,7 +1820,7 @@ def selectorsyncset_managed_resources(ctx):
                         "namespace": namespace,
                         "name": name,
                     }
-                data.append(item)
+                    data.append(item)
             except KeyError:
                 pass
 


### PR DESCRIPTION
without this indentation we are missing all items except the last one :facepalm: