### PR TITLE
Use long polling to receive messages from SQS

### DIFF
--- a/reconcile/test/test_utils_sqs_gateway.py
+++ b/reconcile/test/test_utils_sqs_gateway.py
@@ -1,0 +1,48 @@
+from unittest.mock import create_autospec
+
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.utils.secret_reader import SecretReader
+from reconcile.utils.sqs_gateway import SQSGateway
+
+
+@pytest.fixture
+def aws_account() -> dict:
+    return {
+        "uid": "123",
+        "name": "my-account",
+    }
+
+
+def test_receive_messages(
+    mocker: MockerFixture,
+    aws_account: dict,
+) -> None:
+    queue_url = f"https://sqs/{aws_account['uid']}/queue"
+    mocked_os = mocker.patch("reconcile.utils.sqs_gateway.os")
+    mocked_os.environ.get.return_value = queue_url
+    mocked_aws_api = mocker.patch("reconcile.utils.sqs_gateway.AWSApi")
+    mocked_sqs = mocked_aws_api.return_value.get_session_client.return_value
+    mocked_sqs.receive_message.return_value = {
+        "Messages": [
+            {
+                "ReceiptHandle": "receipt-handle",
+                "Body": '{"key": "value"}',
+            }
+        ]
+    }
+    sqs_gateway = SQSGateway(
+        [aws_account],
+        create_autospec(SecretReader),
+    )
+
+    messages = sqs_gateway.receive_messages()
+    expected_messages = [("receipt-handle", {"key": "value"})]
+
+    assert messages == expected_messages
+    mocked_sqs.receive_message.assert_called_once_with(
+        QueueUrl=queue_url,
+        VisibilityTimeout=30,
+        WaitTimeSeconds=20,
+    )

--- a/reconcile/utils/sqs_gateway.py
+++ b/reconcile/utils/sqs_gateway.py
@@ -54,9 +54,15 @@ class SQSGateway:
     def send_message(self, body):
         self.sqs.send_message(QueueUrl=self.queue_url, MessageBody=json.dumps(body))
 
-    def receive_messages(self, visibility_timeout=30):
+    def receive_messages(
+        self,
+        visibility_timeout=30,
+        wait_time_seconds=20,
+    ):
         messages = self.sqs.receive_message(
-            QueueUrl=self.queue_url, VisibilityTimeout=visibility_timeout
+            QueueUrl=self.queue_url,
+            VisibilityTimeout=visibility_timeout,
+            WaitTimeSeconds=wait_time_seconds,
         ).get("Messages", [])
         return [(m["ReceiptHandle"], json.loads(m["Body"])) for m in messages]
 


### PR DESCRIPTION
`receive_message` should be called with `WaitTimeSeconds` to use long polling, default to max 20s. this will reduce cost.

[Consuming messages using long polling](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 670cdb3</samp>

This pull request adds a new test function for the `SQSGateway` class and modifies its `receive_messages` method to accept a `wait_time_seconds` parameter. These changes improve the testability and flexibility of the class.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 670cdb3</samp>

*  Add a new parameter `wait_time_seconds` to the `SQSGateway.receive_messages` method to control how long the SQS client will wait for a message to arrive in the queue ([link](https://github.com/app-sre/qontract-reconcile/pull/3545/files?diff=unified&w=0#diff-6be691821f3687f9a43d7c535511105b8f4c032813b11493eea95d3984d7245aL57-R65))
*  Pass the `wait_time_seconds` parameter to the SQS client's `receive_message` method in `SQSGateway.receive_messages` ([link](https://github.com/app-sre/qontract-reconcile/pull/3545/files?diff=unified&w=0#diff-6be691821f3687f9a43d7c535511105b8f4c032813b11493eea95d3984d7245aL57-R65))
*  Add a new test function `test_receive_messages` to the `test_utils_sqs_gateway.py` module to verify the behavior and output of the `SQSGateway.receive_messages` method with different values of `wait_time_seconds` ([link](https://github.com/app-sre/qontract-reconcile/pull/3545/files?diff=unified&w=0#diff-2d18db5f67e41b06e032b588b9f7cf8015b4eca17bc0431294c0547d2ba8816cR1-R48))
*  Use pytest fixtures and mocks to set up a fake AWS account, queue URL, and SQS client in `test_receive_messages` ([link](https://github.com/app-sre/qontract-reconcile/pull/3545/files?diff=unified&w=0#diff-2d18db5f67e41b06e032b588b9f7cf8015b4eca17bc0431294c0547d2ba8816cR1-R48))
*  Create an instance of the `SQSGateway` class and call its `receive_messages` method with different values of `wait_time_seconds` in `test_receive_messages` ([link](https://github.com/app-sre/qontract-reconcile/pull/3545/files?diff=unified&w=0#diff-2d18db5f67e41b06e032b588b9f7cf8015b4eca17bc0431294c0547d2ba8816cR1-R48))
*  Assert that the `receive_messages` method returns the expected messages and that the SQS client is called with the correct parameters in `test_receive_messages` ([link](https://github.com/app-sre/qontract-reconcile/pull/3545/files?diff=unified&w=0#diff-2d18db5f67e41b06e032b588b9f7cf8015b4eca17bc0431294c0547d2ba8816cR1-R48))