### PR TITLE
[gitlab-members] grant user higher access level if defined twice

### DIFF
--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -83,9 +83,8 @@ def get_desired_state(
             if p.group == g:
                 for r in p.roles or []:
                     for u in (r.users or []) + (r.bots or []):
-                        desired_group_members[g].append(
-                            GitlabUser(user=u.org_username, access_level=p.access)
-                        )
+                        gu = GitlabUser(user=u.org_username, access_level=p.access)
+                        desired_group_members[g].append(gu)
                 if p.pagerduty:
                     usernames_from_pagerduty = get_usernames_from_pagerduty(
                         p.pagerduty,
@@ -95,9 +94,8 @@ def get_desired_state(
                         get_username_method=lambda u: u.org_username,
                     )
                     for u in usernames_from_pagerduty:
-                        desired_group_members[g].append(
-                            GitlabUser(user=u, access_level=p.access)
-                        )
+                        gu = GitlabUser(user=u, access_level=p.access)
+                        desired_group_members[g].append(gu)
 
     return desired_group_members
 

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -70,19 +70,20 @@ def get_current_state(instance: GitlabInstanceV1, gl: GitLabApi) -> State:
     }
 
 
-def add_or_update_user(group_members: State, group_name: str, gitlab_user: GitlabUser):
+def add_or_update_user(
+    group_members: State, group_name: str, gitlab_user: GitlabUser
+) -> None:
     existing_users = [
         gu for gu in group_members[group_name] if gu.user == gitlab_user.user
     ]
     if not existing_users:
         group_members[group_name].append(gitlab_user)
-        return
-
-    existing_user = existing_users[0]
-    if GitLabApi.get_access_level(
-        existing_user.access_level
-    ) < GitLabApi.get_access_level(gitlab_user.access_level):
-        existing_user.access_level = gitlab_user.access_level
+    else:
+        existing_user = existing_users[0]
+        if GitLabApi.get_access_level(
+            existing_user.access_level
+        ) < GitLabApi.get_access_level(gitlab_user.access_level):
+            existing_user.access_level = gitlab_user.access_level
 
 
 def get_desired_state(

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -71,7 +71,18 @@ def get_current_state(instance: GitlabInstanceV1, gl: GitLabApi) -> State:
 
 
 def add_or_update_user(group_members: State, group_name: str, gitlab_user: GitlabUser):
-    group_members[group_name].append(gitlab_user)
+    existing_users = [
+        gu for gu in group_members[group_name] if gu.user == gitlab_user.user
+    ]
+    if not existing_users:
+        group_members[group_name].append(gitlab_user)
+        return
+
+    existing_user = existing_users[0]
+    if GitLabApi.get_access_level(
+        existing_user.access_level
+    ) < GitLabApi.get_access_level(gitlab_user.access_level):
+        existing_user.access_level = gitlab_user.access_level
 
 
 def get_desired_state(

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -70,6 +70,12 @@ def get_current_state(instance: GitlabInstanceV1, gl: GitLabApi) -> State:
     }
 
 
+def add_or_update_user(
+    desired_group_members: State, group_name: str, gitlab_user: GitlabUser
+):
+    desired_group_members[group_name].append(gitlab_user)
+
+
 def get_desired_state(
     instance: GitlabInstanceV1,
     pagerduty_map: PagerDutyMap,
@@ -84,7 +90,7 @@ def get_desired_state(
                 for r in p.roles or []:
                     for u in (r.users or []) + (r.bots or []):
                         gu = GitlabUser(user=u.org_username, access_level=p.access)
-                        desired_group_members[g].append(gu)
+                        add_or_update_user(desired_group_members, g, gu)
                 if p.pagerduty:
                     usernames_from_pagerduty = get_usernames_from_pagerduty(
                         p.pagerduty,
@@ -95,7 +101,7 @@ def get_desired_state(
                     )
                     for u in usernames_from_pagerduty:
                         gu = GitlabUser(user=u, access_level=p.access)
-                        desired_group_members[g].append(gu)
+                        add_or_update_user(desired_group_members, g, gu)
 
     return desired_group_members
 

--- a/reconcile/gitlab_members.py
+++ b/reconcile/gitlab_members.py
@@ -70,10 +70,8 @@ def get_current_state(instance: GitlabInstanceV1, gl: GitLabApi) -> State:
     }
 
 
-def add_or_update_user(
-    desired_group_members: State, group_name: str, gitlab_user: GitlabUser
-):
-    desired_group_members[group_name].append(gitlab_user)
+def add_or_update_user(group_members: State, group_name: str, gitlab_user: GitlabUser):
+    group_members[group_name].append(gitlab_user)
 
 
 def get_desired_state(

--- a/reconcile/test/test_gitlab_members.py
+++ b/reconcile/test/test_gitlab_members.py
@@ -10,8 +10,8 @@ from reconcile.gitlab_members import (
     Diff,
     GitlabUser,
     State,
-    get_permissions,
     add_or_update_user,
+    get_permissions,
 )
 from reconcile.gql_definitions.fragments.user import User
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret

--- a/reconcile/test/test_gitlab_members.py
+++ b/reconcile/test/test_gitlab_members.py
@@ -11,6 +11,7 @@ from reconcile.gitlab_members import (
     GitlabUser,
     State,
     get_permissions,
+    add_or_update_user,
 )
 from reconcile.gql_definitions.fragments.user import User
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
@@ -281,3 +282,28 @@ def test_gitlab_members_act_change(mocker: MockerFixture) -> None:
     gl_mock.add_group_member.assert_not_called()
     gl_mock.remove_group_member.assert_not_called()
     gl_mock.change_access.assert_called_once()
+
+
+def test_add_or_update_user_add():
+    group_members: State = {"t": []}
+    gu = GitlabUser(user="u", access_level="owner")
+    add_or_update_user(group_members, "t", gu)
+    assert group_members == {"t": [gu]}
+
+
+def test_add_or_update_user_update_higher():
+    group_members: State = {"t": []}
+    gu1 = GitlabUser(user="u", access_level="maintainer")
+    gu2 = GitlabUser(user="u", access_level="owner")
+    add_or_update_user(group_members, "t", gu1)
+    add_or_update_user(group_members, "t", gu2)
+    assert group_members == {"t": [gu2]}
+
+
+def test_add_or_update_user_update_lower():
+    group_members: State = {"t": []}
+    gu1 = GitlabUser(user="u", access_level="owner")
+    gu2 = GitlabUser(user="u", access_level="maintainer")
+    add_or_update_user(group_members, "t", gu1)
+    add_or_update_user(group_members, "t", gu2)
+    assert group_members == {"t": [gu1]}


### PR DESCRIPTION
if a user is associated to the same gitlab group with different access levels - grant them the higher one instead of simply taking the later one that appears in queries.