### PR TITLE
Add support for account_name to terraform_tgw_attachments

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1790,8 +1790,15 @@ def vpc_peerings_validator(ctx):
 @binary(["terraform", "git"])
 @binary_version("terraform", ["version"], TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @enable_deletion(default=False)
+@account_name
 @click.pass_context
-def terraform_tgw_attachments(ctx, print_to_file, enable_deletion, thread_pool_size):
+def terraform_tgw_attachments(
+    ctx,
+    print_to_file,
+    enable_deletion,
+    thread_pool_size,
+    account_name,
+):
     import reconcile.terraform_tgw_attachments
 
     if print_to_file and is_file_in_git_repo(print_to_file):
@@ -1802,6 +1809,7 @@ def terraform_tgw_attachments(ctx, print_to_file, enable_deletion, thread_pool_s
         print_to_file,
         enable_deletion,
         thread_pool_size,
+        account_name,
     )
 
 


### PR DESCRIPTION
This change adds `account_name` to `terraform_tgw_attachments` to support sharding for [APPSRE-7404](https://issues.redhat.com/browse/APPSRE-7404).

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1287f24</samp>

This pull request adds a new `account_name` parameter to the `terraform_tgw_attachments` integration and its tests, which allows running the integration for a single AWS account and improves its performance and usability.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1287f24</samp>

*  Add a new parameter `account_name` to the `terraform_tgw_attachments` function in `reconcile/cli.py`, and pass it to the `run` function in `reconcile/terraform_tgw_attachments.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-2ac404c3a4f4d289c1811816c94253a70cc6559b8de427388de06546141f1f43L1793-R1801), [link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-2ac404c3a4f4d289c1811816c94253a70cc6559b8de427388de06546141f1f43R1812))
*  Modify the `run` function in `reconcile/terraform_tgw_attachments.py` to use the `account_name` parameter to filter the clusters and accounts that have TGW connections with the given account name, and to pass a `Terrascript` object to the `_populate_tgw_attachments_working_dirs` function ([link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L47-R48), [link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L258-R281), [link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L271-R309))
*  Rename the `build_desired_state_tgw_attachments` function to `_build_desired_state_items`, and add a default value of `None` to the `account_name` parameter in `reconcile/terraform_tgw_attachments.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L35-R39), [link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L55-R60))
*  Use a new helper function `_is_tgw_peer_connection` to check if a peer connection is a TGW connection, and if it matches the `account_name` parameter, in the `_build_desired_state_items` function and the other helper functions in `reconcile/terraform_tgw_attachments.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L67-R69), [link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L229-R249))
*  Simplify the signature of the `_populate_tgw_attachments_working_dirs` function in `reconcile/terraform_tgw_attachments.py`, and remove some parameters that are no longer needed ([link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L213-R219))
*  Modify the call to the `queries.get_aws_accounts` function in the `run` function in `reconcile/terraform_tgw_attachments.py`, and add the `account_name` parameter to it ([link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L258-R281))
*  Add a new fixture function `additional_tgw_account` in `reconcile/test/test_terraform_tgw_attachments.py` to create a mock AWS account object that has a TGW connection with another account ([link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R51-R59))
*  Add a new fixture function `additional_account_tgw_connection` in `reconcile/test/test_terraform_tgw_attachments.py` to create a mock TGW connection object that connects to the `additional_tgw_account` fixture ([link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R101-R117))
*  Add two new fixture functions `cluster_with_2_tgw_connections` and `additional_cluster_with_tgw_connection` in `reconcile/test/test_terraform_tgw_attachments.py` to create mock cluster objects that have TGW connections with the `additional_tgw_account` fixture ([link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R170-R203))
*  Modify the assertions of the `mocks["queries"].get_aws_accounts` calls in the `test_dry_run` and `test_non_dry_run` functions in `reconcile/test/test_terraform_tgw_attachments.py`, and add the `name=None` parameter to them ([link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L333-R395), [link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4L347-R411))
*  Add two new test functions `test_run_with_account_name_for_multiple_clusters` and `test_run_with_account_name_for_multiple_connections` in `reconcile/test/test_terraform_tgw_attachments.py` to test the `run` function with the `account_name` parameter ([link](https://github.com/app-sre/qontract-reconcile/pull/3453/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R587-R695))