### PR TITLE
[AUS] add option to ignore STS clusters

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -59,6 +59,7 @@ class AdvancedUpgradeSchedulerBaseIntegrationParams(PydanticRunParams):
 
     ocm_environment: Optional[str] = None
     ocm_organization_ids: Optional[set[str]] = None
+    ignore_sts_clusters: bool = False
 
 
 class AdvancedUpgradeSchedulerBaseIntegration(

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2000,7 +2000,7 @@ def ocm_addons_upgrade_scheduler_org(ctx):
     "--ignore-sts-clusters",
     is_flag=True,
     default=os.environ.get("IGNORE_STS_CLUSTERS", False),
-    help="Defines is STS clusters should be ignored.",
+    help="Ignore STS clusters",
 )
 @click.pass_context
 def aus_upgrade_scheduler_org(ctx, ocm_env, ocm_org_ids, ignore_sts_clusters):

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1996,8 +1996,14 @@ def ocm_addons_upgrade_scheduler_org(ctx):
     required=False,
     envvar="AUS_OCM_ORG_IDS",
 )
+@click.option(
+    "--ignore-sts-clusters",
+    is_flag=True,
+    default=os.environ.get("IGNORE_STS_CLUSTERS", False),
+    help="Defines is STS clusters should be ignored.",
+)
 @click.pass_context
-def aus_upgrade_scheduler_org(ctx, ocm_env, ocm_org_ids):
+def aus_upgrade_scheduler_org(ctx, ocm_env, ocm_org_ids, ignore_sts_clusters):
     from reconcile.aus.advanced_upgrade_service import AdvancedUpgradeServiceIntegration
     from reconcile.aus.base import AdvancedUpgradeSchedulerBaseIntegrationParams
 
@@ -2007,6 +2013,7 @@ def aus_upgrade_scheduler_org(ctx, ocm_env, ocm_org_ids):
             AdvancedUpgradeSchedulerBaseIntegrationParams(
                 ocm_environment=ocm_env,
                 ocm_organization_ids=parsed_ocm_org_ids,
+                ignore_sts_clusters=ignore_sts_clusters,
             )
         ),
         ctx=ctx.obj,

--- a/reconcile/test/ocm/fixtures.py
+++ b/reconcile/test/ocm/fixtures.py
@@ -16,6 +16,8 @@ from pydantic import (
 from reconcile.utils.ocm.base import OCMModelLink
 from reconcile.utils.ocm.clusters import (
     OCMCluster,
+    OCMClusterAWSSettings,
+    OCMClusterFlag,
     OCMClusterState,
 )
 from reconcile.utils.ocm.labels import (
@@ -88,7 +90,12 @@ def build_organization_label(key: str, value: str, org_id: str = "org-id") -> OC
 def build_ocm_cluster(
     name: str,
     subs_id: str = "subs_id",
+    aws_cluster: bool = True,
+    sts_cluster: bool = False,
 ) -> OCMCluster:
+    aws_config = None
+    if aws_cluster:
+        aws_config = OCMClusterAWSSettings(sts=OCMClusterFlag(enabled=sts_cluster))
     return OCMCluster(
         id=f"{name}_id",
         external_id=f"{name}_external_id",
@@ -99,6 +106,6 @@ def build_ocm_cluster(
         product=OCMModelLink(id="OCP"),
         cloud_provider=OCMModelLink(id="aws"),
         state=OCMClusterState.READY,
-        openshift_version="4.12.0",
         managed=True,
+        aws=aws_config,
     )

--- a/reconcile/test/ocm/test_utils_ocm_clusters.py
+++ b/reconcile/test/ocm/test_utils_ocm_clusters.py
@@ -17,6 +17,7 @@ from reconcile.utils.ocm import (
     subscriptions,
 )
 from reconcile.utils.ocm.clusters import (
+    ACTIVE_SUBSCRIPTION_STATES,
     ClusterDetails,
     OCMCluster,
     discover_clusters_by_labels,
@@ -240,7 +241,8 @@ def test_get_clusters_for_subscriptions(
 
     get_subscriptions_mock.assert_called_once_with(
         ocm_api=ocm_api,
-        filter=subscription_filter & subscriptions.build_subscription_filter(),
+        filter=subscription_filter
+        & subscriptions.build_subscription_filter(states=ACTIVE_SUBSCRIPTION_STATES),
     )
     get_organization_labels_mock.assert_called_once_with(
         ocm_api=ocm_api, filter=Filter().is_in("organization_id", [organization_id])
@@ -274,7 +276,8 @@ def test_get_clusters_for_subscriptions_none_found(
 
     get_subscriptions_mock.assert_called_once_with(
         ocm_api=ocm_api,
-        filter=subscription_filter & subscriptions.build_subscription_filter(),
+        filter=subscription_filter
+        & subscriptions.build_subscription_filter(states=ACTIVE_SUBSCRIPTION_STATES),
     )
 
 

--- a/reconcile/test/ocm/test_utils_ocm_subscriptions.py
+++ b/reconcile/test/ocm/test_utils_ocm_subscriptions.py
@@ -60,15 +60,15 @@ def test_get_subscriptions(
 
 
 def test_build_subscription_filter() -> None:
-    filter = build_subscription_filter()
+    filter = build_subscription_filter(states={"Active"})
     assert filter.render() == "managed='true' and status='Active'"
 
 
 def test_build_subscription_filter_unmanaged() -> None:
     filter = build_subscription_filter(managed=False)
-    assert filter.render() == "managed='false' and status='Active'"
+    assert filter.render() == "managed='false'"
 
 
-def test_build_subscription_filter_state() -> None:
-    filter = build_subscription_filter(state="Stale")
-    assert filter.render() == "managed='true' and status='Stale'"
+def test_build_subscription_filter_multiple_states() -> None:
+    filter = build_subscription_filter(states={"Active", "Reserved"})
+    assert filter.render() == "managed='true' and status in ('Active','Reserved')"

--- a/reconcile/utils/ocm/subscriptions.py
+++ b/reconcile/utils/ocm/subscriptions.py
@@ -77,9 +77,11 @@ def get_subscriptions(
     return subscriptions
 
 
-def build_subscription_filter(state: str = "Active", managed: bool = True) -> Filter:
+def build_subscription_filter(
+    states: Optional[set[str]] = None, managed: bool = True
+) -> Filter:
     """
     Helper function to create a subscription search filer for two very common
     fields: status and managed.
     """
-    return Filter().eq("status", state).eq("managed", str(managed).lower())
+    return Filter().is_in("status", states).eq("managed", str(managed).lower())

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -630,8 +630,14 @@ def ocm_fleet_upgrade_policies(
     required=False,
     envvar="AUS_OCM_ORG_IDS",
 )
+@click.option(
+    "--ignore-sts-clusters",
+    is_flag=True,
+    default=os.environ.get("IGNORE_STS_CLUSTERS", False),
+    help="Defines is STS clusters should be ignored.",
+)
 @click.pass_context
-def aus_fleet_upgrade_policies(ctx, ocm_env, ocm_org_ids):
+def aus_fleet_upgrade_policies(ctx, ocm_env, ocm_org_ids, ignore_sts_clusters):
     from reconcile.aus.advanced_upgrade_service import AdvancedUpgradeServiceIntegration
 
     parsed_ocm_org_ids = set(ocm_org_ids.split(",")) if ocm_org_ids else None
@@ -641,6 +647,7 @@ def aus_fleet_upgrade_policies(ctx, ocm_env, ocm_org_ids):
             AdvancedUpgradeSchedulerBaseIntegrationParams(
                 ocm_environment=ocm_env,
                 ocm_organization_ids=parsed_ocm_org_ids,
+                ignore_sts_clusters=ignore_sts_clusters,
             )
         ),
     )

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -634,7 +634,7 @@ def ocm_fleet_upgrade_policies(
     "--ignore-sts-clusters",
     is_flag=True,
     default=os.environ.get("IGNORE_STS_CLUSTERS", False),
-    help="Defines is STS clusters should be ignored.",
+    help="Ignore STS clusters",
 )
 @click.pass_context
 def aus_fleet_upgrade_policies(ctx, ocm_env, ocm_org_ids, ignore_sts_clusters):


### PR DESCRIPTION
cluster upgrade policies can't be created for STS clusters using a service-account that is not bound to the clusters organization. until that is adressed in OCM, we will ignore STS clusters when using such a service account.

the AUS integration now supports a flag `--ignore-sts-clusters` to ignore STS clusters.

part of https://issues.redhat.com/browse/APPSRE-7578