### PR TITLE
[AUS] fix cluster discovery

### DIFF
--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -41,6 +41,7 @@ from reconcile.utils.ocm.labels import (
     OCMOrganizationLabel,
     build_label_container,
     get_organization_labels,
+    subscription_label_filter,
 )
 from reconcile.utils.ocm.search_filters import Filter
 from reconcile.utils.ocm.service_log import (
@@ -126,7 +127,7 @@ def discover_clusters(
     """
     clusters = discover_clusters_by_labels(
         ocm_api=ocm_api,
-        label_filter=Filter().like("key", aus_label_key("%")),
+        label_filter=subscription_label_filter().like("key", aus_label_key("%")),
     )
 
     # group by org and filter if org_id is specified

--- a/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
+++ b/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
@@ -29,6 +29,7 @@ from reconcile.utils.ocm.clusters import ClusterDetails
 from reconcile.utils.ocm.labels import (
     LabelContainer,
     build_label_container,
+    subscription_label_filter,
 )
 from reconcile.utils.ocm.search_filters import Filter
 from reconcile.utils.ocm.sre_capability_labels import build_labelset
@@ -313,7 +314,8 @@ def test_discover_clusters(mocker: MockerFixture) -> None:
     clusters = discover_clusters(None, "org-id")  # type: ignore
 
     discover_clusters_by_labels_mock.assert_called_once_with(
-        ocm_api=None, label_filter=Filter().like("key", aus_label_key("%"))
+        ocm_api=None,
+        label_filter=subscription_label_filter().like("key", aus_label_key("%")),
     )
 
     assert org_id in clusters

--- a/reconcile/utils/ocm/labels.py
+++ b/reconcile/utils/ocm/labels.py
@@ -21,10 +21,17 @@ def get_subscription_labels(
     Finds all subscription labels that match the given filter.
     """
     for subscription_label in get_labels(
-        ocm_api=ocm_api, filter=filter.eq("type", "Subscription")
+        ocm_api=ocm_api, filter=filter & subscription_label_filter()
     ):
         if isinstance(subscription_label, OCMSubscriptionLabel):
             yield subscription_label
+
+
+def subscription_label_filter() -> Filter:
+    """
+    Returns a filter that can be used to find only subscription labels.
+    """
+    return Filter().eq("type", "Subscription")
 
 
 def get_organization_labels(
@@ -34,10 +41,17 @@ def get_organization_labels(
     Finds all organization labels that match the given filter.
     """
     for org_label in get_labels(
-        ocm_api=ocm_api, filter=filter.eq("type", "Organization")
+        ocm_api=ocm_api, filter=filter & organization_label_filter()
     ):
         if isinstance(org_label, OCMOrganizationLabel):
             yield org_label
+
+
+def organization_label_filter() -> Filter:
+    """
+    Returns a filter that can be used to find only organization labels.
+    """
+    return Filter().eq("type", "Organization")
 
 
 def get_labels(


### PR DESCRIPTION
discover clusters for AUS based only on subscription labels. the organization labels don't hold any cluster configuration, only org-wide configuration for blocked versions and sectors.