### PR TITLE
make sshuttle command compatible with local dev container

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1261,7 +1261,7 @@ def sshuttle_command(
             jh_clusters = [c for c in jh_clusters if c.name == cluster_name]
 
         vpc_cidr_blocks = [c.network.vpc for c in jh_clusters if c.network]
-        cmd = f"sshuttle -r {jh.hostname} {' '.join(vpc_cidr_blocks)}"
+        cmd = f"sshuttle -r {jh.hostname} -l 0.0.0.0 {' '.join(vpc_cidr_blocks)}"
         print(cmd)
 
 


### PR DESCRIPTION
When developing locally with containers, we need `-l 0.0.0.0` in sshuttle to allow any remote IP to connect to the tunnels on the host machine. The dev container (e.g., `qd profile run ...`) can then also connect to private clusters.

Highlighting this option also in the docs now https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/68270