### PR TITLE
[AUS] metrics improvements

### DIFF
--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -84,9 +84,13 @@ class AdvancedUpgradeServiceIntegration(OCMClusterUpgradeSchedulerOrgIntegration
             org_ids=org_ids,
             ignore_sts_clusters=self.params.ignore_sts_clusters,
         )
-        orgs = get_organizations(
-            ocm_api=ocm_api, filter=Filter().is_in("id", clusters_by_org.keys())
-        ) if clusters_by_org else {}
+        orgs = (
+            get_organizations(
+                ocm_api=ocm_api, filter=Filter().is_in("id", clusters_by_org.keys())
+            )
+            if clusters_by_org
+            else {}
+        )
         labels_by_org = _get_org_labels(ocm_api=ocm_api, org_ids=org_ids)
 
         return _build_org_upgrade_specs_for_ocm_env(

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -21,8 +21,7 @@ from semver import VersionInfo
 
 from reconcile.aus.metrics import (
     AUSClusterUpgradePolicyInfoMetric,
-    AUSOrganizationReconcileCounter,
-    AUSOrganizationReconcileErrorCounter,
+    AUSOrganizationErrorRate,
     AUSOrganizationValidationErrorsGauge,
 )
 from reconcile.aus.models import (
@@ -78,29 +77,31 @@ class AdvancedUpgradeSchedulerBaseIntegration(
         with metrics.transactional_metrics(self.name):
             upgrade_specs = self.get_upgrade_specs()
             for ocm_env, env_upgrade_specs in upgrade_specs.items():
-                for org_name, org_upgrade_spec in env_upgrade_specs.items():
-                    self.expose_org_upgrade_spec_metrics(ocm_env, org_upgrade_spec)
-                    if org_upgrade_spec.has_validation_errors:
-                        self.signal_validation_issues(dry_run, org_upgrade_spec)
-                    elif org_upgrade_spec.specs:
-                        try:
-                            self.process_upgrade_policies_in_org(
-                                dry_run, org_upgrade_spec
-                            )
-                        except Exception as e:
-                            metrics.inc_counter(
-                                AUSOrganizationReconcileErrorCounter(
-                                    integration=self.name,
-                                    ocm_env=ocm_env,
-                                    org_id=org_upgrade_spec.org.org_id,
-                                )
-                            )
-                            self.signal_reconcile_issues(dry_run, org_upgrade_spec, e)
-                    else:
-                        logging.debug(
-                            f"Skip org {org_name} in {ocm_env} because it defines no upgrade policies"
-                        )
+                for org_upgrade_spec in env_upgrade_specs.values():
+                    try:
+                        with AUSOrganizationErrorRate(
+                            integration=self.name,
+                            ocm_env=ocm_env,
+                            org_id=org_upgrade_spec.org.org_id,
+                        ):
+                            self.process_org(dry_run, ocm_env, org_upgrade_spec)
+                    except Exception as e:
+                        self.signal_reconcile_issues(dry_run, org_upgrade_spec, e)
         sys.exit(0)
+
+    def process_org(
+        self, dry_run: bool, ocm_env: str, org_upgrade_spec: OrganizationUpgradeSpec
+    ) -> None:
+        org_name = org_upgrade_spec.org.name
+        self.expose_org_upgrade_spec_metrics(ocm_env, org_upgrade_spec)
+        if org_upgrade_spec.has_validation_errors:
+            self.signal_validation_issues(dry_run, org_upgrade_spec)
+        elif org_upgrade_spec.specs:
+            self.process_upgrade_policies_in_org(dry_run, org_upgrade_spec)
+        else:
+            logging.debug(
+                f"Skip org {org_name} in {ocm_env} because it defines no upgrade policies"
+            )
 
     def get_upgrade_specs(self) -> dict[str, dict[str, OrganizationUpgradeSpec]]:
         return {
@@ -151,13 +152,6 @@ class AdvancedUpgradeSchedulerBaseIntegration(
     def expose_org_upgrade_spec_metrics(
         self, ocm_env: str, org_upgrade_spec: OrganizationUpgradeSpec
     ) -> None:
-        metrics.inc_counter(
-            AUSOrganizationReconcileCounter(
-                integration=self.name,
-                ocm_env=ocm_env,
-                org_id=org_upgrade_spec.org.org_id,
-            )
-        )
         metrics.set_gauge(
             AUSOrganizationValidationErrorsGauge(
                 integration=self.name,

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -168,6 +168,8 @@ class AdvancedUpgradeSchedulerBaseIntegration(
                     ocm_env=ocm_env,
                     cluster_uuid=cluster_upgrade_spec.cluster_uuid,
                     org_id=cluster_upgrade_spec.ocm.org_id,
+                    org_name=org_upgrade_spec.org.name,
+                    current_version=cluster_upgrade_spec.current_version,
                     cluster_name=cluster_upgrade_spec.name,
                     schedule=cluster_upgrade_spec.upgrade_policy.schedule,
                     sector=cluster_upgrade_spec.upgrade_policy.conditions.sector or "",

--- a/reconcile/aus/metrics.py
+++ b/reconcile/aus/metrics.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 
 from reconcile.utils.metrics import (
     CounterMetric,
+    ErrorRateMetricSet,
     GaugeMetric,
     InfoMetric,
 )
@@ -70,3 +71,21 @@ class AUSOrganizationReconcileErrorCounter(AUSBaseMetric, CounterMetric):
     @classmethod
     def name(cls) -> str:
         return "aus_organization_reconcile_errors"
+
+
+class AUSOrganizationErrorRate(ErrorRateMetricSet):
+    "Collection of AUS metrics for an OCM organization"
+
+    def __init__(self, integration: str, org_id: str, ocm_env: str) -> None:
+        super().__init__(
+            counter=AUSOrganizationReconcileCounter(
+                integration=integration,
+                ocm_env=ocm_env,
+                org_id=org_id,
+            ),
+            error_counter=AUSOrganizationReconcileErrorCounter(
+                integration=integration,
+                ocm_env=ocm_env,
+                org_id=org_id,
+            ),
+        )

--- a/reconcile/aus/metrics.py
+++ b/reconcile/aus/metrics.py
@@ -31,6 +31,8 @@ class AUSClusterUpgradePolicyInfoMetric(AUSBaseMetric, InfoMetric):
 
     cluster_uuid: str
     org_id: str
+    org_name: str
+    current_version: str
     cluster_name: str
     schedule: str
     sector: str

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -22,6 +22,7 @@ class ClusterUpgradeSpec(BaseModel):
     ocm: AUSOCMOrganization
     upgrade_policy: ClusterUpgradePolicy = Field(..., alias="upgradePolicy")
     cluster_uuid: str
+    current_version: str
 
 
 class ClusterValidationError(BaseModel):

--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -106,6 +106,7 @@ class OCMClusterUpgradeSchedulerIntegration(
                         cluster_uuid=cluster_uuid,
                         ocm=cluster.ocm,
                         upgradePolicy=cluster.upgrade_policy,
+                        current_version=cluster.spec.version if cluster.spec else "?",
                     )
                 )
         return {

--- a/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.gql
+++ b/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.gql
@@ -12,6 +12,7 @@ query AUSClusters($name: String) {
     spec {
         product
         external_id
+        version
     }
     disable {
         integrations

--- a/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.py
+++ b/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.py
@@ -110,6 +110,7 @@ query AUSClusters($name: String) {
     spec {
         product
         external_id
+        version
     }
     disable {
         integrations
@@ -128,6 +129,7 @@ class ConfiguredBaseModel(BaseModel):
 class ClusterSpecV1(ConfiguredBaseModel):
     product: str = Field(..., alias="product")
     external_id: Optional[str] = Field(..., alias="external_id")
+    version: str = Field(..., alias="version")
 
 
 class DisableClusterAutomationsV1(ConfiguredBaseModel):

--- a/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
+++ b/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
@@ -25,6 +25,7 @@ from reconcile.test.ocm.fixtures import (
     build_label,
     build_organization_label,
 )
+from reconcile.utils.ocm.subscriptions import OCMOrganization
 from reconcile.utils.ocm.labels import (
     LabelContainer,
     build_label_container,
@@ -185,7 +186,10 @@ def test_build_org_upgrade_spec(
 ) -> None:
     org_upgrade_spec = _build_org_upgrade_spec(
         ocm_env=ocm_env,
-        org_id="org-id",
+        org=OCMOrganization(
+            id="org-id",
+            name="org-name",
+        ),
         clusters=[
             build_cluster_details(
                 "cluster-1",
@@ -203,7 +207,10 @@ def test_build_org_upgrade_spec_with_cluster_error(
 ) -> None:
     org_upgrade_spec = _build_org_upgrade_spec(
         ocm_env=ocm_env,
-        org_id="org-id",
+        org=OCMOrganization(
+            id="org-id",
+            name="org-name",
+        ),
         clusters=[
             build_cluster_details(
                 "cluster-1",
@@ -230,6 +237,12 @@ def test_build_org_upgrade_specs_for_ocm_env(ocm_env: OCMEnvironment) -> None:
     )
     upgrade_specs = _build_org_upgrade_specs_for_ocm_env(
         ocm_env=ocm_env,
+        orgs={
+            org_id: OCMOrganization(
+                id=org_id,
+                name="org-name",
+            ),
+        },
         clusters_by_org={org_id: [cluster_details]},
         labels_by_org={
             org_id: build_org_config_labels(),
@@ -256,6 +269,12 @@ def test_build_org_upgrade_specs_for_ocm_env_with_cluster_error(
     )
     upgrade_specs = _build_org_upgrade_specs_for_ocm_env(
         ocm_env=ocm_env,
+        orgs={
+            org_id: OCMOrganization(
+                id=org_id,
+                name="org-name",
+            ),
+        },
         clusters_by_org={org_id: [cluster_details]},
         labels_by_org={
             org_id: build_org_config_labels(),
@@ -439,6 +458,12 @@ def build_org_upgrade_specs(
     )
     return _build_org_upgrade_specs_for_ocm_env(
         ocm_env=ocm_env,
+        orgs={
+            org_id: OCMOrganization(
+                id=org_id,
+                name="org-name",
+            ),
+        },
         clusters_by_org={org_id: [cluster_details]},
         labels_by_org={
             org_id: build_org_config_labels(),

--- a/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
+++ b/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
@@ -25,7 +25,6 @@ from reconcile.test.ocm.fixtures import (
     build_label,
     build_organization_label,
 )
-from reconcile.utils.ocm.subscriptions import OCMOrganization
 from reconcile.utils.ocm.labels import (
     LabelContainer,
     build_label_container,
@@ -33,6 +32,7 @@ from reconcile.utils.ocm.labels import (
 )
 from reconcile.utils.ocm.search_filters import Filter
 from reconcile.utils.ocm.sre_capability_labels import build_labelset
+from reconcile.utils.ocm.subscriptions import OCMOrganization
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 #

--- a/reconcile/test/ocm/fixtures.py
+++ b/reconcile/test/ocm/fixtures.py
@@ -18,6 +18,7 @@ from reconcile.utils.ocm.clusters import (
     ClusterDetails,
     OCMCapability,
     OCMCluster,
+    OCMClusterVersion,
     OCMClusterAWSSettings,
     OCMClusterFlag,
     OCMClusterState,
@@ -95,6 +96,7 @@ def build_ocm_cluster(
     subs_id: str = "subs_id",
     aws_cluster: bool = True,
     sts_cluster: bool = False,
+    version: str = "4.13.0"
 ) -> OCMCluster:
     aws_config = None
     if aws_cluster:
@@ -111,6 +113,10 @@ def build_ocm_cluster(
         state=OCMClusterState.READY,
         managed=True,
         aws=aws_config,
+        version=OCMClusterVersion(
+            id=f"openshift-v{version}",
+            raw_id="version"
+        )
     )
 
 

--- a/reconcile/test/ocm/fixtures.py
+++ b/reconcile/test/ocm/fixtures.py
@@ -18,10 +18,10 @@ from reconcile.utils.ocm.clusters import (
     ClusterDetails,
     OCMCapability,
     OCMCluster,
-    OCMClusterVersion,
     OCMClusterAWSSettings,
     OCMClusterFlag,
     OCMClusterState,
+    OCMClusterVersion,
 )
 from reconcile.utils.ocm.labels import (
     LabelContainer,
@@ -96,7 +96,7 @@ def build_ocm_cluster(
     subs_id: str = "subs_id",
     aws_cluster: bool = True,
     sts_cluster: bool = False,
-    version: str = "4.13.0"
+    version: str = "4.13.0",
 ) -> OCMCluster:
     aws_config = None
     if aws_cluster:
@@ -113,10 +113,7 @@ def build_ocm_cluster(
         state=OCMClusterState.READY,
         managed=True,
         aws=aws_config,
-        version=OCMClusterVersion(
-            id=f"openshift-v{version}",
-            raw_id="version"
-        )
+        version=OCMClusterVersion(id=f"openshift-v{version}", raw_id="version"),
     )
 
 

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -501,3 +501,60 @@ def inc_counter(counter: CounterMetric, by: int = 1) -> None:
     Honors running transactions.
     """
     _STATE.get_current_container().inc_counter(counter, by)
+
+
+#
+# MetricSet
+#
+
+
+ERMS = TypeVar("ERMS", bound="ErrorRateMetricSet")
+
+
+class ErrorRateMetricSet:
+    """
+    A context manager that exposes a counter metric and an error counter metric
+    for a code block. The code block within the contextmanager is considered
+    failed if an exception is raised of if the `fail` method is called.
+    """
+    def __init__(
+        self: ERMS, counter: CounterMetric, error_counter: CounterMetric
+    ) -> None:
+        self._counter = counter
+        self._error_counter = error_counter
+        self._errors: list[BaseException] = []
+
+    def __enter__(self: ERMS) -> ERMS:
+        inc_counter(self._counter)
+        return self
+
+    def fail(self: ERMS, error: BaseException) -> None:
+        """
+        Mark the context as failed and record it as an event
+        that increases the error counter.
+        """
+        self._errors.append(error)
+
+    @property
+    def failed(self: ERMS) -> bool:
+        """
+        Returns True if the context manager was marked as failed.
+        """
+        return bool(self._errors)
+
+    @property
+    def errors(self: ERMS) -> list[BaseException]:
+        """
+        Return the list of errors that caused the context manager to fail.
+        """
+        return self._errors
+
+    def __exit__(
+        self: ERMS,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        if exc_value:
+            self.fail(exc_value)
+        inc_counter(self._error_counter, by=(1 if self._errors else 0))

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -517,6 +517,7 @@ class ErrorRateMetricSet:
     for a code block. The code block within the contextmanager is considered
     failed if an exception is raised of if the `fail` method is called.
     """
+
     def __init__(
         self: ERMS, counter: CounterMetric, error_counter: CounterMetric
     ) -> None:

--- a/reconcile/utils/ocm/clusters.py
+++ b/reconcile/utils/ocm/clusters.py
@@ -55,6 +55,12 @@ class OCMClusterAWSSettings(BaseModel):
         return self.sts is not None and self.sts.enabled
 
 
+class OCMClusterVersion(BaseModel):
+
+    id: str
+    raw_id: str
+
+
 class OCMCluster(BaseModel):
 
     kind: str = "Cluster"
@@ -76,6 +82,8 @@ class OCMCluster(BaseModel):
     product: OCMModelLink
 
     aws: Optional[OCMClusterAWSSettings]
+
+    version: OCMClusterVersion
 
 
 class ClusterDetails(BaseModel):

--- a/reconcile/utils/ocm/subscriptions.py
+++ b/reconcile/utils/ocm/subscriptions.py
@@ -7,7 +7,10 @@ from pydantic import (
     ValidationError,
 )
 
-from reconcile.utils.ocm.labels import OCMSubscriptionLabel
+from reconcile.utils.ocm.labels import (
+    OCMOrganizationLabel,
+    OCMSubscriptionLabel,
+)
 from reconcile.utils.ocm.search_filters import Filter
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
@@ -93,3 +96,45 @@ def build_subscription_filter(
     fields: status and managed.
     """
     return Filter().is_in("status", states).eq("managed", str(managed).lower())
+
+
+class OCMOrganization(BaseModel):
+    """
+    Represents an organization in OCM.
+    """
+
+    id: str
+    name: str
+
+    labels: Optional[list[OCMOrganizationLabel]] = None
+    capabilities: Optional[list[OCMCapability]] = None
+    """
+    Capabilities are a list of features/features flags that are enabled for an organization.
+    """
+
+
+def get_organizations(
+    ocm_api: OCMBaseClient, filter: Filter
+) -> dict[str, OCMOrganization]:
+    """
+    Returns a dictionary of organizations based on the provided filter.
+    The result is keyed by organization ID.
+    """
+    organizations = {}
+    chunk_size = 100
+    for filter_chunk in filter.chunk_by("id", chunk_size, ignore_missing=True):
+        for organization_dict in ocm_api.get_paginated(
+            api_path="/api/accounts_mgmt/v1/organizations?fetchCapabilities=true&fetchLabels=true",
+            params={"search": filter_chunk.render()},
+            max_page_size=chunk_size,
+        ):
+            try:
+                org = OCMOrganization(
+                    **organization_dict,
+                )
+                organizations[org.id] = org
+            except ValidationError:
+                pass
+                # ignore subscriptions that fail to validate
+                # against the OCMSubscription, since the lack important fields
+    return organizations


### PR DESCRIPTION
* track organization reconciling total + error with a context manager (automatic counter increases when entering and when failing)
* add the organization name and the current version of a cluster to the `aus_cluster_upgrade_policy_info` metric - useful for dashboards

replaces https://github.com/app-sre/qontract-reconcile/pull/3547