### PR TITLE
[AUS] more details in action logging

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -170,7 +170,7 @@ class AddonUpgradePolicy(AbstractUpgradePolicy):
     def summarize(self, ocm_org_name: str) -> str:
         details = {
             "cluster": self.cluster,
-            "ocm-org": ocm_org_name,
+            "ocm_org": ocm_org_name,
             "version": self.version,
             "next_run": self.next_run,
             "addon_id": self.addon_id,
@@ -206,7 +206,7 @@ class ClusterUpgradePolicy(AbstractUpgradePolicy):
     def summarize(self, ocm_org_name: str) -> str:
         details = {
             "cluster": self.cluster,
-            "ocm-org": ocm_org_name,
+            "ocm_org": ocm_org_name,
             "version": self.version,
             "next_run": self.next_run,
         }

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -38,6 +38,7 @@ from reconcile.utils.cluster_version_data import (
     get_version_data,
 )
 from reconcile.utils.defer import defer
+from reconcile.utils.filtering import remove_none_values_from_dict
 from reconcile.utils.ocm import (
     OCM,
     OCMMap,
@@ -109,11 +110,8 @@ class GateAgreement(BaseModel):
     id: str
 
     def create(self, ocm: OCM, cluster_name: str) -> None:
-        action_log(
-            "create",
-            ocm.name,
-            cluster_name,
-            f"Creating version agreement for gate {self.id}",
+        logging.info(
+            f"create agreement for gate {self.id} on cluster {cluster_name} in OCM org {ocm.name}"
         )
         agreement = ocm.create_version_agreement(self.id, cluster_name)
         if agreement.get("version_gate") is None:
@@ -142,6 +140,10 @@ class AbstractUpgradePolicy(ABC, BaseModel):
     def delete(self, ocm: OCM) -> None:
         pass
 
+    @abstractmethod
+    def summarize(self, ocm_org_name: str) -> str:
+        pass
+
 
 class AddonUpgradePolicy(AbstractUpgradePolicy):
     """Class to create and delete Addon upgrade policies in OCM"""
@@ -164,6 +166,16 @@ class AddonUpgradePolicy(AbstractUpgradePolicy):
             "id": self.id,
         }
         ocm.delete_addon_upgrade_policy(self.cluster, item)
+
+    def summarize(self, ocm_org_name: str) -> str:
+        details = {
+            "cluster": self.cluster,
+            "ocm-org": ocm_org_name,
+            "version": self.version,
+            "next_run": self.next_run,
+            "addon_id": self.addon_id,
+        }
+        return f"addon upgrade policy - {remove_none_values_from_dict(details)}"
 
 
 class ClusterUpgradePolicy(AbstractUpgradePolicy):
@@ -191,6 +203,15 @@ class ClusterUpgradePolicy(AbstractUpgradePolicy):
         }
         ocm.delete_upgrade_policy(self.cluster, item)
 
+    def summarize(self, ocm_org_name: str) -> str:
+        details = {
+            "cluster": self.cluster,
+            "ocm-org": ocm_org_name,
+            "version": self.version,
+            "next_run": self.next_run,
+        }
+        return f"cluster upgrade policy - {remove_none_values_from_dict(details)}"
+
 
 class UpgradePolicyHandler(BaseModel):
     """Class to handle upgrade policy actions"""
@@ -199,13 +220,7 @@ class UpgradePolicyHandler(BaseModel):
     policy: AbstractUpgradePolicy
 
     def act(self, dry_run: bool, ocm: OCM) -> None:
-        action_log(
-            self.action,
-            ocm.name,
-            self.policy.cluster,
-            self.policy.version,
-            self.policy.next_run,
-        )
+        logging.info(f"{self.action} {self.policy.summarize(ocm.name)}")
         if dry_run:
             return
 
@@ -719,11 +734,6 @@ def sort_diffs(diff: UpgradePolicyHandler) -> int:
     if diff.action == "delete":
         return 1
     return 2
-
-
-def action_log(*items: Optional[str]) -> None:
-    # log all non-empty, non-null items
-    logging.info([item for item in items if item])
 
 
 def act(

--- a/reconcile/test/test_ocm_upgrade_scheduler.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler.py
@@ -629,6 +629,9 @@ class TestAct:
         def delete(self, ocm: OCM):
             self.deleted = True
 
+        def summarize(self, ocm_org_name: str) -> str:
+            return "do-something"
+
     @staticmethod
     def create_policy_with_action(action: str):
         return aus.UpgradePolicyHandler(

--- a/reconcile/test/utils/test_filtering.py
+++ b/reconcile/test/utils/test_filtering.py
@@ -1,0 +1,27 @@
+from typing import (
+    Any,
+    Optional,
+)
+
+from reconcile.utils.filtering import remove_none_values_from_dict
+
+
+def test_remove_none_values_from_dict_all_none() -> None:
+    assert remove_none_values_from_dict({"a": None, "b": None}) == {}
+
+
+def test_remove_empty_values_from_dict_dont_remove_not_none() -> None:
+    a_dict: dict[str, Optional[Any]] = {
+        "a": "",
+        "b": [],
+        "c": {},
+        "d": 0,
+        "e": "str",
+        "f": False,
+    }
+    filtered_dict = remove_none_values_from_dict(a_dict)
+    assert filtered_dict == a_dict
+
+
+def test_remove_none_values_from_empty_dict() -> None:
+    assert remove_none_values_from_dict({}) == {}

--- a/reconcile/utils/filtering.py
+++ b/reconcile/utils/filtering.py
@@ -1,0 +1,17 @@
+from typing import (
+    Optional,
+    TypeVar,
+)
+
+KeyType = TypeVar("KeyType")
+ValueType = TypeVar("ValueType")
+
+
+def remove_none_values_from_dict(
+    a_dict: dict[KeyType, Optional[ValueType]]
+) -> dict[KeyType, ValueType]:
+    """
+    Creates a new dictionary based on the input dictionary but skips items
+    with None values.
+    """
+    return {key: value for key, value in a_dict.items() if value is not None}


### PR DESCRIPTION
instead of

```
[ocm-addons-upgrade-scheduler-org] ['create', 'my-org', 'my-cluster', '1.2.3']
```

action logging will look like this

```
[ocm-addons-upgrade-scheduler-org] create addon upgrade policy - {'cluster': 'my-cluster', 'ocm-org': 'my-org', 'addon-id': 'my-addon', 'version': '1.2.3', 'next-run': 'soon'}
```

this change also adds back the addon-id to the action log