### PR TITLE
[gitlab-members] allow to run without a pagerduty instance

### DIFF
--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -199,8 +199,6 @@ def run(
     pagerduty_instances = pagerduty_instances_query(
         query_func=gqlapi.query
     ).pagerduty_instances
-    if not pagerduty_instances:
-        raise AppInterfaceSettingsError("no pagerduty instance(s) configured")
 
     # APIs
     secret_reader = SecretReader(queries.get_secret_reader_settings())

--- a/reconcile/test/test_utils_pagerduty_api.py
+++ b/reconcile/test/test_utils_pagerduty_api.py
@@ -104,6 +104,19 @@ def test_get_pagerduty_map(secret_reader: Mock, vault_secret: VaultSecret) -> No
         pd_map.get("doesn't-exist")
 
 
+def test_get_pagerduty_map_empty(
+    secret_reader: Mock, vault_secret: VaultSecret
+) -> None:
+    pager_duty_api_class = create_autospec(pagerduty_api.PagerDutyApi)
+    pd_map = pagerduty_api.get_pagerduty_map(
+        secret_reader=secret_reader,
+        pagerduty_instances=[],
+        init_users=True,
+        pager_duty_api_class=pager_duty_api_class,
+    )
+    assert len(pd_map.pd_apis) == 0
+
+
 def test_get_pagerduty_username_org_username(user: User) -> None:
     assert pagerduty_api.get_pagerduty_name(user) == user.pagerduty_username
     user.pagerduty_username = None

--- a/reconcile/utils/pagerduty_api.py
+++ b/reconcile/utils/pagerduty_api.py
@@ -164,16 +164,21 @@ class PagerDutyMap:
 
 def get_pagerduty_map(
     secret_reader: SecretReader,
-    pagerduty_instances: Iterable[PagerDutyInstance],
+    pagerduty_instances: Optional[Iterable[PagerDutyInstance]],
     init_users: bool = True,
     pager_duty_api_class: type[PagerDutyApi] = PagerDutyApi,
 ) -> PagerDutyMap:
     """Initiate a PagerDutyMap for given PagerDuty instances."""
-    return PagerDutyMap(
-        instances=[
+    instances = (
+        [
             PagerDutyConfig(name=i.name, token=secret_reader.read_secret(i.token))
             for i in pagerduty_instances
-        ],
+        ]
+        if pagerduty_instances
+        else []
+    )
+    return PagerDutyMap(
+        instances=instances,
         init_users=init_users,
         pager_duty_api_class=pager_duty_api_class,
     )


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-7755

the integration seems to be fine with this, as long as there are no permissions with a pagerduty target.
than again, if there are permissions with a pagerduty target, there is a pagerduty instance.

tl;dr this should be fine