### PR TITLE
[APPSRE-7463] OCConnectionParameters should support flexible vault token field

### DIFF
--- a/reconcile/test/fixtures/oc_connection_parameters/cluster_custom_token.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/cluster_custom_token.yml
@@ -1,0 +1,91 @@
+---
+path: test.yml
+name: test-cluster
+additionalRouters: null
+addons: null
+auth: []
+automationToken:
+  field: automationToken
+  format: null
+  path: path/to/automation_token
+  version: null
+awsInfrastructureAccess: []
+awsInfrastructureManagementAccounts: []
+clusterAdmin: false
+clusterAdminAutomationToken:
+  field: token
+  format: null
+  path: path/to/cluster_admin_token
+  version: null
+consoleUrl: test-url
+disable: null
+elbFQDN: elb-url
+externalConfiguration: null
+insecureSkipTLSVerify: null
+internal: false
+jumpHost: null
+kibanaUrl: ''
+machinePools: null
+managedClusterRoles: true
+managedGroups: []
+
+network:
+  pod: 10.10.10.0/14
+  service: 10.10.0.0/16
+  type: OpenShiftSDN
+  vpc: 10.10.10.0/22
+ocm:
+  environment:
+    name: name
+    url: ocm-url
+    accessTokenClientId: client-id
+    accessTokenClientSecret:
+      field: client_secret
+      format: null
+      path: path/to/client_secret
+      version: null
+    accessTokenUrl: access-token-url
+  accessTokenClientId: client-id
+  accessTokenClientSecret:
+    field: client_secret
+    format: null
+    path: path/to/client_secret
+    version: null
+  accessTokenUrl: access-token-url
+  blockedVersions: []
+  inheritVersionData: null
+  name: ocm-production
+  sectors: null
+  orgId: org-id
+peering:
+  connections: []
+prometheusUrl: prom-url
+serverUrl: server-url
+spec:
+  autoscale:
+    max_replicas: 2
+    min_replicas: 1
+  channel: candidate
+  disable_user_workload_monitoring: true
+  external_id: some-id
+  hypershift: null
+  id: some-other-id
+  initial_version: 1.0.0
+  instance_type: m5.xlarge
+  load_balancers: 0
+  multi_az: true
+  nodes: null
+  private: true
+  product: osd
+  provider: aws
+  provision_shard_id: shard-id
+  region: us-east-1
+  storage: 100
+  version: 1.0.0
+upgradePolicy:
+  conditions:
+    mutexes: null
+    sector: null
+    soakDays: 7
+  schedule: 0 12 * * 1-5
+  workloads: []

--- a/reconcile/test/oc/test_oc_connection_parameters.py
+++ b/reconcile/test/oc/test_oc_connection_parameters.py
@@ -155,6 +155,24 @@ def test_wrong_server_url():
         assert parameters is None
 
 
+def test_custom_token_field():
+    test_cluster = load_cluster_for_connection_parameters("cluster_custom_token.yml")
+
+    secret_reader = create_autospec(SecretReaderBase)
+    secret_reader.read_secret.side_effect = ["secret2"]
+    secret_reader.read_all_secret.side_effect = [
+        {"server": "server-url", "automationToken": "secret1", "username": "foo"}
+    ]
+
+    parameters = OCConnectionParameters.from_cluster(
+        secret_reader=secret_reader,
+        cluster=test_cluster,
+        cluster_admin=False,
+        use_jump_host=False,
+    )
+    assert parameters.automation_token == "secret1"
+
+
 @dataclass
 class ExpectedConnection:
     cluster_name: str

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -123,7 +123,7 @@ class OCConnectionParameters:
         return OCConnectionParameters._get_token_verify_server_url(
             ClusterSecret(
                 server=secret_raw["server"],
-                token=secret_raw["token"],
+                token=secret_raw[secret.field],
                 username=secret_raw["username"],
             ),
             cluster,


### PR DESCRIPTION
Fix for #3354 so that `automationToken` no longer assumes that `token` is always the field specified for a cluster file. Also adds a test for it.

https://issues.redhat.com/browse/APPSRE-7463