### PR TITLE
[ocm-upgrade-scheduler] fix ocm env sharding/filtering

### DIFF
--- a/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
@@ -78,7 +78,9 @@ class OCMAddonsUpgradeSchedulerOrgIntegration(
                 query_func=gql.get_api().query
             ).organizations
             or []
-            if org.addon_managed_upgrades and (org_name is None or org.name == org_name)
+            if org.environment.name == ocm_env.name
+            and org.addon_managed_upgrades
+            and (org_name is None or org.name == org_name)
         }
 
 

--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -70,15 +70,17 @@ class OCMClusterUpgradeSchedulerIntegration(
             supported_product = (
                 cluster.spec and cluster.spec.product in SUPPORTED_OCM_PRODUCTS
             )
+            in_env_shard = cluster.ocm and ocm_env.name == cluster.ocm.environment.name
             in_org_shard = org_name is None or (
                 cluster.ocm and cluster.ocm.name == org_name
             )
+            in_shard = in_env_shard and in_org_shard
             if (
                 integration_is_enabled(self.name, cluster)
                 and cluster.ocm
                 and cluster.upgrade_policy
                 and supported_product
-                and in_org_shard
+                and in_shard
             ):
                 specs_per_org[cluster.ocm.name].append(
                     ClusterUpgradeSpec(

--- a/reconcile/aus/ocm_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_upgrade_scheduler_org.py
@@ -38,5 +38,6 @@ class OCMClusterUpgradeSchedulerOrgIntegration(OCMClusterUpgradeSchedulerIntegra
                 query_func=gql.get_api().query
             ).organizations
             or []
-            if org_name is None or org.name == org_name
+            if org.environment.name == ocm_env.name
+            and (org_name is None or org.name == org_name)
         }


### PR DESCRIPTION
the ocm env filter was not handled so all clusters/orgs/upgrade policies from all orgs were provided as state.