### PR TITLE
[openshift_base] catch namespace does not exist (and wait more)

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -353,10 +353,10 @@ def fetch_current_state(
     return ri, oc_map
 
 
-@retry(max_attempts=20)
+@retry(max_attempts=30)
 def wait_for_namespace_exists(oc, namespace):
     if not oc.project_exists(namespace):
-        raise Exception(f"namespace {namespace} does not exist")
+        raise StatusCodeError(f"namespace {namespace} does not exist")
 
 
 def apply(


### PR DESCRIPTION
fix following up on #813

we expect the namespace to eventually be created, so let's wait more. 30 attempts == 465 seconds.
we also want to catch the last attempt, should there be a real problem with creating the namespace. this PR updates the exception that is raised to one that is caught here:
https://github.com/app-sre/qontract-reconcile/blob/c9f902831b038b7b5986af4433f3d284728dc316/reconcile/openshift_base.py#L649-L682

this will cause an error to be registered and the deployment will be marked as failed.