### PR TITLE
[addons-upgrade-scheduler] don't fail when clusters get deprovisioned

### DIFF
--- a/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
@@ -117,6 +117,9 @@ class OCMAddonsUpgradeSchedulerOrgIntegration(
                 upgradePolicy=cluster.upgrade_policy,
             )
             for cluster in org.upgrade_policy_clusters or []
+            # clusters that are not in the UUID dict will be ignored because
+            # they don't exist in the OCM organization (or have been deprovisioned)
+            if cluster.name in cluster_name_to_uuid
         ]
 
     def expose_org_upgrade_spec_metrics(

--- a/reconcile/aus/ocm_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_upgrade_scheduler_org.py
@@ -72,6 +72,6 @@ class OCMClusterUpgradeSchedulerOrgIntegration(OCMClusterUpgradeSchedulerIntegra
             )
             for cluster in org.upgrade_policy_clusters or []
             # clusters that are not in the UUID dict will be ignored because
-            # they don't exist in the OCM organization
+            # they don't exist in the OCM organization (or have been deprovisioned)
             if cluster.name in cluster_name_to_uuid
         ]


### PR DESCRIPTION
fix a bug that fails the addons-upgrade-scheduler integration if a cluster mentioned in an a-i OCM org file is deprovisioned. ignoring such declarations is a valid solution because such clusters get cleaned up automatically after a while anyways.