### PR TITLE
Fix cluster console update attribute

### DIFF
--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -416,7 +416,7 @@ class OCMProductRosa(OCMProduct):
         )
 
         ocm_spec = OCMSpec(
-            # Hosted-control-plane clusters can reach a Ready State without having the console
+            # Hosted control plane clusters can reach a Ready State without having the console
             # Endpoint
             console_url=cluster.get("console", {}).get("url", ""),
             server_url=cluster["api"]["url"],

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -416,7 +416,7 @@ class OCMProductRosa(OCMProduct):
         )
 
         ocm_spec = OCMSpec(
-            # Hosted cp clusters can reach a Ready State without having the console
+            # Hosted-control-plane clusters can reach a Ready State without having the console
             # Endpoint
             console_url=cluster.get("console", {}).get("url", ""),
             server_url=cluster["api"]["url"],

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -416,7 +416,9 @@ class OCMProductRosa(OCMProduct):
         )
 
         ocm_spec = OCMSpec(
-            console_url=cluster["console"]["url"],
+            # Hosted cp clusters can reach a Ready State without having the console
+            # Endpoint
+            console_url=cluster.get("console", {}).get("url", ""),
             server_url=cluster["api"]["url"],
             domain=cluster["dns"]["base_domain"],
             spec=spec,


### PR DESCRIPTION
Hosted-CP clusters can become READY before the console attribute is populated
