### PR TITLE
hard coded typeguard version

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -9,6 +9,7 @@ pytest-cov~=2.12
 pytest-mock~=3.6
 responses
 testslide~=2.7
+typeguard==2.13.3
 moto~=2.2
 MarkupSafe==2.1.1
 smtpdfix==0.3.3


### PR DESCRIPTION
[new version](https://pypi.org/project/typeguard/3.0.0/) does not work for our testslide package.

`AttributeError: module 'typeguard' has no attribute 'qualified_name'`