### PR TITLE
[terraform-vpc-peerings] add support for cluster2cluster vpc peerings with assume role

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1076,6 +1076,7 @@ CLUSTER_PEERING_QUERY = """
             }
           }
           tags
+          assumeRole
         }
         ... on ClusterPeeringConnectionAccountTGW_v1 {
           account {


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-7652

depends on https://github.com/app-sre/qontract-schemas/pull/444

this PR adds support to provide `assumeRole` to a cluster to vpc mesh peering, to be used instead of OCM infrastructure access.

similar to #3515, #2000