### PR TITLE
Fix Pylint consider-using-with

### DIFF
--- a/reconcile/test/test_quay_mirror.py
+++ b/reconcile/test/test_quay_mirror.py
@@ -48,7 +48,7 @@ class TestIsCompareTags:
         with open(os.path.join(self.tmp_dir.name, CONTROL_FILE_NAME), "w") as fh:
             fh.write(str(NOW - 100.0))
 
-    def teardown_mehtod(self):
+    def teardown_method(self):
         self.tmp_dir.cleanup()
 
     # Last run was in NOW - 100s, we run compare tags every 10s.

--- a/reconcile/test/test_quay_mirror_org.py
+++ b/reconcile/test/test_quay_mirror_org.py
@@ -36,7 +36,7 @@ class TestIsCompareTags:
         with open(os.path.join(self.tmp_dir.name, CONTROL_FILE_NAME), "w") as fh:
             fh.write(str(NOW - 100.0))
 
-    def teardown_mehtod(self):
+    def teardown_method(self):
         self.tmp_dir.cleanup()
 
     # Last run was in NOW - 100s, we run compare tags every 10s.

--- a/reconcile/utils/git_secrets.py
+++ b/reconcile/utils/git_secrets.py
@@ -1,54 +1,38 @@
 import logging
 import os
-import shutil
+import subprocess
 import tempfile
-from subprocess import (
-    PIPE,
-    Popen,
-)
 
 import requests
 from sretoolbox.utils import retry
 
 from reconcile.utils import git
-from reconcile.utils.defer import defer
 
 
-@defer
 @retry()
-def scan_history(repo_url, existing_keys, defer=None):
-    # pylint: disable=consider-using-with
+def scan_history(repo_url, existing_keys):
     logging.info("scanning {}".format(repo_url))
     if requests.get(repo_url, timeout=60).status_code == 404:
         logging.info("not found {}".format(repo_url))
         return []
 
-    wd = tempfile.mkdtemp()
-    defer(lambda: cleanup(wd))
-
-    git.clone(repo_url, wd)
-    DEVNULL = open(os.devnull, "w")
-    proc = Popen(["git", "secrets", "--register-aws"], cwd=wd, stdout=DEVNULL)
-    proc.communicate()
-    proc = Popen(["git", "secrets", "--scan-history"], cwd=wd, stdout=PIPE, stderr=PIPE)
-    _, err = proc.communicate()
-    if proc.returncode == 0:
-        return []
-
-    logging.info("found suspects in {}".format(repo_url))
-    suspected_files = get_suspected_files(err.decode("utf-8"))
-    leaked_keys = get_leaked_keys(wd, suspected_files, existing_keys)
-    if leaked_keys:
-        logging.info("found suspected leaked keys: {}".format(leaked_keys))
-
-    return leaked_keys
-
-
-def cleanup(wd):
-    try:
-        shutil.rmtree(wd)
-    except Exception:
-        pass
+    with tempfile.TemporaryDirectory() as wd:
+        git.clone(repo_url, wd)
+        subprocess.run(["git", "secrets", "--install"], check=False, cwd=wd)
+        result = subprocess.run(
+            ["git", "secrets", "--scan-history"],
+            capture_output=True,
+            check=False,
+            cwd=wd,
+        )
+        if result.returncode == 0:
+            return []
+        logging.info("found suspects in {}".format(repo_url))
+        suspected_files = get_suspected_files(result.stderr.decode("utf-8"))
+        leaked_keys = get_leaked_keys(wd, suspected_files, existing_keys)
+        if leaked_keys:
+            logging.info("found suspected leaked keys: {}".format(leaked_keys))
+        return leaked_keys
 
 
 def get_suspected_files(error):

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -488,8 +488,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             r = requests.get(zip_url, timeout=60)
             r.raise_for_status()
             os.makedirs(os.path.dirname(zip_file), exist_ok=True)
-            # pylint: disable=consider-using-with
-            open(zip_file, "wb").write(r.content)
+            with open(zip_file, "wb") as f:
+                f.write(r.content)
         return zip_file
 
     def get_logtoes_zip(self, release_url):
@@ -513,8 +513,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         if not os.path.exists(zip_file):
             r = requests.get(zip_url, timeout=60)
             r.raise_for_status()
-            # pylint: disable=consider-using-with
-            open(zip_file, "wb").write(r.content)
+            with open(zip_file, "wb") as f:
+                f.write(r.content)
         return zip_file
 
     def get_rosa_authenticator_zip(self, release_url):
@@ -542,8 +542,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         if not os.path.exists(zip_file):
             r = requests.get(zip_url, timeout=60)
             r.raise_for_status()
-            # pylint: disable=consider-using-with
-            open(zip_file, "wb").write(r.content)
+            with open(zip_file, "wb") as f:
+                f.write(r.content)
         return zip_file
 
     def init_github(self) -> Github:

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -3,7 +3,7 @@ flake8~=4.0
 # Pin httpretty because of https://github.com/gabrielfalcao/HTTPretty/issues/425. version 1.1.5 should be fine when released
 git+https://github.com/gabrielfalcao/HTTPretty.git@c255165a86bef7f894c3a446b41d0b3379c5c2be
 kubernetes~=24.0
-pylint~=2.13
+pylint>=2.16
 pytest~=7.2
 pytest-cov~=4.0.0
 pytest-mock~=3.6


### PR DESCRIPTION
This change fixed lint `consider-using-with` to ensure external resources are properly handled and release when not used.

* Replace `_log_lock.acquire()` and `_log_lock. release()` with `with _log_lock`
* Fix typo `teardown_mehtod` to `teardown_method`
* Replace `tempfile.mkdtemp()` and `shutil.rmtree(wd)` with `with tempfile.TemporaryDirectory() as wd`
* Replace `Popen` with high level `subprocess.run`
* Ensure `open` called using context manager `with open(...) as f:`
* Specify `pylint` version to `>=2.16` so all options in `.pylintrc` are supported