### PR TITLE
Revert "Check the server url before returning the client"

### DIFF
--- a/reconcile/test/oc/test_oc_connection_parameters.py
+++ b/reconcile/test/oc/test_oc_connection_parameters.py
@@ -10,7 +10,6 @@ from reconcile.test.oc.fixtures import (
     load_namespace_for_connection_parameters,
 )
 from reconcile.utils.oc_connection_parameters import (
-    OCConnectionError,
     OCConnectionParameters,
     get_oc_connection_parameters_from_namespaces,
 )
@@ -122,37 +121,15 @@ def test_from_cluster(
 ):
     test_cluster = load_cluster_for_connection_parameters(f"{cluster}.yml")
     secret_reader = create_autospec(SecretReaderBase)
-    secret_reader.read_secret.side_effect = ["secret2"]
-    secret_reader.read_all_secret.side_effect = [
-        {"server": "server-url", "token": "secret1", "username": "foo"}
-    ]
-
+    secret_reader.read_secret.side_effect = ["secret1", "secret2"]
     parameters = OCConnectionParameters.from_cluster(
         secret_reader=secret_reader,
         cluster=test_cluster,
         cluster_admin=False,
         use_jump_host=use_jump_host,
     )
+
     assert parameters == expected_parameters
-
-
-def test_wrong_server_url():
-    test_cluster = load_cluster_for_connection_parameters("cluster_no_jumphost.yml")
-    secret_reader = create_autospec(SecretReaderBase)
-    secret_reader.read_secret.side_effect = ["secret2"]
-    secret_reader.read_all_secret.side_effect = [
-        {"server": "wrong", "token": "secret1", "username": "foo"}
-    ]
-
-    with pytest.raises(OCConnectionError):
-        parameters = OCConnectionParameters.from_cluster(
-            secret_reader=secret_reader,
-            cluster=test_cluster,
-            cluster_admin=False,
-            use_jump_host=False,
-        )
-
-        assert parameters is None
 
 
 @dataclass
@@ -336,17 +313,9 @@ def test_from_namespaces(
         load_namespace_for_connection_parameters(f"{ns}.yml") for ns in namespaces
     ]
     secret_reader = create_autospec(SecretReaderBase)
-
-    if mock_secrets:
-        secret_reader.read_secret.return_value = "secret"
-        secret_reader.read_all_secret.return_value = {
-            "server": "server-url",
-            "token": "secret",
-            "username": "foo",
-        }
-    else:
-        secret_reader.read_all_secret.side_effect = SecretNotFound("secret")
-        secret_reader.read_secret.side_effect = SecretNotFound("secret")
+    secret_reader.read_secret.side_effect = (
+        ["secret"] * 100 if mock_secrets else SecretNotFound("secret")
+    )
 
     def _sort(items: Iterable[OCConnectionParameters]) -> list[OCConnectionParameters]:
         return sorted(items, key=lambda x: (x.cluster_name, str(x.automation_token)))

--- a/reconcile/test/test_gabi_authorized_users.py
+++ b/reconcile/test/test_gabi_authorized_users.py
@@ -68,20 +68,13 @@ def mock_get_gabi_instances(expiration_date: str) -> list[dict]:
 
 @patch.object(queries, "get_app_interface_settings", autospec=True)
 @patch.object(SecretReader, "read", autospec=True)
-@patch.object(SecretReader, "read_all", autospec=True)
 @patch.object(OCDeprecated, "get_version", autospec=True)
 @patch.object(queries, "get_gabi_instances", autospec=True)
 @patch.object(ApiClient, "request")
 @patch.dict(os.environ, {"USE_NATIVE_CLIENT": "True"}, clear=True)
 class TestGabiAuthorizedUser(TestCase):
     def test_gabi_authorized_users_exceed(
-        self,
-        mock_request,
-        get_gabi_instances,
-        oc_version,
-        secret_read,
-        secrect_read_all,
-        get_settings,
+        self, mock_request, get_gabi_instances, oc_version, secret_read, get_settings
     ):
         expiration_date = date.today() + timedelta(
             days=(gabi_u.EXPIRATION_DAYS_MAX + 1)
@@ -98,13 +91,11 @@ class TestGabiAuthorizedUser(TestCase):
         mock_request,
         get_gabi_instances,
         oc_version,
-        secrect_read_all,
         secret_read,
         get_settings,
     ):
         expiration_date = date(2023, 1, 1)
         get_gabi_instances.return_value = mock_get_gabi_instances(expiration_date)
-        secrect_read_all.return_value = {"server": "server", "token": "foo"}
         mock_request.side_effect = apply_request
         gabi_u.run(dry_run=False)
         expected = OR(
@@ -124,13 +115,11 @@ class TestGabiAuthorizedUser(TestCase):
         mock_request,
         get_gabi_instances,
         oc_version,
-        secrect_read_all,
         secret_read,
         get_settings,
     ):
         expiration_date = date.today()
         get_gabi_instances.return_value = mock_get_gabi_instances(expiration_date)
-        secrect_read_all.return_value = {"server": "server", "token": "foo"}
         mock_request.side_effect = delete_request
         sha.return_value = "abc"
         gabi_u.run(dry_run=False)
@@ -143,13 +132,11 @@ class TestGabiAuthorizedUser(TestCase):
         mock_request,
         get_gabi_instances,
         oc_version,
-        secrect_read_all,
         secret_read,
         get_settings,
     ):
         expiration_date = date(2023, 1, 1) - timedelta(days=1)
         get_gabi_instances.return_value = mock_get_gabi_instances(expiration_date)
-        secrect_read_all.return_value = {"server": "server", "token": "foo"}
         mock_request.side_effect = delete_request
         gabi_u.run(dry_run=False)
         expected = OR(

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -372,7 +372,7 @@ class TestOCMapInit(TestCase):
         )
         self.assertEqual(len(oc_map.clusters()), 0)
 
-    @patch.object(SecretReader, "read_all", autospec=True)
+    @patch.object(SecretReader, "read", autospec=True)
     def test_automationtoken_not_found(self, mock_secret_reader):
 
         mock_secret_reader.side_effect = SecretNotFound
@@ -391,38 +391,14 @@ class TestOCMapInit(TestCase):
         )
         self.assertEqual(len(oc_map.clusters()), 0)
 
-    @patch.object(SecretReader, "read_all", autospec=True)
-    def test_server_url_mismatch(self, mock_secret_reader):
-        mock_secret_reader.return_value = {"server": "foo", "some-field": "bar"}
-
-        cluster = {
-            "name": "test-1",
-            "serverUrl": "http://localhost",
-            "automationToken": {"path": "some-path", "field": "some-field"},
-        }
-
-        oc_map = OC_Map(clusters=[cluster])
-
-        self.assertIsInstance(oc_map.get(cluster["name"]), OCLogMsg)
-        self.assertEqual(
-            oc_map.get(cluster["name"]).message,
-            f'[{cluster["name"]}] server URL mismatch',
-        )
-        self.assertEqual(len(oc_map.clusters()), 0)
-
 
 class TestOCMapGetClusters(TestCase):
-    @patch.object(SecretReader, "read_all", autospec=True)
+    @patch.object(SecretReader, "read", autospec=True)
     def test_clusters_errors_empty_return(self, mock_secret_reader):
         """
         clusters() shouldn't return the names of any clusters that didn't
         initialize a client successfully.
         """
-        mock_secret_reader.return_value = {
-            "server": "http://localhost",
-            "some-field": "bar",
-        }
-
         cluster = {
             "name": "test-1",
             "serverUrl": "http://localhost",
@@ -434,17 +410,12 @@ class TestOCMapGetClusters(TestCase):
         self.assertIsInstance(oc_map.oc_map.get(cluster["name"]), OCLogMsg)
 
     @patch.object(reconcile.utils.oc, "OC", autospec=True)
-    @patch.object(SecretReader, "read_all", autospec=True)
+    @patch.object(SecretReader, "read", autospec=True)
     def test_clusters_errors_with_include_errors(self, mock_secret_reader, mock_oc):
         """
         With the include_errors kwarg set to true, clusters that didn't
         initialize a client are still included.
         """
-        mock_secret_reader.return_value = {
-            "server": "http://localhost",
-            "some-field": "bar",
-        }
-
         cluster_1 = {
             "name": "test-1",
             "serverUrl": "http://localhost",
@@ -464,13 +435,8 @@ class TestOCMapGetClusters(TestCase):
         self.assertIsInstance(oc_map.oc_map.get(cluster_1["name"]), OCLogMsg)
 
     @patch.object(reconcile.utils.oc, "OC", autospec=True)
-    @patch.object(SecretReader, "read_all", autospec=True)
+    @patch.object(SecretReader, "read", autospec=True)
     def test_namespace_with_cluster_admin(self, mock_secret_reader, mock_oc):
-        mock_secret_reader.return_value = {
-            "server": "http://localhost",
-            "some-field": "bar",
-        }
-
         cluster_1 = {
             "name": "cl1",
             "serverUrl": "http://localhost",
@@ -501,13 +467,8 @@ class TestOCMapGetClusters(TestCase):
         self.assertIsInstance(oc_map.get(cluster_2["name"], privileged=True), OCLogMsg)
 
     @patch.object(reconcile.utils.oc, "OC", autospec=True)
-    @patch.object(SecretReader, "read_all", autospec=True)
+    @patch.object(SecretReader, "read", autospec=True)
     def test_missing_cluster_automation_token(self, mock_secret_reader, mock_oc):
-        mock_secret_reader.return_value = {
-            "server": "http://localhost",
-            "some-field": "bar",
-        }
-
         cluster_1 = {
             "name": "cl1",
             "serverUrl": "http://localhost",
@@ -528,13 +489,8 @@ class TestOCMapGetClusters(TestCase):
         self.assertFalse(oc_map.get(cluster_1["name"], privileged=True))
 
     @patch.object(reconcile.utils.oc, "OC", autospec=True)
-    @patch.object(SecretReader, "read_all", autospec=True)
-    def test_internal_clusters(self, mock_secret_reader, mock_oc):
-        mock_secret_reader.return_value = {
-            "server": "http://localhost",
-            "some-field": "bar",
-        }
-
+    @patch.object(SecretReader, "read", autospec=True)
+    def test_internal_clusters(self, selfmock_secret_reader, mock_oc):
         cluster = {
             "name": "cl1",
             "serverUrl": "http://localhost",
@@ -552,13 +508,8 @@ class TestOCMapGetClusters(TestCase):
         self.assertFalse(oc_map.get(cluster["name"]))
 
     @patch.object(reconcile.utils.oc, "OC", autospec=True)
-    @patch.object(SecretReader, "read_all", autospec=True)
-    def test_disabled_integration(self, mock_secret_reader, mock_oc):
-        mock_secret_reader.return_value = {
-            "server": "http://localhost",
-            "some-field": "bar",
-        }
-
+    @patch.object(SecretReader, "read", autospec=True)
+    def test_disabled_integration(self, selfmock_secret_reader, mock_oc):
         calling_int = "calling_integration"
         cluster = {
             "name": "cl1",

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1655,26 +1655,12 @@ class OC_Map:
             secret_reader = SecretReader(settings=self.settings)
 
             try:
-                token_secret = secret_reader.read_all(automation_token)
+                token = secret_reader.read(automation_token)
             except SecretNotFound:
                 self.set_oc(
                     cluster,
                     OCLogMsg(
                         log_level=logging.ERROR, message=f"[{cluster}] secret not found"
-                    ),
-                    privileged,
-                )
-                return
-
-            token = token_secret[automation_token["field"]]
-            known_server_url = token_secret["server"]
-
-            if server_url != known_server_url:
-                self.set_oc(
-                    cluster,
-                    OCLogMsg(
-                        log_level=logging.ERROR,
-                        message=f"[{cluster}] server URL mismatch",
                     ),
                     privileged,
                 )

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -17,10 +17,6 @@ from reconcile.utils.secret_reader import (
 )
 
 
-class OCConnectionError(Exception):
-    pass
-
-
 class Disable(Protocol):
     integrations: Optional[list[str]]
     e2e_tests: Optional[list[str]]
@@ -70,13 +66,6 @@ class Namespace(Protocol):
 
 
 @dataclass
-class ClusterSecret:
-    server: str
-    token: str
-    username: str
-
-
-@dataclass
 class OCConnectionParameters:
     """
     Container for Openshift Client (OC) parameters.
@@ -104,29 +93,6 @@ class OCConnectionParameters:
     jumphost_local_port: Optional[int]
 
     @staticmethod
-    def _get_token_verify_server_url(secret: ClusterSecret, cluster: Cluster) -> str:
-        if secret.server != cluster.server_url:
-            logging.error(
-                f"[{cluster.name}] server URL {cluster.server_url} does not match url in secret {secret.server}"
-            )
-            raise OCConnectionError(f"{cluster} server URL mismatch")
-        return secret.token
-
-    @staticmethod
-    def _get_automation_token(
-        secret_reader: SecretReaderBase, secret: HasSecret, cluster: Cluster
-    ) -> Optional[str]:
-        secret_raw = secret_reader.read_all_secret(secret)
-        return OCConnectionParameters._get_token_verify_server_url(
-            ClusterSecret(
-                server=secret_raw["server"],
-                token=secret_raw["token"],
-                username=secret_raw["username"],
-            ),
-            cluster,
-        )
-
-    @staticmethod
     def from_cluster(
         cluster: Cluster,
         secret_reader: SecretReaderBase,
@@ -139,12 +105,8 @@ class OCConnectionParameters:
         if cluster_admin:
             if cluster.cluster_admin_automation_token:
                 try:
-                    cluster_admin_automation_token = (
-                        OCConnectionParameters._get_automation_token(
-                            secret_reader,
-                            cluster.cluster_admin_automation_token,
-                            cluster,
-                        )
+                    cluster_admin_automation_token = secret_reader.read_secret(
+                        cluster.cluster_admin_automation_token
                     )
                 except SecretNotFound:
                     logging.error(
@@ -159,8 +121,8 @@ class OCConnectionParameters:
         else:
             if cluster.automation_token:
                 try:
-                    automation_token = OCConnectionParameters._get_automation_token(
-                        secret_reader, cluster.automation_token, cluster
+                    automation_token = secret_reader.read_secret(
+                        cluster.automation_token
                     )
                 except SecretNotFound:
                     logging.error(


### PR DESCRIPTION
Failing with some exception that looks related. Need to check
```
08:15:02   File "/usr/local/lib/python3.9/site-packages/reconcile/utils/oc_map.py", line 83, in _init_oc_client
08:15:02     cluster = connection_parameters.cluster_name
08:15:02 AttributeError: 'OCConnectionError' object has no attribute 'cluster_name'
```
Reverts app-sre/qontract-reconcile#3338