### PR TITLE
[AUS] filter clusters to process on a set of org IDs

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -58,7 +58,7 @@ from reconcile.utils.state import init_state
 class AdvancedUpgradeSchedulerBaseIntegrationParams(PydanticRunParams):
 
     ocm_environment: Optional[str] = None
-    ocm_organization: Optional[str] = None
+    ocm_organization_ids: Optional[set[str]] = None
 
 
 class AdvancedUpgradeSchedulerBaseIntegration(
@@ -82,7 +82,7 @@ class AdvancedUpgradeSchedulerBaseIntegration(
         return {
             ocm_env.name: self.get_ocm_env_upgrade_specs(
                 ocm_env,
-                self.params.ocm_organization,
+                self.params.ocm_organization_ids,
             )
             for ocm_env in self.get_ocm_environments()
         }
@@ -103,7 +103,7 @@ class AdvancedUpgradeSchedulerBaseIntegration(
 
     @abstractmethod
     def get_ocm_env_upgrade_specs(
-        self, ocm_env: OCMEnvironment, org_name: Optional[str] = None
+        self, ocm_env: OCMEnvironment, org_ids: Optional[set[str]]
     ) -> dict[str, OrganizationUpgradeSpec]:
         ...
 

--- a/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
@@ -61,7 +61,7 @@ class OCMAddonsUpgradeSchedulerOrgIntegration(
             aus.act(dry_run, diffs, ocm_map, addon_id=addon_state.addon_id)
 
     def get_ocm_env_upgrade_specs(
-        self, ocm_env: OCMEnvironment, org_name: Optional[str] = None
+        self, ocm_env: OCMEnvironment, org_ids: Optional[set[str]]
     ) -> dict[str, OrganizationUpgradeSpec]:
         return {
             org.name: OrganizationUpgradeSpec(
@@ -81,7 +81,7 @@ class OCMAddonsUpgradeSchedulerOrgIntegration(
             or []
             if org.environment.name == ocm_env.name
             and org.addon_managed_upgrades
-            and (org_name is None or org.name == org_name)
+            and (org_ids is None or org.org_id in org_ids)
         }
 
 

--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -61,7 +61,7 @@ class OCMClusterUpgradeSchedulerIntegration(
         aus.act(dry_run, diffs, ocm_map)
 
     def get_ocm_env_upgrade_specs(
-        self, ocm_env: OCMEnvironment, org_name: Optional[str] = None
+        self, ocm_env: OCMEnvironment, org_ids: Optional[set[str]]
     ) -> dict[str, OrganizationUpgradeSpec]:
         specs_per_org: dict[str, list[ClusterUpgradeSpec]] = defaultdict(list)
         for cluster in (
@@ -71,8 +71,8 @@ class OCMClusterUpgradeSchedulerIntegration(
                 cluster.spec and cluster.spec.product in SUPPORTED_OCM_PRODUCTS
             )
             in_env_shard = cluster.ocm and ocm_env.name == cluster.ocm.environment.name
-            in_org_shard = org_name is None or (
-                cluster.ocm and cluster.ocm.name == org_name
+            in_org_shard = org_ids is None or (
+                cluster.ocm and cluster.ocm.org_id in org_ids
             )
             in_shard = in_env_shard and in_org_shard
             if (

--- a/reconcile/aus/ocm_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_upgrade_scheduler_org.py
@@ -20,7 +20,7 @@ class OCMClusterUpgradeSchedulerOrgIntegration(OCMClusterUpgradeSchedulerIntegra
         return QONTRACT_INTEGRATION
 
     def get_ocm_env_upgrade_specs(
-        self, ocm_env: OCMEnvironment, org_name: Optional[str] = None
+        self, ocm_env: OCMEnvironment, org_ids: Optional[set[str]]
     ) -> dict[str, OrganizationUpgradeSpec]:
         return {
             org.name: OrganizationUpgradeSpec(
@@ -39,5 +39,5 @@ class OCMClusterUpgradeSchedulerOrgIntegration(OCMClusterUpgradeSchedulerIntegra
             ).organizations
             or []
             if org.environment.name == ocm_env.name
-            and (org_name is None or org.name == org_name)
+            and (org_ids is None or org.org_id in org_ids)
         }

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1984,14 +1984,30 @@ def ocm_addons_upgrade_scheduler_org(ctx):
 @integration.command(
     short_help="Manage Cluster Upgrade Policy schedules in OCM organizations based on OCM labels."
 )
+@click.option(
+    "--ocm-env",
+    help="The OCM environment AUS should operator on. If none is specified, all environments will be operated on.",
+    required=False,
+    envvar="AUS_OCM_ENV",
+)
+@click.option(
+    "--ocm-org-ids",
+    help="A comma seperated list of OCM organization IDs AUS should operator on. If none is specified, all organizations are considered.",
+    required=False,
+    envvar="AUS_OCM_ORG_IDS",
+)
 @click.pass_context
-def aus_upgrade_scheduler_org(ctx):
+def aus_upgrade_scheduler_org(ctx, ocm_env, ocm_org_ids):
     from reconcile.aus.advanced_upgrade_service import AdvancedUpgradeServiceIntegration
     from reconcile.aus.base import AdvancedUpgradeSchedulerBaseIntegrationParams
 
+    parsed_ocm_org_ids = set(ocm_org_ids.split(",")) if ocm_org_ids else None
     run_class_integration(
         integration=AdvancedUpgradeServiceIntegration(
-            AdvancedUpgradeSchedulerBaseIntegrationParams()
+            AdvancedUpgradeSchedulerBaseIntegrationParams(
+                ocm_environment=ocm_env,
+                ocm_organization_ids=parsed_ocm_org_ids,
+            )
         ),
         ctx=ctx.obj,
     )

--- a/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
+++ b/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
@@ -331,10 +331,10 @@ def test_discover_clusters_with_org_filter(mocker: MockerFixture) -> None:
         )
     ]
 
-    clusters = _discover_clusters(None, "org-id")  # type: ignore
+    clusters = _discover_clusters(None, {"org-id"})  # type: ignore
     assert org_id in clusters
 
-    clusters = _discover_clusters(None, "another-org-id")  # type: ignore
+    clusters = _discover_clusters(None, {"another-org-id"})  # type: ignore
     assert org_id not in clusters
 
 
@@ -398,7 +398,7 @@ def test_org_labels_with_org_filter(
         [build_organization_label("label", "value", org_id)]
     )
 
-    _get_org_labels(ocm_api, org_id)
+    _get_org_labels(ocm_api, {org_id})
 
     get_organization_labels_mock.assert_called_once_with(
         ocm_api, Filter().like("key", aus_label_key("%")).eq("organization_id", org_id)


### PR DESCRIPTION
optionally define OCM env and OCM organization ID filters for OCM label based AUS

https://issues.redhat.com/browse/APPSRE-7602

hint for reviewer: the changes in qontract-cli on the various set commands is some cleanup because defining a func called set hides the `set` function that creates ... well a set