### PR TITLE
[change-owners] make file moves self-serviceable

### DIFF
--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -19,7 +19,6 @@ from typing import (
     Tuple,
 )
 
-import anymarkup
 import jinja2
 import jinja2.meta
 import jsonpath_ng
@@ -37,10 +36,7 @@ from reconcile.change_owners.bundle import (
 from reconcile.change_owners.diff import (
     PATH_FIELD_NAME,
     SHA256SUM_FIELD_NAME,
-    SHA256SUM_PATH,
     Diff,
-    DiffType,
-    extract_diffs,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import (
     ChangeTypeChangeDetectorChangeTypeProviderV1,
@@ -215,202 +211,6 @@ class DiffCoverage:
             coverages[self.diff.path_str()] = self
 
         return coverages
-
-
-class InvalidBundleFileChangeError(Exception):
-    """
-    Raised when an invalid BundleFileChange is detected.
-    """
-
-
-@dataclass
-class BundleFileChange:
-    """
-    Represents a file within an app-interface bundle that changed during an MR.
-    It holds the old and new state of that file, along with precise differences
-    between those states.
-    """
-
-    fileref: FileRef
-    old: Optional[dict[str, Any]]
-    new: Optional[dict[str, Any]]
-    diffs: list[Diff]
-    _diff_coverage: dict[str, DiffCoverage] = field(init=False, default_factory=dict)
-
-    def __post_init__(self) -> None:
-        self._diff_coverage = {d.path_str(): DiffCoverage(d, []) for d in self.diffs}
-
-    def old_content_sha(self) -> Optional[str]:
-        if self.old is None:
-            return None
-        if SHA256SUM_FIELD_NAME not in self.old:
-            raise InvalidBundleFileChangeError(
-                f"The detected change for {self.fileref} does not contain a {SHA256SUM_FIELD_NAME} for the previous state."
-            )
-        return self.old[SHA256SUM_FIELD_NAME]
-
-    def new_content_sha(self) -> Optional[str]:
-        if self.new is None:
-            return None
-        if SHA256SUM_FIELD_NAME not in self.new:
-            raise InvalidBundleFileChangeError(
-                f"The detected change for {self.fileref} does not contain a {SHA256SUM_FIELD_NAME} for the new state."
-            )
-        return self.new[SHA256SUM_FIELD_NAME]
-
-    def is_file_deletion(self) -> bool:
-        return self.old is not None and self.new is None
-
-    def is_file_creation(self) -> bool:
-        return self.old is None and self.new is not None
-
-    def cover_changes(self, change_type_context: "ChangeTypeContext") -> list[Diff]:
-        """
-        Figure out if a ChangeTypeV1 covers detected changes within the BundleFile.
-        Base idea:
-
-        - a ChangeTypeV1 defines path patterns that are considered self-approvable
-        - if a change (diff) is located under one of the allowed paths of the
-          ChangeTypeV1, it is considered "covered" by that ChangeTypeV1 in a certain
-          context (e.g. a RoleV1) and allows the approvers of that context (e.g.
-          the members of that role) to approve that particular change.
-
-        The change-type contexts that cover a change, are registered in the
-        `DiffCoverage.coverage` list right next to the Diff that is covered.
-        """
-        covered_diffs = {}
-        # observe the new state for added fields or list items or entire object sutrees
-        covered_diffs.update(
-            self._cover_changes_for_diffs(
-                self._filter_diffs([DiffType.ADDED, DiffType.CHANGED]),
-                self.new,
-                change_type_context,
-            )
-        )
-        # look at the old state for removed fields or list items or object subtrees
-        covered_diffs.update(
-            self._cover_changes_for_diffs(
-                self._filter_diffs([DiffType.REMOVED]), self.old, change_type_context
-            )
-        )
-        return list(covered_diffs.values())
-
-    def _cover_changes_for_diffs(
-        self,
-        diffs: list[DiffCoverage],
-        file_content: Any,
-        change_type_context: "ChangeTypeContext",
-    ) -> dict[str, Diff]:
-
-        covered_diffs = {}
-        if diffs:
-            for (
-                allowed_path
-            ) in change_type_context.change_type_processor.allowed_changed_paths(
-                self.fileref, file_content, change_type_context
-            ):
-                for dc in diffs:
-                    if dc.changed_path_covered_by_path(allowed_path):
-                        covered_diffs[dc.diff.path_str()] = dc.diff
-                        dc.coverage.append(change_type_context)
-                    elif SHA256SUM_PATH != allowed_path and dc.path_under_changed_path(
-                        allowed_path
-                    ):
-                        # the self-service path allowed by the change-type is covering
-                        # only parts of the diff. we will split the diff into a
-                        # smaller part, that can be covered by the change-type.
-                        # but the rest of the diff needs to be covered by another
-                        # change-type, either in full or again as a split.
-                        sub_dc = dc.split(allowed_path, change_type_context)
-                        if not sub_dc:
-                            raise Exception(
-                                f"unable to create a subdiff for path {allowed_path} on diff {dc.diff.path_str()}"
-                            )
-                        covered_diffs[str(allowed_path)] = sub_dc.diff
-
-        return covered_diffs
-
-    def _filter_diffs(self, diff_types: list[DiffType]) -> list[DiffCoverage]:
-        return [
-            d for d in self._diff_coverage.values() if d.diff.diff_type in diff_types
-        ]
-
-    def all_changes_covered(self) -> bool:
-        return all(d.is_covered() for d in self.diff_coverage)
-
-    def raw_diff_count(self) -> int:
-        return len(self._diff_coverage)
-
-    @property
-    def diff_coverage(self) -> Sequence[DiffCoverage]:
-        """
-        returns the meaningful set of diffs, potentially more fine grained than
-        what was originally detected for to the BundleFileChange.
-        """
-        coverages: list[DiffCoverage] = []
-        for dc in self._diff_coverage.values():
-            coverages.extend(dc.fine_grained_diff_coverages().values())
-        return coverages
-
-    def involved_change_types(self) -> list["ChangeTypeProcessor"]:
-        """
-        returns all the change-types that are involved in the coverage
-        of all changes
-        """
-        change_types = []
-        for dc in self.diff_coverage:
-            for ctx in dc.coverage:
-                change_types.append(ctx.change_type_processor)
-        return change_types
-
-
-def parse_resource_file_content(content: Optional[Any]) -> tuple[Any, Optional[str]]:
-    if content:
-        try:
-            data = anymarkup.parse(content, force_types=None)
-            return data, data.get("$schema")
-        except Exception:
-            # not parsable content - we will just deal with the plain content
-            return content, None
-    else:
-        return None, None
-
-
-def create_bundle_file_change(
-    path: str,
-    schema: Optional[str],
-    file_type: BundleFileType,
-    old_file_content: Any,
-    new_file_content: Any,
-) -> Optional[BundleFileChange]:
-    """
-    this is a factory method that creates a BundleFileChange object based
-    on the old and new content of a file from app-interface. it detects differences
-    within the old and new state of the file and represents them as instances
-    of the Diff dataclass. for diff detection, the amazing `deepdiff` python
-    library is used.
-    """
-    fileref = FileRef(path=path, schema=schema, file_type=file_type)
-
-    # try to parse the content of a resourcefile
-    # it falls back to the plain file content if parsing does not work
-    if file_type == BundleFileType.RESOURCEFILE:
-        old_file_content, _ = parse_resource_file_content(old_file_content)
-        new_file_content, _ = parse_resource_file_content(new_file_content)
-
-    diffs = extract_diffs(
-        old_file_content=old_file_content,
-        new_file_content=new_file_content,
-    )
-
-    if diffs:
-        return BundleFileChange(
-            fileref=fileref,
-            old=old_file_content,
-            new=new_file_content,
-            diffs=diffs,
-        )
-    return None
 
 
 class PathExpression:
@@ -958,20 +758,3 @@ JSON_PATH_ROOT = "$"
 
 def change_path_covered_by_allowed_path(changed_path: str, allowed_path: str) -> bool:
     return changed_path.startswith(allowed_path) or allowed_path == JSON_PATH_ROOT
-
-
-def get_priority_for_changes(
-    bundle_file_changes: list[BundleFileChange],
-) -> Optional[ChangeTypePriority]:
-    """
-    Finds the lowest priority of all change types involved in the provided bundle file changes.
-    """
-    priorities: set[ChangeTypePriority] = set()
-    for bfc in bundle_file_changes:
-        for ct in bfc.involved_change_types():
-            priorities.add(ct.priority)
-    # get the lowest priority
-    for p in reversed(ChangeTypePriority):
-        if p in priorities:
-            return p
-    return None

--- a/reconcile/change_owners/changes.py
+++ b/reconcile/change_owners/changes.py
@@ -279,8 +279,7 @@ class _MoveCandidates:
             creation = self.creations[0]
             deletion = self.deletions[0]
             if (
-                creation != deletion
-                and deletion.fileref.file_type == creation.fileref.file_type
+                deletion.fileref.file_type == creation.fileref.file_type
                 and deletion.fileref.path != creation.fileref.path
             ):
                 move_change = create_bundle_file_change(
@@ -291,8 +290,11 @@ class _MoveCandidates:
                     creation.new,
                 )
                 if move_change:
+                    # make mypy happy
                     return [move_change]
 
+        # the candidates turned out to be not a file move, so we
+        # will use the original changes as is
         return self.creations + self.deletions
 
 

--- a/reconcile/change_owners/changes.py
+++ b/reconcile/change_owners/changes.py
@@ -1,0 +1,363 @@
+from collections.abc import Sequence
+from collections import defaultdict
+from dataclasses import (
+    dataclass,
+    field,
+)
+import logging
+from typing import (
+    Any,
+    Optional,
+)
+
+import anymarkup
+
+from reconcile.change_owners.bundle import (
+    BundleFileType,
+    FileRef,
+)
+from reconcile.change_owners.change_types import (
+    ChangeTypeContext,
+    ChangeTypePriority,
+    ChangeTypeProcessor,
+    DiffCoverage,
+)
+from reconcile.change_owners.diff import (
+    SHA256SUM_FIELD_NAME,
+    SHA256SUM_PATH,
+    Diff,
+    DiffType,
+    extract_diffs,
+)
+from reconcile.utils import gql
+
+
+class InvalidBundleFileMetadataError(Exception):
+    """
+    Raised when invalid or missing metadata in a bundle file is detected.
+    """
+
+
+@dataclass
+class BundleFileChange:
+    """
+    Represents a file within an app-interface bundle that changed during an MR.
+    It holds the old and new state of that file, along with precise differences
+    between those states.
+    """
+
+    fileref: FileRef
+    old: Optional[dict[str, Any]]
+    new: Optional[dict[str, Any]]
+    diffs: list[Diff]
+    _diff_coverage: dict[str, DiffCoverage] = field(init=False, default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self._diff_coverage = {d.path_str(): DiffCoverage(d, []) for d in self.diffs}
+
+    def old_content_sha(self) -> Optional[str]:
+        if self.old is None:
+            return None
+        if SHA256SUM_FIELD_NAME not in self.old:
+            raise InvalidBundleFileMetadataError(
+                f"The detected change for {self.fileref} does not contain a {SHA256SUM_FIELD_NAME} for the previous state."
+            )
+        return self.old[SHA256SUM_FIELD_NAME]
+
+    def new_content_sha(self) -> Optional[str]:
+        if self.new is None:
+            return None
+        if SHA256SUM_FIELD_NAME not in self.new:
+            raise InvalidBundleFileMetadataError(
+                f"The detected change for {self.fileref} does not contain a {SHA256SUM_FIELD_NAME} for the new state."
+            )
+        return self.new[SHA256SUM_FIELD_NAME]
+
+    def is_file_deletion(self) -> bool:
+        return self.old is not None and self.new is None
+
+    def is_file_creation(self) -> bool:
+        return self.old is None and self.new is not None
+
+    def cover_changes(self, change_type_context: ChangeTypeContext) -> list[Diff]:
+        """
+        Figure out if a ChangeTypeV1 covers detected changes within the BundleFile.
+        Base idea:
+
+        - a ChangeTypeV1 defines path patterns that are considered self-approvable
+        - if a change (diff) is located under one of the allowed paths of the
+          ChangeTypeV1, it is considered "covered" by that ChangeTypeV1 in a certain
+          context (e.g. a RoleV1) and allows the approvers of that context (e.g.
+          the members of that role) to approve that particular change.
+
+        The change-type contexts that cover a change, are registered in the
+        `DiffCoverage.coverage` list right next to the Diff that is covered.
+        """
+        covered_diffs = {}
+        # observe the new state for added fields or list items or entire object sutrees
+        covered_diffs.update(
+            self._cover_changes_for_diffs(
+                self._filter_diffs([DiffType.ADDED, DiffType.CHANGED]),
+                self.new,
+                change_type_context,
+            )
+        )
+        # look at the old state for removed fields or list items or object subtrees
+        covered_diffs.update(
+            self._cover_changes_for_diffs(
+                self._filter_diffs([DiffType.REMOVED]), self.old, change_type_context
+            )
+        )
+        return list(covered_diffs.values())
+
+    def _cover_changes_for_diffs(
+        self,
+        diffs: list[DiffCoverage],
+        file_content: Any,
+        change_type_context: ChangeTypeContext,
+    ) -> dict[str, Diff]:
+
+        covered_diffs = {}
+        if diffs:
+            for (
+                allowed_path
+            ) in change_type_context.change_type_processor.allowed_changed_paths(
+                self.fileref, file_content, change_type_context
+            ):
+                for dc in diffs:
+                    if dc.changed_path_covered_by_path(allowed_path):
+                        covered_diffs[dc.diff.path_str()] = dc.diff
+                        dc.coverage.append(change_type_context)
+                    elif SHA256SUM_PATH != allowed_path and dc.path_under_changed_path(
+                        allowed_path
+                    ):
+                        # the self-service path allowed by the change-type is covering
+                        # only parts of the diff. we will split the diff into a
+                        # smaller part, that can be covered by the change-type.
+                        # but the rest of the diff needs to be covered by another
+                        # change-type, either in full or again as a split.
+                        sub_dc = dc.split(allowed_path, change_type_context)
+                        if not sub_dc:
+                            raise Exception(
+                                f"unable to create a subdiff for path {allowed_path} on diff {dc.diff.path_str()}"
+                            )
+                        covered_diffs[str(allowed_path)] = sub_dc.diff
+
+        return covered_diffs
+
+    def _filter_diffs(self, diff_types: list[DiffType]) -> list[DiffCoverage]:
+        return [
+            d for d in self._diff_coverage.values() if d.diff.diff_type in diff_types
+        ]
+
+    def all_changes_covered(self) -> bool:
+        return all(d.is_covered() for d in self.diff_coverage)
+
+    def raw_diff_count(self) -> int:
+        return len(self._diff_coverage)
+
+    @property
+    def diff_coverage(self) -> Sequence[DiffCoverage]:
+        """
+        returns the meaningful set of diffs, potentially more fine grained than
+        what was originally detected for to the BundleFileChange.
+        """
+        coverages: list[DiffCoverage] = []
+        for dc in self._diff_coverage.values():
+            coverages.extend(dc.fine_grained_diff_coverages().values())
+        return coverages
+
+    def involved_change_types(self) -> list[ChangeTypeProcessor]:
+        """
+        returns all the change-types that are involved in the coverage
+        of all changes
+        """
+        change_types = []
+        for dc in self.diff_coverage:
+            for ctx in dc.coverage:
+                change_types.append(ctx.change_type_processor)
+        return change_types
+
+
+def parse_resource_file_content(content: Optional[Any]) -> tuple[Any, Optional[str]]:
+    if content:
+        try:
+            data = anymarkup.parse(content, force_types=None)
+            return data, data.get("$schema")
+        except Exception:
+            # not parsable content - we will just deal with the plain content
+            return content, None
+    else:
+        return None, None
+
+
+def create_bundle_file_change(
+    path: str,
+    schema: Optional[str],
+    file_type: BundleFileType,
+    old_file_content: Any,
+    new_file_content: Any,
+) -> Optional[BundleFileChange]:
+    """
+    this is a factory method that creates a BundleFileChange object based
+    on the old and new content of a file from app-interface. it detects differences
+    within the old and new state of the file and represents them as instances
+    of the Diff dataclass. for diff detection, the amazing `deepdiff` python
+    library is used.
+    """
+    fileref = FileRef(path=path, schema=schema, file_type=file_type)
+
+    # try to parse the content of a resourcefile
+    # it falls back to the plain file content if parsing does not work
+    if file_type == BundleFileType.RESOURCEFILE:
+        old_file_content, _ = parse_resource_file_content(old_file_content)
+        new_file_content, _ = parse_resource_file_content(new_file_content)
+
+    diffs = extract_diffs(
+        old_file_content=old_file_content,
+        new_file_content=new_file_content,
+    )
+
+    if diffs:
+        return BundleFileChange(
+            fileref=fileref,
+            old=old_file_content,
+            new=new_file_content,
+            diffs=diffs,
+        )
+    return None
+
+
+def get_priority_for_changes(
+    bundle_file_changes: list[BundleFileChange],
+) -> Optional[ChangeTypePriority]:
+    """
+    Finds the lowest priority of all change types involved in the provided bundle file changes.
+    """
+    priorities: set[ChangeTypePriority] = set()
+    for bfc in bundle_file_changes:
+        for ct in bfc.involved_change_types():
+            priorities.add(ct.priority)
+    # get the lowest priority
+    for p in reversed(ChangeTypePriority):
+        if p in priorities:
+            return p
+    return None
+
+
+def fetch_bundle_changes(comparison_sha: str) -> list[BundleFileChange]:
+    """
+    reaches out to the qontract-server diff endpoint to find the files that
+    changed within two bundles (the current one representing the MR and the
+    explicitely passed comparision bundle - usually the state of the master branch).
+    """
+    changes = gql.get_diff(comparison_sha)
+    bundle_changes = _parse_bundle_changes(changes)
+    try:
+        return aggregate_file_moves(bundle_changes)
+    except Exception as e:
+        logging.error(f"Failed to post process bundle changes: {e}")
+        # if any post processing action fails, we want the raw bundle changes
+        # to be reviewed
+        return bundle_changes
+
+
+def aggregate_file_moves(
+    bundle_changes: list[BundleFileChange],
+) -> list[BundleFileChange]:
+    """
+    This function tries to detect file moves by looking at the bundle changes. If an
+    add and remove file change with the same content is detected, those changes are
+    replaced with a single move change where the only difference is the path.
+    """
+    move_candidates: dict[str, list[BundleFileChange]] = defaultdict(list)
+    new_bundle_changes = []
+    for c in bundle_changes:
+        potential_move_sha = None
+        if c.is_file_creation():
+            potential_move_sha = c.new_content_sha()
+        elif c.is_file_deletion():
+            potential_move_sha = c.old_content_sha()
+        if potential_move_sha:
+            move_candidates[potential_move_sha].append(c)
+        else:
+            new_bundle_changes.append(c)
+
+    for candidates in move_candidates.values():
+        if len(candidates) == 2:
+            # if there are two candidates, they could represent a file move.
+            # lets check if that is the case
+            deletion = (
+                candidates[0] if candidates[0].is_file_deletion() else candidates[1]
+            )
+            addition = (
+                candidates[0] if candidates[0].is_file_creation() else candidates[1]
+            )
+            if (
+                deletion != addition
+                and deletion.fileref.file_type == addition.fileref.file_type
+                and deletion.fileref.path != addition.fileref.path
+            ):
+                # the candidates represent a file move. let's add a new
+                # change that represents the move
+                move_change = create_bundle_file_change(
+                    deletion.fileref.path,
+                    deletion.fileref.schema,
+                    deletion.fileref.file_type,
+                    deletion.old,
+                    addition.new,
+                )
+                if move_change:
+                    # move_change will always be present. this check is just to
+                    # satisfy mypy
+                    new_bundle_changes.append(move_change)
+                    continue
+
+        # the candidates turned out to be unrelated changes. lets add them back
+        # to the list of changes
+        new_bundle_changes.extend(candidates)
+    return new_bundle_changes
+
+
+def _parse_bundle_changes(bundle_changes: Any) -> list[BundleFileChange]:
+    """
+    parses the output of the qontract-server /diff endpoint
+    """
+    datafiles = bundle_changes["datafiles"].values()
+    resourcefiles = bundle_changes["resources"].values()
+    logging.debug(
+        f"bundle contains {len(datafiles)} changed datafiles and {len(resourcefiles)} changed resourcefiles"
+    )
+
+    change_list = []
+    for c in datafiles:
+        bc = create_bundle_file_change(
+            path=c.get("datafilepath"),
+            schema=c.get("datafileschema"),
+            file_type=BundleFileType.DATAFILE,
+            old_file_content=c.get("old"),
+            new_file_content=c.get("new"),
+        )
+        if bc is not None:
+            change_list.append(bc)
+        else:
+            logging.debug(
+                f"skipping datafile {c.get('datafilepath')} - no changes detected"
+            )
+
+    for c in resourcefiles:
+        bc = create_bundle_file_change(
+            path=c.get("resourcepath"),
+            schema=c.get("new", {}).get("$schema", c.get("old", {}).get("$schema")),
+            file_type=BundleFileType.RESOURCEFILE,
+            old_file_content=c.get("old", {}).get("content"),
+            new_file_content=c.get("new", {}).get("content"),
+        )
+        if bc is not None:
+            change_list.append(bc)
+        else:
+            logging.debug(
+                f"skipping resourcefile {c.get('resourcepath')} - no changes detected"
+            )
+
+    return change_list

--- a/reconcile/change_owners/decision.py
+++ b/reconcile/change_owners/decision.py
@@ -8,10 +8,8 @@ from enum import Enum
 from typing import Any
 
 from reconcile.change_owners.bundle import FileRef
-from reconcile.change_owners.change_types import (
-    BundleFileChange,
-    ChangeTypeContext,
-)
+from reconcile.change_owners.change_types import ChangeTypeContext
+from reconcile.change_owners.changes import BundleFileChange
 from reconcile.change_owners.diff import Diff
 
 

--- a/reconcile/change_owners/diff.py
+++ b/reconcile/change_owners/diff.py
@@ -153,6 +153,7 @@ def compare_object_ctx_identifier(
 SCHEMA_FIELD = "$schema"
 PATH_FIELD = "path"
 SHA256SUM_FIELD_NAME = "$file_sha256sum"
+PATH_FIELD_NAME = "path"
 SHA256SUM_PATH = jsonpath_ng.parse(f"'{SHA256SUM_FIELD_NAME}'")
 
 

--- a/reconcile/change_owners/implicit_ownership.py
+++ b/reconcile/change_owners/implicit_ownership.py
@@ -2,10 +2,10 @@ import logging
 
 from reconcile.change_owners.approver import ApproverResolver
 from reconcile.change_owners.change_types import (
-    BundleFileChange,
     ChangeTypeContext,
     ChangeTypeProcessor,
 )
+from reconcile.change_owners.changes import BundleFileChange
 from reconcile.gql_definitions.change_owners.queries.change_types import (
     ChangeTypeImplicitOwnershipJsonPathProviderV1,
 )

--- a/reconcile/change_owners/self_service_roles.py
+++ b/reconcile/change_owners/self_service_roles.py
@@ -8,10 +8,10 @@ from reconcile.change_owners.approver import (
 from reconcile.change_owners.bundle import BundleFileType
 from reconcile.change_owners.change_types import (
     Approver,
-    BundleFileChange,
     ChangeTypeContext,
     ChangeTypeProcessor,
 )
+from reconcile.change_owners.changes import BundleFileChange
 from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
     PermissionGitlabGroupMembershipV1,
     PermissionSlackUsergroupV1,

--- a/reconcile/change_owners/tester.py
+++ b/reconcile/change_owners/tester.py
@@ -17,10 +17,12 @@ from pygments.token import Name
 
 from reconcile.change_owners.change_owners import fetch_change_type_processors
 from reconcile.change_owners.change_types import (
-    BundleFileChange,
     BundleFileType,
     ChangeTypeProcessor,
     FileRef,
+)
+from reconcile.change_owners.changes import (
+    BundleFileChange,
     parse_resource_file_content,
 )
 from reconcile.change_owners.self_service_roles import (

--- a/reconcile/test/change_owners/fixtures.py
+++ b/reconcile/test/change_owners/fixtures.py
@@ -1,4 +1,6 @@
 import copy
+import hashlib
+import json
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -19,6 +21,10 @@ from reconcile.change_owners.change_types import (
     ChangeTypeProcessor,
     create_bundle_file_change,
     init_change_type_processors,
+)
+from reconcile.change_owners.diff import (
+    PATH_FIELD_NAME,
+    SHA256SUM_FIELD_NAME,
 )
 from reconcile.gql_definitions.change_owners.queries import self_service_roles
 from reconcile.gql_definitions.change_owners.queries.change_types import (
@@ -41,6 +47,12 @@ from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
 )
 
 
+def _sha256_sum(content: dict[str, Any]) -> str:
+    m = hashlib.sha256()
+    m.update(json.dumps(content, sort_keys=True).encode("utf-8"))
+    return m.hexdigest()
+
+
 @dataclass
 class StubFile:
     filepath: str
@@ -58,20 +70,53 @@ class StubFile:
     def create_bundle_change(
         self, jsonpath_patches: dict[str, Any]
     ) -> BundleFileChange:
-        new_content = copy.deepcopy(self.content)
-        if jsonpath_patches:
-            for jp, v in jsonpath_patches.items():
-                e = jsonpath_ng.ext.parse(jp)
-                e.update(new_content, v)
         bundle_file_change = create_bundle_file_change(
             path=self.filepath,
             schema=self.fileschema,
             file_type=BundleFileType[self.filetype.upper()],
-            old_file_content=self.content,
-            new_file_content=new_content,
+            old_file_content=StubFile._prepare_content(self.content, self.filepath, {}),
+            new_file_content=StubFile._prepare_content(
+                self.content, self.filepath, jsonpath_patches
+            ),
         )
         assert bundle_file_change
         return bundle_file_change
+
+    @staticmethod
+    def _prepare_content(
+        content: dict[str, Any], path: str, jsonpath_patches: dict[str, Any]
+    ) -> dict[str, Any]:
+        new_content = copy.deepcopy(content)
+        if jsonpath_patches:
+            for jp, v in jsonpath_patches.items():
+                e = jsonpath_ng.ext.parse(jp)
+                e.update(new_content, v)
+        new_content[SHA256SUM_FIELD_NAME] = _sha256_sum(new_content)
+        new_content[PATH_FIELD_NAME] = path
+        return new_content
+
+    def move(
+        self, new_path: str, jsonpath_patches: Optional[dict[str, Any]] = None
+    ) -> tuple[BundleFileChange, BundleFileChange]:
+        old_bundle_change = create_bundle_file_change(
+            path=self.filepath,
+            schema=self.fileschema,
+            file_type=BundleFileType[self.filetype.upper()],
+            old_file_content=StubFile._prepare_content(self.content, self.filepath, {}),
+            new_file_content=None,
+        )
+        new_bundle_change = create_bundle_file_change(
+            path=new_path,
+            schema=self.fileschema,
+            file_type=BundleFileType[self.filetype.upper()],
+            old_file_content=None,
+            new_file_content=StubFile._prepare_content(
+                self.content, new_path, jsonpath_patches or {}
+            ),
+        )
+        assert old_bundle_change
+        assert new_bundle_change
+        return (old_bundle_change, new_bundle_change)
 
 
 def build_test_datafile(

--- a/reconcile/test/change_owners/fixtures.py
+++ b/reconcile/test/change_owners/fixtures.py
@@ -17,10 +17,12 @@ from reconcile.change_owners.bundle import (
     FileRef,
 )
 from reconcile.change_owners.change_types import (
-    BundleFileChange,
     ChangeTypeProcessor,
-    create_bundle_file_change,
     init_change_type_processors,
+)
+from reconcile.change_owners.changes import (
+    BundleFileChange,
+    create_bundle_file_change,
 )
 from reconcile.change_owners.diff import (
     PATH_FIELD_NAME,

--- a/reconcile/test/change_owners/test_change_type_bundle_change_post_processing.py
+++ b/reconcile/test/change_owners/test_change_type_bundle_change_post_processing.py
@@ -1,0 +1,89 @@
+import pytest
+
+from reconcile.change_owners.change_owners import _aggregate_file_moves
+from reconcile.change_owners.diff import (
+    PATH_FIELD_NAME,
+    DiffType,
+)
+from reconcile.test.change_owners.fixtures import build_test_datafile
+
+
+def test_aggregate_file_moves() -> None:
+    """
+    This test only moves the file and does not change the content.
+    Therefore the result is a single change.
+    """
+    file = build_test_datafile(
+        filepath="/old/path.yml",
+        content={"foo": "bar"},
+        schema="/my/schema.yml",
+    )
+    result = _aggregate_file_moves(list(file.move("/new/path.yml")))
+    assert len(result) == 1
+    file_change = result[0]
+    assert len(file_change.diffs) == 1
+    diff = file_change.diffs[0]
+    assert diff.path_str() == PATH_FIELD_NAME
+
+
+def test_aggregate_file_moves_additional_changes() -> None:
+    """
+    This test does not only move the file but changes a field as well.
+    Therefore it is not a pure move anymore and the result are the regular two
+    detected changes.
+    """
+    file = build_test_datafile(
+        filepath="/old/path.yml",
+        content={"foo": "bar"},
+        schema="/my/schema.yml",
+    )
+    result = _aggregate_file_moves(list(file.move("/new/path.yml", {"foo": "baz"})))
+    assert len(result) == 2
+    for c in result:
+        if c.fileref.path == "/old/path.yml":
+            assert (
+                c.diffs[0].path_str() == "$"
+                and c.diffs[0].diff_type == DiffType.REMOVED
+            )
+        elif c.fileref.path == "/new/path.yml":
+            assert (
+                c.diffs[0].path_str() == "$" and c.diffs[0].diff_type == DiffType.ADDED
+            )
+        else:
+            pytest.fail("Unexpected change")
+
+
+def test_aggregate_file_moves_mixed() -> None:
+    """
+    This test covers the case where a regular file change and a file move happen
+    in the same MR.
+    """
+    changes = list(
+        build_test_datafile(
+            filepath="/old/path.yml",
+            content={"foo": "bar"},
+            schema="/my/schema.yml",
+        ).move("/new/path.yml")
+    )
+    changes.append(
+        build_test_datafile(
+            filepath="/another/path.yml",
+            content={"hey": "ho"},
+            schema="/my/schema.yml",
+        ).create_bundle_change({"hey": "you"})
+    )
+    result = _aggregate_file_moves(changes)
+    assert len(result) == 2
+    for c in result:
+        if c.fileref.path == "/old/path.yml":
+            assert (
+                c.diffs[0].path_str() == PATH_FIELD_NAME
+                and c.diffs[0].diff_type == DiffType.CHANGED
+            )
+        elif c.fileref.path == "/another/path.yml":
+            assert (
+                c.diffs[0].path_str() == "hey"
+                and c.diffs[0].diff_type == DiffType.CHANGED
+            )
+        else:
+            pytest.fail("Unexpected change")

--- a/reconcile/test/change_owners/test_change_type_bundle_change_post_processing.py
+++ b/reconcile/test/change_owners/test_change_type_bundle_change_post_processing.py
@@ -1,6 +1,6 @@
 import pytest
 
-from reconcile.change_owners.change_owners import _aggregate_file_moves
+from reconcile.change_owners.changes import aggregate_file_moves
 from reconcile.change_owners.diff import (
     PATH_FIELD_NAME,
     DiffType,
@@ -18,7 +18,7 @@ def test_aggregate_file_moves() -> None:
         content={"foo": "bar"},
         schema="/my/schema.yml",
     )
-    result = _aggregate_file_moves(list(file.move("/new/path.yml")))
+    result = aggregate_file_moves(list(file.move("/new/path.yml")))
     assert len(result) == 1
     file_change = result[0]
     assert len(file_change.diffs) == 1
@@ -37,7 +37,7 @@ def test_aggregate_file_moves_additional_changes() -> None:
         content={"foo": "bar"},
         schema="/my/schema.yml",
     )
-    result = _aggregate_file_moves(list(file.move("/new/path.yml", {"foo": "baz"})))
+    result = aggregate_file_moves(list(file.move("/new/path.yml", {"foo": "baz"})))
     assert len(result) == 2
     for c in result:
         if c.fileref.path == "/old/path.yml":
@@ -72,7 +72,7 @@ def test_aggregate_file_moves_mixed() -> None:
             schema="/my/schema.yml",
         ).create_bundle_change({"hey": "you"})
     )
-    result = _aggregate_file_moves(changes)
+    result = aggregate_file_moves(changes)
     assert len(result) == 2
     for c in result:
         if c.fileref.path == "/old/path.yml":

--- a/reconcile/test/change_owners/test_change_type_context.py
+++ b/reconcile/test/change_owners/test_change_type_context.py
@@ -2,7 +2,7 @@ from reconcile.change_owners.bundle import (
     BundleFileType,
     FileRef,
 )
-from reconcile.change_owners.change_types import create_bundle_file_change
+from reconcile.change_owners.changes import create_bundle_file_change
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
 from reconcile.test.change_owners.fixtures import (
     StubFile,

--- a/reconcile/test/change_owners/test_change_type_coverage.py
+++ b/reconcile/test/change_owners/test_change_type_coverage.py
@@ -5,8 +5,8 @@ from reconcile.change_owners.change_types import (
     Approver,
     ChangeTypeContext,
     DiffCoverage,
-    create_bundle_file_change,
 )
+from reconcile.change_owners.changes import create_bundle_file_change
 from reconcile.change_owners.diff import (
     Diff,
     DiffType,

--- a/reconcile/test/change_owners/test_change_type_decision.py
+++ b/reconcile/test/change_owners/test_change_type_decision.py
@@ -4,8 +4,8 @@ from reconcile.change_owners.bundle import BundleFileType
 from reconcile.change_owners.change_types import (
     Approver,
     ChangeTypeContext,
-    create_bundle_file_change,
 )
+from reconcile.change_owners.changes import create_bundle_file_change
 from reconcile.change_owners.decision import (
     Decision,
     DecisionCommand,

--- a/reconcile/test/change_owners/test_change_type_diff.py
+++ b/reconcile/test/change_owners/test_change_type_diff.py
@@ -3,10 +3,8 @@ import jsonpath_ng.ext
 import pytest
 
 from reconcile.change_owners.bundle import BundleFileType
-from reconcile.change_owners.change_types import (
-    DiffCoverage,
-    create_bundle_file_change,
-)
+from reconcile.change_owners.change_types import DiffCoverage
+from reconcile.change_owners.changes import create_bundle_file_change
 from reconcile.change_owners.diff import (
     SHA256SUM_FIELD_NAME,
     Diff,

--- a/reconcile/test/change_owners/test_change_type_diff_splitting.py
+++ b/reconcile/test/change_owners/test_change_type_diff_splitting.py
@@ -7,8 +7,8 @@ from reconcile.change_owners.bundle import (
 from reconcile.change_owners.change_types import (
     ChangeTypeContext,
     DiffCoverage,
-    create_bundle_file_change,
 )
+from reconcile.change_owners.changes import create_bundle_file_change
 from reconcile.change_owners.diff import (
     Diff,
     DiffType,

--- a/reconcile/test/change_owners/test_change_type_implicit_ownership.py
+++ b/reconcile/test/change_owners/test_change_type_implicit_ownership.py
@@ -9,10 +9,10 @@ from reconcile.change_owners.bundle import (
     FileRef,
 )
 from reconcile.change_owners.change_types import (
-    BundleFileChange,
     ChangeTypeProcessor,
     OwnershipContext,
 )
+from reconcile.change_owners.changes import BundleFileChange
 from reconcile.change_owners.implicit_ownership import (
     change_type_contexts_for_implicit_ownership,
     find_approvers_with_implicit_ownership_jsonpath_selector,

--- a/reconcile/test/change_owners/test_change_type_priorities.py
+++ b/reconcile/test/change_owners/test_change_type_priorities.py
@@ -1,8 +1,8 @@
 from unittest.mock import MagicMock
 
-from reconcile.change_owners.change_types import (
+from reconcile.change_owners.change_types import ChangeTypePriority
+from reconcile.change_owners.changes import (
     BundleFileChange,
-    ChangeTypePriority,
     get_priority_for_changes,
 )
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1

--- a/reconcile/test/change_owners/test_change_type_processor.py
+++ b/reconcile/test/change_owners/test_change_type_processor.py
@@ -6,6 +6,10 @@ from reconcile.change_owners.change_types import (
     ChangeTypeContext,
     ChangeTypeProcessor,
 )
+from reconcile.change_owners.diff import (
+    PATH_FIELD_NAME,
+    SHA256SUM_FIELD_NAME,
+)
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
 from reconcile.test.change_owners.fixtures import (
     StubFile,
@@ -53,7 +57,7 @@ def test_change_type_processor_allowed_paths_simple(
         ),
     )
 
-    assert [str(p) for p in paths] == ["roles"]
+    assert {str(p) for p in paths} == {"roles", SHA256SUM_FIELD_NAME, PATH_FIELD_NAME}
 
 
 def test_change_type_processor_allowed_paths_conditions(
@@ -75,7 +79,11 @@ def test_change_type_processor_allowed_paths_conditions(
         ),
     )
 
-    assert [str(p) for p in paths] == ["openshiftResources.[1].version"]
+    assert {str(p) for p in paths} == {
+        "openshiftResources.[1].version",
+        SHA256SUM_FIELD_NAME,
+        PATH_FIELD_NAME,
+    }
 
 
 @pytest.fixture
@@ -111,7 +119,11 @@ def test_change_type_processor_allowed_paths_conditions_ct_without_schema_file_w
         ),
     )
 
-    assert [str(p) for p in paths] == ["$"]
+    assert {str(p) for p in paths} == {
+        "$",
+        SHA256SUM_FIELD_NAME,
+        PATH_FIELD_NAME,
+    }
 
 
 def test_change_type_processor_allowed_paths_conditions_ct_without_schema_file_without_schema(
@@ -135,4 +147,8 @@ def test_change_type_processor_allowed_paths_conditions_ct_without_schema_file_w
         ),
     )
 
-    assert [str(p) for p in paths] == ["$"]
+    assert {str(p) for p in paths} == {
+        "$",
+        SHA256SUM_FIELD_NAME,
+        PATH_FIELD_NAME,
+    }

--- a/reconcile/test/change_owners/test_change_type_various.py
+++ b/reconcile/test/change_owners/test_change_type_various.py
@@ -9,8 +9,8 @@ from reconcile.change_owners.change_owners import manage_conditional_label
 from reconcile.change_owners.change_types import (
     ChangeTypeContext,
     PathExpression,
-    parse_resource_file_content,
 )
+from reconcile.change_owners.changes import parse_resource_file_content
 
 #
 # label management tests


### PR DESCRIPTION
Moving files without changing their content is not necessarily self-serviceable via change-types. Since a-i is path-agnostic, we don't really care too much about path changes.

this PR introduces the ability to aggreate an delete/add change that represents a file move, into one change that only has the path as the changing attribute.

https://issues.redhat.com/browse/APPSRE-7590