### PR TITLE
update cronjob template for sql-query to batch/v1

### DIFF
--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -131,7 +131,7 @@ metadata:
 
 
 CRONJOB_TEMPLATE = """
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ JOB_NAME }}


### PR DESCRIPTION
part of https://issues.redhat.com/browse/ASIC-417

the sql-query integration is running in a loop, while the previous apiVersion is now deprecated.