### PR TITLE
Limit the size of Tekton Pipeline names

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -10,7 +10,9 @@ from reconcile import (
     queries,
 )
 from reconcile.gql_definitions.common.saas_files import PipelinesProviderTektonV1
-from reconcile.openshift_tekton_resources import build_one_per_saas_file_tkn_object_name
+from reconcile.openshift_tekton_resources import (
+    build_one_per_saas_file_tkn_pipeline_name,
+)
 from reconcile.slack_base import slackapi_from_slack_workspace
 from reconcile.status import ExitCodes
 from reconcile.typed_queries.app_interface_vault_settings import (
@@ -44,7 +46,7 @@ def compose_console_url(saas_file: SaasFile, env_name: str) -> str:
         if not saas_file.pipelines_provider.pipeline_templates
         else saas_file.pipelines_provider.pipeline_templates.openshift_saas_deploy.name
     )
-    pipeline_name = build_one_per_saas_file_tkn_object_name(
+    pipeline_name = build_one_per_saas_file_tkn_pipeline_name(
         pipeline_template_name, saas_file.name
     )
     tkn_name, _ = SaasHerder.build_saas_file_env_combo(saas_file.name, env_name)

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -14,7 +14,9 @@ from reconcile import (
     jenkins_base,
     queries,
 )
-from reconcile.openshift_tekton_resources import build_one_per_saas_file_tkn_object_name
+from reconcile.openshift_tekton_resources import (
+    build_one_per_saas_file_tkn_pipeline_name,
+)
 from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,
 )
@@ -248,7 +250,7 @@ def _trigger_tekton(
         if spec.pipelines_provider.pipeline_templates
         else spec.pipelines_provider.defaults.pipeline_templates.openshift_saas_deploy.name
     )
-    tkn_pipeline_name = build_one_per_saas_file_tkn_object_name(
+    tkn_pipeline_name = build_one_per_saas_file_tkn_pipeline_name(
         pipeline_template_name, spec.saas_file_name
     )
     tkn_namespace_name = spec.pipelines_provider.namespace.name

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider2-with-resources.json
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider2-with-resources.json
@@ -23,9 +23,9 @@
     ],
     "pipelineTemplates": {
       "openshiftSaasDeploy": {
-        "name": "openshift-saas-deploy",
+        "name": "saas-deploy",
         "type": "onePerSaasFile",
-        "path": "openshift-saas-deploy.pipeline.yaml.j2",
+        "path": "saas-deploy.pipeline.yaml.j2",
         "variables": null
       }
     }

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider4-with-task-duplicates.json
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider4-with-task-duplicates.json
@@ -22,9 +22,9 @@
     ],
     "pipelineTemplates": {
       "openshiftSaasDeploy": {
-        "name": "openshift-saas-deploy",
+        "name": "saas-deploy",
         "type": "onePerSaasFile",
-        "path": "openshift-saas-deploy.pipeline.yaml.j2",
+        "path": "saas-deploy.pipeline.yaml.j2",
         "variables": null
       }
     }

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider5-with-unknown-task.json
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider5-with-unknown-task.json
@@ -22,9 +22,9 @@
     ],
     "pipelineTemplates": {
       "openshiftSaasDeploy": {
-        "name": "openshift-saas-deploy",
+        "name": "saas-deploy",
         "type": "onePerSaasFile",
-        "path": "openshift-saas-deploy.pipeline.yaml.j2",
+        "path": "saas-deploy.pipeline.yaml.j2",
         "variables": null
       }
     }
@@ -46,9 +46,9 @@
   },
   "pipelineTemplates": {
     "openshiftSaasDeploy": {
-      "name": "openshift-saas-deploy",
+      "name": "saas-deploy",
       "type": "onePerSaasFile",
-      "path": "openshift-saas-deploy-with-unknown-task.pipeline.yaml.j2",
+      "path": "saas-deploy-with-unknown-task.pipeline.yaml.j2",
       "variables": null
     }
   }

--- a/reconcile/test/fixtures/openshift_tekton_resources/provider6-too-long-pipeline-name.yaml
+++ b/reconcile/test/fixtures/openshift_tekton_resources/provider6-too-long-pipeline-name.yaml
@@ -1,5 +1,5 @@
 {
-  "name": "provider1",
+  "name": "provider6-too-long-pipeline-name",
   "provider": "tekton",
   "defaults": {
     "retention": {
@@ -22,9 +22,9 @@
     ],
     "pipelineTemplates": {
       "openshiftSaasDeploy": {
-        "name": "saas-deploy",
+        "name": "saas-deploy-too-long-name",
         "type": "onePerSaasFile",
-        "path": "saas-deploy.pipeline.yaml.j2",
+        "path": "saas-deploy-too-long-name.pipeline.yaml.j2",
         "variables": null
       }
     }

--- a/reconcile/test/fixtures/openshift_tekton_resources/saas-deploy-too-long-name.pipeline.yaml.j2
+++ b/reconcile/test/fixtures/openshift_tekton_resources/saas-deploy-too-long-name.pipeline.yaml.j2
@@ -1,0 +1,51 @@
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: saas-deploy-too-long-name
+spec:
+  params:
+  - name: saas_file_name
+    type: string
+  - name: env_name
+    type: string
+  - name: tkn_cluster_console_url
+    type: string
+  - name: tkn_namespace_name
+    type: string
+  tasks:
+  - name: openshift-saas-deploy
+    taskRef:
+      name: openshift-saas-deploy
+    params:
+    - name: saas_file_name
+      value: "$(params.saas_file_name)"
+    - name: env_name
+      value: "$(params.env_name)"
+  finally:
+  - name: push-gateway-openshift-saas-deploy-task-status-metric
+    retries: 10
+    taskRef:
+      name: push-gateway-openshift-saas-deploy-task-status-metric
+    params:
+    - name: saas_file_name
+      value: "$(params.saas_file_name)"
+    - name: env_name
+      value: "$(params.env_name)"
+    - name: metric_name
+      value: app_sre_tekton_pipelinerun_task_status
+    - name: job_name
+      value: openshift-saas-deploy-push-metric
+    - name: task_name
+      value: openshift-saas-deploy
+    - name: task_status
+      value: "$(tasks.openshift-saas-deploy.status)"
+    - name: pipeline_name
+      value: openshift-saas-deploy
+    - name: pipelinerun_name
+      value: "$(context.pipelineRun.name)"
+    - name: retry_cooldown_seconds
+      value: "60"
+    - name: tkn_cluster_console_url
+      value: "$(params.tkn_cluster_console_url)"
+    - name: tkn_namespace_name
+      value: "$(params.tkn_namespace_name)"

--- a/reconcile/test/fixtures/openshift_tekton_resources/saas-deploy-with-unknown-task.pipeline.yaml.j2
+++ b/reconcile/test/fixtures/openshift_tekton_resources/saas-deploy-with-unknown-task.pipeline.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: openshift-saas-deploy
+  name: saas-deploy
 spec:
   params:
   - name: saas_file_name

--- a/reconcile/test/fixtures/openshift_tekton_resources/saas-deploy.pipeline.yaml.j2
+++ b/reconcile/test/fixtures/openshift_tekton_resources/saas-deploy.pipeline.yaml.j2
@@ -1,7 +1,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Pipeline
 metadata:
-  name: openshift-saas-deploy
+  name: saas-deploy
 spec:
   params:
   - name: saas_file_name

--- a/reconcile/test/fixtures/openshift_tekton_resources/saas6-39-chars-name.yaml
+++ b/reconcile/test/fixtures/openshift_tekton_resources/saas6-39-chars-name.yaml
@@ -1,0 +1,9 @@
+{
+  "path": "saas6-long-name.yaml",
+  "name": "this-is-a-saas-file-with-a-39-char-name",
+  "pipelinesProvider": {
+    "name": "provider6-too-long-pipeline-name",
+    "provider": "tekton"
+  },
+  "deployResources": null
+}

--- a/reconcile/test/fixtures/queries/pipelines_providers_all_defaults.json
+++ b/reconcile/test/fixtures/queries/pipelines_providers_all_defaults.json
@@ -24,9 +24,9 @@
         ],
         "pipelineTemplates": {
           "openshiftSaasDeploy": {
-            "name": "openshift-saas-deploy",
+            "name": "saas-deploy",
             "type": "onePerSaasFile",
-            "path": "openshift-saas-deploy.pipeline.yaml.j2",
+            "path": "saas-deploy.pipeline.yaml.j2",
             "variables": null
           }
         },

--- a/reconcile/test/fixtures/queries/pipelines_providers_mixed.json
+++ b/reconcile/test/fixtures/queries/pipelines_providers_mixed.json
@@ -24,9 +24,9 @@
         ],
         "pipelineTemplates": {
           "openshiftSaasDeploy": {
-            "name": "openshift-saas-deploy",
+            "name": "saas-deploy",
             "type": "onePerSaasFile",
-            "path": "openshift-saas-deploy.pipeline.yaml.j2",
+            "path": "saas-deploy.pipeline.yaml.j2",
             "variables": null
           }
         },

--- a/reconcile/test/fixtures/saasherder/saas-templated-params.gql.yml
+++ b/reconcile/test/fixtures/saasherder/saas-templated-params.gql.yml
@@ -17,10 +17,10 @@ pipelinesProvider:
   defaults:
     pipelineTemplates:
       openshiftSaasDeploy:
-        name: openshift-saas-deploy
+        name: saas-deploy
   pipelineTemplates:
     openshiftSaasDeploy:
-      name: openshift-saas-deploy
+      name: saas-deploy
 
 
 managedResourceTypes: []

--- a/reconcile/test/fixtures/saasherder/saas.gql.yml
+++ b/reconcile/test/fixtures/saasherder/saas.gql.yml
@@ -17,10 +17,10 @@ pipelinesProvider:
   defaults:
     pipelineTemplates:
       openshiftSaasDeploy:
-        name: openshift-saas-deploy
+        name: saas-deploy
   pipelineTemplates:
     openshiftSaasDeploy:
-      name: openshift-saas-deploy
+      name: saas-deploy
 
 slack:
   workspace:

--- a/reconcile/test/fixtures/saasherder_populate_desired/saas_remote_openshift_template.yaml
+++ b/reconcile/test/fixtures/saasherder_populate_desired/saas_remote_openshift_template.yaml
@@ -41,10 +41,10 @@ pipelinesProvider:
   defaults:
     pipelineTemplates:
       openshiftSaasDeploy:
-        name: openshift-saas-deploy
+        name: saas-deploy
   pipelineTemplates:
     openshiftSaasDeploy:
-      name: openshift-saas-deploy
+      name: saas-deploy
 
 managedResourceTypes:
 - Deployment

--- a/reconcile/test/fixtures/typed_queries/saas_files-missing-provider.yml
+++ b/reconcile/test/fixtures/typed_queries/saas_files-missing-provider.yml
@@ -20,7 +20,7 @@ saas_files:
     defaults:
       pipelineTemplates:
         openshiftSaasDeploy:
-          name: openshift-saas-deploy
+          name: saas-deploy
   managedResourceTypes: []
   imagePatterns: []
   resourceTemplates:

--- a/reconcile/test/fixtures/typed_queries/saas_files.yml
+++ b/reconcile/test/fixtures/typed_queries/saas_files.yml
@@ -20,7 +20,7 @@ saas_files:
     defaults:
       pipelineTemplates:
         openshiftSaasDeploy:
-          name: openshift-saas-deploy
+          name: saas-deploy
   managedResourceTypes: []
   imagePatterns: []
   parameters: |
@@ -86,7 +86,7 @@ saas_files:
     defaults:
       pipelineTemplates:
         openshiftSaasDeploy:
-          name: openshift-saas-deploy
+          name: saas-deploy
   managedResourceTypes: []
   imagePatterns: []
   resourceTemplates:
@@ -144,7 +144,7 @@ saas_files:
     defaults:
       pipelineTemplates:
         openshiftSaasDeploy:
-          name: openshift-saas-deploy
+          name: saas-deploy
   managedResourceTypes: []
   imagePatterns: []
   resourceTemplates:

--- a/reconcile/test/test_openshift_saas_deploy.py
+++ b/reconcile/test/test_openshift_saas_deploy.py
@@ -26,7 +26,7 @@ def saas_file_builder(
                     },
                     "defaults": {
                         "pipelineTemplates": {
-                            "openshiftSaasDeploy": {"name": "openshift-saas-deploy"}
+                            "openshiftSaasDeploy": {"name": "saas-deploy"}
                         },
                     },
                 },
@@ -49,7 +49,7 @@ def test_compose_console_url(
 
     assert (
         url
-        == "https://console.url/k8s/ns/namespace_name/tekton.dev~v1beta1~Pipeline/o-openshift-saas-deploy-saas_name/"
+        == "https://console.url/k8s/ns/namespace_name/tekton.dev~v1beta1~Pipeline/o-saas-deploy-saas_name/"
         "Runs?name=saas_name-production"
     )
 
@@ -66,7 +66,7 @@ def test_compose_console_url_with_medium_saas_name(
     expected_run_name = f"{saas_name}-{env_name}"[:50]
     assert (
         url == "https://console.url/k8s/ns/namespace_name/tekton.dev~v1beta1~Pipeline/"
-        "o-openshift-saas-deploy-saas-openshift-cert-manager-routes/"
+        "o-saas-deploy-saas-openshift-cert-manager-routes/"
         f"Runs?name={expected_run_name}"
     )
 
@@ -82,6 +82,6 @@ def test_compose_console_url_with_long_saas_name(
         compose_console_url(saas_file, env_name)
 
     assert (
-        "name o-openshift-saas-deploy-this-is-a-very-looooooooooooooooooooooong-saas-name is longer than 63 characters"
+        f"Pipeline name o-saas-deploy-{saas_name} is longer than 56 characters"
         == str(e.value)
     )

--- a/reconcile/test/test_openshift_saas_deploy_change_tester.py
+++ b/reconcile/test/test_openshift_saas_deploy_change_tester.py
@@ -34,7 +34,7 @@ def saas_files(gql_class_factory: Callable[..., SaasFile]) -> list[SaasFile]:
                     },
                     "defaults": {
                         "pipelineTemplates": {
-                            "openshiftSaasDeploy": {"name": "openshift-saas-deploy"}
+                            "openshiftSaasDeploy": {"name": "saas-deploy"}
                         }
                     },
                 },

--- a/reconcile/test/test_typed_queries/test_saas_files.py
+++ b/reconcile/test/test_typed_queries/test_saas_files.py
@@ -303,9 +303,7 @@ PIPELINE_PROVIDER = {
             "consoleUrl": "https://console-url",
         },
     },
-    "defaults": {
-        "pipelineTemplates": {"openshiftSaasDeploy": {"name": "openshift-saas-deploy"}}
-    },
+    "defaults": {"pipelineTemplates": {"openshiftSaasDeploy": {"name": "saas-deploy"}}},
 }
 
 
@@ -640,7 +638,7 @@ def test_export_model(
                 },
                 "defaults": {
                     "pipelineTemplates": {
-                        "openshiftSaasDeploy": {"name": "openshift-saas-deploy"}
+                        "openshiftSaasDeploy": {"name": "saas-deploy"}
                     }
                 },
                 "pipelineTemplates": None,
@@ -794,7 +792,7 @@ def test_export_model(
                 },
                 "defaults": {
                     "pipelineTemplates": {
-                        "openshiftSaasDeploy": {"name": "openshift-saas-deploy"}
+                        "openshiftSaasDeploy": {"name": "saas-deploy"}
                     }
                 },
                 "pipelineTemplates": None,
@@ -948,7 +946,7 @@ def test_export_model(
                 },
                 "defaults": {
                     "pipelineTemplates": {
-                        "openshiftSaasDeploy": {"name": "openshift-saas-deploy"}
+                        "openshiftSaasDeploy": {"name": "saas-deploy"}
                     }
                 },
                 "pipelineTemplates": None,


### PR DESCRIPTION
Pipeline names are built using the following convention:

```
o-<one per saas file pipeline name>-<saas file name>
```

The max size of `<saas file name>` was chosen to be 39 characters taking
into account that pipeline name was `openshift-saas-file`, so that we
can have pipelines with names up to 63 characters. This also worked well
with our PipelineRuns, which appended a 14 characeters date but trimmed
the Pipeline size so that, again, objects were right in size.

This didn't take into account that Tekton retries create PipelineRun names
that are named appending a 7 character random string to the corresponing
Pipeline name, which make certain Pipeline names not possible.

This patch makes sure that we have Pipeline names that will be suitable
for Tekton retries. It also changes many fixtures that use the old and
not longer allowed long pipeline name so that they are more realistic.

The code protects beyond what the schema will allow, since pipeline
names [are also being limited in their length](https://github.com/app-sre/qontract-schemas/pull/472)

part of [APPSRE-6031](https://issues.redhat.com/browse/APPSRE-6031)

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>