### PR TITLE
glitchtip access revalidation and report

### DIFF
--- a/reconcile/gql_definitions/glitchtip/glitchtip_project.gql
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_project.gql
@@ -14,6 +14,7 @@ query Projects {
           role
         }
         users {
+          name
           org_username
         }
       }

--- a/reconcile/gql_definitions/glitchtip/glitchtip_project.gql
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_project.gql
@@ -53,5 +53,9 @@ query Projects {
         }
       }
     }
+    # for gltichtip access revalidation
+    app {
+      path
+    }
   }
 }

--- a/reconcile/gql_definitions/glitchtip/glitchtip_project.py
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_project.py
@@ -95,6 +95,10 @@ query Projects {
         }
       }
     }
+    # for gltichtip access revalidation
+    app {
+      path
+    }
   }
 }
 """
@@ -171,6 +175,10 @@ class NamespaceV1(ConfiguredBaseModel):
     cluster: ClusterV1 = Field(..., alias="cluster")
 
 
+class AppV1(ConfiguredBaseModel):
+    path: str = Field(..., alias="path")
+
+
 class GlitchtipProjectsV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     platform: str = Field(..., alias="platform")
@@ -179,6 +187,7 @@ class GlitchtipProjectsV1(ConfiguredBaseModel):
         ..., alias="organization"
     )
     namespaces: list[NamespaceV1] = Field(..., alias="namespaces")
+    app: AppV1 = Field(..., alias="app")
 
 
 class ProjectsQueryData(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/glitchtip/glitchtip_project.py
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_project.py
@@ -56,6 +56,7 @@ query Projects {
           role
         }
         users {
+          name
           org_username
         }
       }
@@ -115,6 +116,7 @@ class GlitchtipRoleV1(ConfiguredBaseModel):
 
 
 class UserV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
     org_username: str = Field(..., alias="org_username")
 
 

--- a/reconcile/test/fixtures/glitchtip/desire_state_projects.yml
+++ b/reconcile/test/fixtures/glitchtip/desire_state_projects.yml
@@ -11,6 +11,7 @@
               role: member
           users:
             - org_username: SamanthaCristoforetti
+              name: Samantha Cristoforetti
     - name: esa-flight-control
       roles:
         - glitchtip_roles:
@@ -22,17 +23,22 @@
               role: owner
           users:
             - org_username: GlobalFlightDirector
+              name: Global  Fligh t Director
         - glitchtip_roles:
             - organization:
                 name: ESA
               role: member
           users:
             - org_username: MatthiasMaurer
+              name: Matthias Maurer
             - org_username: TimPeake
+              name: Tim Peake
   organization:
     name: ESA
     instance:
       name: glitchtip-dev
+  app:
+    path: /path/to/app
 - name: rosetta-flight-control
   platform: python
   namespaces: []
@@ -48,17 +54,22 @@
               role: owner
           users:
             - org_username: GlobalFlightDirector
+              name: Global Flight Director
         - glitchtip_roles:
             - organization:
                 name: ESA
               role: member
           users:
             - org_username: MatthiasMaurer
+              name: Matthias Maurer
             - org_username: TimPeake
+              name: Tim Peake
   organization:
     name: ESA
     instance:
       name: glitchtip-dev
+  app:
+    path: /path/to/app
 - name: apollo-11-spacecraft
   platform: python
   namespaces: []
@@ -71,7 +82,9 @@
               role: member
           users:
             - org_username: NeilArmstrong
+              name: Neil Armstrong
             - org_username: BuzzAldrin
+              name: Buzz Aldrin
     - name: nasa-flight-control
       roles:
         - glitchtip_roles:
@@ -83,16 +96,20 @@
               role: owner
           users:
             - org_username: GlobalFlightDirector
+              name: Global Flight Director
         - glitchtip_roles:
             - organization:
                 name: NASA
               role: member
           users:
             - org_username: MichaelCollins
+              name: Michael Collins
   organization:
     name: NASA
     instance:
       name: glitchtip-dev
+  app:
+    path: /path/to/app
 - name: apollo-11-flight-control
   platform: python
   namespaces: []
@@ -108,13 +125,17 @@
               role: owner
           users:
             - org_username: GlobalFlightDirector
+              name: Global Flight Director
         - glitchtip_roles:
             - organization:
                 name: NASA
               role: member
           users:
             - org_username: MichaelCollins
+              name: Michael Collins
   organization:
     name: NASA
     instance:
       name: glitchtip-dev
+  app:
+    path: /path/to/app

--- a/reconcile/test/fixtures/glitchtip/dsn_projects.yml
+++ b/reconcile/test/fixtures/glitchtip/dsn_projects.yml
@@ -8,6 +8,8 @@ glitchtip_projects:
     name: NASA
     instance:
       name: glitchtip-dev
+  app:
+    path: /path/to/app
 - name: integration-disabled
   platform: python
   namespaces:
@@ -26,6 +28,8 @@ glitchtip_projects:
     name: NASA
     instance:
       name: glitchtip-dev
+  app:
+    path: /path/to/app
 - name: namespace_delete
   platform: python
   namespaces:
@@ -42,6 +46,8 @@ glitchtip_projects:
     name: NASA
     instance:
       name: glitchtip-dev
+  app:
+    path: /path/to/app
 - name: apollo-11-flight-control
   platform: python
   teams: []
@@ -82,6 +88,8 @@ glitchtip_projects:
       disable:
         integrations:
         - glitchtip-project-dsn
+  app:
+    path: /path/to/app
 - name: project-does-not-exist-yet
   platform: python
   namespaces:
@@ -97,3 +105,5 @@ glitchtip_projects:
     name: empty-org
     instance:
       name: glitchtip-dev
+  app:
+    path: /path/to/app

--- a/reconcile/utils/mr/glitchtip_access_reporter.py
+++ b/reconcile/utils/mr/glitchtip_access_reporter.py
@@ -25,9 +25,11 @@ class GlitchtipAccessReportOrg(BaseModel):
     access_level: str
 
     def __eq__(self, other: object) -> bool:
-        if not isinstance(other, str):
-            raise NotImplementedError("Cannot compare to non string objects.")
-        return self.name == other
+        if not isinstance(other, GlitchtipAccessReportOrg):
+            raise NotImplementedError(
+                "Cannot compare to non GlitchtipAccessReportOrg objects."
+            )
+        return self.name == other.name
 
 
 class GlitchtipAccessReportUser(BaseModel):

--- a/reconcile/utils/mr/glitchtip_access_reporter.py
+++ b/reconcile/utils/mr/glitchtip_access_reporter.py
@@ -1,0 +1,122 @@
+from collections.abc import Sequence
+from datetime import date
+from datetime import datetime as dt
+from datetime import timezone
+from pathlib import Path
+
+from jinja2 import Template
+from pydantic import BaseModel
+
+from reconcile.utils.gitlab_api import GitLabApi
+from reconcile.utils.mr.base import MergeRequestBase
+from reconcile.utils.mr.labels import AUTO_MERGE
+
+CURRENT_USERS_TABLE_TEMPLATE = """
+| Username | Name | Organizations and Access Levels |
+| -------- | ---- | ------------------------------- |
+{% for user in users|sort -%}
+| {{ user.username }} | {{ user.name }} |{% for org in user.organizations %} {{org.name}} ({{ org.access_level }}){% if not loop.last%},{% endif %}{% endfor %} |
+{% endfor %}
+""".strip()
+
+
+class GlitchtipAccessReportOrg(BaseModel):
+    name: str
+    access_level: str
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, str):
+            raise NotImplementedError("Cannot compare to non string objects.")
+        return self.name == other
+
+
+class GlitchtipAccessReportUser(BaseModel):
+    name: str
+    username: str
+    organizations: list[GlitchtipAccessReportOrg]
+
+    def __lt__(self, other: object) -> bool:
+        if not isinstance(other, GlitchtipAccessReportUser):
+            raise NotImplementedError(
+                "Cannot compare to non GlitchtipAccessReportUser objects."
+            )
+        return self.username < other.username
+
+
+class UpdateGlitchtipAccessReport(MergeRequestBase):
+
+    name = "glitchtip_access_report_mr"
+
+    def __init__(
+        self,
+        users: Sequence[GlitchtipAccessReportUser],
+        glitchtip_access_revalidation_workbook: Path,
+    ):
+        super().__init__()
+        self.users = users
+        self.glitchtip_access_revalidation_workbook = str(
+            glitchtip_access_revalidation_workbook
+        )
+        self.labels = [AUTO_MERGE]
+        self.isodate = dt.now(tz=timezone.utc).isoformat()
+
+    @property
+    def title(self) -> str:
+        return f"[{self.name}] reports for {self.isodate}"
+
+    @property
+    def description(self) -> str:
+        return f"glitchtip access report for {self.isodate}"
+
+    def _render_current_users_table(self) -> str:
+        template = Template(CURRENT_USERS_TABLE_TEMPLATE, keep_trailing_newline=True)
+        return template.render(users=self.users)
+
+    def _render_tracking_table_row(self, old_number_of_users: int) -> str:
+        # | Date Reviewed | Number of Current Users | +/- Red Hat Users |
+        return f"| {date.today()} | {len(self.users)} | {len(self.users) - old_number_of_users} |\n"
+
+    def _update_workbook(self, workbook_md: str) -> str:
+        new_workbook_md = ""
+        number_of_skipped_lines = 0
+        skip = False
+        for line in workbook_md.splitlines():
+            if "<!-- current users table: start -->" in line:
+                # do not copy the old current users table
+                skip = True
+                # insert the new table including the marker
+                new_workbook_md += line + "\n"
+                new_workbook_md += self._render_current_users_table()
+            elif "<!-- current users table: end -->" in line:
+                skip = False
+                # insert the marker
+                new_workbook_md += line + "\n"
+            elif "<!-- tracking table: next row -->" in line:
+                # insert the new row including the marker
+                new_workbook_md += self._render_tracking_table_row(
+                    old_number_of_users=number_of_skipped_lines - 2
+                    if number_of_skipped_lines > 0
+                    else 0
+                )
+                new_workbook_md += line + "\n"
+            elif not skip:
+                new_workbook_md += line + "\n"
+            else:
+                # count the number of skipped current users table lines
+                # this number minus the table header is the old number of users
+                number_of_skipped_lines += 1
+
+        return new_workbook_md
+
+    def process(self, gitlab_cli: GitLabApi) -> None:
+        workbook_md = gitlab_cli.project.files.get(
+            file_path=self.glitchtip_access_revalidation_workbook, ref=self.branch
+        )
+        workbook_md = self._update_workbook(workbook_md.decode().decode("utf-8"))
+
+        gitlab_cli.update_file(
+            branch_name=self.branch,
+            file_path=self.glitchtip_access_revalidation_workbook,
+            commit_message="update glitchtip access report",
+            content=workbook_md,
+        )

--- a/reconcile/utils/mr/notificator.py
+++ b/reconcile/utils/mr/notificator.py
@@ -81,7 +81,7 @@ class CreateAppInterfaceNotificator(MergeRequestBase):
         email_path = self._email_base_path / f"{ts}.yml"
         commit_message = f"[{self.name}] adding notification"
         if not self._dry_run:
-            logging.info("no-dry-run: creating gitlab file")
+            logging.info(f"no-dry-run: creating gitlab file: {email_path}")
             gitlab_cli.create_file(
                 branch_name=self.branch,
                 file_path=str(email_path),
@@ -89,5 +89,5 @@ class CreateAppInterfaceNotificator(MergeRequestBase):
                 content=content,
             )
         else:
-            logging.info("dry-run: skipping gitlab file creation")
+            logging.info(f"dry-run: skipping gitlab file creation: {email_path}")
             logging.info(f"email: {content}")

--- a/reconcile/utils/mr/notificator.py
+++ b/reconcile/utils/mr/notificator.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -34,11 +35,13 @@ class CreateAppInterfaceNotificator(MergeRequestBase):
         notification: Notification,
         labels: Optional[list[str]] = None,
         email_base_path: Path = Path("data") / "app-interface" / "emails",
+        dry_run: bool = False,
     ):
         self._notification_as_dict = notification.dict()
         super().__init__()
         self._notification = notification
         self._email_base_path = email_base_path
+        self._dry_run = dry_run
         self.labels = labels if labels else [DO_NOT_MERGE_HOLD]
 
     @property
@@ -70,15 +73,21 @@ class CreateAppInterfaceNotificator(MergeRequestBase):
         content = app_interface_email(
             name=f"{self.name}-{ts}",
             subject=subject,
-            users=self._notification.recipients,
             body=self._notification.description,
+            users=self._notification.recipients,
+            apps=self._notification.services,
         )
 
         email_path = self._email_base_path / f"{ts}.yml"
         commit_message = f"[{self.name}] adding notification"
-        gitlab_cli.create_file(
-            branch_name=self.branch,
-            file_path=str(email_path),
-            commit_message=commit_message,
-            content=content,
-        )
+        if not self._dry_run:
+            logging.info("no-dry-run: creating gitlab file")
+            gitlab_cli.create_file(
+                branch_name=self.branch,
+                file_path=str(email_path),
+                commit_message=commit_message,
+                content=content,
+            )
+        else:
+            logging.info("dry-run: skipping gitlab file creation")
+            logging.info(f"email: {content}")

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,8 @@ setup(
             "qontract-reconcile = reconcile.cli:integration",
             "e2e-tests = e2e_tests.cli:test",
             "app-interface-reporter = tools.app_interface_reporter:main",
+            "glitchtip-access-reporter = tools.glitchtip_access_reporter:main",
+            "glitchtip-access-revalidation = tools.glitchtip_access_revalidation:main",
             "qontract-cli = tools.qontract_cli:root",
         ],
     },

--- a/tools/glitchtip_access_reporter.py
+++ b/tools/glitchtip_access_reporter.py
@@ -1,0 +1,84 @@
+import logging
+from pathlib import Path
+
+import click
+
+from reconcile import mr_client_gateway
+from reconcile.cli import (
+    config_file,
+    dry_run,
+    gitlab_project_id,
+    log_level,
+)
+from reconcile.glitchtip.integration import get_user_role
+from reconcile.gql_definitions.glitchtip.glitchtip_project import (
+    query as glitchtip_project_query,
+)
+from reconcile.utils import gql
+from reconcile.utils.glitchtip.models import Organization
+from reconcile.utils.mr.glitchtip_access_reporter import (
+    GlitchtipAccessReportOrg,
+    GlitchtipAccessReportUser,
+    UpdateGlitchtipAccessReport,
+)
+from reconcile.utils.runtime.environment import init_env
+
+
+@click.command()
+@config_file
+@dry_run
+@log_level
+@gitlab_project_id
+@click.option(
+    "--glitchtip-access-revalidation-workbook-path",
+    help="path to glitchtip accessrevalidationworkbook markdown file",
+)
+def main(
+    configfile: str,
+    dry_run: bool,
+    log_level: str,
+    gitlab_project_id: int,
+    glitchtip_access_revalidation_workbook_path: Path,
+) -> None:
+
+    init_env(log_level=log_level, config_file=configfile)
+
+    glitchtip_projects = (
+        glitchtip_project_query(query_func=gql.get_api().query).glitchtip_projects or []
+    )
+
+    users: dict[str, GlitchtipAccessReportUser] = {}
+    for project in glitchtip_projects:
+        org = Organization(name=project.organization.name)
+        for team in project.teams:
+            for role in team.roles:
+                for user in role.users:
+                    report_user = users.setdefault(
+                        user.org_username,
+                        GlitchtipAccessReportUser(
+                            name=user.name, username=user.org_username, organizations=[]
+                        ),
+                    )
+                    if org.name not in report_user.organizations:
+                        report_user.organizations.append(
+                            GlitchtipAccessReportOrg(
+                                name=org.name,
+                                access_level=get_user_role(org, role),
+                            )
+                        )
+
+    if not dry_run:
+        mr = UpdateGlitchtipAccessReport(
+            users=list(users.values()),
+            glitchtip_access_revalidation_workbook=glitchtip_access_revalidation_workbook_path,
+        )
+        with mr_client_gateway.init(
+            gitlab_project_id=gitlab_project_id, sqs_or_gitlab="gitlab"
+        ) as mr_cli:
+            result = mr.submit(cli=mr_cli)
+        if result:
+            logging.info(["created_mr", result.web_url])
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/glitchtip_access_reporter.py
+++ b/tools/glitchtip_access_reporter.py
@@ -59,7 +59,9 @@ def main(
                             name=user.name, username=user.org_username, organizations=[]
                         ),
                     )
-                    if org.name not in report_user.organizations:
+                    if org.name not in [
+                        _org.name for _org in report_user.organizations
+                    ]:
                         report_user.organizations.append(
                             GlitchtipAccessReportOrg(
                                 name=org.name,

--- a/tools/glitchtip_access_reporter.py
+++ b/tools/glitchtip_access_reporter.py
@@ -83,4 +83,4 @@ def main(
 
 
 if __name__ == "__main__":
-    main()
+    main()  # pylint: disable=no-value-for-parameter

--- a/tools/glitchtip_access_reporter.py
+++ b/tools/glitchtip_access_reporter.py
@@ -31,15 +31,21 @@ from reconcile.utils.runtime.environment import init_env
 @gitlab_project_id
 @click.option(
     "--glitchtip-access-revalidation-workbook-path",
-    help="path to glitchtip accessrevalidationworkbook markdown file",
+    help="path to glitchtip access revalidation workbook markdown file",
+    default="docs/glitchtip/access_revalidation_workbook.md",
 )
 def main(
     configfile: str,
     dry_run: bool,
     log_level: str,
     gitlab_project_id: int,
-    glitchtip_access_revalidation_workbook_path: Path,
+    glitchtip_access_revalidation_workbook_path: str,
 ) -> None:
+    """Update Glitchtip access report.
+
+    This script updates the Glitchtip access report (markdown file) with the latest
+    access information.
+    """
 
     init_env(log_level=log_level, config_file=configfile)
 
@@ -72,7 +78,9 @@ def main(
     if not dry_run:
         mr = UpdateGlitchtipAccessReport(
             users=list(users.values()),
-            glitchtip_access_revalidation_workbook=glitchtip_access_revalidation_workbook_path,
+            glitchtip_access_revalidation_workbook=Path(
+                glitchtip_access_revalidation_workbook_path
+            ),
         )
         with mr_client_gateway.init(
             gitlab_project_id=gitlab_project_id, sqs_or_gitlab="gitlab"

--- a/tools/glitchtip_access_reporter.py
+++ b/tools/glitchtip_access_reporter.py
@@ -75,17 +75,17 @@ def main(
                             )
                         )
 
-    if not dry_run:
-        mr = UpdateGlitchtipAccessReport(
-            users=list(users.values()),
-            glitchtip_access_revalidation_workbook=Path(
-                glitchtip_access_revalidation_workbook_path
-            ),
-        )
-        with mr_client_gateway.init(
-            gitlab_project_id=gitlab_project_id, sqs_or_gitlab="gitlab"
-        ) as mr_cli:
-            result = mr.submit(cli=mr_cli)
+    mr = UpdateGlitchtipAccessReport(
+        users=list(users.values()),
+        glitchtip_access_revalidation_workbook=Path(
+            glitchtip_access_revalidation_workbook_path
+        ),
+        dry_run=dry_run,
+    )
+    with mr_client_gateway.init(
+        gitlab_project_id=gitlab_project_id, sqs_or_gitlab="gitlab"
+    ) as mr_cli:
+        result = mr.submit(cli=mr_cli)
         if result:
             logging.info(["created_mr", result.web_url])
 

--- a/tools/glitchtip_access_revalidation.py
+++ b/tools/glitchtip_access_revalidation.py
@@ -52,7 +52,12 @@ def main(
     gitlab_project_id: int,
     glitchtip_access_revalidation_email_path: str,
 ) -> None:
+    """Revalidate Glitchtip access.
 
+    This script sends an email (via MR) to all App-Interface service owners (apps)
+    referencing Glitchtip projects. The email asks the service owners to
+    revalidate Glitchtip access for their projects.
+    """
     init_env(log_level=log_level, config_file=configfile)
 
     glitchtip_projects = (

--- a/tools/glitchtip_access_revalidation.py
+++ b/tools/glitchtip_access_revalidation.py
@@ -82,4 +82,4 @@ def main(
 
 
 if __name__ == "__main__":
-    main()
+    main()  # pylint: disable=no-value-for-parameter

--- a/tools/glitchtip_access_revalidation.py
+++ b/tools/glitchtip_access_revalidation.py
@@ -1,0 +1,85 @@
+import logging
+from pathlib import Path
+
+import click
+
+from reconcile import mr_client_gateway
+from reconcile.cli import (
+    config_file,
+    dry_run,
+    gitlab_project_id,
+    log_level,
+)
+from reconcile.gql_definitions.glitchtip.glitchtip_project import (
+    query as glitchtip_project_query,
+)
+from reconcile.utils import gql
+from reconcile.utils.mr.labels import AUTO_MERGE
+from reconcile.utils.mr.notificator import (
+    CreateAppInterfaceNotificator,
+    Notification,
+)
+from reconcile.utils.runtime.environment import init_env
+
+EMAIL_BODY = """Hello App-Interface service owner,
+
+Access to all Glitchtip organizations and projects must be revalidated regularly.
+This ensures that the access is still valid and is needed to safeguard against unauthorized access.
+Please review, within one week, all your App-Interface roles referencing Glitchtip
+organizations (https://gitlab.cee.redhat.com/search?search=glitchtip_roles%3A&nav_source=navbar&project_id=13582&group_id=5301&search_code=true&repository_ref=master).
+
+If you have questions about this, please post a question in the #sd-app-sre Slack channel.
+
+Thank you,
+The SRE team
+"""
+
+
+@click.command()
+@config_file
+@dry_run
+@log_level
+@gitlab_project_id
+@click.option(
+    "--glitchtip-access-revalidation-workbook-path",
+    help="path to glitchtip accessrevalidationworkbook markdown file",
+)
+def main(
+    configfile: str,
+    dry_run: bool,
+    log_level: str,
+    gitlab_project_id: int,
+    glitchtip_access_revalidation_email_path: Path,
+) -> None:
+
+    init_env(log_level=log_level, config_file=configfile)
+
+    glitchtip_projects = (
+        glitchtip_project_query(query_func=gql.get_api().query).glitchtip_projects or []
+    )
+
+    apps = {project.app.path for project in glitchtip_projects}
+
+    if not dry_run:
+        notification = Notification(
+            notification_type="Action Required",
+            short_description="Glitchtip Access Revalidation",
+            description=EMAIL_BODY,
+            services=list(apps),
+            recipients=[],
+        )
+        mr = CreateAppInterfaceNotificator(
+            notification,
+            labels=[AUTO_MERGE],
+            email_base_path=glitchtip_access_revalidation_email_path,
+        )
+        with mr_client_gateway.init(
+            gitlab_project_id=gitlab_project_id, sqs_or_gitlab="gitlab"
+        ) as mr_cli:
+            result = mr.submit(cli=mr_cli)
+        if result:
+            logging.info(["created_mr", result.web_url])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
We need an access revalidation policy for Glitchtip because we are subject to internal and corporate-level audits that will ask for evidence of risk being mitigated. 

This PR introduces: 

- an access report generator (1st commit)
- and sending an access revalidation email to all service owners with Glitchtip projects (2nd commit)

Depends on: https://github.com/app-sre/qontract-reconcile/pull/3371

Ticket: [APPSRE-7329](https://issues.redhat.com/browse/APPSRE-7329)
