### PR TITLE
[cluster-upgrades] use available upgrade versions from OCM cache

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -408,7 +408,7 @@ def fetch_upgrade_policies(
                 cluster,
                 current_version=spec.version,
                 channel=spec.channel,
-                available_upgrades=ocm.available_cluster_upgrades.get(cluster_name),
+                available_upgrades=ocm.get_available_upgrades(cluster_name),
                 sector=sector,
             )
             desired_state.append(ccup)
@@ -743,7 +743,7 @@ def get_upgrades(addon_id: str, d: ConfiguredUpgradePolicy, ocm: OCM) -> list[st
             if a["id"] == addon_id and a["version"]["id"] != d.current_version
         ]
     elif isinstance(d, ConfiguredClusterUpgradePolicy):
-        upgrades = ocm.get_available_upgrades(d.current_version, d.channel)
+        upgrades = ocm.get_available_upgrades(d.cluster) or []
     return upgrades
 
 

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -743,7 +743,7 @@ def get_upgrades(addon_id: str, d: ConfiguredUpgradePolicy, ocm: OCM) -> list[st
             if a["id"] == addon_id and a["version"]["id"] != d.current_version
         ]
     elif isinstance(d, ConfiguredClusterUpgradePolicy):
-        upgrades = ocm.get_available_upgrades(d.cluster) or []
+        upgrades = ocm.get_available_upgrades(d.cluster)
     return upgrades
 
 

--- a/reconcile/test/ocm/test_utils_ocm_versions.py
+++ b/reconcile/test/ocm/test_utils_ocm_versions.py
@@ -69,7 +69,7 @@ def test_version_invalid_regex(ocm: OCM) -> None:
 
 
 def test_available_upgrades_versions(ocm: OCM) -> None:
-    assert ocm.available_cluster_upgrades["test-cluster"] == [
+    assert ocm.get_available_upgrades("test-cluster") == [
         "4.11.33",
         "4.12.1",
         "4.12.8",

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -1159,27 +1159,16 @@ class OCM:  # pylint: disable=too-many-public-methods
         """
         return any(re.search(b, version) for b in self.blocked_versions)
 
-    def get_available_upgrades(self, version, channel):
-        """Get available versions to upgrade from specified version
-        in the specified channel
+    def get_available_upgrades(self, cluster_name: str) -> list[str]:
+        """Get available versions to upgrade for a specific cluster.
 
         Args:
-            version (string): OpenShift version ID
-            channel (string): Upgrade channel
-
-        Raises:
-            KeyError: if specified channel is not valid
+            cluster_name (string): cluster display name to get available upgrades for
 
         Returns:
-            list: available versions to upgrade to
+            list: a non-null but potentially empty list of available versions to upgrade to
         """
-        if channel not in UPGRADE_CHANNELS:
-            raise KeyError(f"channel should be one of {UPGRADE_CHANNELS}")
-        version_id = f"openshift-v{version}"
-        if channel != "stable":
-            version_id = f"{version_id}-{channel}"
-        api = f"{CS_API_BASE}/v1/versions/{version_id}"
-        return self._get_json(api).get("available_upgrades", [])
+        return self.available_cluster_upgrades.get(cluster_name) or []
 
     def get_control_plan_upgrade_policies(
         self, cluster, schedule_type=None


### PR DESCRIPTION
the `OCM.get_available_upgrades()` function gets available upgrades for a specific version in a specific channel. behind the scenes it uses the CS `/v1/versions` endpoint, which potentially fails requests for non stable channels if the requesting account/service-account belongs to an OCM organization that lacks the capability to use such versions.

using this endpoint with a service-account that is not bound to an OCM organization, always fails. 

this PR changes the datasource for the available upgrades information to the`version` section of the OCM cluster spec, which can be safely consumed by service accounts.

`OCM.get_available_upgrades()` is changed to accept a cluster name instead of a current version and channel.