### PR TITLE
[openshift saas deploy] multiple publishers

### DIFF
--- a/reconcile/saas_auto_promotions_manager/publisher.py
+++ b/reconcile/saas_auto_promotions_manager/publisher.py
@@ -28,10 +28,19 @@ class Publisher:
     def __init__(
         self,
         ref: str,
+        uid: str,
         repo_url: str,
         auth_code: Optional[HasSecret],
     ):
+        """Init.
+
+        ref: The target git ref to fetch the commit sha from.
+        uid: The uid of the saas publisher target.
+        repo_url: The git repo url of the saas publisher target.
+        auth_code: The auth code to use to fetch the commit sha.
+        """
         self._ref = ref
+        self._uid = uid
         self._repo_url = repo_url
         self._auth_code = auth_code
         self.channels: set[str] = set()
@@ -51,6 +60,7 @@ class Publisher:
             promotion_data = deployment_state.get_promotion_data(
                 sha=self.commit_sha,
                 channel=channel,
+                saas_target_uid=self._uid,
             )
             if not (
                 promotion_data

--- a/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
+++ b/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
@@ -30,29 +30,9 @@ class SaasFilesInventory:
         self._channels_by_name: dict[str, Channel] = {}
         self.subscribers: list[Subscriber] = []
         self.publishers: list[Publisher] = []
-        self._assemble_channels()
         self._assemble_subscribers_with_auto_promotions()
         self._assemble_publishers()
         self._remove_unsupported()
-
-    def _assemble_channels(self) -> None:
-        for saas_file in self._saas_files:
-            for resource_template in saas_file.resource_templates:
-                for target in resource_template.targets:
-                    if not target.promotion:
-                        continue
-                    for publish_channel in target.promotion.publish or []:
-                        if publish_channel not in self._channels_by_name:
-                            self._channels_by_name[publish_channel] = Channel(
-                                name=publish_channel,
-                                publishers=[],
-                            )
-                    for subscribe_channel in target.promotion.subscribe or []:
-                        if subscribe_channel not in self._channels_by_name:
-                            self._channels_by_name[subscribe_channel] = Channel(
-                                name=subscribe_channel,
-                                publishers=[],
-                            )
 
     def _assemble_publishers(self) -> None:
         for saas_file in self._saas_files:

--- a/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
+++ b/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
@@ -47,7 +47,7 @@ class SaasFilesInventory:
                     )
                     publisher = Publisher(
                         ref=target.ref,
-                        uid=target.uid(saas_file.name, resource_template.name),
+                        uid=target.uid,
                         repo_url=resource_template.url,
                         auth_code=auth_code,
                     )

--- a/reconcile/test/saas_auto_promotions_manager/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/conftest.py
@@ -32,6 +32,11 @@ def saas_files_builder(
                 d["imagePatterns"] = []
             for rt in d.get("resourceTemplates", []):
                 for t in rt.get("targets", []):
+                    if "parent_saas_file_name" not in t:
+                        t["parent_saas_file_name"] = "saas-file-name"
+                    if "parent_resource_template_name" not in t:
+                        t["parent_resource_template_name"] = "resource-template-name"
+
                     ns = t["namespace"]
                     if "name" not in ns:
                         ns["name"] = "some_name"

--- a/reconcile/test/saas_auto_promotions_manager/subscriber/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/subscriber/conftest.py
@@ -41,6 +41,7 @@ def subscriber_builder() -> Callable[[Mapping[str, Any]], Subscriber]:
             for publisher_name, publisher_data in channel_data.items():
                 publisher = Publisher(
                     ref="",
+                    uid="",
                     repo_url="",
                     auth_code=None,
                 )

--- a/reconcile/test/saas_auto_promotions_manager/test_integration_test.py
+++ b/reconcile/test/saas_auto_promotions_manager/test_integration_test.py
@@ -92,6 +92,8 @@ def test_integration_test(
                 "ls": [
                     "/promotions/channel-1/new_sha",
                     "/promotions/channel-2/new_sha",
+                    "/deployments/channel-3/target-uid/new_sha",
+                    "/deployments/channel-4/target-uid/new_sha",
                 ],
                 "get": {
                     "promotions/channel-1/new_sha": {
@@ -100,6 +102,16 @@ def test_integration_test(
                         "saas_file": "saas_1",
                     },
                     "promotions/channel-2/new_sha": {
+                        "success": True,
+                        "target_config_hash": "new_hash",
+                        "saas_file": "saas_1",
+                    },
+                    "/deployments/channel-3/target-uid/new_sha": {
+                        "success": True,
+                        "target_config_hash": "new_hash",
+                        "saas_file": "saas_1",
+                    },
+                    "/deployments/channel-4/target-uid/new_sha": {
                         "success": True,
                         "target_config_hash": "new_hash",
                         "saas_file": "saas_1",

--- a/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_multiple_publishers_for_single_channel.py
+++ b/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_multiple_publishers_for_single_channel.py
@@ -65,6 +65,4 @@ def test_multiple_publishers_for_single_channel(
     )
     inventory = SaasFilesInventory(saas_files=saas_files)
     assert len(inventory.publishers) == 2
-    # As of now we do not support this, i.e., all
-    # subscribers should be removed from the inventory
-    assert len(inventory.subscribers) == 0
+    assert len(inventory.subscribers) == 1

--- a/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_without_auto_promote.py
+++ b/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_without_auto_promote.py
@@ -61,5 +61,5 @@ def test_saas_files_without_auto_promote(
         ]
     )
     inventory = SaasFilesInventory(saas_files=saas_files)
-    assert len(inventory.publishers) == 2
+    assert len(inventory.publishers) == 0
     assert len(inventory.subscribers) == 0

--- a/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_without_auto_promote.py
+++ b/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_without_auto_promote.py
@@ -61,5 +61,5 @@ def test_saas_files_without_auto_promote(
         ]
     )
     inventory = SaasFilesInventory(saas_files=saas_files)
-    assert len(inventory.publishers) == 0
+    assert len(inventory.publishers) == 2
     assert len(inventory.subscribers) == 0

--- a/reconcile/test/test_auto_promoter.py
+++ b/reconcile/test/test_auto_promoter.py
@@ -15,6 +15,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="123123123",
+            saas_target_uid="saas_target_uid",
         )
 
         expected = {
@@ -50,6 +51,7 @@ class TestPromotions(TestCase):
             publish=["test-channel"],
             commit_sha="ahash",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         target_promotion = {
@@ -74,6 +76,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         target_promotion = {
@@ -110,6 +113,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         target_promotion = {
@@ -142,11 +146,12 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         ap = AutoPromoter([promotion])
         self.assertEqual(
-            ap.title, "[auto_promoter] openshift-saas-deploy automated promotion 4af7b1"
+            ap.title, "[auto_promoter] openshift-saas-deploy automated promotion 0a3d57"
         )
 
     def test_description_property(self) -> None:
@@ -157,6 +162,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         ap = AutoPromoter([promotion])
@@ -170,15 +176,13 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         ap = AutoPromoter([promotion])
         self.assertTrue(ap.gitlab_data["source_branch"].startswith("auto_promoter-"))
         self.assertEqual(ap.gitlab_data["target_branch"], "master")
-        self.assertEqual(
-            ap.gitlab_data["title"],
-            "[auto_promoter] openshift-saas-deploy automated promotion 4af7b1",
-        )
+        self.assertEqual(ap.gitlab_data["title"], ap.title)
         self.assertEqual(
             ap.gitlab_data["description"], "openshift-saas-deploy automated promotion"
         )
@@ -193,6 +197,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         ap = AutoPromoter([promotion])
@@ -210,6 +215,7 @@ class TestPromotions(TestCase):
                         "subscribe": None,
                         "promotion_data": None,
                         "saas_file_paths": ["destination-saas-file"],
+                        "saas_target_uid": "saas_target_uid",
                         "target_paths": None,
                     }
                 ],
@@ -224,6 +230,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
             promotion_data=[
                 {
                     "channel": "test-channel",
@@ -239,7 +246,7 @@ class TestPromotions(TestCase):
         )
 
         ap = AutoPromoter([promotion])
-        sqs_json = '{"pr_type": "auto_promoter", "promotions": [{"commit_sha": "ahash", "saas_file": "saas_file", "target_config_hash": "111111111", "auto": true, "publish": ["test-channel"], "subscribe": null, "promotion_data": [{"channel": "test-channel", "data": [{"type": "parent_saas_config", "parent_saas": "saas_file", "target_config_hash": "111111111"}]}], "saas_file_paths": ["destination-saas-file"], "target_paths": null}]}'
+        sqs_json = '{"pr_type": "auto_promoter", "promotions": [{"commit_sha": "ahash", "saas_file": "saas_file", "target_config_hash": "111111111", "saas_target_uid": "saas_target_uid", "auto": true, "publish": ["test-channel"], "subscribe": null, "promotion_data": [{"channel": "test-channel", "data": [{"type": "parent_saas_config", "parent_saas": "saas_file", "target_config_hash": "111111111"}]}], "saas_file_paths": ["destination-saas-file"], "target_paths": null}]}'
         self.assertEqual(json.dumps(ap.sqs_data), sqs_json)
 
     def test_init_with_promotion_object(self) -> None:
@@ -250,6 +257,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
             promotion_data=[
                 {
                     "channel": "test-channel",
@@ -276,6 +284,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
             promotion_data=[
                 {
                     "channel": "test-channel",

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -28,10 +28,11 @@ from reconcile.gql_definitions.common.saas_files import (
     SaasResourceTemplateTargetV2_SaasSecretParametersV1,
     SaasResourceTemplateV2,
 )
+from reconcile.typed_queries.saas_files import SaasFile
 from reconcile.utils.jjb_client import JJB
 from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.saasherder import SaasHerder
-from reconcile.utils.saasherder.interfaces import SaasFile
+from reconcile.utils.saasherder.interfaces import SaasFile as SaasFileInterface
 from reconcile.utils.saasherder.models import TriggerSpecMovingCommit
 from reconcile.utils.secret_reader import SecretReaderBase
 
@@ -607,7 +608,7 @@ class TestPopulateDesiredState(TestCase):
         self.saasherder.populate_desired_state(ri)
 
         cnt = 0
-        for (cluster, namespace, resource_type, data) in ri:
+        for cluster, namespace, resource_type, data in ri:
             for _, d_item in data["desired"].items():
                 expected = yaml.safe_load(
                     self.fxts.get(
@@ -761,7 +762,7 @@ class TestConfigHashPromotionsValidation(TestCase):
 
     def setUp(self) -> None:
         self.saas_file = self.gql_class_factory(  # type: ignore[attr-defined] # it's set in the fixture
-            SaasFileV2, Fixtures("saasherder").get_anymarkup("saas.gql.yml")
+            SaasFile, Fixtures("saasherder").get_anymarkup("saas.gql.yml")
         )
         self.all_saas_files = [self.saas_file]
 
@@ -959,7 +960,7 @@ class TestRemoveNoneAttributes(TestCase):
 
 
 def test_render_templated_parameters(
-    gql_class_factory: Callable[..., SaasFile]
+    gql_class_factory: Callable[..., SaasFileInterface]
 ) -> None:
     saas_file = gql_class_factory(
         SaasFileV2,

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -28,7 +28,10 @@ from reconcile.gql_definitions.common.saas_files import (
     SaasResourceTemplateTargetV2_SaasSecretParametersV1,
     SaasResourceTemplateV2,
 )
-from reconcile.typed_queries.saas_files import SaasFile
+from reconcile.typed_queries.saas_files import (
+    SaasFile,
+    convert_saas_file_v2_to_saas_file,
+)
 from reconcile.utils.jjb_client import JJB
 from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.saasherder import SaasHerder
@@ -762,8 +765,9 @@ class TestConfigHashPromotionsValidation(TestCase):
 
     def setUp(self) -> None:
         self.saas_file = self.gql_class_factory(  # type: ignore[attr-defined] # it's set in the fixture
-            SaasFile, Fixtures("saasherder").get_anymarkup("saas.gql.yml")
+            SaasFileV2, Fixtures("saasherder").get_anymarkup("saas.gql.yml")
         )
+        self.saas_file = convert_saas_file_v2_to_saas_file(self.saas_file)
         self.all_saas_files = [self.saas_file]
 
         self.state_patcher = patch("reconcile.utils.state.State", autospec=True)

--- a/reconcile/test/test_typed_queries/test_saas_files.py
+++ b/reconcile/test/test_typed_queries/test_saas_files.py
@@ -19,6 +19,7 @@ from reconcile.gql_definitions.fragments.saas_target_namespace import (
 from reconcile.test.fixtures import Fixtures
 from reconcile.typed_queries.saas_files import (
     SaasFile,
+    SaasResourceTemplateTarget,
     create_targets_for_namespace_selector,
     export_model,
     get_namespaces_by_selector,
@@ -600,6 +601,30 @@ def test_get_saasherder_settings(
     )
     assert setting.repo_url == "https://repo-url"
     assert setting.hash_length == 42
+
+
+def test_saas_target_uid(gql_class_factory: Callable) -> None:
+    target = gql_class_factory(
+        SaasResourceTemplateTarget,
+        {
+            "namespace": {
+                "name": "namespace-test",
+                "path": "some-path",
+                "environment": {
+                    "name": "test",
+                    "parameters": '{"ENV_PARAM": "foobar"}',
+                },
+                "app": {"name": "app-01"},
+                "cluster": CLUSTER,
+            },
+            "ref": "main",
+            "parameters": '{ "TARGET_PARAM": "foobar" }',
+        },
+    )
+    assert (
+        target.uid(saas_file_name="saas-file-01", resource_template_name="resource")
+        == "da117fd8c723f33f707012fc1317daf90d63013d"
+    )
 
 
 def test_export_model(

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -38,9 +38,9 @@ def test_key_exists_old_format(s3_state_builder: Callable[[Mapping], State]):
 def test_key_exists(s3_state_builder: Callable[[Mapping], State]):
     state = s3_state_builder(
         {
-            "ls": ["/deployments/saas_target_uid/channel/sha"],
+            "ls": ["/deployments/channel/saas_target_uid/sha"],
             "get": {
-                "deployments/saas_target_uid/channel/sha": {
+                "deployments/channel/saas_target_uid/sha": {
                     "success": True,
                     "target_config_hash": "hash",
                     "saas_file": "saas_file",
@@ -107,7 +107,7 @@ def test_key_does_not_exist_locally(s3_state_builder: Callable[[Mapping], State]
         {
             "ls": [],
             "get": {
-                "deployments/saas_target_uid/channel/sha": {
+                "deployments/channel/saas_target_uid/sha": {
                     "success": True,
                     "target_config_hash": "hash",
                     "saas_file": "saas_file",
@@ -147,5 +147,5 @@ def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
         data=promotion_info,
     )
     deployment_state._state.add.assert_called_once_with(  # type: ignore[attr-defined]
-        "deployments/saas_target_uid/channel/sha", promotion_info.dict(), True
+        "deployments/channel/saas_target_uid/sha", promotion_info.dict(), True
     )

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -24,6 +24,7 @@ from reconcile.gql_definitions.common.saas_files import (
     PipelinesProviderV1,
     RoleV1,
     SaasFileAuthenticationV1,
+    SaasFileV2,
     SaasResourceTemplateTargetImageV1,
     SaasResourceTemplateTargetNamespaceSelectorV1,
     SaasResourceTemplateTargetPromotionV1,
@@ -71,15 +72,24 @@ class SaasResourceTemplateTarget(ConfiguredBaseModel):
     image: Optional[SaasResourceTemplateTargetImageV1] = Field(..., alias="image")
     disable: Optional[bool] = Field(..., alias="disable")
     delete: Optional[bool] = Field(..., alias="delete")
+    parent_saas_file_name: Optional[str] = None
+    parent_resource_template_name: Optional[str] = None
 
     class Config:
         # ignore `namespaceSelector` and 'provider' fields from the GQL schema
         extra = Extra.ignore
 
-    def uid(self, saas_file_name: str, resource_template_name: str) -> str:
+    @property
+    def uid(self) -> str:
         """Returns a unique identifier for a target."""
+        if not self.parent_resource_template_name:
+            raise ValueError(
+                "parent_resource_template_name must be set before calling uid()"
+            )
+        if not self.parent_saas_file_name:
+            raise ValueError("parent_saas_file_name must be set before calling uid()")
         return hashlib.blake2s(
-            f"{saas_file_name}:{resource_template_name}:{self.name if self.name else 'default'}:{self.namespace.cluster.name}:{self.namespace.name}".encode(),
+            f"{self.parent_saas_file_name}:{self.parent_resource_template_name}:{self.name if self.name else 'default'}:{self.namespace.cluster.name}:{self.namespace.name}".encode(),
             digest_size=20,
         ).hexdigest()
 
@@ -213,6 +223,16 @@ def create_targets_for_namespace_selector(
     return targets
 
 
+def convert_saas_file_v2_to_saas_file(saas_file_gql: SaasFileV2) -> SaasFile:
+    """Convert a SaasFileV2 to a SaasFile and inject the parent objects."""
+    saas_file = SaasFile(**export_model(saas_file_gql))
+    for tmpl in saas_file.resource_templates:
+        for target in tmpl.targets:
+            target.parent_saas_file_name = saas_file.name
+            target.parent_resource_template_name = tmpl.name
+    return saas_file
+
+
 def get_saas_files(
     name: Optional[str] = None,
     env_name: Optional[str] = None,
@@ -253,7 +273,7 @@ def get_saas_files(
                     )
         # convert SaasFileV2 (with optional resource_templates.targets.namespace field)
         # to SaasFile (with required resource_templates.targets.namespace field)
-        saas_files.append(SaasFile(**export_model(saas_file_gql)))
+        saas_files.append(convert_saas_file_v2_to_saas_file(saas_file_gql))
 
     if name is None and env_name is None and app_name is None:
         return saas_files

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from collections.abc import Callable
 from typing import (
@@ -74,6 +75,13 @@ class SaasResourceTemplateTarget(ConfiguredBaseModel):
     class Config:
         # ignore `namespaceSelector` and 'provider' fields from the GQL schema
         extra = Extra.ignore
+
+    def uid(self, saas_file_name: str, resource_template_name: str) -> str:
+        """Returns a unique identifier for a target."""
+        return hashlib.blake2s(
+            f"{saas_file_name}:{resource_template_name}:{self.name if self.name else 'default'}:{self.namespace.cluster.name}:{self.namespace.name}".encode(),
+            digest_size=20,
+        ).hexdigest()
 
 
 class SaasResourceTemplate(ConfiguredBaseModel):

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -333,11 +333,9 @@ class SaasResourceTemplateTarget(HasParameters, HasSecretParameters, Protocol):
 
     def dict(self, *, by_alias: bool = False) -> dict[str, Any]:
         """Return a dictionary representation of the model."""
-        ...
 
     def uid(self, saas_file_name: str, resource_template_name: str) -> str:
         """Return a unique identifier for the target."""
-        ...
 
 
 class SaasResourceTemplate(HasParameters, HasSecretParameters, Protocol):

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -332,6 +332,11 @@ class SaasResourceTemplateTarget(HasParameters, HasSecretParameters, Protocol):
         ...
 
     def dict(self, *, by_alias: bool = False) -> dict[str, Any]:
+        """Return a dictionary representation of the model."""
+        ...
+
+    def uid(self, saas_file_name: str, resource_template_name: str) -> str:
+        """Return a unique identifier for the target."""
         ...
 
 

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -334,7 +334,8 @@ class SaasResourceTemplateTarget(HasParameters, HasSecretParameters, Protocol):
     def dict(self, *, by_alias: bool = False) -> dict[str, Any]:
         """Return a dictionary representation of the model."""
 
-    def uid(self, saas_file_name: str, resource_template_name: str) -> str:
+    @property
+    def uid(self) -> str:
         """Return a unique identifier for the target."""
 
 

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -167,6 +167,7 @@ class Promotion(BaseModel):
     commit_sha: str
     saas_file: str
     target_config_hash: str
+    saas_target_uid: str
     auto: Optional[bool] = None
     publish: Optional[list[str]] = None
     subscribe: Optional[list[str]] = None

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -996,6 +996,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 commit_sha=commit_sha,
                 saas_file=saas_file_name,
                 target_config_hash=target_config_hash,
+                saas_target_uid=target.uid(saas_file_name, resource_template_name),
             )
         return resources, html_url, target_promotion
 
@@ -1768,7 +1769,10 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             if promotion.subscribe:
                 for channel in promotion.subscribe:
                     info = self._promotion_state.get_promotion_data(
-                        sha=promotion.commit_sha, channel=channel, local_lookup=False
+                        sha=promotion.commit_sha,
+                        channel=channel,
+                        saas_target_uid=promotion.saas_target_uid,
+                        local_lookup=False,
                     )
                     if not (info and info.success):
                         logging.error(
@@ -1860,6 +1864,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     self._promotion_state.publish_promotion_data(
                         sha=promotion.commit_sha,
                         channel=channel,
+                        saas_target_uid=promotion.saas_target_uid,
                         data=PromotionData(
                             saas_file=promotion.saas_file,
                             success=success,

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -996,7 +996,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 commit_sha=commit_sha,
                 saas_file=saas_file_name,
                 target_config_hash=target_config_hash,
-                saas_target_uid=target.uid(saas_file_name, resource_template_name),
+                saas_target_uid=target.uid,
             )
         return resources, html_url, target_promotion
 


### PR DESCRIPTION
The deployment information (promotion data) is stored in an S3 bucket. Make the S3 key unique to avoid overwrites if multiple publishers are using the same channel name.

`promotions/{channel}/{commit_sha}`  -> `/deployments/{saas_target_uid}/{commit_sha}`

`saas_target_uid` is an unique blake2s hash composed of `{saas_name}/{resource_template_name}/{target_name|"default"}/{cluster_name}/namespace_name}`

Ticket: [APPSRE-7414](https://issues.redhat.com/browse/APPSRE-7414)