### PR TITLE
Add error handling for already decoded strings in get_api_resources

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -711,27 +711,33 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
         cmd = ["sa", "-n", namespace, "get-token", name]
         return self._run(cmd)
 
+    def _process_api_resources(self, results):
+        for line in results:
+            r = line.split()
+            kind = r[-1]
+            namespaced = r[-2].lower() == "true"
+            group_version = r[-3].split("/", 1)
+            # Core group (v1)
+            group = ""
+            api_version = group_version
+            if len(group_version) > 1:
+                # group/version
+                group = group_version[0]
+                api_version = group_version[1]
+            obj = OCDeprecatedApiResource(kind, group, api_version, namespaced)
+            d = self.api_resources.setdefault(kind, [])
+            d.append(obj)
+
     def get_api_resources(self):
         with self.api_resources_lock:
             if not self.api_resources:
                 cmd = ["api-resources", "--no-headers"]
-                results = self._run(cmd).decode("utf-8").split("\n")
-                for line in results:
-                    r = line.split()
-                    kind = r[-1]
-                    namespaced = r[-2].lower() == "true"
-                    group_version = r[-3].split("/", 1)
-                    # Core group (v1)
-                    group = ""
-                    api_version = group_version
-                    if len(group_version) > 1:
-                        # group/version
-                        group = group_version[0]
-                        api_version = group_version[1]
-                    obj = OCDeprecatedApiResource(kind, group, api_version, namespaced)
-                    d = self.api_resources.setdefault(kind, [])
-                    d.append(obj)
-
+                try:
+                    results = self._run(cmd).decode("utf-8").split("\n")
+                    self._process_api_resources(results)
+                except AttributeError:
+                    results = self._run(cmd).split("\n")
+                    self._process_api_resources(results)
         return self.api_resources
 
     def get_version(self):


### PR DESCRIPTION
A recent change modified the behavior of `OCDeprecated._run()` to sometimes return undecoded strings and other times return utf-8 decoded strings. Thus in FedRamp where we only utilize `OCDeprecated`, we were seeing the following error in PR checks:

```py
File "/usr/local/lib/python3.9/site-packages/reconcile/utils/oc.py", line 371, in _init_old_without_types
  self.api_resources = self.get_api_resources()
File "/usr/local/lib/python3.9/site-packages/reconcile/utils/oc.py", line 718, in get_api_resources
  results = self._run(cmd).decode("utf-8").split("\n")
AttributeError: 'str' object has no attribute 'decode'
```

This adds error handling so that if a string is already utf-8 decoded, `decode()` isn't called again.