### PR TITLE
Refactor terraform tgw attachments

### DIFF
--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -1,11 +1,13 @@
 import json
 import logging
 import sys
-from typing import (
-    Any,
+from collections.abc import (
     Callable,
     Generator,
     Mapping,
+)
+from typing import (
+    Any,
     Optional,
 )
 

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -145,11 +145,7 @@ def run(
 
     participating_accounts = [item["requester"]["account"] for item in desired_state]
     participating_account_names = [a["name"] for a in participating_accounts]
-    accounts = [
-        a
-        for a in queries.get_aws_accounts(terraform_state=True, ecrs=False)
-        if a["name"] in participating_account_names
-    ]
+    accounts = [a for a in accounts if a["name"] in participating_account_names]
 
     ts = Terrascript(
         QONTRACT_INTEGRATION, "", thread_pool_size, accounts, settings=settings

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -4,6 +4,7 @@ import sys
 from collections.abc import (
     Callable,
     Generator,
+    Iterable,
     Mapping,
 )
 from typing import (
@@ -29,7 +30,7 @@ TGW_CONNECTION_PROVIDER = "account-tgw"
 
 
 def build_desired_state_tgw_attachments(
-    clusters: list[dict],
+    clusters: Iterable[Mapping],
     ocm_map: Optional[OCMMap],
     awsapi: AWSApi,
 ) -> tuple[list[dict], bool]:
@@ -49,7 +50,7 @@ def build_desired_state_tgw_attachments(
 
 
 def _build_desired_state_tgw_attachments(
-    clusters: list[dict],
+    clusters: Iterable[Mapping],
     ocm_map: Optional[OCMMap],
     awsapi: AWSApi,
 ) -> Generator[Optional[dict], Any, None]:
@@ -67,8 +68,8 @@ def _build_desired_state_tgw_attachments(
 
 
 def _build_desired_state_tgw_connection(
-    peer_connection: dict,
-    cluster_info: dict,
+    peer_connection: Mapping,
+    cluster_info: Mapping,
     ocm: Optional[OCM],
     awsapi: AWSApi,
 ) -> Generator[Optional[dict], Any, None]:
@@ -115,7 +116,7 @@ def _build_desired_state_tgw_connection(
 
 
 def _account_with_assume_role_data(
-    peer_connection: dict,
+    peer_connection: Mapping,
     cluster_name: str,
     region: str,
     cidr_block: str,
@@ -144,12 +145,12 @@ def _account_with_assume_role_data(
 
 
 def _build_accepter(
-    peer_connection: dict,
-    account: dict,
+    peer_connection: Mapping,
+    account: Mapping,
     region: str,
     cidr_block: str,
     awsapi: AWSApi,
-) -> dict:
+) -> dict[str, Any]:
     (vpc_id, route_table_ids, subnets_id_az) = awsapi.get_cluster_vpc_details(
         account,
         route_tables=peer_connection.get("manageRoutes"),
@@ -166,10 +167,10 @@ def _build_accepter(
 
 
 def _build_requester(
-    peer_connection: dict,
-    account: dict,
-    tgw: dict,
-) -> dict:
+    peer_connection: Mapping,
+    account: Mapping,
+    tgw: Mapping,
+) -> dict[str, Any]:
     return {
         "tgw_id": tgw["tgw_id"],
         "tgw_arn": tgw["tgw_arn"],
@@ -183,7 +184,7 @@ def _build_requester(
 
 
 def _build_ocm_map(
-    clusters: list,
+    clusters: Iterable[Mapping],
     settings: Optional[Mapping[str, Any]],
 ) -> Optional[OCMMap]:
     ocm_clusters = [c for c in clusters if c.get("ocm")]
@@ -199,23 +200,26 @@ def _build_ocm_map(
     )
 
 
-def _validate_vpc_connection_names(desired_state: list) -> None:
+def _validate_vpc_connection_names(desired_state: Iterable[Mapping]) -> None:
     connection_names = [c["connection_name"] for c in desired_state]
     if len(set(connection_names)) != len(connection_names):
         logging.error("duplicate vpc connection names found")
         sys.exit(1)
 
 
-def _filter_accounts(accounts: list, participating_accounts: list) -> list:
+def _filter_accounts(
+    accounts: Iterable[Mapping],
+    participating_accounts: Iterable[Mapping],
+) -> list:
     participating_account_names = {a["name"] for a in participating_accounts}
     return [a for a in accounts if a["name"] in participating_account_names]
 
 
 def _populate_tgw_attachments_working_dirs(
-    desired_state: list,
-    accounts: list,
+    desired_state: Iterable,
+    accounts: Iterable,
     settings: Optional[Mapping[str, Any]],
-    participating_accounts: list,
+    participating_accounts: Iterable,
     print_to_file: Optional[str],
     thread_pool_size: int,
 ) -> dict[str, str]:

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -144,7 +144,7 @@ def run(
         sys.exit(1)
 
     participating_accounts = [item["requester"]["account"] for item in desired_state]
-    participating_account_names = [a["name"] for a in participating_accounts]
+    participating_account_names = {a["name"] for a in participating_accounts}
     accounts = [a for a in accounts if a["name"] in participating_account_names]
 
     ts = Terrascript(

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -144,7 +144,6 @@ def run(
         sys.exit(1)
 
     participating_accounts = [item["requester"]["account"] for item in desired_state]
-    participating_accounts += [item["accepter"]["account"] for item in desired_state]
     participating_account_names = [a["name"] for a in participating_accounts]
     accounts = [
         a

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -72,7 +72,7 @@ def _build_desired_state_tgw_connection(
     cluster_region = cluster_info["spec"]["region"]
     cluster_cidr_block = cluster_info["network"]["vpc"]
 
-    account = _enrich_account(
+    account = _account_with_assume_role_data(
         peer_connection, cluster_name, cluster_region, cluster_cidr_block, ocm
     )
 
@@ -110,7 +110,7 @@ def _build_desired_state_tgw_connection(
         yield item
 
 
-def _enrich_account(
+def _account_with_assume_role_data(
     peer_connection: dict,
     cluster_name: str,
     region: str,
@@ -197,7 +197,7 @@ def _validate_vpc_connection_names(desired_state: list) -> None:
         sys.exit(1)
 
 
-def _get_filtered_accounts(accounts: list, participating_accounts: list) -> list:
+def _filter_accounts(accounts: list, participating_accounts: list) -> list:
     participating_account_names = {a["name"] for a in participating_accounts}
     return [a for a in accounts if a["name"] in participating_account_names]
 
@@ -248,7 +248,7 @@ def run(
     _validate_vpc_connection_names(desired_state)
 
     participating_accounts = [item["requester"]["account"] for item in desired_state]
-    filtered_accounts = _get_filtered_accounts(accounts, participating_accounts)
+    filtered_accounts = _filter_accounts(accounts, participating_accounts)
 
     working_dirs = _populate_tgw_attachments_working_dirs(
         desired_state,

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -245,7 +245,7 @@ def test_run_when_cluster_with_tgw_connection(
     }
 
     mocks["ts"].populate_additional_providers.assert_called_once_with(
-        [expected_tgw_account, expected_tgw_account]
+        [expected_tgw_account]
     )
     mocks["ts"].populate_tgw_attachments.assert_called_once_with(
         [
@@ -308,7 +308,7 @@ def test_run_when_cluster_with_mixed_connections(
     }
 
     mocks["ts"].populate_additional_providers.assert_called_once_with(
-        [expected_tgw_account, expected_tgw_account]
+        [expected_tgw_account]
     )
     mocks["ts"].populate_tgw_attachments.assert_called_once_with(
         [

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -1,4 +1,8 @@
-from collections.abc import Callable
+from collections.abc import (
+    Callable,
+    Iterable,
+    Mapping,
+)
 from typing import Optional
 
 import pytest
@@ -103,7 +107,7 @@ def cluster_with_tgw_connection(
 @pytest.fixture
 def cluster_with_vpc_connection(
     cluster_builder: Callable[..., dict],
-    account_vpc_connection: dict,
+    account_vpc_connection: Mapping,
 ) -> dict:
     return cluster_builder(
         name="cluster_with_vpc_connection",
@@ -121,8 +125,8 @@ def cluster_with_vpc_connection(
 @pytest.fixture
 def cluster_with_mixed_connections(
     cluster_builder: Callable[..., dict],
-    account_tgw_connection: dict,
-    account_vpc_connection: dict,
+    account_tgw_connection: Mapping,
+    account_vpc_connection: Mapping,
 ) -> dict:
     return cluster_builder(
         name="cluster_with_mixed_connections",
@@ -166,10 +170,10 @@ def assume_role() -> str:
 
 def _setup_mocks(
     mocker: MockerFixture,
-    clusters: Optional[list] = None,
-    accounts: Optional[list] = None,
+    clusters: Optional[Iterable] = None,
+    accounts: Optional[Iterable] = None,
     vpc: Optional[tuple[str, str, str]] = None,
-    tgws: Optional[list] = None,
+    tgws: Optional[Iterable] = None,
     assume_role: Optional[str] = None,
 ) -> dict:
     mocked_queries = mocker.patch("reconcile.terraform_tgw_attachments.queries")
@@ -235,10 +239,10 @@ def test_non_dry_run(mocker: MockerFixture) -> None:
 
 def test_run_when_cluster_with_tgw_connection(
     mocker: MockerFixture,
-    cluster_with_tgw_connection: dict,
-    account_tgw_connection: dict,
-    tgw: dict,
-    vpc_details: dict,
+    cluster_with_tgw_connection: Mapping,
+    account_tgw_connection: Mapping,
+    tgw: Mapping,
+    vpc_details: Mapping,
     assume_role: str,
 ) -> None:
     mocks = _setup_mocks(
@@ -298,10 +302,10 @@ def test_run_when_cluster_with_tgw_connection(
 
 def test_run_when_cluster_with_mixed_connections(
     mocker: MockerFixture,
-    cluster_with_mixed_connections: dict,
-    account_tgw_connection: dict,
-    tgw: dict,
-    vpc_details: dict,
+    cluster_with_mixed_connections: Mapping,
+    account_tgw_connection: Mapping,
+    tgw: Mapping,
+    vpc_details: Mapping,
     assume_role: str,
 ) -> None:
     mocks = _setup_mocks(
@@ -361,7 +365,7 @@ def test_run_when_cluster_with_mixed_connections(
 
 def test_run_when_cluster_with_vpc_connection_only(
     mocker: MockerFixture,
-    cluster_with_vpc_connection: dict,
+    cluster_with_vpc_connection: Mapping,
 ) -> None:
     mocks = _setup_mocks(
         mocker,

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -837,7 +837,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             alias = self.get_alias_name_from_assume_role(assume_role)
             ts = self.tss[account_name]
             config = self.configs[account_name]
-            existing_provider_aliases = [p.get("alias") for p in ts["provider"]["aws"]]
+            existing_provider_aliases = {p.get("alias") for p in ts["provider"]["aws"]}
             if alias not in existing_provider_aliases:
                 ts += provider.aws(
                     access_key=config["aws_access_key_id"],

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -328,7 +328,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         integration: str,
         integration_prefix: str,
         thread_pool_size: int,
-        accounts: list[dict[str, Any]],
+        accounts: Iterable[dict[str, Any]],
         settings: Optional[Mapping[str, Any]] = None,
         prefetch_resources_by_schemas: Optional[list[str]] = None,
     ) -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -444,11 +444,6 @@ disallow_incomplete_defs = False
 disallow_untyped_defs = False
 disallow_incomplete_defs = False
 
-[mypy-reconcile.terraform_tgw_attachments]
-check_untyped_defs = False
-disallow_untyped_defs = False
-disallow_incomplete_defs = False
-
 [mypy-reconcile.terraform_users]
 disallow_untyped_defs = False
 disallow_incomplete_defs = False


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 64e5449</samp>

Refactor and optimize the `terraform_tgw_attachments` integration and its tests. Improve the code quality, error handling, logging, and performance of the integration and the `terrascript_aws_client` module.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 64e5449</samp>

*  Add type annotations and imports for typing module to support them ([link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L4-R19), [link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L17-R34), [link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L7-R120))
* Define constant for TGW connection provider string and use it throughout the file ([link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L17-R34), [link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L26-R192), [link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L146-R211), [link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L165-R267))
* Refactor `build_desired_state_tgw_attachments` function to use generator functions and helper functions, add logging and error handling, and simplify logic ([link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L26-R192))
* Extract filtering accounts logic into `_get_filtered_accounts` function and move OCM map and AWS API creation to `run` function ([link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L146-R211), [link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L180-R277))
* Extract populating working directories logic into `_populate_tgw_attachments_working_dirs` function and pass filtered accounts to it ([link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L165-R267))
* Add condition to check defer parameter before calling cleanup on Terraform client to pass mypy check ([link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L180-R277))
* Replace individual fixtures for peering connections and clusters with builder pattern for more flexibility and customization in tests ([link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L7-R120), [link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L80-R126))
* Patch queries module instead of individual functions and add it to return value of `_setup_mocks` function for easier access in tests ([link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L112-R161), [link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R187))
* Add assertions to check queries module functions are called with expected arguments in `test_dry_run` and `test_non_dry_run` functions ([link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R196-R200), [link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R210-R214))
* Fix bugs in `test_run_when_cluster_with_tgw_connection` and `test_run_when_cluster_with_mixed_connections` functions where expected additional providers list had duplicate entries and update assertions accordingly ([link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L196-R251), [link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L259-R314))
* Optimize performance of `populate_additional_providers` function in `reconcile/utils/terrascript_aws_client.py` by using a set instead of a list for existing provider aliases ([link](https://github.com/app-sre/qontract-reconcile/pull/3440/files?diff=unified&w=0#diff-4db367e141fd1992ae5a98872e6101dde4bf61a460c1bd0097176c6fbc849ac2L840-R840))