### PR TITLE
remove state-bucket env var checks in cli.py

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -22,7 +22,6 @@ from reconcile.utils.binary import (
     binary,
     binary_version,
 )
-from reconcile.utils.environ import environ
 from reconcile.utils.exceptions import PrintToFileInGitRepositoryError
 from reconcile.utils.git import is_file_in_git_repo
 from reconcile.utils.runtime.environment import init_env
@@ -613,7 +612,6 @@ def github_owners(ctx):
 
 
 @integration.command(short_help="Validate compliance of GitHub user profiles.")
-@environ(["gitlab_pr_submitter_queue_url"])
 @gitlab_project_id
 @threaded()
 @enable_deletion(default=False)
@@ -636,7 +634,6 @@ def github_users(ctx, gitlab_project_id, thread_pool_size, enable_deletion, send
     short_help="Scan GitHub repositories for leaked keys "
     "and remove them (only submits PR)."
 )
-@environ(["gitlab_pr_submitter_queue_url"])
 @gitlab_project_id
 @threaded()
 @binary(["git", "git-secrets"])
@@ -777,7 +774,6 @@ def jenkins_worker_fleets(ctx):
 @integration.command(
     short_help="Manage Jenkins jobs configurations using jenkins-jobs."
 )
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @print_only
 @config_name
 @job_name
@@ -831,7 +827,6 @@ def jenkins_webhooks_cleaner(ctx):
 
 
 @integration.command(short_help="Watch for changes in Jira boards and notify on Slack.")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def jira_watcher(ctx):
     import reconcile.jira_watcher
@@ -842,7 +837,6 @@ def jira_watcher(ctx):
 @integration.command(
     short_help="Watch for changes in Unleah feature toggles " "and notify on Slack."
 )
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def unleash_watcher(ctx):
     import reconcile.unleash_watcher
@@ -853,7 +847,6 @@ def unleash_watcher(ctx):
 @integration.command(
     short_help="Watches for OpenShift upgrades and sends notifications."
 )
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @binary(["oc", "ssh"])
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
 @threaded()
@@ -918,7 +911,6 @@ def gitlab_housekeeping(ctx, wait_for_pipeline):
 
 
 @integration.command(short_help="Listen to SQS and creates MRs out of the messages.")
-@environ(["gitlab_pr_submitter_queue_url"])
 @click.argument("gitlab-project-id")
 @click.pass_context
 def gitlab_mr_sqs_consumer(ctx, gitlab_project_id):
@@ -939,7 +931,6 @@ def aws_garbage_collector(ctx, thread_pool_size):
 @integration.command(short_help="Delete IAM access keys by access key ID.")
 @threaded()
 @account_name
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def aws_iam_keys(ctx, thread_pool_size, account_name):
     import reconcile.aws_iam_keys
@@ -950,7 +941,6 @@ def aws_iam_keys(ctx, thread_pool_size, account_name):
 
 
 @integration.command(short_help="Reset IAM user password by user reference.")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def aws_iam_password_reset(ctx):
     import reconcile.aws_iam_password_reset
@@ -981,7 +971,6 @@ def aws_ecr_image_pull_secrets(ctx, vault_output_path):
     short_help="Scan AWS support cases for reports of leaked keys and "
     "remove them (only submits PR)"
 )
-@environ(["gitlab_pr_submitter_queue_url"])
 @gitlab_project_id
 @threaded()
 @click.pass_context
@@ -1019,8 +1008,6 @@ def openshift_resources(
 
 
 @integration.command(short_help="Manage OpenShift resources defined in Saas files.")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
-@environ(["gitlab_pr_submitter_queue_url"])
 @gitlab_project_id
 @threaded()
 @throughput
@@ -1058,8 +1045,6 @@ def openshift_saas_deploy(
 )
 @click.argument("gitlab-project-id")
 @click.argument("gitlab-merge-request-id")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
-@environ(["gitlab_pr_submitter_queue_url"])  # do we need this???
 @threaded()
 @click.option(
     "--comparison-sha",
@@ -1099,7 +1084,6 @@ def saas_file_validator(ctx):
 
 
 @integration.command(short_help="Trigger deployments when a commit changed for a ref.")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @threaded()
 @binary(["oc", "ssh"])
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
@@ -1123,7 +1107,6 @@ def openshift_saas_deploy_trigger_moving_commits(
 
 
 @integration.command(short_help="Trigger deployments when upstream job runs.")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @threaded()
 @binary(["oc", "ssh"])
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
@@ -1147,7 +1130,6 @@ def openshift_saas_deploy_trigger_upstream_jobs(
 
 
 @integration.command(short_help="Trigger deployments when images are pushed.")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @threaded()
 @binary(["oc", "ssh"])
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
@@ -1171,7 +1153,6 @@ def openshift_saas_deploy_trigger_images(
 
 
 @integration.command(short_help="Trigger deployments when configuration changes.")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @threaded()
 @binary(["oc", "ssh"])
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
@@ -1255,7 +1236,6 @@ def gitlab_labeler(ctx, gitlab_project_id, gitlab_merge_request_id):
 
 @integration.command(short_help="Manages labels on OpenShift namespaces.")
 @threaded()
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @binary(["oc", "ssh"])
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
 @internal()
@@ -1560,7 +1540,6 @@ def ldap_users(ctx, infra_project_id, app_interface_project_id):
 @binary(["terraform", "oc", "git"])
 @binary_version("terraform", ["version"], TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @internal()
 @use_jump_host()
 @enable_deletion(default=False)
@@ -1871,7 +1850,6 @@ def ocm_groups(ctx, thread_pool_size):
 
 
 @integration.command(short_help="Manages clusters via OCM.")
-@environ(["gitlab_pr_submitter_queue_url"])
 @gitlab_project_id
 @threaded()
 @click.pass_context
@@ -1903,7 +1881,6 @@ def ocm_cluster_admin(ctx):
 
 
 @integration.command(short_help="Trigger jenkins jobs following Addon upgrades.")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def ocm_addons_upgrade_tests_trigger(ctx):
     import reconcile.ocm_addons_upgrade_tests_trigger
@@ -1921,7 +1898,6 @@ def ocm_machine_pools(ctx, thread_pool_size):
 
 
 @integration.command(short_help="Manage Upgrade Policy schedules in OCM.")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def ocm_upgrade_scheduler(ctx):
     from reconcile.aus.base import AdvancedUpgradeSchedulerBaseIntegrationParams
@@ -1938,7 +1914,6 @@ def ocm_upgrade_scheduler(ctx):
 
 
 @integration.command(short_help="Manage Upgrade Policy schedules in OCM organizations.")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def ocm_upgrade_scheduler_org(ctx):
     from reconcile.aus.base import AdvancedUpgradeSchedulerBaseIntegrationParams
@@ -1957,7 +1932,6 @@ def ocm_upgrade_scheduler_org(ctx):
 
 
 @integration.command(short_help="Update Upgrade Policy schedules in OCM organizations.")
-@environ(["gitlab_pr_submitter_queue_url"])
 @gitlab_project_id
 @click.pass_context
 def ocm_upgrade_scheduler_org_updater(ctx, gitlab_project_id):
@@ -1971,7 +1945,6 @@ def ocm_upgrade_scheduler_org_updater(ctx, gitlab_project_id):
 @integration.command(
     short_help="Manage Addons Upgrade Policy schedules in OCM organizations."
 )
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def ocm_addons_upgrade_scheduler_org(ctx):
 
@@ -1991,7 +1964,6 @@ def ocm_addons_upgrade_scheduler_org(ctx):
 @integration.command(
     short_help="Manage Cluster Upgrade Policy schedules in OCM organizations based on OCM labels."
 )
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def aus_upgrade_scheduler_org(ctx):
 
@@ -2007,7 +1979,6 @@ def aus_upgrade_scheduler_org(ctx):
 
 
 @integration.command(short_help="Update recommended version for OCM orgs")
-@environ(["gitlab_pr_submitter_queue_url"])
 @gitlab_project_id
 @click.pass_context
 def ocm_update_recommended_version(ctx, gitlab_project_id):
@@ -2064,7 +2035,6 @@ def ocm_additional_routers(ctx):
 
 
 @integration.command(short_help="Send email notifications to app-interface audience.")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def email_sender(ctx):
     import reconcile.email_sender
@@ -2073,7 +2043,6 @@ def email_sender(ctx):
 
 
 @integration.command(short_help="Watch for Sentry access requests and notify on Slack.")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def sentry_helper(ctx):
     import reconcile.sentry_helper
@@ -2084,7 +2053,6 @@ def sentry_helper(ctx):
 @integration.command(
     short_help="Send emails to users based on " "requests submitted to app-interface."
 )
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @click.pass_context
 def requests_sender(ctx):
     import reconcile.requests_sender
@@ -2109,7 +2077,6 @@ def sentry_config(ctx):
 
 
 @integration.command(short_help="Runs SQL Queries against app-interface RDS resources.")
-@environ(["APP_INTERFACE_STATE_BUCKET", "APP_INTERFACE_STATE_BUCKET_ACCOUNT"])
 @enable_deletion(default=False)
 @click.pass_context
 def sql_query(ctx, enable_deletion):

--- a/reconcile/utils/sqs_gateway.py
+++ b/reconcile/utils/sqs_gateway.py
@@ -13,7 +13,13 @@ class SQSGateway:
     """Wrapper around SQS AWS SDK"""
 
     def __init__(self, accounts, secret_reader: SecretReader):
-        queue_url = os.environ["gitlab_pr_submitter_queue_url"]
+        queue_url = os.environ.get("gitlab_pr_submitter_queue_url")
+        if not queue_url:
+            raise SQSGatewayInitError(
+                "when /app-interface/app-interface-settings-1.yml#mergeRequestGateway "
+                "is set to 'sqs', an ENV variable 'gitlab_pr_submitter_queue_url' needs "
+                "to be provided"
+            )
         account = self.get_queue_account(accounts, queue_url)
         accounts = [a for a in accounts if a["name"] == account]
         self._aws_api = AWSApi(

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -531,7 +531,6 @@ def get_repo_url(job):
 @config_file
 @dry_run
 @log_level
-# TODO: @environ(['gitlab_pr_submitter_queue_url'])
 @gitlab_project_id
 @click.option("--reports-path", help="path to write reports")
 def main(


### PR DESCRIPTION
the checks for env vars are not required in cli.py anymore because the check for the vars and also check for alternative state bucket settings is done in state.py

part of: https://issues.redhat.com/browse/APPSRE-7226