### PR TITLE
Close VaultClient after replication to fix memory leak

### DIFF
--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -118,6 +118,12 @@ class _VaultClient:
             t = threading.Thread(target=self._auto_refresh_client_auth, daemon=True)
             t.start()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self._client.adapter.close()
+
     def _auto_refresh_client_auth(self):
         """
         Thread that periodically refreshes the vault token

--- a/reconcile/vault_replication.py
+++ b/reconcile/vault_replication.py
@@ -436,20 +436,18 @@ def run(dry_run: bool) -> None:
                     # Private class _VaultClient is used because the public class is
                     # defined as a singleton, and we need to create multiple instances
                     # as the source vault is different than the replication.
-                    source_vault = _VaultClient(
+                    with _VaultClient(
                         server=source_creds["server"],
                         role_id=source_creds["role_id"],
                         secret_id=source_creds["secret_id"],
-                    )
-                    dest_vault = _VaultClient(
+                    ) as source_vault, _VaultClient(
                         server=dest_creds["server"],
                         role_id=dest_creds["role_id"],
                         secret_id=dest_creds["secret_id"],
-                    )
-
-                    replicate_paths(
-                        dry_run=dry_run,
-                        source_vault=source_vault,
-                        dest_vault=dest_vault,
-                        replications=replication,
-                    )
+                    ) as dest_vault:
+                        replicate_paths(
+                            dry_run=dry_run,
+                            source_vault=source_vault,
+                            dest_vault=dest_vault,
+                            replications=replication,
+                        )


### PR DESCRIPTION
`vault-replication` integration is leaking memory, every time it runs it will leak fd (sockets to vault).
`requests.Session()` need to be closed after the client is no longer needed.
In this change, I implemented context manager for `_VaultClient`, so it can be used with `with` to proper close session.

APPSRE-7274