### PR TITLE
Add new sharding strategy per-aws-tgw-account

### DIFF
--- a/reconcile/gql_definitions/integrations/integrations.gql
+++ b/reconcile/gql_definitions/integrations/integrations.gql
@@ -66,41 +66,55 @@ query Integrations {
         }
 
         ... on OpenshiftClusterSharding_v1 {
-            shardSpecOverrides {
-                shard {
-                    name
-                }
-                imageRef
-                disabled
-                resources {
-                  ... DeployResourcesFields
-                }
-                subSharding {
-                  strategy
-                  ... on StaticSubSharding_v1 {
-                    shards
-                  }
-                }
+          shardSpecOverrides {
+            shard {
+              name
             }
+            imageRef
+            disabled
+            resources {
+              ... DeployResourcesFields
+            }
+            subSharding {
+              strategy
+              ... on StaticSubSharding_v1 {
+                shards
+              }
+            }
+          }
         }
-
 
         ... on AWSAccountSharding_v1 {
-            shardSpecOverrides {
-              shard {
-                name
-                disable {
-                  integrations
-                }
-              }
-              imageRef
-              disabled
-              resources {
-                ... DeployResourcesFields
+          shardSpecOverrides {
+            shard {
+              name
+              disable {
+                integrations
               }
             }
+            imageRef
+            disabled
+            resources {
+              ... DeployResourcesFields
+            }
+          }
         }
 
+        ... on AWSTGWAccountSharding_v1 {
+          shardSpecOverrides {
+            shard {
+              name
+              disable {
+                integrations
+              }
+            }
+            imageRef
+            disabled
+            resources {
+              ... DeployResourcesFields
+            }
+          }
+        }
 
         ... on CloudflareDNSZoneSharding_v1 {
           shardSpecOverrides {

--- a/reconcile/gql_definitions/integrations/integrations.py
+++ b/reconcile/gql_definitions/integrations/integrations.py
@@ -120,41 +120,55 @@ query Integrations {
         }
 
         ... on OpenshiftClusterSharding_v1 {
-            shardSpecOverrides {
-                shard {
-                    name
-                }
-                imageRef
-                disabled
-                resources {
-                  ... DeployResourcesFields
-                }
-                subSharding {
-                  strategy
-                  ... on StaticSubSharding_v1 {
-                    shards
-                  }
-                }
+          shardSpecOverrides {
+            shard {
+              name
             }
+            imageRef
+            disabled
+            resources {
+              ... DeployResourcesFields
+            }
+            subSharding {
+              strategy
+              ... on StaticSubSharding_v1 {
+                shards
+              }
+            }
+          }
         }
-
 
         ... on AWSAccountSharding_v1 {
-            shardSpecOverrides {
-              shard {
-                name
-                disable {
-                  integrations
-                }
-              }
-              imageRef
-              disabled
-              resources {
-                ... DeployResourcesFields
+          shardSpecOverrides {
+            shard {
+              name
+              disable {
+                integrations
               }
             }
+            imageRef
+            disabled
+            resources {
+              ... DeployResourcesFields
+            }
+          }
         }
 
+        ... on AWSTGWAccountSharding_v1 {
+          shardSpecOverrides {
+            shard {
+              name
+              disable {
+                integrations
+              }
+            }
+            imageRef
+            disabled
+            resources {
+              ... DeployResourcesFields
+            }
+          }
+        }
 
         ... on CloudflareDNSZoneSharding_v1 {
           shardSpecOverrides {
@@ -299,6 +313,32 @@ class AWSAccountShardingV1(IntegrationShardingV1):
     )
 
 
+class AWSTGWAccountShardSpecOverrideV1_AWSAccountV1_DisableClusterAutomationsV1(
+    ConfiguredBaseModel
+):
+    integrations: Optional[list[str]] = Field(..., alias="integrations")
+
+
+class AWSTGWAccountShardSpecOverrideV1_AWSAccountV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+    disable: Optional[
+        AWSTGWAccountShardSpecOverrideV1_AWSAccountV1_DisableClusterAutomationsV1
+    ] = Field(..., alias="disable")
+
+
+class AWSTGWAccountShardSpecOverrideV1(ConfiguredBaseModel):
+    shard: AWSTGWAccountShardSpecOverrideV1_AWSAccountV1 = Field(..., alias="shard")
+    image_ref: Optional[str] = Field(..., alias="imageRef")
+    disabled: Optional[bool] = Field(..., alias="disabled")
+    resources: Optional[DeployResourcesFields] = Field(..., alias="resources")
+
+
+class AWSTGWAccountShardingV1(IntegrationShardingV1):
+    shard_spec_overrides: Optional[list[AWSTGWAccountShardSpecOverrideV1]] = Field(
+        ..., alias="shardSpecOverrides"
+    )
+
+
 class CloudflareDnsZoneV1(ConfiguredBaseModel):
     zone: str = Field(..., alias="zone")
     identifier: str = Field(..., alias="identifier")
@@ -325,6 +365,7 @@ class IntegrationManagedV1(ConfiguredBaseModel):
             StaticShardingV1,
             OpenshiftClusterShardingV1,
             AWSAccountShardingV1,
+            AWSTGWAccountShardingV1,
             CloudflareDNSZoneShardingV1,
             IntegrationShardingV1,
         ]

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -23493,6 +23493,11 @@
                             "kind": "OBJECT",
                             "name": "AWSAccountSharding_v1",
                             "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "AWSTGWAccountSharding_v1",
+                            "ofType": null
                         }
                     ]
                 },
@@ -39291,6 +39296,122 @@
                 {
                     "kind": "OBJECT",
                     "name": "AWSAccountShardSpecOverride_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "shard",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "AWSAccount_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "imageRef",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "resources",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "DeployResources_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "disabled",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "AWSTGWAccountSharding_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "strategy",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "shardSpecOverrides",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "AWSTGWAccountShardSpecOverride_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "IntegrationSharding_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "AWSTGWAccountShardSpecOverride_v1",
                     "description": null,
                     "fields": [
                         {

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -19,14 +19,14 @@ from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.gql_definitions.integrations.integrations import (
     AWSAccountShardSpecOverrideV1,
     AWSTGWAccountShardingV1,
+    AWSTGWAccountShardSpecOverrideV1,
+    AWSTGWAccountShardSpecOverrideV1_AWSAccountV1,
     EnvironmentV1,
     IntegrationSpecV1,
     IntegrationV1,
     OpenshiftClusterShardSpecOverrideV1,
     OpenshiftClusterShardSpecOverrideV1_ClusterV1,
     StaticSubShardingV1,
-    AWSTGWAccountShardSpecOverrideV1,
-    AWSTGWAccountShardSpecOverrideV1_AWSAccountV1,
 )
 from reconcile.gql_definitions.sharding import aws_accounts as sharding_aws_accounts
 from reconcile.gql_definitions.terraform_cloudflare_dns.terraform_cloudflare_zones import (
@@ -352,7 +352,7 @@ def aws_tgw_account_with_disable_integration(
 
 
 @pytest.fixture
-def mock_aws_tgw_repository() -> AWSTGWRepository:
+def mock_aws_tgw_repository() -> Any:
     return create_autospec(AWSTGWRepository)
 
 
@@ -505,7 +505,7 @@ def test_shard_manager_aws_account_filtering(
 ):
     assert ["acc-1", "acc-2", "acc-3", "acc-4"] == [
         a.name
-        for a in aws_account_sharding_strategy.filter_objects("another-integration")
+        for a in aws_account_sharding_strategy.filter_accounts("another-integration")
     ]
 
 
@@ -514,7 +514,7 @@ def test_shard_manager_aws_account_filtering_disabled(
 ):
     # acc-4 is disabled for AWS_INTEGRATION
     assert ["acc-1", "acc-2", "acc-3"] == [
-        a.name for a in aws_account_sharding_strategy.filter_objects(AWS_INTEGRATION)
+        a.name for a in aws_account_sharding_strategy.filter_accounts(AWS_INTEGRATION)
     ]
 
 
@@ -971,7 +971,7 @@ def test_initialize_shard_specs_openshift_clusters_disabled_shard(
 def test_initialize_shard_specs_aws_tgw_account_shards(
     basic_integration: IntegrationV1,
     shard_manager: IntegrationShardManager,
-    mock_aws_tgw_repository: AWSTGWRepository,
+    mock_aws_tgw_repository: Any,
     aws_tgw_account_with_no_disable: aws_tgw_accounts.AWSAccountV1,
     aws_tgw_account_with_disable_none: aws_tgw_accounts.AWSAccountV1,
     aws_tgw_account_with_disable_empty: aws_tgw_accounts.AWSAccountV1,
@@ -980,7 +980,6 @@ def test_initialize_shard_specs_aws_tgw_account_shards(
     aws_tgw_acc_sharding = AWSTGWAccountShardingV1(
         strategy="per-aws-tgw-account", shardSpecOverrides=None
     )
-
     mock_aws_tgw_repository.get_tgw_clusters_and_accounts.return_value = (
         AWSTGWClustersAndAccounts(
             clusters=[],
@@ -1082,7 +1081,7 @@ def aws_tgw_account_with_disable_empty_shard_overrides(
 def test_initialize_shard_specs_aws_tgw_account_shards_with_overrides(
     basic_integration: IntegrationV1,
     shard_manager: IntegrationShardManager,
-    mock_aws_tgw_repository: AWSTGWRepository,
+    mock_aws_tgw_repository: Any,
     aws_tgw_account_with_no_disable: aws_tgw_accounts.AWSAccountV1,
     aws_tgw_account_with_disable_none: aws_tgw_accounts.AWSAccountV1,
     aws_tgw_account_with_disable_empty: aws_tgw_accounts.AWSAccountV1,

--- a/reconcile/test/test_utils_aws_tgw_repository.py
+++ b/reconcile/test/test_utils_aws_tgw_repository.py
@@ -1,0 +1,589 @@
+from collections.abc import (
+    Callable,
+    Iterable,
+)
+from typing import (
+    Optional,
+    Union,
+)
+from unittest.mock import create_autospec
+
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.gql_definitions.common.clusters_with_peering import (
+    ClusterPeeringConnectionAccountTGWV1,
+    ClusterPeeringConnectionAccountTGWV1_AWSAccountV1,
+    ClusterPeeringConnectionAccountV1,
+    ClusterPeeringConnectionAccountVPCMeshV1,
+    ClusterPeeringConnectionClusterRequesterV1,
+    ClusterPeeringConnectionV1,
+    ClusterPeeringV1,
+    ClusterV1,
+)
+from reconcile.gql_definitions.terraform_tgw_attachments.aws_accounts import (
+    AWSAccountV1,
+)
+from reconcile.utils.aws_tgw_repository import (
+    AWSTGWClustersAndAccounts,
+    AWSTGWRepository,
+)
+from reconcile.utils.gql import GqlApi
+
+
+@pytest.fixture
+def account_builder(
+    gql_class_factory: Callable[..., AWSAccountV1],
+) -> Callable[..., AWSAccountV1]:
+    def builder(
+        name: str,
+        uid: str,
+        terraform_username: str,
+    ) -> AWSAccountV1:
+        return gql_class_factory(
+            AWSAccountV1,
+            {
+                "name": name,
+                "uid": uid,
+                "terraformUsername": terraform_username,
+                "accountOwners": [],
+                "automationToken": {},
+                "premiumSupport": False,
+            },
+        )
+
+    return builder
+
+
+@pytest.fixture
+def connection_account_builder(
+    gql_class_factory: Callable[..., ClusterPeeringConnectionAccountTGWV1_AWSAccountV1],
+) -> Callable[..., ClusterPeeringConnectionAccountTGWV1_AWSAccountV1]:
+    def builder(
+        name: str,
+        uid: str,
+        terraform_username: str,
+    ) -> ClusterPeeringConnectionAccountTGWV1_AWSAccountV1:
+        return gql_class_factory(
+            ClusterPeeringConnectionAccountTGWV1_AWSAccountV1,
+            {
+                "name": name,
+                "uid": uid,
+                "terraformUsername": terraform_username,
+                "automationToken": {},
+            },
+        )
+
+    return builder
+
+
+@pytest.fixture
+def tgw_account(account_builder: Callable[..., AWSAccountV1]) -> AWSAccountV1:
+    return account_builder(
+        name="tgw_account",
+        uid="tgw-account-uid",
+        terraform_username="tgw-account-terraform-username",
+    )
+
+
+@pytest.fixture
+def tgw_connection_account(
+    connection_account_builder: Callable[
+        ..., ClusterPeeringConnectionAccountTGWV1_AWSAccountV1
+    ],
+    tgw_account: AWSAccountV1,
+) -> ClusterPeeringConnectionAccountTGWV1_AWSAccountV1:
+    return connection_account_builder(
+        name=tgw_account.name,
+        uid=tgw_account.uid,
+        terraform_username=tgw_account.terraform_username,
+    )
+
+
+@pytest.fixture
+def vpc_account(account_builder: Callable[..., AWSAccountV1]) -> AWSAccountV1:
+    return account_builder(
+        name="vpc_account",
+        uid="vpc-account-uid",
+        terraform_username="vpc-account-terraform-username",
+    )
+
+
+@pytest.fixture
+def vpc_connection_account(
+    connection_account_builder: Callable[
+        ..., ClusterPeeringConnectionAccountTGWV1_AWSAccountV1
+    ],
+    vpc_account: AWSAccountV1,
+) -> ClusterPeeringConnectionAccountTGWV1_AWSAccountV1:
+    return connection_account_builder(
+        name=vpc_account.name,
+        uid=vpc_account.uid,
+        terraform_username=vpc_account.terraform_username,
+    )
+
+
+@pytest.fixture
+def additional_tgw_account(
+    account_builder: Callable[..., AWSAccountV1]
+) -> AWSAccountV1:
+    return account_builder(
+        name="additional_tgw_account",
+        uid="additional_tgw-account-uid",
+        terraform_username="additional_tgw-account-terraform-username",
+    )
+
+
+@pytest.fixture
+def additional_tgw_connection_account(
+    connection_account_builder: Callable[
+        ..., ClusterPeeringConnectionAccountTGWV1_AWSAccountV1
+    ],
+    additional_tgw_account: AWSAccountV1,
+) -> ClusterPeeringConnectionAccountTGWV1_AWSAccountV1:
+    return connection_account_builder(
+        name=additional_tgw_account.name,
+        uid=additional_tgw_account.uid,
+        terraform_username=additional_tgw_account.terraform_username,
+    )
+
+
+@pytest.fixture
+def peering_connection_builder(
+    gql_class_factory: Callable[..., ClusterPeeringConnectionAccountTGWV1],
+) -> Callable[..., ClusterPeeringConnectionAccountTGWV1]:
+    def builder(
+        name: str,
+        provider: str,
+        manage_routes: bool = False,
+        account: Optional[ClusterPeeringConnectionAccountTGWV1_AWSAccountV1] = None,
+        assume_role: Optional[str] = None,
+        cidr_block: Optional[str] = None,
+        delete: Optional[bool] = None,
+    ) -> ClusterPeeringConnectionAccountTGWV1:
+        return gql_class_factory(
+            ClusterPeeringConnectionAccountTGWV1,
+            {
+                "name": name,
+                "provider": provider,
+                "manageRoutes": manage_routes,
+                "account": account.dict(by_alias=True) if account is not None else None,
+                "assumeRole": assume_role,
+                "cidrBlock": cidr_block,
+                "delete": delete,
+            },
+        )
+
+    return builder
+
+
+@pytest.fixture
+def account_tgw_connection(
+    peering_connection_builder: Callable[..., ClusterPeeringConnectionAccountTGWV1],
+    tgw_connection_account: ClusterPeeringConnectionAccountTGWV1_AWSAccountV1,
+) -> ClusterPeeringConnectionAccountTGWV1:
+    return peering_connection_builder(
+        name="account_tgw_connection",
+        provider="account-tgw",
+        manage_routes=True,
+        account=tgw_connection_account,
+        assume_role=None,
+        cidr_block="172.16.0.0/16",
+        delete=False,
+    )
+
+
+@pytest.fixture
+def additional_account_tgw_connection(
+    peering_connection_builder: Callable[..., ClusterPeeringConnectionAccountTGWV1],
+    additional_tgw_connection_account: ClusterPeeringConnectionAccountTGWV1_AWSAccountV1,
+) -> ClusterPeeringConnectionAccountTGWV1:
+    return peering_connection_builder(
+        name="additional_account_tgw_connection",
+        provider="account-tgw",
+        manage_routes=True,
+        account=additional_tgw_connection_account,
+        assume_role=None,
+        cidr_block="172.16.0.0/16",
+        delete=False,
+    )
+
+
+@pytest.fixture
+def account_vpc_connection(
+    peering_connection_builder: Callable[..., ClusterPeeringConnectionAccountTGWV1],
+    vpc_connection_account: ClusterPeeringConnectionAccountTGWV1_AWSAccountV1,
+) -> ClusterPeeringConnectionAccountTGWV1:
+    return peering_connection_builder(
+        name="account_vpc_connection",
+        provider="account-vpc",
+        account=vpc_connection_account,
+    )
+
+
+@pytest.fixture
+def cluster_builder(
+    gql_class_factory: Callable[..., ClusterV1],
+) -> Callable[..., ClusterV1]:
+    def builder(
+        name: str,
+        ocm: dict,
+        region: str,
+        vpc_cidr: str,
+        peering: ClusterPeeringV1,
+    ) -> ClusterV1:
+        return gql_class_factory(
+            ClusterV1,
+            {
+                "name": name,
+                "ocm": ocm,
+                "spec": {
+                    "region": region,
+                },
+                "network": {"vpc": vpc_cidr},
+                "peering": peering,
+            },
+        )
+
+    return builder
+
+
+@pytest.fixture
+def peering_builder(
+    gql_class_factory: Callable[..., ClusterPeeringV1],
+) -> Callable[..., ClusterPeeringV1]:
+    def builder(
+        connections: list[
+            Union[
+                ClusterPeeringConnectionAccountTGWV1,
+                ClusterPeeringConnectionAccountV1,
+                ClusterPeeringConnectionAccountVPCMeshV1,
+                ClusterPeeringConnectionClusterRequesterV1,
+                ClusterPeeringConnectionV1,
+            ]
+        ]
+    ) -> ClusterPeeringV1:
+        return gql_class_factory(
+            ClusterPeeringV1,
+            {
+                "connections": connections,
+            },
+        )
+
+    return builder
+
+
+@pytest.fixture
+def cluster_with_tgw_connection(
+    cluster_builder: Callable[..., ClusterV1],
+    peering_builder: Callable[..., ClusterPeeringV1],
+    account_tgw_connection: ClusterPeeringConnectionAccountTGWV1,
+) -> ClusterV1:
+    return cluster_builder(
+        name="cluster_with_tgw_connection",
+        ocm={
+            "name": "cluster_with_tgw_connection-ocm",
+            "environment": {"accessTokenClientSecret": {}},
+        },
+        region="us-east-1",
+        vpc_cidr="10.0.0.0/16",
+        peering=peering_builder(
+            [
+                account_tgw_connection,
+            ]
+        ),
+    )
+
+
+@pytest.fixture
+def cluster_with_2_tgw_connections(
+    cluster_builder: Callable[..., ClusterV1],
+    peering_builder: Callable[..., ClusterPeeringV1],
+    account_tgw_connection: ClusterPeeringConnectionAccountTGWV1,
+    additional_account_tgw_connection: ClusterPeeringConnectionAccountTGWV1,
+) -> ClusterV1:
+    return cluster_builder(
+        name="cluster_with_2_tgw_connections",
+        ocm={
+            "name": "cluster_with_2_tgw_connections-ocm",
+            "environment": {"accessTokenClientSecret": {}},
+        },
+        region="us-east-1",
+        vpc_cidr="10.0.0.0/16",
+        peering=peering_builder(
+            [
+                account_tgw_connection,
+                additional_account_tgw_connection,
+            ]
+        ),
+    )
+
+
+@pytest.fixture
+def additional_cluster_with_tgw_connection(
+    cluster_builder: Callable[..., ClusterV1],
+    peering_builder: Callable[..., ClusterPeeringV1],
+    additional_account_tgw_connection: ClusterPeeringConnectionAccountTGWV1,
+) -> ClusterV1:
+    return cluster_builder(
+        name="additional_cluster_with_tgw_connection",
+        ocm={
+            "name": "additional_cluster_with_tgw_connection-ocm",
+            "environment": {"accessTokenClientSecret": {}},
+        },
+        region="us-east-1",
+        vpc_cidr="10.0.0.0/16",
+        peering=peering_builder(
+            [
+                additional_account_tgw_connection,
+            ]
+        ),
+    )
+
+
+@pytest.fixture
+def cluster_with_duplicate_tgw_connections(
+    cluster_builder: Callable[..., ClusterV1],
+    peering_builder: Callable[..., ClusterPeeringV1],
+    account_tgw_connection: ClusterPeeringConnectionAccountTGWV1,
+) -> ClusterV1:
+    return cluster_builder(
+        name="cluster_with_duplicate_tgw_connections",
+        ocm={
+            "name": "cluster_with_duplicate_tgw_connections-ocm",
+            "environment": {"accessTokenClientSecret": {}},
+        },
+        region="us-east-1",
+        vpc_cidr="10.0.0.0/16",
+        peering=peering_builder(
+            [
+                account_tgw_connection,
+                account_tgw_connection,
+            ]
+        ),
+    )
+
+
+@pytest.fixture
+def cluster_with_vpc_connection(
+    cluster_builder: Callable[..., ClusterV1],
+    peering_builder: Callable[..., ClusterPeeringV1],
+    account_vpc_connection: ClusterPeeringConnectionAccountTGWV1,
+) -> ClusterV1:
+    return cluster_builder(
+        name="cluster_with_vpc_connection",
+        ocm={
+            "name": "cluster_with_vpc_connection-ocm",
+            "environment": {"accessTokenClientSecret": {}},
+        },
+        region="us-east-1",
+        vpc_cidr="10.0.0.1/16",
+        peering=peering_builder(
+            [
+                account_vpc_connection,
+            ]
+        ),
+    )
+
+
+@pytest.fixture
+def cluster_with_mixed_connections(
+    cluster_builder: Callable[..., ClusterV1],
+    peering_builder: Callable[..., ClusterPeeringV1],
+    account_tgw_connection: ClusterPeeringConnectionAccountTGWV1,
+    account_vpc_connection: ClusterPeeringConnectionAccountTGWV1,
+) -> ClusterV1:
+    return cluster_builder(
+        name="cluster_with_mixed_connections",
+        ocm={
+            "name": "cluster_with_mixed_connections-ocm",
+            "environment": {"accessTokenClientSecret": {}},
+        },
+        region="us-east-1",
+        vpc_cidr="10.0.0.2/16",
+        peering=peering_builder(
+            [
+                account_tgw_connection,
+                account_vpc_connection,
+            ]
+        ),
+    )
+
+
+def _setup_mocks(
+    mocker: MockerFixture,
+    clusters: Optional[Iterable[ClusterV1]] = None,
+    accounts: Optional[Iterable[AWSAccountV1]] = None,
+) -> dict:
+    mocked_gql_api = create_autospec(GqlApi)
+    mocker.patch(
+        "reconcile.utils.aws_tgw_repository.gql"
+    ).get_api.return_value = mocked_gql_api
+
+    mocked_get_clusters_with_peering = mocker.patch(
+        "reconcile.utils.aws_tgw_repository.get_clusters_with_peering"
+    )
+    mocked_get_clusters_with_peering.return_value = clusters or []
+
+    mocked_get_aws_accounts = mocker.patch(
+        "reconcile.utils.aws_tgw_repository.get_aws_accounts"
+    )
+    mocked_get_aws_accounts.return_value = accounts or []
+
+    return {
+        "get_aws_accounts": mocked_get_aws_accounts,
+        "get_clusters_with_peering": mocked_get_clusters_with_peering,
+        "gql_api": mocked_gql_api,
+    }
+
+
+def test_get_tgw_clusters_and_accounts_when_cluster_with_tgw_connection(
+    mocker: MockerFixture,
+    cluster_with_tgw_connection: ClusterV1,
+    account_tgw_connection: ClusterPeeringConnectionAccountTGWV1,
+    tgw_account: AWSAccountV1,
+) -> None:
+    mocks = _setup_mocks(
+        mocker,
+        clusters=[cluster_with_tgw_connection],
+        accounts=[tgw_account],
+    )
+    repo = AWSTGWRepository(mocks["gql_api"])
+
+    result = repo.get_tgw_clusters_and_accounts()
+
+    expected_result = AWSTGWClustersAndAccounts(
+        clusters=[cluster_with_tgw_connection],
+        accounts=[tgw_account],
+    )
+    assert result == expected_result
+    mocks["get_clusters_with_peering"].assert_called_once_with(mocks["gql_api"])
+    mocks["get_aws_accounts"].assert_called_once_with(mocks["gql_api"], name=None)
+
+
+def test_get_tgw_clusters_and_accounts_when_cluster_with_mixed_connections(
+    mocker: MockerFixture,
+    cluster_with_mixed_connections: ClusterV1,
+    account_tgw_connection: ClusterPeeringConnectionAccountTGWV1,
+    tgw_account: AWSAccountV1,
+    vpc_account: AWSAccountV1,
+) -> None:
+    mocks = _setup_mocks(
+        mocker,
+        clusters=[cluster_with_mixed_connections],
+        accounts=[tgw_account, vpc_account],
+    )
+    repo = AWSTGWRepository(mocks["gql_api"])
+
+    result = repo.get_tgw_clusters_and_accounts()
+
+    expected_result = AWSTGWClustersAndAccounts(
+        clusters=[cluster_with_mixed_connections],
+        accounts=[tgw_account],
+    )
+    assert result == expected_result
+    mocks["get_clusters_with_peering"].assert_called_once_with(mocks["gql_api"])
+    mocks["get_aws_accounts"].assert_called_once_with(mocks["gql_api"], name=None)
+
+
+def test_get_tgw_clusters_and_accounts_when_cluster_with_vpc_connection_only(
+    mocker: MockerFixture,
+    cluster_with_vpc_connection: ClusterV1,
+    vpc_account: AWSAccountV1,
+) -> None:
+    mocks = _setup_mocks(
+        mocker,
+        clusters=[cluster_with_vpc_connection],
+        accounts=[vpc_account],
+    )
+    repo = AWSTGWRepository(mocks["gql_api"])
+
+    result = repo.get_tgw_clusters_and_accounts()
+
+    expected_result = AWSTGWClustersAndAccounts(
+        clusters=[],
+        accounts=[],
+    )
+    assert result == expected_result
+    mocks["get_clusters_with_peering"].assert_called_once_with(mocks["gql_api"])
+    mocks["get_aws_accounts"].assert_called_once_with(mocks["gql_api"], name=None)
+
+
+def test_get_tgw_clusters_and_accounts_with_multiple_clusters(
+    mocker: MockerFixture,
+    cluster_with_tgw_connection: ClusterV1,
+    cluster_with_vpc_connection: ClusterV1,
+    account_tgw_connection: ClusterPeeringConnectionAccountTGWV1,
+    account_vpc_connection: ClusterPeeringConnectionAccountTGWV1,
+    tgw_account: AWSAccountV1,
+    vpc_account: AWSAccountV1,
+) -> None:
+    mocks = _setup_mocks(
+        mocker,
+        clusters=[cluster_with_tgw_connection, cluster_with_vpc_connection],
+        accounts=[tgw_account, vpc_account],
+    )
+    repo = AWSTGWRepository(mocks["gql_api"])
+
+    result = repo.get_tgw_clusters_and_accounts()
+
+    expected_result = AWSTGWClustersAndAccounts(
+        clusters=[cluster_with_tgw_connection],
+        accounts=[tgw_account],
+    )
+    assert result == expected_result
+    mocks["get_clusters_with_peering"].assert_called_once_with(mocks["gql_api"])
+    mocks["get_aws_accounts"].assert_called_once_with(mocks["gql_api"], name=None)
+
+
+def test_get_tgw_clusters_and_accounts_with_account_name_for_multiple_clusters(
+    mocker: MockerFixture,
+    cluster_with_tgw_connection: ClusterV1,
+    additional_cluster_with_tgw_connection: ClusterV1,
+    account_tgw_connection: ClusterPeeringConnectionAccountTGWV1,
+    tgw_account: AWSAccountV1,
+) -> None:
+    mocks = _setup_mocks(
+        mocker,
+        clusters=[cluster_with_tgw_connection, additional_cluster_with_tgw_connection],
+        accounts=[tgw_account],
+    )
+    repo = AWSTGWRepository(mocks["gql_api"])
+
+    result = repo.get_tgw_clusters_and_accounts(tgw_account.name)
+
+    expected_result = AWSTGWClustersAndAccounts(
+        clusters=[cluster_with_tgw_connection],
+        accounts=[tgw_account],
+    )
+    assert result == expected_result
+    mocks["get_clusters_with_peering"].assert_called_once_with(mocks["gql_api"])
+    mocks["get_aws_accounts"].assert_called_once_with(
+        mocks["gql_api"], name=tgw_account.name
+    )
+
+
+def test_get_tgw_clusters_and_accounts_with_account_name_for_multiple_connections(
+    mocker: MockerFixture,
+    cluster_with_2_tgw_connections: ClusterV1,
+    account_tgw_connection: ClusterPeeringConnectionAccountTGWV1,
+    tgw_account: AWSAccountV1,
+) -> None:
+    mocks = _setup_mocks(
+        mocker,
+        clusters=[cluster_with_2_tgw_connections],
+        accounts=[tgw_account],
+    )
+    repo = AWSTGWRepository(mocks["gql_api"])
+
+    result = repo.get_tgw_clusters_and_accounts(tgw_account.name)
+
+    expected_result = AWSTGWClustersAndAccounts(
+        clusters=[cluster_with_2_tgw_connections],
+        accounts=[tgw_account],
+    )
+    assert result == expected_result
+    mocks["get_clusters_with_peering"].assert_called_once_with(mocks["gql_api"])
+    mocks["get_aws_accounts"].assert_called_once_with(
+        mocks["gql_api"], name=tgw_account.name
+    )

--- a/reconcile/utils/aws_tgw_repository.py
+++ b/reconcile/utils/aws_tgw_repository.py
@@ -1,0 +1,104 @@
+from typing import (
+    Iterable,
+    Optional,
+    Union,
+    cast,
+)
+
+from pydantic.main import BaseModel
+
+from reconcile.gql_definitions.common.clusters_with_peering import (
+    ClusterPeeringConnectionAccountTGWV1,
+    ClusterPeeringConnectionAccountV1,
+    ClusterPeeringConnectionAccountVPCMeshV1,
+    ClusterPeeringConnectionClusterRequesterV1,
+    ClusterPeeringConnectionV1,
+    ClusterV1,
+)
+from reconcile.gql_definitions.terraform_tgw_attachments.aws_accounts import (
+    AWSAccountV1,
+)
+from reconcile.typed_queries.clusters_with_peering import get_clusters_with_peering
+from reconcile.typed_queries.terraform_tgw_attachments.aws_accounts import (
+    get_aws_accounts,
+)
+from reconcile.utils import gql
+
+TGW_CONNECTION_PROVIDER = "account-tgw"
+
+
+class AWSTGWClustersAndAccounts(BaseModel):
+    clusters: list[ClusterV1]
+    accounts: list[AWSAccountV1]
+
+
+class AWSTGWRepository:
+    def __init__(self, gql_api: gql.GqlApi) -> None:
+        self.gql_api = gql_api
+
+    def get_tgw_clusters_and_accounts(
+        self,
+        account_name: Optional[str] = None,
+    ) -> AWSTGWClustersAndAccounts:
+        clusters = get_clusters_with_peering(self.gql_api)
+        tgw_clusters = self._filter_tgw_clusters(clusters, account_name)
+        accounts = get_aws_accounts(self.gql_api, name=account_name)
+        tgw_accounts = self._filter_tgw_accounts(accounts, tgw_clusters)
+        return AWSTGWClustersAndAccounts(
+            clusters=tgw_clusters,
+            accounts=tgw_accounts,
+        )
+
+    @staticmethod
+    def is_tgw_peer_connection(
+        peer_connection: Union[
+            ClusterPeeringConnectionAccountTGWV1,
+            ClusterPeeringConnectionAccountV1,
+            ClusterPeeringConnectionAccountVPCMeshV1,
+            ClusterPeeringConnectionClusterRequesterV1,
+            ClusterPeeringConnectionV1,
+        ],
+        account_name: Optional[str],
+    ) -> bool:
+        if peer_connection.provider != TGW_CONNECTION_PROVIDER:
+            return False
+        if account_name is None:
+            return True
+        tgw_peer_connection = cast(
+            ClusterPeeringConnectionAccountTGWV1, peer_connection
+        )
+        return tgw_peer_connection.account.name == account_name
+
+    @staticmethod
+    def _is_tgw_cluster(
+        cluster: ClusterV1,
+        account_name: Optional[str] = None,
+    ) -> bool:
+        return any(
+            AWSTGWRepository.is_tgw_peer_connection(pc, account_name)
+            for pc in cluster.peering.connections  # type: ignore[union-attr]
+        )
+
+    @staticmethod
+    def _filter_tgw_clusters(
+        clusters: Iterable[ClusterV1],
+        account_name: Optional[str] = None,
+    ) -> list[ClusterV1]:
+        return [
+            c for c in clusters if AWSTGWRepository._is_tgw_cluster(c, account_name)
+        ]
+
+    @staticmethod
+    def _filter_tgw_accounts(
+        accounts: Iterable[AWSAccountV1],
+        tgw_clusters: Iterable[ClusterV1],
+    ) -> list[AWSAccountV1]:
+        tgw_account_names = set()
+        for cluster in tgw_clusters:
+            for peer_connection in cluster.peering.connections:  # type: ignore[union-attr]
+                if peer_connection.provider == TGW_CONNECTION_PROVIDER:
+                    tgw_peer_connection = cast(
+                        ClusterPeeringConnectionAccountTGWV1, peer_connection
+                    )
+                    tgw_account_names.add(tgw_peer_connection.account.name)
+        return [a for a in accounts if a.name in tgw_account_names]

--- a/reconcile/utils/helm.py
+++ b/reconcile/utils/helm.py
@@ -1,6 +1,7 @@
 import json
 import tempfile
 from collections.abc import Mapping
+from os.path import dirname
 from subprocess import (
     PIPE,
     CalledProcessError,
@@ -29,6 +30,7 @@ def template(values: Mapping[str, Any]) -> Mapping[str, Any]:
         with tempfile.NamedTemporaryFile(mode="w+") as values_file:
             values_file.write(json.dumps(values, cls=JSONEncoder))
             values_file.flush()
+            repo_root = dirname(dirname(dirname(__file__)))
             cmd = [
                 "helm",
                 "template",
@@ -38,7 +40,7 @@ def template(values: Mapping[str, Any]) -> Mapping[str, Any]:
                 "-f",
                 values_file.name,
             ]
-            result = run(cmd, stdout=PIPE, stderr=PIPE, check=True)
+            result = run(cmd, stdout=PIPE, stderr=PIPE, check=True, cwd=repo_root)
     except CalledProcessError as e:
         msg = f'Error running helm template [{" ".join(cmd)}]'
         if e.stdout:


### PR DESCRIPTION
New sharding strategy, very similar to `per-aws-account`, but will filter only accounts with transit gateway. This will allow `terraform-tgw-attachments` integration to skip deployment for aws accounts without tgw. This can save some resource because `terraform-tgw-attachments` has a large memory limit due to some large account.

[APPSRE-7624](https://issues.redhat.com/browse/APPSRE-7624)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f0c908f</samp>

This pull request adds a new feature to shard AWS TGW accounts based on a spec override, and refactors some existing code to support it. It also fixes a working directory issue in the `helm.py` module and removes some extra blank lines from the `integrations.gql` file. The main changes are in the `integrations_manager.py`, `terraform_tgw_attachments.py`, `test_integrations_manager.py`, `sharding.py`, and `aws_tgw_repository.py` files.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f0c908f</samp>

*  Add a new module `aws_tgw_repository.py` with utility classes for fetching and filtering AWS TGW clusters and accounts ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-cbce79f28c296529a5c6734d639c93b8b931760d8fa58a7b763440618d196254R1-R104))
*  Add class definitions for the new `AWSTGWAccountShardingV1` and related models, which represent the sharding configuration for AWS TGW accounts ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-c9e6324625ac71b88d96b8973b435bb20caa237df38709e9bfd0da7dafbc4c31R316-R341), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-261fe097cb43d519f3ea989a4b61770e7c7417547fbdf9e2ab9c00c163b06c9dR16-R17), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-261fe097cb43d519f3ea989a4b61770e7c7417547fbdf9e2ab9c00c163b06c9dR52))
*  Add the `AWSTGWAccountShardingStrategy` class, which is a sharding strategy implementation for AWS TGW accounts ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-261fe097cb43d519f3ea989a4b61770e7c7417547fbdf9e2ab9c00c163b06c9dR231-R262), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-d5e967e5df7cec08ff893257386f7d7f46f31762c4b8c17f08f0fa0cfc5737abR46), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-d5e967e5df7cec08ff893257386f7d7f46f31762c4b8c17f08f0fa0cfc5737abR249-R251), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-a4da4e19b0266c0ccae4f390df073c2b3422687eee329fa450fd9223e8a76601R53), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-a4da4e19b0266c0ccae4f390df073c2b3422687eee329fa450fd9223e8a76601R466), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-a4da4e19b0266c0ccae4f390df073c2b3422687eee329fa450fd9223e8a76601R475))
*  Add the `build_shard_spec` static method to the `AWSAccountShardingStrategy` class, which constructs a `ShardSpec` object from an AWS account, an integration spec, and an optional shard spec override ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-261fe097cb43d519f3ea989a4b61770e7c7417547fbdf9e2ab9c00c163b06c9dL141-R222))
*  Add the `AWSTGWAccountShardingV1` class to the `IntegrationManagedV1` class, which represents the managed configuration for an integration ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-c9e6324625ac71b88d96b8973b435bb20caa237df38709e9bfd0da7dafbc4c31R368))
*  Add some test cases for the `AWSTGWAccountShardingStrategy` class and its methods, to verify the expected behavior and functionality of the AWS TGW account sharding feature ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-a4da4e19b0266c0ccae4f390df073c2b3422687eee329fa450fd9223e8a76601R971-R1166))
*  Add some fixtures and helper functions for creating and mocking AWS TGW accounts and shard spec overrides, to support the new test cases ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-a4da4e19b0266c0ccae4f390df073c2b3422687eee329fa450fd9223e8a76601R296-R366))
*  Add some import statements for the `AWSTGWRepository` and related classes, to use them in the `integrations_manager.py` and `terraform_tgw_attachments.py` modules and the test cases ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-d5e967e5df7cec08ff893257386f7d7f46f31762c4b8c17f08f0fa0cfc5737abR36), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-a4da4e19b0266c0ccae4f390df073c2b3422687eee329fa450fd9223e8a76601R21-R23), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-a4da4e19b0266c0ccae4f390df073c2b3422687eee329fa450fd9223e8a76601L33-R47))
*  Add some import statements for the `Optional` and `create_autospec` functions, to use them in the new test cases ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-a4da4e19b0266c0ccae4f390df073c2b3422687eee329fa450fd9223e8a76601L7-R11))
*  Add the `AWS_TGW_INTEGRATION` meta to the `integration_runtime_meta` fixture, to use it in the new test cases ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-a4da4e19b0266c0ccae4f390df073c2b3422687eee329fa450fd9223e8a76601R488-R490))
*  Add the `AWS_TGW_INTEGRATION` constant to the `test_integrations_manager.py` module, to use it in the new test cases ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-a4da4e19b0266c0ccae4f390df073c2b3422687eee329fa450fd9223e8a76601R65))
*  Replace the `_is_tgw_peer_connection` function call with the `AWSTGWRepository.is_tgw_peer_connection` function call in the `_build_desired_state_items` function of the `terraform_tgw_attachments.py` module, as the former function is moved to the latter class ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L132-R118))
*  Remove the `_is_tgw_peer_connection`, `_is_tgw_cluster`, `_filter_tgw_clusters`, `_filter_tgw_accounts`, and `_fetch_desired_state_data_source` functions from the `terraform_tgw_attachments.py` module, as they are moved to the `AWSTGWRepository` class ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L298-R288))
*  Remove the `ValidationError` and `DesiredStateDataSource` class definitions from the `terraform_tgw_attachments.py` module, as they are not used in this module ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L54-R47), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L97-L101))
*  Remove some unused import statements from the `terraform_tgw_attachments.py` module ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L11), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-b2a48a56ab3feb0903c9b33c5eec954718a01524b0dd49a99d882637bb2cc226L22-R32))
*  Remove some extra blank lines from the `integrations.gql` and `integrations.py` files, to improve readability and consistency ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-9f02cb3e667c19489435601b05cf337c53ee2d4185c7d0a60e5dea0863e2a877L69-R118), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-c9e6324625ac71b88d96b8973b435bb20caa237df38709e9bfd0da7dafbc4c31L123-R172))
*  Assign the `gql_api` variable to avoid calling `gql.get_api()` multiple times in the `run` function of the `integrations_manager.py` module ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-d5e967e5df7cec08ff893257386f7d7f46f31762c4b8c17f08f0fa0cfc5737abL238-R241))
*  Rename the `filter_objects` method to `filter_accounts` in the `AWSAccountShardingStrategy` class and the test case `test_shard_manager_aws_account_filtering_disabled`, as it is more specific and consistent with the `AWSTGWAccountShardingStrategy` class ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-a4da4e19b0266c0ccae4f390df073c2b3422687eee329fa450fd9223e8a76601L416-R508), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-a4da4e19b0266c0ccae4f390df073c2b3422687eee329fa450fd9223e8a76601L425-R517), [link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-261fe097cb43d519f3ea989a4b61770e7c7417547fbdf9e2ab9c00c163b06c9dL195-R277))
*  Add the `cwd` argument to the `run` function call in the `template` function of the `helm.py` module, as it sets the working directory to the repository root path ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-b1dab64139515cc76cf5052912473f2813d58c19c3dd54cac4e718fb7318b637L41-R43))
*  Assign the `repo_root` variable to the repository root path in the `template` function of the `helm.py` module, as it is used as the working directory for the `run` function ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-b1dab64139515cc76cf5052912473f2813d58c19c3dd54cac4e718fb7318b637R33))
*  Add an import statement for the `dirname` function to the `helm.py` module, as it is used to get the repository root path ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-b1dab64139515cc76cf5052912473f2813d58c19c3dd54cac4e718fb7318b637R4))
*  Remove an extra space from the error message in the `check_integration_sharding_params` method of the `OpenshiftClusterShardingStrategy` class, to improve readability and consistency ([link](https://github.com/app-sre/qontract-reconcile/pull/3542/files?diff=unified&w=0#diff-261fe097cb43d519f3ea989a4b61770e7c7417547fbdf9e2ab9c00c163b06c9dL251-R325))