### PR TITLE
[jenkins-webhooks] allow no push hook

### DIFF
--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -293,7 +293,10 @@ class JJB:  # pylint: disable=too-many-public-methods
                     project_url = project_url_raw.strip("/").replace(".git", "")
                     gitlab_triggers = job["triggers"][0]["gitlab"]
                     mr_trigger = gitlab_triggers["trigger-merge-request"]
-                    trigger = "mr" if mr_trigger else "push"
+                    push_trigger = gitlab_triggers["trigger-push"]
+                    trigger = "mr" if mr_trigger else "push" if push_trigger else None
+                    if trigger is None:
+                        continue
                     hook = {
                         "job_url": job_url,
                         "trigger": trigger,


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-7536

the `jenkins-webhooks` integration creates webhooks from gitlab to jenkins based on the job - either a hook for a merge request or a hook for a push.

in this [MR](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/66494) we added an option for a build job to not be triggered by a push. in such a case, there should be no webhook created:
```
        triggers:
        - gitlab:
            trigger-push: false
```
ref: https://jenkins-job-builder.readthedocs.io/en/latest/triggers.html#triggers.gitlab