### PR TITLE
APPSRE-7526: RDS backup best practices

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -30386,6 +30386,29 @@
                 },
                 {
                     "kind": "OBJECT",
+                    "name": "AWSRDSDataClassification_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "loss_impact",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
                     "name": "ACMDomain_v1",
                     "description": null,
                     "fields": [
@@ -33816,6 +33839,18 @@
                                         "ofType": null
                                     }
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "data_classification",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "AWSRDSDataClassification_v1",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
@@ -45,6 +45,9 @@ query TerraformResourcesNamespaces {
                     source_type
                     event_categories
                 }
+                data_classification {
+                    loss_impact
+                }
             }
             ... on NamespaceTerraformResourceS3_v1 {
                 region

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
@@ -84,6 +84,9 @@ query TerraformResourcesNamespaces {
                     source_type
                     event_categories
                 }
+                data_classification {
+                    loss_impact
+                }
             }
             ... on NamespaceTerraformResourceS3_v1 {
                 region
@@ -512,6 +515,10 @@ class AWSRDSEventNotificationV1(ConfiguredBaseModel):
     event_categories: Optional[list[str]] = Field(..., alias="event_categories")
 
 
+class AWSRDSDataClassificationV1(ConfiguredBaseModel):
+    loss_impact: Optional[str] = Field(..., alias="loss_impact")
+
+
 class NamespaceTerraformResourceRDSV1(NamespaceTerraformResourceAWSV1):
     region: Optional[str] = Field(..., alias="region")
     identifier: str = Field(..., alias="identifier")
@@ -529,6 +536,9 @@ class NamespaceTerraformResourceRDSV1(NamespaceTerraformResourceAWSV1):
     annotations: Optional[str] = Field(..., alias="annotations")
     event_notifications: Optional[list[AWSRDSEventNotificationV1]] = Field(
         ..., alias="event_notifications"
+    )
+    data_classification: Optional[AWSRDSDataClassificationV1] = Field(
+        ..., alias="data_classification"
     )
 
 

--- a/reconcile/test/test_utils_aws_rds.py
+++ b/reconcile/test/test_utils_aws_rds.py
@@ -10,8 +10,8 @@ from reconcile.utils.cloud_resource_best_practice.aws_rds import (
 def test_rds_best_practices_compliant_db():
     db = aws_db_instance(
         "my-db",
-        delete_automated_backups="no",
-        skip_final_snapshot="no",
+        delete_automated_backups=False,
+        skip_final_snapshot=False,
         backup_retention_period=7,
     )
 
@@ -22,8 +22,8 @@ def test_rds_best_practices_non_compliant_db():
 
     db = aws_db_instance(
         "my-db",
-        delete_automated_backups="yes",
-        skip_final_snapshot="yes",
+        delete_automated_backups=True,
+        skip_final_snapshot=True,
         backup_retention_period=7,
     )
     with pytest.raises(RDSBestPracticesNotComplied) as e:
@@ -31,5 +31,5 @@ def test_rds_best_practices_non_compliant_db():
     assert (
         e.value.message
         == "AWS RDS instance my-db does not comply with best practices\nExpected field delete_automated_backups with "
-        'value "no", found "yes" \nExpected field skip_final_snapshot with value "no", found "yes" \n'
+        'value "False", found "True" \nExpected field skip_final_snapshot with value "False", found "True" \n'
     )

--- a/reconcile/test/test_utils_aws_rds.py
+++ b/reconcile/test/test_utils_aws_rds.py
@@ -1,0 +1,35 @@
+import pytest
+from terrascript.resource import aws_db_instance
+
+from reconcile.utils.cloud_resource_best_practice.aws_rds import (
+    RDSBestPracticesNotComplied,
+    verify_rds_best_practices,
+)
+
+
+def test_rds_best_practices_compliant_db():
+    db = aws_db_instance(
+        "my-db",
+        delete_automated_backups="no",
+        skip_final_snapshot="no",
+        backup_retention_period=7,
+    )
+
+    verify_rds_best_practices(db, {"loss_impact": "high"})
+
+
+def test_rds_best_practices_non_compliant_db():
+
+    db = aws_db_instance(
+        "my-db",
+        delete_automated_backups="yes",
+        skip_final_snapshot="yes",
+        backup_retention_period=7,
+    )
+    with pytest.raises(RDSBestPracticesNotComplied) as e:
+        verify_rds_best_practices(db, {"loss_impact": "high"})
+    assert (
+        e.value.message
+        == "AWS RDS instance my-db does not comply with best practices\nExpected field delete_automated_backups with "
+        'value "no", found "yes" \nExpected field skip_final_snapshot with value "no", found "yes" \n'
+    )

--- a/reconcile/test/test_utils_aws_rds.py
+++ b/reconcile/test/test_utils_aws_rds.py
@@ -2,7 +2,7 @@ import pytest
 from terrascript.resource import aws_db_instance
 
 from reconcile.utils.cloud_resource_best_practice.aws_rds import (
-    RDSBestPracticesNotComplied,
+    RDSResourceComplianceError,
     verify_rds_best_practices,
 )
 
@@ -26,7 +26,7 @@ def test_rds_best_practices_non_compliant_db():
         skip_final_snapshot=True,
         backup_retention_period=7,
     )
-    with pytest.raises(RDSBestPracticesNotComplied) as e:
+    with pytest.raises(RDSResourceComplianceError) as e:
         verify_rds_best_practices(db, {"loss_impact": "high"})
     assert (
         e.value.message

--- a/reconcile/utils/cloud_resource_best_practice/aws_rds.py
+++ b/reconcile/utils/cloud_resource_best_practice/aws_rds.py
@@ -46,7 +46,7 @@ __loss_impact_none = [(backup_retention_period, 0, OPERATOR_GREATER_THAN_OR_EQUA
 
 
 # Keeping this method here for now, we can re-evaluate if this needs to go to separate util once more
-# use-cases are built.
+# use-cases are built. We could also couple operator with the operations, but keeping that for future iteration.
 def _check(aws_db_instance: aws_db_instance, checks: list) -> None:
     rds_fields_not_complied = []
     for field, expected_value, operator in checks:

--- a/reconcile/utils/cloud_resource_best_practice/aws_rds.py
+++ b/reconcile/utils/cloud_resource_best_practice/aws_rds.py
@@ -46,8 +46,8 @@ __loss_impact_levels = {
 # use-cases are built.
 def _check(aws_db_instance: aws_db_instance, checks: list) -> None:
     rds_fields_not_complied = []
-    for field, expected_value, operator in checks:
-        if not operator(aws_db_instance.get(field), expected_value):
+    for field, expected_value, op in checks:
+        if not op(aws_db_instance.get(field), expected_value):
             rds_fields_not_complied.append(
                 (field, aws_db_instance.get(field), expected_value)
             )

--- a/reconcile/utils/cloud_resource_best_practice/aws_rds.py
+++ b/reconcile/utils/cloud_resource_best_practice/aws_rds.py
@@ -1,0 +1,87 @@
+from typing import Any
+
+from terrascript.resource import aws_db_instance
+
+delete_automated_backups = "delete_automated_backups"
+skip_final_snapshot = "skip_final_snapshot"
+backup_retention_period = "backup_retention_period"
+
+
+# Keeping the exception specific now, we can build a generic exception and refactor later
+# as more cases arise in the future.
+class RDSBestPracticesNotComplied(Exception):
+    def __init__(
+        self, field_expected_actual: list[tuple[str, Any, Any]], db_identifier: str
+    ):
+        self.actual_vs_expected = field_expected_actual
+
+        self.message = (
+            f"AWS RDS instance {db_identifier} does not comply with best practices\n"
+        )
+
+        for field, actual, expected in field_expected_actual:
+            self.message += (
+                f'Expected field {field} with value "{expected}", found "{actual}" \n'
+            )
+        super().__init__(self.message)
+
+
+__loss_impact_high = {
+    delete_automated_backups: "no",
+    skip_final_snapshot: "no",
+    backup_retention_period: 7,
+}
+
+__loss_impact_medium = {
+    delete_automated_backups: "yes",
+    skip_final_snapshot: "no",
+    backup_retention_period: 7,
+}
+
+__loss_impact_low = {
+    delete_automated_backups: "yes",
+    skip_final_snapshot: "yes",
+    backup_retention_period: 3,
+}
+
+__loss_impact_none = {
+    delete_automated_backups: "yes",
+    skip_final_snapshot: "yes",
+    backup_retention_period: 0,
+}
+
+
+# Keeping this method here for now, we can re-evaluate if this needs to go to separate util once more
+# use-cases are built.
+def _check(aws_db_instance: aws_db_instance, d: dict) -> None:
+    rds_fields_not_complied = []
+    for k, v in d.items():
+        if k in aws_db_instance:
+            if v != aws_db_instance[k]:
+                rds_fields_not_complied.append((k, aws_db_instance[k], v))
+        else:
+            rds_fields_not_complied.append((k, None, v))
+
+    if len(rds_fields_not_complied) > 0:
+        raise RDSBestPracticesNotComplied(
+            rds_fields_not_complied, aws_db_instance._name
+        )
+
+
+def _verify_loss_impact(aws_db_instance: aws_db_instance, loss_impact: str) -> None:
+    if loss_impact == "high":
+        _check(aws_db_instance, __loss_impact_high)
+    if loss_impact == "medium":
+        _check(aws_db_instance, __loss_impact_medium)
+    if loss_impact == "low":
+        _check(aws_db_instance, __loss_impact_low)
+    if loss_impact == "none":
+        _check(aws_db_instance, __loss_impact_none)
+
+
+def verify_rds_best_practices(
+    aws_db_instance: aws_db_instance, data_classification: dict
+) -> None:
+    if data_classification is None:
+        return
+    _verify_loss_impact(aws_db_instance, data_classification["loss_impact"])

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -149,6 +149,9 @@ from reconcile.utils.aws_api import (
     AmiTag,
     AWSApi,
 )
+from reconcile.utils.cloud_resource_best_practice.aws_rds import (
+    verify_rds_best_practices,
+)
 from reconcile.utils.disabled_integrations import integration_is_enabled
 from reconcile.utils.elasticsearch_exceptions import (
     ElasticSearchResourceMissingSubnetIdError,
@@ -1659,6 +1662,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         # rds instance
         # Ref: https://www.terraform.io/docs/providers/aws/r/db_instance.html
         tf_resource = aws_db_instance(identifier, **values)
+        verify_rds_best_practices(tf_resource, spec.resource["data_classification"])
         tf_resources.append(tf_resource)
 
         # rds outputs


### PR DESCRIPTION
Ensure AWS RDS instances abide by best practices as per https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/aws-rds-backup-config-best-practices.md.

The integration terraform-resources fails if the database attributes does not comply with necessary attributes based on data_classification and loss_impact.

The exception thrown is of the following format

```
          reconcile.utils.cloud_resource_best_practice.aws_rds.RDSBestPracticesNotComplied: AWS RDS instance my-db does not comply with best practices
          Expected field delete_automated_backups with value "False", found "True" 
          Expected field skip_final_snapshot with value "False", found "True"
```
Schema: https://github.com/app-sre/qontract-schemas/pull/439/files

Testing:

- (Happy path, no exceptions) Create a db with required data_classification and loss_impact, and set the parameters accordingly. Run the terraform-resources integration in dry-run and validate it does not error out.
- (Unhappy path, expect exception! ) Create a db with required data_classification and loss_impact, and set the parameters which are not in line with best practices ( see test case for example ). Run the terraform-resources integration in dry-run and validate exception is thrown.