### PR TITLE
consume peering assumeRole from interface

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -20042,6 +20042,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "assumeRole",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1043,6 +1043,7 @@ CLUSTER_PEERING_QUERY = """
         provider
         manageRoutes
         delete
+        assumeRole
         ... on ClusterPeeringConnectionAccount_v1 {
           vpc {
             account {
@@ -1060,7 +1061,6 @@ CLUSTER_PEERING_QUERY = """
             cidr_block
             region
           }
-          assumeRole
           manageAccountRoutes
         }
         ... on ClusterPeeringConnectionAccountVPCMesh_v1 {
@@ -1076,7 +1076,6 @@ CLUSTER_PEERING_QUERY = """
             }
           }
           tags
-          assumeRole
         }
         ... on ClusterPeeringConnectionAccountTGW_v1 {
           account {
@@ -1094,7 +1093,6 @@ CLUSTER_PEERING_QUERY = """
           cidrBlock
           manageSecurityGroups
           manageRoute53Associations
-          assumeRole
         }
         ... on ClusterPeeringConnectionClusterRequester_v1 {
           cluster {
@@ -1127,12 +1125,12 @@ CLUSTER_PEERING_QUERY = """
                 name
                 provider
                 manageRoutes
+                assumeRole
                 ... on ClusterPeeringConnectionClusterAccepter_v1 {
                   name
                   cluster {
                     name
                   }
-                  assumeRole
                   awsInfrastructureManagementAccount {
                     name
                     uid
@@ -1148,7 +1146,6 @@ CLUSTER_PEERING_QUERY = """
               }
             }
           }
-          assumeRole
         }
       }
     }


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/445

once a field is defined at the interface level, we can consume it without a `... on` section to validate the class.