### PR TITLE
upgrade ruamel.yaml and fix mypy errors

### DIFF
--- a/reconcile/utils/mr/auto_promoter.py
+++ b/reconcile/utils/mr/auto_promoter.py
@@ -202,7 +202,7 @@ class AutoPromoter(MergeRequestBase):
                 content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
                 if self.process_target(content, promotion):
                     new_content = "---\n"
-                    new_content += yaml.dump(content, Dumper=yaml.RoundTripDumper)  # type: ignore
+                    new_content += yaml.dump(content, Dumper=yaml.RoundTripDumper)
                     msg = f"auto promote {promotion.commit_sha} in {target_path}"
                     gitlab_cli.update_file(
                         branch_name=self.branch,

--- a/reconcile/utils/mr/clusters_updates.py
+++ b/reconcile/utils/mr/clusters_updates.py
@@ -6,7 +6,7 @@ from reconcile.change_owners.decision import DecisionCommand
 from reconcile.utils.mr.base import MergeRequestBase
 
 yaml = YAML()
-yaml.explicit_start = True  # type: ignore
+yaml.explicit_start = True
 
 
 class CreateClustersUpdates(MergeRequestBase):

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
         "Jinja2>=2.10.1,<3.2.0",
         "jira~=3.1",
         "pyOpenSSL~=23.0",
-        "ruamel.yaml>=0.16.5,<0.18.0",
+        "ruamel.yaml>=0.17.22,<0.18.0",
         "terrascript==0.9.0",
         "tabulate>=0.8.6,<0.9.0",
         "UnleashClient~=5.3",


### PR DESCRIPTION
Latest `ruamel.yaml==0.17.22` fixes mypy typing issues. Upgrade it and remove unneeded 'type: ignore' comments