### PR TITLE
[change-owners] fix self-referenced implicit ownership

### DIFF
--- a/reconcile/change_owners/changes.py
+++ b/reconcile/change_owners/changes.py
@@ -1,3 +1,4 @@
+import copy
 import itertools
 import logging
 from collections import defaultdict
@@ -14,6 +15,8 @@ from typing import (
 import anymarkup
 
 from reconcile.change_owners.bundle import (
+    DATAFILE_PATH_FIELD_NAME,
+    DATAFILE_SCHEMA_FIELD_NAME,
     BundleFileType,
     FileRef,
     QontractServerDiff,
@@ -74,6 +77,25 @@ class BundleFileChange:
                 [],
             )
         return self._diff_coverage[METADATA_CHANGE_PATH]
+
+    @property
+    def old_content_with_metadata(self) -> Optional[dict[str, Any]]:
+        return self._content_with_metadata(self.old)
+
+    @property
+    def new_content_with_metadata(self) -> Optional[dict[str, Any]]:
+        return self._content_with_metadata(self.new)
+
+    def _content_with_metadata(
+        self, content: Optional[dict[str, Any]]
+    ) -> Optional[dict[str, Any]]:
+        if content and self.fileref.file_type == BundleFileType.DATAFILE:
+            content_copy = copy.deepcopy(content)
+            content_copy[DATAFILE_PATH_FIELD_NAME] = self.fileref.path
+            content_copy[DATAFILE_SCHEMA_FIELD_NAME] = self.fileref.schema
+            return content_copy
+
+        return content
 
     def is_file_deletion(self) -> bool:
         return self.old is not None and self.new is None

--- a/reconcile/change_owners/implicit_ownership.py
+++ b/reconcile/change_owners/implicit_ownership.py
@@ -87,7 +87,7 @@ def find_approvers_with_implicit_ownership_jsonpath_selector(
     implicit_ownership: ChangeTypeImplicitOwnershipJsonPathProviderV1,
 ) -> set[str]:
 
-    context_file_content = bc.old or bc.new
+    context_file_content = bc.old_content_with_metadata or bc.new_content_with_metadata
     if context_file_content is None:
         # this can't happen. either bc.old or bc.new is set
         # but to make mypy happy, we need to check for None

--- a/reconcile/test/change_owners/test_change_type_bundle_change.py
+++ b/reconcile/test/change_owners/test_change_type_bundle_change.py
@@ -16,6 +16,7 @@ from reconcile.change_owners.changes import (
 )
 from reconcile.test.change_owners.fixtures import (
     QontractServerBundleDiffDataBuilder,
+    build_bundle_datafile_change,
     build_test_datafile,
 )
 
@@ -316,3 +317,52 @@ def test_aggregate_file_moves_mixed() -> None:
     )
     result = aggregate_file_moves(changes)
     assert len(result) == 2
+
+
+#
+# content with metadata
+#
+
+
+def test_get_new_content_with_metadata() -> None:
+    path = "/my/path.yml"
+    schema = "/my/schema.yml"
+    bc = build_bundle_datafile_change(
+        path=path,
+        schema=schema,
+        old_content=None,
+        new_content={
+            "field": "new",
+        },
+    )
+    assert bc
+
+    assert bc.old_content_with_metadata is None
+
+    assert bc.new_content_with_metadata == {
+        "path": path,
+        "$schema": schema,
+        "field": "new",
+    }
+
+
+def test_get_old_content_with_metadata() -> None:
+    path = "/my/path.yml"
+    schema = "/my/schema.yml"
+    bc = build_bundle_datafile_change(
+        path=path,
+        schema=schema,
+        old_content={
+            "field": "old",
+        },
+        new_content=None,
+    )
+    assert bc
+
+    assert bc.old_content_with_metadata == {
+        "path": path,
+        "$schema": schema,
+        "field": "old",
+    }
+
+    assert bc.new_content_with_metadata is None


### PR DESCRIPTION
resolving the approver of a change failed when implicit ownership was defined to use the changed file itself as the owner/approver.

this was a side-effect of https://github.com/app-sre/qontract-reconcile/pull/3501

https://issues.redhat.com/browse/APPSRE-7625