### PR TITLE
Support _records_from_vault in terraform-aws-route53 integration

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2686,6 +2686,12 @@ DNS_ZONES_QUERY = """
         name
         elbFQDN
       }
+      _records_from_vault {
+        path
+        field
+        key
+        version
+      }
       _target_namespace_zone {
         namespace {
           managedExternalResources

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2671,6 +2671,7 @@ DNS_ZONES_QUERY = """
       vpc_id
       region
     }
+    allowed_vault_secret_paths
     records {
       %s
       _healthcheck {

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -4,7 +4,10 @@ from collections.abc import (
     Iterable,
     Mapping,
 )
-from typing import Any
+from typing import (
+    Any,
+    Optional,
+)
 
 from reconcile import queries
 from reconcile.status import ExitCodes
@@ -180,6 +183,16 @@ def build_desired_state(
                 )
                 record["healthcheck"] = healthcheck
 
+            # Process '_records_from_vault'
+            records_from_vault = record.pop("_records_from_vault", None)
+            if records_from_vault:
+                logging.debug(
+                    f"{zone_name}: field `_records_from_vault` found "
+                    f"for record {record_name}. Values are: "
+                    f"{records_from_vault}"
+                )
+                record["records_from_vault"] = records_from_vault
+
             zone_values["records"].append(record)
 
         desired_state.append(zone_values)
@@ -188,11 +201,11 @@ def build_desired_state(
 
 @defer
 def run(
-    dry_run=False,
-    print_to_file=None,
-    enable_deletion=True,
-    thread_pool_size=10,
-    account_name=None,
+    dry_run: bool = False,
+    print_to_file: Optional[str] = None,
+    enable_deletion: bool = True,
+    thread_pool_size: int = 10,
+    account_name: Optional[str] = None,
     defer=None,
 ):
     settings = queries.get_app_interface_settings()

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -66,6 +66,10 @@ def build_desired_state(
         if vpc:
             zone_values["vpc"] = {"vpc_id": vpc["vpc_id"], "vpc_region": vpc["region"]}
 
+        allowed_vault_secret_paths = zone.get("allowed_vault_secret_paths")
+        if allowed_vault_secret_paths:
+            zone_values["allowed_vault_secret_paths"] = set(allowed_vault_secret_paths)
+
         for record in zone["records"]:
             record_name = record["name"]
             record_type = record["type"]

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -913,6 +913,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                             "version": rec["version"],
                         }
                     )
+                    # 'key' is only set when the secret data is in JSON format and a
+                    # specific item from the object needs to be selected, otherwise the
+                    # value is used as-is.
                     if rec["key"]:
                         try:
                             value = json.loads(value)[rec["key"]]

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -252,6 +252,10 @@ class UnknownProviderError(Exception):
         super().__init__("unknown provider error: " + str(msg))
 
 
+class UnapprovedSecretPathError(Exception):
+    pass
+
+
 class aws_ecrpublic_repository(Resource):
     pass
 
@@ -901,8 +905,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 vault_values: list[str] = []
                 for rec in records_from_vault:
                     if not rec["path"] in allowed_vault_secret_paths:
-                        raise ValueError(
-                            "{} is not in the list of approved Vault secret paths (allowed_vault_secret_paths)".format(
+                        raise UnapprovedSecretPathError(
+                            "'{}' is not in the list of approved Vault secret paths. Add this path to 'allowed_vault_secret_paths'.".format(
                                 rec["path"]
                             )
                         )
@@ -926,12 +930,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                             )
                             raise
                         except KeyError:
-                            logging.error(
-                                "Key '%s' was not found in secret: %s",
-                                rec["key"],
-                                rec["path"],
-                            )
-                            raise
+                            msg = f"Key '{rec['key']}' was not found in the contents of secret '{rec['path']}'"
+                            logging.error(msg)
+                            raise KeyError(msg)
                     vault_values.append(value)
                 record["records"] = vault_values
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -895,8 +895,17 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 "records_from_vault", None
             )
             if records_from_vault:
+                allowed_vault_secret_paths = cast(
+                    set[str], zone.get("allowed_vault_secret_paths")
+                ) or set()
                 vault_values: list[str] = []
                 for rec in records_from_vault:
+                    if not rec["path"] in allowed_vault_secret_paths:
+                        raise ValueError(
+                            "{} is not in the list of approved Vault secret paths (allowed_vault_secret_paths)".format(
+                                rec["path"]
+                            )
+                        )
                     value = self.secret_reader.read(
                         {
                             "path": rec["path"],

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -895,9 +895,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 "records_from_vault", None
             )
             if records_from_vault:
-                allowed_vault_secret_paths = cast(
-                    set[str], zone.get("allowed_vault_secret_paths")
-                ) or set()
+                allowed_vault_secret_paths = (
+                    cast(set[str], zone.get("allowed_vault_secret_paths")) or set()
+                )
                 vault_values: list[str] = []
                 for rec in records_from_vault:
                     if not rec["path"] in allowed_vault_secret_paths:


### PR DESCRIPTION
Related: https://issues.redhat.com/browse/APPSRE-6948

This feature will allow us to consume Vault records from other integrations and use them as a source for creating DNS records in the `terraform-aws-route53` integration. The primary use case is domain control validation (DCV) records for certificates created in Cloudflare through the ACM feature: https://blog.cloudflare.com/advanced-certificate-manager/

## Example

```yaml
---
$schema: /dependencies/dns-zone-1.yml

...

allowed_vault_secret_paths:
- some-path/to-a/secret

records:
- name: _acme-challenge.subdomain
  type: TXT
  _records_from_vault:
    - path: some-path/to-a/secret
      field: validation_records
      key: _acme-challenge.subdomain.domain.com
```

`allowed_vault_secret_paths` must contain the approved paths from which a secret can be pulled. This will not be self-serviceable. This prevents a user from picking any path from which they could expose secrets.

`validation_records` is an output of `terraform-cloudflare-resources` where it is a JSON mapping of Cloudflare ACM DNS records values to the DCV values needed to prove ownership of the domain.

## Testing

1. Happy path of creating a record with 1 or more secrets sourced from Vault
2. Create a record that has a secret that doesn't exist
3. Create a record that uses a `key` in the secret that doesn't exist
4. Create a record that has a secret that cannot be decoded as JSON