### PR TITLE
Union lists fix

### DIFF
--- a/reconcile/test/conftest.py
+++ b/reconcile/test/conftest.py
@@ -135,8 +135,8 @@ def gql_class_factory() -> Callable[
         try:
             return klass(**data_default_none(klass, data or {}))
         except ValidationError as e:
-            msg = "[gql_class_factory] Your given data does not match the class!\n"
-            msg += "\n".join(list(e.raw_errors))
+            msg = "[gql_class_factory] Your given data does not match the class ...\n"
+            msg += "\n".join([str(m) for m in list(e.raw_errors)])
             raise GQLClassFactoryError(msg) from e
 
     return _gql_class_factory

--- a/reconcile/test/conftest.py
+++ b/reconcile/test/conftest.py
@@ -134,6 +134,6 @@ def gql_class_factory() -> Callable[
             msg = "[gql_class_factory] Your given data does not match the class!\n"
             for raw_error in e.raw_errors:
                 msg += f"{raw_error}\n"
-            raise RuntimeError(raw_error)
+            raise RuntimeError(raw_error) from e
 
     return _gql_class_factory

--- a/reconcile/test/conftest.py
+++ b/reconcile/test/conftest.py
@@ -119,6 +119,10 @@ def data_factory() -> Callable[
     return _data_factory
 
 
+class GQLClassFactoryError(Exception):
+    pass
+
+
 @pytest.fixture
 def gql_class_factory() -> Callable[
     [type[BaseModel], Optional[MutableMapping[str, Any]]], BaseModel
@@ -132,8 +136,7 @@ def gql_class_factory() -> Callable[
             return klass(**data_default_none(klass, data or {}))
         except ValidationError as e:
             msg = "[gql_class_factory] Your given data does not match the class!\n"
-            for raw_error in e.raw_errors:
-                msg += f"{raw_error}\n"
-            raise RuntimeError(raw_error) from e
+            msg += "\n".join(list(e.raw_errors))
+            raise GQLClassFactoryError(msg) from e
 
     return _gql_class_factory


### PR DESCRIPTION
This fixes dict <-> union matching.

1. For every class in a union we try if the given data matches -> first match wins
2. Lists like `list[Union[A, B]]` are handled a little differently -> we do the first step for every item in the list
3. We increase log verbosity, i.e., print what attributes are missing from your data in order to match a generated class