### PR TITLE
Improve doc and experience to run integration in container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,13 +66,17 @@ test: test-app test-container-image
 dev-reconcile-loop: build-dev ## Trigger the reconcile loop inside a container for an integration
 	@$(CONTAINER_ENGINE) run --rm -it \
 		--add-host=host.docker.internal:host-gateway \
-		-v $(CURDIR):/work \
+		-v "$(CURDIR)":/work \
 		-p 5678:5678 \
-		-e INTEGRATION_NAME=$(INTEGRATION_NAME) \
-		-e INTEGRATION_EXTRA_ARGS=$(INTEGRATION_EXTRA_ARGS) \
-		-e SLEEP_DURATION_SECS=$(SLEEP_DURATION_SECS) \
-		-e DRY_RUN=$(DRY_RUN) \
-		-e DEBUGGER=$(DEBUGGER) \
+		-e INTEGRATION_NAME="$(INTEGRATION_NAME)" \
+		-e INTEGRATION_EXTRA_ARGS="$(INTEGRATION_EXTRA_ARGS)" \
+		-e SLEEP_DURATION_SECS="$(SLEEP_DURATION_SECS)" \
+		-e APP_INTERFACE_STATE_BUCKET="$(APP_INTERFACE_STATE_BUCKET)" \
+		-e APP_INTERFACE_STATE_BUCKET_ACCOUNT="$(APP_INTERFACE_STATE_BUCKET_ACCOUNT)" \
+		-e gitlab_pr_submitter_queue_url="$(gitlab_pr_submitter_queue_url)" \
+		-e LOG_LEVEL="$(LOG_LEVEL)" \
+		-e DRY_RUN="$(DRY_RUN)" \
+		-e DEBUGGER="$(DEBUGGER)" \
 		-e CONFIG=/work/config.dev.toml \
 		$(IMAGE_NAME)-dev:latest
 

--- a/README.md
+++ b/README.md
@@ -328,7 +328,9 @@ tox -e type -- reconcile/utils/slack_api.py
 
 ## Run reconcile loop for an integration locally in a container
 
- This is currently only tested with the docker container engine.
+This is currently only tested with the docker container engine.
+
+For more flexible way to run in container, please see [qontract-development-cli](https://github.com/app-sre/qontract-development-cli).
 
 ### Prepare config.toml
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -41,7 +41,7 @@ RUN chown -R reconcile /work && \
 
 USER reconcile
 VOLUME ["/work"]
-CMD [ "/work/dev/run.sh" ]
+ENTRYPOINT ["/work/dev/run.sh"]
 
 
 FROM quay.io/app-sre/qontract-reconcile-base:0.8.12 as prod-image


### PR DESCRIPTION
* quote `run` parameters to avoid `INTEGRATION_EXTRA_ARGS` break command syntax
* use `exec` in `run.sh` to allow container process to handle signal
* add `qontract-development-cli` to README