### PR TITLE
Use typed query and dataclass in terraform-tgw-attachments

### DIFF
--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -20,7 +20,6 @@ from reconcile.gql_definitions.common.app_interface_vault_settings import (
 )
 from reconcile.gql_definitions.common.clusters_with_peering import (
     ClusterPeeringConnectionAccountTGWV1,
-    ClusterPeeringConnectionAccountTGWV1_AWSAccountV1,
     ClusterPeeringConnectionAccountV1,
     ClusterPeeringConnectionAccountVPCMeshV1,
     ClusterPeeringConnectionClusterRequesterV1,
@@ -59,7 +58,9 @@ class ValidationError(Exception):
     pass
 
 
-class AccountWithAssumeRole(ClusterPeeringConnectionAccountTGWV1_AWSAccountV1):
+class AccountWithAssumeRole(BaseModel):
+    name: str
+    uid: str
     assume_role: str
     assume_region: str
     assume_cidr: str
@@ -203,10 +204,11 @@ def _build_account_with_assume_role(
             cluster_name, account.uid, account.terraform_username
         )
     return AccountWithAssumeRole(
+        name=account.name,
+        uid=account.uid,
         assume_role=assume_role,
         assume_region=region,
         assume_cidr=cidr_block,
-        **peer_connection.account.dict(by_alias=True),
     )
 
 

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -24,6 +24,7 @@ from reconcile.utils.ocm import (
     OCM,
     OCMMap,
 )
+from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.terraform_client import TerraformClient as Terraform
 from reconcile.utils.terrascript_aws_client import TerrascriptClient as Terrascript
@@ -279,6 +280,7 @@ def run(
     defer: Optional[Callable] = None,
 ) -> None:
     vault_settings = get_app_interface_vault_settings()
+    secret_reader = create_secret_reader(vault_settings.vault)
     clusters = queries.get_clusters_with_peering_settings()
     tgw_clusters = _filter_tgw_clusters(clusters, account_name)
     ocm_map = _build_ocm_map(tgw_clusters, vault_settings)
@@ -289,9 +291,7 @@ def run(
     )
     tgw_accounts = _filter_tgw_accounts(accounts, tgw_clusters)
 
-    aws_api = AWSApi(
-        1, tgw_accounts, settings=vault_settings.dict(by_alias=True), init_users=False
-    )
+    aws_api = AWSApi(1, tgw_accounts, secret_reader=secret_reader, init_users=False)
     if defer:
         defer(aws_api.cleanup)
 

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -161,7 +161,7 @@ def _build_desired_state_tgw_connection(
         yield None
 
     account_tgws = awsapi.get_tgws_details(
-        account,
+        account.dict(by_alias=True),
         cluster_region,
         cluster_cidr_block,
         tags=peer_connection.tags or {},
@@ -218,7 +218,7 @@ def _build_accepter(
     awsapi: AWSApi,
 ) -> Accepter:
     (vpc_id, route_table_ids, subnets_id_az) = awsapi.get_cluster_vpc_details(
-        account,
+        account.dict(by_alias=True),
         route_tables=peer_connection.manage_routes,
         subnets=True,
     )

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -4,6 +4,7 @@ from collections.abc import (
     Mapping,
 )
 from typing import Optional
+from unittest.mock import create_autospec
 
 import pytest
 from pytest_mock import MockerFixture
@@ -12,6 +13,7 @@ import reconcile.terraform_tgw_attachments as integ
 from reconcile.gql_definitions.common.app_interface_vault_settings import (
     AppInterfaceSettingsV1,
 )
+from reconcile.utils.secret_reader import SecretReaderBase
 
 QONTRACT_INTEGRATION = "terraform_tgw_attachments"
 
@@ -362,6 +364,11 @@ def _setup_mocks(
     )
     mocked_get_app_interface_vault_settings.return_value = vault_settings
 
+    mocked_secret_reader = create_autospec(SecretReaderBase)
+    mocker.patch(
+        "reconcile.terraform_tgw_attachments.create_secret_reader"
+    ).return_value = mocked_secret_reader
+
     mocked_aws_api = mocker.patch(
         "reconcile.terraform_tgw_attachments.AWSApi", autospec=True
     )
@@ -398,6 +405,7 @@ def _setup_mocks(
         "ts": mocked_ts,
         "queries": mocked_queries,
         "get_app_interface_vault_settings": mocked_get_app_interface_vault_settings,
+        "secret_reader": mocked_secret_reader,
         "ocm": mocked_ocm,
         "aws_api": mocked_aws_api,
     }
@@ -485,7 +493,7 @@ def test_run_when_cluster_with_tgw_connection(
     mocks["aws_api"].assert_called_once_with(
         1,
         [tgw_account],
-        settings=app_interface_vault_settings.dict(by_alias=True),
+        secret_reader=mocks["secret_reader"],
         init_users=False,
     )
     mocks["ocm"].assert_called_once_with(
@@ -540,7 +548,7 @@ def test_run_when_cluster_with_mixed_connections(
     mocks["aws_api"].assert_called_once_with(
         1,
         [tgw_account],
-        settings=app_interface_vault_settings.dict(by_alias=True),
+        secret_reader=mocks["secret_reader"],
         init_users=False,
     )
     mocks["ocm"].assert_called_once_with(
@@ -574,7 +582,7 @@ def test_run_when_cluster_with_vpc_connection_only(
     mocks["aws_api"].assert_called_once_with(
         1,
         [],
-        settings=app_interface_vault_settings.dict(by_alias=True),
+        secret_reader=mocks["secret_reader"],
         init_users=False,
     )
     mocks["ocm"].assert_not_called()
@@ -623,7 +631,7 @@ def test_run_with_multiple_clusters(
     mocks["aws_api"].assert_called_once_with(
         1,
         [tgw_account],
-        settings=app_interface_vault_settings.dict(by_alias=True),
+        secret_reader=mocks["secret_reader"],
         init_users=False,
     )
     mocks["ocm"].assert_called_once_with(
@@ -683,7 +691,7 @@ def test_run_with_account_name_for_multiple_clusters(
     mocks["aws_api"].assert_called_once_with(
         1,
         [tgw_account],
-        settings=app_interface_vault_settings.dict(by_alias=True),
+        secret_reader=mocks["secret_reader"],
         init_users=False,
     )
     mocks["ocm"].assert_called_once_with(
@@ -742,7 +750,7 @@ def test_run_with_account_name_for_multiple_connections(
     mocks["aws_api"].assert_called_once_with(
         1,
         [tgw_account],
-        settings=app_interface_vault_settings.dict(by_alias=True),
+        secret_reader=mocks["secret_reader"],
         init_users=False,
     )
     mocks["ocm"].assert_called_once_with(

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -455,7 +455,9 @@ def build_expected_tgw_account(
     connection: ClusterPeeringConnectionAccountTGWV1,
     assume_role: str,
 ) -> dict:
-    return connection.account.dict(by_alias=True) | {
+    return {
+        "name": connection.account.name,
+        "uid": connection.account.uid,
         "assume_role": assume_role,
         "assume_region": cluster.spec.region if cluster.spec is not None else "",
         "assume_cidr": cluster.network.vpc if cluster.network is not None else "",

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -171,7 +171,7 @@ def peering_connection_builder(
                 "name": name,
                 "provider": provider,
                 "manageRoutes": manage_routes,
-                "account": account.dict(by_alias=True),
+                "account": account.dict(by_alias=True) if account is not None else None,
                 "assumeRole": assume_role,
                 "cidrBlock": cidr_block,
                 "delete": delete,
@@ -457,8 +457,8 @@ def build_expected_tgw_account(
 ) -> dict:
     return connection.account.dict(by_alias=True) | {
         "assume_role": assume_role,
-        "assume_region": cluster.spec.region,
-        "assume_cidr": cluster.network.vpc,
+        "assume_region": cluster.spec.region if cluster.spec is not None else "",
+        "assume_cidr": cluster.network.vpc if cluster.network is not None else "",
     }
 
 
@@ -484,8 +484,8 @@ def build_expected_desired_state_item(
         },
         "accepter": {
             "vpc_id": vpc_details["vpc_id"],
-            "region": cluster.spec.region,
-            "cidr_block": cluster.network.vpc,
+            "region": cluster.spec.region if cluster.spec is not None else "",
+            "cidr_block": cluster.network.vpc if cluster.network is not None else "",
             "route_table_ids": vpc_details["route_table_ids"],
             "subnets_id_az": vpc_details["subnets_id_az"],
             "account": expected_tgw_account,
@@ -803,7 +803,7 @@ def test_run_with_account_name_for_multiple_clusters(
     mocker: MockerFixture,
     app_interface_vault_settings: AppInterfaceSettingsV1,
     cluster_with_tgw_connection: ClusterV1,
-    additional_cluster_with_tgw_connection: ClusterPeeringConnectionAccountTGWV1,
+    additional_cluster_with_tgw_connection: ClusterV1,
     account_tgw_connection: ClusterPeeringConnectionAccountTGWV1,
     tgw_account: AWSAccountV1,
     tgw: Mapping,


### PR DESCRIPTION
This change replaces all `queries` with typed queries, and extracts intermediate `dict` into dataclass.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b0e180</samp>

Migrate TGW attachments integration to use pydantic models and typed queries, and improve secret handling and naming.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 6b0e180</samp>

*  Migrate to use pydantic models instead of plain dictionaries for the data structures of the TGW attachments integration ([link](https://github.com/app-sre/qontract-reconcile/pull/3484/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L12-R40), [link](https://github.com/app-sre/qontract-reconcile/pull/3484/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L35-R101), [link](https://github.com/app-sre/qontract-reconcile/pull/3484/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L57-R147), [link](https://github.com/app-sre/qontract-reconcile/pull/3484/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L97-R159), [link](https://github.com/app-sre/qontract-reconcile/pull/3484/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L105-R261), [link](https://github.com/app-sre/qontract-reconcile/pull/3484/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L208-R272), [link](https://github.com/app-sre/qontract-reconcile/pull/3484/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L216-R286), [link](https://github.com/app-sre/qontract-reconcile/pull/3484/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L227-R337))
* Refactor to use a secret reader object instead of passing the settings dictionary around for accessing vault secrets ([link](https://github.com/app-sre/qontract-reconcile/pull/3484/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226R47), [link](https://github.com/app-sre/qontract-reconcile/pull/3484/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L273-R359), [link](https://github.com/app-sre/qontract-reconcile/pull/3484/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L304-R379))
* Rename the `vault_settings` variable and the `get_app_interface_vault_settings` function to reflect the new pydantic model ([link](https://github.com/app-sre/qontract-reconcile/pull/3484/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L273-R359))
* Remove the unused import of the `json` module as part of a code cleanup ([link](https://github.com/app-sre/qontract-reconcile/pull/3484/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L1))