### PR TITLE
allow recycled object to be not found

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -952,7 +952,13 @@ class OCDeprecated:  # pylint: disable=too-many-public-methods
             recycle_time = now.strftime("%d/%m/%Y %H:%M:%S")
 
             # get the object in case it was modified
-            obj = self.get(namespace, kind, name)
+            # if the resource is gone, there is nothing to recycle
+            obj = self.get(namespace, kind, name, allow_not_found=True)
+            if not obj:
+                logging.info(
+                    f"[{self.cluster_name}/{namespace}] {kind.lower()}/{name} not found."
+                )
+                return
             # honor update strategy by setting annotations to force
             # a new rollout
             a = obj["spec"]["template"]["metadata"].get("annotations", {})


### PR DESCRIPTION
in this [MR](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/65169) there was a failure in the deployment where it tried to delete a STS and also recycle it.

this is likely due to an immutable change and also a change in a configmap.

if when trying to recycle, the recycled object is not there - there is nothing left to do?