### PR TITLE
[metrics] pydantic based metrics + metric transactions

### DIFF
--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -36,6 +36,7 @@ DRY_RUN = (
 )
 INTEGRATION_EXTRA_ARGS = os.environ.get("INTEGRATION_EXTRA_ARGS")
 CONFIG = os.environ.get("CONFIG", "/config/config.toml")
+PROMETHEUS_PORT = os.environ.get("PROMETHEUS_PORT", 9090)
 
 LOG_FILE = os.environ.get("LOG_FILE")
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO")
@@ -149,7 +150,7 @@ def main():
         $INTEGRATION_EXTRA_ARGS
     """
 
-    start_http_server(9090)
+    start_http_server(int(PROMETHEUS_PORT))
 
     command = build_entry_point_func(COMMAND_NAME)
     while True:

--- a/reconcile/test/test_utils_metrics.py
+++ b/reconcile/test/test_utils_metrics.py
@@ -45,7 +45,7 @@ class DemoInfoMetric(InfoMetric):
 
     @classmethod
     def name(cls) -> str:
-        return "demo_info"
+        return "some_demo_info_metric"
 
 
 @pytest.fixture
@@ -82,9 +82,56 @@ def test_counter_metric_family() -> None:
 def test_info_metric_family() -> None:
     metric_family = DemoInfoMetric.metric_family()
     assert isinstance(metric_family, GaugeMetricFamily)
-    assert metric_family.name == "demo_info"
+    assert metric_family.name == "some_demo_info_metric"
     assert metric_family.documentation == "demo info metric"
     assert set(metric_family._labelnames) == {"string_field", "int_field", "bool_field"}
+
+
+#
+# metric names
+#
+
+
+def test_default_counter_metric_name() -> None:
+    class AppErrors(CounterMetric):
+        field: str
+
+    assert AppErrors.name() == "app_errors"
+
+
+def test_default_counter_metric_name_remove_metric_suffix() -> None:
+    class AppErrorsMetric(CounterMetric):
+        field: str
+
+    assert AppErrorsMetric.name() == "app_errors"
+
+
+def test_default_counter_metric_name_remove_counter_suffix() -> None:
+    class AppErrorsCounter(CounterMetric):
+        field: str
+
+    assert AppErrorsCounter.name() == "app_errors"
+
+
+def test_default_gauge_metric_name_remove_metric_suffix() -> None:
+    class AppRuntimeMetric(GaugeMetric):
+        field: str
+
+    assert AppRuntimeMetric.name() == "app_runtime"
+
+
+def test_default_gauge_metric_name_remove_gauge_suffix() -> None:
+    class AppRuntimeGauge(GaugeMetric):
+        field: str
+
+    assert AppRuntimeGauge.name() == "app_runtime"
+
+
+def test_default_info_metric_name_remove_metric_suffix() -> None:
+    class AppInfoMetric(InfoMetric):
+        field: str
+
+    assert AppInfoMetric.name() == "app_info"
 
 
 #

--- a/reconcile/test/test_utils_metrics.py
+++ b/reconcile/test/test_utils_metrics.py
@@ -1,0 +1,428 @@
+import pytest
+from prometheus_client.core import (
+    CounterMetricFamily,
+    GaugeMetricFamily,
+)
+
+from reconcile.utils.metrics import (
+    CounterMetric,
+    GaugeMetric,
+    InfoMetric,
+    MetricsContainer,
+    inc_counter,
+    join_metric_containers,
+    set_gauge,
+    transactional_metrics,
+)
+
+
+class DemoGauge(GaugeMetric):
+    "demo gauge metric"
+
+    field: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "demo_gauge"
+
+
+class DemoCounter(CounterMetric):
+    "demo counter metric"
+
+    field: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "demo_counter"
+
+
+class DemoInfoMetric(InfoMetric):
+    "demo info metric"
+
+    string_field: str
+    int_field: int
+    bool_field: bool
+
+    @classmethod
+    def name(cls) -> str:
+        return "demo_info"
+
+
+@pytest.fixture
+def demo_counter() -> DemoCounter:
+    return DemoCounter(field="field_value")
+
+
+@pytest.fixture
+def demo_gauge() -> DemoGauge:
+    return DemoGauge(field="field_value")
+
+
+#
+# metric families
+#
+
+
+def test_gauge_metric_family() -> None:
+    metric_family = DemoGauge.metric_family()
+    assert isinstance(metric_family, GaugeMetricFamily)
+    assert metric_family.name == "demo_gauge"
+    assert metric_family.documentation == "demo gauge metric"
+    assert set(metric_family._labelnames) == {"field"}
+
+
+def test_counter_metric_family() -> None:
+    metric_family = DemoCounter.metric_family()
+    assert isinstance(metric_family, CounterMetricFamily)
+    assert metric_family.name == "demo_counter"
+    assert metric_family.documentation == "demo counter metric"
+    assert set(metric_family._labelnames) == {"field"}
+
+
+def test_info_metric_family() -> None:
+    metric_family = DemoInfoMetric.metric_family()
+    assert isinstance(metric_family, GaugeMetricFamily)
+    assert metric_family.name == "demo_info"
+    assert metric_family.documentation == "demo info metric"
+    assert set(metric_family._labelnames) == {"string_field", "int_field", "bool_field"}
+
+
+#
+# metric label type conversion
+#
+
+
+def test_metric_non_string_label_conversion() -> None:
+    info_metric = DemoInfoMetric(string_field="string", int_field=42, bool_field=True)
+    container = MetricsContainer()
+    container.set_info(info_metric)
+
+    metrics = list(container.collect())
+    sample = metrics[0].samples[0]
+    assert sample.labels == {
+        "string_field": "string",
+        "int_field": "42",
+        "bool_field": "true",
+    }
+    assert sample.value == 1
+
+
+#
+# metrics container counter
+#
+
+
+def test_metrics_container_inc_counter(demo_counter: DemoCounter) -> None:
+    container = MetricsContainer()
+    container.inc_counter(demo_counter)
+    container.inc_counter(demo_counter, by=2)
+
+    metrics = list(container.collect())
+    assert metrics[0].type == "counter"
+    assert len(metrics[0].samples) == 1
+    sample = metrics[0].samples[0]
+    assert sample.labels == demo_counter.dict(by_alias=True)
+    assert sample.value == 3
+
+
+#
+# metric container aborb
+#
+
+
+@pytest.mark.parametrize(
+    "aggregate_counters,expected_counter_value",
+    [
+        (True, 3),
+        (False, 2),
+    ],
+)
+def test_metric_container_absorb_counters(
+    demo_counter: DemoCounter, aggregate_counters: bool, expected_counter_value: int
+) -> None:
+    container = MetricsContainer()
+    container.inc_counter(demo_counter)
+
+    another_container = MetricsContainer()
+    another_container.inc_counter(demo_counter, by=2)
+
+    container.absorb(another_container, aggregate_counters=aggregate_counters)
+
+    metrics = list(container.collect())
+    assert metrics[0].type == "counter"
+    assert len(metrics[0].samples) == 1
+    assert metrics[0].samples[0].value == expected_counter_value
+
+
+def test_metric_container_absorb_gauges(demo_gauge: DemoGauge) -> None:
+    container = MetricsContainer()
+    container.set_gauge(demo_gauge, 10)
+
+    another_container = MetricsContainer()
+    another_container.set_gauge(demo_gauge, 20)
+
+    container.absorb(another_container)
+
+    metrics = list(container.collect())
+    assert metrics[0].type == "gauge"
+    assert len(metrics[0].samples) == 1
+    assert metrics[0].samples[0].value == 20
+
+
+def test_metric_container_absorb_with_scopes(
+    demo_gauge: DemoGauge, demo_counter: DemoCounter
+) -> None:
+    container = MetricsContainer()
+    container.set_gauge(demo_gauge, 10)
+
+    another_container = MetricsContainer()
+    with transactional_metrics("some-scope", another_container):
+        inc_counter(demo_counter)
+
+    container.absorb(another_container)
+    metrics = list(container.collect())
+    assert len(metrics) == 2
+
+
+#
+# metrics container join
+#
+
+
+def test_metrics_container_join_counters() -> None:
+    cnt_1 = DemoCounter(field="1")
+    cnt_2 = DemoCounter(field="2")
+    cnt_shared = DemoCounter(field="shared")
+
+    container_1 = MetricsContainer()
+    container_1.inc_counter(cnt_1)
+    container_1.inc_counter(cnt_shared)
+
+    container_2 = MetricsContainer()
+    container_2.inc_counter(cnt_2)
+    container_2.inc_counter(cnt_shared, by=2)
+
+    joined_container = join_metric_containers([container_1, container_2])
+
+    metrics = list(joined_container.collect())
+    assert metrics[0].type == "counter"
+    assert len(metrics[0].samples) == 3
+
+    for s in metrics[0].samples:
+        if s.labels["field"] == "1":
+            assert s.value == 1
+        elif s.labels["field"] == "2":
+            assert s.value == 1
+        elif s.labels["field"] == "shared":
+            assert s.value == 3
+
+
+def test_metrics_container_join_gauges() -> None:
+    g_1 = DemoGauge(field="1")
+    g_2 = DemoGauge(field="2")
+    g_shared = DemoGauge(field="shared")
+
+    container_1 = MetricsContainer()
+    container_1.set_gauge(g_1, 1)
+    container_1.set_gauge(g_shared, 1)
+
+    container_2 = MetricsContainer()
+    container_2.set_gauge(g_2, 2)
+    container_2.set_gauge(g_shared, 2)
+
+    joined_container = join_metric_containers([container_1, container_2])
+
+    metrics = list(joined_container.collect())
+    assert metrics[0].type == "gauge"
+    assert len(metrics[0].samples) == 3
+
+    for s in metrics[0].samples:
+        if s.labels["field"] == "1":
+            assert s.value == 1
+        elif s.labels["field"] == "2":
+            assert s.value == 2
+        elif s.labels["field"] == "shared":
+            assert s.value == 2
+
+
+#
+# transactional metrics
+#
+
+
+def test_transactional_metrics(
+    demo_gauge: DemoGauge, demo_counter: DemoCounter
+) -> None:
+    root = MetricsContainer()
+    with transactional_metrics("scope", root) as c:
+        c.set_gauge(demo_gauge, 42)
+        c.inc_counter(demo_counter)
+
+        # the transaction is still pending so we should not see the metrics in root
+        assert len(list(root.collect())) == 0
+
+    # the transaction is committed so we should see the metrics in root
+    assert len(list(root.collect())) == 2
+
+
+def test_transactional_metrics_gauge_same_scope() -> None:
+    """
+    A transaction with the same scope as an earlier transaction should override
+    the earlier transactions gauges.
+    """
+    g_1 = DemoGauge(field="1", another_field_alias="1")
+    g_2 = DemoGauge(field="2", another_field_alias="2")
+
+    scope = "scope"
+    root = MetricsContainer()
+    with transactional_metrics(scope, root) as c:
+        c.set_gauge(g_1, 42)
+        # the transaction is still pending so we should not see the gauge in root
+        assert len(list(root.collect())) == 0
+
+    # now that the transaction is committed we should see the gauge value in root
+    metrics = list(root.collect())
+    samples = metrics[0].samples
+    assert len(samples) == 1
+    assert samples[0].labels == g_1.dict(by_alias=True)
+    assert samples[0].value == 42
+
+    with transactional_metrics(scope, root) as c:
+        c.set_gauge(g_2, 84)
+        # the transaction is still pending so we should still see the gauge from the previous transaction
+        # and the new gauge should not be visible
+        metrics = list(root.collect())
+        assert len(metrics) == 1
+        samples = metrics[0].samples
+        assert len(samples) == 1
+        assert samples[0].labels == g_1.dict(by_alias=True)
+        assert samples[0].value == 42
+
+    # now that the transaction is committed we should see the new gauge value in root
+    metrics = list(root.collect())
+    samples = metrics[0].samples
+    assert len(samples) == 1
+    assert samples[0].labels == g_2.dict(by_alias=True)
+    assert samples[0].value == 84
+
+
+def test_transactional_metrics_gauges_different_scope() -> None:
+    """
+    Two transactions with different scopes should not replace each others gauges.
+    """
+    g_1 = DemoGauge(field="1", another_field_alias="1")
+    g_2 = DemoGauge(field="2", another_field_alias="2")
+
+    root = MetricsContainer()
+    with transactional_metrics("scope-1", root) as c:
+        c.set_gauge(g_1, 42)
+
+    with transactional_metrics("scope-2", root) as c:
+        c.set_gauge(g_2, 84)
+
+    # now that the transaction is committed we should see the new metric value in root
+    metrics = list(root.collect())
+    samples = metrics[0].samples
+    assert len(samples) == 2
+    for s in samples:
+        if s.labels["field"] == "1":
+            assert s.value == 42
+        elif s.labels["field"] == "2":
+            assert s.value == 84
+
+
+def test_transactional_metrics_counter_same_scope() -> None:
+    """
+    Counter values are kept between transactions with the same scope.
+    Transactional visibility still applies.
+    """
+    cnt = DemoCounter(field="1", another_field_alias="1")
+
+    scope = "scope"
+    root = MetricsContainer()
+    with transactional_metrics(scope, root) as c:
+        c.inc_counter(cnt)
+        # the transaction is still pending so we should not see the counter in root
+        assert len(list(root.collect())) == 0
+
+    metrics = list(root.collect())
+    samples = metrics[0].samples
+    assert len(samples) == 1
+    assert samples[0].labels == cnt.dict(by_alias=True)
+    assert samples[0].value == 1
+
+    with transactional_metrics(scope, root) as c:
+        # we took the previous counter with us, so we should see it within this pending transaction
+        assert len(list(c.collect())) == 1
+
+        c.inc_counter(cnt)
+
+        # the transaction is still pending so while we should see the counter increased within the transaction
+        assert list(c.collect())[0].samples[0].value == 2
+
+        # ... we should not see the counter increased in root yet
+        assert list(root.collect())[0].samples[0].value == 1
+
+    # but when the transaction is committed we should see the counter increased in root
+    assert list(root.collect())[0].samples[0].value == 2
+
+
+def test_transactional_metrics_counter_different_scope() -> None:
+    """
+    Counter values are aggregated between transactions with different scopes.
+    """
+    cnt = DemoCounter(field="1", another_field_alias="1")
+
+    root = MetricsContainer()
+    with transactional_metrics("scope-1", root) as c:
+        c.inc_counter(cnt)
+
+    metrics = list(root.collect())
+    samples = metrics[0].samples
+    assert len(samples) == 1
+    assert samples[0].labels == cnt.dict(by_alias=True)
+    assert samples[0].value == 1
+
+    with transactional_metrics("scope-2", root) as c:
+        # we are in a different scope so we don't see the counter from the previous transaction
+        assert len(list(c.collect())) == 0
+
+        c.inc_counter(cnt)
+
+        # now we see the counter but it has value 1, so freshly initialized
+        assert list(c.collect())[0].samples[0].value == 1
+
+    # but when the transaction is committed we should see the counter values from both scopes aggregated in root
+    assert list(root.collect())[0].samples[0].value == 2
+
+
+#
+# implicit nested transaction
+#
+
+
+def test_transactional_metrics_implicitely_nested(demo_gauge: DemoGauge) -> None:
+    """
+    Nested transactions should be implicitely nested without the need to pass the parent container.
+    """
+    root = MetricsContainer()
+    with transactional_metrics(parent_container=root) as outer:
+        set_gauge(demo_gauge, 42)
+
+        # the transaction is still pending so we should not see the metric in root
+        assert len(list(root.collect())) == 0
+
+        # nested transaction called without explicit parent so it
+        # should automatically be nested within the outer transaction
+        with transactional_metrics():
+            set_gauge(demo_gauge, 84)
+
+            # the transaction is still pending so we should not see the metrics in root
+            assert len(list(root.collect())) == 0
+
+            # the value in the outer transaction should not be affected
+            assert list(outer.collect())[0].samples[0].value == 42
+
+    # the transaction is committed so we should see the metrics in root
+    assert len(list(root.collect())) == 1
+    assert list(root.collect())[0].samples[0].value == 84

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -1,8 +1,34 @@
-from prometheus_client import (
-    Counter,
-    Gauge,
-    Histogram,
+import copy
+import threading
+from abc import (
+    ABC,
+    abstractmethod,
 )
+from collections import defaultdict
+from collections.abc import (
+    Generator,
+    Hashable,
+    Iterable,
+    Sequence,
+)
+from types import TracebackType
+from typing import (
+    Any,
+    Optional,
+    Type,
+)
+
+from prometheus_client.core import (
+    REGISTRY,
+    Counter,
+    CounterMetricFamily,
+    Gauge,
+    GaugeMetricFamily,
+    Histogram,
+    Metric,
+)
+from prometheus_client.registry import Collector
+from pydantic import BaseModel
 
 run_time = Gauge(
     name="qontract_reconcile_last_run_seconds",
@@ -64,3 +90,319 @@ gitlab_request = Counter(
     documentation="Number of calls made to Gitlab API",
     labelnames=["integration"],
 )
+
+
+#
+# Class based metrics
+#
+
+
+class BaseMetric(ABC, BaseModel):
+    @classmethod
+    @abstractmethod
+    def name(cls) -> str:
+        """
+        Returns the prometheus metric name.
+        """
+
+
+class GaugeMetric(BaseMetric):
+    """
+    Base class for gauge metrics.
+    """
+
+    @classmethod
+    def metric_family(cls) -> GaugeMetricFamily:
+        labels = [f.alias for f in cls.__fields__.values()]
+        return GaugeMetricFamily(cls.name(), cls.__doc__ or "", labels=labels)
+
+
+class InfoMetric(GaugeMetric):
+    """
+    Base class for info metrics.
+    """
+
+
+class CounterMetric(BaseMetric):
+    """
+    Base class for counter metrics
+    """
+
+    @classmethod
+    def metric_family(cls) -> CounterMetricFamily:
+        labels = [f.alias for f in cls.__fields__.values()]
+        return CounterMetricFamily(cls.name(), cls.__doc__ or "", labels=labels)
+
+
+class MetricsContainer:
+    """
+    A container for metrics, supporting transactional behaviour and scoped metrics.
+    """
+
+    def __init__(
+        self,
+    ) -> None:
+        self._gauges: dict[Type[GaugeMetric], dict[Sequence[str], float]] = defaultdict(
+            dict
+        )
+        self._counters: dict[
+            Type[CounterMetric], dict[Sequence[str], float]
+        ] = defaultdict(dict)
+
+        self._scopes: dict[Hashable, MetricsContainer] = {}
+
+    def set_gauge(self, metric: GaugeMetric, value: float) -> None:
+        """
+        Sets the value of the given gauge metric to the given value.
+        """
+        label_values = tuple(metric.dict(by_alias=True).values())
+        self._gauges[metric.__class__][label_values] = value
+
+    def set_info(self, metric: InfoMetric) -> None:
+        """
+        Adds an info metric. Info metrics are gauges with a value of 1,
+        so they can be used to join with other metrics by multiplying.
+        """
+        self.set_gauge(metric, 1.0)
+
+    def inc_counter(self, counter: CounterMetric, by: int = 1) -> None:
+        """
+        Increases the value of the given counter by the given amount.
+        """
+        label_values = tuple(counter.dict(by_alias=True).values())
+        current_value = self._counters[counter.__class__].get(label_values) or 0
+        self._counters[counter.__class__][label_values] = current_value + by
+
+    def _aggregate_scopes(self) -> "MetricsContainer":
+        containers = [self]
+        for sub in self._scopes.values():
+            containers.append(sub._aggregate_scopes())
+        return join_metric_containers(containers)
+
+    def collect(self) -> Generator[Metric, None, None]:
+        """
+        Collects all metrics from this container and all its scopes.
+        """
+        return self._aggregate_scopes()._collect_local()
+
+    def _collect_local(self) -> Generator[Metric, None, None]:
+        """
+        Collects only the metrics present in this container, ignoring
+        any scopes.
+        """
+        # collect all gauges
+        for gauge_metric_class, values in self._gauges.items():
+            gauge_metric_family = gauge_metric_class.metric_family()
+            for labels, value in values.items():
+                gauge_metric_family.add_metric(
+                    self._convert_labels_to_strings(labels), value
+                )
+            yield gauge_metric_family
+
+        # collect all counters
+        for counter_metric_class, values in self._counters.items():
+            counter_metric_family = counter_metric_class.metric_family()
+            for labels, value in values.items():
+                counter_metric_family.add_metric(
+                    self._convert_labels_to_strings(labels), value
+                )
+            yield counter_metric_family
+
+    def _convert_labels_to_strings(self, raw_labels: Iterable[Any]) -> list[str]:
+        return [
+            str(label).lower() if isinstance(label, bool) else str(label)
+            for label in raw_labels
+        ]
+
+    def clone(self, keep_gauges: bool, keep_counters: bool) -> "MetricsContainer":
+        """
+        Clones this container.
+        """
+        cloned_container = MetricsContainer()
+        if keep_gauges:
+            cloned_container._gauges = copy.deepcopy(self._gauges)
+        if keep_counters:
+            cloned_container._counters = copy.deepcopy(self._counters)
+        return cloned_container
+
+    def absorb(
+        self, other: "MetricsContainer", aggregate_counters: bool = True
+    ) -> None:
+        """
+        Absorbs the gauges and counter from the given container into this one.
+        """
+        # bring all gauges together
+        for gauge_metric_class, values in other._gauges.items():
+            self._gauges[gauge_metric_class].update(values)
+
+        # bring all counters together, add their values up when the labels match
+        for counter_metric_class, values in other._counters.items():
+            if aggregate_counters:
+                for labels, counter_state in values.items():
+                    aggregated_counter_state = (
+                        self._counters[counter_metric_class].get(labels) or 0
+                    )
+                    self._counters[counter_metric_class][labels] = (
+                        aggregated_counter_state + counter_state
+                    )
+            else:
+                self._counters[counter_metric_class].update(values)
+
+        # bring scopes along
+        self._scopes.update(other._scopes)
+
+
+def join_metric_containers(
+    metric_containers: Iterable["MetricsContainer"], aggregate_counters: bool = True
+) -> "MetricsContainer":
+    """
+    Join all given metric containers into a single one.
+    If gauge duplicates are found, the last one wins.
+    If counter duplicates are found, their values are added up.
+    """
+    aggregated_metrics = MetricsContainer()
+    for mc in metric_containers:
+        aggregated_metrics.absorb(mc, aggregate_counters=aggregate_counters)
+    return aggregated_metrics
+
+
+class _MetricsContext:
+    """
+    Context manager for the metrics container. Metrics collected within the
+    context will be aggregated and exposed to the prometheus client when the
+    context exits.
+
+    See `transactional_metrics` to learn more about the `scope`and `aggregate_counters`
+    parameters.
+    """
+
+    def __init__(
+        self,
+        scope: Optional[Hashable],
+        parent: MetricsContainer,
+        aggregate_counters: bool,
+    ):
+        self.scope = scope
+        self.parent = parent
+        self.aggregate_counters = aggregate_counters
+
+    def __enter__(self) -> MetricsContainer:
+        # if the context manager is used with the scope parameter, it opens a new
+        # scope within the parent container. Otherwise, it opens a new container
+        # that will be absorbed into the parent container after exit
+        self.container = MetricsContainer()
+        if self.scope:
+            previous_scope_container = self.parent._scopes.get(self.scope)
+            if previous_scope_container:
+                self.container = previous_scope_container.clone(
+                    keep_gauges=False, keep_counters=self.aggregate_counters
+                )
+
+        _STATE.set_current_container(self.container)
+        return self.container
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        if self.scope:
+            self.parent._scopes[self.scope] = self.container
+        else:
+            self.parent.absorb(self.container)
+        _STATE.set_current_container(self.parent)
+
+
+def transactional_metrics(
+    scope: Optional[Hashable] = None,
+    parent_container: Optional[MetricsContainer] = None,
+    aggregate_counters: bool = True,
+) -> _MetricsContext:
+    """
+    Creates the context manager for the metrics container, providing
+    transactional behaviour. All metrics exposed within the context manager
+    will be exposed only after the context manager ends.
+
+    If a `scope` parameter is given, the metrics will be grouped by that scope
+    and will replace all metrics collected in the same scope in previous runs.
+    This can be used to forget metrics from previous runs and only expose the
+    ones collected in the current run. For counters this is only true if
+    `aggregate_counters` is set to False, which makes mostly sense if a counter
+    value is provided by an external source and we want to expose the latest
+    value only, so being an ever increasing gauge but with prometheus counter
+    semantics. Otherwise counter metrics will be aggregated across transactions.
+
+    If a `parent_container` is provided, the metrics will be collected in that
+    container (and its scopes). If no `parent_container` is provided, the container
+    of another currently running transaction will be used, if any. Otherwise the
+    global container will be used.
+    """
+    return _MetricsContext(
+        scope=scope,
+        parent=(parent_container or _STATE.get_current_container()),
+        aggregate_counters=aggregate_counters,
+    )
+
+
+class MetricCollector(Collector):
+    """
+    Acts as the bridge between the metrics collected in the MetricsContainers
+    and the prometheus client. The `collect` function is called by the
+    prometheus client during a scrape.
+    """
+
+    def __init__(self, metric_container: MetricsContainer) -> None:
+        self.metric_container = metric_container
+        super().__init__()
+
+    def collect(self) -> Generator[Metric, None, None]:
+        return self.metric_container.collect()
+
+
+# define the top level metrics container and register it with the prometheus
+_GLOBAL_METRICS_CONTAINER = MetricsContainer()
+REGISTRY.register(MetricCollector(_GLOBAL_METRICS_CONTAINER))
+
+
+class _CurrentContainerState(threading.local):
+    """
+    Thread-local state for the current metrics container.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.container: MetricsContainer = _GLOBAL_METRICS_CONTAINER
+
+    def get_current_container(self) -> MetricsContainer:
+        return self.container
+
+    def set_current_container(self, container: MetricsContainer) -> None:
+        self.container = container
+
+
+_STATE = _CurrentContainerState()
+
+
+def set_gauge(metric: GaugeMetric, value: float) -> None:
+    """
+    Expose a gauge metric into the current metrics container.
+    Honors running transactions.
+    """
+    _STATE.get_current_container().set_gauge(metric, value)
+
+
+def set_info(metric: InfoMetric) -> None:
+    """
+    Expose an info metric into the current metrics container.
+    Honors running transactions.
+    """
+    set_gauge(metric, 1.0)
+
+
+def inc_counter(counter: CounterMetric, by: int = 1) -> None:
+    """
+    Increases a counter in the current metrics container.
+    Honors running transactions.
+    """
+    _STATE.get_current_container().inc_counter(counter, by)

--- a/reconcile/utils/runtime/runner.py
+++ b/reconcile/utils/runtime/runner.py
@@ -10,10 +10,7 @@ from typing import (
 from sretoolbox.utils import threaded as sretoolbox_threaded
 
 from reconcile.status import ExitCodes
-from reconcile.utils import (
-    gql,
-    metrics,
-)
+from reconcile.utils import gql
 from reconcile.utils.runtime.desired_state_diff import (
     DesiredStateDiff,
     build_desired_state_diff,
@@ -164,25 +161,13 @@ def run_integration_cfg(run_cfg: IntegrationRunConfiguration) -> None:
         _integration_wet_run(run_cfg.integration)
 
 
-def _integration_metric_scope_name(
-    integration_name: str, shard: Optional[str] = None
-) -> str:
-    scope = f"integration-runner-scope-{integration_name}"
-    if shard:
-        scope += f"-{shard}"
-    return scope
-
-
 def _integration_wet_run(
     integration: QontractReconcileIntegration[RunParamsTypeVar],
 ) -> None:
     """
     Runs an integration in wet mode, i.e. not in dry-run mode.
     """
-    with metrics.transactional_metrics(
-        _integration_metric_scope_name(integration.name)
-    ):
-        integration.run(False)
+    integration.run(False)
 
 
 def _integration_dry_run(
@@ -221,10 +206,7 @@ def _integration_dry_run(
             sharded_integration = integration.build_integration_instance_for_shard(
                 shard
             )
-            with metrics.transactional_metrics(
-                _integration_metric_scope_name(integration.name, shard)
-            ):
-                sharded_integration.run(True)
+            sharded_integration.run(True)
 
         # run all shards
         results = sretoolbox_threaded.run(
@@ -244,10 +226,7 @@ def _integration_dry_run(
             return
 
     # if not, we run the integration in full
-    with metrics.transactional_metrics(
-        _integration_metric_scope_name(integration.name)
-    ):
-        integration.run(True)
+    integration.run(True)
 
 
 def _is_task_result_an_error(result: Any) -> bool:


### PR DESCRIPTION
## Represent a prometheus metric family as a pydantic dataclass

Metric families can be represented with pydantic dataclasses.

* use properties as labels - even though prometheus labels are always strings, all types that are convertable to a string can be used. the additional type safety is nice
* the dataclass docstring is used as the metrics description
* the metric name is provided via the `name` classmethod a metric dataclass must implement
* base classes `GaugeMetric`, `InfoMetric` and `CounterMetric` can be used to define what kind of metric a dataclass represents (histogram support will be added later)

```python
class SomeErrorCounter(CounterMetric):
    """
    How often some error occured.
    """

    component: str
    subcomponent: str
    critical: bool

    @classmethod
    def name() -> str:
        "some_error_counter"
```

## Exposing metrics

Metrics can be exposed by using the `set_gauge`, `set_info` or `inc_counter` functions from the `reconcile.utils.metrics` module. All these functions take a dataclass as an argument, and some additional function dependent parameters regarding in the metric value.

```python
metrics.set_gauge(SomeGauge(label_a="foo"), 12.5)
metrics.set_info(SomeInfo(cluster_name="foo", version="4.13.0", region="us-east-1"))
metrics.inc_counter(SomeErrorCounter(component="A", subcomponent="B", critical=True))
metrics.inc_counter(SomeErrorCounter(component="A", subcomponent="C", critical=False), by=3)
```

Metrics exposed like this are immediately visible and can be scraped.

## Transactional metrics

Metrics can also be exposed in a transactional way, where a group of metrics becomes visible together in a controlled way by wrapping all expore calls within the `metrics.transactional_metrics()` context manager. The metrics become available for scrape after the context manager exits.

```python
with metrics.transactional_metrics():
  metrics.set_info(SomeInfo(cluster_name="foo", version="4.13.0", region="us-east-1"))
  metrics.inc_counter(SomeErrorCounter(component="A", subcomponent="B", critical=True))
```

Such context managers can also be nested.

## Scoped metrics

Sometimes it is useful to stop exposing a certain timeseries, e.g. if the aspect it represents does not exist anymore, e.g. the K8S info metric `kube_pod_info` represents base information for each pod. If a pod is deleted, the `kube_pod_info` timeseries for that pod is not exposed anymore.

This behaviour can be achieved with the `metrics.transactional_metrics(scope="a-scope")` context manager, by passing it a scope.

```python
with metrics.transactional_metrics(scope="pods"):
  metrics.set_info(KubePodInfo(pod_name="foo", node_name="node-1", ...))
  metrics.set_info(KubePodInfo(pod_name="bar", node_name="node-3", ...))
```

When the context manager exits, it replaces all previously known metrics under the same scope. Metrics not mentioned again within the context manager, will vanish from the scrape endpoint.

Counter metrics are handled differently. If a counter does not increase / is not mentioned within a scoped transaction, the metric is still not forgotten after the context manager exits.

```python
# counter value 0

with metrics.transactional_metrics(scope="pods"):
  metrics.inc_counter(SomeErrorCounter(component="A", subcomponent="B", critical=True), by=3)
# counter has value 3

with metrics.transactional_metrics(scope="pods"):
  metrics.inc_counter(SomeErrorCounter(component="A", subcomponent="B", critical=True), by=5)
# counter has value 8
```

This behaviour can be disabled by passing `aggregate_counters=False` to the context manager and counter metrics would behave exactly like gauges in scoped transactions. This is useful if the counter value comes from an external source, so behaves like an ever increasing gauge but should still hold counter semantics in prometheus.

```python
# counter has value 0

with metrics.transactional_metrics(scope="pods", aggregate_counters=False):
  metrics.inc_counter(SomeErrorCounter(component="A", subcomponent="B", critical=True), by=3)
# counter has value 3

with metrics.transactional_metrics(scope="pods", aggregate_counters=False):
  metrics.inc_counter(SomeErrorCounter(component="A", subcomponent="B", critical=True), by=5)
# counter has value 5

with metrics.transactional_metrics(scope="pods", aggregate_counters=False):
  pass
# counter does not exist
```
