### PR TITLE
Reduce noise on GitLab housekeeping

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -176,7 +176,7 @@ def close_item(
             + "Please run the integration manually "
             + "with the '--enable-deletion' flag."
         )
-        logging.warning(warning_message)
+        logging.debug(warning_message)
 
 
 def handle_stale_items(dry_run, gl, days_interval, enable_closing, item_type):

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -171,12 +171,11 @@ def close_item(
         if not dry_run:
             gl.close(item)
     else:
-        warning_message = (
+        logging.debug(
             "'close_item' action is not enabled. "
             + "Please run the integration manually "
             + "with the '--enable-deletion' flag."
         )
-        logging.debug(warning_message)
 
 
 def handle_stale_items(dry_run, gl, days_interval, enable_closing, item_type):


### PR DESCRIPTION
[APPSRE-7471](https://issues.redhat.com/browse/APPSRE-7471)

This error message constantly appears in the GitLab housekeeping integration. Let's clean up that noise and have it only do a debug log message as a warning for expected behavior isn't very useful.