### PR TITLE
[openshift saas deploy] multiple publishers

### DIFF
--- a/reconcile/saas_auto_promotions_manager/publisher.py
+++ b/reconcile/saas_auto_promotions_manager/publisher.py
@@ -28,10 +28,19 @@ class Publisher:
     def __init__(
         self,
         ref: str,
+        uid: str,
         repo_url: str,
         auth_code: Optional[HasSecret],
     ):
+        """Init.
+
+        ref: The target git ref to fetch the commit sha from.
+        uid: The uid of the saas publisher target.
+        repo_url: The git repo url of the saas publisher target.
+        auth_code: The auth code to use to fetch the commit sha.
+        """
         self._ref = ref
+        self._uid = uid
         self._repo_url = repo_url
         self._auth_code = auth_code
         self.channels: set[str] = set()
@@ -51,6 +60,7 @@ class Publisher:
             promotion_data = deployment_state.get_promotion_data(
                 sha=self.commit_sha,
                 channel=channel,
+                saas_target_uid=self._uid,
             )
             if not (
                 promotion_data

--- a/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
+++ b/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
@@ -47,7 +47,7 @@ class SaasFilesInventory:
                     )
                     publisher = Publisher(
                         ref=target.ref,
-                        uid=target.uid,
+                        uid=target.uid(saas_file.name, resource_template.name),
                         repo_url=resource_template.url,
                         auth_code=auth_code,
                     )

--- a/reconcile/test/saas_auto_promotions_manager/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/conftest.py
@@ -32,6 +32,11 @@ def saas_files_builder(
                 d["imagePatterns"] = []
             for rt in d.get("resourceTemplates", []):
                 for t in rt.get("targets", []):
+                    if "parent_saas_file_name" not in t:
+                        t["parent_saas_file_name"] = "saas-file-name"
+                    if "parent_resource_template_name" not in t:
+                        t["parent_resource_template_name"] = "resource-template-name"
+
                     ns = t["namespace"]
                     if "name" not in ns:
                         ns["name"] = "some_name"

--- a/reconcile/test/saas_auto_promotions_manager/subscriber/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/subscriber/conftest.py
@@ -41,6 +41,7 @@ def subscriber_builder() -> Callable[[Mapping[str, Any]], Subscriber]:
             for publisher_name, publisher_data in channel_data.items():
                 publisher = Publisher(
                     ref="",
+                    uid="",
                     repo_url="",
                     auth_code=None,
                 )

--- a/reconcile/test/saas_auto_promotions_manager/test_integration_test.py
+++ b/reconcile/test/saas_auto_promotions_manager/test_integration_test.py
@@ -92,6 +92,8 @@ def test_integration_test(
                 "ls": [
                     "/promotions/channel-1/new_sha",
                     "/promotions/channel-2/new_sha",
+                    "/deployments/channel-3/target-uid/new_sha",
+                    "/deployments/channel-4/target-uid/new_sha",
                 ],
                 "get": {
                     "promotions/channel-1/new_sha": {
@@ -100,6 +102,16 @@ def test_integration_test(
                         "saas_file": "saas_1",
                     },
                     "promotions/channel-2/new_sha": {
+                        "success": True,
+                        "target_config_hash": "new_hash",
+                        "saas_file": "saas_1",
+                    },
+                    "/deployments/channel-3/target-uid/new_sha": {
+                        "success": True,
+                        "target_config_hash": "new_hash",
+                        "saas_file": "saas_1",
+                    },
+                    "/deployments/channel-4/target-uid/new_sha": {
                         "success": True,
                         "target_config_hash": "new_hash",
                         "saas_file": "saas_1",

--- a/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_multiple_publishers_for_single_channel.py
+++ b/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_multiple_publishers_for_single_channel.py
@@ -65,6 +65,4 @@ def test_multiple_publishers_for_single_channel(
     )
     inventory = SaasFilesInventory(saas_files=saas_files)
     assert len(inventory.publishers) == 2
-    # As of now we do not support this, i.e., all
-    # subscribers should be removed from the inventory
-    assert len(inventory.subscribers) == 0
+    assert len(inventory.subscribers) == 1

--- a/reconcile/test/test_auto_promoter.py
+++ b/reconcile/test/test_auto_promoter.py
@@ -15,6 +15,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="123123123",
+            saas_target_uid="saas_target_uid",
         )
 
         expected = {
@@ -50,6 +51,7 @@ class TestPromotions(TestCase):
             publish=["test-channel"],
             commit_sha="ahash",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         target_promotion = {
@@ -74,6 +76,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         target_promotion = {
@@ -110,6 +113,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         target_promotion = {
@@ -142,11 +146,12 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         ap = AutoPromoter([promotion])
         self.assertEqual(
-            ap.title, "[auto_promoter] openshift-saas-deploy automated promotion 4af7b1"
+            ap.title, "[auto_promoter] openshift-saas-deploy automated promotion 0a3d57"
         )
 
     def test_description_property(self) -> None:
@@ -157,6 +162,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         ap = AutoPromoter([promotion])
@@ -170,15 +176,13 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         ap = AutoPromoter([promotion])
         self.assertTrue(ap.gitlab_data["source_branch"].startswith("auto_promoter-"))
         self.assertEqual(ap.gitlab_data["target_branch"], "master")
-        self.assertEqual(
-            ap.gitlab_data["title"],
-            "[auto_promoter] openshift-saas-deploy automated promotion 4af7b1",
-        )
+        self.assertEqual(ap.gitlab_data["title"], ap.title)
         self.assertEqual(
             ap.gitlab_data["description"], "openshift-saas-deploy automated promotion"
         )
@@ -193,6 +197,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
         )
 
         ap = AutoPromoter([promotion])
@@ -210,6 +215,7 @@ class TestPromotions(TestCase):
                         "subscribe": None,
                         "promotion_data": None,
                         "saas_file_paths": ["destination-saas-file"],
+                        "saas_target_uid": "saas_target_uid",
                         "target_paths": None,
                     }
                 ],
@@ -224,6 +230,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
             promotion_data=[
                 {
                     "channel": "test-channel",
@@ -239,7 +246,7 @@ class TestPromotions(TestCase):
         )
 
         ap = AutoPromoter([promotion])
-        sqs_json = '{"pr_type": "auto_promoter", "promotions": [{"commit_sha": "ahash", "saas_file": "saas_file", "target_config_hash": "111111111", "auto": true, "publish": ["test-channel"], "subscribe": null, "promotion_data": [{"channel": "test-channel", "data": [{"type": "parent_saas_config", "parent_saas": "saas_file", "target_config_hash": "111111111"}]}], "saas_file_paths": ["destination-saas-file"], "target_paths": null}]}'
+        sqs_json = '{"pr_type": "auto_promoter", "promotions": [{"commit_sha": "ahash", "saas_file": "saas_file", "target_config_hash": "111111111", "saas_target_uid": "saas_target_uid", "auto": true, "publish": ["test-channel"], "subscribe": null, "promotion_data": [{"channel": "test-channel", "data": [{"type": "parent_saas_config", "parent_saas": "saas_file", "target_config_hash": "111111111"}]}], "saas_file_paths": ["destination-saas-file"], "target_paths": null}]}'
         self.assertEqual(json.dumps(ap.sqs_data), sqs_json)
 
     def test_init_with_promotion_object(self) -> None:
@@ -250,6 +257,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
             promotion_data=[
                 {
                     "channel": "test-channel",
@@ -276,6 +284,7 @@ class TestPromotions(TestCase):
             commit_sha="ahash",
             saas_file="saas_file",
             target_config_hash="111111111",
+            saas_target_uid="saas_target_uid",
             promotion_data=[
                 {
                     "channel": "test-channel",

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -28,10 +28,14 @@ from reconcile.gql_definitions.common.saas_files import (
     SaasResourceTemplateTargetV2_SaasSecretParametersV1,
     SaasResourceTemplateV2,
 )
+from reconcile.typed_queries.saas_files import (
+    SaasFile,
+    convert_saas_file_v2_to_saas_file,
+)
 from reconcile.utils.jjb_client import JJB
 from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.saasherder import SaasHerder
-from reconcile.utils.saasherder.interfaces import SaasFile
+from reconcile.utils.saasherder.interfaces import SaasFile as SaasFileInterface
 from reconcile.utils.saasherder.models import TriggerSpecMovingCommit
 from reconcile.utils.secret_reader import SecretReaderBase
 
@@ -607,7 +611,7 @@ class TestPopulateDesiredState(TestCase):
         self.saasherder.populate_desired_state(ri)
 
         cnt = 0
-        for (cluster, namespace, resource_type, data) in ri:
+        for cluster, namespace, resource_type, data in ri:
             for _, d_item in data["desired"].items():
                 expected = yaml.safe_load(
                     self.fxts.get(
@@ -763,6 +767,7 @@ class TestConfigHashPromotionsValidation(TestCase):
         self.saas_file = self.gql_class_factory(  # type: ignore[attr-defined] # it's set in the fixture
             SaasFileV2, Fixtures("saasherder").get_anymarkup("saas.gql.yml")
         )
+        self.saas_file = convert_saas_file_v2_to_saas_file(self.saas_file)
         self.all_saas_files = [self.saas_file]
 
         self.state_patcher = patch("reconcile.utils.state.State", autospec=True)
@@ -959,7 +964,7 @@ class TestRemoveNoneAttributes(TestCase):
 
 
 def test_render_templated_parameters(
-    gql_class_factory: Callable[..., SaasFile]
+    gql_class_factory: Callable[..., SaasFileInterface]
 ) -> None:
     saas_file = gql_class_factory(
         SaasFileV2,

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -28,10 +28,7 @@ from reconcile.gql_definitions.common.saas_files import (
     SaasResourceTemplateTargetV2_SaasSecretParametersV1,
     SaasResourceTemplateV2,
 )
-from reconcile.typed_queries.saas_files import (
-    SaasFile,
-    convert_saas_file_v2_to_saas_file,
-)
+from reconcile.typed_queries.saas_files import SaasFile
 from reconcile.utils.jjb_client import JJB
 from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.saasherder import SaasHerder
@@ -765,9 +762,8 @@ class TestConfigHashPromotionsValidation(TestCase):
 
     def setUp(self) -> None:
         self.saas_file = self.gql_class_factory(  # type: ignore[attr-defined] # it's set in the fixture
-            SaasFileV2, Fixtures("saasherder").get_anymarkup("saas.gql.yml")
+            SaasFile, Fixtures("saasherder").get_anymarkup("saas.gql.yml")
         )
-        self.saas_file = convert_saas_file_v2_to_saas_file(self.saas_file)
         self.all_saas_files = [self.saas_file]
 
         self.state_patcher = patch("reconcile.utils.state.State", autospec=True)

--- a/reconcile/test/test_typed_queries/test_saas_files.py
+++ b/reconcile/test/test_typed_queries/test_saas_files.py
@@ -12,6 +12,7 @@ from reconcile.gql_definitions.common.saas_files import (
     SaasResourceTemplateTargetNamespaceSelectorV1,
     SaasResourceTemplateTargetV2,
 )
+from reconcile.gql_definitions.common.saas_files import query as saas_files_query
 from reconcile.gql_definitions.common.saasherder_settings import AppInterfaceSettingsV1
 from reconcile.gql_definitions.fragments.saas_target_namespace import (
     SaasTargetNamespace,
@@ -19,6 +20,7 @@ from reconcile.gql_definitions.fragments.saas_target_namespace import (
 from reconcile.test.fixtures import Fixtures
 from reconcile.typed_queries.saas_files import (
     SaasFile,
+    convert_saas_file_v2_to_saas_file,
     create_targets_for_namespace_selector,
     export_model,
     get_namespaces_by_selector,
@@ -346,6 +348,8 @@ PIPELINE_PROVIDER = {
                                     },
                                     "ref": "main",
                                     "parameters": '{ "TARGET_PARAM": "foobar" }',
+                                    "parent_saas_file_name": "saas-file-01",
+                                    "parent_resource_template_name": "deploy-app",
                                 },
                                 {
                                     "namespace": {
@@ -357,6 +361,8 @@ PIPELINE_PROVIDER = {
                                     },
                                     "provider": "static",
                                     "ref": "1234567890123456789012345678901234567890",
+                                    "parent_saas_file_name": "saas-file-01",
+                                    "parent_resource_template_name": "deploy-app",
                                 },
                             ],
                         }
@@ -392,6 +398,8 @@ PIPELINE_PROVIDER = {
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "main",
+                                    "parent_saas_file_name": "saas-file-02",
+                                    "parent_resource_template_name": "deploy-app",
                                 },
                                 {
                                     "namespace": {
@@ -403,6 +411,8 @@ PIPELINE_PROVIDER = {
                                     },
                                     "provider": "static",
                                     "ref": "1234567890123456789012345678901234567890",
+                                    "parent_saas_file_name": "saas-file-02",
+                                    "parent_resource_template_name": "deploy-app",
                                 },
                             ],
                         }
@@ -438,6 +448,8 @@ PIPELINE_PROVIDER = {
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "main",
+                                    "parent_saas_file_name": "saas-file-02",
+                                    "parent_resource_template_name": "deploy-app",
                                 },
                             ],
                         }
@@ -479,6 +491,8 @@ PIPELINE_PROVIDER = {
                                     },
                                     "ref": "main",
                                     "parameters": '{ "TARGET_PARAM": "foobar" }',
+                                    "parent_saas_file_name": "saas-file-01",
+                                    "parent_resource_template_name": "deploy-app",
                                 }
                             ],
                         }
@@ -506,6 +520,8 @@ PIPELINE_PROVIDER = {
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "main",
+                                    "parent_saas_file_name": "saas-file-02",
+                                    "parent_resource_template_name": "deploy-app",
                                 },
                             ],
                         }
@@ -542,6 +558,8 @@ PIPELINE_PROVIDER = {
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "1234567890123456789012345678901234567890",
+                                    "parent_saas_file_name": "saas-file-03",
+                                    "parent_resource_template_name": "deploy-app",
                                 },
                                 {
                                     "namespace": {
@@ -552,6 +570,8 @@ PIPELINE_PROVIDER = {
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "1234567890123456789012345678901234567890",
+                                    "parent_saas_file_name": "saas-file-03",
+                                    "parent_resource_template_name": "deploy-app",
                                 },
                             ],
                         }
@@ -711,6 +731,8 @@ def test_export_model(
                             "image": None,
                             "disable": None,
                             "delete": None,
+                            "parent_saas_file_name": "saas-file-01",
+                            "parent_resource_template_name": "deploy-app",
                         },
                         {
                             "path": None,
@@ -752,6 +774,8 @@ def test_export_model(
                             "image": None,
                             "disable": None,
                             "delete": None,
+                            "parent_saas_file_name": "saas-file-01",
+                            "parent_resource_template_name": "deploy-app",
                         },
                     ],
                 }
@@ -857,6 +881,8 @@ def test_export_model(
                             "image": None,
                             "disable": None,
                             "delete": None,
+                            "parent_saas_file_name": "saas-file-02",
+                            "parent_resource_template_name": "deploy-app",
                         },
                         {
                             "path": None,
@@ -898,6 +924,8 @@ def test_export_model(
                             "image": None,
                             "disable": None,
                             "delete": None,
+                            "parent_saas_file_name": "saas-file-02",
+                            "parent_resource_template_name": "deploy-app",
                         },
                     ],
                 }
@@ -1003,6 +1031,8 @@ def test_export_model(
                             "image": None,
                             "disable": None,
                             "delete": None,
+                            "parent_saas_file_name": "saas-file-03",
+                            "parent_resource_template_name": "deploy-app",
                         },
                         {
                             "path": None,
@@ -1044,6 +1074,8 @@ def test_export_model(
                             "image": None,
                             "disable": None,
                             "delete": None,
+                            "parent_saas_file_name": "saas-file-03",
+                            "parent_resource_template_name": "deploy-app",
                         },
                     ],
                 }
@@ -1051,3 +1083,38 @@ def test_export_model(
             "selfServiceRoles": None,
         },
     ]
+
+
+def test_convert_saas_file_v2_to_saas_file(
+    query_func_from_fixture: Callable[..., Callable],
+) -> None:
+    data = saas_files_query(
+        query_func=query_func_from_fixture("saas_files.yml", SaasFileV2, "saas_files")
+    )
+    if not data.saas_files:
+        raise AssertionError("No data loaded")
+
+    saas_file = convert_saas_file_v2_to_saas_file(data.saas_files[0])
+    assert len(saas_file.resource_templates) >= 1
+    for rt in saas_file.resource_templates:
+        assert len(rt.targets) >= 1
+        for t in rt.targets:
+            assert t.parent_saas_file_name
+            assert t.parent_resource_template_name
+
+
+def test_saas_target_uid(
+    query_func_from_fixture: Callable[..., Callable],
+) -> None:
+    data = saas_files_query(
+        query_func=query_func_from_fixture("saas_files.yml", SaasFileV2, "saas_files")
+    )
+    if not data.saas_files:
+        raise AssertionError("No data loaded")
+
+    saas_file = convert_saas_file_v2_to_saas_file(data.saas_files[0])
+
+    assert (
+        saas_file.resource_templates[0].targets[0].uid
+        == "b30e3297c8e3c7c94bd7264f80386cf042b0285d"
+    )

--- a/reconcile/test/test_typed_queries/test_saas_files.py
+++ b/reconcile/test/test_typed_queries/test_saas_files.py
@@ -12,7 +12,6 @@ from reconcile.gql_definitions.common.saas_files import (
     SaasResourceTemplateTargetNamespaceSelectorV1,
     SaasResourceTemplateTargetV2,
 )
-from reconcile.gql_definitions.common.saas_files import query as saas_files_query
 from reconcile.gql_definitions.common.saasherder_settings import AppInterfaceSettingsV1
 from reconcile.gql_definitions.fragments.saas_target_namespace import (
     SaasTargetNamespace,
@@ -20,7 +19,7 @@ from reconcile.gql_definitions.fragments.saas_target_namespace import (
 from reconcile.test.fixtures import Fixtures
 from reconcile.typed_queries.saas_files import (
     SaasFile,
-    convert_saas_file_v2_to_saas_file,
+    SaasResourceTemplateTarget,
     create_targets_for_namespace_selector,
     export_model,
     get_namespaces_by_selector,
@@ -348,8 +347,6 @@ PIPELINE_PROVIDER = {
                                     },
                                     "ref": "main",
                                     "parameters": '{ "TARGET_PARAM": "foobar" }',
-                                    "parent_saas_file_name": "saas-file-01",
-                                    "parent_resource_template_name": "deploy-app",
                                 },
                                 {
                                     "namespace": {
@@ -361,8 +358,6 @@ PIPELINE_PROVIDER = {
                                     },
                                     "provider": "static",
                                     "ref": "1234567890123456789012345678901234567890",
-                                    "parent_saas_file_name": "saas-file-01",
-                                    "parent_resource_template_name": "deploy-app",
                                 },
                             ],
                         }
@@ -398,8 +393,6 @@ PIPELINE_PROVIDER = {
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "main",
-                                    "parent_saas_file_name": "saas-file-02",
-                                    "parent_resource_template_name": "deploy-app",
                                 },
                                 {
                                     "namespace": {
@@ -411,8 +404,6 @@ PIPELINE_PROVIDER = {
                                     },
                                     "provider": "static",
                                     "ref": "1234567890123456789012345678901234567890",
-                                    "parent_saas_file_name": "saas-file-02",
-                                    "parent_resource_template_name": "deploy-app",
                                 },
                             ],
                         }
@@ -448,8 +439,6 @@ PIPELINE_PROVIDER = {
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "main",
-                                    "parent_saas_file_name": "saas-file-02",
-                                    "parent_resource_template_name": "deploy-app",
                                 },
                             ],
                         }
@@ -491,8 +480,6 @@ PIPELINE_PROVIDER = {
                                     },
                                     "ref": "main",
                                     "parameters": '{ "TARGET_PARAM": "foobar" }',
-                                    "parent_saas_file_name": "saas-file-01",
-                                    "parent_resource_template_name": "deploy-app",
                                 }
                             ],
                         }
@@ -520,8 +507,6 @@ PIPELINE_PROVIDER = {
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "main",
-                                    "parent_saas_file_name": "saas-file-02",
-                                    "parent_resource_template_name": "deploy-app",
                                 },
                             ],
                         }
@@ -558,8 +543,6 @@ PIPELINE_PROVIDER = {
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "1234567890123456789012345678901234567890",
-                                    "parent_saas_file_name": "saas-file-03",
-                                    "parent_resource_template_name": "deploy-app",
                                 },
                                 {
                                     "namespace": {
@@ -570,8 +553,6 @@ PIPELINE_PROVIDER = {
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "1234567890123456789012345678901234567890",
-                                    "parent_saas_file_name": "saas-file-03",
-                                    "parent_resource_template_name": "deploy-app",
                                 },
                             ],
                         }
@@ -620,6 +601,30 @@ def test_get_saasherder_settings(
     )
     assert setting.repo_url == "https://repo-url"
     assert setting.hash_length == 42
+
+
+def test_saas_target_uid(gql_class_factory: Callable) -> None:
+    target = gql_class_factory(
+        SaasResourceTemplateTarget,
+        {
+            "namespace": {
+                "name": "namespace-test",
+                "path": "some-path",
+                "environment": {
+                    "name": "test",
+                    "parameters": '{"ENV_PARAM": "foobar"}',
+                },
+                "app": {"name": "app-01"},
+                "cluster": CLUSTER,
+            },
+            "ref": "main",
+            "parameters": '{ "TARGET_PARAM": "foobar" }',
+        },
+    )
+    assert (
+        target.uid(saas_file_name="saas-file-01", resource_template_name="resource")
+        == "da117fd8c723f33f707012fc1317daf90d63013d"
+    )
 
 
 def test_export_model(
@@ -731,8 +736,6 @@ def test_export_model(
                             "image": None,
                             "disable": None,
                             "delete": None,
-                            "parent_saas_file_name": "saas-file-01",
-                            "parent_resource_template_name": "deploy-app",
                         },
                         {
                             "path": None,
@@ -774,8 +777,6 @@ def test_export_model(
                             "image": None,
                             "disable": None,
                             "delete": None,
-                            "parent_saas_file_name": "saas-file-01",
-                            "parent_resource_template_name": "deploy-app",
                         },
                     ],
                 }
@@ -881,8 +882,6 @@ def test_export_model(
                             "image": None,
                             "disable": None,
                             "delete": None,
-                            "parent_saas_file_name": "saas-file-02",
-                            "parent_resource_template_name": "deploy-app",
                         },
                         {
                             "path": None,
@@ -924,8 +923,6 @@ def test_export_model(
                             "image": None,
                             "disable": None,
                             "delete": None,
-                            "parent_saas_file_name": "saas-file-02",
-                            "parent_resource_template_name": "deploy-app",
                         },
                     ],
                 }
@@ -1031,8 +1028,6 @@ def test_export_model(
                             "image": None,
                             "disable": None,
                             "delete": None,
-                            "parent_saas_file_name": "saas-file-03",
-                            "parent_resource_template_name": "deploy-app",
                         },
                         {
                             "path": None,
@@ -1074,8 +1069,6 @@ def test_export_model(
                             "image": None,
                             "disable": None,
                             "delete": None,
-                            "parent_saas_file_name": "saas-file-03",
-                            "parent_resource_template_name": "deploy-app",
                         },
                     ],
                 }
@@ -1083,38 +1076,3 @@ def test_export_model(
             "selfServiceRoles": None,
         },
     ]
-
-
-def test_convert_saas_file_v2_to_saas_file(
-    query_func_from_fixture: Callable[..., Callable],
-) -> None:
-    data = saas_files_query(
-        query_func=query_func_from_fixture("saas_files.yml", SaasFileV2, "saas_files")
-    )
-    if not data.saas_files:
-        raise AssertionError("No data loaded")
-
-    saas_file = convert_saas_file_v2_to_saas_file(data.saas_files[0])
-    assert len(saas_file.resource_templates) >= 1
-    for rt in saas_file.resource_templates:
-        assert len(rt.targets) >= 1
-        for t in rt.targets:
-            assert t.parent_saas_file_name
-            assert t.parent_resource_template_name
-
-
-def test_saas_target_uid(
-    query_func_from_fixture: Callable[..., Callable],
-) -> None:
-    data = saas_files_query(
-        query_func=query_func_from_fixture("saas_files.yml", SaasFileV2, "saas_files")
-    )
-    if not data.saas_files:
-        raise AssertionError("No data loaded")
-
-    saas_file = convert_saas_file_v2_to_saas_file(data.saas_files[0])
-
-    assert (
-        saas_file.resource_templates[0].targets[0].uid
-        == "b30e3297c8e3c7c94bd7264f80386cf042b0285d"
-    )

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -10,7 +10,7 @@ from reconcile.utils.promotion_state import (
 from reconcile.utils.state import State
 
 
-def test_key_exists(s3_state_builder: Callable[[Mapping], State]):
+def test_key_exists_old_format(s3_state_builder: Callable[[Mapping], State]):
     state = s3_state_builder(
         {
             "ls": ["/promotions/channel/sha"],
@@ -25,7 +25,34 @@ def test_key_exists(s3_state_builder: Callable[[Mapping], State]):
     )
     deployment_state = PromotionState(state=state)
     deployment_state.cache_commit_shas_from_s3()
-    deployment_info = deployment_state.get_promotion_data(channel="channel", sha="sha")
+    deployment_info = deployment_state.get_promotion_data(
+        channel="channel", sha="sha", saas_target_uid="saas_target_uid"
+    )
+    assert deployment_info == PromotionData(
+        success=True,
+        target_config_hash="hash",
+        saas_file="saas_file",
+    )
+
+
+def test_key_exists(s3_state_builder: Callable[[Mapping], State]):
+    state = s3_state_builder(
+        {
+            "ls": ["/deployments/channel/saas_target_uid/sha"],
+            "get": {
+                "deployments/channel/saas_target_uid/sha": {
+                    "success": True,
+                    "target_config_hash": "hash",
+                    "saas_file": "saas_file",
+                }
+            },
+        }
+    )
+    deployment_state = PromotionState(state=state)
+    deployment_state.cache_commit_shas_from_s3()
+    deployment_info = deployment_state.get_promotion_data(
+        channel="channel", sha="sha", saas_target_uid="saas_target_uid"
+    )
     assert deployment_info == PromotionData(
         success=True,
         target_config_hash="hash",
@@ -42,11 +69,15 @@ def test_key_does_not_exist(s3_state_builder: Callable[[Mapping], State]):
     )
     deployment_state = PromotionState(state=state)
     deployment_state.cache_commit_shas_from_s3()
-    deployment_info = deployment_state.get_promotion_data(channel="channel", sha="sha")
+    deployment_info = deployment_state.get_promotion_data(
+        channel="channel", sha="sha", saas_target_uid="saas_target_uid"
+    )
     assert deployment_info is None
 
 
-def test_key_does_not_exist_locally(s3_state_builder: Callable[[Mapping], State]):
+def test_key_does_not_exist_locally_old_format(
+    s3_state_builder: Callable[[Mapping], State]
+):
     state = s3_state_builder(
         {
             "ls": [],
@@ -61,7 +92,35 @@ def test_key_does_not_exist_locally(s3_state_builder: Callable[[Mapping], State]
     )
     deployment_state = PromotionState(state=state)
     deployment_info = deployment_state.get_promotion_data(
-        channel="channel", sha="sha", local_lookup=False
+        channel="channel",
+        sha="sha",
+        saas_target_uid="saas_target_uid",
+        local_lookup=False,
+    )
+    assert deployment_info == PromotionData(
+        success=True, target_config_hash="hash", saas_file="saas_file"
+    )
+
+
+def test_key_does_not_exist_locally(s3_state_builder: Callable[[Mapping], State]):
+    state = s3_state_builder(
+        {
+            "ls": [],
+            "get": {
+                "deployments/channel/saas_target_uid/sha": {
+                    "success": True,
+                    "target_config_hash": "hash",
+                    "saas_file": "saas_file",
+                }
+            },
+        }
+    )
+    deployment_state = PromotionState(state=state)
+    deployment_info = deployment_state.get_promotion_data(
+        channel="channel",
+        sha="sha",
+        saas_target_uid="saas_target_uid",
+        local_lookup=False,
     )
     assert deployment_info == PromotionData(
         success=True, target_config_hash="hash", saas_file="saas_file"
@@ -84,8 +143,9 @@ def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
     deployment_state.publish_promotion_data(
         channel="channel",
         sha="sha",
+        saas_target_uid="saas_target_uid",
         data=promotion_info,
     )
     deployment_state._state.add.assert_called_once_with(  # type: ignore[attr-defined]
-        "promotions/channel/sha", promotion_info.dict(), True
+        "deployments/channel/saas_target_uid/sha", promotion_info.dict(), True
     )

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -24,7 +24,6 @@ from reconcile.gql_definitions.common.saas_files import (
     PipelinesProviderV1,
     RoleV1,
     SaasFileAuthenticationV1,
-    SaasFileV2,
     SaasResourceTemplateTargetImageV1,
     SaasResourceTemplateTargetNamespaceSelectorV1,
     SaasResourceTemplateTargetPromotionV1,
@@ -72,24 +71,15 @@ class SaasResourceTemplateTarget(ConfiguredBaseModel):
     image: Optional[SaasResourceTemplateTargetImageV1] = Field(..., alias="image")
     disable: Optional[bool] = Field(..., alias="disable")
     delete: Optional[bool] = Field(..., alias="delete")
-    parent_saas_file_name: Optional[str] = None
-    parent_resource_template_name: Optional[str] = None
 
     class Config:
         # ignore `namespaceSelector` and 'provider' fields from the GQL schema
         extra = Extra.ignore
 
-    @property
-    def uid(self) -> str:
+    def uid(self, saas_file_name: str, resource_template_name: str) -> str:
         """Returns a unique identifier for a target."""
-        if not self.parent_resource_template_name:
-            raise ValueError(
-                "parent_resource_template_name must be set before calling uid()"
-            )
-        if not self.parent_saas_file_name:
-            raise ValueError("parent_saas_file_name must be set before calling uid()")
         return hashlib.blake2s(
-            f"{self.parent_saas_file_name}:{self.parent_resource_template_name}:{self.name if self.name else 'default'}:{self.namespace.cluster.name}:{self.namespace.name}".encode(),
+            f"{saas_file_name}:{resource_template_name}:{self.name if self.name else 'default'}:{self.namespace.cluster.name}:{self.namespace.name}".encode(),
             digest_size=20,
         ).hexdigest()
 
@@ -223,16 +213,6 @@ def create_targets_for_namespace_selector(
     return targets
 
 
-def convert_saas_file_v2_to_saas_file(saas_file_gql: SaasFileV2) -> SaasFile:
-    """Convert a SaasFileV2 to a SaasFile and inject the parent objects."""
-    saas_file = SaasFile(**export_model(saas_file_gql))
-    for tmpl in saas_file.resource_templates:
-        for target in tmpl.targets:
-            target.parent_saas_file_name = saas_file.name
-            target.parent_resource_template_name = tmpl.name
-    return saas_file
-
-
 def get_saas_files(
     name: Optional[str] = None,
     env_name: Optional[str] = None,
@@ -273,7 +253,7 @@ def get_saas_files(
                     )
         # convert SaasFileV2 (with optional resource_templates.targets.namespace field)
         # to SaasFile (with required resource_templates.targets.namespace field)
-        saas_files.append(convert_saas_file_v2_to_saas_file(saas_file_gql))
+        saas_files.append(SaasFile(**export_model(saas_file_gql)))
 
     if name is None and env_name is None and app_name is None:
         return saas_files

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from collections.abc import Callable
 from typing import (
@@ -23,6 +24,7 @@ from reconcile.gql_definitions.common.saas_files import (
     PipelinesProviderV1,
     RoleV1,
     SaasFileAuthenticationV1,
+    SaasFileV2,
     SaasResourceTemplateTargetImageV1,
     SaasResourceTemplateTargetNamespaceSelectorV1,
     SaasResourceTemplateTargetPromotionV1,
@@ -70,10 +72,26 @@ class SaasResourceTemplateTarget(ConfiguredBaseModel):
     image: Optional[SaasResourceTemplateTargetImageV1] = Field(..., alias="image")
     disable: Optional[bool] = Field(..., alias="disable")
     delete: Optional[bool] = Field(..., alias="delete")
+    parent_saas_file_name: Optional[str] = None
+    parent_resource_template_name: Optional[str] = None
 
     class Config:
         # ignore `namespaceSelector` and 'provider' fields from the GQL schema
         extra = Extra.ignore
+
+    @property
+    def uid(self) -> str:
+        """Returns a unique identifier for a target."""
+        if not self.parent_resource_template_name:
+            raise ValueError(
+                "parent_resource_template_name must be set before calling uid()"
+            )
+        if not self.parent_saas_file_name:
+            raise ValueError("parent_saas_file_name must be set before calling uid()")
+        return hashlib.blake2s(
+            f"{self.parent_saas_file_name}:{self.parent_resource_template_name}:{self.name if self.name else 'default'}:{self.namespace.cluster.name}:{self.namespace.name}".encode(),
+            digest_size=20,
+        ).hexdigest()
 
 
 class SaasResourceTemplate(ConfiguredBaseModel):
@@ -205,6 +223,16 @@ def create_targets_for_namespace_selector(
     return targets
 
 
+def convert_saas_file_v2_to_saas_file(saas_file_gql: SaasFileV2) -> SaasFile:
+    """Convert a SaasFileV2 to a SaasFile and inject the parent objects."""
+    saas_file = SaasFile(**export_model(saas_file_gql))
+    for tmpl in saas_file.resource_templates:
+        for target in tmpl.targets:
+            target.parent_saas_file_name = saas_file.name
+            target.parent_resource_template_name = tmpl.name
+    return saas_file
+
+
 def get_saas_files(
     name: Optional[str] = None,
     env_name: Optional[str] = None,
@@ -245,7 +273,7 @@ def get_saas_files(
                     )
         # convert SaasFileV2 (with optional resource_templates.targets.namespace field)
         # to SaasFile (with required resource_templates.targets.namespace field)
-        saas_files.append(SaasFile(**export_model(saas_file_gql)))
+        saas_files.append(convert_saas_file_v2_to_saas_file(saas_file_gql))
 
     if name is None and env_name is None and app_name is None:
         return saas_files

--- a/reconcile/utils/promotion_state.py
+++ b/reconcile/utils/promotion_state.py
@@ -47,28 +47,51 @@ class PromotionState:
         """
         all_keys = self._state.ls()
         for commit in all_keys:
-            # Format: /promotions/{channel}/{commit-sha}
-            if not commit.startswith("/promotions/"):
+            # for backwards compatibility - remove this after a while
+            if commit.startswith("/promotions/"):
+                # Format: /promotions/{channel}/{commit-sha}
+                _, _, channel_name, commit_sha = commit.split("/")
+                self._commits_by_channel[channel_name].add(commit_sha)
+            # / for backwards compatibility - remove this after a while
+
+            # Format: /deployments/{channel}/{saas-target-uid}/{commit-sha}
+            if not commit.startswith("/deployments/"):
                 continue
-            _, _, channel_name, commit_sha = commit.split("/")
-            self._commits_by_channel[channel_name].add(commit_sha)
+            _, _, channel_name, saas_target_uid, commit_sha = commit.split("/")
+            self._commits_by_channel[f"{channel_name}/{saas_target_uid}"].add(
+                commit_sha
+            )
 
     def get_promotion_data(
-        self, sha: str, channel: str, local_lookup: bool = True
+        self, sha: str, channel: str, saas_target_uid: str, local_lookup: bool = True
     ) -> Optional[PromotionData]:
-        if local_lookup and sha not in self._commits_by_channel[channel]:
+        if (
+            local_lookup
+            and sha not in self._commits_by_channel[channel]
+            and sha not in self._commits_by_channel[f"{channel}/{saas_target_uid}"]
+        ):
             # Lets reduce unecessary calls to S3
             return None
+
+        # for backwards compatibility - remove this after a while
         key = f"promotions/{channel}/{sha}"
         try:
             data = self._state.get(key)
+            return PromotionData(**data)
+        except KeyError:
+            pass
+        # / for backwards compatibility - remove this after a while
+
+        key = f"deployments/{channel}/{saas_target_uid}/{sha}"
+        try:
+            data = self._state.get(key)
+            return PromotionData(**data)
         except KeyError:
             return None
-        return PromotionData(**data)
 
     def publish_promotion_data(
-        self, sha: str, channel: str, data: PromotionData
+        self, sha: str, channel: str, saas_target_uid: str, data: PromotionData
     ) -> None:
-        state_key = f"promotions/{channel}/{sha}"
+        state_key = f"deployments/{channel}/{saas_target_uid}/{sha}"
         self._state.add(state_key, data.dict(), force=True)
         logging.info("Uploaded %s to %s", data, state_key)

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -332,7 +332,11 @@ class SaasResourceTemplateTarget(HasParameters, HasSecretParameters, Protocol):
         ...
 
     def dict(self, *, by_alias: bool = False) -> dict[str, Any]:
-        ...
+        """Return a dictionary representation of the model."""
+
+    @property
+    def uid(self) -> str:
+        """Return a unique identifier for the target."""
 
 
 class SaasResourceTemplate(HasParameters, HasSecretParameters, Protocol):

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -334,8 +334,7 @@ class SaasResourceTemplateTarget(HasParameters, HasSecretParameters, Protocol):
     def dict(self, *, by_alias: bool = False) -> dict[str, Any]:
         """Return a dictionary representation of the model."""
 
-    @property
-    def uid(self) -> str:
+    def uid(self, saas_file_name: str, resource_template_name: str) -> str:
         """Return a unique identifier for the target."""
 
 

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -167,6 +167,7 @@ class Promotion(BaseModel):
     commit_sha: str
     saas_file: str
     target_config_hash: str
+    saas_target_uid: str
     auto: Optional[bool] = None
     publish: Optional[list[str]] = None
     subscribe: Optional[list[str]] = None

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -996,6 +996,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 commit_sha=commit_sha,
                 saas_file=saas_file_name,
                 target_config_hash=target_config_hash,
+                saas_target_uid=target.uid,
             )
         return resources, html_url, target_promotion
 
@@ -1768,7 +1769,10 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             if promotion.subscribe:
                 for channel in promotion.subscribe:
                     info = self._promotion_state.get_promotion_data(
-                        sha=promotion.commit_sha, channel=channel, local_lookup=False
+                        sha=promotion.commit_sha,
+                        channel=channel,
+                        saas_target_uid=promotion.saas_target_uid,
+                        local_lookup=False,
                     )
                     if not (info and info.success):
                         logging.error(
@@ -1860,6 +1864,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     self._promotion_state.publish_promotion_data(
                         sha=promotion.commit_sha,
                         channel=channel,
+                        saas_target_uid=promotion.saas_target_uid,
                         data=PromotionData(
                             saas_file=promotion.saas_file,
                             success=success,

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -996,7 +996,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 commit_sha=commit_sha,
                 saas_file=saas_file_name,
                 target_config_hash=target_config_hash,
-                saas_target_uid=target.uid,
+                saas_target_uid=target.uid(saas_file_name, resource_template_name),
             )
         return resources, html_url, target_promotion
 


### PR DESCRIPTION
2nd try (#3473)!

The deployment information (promotion data) is stored in an S3 bucket. Make the S3 key unique to avoid overwrites if multiple publishers are using the same channel name.

promotions/{channel}/{commit_sha} -> /deployments/{saas_target_uid}/{commit_sha}

saas_target_uid is an unique blake2s hash composed of {saas_name}/{resource_template_name}/{target_name|"default"}/{cluster_name}/namespace_name}

Ticket: [APPSRE-7414](https://issues.redhat.com/browse/APPSRE-7414)