### PR TITLE
Do not on compare tags error in dry-run in cleanup

### DIFF
--- a/reconcile/aws_ami_cleanup/integration.py
+++ b/reconcile/aws_ami_cleanup/integration.py
@@ -259,8 +259,9 @@ def run(dry_run: bool, thread_pool_size: int, defer: Optional[Callable] = None) 
                         )
                         continue
                 except CannotCompareTagsError as e:
-                    exit_code = ExitCodes.ERROR
                     logging.error(e)
+                    if not dry_run:
+                        exit_code = ExitCodes.ERROR
                     continue
 
                 logging.info(


### PR DESCRIPTION
It is a condition that won't be solved in a MR, so it doesn't make sense to exit in error.