### PR TITLE
print CI tooling versions

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,18 +9,23 @@ envlist =
 
 [testenv]
 commands =
+    pytest --version
     pytest {posargs:--cov=reconcile --cov-report=term-missing --cov-report xml}
 deps = -r{toxinidir}/requirements/requirements-test.txt
 parallel_show_output = true
 
 [testenv:format]
 skip_install = true
-commands = black {posargs:--check reconcile tools release e2e_tests dockerfiles/hack setup.py}
+commands = 
+    black --version
+    black {posargs:--check reconcile tools release e2e_tests dockerfiles/hack setup.py}
 deps = -r{toxinidir}/requirements/requirements-format.txt
 
 [testenv:lint]
 commands =
+    flake8 --version
     flake8 reconcile tools release e2e_tests dockerfiles/hack setup.py
+    pylint --version
     pylint --extension-pkg-whitelist='pydantic' reconcile tools release e2e_tests dockerfiles/hack setup.py
 
 [testenv:imports]
@@ -28,7 +33,9 @@ skip_install = true
 commands = isort --check-only reconcile tools release e2e_tests dockerfiles/hack setup.py
 
 [testenv:type]
-commands = mypy {posargs}
+commands = 
+    mypy --version
+    mypy {posargs}
 deps = -r{toxinidir}/requirements/requirements-type.txt
 
 [testenv:generate]
@@ -38,6 +45,7 @@ deps = -r{toxinidir}/requirements/requirements-type.txt
 depends = py39
 allowlist_externals = git
 commands =
+    qenerate --version
     qenerate code -i reconcile/gql_definitions/introspection.json reconcile/gql_definitions
     black reconcile/gql_definitions
     git diff --exit-code


### PR DESCRIPTION
We do not use lockfiles (yet). So for debugging purposes it would be nice to see which tool versions where run during a jenkins check.