### PR TITLE
Fix integrations manager

### DIFF
--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -239,6 +239,8 @@ def run(
         integrations.query(query_func=gql.get_api().query).integrations or []
     )
 
+    filtered_integrations = filter_integrations(all_integrations, upstream)
+
     shard_manager = IntegrationShardManager(
         strategies={
             StaticShardingStrategy.IDENTIFIER: StaticShardingStrategy(),
@@ -250,7 +252,7 @@ def run(
     )
 
     integration_environments = collect_integrations_environment(
-        all_integrations, environment_name, shard_manager
+        filtered_integrations, environment_name, shard_manager
     )
 
     if not integration_environments:


### PR DESCRIPTION
Filtering integrations was removed here: https://github.com/app-sre/qontract-reconcile/pull/3461

Adding it again, since it is required for running multiple instances of integrations-manager