### PR TITLE
[ocm-cluster-upgrades] get available_upgrades from cluster endpoint

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -149,6 +149,9 @@ def fetch_desired_state(
             spec = ocm.clusters[cluster_name].spec
             upgrade_policy["current_version"] = spec.version
             upgrade_policy["channel"] = spec.channel
+            upgrade_policy["available_upgrades"] = ocm.available_cluster_upgrades.get(
+                cluster_name
+            )
             desired_state.append(upgrade_policy)
 
     sorted_desired_state = sorted(desired_state, key=sort_key)

--- a/reconcile/test/fixtures/clusters/osd_spec.json
+++ b/reconcile/test/fixtures/clusters/osd_spec.json
@@ -96,6 +96,12 @@
     "href": "/api/clusters_mgmt/v1/versions/openshift-v4.10.6-candidate",
     "raw_id": "4.10.6",
     "channel_group": "candidate",
+    "available_upgrades": [
+      "4.11.33",
+      "4.12.1",
+      "4.12.8",
+      "4.12.9"
+    ],
     "end_of_life_timestamp": "2022-12-10T00:00:00Z"
   },
   "storage_quota": {

--- a/reconcile/test/fixtures/clusters/rosa_spec.json
+++ b/reconcile/test/fixtures/clusters/rosa_spec.json
@@ -158,6 +158,12 @@
     "href": "/api/clusters_mgmt/v1/versions/openshift-v4.10.5",
     "raw_id": "4.10.16",
     "channel_group": "stable",
+    "available_upgrades": [
+      "4.11.33",
+      "4.12.1",
+      "4.12.8",
+      "4.12.9"
+    ],
     "end_of_life_timestamp": "2022-12-10T00:00:00Z"
   },
   "identity_providers": {

--- a/reconcile/test/ocm/test_utils_ocm_versions.py
+++ b/reconcile/test/ocm/test_utils_ocm_versions.py
@@ -66,3 +66,12 @@ def test_version_not_blocked_regex(ocm: OCM) -> None:
 def test_version_invalid_regex(ocm: OCM) -> None:
     with pytest.raises(TypeError):
         OCM("name", "org_id", ocm._ocm_client, blocked_versions=["["])
+
+
+def test_available_upgrades_versions(ocm: OCM) -> None:
+    assert ocm.available_cluster_upgrades["test-cluster"] == [
+        "4.11.33",
+        "4.12.1",
+        "4.12.8",
+        "4.12.9",
+    ]

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -654,6 +654,7 @@ class OCM:  # pylint: disable=too-many-public-methods
         self.cluster_ids = {c["name"]: c["id"] for c in clusters}
 
         self.clusters: dict[str, OCMSpec] = {}
+        self.available_cluster_upgrades: dict[str, list[str]] = {}
         self.not_ready_clusters: set[str] = set()
 
         for c in clusters:
@@ -661,6 +662,9 @@ class OCM:  # pylint: disable=too-many-public-methods
             if self._ready_for_app_interface(c):
                 ocm_spec = self._get_cluster_ocm_spec(c, init_provision_shards)
                 self.clusters[cluster_name] = ocm_spec
+                self.available_cluster_upgrades[cluster_name] = c.get(
+                    "version", {}
+                ).get("available_upgrades")
             else:
                 self.not_ready_clusters.add(cluster_name)
 


### PR DESCRIPTION
using the CS `versions` endpoint to get upgrade paths for version+channel requires a special AMS capability only available to service-accounts that are bound to an organization. by using the `version.available_upgrades` data from the CS `clusters` endpoint, we can avoid that capability.