### PR TITLE
APPSRE-7367 fix renderer

### DIFF
--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
@@ -53,7 +53,7 @@ class Renderer:
                     continue
                 if not bool(target_promotion.get("auto", False)):
                     continue
-                subscriber_channels = set([ch.name for ch in subscriber.channels])
+                subscriber_channels = {ch.name for ch in subscriber.channels}
                 target_channels = set(target_promotion.get("subscribe", []))
                 if subscriber_channels != target_channels:
                     continue

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
@@ -51,6 +51,12 @@ class Renderer:
                 target_promotion = target.get("promotion")
                 if not target_promotion:
                     continue
+                if not bool(target_promotion.get("auto", False)):
+                    continue
+                subscriber_channels = set([ch.name for ch in subscriber.channels])
+                target_channels = set(target_promotion.get("subscribe", []))
+                if subscriber_channels != target_channels:
+                    continue
                 targets.append(target)
         return targets
 

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/conftest.py
@@ -6,13 +6,16 @@ from collections.abc import (
 
 import pytest
 
-from reconcile.saas_auto_promotions_manager.subscriber import Subscriber, Channel
+from reconcile.saas_auto_promotions_manager.subscriber import (
+    Channel,
+    Subscriber,
+)
 
 from .data_keys import (
+    CHANNELS,
     CONFIG_HASHES,
     NAMESPACE_PATH,
     REF,
-    CHANNELS,
 )
 
 
@@ -48,10 +51,12 @@ def subscriber_builder() -> Callable[[Mapping], Subscriber]:
         subscriber.desired_ref = data[REF]
         subscriber.desired_hashes = data[CONFIG_HASHES]
         for channel in data.get(CHANNELS, []):
-            subscriber.channels.append(Channel(
-                name=channel,
-                publishers=[],
-            ))
+            subscriber.channels.append(
+                Channel(
+                    name=channel,
+                    publishers=[],
+                )
+            )
         return subscriber
 
     return builder

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/conftest.py
@@ -6,12 +6,13 @@ from collections.abc import (
 
 import pytest
 
-from reconcile.saas_auto_promotions_manager.subscriber import Subscriber
+from reconcile.saas_auto_promotions_manager.subscriber import Subscriber, Channel
 
 from .data_keys import (
     CONFIG_HASHES,
     NAMESPACE_PATH,
     REF,
+    CHANNELS,
 )
 
 
@@ -46,6 +47,11 @@ def subscriber_builder() -> Callable[[Mapping], Subscriber]:
         )
         subscriber.desired_ref = data[REF]
         subscriber.desired_hashes = data[CONFIG_HASHES]
+        for channel in data.get(CHANNELS, []):
+            subscriber.channels.append(Channel(
+                name=channel,
+                publishers=[],
+            ))
         return subscriber
 
     return builder

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/data_keys.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/data_keys.py
@@ -1,3 +1,4 @@
 NAMESPACE_PATH = "namespace_path"
 REF = "ref"
 CONFIG_HASHES = "config_hashes"
+CHANNELS = "channels"

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/files/multiple_namespaces.result.yml
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/files/multiple_namespaces.result.yml
@@ -40,3 +40,20 @@ resourceTemplates:
         - parent_saas: parent_saas
           target_config_hash: current_hash
           type: parent_saas_config
+  - namespace:
+      $ref: /some/namespace.yml
+    ref: current_sha
+    parameters:
+      SOME: parameter
+    promotion:
+      auto: true
+      subscribe:
+      - channel-c
+  - namespace:
+      $ref: /some/namespace.yml
+    ref: current_sha
+    parameters:
+      SOME: parameter
+    promotion:
+      subscribe:
+      - channel-a

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/files/multiple_namespaces.yml
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/files/multiple_namespaces.yml
@@ -40,3 +40,20 @@ resourceTemplates:
         - parent_saas: parent_saas
           target_config_hash: current_hash
           type: parent_saas_config
+  - namespace:
+      $ref: /some/namespace.yml
+    ref: current_sha
+    parameters:
+      SOME: parameter
+    promotion:
+      auto: true
+      subscribe:
+      - channel-c
+  - namespace:
+      $ref: /some/namespace.yml
+    ref: current_sha
+    parameters:
+      SOME: parameter
+    promotion:
+      subscribe:
+      - channel-a

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/test_content_multiple_namespaces.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/test_content_multiple_namespaces.py
@@ -12,10 +12,10 @@ from reconcile.saas_auto_promotions_manager.subscriber import (
 )
 
 from .data_keys import (
+    CHANNELS,
     CONFIG_HASHES,
     NAMESPACE_PATH,
     REF,
-    CHANNELS,
 )
 
 

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/test_content_multiple_namespaces.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/test_content_multiple_namespaces.py
@@ -15,6 +15,7 @@ from .data_keys import (
     CONFIG_HASHES,
     NAMESPACE_PATH,
     REF,
+    CHANNELS,
 )
 
 
@@ -33,6 +34,7 @@ def test_content_multiple_namespaces(
                     parent_saas="parent_saas",
                 )
             ],
+            CHANNELS: ["channel-a"],
         }
     )
     saas_content, expected = file_contents("multiple_namespaces")

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/test_content_single_namespace.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/test_content_single_namespace.py
@@ -12,10 +12,10 @@ from reconcile.saas_auto_promotions_manager.subscriber import (
 )
 
 from .data_keys import (
+    CHANNELS,
     CONFIG_HASHES,
     NAMESPACE_PATH,
     REF,
-    CHANNELS,
 )
 
 
@@ -34,7 +34,7 @@ def test_content_single_namespace(
                     parent_saas="parent_saas",
                 )
             ],
-            CHANNELS: ["channel-a"]
+            CHANNELS: ["channel-a"],
         }
     )
     saas_content, expected = file_contents("single_namespace")
@@ -61,7 +61,7 @@ def test_content_single_namespace_no_hash(
                     parent_saas="parent_saas",
                 )
             ],
-            CHANNELS: ["channel-a"]
+            CHANNELS: ["channel-a"],
         }
     )
     saas_content, expected = file_contents("single_namespace_no_hash")

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/test_content_single_namespace.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/test_content_single_namespace.py
@@ -15,6 +15,7 @@ from .data_keys import (
     CONFIG_HASHES,
     NAMESPACE_PATH,
     REF,
+    CHANNELS,
 )
 
 
@@ -33,6 +34,7 @@ def test_content_single_namespace(
                     parent_saas="parent_saas",
                 )
             ],
+            CHANNELS: ["channel-a"]
         }
     )
     saas_content, expected = file_contents("single_namespace")
@@ -59,6 +61,7 @@ def test_content_single_namespace_no_hash(
                     parent_saas="parent_saas",
                 )
             ],
+            CHANNELS: ["channel-a"]
         }
     )
     saas_content, expected = file_contents("single_namespace_no_hash")


### PR DESCRIPTION
The SAPM renderer added data to targets that where not subscribed, when any target within the same saas file had a subscription.

This PR fixes that behavior by checking each targets channel subscriptions when rendering.