### PR TITLE
Bump sretoolbox to 2.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     packages=find_packages(exclude=("tests",)),
     package_data={"reconcile": ["templates/*.j2", "gql_queries/*/*.gql"]},
     install_requires=[
-        "sretoolbox~=2.3.0",
+        "sretoolbox~=2.4.1",
         "Click>=7.0,<9.0",
         "gql==3.1.0",
         "toml>=0.10.0,<0.11.0",


### PR DESCRIPTION
New changes since 2.3.0:

* [Use ThreadPoolExecutor and ProcessPoolExecutor for concurrent runs](https://github.com/app-sre/sretoolbox/pull/91)
* [Adding kubectl-package binary lib](https://github.com/app-sre/sretoolbox/pull/92)