### PR TITLE
[change-owners] avoid orphaned self-service roles

### DIFF
--- a/reconcile/change_owners/self_service_roles.py
+++ b/reconcile/change_owners/self_service_roles.py
@@ -68,8 +68,8 @@ def change_type_contexts_for_self_service_roles(
                         ].append(r)
     if orphaned_roles:
         raise EmptySelfServiceRoleError(
-            f"The roles {', '.join([r.name for r in orphaned_roles])} has no users or bots "
-            "to drive the self-service process. A approvers to the role."
+            f"The roles {', '.join([r.name for r in orphaned_roles])} have no users or bots "
+            "to drive the self-service process. Add approvers to the roles."
         )
 
     # match every BundleChange with every relevant ChangeTypeV1

--- a/reconcile/change_owners/self_service_roles.py
+++ b/reconcile/change_owners/self_service_roles.py
@@ -19,6 +19,10 @@ from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
 )
 
 
+class EmptySelfServiceRoleError(Exception):
+    pass
+
+
 def cover_changes_with_self_service_roles(
     roles: list[RoleV1],
     change_type_processors: list[ChangeTypeProcessor],
@@ -44,9 +48,13 @@ def change_type_contexts_for_self_service_roles(
 
     # role lookup enables fast lookup roles for (filetype, filepath, changetype-name)
     role_lookup: dict[tuple[BundleFileType, str, str], list[RoleV1]] = defaultdict(list)
+    orphaned_roles: list[RoleV1] = []
     for r in roles:
         # build role lookup for self_service section of a role
         if r.self_service:
+            if not r.users and not r.bots:
+                orphaned_roles.append(r)
+                continue
             for ss in r.self_service:
                 if ss.datafiles:
                     for df in ss.datafiles:
@@ -58,6 +66,11 @@ def change_type_contexts_for_self_service_roles(
                         role_lookup[
                             (BundleFileType.RESOURCEFILE, res, ss.change_type.name)
                         ].append(r)
+    if orphaned_roles:
+        raise EmptySelfServiceRoleError(
+            f"The roles {', '.join([r.name for r in orphaned_roles])} has no users or bots "
+            "to drive the self-service process. A approvers to the role."
+        )
 
     # match every BundleChange with every relevant ChangeTypeV1
     change_type_contexts = []

--- a/reconcile/test/change_owners/test_change_type_self_service_roles.py
+++ b/reconcile/test/change_owners/test_change_type_self_service_roles.py
@@ -5,7 +5,11 @@ from reconcile.change_owners.approver import (
     SlackGroupApproverReachability,
 )
 from reconcile.change_owners.change_owners import validate_self_service_role
-from reconcile.change_owners.self_service_roles import approver_reachability_from_role
+from reconcile.change_owners.self_service_roles import (
+    EmptySelfServiceRoleError,
+    approver_reachability_from_role,
+    change_type_contexts_for_self_service_roles,
+)
 from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
     ChangeTypeV1,
     DatafileObjectV1,
@@ -106,3 +110,26 @@ def test_self_service_role_gitlab_user_group_approver_reachability():
     assert reachability == [
         GitlabGroupApproverReachability(gitlab_group=g) for g in gitlab_groups
     ]
+
+
+#
+# test change_type_contexts_for_self_service_roles
+#
+
+
+def test_change_type_contexts_for_self_service_roles_no_approvers():
+    with pytest.raises(EmptySelfServiceRoleError):
+        role = build_role(
+            name="team-role",
+            change_type_name="change-type-name",
+            datafiles=[
+                DatafileObjectV1(datafileSchema="/access/role-1.yml", path="path")
+            ],
+            users=[],
+        )
+
+        change_type_contexts_for_self_service_roles(
+            roles=[role],
+            change_type_processors=[],
+            bundle_changes=[],
+        )


### PR DESCRIPTION
self-service roles (roles with a self-service section) must be assigned to at least one approver (user or bot). this avoids the situation that an MR is marked as self-serviceable but no approvers are available.

https://issues.redhat.com/browse/APPSRE-7535