### PR TITLE
Set OCNative request timeout to 60s

### DIFF
--- a/reconcile/test/test_utils_oc.py
+++ b/reconcile/test/test_utils_oc.py
@@ -1025,7 +1025,7 @@ def test_oc_native_get(oc_native: OCNative) -> None:
     oc_native.client.resources.get.return_value.get.assert_called_once_with(
         namespace="namespace",
         name="name",
-        _request_time=60,
+        _request_timeout=60,
     )
 
 
@@ -1039,7 +1039,7 @@ def test_oc_native_get_items(oc_native: OCNative) -> None:
     oc_native.client.resources.get.return_value.get.assert_called_once_with(
         namespace="",
         label_selector="label1=value1",
-        _request_time=60,
+        _request_timeout=60,
     )
 
 
@@ -1054,7 +1054,7 @@ def test_oc_native_get_items_with_resource_names(oc_native: OCNative) -> None:
         namespace="",
         name="name",
         label_selector="label1=value1",
-        _request_time=60,
+        _request_timeout=60,
     )
 
 
@@ -1066,5 +1066,5 @@ def test_oc_native_get_all(oc_native: OCNative) -> None:
         kind="kind1",
     )
     oc_native.client.resources.get.return_value.get.assert_called_once_with(
-        _request_time=60,
+        _request_timeout=60,
     )

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1194,6 +1194,9 @@ class OCCli:  # pylint: disable=too-many-public-methods
         return kind_resources[0].namespaced
 
 
+REQUEST_TIMEOUT = 60
+
+
 class OCNative(OCCli):
     def __init__(
         self,
@@ -1322,7 +1325,10 @@ class OCNative(OCCli):
             for resource_name in resource_names:
                 try:
                     item = obj_client.get(
-                        name=resource_name, namespace=namespace, label_selector=labels
+                        name=resource_name,
+                        namespace=namespace,
+                        label_selector=labels,
+                        _request_time=REQUEST_TIMEOUT,
                     )
                     if item:
                         items.append(item.to_dict())
@@ -1331,7 +1337,9 @@ class OCNative(OCCli):
             items_list = {"items": items}
         else:
             items_list = obj_client.get(
-                namespace=namespace, label_selector=labels
+                namespace=namespace,
+                label_selector=labels,
+                _request_time=REQUEST_TIMEOUT,
             ).to_dict()
 
         items = items_list.get("items")
@@ -1345,7 +1353,11 @@ class OCNative(OCCli):
         k, group_version = self._parse_kind(kind)
         obj_client = self._get_obj_client(group_version=group_version, kind=k)
         try:
-            obj = obj_client.get(name=name, namespace=namespace)
+            obj = obj_client.get(
+                name=name,
+                namespace=namespace,
+                _request_time=REQUEST_TIMEOUT,
+            )
             return obj.to_dict()
         except NotFoundError as e:
             if allow_not_found:
@@ -1356,7 +1368,7 @@ class OCNative(OCCli):
         k, group_version = self._parse_kind(kind)
         obj_client = self._get_obj_client(group_version=group_version, kind=k)
         try:
-            return obj_client.get().to_dict()
+            return obj_client.get(_request_time=REQUEST_TIMEOUT).to_dict()
         except NotFoundError as e:
             raise StatusCodeError(f"[{self.server}]: {e}")
 

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1328,7 +1328,7 @@ class OCNative(OCCli):
                         name=resource_name,
                         namespace=namespace,
                         label_selector=labels,
-                        _request_time=REQUEST_TIMEOUT,
+                        _request_timeout=REQUEST_TIMEOUT,
                     )
                     if item:
                         items.append(item.to_dict())
@@ -1339,7 +1339,7 @@ class OCNative(OCCli):
             items_list = obj_client.get(
                 namespace=namespace,
                 label_selector=labels,
-                _request_time=REQUEST_TIMEOUT,
+                _request_timeout=REQUEST_TIMEOUT,
             ).to_dict()
 
         items = items_list.get("items")
@@ -1356,7 +1356,7 @@ class OCNative(OCCli):
             obj = obj_client.get(
                 name=name,
                 namespace=namespace,
-                _request_time=REQUEST_TIMEOUT,
+                _request_timeout=REQUEST_TIMEOUT,
             )
             return obj.to_dict()
         except NotFoundError as e:
@@ -1368,7 +1368,7 @@ class OCNative(OCCli):
         k, group_version = self._parse_kind(kind)
         obj_client = self._get_obj_client(group_version=group_version, kind=k)
         try:
-            return obj_client.get(_request_time=REQUEST_TIMEOUT).to_dict()
+            return obj_client.get(_request_timeout=REQUEST_TIMEOUT).to_dict()
         except NotFoundError as e:
             raise StatusCodeError(f"[{self.server}]: {e}")
 


### PR DESCRIPTION
OCNative request may hang indefinitely without timeout, this change adds a default timeout 60s.

[APPSRE-7677](https://issues.redhat.com/browse/APPSRE-7677)

[timeout-settings.md](https://github.com/kubernetes-client/python/blob/master/examples/watch/timeout-settings.md)

[example request_timeout.py](https://github.com/kubernetes-client/python/blob/master/examples/dynamic-client/request_timeout.py)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a1ca233</samp>

Improved testing and timeout handling for the `oc` module. Renamed the `oc` fixture and parameter in `test_utils_oc.py` to avoid confusion with the native client. Added tests for the `OCNative` class and its methods. Added a 60-second timeout for native client requests in `oc.py`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a1ca233</samp>

*  Add a constant `REQUEST_TIMEOUT` to the `oc` module and use it to set the timeout for the native client requests ([link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-006493679cf46d27e100feeb8475e6e29987fe85cca4858a1f05608b2d536dc8R1197-R1199), [link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-006493679cf46d27e100feeb8475e6e29987fe85cca4858a1f05608b2d536dc8L1325-R1331), [link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-006493679cf46d27e100feeb8475e6e29987fe85cca4858a1f05608b2d536dc8L1334-R1342), [link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-006493679cf46d27e100feeb8475e6e29987fe85cca4858a1f05608b2d536dc8L1348-R1360), [link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-006493679cf46d27e100feeb8475e6e29987fe85cca4858a1f05608b2d536dc8L1359-R1371))
* Rename the `oc` fixture to `oc_cli` and annotate it with the `OCCli` type in `test_utils_oc.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-0a81da15b33af432e42fa7b0063ca76990d9162f1bff6e1b8236717ee3cdd350L576-R578), [link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-0a81da15b33af432e42fa7b0063ca76990d9162f1bff6e1b8236717ee3cdd350L962-R986))
* Rename and annotate the `oc` parameter to `oc_cli` in the test functions that use the `oc_cli` fixture ([link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-0a81da15b33af432e42fa7b0063ca76990d9162f1bff6e1b8236717ee3cdd350L623-R634), [link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-0a81da15b33af432e42fa7b0063ca76990d9162f1bff6e1b8236717ee3cdd350L640-R660), [link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-0a81da15b33af432e42fa7b0063ca76990d9162f1bff6e1b8236717ee3cdd350L900-R907), [link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-0a81da15b33af432e42fa7b0063ca76990d9162f1bff6e1b8236717ee3cdd350L911-R944), [link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-0a81da15b33af432e42fa7b0063ca76990d9162f1bff6e1b8236717ee3cdd350L935-R964))
* Import the `OCNative` class from the `oc` module in `test_utils_oc.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-0a81da15b33af432e42fa7b0063ca76990d9162f1bff6e1b8236717ee3cdd350L900-R907))
* Add a new fixture `oc_native` that returns an `OCNative` instance with mocked API resources and client in `test_utils_oc.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-0a81da15b33af432e42fa7b0063ca76990d9162f1bff6e1b8236717ee3cdd350R1003-R1070))
* Add four new test functions to test the `get`, `get_items`, and `get_all` methods of the `OCNative` class using the `oc_native` fixture ([link](https://github.com/app-sre/qontract-reconcile/pull/3549/files?diff=unified&w=0#diff-0a81da15b33af432e42fa7b0063ca76990d9162f1bff6e1b8236717ee3cdd350R1003-R1070))