### PR TITLE
[openshift-saas-deploy] add trigger-reason to slack notification

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -445,6 +445,16 @@ def include_trigger_trace(function):
     return function
 
 
+def trigger_reason(function):
+    function = click.option(
+        "--trigger-reason",
+        help="reason deployment was triggered.",
+        default=None,
+    )(function)
+
+    return function
+
+
 def register_faulthandler(fileobj=sys.__stderr__):
     if fileobj:
         if not faulthandler.is_enabled():
@@ -1016,6 +1026,7 @@ def openshift_resources(
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
 @click.option("--saas-file-name", default=None, help="saas-file to act on.")
 @click.option("--env-name", default=None, help="environment to deploy to.")
+@trigger_reason
 @click.pass_context
 def openshift_saas_deploy(
     ctx,
@@ -1025,6 +1036,7 @@ def openshift_saas_deploy(
     saas_file_name,
     env_name,
     gitlab_project_id,
+    trigger_reason,
 ):
     import reconcile.openshift_saas_deploy
 
@@ -1037,6 +1049,7 @@ def openshift_saas_deploy(
         saas_file_name=saas_file_name,
         env_name=env_name,
         gitlab_project_id=gitlab_project_id,
+        trigger_reason=trigger_reason,
     )
 
 

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -61,6 +61,7 @@ def slack_notify(
     ri: ResourceInventory,
     console_url: str,
     in_progress: bool,
+    trigger_reason: Optional[str] = None,
 ) -> None:
     success = not ri.has_error_registered()
     if in_progress:
@@ -77,6 +78,8 @@ def slack_notify(
         + f"deployment to environment *{env_name}*: "
         + f"{description} (<{console_url}|Open>)"
     )
+    if trigger_reason:
+        message += f". Reason: {trigger_reason}"
     slack.chat_post_message(message)
 
 
@@ -89,6 +92,7 @@ def run(
     saas_file_name: Optional[str] = None,
     env_name: Optional[str] = None,
     gitlab_project_id: Optional[str] = None,
+    trigger_reason: Optional[str] = None,
     defer: Optional[Callable] = None,
 ) -> None:
     vault_settings = get_app_interface_vault_settings()
@@ -134,6 +138,7 @@ def run(
                         ri,
                         console_url,
                         in_progress=False,
+                        trigger_reason=trigger_reason,
                     )
                 )
             # deployment start notification
@@ -145,6 +150,7 @@ def run(
                     ri,
                     console_url,
                     in_progress=True,
+                    trigger_reason=trigger_reason,
                 )
 
     jenkins_map = jenkins_base.get_jenkins_map()


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-6647

with this change, when we pass `--trigger-reason` to `openshift-saas-deploy`, it will add the content to the slack notification.

the content comes from the tekton [Pipeline/Taks](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/66496) (originating from the trigger integrations: #2422, #3303)