### PR TITLE
fix typo in env variable in run.sh

### DIFF
--- a/dev/run.sh
+++ b/dev/run.sh
@@ -8,10 +8,10 @@ DEBUGPY_PORT=${DEBUGPY_PORT:-5678}
 if [[ -n "$QONTRACT_CLI_COMMAND" ]]; then
     if [ "$QONTRACT_CLI_COMMAND" == "app-interface-reporter" ]; then
         COMMAND="tools/app_interface_reporter.py"
-        COMMAD_EXTRA_ARGS="--gitlab-project-id=app-interface --reports-path=/tmp/report"
+        COMMAND_EXTRA_ARGS="--gitlab-project-id=app-interface --reports-path=/tmp/report"
     else
         COMMAND="${COMMAND:-tools/qontract_cli.py}"
-        COMMAD_EXTRA_ARGS="$QONTRACT_CLI_COMMAND"
+        COMMAND_EXTRA_ARGS="$QONTRACT_CLI_COMMAND"
     fi
 fi
 COMMAND="${COMMAND:-dockerfiles/hack/run-integration.py}"
@@ -19,12 +19,12 @@ COMMAND="${COMMAND:-dockerfiles/hack/run-integration.py}"
 
 # set default options
 if [ "$COMMAND" == "tools/qontract_cli.py" ]; then
-    COMMAD_EXTRA_ARGS="--config ${CONFIG} ${COMMAD_EXTRA_ARGS}"
+    COMMAND_EXTRA_ARGS="--config ${CONFIG} ${COMMAND_EXTRA_ARGS}"
 else
-    COMMAD_EXTRA_ARGS="--config ${CONFIG} ${DRY_RUN} ${COMMAD_EXTRA_ARGS}"
+    COMMAND_EXTRA_ARGS="--config ${CONFIG} ${DRY_RUN} ${COMMAND_EXTRA_ARGS}"
 fi
 
-echo "Running command: $COMMAND $COMMAD_EXTRA_ARGS"
+echo "Running command: $COMMAND $COMMAND_EXTRA_ARGS"
 # adding /work to the command so we can it from the root of the repo
 COMMAND="/work/$COMMAND"
 
@@ -34,4 +34,4 @@ if [ "$DEBUGGER" == "debugpy" ]; then
 fi
 
 # shellcheck disable=SC2086
-exec $COMMAND $COMMAD_EXTRA_ARGS
+exec $COMMAND $COMMAND_EXTRA_ARGS


### PR DESCRIPTION
<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at d1fa831</samp>

### Summary
🐛📝🚀

<!--
1.  🐛 - This emoji represents a bug fix, which is what correcting a typo is. The bug emoji can be used to indicate any kind of error, flaw, or malfunction that is resolved by the change.
2.  📝 - This emoji represents a documentation update, which is what changing a variable name is. The memo emoji can be used to indicate any kind of change that affects the readability, clarity, or style of the code or comments.
3.  🚀 - This emoji represents a performance improvement, which is what customizing the command options and arguments can achieve. The rocket emoji can be used to indicate any kind of change that makes the code faster, more efficient, or more scalable.
-->
Fix a typo in a dev script variable name.

> _Sing, O Muse, of the skillful coder who fixed a typo_
> _In the `COMMAND_EXTRA_ARGS` of the `run.sh` script_
> _That he might run his code with custom options and arguments_
> _And please the gods of software development with his craft_

### Walkthrough
* Fix typo in variable name `COMMAD_EXTRA_ARGS` to `COMMAND_EXTRA_ARGS` in `dev/run.sh` ([link](https://github.com/app-sre/qontract-reconcile/pull/3405/files?diff=unified&w=0#diff-88e0128c6d365e328708045142292d7aca8b4d8aa8e01444ffa9053ff27f3df5L11-R14), [link](https://github.com/app-sre/qontract-reconcile/pull/3405/files?diff=unified&w=0#diff-88e0128c6d365e328708045142292d7aca8b4d8aa8e01444ffa9053ff27f3df5L22-R27), [link](https://github.com/app-sre/qontract-reconcile/pull/3405/files?diff=unified&w=0#diff-88e0128c6d365e328708045142292d7aca8b4d8aa8e01444ffa9053ff27f3df5L37-R37))

