### PR TITLE
fix PyTest warnings

### DIFF
--- a/reconcile/ocm_update_recommended_version.py
+++ b/reconcile/ocm_update_recommended_version.py
@@ -18,8 +18,12 @@ QONTRACT_INTEGRATION = "ocm-update-recommended-version"
 
 
 def get_highest(version_set: set[str]) -> str:
+    def _compare(v1: str, v2: str) -> int:
+        _v1 = semver.VersionInfo.parse(v1)
+        return _v1.compare(v2)
+
     sorted_version_set = sorted(
-        version_set, key=functools.cmp_to_key(semver.compare), reverse=True
+        version_set, key=functools.cmp_to_key(_compare), reverse=True
     )
     return sorted_version_set[0]
 

--- a/reconcile/test/change_owners/conftest.py
+++ b/reconcile/test/change_owners/conftest.py
@@ -1,0 +1,57 @@
+import pytest
+
+from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
+from reconcile.test.change_owners.fixtures import StubFile
+from reconcile.test.fixtures import Fixtures
+
+fxt = Fixtures("change_owners")
+
+
+@pytest.fixture
+def saas_file_changetype() -> ChangeTypeV1:
+    return load_change_type("changetype_saas_file.yaml")
+
+
+@pytest.fixture
+def role_member_change_type() -> ChangeTypeV1:
+    return load_change_type("changetype_role_member.yaml")
+
+
+@pytest.fixture
+def cluster_owner_change_type() -> ChangeTypeV1:
+    return load_change_type("changetype_cluster_owner.yml")
+
+
+@pytest.fixture
+def secret_promoter_change_type() -> ChangeTypeV1:
+    return load_change_type("changetype_secret_promoter.yaml")
+
+
+@pytest.fixture
+def change_types() -> list[ChangeTypeV1]:
+    return [saas_file_changetype(), role_member_change_type()]
+
+
+@pytest.fixture
+def saas_file() -> StubFile:
+    return StubFile(**fxt.get_anymarkup("datafile_saas_file.yaml"))
+
+
+@pytest.fixture
+def user_file() -> StubFile:
+    return StubFile(**fxt.get_anymarkup("datafile_user.yaml"))
+
+
+@pytest.fixture
+def namespace_file() -> StubFile:
+    return StubFile(**fxt.get_anymarkup("datafile_namespace.yaml"))
+
+
+@pytest.fixture
+def rds_defaults_file() -> StubFile:
+    return StubFile(**fxt.get_anymarkup("resourcefile_rds_defaults.yaml"))
+
+
+def load_change_type(path: str) -> ChangeTypeV1:
+    content = fxt.get_anymarkup(path)
+    return ChangeTypeV1(**content)

--- a/reconcile/test/change_owners/fixtures.py
+++ b/reconcile/test/change_owners/fixtures.py
@@ -8,7 +8,6 @@ from typing import (
 
 import jsonpath_ng
 import jsonpath_ng.ext
-import pytest
 
 from reconcile.change_owners.bundle import (
     BundleFileType,
@@ -36,18 +35,14 @@ from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
     PermissionGitlabGroupMembershipV1,
     PermissionSlackUsergroupV1,
     PermissionV1,
-    RoleV1,
     SelfServiceConfigV1,
     SlackWorkspaceV1,
     UserV1,
 )
-from reconcile.test.fixtures import Fixtures
-
-fxt = Fixtures("change_owners")
 
 
 @dataclass
-class TestFile:
+class StubFile:
     filepath: str
     fileschema: str
     filetype: str
@@ -83,8 +78,8 @@ def build_test_datafile(
     content: dict[str, Any],
     filepath: Optional[str] = None,
     schema: Optional[str] = None,
-) -> TestFile:
-    return TestFile(
+) -> StubFile:
+    return StubFile(
         filepath=filepath or "datafile.yaml",
         fileschema=schema or "schema-1.yml",
         filetype=BundleFileType.DATAFILE.value,
@@ -126,61 +121,6 @@ def build_role(
         bots=[BotV1(org_username=b) for b in bots or []],
         permissions=permissions,
     )
-
-
-def load_change_type(path: str) -> ChangeTypeV1:
-    content = fxt.get_anymarkup(path)
-    return ChangeTypeV1(**content)
-
-
-def load_self_service_roles(path: str) -> list[RoleV1]:
-    roles = fxt.get_anymarkup(path)["self_service_roles"]
-    return [RoleV1(**r) for r in roles]
-
-
-@pytest.fixture
-def saas_file_changetype() -> ChangeTypeV1:
-    return load_change_type("changetype_saas_file.yaml")
-
-
-@pytest.fixture
-def role_member_change_type() -> ChangeTypeV1:
-    return load_change_type("changetype_role_member.yaml")
-
-
-@pytest.fixture
-def cluster_owner_change_type() -> ChangeTypeV1:
-    return load_change_type("changetype_cluster_owner.yml")
-
-
-@pytest.fixture
-def secret_promoter_change_type() -> ChangeTypeV1:
-    return load_change_type("changetype_secret_promoter.yaml")
-
-
-@pytest.fixture
-def change_types() -> list[ChangeTypeV1]:
-    return [saas_file_changetype(), role_member_change_type()]
-
-
-@pytest.fixture
-def saas_file() -> TestFile:
-    return TestFile(**fxt.get_anymarkup("datafile_saas_file.yaml"))
-
-
-@pytest.fixture
-def user_file() -> TestFile:
-    return TestFile(**fxt.get_anymarkup("datafile_user.yaml"))
-
-
-@pytest.fixture
-def namespace_file() -> TestFile:
-    return TestFile(**fxt.get_anymarkup("datafile_namespace.yaml"))
-
-
-@pytest.fixture
-def rds_defaults_file() -> TestFile:
-    return TestFile(**fxt.get_anymarkup("resourcefile_rds_defaults.yaml"))
 
 
 def build_jsonpath_change(

--- a/reconcile/test/change_owners/test_change_type_context.py
+++ b/reconcile/test/change_owners/test_change_type_context.py
@@ -5,13 +5,9 @@ from reconcile.change_owners.bundle import (
 from reconcile.change_owners.change_types import create_bundle_file_change
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
 from reconcile.test.change_owners.fixtures import (
-    TestFile,
+    StubFile,
     change_type_to_processor,
 )
-
-pytest_plugins = [
-    "reconcile.test.change_owners.fixtures",
-]
 
 #
 # testcases for context file refs extraction from bundle changes
@@ -19,7 +15,7 @@ pytest_plugins = [
 
 
 def test_extract_context_file_refs_from_bundle_change(
-    saas_file_changetype: ChangeTypeV1, saas_file: TestFile
+    saas_file_changetype: ChangeTypeV1, saas_file: StubFile
 ):
     """
     in this testcase, a changed datafile matches directly the context schema
@@ -37,7 +33,7 @@ def test_extract_context_file_refs_from_bundle_change(
 
 
 def test_extract_context_file_refs_from_bundle_change_schema_mismatch(
-    saas_file_changetype: ChangeTypeV1, saas_file: TestFile
+    saas_file_changetype: ChangeTypeV1, saas_file: StubFile
 ):
     """
     in this testcase, the schema of the bundle change and the schema of the

--- a/reconcile/test/change_owners/test_change_type_coverage.py
+++ b/reconcile/test/change_owners/test_change_type_coverage.py
@@ -13,13 +13,9 @@ from reconcile.change_owners.diff import (
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
 from reconcile.test.change_owners.fixtures import (
-    TestFile,
+    StubFile,
     change_type_to_processor,
 )
-
-pytest_plugins = [
-    "reconcile.test.change_owners.fixtures",
-]
 
 #
 # processing change coverage on a change type context
@@ -27,7 +23,7 @@ pytest_plugins = [
 
 
 def test_cover_changes_one_file(
-    saas_file_changetype: ChangeTypeV1, saas_file: TestFile
+    saas_file_changetype: ChangeTypeV1, saas_file: StubFile
 ):
     saas_file_change = saas_file.create_bundle_change(
         {"resourceTemplates[0].targets[0].ref": "new-ref"}
@@ -47,7 +43,7 @@ def test_cover_changes_one_file(
 
 
 def test_uncovered_change_because_change_type_is_disabled(
-    saas_file_changetype: ChangeTypeV1, saas_file: TestFile
+    saas_file_changetype: ChangeTypeV1, saas_file: StubFile
 ):
     saas_file_changetype.disabled = True
     saas_file_change = saas_file.create_bundle_change(
@@ -68,7 +64,7 @@ def test_uncovered_change_because_change_type_is_disabled(
 
 
 def test_uncovered_change_one_file(
-    saas_file_changetype: ChangeTypeV1, saas_file: TestFile
+    saas_file_changetype: ChangeTypeV1, saas_file: StubFile
 ):
     saas_file_change = saas_file.create_bundle_change({"name": "new-name"})
     ctx = ChangeTypeContext(
@@ -83,7 +79,7 @@ def test_uncovered_change_one_file(
 
 
 def test_partially_covered_change_one_file(
-    saas_file_changetype: ChangeTypeV1, saas_file: TestFile
+    saas_file_changetype: ChangeTypeV1, saas_file: StubFile
 ):
     ref_update_path = "resourceTemplates.[0].targets.[0].ref"
     saas_file_change = saas_file.create_bundle_change(
@@ -104,7 +100,7 @@ def test_partially_covered_change_one_file(
     assert [ref_update_diff.diff] == covered_diffs
 
 
-def test_root_change_type(cluster_owner_change_type: ChangeTypeV1, saas_file: TestFile):
+def test_root_change_type(cluster_owner_change_type: ChangeTypeV1, saas_file: StubFile):
     namespace_change = create_bundle_file_change(
         path="/my/namespace.yml",
         schema="/openshift/namespace-1.yml",

--- a/reconcile/test/change_owners/test_change_type_decision.py
+++ b/reconcile/test/change_owners/test_change_type_decision.py
@@ -15,10 +15,6 @@ from reconcile.change_owners.decision import (
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
 from reconcile.test.change_owners.fixtures import change_type_to_processor
 
-pytest_plugins = [
-    "reconcile.test.change_owners.fixtures",
-]
-
 #
 # test MR decision comment parsing
 #

--- a/reconcile/test/change_owners/test_change_type_implicit_ownership.py
+++ b/reconcile/test/change_owners/test_change_type_implicit_ownership.py
@@ -26,11 +26,6 @@ from reconcile.test.change_owners.fixtures import (
     build_test_datafile,
 )
 
-pytest_plugins = [
-    "reconcile.test.change_owners.fixtures",
-]
-
-
 #
 # test finding implicit approver in bundle change
 #

--- a/reconcile/test/change_owners/test_change_type_integration.py
+++ b/reconcile/test/change_owners/test_change_type_integration.py
@@ -8,21 +8,17 @@ from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
     DatafileObjectV1,
 )
 from reconcile.test.change_owners.fixtures import (
-    TestFile,
+    StubFile,
     build_role,
     change_type_to_processor,
 )
 
-pytest_plugins = [
-    "reconcile.test.change_owners.fixtures",
-]
-
 
 def test_change_coverage(
     secret_promoter_change_type: ChangeTypeV1,
-    namespace_file: TestFile,
+    namespace_file: StubFile,
     role_member_change_type: ChangeTypeV1,
-    user_file: TestFile,
+    user_file: StubFile,
 ):
     role_approver_user = "the-one-that-approves-roles"
     team_role_path = "/team-role.yml"

--- a/reconcile/test/change_owners/test_change_type_priorities.py
+++ b/reconcile/test/change_owners/test_change_type_priorities.py
@@ -8,10 +8,6 @@ from reconcile.change_owners.change_types import (
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
 from reconcile.test.change_owners.fixtures import change_type_to_processor
 
-pytest_plugins = [
-    "reconcile.test.change_owners.fixtures",
-]
-
 #
 # priority tests
 #

--- a/reconcile/test/change_owners/test_change_type_processor.py
+++ b/reconcile/test/change_owners/test_change_type_processor.py
@@ -4,14 +4,9 @@ from jsonpath_ng.exceptions import JsonPathParserError
 from reconcile.change_owners.change_types import ChangeTypeContext
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
 from reconcile.test.change_owners.fixtures import (
-    TestFile,
+    StubFile,
     change_type_to_processor,
 )
-
-pytest_plugins = [
-    "reconcile.test.change_owners.fixtures",
-]
-
 
 #
 # change type processor validations
@@ -34,7 +29,7 @@ def test_change_type_processor_building_invalid_jsonpaths(
 
 
 def test_change_type_processor_allowed_paths_simple(
-    role_member_change_type: ChangeTypeV1, user_file: TestFile
+    role_member_change_type: ChangeTypeV1, user_file: StubFile
 ):
     changed_user_file = user_file.create_bundle_change(
         {"roles[0]": {"$ref": "some-role"}}
@@ -56,7 +51,7 @@ def test_change_type_processor_allowed_paths_simple(
 
 
 def test_change_type_processor_allowed_paths_conditions(
-    secret_promoter_change_type: ChangeTypeV1, namespace_file: TestFile
+    secret_promoter_change_type: ChangeTypeV1, namespace_file: StubFile
 ):
     changed_namespace_file = namespace_file.create_bundle_change(
         {"openshiftResources[1].version": 2}

--- a/reconcile/test/change_owners/test_change_type_various.py
+++ b/reconcile/test/change_owners/test_change_type_various.py
@@ -12,11 +12,6 @@ from reconcile.change_owners.change_types import (
     parse_resource_file_content,
 )
 
-pytest_plugins = [
-    "reconcile.test.change_owners.fixtures",
-]
-
-
 #
 # label management tests
 #

--- a/reconcile/test/runtime/conftest.py
+++ b/reconcile/test/runtime/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from reconcile.test.runtime.fixtures import (
+    ShardableTestIntegration,
+    ShardableTestIntegrationParams,
+    SimpleTestIntegration,
+    SimpleTestIntegrationParams,
+)
+
+
+@pytest.fixture
+def shardable_test_integration() -> ShardableTestIntegration:
+    return ShardableTestIntegration(params=ShardableTestIntegrationParams())
+
+
+@pytest.fixture
+def simple_test_integration() -> SimpleTestIntegration:
+    return SimpleTestIntegration(params=SimpleTestIntegrationParams(int_arg=1))

--- a/reconcile/test/runtime/fixtures.py
+++ b/reconcile/test/runtime/fixtures.py
@@ -3,8 +3,6 @@ from typing import (
     Optional,
 )
 
-import pytest
-
 from reconcile.utils.runtime.integration import (
     DesiredStateShardConfig,
     PydanticRunParams,
@@ -36,11 +34,6 @@ class SimpleTestIntegration(QontractReconcileIntegration[SimpleTestIntegrationPa
         print(self.params.int_arg)
 
 
-@pytest.fixture
-def simple_test_integration() -> SimpleTestIntegration:
-    return SimpleTestIntegration(params=SimpleTestIntegrationParams(int_arg=1))
-
-
 class ShardableTestIntegrationParams(PydanticRunParams):
     shard: Optional[str] = None
 
@@ -68,8 +61,3 @@ class ShardableTestIntegration(
 
     def run(self, dry_run: bool) -> None:
         pass
-
-
-@pytest.fixture
-def shardable_test_integration() -> ShardableTestIntegration:
-    return ShardableTestIntegration(params=ShardableTestIntegrationParams())

--- a/reconcile/test/runtime/test_utils_desired_state_diff.py
+++ b/reconcile/test/runtime/test_utils_desired_state_diff.py
@@ -23,10 +23,6 @@ from reconcile.utils.runtime.desired_state_diff import (
 )
 from reconcile.utils.runtime.integration import DesiredStateShardConfig
 
-pytest_plugins = [
-    "reconcile.test.runtime.fixtures",
-]
-
 #
 # build desired state diff
 #

--- a/reconcile/test/runtime/test_utils_runtime_runner.py
+++ b/reconcile/test/runtime/test_utils_runtime_runner.py
@@ -25,10 +25,6 @@ from reconcile.utils.runtime.runner import (
     run_integration_cfg,
 )
 
-pytest_plugins = [
-    "reconcile.test.runtime.fixtures",
-]
-
 
 @dataclass
 class MockIntegrationRunConfiguration(IntegrationRunConfiguration):

--- a/reconcile/test/test_gitlab_labeler.py
+++ b/reconcile/test/test_gitlab_labeler.py
@@ -14,7 +14,7 @@ from reconcile.utils import gql
 from .fixtures import Fixtures
 
 
-class TestData:
+class StubData:
     """Class to add data to tests in setUp. It will be used by mocks"""
 
     def __init__(self):
@@ -35,7 +35,7 @@ class TestData:
 # setup/teardown methods instead of pytest fixtures.
 class TestOnboardingGuesser:
     def setup_method(self) -> None:
-        self.test_data = TestData()
+        self.test_data = StubData()
 
         self.fxt = Fixtures("apps")
         self.app1 = self.fxt.get_json("app1.json")

--- a/reconcile/test/test_utils_mr_clusters_updates.py
+++ b/reconcile/test/test_utils_mr_clusters_updates.py
@@ -1,10 +1,9 @@
+from io import StringIO
 from unittest import TestCase
 from unittest.mock import (
     MagicMock,
     patch,
 )
-
-from ruamel import yaml
 
 import reconcile.utils.mr.clusters_updates as sut
 
@@ -40,14 +39,13 @@ class TestProcess(TestCase):
         c.process(cli)
         self.clusters[0]["spec"]["id"] = "42"
 
-        cnt = yaml.dump(
-            self.clusters[0], Dumper=yaml.RoundTripDumper, explicit_start=True
-        )
+        cnt = StringIO()
+        sut.yaml.dump(self.clusters[0], cnt)
         cli.update_file.assert_called_once_with(
             branch_name="abranch",
             file_path="/a/path",
             commit_message="update cluster cluster1 spec fields",
-            content=cnt,
+            content=cnt.getvalue(),
         )
         cancel.assert_not_called()
 
@@ -68,13 +66,12 @@ class TestProcess(TestCase):
         c.process(cli)
         self.clusters[0]["prometheusUrl"] = "aprometheusurl"
 
-        cnt = yaml.dump(
-            self.clusters[0], Dumper=yaml.RoundTripDumper, explicit_start=True
-        )
+        cnt = StringIO()
+        sut.yaml.dump(self.clusters[0], cnt)
         cli.update_file.assert_called_once_with(
             branch_name="abranch",
             file_path="/a/path",
             commit_message="update cluster cluster1 spec fields",
-            content=cnt,
+            content=cnt.getvalue(),
         )
         cancel.assert_not_called()

--- a/reconcile/utils/runtime/runner.py
+++ b/reconcile/utils/runtime/runner.py
@@ -218,7 +218,9 @@ def _integration_dry_run(
         for shard, ex in zip(affected_shard_list, exceptions):
             if ex:
                 logging.error(f"Failed to run integration shard {shard}: {ex}")
-        failed_shards_count = sum(1 for _ in filter(None.__ne__, exceptions))
+        failed_shards_count = sum(
+            1 for _ in filter(lambda e: e is not None, exceptions)
+        )
         if failed_shards_count > 0:
             sys.exit(failed_shards_count)
         else:

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -4,8 +4,8 @@ flake8~=4.0
 git+https://github.com/gabrielfalcao/HTTPretty.git@c255165a86bef7f894c3a446b41d0b3379c5c2be
 kubernetes~=24.0
 pylint~=2.13
-pytest~=7.1
-pytest-cov~=2.12
+pytest~=7.2
+pytest-cov~=4.0.0
 pytest-mock~=3.6
 responses
 testslide~=2.7


### PR DESCRIPTION
Fix a lot of pytest warnings:

* upgrade `pytest-cov`
* move `change-owners` and `runtime` pytest fixtures into a proper `contest.py`
* rename some stub classes. pytest considers a `class Test..." as a class with test cases
* fix `ruamel` and `semver` deprecations

Ticket: [APPSRE-7313](https://issues.redhat.com/browse/APPSRE-7313)