### PR TITLE
add version bumps for q-r base image missing from #3359

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -15,7 +15,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
     python3 -m pip wheel . --wheel-dir /work/wheels
 
 
-FROM quay.io/app-sre/qontract-reconcile-base:0.8.10 as dev-image
+FROM quay.io/app-sre/qontract-reconcile-base:0.8.11 as dev-image
 
 ARG CONTAINER_UID=1000
 RUN useradd --uid ${CONTAINER_UID} reconcile
@@ -44,7 +44,7 @@ VOLUME ["/work"]
 CMD [ "/work/dev/run.sh" ]
 
 
-FROM quay.io/app-sre/qontract-reconcile-base:0.8.10 as prod-image
+FROM quay.io/app-sre/qontract-reconcile-base:0.8.11 as prod-image
 
 # Cache mount. We don't need te wheel files in the final image.
 # This COPY will create a layer with all the wheel files to install the app.


### PR DESCRIPTION
Missed a few version bumps in the main Dockerfile in #3359