### PR TITLE
Add a generic differ function to get diff result of 2 mappings/lists

### DIFF
--- a/reconcile/test/utils/test_differ.py
+++ b/reconcile/test/utils/test_differ.py
@@ -1,8 +1,7 @@
+import typing
 from dataclasses import dataclass
-from typing import Any
 
 from reconcile.utils import differ
-from reconcile.utils.differ import DiffResult
 
 
 def test_diff_mappings_with_default_equal() -> None:
@@ -118,10 +117,11 @@ def test_diff_any_iterables_with_custom_equal() -> None:
     )
 
 
+@typing.no_type_check
 def test_diff_any_iterables_with_scalar_types() -> None:
     current = ["i", "d"]
     desired = ["i", "a"]
-    result = differ.diff_any_iterables(current, desired)  # type: ignore
+    result = differ.diff_any_iterables(current, desired)
 
     assert result == differ.DiffResult(
         add={"a": "a"},
@@ -146,6 +146,7 @@ class Foo:
         return hash(self.name)
 
 
+@typing.no_type_check
 def test_diff_any_iterables_with_custom_types() -> None:
     current = [
         Foo(name="i", value=1),
@@ -156,7 +157,7 @@ def test_diff_any_iterables_with_custom_types() -> None:
         Foo(name="a", value=30),
     ]
 
-    result: DiffResult[Foo, Foo, Foo] = differ.diff_any_iterables(current, desired)
+    result = differ.diff_any_iterables(current, desired)
 
     assert len(result.add) == 1
     assert result.add[Foo(name="a", value=30)].name == "a"

--- a/reconcile/test/utils/test_differ.py
+++ b/reconcile/test/utils/test_differ.py
@@ -1,27 +1,157 @@
+from dataclasses import dataclass
+
 from reconcile.utils import differ
 
 
-def test_diff_with_default_equal():
+def test_diff_mappings_with_default_equal():
     current = {"a": 1, "b": 2, "c": 3}
     desired = {"a": 1, "b": 20, "d": 30}
 
-    result = differ.diff(current, desired)
+    result = differ.diff_mappings(current, desired)
 
-    assert result == differ.DiffResult(
+    assert result == differ.DiffKeyedResult(
         add={"d": 30},
         delete={"c": 3},
         change={"b": (2, 20)},
     )
 
 
-def test_diff_with_custom_equal():
+def test_diff_mappings_with_custom_equal():
     current = {"a": 1, "b": 2, "c": 3}
     desired = {"a": [1], "b": [20], "d": [30]}
 
-    result = differ.diff(current, desired, equal=lambda x, y: x == y[0])
+    result = differ.diff_mappings(current, desired, equal=lambda c, d: c == d[0])
 
-    assert result == differ.DiffResult(
+    assert result == differ.DiffKeyedResult(
         add={"d": [30]},
         delete={"c": 3},
         change={"b": (2, [20])},
     )
+
+
+def test_diff_by_key_with_default_equal():
+    current = [
+        {"name": "a", "value": 1},
+        {"name": "b", "value": 2},
+        {"name": "c", "value": 3},
+    ]
+
+    desired = [
+        {"name": "a", "value": 1},
+        {"name": "b", "value": 20},
+        {"name": "d", "value": 30},
+    ]
+
+    result = differ.diff_by_key(
+        current,
+        desired,
+        current_key=lambda c: c["name"],
+        desired_key=lambda d: d["name"],
+    )
+
+    assert result == differ.DiffKeyedResult(
+        add={
+            "d": {"name": "d", "value": 30},
+        },
+        delete={
+            "c": {"name": "c", "value": 3},
+        },
+        change={
+            "b": (
+                {"name": "b", "value": 2},
+                {"name": "b", "value": 20},
+            )
+        },
+    )
+
+
+def test_diff_by_key_with_custom_equal():
+    current = [
+        {"name": "a", "value": 1},
+        {"name": "b", "value": 2},
+        {"name": "c", "value": 3},
+    ]
+
+    desired = [
+        {"name": "a", "value": [1]},
+        {"name": "b", "value": [20]},
+        {"name": "d", "value": [30]},
+    ]
+
+    result = differ.diff_by_key(
+        current,
+        desired,
+        current_key=lambda c: c["name"],
+        desired_key=lambda d: d["name"],
+        equal=lambda c, d: c["value"] == d["value"][0],
+    )
+
+    assert result == differ.DiffKeyedResult(
+        add={
+            "d": {"name": "d", "value": [30]},
+        },
+        delete={
+            "c": {"name": "c", "value": 3},
+        },
+        change={
+            "b": (
+                {"name": "b", "value": 2},
+                {"name": "b", "value": [20]},
+            )
+        },
+    )
+
+
+def test_diff_lists_with_scalar_types():
+    current = ["a", "b"]
+    desired = ["a", "c"]
+
+    result = differ.diff_lists(current, desired)
+
+    assert result == differ.DiffListsResult(
+        add=["c"],
+        delete=["b"],
+        identical=[("a", "a")],
+    )
+
+
+@dataclass
+class Foo:
+    name: str
+    value: int
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Foo):
+            return False
+
+        return self.name == other.name
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
+
+def test_diff_lists_with_custom_types():
+    current = [
+        Foo(name="a", value=1),
+        Foo(name="b", value=2),
+    ]
+    desired = [
+        Foo(name="a", value=10),
+        Foo(name="c", value=30),
+    ]
+
+    result = differ.diff_lists(current, desired)
+
+    assert len(result.add) == 1
+    assert result.add[0].name == "c"
+    assert result.add[0].value == 30
+
+    assert len(result.delete) == 1
+    assert result.delete[0].name == "b"
+    assert result.delete[0].value == 2
+
+    assert len(result.identical) == 1
+    assert result.identical[0][0].name == "a"
+    assert result.identical[0][0].value == 1
+    assert result.identical[0][1].name == "a"
+    assert result.identical[0][1].value == 10

--- a/reconcile/test/utils/test_differ.py
+++ b/reconcile/test/utils/test_differ.py
@@ -1,0 +1,27 @@
+from reconcile.utils import differ
+
+
+def test_diff_with_default_equal():
+    current = {"a": 1, "b": 2, "c": 3}
+    desired = {"a": 1, "b": 20, "d": 30}
+
+    result = differ.diff(current, desired)
+
+    assert result == differ.DiffResult(
+        add={"d": 30},
+        delete={"c": 3},
+        change={"b": (2, 20)},
+    )
+
+
+def test_diff_with_custom_equal():
+    current = {"a": 1, "b": 2, "c": 3}
+    desired = {"a": [1], "b": [20], "d": [30]}
+
+    result = differ.diff(current, desired, equal=lambda x, y: x == y[0])
+
+    assert result == differ.DiffResult(
+        add={"d": [30]},
+        delete={"c": 3},
+        change={"b": (2, [20])},
+    )

--- a/reconcile/utils/differ.py
+++ b/reconcile/utils/differ.py
@@ -2,7 +2,6 @@ from collections.abc import (
     Callable,
     Iterable,
     Mapping,
-    Sequence,
 )
 from dataclasses import dataclass
 from typing import (
@@ -12,32 +11,45 @@ from typing import (
     cast,
 )
 
+T = TypeVar("T")
 Current = TypeVar("Current")
 Desired = TypeVar("Desired")
 Key = TypeVar("Key")
 
 
 @dataclass(frozen=True, eq=True)
-class DiffKeyedResult(Generic[Current, Desired, Key]):
-    add: dict[Key, Desired]
-    delete: dict[Key, Current]
-    change: dict[Key, tuple[Current, Desired]]
+class DiffPair(Generic[Current, Desired]):
+    current: Current
+    desired: Desired
 
 
 @dataclass(frozen=True, eq=True)
-class DiffListsResult(Generic[Current, Desired]):
-    add: list[Desired]
-    delete: list[Current]
-    identical: list[tuple[Current, Desired]]
+class DiffResult(Generic[Current, Desired, Key]):
+    add: dict[Key, Desired]
+    delete: dict[Key, Current]
+    change: dict[Key, DiffPair[Current, Desired]]
+    identical: dict[Key, DiffPair[Current, Desired]]
+
+
+def _default_equal(current: Current, desired: Desired) -> bool:
+    return current == desired
+
+
+def _default_current_key(current: Current) -> Key:
+    return cast(Key, current)
+
+
+def _default_desired_key(desired: Desired) -> Key:
+    return cast(Key, desired)
 
 
 def diff_mappings(
     current: Mapping[Key, Current],
     desired: Mapping[Key, Desired],
     equal: Optional[Callable[[Current, Desired], bool]] = None,
-) -> DiffKeyedResult[Current, Desired, Key]:
+) -> DiffResult[Current, Desired, Key]:
     """
-    Compare two mappings and return a `DiffKeyedResult` instance containing the differences between them.
+    Compare two mappings and return a `DiffResult` instance containing the differences between them.
 
     :param current: The current mapping to compare.
     :type current: Mapping[Key, Current]
@@ -47,113 +59,157 @@ def diff_mappings(
         If not provided, the default behavior is to use the `==` operator.
     :type equal: Optional[Callable[[Current, Desired], bool]]
     :return: A `DiffResult` instance containing the differences between the `current` and `desired` mappings,
-        including elements that were added, deleted, or changed.
-    :rtype: DiffKeyedResult[Current, Desired, Key]
+        including elements that were added, deleted, changed or identical.
+    :rtype: DiffResult[Current, Desired, Key]
     :raises: None
 
     Example:
-        >>> current = {"a": 1, "b": 2, "c": 3}
-        >>> desired = {"a": 1, "b": 20, "d": 30}
+        >>> current = {"i": 1, "c": 2, "d": 3}
+        >>> desired = {"i": 1, "c": 20, "a": 30}
         >>> result = diff_mappings(current, desired, equal=lambda c, d: c == d)
-        DiffKeyedResult(add={'d': 30}, delete={'c': 3}, change={'b': (2, 20)})
+        DiffResult(
+            add={'a': 30},
+            delete={'d': 3},
+            change={'c': DiffPair(current=2, desired=20),
+            identical={'i': DiffPair(current=1, desired=1)},
+        )
     """
-    eq = equal or (lambda c, d: c == d)
+    if equal is None:
+        equal = _default_equal
     add = {k: desired[k] for k in desired.keys() - current.keys()}
     delete = {k: current[k] for k in current.keys() - desired.keys()}
-    change = {
-        k: (current[k], desired[k])
-        for k in current.keys() & desired.keys()
-        if not eq(current[k], desired[k])
-    }
-    return DiffKeyedResult(add=add, delete=delete, change=change)
+    change, identical = {}, {}
+    for k in current.keys() & desired.keys():
+        diff_pair = DiffPair(current=current[k], desired=desired[k])
+        if equal(diff_pair.current, diff_pair.desired):
+            identical[k] = diff_pair
+        else:
+            change[k] = diff_pair
+    return DiffResult(
+        add=add,
+        delete=delete,
+        change=change,
+        identical=identical,
+    )
 
 
-def diff_by_key(
+def diff_any_iterables(
     current: Iterable[Current],
     desired: Iterable[Desired],
-    current_key: Callable[[Current], Key],
-    desired_key: Callable[[Desired], Key],
+    current_key: Optional[Callable[[Current], Key]] = None,
+    desired_key: Optional[Callable[[Desired], Key]] = None,
     equal: Optional[Callable[[Current, Desired], bool]] = None,
-) -> DiffKeyedResult[Current, Desired, Key]:
+) -> DiffResult[Current, Desired, Key]:
     """
-    Compare two iterables and return a `DiffKeyedResult` instance containing the differences between them.
+    Compare two iterables and return a `DiffResult` instance containing the differences between them.
 
     :param current: The current iterable to compare.
     :type current: Iterable[Current]
     :param desired: The desired iterable to compare.
     :type desired: Iterable[Desired]
-    :param current_key: A function that returns the key for an element in the `current` iterable.
-    :type current_key: Callable[[Current], Key]
-    :param desired_key: A function that returns the key for an element in the `desired` iterable.
-    :type desired_key: Callable[[Desired], Key]
+    :param current_key: An optional function that returns the key for an element in the `current` iterable.
+        If not provided, the default behavior is to use the element itself as the key.
+    :type current_key: Optional[Callable[[Current], Key]]
+    :param desired_key: An optaionl function that returns the key for an element in the `desired` iterable.
+        If not provided, the default behavior is to use the element itself as the key.
+    :type desired_key: Optional[Callable[[Desired], Key]]
     :param equal: An optional function that compares two elements in the iterables and returns True if they are equal.
         If not provided, the default behavior is to use the `==` operator.
     :type equal: Optional[Callable[[Current, Desired], bool]]
-    :return: A `DiffKeyedResult` instance containing the differences between the `current` and `desired` mappings,
-        including elements that were added, deleted, or changed.
-    :rtype: DiffKeyedResult[Current, Desired, Key]
+    :return: A `DiffResult` instance containing the differences between the `current` and `desired` iterables,
+        including elements that were added, deleted, changed or identical.
+    :rtype: DiffResult[Current, Desired, Key]
     :raises: None
 
     Example:
-    >>> current = [
-    ...     {"name": "a", "value": 1},
-    ...     {"name": "b", "value": 2},
-    ...     {"name": "c", "value": 3},
-    ... ]
-    >>> desired = [
-    ...     {"name": "a", "value": 1},
-    ...     {"name": "b", "value": 20},
-    ...     {"name": "d", "value": 30},
-    ... ]
-    >>> result = diff_by_key(
-    ...     current,
-    ...     desired,
-    ...     lambda c: c["name"],
-    ...     lambda d: d["name"],
-    ...     equal=lambda c, d: c["value"] == d["value"],
-    ... )
-    DiffKeyedResult(
-        add={'d': {'name': 'd', 'value': 30}},
-        delete={'c': {'name': 'c', 'value': 3}},
-        change={'b': ({'name': 'b', 'value': 2}, {'name': 'b', 'value': 20}))
-    )
+        >>> current = [
+        ...     {"name": "i", "value": 1},
+        ...     {"name": "c", "value": 2},
+        ...     {"name": "d", "value": 3},
+        ... ]
+        >>> desired = [
+        ...     {"name": "i", "value": 1},
+        ...     {"name": "c", "value": 20},
+        ...     {"name": "a", "value": 30},
+        ... ]
+        >>> result = diff_any_iterables(
+        ...     current,
+        ...     desired,
+        ...     lambda c: c["name"],
+        ...     lambda d: d["name"],
+        ...     equal=lambda c, d: c["value"] == d["value"],
+        ... )
+        DiffResult(
+            add={'a': {'name': 'a', 'value': 30}},
+            delete={'d': {'name': 'd', 'value': 3}},
+            change={'c': DiffPair(current={'name': 'c', 'value': 2}, desired={'name': 'c', 'value': 20})),
+            identical={'i': DiffPair(current={'name': 'i', 'value': 1}, desired={'name': 'i', 'value': 1})},
+        )
     """
+    if current_key is None:
+        current_key = _default_current_key
+    if desired_key is None:
+        desired_key = _default_desired_key
     current_dict = {current_key(c): c for c in current}
     desired_dict = {desired_key(d): d for d in desired}
-    return diff_mappings(current_dict, desired_dict, equal=equal)
+    return diff_mappings(
+        current_dict,
+        desired_dict,
+        equal=equal,
+    )
 
 
-def diff_lists(
-    current: Sequence[Current],
-    desired: Sequence[Desired],
-) -> DiffListsResult[Current, Desired]:
+def diff_iterables(
+    current: Iterable[T],
+    desired: Iterable[T],
+    key: Optional[Callable[[T], Key]] = None,
+    equal: Optional[Callable[[T, T], bool]] = None,
+) -> DiffResult[T, T, Key]:
     """
-    Compare two iterables and return a `DiffListsResult` instance containing the differences between them.
-
-    :param current: The current sequence to compare.
-    :type current: Sequence[Current]
-    :param desired: The desired sequence to compare.
-    :type desired: Sequence[Desired]
-    :return: A `DiffListsResult` instance containing the differences between the `current` and `desired` mappings,
-        including elements that were added ,deleted or identical.
-    :rtype: DiffListsResult[Current, Desired]
+    Compare two iterables with same type and return a `DiffResult` instance containing the differences between them.
+    :param current: The current iterable to compare.
+    :type current: Iterable[T]
+    :param desired: The desired iterable to compare.
+    :type desired: Iterable[T]
+    :param key: An optional function that returns the key for an element in the `current` and `desired` iterable.
+        If not provided, the default behavior is to use the element itself as the key.
+    :type key: Optional[Callable[[Current], Key]]
+    :param equal: An optional function that compares two elements in the iterables and returns True if they are equal.
+        If not provided, the default behavior is to use the `==` operator.
+    :type equal: Optional[Callable[[Current, Desired], bool]]
+    :return: A `DiffResult` instance containing the differences between the `current` and `desired` iterables,
+        including elements that were added, deleted, changed or identical.
+    :rtype: DiffResult[T, T, Key]
     :raises: None
 
     Example:
-    >>> current = [1, 2]
-    >>> desired = [1, 3]
-    >>> result = diff_lists(current, desired)
-    DiffListsResult(add=[3], delete=[2], identical=[(1, 1)])
-    """
-    current_to_index = {c: idx for idx, c in enumerate(current)}
-    desired_to_index = {d: idx for idx, d in enumerate(desired)}
-    add = list(desired_to_index.keys() - current_to_index.keys())
-    delete = list(current_to_index.keys() - desired_to_index.keys())
-    identical = [
-        (
-            current[current_to_index[cast(Current, k)]],
-            desired[desired_to_index[cast(Desired, k)]],
+        >>> current = [
+        ...     {"name": "i", "value": 1},
+        ...     {"name": "c", "value": 2},
+        ...     {"name": "d", "value": 3},
+        ... ]
+        >>> desired = [
+        ...     {"name": "i", "value": 1},
+        ...     {"name": "c", "value": 20},
+        ...     {"name": "a", "value": 30},
+        ... ]
+        >>> result = diff_iterables(
+        ...     current,
+        ...     desired,
+        ...     lambda x: x["name"],
+        ...     equal=lambda c, d: c["value"] == d["value"],
+        ... )
+        DiffResult(
+            add={'a': {'name': 'a', 'value': 30}},
+            delete={'d': {'name': 'd', 'value': 3}},
+            change={'c': DiffPair(current={'name': 'c', 'value': 2}, desired={'name': 'c', 'value': 20})),
+            identical={'i': DiffPair(current={'name': 'i', 'value': 1}, desired={'name': 'i', 'value': 1})},
         )
-        for k in current_to_index.keys() & desired_to_index.keys()
-    ]
-    return DiffListsResult(add=add, delete=delete, identical=identical)
+    """
+    return diff_any_iterables(
+        current,
+        desired,
+        current_key=key,
+        desired_key=key,
+        equal=equal,
+    )

--- a/reconcile/utils/differ.py
+++ b/reconcile/utils/differ.py
@@ -1,6 +1,8 @@
 from collections.abc import (
     Callable,
+    Iterable,
     Mapping,
+    Sequence,
 )
 from dataclasses import dataclass
 from typing import (
@@ -15,19 +17,26 @@ K = TypeVar("K")
 
 
 @dataclass(frozen=True, eq=True)
-class DiffResult(Generic[C, D, K]):
+class DiffKeyedResult(Generic[C, D, K]):
     add: dict[K, D]
     delete: dict[K, C]
     change: dict[K, tuple[C, D]]
 
 
-def diff(
+@dataclass(frozen=True, eq=True)
+class DiffListsResult(Generic[C, D]):
+    add: list[D]
+    delete: list[C]
+    identical: list[tuple[C, D]]
+
+
+def diff_mappings(
     current: Mapping[K, C],
     desired: Mapping[K, D],
     equal: Optional[Callable[[C, D], bool]] = None,
-) -> DiffResult[C, D, K]:
+) -> DiffKeyedResult[C, D, K]:
     """
-    Compare two mappings and return a `DiffResult` instance containing the differences between them.
+    Compare two mappings and return a `DiffKeyedResult` instance containing the differences between them.
 
     :param current: The current mapping to compare.
     :type current: Mapping[K, C]
@@ -38,10 +47,16 @@ def diff(
     :type equal: Optional[Callable[[C, D], bool]]
     :return: A `DiffResult` instance containing the differences between the `current` and `desired` mappings,
         including elements that were added, deleted, or changed.
-    :rtype: DiffResult[C, D, K]
+    :rtype: DiffKeyedResult[C, D, K]
     :raises: None
+
+    Example:
+        >>> current = {"a": 1, "b": 2, "c": 3}
+        >>> desired = {"a": 1, "b": 20, "d": 30}
+        >>> result = diff_mappings(current, desired, equal=lambda c, d: c == d)
+        DiffKeyedResult(add={'d': 30}, delete={'c': 3}, change={'b': (2, 20)})
     """
-    eq = equal or (lambda x, y: x == y)
+    eq = equal or (lambda c, d: c == d)
     add = {k: desired[k] for k in desired.keys() - current.keys()}
     delete = {k: current[k] for k in current.keys() - desired.keys()}
     change = {
@@ -49,4 +64,96 @@ def diff(
         for k in current.keys() & desired.keys()
         if not eq(current[k], desired[k])
     }
-    return DiffResult(add=add, delete=delete, change=change)
+    return DiffKeyedResult(add=add, delete=delete, change=change)
+
+
+def diff_by_key(
+    current: Iterable[C],
+    desired: Iterable[D],
+    current_key: Callable[[C], K],
+    desired_key: Callable[[D], K],
+    equal: Optional[Callable[[C, D], bool]] = None,
+) -> DiffKeyedResult[C, D, K]:
+    """
+    Compare two iterables and return a `DiffKeyedResult` instance containing the differences between them.
+
+    :param current: The current iterable to compare.
+    :type current: Iterable[C]
+    :param desired: The desired iterable to compare.
+    :type desired: Iterable[D]
+    :param current_key: A function that returns the key for an element in the `current` iterable.
+    :type current_key: Callable[[C], K]
+    :param desired_key: A function that returns the key for an element in the `desired` iterable.
+    :type desired_key: Callable[[D], K]
+    :param equal: An optional function that compares two elements in the iterables and returns True if they are equal.
+        If not provided, the default behavior is to use the `==` operator.
+    :type equal: Optional[Callable[[C, D], bool]]
+    :return: A `DiffKeyedResult` instance containing the differences between the `current` and `desired` mappings,
+        including elements that were added, deleted, or changed.
+    :rtype: DiffKeyedResult[C, D, K]
+    :raises: None
+
+    Example:
+    >>> current = [
+    ...     {"name": "a", "value": 1},
+    ...     {"name": "b", "value": 2},
+    ...     {"name": "c", "value": 3},
+    ... ]
+    >>> desired = [
+    ...     {"name": "a", "value": 1},
+    ...     {"name": "b", "value": 20},
+    ...     {"name": "d", "value": 30},
+    ... ]
+    >>> result = diff_by_key(
+    ...     current,
+    ...     desired,
+    ...     lambda c: c["name"],
+    ...     lambda d: d["name"],
+    ...     equal=lambda c, d: c["value"] == d["value"],
+    ... )
+    DiffKeyedResult(
+        add={'d': {'name': 'd', 'value': 30}},
+        delete={'c': {'name': 'c', 'value': 3}},
+        change={'b': ({'name': 'b', 'value': 2}, {'name': 'b', 'value': 20}))
+    )
+    """
+    current_dict = {current_key(x): x for x in current}
+    desired_dict = {desired_key(x): x for x in desired}
+    return diff_mappings(current_dict, desired_dict, equal=equal)
+
+
+def diff_lists(
+    current: Sequence[C],
+    desired: Sequence[D],
+) -> DiffListsResult[C, D]:
+    """
+    Compare two iterables and return a `DiffListsResult` instance containing the differences between them.
+
+    :param current: The current sequence to compare.
+    :type current: Sequence[C]
+    :param desired: The desired sequence to compare.
+    :type desired: Sequence[D]
+    :return: A `DiffListsResult` instance containing the differences between the `current` and `desired` mappings,
+        including elements that were added ,deleted or identical.
+    :rtype: DiffListsResult[C, D]
+    :raises: None
+
+    Example:
+    >>> current = [1, 2]
+    >>> desired = [1, 3]
+    >>> result = diff_lists(current, desired)
+    DiffListsResult(add=[3], delete=[2], identical=[(1, 1)])
+    """
+    current_with_index = {x: idx for idx, x in enumerate(current)}
+    desired_with_index = {x: idx for idx, x in enumerate(desired)}
+    add = list(desired_with_index.keys() - current_with_index.keys())
+    delete = list(current_with_index.keys() - desired_with_index.keys())
+    identical = [
+        (current[current_with_index[k]], desired[desired_with_index[k]])
+        for k in current_with_index.keys() & desired_with_index.keys()
+    ]
+    return DiffListsResult(
+        add=add,
+        delete=delete,
+        identical=identical,
+    )

--- a/reconcile/utils/differ.py
+++ b/reconcile/utils/differ.py
@@ -1,0 +1,52 @@
+from collections.abc import (
+    Callable,
+    Mapping,
+)
+from dataclasses import dataclass
+from typing import (
+    Generic,
+    Optional,
+    TypeVar,
+)
+
+C = TypeVar("C")
+D = TypeVar("D")
+K = TypeVar("K")
+
+
+@dataclass(frozen=True, eq=True)
+class DiffResult(Generic[C, D, K]):
+    add: dict[K, D]
+    delete: dict[K, C]
+    change: dict[K, tuple[C, D]]
+
+
+def diff(
+    current: Mapping[K, C],
+    desired: Mapping[K, D],
+    equal: Optional[Callable[[C, D], bool]] = None,
+) -> DiffResult[C, D, K]:
+    """
+    Compare two mappings and return a `DiffResult` instance containing the differences between them.
+
+    :param current: The current mapping to compare.
+    :type current: Mapping[K, C]
+    :param desired: The desired mapping to compare.
+    :type desired: Mapping[K, D]
+    :param equal: An optional function that compares two elements in the mappings and returns True if they are equal.
+        If not provided, the default behavior is to use the `==` operator.
+    :type equal: Optional[Callable[[C, D], bool]]
+    :return: A `DiffResult` instance containing the differences between the `current` and `desired` mappings,
+        including elements that were added, deleted, or changed.
+    :rtype: DiffResult[C, D, K]
+    :raises: None
+    """
+    eq = equal or (lambda x, y: x == y)
+    add = {k: desired[k] for k in desired.keys() - current.keys()}
+    delete = {k: current[k] for k in current.keys() - desired.keys()}
+    change = {
+        k: (current[k], desired[k])
+        for k in current.keys() & desired.keys()
+        if not eq(current[k], desired[k])
+    }
+    return DiffResult(add=add, delete=delete, change=change)


### PR DESCRIPTION
This is a generic differ function can be used to simplify repeated logic in multiple places.

It supports diff 2 mappings, 2 simple lists, or 2 lists with key selectors.

Based on comments from https://github.com/app-sre/qontract-reconcile/pull/3464#discussion_r1177584112.


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ac0202a</samp>

This pull request introduces the `differ` module, which provides functions and data classes to compare mappings and iterables. It also adds unit tests for the `differ` module in the `reconcile/test/utils` directory. The `differ` module is used to compare the current and desired states of various resources managed by the qontract-reconcile tool.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ac0202a</samp>

*  Implement a generic and reusable way to compare mappings and iterables ([link](https://github.com/app-sre/qontract-reconcile/pull/3475/files?diff=unified&w=0#diff-92d30bcad821fdb092179a4ba46aa1d77b5236d0e96c94856e607ca5e4c1e648R1-R205))
* Add unit tests for the `differ` module ([link](https://github.com/app-sre/qontract-reconcile/pull/3475/files?diff=unified&w=0#diff-aeaafcb70467dc4315824cf6e4cc3eaf3508822fd4b9eb7ea5040164454cf963R1-R217))