### PR TITLE
tf-cloudflare-resources: add ability to set tiered_cache type

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -4201,6 +4201,11 @@
                         },
                         {
                             "kind": "OBJECT",
+                            "name": "CloudflareAccount_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
                             "name": "PermissionSlackUsergroup_v1",
                             "ofType": null
                         },
@@ -12841,6 +12846,11 @@
                         {
                             "kind": "INTERFACE",
                             "name": "ExternalResourcesProvisioner_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
                             "ofType": null
                         }
                     ],
@@ -31854,6 +31864,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "tiered_cache",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "CloudflareZoneTieredCache_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "cache_reserve",
                             "description": null,
                             "args": [],
@@ -31962,6 +31984,33 @@
                                 "kind": "SCALAR",
                                 "name": "Boolean",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "CloudflareZoneTieredCache_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "cache_type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -38560,16 +38609,24 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "awsAccount",
+                            "name": "awsAccounts",
                             "description": null,
                             "args": [],
                             "type": {
                                 "kind": "NON_NULL",
                                 "name": null,
                                 "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "AWSAccount_v1",
-                                    "ofType": null
+                                    "kind": "LIST",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "NON_NULL",
+                                        "name": null,
+                                        "ofType": {
+                                            "kind": "OBJECT",
+                                            "name": "AWSAccount_v1",
+                                            "ofType": null
+                                        }
+                                    }
                                 }
                             },
                             "isDeprecated": false,

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.gql
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.gql
@@ -59,6 +59,9 @@ query TerraformCloudflareResources {
               smart_routing
               tiered_caching
             }
+            tiered_cache {
+              cache_type
+            }
             cache_reserve {
               enabled
             }

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.py
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.py
@@ -102,6 +102,9 @@ query TerraformCloudflareResources {
               smart_routing
               tiered_caching
             }
+            tiered_cache {
+              cache_type
+            }
             cache_reserve {
               enabled
             }
@@ -205,6 +208,10 @@ class CloudflareZoneArgoV1(ConfiguredBaseModel):
     tiered_caching: Optional[bool] = Field(..., alias="tiered_caching")
 
 
+class CloudflareZoneTieredCacheV1(ConfiguredBaseModel):
+    cache_type: str = Field(..., alias="cache_type")
+
+
 class CloudflareZoneCacheReserveV1(ConfiguredBaseModel):
     enabled: Optional[bool] = Field(..., alias="enabled")
 
@@ -244,6 +251,9 @@ class NamespaceTerraformResourceCloudflareZoneV1(
     q_type: Optional[str] = Field(..., alias="type")
     settings: Optional[Json] = Field(..., alias="settings")
     argo: Optional[CloudflareZoneArgoV1] = Field(..., alias="argo")
+    tiered_cache: Optional[CloudflareZoneTieredCacheV1] = Field(
+        ..., alias="tiered_cache"
+    )
     cache_reserve: Optional[CloudflareZoneCacheReserveV1] = Field(
         ..., alias="cache_reserve"
     )

--- a/reconcile/test/test_terraform_cloudflare_resources.py
+++ b/reconcile/test/test_terraform_cloudflare_resources.py
@@ -64,6 +64,9 @@ def external_resources(provisioner_config):
                     "tiered_caching": True,
                     "smart_routing": True,
                 },
+                tiered_cache={
+                    "cache_type": "smart",
+                },
                 cache_reserve={
                     "enabled": True,
                 },

--- a/reconcile/utils/terrascript/cloudflare_resources.py
+++ b/reconcile/utils/terrascript/cloudflare_resources.py
@@ -52,6 +52,15 @@ class cloudflare_certificate_pack(Resource):
     """
 
 
+class cloudflare_tiered_cache(Resource):
+    """
+    https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/tiered_cache
+
+    This resource isn't supported directly by Terrascript, which is why it needs to be
+    defined like this as a Resource.
+    """
+
+
 class cloudflare_accounts(Data):
     """
     https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/data-sources/accounts
@@ -173,6 +182,7 @@ class CloudflareZoneTerrascriptResource(TerrascriptResource):
         #       We pop the value here because it's not supported by the provider at this
         #       time.
         _ = values.pop("cache_reserve", None)
+        zone_tiered_cache = values.pop("tiered_cache", None)
         zone_records = values.pop("records", [])
         zone_workers = values.pop("workers", [])
         zone_certs = values.pop("certificates", [])
@@ -211,6 +221,17 @@ class CloudflareZoneTerrascriptResource(TerrascriptResource):
             }
 
             resources.append(cloudflare_argo(self._spec.identifier, **argo_values))
+
+        if zone_tiered_cache is not None:
+            tiered_cache_values = {
+                "zone_id": f"${{{zone.id}}}",
+                "depends_on": self._get_dependencies([zone]),
+                **zone_tiered_cache,
+            }
+
+            resources.append(
+                cloudflare_tiered_cache(self._spec.identifier, **tiered_cache_values)
+            )
 
         for record in zone_records:
             identifier = safe_resource_id(record.pop("identifier"))


### PR DESCRIPTION
Adds ability to set [tiered_cache](https://registry.terraform.io/providers/cloudflare/cloudflare/3.32.0/docs/resources/tiered_cache) on a zone

Schema: https://github.com/app-sre/qontract-schemas/pull/421

Ref.: https://issues.redhat.com/browse/APPSRE-7363