### PR TITLE
Update oc._run to return bytes to be backward compatible

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -711,33 +711,27 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
         cmd = ["sa", "-n", namespace, "get-token", name]
         return self._run(cmd)
 
-    def _process_api_resources(self, results):
-        for line in results:
-            r = line.split()
-            kind = r[-1]
-            namespaced = r[-2].lower() == "true"
-            group_version = r[-3].split("/", 1)
-            # Core group (v1)
-            group = ""
-            api_version = group_version
-            if len(group_version) > 1:
-                # group/version
-                group = group_version[0]
-                api_version = group_version[1]
-            obj = OCDeprecatedApiResource(kind, group, api_version, namespaced)
-            d = self.api_resources.setdefault(kind, [])
-            d.append(obj)
-
     def get_api_resources(self):
         with self.api_resources_lock:
             if not self.api_resources:
                 cmd = ["api-resources", "--no-headers"]
-                try:
-                    results = self._run(cmd).decode("utf-8").split("\n")
-                    self._process_api_resources(results)
-                except AttributeError:
-                    results = self._run(cmd).split("\n")
-                    self._process_api_resources(results)
+                results = self._run(cmd).decode("utf-8").split("\n")
+                for line in results:
+                    r = line.split()
+                    kind = r[-1]
+                    namespaced = r[-2].lower() == "true"
+                    group_version = r[-3].split("/", 1)
+                    # Core group (v1)
+                    group = ""
+                    api_version = group_version
+                    if len(group_version) > 1:
+                        # group/version
+                        group = group_version[0]
+                        api_version = group_version[1]
+                    obj = OCDeprecatedApiResource(kind, group, api_version, namespaced)
+                    d = self.api_resources.setdefault(kind, [])
+                    d.append(obj)
+
         return self.api_resources
 
     def get_version(self):

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1067,7 +1067,7 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
         return resources
 
     @retry(exceptions=(StatusCodeError, NoOutputError), max_attempts=10)
-    def _run(self, cmd, **kwargs):
+    def _run(self, cmd, **kwargs) -> bytes:
         stdin = kwargs.get("stdin")
         stdin_text = stdin.encode() if stdin else None
         result = subprocess.run(
@@ -1110,10 +1110,10 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
 
         if not result.stdout:
             if allow_not_found:
-                return "{}"
+                return b"{}"
             raise NoOutputError(err)
 
-        return result.stdout.decode("utf-8").strip()
+        return result.stdout.strip()
 
     def _run_json(self, cmd, allow_not_found=False):
         out = self._run(cmd, allow_not_found=allow_not_found)


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 90806f9</samp>

Revert #3414, Details in https://github.com/app-sre/qontract-reconcile/pull/3414#issuecomment-1502476986

Refactor the `OCDeprecated` class in `oc.py` to simplify its logic, add type hints, and ensure consistent output.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 90806f9</samp>

* Refactor `get_api_resources` method of `OCDeprecated` class to inline `_process_api_resources` logic and simplify code ([link](https://github.com/app-sre/qontract-reconcile/pull/3426/files?diff=unified&w=0#diff-006493679cf46d27e100feeb8475e6e29987fe85cca4858a1f05608b2d536dc8L714-R734))
* Add type annotation to `_run` method of `OCDeprecated` class to indicate return type of `bytes` ([link](https://github.com/app-sre/qontract-reconcile/pull/3426/files?diff=unified&w=0#diff-006493679cf46d27e100feeb8475e6e29987fe85cca4858a1f05608b2d536dc8L1076-R1070))
* Change `_run` method of `OCDeprecated` class to return `bytes` instead of decoded and stripped `str` and adjust default return value for `allow_not_found` argument accordingly ([link](https://github.com/app-sre/qontract-reconcile/pull/3426/files?diff=unified&w=0#diff-006493679cf46d27e100feeb8475e6e29987fe85cca4858a1f05608b2d536dc8L1119-R1116))