### PR TITLE
[jsonpath parsing] speed up jsonpath expression parsing

### DIFF
--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -23,7 +23,6 @@ import anymarkup
 import jinja2
 import jinja2.meta
 import jsonpath_ng
-import jsonpath_ng.ext
 import networkx
 
 from reconcile.change_owners.approver import (
@@ -49,6 +48,7 @@ from reconcile.gql_definitions.change_owners.queries.change_types import (
     ChangeTypeV1,
 )
 from reconcile.utils.jsonpath import (
+    parse_jsonpath,
     remove_prefix_from_path,
     sortable_jsonpath_string_repr,
 )
@@ -405,7 +405,7 @@ class PathExpression:
                 )
             self.template = env.from_string(self.jsonpath_expression)
         else:
-            self.parsed_jsonpath = jsonpath_ng.ext.parse(jsonpath_expression)
+            self.parsed_jsonpath = parse_jsonpath(jsonpath_expression)
 
     def jsonpath_for_context(self, ctx: "ChangeTypeContext") -> jsonpath_ng.JSONPath:
         if self.parsed_jsonpath:
@@ -416,7 +416,7 @@ class PathExpression:
                 self.CTX_FILE_PATH_VAR_NAME: ctx.context_file.path,
             }
         )
-        return jsonpath_ng.ext.parse(expr)
+        return parse_jsonpath(expr)
 
     def __eq__(self, obj):
         return (
@@ -815,9 +815,7 @@ def init_change_type_processors(
                 ownership_context = None
                 if change_detector.context:
                     ownership_context = OwnershipContext(
-                        selector=jsonpath_ng.ext.parse(
-                            change_detector.context.selector
-                        ),
+                        selector=parse_jsonpath(change_detector.context.selector),
                         when=change_detector.context.when,
                     )
                 processor.add_change_detector(
@@ -843,7 +841,7 @@ def init_change_type_processors(
                         ContextExpansion(
                             change_type=processor,
                             context=OwnershipContext(
-                                selector=jsonpath_ng.ext.parse(
+                                selector=parse_jsonpath(
                                     change_detector.ownership_context.selector
                                 ),
                                 when=change_detector.ownership_context.when,

--- a/reconcile/change_owners/diff.py
+++ b/reconcile/change_owners/diff.py
@@ -11,10 +11,11 @@ from typing import (
 )
 
 import jsonpath_ng
-import jsonpath_ng.ext
 from deepdiff import DeepDiff
 from deepdiff.helper import CannotCompare
 from deepdiff.model import DiffLevel
+
+from reconcile.utils.jsonpath import parse_jsonpath
 
 
 class DiffType(Enum):
@@ -43,7 +44,7 @@ class Diff:
         if self.path == jsonpath_ng.Root():
             absolute_sub_path = sub_path
         elif sub_path_str.startswith(self.path_str()):
-            absolute_sub_path = jsonpath_ng.ext.parse(
+            absolute_sub_path = parse_jsonpath(
                 f"${sub_path_str[len(self.path_str()):]}"
             )
         else:

--- a/reconcile/change_owners/implicit_ownership.py
+++ b/reconcile/change_owners/implicit_ownership.py
@@ -1,7 +1,5 @@
 import logging
 
-import jsonpath_ng.ext
-
 from reconcile.change_owners.approver import ApproverResolver
 from reconcile.change_owners.change_types import (
     BundleFileChange,
@@ -11,6 +9,7 @@ from reconcile.change_owners.change_types import (
 from reconcile.gql_definitions.change_owners.queries.change_types import (
     ChangeTypeImplicitOwnershipJsonPathProviderV1,
 )
+from reconcile.utils.jsonpath import parse_jsonpath
 
 
 def cover_changes_with_implicit_ownership(
@@ -96,7 +95,7 @@ def find_approvers_with_implicit_ownership_jsonpath_selector(
 
     return {
         owner_ref.value
-        for owner_ref in jsonpath_ng.ext.parse(
-            implicit_ownership.json_path_selector
-        ).find(context_file_content)
+        for owner_ref in parse_jsonpath(implicit_ownership.json_path_selector).find(
+            context_file_content
+        )
     }

--- a/reconcile/test/test_utils_jsonpath.py
+++ b/reconcile/test/test_utils_jsonpath.py
@@ -18,6 +18,7 @@ from reconcile.utils.jsonpath import (
     apply_constraint_to_path,
     jsonpath_parts,
     narrow_jsonpath_node,
+    parse_jsonpath,
     remove_prefix_from_path,
     sortable_jsonpath_string_repr,
 )
@@ -265,3 +266,21 @@ def test_sortable_jsonpath_string_repr(jsonpath: str, sortable_jsonpath: str):
 def test_remove_prefix_from_path(path: str, prefix: str, expected: Optional[str]):
     expected_path = parse(expected) if expected else None
     assert remove_prefix_from_path(parse(path), parse(prefix)) == expected_path
+
+
+#
+# P A R S I N G
+#
+
+
+@pytest.mark.parametrize(
+    "path, rendered",
+    [
+        # simple path for the regular parser
+        ("a.b.c", "a.b.c"),
+        # this one requires the extended parser
+        ("a[?(@.b=='b')]", "a.[?[Expression(Child(This(), Fields('b')) == 'b')]]"),
+    ],
+)
+def test_parse_jsonpath(path: str, rendered: str):
+    assert str(parse_jsonpath(path)) == rendered


### PR DESCRIPTION
With more and more jsonpaths being added to existing and new change-types, parsing those has a noticeable performance impact.

There are two parsers for jsonpath expressions, a simple one and an extended one. the simple one is considerably faster and works for most of the expressions. the extended parser is required when filters are involved. For now we can detect the difference between those two types expressions by looking for a filter literal and choose the appropriate parser.

https://issues.redhat.com/browse/APPSRE-7467