### PR TITLE
Aws api memory leak fix

### DIFF
--- a/reconcile/aws_ami_share.py
+++ b/reconcile/aws_ami_share.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from reconcile import queries
 from reconcile.utils.aws_api import AWSApi
+from reconcile.utils.defer import defer
 
 QONTRACT_INTEGRATION = "aws-ami-share"
 MANAGED_TAG = {"Key": "managed_by_integration", "Value": QONTRACT_INTEGRATION}
@@ -36,11 +37,13 @@ def get_region(
     return region
 
 
-def run(dry_run):
+@defer
+def run(dry_run, defer=None):
     accounts = queries.get_aws_accounts(sharing=True)
     sharing_accounts = filter_accounts(accounts)
     settings = queries.get_app_interface_settings()
     aws_api = AWSApi(1, sharing_accounts, settings=settings, init_users=False)
+    defer(aws_api.cleanup)
 
     for src_account in sharing_accounts:
         sharing = src_account.get("sharing")

--- a/reconcile/aws_ecr_image_pull_secrets.py
+++ b/reconcile/aws_ecr_image_pull_secrets.py
@@ -57,8 +57,9 @@ def write_output_to_vault(dry_run, vault_path, account, secret_data, name):
 def run(dry_run, vault_output_path=""):
     accounts = [a for a in queries.get_aws_accounts() if a.get("ecrs")]
     settings = queries.get_app_interface_settings()
-    aws = AWSApi(1, accounts, settings=settings, init_ecr_auth_tokens=True)
-    for account, data in aws.auth_tokens.items():
+    with AWSApi(1, accounts, settings=settings, init_ecr_auth_tokens=True) as aws:
+        auth_tokens = aws.auth_tokens
+    for account, data in auth_tokens.items():
         dockercfg_secret_data = construct_dockercfg_secret_data(data)
         basic_auth_secret_data = construct_basic_auth_secret_data(data)
         write_output_to_vault(

--- a/reconcile/aws_garbage_collector.py
+++ b/reconcile/aws_garbage_collector.py
@@ -7,6 +7,6 @@ QONTRACT_INTEGRATION = "aws-garbage-collector"
 def run(dry_run, thread_pool_size=10):
     accounts = [a for a in queries.get_aws_accounts() if a.get("garbageCollection")]
     settings = queries.get_app_interface_settings()
-    aws = AWSApi(thread_pool_size, accounts, settings=settings)
-    aws.map_resources()
-    aws.delete_resources_without_owner(dry_run)
+    with AWSApi(thread_pool_size, accounts, settings=settings) as aws:
+        aws.map_resources()
+        aws.delete_resources_without_owner(dry_run)

--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -94,12 +94,12 @@ def run(
         # may be the calling entity, and has more to do
         return
 
-    aws = AWSApi(thread_pool_size, accounts, settings=settings)
     working_dirs = init_tf_working_dirs(accounts, thread_pool_size, settings)
     defer(lambda: cleanup(working_dirs))
-    error, service_account_recycle_complete = aws.delete_keys(
-        dry_run, keys_to_delete, working_dirs, disable_service_account_keys
-    )
+    with AWSApi(thread_pool_size, accounts, settings=settings) as aws:
+        error, service_account_recycle_complete = aws.delete_keys(
+            dry_run, keys_to_delete, working_dirs, disable_service_account_keys
+        )
     if error:
         sys.exit(1)
 

--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -87,6 +87,7 @@ def run(
 
     settings = queries.get_app_interface_settings()
     state = init_state(integration=QONTRACT_INTEGRATION)
+    defer(state.cleanup)
     keys_to_delete = get_keys_to_delete(accounts)
     if not should_run(state, keys_to_delete):
         logging.debug("nothing to do here")

--- a/reconcile/aws_iam_password_reset.py
+++ b/reconcile/aws_iam_password_reset.py
@@ -11,6 +11,7 @@ from typing import (
 
 from reconcile import queries
 from reconcile.utils.aws_api import AWSApi
+from reconcile.utils.defer import defer
 from reconcile.utils.state import init_state
 
 QONTRACT_INTEGRATION = "aws-iam-password-reset"
@@ -33,11 +34,13 @@ def account_in_roles(roles: Iterable[Mapping[str, Any]], aws_account: str) -> bo
     return False
 
 
-def run(dry_run):
+@defer
+def run(dry_run, defer=None):
     accounts = queries.get_aws_accounts(reset_passwords=True)
     settings = queries.get_app_interface_settings()
     roles = queries.get_roles(aws=True)
     state = init_state(integration=QONTRACT_INTEGRATION)
+    defer(state.cleanup)
 
     for a in accounts:
         account_name = a["name"]

--- a/reconcile/aws_support_cases_sos.py
+++ b/reconcile/aws_support_cases_sos.py
@@ -6,6 +6,7 @@ from reconcile import (
     queries,
 )
 from reconcile.utils.aws_api import AWSApi
+from reconcile.utils.defer import defer
 from reconcile.utils.mr import CreateDeleteAwsAccessKey
 
 QONTRACT_INTEGRATION = "aws-support-cases-sos"
@@ -41,9 +42,11 @@ def get_keys_to_delete(aws_support_cases):
     return keys
 
 
-def act(dry_run, gitlab_project_id, accounts, keys_to_delete):
+@defer
+def act(dry_run, gitlab_project_id, accounts, keys_to_delete, defer=None):
     if not dry_run and keys_to_delete:
         mr_cli = mr_client_gateway.init(gitlab_project_id=gitlab_project_id)
+        defer(mr_cli.cleanup)
 
     for k in keys_to_delete:
         account = k["account"]

--- a/reconcile/aws_support_cases_sos.py
+++ b/reconcile/aws_support_cases_sos.py
@@ -59,10 +59,10 @@ def act(dry_run, gitlab_project_id, accounts, keys_to_delete):
 def run(dry_run, gitlab_project_id=None, thread_pool_size=10, enable_deletion=False):
     accounts = filter_accounts(queries.get_aws_accounts())
     settings = queries.get_app_interface_settings()
-    aws = AWSApi(thread_pool_size, accounts, settings=settings)
     deleted_keys = get_deleted_keys(accounts)
-    existing_keys = aws.get_users_keys()
-    aws_support_cases = aws.get_support_cases()
+    with AWSApi(thread_pool_size, accounts, settings=settings) as aws:
+        existing_keys = aws.get_users_keys()
+        aws_support_cases = aws.get_support_cases()
     keys_to_delete_from_cases = get_keys_to_delete(aws_support_cases)
     keys_to_delete = []
     for ktd in keys_to_delete_from_cases:

--- a/reconcile/ecr_mirror.py
+++ b/reconcile/ecr_mirror.py
@@ -67,8 +67,12 @@ class EcrMirror:
             self.image_password = raw_data["token"]
             self.image_auth = f"{self.image_username}:{self.image_password}"
 
+    def _cleanup(self):
+        self.aws_cli.cleanup()
+
     def run(self):
         if self.error:
+            self._cleanup()
             return
 
         ecr_mirror = Image(
@@ -93,6 +97,7 @@ class EcrMirror:
                     )
                 except SkopeoCmdError as details:
                     LOG.error("[%s]", details)
+        self._cleanup()
 
     def _get_ecr_creds(self, account, region):
         if region is None:

--- a/reconcile/email_sender.py
+++ b/reconcile/email_sender.py
@@ -8,6 +8,7 @@ from reconcile import (
 from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,
 )
+from reconcile.utils.defer import defer
 from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.smtp_client import (
     DEFAULT_SMTP_TIMEOUT,
@@ -85,10 +86,12 @@ def collect_to(to):
     return audience
 
 
-def run(dry_run):
+@defer
+def run(dry_run, defer=None):
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
     state = init_state(integration=QONTRACT_INTEGRATION, secret_reader=secret_reader)
+    defer(state.cleanup)
     emails = queries.get_app_interface_emails()
     smtp_settings = typed_queries.smtp.settings()
     smtp_client = SmtpClient(

--- a/reconcile/github_scanner.py
+++ b/reconcile/github_scanner.py
@@ -41,8 +41,8 @@ def get_all_repos_to_scan(repos):
 def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
     accounts = queries.get_aws_accounts()
     settings = queries.get_app_interface_settings()
-    aws = AWSApi(thread_pool_size, accounts, settings=settings)
-    existing_keys = aws.get_users_keys()
+    with AWSApi(thread_pool_size, accounts, settings=settings) as aws:
+        existing_keys = aws.get_users_keys()
     existing_keys_list = [
         key
         for user_key in existing_keys.values()

--- a/reconcile/gitlab_mr_sqs_consumer.py
+++ b/reconcile/gitlab_mr_sqs_consumer.py
@@ -8,6 +8,7 @@ import sys
 
 from reconcile import queries
 from reconcile.utils import mr
+from reconcile.utils.defer import defer
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.sqs_gateway import SQSGateway
@@ -15,11 +16,13 @@ from reconcile.utils.sqs_gateway import SQSGateway
 QONTRACT_INTEGRATION = "gitlab-mr-sqs-consumer"
 
 
-def run(dry_run, gitlab_project_id):
+@defer
+def run(dry_run, gitlab_project_id, defer=None):
     secret_reader = SecretReader(queries.get_secret_reader_settings())
 
     accounts = queries.get_queue_aws_accounts()
     sqs_cli = SQSGateway(accounts, secret_reader)
+    defer(sqs_cli.cleanup)
 
     instance = queries.get_gitlab_instance()
     gitlab_cli = GitLabApi(

--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -128,6 +128,7 @@ def run(
         sys.exit(0)
 
     state = init_state(QONTRACT_INTEGRATION, secret_reader)
+    defer(state.cleanup)
 
     if dry_run:
         validate_repos_and_admins(jjb)

--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -128,7 +128,8 @@ def run(
         sys.exit(0)
 
     state = init_state(QONTRACT_INTEGRATION, secret_reader)
-    defer(state.cleanup)
+    if defer:
+        defer(state.cleanup)
 
     if dry_run:
         validate_repos_and_admins(jjb)

--- a/reconcile/jira_watcher.py
+++ b/reconcile/jira_watcher.py
@@ -2,6 +2,7 @@ import logging
 
 from reconcile import queries
 from reconcile.slack_base import slackapi_from_slack_workspace
+from reconcile.utils.defer import defer
 from reconcile.utils.jira_client import JiraClient
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.sharding import is_in_shard_round_robin
@@ -92,10 +93,12 @@ def write_state(state: State, project, state_to_write):
     state.add(project, value=state_to_write, force=True)
 
 
+@defer
 def run(dry_run):
     jira_boards = [j for j in queries.get_jira_boards() if j.get("slack")]
     settings = queries.get_app_interface_settings()
     state = init_state(integration=QONTRACT_INTEGRATION)
+    defer(state.cleanup)
     for index, jira_board in enumerate(jira_boards):
         if not is_in_shard_round_robin(jira_board["name"], index):
             continue

--- a/reconcile/ocm_addons_upgrade_tests_trigger.py
+++ b/reconcile/ocm_addons_upgrade_tests_trigger.py
@@ -1,5 +1,8 @@
 import logging
-from typing import Optional, Callable
+from typing import (
+    Callable,
+    Optional,
+)
 
 from reconcile import queries
 from reconcile.typed_queries.app_interface_vault_settings import (

--- a/reconcile/ocm_addons_upgrade_tests_trigger.py
+++ b/reconcile/ocm_addons_upgrade_tests_trigger.py
@@ -23,7 +23,8 @@ def run(dry_run: bool, defer: Optional[Callable] = None) -> None:
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
     state = init_state(integration=QONTRACT_INTEGRATION, secret_reader=secret_reader)
-    defer(state.cleanup)
+    if defer:
+        defer(state.cleanup)
     ocms = queries.get_openshift_cluster_managers()
     for ocm_info in ocms:
         ocm_name = ocm_info["name"]

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -269,9 +269,9 @@ def _app_interface_updates_mr(
             create_update_mr = True
 
     if create_update_mr and not dry_run:
-        mr_cli = mr_client_gateway.init(gitlab_project_id=gitlab_project_id)
         mr = cu.CreateClustersUpdates(clusters_updates)
-        mr.submit(cli=mr_cli)
+        with mr_client_gateway.init(gitlab_project_id=gitlab_project_id) as mr_cli:
+            mr.submit(cli=mr_cli)
 
 
 def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:

--- a/reconcile/ocm_update_recommended_version.py
+++ b/reconcile/ocm_update_recommended_version.py
@@ -129,5 +129,5 @@ def run(dry_run: bool, gitlab_project_id: int) -> None:
         )
         if not dry_run:
             logging.info(f"Creating MR for {ocm_info['name']}")
-            mr_cli = mr_client_gateway.init(gitlab_project_id=gitlab_project_id)
-            mr.submit(cli=mr_cli)
+            with mr_client_gateway.init(gitlab_project_id=gitlab_project_id) as mr_cli:
+                mr.submit(cli=mr_cli)

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -7,6 +7,7 @@ from typing import (
     Any,
     Iterable,
     Optional,
+    Callable,
 )
 
 from croniter import croniter
@@ -18,6 +19,7 @@ from reconcile.utils.cluster_version_data import (
     WorkloadHistory,
     get_version_data,
 )
+from reconcile.utils.defer import defer
 from reconcile.utils.disabled_integrations import integration_is_enabled
 from reconcile.utils.ocm import (
     OCM,
@@ -132,11 +134,13 @@ def update_history(version_data: VersionData, upgrade_policies: list[dict[str, A
     version_data.check_in = now
 
 
+@defer
 def get_version_data_map(
     dry_run: bool,
     upgrade_policies: list[dict[str, Any]],
     ocm_map: OCMMap,
     addon_id: str = "",
+    defer: Optional[Callable] = None,
 ) -> dict[str, VersionData]:
     """Get a summary of versions history per OCM instance
 
@@ -146,11 +150,13 @@ def get_version_data_map(
         ocm_map (OCMMap): OCM clients per OCM instance
         addon_id (str): optional addon id to get & store the addon specific state,
           additionally to the ocm org name
+        defer (Optional<Callable>): defer function
 
     Returns:
         dict: version data per OCM instance
     """
     state = init_state(integration=QONTRACT_INTEGRATION)
+    defer(state.cleanup)
     results: dict[str, VersionData] = {}
     # we keep a remote state per OCM instance
     for ocm_name in ocm_map.instances():

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -156,7 +156,8 @@ def get_version_data_map(
         dict: version data per OCM instance
     """
     state = init_state(integration=QONTRACT_INTEGRATION)
-    defer(state.cleanup)
+    if defer:
+        defer(state.cleanup)
     results: dict[str, VersionData] = {}
     # we keep a remote state per OCM instance
     for ocm_name in ocm_map.instances():

--- a/reconcile/ocm_upgrade_scheduler.py
+++ b/reconcile/ocm_upgrade_scheduler.py
@@ -5,9 +5,9 @@ from collections.abc import Mapping
 from datetime import datetime
 from typing import (
     Any,
+    Callable,
     Iterable,
     Optional,
-    Callable,
 )
 
 from croniter import croniter

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -103,11 +103,11 @@ def run(dry_run, gitlab_project_id):
                 updates.append(item)
 
         if create_update_mr and not dry_run:
-            mr_cli = mr_client_gateway.init(gitlab_project_id=gitlab_project_id)
             updates_info = {
                 "path": "data" + ocm_path,
                 "name": ocm_name,
                 "updates": updates,
             }
             mr = ousou.CreateOCMUpgradeSchedulerOrgUpdates(updates_info)
-            mr.submit(cli=mr_cli)
+            with mr_client_gateway.init(gitlab_project_id=gitlab_project_id) as mr_cli:
+                mr.submit(cli=mr_cli)

--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -368,5 +368,5 @@ def run(dry_run: bool) -> None:
             LOG.error(str(details))
             sys.exit(ExitCodes.ERROR)
         finally:
-            if quay_mirror:
+            if quay_mirror is not None:
                 quay_mirror.cleanup()

--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -192,8 +192,7 @@ class OcpReleaseMirror:
         self.channel_groups = instance.mirror_channels
 
     def cleanup(self):
-        if self.aws_cli:
-            self.aws_cli.cleanup()
+        self.aws_cli.cleanup()
 
     def run(self):
         ocp_releases = self._get_ocp_releases()
@@ -368,5 +367,7 @@ def run(dry_run: bool) -> None:
             LOG.error(str(details))
             sys.exit(ExitCodes.ERROR)
         finally:
-            if quay_mirror is not None:
+            try:
                 quay_mirror.cleanup()
+            except NameError:
+                LOG.debug("No quay_mirror to cleanup")

--- a/reconcile/ocp_release_mirror.py
+++ b/reconcile/ocp_release_mirror.py
@@ -191,6 +191,10 @@ class OcpReleaseMirror:
         # Initiate channel groups
         self.channel_groups = instance.mirror_channels
 
+    def cleanup(self):
+        if self.aws_cli:
+            self.aws_cli.cleanup()
+
     def run(self):
         ocp_releases = self._get_ocp_releases()
         if not ocp_releases:
@@ -363,3 +367,6 @@ def run(dry_run: bool) -> None:
         except OcpReleaseMirrorError as details:
             LOG.error(str(details))
             sys.exit(ExitCodes.ERROR)
+        finally:
+            if quay_mirror:
+                quay_mirror.cleanup()

--- a/reconcile/openshift_namespace_labels.py
+++ b/reconcile/openshift_namespace_labels.py
@@ -440,7 +440,8 @@ def run(
     get_desired(inventory, oc_map, namespaces)
 
     state = init_state(integration=QONTRACT_INTEGRATION)
-    defer(state.cleanup)
+    if defer:
+        defer(state.cleanup)
     _LOG.debug("Collecting managed state ...")
     get_managed(inventory, state)
 

--- a/reconcile/openshift_namespace_labels.py
+++ b/reconcile/openshift_namespace_labels.py
@@ -440,6 +440,7 @@ def run(
     get_desired(inventory, oc_map, namespaces)
 
     state = init_state(integration=QONTRACT_INTEGRATION)
+    defer(state.cleanup)
     _LOG.debug("Collecting managed state ...")
     get_managed(inventory, state)
 

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -235,8 +235,8 @@ def run(
         # Auto-promote next stages only if there are changes in the
         # promoting stage. This prevents trigger promotions on job re-runs
         auto_promote = len(actions) > 0
-        mr_cli = mr_client_gateway.init(gitlab_project_id=gitlab_project_id)
-        saasherder.publish_promotions(success, all_saas_files, mr_cli, auto_promote)
+        with mr_client_gateway.init(gitlab_project_id=gitlab_project_id) as mr_cli:
+            saasherder.publish_promotions(success, all_saas_files, mr_cli, auto_promote)
 
     if not success:
         sys.exit(ExitCodes.ERROR)

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -172,6 +172,7 @@ def run(
         jenkins_map=jenkins_map,
         state=init_state(integration=QONTRACT_INTEGRATION, secret_reader=secret_reader),
     )
+    defer(saasherder.cleanup)
     if len(saasherder.namespaces) == 0:
         logging.warning("no targets found")
         sys.exit(ExitCodes.SUCCESS)

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -172,7 +172,8 @@ def run(
         jenkins_map=jenkins_map,
         state=init_state(integration=QONTRACT_INTEGRATION, secret_reader=secret_reader),
     )
-    defer(saasherder.cleanup)
+    if defer:
+        defer(saasherder.cleanup)
     if len(saasherder.namespaces) == 0:
         logging.warning("no targets found")
         sys.exit(ExitCodes.SUCCESS)

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -81,6 +81,7 @@ def run(
         include_trigger_trace=include_trigger_trace,
     )
     if defer:  # defer is set by method decorator. this makes just mypy happy
+        defer(saasherder.cleanup)
         defer(oc_map.cleanup)
 
     trigger_specs, diff_err = saasherder.get_diff(trigger_type, dry_run)

--- a/reconcile/openshift_upgrade_watcher.py
+++ b/reconcile/openshift_upgrade_watcher.py
@@ -124,7 +124,8 @@ def run(
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
     state = init_state(integration=QONTRACT_INTEGRATION, secret_reader=secret_reader)
-    defer(state.cleanup)
+    if defer:
+        defer(state.cleanup)
 
     clusters = [
         c for c in get_clusters() if c.ocm and not (c.spec and c.spec.hypershift)

--- a/reconcile/openshift_upgrade_watcher.py
+++ b/reconcile/openshift_upgrade_watcher.py
@@ -124,6 +124,7 @@ def run(
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
     state = init_state(integration=QONTRACT_INTEGRATION, secret_reader=secret_reader)
+    defer(state.cleanup)
 
     clusters = [
         c for c in get_clusters() if c.ocm and not (c.spec and c.spec.hypershift)

--- a/reconcile/requests_sender.py
+++ b/reconcile/requests_sender.py
@@ -9,6 +9,7 @@ from reconcile import (
 from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,
 )
+from reconcile.utils.defer import defer
 from reconcile.utils.gpg import gpg_encrypt
 from reconcile.utils.secret_reader import (
     SecretReader,
@@ -57,7 +58,8 @@ def get_encrypted_credentials(credentials_name, user, settings):
     return encrypted_credentials
 
 
-def run(dry_run):
+@defer
+def run(dry_run, defer=None):
     settings = queries.get_app_interface_settings()
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
@@ -74,6 +76,7 @@ def run(dry_run):
         integration=QONTRACT_INTEGRATION,
         secret_reader=secret_reader,
     )
+    defer(state.cleanup)
     credentials_requests = queries.get_credentials_requests()
 
     # validate no 2 requests have the same name

--- a/reconcile/saas_file_validator.py
+++ b/reconcile/saas_file_validator.py
@@ -1,5 +1,9 @@
 import logging
 import sys
+from typing import (
+    Callable,
+    Optional,
+)
 
 from reconcile.jenkins_job_builder import init_jjb
 from reconcile.status import ExitCodes
@@ -11,6 +15,7 @@ from reconcile.typed_queries.saas_files import (
     get_saas_files,
     get_saasherder_settings,
 )
+from reconcile.utils.defer import defer
 from reconcile.utils.jjb_client import JJB
 from reconcile.utils.saasherder import SaasHerder
 from reconcile.utils.secret_reader import create_secret_reader
@@ -20,7 +25,8 @@ QONTRACT_INTEGRATION = "saas-file-validator"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
-def run(dry_run: bool) -> None:
+@defer
+def run(dry_run: bool, defer: Optional[Callable] = None) -> None:
     vault_settings = get_app_interface_vault_settings()
     saasherder_settings = get_saasherder_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
@@ -39,6 +45,8 @@ def run(dry_run: bool) -> None:
         repo_url=saasherder_settings.repo_url,
         validate=True,
     )
+    if defer:
+        defer(saasherder.cleanup)
     app_int_repos = get_repos()
     missing_repos = [r for r in saasherder.repo_urls if r not in app_int_repos]
     for r in missing_repos:

--- a/reconcile/sentry_helper.py
+++ b/reconcile/sentry_helper.py
@@ -2,6 +2,7 @@ import logging
 
 from reconcile import queries
 from reconcile.slack_base import slackapi_from_queries
+from reconcile.utils.defer import defer
 from reconcile.utils.imap_client import ImapClient
 from reconcile.utils.state import init_state
 
@@ -33,10 +34,12 @@ def get_sentry_users_from_mails(mails):
     return user_names
 
 
-def run(dry_run):
+@defer
+def run(dry_run, defer=None):
     settings = queries.get_app_interface_settings()
     users = queries.get_users()
     state = init_state(integration=QONTRACT_INTEGRATION)
+    defer(state.cleanup)
     with ImapClient(settings=settings) as imap_client:
         mails = imap_client.get_mails(
             folder="[Gmail]/Sent Mail", criteria='SUBJECT "Sentry Access Request"'

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -563,7 +563,8 @@ def run(
 ) -> None:
     settings = queries.get_app_interface_settings()
     state = init_state(integration=QONTRACT_INTEGRATION)
-    defer(state.cleanup)
+    if defer:
+        defer(state.cleanup)
     smtp_settings = typed_queries.smtp.settings()
     smtp_client = SmtpClient(
         server=get_smtp_server_connection(

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -8,9 +8,9 @@ from collections.abc import (
 from textwrap import indent
 from typing import (
     Any,
+    Callable,
     Optional,
     Union,
-    Callable,
 )
 
 import jinja2

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -10,6 +10,7 @@ from typing import (
     Any,
     Optional,
     Union,
+    Callable,
 )
 
 import jinja2
@@ -22,6 +23,7 @@ from reconcile import (
     typed_queries,
 )
 from reconcile.status import ExitCodes
+from reconcile.utils.defer import defer
 from reconcile.utils.external_resources import get_external_resource_specs
 from reconcile.utils.oc import (
     OC_Map,
@@ -555,9 +557,13 @@ def openshift_delete_by_label(
             )
 
 
-def run(dry_run: bool, enable_deletion: bool = False) -> None:
+@defer
+def run(
+    dry_run: bool, enable_deletion: bool = False, defer: Optional[Callable] = None
+) -> None:
     settings = queries.get_app_interface_settings()
     state = init_state(integration=QONTRACT_INTEGRATION)
+    defer(state.cleanup)
     smtp_settings = typed_queries.smtp.settings()
     smtp_client = SmtpClient(
         server=get_smtp_server_connection(

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -146,14 +146,16 @@ def build_desired_state(
                 zone_account = [
                     a for a in all_accounts if a["name"] == tf_zone_account_name
                 ][0]
-                awsapi = AWSApi(1, [zone_account], settings=settings, init_users=False)
                 tf_zone_region = (
                     tf_zone_spec.resource.get("region")
                     or zone_account["resourcesDefaultRegion"]
                 )
-                tf_zone_ns_records = awsapi.get_route53_zone_ns_records(
-                    tf_zone_account_name, tf_zone_name, tf_zone_region
-                )
+                with AWSApi(
+                    1, [zone_account], settings=settings, init_users=False
+                ) as awsapi:
+                    tf_zone_ns_records = awsapi.get_route53_zone_ns_records(
+                        tf_zone_account_name, tf_zone_name, tf_zone_region
+                    )
                 if not tf_zone_ns_records:
                     logging.warning(
                         f"{zone_name}: field `_target_namespace_zone` found "

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -128,10 +128,12 @@ def run(
         ocm_map = {}
 
     accounts = queries.get_aws_accounts(terraform_state=True, ecrs=False)
-    awsapi = AWSApi(1, accounts, settings=settings, init_users=False)
 
     # Fetch desired state for cluster-to-vpc(account) VPCs
-    desired_state, err = build_desired_state_tgw_attachments(clusters, ocm_map, awsapi)
+    with AWSApi(1, accounts, settings=settings, init_users=False) as awsapi:
+        desired_state, err = build_desired_state_tgw_attachments(
+            clusters, ocm_map, awsapi
+        )
     if err:
         sys.exit(1)
 
@@ -156,10 +158,12 @@ def run(
     ts.populate_additional_providers(participating_accounts)
     ts.populate_tgw_attachments(desired_state)
     working_dirs = ts.dump(print_to_file=print_to_file)
-    aws_api = AWSApi(1, accounts, settings=settings, init_users=False)
 
     if print_to_file:
         sys.exit()
+
+    aws_api = AWSApi(1, accounts, settings=settings, init_users=False)
+    defer(aws_api.close)
 
     tf = Terraform(
         QONTRACT_INTEGRATION,

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -163,7 +163,6 @@ def run(
         sys.exit()
 
     aws_api = AWSApi(1, accounts, settings=settings, init_users=False)
-    defer(aws_api.close)
 
     tf = Terraform(
         QONTRACT_INTEGRATION,

--- a/reconcile/test/test_utils_state.py
+++ b/reconcile/test/test_utils_state.py
@@ -46,7 +46,7 @@ def test_ls_returns_correct_file(accounts, s3_client, mocker):
     )
 
     mock_aws_api = mocker.patch("reconcile.utils.state.AWSApi", autospec=True)
-    mock_aws_api.return_value.get_session.return_value.client.return_value = s3_client
+    mock_aws_api.return_value.get_session_client.return_value = s3_client
 
     state = init_state_from_accounts(
         integration="integration-name",
@@ -78,7 +78,7 @@ def test_ls_when_integration_is_empty_string(accounts, s3_client, mocker):
     )
 
     mock_aws_api = mocker.patch("reconcile.utils.state.AWSApi", autospec=True)
-    mock_aws_api.return_value.get_session.return_value.client.return_value = s3_client
+    mock_aws_api.return_value.get_session_client.return_value = s3_client
 
     state = init_state_from_accounts(
         integration="",
@@ -103,7 +103,7 @@ def test_ls_when_state_is_empty(accounts, s3_client, mocker):
     s3_client.create_bucket(Bucket="some-bucket")
 
     mock_aws_api = mocker.patch("reconcile.utils.state.AWSApi", autospec=True)
-    mock_aws_api.return_value.get_session.return_value.client.return_value = s3_client
+    mock_aws_api.return_value.get_session_client.return_value = s3_client
 
     state = init_state_from_accounts(
         integration="integration-name",
@@ -135,7 +135,7 @@ def test_ls_when_that_are_more_than_1000_keys(accounts, s3_client, mocker):
     expected.sort()
 
     mock_aws_api = mocker.patch("reconcile.utils.state.AWSApi", autospec=True)
-    mock_aws_api.return_value.get_session.return_value.client.return_value = s3_client
+    mock_aws_api.return_value.get_session_client.return_value = s3_client
 
     state = init_state_from_accounts(
         integration="integration",
@@ -159,7 +159,7 @@ def test_exists_for_existing_key(accounts, s3_client, mocker):
     )
 
     mock_aws_api = mocker.patch("reconcile.utils.state.AWSApi", autospec=True)
-    mock_aws_api.return_value.get_session.return_value.client.return_value = s3_client
+    mock_aws_api.return_value.get_session_client.return_value = s3_client
 
     state = init_state_from_accounts(
         integration="integration-name",
@@ -175,7 +175,7 @@ def test_exists_for_missing_key(accounts, s3_client, mocker):
     s3_client.create_bucket(Bucket="some-bucket")
 
     mock_aws_api = mocker.patch("reconcile.utils.state.AWSApi", autospec=True)
-    mock_aws_api.return_value.get_session.return_value.client.return_value = s3_client
+    mock_aws_api.return_value.get_session_client.return_value = s3_client
 
     state = init_state_from_accounts(
         integration="integration-name",
@@ -190,7 +190,7 @@ def test_exists_for_missing_key(accounts, s3_client, mocker):
 def test_exists_for_missing_bucket(accounts, s3_client, mocker):
     # don't create a bucket unlink in all the other tests
     mock_aws_api = mocker.patch("reconcile.utils.state.AWSApi", autospec=True)
-    mock_aws_api.return_value.get_session.return_value.client.return_value = s3_client
+    mock_aws_api.return_value.get_session_client.return_value = s3_client
 
     with pytest.raises(StateInaccessibleException, match=r".*404.*"):
         init_state_from_accounts(
@@ -205,7 +205,7 @@ def test_exists_for_missing_bucket(accounts, s3_client, mocker):
 def test_exists_for_forbidden(accounts, s3_client, mocker):
     forbidden_error = ClientError({"Error": {"Code": "403"}}, None)
     mock_aws_api = mocker.patch("reconcile.utils.state.AWSApi", autospec=True)
-    mock_aws_api.return_value.get_session.return_value.client.return_value.head_object.side_effect = (
+    mock_aws_api.return_value.get_session_client.return_value.head_object.side_effect = (
         forbidden_error
     )
 

--- a/reconcile/test/test_utils_terrascript_aws_client.py
+++ b/reconcile/test/test_utils_terrascript_aws_client.py
@@ -65,7 +65,8 @@ def test_use_previous_image_id(mocker, ts, result):
 
 def test_get_asg_image_id(mocker, ts: tsclient.TerrascriptClient):
     awsapi = mocker.patch("reconcile.utils.terrascript_aws_client.AWSApi")
-    get_image_id_mock = awsapi().get_image_id
+    with awsapi() as aws:
+        get_image_id_mock = aws.get_image_id
     get_image_id_mock.return_value = "ami-123456"
 
     ref = "sha-12345"

--- a/reconcile/unleash_watcher.py
+++ b/reconcile/unleash_watcher.py
@@ -2,6 +2,7 @@ import logging
 
 from reconcile import queries
 from reconcile.slack_base import slackapi_from_slack_workspace
+from reconcile.utils.defer import defer
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.slack_api import SlackApi
 from reconcile.utils.state import init_state
@@ -98,10 +99,12 @@ def act(dry_run, state, unleash_instance, diffs, secret_reader: SecretReader):
                 state.add(key, diff["to"], force=True)
 
 
-def run(dry_run):
+@defer
+def run(dry_run, defer=None):
     secret_reader = SecretReader(settings=queries.get_secret_reader_settings())
     unleash_instances = queries.get_unleash_instances()
     state = init_state(QONTRACT_INTEGRATION, secret_reader)
+    defer(state.cleanup)
     for unleash_instance in unleash_instances:
         instance_name = unleash_instance["name"]
         current_state = fetch_current_state(unleash_instance, secret_reader)

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1,4 +1,3 @@
-import functools
 import logging
 import re
 import time
@@ -7,6 +6,7 @@ from collections.abc import (
     Mapping,
 )
 from datetime import datetime
+from functools import lru_cache
 from threading import Lock
 from typing import (
     TYPE_CHECKING,
@@ -131,27 +131,23 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         # store the app-interface accounts in a dictionary indexed by name
         self.accounts = {acc["name"]: acc for acc in accounts}
 
+        self._session_clients = []
         # Setup caches on the instance itself to avoid leak
         # https://stackoverflow.com/questions/33672412/python-functools-lru-cache-with-class-methods-release-object
         # using @lru_cache decorators on methods would lek AWSApi instances
         # since the cache keeps a reference to self.
-        self._account_ec2_client = functools.lru_cache()(self._account_ec2_client)
-        self._account_route53_client = functools.lru_cache()(
-            self._account_route53_client
-        )
-        self._account_ec2_resource = functools.lru_cache()(self._account_ec2_resource)
-        self._get_assumed_role_client = functools.lru_cache()(
-            self._get_assumed_role_client
-        )
-        self.get_account_vpcs = functools.lru_cache()(self.get_account_vpcs)
-        self.get_account_amis = functools.lru_cache()(self.get_account_amis)
-        self.get_vpc_route_tables = functools.lru_cache()(self.get_vpc_route_tables)
-        self.get_vpc_subnets = functools.lru_cache()(self.get_vpc_subnets)
-        self.get_vpc_default_sg_id = functools.lru_cache()(self.get_vpc_default_sg_id)
-        self.get_transit_gateways = functools.lru_cache()(self.get_transit_gateways)
-        self.get_transit_gateway_vpc_attachments = functools.lru_cache()(
+        self._get_assume_role_session = lru_cache()(self._get_assume_role_session)
+        self._get_session_client = lru_cache()(self._get_session_client)
+        self._get_session_resource = lru_cache()(self._get_session_resource)
+        self.get_account_amis = lru_cache()(self.get_account_amis)
+        self.get_account_vpcs = lru_cache()(self.get_account_vpcs)
+        self.get_transit_gateway_vpc_attachments = lru_cache()(
             self.get_transit_gateway_vpc_attachments
         )
+        self.get_transit_gateways = lru_cache()(self.get_transit_gateways)
+        self.get_vpc_default_sg_id = lru_cache()(self.get_vpc_default_sg_id)
+        self.get_vpc_route_tables = lru_cache()(self.get_vpc_route_tables)
+        self.get_vpc_subnets = lru_cache()(self.get_vpc_subnets)
 
     def init_sessions_and_resources(self, accounts: Iterable[awsh.Account]):
         results = threaded.run(
@@ -175,44 +171,68 @@ class AWSApi:  # pylint: disable=too-many-public-methods
             self.sessions[account_name] = session
             self.resources[account_name] = {}
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def close(self):
+        """
+        Close all session clients
+        :return:
+        """
+        for client in self._session_clients:
+            client.close()
+
     def get_session(self, account: str) -> Session:
         return self.sessions[account]
 
     # pylint: disable=method-hidden
+    def _get_session_client(
+        self, session: Session, service_name: str, region_name: Optional[str] = None
+    ):
+        region = region_name if region_name else session.region_name
+        client = session.client(service_name, region_name=region)
+        self._session_clients.append(client)
+        return client
+
+    @staticmethod
+    # pylint: disable=method-hidden
+    def _get_session_resource(
+        session: Session, service_name: str, region_name: Optional[str] = None
+    ):
+        region = region_name if region_name else session.region_name
+        return session.resource(service_name, region_name=region)
+
     def _account_ec2_client(
         self, account_name: str, region_name: Optional[str] = None
     ) -> EC2Client:
         session = self.get_session(account_name)
-        region = region_name if region_name else session.region_name
-        return session.client("ec2", region_name=region)
+        return self._get_session_client(session, "ec2", region_name)
 
     def _account_ec2_resource(
         self, account_name: str, region_name: Optional[str] = None
     ) -> EC2ServiceResource:
         session = self.get_session(account_name)
-        region = region_name if region_name else session.region_name
-        return session.resource("ec2", region_name=region)
+        return self._get_session_resource(session, "ec2", region_name)
 
-    # pylint: disable=method-hidden
     def _account_route53_client(
         self, account_name: str, region_name: Optional[str] = None
     ) -> Route53Client:
         session = self.get_session(account_name)
-        region = region_name if region_name else session.region_name
-        return session.client("route53", region_name=region)
+        return self._get_session_client(session, "route53", region_name)
 
-    # pylint: disable=method-hidden
     def _account_rds_client(
         self, account_name: str, region_name: Optional[str] = None
     ) -> RDSClient:
         session = self.get_session(account_name)
-        region = region_name if region_name else session.region_name
-        return session.client("rds", region_name=region)
+        return self._get_session_client(session, "rds", region_name)
 
     def init_users(self):
         self.users = {}
         for account, s in self.sessions.items():
-            iam = s.client("iam")
+            iam = self._get_session_client(s, "iam")
             users = self.paginate(iam, "list_users", "Users")
             users = [u["UserName"] for u in users]
             self.users[account] = users
@@ -238,7 +258,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
     def map_s3_resources(self):
         for account, s in self.sessions.items():
-            s3 = s.client("s3")
+            s3 = self._get_session_client(s, "s3")
             buckets_list = s3.list_buckets()
             if "Buckets" not in buckets_list:
                 continue
@@ -252,7 +272,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
     def map_sqs_resources(self):
         for account, s in self.sessions.items():
-            sqs = s.client("sqs")
+            sqs = self._get_session_client(s, "sqs")
             queues_list = sqs.list_queues()
             if "QueueUrls" not in queues_list:
                 continue
@@ -266,7 +286,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
     def map_dynamodb_resources(self):
         for account, s in self.sessions.items():
-            dynamodb = s.client("dynamodb")
+            dynamodb = self._get_session_client(s, "dynamodb")
             tables = self.paginate(dynamodb, "list_tables", "TableNames")
             self.set_resouces(account, "dynamodb", tables)
             tables_without_owner = self.get_resources_without_owner(account, tables)
@@ -277,7 +297,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
     def map_rds_resources(self):
         for account, s in self.sessions.items():
-            rds = s.client("rds")
+            rds = self._get_session_client(s, "rds")
             results = self.paginate(rds, "describe_db_instances", "DBInstances")
             instances = [t["DBInstanceIdentifier"] for t in results]
             self.set_resouces(account, "rds", instances)
@@ -292,7 +312,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
     def map_rds_snapshots(self):
         self.wait_for_resource("rds")
         for account, s in self.sessions.items():
-            rds = s.client("rds")
+            rds = self._get_session_client(s, "rds")
             results = self.paginate(rds, "describe_db_snapshots", "DBSnapshots")
             snapshots = [t["DBSnapshotIdentifier"] for t in results]
             self.set_resouces(account, "rds_snapshots", snapshots)
@@ -308,7 +328,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
     def map_route53_resources(self):
         for account, s in self.sessions.items():
-            client = s.client("route53")
+            client = self._get_session_client(s, "route53")
             results = self.paginate(client, "list_hosted_zones", "HostedZones")
             zones = list(results)
             for zone in zones:
@@ -323,7 +343,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
     def map_ecr_resources(self):
         for account, s in self.sessions.items():
-            client = s.client("ecr")
+            client = self._get_session_client(s, "ecr")
             repositories = self.paginate(
                 client=client, method="describe_repositories", key="repositories"
             )
@@ -400,7 +420,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
     def custom_dynamodb_filter(self, account, session, dynamodb, tables):
         type = "dynamodb table"
-        dynamodb_resource = session.resource("dynamodb")
+        dynamodb_resource = self._get_session_resource(session, "dynamodb")
         unfiltered_tables = []
         for t in tables:
             table_arn = dynamodb_resource.Table(t).table_arn
@@ -507,19 +527,19 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
     def delete_resource(self, session, resource_type, resource_name):
         if resource_type == "s3":
-            resource = session.resource(resource_type)
+            resource = self._get_session_resource(session, resource_type)
             self.delete_bucket(resource, resource_name)
         elif resource_type == "sqs":
-            client = session.client(resource_type)
+            client = self._get_session_client(session, resource_type)
             self.delete_queue(client, resource_name)
         elif resource_type == "dynamodb":
-            resource = session.resource(resource_type)
+            resource = self._get_session_resource(session, resource_type)
             self.delete_table(resource, resource_name)
         elif resource_type == "rds":
-            client = session.client(resource_type)
+            client = self._get_session_client(session, resource_type)
             self.delete_instance(client, resource_name)
         elif resource_type == "rds_snapshots":
-            client = session.client(resource_type)
+            client = self._get_session_client(session, resource_type)
             self.delete_snapshot(client, resource_name)
         else:
             raise InvalidResourceTypeError(resource_type)
@@ -585,7 +605,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         service_account_recycle_complete = True
         users_keys = self.get_users_keys()
         for account, s in self.sessions.items():
-            iam = s.client("iam")
+            iam = self._get_session_client(s, "iam")
             keys = keys_to_delete.get(account, [])
             for key in keys:
                 user_and_user_keys = [
@@ -663,7 +683,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
     def get_users_keys(self):
         users_keys = {}
         for account, s in self.sessions.items():
-            iam = s.client("iam")
+            iam = self._get_session_client(s, "iam")
             users_keys[account] = {
                 user: self.get_user_keys(iam, user) for user in self.users[account]
             }
@@ -672,12 +692,12 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
     def reset_password(self, account, user_name):
         s = self.sessions[account]
-        iam = s.client("iam")
+        iam = self._get_session_client(s, "iam")
         iam.delete_login_profile(UserName=user_name)
 
     def reset_mfa(self, account, user_name):
         s = self.sessions[account]
-        iam = s.client("iam")
+        iam = self._get_session_client(s, "iam")
         mfa_devices = iam.list_mfa_devices(UserName=user_name)["MFADevices"]
         for d in mfa_devices:
             serial_number = d["SerialNumber"]
@@ -708,7 +728,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
                 self.accounts[account]["partition"]
             )
             try:
-                support = s.client("support", region_name=support_region)
+                support = self._get_session_client(s, "support", support_region)
                 support_cases = support.describe_cases(
                     includeResolvedCases=True, includeCommunications=True
                 )["cases"]
@@ -761,7 +781,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
                     aws_secret_access_key=secret_key,
                     region_name=region_name,
                 )
-                client = session.client("ecr")
+                client = self._get_session_client(session, "ecr")
                 token = client.get_authorization_token()
                 auth_tokens[f"{account_name}/{region_name}"] = token
 
@@ -780,19 +800,21 @@ class AWSApi:  # pylint: disable=too-many-public-methods
             raise KeyError("[{}] account is missing required keys".format(account_name))
         return (account["name"], account["assume_role"], account["assume_region"])
 
+    @staticmethod
+    # pylint: disable=method-hidden
     def _get_assume_role_session(
-        self, account_name: str, assume_role: str, assume_region: str
+        sts, account_name: str, assume_role: str, assume_region: str
     ) -> Session:
         """
         Returns a session for a supplied role to assume:
 
-        :param name:          name of the AWS account
+        :param sts:           boto3 sts client
+        :param account_name:  name of the AWS account
         :param assume_role:   role to assume to get access
                               to the cluster's AWS account
         :param assume_region: region in which to operate
         """
-        session = self.get_session(account_name)
-        sts = session.client("sts")
+
         if not assume_role:
             raise MissingARNError(
                 f"Could not find Role ARN {assume_role} on account "
@@ -812,14 +834,15 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
         return assumed_session
 
-    # pylint: disable=method-hidden
     def _get_assumed_role_client(
         self, account_name: str, assume_role: str, assume_region: str, client_type="ec2"
     ) -> EC2Client:
+        session = self.get_session(account_name)
+        sts = self._get_session_client(session, "sts")
         assumed_session = self._get_assume_role_session(
-            account_name, assume_role, assume_region
+            sts, account_name, assume_role, assume_region
         )
-        return assumed_session.client(client_type)
+        return self._get_session_client(assumed_session, client_type)
 
     @staticmethod
     # pylint: disable=method-hidden
@@ -1277,7 +1300,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         :type zone_name: str
         """
         session = self.get_session(account_name)
-        client = session.client("route53")
+        client = self._get_session_client(session, "route53")
 
         try:
             caller_ref = f"{datetime.now()}"
@@ -1307,7 +1330,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         :type zone_id: str
         """
         session = self.get_session(account_name)
-        client = session.client("route53")
+        client = self._get_session_client(session, "route53")
 
         try:
             client.delete_hosted_zone(Id=zone_id)
@@ -1336,7 +1359,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         :type awsdata: dict
         """
         session = self.get_session(account_name)
-        client = session.client("route53")
+        client = self._get_session_client(session, "route53")
 
         try:
             client.change_resource_record_sets(
@@ -1370,7 +1393,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         :type recordset: dict
         """
         session = self.get_session(account_name)
-        client = session.client("route53")
+        client = self._get_session_client(session, "route53")
 
         try:
             client.change_resource_record_sets(

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -190,7 +190,10 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
     # pylint: disable=method-hidden
     def get_session_client(
-        self, session: Session, service_name: str, region_name: Optional[str] = None
+        self,
+        session: Session,
+        service_name,
+        region_name: Optional[str] = None,
     ):
         region = region_name if region_name else session.region_name
         client = session.client(service_name, region_name=region)
@@ -200,7 +203,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
     @staticmethod
     # pylint: disable=method-hidden
     def _get_session_resource(
-        session: Session, service_name: str, region_name: Optional[str] = None
+        session: Session, service_name, region_name: Optional[str] = None
     ):
         region = region_name if region_name else session.region_name
         return session.resource(service_name, region_name=region)

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -93,6 +93,18 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             self.project = self.gl.projects.get(project_id)
         self.saas_files = saas_files
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.cleanup()
+
+    def cleanup(self):
+        """
+        This method is a placeholder for cleanup actions. This is aligned with SQSGateway.
+        """
+        pass
+
     @retry()
     def _auth(self):
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -103,7 +103,6 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         """
         This method is a placeholder for cleanup actions. This is aligned with SQSGateway.
         """
-        pass
 
     @retry()
     def _auth(self):

--- a/reconcile/utils/mr/README.md
+++ b/reconcile/utils/mr/README.md
@@ -175,10 +175,10 @@ from reconcile.utils.mr import CreateDeleteAwsAccessKey
 
 
 def run(dry_run, gitlab_project_id):
-    ...    
-    mr_cli = mr_client_gateway.init(gitlab_project_id=gitlab_project_id)
+    ...
     mr = CreateDeleteAwsAccessKey(...)
-    mr.submit(cli=mr_cli)
+    with mr_client_gateway.init(gitlab_project_id=gitlab_project_id) as mr_cli:
+      mr.submit(cli=mr_cli)
 ```
 
 If we want to override what's set in App Interface and get a specific client,
@@ -191,8 +191,8 @@ from reconcile.utils.mr import CreateDeleteAwsAccessKey
 
 def run(dry_run, gitlab_project_id):
     ...
-    mr_cli = mr_client_gateway.init(sqs_or_gitlab='gitlab',
-                                    gitlab_project_id=gitlab_project_id)
     mr = CreateDeleteAwsAccessKey(...)
-    mr.submit(cli=mr_cli)
+    with mr_client_gateway.init(sqs_or_gitlab='gitlab',
+                           gitlab_project_id=gitlab_project_id) as mr_cli:
+      mr.submit(cli=mr_cli)
 ```

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -13,10 +13,12 @@ from collections.abc import (
     Sequence,
 )
 from contextlib import suppress
+from types import TracebackType
 from typing import (
     Any,
     Generator,
     Optional,
+    Type,
     Union,
 )
 
@@ -144,14 +146,19 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         self.publish_job_logs = self._get_saas_file_feature_enabled("publish_job_logs")
         self.cluster_admin = self._get_saas_file_feature_enabled("cluster_admin")
 
-    def __enter__(self):
+    def __enter__(self) -> "SaasHerder":
         return self
 
-    def __exit__(self, *exc):
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
         self.cleanup()
 
     def cleanup(self) -> None:
-        if self.state:
+        if hasattr(self, "state") and self.state is not None:
             self.state.cleanup()
 
     def _register_error(self) -> None:

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -94,7 +94,7 @@ Resource = dict[str, Any]
 Resources = list[Resource]
 
 
-class SaasHerder:
+class SaasHerder:  # pylint: disable=too-many-public-methods
     """Wrapper around SaaS deployment actions."""
 
     def __init__(

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -144,6 +144,16 @@ class SaasHerder:
         self.publish_job_logs = self._get_saas_file_feature_enabled("publish_job_logs")
         self.cluster_admin = self._get_saas_file_feature_enabled("cluster_admin")
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.cleanup()
+
+    def cleanup(self) -> None:
+        if self.state:
+            self.state.cleanup()
+
     def _register_error(self) -> None:
         self.error_registered = True
 

--- a/reconcile/utils/state.py
+++ b/reconcile/utils/state.py
@@ -128,6 +128,18 @@ class State:
                 f"Bucket {self.bucket} is not accessible - {str(details)}"
             )
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.cleanup()
+
+    def cleanup(self):
+        """
+        Closes the S3 client
+        """
+        self.client.close()
+
     def exists(self, key):
         """
         Checks if a key exists in the state.

--- a/reconcile/utils/state.py
+++ b/reconcile/utils/state.py
@@ -93,7 +93,7 @@ def init_state_from_accounts(
     return State(
         integration=integration,
         bucket=bucket_name,
-        client=session.client("s3"),
+        client=aws_api.get_session_client(session, "s3"),
     )
 
 

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -587,6 +587,8 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         return split_outputs
 
     def cleanup(self):
+        if self._aws_api:
+            self._aws_api.cleanup()
         for _, wd in self.working_dirs.items():
             shutil.rmtree(wd)
 

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -587,7 +587,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         return split_outputs
 
     def cleanup(self):
-        if self._aws_api:
+        if self._aws_api is not None:
             self._aws_api.cleanup()
         for _, wd in self.working_dirs.items():
             shutil.rmtree(wd)

--- a/requirements/requirements-type.txt
+++ b/requirements/requirements-type.txt
@@ -10,5 +10,5 @@ types-requests
 types-setuptools
 types-tabulate
 types-toml
-boto3-stubs[ec2,s3,rds,iam,route53]==1.24.29
+boto3-stubs[ec2,s3,rds,iam,route53]==1.24.71
 qenerate==0.5.2

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,9 @@ setup(
         "python-gitlab>=1.11.0,<1.12.0",
         "semver~=2.13",
         "python-terraform>=0.10.0,<0.11.0",
-        "boto3>=1.17.49,<=1.18.0",
-        "botocore>=1.20.49,<=1.21.0",
+        # memory leak after boto3 1.24.72, https://github.com/boto/boto3/issues/3614
+        "boto3==1.24.71",
+        "botocore==1.27.71",
         "urllib3>=1.25.4,<1.27.0",
         "slack_sdk>=3.10,<4.0",
         "pypd>=1.1.0,<1.2.0",

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -577,15 +577,15 @@ def main(
             https://gitlab.cee.redhat.com/service/app-interface
             """
 
-        mr_cli = mr_client_gateway.init(
-            gitlab_project_id=gitlab_project_id, sqs_or_gitlab="gitlab"
-        )
         mr = CreateAppInterfaceReporter(
             reports=reports,
             email_body=textwrap.dedent(email_body),
             reports_path=reports_path,
         )
-        result = mr.submit(cli=mr_cli)
+        with mr_client_gateway.init(
+            gitlab_project_id=gitlab_project_id, sqs_or_gitlab="gitlab"
+        ) as mr_cli:
+            result = mr.submit(cli=mr_cli)
         logging.info(["created_mr", result.web_url])
 
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -796,11 +796,11 @@ def clusters_network(ctx, name):
         if not account:
             continue
         account["resourcesDefaultRegion"] = management_account["resourcesDefaultRegion"]
-        aws_api = AWSApi(1, [account], settings=settings, init_users=False)
-        vpc_id, _, _ = aws_api.get_cluster_vpc_details(account)
-        cluster["vpc_id"] = vpc_id
-        egress_ips = aws_api.get_cluster_nat_gateways_egress_ips(account)
-        cluster["egress_ips"] = ", ".join(sorted(egress_ips))
+        with AWSApi(1, [account], settings=settings, init_users=False) as aws_api:
+            vpc_id, _, _ = aws_api.get_cluster_vpc_details(account)
+            cluster["vpc_id"] = vpc_id
+            egress_ips = aws_api.get_cluster_nat_gateways_egress_ips(account)
+            cluster["egress_ips"] = ", ".join(sorted(egress_ips))
 
     # TODO(mafriedm): fix this
     # do not sort
@@ -887,8 +887,8 @@ def clusters_egress_ips(ctx):
         if not account:
             continue
         account["resourcesDefaultRegion"] = management_account["resourcesDefaultRegion"]
-        aws_api = AWSApi(1, [account], settings=settings, init_users=False)
-        egress_ips = aws_api.get_cluster_nat_gateways_egress_ips(account)
+        with AWSApi(1, [account], settings=settings, init_users=False) as aws_api:
+            egress_ips = aws_api.get_cluster_nat_gateways_egress_ips(account)
         item = {"cluster": cluster_name, "egress_ips": ", ".join(sorted(egress_ips))}
         results.append(item)
 


### PR DESCRIPTION
This change fixed memory leak in AWS API.

1. bump boto3 version so `close` is available
2. refactored `lru_cache` to merge methods for clients
3. collect all clients in `AWSApi` so they can be closed
4. update all usages of `AWSApi` to run `cleanup`

APPSRE-4141