### PR TITLE
[AUS] expose metrics

### DIFF
--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -105,6 +105,10 @@ class AdvancedUpgradeServiceIntegration(OCMClusterUpgradeSchedulerOrgIntegration
         org_upgrade_spec: OrganizationUpgradeSpec,
         exception: Exception,
     ) -> None:
+        """
+        AUS will not fail on a reconcile issue. If issues should be noticed by an SRE team,
+        alerts based on the metrics in the `reconcile.aus.metrics` module should be set up.
+        """
         logging.error(
             f"Failed to reconcile cluster upgrades in OCM organization {org_upgrade_spec.org.org_id}",
             exc_info=exception,

--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -99,6 +99,17 @@ class AdvancedUpgradeServiceIntegration(OCMClusterUpgradeSchedulerOrgIntegration
                 ocm_api=ocm_api, org_upgrade_spec=org_upgrade_spec
             )
 
+    def signal_reconcile_issues(
+        self,
+        dry_run: bool,
+        org_upgrade_spec: OrganizationUpgradeSpec,
+        exception: Exception,
+    ) -> None:
+        logging.error(
+            f"Failed to reconcile cluster upgrades in OCM organization {org_upgrade_spec.org.org_id}",
+            exc_info=exception,
+        )
+
 
 def discover_clusters(
     ocm_api: OCMBaseClient,

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -23,7 +23,7 @@ from reconcile.aus.metrics import (
     AUSClusterUpgradePolicyInfoMetric,
     AUSOrganizationReconcileCounter,
     AUSOrganizationReconcileErrorCounter,
-    AUSOrganizationValidationErrorMetric,
+    AUSOrganizationValidationErrorsGauge,
 )
 from reconcile.aus.models import (
     ClusterUpgradeSpec,
@@ -159,7 +159,7 @@ class AdvancedUpgradeSchedulerBaseIntegration(
             )
         )
         metrics.set_gauge(
-            AUSOrganizationValidationErrorMetric(
+            AUSOrganizationValidationErrorsGauge(
                 integration=self.name,
                 ocm_env=ocm_env,
                 org_id=org_upgrade_spec.org.org_id,

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -19,6 +19,12 @@ from croniter import croniter
 from pydantic import BaseModel
 from semver import VersionInfo
 
+from reconcile.aus.metrics import (
+    AUSClusterUpgradePolicyInfoMetric,
+    AUSOrganizationReconcileCounter,
+    AUSOrganizationReconcileErrorCounter,
+    AUSOrganizationValidationErrorMetric,
+)
 from reconcile.aus.models import (
     ClusterUpgradeSpec,
     ConfiguredAddonUpgradePolicy,
@@ -31,7 +37,10 @@ from reconcile.gql_definitions.common.ocm_environments import (
     query as ocm_environment_query,
 )
 from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
-from reconcile.utils import gql
+from reconcile.utils import (
+    gql,
+    metrics,
+)
 from reconcile.utils.cluster_version_data import (
     VersionData,
     WorkloadHistory,
@@ -66,17 +75,31 @@ class AdvancedUpgradeSchedulerBaseIntegration(
     QontractReconcileIntegration[AdvancedUpgradeSchedulerBaseIntegrationParams]
 ):
     def run(self, dry_run: bool) -> None:
-        upgrade_specs = self.get_upgrade_specs()
-        for ocm_env, env_upgrade_specs in upgrade_specs.items():
-            for org_name, org_upgrade_spec in env_upgrade_specs.items():
-                if org_upgrade_spec.has_validation_errors:
-                    self.signal_validation_issues(dry_run, org_upgrade_spec)
-                elif org_upgrade_spec.specs:
-                    self.process_upgrade_policies_in_org(dry_run, org_upgrade_spec)
-                else:
-                    logging.debug(
-                        f"Skip org {org_name} in {ocm_env} because it defines no upgrade policies"
-                    )
+        with metrics.transactional_metrics(self.name):
+            upgrade_specs = self.get_upgrade_specs()
+            for ocm_env, env_upgrade_specs in upgrade_specs.items():
+                for org_name, org_upgrade_spec in env_upgrade_specs.items():
+                    self.expose_org_upgrade_spec_metrics(ocm_env, org_upgrade_spec)
+                    if org_upgrade_spec.has_validation_errors:
+                        self.signal_validation_issues(dry_run, org_upgrade_spec)
+                    elif org_upgrade_spec.specs:
+                        try:
+                            self.process_upgrade_policies_in_org(
+                                dry_run, org_upgrade_spec
+                            )
+                        except Exception as e:
+                            metrics.inc_counter(
+                                AUSOrganizationReconcileErrorCounter(
+                                    integration=self.name,
+                                    ocm_env=ocm_env,
+                                    org_id=org_upgrade_spec.org.org_id,
+                                )
+                            )
+                            self.signal_reconcile_issues(dry_run, org_upgrade_spec, e)
+                    else:
+                        logging.debug(
+                            f"Skip org {org_name} in {ocm_env} because it defines no upgrade policies"
+                        )
         sys.exit(0)
 
     def get_upgrade_specs(self) -> dict[str, dict[str, OrganizationUpgradeSpec]]:
@@ -112,6 +135,55 @@ class AdvancedUpgradeSchedulerBaseIntegration(
         self, dry_run: bool, org_upgrade_spec: OrganizationUpgradeSpec
     ) -> None:
         ...
+
+    def signal_reconcile_issues(
+        self,
+        dry_run: bool,
+        org_upgrade_spec: OrganizationUpgradeSpec,
+        exception: Exception,
+    ) -> None:
+        """
+        The default behaviour is to reraise the exception again so it is handled
+        high up in the stack, potentially also failing the integration.
+        """
+        raise exception
+
+    def expose_org_upgrade_spec_metrics(
+        self, ocm_env: str, org_upgrade_spec: OrganizationUpgradeSpec
+    ) -> None:
+        metrics.inc_counter(
+            AUSOrganizationReconcileCounter(
+                integration=self.name,
+                ocm_env=ocm_env,
+                org_id=org_upgrade_spec.org.org_id,
+            )
+        )
+        metrics.set_gauge(
+            AUSOrganizationValidationErrorMetric(
+                integration=self.name,
+                ocm_env=ocm_env,
+                org_id=org_upgrade_spec.org.org_id,
+            ),
+            org_upgrade_spec.nr_of_validation_errors,
+        )
+        for cluster_upgrade_spec in org_upgrade_spec.specs:
+            mutexes = cluster_upgrade_spec.upgrade_policy.conditions.mutexes
+            metrics.set_info(
+                AUSClusterUpgradePolicyInfoMetric(
+                    integration=self.name,
+                    ocm_env=ocm_env,
+                    cluster_uuid=cluster_upgrade_spec.cluster_uuid,
+                    org_id=cluster_upgrade_spec.ocm.org_id,
+                    cluster_name=cluster_upgrade_spec.name,
+                    schedule=cluster_upgrade_spec.upgrade_policy.schedule,
+                    sector=cluster_upgrade_spec.upgrade_policy.conditions.sector or "",
+                    mutexes=",".join(mutexes) if mutexes else "",
+                    soak_days=str(
+                        cluster_upgrade_spec.upgrade_policy.conditions.soak_days or 0
+                    ),
+                    workloads=",".join(cluster_upgrade_spec.upgrade_policy.workloads),
+                ),
+            )
 
 
 class GateAgreement(BaseModel):
@@ -761,3 +833,18 @@ def act(
             continue
         ocm = ocm_map.get(policy.cluster)
         diff.act(dry_run, ocm)
+
+
+def soaking_days(
+    version_data: VersionData,
+    upgrades: list[str],
+    workload: str,
+    only_soaking: bool,
+) -> dict[str, float]:
+    soaking = {}
+    for version in upgrades:
+        workload_history = version_data.workload_history(version, workload)
+        soaking[version] = round(workload_history.soak_days, 2)
+        if not only_soaking and version not in soaking:
+            soaking[version] = 0
+    return soaking

--- a/reconcile/aus/metrics.py
+++ b/reconcile/aus/metrics.py
@@ -14,7 +14,7 @@ class AUSBaseMetric(BaseModel):
     ocm_env: str
 
 
-class AUSClusterVersionRemainingSoakDaysMetric(AUSBaseMetric, GaugeMetric):
+class AUSClusterVersionRemainingSoakDaysGauge(AUSBaseMetric, GaugeMetric):
     "Remaining days a version needs to soak for a cluster"
 
     cluster_uuid: str
@@ -42,7 +42,7 @@ class AUSClusterUpgradePolicyInfoMetric(AUSBaseMetric, InfoMetric):
         return "aus_cluster_upgrade_policy_info"
 
 
-class AUSOrganizationValidationErrorMetric(AUSBaseMetric, GaugeMetric):
+class AUSOrganizationValidationErrorsGauge(AUSBaseMetric, GaugeMetric):
     "Current validation errors within an OCM organization"
 
     org_id: str
@@ -69,4 +69,4 @@ class AUSOrganizationReconcileErrorCounter(AUSBaseMetric, CounterMetric):
 
     @classmethod
     def name(cls) -> str:
-        return "aus_organization_reconcile_error"
+        return "aus_organization_reconcile_errors"

--- a/reconcile/aus/metrics.py
+++ b/reconcile/aus/metrics.py
@@ -1,0 +1,72 @@
+from pydantic import BaseModel
+
+from reconcile.utils.metrics import (
+    CounterMetric,
+    GaugeMetric,
+    InfoMetric,
+)
+
+
+class AUSBaseMetric(BaseModel):
+    "Base class for AUS metrics"
+
+    integration: str
+    ocm_env: str
+
+
+class AUSClusterVersionRemainingSoakDaysMetric(AUSBaseMetric, GaugeMetric):
+    "Remaining days a version needs to soak for a cluster"
+
+    cluster_uuid: str
+    soaking_version: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "aus_cluster_version_remaining_soak_days"
+
+
+class AUSClusterUpgradePolicyInfoMetric(AUSBaseMetric, InfoMetric):
+    "Info metric for clusters under AUS upgrade control"
+
+    cluster_uuid: str
+    org_id: str
+    cluster_name: str
+    schedule: str
+    sector: str
+    mutexes: str
+    soak_days: str
+    workloads: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "aus_cluster_upgrade_policy_info"
+
+
+class AUSOrganizationValidationErrorMetric(AUSBaseMetric, GaugeMetric):
+    "Current validation errors within an OCM organization"
+
+    org_id: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "aus_organization_validation_errors"
+
+
+class AUSOrganizationReconcileCounter(AUSBaseMetric, CounterMetric):
+    "Counter for the number of times an OCM organization was reconciled"
+
+    org_id: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "aus_organization_reconciled"
+
+
+class AUSOrganizationReconcileErrorCounter(AUSBaseMetric, CounterMetric):
+    "Counter for the failed reconcile runs for an OCM organization"
+
+    org_id: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "aus_organization_reconcile_error"

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -46,7 +46,11 @@ class OrganizationUpgradeSpec(BaseModel):
 
     @property
     def has_validation_errors(self) -> bool:
-        return len(self._cluster_errors) > 0
+        return self.nr_of_validation_errors > 0
+
+    @property
+    def nr_of_validation_errors(self) -> int:
+        return len(self._cluster_errors)
 
     @property
     def cluster_errors(self) -> list[ClusterValidationError]:
@@ -64,7 +68,7 @@ class ConfiguredUpgradePolicyConditions(BaseModel):
     """This class is used to represent the conditions of upgrade policies."""
 
     mutexes: Optional[list[str]]
-    soakDays: Optional[int]
+    soakDays: int
     sector: Optional[Sector]
 
     def get_mutexes(self) -> list[str]:
@@ -79,6 +83,7 @@ class ConfiguredUpgradePolicy(BaseModel):
     """
 
     cluster: str
+    cluster_uuid: str
     conditions: ConfiguredUpgradePolicyConditions
     current_version: str
     schedule: str
@@ -101,6 +106,7 @@ class ConfiguredAddonUpgradePolicy(ConfiguredUpgradePolicy):
     ) -> ConfiguredAddonUpgradePolicy:
         created_instance = cls(
             cluster=ous.name,
+            cluster_uuid=ous.cluster_uuid,
             conditions=ConfiguredUpgradePolicyConditions(
                 mutexes=ous.upgrade_policy.conditions.mutexes,
                 soakDays=ous.upgrade_policy.conditions.soak_days,
@@ -134,6 +140,7 @@ class ConfiguredClusterUpgradePolicy(ConfiguredUpgradePolicy):
     ) -> ConfiguredClusterUpgradePolicy:
         created_instance = cls(
             cluster=ous.name,
+            cluster_uuid=ous.cluster_uuid,
             conditions=ConfiguredUpgradePolicyConditions(
                 mutexes=ous.upgrade_policy.conditions.mutexes,
                 soakDays=ous.upgrade_policy.conditions.soak_days,

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -21,7 +21,7 @@ class ClusterUpgradeSpec(BaseModel):
     name: str
     ocm: AUSOCMOrganization
     upgrade_policy: ClusterUpgradePolicy = Field(..., alias="upgradePolicy")
-    cluster_uuid: Optional[str] = None
+    cluster_uuid: str
 
 
 class ClusterValidationError(BaseModel):

--- a/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
@@ -84,6 +84,17 @@ class OCMAddonsUpgradeSchedulerOrgIntegration(
             and (org_ids is None or org.org_id in org_ids)
         }
 
+    def expose_org_upgrade_spec_metrics(
+        self, ocm_env: str, org_upgrade_spec: OrganizationUpgradeSpec
+    ) -> None:
+        metrics.inc_counter(
+            AUSOrganizationReconcileCounter(
+                integration=self.name,
+                ocm_env=ocm_env,
+                org_id=org_upgrade_spec.org.org_id,
+            )
+        )
+
 
 def get_state_for_org_spec(
     org_upgrade_spec: OrganizationUpgradeSpec, fetch_current_state: bool

--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -90,17 +90,19 @@ class OCMClusterUpgradeSchedulerIntegration(
                 cluster.ocm and cluster.ocm.org_id in org_ids
             )
             in_shard = in_env_shard and in_org_shard
+            cluster_uuid = cluster.spec.external_id if cluster.spec else None
             if (
-                integration_is_enabled(self.name, cluster)
+                integration_is_enabled(self.name, cluster)  # pylint: disable=R0916
                 and cluster.ocm
                 and cluster.upgrade_policy
                 and supported_product
+                and cluster_uuid
                 and in_shard
             ):
                 specs_per_org[cluster.ocm.name].append(
                     ClusterUpgradeSpec(
                         name=cluster.name,
-                        cluster_uuid=cluster.spec.external_id if cluster.spec else None,
+                        cluster_uuid=cluster_uuid,
                         ocm=cluster.ocm,
                         upgradePolicy=cluster.upgrade_policy,
                     )

--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -3,7 +3,7 @@ from typing import Optional
 
 from reconcile import queries
 from reconcile.aus import base as aus
-from reconcile.aus.metrics import AUSClusterVersionRemainingSoakDaysMetric
+from reconcile.aus.metrics import AUSClusterVersionRemainingSoakDaysGauge
 from reconcile.aus.models import (
     ClusterUpgradeSpec,
     ConfiguredUpgradePolicy,
@@ -131,7 +131,7 @@ class OCMClusterUpgradeSchedulerIntegration(
             for version in upgrades or []:
                 soaks = [s.get(version, 0) for s in workload_soaking_upgrades]
                 metrics.set_gauge(
-                    AUSClusterVersionRemainingSoakDaysMetric(
+                    AUSClusterVersionRemainingSoakDaysGauge(
                         integration=self.name,
                         ocm_env=ocm_env,
                         cluster_uuid=up.cluster_uuid,

--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -3,15 +3,21 @@ from typing import Optional
 
 from reconcile import queries
 from reconcile.aus import base as aus
+from reconcile.aus.metrics import AUSClusterVersionRemainingSoakDaysMetric
 from reconcile.aus.models import (
     ClusterUpgradeSpec,
+    ConfiguredUpgradePolicy,
     OrganizationUpgradeSpec,
 )
 from reconcile.gql_definitions.advanced_upgrade_service.aus_clusters import (
     query as aus_clusters_query,
 )
 from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
-from reconcile.utils import gql
+from reconcile.utils import (
+    gql,
+    metrics,
+)
+from reconcile.utils.cluster_version_data import VersionData
 from reconcile.utils.disabled_integrations import integration_is_enabled
 from reconcile.utils.ocm import (
     OCM_PRODUCT_OSD,
@@ -43,6 +49,7 @@ class OCMClusterUpgradeSchedulerIntegration(
             settings=settings,
             init_version_gates=True,
         )
+        ocm_org = ocm_map[org_upgrade_spec.org.name]
         current_state = aus.fetch_current_state(
             clusters=org_upgrade_spec.specs, ocm_map=ocm_map
         )
@@ -55,6 +62,14 @@ class OCMClusterUpgradeSchedulerIntegration(
             ocm_map=ocm_map,
             integration=self.name,
         )
+
+        self.expose_remaining_soak_day_metrics(
+            ocm_env=org_upgrade_spec.org.environment.name,
+            upgrade_policies=upgrade_policies,
+            version_data=version_data_map[ocm_org.name],
+            available_upgrades=ocm_org.non_blocked_cluster_upgrades,
+        )
+
         diffs = aus.calculate_diff(
             current_state, upgrade_policies, ocm_map, version_data_map
         )
@@ -94,3 +109,31 @@ class OCMClusterUpgradeSchedulerIntegration(
             org_name: OrganizationUpgradeSpec(org=specs[0].ocm, specs=specs)
             for org_name, specs in specs_per_org.items()
         }
+
+    def expose_remaining_soak_day_metrics(
+        self,
+        ocm_env: str,
+        upgrade_policies: list[ConfiguredUpgradePolicy],
+        version_data: VersionData,
+        available_upgrades: dict[str, list[str]],
+    ) -> None:
+        for up in upgrade_policies:
+            upgrades = available_upgrades.get(up.cluster) or []
+            if not upgrades:
+                continue
+
+            workload_soaking_upgrades = [
+                aus.soaking_days(version_data, upgrades, wl, False)
+                for wl in up.workloads
+            ]
+            for version in upgrades or []:
+                soaks = [s.get(version, 0) for s in workload_soaking_upgrades]
+                metrics.set_gauge(
+                    AUSClusterVersionRemainingSoakDaysMetric(
+                        integration=self.name,
+                        ocm_env=ocm_env,
+                        cluster_uuid=up.cluster_uuid,
+                        soaking_version=version,
+                    ),
+                    max(up.conditions.soakDays - (min(soaks) or 0), 0),
+                )

--- a/reconcile/aus/ocm_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_upgrade_scheduler_org.py
@@ -8,8 +8,11 @@ from reconcile.aus.ocm_upgrade_scheduler import OCMClusterUpgradeSchedulerIntegr
 from reconcile.gql_definitions.advanced_upgrade_service.aus_organization import (
     query as aus_organizations_query,
 )
+from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
 from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.utils import gql
+from reconcile.utils.ocm.clusters import discover_clusters_for_organizations
+from reconcile.utils.ocm_base_client import init_ocm_base_client
 
 QONTRACT_INTEGRATION = "ocm-upgrade-scheduler-org"
 
@@ -22,22 +25,53 @@ class OCMClusterUpgradeSchedulerOrgIntegration(OCMClusterUpgradeSchedulerIntegra
     def get_ocm_env_upgrade_specs(
         self, ocm_env: OCMEnvironment, org_ids: Optional[set[str]]
     ) -> dict[str, OrganizationUpgradeSpec]:
-        return {
-            org.name: OrganizationUpgradeSpec(
-                org=org,
-                specs=[
-                    ClusterUpgradeSpec(
-                        name=cluster.name,
-                        ocm=org,
-                        upgradePolicy=cluster.upgrade_policy,
-                    )
-                    for cluster in org.upgrade_policy_clusters or []
-                ],
-            )
+        # query all OCM organizations from app-interface and filter by and orgs
+        organizations = [
+            org
             for org in aus_organizations_query(
                 query_func=gql.get_api().query
             ).organizations
             or []
             if org.environment.name == ocm_env.name
             and (org_ids is None or org.org_id in org_ids)
+        ]
+        if not organizations:
+            return {}
+
+        # lookup cluster in OCM to figure out if they exist
+        # and to get their UUID
+        ocm_api = init_ocm_base_client(ocm_env, self.secret_reader)
+        clusters = discover_clusters_for_organizations(
+            ocm_api, [org.org_id for org in organizations]
+        )
+
+        return {
+            org.name: OrganizationUpgradeSpec(
+                org=org,
+                specs=self._build_cluster_upgrade_specs(
+                    org,
+                    {
+                        c.ocm_cluster.name: c.ocm_cluster.external_id
+                        for c in clusters
+                        if c.organization_id == org.org_id
+                    },
+                ),
+            )
+            for org in organizations
         }
+
+    def _build_cluster_upgrade_specs(
+        self, org: AUSOCMOrganization, cluster_name_to_uuid: dict[str, str]
+    ) -> list[ClusterUpgradeSpec]:
+        return [
+            ClusterUpgradeSpec(
+                name=cluster.name,
+                ocm=org,
+                upgradePolicy=cluster.upgrade_policy,
+                cluster_uuid=cluster_name_to_uuid[cluster.name],
+            )
+            for cluster in org.upgrade_policy_clusters or []
+            # clusters that are not in the UUID dict will be ignored because
+            # they don't exist in the OCM organization
+            if cluster.name in cluster_name_to_uuid
+        ]

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2023,7 +2023,7 @@ def ocm_addons_upgrade_scheduler_org(ctx):
     help="Ignore STS clusters",
 )
 @click.pass_context
-def aus_upgrade_scheduler(ctx, ocm_env, ocm_org_ids, ignore_sts_clusters):
+def advanced_upgrade_scheduler(ctx, ocm_env, ocm_org_ids, ignore_sts_clusters):
     from reconcile.aus.advanced_upgrade_service import AdvancedUpgradeServiceIntegration
     from reconcile.aus.base import AdvancedUpgradeSchedulerBaseIntegrationParams
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2023,7 +2023,7 @@ def ocm_addons_upgrade_scheduler_org(ctx):
     help="Ignore STS clusters",
 )
 @click.pass_context
-def aus_upgrade_scheduler_org(ctx, ocm_env, ocm_org_ids, ignore_sts_clusters):
+def aus_upgrade_scheduler(ctx, ocm_env, ocm_org_ids, ignore_sts_clusters):
     from reconcile.aus.advanced_upgrade_service import AdvancedUpgradeServiceIntegration
     from reconcile.aus.base import AdvancedUpgradeSchedulerBaseIntegrationParams
 

--- a/reconcile/test/test_ocm_addons_upgrade_scheduler_org.py
+++ b/reconcile/test/test_ocm_addons_upgrade_scheduler_org.py
@@ -49,6 +49,7 @@ def desired_state(addon_id, cluster):
             "conditions": {"soakDays": 0},
             "addon_id": addon_id,
             "cluster": cluster,
+            "cluster_uuid": f"{cluster}-uuid",
             "current_version": "2.0.0",
         }
     )

--- a/reconcile/test/test_ocm_upgrade_scheduler.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler.py
@@ -54,8 +54,9 @@ class TestUpdateHistory(TestCase):
                 **{
                     "workloads": ["workload1"],
                     "cluster": "cluster1",
+                    "cluster_uuid": "cluster1_uuid",
                     "current_version": "4.12.1",
-                    "conditions": {},
+                    "conditions": {"soakDays": 0},
                     "schedule": "0 0 * * *",
                 }
             ),
@@ -63,8 +64,9 @@ class TestUpdateHistory(TestCase):
                 **{
                     "workloads": ["workload1"],
                     "cluster": "cluster2",
+                    "cluster_uuid": "cluster1_uuid",
                     "current_version": "4.12.1",
-                    "conditions": {},
+                    "conditions": {"soakDays": 0},
                     "schedule": "0 0 * * *",
                 }
             ),
@@ -72,8 +74,9 @@ class TestUpdateHistory(TestCase):
                 **{
                     "workloads": ["workload2"],
                     "cluster": "cluster3",
+                    "cluster_uuid": "cluster1_uuid",
                     "current_version": "4.12.1",
-                    "conditions": {},
+                    "conditions": {"soakDays": 0},
                     "schedule": "0 0 * * *",
                 }
             ),
@@ -204,11 +207,12 @@ class TestUpgradeLock:
     desired_cluster1 = ConfiguredClusterUpgradePolicy(
         **{
             "cluster": "cluster1",
+            "cluster_uuid": "cluster1_uuid",
             "current_version": "4.3.0",
             "channel": "stable",
             "schedule": "* * * * *",
             "workloads": [],
-            "conditions": {"mutexes": ["mutex1"]},
+            "conditions": {"mutexes": ["mutex1"], "soakDays": 0},
         }
     )
 
@@ -290,6 +294,7 @@ class TestUpgradeableVersion:
                 "current_version": "4.3.5",
                 "channel": "stable",
                 "cluster": "test",
+                "cluster_uuid": "test_uuid",
                 "schedule": "manual",
                 "workloads": ["workload1"],
                 "conditions": ConfiguredUpgradePolicyConditions(soakDays=1),
@@ -367,6 +372,7 @@ class TestUpgradePriority(TestCase):
         return ConfiguredUpgradePolicy(
             **{
                 "cluster": name,
+                "cluster_uuid": "test_uuid",
                 "current_version": version,
                 "schedule": "",
                 "workloads": [],
@@ -494,7 +500,9 @@ class TestVersionConditionsMetSector:
     def test_conditions_met_no_deps(
         self, sector1_ocm1: Sector, empty_version_data_map: dict[str, VersionData]
     ):
-        upgrade_conditions = ConfiguredUpgradePolicyConditions(sector=sector1_ocm1)
+        upgrade_conditions = ConfiguredUpgradePolicyConditions(
+            sector=sector1_ocm1, soakDays=0
+        )
         assert aus.version_conditions_met(
             "1.2.3", empty_version_data_map, "ocm1", ["workload1"], upgrade_conditions
         )
@@ -502,7 +510,9 @@ class TestVersionConditionsMetSector:
     def test_conditions_met_single_deps_no_cluster(
         self, sector2_ocm1: Sector, empty_version_data_map: dict[str, VersionData]
     ):
-        upgrade_conditions = ConfiguredUpgradePolicyConditions(sector=sector2_ocm1)
+        upgrade_conditions = ConfiguredUpgradePolicyConditions(
+            sector=sector2_ocm1, soakDays=0
+        )
         assert aus.version_conditions_met(
             "1.2.3", empty_version_data_map, "ocm1", ["workload1"], upgrade_conditions
         )
@@ -528,7 +538,9 @@ class TestVersionConditionsMetSector:
         cluster_high_version: dict[str, Any],
         empty_version_data_map: dict[str, VersionData],
     ):
-        upgrade_conditions = ConfiguredUpgradePolicyConditions(sector=sector2_ocm1)
+        upgrade_conditions = ConfiguredUpgradePolicyConditions(
+            sector=sector2_ocm1, soakDays=0
+        )
         self.set_clusters(mocker, sector1_ocm1, [cluster_high_version])
         assert aus.version_conditions_met(
             "1.2.3", empty_version_data_map, "ocm1", ["workload1"], upgrade_conditions
@@ -542,7 +554,9 @@ class TestVersionConditionsMetSector:
         cluster_low_version: dict[str, Any],
         empty_version_data_map: dict[str, VersionData],
     ):
-        upgrade_conditions = ConfiguredUpgradePolicyConditions(sector=sector2_ocm1)
+        upgrade_conditions = ConfiguredUpgradePolicyConditions(
+            sector=sector2_ocm1, soakDays=0
+        )
         self.set_clusters(mocker, sector1_ocm1, [cluster_low_version])
         assert not aus.version_conditions_met(
             "1.2.3", empty_version_data_map, "ocm1", ["workload1"], upgrade_conditions
@@ -557,7 +571,9 @@ class TestVersionConditionsMetSector:
         cluster_high_version: dict[str, Any],
         empty_version_data_map: dict[str, VersionData],
     ):
-        upgrade_conditions = ConfiguredUpgradePolicyConditions(sector=sector2_ocm1)
+        upgrade_conditions = ConfiguredUpgradePolicyConditions(
+            sector=sector2_ocm1, soakDays=0
+        )
         self.set_clusters(
             mocker, sector1_ocm1, [cluster_low_version, cluster_high_version]
         )
@@ -577,7 +593,9 @@ class TestVersionConditionsMetSector:
         cluster_high_version: dict[str, Any],
         empty_version_data_map: dict[str, VersionData],
     ):
-        upgrade_conditions = ConfiguredUpgradePolicyConditions(sector=sector3_ocm1)
+        upgrade_conditions = ConfiguredUpgradePolicyConditions(
+            sector=sector3_ocm1, soakDays=0
+        )
 
         # no clusters in deps: upgrade ok
         assert aus.version_conditions_met(
@@ -687,6 +705,7 @@ class TestCalculateDiff:
         return ConfiguredClusterUpgradePolicy(
             **{
                 "cluster": "cluster1",
+                "cluster_uuid": "cluster1_uuid",
                 "current_version": "4.3.0",
                 "channel": "stable",
                 "schedule": "* * * * *",
@@ -702,6 +721,7 @@ class TestCalculateDiff:
             **{
                 "addon_id": "addon1",
                 "cluster": "cluster1",
+                "cluster_uuid": "cluster1_uuid",
                 "current_version": "4.3.0",
                 "schedule": "* * * * *",
                 "workloads": ["workload1"],

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -629,6 +629,13 @@ class OCM:  # pylint: disable=too-many-public-methods
             else:
                 self.not_ready_clusters.add(cluster_name)
 
+    @property
+    def non_blocked_cluster_upgrades(self) -> dict[str, list[str]]:
+        return {
+            cluster: [v for v in versions or [] if not self.version_blocked(v)]
+            for cluster, versions in self.available_cluster_upgrades.items()
+        }
+
     def is_ready(self, cluster):
         return cluster in self.clusters
 

--- a/reconcile/utils/ocm/subscriptions.py
+++ b/reconcile/utils/ocm/subscriptions.py
@@ -2,7 +2,10 @@ from datetime import datetime
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import (
+    BaseModel,
+    ValidationError,
+)
 
 from reconcile.utils.ocm.labels import OCMSubscriptionLabel
 from reconcile.utils.ocm.search_filters import Filter
@@ -70,10 +73,15 @@ def get_subscriptions(
             params={"search": filter_chunk.render()},
             max_page_size=chunk_size,
         ):
-            sub = OCMSubscription(
-                **subscription_dict,
-            )
-            subscriptions[sub.id] = sub
+            try:
+                sub = OCMSubscription(
+                    **subscription_dict,
+                )
+                subscriptions[sub.id] = sub
+            except ValidationError:
+                pass
+                # ignore subscriptions that fail to validate
+                # against the OCMSubscription, since the lack important fields
     return subscriptions
 
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -67,7 +67,6 @@ from reconcile.utils import (
     promtool,
 )
 from reconcile.utils.aws_api import AWSApi
-from reconcile.utils.cluster_version_data import VersionData
 from reconcile.utils.environ import environ
 from reconcile.utils.external_resources import (
     PROVIDER_AWS,
@@ -289,21 +288,6 @@ def version_history(ctx):
     print_output(ctx.obj["options"], results, columns)
 
 
-def soaking_days(
-    version_data: VersionData,
-    upgrades: list[str],
-    workload: str,
-    only_soaking: bool,
-) -> dict[str, float]:
-    soaking = {}
-    for version in upgrades:
-        workload_history = version_data.workload_history(version, workload)
-        soaking[version] = round(workload_history.soak_days, 2)
-        if not only_soaking and version not in soaking:
-            soaking[version] = 0
-    return soaking
-
-
 def get_upgrade_policies_data(
     clusters,
     md_output,
@@ -401,7 +385,7 @@ def get_upgrade_policies_data(
         workload_soaking_upgrades = {}
         for w in c.workloads or []:
             if not workload or workload == w:
-                s = soaking_days(
+                s = aus.soaking_days(
                     version_data_map[ocm_org.name],
                     upgrades,
                     w,


### PR DESCRIPTION
Advanced Upgrade Service is not a regular qontract-reconcile integration but rather an SRE capability with a different support model. AUS will not fail as a mean to signal an issue if it detects something problematic during reconciling. Instead it will expose enough metrics so that fine grained alerts can be defined.

The `aus_cluster_upgrade_policy_info` and `aus_cluster_upgrade_policy_info` metrics are going to be used for reporting purposes.

All metrics are exposed by all flavours of cluster upgrade integrations (the addons upgrade scheduler exposes only counters for reconcile loops & failures per org for now).

See https://service.pages.redhat.com/dev-guidelines/docs/appsre/expose-metrics/ for more information about transactional and scoped metric exposure.

## aus_organization_validation_errors

Gauge - Current validation errors within an OCM organization

```
aus_organization_validation_errors{integration="advanced-upgrade-scheduler",ocm_env="ocm-stage",org_id="xxx"} 0.0
```

## aus_organization_reconciled_total

Counter - Counter for the number of times an OCM organization was reconciled

```
aus_organization_reconciled_total{integration="advanced-upgrade-scheduler",ocm_env="ocm-stage",org_id="xxx"} 1.0
```


## aus_organization_reconcile_error_total

Counter - Counter for the failed reconcile runs for an OCM organization

```
aus_organization_reconcile_error_total{integration="advanced-upgrade-scheduler",ocm_env="ocm-stage",org_id="xxx"} 1.0
```

## aus_cluster_upgrade_policy_info

Info - An info metric for cluster upgrade policy details under AUS upgrade control

```
aus_cluster_upgrade_policy_info{cluster_name="my-cluster",cluster_uuid="some-uuid",integration="advanced-upgrade-scheduler",mutexes="",ocm_env="ocm-stage",org_id="xxx",schedule="* * * * *",sector="",soak_days="1",workloads="test"} 1.0
```

## aus_cluster_version_remaining_soak_days

Gauge - Remaining days a version needs to soak for a cluster

```
aus_cluster_version_remaining_soak_days{cluster_uuid="some-uid",integration="advanced-upgrade-scheduler",ocm_env="ocm-stage",soaking_version="4.12.15"} 5.20
```

part of https://issues.redhat.com/browse/APPSRE-7360