### PR TITLE
[saasherder] add information to recover from configuration mismatch

### DIFF
--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1759,7 +1759,9 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     logging.error(
                         "Parent saas target has run with a newer "
                         "configuration and the same commit (ref). "
-                        "Check if other MR exists for this target"
+                        "Check if other MR exists for this target, "
+                        f"or update {parent_saas_config.target_config_hash} "
+                        f"to {state_config_hash} for channel {channel}"
                     )
                     return False
         return True


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-7269

```
[ERROR] [saasherder.py:validate_promotions:1837] - Parent saas target has run with a newer configuration and the same commit (ref). Check if other MR exists for this target
[ERROR] [openshift_saas_deploy.py:run:172] - invalid promotions 
```

the workaround to this error is to remove the `promotion_data` section in a separate MR.
while we are working on a better solution, we can add information to the error message that will allow a user to update the same MR with the updated config hash in order to get a passing pr-check.