### PR TITLE
APPSRE-7414 promotion-state for utils

### DIFF
--- a/reconcile/saas_auto_promotions_manager/integration.py
+++ b/reconcile/saas_auto_promotions_manager/integration.py
@@ -17,9 +17,6 @@ from reconcile.saas_auto_promotions_manager.subscriber import (
     ConfigHash,
     Subscriber,
 )
-from reconcile.saas_auto_promotions_manager.utils.deployment_state import (
-    DeploymentState,
-)
 from reconcile.saas_auto_promotions_manager.utils.saas_files_inventory import (
     SaasFilesInventory,
 )
@@ -31,6 +28,7 @@ from reconcile.typed_queries.github_orgs import get_github_orgs
 from reconcile.typed_queries.gitlab_instances import get_gitlab_instances
 from reconcile.typed_queries.saas_files import get_saas_files
 from reconcile.utils.defer import defer
+from reconcile.utils.promotion_state import PromotionState
 from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.state import init_state
@@ -43,7 +41,7 @@ QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 class SaasAutoPromotionsManager:
     def __init__(
         self,
-        deployment_state: DeploymentState,
+        deployment_state: PromotionState,
         vcs: VCS,
         saas_file_inventory: SaasFilesInventory,
         merge_request_manager: MergeRequestManager,
@@ -105,7 +103,7 @@ class SaasAutoPromotionsManager:
 
 def init_external_dependencies(
     dry_run: bool,
-) -> tuple[DeploymentState, VCS, SaasFilesInventory, MergeRequestManager]:
+) -> tuple[PromotionState, VCS, SaasFilesInventory, MergeRequestManager]:
     """
     Lets initialize everything that involves calls to external dependencies:
     - VCS -> Gitlab / Github queries
@@ -138,7 +136,7 @@ def init_external_dependencies(
     )
     saas_files = get_saas_files()
     saas_inventory = SaasFilesInventory(saas_files=saas_files)
-    deployment_state = DeploymentState(
+    deployment_state = PromotionState(
         state=init_state(integration=OPENSHIFT_SAAS_DEPLOY, secret_reader=secret_reader)
     )
     return deployment_state, vcs, saas_inventory, merge_request_manager

--- a/reconcile/saas_auto_promotions_manager/publisher.py
+++ b/reconcile/saas_auto_promotions_manager/publisher.py
@@ -1,10 +1,10 @@
 from typing import Optional
 
-from reconcile.saas_auto_promotions_manager.utils.deployment_state import (
-    DeploymentInfo,
-    DeploymentState,
-)
 from reconcile.saas_auto_promotions_manager.utils.vcs import VCS
+from reconcile.utils.promotion_state import (
+    PromotionInfo,
+    PromotionState,
+)
 from reconcile.utils.secret_reader import HasSecret
 
 
@@ -20,10 +20,10 @@ class Publisher:
         self._auth_code = auth_code
         self.channels: set[str] = set()
         self.commit_sha: str = ""
-        self.deployment_info_by_channel: dict[str, Optional[DeploymentInfo]] = {}
+        self.deployment_info_by_channel: dict[str, Optional[PromotionInfo]] = {}
 
     def fetch_commit_shas_and_deployment_info(
-        self, vcs: VCS, deployment_state: DeploymentState
+        self, vcs: VCS, deployment_state: PromotionState
     ) -> None:
         self.commit_sha = vcs.get_commit_sha(
             auth_code=self._auth_code,
@@ -32,7 +32,7 @@ class Publisher:
         )
         for channel in self.channels:
             self.deployment_info_by_channel[channel] = None
-            deployment_info = deployment_state.get_deployment_info(
+            deployment_info = deployment_state.get_promotion_info(
                 sha=self.commit_sha,
                 channel=channel,
             )

--- a/reconcile/saas_auto_promotions_manager/subscriber.py
+++ b/reconcile/saas_auto_promotions_manager/subscriber.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from reconcile.saas_auto_promotions_manager.publisher import Publisher
-from reconcile.saas_auto_promotions_manager.utils.deployment_state import DeploymentInfo
+from reconcile.utils.promotion_state import PromotionInfo
 
 CONTENT_HASH_LENGTH = 32
 
@@ -48,7 +48,7 @@ class Subscriber:
 
     def _validate_deployment(
         self, publisher: Publisher, channel: Channel
-    ) -> Optional[DeploymentInfo]:
+    ) -> Optional[PromotionInfo]:
         deployment_info = publisher.deployment_info_by_channel.get(channel.name)
         if not deployment_info:
             logging.info(

--- a/reconcile/test/saas_auto_promotions_manager/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/conftest.py
@@ -14,7 +14,6 @@ import pytest
 from reconcile.saas_auto_promotions_manager.utils.vcs import VCS
 from reconcile.typed_queries.saas_files import SaasFile
 from reconcile.utils.gitlab_api import GitLabApi
-from reconcile.utils.state import State
 
 
 @pytest.fixture

--- a/reconcile/test/saas_auto_promotions_manager/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/conftest.py
@@ -59,20 +59,6 @@ def vcs_builder() -> Callable[..., VCS]:
 
 
 @pytest.fixture
-def s3_state_builder() -> Callable[[Mapping], State]:
-    def builder(data: Mapping) -> State:
-        def get(key: str) -> dict:
-            return data["get"][key]
-
-        state = create_autospec(spec=State)
-        state.get = get
-        state.ls.side_effect = [data["ls"]]
-        return state
-
-    return builder
-
-
-@pytest.fixture
 def gql_client_builder() -> Callable[..., GitLabApi]:
     def builder() -> GitLabApi:
         api = create_autospec(spec=GitLabApi)

--- a/reconcile/test/saas_auto_promotions_manager/subscriber/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/subscriber/conftest.py
@@ -14,7 +14,7 @@ from reconcile.saas_auto_promotions_manager.subscriber import (
     ConfigHash,
     Subscriber,
 )
-from reconcile.saas_auto_promotions_manager.utils.deployment_state import DeploymentInfo
+from reconcile.utils.promotion_state import PromotionInfo
 
 from .data_keys import (
     CHANNELS,
@@ -56,7 +56,7 @@ def subscriber_builder() -> Callable[[Mapping[str, Any]], Subscriber]:
                     auth_code=None,
                 )
                 publisher.commit_sha = publisher_data[REAL_WORLD_SHA]
-                publisher.deployment_info_by_channel[channel_name] = DeploymentInfo(
+                publisher.deployment_info_by_channel[channel_name] = PromotionInfo(
                     success=publisher_data.get(SUCCESSFUL_DEPLOYMENT, True),
                     target_config_hash=publisher_data.get(CONFIG_HASH, ""),
                     saas_file=publisher_name,

--- a/reconcile/test/saas_auto_promotions_manager/test_integration_test.py
+++ b/reconcile/test/saas_auto_promotions_manager/test_integration_test.py
@@ -12,14 +12,12 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request_
 from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
     Renderer,
 )
-from reconcile.saas_auto_promotions_manager.utils.deployment_state import (
-    DeploymentState,
-)
 from reconcile.saas_auto_promotions_manager.utils.saas_files_inventory import (
     SaasFilesInventory,
 )
 from reconcile.saas_auto_promotions_manager.utils.vcs import VCS
 from reconcile.typed_queries.saas_files import SaasFile
+from reconcile.utils.promotion_state import PromotionState
 from reconcile.utils.state import State
 
 
@@ -88,7 +86,7 @@ def test_integration_test(
         ]
     )
     vcs = vcs_builder()
-    deployment_state = DeploymentState(
+    deployment_state = PromotionState(
         state=s3_state_builder(
             {
                 "ls": [

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -3,9 +3,9 @@ from collections.abc import (
     Mapping,
 )
 
-from reconcile.saas_auto_promotions_manager.utils.deployment_state import (
-    DeploymentInfo,
-    DeploymentState,
+from reconcile.utils.promotion_state import (
+    PromotionInfo,
+    PromotionState,
 )
 from reconcile.utils.state import State
 
@@ -23,9 +23,9 @@ def test_key_exists(s3_state_builder: Callable[[Mapping], State]):
             },
         }
     )
-    deployment_state = DeploymentState(state=state)
-    deployment_info = deployment_state.get_deployment_info(channel="channel", sha="sha")
-    assert deployment_info == DeploymentInfo(
+    deployment_state = PromotionState(state=state)
+    deployment_info = deployment_state.get_promotion_info(channel="channel", sha="sha")
+    assert deployment_info == PromotionInfo(
         success=True,
         target_config_hash="hash",
         saas_file="saas_file",
@@ -39,6 +39,6 @@ def test_key_does_not_exist(s3_state_builder: Callable[[Mapping], State]):
             "get": {},
         }
     )
-    deployment_state = DeploymentState(state=state)
-    deployment_info = deployment_state.get_deployment_info(channel="channel", sha="sha")
+    deployment_state = PromotionState(state=state)
+    deployment_info = deployment_state.get_promotion_info(channel="channel", sha="sha")
     assert deployment_info is None

--- a/reconcile/utils/promotion_state.py
+++ b/reconcile/utils/promotion_state.py
@@ -38,10 +38,11 @@ class PromotionState:
     def _fetch_promotions_list(self) -> None:
         all_keys = self._state.ls()
         for commit in all_keys:
+            # Format: /promotions/{channel}/{commit-sha}
             if not commit.startswith("/promotions/"):
                 continue
-            parts = commit.split("/")
-            self._commits_by_channel[parts[2]].add(parts[3])
+            _, _, channel_name, commit_sha = commit.split("/")
+            self._commits_by_channel[channel_name].add(commit_sha)
 
     def get_promotion_info(self, sha: str, channel: str) -> Optional[PromotionInfo]:
         if sha not in self._commits_by_channel[channel]:

--- a/reconcile/utils/promotion_state.py
+++ b/reconcile/utils/promotion_state.py
@@ -9,7 +9,7 @@ from pydantic import (
 from reconcile.utils.state import State
 
 
-class DeploymentInfo(BaseModel):
+class PromotionInfo(BaseModel):
     """
     A class that strictly corresponds to the json stored in S3
     """
@@ -23,19 +23,19 @@ class DeploymentInfo(BaseModel):
         extra = Extra.forbid
 
 
-class DeploymentState:
+class PromotionState:
     """
     A wrapper around a reconcile.utils.state.State object.
-    This is dedicated to retrieving information about
-    deployments from S3.
+    This is dedicated to storing and retrieving information
+    about promotions on S3.
     """
 
     def __init__(self, state: State):
         self._state = state
         self._commits_by_channel: dict[str, set[str]] = defaultdict(set)
-        self._fetch_deployment_list()
+        self._fetch_promotions_list()
 
-    def _fetch_deployment_list(self) -> None:
+    def _fetch_promotions_list(self) -> None:
         all_keys = self._state.ls()
         for commit in all_keys:
             if not commit.startswith("/promotions/"):
@@ -43,9 +43,9 @@ class DeploymentState:
             parts = commit.split("/")
             self._commits_by_channel[parts[2]].add(parts[3])
 
-    def get_deployment_info(self, sha: str, channel: str) -> Optional[DeploymentInfo]:
+    def get_promotion_info(self, sha: str, channel: str) -> Optional[PromotionInfo]:
         if sha not in self._commits_by_channel[channel]:
             return None
         key = f"promotions/{channel}/{sha}"
         data = self._state.get(key)
-        return DeploymentInfo(**data)
+        return PromotionInfo(**data)


### PR DESCRIPTION
This is an attempt to make SAPM's DeploymentState usable by multiple integrations. In a next step, `openshift-saas-deploy` will use `DeploymentState` to store information about promotion. Afterwards we will make changes to this class to support multiple publishers per channel. 

In a gist what happens:

- Rename SAPM's `DeploymentState` to `PromotionState`
- Move `PromotionState` to general utlis module