### PR TITLE
APPSRE-7367 turning on SAPM w/o auto-merge

### DIFF
--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request.py
@@ -2,25 +2,31 @@ import logging
 
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.mr.base import MergeRequestBase
-from reconcile.utils.mr.labels import AUTO_MERGE
+
+# from reconcile.utils.mr.labels import AUTO_MERGE
 
 LOG = logging.getLogger(__name__)
-
-
-# TODO: remove
-class DoNotPromote(Exception):
-    pass
 
 
 class SAPMMR(MergeRequestBase):
     name = "SAPM"
 
-    def __init__(self, content: str, description: str, title: str, sapm_label: str):
+    def __init__(
+        self,
+        file_path: str,
+        content: str,
+        description: str,
+        title: str,
+        sapm_label: str,
+    ):
         super().__init__()
         self._content = content
         self._title = title
         self._description = description
-        self.labels = [AUTO_MERGE, sapm_label]
+        self._file_path = file_path
+        # TODO: enable auto-merge again
+        # self.labels = [AUTO_MERGE, sapm_label]
+        self.labels = [sapm_label]
 
     @property
     def title(self) -> str:
@@ -31,12 +37,10 @@ class SAPMMR(MergeRequestBase):
         return self._description
 
     def process(self, gitlab_cli: GitLabApi) -> None:
-        # TODO: remove
-        raise DoNotPromote("I dont want to open a MR")
-        # msg = f"auto-promote {self._subscriber.desired_ref} in {self._subscriber.target_file_path}"
-        # gitlab_cli.update_file(
-        #     branch_name=self.branch,
-        #     file_path=f"data{self._subscriber.target_file_path}",
-        #     commit_message=msg,
-        #     content=self._content,
-        # )
+        msg = self._title
+        gitlab_cli.update_file(
+            branch_name=self.branch,
+            file_path=f"data{self._file_path}",
+            commit_message=msg,
+            content=self._content,
+        )

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
@@ -9,16 +9,15 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request 
     SAPMMR,
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
+    CONTENT_HASH,
+    FILE_PATH,
+    NAMESPACE_REF,
     PROMOTION_DATA_SEPARATOR,
+    SAPM_LABEL,
     Renderer,
 )
 from reconcile.saas_auto_promotions_manager.subscriber import Subscriber
 from reconcile.saas_auto_promotions_manager.utils.vcs import VCS
-
-SAPM_LABEL = "SAPM"
-NAMESPACE_REF = "namespace_ref"
-CONTENT_HASH = "content_hash"
-TARGET_FILE_PATH = "target_file_path"
 
 
 @dataclass
@@ -34,9 +33,7 @@ class MergeRequestManager:
         self._vcs = vcs
         self._renderer = renderer
         self._namespace_ref_regex = re.compile(rf"{NAMESPACE_REF}: (.*)$", re.MULTILINE)
-        self._target_file_path_regex = re.compile(
-            rf"{TARGET_FILE_PATH}: (.*)$", re.MULTILINE
-        )
+        self._target_file_path_regex = re.compile(rf"{FILE_PATH}: (.*)$", re.MULTILINE)
         self._content_hash_regex = re.compile(rf"{CONTENT_HASH}: (.*)$", re.MULTILINE)
         self._open_mrs: list[OpenMergeRequest] = []
         self._open_mrs_with_problems: list[OpenMergeRequest] = []

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
@@ -65,7 +65,9 @@ class MergeRequestManager:
                     "Merge-conflict detected. Closing %s",
                     mr.attributes.get("web_url", "NO_WEBURL"),
                 )
-                self._vcs.close_app_interface_mr(mr)
+                self._vcs.close_app_interface_mr(
+                    mr, "Closing this MR because of a merge-conflict."
+                )
                 continue
             parts = desc.split(PROMOTION_DATA_SEPARATOR)
             if not len(parts) == 2:
@@ -73,7 +75,9 @@ class MergeRequestManager:
                     "Bad data separator format. Closing %s",
                     mr.attributes.get("web_url", "NO_WEBURL"),
                 )
-                self._vcs.close_app_interface_mr(mr)
+                self._vcs.close_app_interface_mr(
+                    mr, "Closing this MR because of bad data separator format."
+                )
                 continue
             promotion_data = parts[1]
 
@@ -86,7 +90,9 @@ class MergeRequestManager:
                     NAMESPACE_REF,
                     mr.attributes.get("web_url", "NO_WEBURL"),
                 )
-                self._vcs.close_app_interface_mr(mr)
+                self._vcs.close_app_interface_mr(
+                    mr, f"Closing this MR because of bad {NAMESPACE_REF} format."
+                )
                 continue
 
             target_file_path = self._apply_regex(
@@ -98,7 +104,9 @@ class MergeRequestManager:
                     FILE_PATH,
                     mr.attributes.get("web_url", "NO_WEBURL"),
                 )
-                self._vcs.close_app_interface_mr(mr)
+                self._vcs.close_app_interface_mr(
+                    mr, f"Closing this MR because of bad {FILE_PATH} format."
+                )
                 continue
 
             content_hash = self._apply_regex(
@@ -110,7 +118,9 @@ class MergeRequestManager:
                     CONTENT_HASH,
                     mr.attributes.get("web_url", "NO_WEBURL"),
                 )
-                self._vcs.close_app_interface_mr(mr)
+                self._vcs.close_app_interface_mr(
+                    mr, f"Closing this MR because of bad {CONTENT_HASH} format."
+                )
                 continue
 
             key = (target_file_path, namespace_ref, content_hash)
@@ -119,7 +129,10 @@ class MergeRequestManager:
                     "Duplicate MR detected. Closing %s",
                     mr.attributes.get("web_url", "NO_WEBURL"),
                 )
-                self._vcs.close_app_interface_mr(mr)
+                self._vcs.close_app_interface_mr(
+                    mr,
+                    "Closing this MR because there is already another MR open with identical content.",
+                )
                 continue
             seen.add(key)
 
@@ -153,7 +166,10 @@ class MergeRequestManager:
                     "Closing MR %s because it has out-dated content",
                     open_mr.raw.attributes.get("web_url", "NO_WEBURL"),
                 )
-                self._vcs.close_app_interface_mr(mr=open_mr.raw)
+                self._vcs.close_app_interface_mr(
+                    mr=open_mr.raw,
+                    comment="Closing this MR because it has out-dated content.",
+                )
             else:
                 has_open_mr_with_same_content = True
         if has_open_mr_with_same_content:

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
@@ -182,5 +182,6 @@ class MergeRequestManager:
                 content=content,
                 title=title,
                 description=description,
+                file_path=subscriber.target_file_path,
             )
         )

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
@@ -10,7 +10,17 @@ CONTENT_HASH = "content_hash"
 NAMESPACE_REF = "namespace_ref"
 FILE_PATH = "file_path"
 SAPM_DESC = """
-This is an auto-promotion triggered by app-interface.
+THIS IS A TEST MR CREATED BY APP-INTERFACE.
+
+Part of [APPSRE-7367](https://issues.redhat.com/browse/APPSRE-7367).
+AppSRE will make sure to remove this MR soon.
+
+**PLEASE DO NOT MERGE THIS!!!**
+
+This is an auto-promotion triggered by app-interface's [saas-auto-promotions-manager](https://github.com/app-sre/qontract-reconcile/tree/master/reconcile/saas_auto_promotions_manager) (SAPM).
+
+Parts of this description are used by SAPM to manage auto-promotions.
+Please do not modify or alter this description.
 """
 
 
@@ -82,14 +92,14 @@ class Renderer:
 
     def render_description(self, subscriber: Subscriber) -> str:
         return f"""
-    {SAPM_DESC}
+{SAPM_DESC}
 
-    {PROMOTION_DATA_SEPARATOR}
+{PROMOTION_DATA_SEPARATOR}
 
-    {FILE_PATH}: {subscriber.target_file_path}
-    {NAMESPACE_REF}: {subscriber.namespace_file_path}
-    {CONTENT_HASH}: {subscriber.content_hash()}
+{FILE_PATH}: {subscriber.target_file_path}
+{NAMESPACE_REF}: {subscriber.namespace_file_path}
+{CONTENT_HASH}: {subscriber.content_hash()}
         """
 
     def render_title(self, subscriber: Subscriber) -> str:
-        return "[SAPM] auto-promotion"
+        return f"Draft: [auto-promotion] for namespace {subscriber.namespace_file_path} in {subscriber.target_file_path}"

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
@@ -6,21 +6,26 @@ from reconcile.saas_auto_promotions_manager.subscriber import Subscriber
 PROMOTION_DATA_SEPARATOR = (
     "**SAPM Data - DO NOT MANUALLY CHANGE ANYTHING BELOW THIS LINE**"
 )
+SAPM_LABEL = "SAPM"
 CONTENT_HASH = "content_hash"
 NAMESPACE_REF = "namespace_ref"
 FILE_PATH = "file_path"
-SAPM_DESC = """
+SAPM_DESC = f"""
 THIS IS A TEST MR CREATED BY APP-INTERFACE.
 
-Part of [APPSRE-7367](https://issues.redhat.com/browse/APPSRE-7367).
-AppSRE will make sure to remove this MR soon.
+AppSRE will make sure to remove this MR.
+
+This is part of effort [APPSRE-7367](https://issues.redhat.com/browse/APPSRE-7367).
 
 **PLEASE DO NOT MERGE THIS!!!**
 
 This is an auto-promotion triggered by app-interface's [saas-auto-promotions-manager](https://github.com/app-sre/qontract-reconcile/tree/master/reconcile/saas_auto_promotions_manager) (SAPM).
 
+Please **do not remove the {SAPM_LABEL} label** from this MR.
+
 Parts of this description are used by SAPM to manage auto-promotions.
-Please do not modify or alter this description.
+
+Please **do not modify or alter this description**.
 """
 
 
@@ -97,7 +102,9 @@ class Renderer:
 {PROMOTION_DATA_SEPARATOR}
 
 {FILE_PATH}: {subscriber.target_file_path}
+
 {NAMESPACE_REF}: {subscriber.namespace_file_path}
+
 {CONTENT_HASH}: {subscriber.content_hash()}
         """
 

--- a/reconcile/saas_auto_promotions_manager/utils/vcs.py
+++ b/reconcile/saas_auto_promotions_manager/utils/vcs.py
@@ -38,6 +38,8 @@ class VCS:
         allow_opening_mrs: bool,
     ):
         self._dry_run = dry_run
+        self._allow_deleting_mrs = allow_deleting_mrs
+        self._allow_opening_mrs = allow_opening_mrs
         self._secret_reader = secret_reader
         self._gh_per_repo_url: dict[str, GithubRepositoryApi] = {}
         self._default_gh_token = self._get_default_gh_token(github_orgs=github_orgs)
@@ -46,8 +48,6 @@ class VCS:
             gitlab_instances=gitlab_instances
         )
         self._is_commit_sha_regex = re.compile(r"^[0-9a-f]{40}$")
-        self._allow_deleting_mrs = allow_deleting_mrs
-        self._allow_opening_mrs = allow_opening_mrs
 
     def _get_default_gh_token(
         self,
@@ -111,8 +111,12 @@ class VCS:
             return self._gitlab_instance.get_commit_sha(ref=ref, repo_url=repo_url)
         raise RuntimeError(f"Unsupported Repo URL {repo_url}")
 
-    def close_app_interface_mr(self, mr: ProjectMergeRequest) -> None:
+    def close_app_interface_mr(self, mr: ProjectMergeRequest, comment: str) -> None:
         if not self._dry_run and self._allow_deleting_mrs:
+            self._app_interface_api.add_comment_on_merge_request(
+                merge_request=mr,
+                comment=comment,
+            )
             self._app_interface_api.close(mr)
 
     def get_file_content_from_app_interface_master(self, file_path: str) -> str:

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/conftest.py
@@ -7,14 +7,12 @@ from unittest.mock import create_autospec
 import pytest
 from gitlab.v4.objects import ProjectMergeRequest
 
-from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request_manager import (
+from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
     CONTENT_HASH,
+    FILE_PATH,
     NAMESPACE_REF,
     PROMOTION_DATA_SEPARATOR,
     SAPM_LABEL,
-    TARGET_FILE_PATH,
-)
-from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
     Renderer,
 )
 from reconcile.saas_auto_promotions_manager.subscriber import Subscriber
@@ -44,7 +42,7 @@ def mr_builder() -> Callable[[Mapping], ProjectMergeRequest]:
                 "description": f"""
                 {PROMOTION_DATA_SEPARATOR}
                 {NAMESPACE_REF}: {data.get(SUBSCRIBER_NAMESPACE_REF, "namespace_ref")}
-                {TARGET_FILE_PATH}: {data.get(SUBSCRIBER_TARGET_PATH, "target_path")}
+                {FILE_PATH}: {data.get(SUBSCRIBER_TARGET_PATH, "target_path")}
                 {CONTENT_HASH}: {data.get(SUBSCRIBER_CONTENT_HASH, "content_hash")}
                 """,
                 "web_url": "http://localhost",

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_housekeeping.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_housekeeping.py
@@ -4,14 +4,14 @@ from collections.abc import (
 )
 
 from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request_manager import (
-    CONTENT_HASH,
-    NAMESPACE_REF,
-    SAPM_LABEL,
-    TARGET_FILE_PATH,
     MergeRequestManager,
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
+    CONTENT_HASH,
+    FILE_PATH,
+    NAMESPACE_REF,
     PROMOTION_DATA_SEPARATOR,
+    SAPM_LABEL,
     Renderer,
 )
 from reconcile.saas_auto_promotions_manager.utils.vcs import VCS
@@ -57,7 +57,7 @@ def test_valid_description(vcs_builder: Callable[[Mapping], VCS], renderer: Rend
                     Blabla
                     {PROMOTION_DATA_SEPARATOR}
                     {NAMESPACE_REF}: some_ref
-                    {TARGET_FILE_PATH}: some_target
+                    {FILE_PATH}: some_target
                     {CONTENT_HASH}: some_hash
                 """,
                 }
@@ -84,7 +84,7 @@ def test_bad_mrs(vcs_builder: Callable[[Mapping], VCS], renderer: Renderer):
                     Blabla
                     {PROMOTION_DATA_SEPARATOR}
                     missing-namespace-key: some_ref
-                    {TARGET_FILE_PATH}: some_target
+                    {FILE_PATH}: some_target
                     {CONTENT_HASH}: some_hash
                 """,
                 },
@@ -104,7 +104,7 @@ def test_bad_mrs(vcs_builder: Callable[[Mapping], VCS], renderer: Renderer):
                     Blabla
                     {PROMOTION_DATA_SEPARATOR}
                     {NAMESPACE_REF}: some_ref
-                    {TARGET_FILE_PATH}: some_target
+                    {FILE_PATH}: some_target
                     missing-content-hash-key: some_hash
                 """,
                 },
@@ -114,7 +114,7 @@ def test_bad_mrs(vcs_builder: Callable[[Mapping], VCS], renderer: Renderer):
                     Blabla
                     missing-data-separator
                     {NAMESPACE_REF}: some_ref
-                    {TARGET_FILE_PATH}: some_target
+                    {FILE_PATH}: some_target
                     {CONTENT_HASH}: some_hash
                 """,
                 },
@@ -124,7 +124,7 @@ def test_bad_mrs(vcs_builder: Callable[[Mapping], VCS], renderer: Renderer):
                     bad order
                     {NAMESPACE_REF}: some_ref
                     {PROMOTION_DATA_SEPARATOR}
-                    {TARGET_FILE_PATH}: some_target
+                    {FILE_PATH}: some_target
                     {CONTENT_HASH}: some_hash
                 """,
                 },
@@ -136,7 +136,7 @@ def test_bad_mrs(vcs_builder: Callable[[Mapping], VCS], renderer: Renderer):
                     Blabla
                     {PROMOTION_DATA_SEPARATOR}
                     {NAMESPACE_REF}: some_ref
-                    {TARGET_FILE_PATH}: some_target
+                    {FILE_PATH}: some_target
                     {CONTENT_HASH}: some_hash
                 """,
                 },

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/files/single_namespace.result.yml
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/files/single_namespace.result.yml
@@ -1,5 +1,10 @@
 ---
 $schema: /app-sre/saas-file-2.yml
+
+# Some comment
+imagePatterns:
+- some/pattern
+
 resourceTemplates:
 - name: template
   url: http://localhost/repo

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/files/single_namespace.yml
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/files/single_namespace.yml
@@ -1,5 +1,10 @@
 ---
 $schema: /app-sre/saas-file-2.yml
+
+# Some comment
+imagePatterns:
+- some/pattern
+
 resourceTemplates:
 - name: template
   url: http://localhost/repo

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/files/single_namespace_no_hash.result.yml
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/files/single_namespace_no_hash.result.yml
@@ -1,5 +1,6 @@
 ---
 $schema: /app-sre/saas-file-2.yml
+
 resourceTemplates:
 - name: template
   url: http://localhost/repo

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/files/single_namespace_no_hash.yml
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/files/single_namespace_no_hash.yml
@@ -1,5 +1,6 @@
 ---
 $schema: /app-sre/saas-file-2.yml
+
 resourceTemplates:
 - name: template
   url: http://localhost/repo

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -403,6 +403,12 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         note.delete()
 
+    def add_comment_on_merge_request(
+        self, merge_request: ProjectMergeRequest, comment: str
+    ) -> None:
+        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
+        merge_request.notes.create({"body": comment})
+
     def add_merge_request_comment(self, mr_id, comment):
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         merge_request = self.project.mergerequests.get(mr_id)


### PR DESCRIPTION
Next step of gradual rollout of SAPM. It will create and manage promotion MRs in Draft mode **without auto-merge**. This behavior can be turned on/off via unleash flags.

**Background**

SAPM has been running successfully  in dry-run mode for some time now. It is time now to allow SAPM to actually open and manage promotion MRs without any of them being merged, i.e., without doing any actual auto-promotion.

**Details**

In this PR the auto-merge tag is removed and draft mode is active, i.e., these MRs will not get merged automatically. Once they go stale (merge-conflict or newer promotion detected), SAPM will close them on its own, i.e., the MRs will clean-up on their own over time.

Doing this we can have SAPM run in parallel with the current auto-promotion mechanism and observe what it does w/o creating too much havoc.

All MRs are created with the `SAPM` label, i.e., worst-case it is fairly simple to find and close them all manually/scripted.

Since this opens draft MRs, none will trigger a MR check or ping any tenants to review.

Further, some minor changes to the housekeeping logic are introduced here.