### PR TITLE
align vault_settings query

### DIFF
--- a/reconcile/test/test_typed_queries/test_app_interface_vault_settings.py
+++ b/reconcile/test/test_typed_queries/test_app_interface_vault_settings.py
@@ -49,4 +49,4 @@ def test_get_vault_settings(
     vault_settings = get_app_interface_vault_settings(
         query_func=query_func(data.dict(by_alias=True))
     )
-    assert vault_settings.vault == True
+    assert vault_settings.vault

--- a/reconcile/test/test_typed_queries/test_app_interface_vault_settings.py
+++ b/reconcile/test/test_typed_queries/test_app_interface_vault_settings.py
@@ -1,0 +1,52 @@
+from collections.abc import (
+    Callable,
+    Mapping,
+)
+
+import pytest
+
+from reconcile.gql_definitions.common.app_interface_vault_settings import (
+    AppInterfaceVaultSettingsQueryData,
+)
+from reconcile.typed_queries.app_interface_vault_settings import (
+    get_app_interface_vault_settings,
+)
+from reconcile.utils.exceptions import AppInterfaceSettingsError
+
+
+def test_no_settings(
+    query_func: Callable[[Mapping], Callable],
+    gql_class_factory: Callable[..., AppInterfaceVaultSettingsQueryData],
+) -> None:
+    data = gql_class_factory(AppInterfaceVaultSettingsQueryData, {"vault_settings": []})
+    with pytest.raises(AppInterfaceSettingsError):
+        get_app_interface_vault_settings(
+            query_func=query_func(data.dict(by_alias=True))
+        )
+
+
+def test_multiple_settings(
+    query_func: Callable[[Mapping], Callable],
+    gql_class_factory: Callable[..., AppInterfaceVaultSettingsQueryData],
+) -> None:
+    data = gql_class_factory(
+        AppInterfaceVaultSettingsQueryData,
+        {"vault_settings": [{"vault": True}, {"vault": False}]},
+    )
+    with pytest.raises(AppInterfaceSettingsError):
+        get_app_interface_vault_settings(
+            query_func=query_func(data.dict(by_alias=True))
+        )
+
+
+def test_get_vault_settings(
+    query_func: Callable[[Mapping], Callable],
+    gql_class_factory: Callable[..., AppInterfaceVaultSettingsQueryData],
+) -> None:
+    data = gql_class_factory(
+        AppInterfaceVaultSettingsQueryData, {"vault_settings": [{"vault": True}]}
+    )
+    vault_settings = get_app_interface_vault_settings(
+        query_func=query_func(data.dict(by_alias=True))
+    )
+    assert vault_settings.vault == True

--- a/reconcile/typed_queries/app_interface_vault_settings.py
+++ b/reconcile/typed_queries/app_interface_vault_settings.py
@@ -1,4 +1,3 @@
-import logging
 from collections.abc import Callable
 from typing import Optional
 

--- a/reconcile/typed_queries/app_interface_vault_settings.py
+++ b/reconcile/typed_queries/app_interface_vault_settings.py
@@ -1,30 +1,22 @@
 import logging
-import sys
+from collections.abc import Callable
 from typing import Optional
 
 from reconcile.gql_definitions.common.app_interface_vault_settings import (
     AppInterfaceSettingsV1,
     query,
 )
-from reconcile.status import ExitCodes
 from reconcile.utils import gql
+from reconcile.utils.exceptions import AppInterfaceSettingsError
 
 
-def get_app_interface_vault_settings_optional() -> Optional[AppInterfaceSettingsV1]:
-    """Returns App Interface Settings"""
-    gqlapi = gql.get_api()
-    data = query(gqlapi.query)
-    if data.vault_settings:
-        # assuming a single settings file for now
+def get_app_interface_vault_settings(
+    query_func: Optional[Callable] = None,
+) -> AppInterfaceSettingsV1:
+    """Returns App Interface Settings and raises err if none are found"""
+    if not query_func:
+        query_func = gql.get_api().query
+    data = query(query_func=query_func)
+    if data.vault_settings and len(data.vault_settings) == 1:
         return data.vault_settings[0]
-    return None
-
-
-def get_app_interface_vault_settings() -> AppInterfaceSettingsV1:
-    """Returns App Interface Settings and exits if none are found"""
-    vault_settings = get_app_interface_vault_settings_optional()
-    if not vault_settings:
-        logging.error("Missing app-interface vault_settings")
-        # TODO: We should raise an exception https://issues.redhat.com/browse/APPSRE-7041
-        sys.exit(ExitCodes.ERROR)
-    return vault_settings
+    raise AppInterfaceSettingsError("vault settings not uniquely defined.")


### PR DESCRIPTION
This aligns our `get_vault_settings` query with conventions we have for other queries:

- add tests
- raise error instead of sys.exit