### PR TITLE
Fix member not saved when already exist for gitlab-permissions

### DIFF
--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -245,6 +245,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         except gitlab.exceptions.GitlabCreateError:
             member = project.members.get(user.id)
             member.access_level = access_level
+            member.save()
 
     def add_group_member(self, group_name, username, access):
         if not self.check_group_exists(group_name):


### PR DESCRIPTION
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 370efdb</samp>

Fix a bug in `gitlab-permissions` integration by saving project members when they already exist, but with different access level.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 370efdb</samp>

*  Persist member changes to GitLab API by saving the member object after adding it to the project ([link](https://github.com/app-sre/qontract-reconcile/pull/3466/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bR248))