### PR TITLE
[change-owners] disable file move detection

### DIFF
--- a/reconcile/change_owners/changes.py
+++ b/reconcile/change_owners/changes.py
@@ -265,8 +265,7 @@ def fetch_bundle_changes(comparison_sha: str) -> list[BundleFileChange]:
     explicitely passed comparision bundle - usually the state of the master branch).
     """
     changes = gql.get_diff(comparison_sha)
-    bundle_changes = _parse_bundle_changes(changes)
-    return aggregate_file_moves(bundle_changes)
+    return _parse_bundle_changes(changes)
 
 
 @dataclass


### PR DESCRIPTION
disable the new aggregate_file_moves functionality for now because there is a situation where expected metadata seems to be not present, which fails the change-owners integration.

a fix will be provided in an upcoming PR.

https://issues.redhat.com/browse/APPSRE-7590