### PR TITLE
Refactor tf-repo for single repo enforcement

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1557,18 +1557,18 @@ def ldap_users(ctx, infra_project_id, app_interface_project_id):
 
 @integration.command(short_help="Manages raw HCL Terraform from a separate repository.")
 @click.option(
-    "-d",
-    "--output-dir",
-    help="Specify a directory to individually output each repo plan to for the executor",
+    "-o",
+    "--output-file",
+    help="Specify where to place the output of the integration",
 )
 @click.pass_context
-def terraform_repo(ctx, output_dir):
+def terraform_repo(ctx, output_file):
     from reconcile import terraform_repo
 
     run_class_integration(
         integration=terraform_repo.TerraformRepoIntegration(
             terraform_repo.TerraformRepoIntegrationParams(
-                output_dir=output_dir, validate_git=True
+                output_file=output_file, validate_git=True
             )
         ),
         ctx=ctx.obj,

--- a/reconcile/test/test_terraform_repo.py
+++ b/reconcile/test/test_terraform_repo.py
@@ -103,7 +103,7 @@ def test_addition_to_existing_repo(existing_repo, new_repo, int_params, state_mo
         existing_state=existing, desired_state=desired, dry_run=False, state=state_mock
     )
 
-    assert diff == [new_repo]
+    assert diff == new_repo
 
     # ensure that the state is saved for the new repo
     state_mock.add.assert_called_once_with(
@@ -124,7 +124,7 @@ def test_updating_repo_ref(existing_repo, int_params, state_mock):
         state=state_mock,
     )
 
-    assert diff == [updated_repo]
+    assert diff == updated_repo
 
     state_mock.add.assert_called_once_with(
         updated_repo.name, updated_repo.dict(by_alias=True), force=True
@@ -165,7 +165,7 @@ def test_delete_repo(existing_repo, int_params, state_mock):
         state=state_mock,
     )
 
-    assert diff == [updated_repo]
+    assert diff == updated_repo
 
     state_mock.rm.assert_called_once_with(updated_repo.name)
 
@@ -213,3 +213,14 @@ def test_update_repo_state(int_params, existing_repo, state_mock):
     state_mock.add.assert_called_once_with(
         existing_repo.name, existing_repo.dict(by_alias=True), force=True
     )
+
+
+def test_fail_on_multiple_repos(int_params, existing_repo, new_repo):
+    integration = TerraformRepoIntegration(params=int_params)
+
+    desired_state = [existing_repo, new_repo]
+
+    with pytest.raises(Exception):
+        integration.calculate_diff(
+            existing_state=[], desired_state=desired_state, dry_run=True, state=None
+        )

--- a/reconcile/test/test_terraform_repo.py
+++ b/reconcile/test/test_terraform_repo.py
@@ -235,4 +235,4 @@ def test_no_op_succeeds(int_params, existing_repo):
         existing_state=state, desired_state=state, dry_run=True, state=None
     )
 
-    assert diff == None
+    assert diff is None

--- a/reconcile/test/test_terraform_repo.py
+++ b/reconcile/test/test_terraform_repo.py
@@ -224,3 +224,15 @@ def test_fail_on_multiple_repos(int_params, existing_repo, new_repo):
         integration.calculate_diff(
             existing_state=[], desired_state=desired_state, dry_run=True, state=None
         )
+
+
+def test_no_op_succeeds(int_params, existing_repo):
+    integration = TerraformRepoIntegration(params=int_params)
+
+    state = [existing_repo]
+
+    diff = integration.calculate_diff(
+        existing_state=state, desired_state=state, dry_run=True, state=None
+    )
+
+    assert diff == None


### PR DESCRIPTION
To prevent tenants from modifying multiple repos in one PR, checks are now in place to throw an exception if this happens. The CLI has also been refactored to only output to one repo.yaml file and tests updated to reflect this change.

Part of https://issues.redhat.com/browse/APPSRE-7672

## Why?
This is to limit complexity particularly on the `terraform apply` stage. Spawning multiple executor containers would probably require us to have a pipeline spawning other pipelines. Additionally, this makes tf-repo changes easier to audit as each modification to a repo's infrastructure is associated with just one MR.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 55530f6</samp>

* Change the `terraform_repo` command option from `-d`/`--output-dir` to `-o`/`--output-file` to reflect the new behavior of the integration ([link](https://github.com/app-sre/qontract-reconcile/pull/3569/files?diff=unified&w=0#diff-2ac404c3a4f4d289c1811816c94253a70cc6559b8de427388de06546141f1f43L1560-R1565))
* Update the `TerraformRepoIntegration` constructor and the `run` method to use the `output_file` parameter instead of the `output_dir` parameter ([link](https://github.com/app-sre/qontract-reconcile/pull/3569/files?diff=unified&w=0#diff-2ac404c3a4f4d289c1811816c94253a70cc6559b8de427388de06546141f1f43L1571-R1571), [link](https://github.com/app-sre/qontract-reconcile/pull/3569/files?diff=unified&w=0#diff-05e8f500c44ae2dc8a3b8087020cc1d2946506df84ea9a118e110c8d8ad82ba2L59-R59), [link](https://github.com/app-sre/qontract-reconcile/pull/3569/files?diff=unified&w=0#diff-05e8f500c44ae2dc8a3b8087020cc1d2946506df84ea9a118e110c8d8ad82ba2L96-R113), [link](https://github.com/app-sre/qontract-reconcile/pull/3569/files?diff=unified&w=0#diff-05e8f500c44ae2dc8a3b8087020cc1d2946506df84ea9a118e110c8d8ad82ba2L121-R122))
* Modify the `calculate_diff` method of the `TerraformRepoIntegration` class to return an optional `TerraformRepoV1` object instead of a list of `TerraformRepoV1` objects, and to raise an exception if more than one repo is modified in the merge request ([link](https://github.com/app-sre/qontract-reconcile/pull/3569/files?diff=unified&w=0#diff-05e8f500c44ae2dc8a3b8087020cc1d2946506df84ea9a118e110c8d8ad82ba2L247-R248), [link](https://github.com/app-sre/qontract-reconcile/pull/3569/files?diff=unified&w=0#diff-05e8f500c44ae2dc8a3b8087020cc1d2946506df84ea9a118e110c8d8ad82ba2L261-R275), [link](https://github.com/app-sre/qontract-reconcile/pull/3569/files?diff=unified&w=0#diff-05e8f500c44ae2dc8a3b8087020cc1d2946506df84ea9a118e110c8d8ad82ba2L293-R308))
* Update the test functions in `test_terraform_repo.py` to assert that the diff is equal to the expected repo object instead of a list containing the repo object, and to add two new test functions to cover the new logic in the `calculate_diff` method ([link](https://github.com/app-sre/qontract-reconcile/pull/3569/files?diff=unified&w=0#diff-f578fef16df2ffb09f95711b988012130afa7eea66f67d80c3168c0effe4c178L106-R106), [link](https://github.com/app-sre/qontract-reconcile/pull/3569/files?diff=unified&w=0#diff-f578fef16df2ffb09f95711b988012130afa7eea66f67d80c3168c0effe4c178L127-R127), [link](https://github.com/app-sre/qontract-reconcile/pull/3569/files?diff=unified&w=0#diff-f578fef16df2ffb09f95711b988012130afa7eea66f67d80c3168c0effe4c178L168-R168), [link](https://github.com/app-sre/qontract-reconcile/pull/3569/files?diff=unified&w=0#diff-f578fef16df2ffb09f95711b988012130afa7eea66f67d80c3168c0effe4c178R216-R238))