### PR TITLE
[terraform-aws-route53] implement early-exit using state

### DIFF
--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -19,7 +19,10 @@ from reconcile.utils.external_resources import (
     get_external_resource_specs,
 )
 from reconcile.utils.semver_helper import make_semver
-from reconcile.utils.state import State, init_state
+from reconcile.utils.state import (
+    State,
+    init_state,
+)
 from reconcile.utils.terraform_client import TerraformClient as Terraform
 from reconcile.utils.terrascript_aws_client import TerrascriptClient as Terrascript
 

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -241,9 +241,7 @@ def run(
     defer(state.cleanup)
     if not should_run(state, zones):
         logging.debug("nothing to do here")
-        # using return because terraform-resources
-        # may be the calling entity, and has more to do
-        return
+        sys.exit(ExitCodes.SUCCESS)
 
     all_accounts = queries.get_aws_accounts(terraform_state=True)
     participating_account_names = [z["account"]["name"] for z in zones]


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-7655

this will reduce the number of calls to Route53 API significantly, as we will only run the integration when there is an actual change that needs to happen due to graphql changes.

in other words - manual actions will now be ignored by the integration, until the next iteration that has changes will act.