### PR TITLE
ocm machine pools add hypershift support

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1889,12 +1889,11 @@ def ocm_addons_upgrade_tests_trigger(ctx):
 
 
 @integration.command(short_help="Manage Machine Pools in OCM.")
-@threaded()
 @click.pass_context
-def ocm_machine_pools(ctx, thread_pool_size):
+def ocm_machine_pools(ctx):
     import reconcile.ocm_machine_pools
 
-    run_integration(reconcile.ocm_machine_pools, ctx.obj, thread_pool_size)
+    run_integration(reconcile.ocm_machine_pools, ctx.obj)
 
 
 @integration.command(short_help="Manage Upgrade Policy schedules in OCM.")

--- a/reconcile/gql_definitions/common/clusters.gql
+++ b/reconcile/gql_definitions/common/clusters.gql
@@ -147,6 +147,7 @@ query Clusters($name: String) {
       instance_type
       replicas
       labels
+      subnet
       taints {
         key
         value

--- a/reconcile/gql_definitions/common/clusters.py
+++ b/reconcile/gql_definitions/common/clusters.py
@@ -217,6 +217,7 @@ query Clusters($name: String) {
       instance_type
       replicas
       labels
+      subnet
       taints {
         key
         value
@@ -540,6 +541,7 @@ class ClusterMachinePoolV1(ConfiguredBaseModel):
     instance_type: str = Field(..., alias="instance_type")
     replicas: int = Field(..., alias="replicas")
     labels: Optional[Json] = Field(..., alias="labels")
+    subnet: Optional[str] = Field(..., alias="subnet")
     taints: Optional[list[TaintV1]] = Field(..., alias="taints")
 
 

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -277,7 +277,7 @@ def calculate_diff(
     diffs: list[PoolHandler] = []
     errors: list[InvalidUpdateError] = []
 
-    all_desired_pools: list[tuple[str, str]] = []
+    all_desired_pools: set[tuple[str, str]] = set()
     for desired in desired_state.cluster_pools:
 
         for desired_machine_pool in desired.pools:
@@ -286,7 +286,7 @@ def calculate_diff(
                 for p in current_state.get(desired.cluster_name, [])
                 if p.id == desired_machine_pool.q_id
             ]
-            all_desired_pools.append((desired_machine_pool.q_id, desired.cluster_name))
+            all_desired_pools.add((desired_machine_pool.q_id, desired.cluster_name))
             if not current_machine_pool:
                 if desired.hypershift:
                     diffs.append(

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -7,7 +7,6 @@ from abc import (
 from collections.abc import Mapping
 from typing import (
     Iterable,
-    MutableMapping,
     Optional,
 )
 

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -1,158 +1,356 @@
-import json
 import logging
 import sys
+from abc import (
+    ABC,
+    abstractmethod,
+)
 from collections.abc import Mapping
 from typing import (
-    Any,
     Iterable,
+    MutableMapping,
+    Optional,
 )
 
 from pydantic import BaseModel
 
 from reconcile import queries
-from reconcile.gql_definitions.common.clusters import ClusterV1
+from reconcile.gql_definitions.common.clusters import (
+    ClusterMachinePoolV1,
+    ClusterV1,
+)
 from reconcile.gql_definitions.common.clusters import query as clusters_query
 from reconcile.utils import gql
 from reconcile.utils.disabled_integrations import integration_is_enabled
-from reconcile.utils.ocm import OCMMap
+from reconcile.utils.ocm import (
+    OCM,
+    OCMMap,
+)
 
 QONTRACT_INTEGRATION = "ocm-machine-pools"
 
 
-class CurrentMachinePool(BaseModel):
-    # Abstract class for machine pools, abstracts OSD/Hypershift
+class InvalidUpdateError(Exception):
+    pass
+
+
+class AbstractPool(ABC, BaseModel):
+    # Abstract class for machine pools, to be implemented by OSD/HyperShift classes
+
     id: str
     replicas: int
-    instance_type: str
-    taints: list[Mapping[str, str]]
-    labels: Mapping[str, str]
+    taints: Optional[list[Mapping[str, str]]]
+    labels: Optional[Mapping[str, str]]
     cluster: str
+
+    @abstractmethod
+    def create(self, ocm: OCM) -> None:
+        pass
+
+    @abstractmethod
+    def delete(self, ocm: OCM) -> None:
+        pass
+
+    @abstractmethod
+    def update(self, ocm: OCM) -> None:
+        pass
+
+    @abstractmethod
+    def has_diff(self, pool: ClusterMachinePoolV1) -> bool:
+        pass
+
+    @abstractmethod
+    def invalid_diff(self, pool: ClusterMachinePoolV1) -> Optional[str]:
+        pass
+
+
+class MachinePool(AbstractPool):
+    # Machine pool, used for OSD clusters
+
+    instance_type: str
+
+    def delete(self, ocm: OCM) -> None:
+        ocm.delete_machine_pool(self.cluster, self.dict(by_alias=True))
+
+    def create(self, ocm: OCM) -> None:
+        ocm.create_machine_pool(self.cluster, self.dict(by_alias=True))
+
+    def update(self, ocm: OCM) -> None:
+        update_dict = self.dict(by_alias=True)
+        # can not update instance_type
+        del update_dict["instance_type"]
+        ocm.update_machine_pool(self.cluster, update_dict)
+
+    def has_diff(self, pool: ClusterMachinePoolV1) -> bool:
+        if self.taints != pool.taints or self.labels != pool.labels:
+            logging.warning(
+                f"updating labels or taints for machine pool {pool.q_id} "
+                f"will only be applied to new Nodes"
+            )
+        return (
+            self.replicas != pool.replicas
+            or self.taints != pool.taints
+            or self.labels != pool.labels
+            or self.instance_type != pool.instance_type
+        )
+
+    def invalid_diff(self, pool: ClusterMachinePoolV1) -> Optional[str]:
+        if self.instance_type != pool.instance_type:
+            return "instance_type"
+        return None
+
+    @classmethod
+    def create_from_gql(cls, pool: ClusterMachinePoolV1, cluster: str):
+        return cls(
+            id=pool.q_id,
+            replicas=pool.replicas,
+            instance_type=pool.instance_type,
+            taints=pool.taints,
+            labels=pool.labels,
+            cluster=cluster,
+        )
+
+
+class AWSNodePool(BaseModel):
+    instance_type: str
+
+
+class NodePool(AbstractPool):
+    # Node pool, used for HyperShift clusters
+
+    aws_node_pool: AWSNodePool
+    subnet: Optional[str]
+
+    def delete(self, ocm: OCM) -> None:
+        ocm.delete_node_pool(self.cluster, self.dict(by_alias=True))
+
+    def create(self, ocm: OCM) -> None:
+        ocm.create_node_pool(self.cluster, self.dict(by_alias=True))
+
+    def update(self, ocm: OCM) -> None:
+        update_dict = self.dict(by_alias=True)
+        # can not update instance_type
+        del update_dict["aws_node_pool"]
+        # can not update subnet
+        del update_dict["subnet"]
+        ocm.update_node_pool(self.cluster, update_dict)
+
+    def has_diff(self, pool: ClusterMachinePoolV1) -> bool:
+        if self.taints != pool.taints or self.labels != pool.labels:
+            logging.warning(
+                f"updating labels or taints for node pool {pool.q_id} "
+                f"will only be applied to new Nodes"
+            )
+        return (
+            self.replicas != pool.replicas
+            or self.taints != pool.taints
+            or self.labels != pool.labels
+            or self.aws_node_pool.instance_type != pool.instance_type
+            or self.subnet != pool.subnet
+        )
+
+    def invalid_diff(self, pool: ClusterMachinePoolV1) -> Optional[str]:
+        if self.aws_node_pool.instance_type != pool.instance_type:
+            return "instance_type"
+        elif self.subnet != pool.subnet:
+            return "subnet"
+        return None
+
+    @classmethod
+    def create_from_gql(cls, pool: ClusterMachinePoolV1, cluster: str):
+        return cls(
+            id=pool.q_id,
+            replicas=pool.replicas,
+            aws_node_pool=AWSNodePool(
+                instance_type=pool.instance_type,
+            ),
+            taints=pool.taints,
+            labels=pool.labels,
+            subnet=pool.subnet,
+            cluster=cluster,
+        )
+
+
+class PoolHandler(BaseModel):
+    # Class, that acts on a pool, based on the action
+
+    action: str
+    pool: AbstractPool
+
+    def act(self, dry_run: bool, ocm: OCM) -> None:
+        logging.info(f"{self.action} {self.pool.dict(by_alias=True)}")
+        if dry_run:
+            return
+
+        if not self.action:
+            pass
+        elif self.action == "delete":
+            self.pool.delete(ocm)
+        elif self.action == "create":
+            self.pool.create(ocm)
+        elif self.action == "update":
+            self.pool.update(ocm)
+
+
+class DesiredMachinePool(BaseModel):
+    cluster_name: str
+    hypershift: bool
+    pools: list[ClusterMachinePoolV1]
+
+
+class DesiredStateList(BaseModel):
+    cluster_pools: list[DesiredMachinePool]
 
 
 def fetch_current_state(
+    ocm_map: OCMMap,
     clusters: Iterable[ClusterV1],
-) -> tuple[OCMMap, list[CurrentMachinePool]]:
-    settings = queries.get_app_interface_settings()
-    cluster_like_objects = [cluster.dict(by_alias=True) for cluster in clusters]
-    ocm_map = OCMMap(
-        clusters=cluster_like_objects,
-        integration=QONTRACT_INTEGRATION,
-        settings=settings,
-    )
-
-    current_state = []
+) -> Mapping[str, list[AbstractPool]]:
+    current_state: MutableMapping[str, list[AbstractPool]] = {}
     for cluster in clusters:
+        current_state[cluster.name] = []
         ocm = ocm_map.get(cluster.name)
-        machine_pools = ocm.get_machine_pools(cluster.name)
-        for machine_pool in machine_pools:
-            machine_pool["cluster"] = cluster.name
-            current_state.append(
-                CurrentMachinePool(
-                    id=machine_pool["id"],
-                    replicas=machine_pool["replicas"],
-                    instance_type=machine_pool["instance_type"],
-                    taints=machine_pool["taints"],
-                    labels=machine_pool["labels"],
-                    cluster=machine_pool["cluster"],
+        if cluster.spec and cluster.spec.hypershift:
+            machine_pools = ocm.get_node_pools(cluster.name)
+            for machine_pool in machine_pools:
+                current_state[cluster.name].append(
+                    NodePool(
+                        id=machine_pool["id"],
+                        replicas=machine_pool["replicas"],
+                        aws_node_pool=AWSNodePool(
+                            instance_type=machine_pool["aws_node_pool"]["instance_type"]
+                        ),
+                        taints=machine_pool.get("taints"),
+                        labels=machine_pool.get("labels"),
+                        subnet=machine_pool.get("subnet"),
+                        cluster=cluster.name,
+                    )
+                )
+        else:
+            machine_pools = ocm.get_machine_pools(cluster.name)
+            for machine_pool in machine_pools:
+                current_state[cluster.name].append(
+                    MachinePool(
+                        id=machine_pool["id"],
+                        replicas=machine_pool["replicas"],
+                        instance_type=machine_pool["instance_type"],
+                        taints=machine_pool.get("taints"),
+                        labels=machine_pool.get("labels"),
+                        cluster=cluster.name,
+                    )
+                )
+
+    return current_state
+
+
+def create_desired_state_from_gql(
+    clusters: Iterable[ClusterV1],
+) -> DesiredStateList:
+    desired_state: DesiredStateList = DesiredStateList(cluster_pools=[])
+    for cluster in clusters:
+        if cluster.machine_pools:
+            is_hypershift = False
+            if cluster.spec:
+                is_hypershift = True if cluster.spec.hypershift else False
+            desired_state.cluster_pools.append(
+                DesiredMachinePool(
+                    cluster_name=cluster.name,
+                    hypershift=is_hypershift,
+                    pools=cluster.machine_pools,
                 )
             )
-
-    return ocm_map, current_state
-
-
-def fetch_desired_state(clusters):
-    desired_state = []
-    for cluster in clusters:
-        cluster_name = cluster["name"]
-        machine_pools = cluster["machinePools"]
-        for machine_pool in machine_pools:
-            machine_pool["cluster"] = cluster_name
-            labels = machine_pool.pop("labels")
-            if labels:
-                machine_pool["labels"] = json.loads(labels)
-            taints = machine_pool.pop("taints")
-            if taints:
-                machine_pool["taints"] = taints
-            desired_state.append(machine_pool)
 
     return desired_state
 
 
-def calculate_diff(current_state, desired_state):
-    diffs = []
-    err = False
-    for d in desired_state:
-        c = [
-            c
-            for c in current_state
-            if d["cluster"] == c["cluster"] and d["id"] == c["id"]
-        ]
-        if not c:
-            d["action"] = "create"
-            diffs.append(d)
-            continue
-        if len(c) != 1:
-            logging.error(f"duplicate id found in {d['cluster']}")
-            err = True
-            continue
-        c = c[0]
-        if c == d:
-            continue
-        if d["instance_type"] != c["instance_type"]:
-            logging.error(
-                f"can not update instance type for existing "
-                f"machine pool {d['id']} in {d['cluster']}"
-            )
-            err = True
-            continue
-        d.pop("instance_type")
-        for key in ["labels", "taints"]:
-            if c.get(key, None) != d.get(key, None):
-                # https://github.com/openshift/machine-api-operator/blob/master/FAQ.md
-                logging.warning(
-                    f"update {key} for machine pool {d['id']} "
-                    f"will only be applied to new Nodes"
+def calculate_diff(
+    current_state: Mapping[str, list[AbstractPool]],
+    desired_state: DesiredStateList,
+) -> tuple[list[PoolHandler], list[InvalidUpdateError]]:
+    diffs: list[PoolHandler] = []
+    errors: list[InvalidUpdateError] = []
+
+    all_desired_pools: list[tuple[str, str]] = []
+    for desired in desired_state.cluster_pools:
+
+        for desired_machine_pool in desired.pools:
+            current_machine_pool = [
+                p
+                for p in current_state.get(desired.cluster_name, [])
+                if p.id == desired_machine_pool.q_id
+            ]
+            all_desired_pools.append((desired_machine_pool.q_id, desired.cluster_name))
+            if not current_machine_pool:
+                if desired.hypershift:
+                    diffs.append(
+                        PoolHandler(
+                            action="create",
+                            pool=NodePool.create_from_gql(
+                                pool=desired_machine_pool,
+                                cluster=desired.cluster_name,
+                            ),
+                        )
+                    )
+                else:
+                    diffs.append(
+                        PoolHandler(
+                            action="create",
+                            pool=MachinePool.create_from_gql(
+                                pool=desired_machine_pool,
+                                cluster=desired.cluster_name,
+                            ),
+                        )
+                    )
+                    continue
+            elif current_machine_pool[0].has_diff(desired_machine_pool):
+                invalid_diff = current_machine_pool[0].invalid_diff(
+                    desired_machine_pool
                 )
-        d["action"] = "update"
-        diffs.append(d)
+                if invalid_diff:
+                    errors.append(
+                        InvalidUpdateError(
+                            f"can not update {invalid_diff} for existing machine pool"
+                        )
+                    )
+                else:
+                    print(current_machine_pool[0])
+                    diffs.append(
+                        PoolHandler(
+                            action="update",
+                            pool=NodePool.create_from_gql(
+                                pool=desired_machine_pool,
+                                cluster=desired.cluster_name,
+                            ),
+                        )
+                    )
 
-    for c in current_state:
-        d = [
-            d
-            for d in desired_state
-            if c["cluster"] == d["cluster"] and c["id"] == d["id"]
-        ]
-        if not d:
-            c["action"] = "delete"
-            diffs.append(c)
+    for cluster_name, machine_pools in current_state.items():
+        for pool in machine_pools:
+            if (pool.id, cluster_name) not in all_desired_pools:
+                if pool.id.startswith("workers"):
+                    # As of now, you can not delete the first worker pool(s)
+                    continue
+                diffs.append(
+                    PoolHandler(
+                        action="delete",
+                        pool=pool,
+                    )
+                )
+    return diffs, errors
 
-    return diffs, err
 
-
-def act(dry_run, diffs, ocm_map):
+def act(dry_run: bool, diffs: Iterable[PoolHandler], ocm_map: OCMMap) -> None:
     for diff in diffs:
-        action = diff.pop("action")
-        cluster = diff.pop("cluster")
-        logging.info([action, cluster, diff["id"]])
+        logging.info([diff.action, diff.pool.cluster, diff.pool.id])
         if not dry_run:
-            ocm = ocm_map.get(cluster)
-            if action == "create":
-                ocm.create_machine_pool(cluster, diff)
-            elif action == "update":
-                ocm.update_machine_pool(cluster, diff)
-            elif action == "delete":
-                ocm.delete_machine_pool(cluster, diff)
+            ocm = ocm_map.get(diff.pool.cluster)
+            diff.act(dry_run, ocm)
 
 
 def _cluster_is_compatible(cluster: ClusterV1) -> bool:
-    return (
-        cluster.ocm is not None
-        and cluster.machine_pools is not None
-        and not cluster.spec.hypershift
-    )
+    return cluster.ocm is not None and cluster.machine_pools is not None
 
 
-def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
+def run(dry_run: bool):
     clusters = clusters_query(query_func=gql.get_api().query).clusters or []
 
     filtered_clusters = [
@@ -164,10 +362,21 @@ def run(dry_run, gitlab_project_id=None, thread_pool_size=10):
         logging.debug("No machinePools definitions found in app-interface")
         sys.exit(0)
 
-    ocm_map, current_state = fetch_current_state(filtered_clusters)
-    desired_state = fetch_desired_state(filtered_clusters)
-    diffs, err = calculate_diff(current_state, desired_state)
+    settings = queries.get_app_interface_settings()
+    cluster_like_objects = [cluster.dict(by_alias=True) for cluster in clusters]
+    ocm_map = OCMMap(
+        clusters=cluster_like_objects,
+        integration=QONTRACT_INTEGRATION,
+        settings=settings,
+    )
+
+    current_state = fetch_current_state(ocm_map, filtered_clusters)
+    desired_state = create_desired_state_from_gql(filtered_clusters)
+    diffs, errors = calculate_diff(current_state, desired_state)
+
     act(dry_run, diffs, ocm_map)
 
-    if err:
+    if errors:
+        for err in errors:
+            logging.error(err)
         sys.exit(1)

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -151,7 +151,7 @@ class NodePool(AbstractPool):
     def invalid_diff(self, pool: ClusterMachinePoolV1) -> Optional[str]:
         if self.aws_node_pool.instance_type != pool.instance_type:
             return "instance_type"
-        elif self.subnet != pool.subnet:
+        if self.subnet != pool.subnet:
             return "subnet"
         return None
 

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -381,7 +381,7 @@ def run(dry_run: bool):
         sys.exit(0)
 
     settings = queries.get_app_interface_settings()
-    cluster_like_objects = [cluster.dict(by_alias=True) for cluster in clusters]
+    cluster_like_objects = [cluster.dict(by_alias=True) for cluster in filtered_clusters]
     ocm_map = OCMMap(
         clusters=cluster_like_objects,
         integration=QONTRACT_INTEGRATION,

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -213,7 +213,10 @@ def fetch_current_state(
     ocm_map: OCMMap,
     clusters: Iterable[ClusterV1],
 ) -> Mapping[str, list[AbstractPool]]:
-    return {c.name: fetch_current_state_for_cluster(c, ocm_map.get(c.name)) for c in clusters}
+    return {
+        c.name: fetch_current_state_for_cluster(c, ocm_map.get(c.name))
+        for c in clusters
+    }
 
 
 def fetch_current_state_for_cluster(cluster, ocm):

--- a/reconcile/test/test_ocm_machine_pools.py
+++ b/reconcile/test/test_ocm_machine_pools.py
@@ -1,36 +1,46 @@
+from typing import Mapping
+
 from reconcile.gql_definitions.common.clusters import ClusterMachinePoolV1
 from reconcile.ocm_machine_pools import (
+    AbstractPool,
+    DesiredMachinePool,
+    DesiredStateList,
     MachinePool,
     calculate_diff,
 )
 
 
 def test_calculate_diff_create():
-    current = {
+    current: Mapping[str, list[AbstractPool]] = {
         "cluster1": [],
     }
-    desired = {
-        "cluster1": {
-            "machine_pools": [
-                ClusterMachinePoolV1(
-                    id="pool1",
-                    instance_type="m5.xlarge",
-                    replicas=1,
-                    labels=None,
-                    taints=None,
-                )
-            ],
-            "hypershift": False,
-        },
-    }
+    desired = DesiredStateList(
+        cluster_pools=[
+            DesiredMachinePool(
+                cluster_name="cluster1",
+                hypershift=False,
+                pools=[
+                    ClusterMachinePoolV1(
+                        id="pool1",
+                        instance_type="m5.xlarge",
+                        replicas=1,
+                        labels=None,
+                        taints=None,
+                        subnet="subnet1",
+                    )
+                ],
+            )
+        ]
+    )
 
     diff, error = calculate_diff(current, desired)
     assert len(diff) == 1
     assert diff[0].action == "create"
+    assert not error
 
 
 def test_calculate_diff_noop():
-    current = {
+    current: Mapping[str, list[AbstractPool]] = {
         "cluster1": [
             MachinePool(
                 id="pool1",
@@ -42,27 +52,31 @@ def test_calculate_diff_noop():
             )
         ]
     }
-    desired = {
-        "cluster1": {
-            "machine_pools": [
-                ClusterMachinePoolV1(
-                    id="pool1",
-                    instance_type="m5.xlarge",
-                    replicas=1,
-                    labels=None,
-                    taints=None,
-                )
-            ],
-            "hypershift": False,
-        },
-    }
-
+    desired = DesiredStateList(
+        cluster_pools=[
+            DesiredMachinePool(
+                cluster_name="cluster1",
+                hypershift=False,
+                pools=[
+                    ClusterMachinePoolV1(
+                        id="pool1",
+                        instance_type="m5.xlarge",
+                        replicas=1,
+                        labels=None,
+                        taints=None,
+                        subnet="subnet1",
+                    )
+                ],
+            )
+        ]
+    )
     diff, error = calculate_diff(current, desired)
     assert len(diff) == 0
+    assert not error
 
 
 def test_calculate_diff_update():
-    current = {
+    current: Mapping[str, list[AbstractPool]] = {
         "cluster1": [
             MachinePool(
                 id="pool1",
@@ -74,28 +88,33 @@ def test_calculate_diff_update():
             )
         ]
     }
-    desired = {
-        "cluster1": {
-            "machine_pools": [
-                ClusterMachinePoolV1(
-                    id="pool1",
-                    instance_type="m5.xlarge",
-                    replicas=1,
-                    labels=None,
-                    taints=None,
-                )
-            ],
-            "hypershift": False,
-        },
-    }
+    desired = DesiredStateList(
+        cluster_pools=[
+            DesiredMachinePool(
+                cluster_name="cluster1",
+                hypershift=False,
+                pools=[
+                    ClusterMachinePoolV1(
+                        id="pool1",
+                        instance_type="m5.xlarge",
+                        replicas=1,
+                        labels=None,
+                        taints=None,
+                        subnet="subnet1",
+                    )
+                ],
+            )
+        ]
+    )
 
     diff, error = calculate_diff(current, desired)
     assert len(diff) == 1
     assert diff[0].action == "update"
+    assert not error
 
 
 def test_calculate_diff_delete():
-    current = {
+    current: Mapping[str, list[AbstractPool]] = {
         "cluster1": [
             MachinePool(
                 id="pool1",
@@ -107,13 +126,13 @@ def test_calculate_diff_delete():
             )
         ]
     }
-    desired = {
-        "cluster1": {
-            "machine_pools": [],
-            "hypershift": False,
-        },
-    }
+    desired = DesiredStateList(
+        cluster_pools=[
+            DesiredMachinePool(cluster_name="cluster1", hypershift=False, pools=[])
+        ]
+    )
 
     diff, error = calculate_diff(current, desired)
     assert len(diff) == 1
     assert diff[0].action == "delete"
+    assert not error

--- a/reconcile/test/test_ocm_machine_pools.py
+++ b/reconcile/test/test_ocm_machine_pools.py
@@ -1,13 +1,115 @@
-from typing import Mapping
+from typing import (
+    Mapping,
+    Optional,
+)
+
+import pytest
 
 from reconcile.gql_definitions.common.clusters import ClusterMachinePoolV1
 from reconcile.ocm_machine_pools import (
     AbstractPool,
+    AWSNodePool,
     DesiredMachinePool,
     DesiredStateList,
     MachinePool,
+    NodePool,
+    PoolHandler,
     calculate_diff,
 )
+from reconcile.utils.ocm import OCM
+
+
+class TestPool(AbstractPool):
+    created = False
+    deleted = False
+    updated = False
+
+    def create(self, ocm: OCM) -> None:
+        self.created = True
+
+    def delete(self, ocm: OCM) -> None:
+        self.deleted = True
+
+    def update(self, ocm: OCM) -> None:
+        self.updated = True
+
+    def has_diff(self, pool: ClusterMachinePoolV1) -> bool:
+        return True
+
+    def invalid_diff(self, pool: ClusterMachinePoolV1) -> Optional[str]:
+        return None
+
+
+@pytest.fixture
+def test_pool() -> TestPool:
+    return TestPool(
+        id="pool1",
+        replicas=2,
+        labels=None,
+        taints=None,
+        cluster="cluster1",
+    )
+
+
+@pytest.fixture
+def current_with_pool() -> Mapping[str, list[AbstractPool]]:
+    return {
+        "cluster1": [
+            MachinePool(
+                id="pool1",
+                instance_type="m5.xlarge",
+                replicas=2,
+                labels=None,
+                taints=None,
+                cluster="cluster1",
+            )
+        ]
+    }
+
+
+@pytest.fixture
+def node_pool() -> NodePool:
+    return NodePool(
+        id="pool1",
+        replicas=2,
+        labels=None,
+        taints=None,
+        cluster="cluster1",
+        subnet="subnet1",
+        aws_node_pool=AWSNodePool(
+            instance_type="m5.xlarge",
+        ),
+    )
+
+
+@pytest.fixture
+def machine_pool() -> MachinePool:
+    return MachinePool(
+        id="pool1",
+        replicas=2,
+        labels=None,
+        taints=None,
+        cluster="cluster1",
+        subnet="subnet1",
+        instance_type="m5.xlarge",
+    )
+
+
+@pytest.fixture
+def cluster_machine_pool() -> ClusterMachinePoolV1:
+    return ClusterMachinePoolV1(
+        id="pool1",
+        instance_type="m5.xlarge",
+        replicas=1,
+        labels=None,
+        taints=None,
+        subnet="subnet1",
+    )
+
+
+@pytest.fixture
+def ocm_mock(mocker):
+    return mocker.patch("reconcile.utils.ocm.OCM")
 
 
 def test_calculate_diff_create():
@@ -39,19 +141,7 @@ def test_calculate_diff_create():
     assert not error
 
 
-def test_calculate_diff_noop():
-    current: Mapping[str, list[AbstractPool]] = {
-        "cluster1": [
-            MachinePool(
-                id="pool1",
-                instance_type="m5.xlarge",
-                replicas=1,
-                labels=None,
-                taints=None,
-                cluster="cluster1",
-            )
-        ]
-    }
+def test_calculate_diff_noop(current_with_pool):
     desired = DesiredStateList(
         cluster_pools=[
             DesiredMachinePool(
@@ -61,7 +151,7 @@ def test_calculate_diff_noop():
                     ClusterMachinePoolV1(
                         id="pool1",
                         instance_type="m5.xlarge",
-                        replicas=1,
+                        replicas=2,
                         labels=None,
                         taints=None,
                         subnet="subnet1",
@@ -70,24 +160,12 @@ def test_calculate_diff_noop():
             )
         ]
     )
-    diff, error = calculate_diff(current, desired)
+    diff, error = calculate_diff(current_with_pool, desired)
     assert len(diff) == 0
     assert not error
 
 
-def test_calculate_diff_update():
-    current: Mapping[str, list[AbstractPool]] = {
-        "cluster1": [
-            MachinePool(
-                id="pool1",
-                instance_type="m5.xlarge",
-                replicas=2,
-                labels=None,
-                taints=None,
-                cluster="cluster1",
-            )
-        ]
-    }
+def test_calculate_diff_update(current_with_pool):
     desired = DesiredStateList(
         cluster_pools=[
             DesiredMachinePool(
@@ -107,32 +185,108 @@ def test_calculate_diff_update():
         ]
     )
 
-    diff, error = calculate_diff(current, desired)
+    diff, error = calculate_diff(current_with_pool, desired)
     assert len(diff) == 1
     assert diff[0].action == "update"
     assert not error
 
 
-def test_calculate_diff_delete():
-    current: Mapping[str, list[AbstractPool]] = {
-        "cluster1": [
-            MachinePool(
-                id="pool1",
-                instance_type="m5.xlarge",
-                replicas=2,
-                labels=None,
-                taints=None,
-                cluster="cluster1",
-            )
-        ]
-    }
+def test_calculate_diff_delete(current_with_pool):
     desired = DesiredStateList(
         cluster_pools=[
             DesiredMachinePool(cluster_name="cluster1", hypershift=False, pools=[])
         ]
     )
 
-    diff, error = calculate_diff(current, desired)
+    diff, error = calculate_diff(current_with_pool, desired)
     assert len(diff) == 1
     assert diff[0].action == "delete"
     assert not error
+
+
+def test_act_dry_run(test_pool, ocm_mock):
+    handler = PoolHandler(action="create", pool=test_pool)
+    handler.act(ocm=ocm_mock, dry_run=True)
+    assert not test_pool.created
+    assert not test_pool.deleted
+    assert not test_pool.updated
+
+
+def test_act_create(test_pool, ocm_mock):
+    handler = PoolHandler(action="create", pool=test_pool)
+    handler.act(ocm=ocm_mock, dry_run=False)
+    assert test_pool.created
+
+
+def test_act_update(test_pool, ocm_mock):
+    handler = PoolHandler(action="update", pool=test_pool)
+    handler.act(ocm=ocm_mock, dry_run=False)
+    assert test_pool.updated
+
+
+def test_act_delete(test_pool, ocm_mock):
+    handler = PoolHandler(action="delete", pool=test_pool)
+    handler.act(ocm=ocm_mock, dry_run=False)
+    assert test_pool.deleted
+
+
+def test_pool_node_pool_has_diff(node_pool, cluster_machine_pool):
+    assert node_pool.has_diff(cluster_machine_pool)
+    cluster_machine_pool.replicas = 2
+    assert not node_pool.has_diff(cluster_machine_pool)
+
+
+def test_pool_node_pool_invalid_diff_subnet(node_pool, cluster_machine_pool):
+    cluster_machine_pool.subnet = "foo"
+    assert node_pool.invalid_diff(cluster_machine_pool)
+
+
+def test_pool_node_pool_invalid_diff_instance_type(node_pool, cluster_machine_pool):
+    cluster_machine_pool.instance_type = "foo"
+    assert node_pool.invalid_diff(cluster_machine_pool)
+
+
+def test_pool_machine_pool_has_diff(machine_pool, cluster_machine_pool):
+    assert machine_pool.has_diff(cluster_machine_pool)
+    cluster_machine_pool.replicas = 2
+    assert not machine_pool.has_diff(cluster_machine_pool)
+
+
+def test_pool_machine_pool_invalid_diff_instance_type(
+    machine_pool, cluster_machine_pool
+):
+    cluster_machine_pool.instance_type = "foo"
+    assert machine_pool.invalid_diff(cluster_machine_pool)
+
+
+def test_machine_pool_update(machine_pool, mocker):
+    ocm = mocker.patch("reconcile.utils.ocm.OCM")
+    machine_pool.update(ocm=ocm)
+
+    assert ocm.update_machine_pool.call_count == 1
+    ocm.update_machine_pool.assert_called_with(
+        "cluster1", {"id": "pool1", "replicas": 2, "cluster": "cluster1"}
+    )
+
+    machine_pool.labels = {"foo": "bar"}
+    machine_pool.update(ocm=ocm)
+    ocm.update_machine_pool.assert_called_with(
+        "cluster1",
+        {"id": "pool1", "replicas": 2, "cluster": "cluster1", "labels": {"foo": "bar"}},
+    )
+
+
+def test_node_pool_update(node_pool, ocm_mock):
+    node_pool.update(ocm=ocm_mock)
+
+    assert ocm_mock.update_node_pool.call_count == 1
+    ocm_mock.update_node_pool.assert_called_with(
+        "cluster1", {"id": "pool1", "replicas": 2, "cluster": "cluster1"}
+    )
+
+    node_pool.labels = {"foo": "bar"}
+    node_pool.update(ocm=ocm_mock)
+    ocm_mock.update_node_pool.assert_called_with(
+        "cluster1",
+        {"id": "pool1", "replicas": 2, "cluster": "cluster1", "labels": {"foo": "bar"}},
+    )

--- a/reconcile/test/test_ocm_machine_pools.py
+++ b/reconcile/test/test_ocm_machine_pools.py
@@ -1,0 +1,119 @@
+from reconcile.gql_definitions.common.clusters import ClusterMachinePoolV1
+from reconcile.ocm_machine_pools import (
+    MachinePool,
+    calculate_diff,
+)
+
+
+def test_calculate_diff_create():
+    current = {
+        "cluster1": [],
+    }
+    desired = {
+        "cluster1": {
+            "machine_pools": [
+                ClusterMachinePoolV1(
+                    id="pool1",
+                    instance_type="m5.xlarge",
+                    replicas=1,
+                    labels=None,
+                    taints=None,
+                )
+            ],
+            "hypershift": False,
+        },
+    }
+
+    diff, error = calculate_diff(current, desired)
+    assert len(diff) == 1
+    assert diff[0].action == "create"
+
+
+def test_calculate_diff_noop():
+    current = {
+        "cluster1": [
+            MachinePool(
+                id="pool1",
+                instance_type="m5.xlarge",
+                replicas=1,
+                labels=None,
+                taints=None,
+                cluster="cluster1",
+            )
+        ]
+    }
+    desired = {
+        "cluster1": {
+            "machine_pools": [
+                ClusterMachinePoolV1(
+                    id="pool1",
+                    instance_type="m5.xlarge",
+                    replicas=1,
+                    labels=None,
+                    taints=None,
+                )
+            ],
+            "hypershift": False,
+        },
+    }
+
+    diff, error = calculate_diff(current, desired)
+    assert len(diff) == 0
+
+
+def test_calculate_diff_update():
+    current = {
+        "cluster1": [
+            MachinePool(
+                id="pool1",
+                instance_type="m5.xlarge",
+                replicas=2,
+                labels=None,
+                taints=None,
+                cluster="cluster1",
+            )
+        ]
+    }
+    desired = {
+        "cluster1": {
+            "machine_pools": [
+                ClusterMachinePoolV1(
+                    id="pool1",
+                    instance_type="m5.xlarge",
+                    replicas=1,
+                    labels=None,
+                    taints=None,
+                )
+            ],
+            "hypershift": False,
+        },
+    }
+
+    diff, error = calculate_diff(current, desired)
+    assert len(diff) == 1
+    assert diff[0].action == "update"
+
+
+def test_calculate_diff_delete():
+    current = {
+        "cluster1": [
+            MachinePool(
+                id="pool1",
+                instance_type="m5.xlarge",
+                replicas=2,
+                labels=None,
+                taints=None,
+                cluster="cluster1",
+            )
+        ]
+    }
+    desired = {
+        "cluster1": {
+            "machine_pools": [],
+            "hypershift": False,
+        },
+    }
+
+    diff, error = calculate_diff(current, desired)
+    assert len(diff) == 1
+    assert diff[0].action == "delete"


### PR DESCRIPTION
Adding Node Pool support to ocm_machine_pools

- Refactoring query, using data class-based Query
- Introduce data classes for handling existing machine/node pools 
- Refactoring calculate_diff to use introduced data classes
- Adding tests 


https://issues.redhat.com/browse/APPSRE-7661


Related schema change: https://github.com/app-sre/qontract-schemas/pull/475