### PR TITLE
Update thread size for openshift_saas_deploy to default 10

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1022,7 +1022,7 @@ def openshift_resources(
 @environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @environ(["gitlab_pr_submitter_queue_url"])
 @gitlab_project_id
-@threaded(default=20)
+@threaded()
 @throughput
 @use_jump_host()
 @binary(["oc", "ssh"])


### PR DESCRIPTION
`openshift_saas_deploy` can spawn 20 `oc` processes at peak time when thread pool size is 20, each `oc` process consumes 50+ MB, reduce thread pool size to limit memory usage.