### PR TITLE
[ocm-addons-upgrade-scheduler-org] Fix delete addon upgrade policy

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -163,7 +163,7 @@ class AddonUpgradePolicy(AbstractUpgradePolicy):
             "version": self.version,
             "id": self.id,
         }
-        ocm.delete_upgrade_policy(self.cluster, item)
+        ocm.delete_addon_upgrade_policy(self.cluster, item)
 
 
 class ClusterUpgradePolicy(AbstractUpgradePolicy):


### PR DESCRIPTION
`AddonUpgradePolicy` should use `delete_addon_upgrade_policy` instead of `delete_upgrade_policy`.