### PR TITLE
[cluster user mgmt] OCM cluster user mgmt based standalone service

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2373,6 +2373,44 @@ def status_page_components(ctx):
 
 
 @integration.command(
+    short_help="Manages OCM cluster usergroups and notifications via OCM labels."
+)
+@click.option(
+    "--ocm-env",
+    help="The OCM environment the integration should operator on. If none is specified, all environments will be operated on.",
+    required=False,
+    envvar="OCM_ENV",
+)
+@click.option(
+    "--ocm-org-ids",
+    help="A comma seperated list of OCM organization IDs the integration should operator on. If none is specified, all organizations are considered.",
+    required=False,
+    envvar="OCM_ORG_IDS",
+)
+@click.option(
+    "--group-provider",
+    help="A group provider spec is the form of <provider-name>:<provider-type>:<provider-args>.",
+    required=False,
+    multiple=True,
+)
+@click.pass_context
+def ocm_standalone_user_management(ctx, ocm_env, ocm_org_ids, group_provider):
+    from reconcile.oum.base import OCMUserManagementIntegrationParams
+    from reconcile.oum.standalone import OCMStandaloneUserManagementIntegration
+
+    run_class_integration(
+        OCMStandaloneUserManagementIntegration(
+            OCMUserManagementIntegrationParams(
+                ocm_environment=ocm_env,
+                ocm_org_ids=ocm_org_ids,
+                group_provider_specs=group_provider,
+            ),
+        ),
+        ctx.obj,
+    )
+
+
+@integration.command(
     short_help="Manages Prometheus Probe resources for blackbox-exporter"
 )
 @threaded()

--- a/reconcile/oum/base.py
+++ b/reconcile/oum/base.py
@@ -1,0 +1,385 @@
+import logging
+from abc import (
+    ABC,
+    abstractmethod,
+)
+from collections import defaultdict
+from typing import Optional
+
+from reconcile.gql_definitions.common.ocm_environments import (
+    query as ocm_environment_query,
+)
+from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
+from reconcile.oum.metrics import (
+    OCMUserManagementOrganizationActionCounter as ReconcileActionCounter,
+)
+from reconcile.oum.metrics import (
+    OCMUserManagementOrganizationReconcileCounter as ReconcileCounter,
+)
+from reconcile.oum.metrics import (
+    OCMUserManagementOrganizationReconcileErrorCounter as ReconcileErrorCounter,
+)
+from reconcile.oum.metrics import (
+    OCMUserManagementOrganizationValidationErrorsGauge as ValidationErrorsGauge,
+)
+from reconcile.oum.models import (
+    ClusterError,
+    ClusterRoleReconcileResult,
+    ClusterUserManagementSpec,
+    OrganizationUserManagementConfiguration,
+)
+from reconcile.oum.providers import (
+    GroupMemberProvider,
+    init_ldap_group_member_provider,
+)
+from reconcile.utils import (
+    gql,
+    metrics,
+)
+from reconcile.utils.ocm.cluster_groups import (
+    OCMClusterGroupId,
+    add_user_to_cluster_group,
+    delete_user_from_cluster_group,
+    get_cluster_groups,
+)
+from reconcile.utils.ocm.clusters import CAPABILITY_MANAGE_CLUSTER_ADMIN
+from reconcile.utils.ocm_base_client import (
+    OCMBaseClient,
+    init_ocm_base_client,
+)
+from reconcile.utils.runtime.integration import (
+    PydanticRunParams,
+    QontractReconcileIntegration,
+)
+
+
+class OCMUserManagementIntegrationParams(PydanticRunParams):
+    ocm_environment: Optional[str] = None
+    ocm_organization_ids: Optional[set[str]] = None
+    group_provider_specs: list[str]
+
+
+class OCMUserManagementIntegration(
+    QontractReconcileIntegration[OCMUserManagementIntegrationParams], ABC
+):
+    def run(self, dry_run: bool) -> None:
+        with metrics.transactional_metrics(self.name):
+            # init group providers
+            self.group_member_providers = get_group_providers(
+                self.params.group_provider_specs
+            )
+
+            for ocm_env in self.get_ocm_environments():
+                self.reconcile_ocm_environment(dry_run, ocm_env)
+
+    @property
+    def group_member_provider_ids(self) -> set[str]:
+        return set(self.group_member_providers.keys())
+
+    def get_ocm_environments(self) -> list[OCMEnvironment]:
+        return ocm_environment_query(
+            gql.get_api().query,
+            variables={"name": self.params.ocm_environment}
+            if self.params.ocm_environment
+            else None,
+        ).environments
+
+    @abstractmethod
+    def get_user_mgmt_config_for_ocm_env(
+        self, ocm_env: OCMEnvironment, org_ids: Optional[set[str]]
+    ) -> dict[str, OrganizationUserManagementConfiguration]:
+        """
+        Discover cluster user mgmt configurations in the given OCM environment.
+        If org_ids are provided, only return configurations for the given organizations.
+
+        To be implemented by subclasses.
+        """
+
+    def reconcile_ocm_environment(self, dry_run: bool, ocm_env: OCMEnvironment) -> None:
+        """
+        Processes user management configuration for all OCM organizations
+        within the given OCM environment.
+        """
+        org_configs = self.get_user_mgmt_config_for_ocm_env(
+            ocm_env, self.params.ocm_organization_ids
+        )
+
+        ocm_api = init_ocm_base_client(ocm_env, self.secret_reader)
+        for org_id, org_config in org_configs.items():
+            specs = build_specs_from_config(org_config, self.group_member_providers)
+            self.reconcile_ocm_organization(
+                dry_run, ocm_api, org_id, ocm_env.name, specs
+            )
+
+    def reconcile_ocm_organization(
+        self,
+        dry_run: bool,
+        ocm_api: OCMBaseClient,
+        org_id: str,
+        ocm_env: str,
+        cluster_specs: list[ClusterUserManagementSpec],
+    ) -> None:
+        """
+        Process user management configuration for all clusters in the
+        given OCM organization.
+        """
+        metrics.inc_counter(
+            ReconcileCounter(
+                integration=self.name,
+                ocm_env=ocm_env,
+                org_id=org_id,
+            )
+        )
+
+        validation_errors = 0
+        errors: list[Exception] = []
+        for spec in cluster_specs:
+            if spec.errors:
+                validation_errors += 1
+                validation_msg = "\n".join([m.message for m in spec.errors])
+                self.signal_cluster_validation_error(
+                    dry_run, ocm_api, spec, Exception(validation_msg)
+                )
+                continue
+            reconcile_result = reconcile_cluster_roles(
+                dry_run=dry_run,
+                ocm_api=ocm_api,
+                org_id=org_id,
+                spec=spec,
+            )
+
+            # expose action metrics
+            # we do this also in error situations to signal partial work
+            # that has been done on a cluster
+            metrics.inc_counter(
+                ReconcileActionCounter(
+                    integration=self.name,
+                    ocm_env=ocm_env,
+                    org_id=org_id,
+                    action=ReconcileActionCounter.Action.AddUser,
+                ),
+                by=reconcile_result.users_added,
+            )
+            metrics.inc_counter(
+                ReconcileActionCounter(
+                    integration=self.name,
+                    ocm_env=ocm_env,
+                    org_id=org_id,
+                    action=ReconcileActionCounter.Action.RemoveUser,
+                ),
+                by=reconcile_result.users_removed,
+            )
+
+            # signal errors
+            if reconcile_result.error:
+                self.signal_cluster_reconcile_error(
+                    dry_run, ocm_api, spec, reconcile_result.error
+                )
+                errors.append(reconcile_result.error)
+
+        # expose organization level metrics
+        metrics.inc_counter(
+            ReconcileErrorCounter(
+                integration=self.name,
+                ocm_env=ocm_env,
+                org_id=org_id,
+            ),
+            by=1 if len(errors) > 0 else 0,
+        )
+        metrics.set_gauge(
+            ValidationErrorsGauge(
+                integration=self.name,
+                ocm_env=ocm_env,
+                org_id=org_id,
+            ),
+            validation_errors,
+        )
+
+    @abstractmethod
+    def signal_cluster_reconcile_success(
+        self,
+        dry_run: bool,
+        ocm_api: OCMBaseClient,
+        spec: ClusterUserManagementSpec,
+        message: str,
+    ) -> None:
+        """
+        This method is called when the cluster reconcile operation was successful.
+        """
+
+    @abstractmethod
+    def signal_cluster_validation_error(
+        self,
+        dry_run: bool,
+        ocm_api: OCMBaseClient,
+        spec: ClusterUserManagementSpec,
+        error: Exception,
+    ) -> None:
+        """
+        This method is called when the configuration for a cluster is invalid.
+
+        If this method throws an exception, reconciliation on the rest of the clusters
+        of an organization will stop.
+        """
+
+    @abstractmethod
+    def signal_cluster_reconcile_error(
+        self,
+        dry_run: bool,
+        ocm_api: OCMBaseClient,
+        spec: ClusterUserManagementSpec,
+        error: Exception,
+    ) -> None:
+        """
+        This method is called when the cluster reconcile operation failed.
+
+        If this method throws an exception, reconciliation on the rest of the clusters
+        of an organization will stop.
+        """
+
+
+def reconcile_cluster_roles(
+    dry_run: bool,
+    ocm_api: OCMBaseClient,
+    org_id: str,
+    spec: ClusterUserManagementSpec,
+) -> ClusterRoleReconcileResult:
+    """
+    Make sure that the cluster roles and given users are synced onto the cluster.
+    This implies adding missing users and removing stale ones.
+    Cluster roles not mentioned in the spec are not touched.
+    """
+    result = ClusterRoleReconcileResult()
+
+    try:
+        org_id = spec.cluster.organization_id
+        cluster = spec.cluster.ocm_cluster
+        desired_groups: dict[OCMClusterGroupId, set[str]] = spec.roles
+        current_groups: dict[OCMClusterGroupId, set[str]] = {
+            role_id: {u.id for u in group.users.items}
+            for role_id, group in get_cluster_groups(
+                ocm_api=ocm_api, cluster_id=cluster.id
+            ).items()
+            if group.users
+        }
+        # only process roles present in the desired state and ignore the ones that are not
+        # this way a role can still be managed manually while another one is managed by this integration
+        for group in desired_groups.keys():
+            desired_members = desired_groups.get(group, set())
+            current_members = current_groups.get(group, set())
+
+            # add missing users
+            for missing_user in desired_members - current_members:
+                logging.info(
+                    f"add user {missing_user} to {group.value} - cluster id={cluster.id}, name={cluster.name}, org={org_id}"
+                )
+                if not dry_run:
+                    add_user_to_cluster_group(
+                        ocm_api=ocm_api,
+                        cluster_id=cluster.id,
+                        user_name=missing_user,
+                        group=group,
+                    )
+                result.users_added += 1
+            # remove obsolete users
+            for obsolete_user in current_members - desired_members:
+                logging.info(
+                    f"remove user {obsolete_user} from {group.value} -  cluster id={cluster.id}, name={cluster.name}, org={org_id}"
+                )
+                if not dry_run:
+                    delete_user_from_cluster_group(
+                        ocm_api=ocm_api,
+                        cluster_id=cluster.id,
+                        user_name=obsolete_user,
+                        group=group,
+                    )
+                result.users_removed += 1
+    except Exception as e:
+        result.error = e
+
+    return result
+
+
+def build_specs_from_config(
+    org_config: OrganizationUserManagementConfiguration,
+    group_member_providers: dict[str, GroupMemberProvider],
+) -> list[ClusterUserManagementSpec]:
+    """
+    Transforms the external provider/group references into actual user names.
+    """
+    # collect external group refs by provider so we can do a bulk resolve
+    external_group_refs_by_provider: dict[str, set[str]] = defaultdict(set)
+    for cluster_config in org_config.cluster_configs:
+        for role_external_group_ref in cluster_config.roles.values():
+            for external_group_ref in role_external_group_ref:
+                external_group_refs_by_provider[external_group_ref.provider].add(
+                    external_group_ref.group_id
+                )
+
+    # resolve all groups using the provider implementations
+    external_group_members_by_provider: dict[str, dict[str, set[str]]] = {}
+    for provider, group_ids in external_group_refs_by_provider.items():
+        external_group_members_by_provider[provider] = group_member_providers[
+            provider
+        ].resolve_groups(group_ids)
+
+    # build specs
+    cluster_specs: list[ClusterUserManagementSpec] = []
+    for cluster_config in org_config.cluster_configs:
+        spec = ClusterUserManagementSpec(
+            cluster=cluster_config.cluster,
+            roles={},
+            errors=cluster_config.errors,
+        )
+        cluster_specs.append(spec)
+
+        # fill roles
+        for (
+            role_id,
+            external_group_refs,
+        ) in cluster_config.roles.items():
+            spec.roles[role_id] = set()
+            if (
+                role_id == OCMClusterGroupId.CLUSTER_ADMINS
+                and not cluster_config.cluster.is_capability_set(
+                    CAPABILITY_MANAGE_CLUSTER_ADMIN, "true"
+                )
+            ):
+                spec.errors.append(
+                    ClusterError(
+                        message="This cluster does not have the capability to manage the cluster-admins role. Go to https://red.ht/ohss-incident and request cluster-admin access."
+                    )
+                )
+            for group_ref in external_group_refs:
+                members = external_group_members_by_provider[group_ref.provider].get(
+                    group_ref.group_id
+                )
+                if members is None:
+                    spec.errors.append(
+                        ClusterError(
+                            message=f"{group_ref.provider} group {group_ref.group_id} for {role_id.value} not found"
+                        )
+                    )
+                    continue
+                spec.roles[role_id].update(members)
+
+            if spec.errors:
+                spec.roles = {}
+
+    return cluster_specs
+
+
+def get_group_providers(
+    group_provider_specs: list[str],
+) -> dict[str, GroupMemberProvider]:
+    """
+    Initialize the group member providers.
+    """
+    providers: dict[str, GroupMemberProvider] = {}
+    for provider_spec in group_provider_specs:
+        provider_name, provider_type, provider_args = provider_spec.split(":")
+        if provider_type == "ldap":
+            providers[provider_name] = init_ldap_group_member_provider(provider_args)
+        else:
+            raise ValueError(f"unknown group member provider type {provider_type}")
+    return providers

--- a/reconcile/oum/labelset.py
+++ b/reconcile/oum/labelset.py
@@ -1,0 +1,56 @@
+from collections import defaultdict
+from typing import Optional
+
+from pydantic import BaseModel
+
+from reconcile.oum.models import ExternalGroupRef
+from reconcile.utils.models import CSV
+from reconcile.utils.ocm import sre_capability_labels
+from reconcile.utils.ocm.cluster_groups import OCMClusterGroupId
+from reconcile.utils.ocm.labels import LabelContainer
+
+
+class _GroupMappingLabelset(BaseModel):
+    """
+    Parses, represents and validates a set of provider labels for the user management SRE capability.
+
+    The full qualified label names supported by the standalone user management are defined as follows:
+
+    * sre-capabilities.user-mgmt.$provider.authz.dedicated-admins: group1,group2
+    * sre-capabilities.user-mgmt.$provider.authz.cluster-admins: group3,group4
+
+    This labelset is processed per provider so it defines labelnames without
+    the sre-capabilities.user-mgmt.$provider prefix.
+    """
+
+    authz_roles: Optional[dict[str, CSV]] = sre_capability_labels.labelset_groupfield(
+        group_prefix="authz."
+    )
+
+
+def build_cluster_config_from_labels(
+    provider: str,
+    org_labels: LabelContainer,
+    subscription_labels: LabelContainer,
+) -> dict[OCMClusterGroupId, list[ExternalGroupRef]]:
+    """
+    Extract the role-group mappings from the given organization and subscription label.
+
+    The label keys are expected to be stripped of the capability prefix and
+    external group provider prefix, resulting in the key names used in the
+    GroupMappingLabelset model.
+    """
+    role_group_mapping: dict[OCMClusterGroupId, list[ExternalGroupRef]] = defaultdict(
+        list
+    )
+
+    # turn org labels and subscription labels individually into a labelset
+    for labels in [org_labels, subscription_labels]:
+        labelset = sre_capability_labels.build_labelset(labels, _GroupMappingLabelset)
+        for ocm_group_name, external_groups in (labelset.authz_roles or {}).items():
+            for external_group_id in external_groups:
+                role_group_mapping[OCMClusterGroupId(ocm_group_name)].append(
+                    ExternalGroupRef(provider=provider, group_id=external_group_id)
+                )
+
+    return role_group_mapping

--- a/reconcile/oum/metrics.py
+++ b/reconcile/oum/metrics.py
@@ -1,0 +1,71 @@
+from enum import Enum
+
+from pydantic import BaseModel
+
+from reconcile.utils.metrics import (
+    CounterMetric,
+    GaugeMetric,
+)
+
+
+class OCMUserManagementBaseMetric(BaseModel):
+    "Base class for OCM user management metrics"
+
+    integration: str
+    ocm_env: str
+
+
+class OCMUserManagementOrganizationValidationErrorsGauge(
+    OCMUserManagementBaseMetric, GaugeMetric
+):
+    "Current validation errors within an OCM organization"
+
+    org_id: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "oum_organization_validation_errors"
+
+
+class OCMUserManagementOrganizationReconcileCounter(
+    OCMUserManagementBaseMetric, CounterMetric
+):
+    "Counter for the number of times an OCM organization was reconciled"
+
+    org_id: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "oum_organization_reconciled"
+
+
+class OCMUserManagementOrganizationReconcileErrorCounter(
+    OCMUserManagementBaseMetric, CounterMetric
+):
+    "Counter for the failed reconcile runs for an OCM organization"
+
+    org_id: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "oum_organization_reconcile_errors"
+
+
+class OCMUserManagementOrganizationActionCounter(
+    OCMUserManagementBaseMetric, CounterMetric
+):
+    "Counter for the number of actions taken for an OCM organization"
+
+    class Action(str, Enum):
+        AddUser = "add-user"
+        RemoveUser = "remove-user"
+
+        def __str__(self) -> str:
+            return self.value
+
+    org_id: str
+    action: Action
+
+    @classmethod
+    def name(cls) -> str:
+        return "oum_organization_actions"

--- a/reconcile/oum/models.py
+++ b/reconcile/oum/models.py
@@ -1,0 +1,71 @@
+from collections import defaultdict
+from typing import Optional
+
+from pydantic import (
+    BaseModel,
+    Field,
+)
+
+from reconcile.utils.ocm.cluster_groups import OCMClusterGroupId
+from reconcile.utils.ocm.clusters import ClusterDetails
+
+
+class ClusterError(BaseModel):
+    """
+    Represents an error that occurred while processing a cluster.
+    """
+
+    message: str
+
+
+class ExternalGroupRef(BaseModel):
+    """
+    A reference to a group in an external identity provider.
+    """
+
+    provider: str
+    group_id: str
+
+
+class ClusterUserManagementConfiguration(BaseModel):
+    """
+    Provider neutral representation of cluster user management configuration.
+    """
+
+    cluster: ClusterDetails
+    roles: dict[OCMClusterGroupId, list[ExternalGroupRef]] = defaultdict(list)
+    errors: list[ClusterError] = Field(default_factory=list)
+
+
+class OrganizationUserManagementConfiguration(BaseModel):
+
+    org_id: str
+    cluster_configs: list[ClusterUserManagementConfiguration] = Field(
+        default_factory=list
+    )
+
+
+class ClusterUserManagementSpec(BaseModel):
+    """
+    Contains the resolved usernames for cluster roles and notifications.
+    ClusterUserManagementSpec objects are derived from ClusterUserManagementConfiguration
+    objects by resolving the ExternalGroupRef objects using the provider
+    implementations.
+    """
+
+    cluster: ClusterDetails
+    roles: dict[OCMClusterGroupId, set[str]]
+    errors: list[ClusterError] = Field(default_factory=list)
+
+
+class ClusterRoleReconcileResult(BaseModel):
+    """
+    Holds the result of a cluster role reconciliation.
+    """
+
+    users_added: int = 0
+    users_removed: int = 0
+    error: Optional[Exception] = None
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/reconcile/oum/providers.py
+++ b/reconcile/oum/providers.py
@@ -1,0 +1,59 @@
+from abc import (
+    ABC,
+    abstractmethod,
+)
+
+from reconcile.ldap_users import get_ldap_settings
+from reconcile.utils.ldap_client import LdapClient
+
+
+class GroupMemberProvider(ABC):
+    """
+    The base class for all group member providers.
+    """
+
+    @abstractmethod
+    def resolve_groups(self, group_ids: set[str]) -> dict[str, set[str]]:
+        """
+        Resolve the set of members for each given group ID.
+        """
+
+
+class LdapGroupMemberProvider(GroupMemberProvider):
+    """
+    Resolve group members using the LDAP groups.
+    """
+
+    def __init__(self, ldap_client: LdapClient, group_base_dn: str):
+        self.ldap_client = ldap_client
+        self.group_base_dn = group_base_dn
+
+    def resolve_groups(self, group_ids: set[str]) -> dict[str, set[str]]:
+        group_dn_mapping = {f"cn={cn},{self.group_base_dn}": cn for cn in group_ids}
+        if len(group_ids) == 0:
+            return {}
+        with self.ldap_client as lc:
+            groups_members_by_dn = lc.get_group_members(group_dn_mapping.keys())
+        return {
+            group_dn_mapping[dn]: members
+            for dn, members in groups_members_by_dn.items()
+        }
+
+
+def init_ldap_group_member_provider(group_base_dn: str) -> LdapGroupMemberProvider:
+    """
+    Initialize a LDAPGroupMemberProvider using the available settings.
+    Right now, it depends on the app-interface settings.
+
+    The group_base_dn is used to find groups by their CN. It is extended as folows
+    to find a group by name:
+        cn={name},{group_base_dn}
+    """
+
+    settings = get_ldap_settings()
+    return LdapGroupMemberProvider(
+        LdapClient.from_params(
+            settings["ldap"]["serverUrl"], None, None, settings["ldap"]["baseDn"]
+        ),
+        group_base_dn,
+    )

--- a/reconcile/oum/standalone.py
+++ b/reconcile/oum/standalone.py
@@ -1,0 +1,197 @@
+import logging
+from collections import defaultdict
+from datetime import timedelta
+from typing import Optional
+
+from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
+from reconcile.oum.base import OCMUserManagementIntegration
+from reconcile.oum.labelset import build_cluster_config_from_labels
+from reconcile.oum.models import (
+    ClusterError,
+    ClusterUserManagementConfiguration,
+    ClusterUserManagementSpec,
+    OrganizationUserManagementConfiguration,
+)
+from reconcile.utils.ocm.clusters import (
+    ClusterDetails,
+    discover_clusters_by_labels,
+)
+from reconcile.utils.ocm.labels import build_container_for_prefix
+from reconcile.utils.ocm.search_filters import Filter
+from reconcile.utils.ocm.service_log import (
+    OCMClusterServiceLogCreateModel,
+    OCMServiceLogSeverity,
+    create_service_log,
+)
+from reconcile.utils.ocm.sre_capability_labels import sre_capability_label_key
+from reconcile.utils.ocm_base_client import (
+    OCMBaseClient,
+    init_ocm_base_client,
+)
+
+
+class OCMStandaloneUserManagementIntegration(OCMUserManagementIntegration):
+    @property
+    def name(self) -> str:
+        return "ocm-standalone-user-management"
+
+    def get_user_mgmt_config_for_ocm_env(
+        self, ocm_env: OCMEnvironment, org_ids: Optional[set[str]]
+    ) -> dict[str, OrganizationUserManagementConfiguration]:
+        ocm_api = init_ocm_base_client(ocm_env, self.secret_reader)
+        clusters_by_org = discover_clusters(
+            ocm_api=ocm_api,
+            org_ids=org_ids,
+        )
+        configs: dict[str, OrganizationUserManagementConfiguration] = {}
+        for org_id, org_clusters in clusters_by_org.items():
+            configs[org_id] = build_user_management_configurations(
+                org_id=org_id,
+                clusters=org_clusters,
+                providers=self.group_member_provider_ids,
+            )
+        return configs
+
+    def signal_cluster_reconcile_success(
+        self,
+        dry_run: bool,
+        ocm_api: OCMBaseClient,
+        spec: ClusterUserManagementSpec,
+        message: str,
+    ) -> None:
+        logging.info(message)
+        if dry_run:
+            return
+        create_service_log(
+            ocm_api=ocm_api,
+            service_log=OCMClusterServiceLogCreateModel(
+                cluster_uuid=spec.cluster.ocm_cluster.external_id,
+                severity=OCMServiceLogSeverity.Info,
+                summary="Reconciled cluster groups",
+                description=message,
+                service_name=self.name,
+            ),
+        )
+
+    def signal_cluster_validation_error(
+        self,
+        dry_run: bool,
+        ocm_api: OCMBaseClient,
+        spec: ClusterUserManagementSpec,
+        error: Exception,
+    ) -> None:
+        """
+        The standalone user management capability will not fail on a configuration
+        validation issue. If issues should be noticed by an SRE team, alerts based on
+        the `oum_organization_validation_errors` metric in the `reconcile.oum.metrics`
+        module should be set up.
+        """
+        logging.warning(
+            "Failed to reconcile cluster user group configuration in "
+            f"OCM organization {spec.cluster.organization_id}",
+            exc_info=error,
+        )
+        if dry_run:
+            return
+        create_service_log(
+            ocm_api=ocm_api,
+            service_log=OCMClusterServiceLogCreateModel(
+                cluster_uuid=spec.cluster.ocm_cluster.external_id,
+                severity=OCMServiceLogSeverity.Error,
+                summary="Failed to reconcile cluster user group configuration",
+                description=str(error),
+                service_name=self.name,
+            ),
+            dedup_interval=timedelta(days=2),
+        )
+
+    def signal_cluster_reconcile_error(
+        self,
+        dry_run: bool,
+        ocm_api: OCMBaseClient,
+        spec: ClusterUserManagementSpec,
+        error: Exception,
+    ) -> None:
+        """
+        The standalone user management capability will not fail on a cluster
+        reconciliation issue. If issues should be noticed by an SRE team, alerts based on
+        the `oum_organization_reconcile_errors` metric in the `reconcile.oum.metrics`
+        module should be set up.
+
+        The user is not notified via service logs because such reconcile issues are not
+        actionable to them.
+        """
+        logging.warning(
+            "Failed to reconcile cluster user group configuration on "
+            f"cluster {spec.cluster.ocm_cluster.name} (id={spec.cluster.ocm_cluster.id}) "
+            f"in the OCM organization {spec.cluster.organization_id}",
+            exc_info=error,
+        )
+
+
+def user_mgmt_label_key(config_atom: str) -> str:
+    """
+    Generates label keys for the user management authz capability, compliant with the naming
+    scheme defined in https://service.pages.redhat.com/dev-guidelines/docs/sre-capabilities/framework/ocm-labels/
+    """
+    return sre_capability_label_key("user-mgmt", config_atom)
+
+
+def discover_clusters(
+    ocm_api: OCMBaseClient,
+    org_ids: Optional[set[str]] = None,
+) -> dict[str, list[ClusterDetails]]:
+    """
+    Discover all clusters with user management enabled on their subscription
+    or their organization. Return the discovered clusters grouped by OCM organization ID.
+
+    If `org_ids` is provided, only clusters from the specified organizations will be returned.
+    """
+    clusters = discover_clusters_by_labels(
+        ocm_api=ocm_api,
+        label_filter=Filter().like("key", user_mgmt_label_key("%")),
+    )
+
+    # group by org ID
+    # optionally also filter on org IDs
+    clusters_by_org: dict[str, list[ClusterDetails]] = defaultdict(list)
+    for c in clusters:
+        passed_ocm_filters = org_ids is None or c.organization_id in org_ids
+        if passed_ocm_filters:
+            clusters_by_org[c.organization_id].append(c)
+
+    return clusters_by_org
+
+
+def build_user_management_configurations(
+    org_id: str,
+    clusters: list[ClusterDetails],
+    providers: set[str],
+) -> OrganizationUserManagementConfiguration:
+    """
+    Extracts the user management configuration from the cluster labels.
+    """
+    org_config = OrganizationUserManagementConfiguration(org_id=org_id)
+    for c in clusters:
+        cluster_config = ClusterUserManagementConfiguration(cluster=c)
+        org_config.cluster_configs.append(cluster_config)
+        for p in providers:
+            provider_org_labels = build_container_for_prefix(
+                c.organization_labels, user_mgmt_label_key(f"{p}."), True
+            )
+            provider_subs_labels = build_container_for_prefix(
+                c.subscription_labels, user_mgmt_label_key(f"{p}."), True
+            )
+            if provider_org_labels or provider_subs_labels:
+                try:
+                    role_groups = build_cluster_config_from_labels(
+                        provider=p,
+                        org_labels=provider_org_labels,
+                        subscription_labels=provider_subs_labels,
+                    )
+                    for role_id, group_refs in role_groups.items():
+                        cluster_config.roles[role_id].extend(group_refs)
+
+                except Exception as e:
+                    cluster_config.errors.append(ClusterError(message=str(e)))
+    return org_config

--- a/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
+++ b/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
@@ -21,11 +21,10 @@ from reconcile.aus.models import OrganizationUpgradeSpec
 from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.test.ocm.fixtures import (
+    build_cluster_details,
     build_label,
-    build_ocm_cluster,
     build_organization_label,
 )
-from reconcile.utils.ocm.clusters import ClusterDetails
 from reconcile.utils.ocm.labels import (
     LabelContainer,
     build_label_container,
@@ -181,26 +180,6 @@ def org_labels() -> LabelContainer:
     return build_org_config_labels(with_blocked_versions=True)
 
 
-def build_cluster_details(
-    cluster_name: str,
-    labels: LabelContainer,
-    org_id: str = "org-id",
-    aws_cluster: bool = True,
-    sts_cluster: bool = False,
-) -> ClusterDetails:
-    return ClusterDetails(
-        ocm_cluster=build_ocm_cluster(
-            name=cluster_name,
-            subs_id=f"{cluster_name}_subs_id",
-            aws_cluster=aws_cluster,
-            sts_cluster=sts_cluster,
-        ),
-        organization_id=org_id,
-        capabilities={},
-        labels=labels,
-    )
-
-
 def test_build_org_upgrade_spec(
     ocm_env: OCMEnvironment, org_labels: LabelContainer
 ) -> None:
@@ -247,7 +226,7 @@ def test_build_org_upgrade_specs_for_ocm_env(ocm_env: OCMEnvironment) -> None:
     soak_days = 10
     cluster_details = build_cluster_details(
         cluster_name="cluster-1",
-        labels=build_cluster_upgrade_policy_labels(soak_days=soak_days),
+        subscription_labels=build_cluster_upgrade_policy_labels(soak_days=soak_days),
     )
     upgrade_specs = _build_org_upgrade_specs_for_ocm_env(
         ocm_env=ocm_env,
@@ -273,7 +252,7 @@ def test_build_org_upgrade_specs_for_ocm_env_with_cluster_error(
     org_id = "org-id"
     cluster_details = build_cluster_details(
         cluster_name="cluster-1",
-        labels=build_cluster_upgrade_policy_labels(soak_days=-10),
+        subscription_labels=build_cluster_upgrade_policy_labels(soak_days=-10),
     )
     upgrade_specs = _build_org_upgrade_specs_for_ocm_env(
         ocm_env=ocm_env,
@@ -306,7 +285,7 @@ def test_discover_clusters(mocker: MockerFixture) -> None:
     discover_clusters_by_labels_mock.return_value = [
         build_cluster_details(
             cluster_name=cluster_name,
-            labels=build_cluster_upgrade_policy_labels(),
+            subscription_labels=build_cluster_upgrade_policy_labels(),
             org_id=org_id,
         )
     ]
@@ -335,7 +314,7 @@ def test_discover_clusters_with_org_filter(mocker: MockerFixture) -> None:
     discover_clusters_by_labels_mock.return_value = [
         build_cluster_details(
             cluster_name=cluster_name,
-            labels=build_cluster_upgrade_policy_labels(),
+            subscription_labels=build_cluster_upgrade_policy_labels(),
             org_id=org_id,
         )
     ]
@@ -359,7 +338,7 @@ def test_discover_clusters_without_org_filter(mocker: MockerFixture) -> None:
     discover_clusters_by_labels_mock.return_value = [
         build_cluster_details(
             cluster_name=cluster_name,
-            labels=build_cluster_upgrade_policy_labels(),
+            subscription_labels=build_cluster_upgrade_policy_labels(),
             org_id=org_id,
         )
     ]
@@ -380,13 +359,13 @@ def test_discover_clusters_ignore_sts_clusters(mocker: MockerFixture) -> None:
     discover_clusters_by_labels_mock.return_value = [
         build_cluster_details(
             cluster_name="cluster-with-sts",
-            labels=build_cluster_upgrade_policy_labels(),
+            subscription_labels=build_cluster_upgrade_policy_labels(),
             org_id=org_id,
             sts_cluster=True,
         ),
         build_cluster_details(
             cluster_name="cluster-without-sts",
-            labels=build_cluster_upgrade_policy_labels(),
+            subscription_labels=build_cluster_upgrade_policy_labels(),
             org_id=org_id,
             sts_cluster=False,
         ),
@@ -454,7 +433,7 @@ def build_org_upgrade_specs(
     org_id = "org-id"
     cluster_details = build_cluster_details(
         cluster_name="cluster-1",
-        labels=build_cluster_upgrade_policy_labels(
+        subscription_labels=build_cluster_upgrade_policy_labels(
             soak_days=(-1 if cluster_error else 1)
         ),
     )

--- a/reconcile/test/ocm/fixtures.py
+++ b/reconcile/test/ocm/fixtures.py
@@ -15,12 +15,15 @@ from pydantic import (
 
 from reconcile.utils.ocm.base import OCMModelLink
 from reconcile.utils.ocm.clusters import (
+    ClusterDetails,
+    OCMCapability,
     OCMCluster,
     OCMClusterAWSSettings,
     OCMClusterFlag,
     OCMClusterState,
 )
 from reconcile.utils.ocm.labels import (
+    LabelContainer,
     OCMLabel,
     OCMOrganizationLabel,
 )
@@ -108,4 +111,33 @@ def build_ocm_cluster(
         state=OCMClusterState.READY,
         managed=True,
         aws=aws_config,
+    )
+
+
+def build_cluster_details(
+    cluster_name: str,
+    subscription_labels: Optional[LabelContainer] = None,
+    organization_labels: Optional[LabelContainer] = None,
+    org_id: str = "org-id",
+    aws_cluster: bool = True,
+    sts_cluster: bool = False,
+    capabilitites: Optional[dict[str, str]] = None,
+) -> ClusterDetails:
+    return ClusterDetails(
+        ocm_cluster=build_ocm_cluster(
+            name=cluster_name,
+            subs_id=f"{cluster_name}_subs_id",
+            aws_cluster=aws_cluster,
+            sts_cluster=sts_cluster,
+        ),
+        organization_id=org_id,
+        capabilities={
+            name: OCMCapability(
+                name=name,
+                value=value,
+            )
+            for name, value in (capabilitites or {}).items()
+        },
+        subscription_labels=subscription_labels or LabelContainer(),
+        organization_labels=organization_labels or LabelContainer(),
     )

--- a/reconcile/test/ocm/oum/test_oum_base.py
+++ b/reconcile/test/ocm/oum/test_oum_base.py
@@ -1,0 +1,621 @@
+from typing import Optional
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
+from reconcile.oum import base
+from reconcile.oum.base import (
+    OCMUserManagementIntegration,
+    OCMUserManagementIntegrationParams,
+    build_specs_from_config,
+    reconcile_cluster_roles,
+)
+from reconcile.oum.metrics import (
+    OCMUserManagementOrganizationActionCounter as ReconcileActionCounter,
+)
+from reconcile.oum.metrics import (
+    OCMUserManagementOrganizationReconcileCounter as ReconcileCounter,
+)
+from reconcile.oum.metrics import (
+    OCMUserManagementOrganizationReconcileErrorCounter as ReconcileErrorCounter,
+)
+from reconcile.oum.metrics import (
+    OCMUserManagementOrganizationValidationErrorsGauge as ValidationErrorsGauge,
+)
+from reconcile.oum.models import (
+    ClusterError,
+    ClusterRoleReconcileResult,
+    ClusterUserManagementConfiguration,
+    ClusterUserManagementSpec,
+    ExternalGroupRef,
+    OrganizationUserManagementConfiguration,
+)
+from reconcile.oum.providers import GroupMemberProvider
+from reconcile.test.ocm.fixtures import build_cluster_details
+from reconcile.utils import metrics
+from reconcile.utils.ocm.cluster_groups import (
+    OCMClusterGroup,
+    OCMClusterGroupId,
+    OCMClusterUser,
+    OCMClusterUserList,
+)
+from reconcile.utils.ocm.clusters import (
+    CAPABILITY_MANAGE_CLUSTER_ADMIN,
+    ClusterDetails,
+)
+from reconcile.utils.ocm_base_client import OCMBaseClient
+
+
+def build_ocm_cluster_group(
+    id: OCMClusterGroupId, user_ids: set[str]
+) -> OCMClusterGroup:
+    return OCMClusterGroup(
+        id=id,
+        href="xxx",
+        users=OCMClusterUserList(
+            items=[OCMClusterUser(id=user_id) for user_id in user_ids]
+        ),
+    )
+
+
+@pytest.fixture
+def org_id() -> str:
+    return "123456"
+
+
+@pytest.fixture
+def cluster(org_id: str) -> ClusterDetails:
+    return build_cluster_details(
+        cluster_name="cluster-1",
+        org_id=org_id,
+    )
+
+
+@pytest.fixture
+def cluster_with_cluster_admin_capability(org_id: str) -> ClusterDetails:
+    return build_cluster_details(
+        cluster_name="cluster-1",
+        org_id=org_id,
+        capabilitites={CAPABILITY_MANAGE_CLUSTER_ADMIN: "true"},
+    )
+
+
+#
+# test reconciling
+#
+
+
+def test_reconcile_cluster_add_and_remove(
+    ocm_api: OCMBaseClient, org_id: str, cluster: ClusterDetails, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(base, "get_cluster_groups").return_value = {
+        OCMClusterGroupId.CLUSTER_ADMINS: build_ocm_cluster_group(
+            OCMClusterGroupId.CLUSTER_ADMINS, {"user-1", "user-2"}
+        )
+    }
+    add_user_mock = mocker.patch.object(base, "add_user_to_cluster_group")
+    add_user_mock.return_value = None
+    remove_user_mock = mocker.patch.object(base, "delete_user_from_cluster_group")
+    remove_user_mock.return_value = None
+
+    result = reconcile_cluster_roles(
+        dry_run=False,
+        ocm_api=ocm_api,
+        org_id=org_id,
+        spec=ClusterUserManagementSpec(
+            cluster=cluster,
+            roles={
+                OCMClusterGroupId.CLUSTER_ADMINS: {
+                    "user-2",
+                    "user-3",
+                },
+            },
+            errors=[],
+        ),
+    )
+    assert result.users_added == 1
+    add_user_mock.assert_called_with(
+        ocm_api=ocm_api,
+        cluster_id=cluster.ocm_cluster.id,
+        user_name="user-3",
+        group=OCMClusterGroupId.CLUSTER_ADMINS,
+    )
+    assert result.users_removed == 1
+    remove_user_mock.assert_called_with(
+        ocm_api=ocm_api,
+        cluster_id=cluster.ocm_cluster.id,
+        user_name="user-1",
+        group=OCMClusterGroupId.CLUSTER_ADMINS,
+    )
+    assert result.error is None
+
+
+def test_reconcile_cluster_only_touch_defined_groups(
+    ocm_api: OCMBaseClient, org_id: str, cluster: ClusterDetails, mocker: MockerFixture
+) -> None:
+    """
+    Test if a group undefined by the spec is not touched in OCM.
+    In this case the spec does not mention dedicated-admins but
+    the current state defines users. The expected behaviour is to
+    not touch the dedicated-admins group in OCM.
+    """
+    mocker.patch.object(base, "get_cluster_groups").return_value = {
+        OCMClusterGroupId.CLUSTER_ADMINS: build_ocm_cluster_group(
+            OCMClusterGroupId.CLUSTER_ADMINS, {"user-1", "user-2"}
+        ),
+        OCMClusterGroupId.DEDICATED_ADMINS: build_ocm_cluster_group(
+            OCMClusterGroupId.CLUSTER_ADMINS, {"user-3", "user-4"}
+        ),
+    }
+    remove_user_mock = mocker.patch.object(base, "delete_user_from_cluster_group")
+    remove_user_mock.return_value = None
+
+    result = reconcile_cluster_roles(
+        dry_run=False,
+        ocm_api=ocm_api,
+        org_id=org_id,
+        spec=ClusterUserManagementSpec(
+            cluster=cluster,
+            roles={
+                OCMClusterGroupId.CLUSTER_ADMINS: set(),
+            },
+            errors=[],
+        ),
+    )
+    assert result.users_added == 0
+    assert result.users_removed == 2
+    assert remove_user_mock.call_count == 2
+    remove_user_mock.assert_any_call(
+        ocm_api=ocm_api,
+        cluster_id=cluster.ocm_cluster.id,
+        user_name="user-1",
+        group=OCMClusterGroupId.CLUSTER_ADMINS,
+    )
+    remove_user_mock.assert_any_call(
+        ocm_api=ocm_api,
+        cluster_id=cluster.ocm_cluster.id,
+        user_name="user-2",
+        group=OCMClusterGroupId.CLUSTER_ADMINS,
+    )
+    assert result.error is None
+
+
+def test_reconcile_cluster_error(
+    ocm_api: OCMBaseClient, org_id: str, cluster: ClusterDetails, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(base, "get_cluster_groups").side_effect = Exception(
+        "something went wrong"
+    )
+
+    org_id = "123456"
+    result = reconcile_cluster_roles(
+        dry_run=False,
+        ocm_api=ocm_api,
+        org_id=org_id,
+        spec=ClusterUserManagementSpec(
+            cluster=cluster,
+            roles={
+                OCMClusterGroupId.CLUSTER_ADMINS: set(),
+            },
+            errors=[],
+        ),
+    )
+
+    assert result.error is not None
+
+
+#
+# test build spec from config
+#
+
+
+class MockGroupMemberProvider(GroupMemberProvider):
+    def __init__(self, groups: dict[str, set[str]]):
+        self.groups = groups
+
+    def resolve_groups(self, group_ids: set[str]) -> dict[str, set[str]]:
+        return {
+            group_id: self.groups[group_id]
+            for group_id in group_ids
+            if group_id in self.groups
+        }
+
+
+@pytest.fixture
+def mock_group_member_provider() -> MockGroupMemberProvider:
+    return MockGroupMemberProvider(
+        {
+            "group-1": {"user-1", "user-2"},
+            "group-2": {"user-3", "user-4"},
+            "group-3": {"user-5", "user-6"},
+            "group-4": {"user-7", "user-8"},
+        }
+    )
+
+
+def build_org_config(
+    cluster: ClusterDetails, roles: dict[OCMClusterGroupId, list[ExternalGroupRef]]
+) -> OrganizationUserManagementConfiguration:
+    return OrganizationUserManagementConfiguration(
+        org_id=cluster.organization_id,
+        cluster_configs=[
+            ClusterUserManagementConfiguration(
+                cluster=cluster,
+                roles=roles,
+            )
+        ],
+    )
+
+
+def test_build_spec_from_config(
+    cluster: ClusterDetails,
+    mock_group_member_provider: MockGroupMemberProvider,
+) -> None:
+    """
+    Happy path
+    """
+    provider = "mock"
+    org_config = build_org_config(
+        cluster=cluster,
+        roles={
+            OCMClusterGroupId.DEDICATED_ADMINS: [
+                ExternalGroupRef(
+                    group_id="group-1",
+                    provider=provider,
+                )
+            ]
+        },
+    )
+
+    specs = build_specs_from_config(
+        org_config=org_config,
+        group_member_providers={
+            provider: mock_group_member_provider,
+        },
+    )
+    assert len(specs) == 1
+    assert specs[0].roles[OCMClusterGroupId.DEDICATED_ADMINS] == {"user-1", "user-2"}
+    assert specs[0].cluster == cluster
+    assert len(specs[0].errors) == 0
+
+
+def test_build_spec_from_config_missing_group(
+    cluster: ClusterDetails,
+    mock_group_member_provider: MockGroupMemberProvider,
+) -> None:
+    """
+    A group defined on a cluster role is missing. The expected behaviour
+    is an exposed error and the role not being listed in the spec.
+    """
+    provider = "mock"
+    org_config = build_org_config(
+        cluster=cluster,
+        roles={
+            OCMClusterGroupId.DEDICATED_ADMINS: [
+                ExternalGroupRef(
+                    group_id="missing-group",
+                    provider=provider,
+                )
+            ]
+        },
+    )
+
+    specs = build_specs_from_config(
+        org_config=org_config,
+        group_member_providers={
+            provider: mock_group_member_provider,
+        },
+    )
+    assert len(specs) == 1
+    assert specs[0].roles == {}
+    assert specs[0].cluster == cluster
+    assert len(specs[0].errors) == 1
+
+
+def test_build_spec_from_config_cluster_admin_without_capability(
+    cluster: ClusterDetails, mock_group_member_provider: MockGroupMemberProvider
+) -> None:
+    """
+    A cluster without the manage cluster admin capability should NOT be able to
+    have cluster admins defined.
+    """
+    provider = "mock"
+    org_config = build_org_config(
+        cluster=cluster,
+        roles={
+            OCMClusterGroupId.CLUSTER_ADMINS: [
+                ExternalGroupRef(
+                    group_id="group-1",
+                    provider=provider,
+                )
+            ]
+        },
+    )
+    specs = build_specs_from_config(
+        org_config=org_config,
+        group_member_providers={
+            provider: mock_group_member_provider,
+        },
+    )
+    assert len(specs) == 1
+    assert specs[0].roles == {}
+    assert specs[0].cluster == cluster
+    assert len(specs[0].errors) == 1
+
+
+def test_build_spec_from_config_cluster_admin_with_capability(
+    cluster_with_cluster_admin_capability: ClusterDetails,
+    mock_group_member_provider: MockGroupMemberProvider,
+) -> None:
+    """
+    A cluster with the manage cluster admin capability should be able to
+    have cluster admins defined.
+    """
+    provider = "mock"
+    org_config = build_org_config(
+        cluster=cluster_with_cluster_admin_capability,
+        roles={
+            OCMClusterGroupId.CLUSTER_ADMINS: [
+                ExternalGroupRef(
+                    group_id="group-1",
+                    provider=provider,
+                )
+            ]
+        },
+    )
+    specs = build_specs_from_config(
+        org_config=org_config,
+        group_member_providers={
+            provider: mock_group_member_provider,
+        },
+    )
+    assert len(specs) == 1
+    assert specs[0].roles[OCMClusterGroupId.CLUSTER_ADMINS] == {"user-1", "user-2"}
+    assert specs[0].cluster == cluster_with_cluster_admin_capability
+    assert len(specs[0].errors) == 0
+
+
+#
+# test reconcile OCM organization
+#
+
+
+class MockOCMUserManagementIntegration(OCMUserManagementIntegration):
+    def get_user_mgmt_config_for_ocm_env(
+        self, ocm_env: OCMEnvironment, org_ids: Optional[set[str]]
+    ) -> dict[str, OrganizationUserManagementConfiguration]:
+        return {}
+
+    @property
+    def name(self) -> str:
+        return "mock-ocm-user-management-integration"
+
+    def signal_cluster_reconcile_success(
+        self,
+        dry_run: bool,
+        ocm_api: OCMBaseClient,
+        spec: ClusterUserManagementSpec,
+        message: str,
+    ) -> None:
+        ...
+
+    def signal_cluster_validation_error(
+        self,
+        dry_run: bool,
+        ocm_api: OCMBaseClient,
+        spec: ClusterUserManagementSpec,
+        error: Exception,
+    ) -> None:
+        ...
+
+    def signal_cluster_reconcile_error(
+        self,
+        dry_run: bool,
+        ocm_api: OCMBaseClient,
+        spec: ClusterUserManagementSpec,
+        error: Exception,
+    ) -> None:
+        ...
+
+
+@pytest.fixture
+def reconcile_cluster_roles_mock(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch.object(base, "reconcile_cluster_roles", autospec=True)
+
+
+@pytest.fixture
+def signal_cluster_validation_error_mock(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch.object(
+        MockOCMUserManagementIntegration,
+        "signal_cluster_validation_error",
+        autospec=True,
+    )
+
+
+@pytest.fixture
+def signal_cluster_reconcile_error_mock(mocker: MockerFixture) -> MagicMock:
+    return mocker.patch.object(
+        MockOCMUserManagementIntegration,
+        "signal_cluster_reconcile_error",
+        autospec=True,
+    )
+
+
+def test_reconcile_ocm_organization_validation_error(
+    cluster: ClusterDetails,
+    ocm_api: OCMBaseClient,
+    org_id: str,
+    reconcile_cluster_roles_mock: MagicMock,
+    signal_cluster_validation_error_mock: MagicMock,
+    signal_cluster_reconcile_error_mock: MagicMock,
+) -> None:
+    """
+    Verify that a spec with validation errors is not reconciled but the error
+    is exposed as a metric.
+    """
+    metrics_container = metrics.MetricsContainer()
+    integration = MockOCMUserManagementIntegration(
+        OCMUserManagementIntegrationParams(group_provider_specs=[])
+    )
+    with metrics.transactional_metrics(integration.name, metrics_container):
+        integration.reconcile_ocm_organization(
+            dry_run=False,
+            ocm_api=ocm_api,
+            org_id=org_id,
+            ocm_env="production",
+            cluster_specs=[
+                ClusterUserManagementSpec(
+                    cluster=cluster,
+                    roles={
+                        OCMClusterGroupId.DEDICATED_ADMINS: {"user-1", "user-2"},
+                    },
+                    errors=[ClusterError(message="an error occured")],
+                )
+            ],
+        )
+
+    # verify exposed metrics
+    assert metrics_container.get_metric_value(ReconcileCounter, org_id=org_id) == 1
+    assert metrics_container.get_metric_value(ReconcileErrorCounter, org_id=org_id) == 0
+    assert metrics_container.get_metric_value(ValidationErrorsGauge, org_id=org_id) == 1
+
+    # verify cluster has not been reconciled
+    reconcile_cluster_roles_mock.assert_not_called()
+
+    # verify issue signaling
+    signal_cluster_validation_error_mock.assert_called()
+    signal_cluster_reconcile_error_mock.assert_not_called()
+
+
+def test_reconcile_ocm_organization_successful_cluster_reconcile(
+    cluster: ClusterDetails,
+    ocm_api: OCMBaseClient,
+    org_id: str,
+    reconcile_cluster_roles_mock: MagicMock,
+    signal_cluster_validation_error_mock: MagicMock,
+    signal_cluster_reconcile_error_mock: MagicMock,
+) -> None:
+    """
+    Verify that a valid spec that reconciles successfully, exposes corret metrics
+    and does not signal any issues.
+    """
+    metrics_container = metrics.MetricsContainer()
+    integration = MockOCMUserManagementIntegration(
+        OCMUserManagementIntegrationParams(group_provider_specs=[])
+    )
+    reconcile_cluster_roles_mock.return_value = ClusterRoleReconcileResult(
+        users_added=2,
+        users_removed=3,
+        errors=[],
+    )
+    with metrics.transactional_metrics(integration.name, metrics_container):
+        integration.reconcile_ocm_organization(
+            dry_run=False,
+            ocm_api=ocm_api,
+            org_id=org_id,
+            ocm_env="production",
+            cluster_specs=[
+                ClusterUserManagementSpec(
+                    cluster=cluster,
+                    roles={
+                        OCMClusterGroupId.DEDICATED_ADMINS: {"user-1", "user-2"},
+                    },
+                )
+            ],
+        )
+
+    # verify exposed metrics
+    assert metrics_container.get_metric_value(ReconcileCounter, org_id=org_id) == 1
+    assert metrics_container.get_metric_value(ReconcileErrorCounter, org_id=org_id) == 0
+    assert metrics_container.get_metric_value(ValidationErrorsGauge, org_id=org_id) == 0
+    assert (
+        metrics_container.get_metric_value(
+            ReconcileActionCounter,
+            org_id=org_id,
+            action=ReconcileActionCounter.Action.AddUser,
+        )
+        == 2
+    )
+    assert (
+        metrics_container.get_metric_value(
+            ReconcileActionCounter,
+            org_id=org_id,
+            action=ReconcileActionCounter.Action.RemoveUser,
+        )
+        == 3
+    )
+
+    # verify cluster has been reconciled
+    reconcile_cluster_roles_mock.assert_called_once()
+
+    # verify issue signaling
+    signal_cluster_validation_error_mock.assert_not_called()
+    signal_cluster_reconcile_error_mock.assert_not_called()
+
+
+def test_reconcile_ocm_organization_failed_cluster_reconcile(
+    cluster: ClusterDetails,
+    ocm_api: OCMBaseClient,
+    org_id: str,
+    reconcile_cluster_roles_mock: MagicMock,
+    signal_cluster_validation_error_mock: MagicMock,
+    signal_cluster_reconcile_error_mock: MagicMock,
+) -> None:
+    """
+    Verify that a valid spec that fails reconciling reports metrics
+    and signals errors correctly.
+    """
+    metrics_container = metrics.MetricsContainer()
+    integration = MockOCMUserManagementIntegration(
+        OCMUserManagementIntegrationParams(group_provider_specs=[])
+    )
+    reconcile_cluster_roles_mock.return_value = ClusterRoleReconcileResult(
+        users_added=1,
+        users_removed=0,
+        error=Exception("an error occured"),
+    )
+    with metrics.transactional_metrics(integration.name, metrics_container):
+        integration.reconcile_ocm_organization(
+            dry_run=False,
+            ocm_api=ocm_api,
+            org_id=org_id,
+            ocm_env="production",
+            cluster_specs=[
+                ClusterUserManagementSpec(
+                    cluster=cluster,
+                    roles={
+                        OCMClusterGroupId.DEDICATED_ADMINS: {"user-1", "user-2"},
+                    },
+                )
+            ],
+        )
+
+    # verify exposed metrics
+    assert metrics_container.get_metric_value(ReconcileCounter, org_id=org_id) == 1
+    assert metrics_container.get_metric_value(ReconcileErrorCounter, org_id=org_id) == 1
+    assert metrics_container.get_metric_value(ValidationErrorsGauge, org_id=org_id) == 0
+    assert (
+        metrics_container.get_metric_value(
+            ReconcileActionCounter,
+            org_id=org_id,
+            action=ReconcileActionCounter.Action.AddUser,
+        )
+        == 1
+    )
+    assert (
+        metrics_container.get_metric_value(
+            ReconcileActionCounter,
+            org_id=org_id,
+            action=ReconcileActionCounter.Action.RemoveUser,
+        )
+        == 0
+    )
+
+    # verify cluster has been reconciled
+    reconcile_cluster_roles_mock.assert_called_once()
+
+    # verify issue signaling
+    signal_cluster_validation_error_mock.assert_not_called()
+    signal_cluster_reconcile_error_mock.assert_called_once()

--- a/reconcile/test/ocm/oum/test_oum_providers.py
+++ b/reconcile/test/ocm/oum/test_oum_providers.py
@@ -1,0 +1,32 @@
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.oum.providers import LdapGroupMemberProvider
+from reconcile.utils.ldap_client import LdapClient
+
+
+@pytest.fixture
+def mock_ldap_client(mocker: MockerFixture) -> LdapClient:
+    lc = mocker.Mock(spec=LdapClient, autospec=True)
+    lc.return_value.get_group_members.return_value = {
+        "cn=group1,dc=example,dc=com": {"user1", "user2"},
+        "cn=group2,dc=example,dc=com": {"user3", "user4"},
+    }
+    lc.__enter__ = lc
+    lc.__exit__ = mocker.Mock(return_value=None)
+    return lc
+
+
+def test_ldap_group_member_provider(mock_ldap_client: LdapClient) -> None:
+    provider = LdapGroupMemberProvider(mock_ldap_client, "dc=example,dc=com")
+    groups = provider.resolve_groups({"group1", "group2"})
+    assert "group1" in groups
+    assert groups["group1"] == {"user1", "user2"}
+    assert "group2" in groups
+    assert groups["group2"] == {"user3", "user4"}
+
+
+def test_ldap_group_member_provider_empty_list(mock_ldap_client: LdapClient) -> None:
+    provider = LdapGroupMemberProvider(mock_ldap_client, "dc=example,dc=com")
+    groups = provider.resolve_groups(set())
+    assert groups == {}

--- a/reconcile/test/ocm/oum/test_oum_standalone.py
+++ b/reconcile/test/ocm/oum/test_oum_standalone.py
@@ -1,0 +1,303 @@
+from typing import Optional
+
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.oum import standalone
+from reconcile.oum.base import OCMUserManagementIntegrationParams
+from reconcile.oum.labelset import build_cluster_config_from_labels
+from reconcile.oum.models import (
+    ClusterUserManagementSpec,
+    ExternalGroupRef,
+)
+from reconcile.test.ocm.fixtures import (
+    build_cluster_details,
+    build_label,
+)
+from reconcile.utils.ocm.cluster_groups import OCMClusterGroupId
+from reconcile.utils.ocm.labels import (
+    LabelContainer,
+    build_container_for_prefix,
+    build_label_container,
+)
+from reconcile.utils.ocm.search_filters import Filter
+from reconcile.utils.ocm_base_client import OCMBaseClient
+
+#
+# test labelset
+#
+
+
+def build_provider_authz_labels(
+    provider: str,
+    dedicated_admins_groups: Optional[set[str]] = None,
+    cluster_admins_groups: Optional[set[str]] = None,
+) -> LabelContainer:
+    labels = []
+    if dedicated_admins_groups:
+        labels.append(
+            build_label(
+                standalone.user_mgmt_label_key(f"{provider}.authz.dedicated-admins"),
+                ",".join(dedicated_admins_groups),
+            )
+        )
+    if cluster_admins_groups:
+        labels.append(
+            build_label(
+                standalone.user_mgmt_label_key(f"{provider}.authz.cluster-admins"),
+                ",".join(cluster_admins_groups),
+            )
+        )
+    return build_label_container(labels)
+
+
+def build_authz_labels(
+    dedicated_admins_groups: Optional[set[str]] = None,
+    cluster_admins_groups: Optional[set[str]] = None,
+) -> LabelContainer:
+    provider = "provider"
+    label_container = build_provider_authz_labels(
+        provider=provider,
+        dedicated_admins_groups=dedicated_admins_groups,
+        cluster_admins_groups=cluster_admins_groups,
+    )
+    return build_container_for_prefix(
+        label_container, standalone.user_mgmt_label_key(f"{provider}."), True
+    )
+
+
+@pytest.mark.parametrize("labelsource", [("org"), ("sub")])
+def test_authz_labels_single_source(labelsource: str) -> None:
+    provider = "provider"
+    labels = build_authz_labels({"da1", "da2"}, {"ca"})
+    mappings = build_cluster_config_from_labels(
+        provider=provider,
+        org_labels=labels if labelsource == "org" else LabelContainer(),
+        subscription_labels=labels if labelsource == "sub" else LabelContainer(),
+    )
+    assert OCMClusterGroupId.DEDICATED_ADMINS in mappings
+    assert {
+        (rm.provider, rm.group_id)
+        for rm in mappings[OCMClusterGroupId.DEDICATED_ADMINS]
+    } == {(provider, "da1"), (provider, "da2")}
+    assert OCMClusterGroupId.CLUSTER_ADMINS in mappings
+    assert {
+        (rm.provider, rm.group_id) for rm in mappings[OCMClusterGroupId.CLUSTER_ADMINS]
+    } == {(provider, "ca")}
+
+
+def test_authz_org_and_sub_labels() -> None:
+    provider = "provider"
+    org_labels = build_authz_labels(
+        {"da_from_org", "da_common"}, {"ca_from_org", "ca_common"}
+    )
+    sub_labels = build_authz_labels(
+        {"da_from_sub", "da_common"}, {"ca_from_sub", "ca_common"}
+    )
+    mappings = build_cluster_config_from_labels(
+        provider=provider,
+        org_labels=org_labels,
+        subscription_labels=sub_labels,
+    )
+    assert OCMClusterGroupId.DEDICATED_ADMINS in mappings
+    assert {
+        (rm.provider, rm.group_id)
+        for rm in mappings[OCMClusterGroupId.DEDICATED_ADMINS]
+    } == {(provider, "da_from_org"), (provider, "da_from_sub"), (provider, "da_common")}
+    assert OCMClusterGroupId.CLUSTER_ADMINS in mappings
+    assert {
+        (rm.provider, rm.group_id) for rm in mappings[OCMClusterGroupId.CLUSTER_ADMINS]
+    } == {(provider, "ca_from_org"), (provider, "ca_from_sub"), (provider, "ca_common")}
+
+
+#
+# test build_user_management_configurations
+#
+
+
+def test_build_user_management_configurations() -> None:
+    org_id = "org_id"
+    provider = "provider"
+    org_config = standalone.build_user_management_configurations(
+        org_id=org_id,
+        clusters=[
+            build_cluster_details(
+                cluster_name="cluster",
+                subscription_labels=build_provider_authz_labels(
+                    provider=provider,
+                    cluster_admins_groups={"ca"},
+                ),
+                organization_labels=build_provider_authz_labels(
+                    provider=provider, dedicated_admins_groups={"da"}
+                ),
+                org_id=org_id,
+            )
+        ],
+        providers={provider},
+    )
+    assert org_config.org_id == org_id
+    assert org_config.cluster_configs[0].cluster.ocm_cluster.name == "cluster"
+    assert org_config.cluster_configs[0].roles[OCMClusterGroupId.DEDICATED_ADMINS] == [
+        ExternalGroupRef(provider=provider, group_id="da")
+    ]
+    assert org_config.cluster_configs[0].roles[OCMClusterGroupId.CLUSTER_ADMINS] == [
+        ExternalGroupRef(provider=provider, group_id="ca")
+    ]
+
+
+def test_build_user_management_configurations_no_authz_labels() -> None:
+    org_id = "org_id"
+    provider = "provider"
+    org_config = standalone.build_user_management_configurations(
+        org_id=org_id,
+        clusters=[
+            build_cluster_details(
+                cluster_name="cluster",
+                subscription_labels=LabelContainer(
+                    labels={
+                        standalone.user_mgmt_label_key("some-other-label"): build_label(
+                            standalone.user_mgmt_label_key("some-other-label"),
+                            "some-value",
+                        )
+                    }
+                ),
+                org_id=org_id,
+            )
+        ],
+        providers={provider},
+    )
+    assert org_config.org_id == org_id
+    assert org_config.cluster_configs[0].cluster.ocm_cluster.name == "cluster"
+    assert org_config.cluster_configs[0].roles == {}
+
+
+#
+# test discover clusters
+#
+
+
+@pytest.mark.parametrize(
+    "org_id_filter,expected_cluster_names",
+    [
+        (None, {"org-id-1": {"cluster-1"}, "org-id-2": {"cluster-2"}}),
+        ({"org-id-1"}, {"org-id-1": {"cluster-1"}}),
+    ],
+)
+def test_discover_clusters(
+    org_id_filter: Optional[set[str]],
+    expected_cluster_names: dict[str, set[str]],
+    ocm_api: OCMBaseClient,
+    mocker: MockerFixture,
+) -> None:
+    org_id_1 = "org-id-1"
+    cluster_name_1 = "cluster-1"
+    org_id_2 = "org-id-2"
+    cluster_name_2 = "cluster-2"
+
+    discover_clusters_by_labels_mock = mocker.patch.object(
+        standalone,
+        "discover_clusters_by_labels",
+        autospec=True,
+    )
+    discover_clusters_by_labels_mock.return_value = [
+        build_cluster_details(
+            cluster_name=cluster_name_1,
+            subscription_labels=build_authz_labels({"group"}),
+            org_id=org_id_1,
+        ),
+        build_cluster_details(
+            cluster_name=cluster_name_2,
+            subscription_labels=build_authz_labels({"group"}),
+            org_id=org_id_2,
+        ),
+    ]
+
+    clusters_by_org = standalone.discover_clusters(ocm_api, org_id_filter)
+
+    discover_clusters_by_labels_mock.assert_called_once_with(
+        ocm_api=ocm_api,
+        label_filter=Filter().like("key", standalone.user_mgmt_label_key("%")),
+    )
+
+    assert {
+        org: {c.ocm_cluster.name for c in clusters}
+        for org, clusters in clusters_by_org.items()
+    } == expected_cluster_names
+
+
+#
+# Test signals
+#
+
+
+@pytest.mark.parametrize(
+    "dry_run",
+    [True, False],
+)
+def test_signal_cluster_reconcile_success(
+    dry_run: bool, ocm_api: OCMBaseClient, mocker: MockerFixture
+) -> None:
+    create_service_log_mock = mocker.patch.object(
+        standalone,
+        "create_service_log",
+        autospec=True,
+    )
+
+    integration = standalone.OCMStandaloneUserManagementIntegration(
+        OCMUserManagementIntegrationParams(group_provider_specs=[])
+    )
+
+    cluster = build_cluster_details(cluster_name="cluster")
+    spec = ClusterUserManagementSpec(
+        cluster=cluster,
+        roles={
+            OCMClusterGroupId.DEDICATED_ADMINS: {"user-1", "user-2"},
+        },
+        errors=[],
+    )
+    integration.signal_cluster_reconcile_success(
+        dry_run=dry_run, ocm_api=ocm_api, spec=spec, message="profit!"
+    )
+
+    if dry_run:
+        assert create_service_log_mock.call_count == 0
+    else:
+        assert create_service_log_mock.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "dry_run",
+    [True, False],
+)
+def test_signal_cluster_validation_error(
+    dry_run: bool, ocm_api: OCMBaseClient, mocker: MockerFixture
+) -> None:
+    create_service_log_mock = mocker.patch.object(
+        standalone,
+        "create_service_log",
+        autospec=True,
+    )
+
+    integration = standalone.OCMStandaloneUserManagementIntegration(
+        OCMUserManagementIntegrationParams(group_provider_specs=[])
+    )
+
+    cluster = build_cluster_details(cluster_name="cluster")
+    spec = ClusterUserManagementSpec(
+        cluster=cluster,
+        roles={
+            OCMClusterGroupId.DEDICATED_ADMINS: {"user-1", "user-2"},
+        },
+        errors=[],
+    )
+    integration.signal_cluster_validation_error(
+        dry_run=dry_run,
+        ocm_api=ocm_api,
+        spec=spec,
+        error=Exception("something went wrong"),
+    )
+
+    if dry_run:
+        assert create_service_log_mock.call_count == 0
+    else:
+        assert create_service_log_mock.call_count == 1

--- a/reconcile/test/ocm/test_utils_ocm_cluster_groups.py
+++ b/reconcile/test/ocm/test_utils_ocm_cluster_groups.py
@@ -47,7 +47,7 @@ def test_get_cluster_groups(
                         OCMClusterGroupId.DEDICATED_ADMINS, {"user-1", "user-2"}
                     ),
                     build_ocm_cluster_group(
-                        OCMClusterGroupId.CLUSTER_ADMIN, {"user-3", "user-4"}
+                        OCMClusterGroupId.CLUSTER_ADMINS, {"user-3", "user-4"}
                     ),
                 ],
             ),
@@ -59,8 +59,8 @@ def test_get_cluster_groups(
     )
     assert OCMClusterGroupId.DEDICATED_ADMINS in groups
     assert groups[OCMClusterGroupId.DEDICATED_ADMINS].user_ids() == {"user-1", "user-2"}
-    assert OCMClusterGroupId.CLUSTER_ADMIN in groups
-    assert groups[OCMClusterGroupId.CLUSTER_ADMIN].user_ids() == {"user-3", "user-4"}
+    assert OCMClusterGroupId.CLUSTER_ADMINS in groups
+    assert groups[OCMClusterGroupId.CLUSTER_ADMINS].user_ids() == {"user-3", "user-4"}
 
 
 def test_add_user_to_cluster_group(

--- a/reconcile/test/ocm/test_utils_ocm_clusters.py
+++ b/reconcile/test/ocm/test_utils_ocm_clusters.py
@@ -44,8 +44,10 @@ def build_cluster_details(
     return ClusterDetails(
         ocm_cluster=ocm_cluster,
         organization_id=org_id,
-        labels=build_label_container(
-            [build_organization_label(k, v, org_id) for k, v in org_labels or []],
+        organization_labels=build_label_container(
+            [build_organization_label(k, v, org_id) for k, v in org_labels or []]
+        ),
+        subscription_labels=build_label_container(
             [
                 build_subscription_label(k, v, ocm_cluster.subscription.id)
                 for k, v in subs_labels or []

--- a/reconcile/test/test_utils_ldap_client.py
+++ b/reconcile/test/test_utils_ldap_client.py
@@ -1,20 +1,39 @@
+from typing import Any
+
 import ldap3
 import pytest
+from pytest_mock import MockerFixture
 
 from reconcile.utils.ldap_client import LdapClient
 
 
 @pytest.fixture
-def connection_search_result():
+def connection_search_result() -> list[dict[str, Any]]:
     result = [
-        {"attributes": {"uid": ["user1"]}},
-        {"attributes": {"uid": ["user2"]}},
-        {"attributes": {"uid": ["user3"]}},
+        {
+            "attributes": {
+                "uid": ["user1"],
+                "memberOf": [
+                    "cn=group1,dc=example,dc=com",
+                    "cn=group2,dc=example,dc=com",
+                ],
+            }
+        },
+        {
+            "attributes": {
+                "uid": ["user2"],
+                "memberOf": [
+                    "cn=group1,dc=example,dc=com",
+                    "cn=some-other-group,dc=example,dc=com",
+                ],
+            }
+        },
+        {"attributes": {"uid": ["user3"], "memberOf": ["cn=group3,dc=example,dc=com"]}},
     ]
     return result
 
 
-def test_ldap_client_from_settings(mocker):
+def test_ldap_client_from_settings(mocker: MockerFixture) -> None:
     mock_connection_bind = mocker.patch(
         "reconcile.utils.ldap_client.Connection", autospec=True
     )
@@ -25,7 +44,9 @@ def test_ldap_client_from_settings(mocker):
         assert mock_connection_bind.call_args.args[0].host == "testUrl"
 
 
-def test_ldap_client(mocker, connection_search_result):
+def test_ldap_client(
+    mocker: MockerFixture, connection_search_result: list[dict[str, Any]]
+) -> None:
     mocked_connection = mocker.Mock(spec=ldap3.Connection)
     mocked_connection.search.return_value = None, None, connection_search_result, None
 
@@ -36,7 +57,9 @@ def test_ldap_client(mocker, connection_search_result):
     mocked_connection.unbind.assert_called_once_with()
 
 
-def test_ldap_client_get_users(mocker, connection_search_result):
+def test_ldap_client_get_users(
+    mocker: MockerFixture, connection_search_result: list[dict[str, Any]]
+) -> None:
     mocked_connection = mocker.Mock(spec=ldap3.Connection)
     mocked_connection.search.return_value = None, None, connection_search_result, None
 
@@ -49,3 +72,36 @@ def test_ldap_client_get_users(mocker, connection_search_result):
         "(&(objectclass=person)(|(uid=user1)(uid=user2)(uid=user3)))",
         attributes=["uid"],
     )
+
+
+#
+# test get_group_members
+#
+
+
+def test_ldap_client_get_rover_groups(
+    mocker: MockerFixture, connection_search_result: list[dict[str, Any]]
+) -> None:
+    mocked_connection = mocker.Mock(spec=ldap3.Connection)
+    mocked_connection.search.return_value = None, None, connection_search_result, None
+
+    with LdapClient("test", mocked_connection) as ldap_client:
+        group_dns = {
+            "cn=group1,dc=example,dc=com",
+            "cn=group2,dc=example,dc=com",
+            "cn=group3,dc=example,dc=com",
+        }
+        groups_by_dn = ldap_client.get_group_members(group_dns)
+
+    # check that the search filter is correct
+    mocked_connection.search.assert_called_once_with(
+        "test",
+        "(|(memberOf=cn=group1,dc=example,dc=com)(memberOf=cn=group2,dc=example,dc=com)(memberOf=cn=group3,dc=example,dc=com))",
+        attributes=["uid", "memberOf"],
+    )
+
+    assert groups_by_dn == {
+        "cn=group1,dc=example,dc=com": {"user1", "user2"},
+        "cn=group2,dc=example,dc=com": {"user1"},
+        "cn=group3,dc=example,dc=com": {"user3"},
+    }

--- a/reconcile/utils/ldap_client.py
+++ b/reconcile/utils/ldap_client.py
@@ -1,4 +1,6 @@
+from collections import defaultdict
 from collections.abc import Iterable
+from typing import Optional
 
 from ldap3 import (
     ALL,
@@ -34,14 +36,42 @@ class LdapClient:
         )
         return set(r["attributes"]["uid"][0] for r in results)
 
+    def get_group_members(self, groups_dns: set[str]) -> dict[str, set[str]]:
+        """
+        Returns a dictionary of group dns and their members.
+        """
+        if not groups_dns:
+            return {}
+        filter = f"(|{''.join([f'(memberOf={dn})' for dn in sorted(groups_dns)])})"
+
+        _, _, users, _ = self.connection.search(
+            self.base_dn,
+            filter,
+            attributes=["uid", "memberOf"],
+        )
+        groups_and_members: dict[str, set[str]] = defaultdict(set[str])
+        for u in users:
+            uid = u["attributes"]["uid"][0]
+            for group in set(u["attributes"]["memberOf"]).intersection(groups_dns):
+                groups_and_members[group].add(uid)
+
+        return dict(groups_and_members)
+
     @classmethod
     def from_settings(cls, settings: dict) -> "LdapClient":
         """Requires a nested dictionary with key 'ldap' in addition sub keys 'serverUrl' and 'baseDn'."""
+        return LdapClient.from_params(
+            settings["ldap"]["serverUrl"], None, None, settings["ldap"]["baseDn"]
+        )
+
+    @classmethod
+    def from_params(
+        cls, server_url: str, user: Optional[str], password: Optional[str], base_dn: str
+    ) -> "LdapClient":
         connection = Connection(
-            Server(settings["ldap"]["serverUrl"], get_info=ALL),
-            None,
-            None,
+            Server(server_url, get_info=ALL),
+            user,
+            password,
             client_strategy=SAFE_SYNC,
         )
-        base_dn = settings["ldap"]["baseDn"]
         return cls(base_dn, connection)

--- a/reconcile/utils/ocm/cluster_groups.py
+++ b/reconcile/utils/ocm/cluster_groups.py
@@ -12,7 +12,7 @@ class OCMClusterGroupId(Enum):
     """
 
     DEDICATED_ADMINS = "dedicated-admins"
-    CLUSTER_ADMIN = "cluster-admins"
+    CLUSTER_ADMINS = "cluster-admins"
 
 
 class OCMClusterUser(BaseModel):

--- a/reconcile/utils/ocm/clusters.py
+++ b/reconcile/utils/ocm/clusters.py
@@ -25,6 +25,7 @@ from reconcile.utils.ocm.subscriptions import (
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 ACTIVE_SUBSCRIPTION_STATES = {"Active", "Reserved"}
+CAPABILITY_MANAGE_CLUSTER_ADMIN = "capability.cluster.manage_cluster_admin"
 
 
 class OCMClusterState(Enum):
@@ -88,7 +89,19 @@ class ClusterDetails(BaseModel):
     found on the subscription of a cluster.
     """
 
-    labels: LabelContainer
+    subscription_labels: LabelContainer
+    organization_labels: LabelContainer
+
+    @property
+    def labels(self) -> LabelContainer:
+        return build_label_container(
+            self.organization_labels.labels.values(),
+            self.subscription_labels.labels.values(),
+        )
+
+    def is_capability_set(self, name: str, value: str) -> bool:
+        capa = self.capabilities.get(name)
+        return capa is not None and capa.value == value
 
 
 def discover_clusters_by_labels(
@@ -125,9 +138,11 @@ def discover_clusters_by_labels(
 
     # fill in labels
     for cluster in clusters:
-        cluster.labels = build_label_container(
-            organization_labels[cluster.organization_id],
-            subscription_labels[cluster.ocm_cluster.subscription.id],
+        cluster.subscription_labels = build_label_container(
+            subscription_labels[cluster.ocm_cluster.subscription.id]
+        )
+        cluster.organization_labels = build_label_container(
+            organization_labels[cluster.organization_id]
         )
 
     return clusters
@@ -236,11 +251,11 @@ def get_cluster_details_for_subscriptions(
                     capability.name: capability
                     for capability in subscription.capabilities or []
                 },
-                labels=build_label_container(
-                    # first org labels...#
-                    organization_labels.get(subscription.organization_id) or [],
-                    # ... then the subscription labels
-                    (subscription.labels or []) if init_labels else [],
+                organization_labels=build_label_container(
+                    organization_labels.get(subscription.organization_id) or []
+                ),
+                subscription_labels=build_label_container(
+                    (subscription.labels or []) if init_labels else []
                 ),
             )
 

--- a/reconcile/utils/ocm/labels.py
+++ b/reconcile/utils/ocm/labels.py
@@ -8,7 +8,10 @@ from typing import (
     Optional,
 )
 
-from pydantic import BaseModel
+from pydantic import (
+    BaseModel,
+    Field,
+)
 
 from reconcile.utils.ocm.search_filters import Filter
 from reconcile.utils.ocm_base_client import OCMBaseClient
@@ -131,10 +134,13 @@ class LabelContainer(BaseModel):
     efficiently with them.
     """
 
-    labels: dict[str, OCMLabel]
+    labels: dict[str, OCMLabel] = Field(default_factory=dict)
 
     def __len__(self) -> int:
         return len(self.labels)
+
+    def __bool__(self) -> bool:
+        return len(self.labels) > 0
 
     def get(self, name: str) -> Optional[OCMLabel]:
         return self.labels.get(name)


### PR DESCRIPTION
Implementation of the [Red Hat User Management SRE capability](https://issues.redhat.com/browse/SDE-2628)

This capability can be used by RH internal teams to attach their LDAP groups (e.g. Rover) to the `cluster-admins` or `dedicated-admins` roles of a cluster. Users can declare their desire for group syncs via OCM organization or subscription labels. Group syncs defined on the organization are applied on all clusters of the organization. Group syncs defined on subscriptions will only be applied to the individual clusters. Configuration on the organization and on the subscriptions are cummulative.

If a cluster role is either managed on the organisation or subscription, its current members will be replaced by the ones from the defined LDAP groups.

The following label keys are supported:

* `sre-capabilities.user-mgmt.rover.authz.dedicated-admins` contains a CSV list of rover group CNs (see LDAP Common Name on the rover group page) for the `dedicated-admins` role
* `sre-capabilities.user-mgmt.rover.authz.cluster-admins` contains a CSV list of rover group CNs for the `cluster-admins` role

The `cluster-admins` role can only be managed if the cluster has the proper capability in OCM.

This standalone capability does not fail on errors but reports them differently based on the kind of issue, e.g. configuration validation errors the user is responsible for (e.g. non-existing LDAP groups) are reported to the cluster owners as OCM service logs. Additionally several prometheus metrics are exposed that can be used for fine grained alerting:

```text
ocm_user_management_organization_validation_errors{ocm_env="ocm-production",org_id="xxx"} 0.0
ocm_user_management_organization_reconciled_total{ocm_env="ocm-production",org_id="xxx"} 1.0
ocm_user_management_organization_actions_total{action="add-user",ocm_env="ocm-production",org_id="xxx"} 24.0
ocm_user_management_organization_actions_total{action="remove-user",ocm_env="ocm-production",org_id="xxx"} 7.0
ocm_user_management_organization_reconcile_errors_total{ocm_env="ocm-production",org_id="xxx"} 0.0
```

part of <https://issues.redhat.com/browse/APPSRE-7709>