### PR TITLE
rename OCDeprecated to OCCli

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -31,8 +31,8 @@ from reconcile.utils.oc import (
     MayNotChangeOnceSetError,
     MetaDataAnnotationsTooLongApplyError,
     OC_Map,
+    OCCli,
     OCClient,
-    OCDeprecated,
     OCLogMsg,
     PrimaryClusterIPCanNotBeUnsetError,
     StatefulSetUpdateForbidden,
@@ -104,12 +104,10 @@ class HasOrgAndGithubUsername(Protocol):
 class ClusterMap(Protocol):
     """An OCMap protocol."""
 
-    def get(
-        self, cluster: str, privileged: bool = False
-    ) -> Union[OCDeprecated, OCLogMsg]:
+    def get(self, cluster: str, privileged: bool = False) -> Union[OCCli, OCLogMsg]:
         ...
 
-    def get_cluster(self, cluster: str, privileged: bool = False) -> OCDeprecated:
+    def get_cluster(self, cluster: str, privileged: bool = False) -> OCCli:
         ...
 
     def clusters(
@@ -775,7 +773,7 @@ def realize_data(
 
 def _validate_resources_used_exist(
     ri: ResourceInventory,
-    oc: OCDeprecated,
+    oc: OCCli,
     spec: dict[str, Any],
     cluster: str,
     namespace: str,

--- a/reconcile/test/oc/test_oc_map.py
+++ b/reconcile/test/oc/test_oc_map.py
@@ -9,7 +9,7 @@ import pytest
 
 from reconcile.utils.oc import (
     OC,
-    OCDeprecated,
+    OCCli,
 )
 from reconcile.utils.oc_connection_parameters import OCConnectionParameters
 from reconcile.utils.oc_map import (
@@ -41,12 +41,12 @@ def make_connection_parameter(data: Mapping[str, Any]) -> OCConnectionParameters
 
 class OCTest(OC):
     def __new__(cls, **kwargs: Any):
-        return create_autospec(spec=OCDeprecated)
+        return create_autospec(spec=OCCli)
 
 
 @pytest.fixture
 def oc_cls() -> type[OC]:
-    return MagicMock(return_value=create_autospec(spec=OCDeprecated))
+    return MagicMock(return_value=create_autospec(spec=OCCli))
 
 
 def test_oc_map_with_errors(oc_cls: type[OC]):
@@ -70,7 +70,7 @@ def test_oc_map_with_errors(oc_cls: type[OC]):
 
     assert oc_map.clusters(include_errors=True) == cluster_names
     assert isinstance(oc_map._oc_map.get(params_1.cluster_name), OCLogMsg)
-    assert isinstance(oc_map._oc_map.get(params_2.cluster_name), OCDeprecated)
+    assert isinstance(oc_map._oc_map.get(params_2.cluster_name), OCCli)
 
 
 def test_privileged_clusters(oc_cls: type[OC]):
@@ -94,8 +94,8 @@ def test_privileged_clusters(oc_cls: type[OC]):
     assert oc_map.clusters() == [param_2.cluster_name]
     assert oc_map.clusters(privileged=True) == [param_1.cluster_name]
     assert isinstance(oc_map.get(param_1.cluster_name), OCLogMsg)
-    assert isinstance(oc_map.get(param_2.cluster_name), OCDeprecated)
-    assert isinstance(oc_map.get(param_1.cluster_name, privileged=True), OCDeprecated)
+    assert isinstance(oc_map.get(param_2.cluster_name), OCCli)
+    assert isinstance(oc_map.get(param_1.cluster_name, privileged=True), OCCli)
     assert isinstance(oc_map.get(param_2.cluster_name, privileged=True), OCLogMsg)
 
 

--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -15,7 +15,7 @@ from reconcile.utils.oc import (
     LABEL_MAX_VALUE_LENGTH,
     OC,
     OC_Map,
-    OCDeprecated,
+    OCCli,
     OCLogMsg,
     OCNative,
     PodNotReadyError,
@@ -32,8 +32,8 @@ from reconcile.utils.secret_reader import (
 
 @patch.dict(os.environ, {"USE_NATIVE_CLIENT": "False"}, clear=True)
 class TestGetOwnedPods(TestCase):
-    @patch.object(OCDeprecated, "get")
-    @patch.object(OCDeprecated, "get_obj_root_owner")
+    @patch.object(OCCli, "get")
+    @patch.object(OCCli, "get_obj_root_owner")
     def test_get_owned_pods(self, oc_get_obj_root_owner, oc_get):
         owner_body = {"kind": "ownerkind", "metadata": {"name": "ownername"}}
         owner_resource = OR(owner_body, "", "")
@@ -95,7 +95,7 @@ class TestGetOwnedPods(TestCase):
 
 @patch.dict(os.environ, {"USE_NATIVE_CLIENT": "False"}, clear=True)
 class TestValidatePodReady(TestCase):
-    @patch.object(OCDeprecated, "get")
+    @patch.object(OCCli, "get")
     def test_validate_pod_ready_all_good(self, oc_get):
         oc_get.return_value = {
             "status": {
@@ -111,7 +111,7 @@ class TestValidatePodReady(TestCase):
         oc = OC("cluster", "server", "token", local=True)
         oc.validate_pod_ready("namespace", "podname")
 
-    @patch.object(OCDeprecated, "get")
+    @patch.object(OCCli, "get")
     def test_validate_pod_ready_one_missing(self, oc_get):
         oc_get.return_value = {
             "status": {
@@ -133,7 +133,7 @@ class TestValidatePodReady(TestCase):
 
 @patch.dict(os.environ, {"USE_NATIVE_CLIENT": "False"}, clear=True)
 class TestGetObjRootOwner(TestCase):
-    @patch.object(OCDeprecated, "get")
+    @patch.object(OCCli, "get")
     def test_owner(self, oc_get):
         obj = {
             "metadata": {
@@ -170,7 +170,7 @@ class TestGetObjRootOwner(TestCase):
         result_obj = oc.get_obj_root_owner("namespace", obj)
         self.assertEqual(result_obj, obj)
 
-    @patch.object(OCDeprecated, "get")
+    @patch.object(OCCli, "get")
     def test_controller_false_return_controller(self, oc_get):
         """Returns owner if all ownerReferences have controller set to false
         and allow_not_controller is set to True
@@ -190,7 +190,7 @@ class TestGetObjRootOwner(TestCase):
         result_obj = oc.get_obj_root_owner("namespace", obj, allow_not_controller=True)
         self.assertEqual(result_obj, owner_obj)
 
-    @patch.object(OCDeprecated, "get")
+    @patch.object(OCCli, "get")
     def test_cont_true_allow_true_ref_not_found_return_obj(self, oc_get):
         """Returns obj if controller is true, allow_not_found is true,
         but referenced object does not exist '{}'
@@ -211,7 +211,7 @@ class TestGetObjRootOwner(TestCase):
         result_obj = oc.get_obj_root_owner("namespace", obj, allow_not_found=True)
         self.assertEqual(result_obj, obj)
 
-    @patch.object(OCDeprecated, "get")
+    @patch.object(OCCli, "get")
     def test_controller_true_allow_false_ref_not_found_raise(self, oc_get):
         """Throws an exception if controller is true, allow_not_found false,
         but referenced object does not exist
@@ -961,9 +961,7 @@ def api_resources():
 @pytest.fixture
 def oc_api_resources(monkeypatch, mocker, api_resources):
     monkeypatch.setenv("USE_NATIVE_CLIENT", "False")
-    get_api_resources = mocker.patch.object(
-        OCDeprecated, "get_api_resources", autospec=True
-    )
+    get_api_resources = mocker.patch.object(OCCli, "get_api_resources", autospec=True)
     get_api_resources.return_value = api_resources
     return OC("cluster", "server", "token", local=True, init_api_resources=True)
 

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -242,9 +242,9 @@ def equal_spec_template(t1: dict, t2: dict) -> bool:
 
 
 @dataclass
-class OCDeprecatedApiResource:
+class OCCliApiResource:
     """This class mimics kubernetes.dynamic.resource.Resource and it's used
-    To get Api Resources with the OCDeprecated client"""
+    To get Api Resources with the OCCli client"""
 
     kind: str
     group: str
@@ -258,7 +258,7 @@ class OCDeprecatedApiResource:
         return self.api_version
 
 
-class OCDeprecated:  # pylint: disable=too-many-public-methods
+class OCCli:  # pylint: disable=too-many-public-methods
     def __init__(
         self,
         cluster_name: Optional[str],
@@ -725,7 +725,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
                     group_version = r[-3].split("/", 1)
                     group = "" if len(group_version) == 1 else group_version[0]
                     api_version = group_version[-1]
-                    obj = OCDeprecatedApiResource(kind, group, api_version, namespaced)
+                    obj = OCCliApiResource(kind, group, api_version, namespaced)
                     d = self.api_resources.setdefault(kind, [])
                     d.append(obj)
 
@@ -1194,7 +1194,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
         return kind_resources[0].namespaced
 
 
-class OCNative(OCDeprecated):
+class OCNative(OCCli):
     def __init__(
         self,
         cluster_name: Optional[str],
@@ -1361,10 +1361,10 @@ class OCNative(OCDeprecated):
             raise StatusCodeError(f"[{self.server}]: {e}")
 
 
-OCClient = Union[OCNative, OCDeprecated]
+OCClient = Union[OCNative, OCCli]
 
 
-class OCLocal(OCDeprecated):
+class OCLocal(OCCli):
     def __init__(
         self,
         cluster_name,
@@ -1428,7 +1428,7 @@ class OC:
             )
 
         OC.client_status.labels(cluster_name=cluster_name, native_client=False).inc()
-        return OCDeprecated(
+        return OCCli(
             cluster_name=cluster_name,
             server=server,
             token=token,

--- a/reconcile/utils/oc_map.py
+++ b/reconcile/utils/oc_map.py
@@ -11,7 +11,7 @@ from sretoolbox.utils import threaded
 from reconcile.utils.jump_host import JumpHostSSH
 from reconcile.utils.oc import (
     OC,
-    OCDeprecated,
+    OCCli,
     OCLogMsg,
     StatusCodeError,
 )
@@ -49,8 +49,8 @@ class OCMap:
         init_api_resources: bool = False,
         oc_cls: Optional[type[OC]] = None,
     ):
-        self._oc_map: dict[str, Union[OCDeprecated, OCLogMsg]] = {}
-        self._privileged_oc_map: dict[str, Union[OCDeprecated, OCLogMsg]] = {}
+        self._oc_map: dict[str, Union[OCCli, OCLogMsg]] = {}
+        self._privileged_oc_map: dict[str, Union[OCCli, OCLogMsg]] = {}
         self._calling_integration = integration
         self._calling_e2e_test = e2e_test
         self._internal = internal
@@ -128,7 +128,7 @@ class OCMap:
                     connection_parameters=connection_parameters
                 )
             try:
-                oc_client: Union[OCDeprecated, OCLogMsg] = self._oc_cls(
+                oc_client: Union[OCCli, OCLogMsg] = self._oc_cls(
                     connection_parameters=connection_parameters,
                     init_projects=self._init_projects,
                     init_api_resources=self._init_api_resources,
@@ -145,7 +145,7 @@ class OCMap:
                 )
 
     def _set_oc(
-        self, cluster: str, value: Union[OCDeprecated, OCLogMsg], privileged: bool
+        self, cluster: str, value: Union[OCCli, OCLogMsg], privileged: bool
     ) -> None:
         with self._lock:
             if privileged:
@@ -169,16 +169,14 @@ class OCMap:
             pass
         return False
 
-    def get(
-        self, cluster: str, privileged: bool = False
-    ) -> Union[OCDeprecated, OCLogMsg]:
+    def get(self, cluster: str, privileged: bool = False) -> Union[OCCli, OCLogMsg]:
         cluster_map = self._privileged_oc_map if privileged else self._oc_map
         return cluster_map.get(
             cluster,
             OCLogMsg(log_level=logging.DEBUG, message=f"[{cluster}] cluster skipped"),
         )
 
-    def get_cluster(self, cluster: str, privileged: bool = False) -> OCDeprecated:
+    def get_cluster(self, cluster: str, privileged: bool = False) -> OCCli:
         result = self.get(cluster, privileged)
         if isinstance(result, OCLogMsg):
             raise result
@@ -200,10 +198,10 @@ class OCMap:
 
     def cleanup(self) -> None:
         for oc in self._oc_map.values():
-            if oc and isinstance(oc, OCDeprecated):
+            if oc and isinstance(oc, OCCli):
                 oc.cleanup()
         for oc in self._privileged_oc_map.values():
-            if oc and isinstance(oc, OCDeprecated):
+            if oc and isinstance(oc, OCCli):
                 oc.cleanup()
 
 


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-6438

this PR is the answer to the question: "can we deprecate `OCDeprecated`"
the answer is: "no" :sweat_smile: 
why: because `OCNative` only implements GET related operations (#1400)