### PR TITLE
[ocm-utils] testability and test refactor

### DIFF
--- a/reconcile/test/fixtures/clusters/osd_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/osd_spec_ai.yml
@@ -20,6 +20,8 @@ ocm:
     accessTokenClientSecret:
       path: "client-secret-path"
       field: "client_secret"
+      version: null
+      format: null
     accessTokenUrl: "https://sso.blah.com/token"
 spec:
   product: osd

--- a/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
@@ -20,6 +20,8 @@ ocm:
     accessTokenClientSecret:
       path: "client-secret-path"
       field: "client_secret"
+      version: null
+      format: null
     accessTokenUrl: "https://sso.blah.com/token"
 spec:
   product: rosa

--- a/reconcile/test/fixtures/ocm/oidc/get_full.yml
+++ b/reconcile/test/fixtures/ocm/oidc/get_full.yml
@@ -1,6 +1,6 @@
 ---
 expected_return_value:
-  cluster: cluster-1
+  cluster: test-cluster
   name: oidc-auth
   id: idp-id-2
   client_id: another-client-id
@@ -15,18 +15,18 @@ expected_return_value:
 
 urls:
   - name: list idps
-    uri: /api/clusters_mgmt/v1/clusters/cluster-1-id/identity_providers
+    uri: /api/clusters_mgmt/v1/clusters/osd-cluster-id/identity_providers
     method: get
     responses:
       - kind: IdentityProviderList
-        href: /api/clusters_mgmt/v1/clusters/cluster-1-id/identity_providers
+        href: /api/clusters_mgmt/v1/clusters/osd-cluster-id/identity_providers
         page: 1
         size: 2
         total: 2
         items:
           - kind: IdentityProvider
             type: GithubIdentityProvider
-            href: /api/clusters_mgmt/v1/clusters/cluster-1-id/identity_providers/idp-id-1
+            href: /api/clusters_mgmt/v1/clusters/osd-cluster-id/identity_providers/idp-id-1
             id: idp-id-1
             name: github-auth
             mapping_method: claim
@@ -36,7 +36,7 @@ urls:
                 - just-a-team-name
           - kind: IdentityProvider
             type: OpenIDIdentityProvider
-            href: /api/clusters_mgmt/v1/clusters/cluster-1-id/identity_providers/idp-id-2
+            href: /api/clusters_mgmt/v1/clusters/osd-cluster-id/identity_providers/idp-id-2
             id: idp-id-2
             name: oidc-auth
             mapping_method: claim

--- a/reconcile/test/fixtures/ocm/oidc/get_minimal.yml
+++ b/reconcile/test/fixtures/ocm/oidc/get_minimal.yml
@@ -1,6 +1,6 @@
 ---
 expected_return_value:
-  cluster: cluster-1
+  cluster: test-cluster
   name: oidc-auth
   id: idp-id-2
   client_id: another-client-id
@@ -15,18 +15,18 @@ expected_return_value:
 
 urls:
   - name: list idps
-    uri: /api/clusters_mgmt/v1/clusters/cluster-1-id/identity_providers
+    uri: /api/clusters_mgmt/v1/clusters/osd-cluster-id/identity_providers
     method: get
     responses:
       - kind: IdentityProviderList
-        href: /api/clusters_mgmt/v1/clusters/cluster-1-id/identity_providers
+        href: /api/clusters_mgmt/v1/clusters/osd-cluster-id/identity_providers
         page: 1
         size: 1
         total: 1
         items:
           - kind: IdentityProvider
             type: OpenIDIdentityProvider
-            href: /api/clusters_mgmt/v1/clusters/cluster-1-id/identity_providers/idp-id-2
+            href: /api/clusters_mgmt/v1/clusters/osd-cluster-id/identity_providers/idp-id-2
             id: idp-id-2
             name: oidc-auth
             open_id:

--- a/reconcile/test/ocm/conftest.py
+++ b/reconcile/test/ocm/conftest.py
@@ -1,21 +1,27 @@
 import json
 from typing import (
-    Any,
     Callable,
     Optional,
 )
+from urllib.parse import urljoin
 
 import httpretty as httpretty_module
 import pytest
 from httpretty.core import HTTPrettyRequest
 from pydantic.json import pydantic_encoder
 
+from reconcile.test.test_utils_ocm import OcmUrl
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 @pytest.fixture
 def access_token_url() -> str:
     return "https://sso/get_token"
+
+
+@pytest.fixture
+def ocm_url() -> str:
+    return "http://ocm"
 
 
 @pytest.fixture
@@ -29,60 +35,35 @@ def ocm_auth_mock(httpretty: httpretty_module, access_token_url: str) -> None:
 
 
 @pytest.fixture
-def ocm_api(ocm_auth_mock: None, access_token_url: str) -> OCMBaseClient:
+def ocm_api(ocm_auth_mock: None, access_token_url: str, ocm_url: str) -> OCMBaseClient:
     return OCMBaseClient(
         access_token_client_id="some_client_id",
         access_token_client_secret="some_client_secret",
         access_token_url=access_token_url,
-        url="http://ocm",
-    )
-
-
-def register_ocm_get_list_request(
-    ocm_api: OCMBaseClient, httpretty: httpretty_module, url: str, result: list[Any]
-) -> None:
-    httpretty.register_uri(
-        httpretty.GET,
-        f"{ocm_api._url}{url}",
-        body=json.dumps({"items": result}, default=pydantic_encoder),
-        content_type="text/json",
+        url=ocm_url,
     )
 
 
 @pytest.fixture
-def register_ocm_get_list_handler(
-    ocm_api: OCMBaseClient,
-    httpretty: httpretty_module,
-) -> Callable[[str, Optional[Any]], None]:
-    def _register_ocm_get_list_handler(url: str, result: Optional[Any] = None) -> None:
-        httpretty.register_uri(
-            "GET",
-            f"{ocm_api._url}{url}",
-            body=json.dumps({"items": result}, default=pydantic_encoder)
-            if result
-            else "{}",
-            content_type="text/json",
-        )
+def register_ocm_url_responses(
+    ocm_url: str, httpretty: httpretty_module
+) -> Callable[[list[OcmUrl]], int]:
+    def f(urls: list[OcmUrl]) -> int:
+        i = 0
+        for url in urls:
+            i += len(url.responses) or 1
+            httpretty.register_uri(
+                url.method.upper(),
+                urljoin(ocm_url, url.uri),
+                responses=[
+                    httpretty.Response(body=json.dumps(r, default=pydantic_encoder))
+                    for r in url.responses
+                ],
+                content_type="text/json",
+            )
+        return i
 
-    return _register_ocm_get_list_handler
-
-
-@pytest.fixture
-def register_ocm_request_handler(
-    ocm_api: OCMBaseClient,
-    httpretty: httpretty_module,
-) -> Callable[[str, str, Optional[Any]], None]:
-    def _register_ocm_request_handler(
-        method: str, url: str, result: Optional[Any] = None
-    ) -> None:
-        httpretty.register_uri(
-            method,
-            f"{ocm_api._url}{url}",
-            body=json.dumps(result, default=pydantic_encoder) if result else "{}",
-            content_type="text/json",
-        )
-
-    return _register_ocm_request_handler
+    return f
 
 
 @pytest.fixture

--- a/reconcile/test/ocm/conftest.py
+++ b/reconcile/test/ocm/conftest.py
@@ -35,7 +35,7 @@ def ocm_url() -> str:
     return "http://ocm"
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def ocm_auth_mock(httpretty: httpretty_module, access_token_url: str) -> None:
     httpretty.register_uri(
         httpretty.POST,
@@ -47,7 +47,6 @@ def ocm_auth_mock(httpretty: httpretty_module, access_token_url: str) -> None:
 
 @pytest.fixture
 def ocm_api(
-    ocm_auth_mock: None,
     access_token_url: str,
     ocm_url: str,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],

--- a/reconcile/test/ocm/conftest.py
+++ b/reconcile/test/ocm/conftest.py
@@ -46,7 +46,20 @@ def ocm_auth_mock(httpretty: httpretty_module, access_token_url: str) -> None:
 
 
 @pytest.fixture
-def ocm_api(ocm_auth_mock: None, access_token_url: str, ocm_url: str) -> OCMBaseClient:
+def ocm_api(
+    ocm_auth_mock: None,
+    access_token_url: str,
+    ocm_url: str,
+    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
+    clusters: list[dict[str, Any]],
+) -> OCMBaseClient:
+    register_ocm_url_responses(
+        [
+            OcmUrl(
+                method="GET", uri="/api/clusters_mgmt/v1/clusters"
+            ).add_list_response(clusters)
+        ]
+    )
     return OCMBaseClient(
         access_token_client_id="some_client_id",
         access_token_client_secret="some_client_secret",
@@ -135,16 +148,7 @@ def clusters() -> list[dict[str, Any]]:
 @pytest.fixture
 def ocm(
     ocm_api: OCMBaseClient,
-    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    clusters: list[dict[str, Any]],
 ) -> OCM:
-    register_ocm_url_responses(
-        [
-            OcmUrl(
-                method="GET", uri="/api/clusters_mgmt/v1/clusters"
-            ).add_list_response(clusters)
-        ]
-    )
     return OCM(
         "my-org",
         "org-id",

--- a/reconcile/test/ocm/fixtures.py
+++ b/reconcile/test/ocm/fixtures.py
@@ -1,0 +1,48 @@
+import json
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from typing import (
+    Any,
+    Optional,
+)
+
+from pydantic import (
+    BaseModel,
+    Field,
+)
+
+
+class OcmResponse(BaseModel, ABC):
+    @abstractmethod
+    def render(self) -> str:
+        ...
+
+
+class OcmRawResponse(OcmResponse):
+    response: Any
+
+    def render(self) -> str:
+        return json.dumps(self.response)
+
+
+class OcmUrl(BaseModel):
+    name: Optional[str]
+    uri: str
+    method: str = "POST"
+    responses: list[Any] = Field(default_factory=list)
+
+    def add_list_response(
+        self, items: list[Any], kind: Optional[str] = None
+    ) -> "OcmUrl":
+        self.responses.append(
+            {
+                "kind": f"{kind}List" if kind else "List",
+                "items": items,
+                "page": 1,
+                "size": len(items),
+                "total": len(items),
+            }
+        )
+        return self

--- a/reconcile/test/ocm/test_utils_ocm_cluster_groups.py
+++ b/reconcile/test/ocm/test_utils_ocm_cluster_groups.py
@@ -1,8 +1,6 @@
 import json
-from typing import (
-    Callable,
-    Optional,
-)
+from collections.abc import Callable
+from typing import Optional
 
 import httpretty as httpretty_module
 from httpretty.core import HTTPrettyRequest
@@ -68,7 +66,7 @@ def test_get_cluster_groups(
 def test_add_user_to_cluster_group(
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
+    find_ocm_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
 ) -> None:
     cluster_id = "cluster_id"
     user_name = "user-to-add"
@@ -83,7 +81,7 @@ def test_add_user_to_cluster_group(
         user_name=user_name,
     )
 
-    post_request = find_http_request("POST", add_user_url)
+    post_request = find_ocm_http_request("POST", add_user_url)
     assert isinstance(post_request, HTTPrettyRequest)
     assert json.loads(post_request.body).get("id") == user_name
 

--- a/reconcile/test/ocm/test_utils_ocm_clusters.py
+++ b/reconcile/test/ocm/test_utils_ocm_clusters.py
@@ -1,11 +1,11 @@
 from typing import (
-    Any,
     Callable,
     Optional,
 )
 
 from pytest_mock import MockerFixture
 
+from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.test.ocm.test_utils_ocm_labels import (
     build_organization_label,
     build_subscription_label,
@@ -140,7 +140,7 @@ def test_utils_ocm_discover_clusters_for_empty_organization_id_list(
 def test_discover_clusters_by_labels(
     mocker: MockerFixture,
     ocm_api: OCMBaseClient,
-    register_ocm_get_list_handler: Callable[[str, Optional[Any]], None],
+    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
 ) -> None:
     """
     Tests that the discover_clusters_by_labels function discovers subscription and
@@ -152,19 +152,22 @@ def test_discover_clusters_by_labels(
         clusters, "get_cluster_details_for_subscriptions"
     )
 
-    register_ocm_get_list_handler(
-        "/api/accounts_mgmt/v1/labels",
+    register_ocm_url_responses(
         [
-            build_subscription_label("label", "subs_value", "sub_id").dict(
-                by_alias=True
-            ),
-            build_subscription_label("label", "subs_value", "sub_id_2").dict(
-                by_alias=True
-            ),
-            build_organization_label("label", "org_value", "org_id").dict(
-                by_alias=True
-            ),
-        ],
+            OcmUrl(method="GET", uri="/api/accounts_mgmt/v1/labels",).add_list_response(
+                [
+                    build_subscription_label("label", "subs_value", "sub_id").dict(
+                        by_alias=True
+                    ),
+                    build_subscription_label("label", "subs_value", "sub_id_2").dict(
+                        by_alias=True
+                    ),
+                    build_organization_label("label", "org_value", "org_id").dict(
+                        by_alias=True
+                    ),
+                ]
+            )
+        ]
     )
 
     # call discovery
@@ -178,7 +181,9 @@ def test_discover_clusters_by_labels(
     get_clusters_for_subscriptions_mock.assert_called_once_with(
         ocm_api=ocm_api,
         subscription_filter=(
-            Filter().is_in("id", ["sub_id", "sub_id_2"])
+            Filter().is_in(  # pylint: disable=unsupported-binary-operation
+                "id", ["sub_id", "sub_id_2"]
+            )
             | Filter().is_in("organization_id", ["org_id"])
         ),
     )
@@ -187,7 +192,7 @@ def test_discover_clusters_by_labels(
 def test_get_clusters_for_subscriptions(
     mocker: MockerFixture,
     ocm_api: OCMBaseClient,
-    register_ocm_get_list_handler: Callable[[str, Optional[Any]], None],
+    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
 ) -> None:
     """
     Tests the subscription and organization labels are properly queried
@@ -212,14 +217,19 @@ def test_get_clusters_for_subscriptions(
         ]
     )
 
-    register_ocm_get_list_handler(
-        "/api/clusters_mgmt/v1/clusters",
+    register_ocm_url_responses(
         [
-            build_ocm_cluster(
-                name="cl1",
-                subs_id=subscription_id,
+            OcmUrl(
+                method="GET", uri="/api/clusters_mgmt/v1/clusters"
+            ).add_list_response(
+                [
+                    build_ocm_cluster(
+                        name="cl1",
+                        subs_id=subscription_id,
+                    )
+                ]
             )
-        ],
+        ]
     )
 
     subscription_filter = Filter().eq("id", subscription_id)

--- a/reconcile/test/ocm/test_utils_ocm_clusters.py
+++ b/reconcile/test/ocm/test_utils_ocm_clusters.py
@@ -1,7 +1,5 @@
-from typing import (
-    Callable,
-    Optional,
-)
+from collections.abc import Callable
+from typing import Optional
 
 from pytest_mock import MockerFixture
 

--- a/reconcile/test/ocm/test_utils_ocm_get_json.py
+++ b/reconcile/test/ocm/test_utils_ocm_get_json.py
@@ -1,0 +1,105 @@
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from httpretty.core import HTTPrettyRequest
+
+from reconcile.test.ocm.fixtures import OcmUrl
+from reconcile.utils.ocm import OCM
+
+
+def buid_ocm_item_page(page: int, items: list[Any], total: int) -> dict[str, Any]:
+    return {
+        "kind": "TestList",
+        "page": page,
+        "size": len(items),
+        "total": total,
+        "items": items,
+    }
+
+
+def build_paged_ocm_response(nr_of_items: int, page_size: int) -> list[dict[str, Any]]:
+    paged_responses = []
+    item_range = range(0, nr_of_items)
+    page_nr = 0
+    for page_nr, page in enumerate(
+        [item_range[i : i + page_size] for i in range(0, nr_of_items, page_size)]
+    ):
+        items = [{"id": x} for x in page]
+        paged_responses.append(buid_ocm_item_page(page_nr + 1, items, nr_of_items))
+    paged_responses.append(buid_ocm_item_page(page_nr + 1, [], nr_of_items))
+    return paged_responses
+
+
+@pytest.mark.parametrize(
+    "nr_of_items, page_size",
+    [(10, 3), (10, 2), (1, 10), (10, 10)],
+)
+def test_get_json_pagination(
+    nr_of_items: int,
+    page_size: int,
+    ocm: OCM,
+    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
+    find_all_ocm_http_requests: Callable[[str, str], list[HTTPrettyRequest]],
+) -> None:
+    register_ocm_url_responses(
+        [
+            OcmUrl(
+                method="GET",
+                uri="/api",
+                responses=build_paged_ocm_response(
+                    nr_of_items=nr_of_items, page_size=page_size
+                ),
+            )
+        ]
+    )
+
+    resp = ocm._get_json("/api", page_size=page_size)
+
+    assert "kind" in resp
+    assert "total" in resp
+    assert "items" in resp
+    assert len(resp["items"]) == nr_of_items
+    assert len(resp["items"]) == resp["total"]
+
+    ocm_calls = find_all_ocm_http_requests("GET", "/api")
+    assert len(ocm_calls) == (nr_of_items // page_size) + 1
+
+
+def test_get_json_empty_list(
+    ocm: OCM,
+    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
+) -> None:
+    register_ocm_url_responses(
+        [
+            OcmUrl(
+                method="GET",
+                uri="/api",
+                responses=build_paged_ocm_response(nr_of_items=0, page_size=10),
+            )
+        ]
+    )
+
+    resp = ocm._get_json("/api", page_size=10)
+
+    assert "kind" in resp
+    assert "total" in resp
+    assert "items" not in resp
+
+
+def test_get_json(
+    ocm: OCM,
+    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
+) -> None:
+    register_ocm_url_responses(
+        [
+            OcmUrl(
+                method="GET",
+                uri="/api",
+                responses=[{"kind": "test", "id": 1}],
+            )
+        ]
+    )
+
+    x = ocm._get_json("/api")
+    assert x["id"] == 1

--- a/reconcile/test/ocm/test_utils_ocm_labels.py
+++ b/reconcile/test/ocm/test_utils_ocm_labels.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 from pytest_mock import MockerFixture

--- a/reconcile/test/ocm/test_utils_ocm_labels.py
+++ b/reconcile/test/ocm/test_utils_ocm_labels.py
@@ -1,12 +1,9 @@
-from typing import (
-    Any,
-    Callable,
-    Optional,
-)
+from typing import Callable
 
 import pytest
 from pytest_mock import MockerFixture
 
+from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.utils.ocm import labels
 from reconcile.utils.ocm.labels import (
     OCMAccountLabel,
@@ -131,16 +128,21 @@ def test_utils_build_ocm_unknown_label_from_dict() -> None:
 def test_utils_get_organization_labels(
     ocm_api: OCMBaseClient,
     mocker: MockerFixture,
-    register_ocm_get_list_handler: Callable[[str, Optional[Any]], None],
+    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
 ) -> None:
     get_labels_call_recorder = mocker.patch.object(
         labels, "get_labels", wraps=labels.get_labels
     )
-    register_ocm_get_list_handler(
-        "/api/accounts_mgmt/v1/labels",
+    register_ocm_url_responses(
         [
-            build_organization_label("label", "value", "org_id").dict(by_alias=True),
-        ],
+            OcmUrl(method="GET", uri="/api/accounts_mgmt/v1/labels").add_list_response(
+                [
+                    build_organization_label("label", "value", "org_id").dict(
+                        by_alias=True
+                    )
+                ]
+            )
+        ]
     )
 
     filter = Filter().eq("additional", "filter")
@@ -165,16 +167,21 @@ def test_utils_get_organization_labels(
 def test_utils_get_subscription_labels(
     ocm_api: OCMBaseClient,
     mocker: MockerFixture,
-    register_ocm_get_list_handler: Callable[[str, Optional[Any]], None],
+    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
 ) -> None:
     get_labels_call_recorder = mocker.patch.object(
         labels, "get_labels", wraps=labels.get_labels
     )
-    register_ocm_get_list_handler(
-        "/api/accounts_mgmt/v1/labels",
+    register_ocm_url_responses(
         [
-            build_subscription_label("label", "value", "sub_id").dict(by_alias=True),
-        ],
+            OcmUrl(method="GET", uri="/api/accounts_mgmt/v1/labels").add_list_response(
+                [
+                    build_subscription_label("label", "value", "sub_id").dict(
+                        by_alias=True
+                    )
+                ]
+            )
+        ]
     )
 
     filter = Filter().eq("additional", "filter")

--- a/reconcile/test/ocm/test_utils_ocm_oidc_idp.py
+++ b/reconcile/test/ocm/test_utils_ocm_oidc_idp.py
@@ -173,6 +173,7 @@ def test_ocm_delete_idp(
     cluster_name: str,
     cluster_id: str,
     register_ocm_url_callback: Callable[[str, str, Callable], None],
+    find_ocm_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
 ) -> None:
     url = f"/api/clusters_mgmt/v1/clusters/{cluster_id}/identity_providers/idp-id-1"
 
@@ -183,3 +184,4 @@ def test_ocm_delete_idp(
 
     register_ocm_url_callback("DELETE", url, request_callback)
     ocm.delete_idp(cluster_name, "idp-id-1")
+    assert find_ocm_http_request("DELETE", url)

--- a/reconcile/test/ocm/test_utils_ocm_oidc_idp.py
+++ b/reconcile/test/ocm/test_utils_ocm_oidc_idp.py
@@ -1,0 +1,185 @@
+import json
+from collections.abc import Callable
+from typing import (
+    Any,
+    Optional,
+)
+
+import pytest
+from httpretty.core import HTTPrettyRequest
+
+from reconcile.ocm.types import OCMOidcIdp
+from reconcile.test.fixtures import Fixtures
+from reconcile.test.ocm.fixtures import OcmUrl
+from reconcile.utils.exceptions import ParameterError
+from reconcile.utils.ocm import OCM
+
+
+@pytest.fixture
+def clusters() -> list[dict[str, Any]]:
+    return [Fixtures("clusters").get_anymarkup("osd_spec.json")]
+
+
+@pytest.fixture
+def cluster_name(clusters: list[dict[str, Any]]) -> str:
+    return str(clusters[0].get("name"))
+
+
+@pytest.fixture
+def cluster_id(clusters: list[dict[str, Any]]) -> str:
+    return str(clusters[0].get("id"))
+
+
+@pytest.fixture
+def oidc_idp(cluster_name: str) -> OCMOidcIdp:
+    return OCMOidcIdp(
+        id="idp-id",
+        cluster=cluster_name,
+        name="idp-name",
+        client_id="client-id",
+        client_secret="client-secret",
+        issuer="http://issuer.com",
+        email_claims=["email"],
+        name_claims=["name"],
+        username_claims=["username"],
+        groups_claims=["groups"],
+    )
+
+
+@pytest.mark.parametrize("fixture_name", ["full", "minimal"])
+def test_ocm_get_oidc_idps(
+    fixture_name: str,
+    fx: Fixtures,
+    ocm: OCM,
+    cluster_name: str,
+    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
+    find_ocm_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
+) -> None:
+    fixture = fx.get_anymarkup(f"oidc/get_{fixture_name}.yml")
+    register_ocm_url_responses([OcmUrl(**i) for i in fixture["urls"]])
+
+    assert ocm.get_oidc_idps(cluster_name) == [
+        OCMOidcIdp(**fixture["expected_return_value"])
+    ]
+    assert find_ocm_http_request(
+        "GET", "/api/clusters_mgmt/v1/clusters/osd-cluster-id/identity_providers"
+    )
+
+
+@pytest.mark.parametrize(
+    "attr, bad_value",
+    [
+        ("client_secret", None),
+        ("email_claims", []),
+        ("name_claims", []),
+        ("username_claims", []),
+    ],
+)
+def test_ocm_create_oidc_idp_must_raise_an_error(
+    attr: str, bad_value: Any, ocm: OCM, oidc_idp: OCMOidcIdp
+) -> None:
+    setattr(oidc_idp, attr, bad_value)
+    with pytest.raises(ParameterError):
+        ocm.create_oidc_idp(oidc_idp)
+
+
+def test_ocm_create_oidc_idp(
+    ocm: OCM,
+    oidc_idp: OCMOidcIdp,
+    cluster_id: str,
+    register_ocm_url_callback: Callable[[str, str, Callable], None],
+) -> None:
+    url = f"/api/clusters_mgmt/v1/clusters/{cluster_id}/identity_providers"
+    request_data = {
+        "type": "OpenIDIdentityProvider",
+        "name": oidc_idp.name,
+        "mapping_method": "claim",
+        "open_id": {
+            "claims": {
+                "email": oidc_idp.email_claims,
+                "name": oidc_idp.name_claims,
+                "preferred_username": oidc_idp.username_claims,
+                "groups": oidc_idp.groups_claims,
+            },
+            "client_id": oidc_idp.client_id,
+            "client_secret": oidc_idp.client_secret,
+            "issuer": oidc_idp.issuer,
+        },
+    }
+
+    def request_callback(
+        request: HTTPrettyRequest, uri: str, response_headers: dict[str, str]
+    ) -> tuple[int, dict, str]:
+        assert request.headers.get("Content-Type") == "application/json"
+        assert json.loads(request.body) == request_data
+        return (201, response_headers, json.dumps({}))
+
+    register_ocm_url_callback("POST", url, request_callback)
+    ocm.create_oidc_idp(oidc_idp)
+
+
+@pytest.mark.parametrize(
+    "attr, bad_value",
+    [
+        ("client_secret", None),
+        ("email_claims", []),
+        ("name_claims", []),
+        ("username_claims", []),
+    ],
+)
+def test_ocm_update_oidc_idp_must_raise_an_error(
+    attr: str, bad_value: Any, ocm: OCM, oidc_idp: OCMOidcIdp
+) -> None:
+    setattr(oidc_idp, attr, bad_value)
+    with pytest.raises(ParameterError):
+        ocm.update_oidc_idp(id="1", oidc_idp=oidc_idp)
+
+
+def test_ocm_update_oidc_idp(
+    ocm: OCM,
+    oidc_idp: OCMOidcIdp,
+    cluster_id: str,
+    register_ocm_url_callback: Callable[[str, str, Callable], None],
+) -> None:
+    url = f"/api/clusters_mgmt/v1/clusters/{cluster_id}/identity_providers/idp-id-1"
+    request_data = {
+        "type": "OpenIDIdentityProvider",
+        "open_id": {
+            "claims": {
+                "email": oidc_idp.email_claims,
+                "name": oidc_idp.name_claims,
+                "preferred_username": oidc_idp.username_claims,
+                "groups": oidc_idp.groups_claims,
+            },
+            "client_id": oidc_idp.client_id,
+            "client_secret": oidc_idp.client_secret,
+            "issuer": oidc_idp.issuer,
+        },
+    }
+
+    def request_callback(
+        request: HTTPrettyRequest, uri: str, response_headers: dict[str, str]
+    ) -> tuple[int, dict, str]:
+        assert request.headers.get("Content-Type") == "application/json"
+        assert json.loads(request.body) == request_data
+        return (201, response_headers, json.dumps({}))
+
+    register_ocm_url_callback("PATCH", url, request_callback)
+    ocm.update_oidc_idp("idp-id-1", oidc_idp)
+
+
+def test_ocm_delete_idp(
+    ocm: OCM,
+    cluster_name: str,
+    cluster_id: str,
+    register_ocm_url_callback: Callable[[str, str, Callable], None],
+) -> None:
+    url = f"/api/clusters_mgmt/v1/clusters/{cluster_id}/identity_providers/idp-id-1"
+
+    def request_callback(
+        request: HTTPrettyRequest, uri: str, response_headers: dict[str, str]
+    ) -> tuple[int, dict, str]:
+        return (201, response_headers, json.dumps({}))
+
+    register_ocm_url_callback("DELETE", url, request_callback)
+    ocm.delete_idp(cluster_name, "idp-id-1")

--- a/reconcile/test/ocm/test_utils_ocm_sectors.py
+++ b/reconcile/test/ocm/test_utils_ocm_sectors.py
@@ -1,0 +1,111 @@
+from typing import Any
+
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.utils.ocm import (
+    OCM,
+    OCMMap,
+    Sector,
+    SectorConfigError,
+)
+from reconcile.utils.ocm_base_client import OCMBaseClient
+
+
+def test_sector_validate_dependencies(ocm: OCM) -> None:
+    sector1 = Sector(name="sector1", ocm=ocm)
+    sector2 = Sector(name="sector2", ocm=ocm, dependencies=[sector1])
+    sector3 = Sector(name="sector3", ocm=ocm, dependencies=[sector2])
+    assert sector3.validate_dependencies()
+
+    # zero-level loop sector1 -> sector1
+    sector1 = Sector(name="sector1", ocm=ocm)
+    sector1.dependencies = [sector1]
+    with pytest.raises(SectorConfigError):
+        sector1.validate_dependencies()
+
+    # single-level loop sector2 -> sector1 -> sector2
+    sector1 = Sector(name="sector1", ocm=ocm)
+    sector2 = Sector(name="sector2", ocm=ocm, dependencies=[sector1])
+    sector1.dependencies = [sector2]
+    with pytest.raises(SectorConfigError):
+        sector2.validate_dependencies()
+
+    # greater-level loop sector3 -> sector2 -> sector1 -> sector3
+    sector1 = Sector(name="sector1", ocm=ocm)
+    sector2 = Sector(name="sector2", ocm=ocm, dependencies=[sector1])
+    sector3 = Sector(name="sector3", ocm=ocm, dependencies=[sector2])
+    sector1.dependencies = [sector3]
+    with pytest.raises(SectorConfigError):
+        sector3.validate_dependencies()
+
+
+def build_ocm_info(
+    org_name: str, ocm_url: str, access_token_url: str
+) -> dict[str, Any]:
+    return {
+        "name": org_name,
+        "sectors": [
+            {"name": "s1"},
+            {"name": "s2", "dependencies": [{"name": "s1"}]},
+            {"name": "s3", "dependencies": [{"ocm": {"name": "ocm1"}, "name": "s1"}]},
+        ],
+        "orgId": org_name,
+        "environment": {
+            "name": "name",
+            "url": ocm_url,
+            "accessTokenClientId": "atci",
+            "accessTokenUrl": access_token_url,
+            "accessTokenClientSecret": {
+                "path": "/path/to/secret",
+                "field": "field",
+                "version": None,
+                "format": None,
+            },
+        },
+    }
+
+
+def test_ocm_map_upgrade_policies_sector(
+    ocm_url: str, access_token_url: str, ocm_api: OCMBaseClient, mocker: MockerFixture
+) -> None:
+    mocker.patch("reconcile.utils.ocm.ocm.SecretReader")
+    ocm_org1_info = build_ocm_info("org-1", ocm_url, access_token_url)
+    c1 = {
+        "name": "c1",
+        "ocm": ocm_org1_info,
+        "upgradePolicy": {"workload": "w1"},
+    }
+    c2 = {
+        "name": "c2",
+        "ocm": ocm_org1_info,
+        "upgradePolicy": {"workload": "w1", "conditions": {"sector": "s2"}},
+    }
+
+    # second org, using the same sector names
+    ocm_org2_info = build_ocm_info("org-2", ocm_url, access_token_url)
+    c3 = {
+        "name": "c3",
+        "ocm": ocm_org2_info,
+        "upgradePolicy": {"workload": "w1", "conditions": {"sector": "s3"}},
+    }
+
+    mocker.patch("reconcile.utils.ocm.OCM.is_ready").return_value = True
+    ocm_map = OCMMap(clusters=[c1, c2, c3])
+    assert "org-1" in ocm_map.ocm_map
+    assert "org-2" in ocm_map.ocm_map
+
+    # all sectors are reported, even the ones without clusters
+    ocm1 = ocm_map["org-1"]
+    assert len(ocm1.sectors) == 3
+
+    ocm2 = ocm_map["org-2"]
+    assert len(ocm2.sectors) == 3
+
+    # no dependencies
+    s1 = Sector(name="s1", ocm=ocm1)
+    assert ocm1.sectors["s1"] == s1
+
+    # partial dependency definition, without ocm org. defaulting to sector's org
+    s2 = Sector(name="s2", ocm=ocm1, dependencies=[s1], cluster_infos=[c2])
+    assert ocm1.sectors["s2"] == s2

--- a/reconcile/test/ocm/test_utils_ocm_service_log.py
+++ b/reconcile/test/ocm/test_utils_ocm_service_log.py
@@ -1,12 +1,10 @@
+from collections.abc import Callable
 from datetime import (
     datetime,
     timedelta,
     timezone,
 )
-from typing import (
-    Callable,
-    Optional,
-)
+from typing import Optional
 
 import pytest
 from httpretty.core import HTTPrettyRequest
@@ -87,7 +85,7 @@ def test_get_service_logs(
 def test_create_service_log(
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
+    find_ocm_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
 ) -> None:
     timestamp = datetime(2020, 1, 2, 0, 0, 0, 0, tzinfo=timezone.utc)
     register_ocm_url_responses(
@@ -119,7 +117,7 @@ def test_create_service_log(
         ),
     )
     assert result is not None
-    assert find_http_request("POST", "/api/service_logs/v1/cluster_logs")
+    assert find_ocm_http_request("POST", "/api/service_logs/v1/cluster_logs")
 
 
 def test_create_service_log_dedup_timedelta_filter(
@@ -166,7 +164,7 @@ def test_create_service_log_dedup_timedelta_filter(
 def test_create_service_log_dedup(
     ocm_api: OCMBaseClient,
     example_service_log: OCMClusterServiceLog,
-    find_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
+    find_ocm_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
 ) -> None:
     create_service_log(
         ocm_api=ocm_api,
@@ -180,13 +178,13 @@ def test_create_service_log_dedup(
         dedup_interval=timedelta(days=1),
     )
     # expect no post call to the service log api
-    assert find_http_request("POST", "/api/service_logs/v1/cluster_logs") is None
+    assert find_ocm_http_request("POST", "/api/service_logs/v1/cluster_logs") is None
 
 
 def test_create_service_log_dedup_no_dup(
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
+    find_ocm_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
 ) -> None:
     register_ocm_url_responses(
         [
@@ -213,4 +211,4 @@ def test_create_service_log_dedup_no_dup(
         dedup_interval=timedelta(days=1),
     )
     # expect a post call to the service log api
-    assert find_http_request("POST", "/api/service_logs/v1/cluster_logs")
+    assert find_ocm_http_request("POST", "/api/service_logs/v1/cluster_logs")

--- a/reconcile/test/ocm/test_utils_ocm_subscriptions.py
+++ b/reconcile/test/ocm/test_utils_ocm_subscriptions.py
@@ -1,7 +1,5 @@
-from typing import (
-    Callable,
-    Optional,
-)
+from collections.abc import Callable
+from typing import Optional
 
 from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.test.ocm.test_utils_ocm_labels import build_subscription_label

--- a/reconcile/test/ocm/test_utils_ocm_subscriptions.py
+++ b/reconcile/test/ocm/test_utils_ocm_subscriptions.py
@@ -1,9 +1,9 @@
 from typing import (
-    Any,
     Callable,
     Optional,
 )
 
+from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.test.ocm.test_utils_ocm_labels import build_subscription_label
 from reconcile.utils.ocm.search_filters import Filter
 from reconcile.utils.ocm.subscriptions import (
@@ -41,16 +41,19 @@ def build_ocm_subscription(
 
 def test_get_subscriptions(
     ocm_api: OCMBaseClient,
-    register_ocm_get_list_handler: Callable[[str, Optional[Any]], None],
+    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
 ) -> None:
     sub = build_ocm_subscription(
         name="sub-1",
         labels=[("label-1", "value-1")],
         capabilities=[("capability-1", "value-1")],
     )
-    register_ocm_get_list_handler(
-        "/api/accounts_mgmt/v1/subscriptions",
-        [sub],
+    register_ocm_url_responses(
+        [
+            OcmUrl(
+                method="GET", uri="/api/accounts_mgmt/v1/subscriptions"
+            ).add_list_response([sub])
+        ]
     )
     subscriptions = get_subscriptions(ocm_api, Filter().eq("some", "condition"))
     assert len(subscriptions) == 1

--- a/reconcile/test/ocm/test_utils_ocm_versions.py
+++ b/reconcile/test/ocm/test_utils_ocm_versions.py
@@ -8,6 +8,11 @@ from reconcile.utils.ocm import OCM
 
 @pytest.fixture
 def clusters() -> list[dict[str, Any]]:
+    """
+    This cluster fixture overrides the one in conftest.py
+    Clusters returned by this fixture are present in the
+    ocm fixture.
+    """
     return [Fixtures("clusters").get_anymarkup("osd_spec.json")]
 
 

--- a/reconcile/test/ocm/test_utils_ocm_versions.py
+++ b/reconcile/test/ocm/test_utils_ocm_versions.py
@@ -1,19 +1,37 @@
-import pytest
-from pytest_mock import MockerFixture
+from collections.abc import Callable
+from typing import Any
 
+import pytest
+
+from reconcile.test.fixtures import Fixtures
+from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.utils.ocm import OCM
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 @pytest.fixture
-def ocm(mocker: MockerFixture) -> OCM:
-    mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient._init_access_token")
-    mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient._init_request_headers")
-    mocker.patch("reconcile.utils.ocm.OCM.whoami")
-    mocker.patch("reconcile.utils.ocm.OCM._init_clusters")
-    mocker.patch("reconcile.utils.ocm.OCM._init_version_gates")
-    ocm_client = OCMBaseClient("url", "tid", "turl", "cid")
-    return OCM("name", "org_id", ocm_client)
+def ocm_osd_cluster_raw_spec() -> dict[str, Any]:
+    return Fixtures("clusters").get_anymarkup("osd_spec.json")
+
+
+@pytest.fixture
+def ocm(
+    ocm_api: OCMBaseClient,
+    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
+    ocm_osd_cluster_raw_spec: dict[str, Any],
+) -> OCM:
+    register_ocm_url_responses(
+        [
+            OcmUrl(
+                method="GET", uri="/api/clusters_mgmt/v1/clusters"
+            ).add_list_response([ocm_osd_cluster_raw_spec])
+        ]
+    )
+    return OCM(
+        "my-org",
+        "org-id",
+        ocm_api,
+    )
 
 
 def test_no_blocked_versions(ocm: OCM) -> None:

--- a/reconcile/test/ocm/test_utils_ocm_versions.py
+++ b/reconcile/test/ocm/test_utils_ocm_versions.py
@@ -1,37 +1,14 @@
-from collections.abc import Callable
 from typing import Any
 
 import pytest
 
 from reconcile.test.fixtures import Fixtures
-from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.utils.ocm import OCM
-from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 @pytest.fixture
-def ocm_osd_cluster_raw_spec() -> dict[str, Any]:
-    return Fixtures("clusters").get_anymarkup("osd_spec.json")
-
-
-@pytest.fixture
-def ocm(
-    ocm_api: OCMBaseClient,
-    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    ocm_osd_cluster_raw_spec: dict[str, Any],
-) -> OCM:
-    register_ocm_url_responses(
-        [
-            OcmUrl(
-                method="GET", uri="/api/clusters_mgmt/v1/clusters"
-            ).add_list_response([ocm_osd_cluster_raw_spec])
-        ]
-    )
-    return OCM(
-        "my-org",
-        "org-id",
-        ocm_api,
-    )
+def clusters() -> list[dict[str, Any]]:
+    return [Fixtures("clusters").get_anymarkup("osd_spec.json")]
 
 
 def test_no_blocked_versions(ocm: OCM) -> None:

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -22,6 +22,7 @@ from reconcile.utils.ocm import (
     SPEC_ATTR_CONSOLE_URL,
     SPEC_ATTR_SERVER_URL,
     OCMMap,
+    ocm,
 )
 
 from .fixtures import Fixtures
@@ -313,7 +314,7 @@ def ocm_mock(ocm_secrets_reader):
     with patch.object(OCM, "_post", autospec=True) as _post:
         with patch.object(OCM, "_patch", autospec=True) as _patch:
             with patch.object(OCM, "whoami", autospec=True):
-                with patch.object(OCM, "_init_ocm_client", autospec=True):
+                with patch.object(ocm, "init_ocm_base_client"):
                     with patch.object(OCM, "get_provision_shard", autospec=True) as gps:
                         gps.return_value = {"id": "provision_shard_id"}
                         yield _post, _patch

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -19,6 +19,7 @@ from reconcile.utils.ocm import (
     Sector,
     SectorConfigError,
 )
+from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 class OcmUrl(BaseModel):
@@ -91,7 +92,8 @@ def ocm(mocker: MockerFixture, ocm_url: str, cluster: str, cluster_id: str) -> O
     mocker.patch("reconcile.utils.ocm.OCM._init_clusters")
     mocker.patch("reconcile.utils.ocm.OCM._init_blocked_versions")
     mocker.patch("reconcile.utils.ocm.OCM._init_version_gates")
-    ocm = OCM("name", "url", "org_id", "tid", "turl", "ot")
+    ocm_client = OCMBaseClient("url", "tid", "turl", "cid")
+    ocm = OCM("name", "org_id", ocm_client)
     ocm._ocm_client._url = ocm_url
     ocm.cluster_ids = {cluster: cluster_id}
     return ocm

--- a/reconcile/test/test_utils_ocm.py
+++ b/reconcile/test/test_utils_ocm.py
@@ -1,9 +1,6 @@
-import json
 from copy import deepcopy
 
-import httpretty
 import pytest
-from httpretty.core import HTTPrettyRequest
 from pytest_mock import MockerFixture
 
 from reconcile.utils.ocm import (
@@ -118,88 +115,6 @@ def test_get_version_gate(ocm):
     gates = ocm.get_version_gates("4.9", sts_only=True)
     assert gates == [{"version_raw_id_prefix": "4.9", "sts_only": True}]
     assert len(ocm.get_version_gates("4.8")) == 0
-
-
-def test__get_json_pagination(ocm):
-    ocm._ocm_client._url = "http://ocm.test"
-    call_cnt = 0
-
-    def paginated_response(request: HTTPrettyRequest, url, response_headers):
-        nonlocal call_cnt
-        call_cnt = call_cnt + 1
-        # Return four pages, last one only partially filled
-        if "page" not in request.querystring:
-            p = 1
-        else:
-            p = int(request.querystring["page"][0])
-
-        if p <= 3:
-            items = [{"id": x} for x in range(0, 100)]
-        elif p == 4:
-            items = [{"id": x} for x in range(0, 11)]
-        else:
-            items = []
-        body = {"kind": "TestList", "page": p, "items": items, "size": len(items)}
-
-        return [200, response_headers, json.dumps(body)]
-
-    httpretty.enable()
-    httpretty.register_uri(
-        httpretty.GET, "http://ocm.test/api", body=paginated_response
-    )
-
-    resp = ocm._get_json("/api")
-
-    httpretty.disable()
-
-    assert "kind" in resp
-    assert "total" in resp
-    assert "items" in resp
-    assert len(resp["items"]) == 311
-    assert len(resp["items"]) == resp["total"]
-    assert call_cnt == 4
-
-
-def test__get_json_empty_list(ocm: OCM):
-    ocm._ocm_client._url = "http://ocm.test"
-    httpretty.enable()
-    httpretty.register_uri(
-        httpretty.GET,
-        "http://ocm.test/api",
-        body=json.dumps({"kind": "TestList", "page": 1, "size": 0, "total": 0}),
-    )
-
-    resp = ocm._get_json("/api")
-    httpretty.disable()
-    assert "items" not in resp
-    assert resp["total"] == 0
-
-
-def test__get_json_simple_list(ocm: OCM):
-    ocm._ocm_client._url = "http://ocm.test"
-    httpretty.enable()
-    httpretty.register_uri(
-        httpretty.GET,
-        "http://ocm.test/api",
-        body=json.dumps({"kind": "TestList", "items": {"foo": "bar"}}),
-    )
-
-    resp = ocm._get_json("/api")
-    httpretty.disable()
-    assert "items" in resp
-
-
-def test__get_json(ocm):
-    ocm._ocm_client._url = "http://ocm.test"
-
-    httpretty.enable()
-    httpretty.register_uri(
-        httpretty.GET, "http://ocm.test/api", body=json.dumps({"kind": "test", "id": 1})
-    )
-    x = ocm._get_json("/api")
-    httpretty.disable()
-
-    assert x["id"] == 1
 
 
 def test_sector_validate_dependencies(ocm):

--- a/reconcile/test/test_utils_ocm_versions.py
+++ b/reconcile/test/test_utils_ocm_versions.py
@@ -1,65 +1,68 @@
 import pytest
+from pytest_mock import MockerFixture
 
 from reconcile.utils.ocm import OCM
+from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 @pytest.fixture
-def ocm(mocker):
+def ocm(mocker: MockerFixture) -> OCM:
     mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient._init_access_token")
     mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient._init_request_headers")
     mocker.patch("reconcile.utils.ocm.OCM.whoami")
     mocker.patch("reconcile.utils.ocm.OCM._init_clusters")
     mocker.patch("reconcile.utils.ocm.OCM._init_version_gates")
-    return OCM("name", "url", "org_id", "tid", "turl", "ot")
+    ocm_client = OCMBaseClient("url", "tid", "turl", "cid")
+    return OCM("name", "org_id", ocm_client)
 
 
-def test_no_blocked_versions(ocm):
+def test_no_blocked_versions(ocm: OCM) -> None:
     result = ocm.version_blocked("1.2.3")
     assert result is False
 
 
-def test_version_blocked(ocm):
+def test_version_blocked(ocm: OCM) -> None:
     ocm.blocked_versions = ["1.2.3"]
     result = ocm.version_blocked("1.2.3")
     assert result is True
 
 
-def test_version_not_blocked(ocm):
+def test_version_not_blocked(ocm: OCM) -> None:
     ocm.blocked_versions = ["1.2.3"]
     result = ocm.version_blocked("1.2.4")
     assert result is False
 
 
-def test_addon_version_blocked(ocm):
+def test_addon_version_blocked(ocm: OCM) -> None:
     ocm.blocked_versions = ["myaddon/1.2.3"]
     result = ocm.addon_version_blocked("1.2.3", "myaddon")
     assert result is True
 
 
-def test_addon_version_not_blocked(ocm):
+def test_addon_version_not_blocked(ocm: OCM) -> None:
     ocm.blocked_versions = ["1.2.4", "myaddon/1.2.3"]
     result = ocm.addon_version_blocked("1.2.4", "myaddon")
     assert result is False
 
 
-def test_version_blocked_multiple(ocm):
+def test_version_blocked_multiple(ocm: OCM) -> None:
     ocm.blocked_versions = ["1.2.3", "1.2.4"]
     result = ocm.version_blocked("1.2.3")
     assert result is True
 
 
-def test_version_blocked_regex(ocm):
+def test_version_blocked_regex(ocm: OCM) -> None:
     ocm.blocked_versions = [r"^.*-fc\..*$"]
     result = ocm.version_blocked("1.2.3-fc.1")
     assert result is True
 
 
-def test_version_not_blocked_regex(ocm):
+def test_version_not_blocked_regex(ocm: OCM) -> None:
     ocm.blocked_versions = [r"^.*-fc\..*$"]
     result = ocm.version_blocked("1.2.3-rc.1")
     assert result is False
 
 
-def test_version_invalid_regex(ocm):
+def test_version_invalid_regex(ocm: OCM) -> None:
     with pytest.raises(TypeError):
-        OCM("name", "url", "org_id", "tid", "turl", "ot", blocked_versions=["["])
+        OCM("name", "org_id", ocm._ocm_client, blocked_versions=["["])

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -1576,12 +1576,12 @@ class OCM:  # pylint: disable=too-many-public-methods
         return rs["kind"].endswith("List")
 
     def _get_json(
-        self, api: str, params: Optional[dict[str, Any]] = None
+        self, api: str, params: Optional[dict[str, Any]] = None, page_size: int = 100
     ) -> dict[str, Any]:
         responses = []
         if not params:
             params = {}
-        params["size"] = 100
+        params["size"] = page_size
         while True:
             rs = self._do_get_request(api, params=params)
             responses.append(rs)

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -23,6 +23,7 @@ from typing import (
 from sretoolbox.utils import retry
 
 import reconcile.utils.aws_helper as awsh
+from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.ocm.types import (
     OCMClusterAutoscale,
     OCMClusterNetwork,
@@ -35,7 +36,11 @@ from reconcile.ocm.types import (
     ROSAOcmAwsAttrs,
 )
 from reconcile.utils.exceptions import ParameterError
-from reconcile.utils.ocm_base_client import OCMBaseClient
+from reconcile.utils.ocm_base_client import (
+    OCMAPIClientConfiguration,
+    OCMBaseClient,
+    init_ocm_base_client,
+)
 from reconcile.utils.secret_reader import SecretReader
 
 STATUS_READY = "ready"
@@ -576,16 +581,10 @@ class OCM:  # pylint: disable=too-many-public-methods
     :param name: OCM instance name
     :param url: OCM instance URL
     :param org_id: OCM org ID
-    :param access_token_client_id: client-id to get access token
-    :param access_token_url: URL to get access token from
-    :param access_token_client_secret: client-secret to get access token
+    :param ocm_client: the OCM API client to talk to OCM
     :param init_provision_shards: should initiate provision shards
     :param init_addons: should initiate addons
     :param blocked_versions: versions to block upgrades for
-    :type url: string
-    :type access_token_client_id: string
-    :type access_token_url: string
-    :type access_token_client_secret: string
     :type init_provision_shards: bool
     :type init_addons: bool
     :type init_version_gates: bool
@@ -639,20 +638,6 @@ class OCM:  # pylint: disable=too-many-public-methods
             s = self.sectors[sector["name"]]
             for dep in sector.get("dependencies") or []:
                 s.dependencies.append(self.sectors[dep["name"]])
-
-    @staticmethod
-    def _init_ocm_client(
-        url: str,
-        access_token_client_secret: str,
-        access_token_url: str,
-        access_token_client_id: str,
-    ):
-        return OCMBaseClient(
-            url=url,
-            access_token_client_secret=access_token_client_secret,
-            access_token_url=access_token_url,
-            access_token_client_id=access_token_client_id,
-        )
 
     @staticmethod
     def _ready_for_app_interface(cluster: dict[str, Any]) -> bool:
@@ -1769,17 +1754,16 @@ class OCMMap:  # pylint: disable=too-many-public-methods
         url = ocm_environment["url"]
         org_id = ocm_info["orgId"]
         name = ocm_info["name"]
-        secret_reader = SecretReader(settings=self.settings)
-        ocm_client = (
-            OCM._init_ocm_client(
+        ocm_client = init_ocm_base_client(
+            cfg=OCMAPIClientConfiguration(
                 url=url,
-                access_token_client_secret=secret_reader.read(
-                    access_token_client_secret
-                ),
                 access_token_url=access_token_url,
                 access_token_client_id=access_token_client_id,
+                access_token_client_secret=VaultSecret(**access_token_client_secret),
             ),
+            secret_reader=SecretReader(settings=self.settings),
         )
+
         self.ocm_map[ocm_name] = OCM(
             name,
             org_id,

--- a/reconcile/utils/ocm_base_client.py
+++ b/reconcile/utils/ocm_base_client.py
@@ -10,6 +10,7 @@ from typing import (
     Union,
 )
 
+from pydantic import BaseModel
 from requests import (
     Session,
     codes,
@@ -151,7 +152,7 @@ class OCMBaseClient:
         r.raise_for_status()
 
 
-class OCMAPIClientConfiguration(Protocol):
+class OCMAPIClientConfigurationProtocol(Protocol):
     url: str
     access_token_client_id: str
     access_token_url: str
@@ -161,8 +162,15 @@ class OCMAPIClientConfiguration(Protocol):
         ...
 
 
+class OCMAPIClientConfiguration(BaseModel, arbitrary_types_allowed=True):
+    url: str
+    access_token_client_id: str
+    access_token_url: str
+    access_token_client_secret: HasSecret
+
+
 def init_ocm_base_client(
-    cfg: OCMAPIClientConfiguration,
+    cfg: OCMAPIClientConfigurationProtocol,
     secret_reader: SecretReaderBase,
     session: Optional[Session] = None,
 ) -> OCMBaseClient:


### PR DESCRIPTION
this PR is a first step to harmonize the httpretty mocks and fixtures for OCM testability.
`reconcile.test.ocm.conftest` defines pluggable fixtures, e.g. for `OCMBaseClient` and `OCM` that enables concise test cases and fixture setup.

not all OCM related tests have been migrated to linted/mypy-verified/lean mocked tests so far, so this is only to be considered a first step.