### PR TITLE
include region in route53 associations

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1152,6 +1152,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 id = f"{identifier}-{zone}"
                 values = {
                     "vpc_id": accepter["vpc_id"],
+                    "vpc_region": accepter["region"],
                     "zone_id": zone,
                 }
                 authorization = aws_route53_vpc_association_authorization(id, **values)
@@ -1159,6 +1160,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 values = {
                     "provider": "aws." + acc_alias,
                     "vpc_id": f"${{aws_route53_vpc_association_authorization.{id}.vpc_id}}",
+                    "vpc_region": accepter["region"],
                     "zone_id": f"${{aws_route53_vpc_association_authorization.{id}.zone_id}}",
                 }
                 association = aws_route53_zone_association(id, **values)


### PR DESCRIPTION
The aim is to avoid issues when using regions which are not the default for the terraform user