### PR TITLE
[terraform-vpc-peerings] add support for cluster2cluster vpc peerings with assume role

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1131,6 +1131,7 @@ CLUSTER_PEERING_QUERY = """
                   cluster {
                     name
                   }
+                  assumeRole
                   awsInfrastructureManagementAccount {
                     name
                     uid
@@ -1146,6 +1147,7 @@ CLUSTER_PEERING_QUERY = """
               }
             }
           }
+          assumeRole
         }
       }
     }

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -245,7 +245,7 @@ def build_desired_state_single_cluster(
 
 
 def build_desired_state_all_clusters(
-    clusters, ocm_map: OCMMap, awsapi: AWSApi, account_filter: Optional[str]
+    clusters, ocm_map: Optional[OCMMap], awsapi: AWSApi, account_filter: Optional[str]
 ):
     """
     Fetch state for VPC peerings between two OCM clusters

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -62,7 +62,7 @@ def _get_default_management_account(
 def _build_infrastructure_assume_role(
     account: dict[str, Any],
     cluster: dict[str, Any],
-    ocm: OCM,
+    ocm: Optional[OCM],
     provided_assume_role: Optional[str],
 ) -> Optional[dict[str, Any]]:
     if provided_assume_role:
@@ -91,7 +91,7 @@ def aws_assume_roles_for_cluster_vpc_peering(
     requester_cluster: dict[str, Any],
     accepter_connection: dict[str, Any],
     accepter_cluster: dict[str, Any],
-    ocm: OCM,
+    ocm: Optional[OCM],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     # check if dedicated infra accounts have been declared on the
     # accepters peering connection or on the accepters cluster
@@ -149,7 +149,7 @@ def aws_assume_roles_for_cluster_vpc_peering(
 
 
 def build_desired_state_single_cluster(
-    cluster_info, ocm: OCM, awsapi: AWSApi, account_filter: Optional[str]
+    cluster_info, ocm: Optional[OCM], awsapi: AWSApi, account_filter: Optional[str]
 ):
     cluster_name = cluster_info["name"]
 
@@ -256,7 +256,7 @@ def build_desired_state_all_clusters(
     for cluster_info in clusters:
         try:
             cluster = cluster_info["name"]
-            ocm = ocm_map.get(cluster)
+            ocm = None if ocm_map is None else ocm_map.get(cluster)
             items = build_desired_state_single_cluster(
                 cluster_info, ocm, awsapi, account_filter
             )

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -167,6 +167,9 @@ def test_c2c_vpc_peering_assume_role_accepter_connection_acc_overwrite(mocker):
     when available. in this test, the overwrite is also allowed
     """
     requester_cluster = build_cluster(name="r_c")
+    requester_connection = build_accepter_connection(
+        name="r_c", cluster="r_c", aws_infra_acc="req_overwrite"
+    )
     accepter_cluster = build_cluster(
         name="a_c", network_mgmt_accounts=["acc", "acc_overwrite"]
     )
@@ -183,7 +186,11 @@ def test_c2c_vpc_peering_assume_role_accepter_connection_acc_overwrite(mocker):
         .auto_speced_mock(mocker)
     )
     req_aws, acc_aws = integ.aws_assume_roles_for_cluster_vpc_peering(
-        requester_cluster, accepter_connection, accepter_cluster, ocm
+        requester_connection,
+        requester_cluster,
+        accepter_connection,
+        accepter_cluster,
+        ocm,
     )
 
     expected_req_aws = {
@@ -215,6 +222,9 @@ def test_c2c_vpc_peering_assume_role_acc_overwrite_fail(mocker):
     account not listed on the accepter cluster
     """
     requester_cluster = build_cluster(name="r_c")
+    requester_connection = build_accepter_connection(
+        name="r_c", cluster="r_c", aws_infra_acc="req_overwrite"
+    )
     accepter_cluster = build_cluster(name="a_c", network_mgmt_accounts=["acc"])
     accepter_connection = build_accepter_connection(
         name="a_c", cluster="a_c", aws_infra_acc="acc_overwrite"
@@ -228,7 +238,11 @@ def test_c2c_vpc_peering_assume_role_acc_overwrite_fail(mocker):
     )
     with pytest.raises(BadTerraformPeeringState) as ex:
         integ.aws_assume_roles_for_cluster_vpc_peering(
-            requester_cluster, accepter_connection, accepter_cluster, ocm
+            requester_connection,
+            requester_cluster,
+            accepter_connection,
+            accepter_cluster,
+            ocm,
         )
     assert str(ex.value).startswith("[account_not_allowed]")
 
@@ -239,6 +253,7 @@ def test_c2c_vpc_peering_assume_role_accepter_cluster_account(mocker):
     connection overwrite exists
     """
     requester_cluster = build_cluster(name="r_c")
+    requester_connection = build_accepter_connection(name="r_c", cluster="r_c")
     accepter_cluster = build_cluster(
         name="a_c", network_mgmt_accounts=["default_acc", "other_acc"]
     )
@@ -253,7 +268,11 @@ def test_c2c_vpc_peering_assume_role_accepter_cluster_account(mocker):
         .auto_speced_mock(mocker)
     )
     req_aws, acc_aws = integ.aws_assume_roles_for_cluster_vpc_peering(
-        requester_cluster, accepter_connection, accepter_cluster, ocm
+        requester_connection,
+        requester_cluster,
+        accepter_connection,
+        accepter_cluster,
+        ocm,
     )
 
     expected_req_aws = {
@@ -285,6 +304,7 @@ def test_c2c_vpc_peering_missing_ocm_assume_role(mocker):
     overwrite exists
     """
     requester_cluster = build_cluster(name="r_c")
+    requester_connection = build_accepter_connection(name="r_c", cluster="r_c")
     accepter_cluster = build_cluster(name="a_c", network_mgmt_accounts=["acc"])
     accepter_connection = build_accepter_connection(name="a_c", cluster="a_c")
 
@@ -292,7 +312,11 @@ def test_c2c_vpc_peering_missing_ocm_assume_role(mocker):
 
     with pytest.raises(BadTerraformPeeringState) as ex:
         integ.aws_assume_roles_for_cluster_vpc_peering(
-            requester_cluster, accepter_connection, accepter_cluster, ocm
+            requester_connection,
+            requester_cluster,
+            accepter_connection,
+            accepter_cluster,
+            ocm,
         )
     assert str(ex.value).startswith("[assume_role_not_found]")
 
@@ -302,6 +326,7 @@ def test_c2c_vpc_peering_missing_account(mocker):
     test the fallback logic, looking for network-mgmt groups accounts
     """
     requester_cluster = build_cluster(name="r_c")
+    requester_connection = build_accepter_connection(name="r_c", cluster="r_c")
     accepter_cluster = build_cluster(name="a_c")
     accepter_connection = build_accepter_connection(name="a_c", cluster="a_c")
 
@@ -309,7 +334,11 @@ def test_c2c_vpc_peering_missing_account(mocker):
 
     with pytest.raises(BadTerraformPeeringState) as ex:
         integ.aws_assume_roles_for_cluster_vpc_peering(
-            requester_cluster, accepter_connection, accepter_cluster, ocm
+            requester_connection,
+            requester_cluster,
+            accepter_connection,
+            accepter_cluster,
+            ocm,
         )
     assert str(ex.value).startswith("[no_account_available]")
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -922,7 +922,10 @@ def clusters_network(ctx, name):
         cluster_name = cluster["name"]
         management_account = tfvpc._get_default_management_account(cluster)
         account = tfvpc._build_infrastructure_assume_role(
-            management_account, cluster, ocm_map.get(cluster_name)
+            management_account,
+            cluster,
+            ocm_map.get(cluster_name),
+            provided_assume_role=None,
         )
         if not account:
             continue
@@ -1013,7 +1016,10 @@ def clusters_egress_ips(ctx):
         cluster_name = cluster["name"]
         management_account = tfvpc._get_default_management_account(cluster)
         account = tfvpc._build_infrastructure_assume_role(
-            management_account, cluster, ocm_map.get(cluster_name)
+            management_account,
+            cluster,
+            ocm_map.get(cluster_name),
+            provided_assume_role=None,
         )
         if not account:
             continue


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-7652

this PR adds support to provide `assumeRole` to a cluster to cluster vpc peering, to be used instead of OCM infrastructure access.

similar to #2000