### PR TITLE
Update terraform-tgw-attachments early exit and shard config

### DIFF
--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -1035,3 +1035,28 @@ def test_error_in_terraform_apply(
         integ.run(False)
 
     assert "Error running terraform apply" == str(e.value)
+
+
+def test_early_exit_desired_state(
+    mocker: MockerFixture,
+    app_interface_vault_settings: AppInterfaceSettingsV1,
+    cluster_with_tgw_connection: ClusterV1,
+    cluster_with_vpc_connection: ClusterV1,
+    tgw_account: AWSAccountV1,
+    vpc_account: AWSAccountV1,
+) -> None:
+    _setup_mocks(
+        mocker,
+        vault_settings=app_interface_vault_settings,
+        clusters=[cluster_with_tgw_connection, cluster_with_vpc_connection],
+        accounts=[tgw_account, vpc_account],
+    )
+
+    desired_state = integ.early_exit_desired_state()
+
+    expected_early_exit_desired_state = {
+        "clusters": [cluster_with_tgw_connection.dict(by_alias=True)],
+        "accounts": [tgw_account.dict(by_alias=True)],
+    }
+
+    assert desired_state == expected_early_exit_desired_state


### PR DESCRIPTION
This change includes update for early exit state and shard config for terraform-tgw-attachments integration.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b4e35e</samp>

Refactor and test `terraform_tgw_attachments` integration. This integration now uses a new class and function to get the desired state and supports sharding by account name. The sharding logic is also tested with a helper class.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7b4e35e</samp>

*  Simplify and refactor the logic of fetching and filtering the data source for the desired state of the integration by defining a new `DesiredStateDataSource` class and a new `_fetch_desired_state_data_source` function ([link](https://github.com/app-sre/qontract-reconcile/pull/3492/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226R97-R101), [link](https://github.com/app-sre/qontract-reconcile/pull/3492/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226R347-R359), [link](https://github.com/app-sre/qontract-reconcile/pull/3492/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L351-R380), [link](https://github.com/app-sre/qontract-reconcile/pull/3492/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L420-R445))
* Add support for sharding the run of the integration based on the account name argument by defining a new `DesiredStateShardConfig` class and a new `desired_state_shard_config` function ([link](https://github.com/app-sre/qontract-reconcile/pull/3492/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226R45), [link](https://github.com/app-sre/qontract-reconcile/pull/3492/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L420-R445), [link](https://github.com/app-sre/qontract-reconcile/pull/3492/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R33), [link](https://github.com/app-sre/qontract-reconcile/pull/3492/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R1039-R1096))
* Rename the `tgw_accounts` variable to `accounts` in the `run` function of the integration to avoid confusion with the function argument of the same name ([link](https://github.com/app-sre/qontract-reconcile/pull/3492/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L380-R394), [link](https://github.com/app-sre/qontract-reconcile/pull/3492/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L396-R410))
* Group the vault and AWS API related logic together in the `run` function of the integration for better readability ([link](https://github.com/app-sre/qontract-reconcile/pull/3492/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L351-R380))
* Remove an unused import of the `queries` module from the integration ([link](https://github.com/app-sre/qontract-reconcile/pull/3492/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L17))
* Add two new test functions to the test module to verify the logic of the `early_exit_desired_state` and the `desired_state_shard_config` functions of the integration using mocked data ([link](https://github.com/app-sre/qontract-reconcile/pull/3492/files?diff=unified&w=0#diff-b5ab464582f4a599b9e05939387fe44570d983cb1a58d777a7af990bfb3124d4R1039-R1096))