### PR TITLE
APPSRE-7414 saasherder uses PromotionState

### DIFF
--- a/reconcile/saas_auto_promotions_manager/integration.py
+++ b/reconcile/saas_auto_promotions_manager/integration.py
@@ -140,6 +140,7 @@ def init_external_dependencies(
     deployment_state = PromotionState(
         state=init_state(integration=OPENSHIFT_SAAS_DEPLOY, secret_reader=secret_reader)
     )
+    deployment_state.cache_commit_shas_from_s3()
     return deployment_state, vcs, saas_inventory, merge_request_manager
 
 

--- a/reconcile/saas_auto_promotions_manager/integration.py
+++ b/reconcile/saas_auto_promotions_manager/integration.py
@@ -92,6 +92,7 @@ class SaasAutoPromotionsManager:
         return subscribers_with_diff
 
     def reconcile(self) -> None:
+        self._deployment_state.cache_commit_shas_from_s3()
         self._fetch_publisher_real_world_states()
         self._compute_desired_subscriber_states()
         subscribers_with_diff = self._get_subscribers_with_diff()
@@ -140,7 +141,6 @@ def init_external_dependencies(
     deployment_state = PromotionState(
         state=init_state(integration=OPENSHIFT_SAAS_DEPLOY, secret_reader=secret_reader)
     )
-    deployment_state.cache_commit_shas_from_s3()
     return deployment_state, vcs, saas_inventory, merge_request_manager
 
 

--- a/reconcile/saas_auto_promotions_manager/publisher.py
+++ b/reconcile/saas_auto_promotions_manager/publisher.py
@@ -1,11 +1,19 @@
+from dataclasses import dataclass
 from typing import Optional
 
 from reconcile.saas_auto_promotions_manager.utils.vcs import VCS
 from reconcile.utils.promotion_state import (
-    PromotionInfo,
+    PromotionData,
     PromotionState,
 )
 from reconcile.utils.secret_reader import HasSecret
+
+
+@dataclass
+class DeploymentInfo:
+    success: bool
+    saas_file: str
+    target_config_hash: str
 
 
 class Publisher:
@@ -20,7 +28,7 @@ class Publisher:
         self._auth_code = auth_code
         self.channels: set[str] = set()
         self.commit_sha: str = ""
-        self.deployment_info_by_channel: dict[str, Optional[PromotionInfo]] = {}
+        self.deployment_info_by_channel: dict[str, Optional[DeploymentInfo]] = {}
 
     def fetch_commit_shas_and_deployment_info(
         self, vcs: VCS, deployment_state: PromotionState
@@ -32,8 +40,19 @@ class Publisher:
         )
         for channel in self.channels:
             self.deployment_info_by_channel[channel] = None
-            deployment_info = deployment_state.get_promotion_info(
+            promotion_data = deployment_state.get_promotion_data(
                 sha=self.commit_sha,
                 channel=channel,
             )
-            self.deployment_info_by_channel[channel] = deployment_info
+            if not (
+                promotion_data
+                and promotion_data.saas_file
+                and promotion_data.target_config_hash
+            ):
+                continue
+
+            self.deployment_info_by_channel[channel] = DeploymentInfo(
+                success=promotion_data.success,
+                saas_file=promotion_data.saas_file,
+                target_config_hash=promotion_data.target_config_hash,
+            )

--- a/reconcile/saas_auto_promotions_manager/publisher.py
+++ b/reconcile/saas_auto_promotions_manager/publisher.py
@@ -2,15 +2,18 @@ from dataclasses import dataclass
 from typing import Optional
 
 from reconcile.saas_auto_promotions_manager.utils.vcs import VCS
-from reconcile.utils.promotion_state import (
-    PromotionData,
-    PromotionState,
-)
+from reconcile.utils.promotion_state import PromotionState
 from reconcile.utils.secret_reader import HasSecret
 
 
 @dataclass
 class DeploymentInfo:
+    """
+    Isolate our logic from utils model.
+    Unlike utils, we strictly require saas_file
+    and target_config_hash to be set.
+    """
+
     success: bool
     saas_file: str
     target_config_hash: str

--- a/reconcile/saas_auto_promotions_manager/subscriber.py
+++ b/reconcile/saas_auto_promotions_manager/subscriber.py
@@ -4,8 +4,10 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Optional
 
-from reconcile.saas_auto_promotions_manager.publisher import Publisher
-from reconcile.utils.promotion_state import PromotionInfo
+from reconcile.saas_auto_promotions_manager.publisher import (
+    DeploymentInfo,
+    Publisher,
+)
 
 CONTENT_HASH_LENGTH = 32
 
@@ -49,7 +51,7 @@ class Subscriber:
 
     def _validate_deployment(
         self, publisher: Publisher, channel: Channel
-    ) -> Optional[PromotionInfo]:
+    ) -> Optional[DeploymentInfo]:
         deployment_info = publisher.deployment_info_by_channel.get(channel.name)
         if not deployment_info:
             logging.info(

--- a/reconcile/test/saas_auto_promotions_manager/subscriber/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/subscriber/conftest.py
@@ -8,13 +8,15 @@ from typing import Any
 
 import pytest
 
-from reconcile.saas_auto_promotions_manager.publisher import Publisher
+from reconcile.saas_auto_promotions_manager.publisher import (
+    DeploymentInfo,
+    Publisher,
+)
 from reconcile.saas_auto_promotions_manager.subscriber import (
     Channel,
     ConfigHash,
     Subscriber,
 )
-from reconcile.utils.promotion_state import PromotionInfo
 
 from .data_keys import (
     CHANNELS,
@@ -58,7 +60,7 @@ def subscriber_builder() -> Callable[[Mapping[str, Any]], Subscriber]:
                     auth_code=None,
                 )
                 publisher.commit_sha = publisher_data[REAL_WORLD_SHA]
-                publisher.deployment_info_by_channel[channel_name] = PromotionInfo(
+                publisher.deployment_info_by_channel[channel_name] = DeploymentInfo(
                     success=publisher_data.get(SUCCESSFUL_DEPLOYMENT, True),
                     target_config_hash=publisher_data.get(CONFIG_HASH, ""),
                     saas_file=publisher_name,

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -4,7 +4,7 @@ from collections.abc import (
 )
 
 from reconcile.utils.promotion_state import (
-    PromotionInfo,
+    PromotionData,
     PromotionState,
 )
 from reconcile.utils.state import State
@@ -25,8 +25,8 @@ def test_key_exists(s3_state_builder: Callable[[Mapping], State]):
     )
     deployment_state = PromotionState(state=state)
     deployment_state.cache_commit_shas_from_s3()
-    deployment_info = deployment_state.get_promotion_info(channel="channel", sha="sha")
-    assert deployment_info == PromotionInfo(
+    deployment_info = deployment_state.get_promotion_data(channel="channel", sha="sha")
+    assert deployment_info == PromotionData(
         success=True,
         target_config_hash="hash",
         saas_file="saas_file",
@@ -42,7 +42,7 @@ def test_key_does_not_exist(s3_state_builder: Callable[[Mapping], State]):
     )
     deployment_state = PromotionState(state=state)
     deployment_state.cache_commit_shas_from_s3()
-    deployment_info = deployment_state.get_promotion_info(channel="channel", sha="sha")
+    deployment_info = deployment_state.get_promotion_data(channel="channel", sha="sha")
     assert deployment_info is None
 
 
@@ -60,10 +60,10 @@ def test_key_does_not_exist_locally(s3_state_builder: Callable[[Mapping], State]
         }
     )
     deployment_state = PromotionState(state=state)
-    deployment_info = deployment_state.get_promotion_info(
+    deployment_info = deployment_state.get_promotion_data(
         channel="channel", sha="sha", local_lookup=False
     )
-    assert deployment_info == PromotionInfo(
+    assert deployment_info == PromotionData(
         success=True, target_config_hash="hash", saas_file="saas_file"
     )
 
@@ -76,12 +76,12 @@ def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
         }
     )
     deployment_state = PromotionState(state=state)
-    promotion_info = PromotionInfo(
+    promotion_info = PromotionData(
         success=True,
         target_config_hash="some_hash",
         saas_file="some_saas",
     )
-    deployment_state.publish_promotion_info(
+    deployment_state.publish_promotion_data(
         channel="channel",
         sha="sha",
         data=promotion_info,

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -24,6 +24,7 @@ def test_key_exists(s3_state_builder: Callable[[Mapping], State]):
         }
     )
     deployment_state = PromotionState(state=state)
+    deployment_state.cache_commit_shas_from_s3()
     deployment_info = deployment_state.get_promotion_info(channel="channel", sha="sha")
     assert deployment_info == PromotionInfo(
         success=True,
@@ -40,5 +41,29 @@ def test_key_does_not_exist(s3_state_builder: Callable[[Mapping], State]):
         }
     )
     deployment_state = PromotionState(state=state)
+    deployment_state.cache_commit_shas_from_s3()
     deployment_info = deployment_state.get_promotion_info(channel="channel", sha="sha")
     assert deployment_info is None
+
+
+def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
+    state = s3_state_builder(
+        {
+            "ls": [],
+            "get": {},
+        }
+    )
+    deployment_state = PromotionState(state=state)
+    promotion_info = PromotionInfo(
+        success=True,
+        target_config_hash="some_hash",
+        saas_file="some_saas",
+    )
+    deployment_state.publish_promotion_info(
+        channel="channel",
+        sha="sha",
+        data=promotion_info,
+    )
+    deployment_state._state.add.assert_called_once_with(
+        "promotions/channel/sha", promotion_info.dict(), True
+    )

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -86,6 +86,6 @@ def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
         sha="sha",
         data=promotion_info,
     )
-    deployment_state._state.add.assert_called_once_with(
+    deployment_state._state.add.assert_called_once_with(  # type: ignore[attr-defined]
         "promotions/channel/sha", promotion_info.dict(), True
     )

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -46,6 +46,28 @@ def test_key_does_not_exist(s3_state_builder: Callable[[Mapping], State]):
     assert deployment_info is None
 
 
+def test_key_does_not_exist_locally(s3_state_builder: Callable[[Mapping], State]):
+    state = s3_state_builder(
+        {
+            "ls": [],
+            "get": {
+                "promotions/channel/sha": {
+                    "success": True,
+                    "target_config_hash": "hash",
+                    "saas_file": "saas_file",
+                }
+            },
+        }
+    )
+    deployment_state = PromotionState(state=state)
+    deployment_info = deployment_state.get_promotion_info(
+        channel="channel", sha="sha", local_lookup=False
+    )
+    assert deployment_info == PromotionInfo(
+        success=True, target_config_hash="hash", saas_file="saas_file"
+    )
+
+
 def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
     state = s3_state_builder(
         {

--- a/reconcile/utils/promotion_state.py
+++ b/reconcile/utils/promotion_state.py
@@ -11,7 +11,11 @@ from reconcile.utils.state import State
 
 class PromotionData(BaseModel):
     """
-    A class that strictly corresponds to the json stored in S3
+    A class that strictly corresponds to the json stored in S3.
+
+    Note, that currently we also accomodate for missing
+    saas_file and target_config_hash because of saasherder
+    requirements.
     """
 
     success: bool

--- a/reconcile/utils/promotion_state.py
+++ b/reconcile/utils/promotion_state.py
@@ -47,12 +47,17 @@ class PromotionState:
             _, _, channel_name, commit_sha = commit.split("/")
             self._commits_by_channel[channel_name].add(commit_sha)
 
-    def get_promotion_info(self, sha: str, channel: str) -> Optional[PromotionInfo]:
-        if sha not in self._commits_by_channel[channel]:
+    def get_promotion_info(
+        self, sha: str, channel: str, local_lookup: bool = True
+    ) -> Optional[PromotionInfo]:
+        if sha not in self._commits_by_channel[channel] and local_lookup:
             # Lets reduce unecessary calls to S3
             return None
         key = f"promotions/{channel}/{sha}"
-        data = self._state.get(key)
+        try:
+            data = self._state.get(key)
+        except KeyError:
+            return None
         return PromotionInfo(**data)
 
     def publish_promotion_info(

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1717,17 +1717,16 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             # was successfully published to the subscribed channel(s)
             if promotion.subscribe:
                 for channel in promotion.subscribe:
-                    state_key = f"promotions/{channel}/{promotion.commit_sha}"
-                    stateobj = self.state.get(state_key, {})
-                    success = stateobj.get("success")
-                    if not success:
+                    info = self._promotion_state.get_promotion_info(
+                        sha=promotion.commit_sha, channel=channel, local_lookup=False
+                    )
+                    if info and info.success:
                         logging.error(
                             f"Commit {promotion.commit_sha} was not "
                             + f"published with success to channel {channel}"
                         )
                         return False
-
-                    state_config_hash = stateobj.get(TARGET_CONFIG_HASH)
+                    state_config_hash = info.target_config_hash
 
                     # This code supports current saas targets that does
                     # not have promotion_data yet


### PR DESCRIPTION
saasherder should use `PromotionState` to publish promotion data. This will make it easier to align SAPM with saasherder when we change the S3 state path layout to support multiple publishers per channel.