### PR TITLE
APPSRE-7367 detect dangling config hashes

### DIFF
--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -220,6 +220,23 @@ class TestSaasFileValid(TestCase):
 
         self.assertFalse(saasherder.valid)
 
+    def test_dangling_target_config_hash(self) -> None:
+        self.saas_file.resource_templates[0].targets[1].promotion.promotion_data[
+            0
+        ].channel = "does-not-exist"
+        saasherder = SaasHerder(
+            [self.saas_file],
+            secret_reader=MockSecretReader(),
+            thread_pool_size=1,
+            integration="",
+            integration_version="",
+            hash_length=7,
+            repo_url="https://repo-url.com",
+            validate=True,
+        )
+
+        self.assertFalse(saasherder.valid)
+
     def test_check_saas_file_upstream_used_with_image(self) -> None:
         self.saas_file.resource_templates[0].targets[
             0

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -578,7 +578,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             return
 
         sub_channels = set(target.promotion.subscribe)
-        for prom_data in target.promotion.promotion_data:
+        for prom_data in target.promotion.promotion_data or []:
             if prom_data.channel not in sub_channels:
                 self.valid = False
                 logging.error(


### PR DESCRIPTION
When an auto subscriber channel is removed from a saas target, then we should also make sure that its `promotion_data` is removed from the target. That way we ensure promotion_data is in synch, which will make logic easier during auto-promotion phase.