### PR TITLE
[saas-file-validator] validate targets in app

### DIFF
--- a/reconcile/gql_definitions/common/saas_files.gql
+++ b/reconcile/gql_definitions/common/saas_files.gql
@@ -86,6 +86,7 @@ query SaasFiles {
         ...VaultSecret
       }
     }
+    validateTargetsInApp
     resourceTemplates {
       name
       url

--- a/reconcile/gql_definitions/common/saas_files.py
+++ b/reconcile/gql_definitions/common/saas_files.py
@@ -179,6 +179,7 @@ query SaasFiles {
         ...VaultSecret
       }
     }
+    validateTargetsInApp
     resourceTemplates {
       name
       url
@@ -524,6 +525,7 @@ class SaasFileV2(ConfiguredBaseModel):
     secret_parameters: Optional[list[SaasSecretParametersV1]] = Field(
         ..., alias="secretParameters"
     )
+    validate_targets_in_app: Optional[bool] = Field(..., alias="validateTargetsInApp")
     resource_templates: list[SaasResourceTemplateV2] = Field(
         ..., alias="resourceTemplates"
     )

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -16780,6 +16780,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "validateTargetsInApp",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "selfServiceRoles",
                             "description": null,
                             "args": [],

--- a/reconcile/test/test_typed_queries/test_saas_files.py
+++ b/reconcile/test/test_typed_queries/test_saas_files.py
@@ -660,6 +660,7 @@ def test_export_model(
             "authentication": None,
             "parameters": '{"SAAS_PARAM": "foobar"}',
             "secretParameters": None,
+            "validateTargetsInApp": None,
             "resourceTemplates": [
                 {
                     "name": "deploy-app",
@@ -805,6 +806,7 @@ def test_export_model(
             "authentication": None,
             "parameters": None,
             "secretParameters": None,
+            "validateTargetsInApp": None,
             "resourceTemplates": [
                 {
                     "name": "deploy-app",
@@ -950,6 +952,7 @@ def test_export_model(
             "authentication": None,
             "parameters": None,
             "secretParameters": None,
+            "validateTargetsInApp": None,
             "resourceTemplates": [
                 {
                     "name": "deploy-app",

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -119,6 +119,7 @@ class SaasFile(ConfiguredBaseModel):
     secret_parameters: Optional[list[SaasSecretParametersV1]] = Field(
         ..., alias="secretParameters"
     )
+    validate_targets_in_app: Optional[bool] = Field(..., alias="validateTargetsInApp")
     resource_templates: list[SaasResourceTemplate] = Field(
         ..., alias="resourceTemplates"
     )

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -374,6 +374,7 @@ class SaasFile(HasParameters, HasSecretParameters, Protocol):
     image_patterns: list[str]
     allowed_secret_parameter_paths: Optional[list[str]]
     use_channel_in_image_tag: Optional[bool]
+    validate_targets_in_app: Optional[bool]
 
     @property
     def app(self) -> SaasApp:

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -309,6 +309,12 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         target.namespace.environment.secret_parameters or [],
                         saas_file.allowed_secret_parameter_paths or [],
                     )
+                    if saas_file.validate_targets_in_app:
+                        if saas_file.app.name != target.namespace.app.name:
+                            logging.error(
+                                f"[{saas_file.name}] targets must be within app {saas_file.app.name}"
+                            )
+                            self.valid = False
 
                     if target.promotion:
                         rt_ref = (


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/438

this PR adds a validation that when `validateTargetsInApp` is set to `true` all targets are validated to be in the same app as the saas file itself.

with such an attribute, we can grant saas file owner full permissions to `targets`.