### PR TITLE
[change-owners] empty self-service-role must render a change non-self-serviceable

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -3,7 +3,10 @@ import sys
 import traceback
 
 from reconcile import queries
-from reconcile.change_owners.approver import GqlApproverResolver
+from reconcile.change_owners.approver import (
+    Approver,
+    GqlApproverResolver,
+)
 from reconcile.change_owners.bundle import (
     BundleFileType,
     FileDiffResolver,
@@ -215,8 +218,21 @@ def write_coverage_report_to_mr(
     results = []
     approver_reachability = set()
     for d in change_decisions:
+
+        def format_approver_list(approvers: list[Approver]) -> str:
+            if approvers:
+                return " ".join(
+                    [
+                        f"@{a.org_username}"
+                        if a.tag_on_merge_requests
+                        else a.org_username
+                        for a in approvers
+                    ]
+                )
+            return "[- no approvers available -]"
+
         approvers = [
-            f"{ctctx.context} - { ' '.join([f'@{a.org_username}' if a.tag_on_merge_requests else a.org_username for a in ctctx.approvers]) }"
+            f"{ctctx.context} - { format_approver_list(ctctx.approvers) }"
             for ctctx in d.deduped_coverage()
         ]
         for cctx in d.deduped_coverage():

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -111,7 +111,7 @@ class DiffCoverage:
         return self.is_directly_covered() or self.is_covered_by_splits()
 
     def is_directly_covered(self) -> bool:
-        return any(not ctx.disabled for ctx in self.coverage)
+        return any(not ctx.disabled and ctx.approvers for ctx in self.coverage)
 
     def is_covered_by_splits(self) -> bool:
         """

--- a/reconcile/test/change_owners/test_change_type_coverage.py
+++ b/reconcile/test/change_owners/test_change_type_coverage.py
@@ -156,7 +156,7 @@ def test_diff_covered(saas_file_changetype: ChangeTypeV1):
                 change_type_processor=change_type_to_processor(saas_file_changetype),
                 context="RoleV1 - some-role",
                 origin="",
-                approvers=[],
+                approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
                 context_file=None,  # type: ignore
             ),
         ],
@@ -176,14 +176,14 @@ def test_diff_covered_many(
                 change_type_processor=change_type_to_processor(saas_file_changetype),
                 context="RoleV1 - some-role",
                 origin="",
-                approvers=[],
+                approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
                 context_file=None,  # type: ignore
             ),
             ChangeTypeContext(
                 change_type_processor=change_type_to_processor(role_member_change_type),
                 context="RoleV1 - some-role",
                 origin="",
-                approvers=[],
+                approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
                 context_file=None,  # type: ignore
             ),
         ],
@@ -204,14 +204,14 @@ def test_diff_covered_partially_disabled(
                 change_type_processor=change_type_to_processor(saas_file_changetype),
                 context="RoleV1 - some-role",
                 origin="",
-                approvers=[],
+                approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
                 context_file=None,  # type: ignore
             ),
             ChangeTypeContext(
                 change_type_processor=change_type_to_processor(role_member_change_type),
                 context="RoleV1 - some-role",
                 origin="",
-                approvers=[],
+                approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
                 context_file=None,  # type: ignore
             ),
         ],
@@ -233,13 +233,32 @@ def test_diff_no_coverage_all_disabled(
                 change_type_processor=change_type_to_processor(saas_file_changetype),
                 context="RoleV1 - some-role",
                 origin="",
-                approvers=[],
+                approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
                 context_file=None,  # type: ignore
             ),
             ChangeTypeContext(
                 change_type_processor=change_type_to_processor(role_member_change_type),
                 context="RoleV1 - some-role",
                 origin="",
+                approvers=[Approver(org_username="user", tag_on_merge_requests=False)],
+                context_file=None,  # type: ignore
+            ),
+        ],
+    )
+    assert not dc.is_covered()
+
+
+def test_diff_no_coverage_because_of_empty_role(saas_file_changetype: ChangeTypeV1):
+    dc = DiffCoverage(
+        diff=Diff(
+            diff_type=DiffType.ADDED, path=jsonpath_ng.parse("$"), new=None, old=None
+        ),
+        coverage=[
+            ChangeTypeContext(
+                change_type_processor=change_type_to_processor(saas_file_changetype),
+                context="RoleV1 - some-role",
+                origin="",
+                # no approvers
                 approvers=[],
                 context_file=None,  # type: ignore
             ),

--- a/reconcile/test/change_owners/test_change_type_diff_splitting.py
+++ b/reconcile/test/change_owners/test_change_type_diff_splitting.py
@@ -1,5 +1,6 @@
 import jsonpath_ng
 
+from reconcile.change_owners.approver import Approver
 from reconcile.change_owners.bundle import (
     BundleFileType,
     FileRef,
@@ -38,7 +39,7 @@ def test_root_diff_fully_covered_by_splits():
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
-        approvers=[],
+        approvers=[Approver("u", False)],
     )
 
     split_b = ChangeTypeContext(
@@ -48,7 +49,7 @@ def test_root_diff_fully_covered_by_splits():
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
-        approvers=[],
+        approvers=[Approver("u", False)],
     )
 
     bundle_change.cover_changes(split_a)
@@ -81,7 +82,7 @@ def test_root_diff_uncovered_fully_covered_by_splits():
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
-        approvers=[],
+        approvers=[Approver("u", False)],
     )
 
     split_b = ChangeTypeContext(
@@ -91,7 +92,7 @@ def test_root_diff_uncovered_fully_covered_by_splits():
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
-        approvers=[],
+        approvers=[Approver("u", False)],
     )
 
     bundle_change.cover_changes(split_a)
@@ -125,7 +126,7 @@ def test_root_diff_uncovered():
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
-        approvers=[],
+        approvers=[Approver("u", False)],
     )
 
     split_b = ChangeTypeContext(
@@ -135,7 +136,7 @@ def test_root_diff_uncovered():
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
-        approvers=[],
+        approvers=[Approver("u", False)],
     )
 
     bundle_change.cover_changes(split_a)
@@ -176,7 +177,7 @@ def test_nested_splits():
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
-        approvers=[],
+        approvers=[Approver("u", False)],
     )
 
     sub = ChangeTypeContext(
@@ -186,7 +187,7 @@ def test_nested_splits():
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
-        approvers=[],
+        approvers=[Approver("u", False)],
     )
 
     sub_sub = ChangeTypeContext(
@@ -196,7 +197,7 @@ def test_nested_splits():
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
-        approvers=[],
+        approvers=[Approver("u", False)],
     )
 
     # call the coverage function in this order is on purpose
@@ -273,7 +274,7 @@ def test_diff_splitting_empty_parent_coverage():
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
-        approvers=[],
+        approvers=[Approver("u", False)],
     )
     bundle_change.cover_changes(role_change_type)
 
@@ -328,7 +329,7 @@ def test_nested_diff_splitting_empty_parent_coverage():
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
-        approvers=[],
+        approvers=[Approver("u", False)],
     )
     bundle_change.cover_changes(role_change_type)
 
@@ -363,7 +364,7 @@ def test_diff_splitting_two_contexts_on_same_split():
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
-        approvers=[],
+        approvers=[Approver("u", False)],
     )
     ctx_2 = ChangeTypeContext(
         change_type_processor=build_change_type("roles", ["roles[*]"]),
@@ -372,7 +373,7 @@ def test_diff_splitting_two_contexts_on_same_split():
         context_file=FileRef(
             path="context_file.yml", file_type=BundleFileType.DATAFILE, schema=None
         ),
-        approvers=[],
+        approvers=[Approver("u", False)],
     )
     bundle_change.cover_changes(ctx_1)
     bundle_change.cover_changes(ctx_2)


### PR DESCRIPTION
# Motivation

If a change is covered by a self-service role without members, nobody can approve the change while at the same time the MR is still marked as self-serviceable. This way it does not show up in the review queue.

But even if IC gets aware of the MR, they can't /lgtm or add an lgtm label. The only way out is a manual force merge by IC.

# What changed?

Refine the term self-serviceable. If a change is only covered by a self-service role without members, the change is not considered self-serviceable. This way AppSRE IC will get aware of the change via the review queue and can approve the regular way.

The change coverage report in the MR should still show that the change would be self-serviceable but is not because of the empty role.

part of APPSRE-7535