### PR TITLE
[ocm-aws-infrastructure-access] ignore IAM SAs with assume_role

### DIFF
--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -119,6 +119,8 @@ def fetch_desired_state():
             )
             if aws_infrastructure_access is None:
                 continue
+            if aws_infrastructure_access.get("assume_role"):
+                continue
             aws_account_uid = [
                 a["uid"] for a in aws_accounts if a["name"] == spec.provisioner_name
             ][0]


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-7735

when `assume_role` is provided on a namespace aws external resource for an `aws-iam-service-account` provider - it means ocm-aws-infrastructure-access is not the entity to grant the access.

in such case, the integration should skip this resource.

the `assume_role` field is widely used in fedramp, where `ocm-aws-infrastructure-access` is not used.