### PR TITLE
prevent openshift integrations from fighting over resources

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -590,11 +590,23 @@ def _realize_resource_data(
             else:
                 # If resource doesn't have annotations, annotate and apply
                 if not c_item.has_qontract_annotations():
-                    msg = (
-                        "[{}/{}] resource '{}/{}' present "
-                        "w/o annotations, annotating and applying"
-                    ).format(cluster, namespace, resource_type, name)
-                    logging.info(msg)
+                    # if resource has annotations from a different integration, error
+                    c_int = c_item.qontract_integration_annotation()
+                    if c_int and c_int != d_item.integration:
+                        ri.register_error()
+                        msg = (
+                            f"[{cluster}/{namespace}] resource '{resource_type}/{name}' "
+                            "present with qontract annotations, conflict with integration: "
+                            f"{c_item.qontract_integration_annotation()}"
+                        )
+                        logging.error(msg)
+                        continue
+                    else:
+                        msg = (
+                            "[{}/{}] resource '{}/{}' present "
+                            "w/o annotations, annotating and applying"
+                        ).format(cluster, namespace, resource_type, name)
+                        logging.info(msg)
 
                 # don't apply if there is a caller (saas file)
                 # and this is not a take over

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -77,6 +77,10 @@ from reconcile.utils.vault import (
 # | Present               | Annotate and apply      | Skip        |
 # | (without annotations) |                         |             |
 # +-----------------------+-------------------------+-------------+
+# | Present               |                         |             |
+# | (with annotations of  | Error                   | Skip        |
+# | another integration)  |                         |             |
+# +-----------------------+-------------------------+-------------+
 # | Not Present           | Apply                   | Skip        |
 # +-----------------------+-------------------------+-------------+
 

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -302,6 +302,9 @@ class OpenshiftResource:
 
         return True
 
+    def qontract_integration_annotation(self) -> Optional[str]:
+        return self.body["metadata"].get("annotations", {}).get("qontract.integration")
+
     def has_owner_reference(self):
         return bool(self.body["metadata"].get("ownerReferences", []))
 


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-7401

this PR adds logic to check if a current resource was applied by the same integration that is currently trying to manage it (desired).
in case of conflict - error.

this will prevent integrations from fighting over resources - taking it from one another again and again.