### PR TITLE
add ability to remove resetPassword entries for users not in LDAP.

### DIFF
--- a/reconcile/ldap_users.py
+++ b/reconcile/ldap_users.py
@@ -16,7 +16,7 @@ from reconcile.utils.mr.user_maintenance import PathTypes
 QONTRACT_INTEGRATION = "ldap-users"
 
 
-def init_users() -> dict:
+def init_users() -> list[dict[str, list]]:
     app_int_users = queries.get_users(refs=True)
 
     users = defaultdict(list)

--- a/reconcile/ldap_users.py
+++ b/reconcile/ldap_users.py
@@ -62,16 +62,11 @@ def get_ldap_settings() -> dict:
     raise ValueError("no app-interface-settings settings found")
 
 
-<<<<<<< HEAD
 def run(dry_run, app_interface_project_id, infra_project_id):
-=======
-def run(dry_run, gitlab_project_id=None) -> None:
->>>>>>> 53018c38 (add ability to remove resetPassword entries for users not in LDAP.  Part of APPSRE-6367)
     users = init_users()
     with LdapClient.from_settings(get_ldap_settings()) as ldap_client:
         ldap_users = ldap_client.get_users([u["username"] for u in users])
 
-    ldap_users.remove("jmosco")
     users_to_delete = [u for u in users if u["username"] not in ldap_users]
 
     if not dry_run:

--- a/reconcile/ldap_users.py
+++ b/reconcile/ldap_users.py
@@ -16,7 +16,7 @@ from reconcile.utils.mr.user_maintenance import PathTypes
 QONTRACT_INTEGRATION = "ldap-users"
 
 
-def init_users():
+def init_users() -> dict:
     app_int_users = queries.get_users(refs=True)
 
     users = defaultdict(list)
@@ -32,6 +32,9 @@ def init_users():
             users[u].append(item)
         for g in user.get("gabi_instances"):
             item = {"type": PathTypes.GABI, "path": "data" + g["path"]}
+            users[u].append(item)
+        for a in user.get("aws_accounts", []):
+            item = {"type": PathTypes.AWS_ACCOUNTS, "path": "data" + a["path"]}
             users[u].append(item)
 
     return [{"username": username, "paths": paths} for username, paths in users.items()]
@@ -59,11 +62,16 @@ def get_ldap_settings() -> dict:
     raise ValueError("no app-interface-settings settings found")
 
 
+<<<<<<< HEAD
 def run(dry_run, app_interface_project_id, infra_project_id):
+=======
+def run(dry_run, gitlab_project_id=None) -> None:
+>>>>>>> 53018c38 (add ability to remove resetPassword entries for users not in LDAP.  Part of APPSRE-6367)
     users = init_users()
     with LdapClient.from_settings(get_ldap_settings()) as ldap_client:
         ldap_users = ldap_client.get_users([u["username"] for u in users])
 
+    ldap_users.remove("jmosco")
     users_to_delete = [u for u in users if u["username"] not in ldap_users]
 
     if not dry_run:

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1805,6 +1805,9 @@ USERS_QUERY = """
     pagerduty_username
     public_gpg_key
     {% if refs %}
+    aws_accounts {
+      path
+    }
     requests {
       path
     }

--- a/reconcile/utils/mr/user_maintenance.py
+++ b/reconcile/utils/mr/user_maintenance.py
@@ -9,6 +9,7 @@ class PathTypes:
     REQUEST = 1
     QUERY = 2
     GABI = 3
+    AWS_ACCOUNTS = 4
 
 
 class CreateDeleteUserAppInterface(MergeRequestBase):
@@ -53,6 +54,7 @@ class CreateDeleteUserAppInterface(MergeRequestBase):
                     commit_message=self.title,
                     content=new_content,
                 )
+<<<<<<< HEAD
 
 
 class CreateDeleteUserInfra(MergeRequestBase):
@@ -100,3 +102,19 @@ class CreateDeleteUserInfra(MergeRequestBase):
             commit_message=self.title,
             content=new_content,
         )
+=======
+            elif path_type == PathTypes.AWS_ACCOUNTS:
+                raw_file = gitlab_cli.project.files.get(file_path=path, ref=self.branch)
+                content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+                for reset_record in content["resetPasswords"]:
+                    if self.username in reset_record["user"]["$ref"]:
+                        content["resetPasswords"].remove(reset_record)
+                        new_content = "---\n"
+                        new_content += yaml.dump(content, Dumper=yaml.RoundTripDumper)
+                        gitlab_cli.update_file(
+                            branch_name=self.branch,
+                            file_path=path,
+                            commit_message=self.title,
+                            content=new_content,
+                        )
+>>>>>>> 53018c38 (add ability to remove resetPassword entries for users not in LDAP.  Part of APPSRE-6367)

--- a/reconcile/utils/mr/user_maintenance.py
+++ b/reconcile/utils/mr/user_maintenance.py
@@ -54,7 +54,20 @@ class CreateDeleteUserAppInterface(MergeRequestBase):
                     commit_message=self.title,
                     content=new_content,
                 )
-<<<<<<< HEAD
+            elif path_type == PathTypes.AWS_ACCOUNTS:
+                raw_file = gitlab_cli.project.files.get(file_path=path, ref=self.branch)
+                content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
+                for reset_record in content["resetPasswords"]:
+                    if self.username in reset_record["user"]["$ref"]:
+                        content["resetPasswords"].remove(reset_record)
+                        new_content = "---\n"
+                        new_content += yaml.dump(content, Dumper=yaml.RoundTripDumper)
+                        gitlab_cli.update_file(
+                            branch_name=self.branch,
+                            file_path=path,
+                            commit_message=self.title,
+                            content=new_content,
+                        )
 
 
 class CreateDeleteUserInfra(MergeRequestBase):
@@ -102,19 +115,3 @@ class CreateDeleteUserInfra(MergeRequestBase):
             commit_message=self.title,
             content=new_content,
         )
-=======
-            elif path_type == PathTypes.AWS_ACCOUNTS:
-                raw_file = gitlab_cli.project.files.get(file_path=path, ref=self.branch)
-                content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
-                for reset_record in content["resetPasswords"]:
-                    if self.username in reset_record["user"]["$ref"]:
-                        content["resetPasswords"].remove(reset_record)
-                        new_content = "---\n"
-                        new_content += yaml.dump(content, Dumper=yaml.RoundTripDumper)
-                        gitlab_cli.update_file(
-                            branch_name=self.branch,
-                            file_path=path,
-                            commit_message=self.title,
-                            content=new_content,
-                        )
->>>>>>> 53018c38 (add ability to remove resetPassword entries for users not in LDAP.  Part of APPSRE-6367)


### PR DESCRIPTION
Part of APPSRE-6367, requires https://github.com/app-sre/qontract-schemas/pull/411.

Extends the `ldap_users` integration to include removal of `resetPasswords` entries that no longer have a user associated in LDAP.  Schema changes are in https://github.com/app-sre/qontract-schemas/pull/411 to provide the paths to `user_maintenance.py`.  

Testing was done with qontract-reconcile-cli and qd.  