### PR TITLE
fix: mutexes may not be set

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -635,8 +635,9 @@ def ocm_addon_upgrade_policies(ctx):
         ocm_output = output.setdefault(ocm_name, [])
         for d in res.desired_state:
             sector = ""
-            if d.get("conditions", {}).get("sector"):
-                sector = d["conditions"]["sector"].name
+            conditions = d.get("conditions") or {}
+            if conditions.get("sector"):
+                sector =conditions["sector"].name
             version = d["current_version"]
             ocm_output.append(
                 {
@@ -645,8 +646,8 @@ def ocm_addon_upgrade_policies(ctx):
                     "current_version": version,
                     "schedule": d["schedule"],
                     "sector": sector,
-                    "mutexes": ", ".join(d.get("conditions", {}).get("mutexes", [])),
-                    "soak_days": d.get("conditions", {}).get("soakDays"),
+                    "mutexes": ", ".join(conditions.get("mutexes") or []),
+                    "soak_days": conditions.get("soakDays"),
                     "workloads": ", ".join(d["workloads"]),
                     "next_version": next_version if next_version != version else "",
                 }

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -637,7 +637,7 @@ def ocm_addon_upgrade_policies(ctx):
             sector = ""
             conditions = d.get("conditions") or {}
             if conditions.get("sector"):
-                sector =conditions["sector"].name
+                sector = conditions["sector"].name
             version = d["current_version"]
             ocm_output.append(
                 {


### PR DESCRIPTION
Noticed that while removing mutexes for a cluster:
```
08:07:10 Traceback (most recent call last):
08:07:10   File "/usr/local/bin/qontract-cli", line 8, in <module>
08:07:10     sys.exit(root())
08:07:10   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1130, in __call__
08:07:10     return self.main(*args, **kwargs)
08:07:10   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1055, in main
08:07:10     rv = self.invoke(ctx)
08:07:10   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
08:07:10     return _process_result(sub_ctx.command.invoke(sub_ctx))
08:07:10   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1657, in invoke
08:07:10     return _process_result(sub_ctx.command.invoke(sub_ctx))
08:07:10   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
08:07:10     return ctx.invoke(self.callback, **ctx.params)
08:07:10   File "/usr/local/lib/python3.9/site-packages/click/core.py", line 760, in invoke
08:07:10     return __callback(*args, **kwargs)
08:07:10   File "/usr/local/lib/python3.9/site-packages/click/decorators.py", line 26, in new_func
08:07:10     return f(get_current_context(), *args, **kwargs)
08:07:10   File "/usr/local/lib/python3.9/site-packages/tools/qontract_cli.py", line 648, in ocm_addon_upgrade_policies
08:07:10     "mutexes": ", ".join(d.get("conditions", {}).get("mutexes", [])),
08:07:10 TypeError: can only join an iterable
```