### PR TITLE
add support for assume action and Federated assume principal

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -34123,6 +34123,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "Federated",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -34291,6 +34303,18 @@
                             "type": {
                                 "kind": "SCALAR",
                                 "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "assume_action",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
                                 "ofType": null
                             },
                             "isDeprecated": false,

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
@@ -100,8 +100,10 @@ query TerraformResourcesNamespaces {
                 assume_role {
                     AWS
                     Service
+                    Federated
                 }
                 assume_condition
+                assume_action
                 inline_policy
                 output_resource_name
                 annotations

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
@@ -139,8 +139,10 @@ query TerraformResourcesNamespaces {
                 assume_role {
                     AWS
                     Service
+                    Federated
                 }
                 assume_condition
+                assume_action
                 inline_policy
                 output_resource_name
                 annotations
@@ -590,12 +592,14 @@ class NamespaceTerraformResourceSecretsManagerServiceAccountV1(
 class AssumeRoleV1(ConfiguredBaseModel):
     aws: Optional[list[str]] = Field(..., alias="AWS")
     service: Optional[list[str]] = Field(..., alias="Service")
+    federated: Optional[str] = Field(..., alias="Federated")
 
 
 class NamespaceTerraformResourceRoleV1(NamespaceTerraformResourceAWSV1):
     identifier: str = Field(..., alias="identifier")
     assume_role: AssumeRoleV1 = Field(..., alias="assume_role")
     assume_condition: Optional[str] = Field(..., alias="assume_condition")
+    assume_action: Optional[str] = Field(..., alias="assume_action")
     inline_policy: Optional[str] = Field(..., alias="inline_policy")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
@@ -1006,10 +1010,10 @@ class NamespaceTerraformProviderResourceAWSV1(NamespaceExternalResourceV1):
             NamespaceTerraformResourceSNSTopicV1,
             NamespaceTerraformResourceElastiCacheV1,
             NamespaceTerraformResourceServiceAccountV1,
+            NamespaceTerraformResourceRoleV1,
             NamespaceTerraformResourceS3SQSV1,
             NamespaceTerraformResourceCloudWatchV1,
             NamespaceTerraformResourceRosaAuthenticatorVPCEV1,
-            NamespaceTerraformResourceRoleV1,
             NamespaceTerraformResourceS3CloudFrontV1,
             NamespaceTerraformResourceKMSV1,
             NamespaceTerraformResourceElasticSearchV1,

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -218,6 +218,7 @@ VARIABLE_KEYS = [
     "assume_role",
     "inline_policy",
     "assume_condition",
+    "assume_action",
     "api_proxy_uri",
     "cognito_callback_bucket_name",
     "openshift_ingress_load_balancer_arn",
@@ -2365,12 +2366,13 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         assume_role = common_values["assume_role"]
         assume_role = {k: v for k, v in assume_role.items() if v is not None}
+        assume_action = common_values.get("assume_action") or "AssumeRole"
         # assume role policy
         assume_role_policy = {
             "Version": "2012-10-17",
             "Statement": [
                 {
-                    "Action": "sts:AssumeRole",
+                    "Action": f"sts:{assume_action}",
                     "Effect": "Allow",
                     "Principal": assume_role,
                 }


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-7734

depends on https://github.com/app-sre/qontract-schemas/pull/460

this PR adds support to allow creating roles with:
- a different assume action (instead of AssumeRole)
- a Federated assume Principal

this is required to attach IAM roles to OpenShift ServiceAccounts.

this fits the backplane usage, but is a good pattern instead of using IAM credentials, so this possibly opens up a door for https://issues.redhat.com/browse/APPSRE-4201