### PR TITLE
[terraform-resources] support records for route53-zone provider

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2586,6 +2586,23 @@ def get_unleash_instances():
     return gqlapi.query(UNLEASH_INSTANCES_QUERY)["unleash_instances"]
 
 
+DNS_RECORD = """
+name
+type
+ttl
+alias {
+  name
+  zone_id
+  evaluate_target_health
+}
+weighted_routing_policy {
+  weight
+}
+set_identifier
+records
+"""
+
+
 DNS_ZONES_QUERY = """
 {
   zones: dns_zone_v1 {
@@ -2607,24 +2624,7 @@ DNS_ZONES_QUERY = """
       region
     }
     records {
-      name
-      type
-      ttl
-      alias {
-        name
-        zone_id
-        evaluate_target_health
-      }
-      weighted_routing_policy {
-        weight
-      }
-      geolocation_routing_policy {
-        continent
-        country
-        subdivision
-      }
-      set_identifier
-      records
+      %s
       _healthcheck {
         fqdn
         port
@@ -2662,7 +2662,9 @@ DNS_ZONES_QUERY = """
     }
   }
 }
-"""
+""" % (
+    indent(DNS_RECORD, 6 * " "),
+)
 
 
 def get_dns_zones(account_name=None):

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -358,6 +358,9 @@ provider
   name
   output_resource_name
   annotations
+  records {
+    %s
+  }
 }
 ... on NamespaceTerraformResourceRosaAuthenticator_V1 {
   region
@@ -385,7 +388,9 @@ provider
   annotations
   defaults
 }
-"""
+""" % (
+    indent(queries.DNS_RECORD, 4 * " "),
+)
 
 
 TF_NAMESPACES_QUERY = """

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -845,41 +845,50 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             zone_resource = aws_route53_zone(zone_res_name, **zone_values)
             self.add_resource(acct_name, zone_resource)
 
-            counts = {}
-            for record in zone["records"]:
-                record_fqdn = f"{record['name']}.{zone['name']}"
-                record_id = safe_resource_id(f"{record_fqdn}_{record['type'].upper()}")
+            self.populate_route53_records(acct_name, zone, zone_resource, default_ttl)
 
-                # Count record names so we can generate unique IDs
-                if record_id not in counts:
-                    counts[record_id] = 0
-                counts[record_id] += 1
+    def populate_route53_records(
+        self,
+        acct_name: str,
+        zone: dict[str, Any],
+        zone_resource: aws_route53_zone,
+        default_ttl: int = 300,
+    ):
+        counts = {}
+        for record in zone.get("records") or []:
+            record_fqdn = f"{record['name']}.{zone['name']}"
+            record_id = safe_resource_id(f"{record_fqdn}_{record['type'].upper()}")
 
-                # If more than one record with a given name, append _{count}
-                if counts[record_id] > 1:
-                    record_id = f"{record_id}_{counts[record_id]}"
+            # Count record names so we can generate unique IDs
+            if record_id not in counts:
+                counts[record_id] = 0
+            counts[record_id] += 1
 
-                # Use default TTL if none is specified
-                # or if this record is an alias
-                # None/zero is accepted but not a good default
-                if not record.get("alias") and record.get("ttl") is None:
-                    record["ttl"] = default_ttl
+            # If more than one record with a given name, append _{count}
+            if counts[record_id] > 1:
+                record_id = f"{record_id}_{counts[record_id]}"
 
-                # Define healthcheck if needed
-                healthcheck = record.pop("healthcheck", None)
-                if healthcheck:
-                    healthcheck_id = record_id
-                    healthcheck_values = {**healthcheck}
-                    healthcheck_resource = aws_route53_health_check(
-                        healthcheck_id, **healthcheck_values
-                    )
-                    self.add_resource(acct_name, healthcheck_resource)
-                    # Assign the healthcheck resource ID to the record
-                    record["health_check_id"] = f"${{{healthcheck_resource.id}}}"
+            # Use default TTL if none is specified
+            # or if this record is an alias
+            # None/zero is accepted but not a good default
+            if not record.get("alias") and record.get("ttl") is None:
+                record["ttl"] = default_ttl
 
-                record_values = {"zone_id": f"${{{zone_resource.id}}}", **record}
-                record_resource = aws_route53_record(record_id, **record_values)
-                self.add_resource(acct_name, record_resource)
+            # Define healthcheck if needed
+            healthcheck = record.pop("healthcheck", None)
+            if healthcheck:
+                healthcheck_id = record_id
+                healthcheck_values = {**healthcheck}
+                healthcheck_resource = aws_route53_health_check(
+                    healthcheck_id, **healthcheck_values
+                )
+                self.add_resource(acct_name, healthcheck_resource)
+                # Assign the healthcheck resource ID to the record
+                record["health_check_id"] = f"${{{healthcheck_resource.id}}}"
+
+            record_values = {"zone_id": f"${{{zone_resource.id}}}", **record}
+            record_resource = aws_route53_record(record_id, **record_values)
+            self.add_resource(acct_name, record_resource)
 
     def populate_vpc_peerings(self, desired_state):
         for item in desired_state:

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -229,6 +229,7 @@ VARIABLE_KEYS = [
     "vpce_id",
     "fifo_topic",
     "subscriptions",
+    "records",
     "extra_tags",
 ]
 
@@ -5123,6 +5124,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         zone_id = safe_resource_id(identifier)
         zone_tf_resource = aws_route53_zone(zone_id, **values)
         tf_resources.append(zone_tf_resource)
+        self.populate_route53_records(account, common_values, zone_tf_resource)
 
         policy = {
             "Version": "2012-10-17",


### PR DESCRIPTION
another attempt at #2920

part of:
- https://issues.redhat.com/browse/APPSRE-5707
- https://issues.redhat.com/browse/APPSRE-7296

this PR adds support to specify records on a route53-zone provider. these records will be added to the zone.

schemas were added in https://github.com/app-sre/qontract-schemas/pull/299