### PR TITLE
Fix long saas_name in console_url on slack notification

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -10,6 +10,7 @@ from reconcile import (
     queries,
 )
 from reconcile.gql_definitions.common.saas_files import PipelinesProviderTektonV1
+from reconcile.openshift_saas_deploy_trigger_base import build_pipeline_run_name_prefix
 from reconcile.openshift_tekton_resources import build_one_per_saas_file_tkn_object_name
 from reconcile.slack_base import slackapi_from_slack_workspace
 from reconcile.status import ExitCodes
@@ -17,6 +18,7 @@ from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,
 )
 from reconcile.typed_queries.saas_files import (
+    SaasFile,
     get_saas_files,
     get_saasherder_settings,
 )
@@ -24,7 +26,6 @@ from reconcile.utils.defer import defer
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.saasherder import SaasHerder
-from reconcile.utils.saasherder.interfaces import SaasFile
 from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.slack_api import SlackApi
@@ -47,10 +48,13 @@ def compose_console_url(saas_file: SaasFile, env_name: str) -> str:
     pipeline_name = build_one_per_saas_file_tkn_object_name(
         pipeline_template_name, saas_file.name
     )
+
+    pipeline_run_name = build_pipeline_run_name_prefix(saas_file.name, env_name)
+
     return (
-        f"{saas_file.pipelines_provider.namespace.cluster.console_url}/k8s/ns/{saas_file.pipelines_provider.namespace.name}/"
-        + "tekton.dev~v1beta1~Pipeline/"
-        + f"{pipeline_name}/Runs?name={saas_file.name}-{env_name}"
+        f"{saas_file.pipelines_provider.namespace.cluster.console_url}/k8s/ns/"
+        f"{saas_file.pipelines_provider.namespace.name}/tekton.dev~v1beta1~Pipeline/"
+        f"{pipeline_name}/Runs?name={pipeline_run_name}"
     )
 
 

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -10,7 +10,6 @@ from reconcile import (
     queries,
 )
 from reconcile.gql_definitions.common.saas_files import PipelinesProviderTektonV1
-from reconcile.openshift_saas_deploy_trigger_base import build_pipeline_run_name_prefix
 from reconcile.openshift_tekton_resources import build_one_per_saas_file_tkn_object_name
 from reconcile.slack_base import slackapi_from_slack_workspace
 from reconcile.status import ExitCodes
@@ -48,13 +47,12 @@ def compose_console_url(saas_file: SaasFile, env_name: str) -> str:
     pipeline_name = build_one_per_saas_file_tkn_object_name(
         pipeline_template_name, saas_file.name
     )
-
-    pipeline_run_name = build_pipeline_run_name_prefix(saas_file.name, env_name)
+    tkn_name, _ = SaasHerder.build_saas_file_env_combo(saas_file.name, env_name)
 
     return (
         f"{saas_file.pipelines_provider.namespace.cluster.console_url}/k8s/ns/"
         f"{saas_file.pipelines_provider.namespace.name}/tekton.dev~v1beta1~Pipeline/"
-        f"{pipeline_name}/Runs?name={pipeline_run_name}"
+        f"{pipeline_name}/Runs?name={tkn_name}"
     )
 
 

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -356,7 +356,7 @@ def _construct_tekton_trigger_resource(
     # we may want to revisit traceability, but this is compatible
     # with what we currently have in Jenkins.
     ts = datetime.datetime.utcnow().strftime("%Y%m%d%H%M")  # len 12
-    name = f"{tkn_name}-{ts}"
+    name = f"{tkn_name.lower()}-{ts}"
 
     parameters = [
         {"name": "saas_file_name", "value": saas_file_name},
@@ -395,7 +395,10 @@ def _construct_tekton_trigger_resource(
 
         body["spec"]["timeout"] = timeout
 
-    return OR(body, integration, integration_version, error_details=name), tkn_long_name
+    return (
+        OR(body, integration, integration_version, error_details=name),
+        tkn_long_name.lower(),
+    )
 
 
 def _register_trigger(name: str, already_triggered: set[str]) -> bool:

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -321,6 +321,22 @@ def _pipeline_exists(
     return False
 
 
+def _build_pipeline_run_long_name(
+    saas_file_name: str,
+    env_name: str,
+) -> str:
+    return f"{saas_file_name}-{env_name}".lower()
+
+
+def build_pipeline_run_name_prefix(
+    saas_file_name: str,
+    env_name: str,
+) -> str:
+    return _build_pipeline_run_long_name(saas_file_name, env_name)[
+        :UNIQUE_SAAS_FILE_ENV_COMBO_LEN
+    ]
+
+
 def _construct_tekton_trigger_resource(
     saas_file_name: str,
     env_name: str,
@@ -350,13 +366,13 @@ def _construct_tekton_trigger_resource(
     Returns:
         OpenshiftResource: OpenShift resource to be applied
     """
-    long_name = f"{saas_file_name}-{env_name}".lower()
+    name_prefix = build_pipeline_run_name_prefix(saas_file_name, env_name)
     # using a timestamp to make the resource name unique.
     # we may want to revisit traceability, but this is compatible
     # with what we currently have in Jenkins.
     ts = datetime.datetime.utcnow().strftime("%Y%m%d%H%M")  # len 12
     # max name length can be 63. leaving 12 for the timestamp - 51
-    name = f"{long_name[:UNIQUE_SAAS_FILE_ENV_COMBO_LEN]}-{ts}"
+    name = f"{name_prefix}-{ts}"
 
     parameters = [
         {"name": "saas_file_name", "value": saas_file_name},
@@ -395,6 +411,7 @@ def _construct_tekton_trigger_resource(
 
         body["spec"]["timeout"] = timeout
 
+    long_name = _build_pipeline_run_long_name(saas_file_name, env_name)
     return OR(body, integration, integration_version, error_details=name), long_name
 
 

--- a/reconcile/test/test_openshift_saas_deploy.py
+++ b/reconcile/test/test_openshift_saas_deploy.py
@@ -1,0 +1,87 @@
+from collections.abc import Callable
+
+import pytest
+
+from reconcile.openshift_saas_deploy import compose_console_url
+from reconcile.openshift_tekton_resources import (
+    OpenshiftTektonResourcesNameTooLongError,
+)
+from reconcile.typed_queries.saas_files import SaasFile
+
+
+@pytest.fixture
+def saas_file_builder(
+    gql_class_factory: Callable[..., SaasFile]
+) -> Callable[..., SaasFile]:
+    def builder(saas_name: str) -> SaasFile:
+        return gql_class_factory(
+            SaasFile,
+            {
+                "name": saas_name,
+                "app": {"name": "app_name"},
+                "pipelinesProvider": {
+                    "namespace": {
+                        "name": "namespace_name",
+                        "cluster": {"consoleUrl": "https://console.url"},
+                    },
+                    "defaults": {
+                        "pipelineTemplates": {
+                            "openshiftSaasDeploy": {"name": "openshift-saas-deploy"}
+                        },
+                    },
+                },
+                "managedResourceTypes": [],
+                "imagePatterns": [],
+                "resourceTemplates": [],
+            },
+        )
+
+    return builder
+
+
+def test_compose_console_url(
+    saas_file_builder: Callable[..., SaasFile],
+) -> None:
+    saas_file = saas_file_builder("saas_name")
+    env_name = "production"
+
+    url = compose_console_url(saas_file, env_name)
+
+    assert (
+        url
+        == "https://console.url/k8s/ns/namespace_name/tekton.dev~v1beta1~Pipeline/o-openshift-saas-deploy-saas_name/"
+        "Runs?name=saas_name-production"
+    )
+
+
+def test_compose_console_url_with_medium_saas_name(
+    saas_file_builder: Callable[..., SaasFile],
+) -> None:
+    saas_name = "saas-openshift-cert-manager-routes"
+    saas_file = saas_file_builder(saas_name)
+    env_name = "app-sre-production"
+
+    url = compose_console_url(saas_file, env_name)
+
+    expected_run_name = f"{saas_name}-{env_name}"[:50]
+    assert (
+        url == "https://console.url/k8s/ns/namespace_name/tekton.dev~v1beta1~Pipeline/"
+        "o-openshift-saas-deploy-saas-openshift-cert-manager-routes/"
+        f"Runs?name={expected_run_name}"
+    )
+
+
+def test_compose_console_url_with_long_saas_name(
+    saas_file_builder: Callable[..., SaasFile],
+) -> None:
+    saas_name = "this-is-a-very-looooooooooooooooooooooong-saas-name"
+    saas_file = saas_file_builder(saas_name)
+    env_name = "app-sre-production"
+
+    with pytest.raises(OpenshiftTektonResourcesNameTooLongError) as e:
+        compose_console_url(saas_file, env_name)
+
+    assert (
+        "name o-openshift-saas-deploy-this-is-a-very-looooooooooooooooooooooong-saas-name is longer than 63 characters"
+        == str(e.value)
+    )

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -483,7 +483,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         :param env_name: name of the environment
         :return: (tkn_name, tkn_long_name)
         """
-        tkn_long_name = f"{saas_file_name}-{env_name}".lower()
+        tkn_long_name = f"{saas_file_name}-{env_name}"
         tkn_name = tkn_long_name[:UNIQUE_SAAS_FILE_ENV_COMBO_LEN]
         return tkn_name, tkn_long_name
 

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -18,6 +18,7 @@ from typing import (
     Any,
     Generator,
     Optional,
+    Tuple,
     Type,
     Union,
 )
@@ -468,17 +469,33 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                             )
                         )
 
+    @staticmethod
+    def build_saas_file_env_combo(
+        saas_file_name: str,
+        env_name: str,
+    ) -> Tuple[str, str]:
+        """
+        Build a tuple of short and long names for a saas file and environment combo,
+        max tekton pipelinerun name length can be 63,
+        leaving 12 for the timestamp leaves us with 51 to create a unique pipelinerun name.
+
+        :param saas_file_name: name of the saas file
+        :param env_name: name of the environment
+        :return: (tkn_name, tkn_long_name)
+        """
+        tkn_long_name = f"{saas_file_name}-{env_name}".lower()
+        tkn_name = tkn_long_name[:UNIQUE_SAAS_FILE_ENV_COMBO_LEN]
+        return tkn_name, tkn_long_name
+
     def _check_saas_file_env_combo_unique(
         self,
         saas_file_name: str,
         env_name: str,
         tkn_unique_pipelineruns: Mapping[str, str],
     ) -> tuple[str, str]:
-        # max tekton pipelinerun name length can be 63.
-        # leaving 12 for the timestamp leaves us with 51
-        # to create a unique pipelinerun name
-        tkn_long_name = f"{saas_file_name}-{env_name}"
-        tkn_name = tkn_long_name[:UNIQUE_SAAS_FILE_ENV_COMBO_LEN]
+        tkn_name, tkn_long_name = self.build_saas_file_env_combo(
+            saas_file_name, env_name
+        )
         if (
             tkn_name in tkn_unique_pipelineruns
             and tkn_unique_pipelineruns[tkn_name] != tkn_long_name


### PR DESCRIPTION
Currently long `saas_name` produces wrong `console_url` in slack notification.

For example, expect `Runs?name=saas-openshift-cert-manager-routes-app-sre-product` but got `Runs?name=saas-openshift-cert-manager-routes-App-SRE-production`.

This change extracts same build `pipeline_run` name logic, reuse in both trigger step and notification step.


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ad9e048</samp>

This pull request refactors and improves the naming and console url generation logic for tekton pipelineruns triggered by saas file deployments. It also adds a new test module to verify the expected console url format for different saas file scenarios. The changes affect the `reconcile.openshift_saas_deploy_trigger_base`, `reconcile.openshift_saas_deploy`, `reconcile.utils.saasherder.saasherder`, and `reconcile.test.test_openshift_saas_deploy` modules.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at ad9e048</samp>

*  Refactor saas file data model to use pydantic instead of dataclasses
  * Replace import of `SaasFile` class from `reconcile.utils.saasherder.interfaces` with `reconcile.typed_queries.saas_files` in `reconcile/openshift_saas_deploy.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3559/files?diff=unified&w=0#diff-304fd1216ea8201e3242ba749fcc1bebbe71e61fd70851f7ed266e7318ed40b2R20), [link](https://github.com/app-sre/qontract-reconcile/pull/3559/files?diff=unified&w=0#diff-304fd1216ea8201e3242ba749fcc1bebbe71e61fd70851f7ed266e7318ed40b2L27))
  * Add unit tests for `compose_console_url` function using mock saas file objects from `reconcile.typed_queries.saas_files` in `reconcile/test/test_openshift_saas_deploy.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3559/files?diff=unified&w=0#diff-0f6dbc40d4600c4527755db5370c8c15906daa9c1269fe71e0de1add0243849eR1-R87))
  * Add helper method `build_saas_file_env_combo` to `SaasHerder` class in `reconcile/utils/saasherder/saasherder.py` that returns a tuple of short and long names for a saas file and environment combo, and checks for length limits ([link](https://github.com/app-sre/qontract-reconcile/pull/3559/files?diff=unified&w=0#diff-52a815feb4bcd8276212403b5f0ae22e3a3d9508acb5b7a75a5134dcf2657bbcR21), [link](https://github.com/app-sre/qontract-reconcile/pull/3559/files?diff=unified&w=0#diff-52a815feb4bcd8276212403b5f0ae22e3a3d9508acb5b7a75a5134dcf2657bbcR472-R489))
  * Use `build_saas_file_env_combo` method in `compose_console_url` function in `reconcile/openshift_saas_deploy.py` to generate tekton pipelinerun name and console url query parameter, and handle long saas file name exception ([link](https://github.com/app-sre/qontract-reconcile/pull/3559/files?diff=unified&w=0#diff-304fd1216ea8201e3242ba749fcc1bebbe71e61fd70851f7ed266e7318ed40b2L50-R55))
  * Use `build_saas_file_env_combo` method in `_construct_tekton_trigger_resource` function in `reconcile/openshift_saas_deploy_trigger_base.py` to generate tekton pipelinerun name and long name, and return both values ([link](https://github.com/app-sre/qontract-reconcile/pull/3559/files?diff=unified&w=0#diff-4135c05c1738ae40c0a45092f3748e2d3768f6777db8a2399f7e6afc50f2ccebL36), [link](https://github.com/app-sre/qontract-reconcile/pull/3559/files?diff=unified&w=0#diff-4135c05c1738ae40c0a45092f3748e2d3768f6777db8a2399f7e6afc50f2ccebL353-R359), [link](https://github.com/app-sre/qontract-reconcile/pull/3559/files?diff=unified&w=0#diff-4135c05c1738ae40c0a45092f3748e2d3768f6777db8a2399f7e6afc50f2ccebL398-R401))
  * Use `build_saas_file_env_combo` method in `_check_saas_file_env_combo_unique` method in `SaasHerder` class in `reconcile/utils/saasherder/saasherder.py` to check for uniqueness of tekton pipelinerun names and long names ([link](https://github.com/app-sre/qontract-reconcile/pull/3559/files?diff=unified&w=0#diff-52a815feb4bcd8276212403b5f0ae22e3a3d9508acb5b7a75a5134dcf2657bbcL477-R498))
