### PR TITLE
[AUS] expose current cluster version in metrics

### DIFF
--- a/reconcile/aus/metrics.py
+++ b/reconcile/aus/metrics.py
@@ -19,6 +19,7 @@ class AUSClusterVersionRemainingSoakDaysGauge(AUSBaseMetric, GaugeMetric):
 
     cluster_uuid: str
     soaking_version: str
+    current_version: str
 
     @classmethod
     def name(cls) -> str:

--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -137,6 +137,7 @@ class OCMClusterUpgradeSchedulerIntegration(
                         ocm_env=ocm_env,
                         cluster_uuid=up.cluster_uuid,
                         soaking_version=version,
+                        current_version=up.current_version,
                     ),
                     max(up.conditions.soakDays - (min(soaks) or 0), 0),
                 )


### PR DESCRIPTION
the current cluster version information can be used in reporting. the metrics now looks as follows:

```
aus_cluster_version_remaining_soak_days{cluster_uuid="xxx", soaking_version="4.13.1", current_version="4.13.0"}
```

i considered putting the `current_version` into another existing metric, but none would quite fit. introducing a new one just for this piece of information would have been an overkill.

i'm more than open for a discussion :) 