### PR TITLE
[change-owners] resourcesfiles with schemas

### DIFF
--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -725,21 +725,16 @@ class ChangeTypeProcessor:
         ChangeTypeV1. the paths are represented as jsonpath expressions pinpointing
         the root element that can be changed
         """
-        paths = []
-        paths.extend(
-            self._allowed_changed_paths_for_file_type_and_schema(
-                file_ref.file_type, file_ref.schema, file_content, ctx
-            )
+        paths = self._allowed_changed_paths_for_file_type_and_schema(
+            file_ref.file_type, file_ref.schema, file_content, ctx
         )
-        if file_ref.schema is not None:
-            # if a file_ref has a schema set, we will still check for allowed paths
-            # regardless of any schemas. this is to allow for generic change types
-            # that don't care about schemas
-            paths.extend(
-                self._allowed_changed_paths_for_file_type_and_schema(
-                    file_ref.file_type, None, file_content, ctx
-                )
-            )
+
+        # lets also check for allowed paths that are not specific to a schema
+        for p in self._allowed_changed_paths_for_file_type_and_schema(
+            file_ref.file_type, None, file_content, ctx
+        ):
+            if p not in paths:
+                paths.append(p)
         return paths
 
     def _allowed_changed_paths_for_file_type_and_schema(

--- a/reconcile/test/change_owners/fixtures.py
+++ b/reconcile/test/change_owners/fixtures.py
@@ -44,7 +44,7 @@ from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
 @dataclass
 class StubFile:
     filepath: str
-    fileschema: str
+    fileschema: Optional[str]
     filetype: str
     content: dict[str, Any]
 
@@ -83,6 +83,19 @@ def build_test_datafile(
         filepath=filepath or "datafile.yaml",
         fileschema=schema or "schema-1.yml",
         filetype=BundleFileType.DATAFILE.value,
+        content=content,
+    )
+
+
+def build_test_resourcefile(
+    content: dict[str, Any],
+    filepath: Optional[str] = None,
+    schema: Optional[str] = None,
+) -> StubFile:
+    return StubFile(
+        filepath=filepath or "path.yaml",
+        fileschema=schema,
+        filetype=BundleFileType.RESOURCEFILE.value,
         content=content,
     )
 
@@ -171,12 +184,13 @@ def build_change_type(
     change_selectors: list[str],
     change_schema: Optional[str] = None,
     context_schema: Optional[str] = None,
+    context_type: BundleFileType = BundleFileType.DATAFILE,
 ) -> ChangeTypeProcessor:
     return change_type_to_processor(
         ChangeTypeV1(
             name=name,
             description=name,
-            contextType=BundleFileType.DATAFILE.value,
+            contextType=context_type.value,
             contextSchema=context_schema,
             changes=[
                 build_jsonpath_change(

--- a/reconcile/test/change_owners/test_change_type_processor.py
+++ b/reconcile/test/change_owners/test_change_type_processor.py
@@ -1,10 +1,16 @@
 import pytest
 from jsonpath_ng.exceptions import JsonPathParserError
 
-from reconcile.change_owners.change_types import ChangeTypeContext
+from reconcile.change_owners.bundle import BundleFileType
+from reconcile.change_owners.change_types import (
+    ChangeTypeContext,
+    ChangeTypeProcessor,
+)
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
 from reconcile.test.change_owners.fixtures import (
     StubFile,
+    build_change_type,
+    build_test_resourcefile,
     change_type_to_processor,
 )
 
@@ -70,3 +76,63 @@ def test_change_type_processor_allowed_paths_conditions(
     )
 
     assert [str(p) for p in paths] == ["openshiftResources.[1].version"]
+
+
+@pytest.fixture
+def resource_owner_change_type_processor() -> ChangeTypeProcessor:
+    return build_change_type(
+        name="resource-owner",
+        change_schema=None,
+        context_schema=None,
+        change_selectors=["$"],
+        context_type=BundleFileType.RESOURCEFILE,
+    )
+
+
+def test_change_type_processor_allowed_paths_conditions_ct_without_schema_file_with_schema(
+    resource_owner_change_type_processor: ChangeTypeProcessor,
+):
+    """
+    test that a change-type that does not enforce a context-schema can still be used by files with schemas
+    """
+    resource_file = build_test_resourcefile(
+        content={"test": "old_value"}, schema="schema-1.yml"
+    )
+    changed_resource_file = resource_file.create_bundle_change({"test": "new_value"})
+    paths = resource_owner_change_type_processor.allowed_changed_paths(
+        file_ref=changed_resource_file.fileref,
+        file_content=changed_resource_file.new,
+        ctx=ChangeTypeContext(
+            change_type_processor=resource_owner_change_type_processor,
+            context="RoleV1 - some role",
+            origin="",
+            approvers=[],
+            context_file=resource_file.file_ref(),
+        ),
+    )
+
+    assert [str(p) for p in paths] == ["$"]
+
+
+def test_change_type_processor_allowed_paths_conditions_ct_without_schema_file_without_schema(
+    resource_owner_change_type_processor: ChangeTypeProcessor,
+):
+    """
+    test that a change-type that does not enforce a context-schema behaves correctly with
+    file that do not have a schema.
+    """
+    resource_file = build_test_resourcefile(content={"test": "old_value"})
+    changed_resource_file = resource_file.create_bundle_change({"test": "new_value"})
+    paths = resource_owner_change_type_processor.allowed_changed_paths(
+        file_ref=changed_resource_file.fileref,
+        file_content=changed_resource_file.new,
+        ctx=ChangeTypeContext(
+            change_type_processor=resource_owner_change_type_processor,
+            context="RoleV1 - some role",
+            origin="",
+            approvers=[],
+            context_file=resource_file.file_ref(),
+        ),
+    )
+
+    assert [str(p) for p in paths] == ["$"]


### PR DESCRIPTION
resources files with schemas were not self-serviceable if they are used with generic change-types like `resource-owners` that does not enforce a schema.

with this change, resourcesfiles with schemas can now be made self-serviceable with change-types that don't enforce a schema.