### PR TITLE
Filter accounts and clusters for terraform tgw attachments

### DIFF
--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -209,14 +209,6 @@ def _validate_tgw_connection_names(desired_state: Iterable[Mapping]) -> None:
         raise ValidationError("duplicate tgw connection names found")
 
 
-def _filter_accounts(
-    accounts: Iterable[Mapping],
-    participating_accounts: Iterable[Mapping],
-) -> list:
-    participating_account_names = {a["name"] for a in participating_accounts}
-    return [a for a in accounts if a["name"] in participating_account_names]
-
-
 def _populate_tgw_attachments_working_dirs(
     desired_state: Iterable,
     accounts: Iterable,
@@ -245,6 +237,18 @@ def _filter_tgw_clusters(clusters: Iterable[Mapping]) -> list:
     return list(filter(_is_tgw_cluster, clusters))
 
 
+def _filter_tgw_accounts(
+    accounts: Iterable[Mapping],
+    tgw_clusters: Iterable[Mapping],
+) -> list:
+    tgw_account_names = set()
+    for cluster in tgw_clusters:
+        for pc in cluster["peering"]["connections"]:
+            if pc["provider"] == TGW_CONNECTION_PROVIDER:
+                tgw_account_names.add(pc["account"]["name"])
+    return [a for a in accounts if a["name"] in tgw_account_names]
+
+
 @defer
 def run(
     dry_run: bool,
@@ -258,12 +262,16 @@ def run(
     tgw_clusters = _filter_tgw_clusters(clusters)
     ocm_map = _build_ocm_map(tgw_clusters, settings)
     accounts = queries.get_aws_accounts(terraform_state=True, ecrs=False)
+    tgw_accounts = _filter_tgw_accounts(accounts, tgw_clusters)
+
+    aws_api = AWSApi(1, tgw_accounts, settings=settings, init_users=False)
+    if defer:
+        defer(aws_api.cleanup)
 
     # Fetch desired state for cluster-to-vpc(account) VPCs
-    with AWSApi(1, accounts, settings=settings, init_users=False) as awsapi:
-        desired_state, err = build_desired_state_tgw_attachments(
-            tgw_clusters, ocm_map, awsapi
-        )
+    desired_state, err = build_desired_state_tgw_attachments(
+        tgw_clusters, ocm_map, aws_api
+    )
     if err:
         raise RuntimeError("Could not find VPC ID for cluster")
 
@@ -271,11 +279,10 @@ def run(
     _validate_tgw_connection_names(desired_state)
 
     participating_accounts = [item["requester"]["account"] for item in desired_state]
-    filtered_accounts = _filter_accounts(accounts, participating_accounts)
 
     working_dirs = _populate_tgw_attachments_working_dirs(
         desired_state,
-        filtered_accounts,
+        tgw_accounts,
         settings,
         participating_accounts,
         print_to_file,
@@ -285,13 +292,11 @@ def run(
     if print_to_file:
         return
 
-    aws_api = AWSApi(1, filtered_accounts, settings=settings, init_users=False)
-
     tf = Terraform(
         QONTRACT_INTEGRATION,
         QONTRACT_INTEGRATION_VERSION,
         "",
-        filtered_accounts,
+        tgw_accounts,
         working_dirs,
         thread_pool_size,
         aws_api,

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -459,11 +459,7 @@ def test_run_when_cluster_with_vpc_connection_only(
     integ.run(True)
 
     mocks["aws_api"].assert_called()
-    mocks["ocm"].assert_called_once_with(
-        clusters=[cluster_with_vpc_connection],
-        integration=QONTRACT_INTEGRATION,
-        settings={},
-    )
+    mocks["ocm"].assert_not_called()
     mocks["ts"].populate_additional_providers.assert_called_once_with([])
     mocks["ts"].populate_tgw_attachments.assert_called_once_with([])
 
@@ -506,7 +502,7 @@ def test_run_with_multiple_clusters(
 
     mocks["aws_api"].assert_called()
     mocks["ocm"].assert_called_once_with(
-        clusters=[cluster_with_tgw_connection, cluster_with_vpc_connection],
+        clusters=[cluster_with_tgw_connection],
         integration=QONTRACT_INTEGRATION,
         settings={},
     )

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -285,18 +285,18 @@ def _setup_mocks(
     mocked_aws_api = mocker.patch(
         "reconcile.terraform_tgw_attachments.AWSApi", autospec=True
     )
-    with mocked_aws_api.return_value as aws_api:
-        vpc = (
-            (
-                vpc_details["vpc_id"],
-                vpc_details["route_table_ids"],
-                vpc_details["subnets_id_az"],
-            )
-            if vpc_details is not None
-            else (None, None, None)
+    aws_api = mocked_aws_api.return_value
+    vpc = (
+        (
+            vpc_details["vpc_id"],
+            vpc_details["route_table_ids"],
+            vpc_details["subnets_id_az"],
         )
-        aws_api.get_cluster_vpc_details.return_value = vpc
-        aws_api.get_tgws_details.return_value = tgws or []
+        if vpc_details is not None
+        else (None, None, None)
+    )
+    aws_api.get_cluster_vpc_details.return_value = vpc
+    aws_api.get_tgws_details.return_value = tgws or []
     mocked_ocm = mocker.patch(
         "reconcile.terraform_tgw_attachments.OCMMap", autospec=True
     )
@@ -383,7 +383,9 @@ def test_run_when_cluster_with_tgw_connection(
         expected_tgw_account=expected_tgw_account,
     )
 
-    mocks["aws_api"].assert_called()
+    mocks["aws_api"].assert_called_once_with(
+        1, [tgw_account], settings={}, init_users=False
+    )
     mocks["ocm"].assert_called_once_with(
         clusters=[cluster_with_tgw_connection],
         integration=QONTRACT_INTEGRATION,
@@ -431,7 +433,9 @@ def test_run_when_cluster_with_mixed_connections(
         expected_tgw_account=expected_tgw_account,
     )
 
-    mocks["aws_api"].assert_called()
+    mocks["aws_api"].assert_called_once_with(
+        1, [tgw_account], settings={}, init_users=False
+    )
     mocks["ocm"].assert_called_once_with(
         clusters=[cluster_with_mixed_connections],
         integration=QONTRACT_INTEGRATION,
@@ -458,7 +462,7 @@ def test_run_when_cluster_with_vpc_connection_only(
 
     integ.run(True)
 
-    mocks["aws_api"].assert_called()
+    mocks["aws_api"].assert_called_once_with(1, [], settings={}, init_users=False)
     mocks["ocm"].assert_not_called()
     mocks["ts"].populate_additional_providers.assert_called_once_with([])
     mocks["ts"].populate_tgw_attachments.assert_called_once_with([])
@@ -500,7 +504,9 @@ def test_run_with_multiple_clusters(
         expected_tgw_account=expected_tgw_account,
     )
 
-    mocks["aws_api"].assert_called()
+    mocks["aws_api"].assert_called_once_with(
+        1, [tgw_account], settings={}, init_users=False
+    )
     mocks["ocm"].assert_called_once_with(
         clusters=[cluster_with_tgw_connection],
         integration=QONTRACT_INTEGRATION,


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e0608f3</samp>

Add cluster and account filter to narrow down tgw clusters and accounts used in this integration.

Refactor `terraform_tgw_attachments` integration and tests to improve readability and test coverage.

This is the prepare for sharding of terraform-tgw-attachemnts. [APPSRE-7404](https://issues.redhat.com/browse/APPSRE-7404)

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at e0608f3</samp>

*  Remove unused `_filter_accounts` function and add new functions to filter clusters and accounts by TGW connections ([link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L212-L219), [link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226R229-R251))
*  Modify `run` function to use new filtering functions and deferred AWS clients ([link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L247-R274), [link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L262-R285), [link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L276-R299))
*  Add `QONTRACT_INTEGRATION` constant and new fixtures to create mock account objects for testing ([link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L13-R50))
*  Simplify `peering_connection_builder` fixture to take an `account` parameter instead of separate account fields ([link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L20-R56), [link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L31-R65))
*  Use mock account objects in `account_tgw_connection` and `account_vpc_connection` fixtures ([link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L45-R84), [link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L60-R99))
*  Add helper functions to create expected account and desired state objects for testing ([link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R226-R272))
*  Modify `_setup_mocks` function to return mocked `ocm` and `aws_api` objects for asserting calls ([link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L204-R303))
*  Modify `test_run_when_cluster_with_tgw_connection` function to use new fixtures and helper functions and assert calls to mocked objects ([link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R320-R321), [link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R357), [link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R365), [link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L286-R398))
*  Modify `test_run_when_cluster_with_mixed_connections` function to use new fixtures and helper functions and assert calls to mocked objects ([link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R406-R407), [link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R415), [link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L345-R448))
*  Modify `test_run_when_cluster_with_vpc_connection_only` function to use mock account object and assert calls to mocked objects ([link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L389-R522))
*  Add `test_run_with_multiple_clusters` function to test scenario with different types of connections ([link](https://github.com/app-sre/qontract-reconcile/pull/3446/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L389-R522))