### PR TITLE
Control Plan Arn is optional

### DIFF
--- a/reconcile/ocm/types.py
+++ b/reconcile/ocm/types.py
@@ -58,7 +58,7 @@ class ROSAOcmAwsAttrs(BaseModel):
     creator_role_arn: str
     installer_role_arn: str
     support_role_arn: str
-    controlplane_role_arn: str
+    controlplane_role_arn: Optional[str]
     worker_role_arn: str
 
     class Config:

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -481,13 +481,17 @@ class OCMProductRosa(OCMProduct):
                         "role_arn": cluster.spec.account.rosa.installer_role_arn,
                         "support_role_arn": cluster.spec.account.rosa.support_role_arn,
                         "instance_iam_roles": {
-                            "master_role_arn": cluster.spec.account.rosa.controlplane_role_arn,
                             "worker_role_arn": cluster.spec.account.rosa.worker_role_arn,
                         },
                         "operator_role_prefix": f"{cluster_name}-{operator_roles_prefix}",
                     },
                 },
             }
+
+            if cluster.spec.account.rosa.controlplane_role_arn:
+                rosa_spec["aws"]["sts"]["instance_iam_roles"][
+                    "master_role_arn"
+                ] = cluster.spec.account.rosa.controlplane_role_arn
 
             if cluster.spec.hypershift:
                 ocm_spec["nodes"][

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -374,9 +374,9 @@ class OCMProductRosa(OCMProduct):
                 creator_role_arn=cluster["properties"]["rosa_creator_arn"],
                 installer_role_arn=cluster["aws"]["sts"]["role_arn"],
                 support_role_arn=cluster["aws"]["sts"]["support_role_arn"],
-                controlplane_role_arn=cluster["aws"]["sts"]["instance_iam_roles"][
-                    "master_role_arn"
-                ],
+                controlplane_role_arn=cluster["aws"]["sts"]["instance_iam_roles"].get(
+                    "master_role_arn", None
+                ),
                 worker_role_arn=cluster["aws"]["sts"]["instance_iam_roles"][
                     "worker_role_arn"
                 ],

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -375,7 +375,7 @@ class OCMProductRosa(OCMProduct):
                 installer_role_arn=cluster["aws"]["sts"]["role_arn"],
                 support_role_arn=cluster["aws"]["sts"]["support_role_arn"],
                 controlplane_role_arn=cluster["aws"]["sts"]["instance_iam_roles"].get(
-                    "master_role_arn", None
+                    "master_role_arn"
                 ),
                 worker_role_arn=cluster["aws"]["sts"]["instance_iam_roles"][
                     "worker_role_arn"


### PR DESCRIPTION
master_role_arn is not always set anymore.
Newer clusters do not report it anymore, therefore making it optional

Related issue:
https://issues.redhat.com/browse/SDA-8935

Related Slack thread: https://redhat-internal.slack.com/archives/C02LM9FABFW/p1683718655087619?thread_ts=1683645279.978359&cid=C02LM9FABFW