### PR TITLE
[user-mgmt] allow cluster-admin mgmt for rosa clusters

### DIFF
--- a/reconcile/oum/base.py
+++ b/reconcile/oum/base.py
@@ -340,7 +340,8 @@ def build_specs_from_config(
         ) in cluster_config.roles.items():
             spec.roles[role_id] = set()
             if (
-                role_id == OCMClusterGroupId.CLUSTER_ADMINS
+                cluster_config.cluster.ocm_cluster.is_osd()
+                and role_id == OCMClusterGroupId.CLUSTER_ADMINS
                 and not cluster_config.cluster.is_capability_set(
                     CAPABILITY_MANAGE_CLUSTER_ADMIN, "true"
                 )

--- a/reconcile/test/ocm/fixtures.py
+++ b/reconcile/test/ocm/fixtures.py
@@ -15,6 +15,7 @@ from pydantic import (
 
 from reconcile.utils.ocm.base import OCMModelLink
 from reconcile.utils.ocm.clusters import (
+    PRODUCT_ID_ROSA,
     ClusterDetails,
     OCMCapability,
     OCMCluster,
@@ -97,6 +98,8 @@ def build_ocm_cluster(
     aws_cluster: bool = True,
     sts_cluster: bool = False,
     version: str = "4.13.0",
+    cluster_product: str = PRODUCT_ID_ROSA,
+    hypershift: bool = False,
 ) -> OCMCluster:
     aws_config = None
     if aws_cluster:
@@ -108,12 +111,13 @@ def build_ocm_cluster(
         display_name=f"{name}_display_name",
         subscription=OCMModelLink(id=subs_id),
         region=OCMModelLink(id="us-east-1"),
-        product=OCMModelLink(id="OCP"),
+        product=OCMModelLink(id=cluster_product),
         cloud_provider=OCMModelLink(id="aws"),
         state=OCMClusterState.READY,
         managed=True,
         aws=aws_config,
         version=OCMClusterVersion(id=f"openshift-v{version}", raw_id="version"),
+        hypershift=OCMClusterFlag(enabled=hypershift),
     )
 
 
@@ -124,6 +128,8 @@ def build_cluster_details(
     org_id: str = "org-id",
     aws_cluster: bool = True,
     sts_cluster: bool = False,
+    cluster_product: str = PRODUCT_ID_ROSA,
+    hypershift: bool = False,
     capabilitites: Optional[dict[str, str]] = None,
 ) -> ClusterDetails:
     return ClusterDetails(
@@ -132,6 +138,8 @@ def build_cluster_details(
             subs_id=f"{cluster_name}_subs_id",
             aws_cluster=aws_cluster,
             sts_cluster=sts_cluster,
+            cluster_product=cluster_product,
+            hypershift=hypershift,
         ),
         organization_id=org_id,
         capabilities={

--- a/reconcile/test/ocm/oum/test_oum_base.py
+++ b/reconcile/test/ocm/oum/test_oum_base.py
@@ -317,13 +317,22 @@ def test_build_spec_from_config_missing_group(
 
 
 @pytest.mark.parametrize(
-    "cluster_product, errors", [(PRODUCT_ID_OSD, True), (PRODUCT_ID_ROSA, False)]
+    "cluster_product, errors, expected_groups",
+    [
+        (PRODUCT_ID_OSD, True, {}),
+        (
+            PRODUCT_ID_ROSA,
+            False,
+            {OCMClusterGroupId.CLUSTER_ADMINS: {"user-1", "user-2"}},
+        ),
+    ],
 )
 def test_build_spec_from_config_osd_cluster_admin_without_capability(
     cluster: ClusterDetails,
     mock_group_member_provider: MockGroupMemberProvider,
     cluster_product: str,
     errors: int,
+    expected_groups: dict[str, set[str]],
 ) -> None:
     """
     An OSD cluster without the manage cluster admin capability should NOT be able to
@@ -349,12 +358,8 @@ def test_build_spec_from_config_osd_cluster_admin_without_capability(
         },
     )
     assert len(specs) == 1
-    if errors:
-        assert specs[0].roles == {}
-        assert len(specs[0].errors) == 1
-    else:
-        assert specs[0].roles[OCMClusterGroupId.CLUSTER_ADMINS] != {}
-        assert len(specs[0].errors) == 0
+    assert len(specs[0].errors) == errors
+    assert specs[0].roles == expected_groups
 
 
 def test_build_spec_from_config_cluster_admin_with_capability(

--- a/reconcile/test/ocm/oum/test_oum_base.py
+++ b/reconcile/test/ocm/oum/test_oum_base.py
@@ -43,6 +43,8 @@ from reconcile.utils.ocm.cluster_groups import (
 )
 from reconcile.utils.ocm.clusters import (
     CAPABILITY_MANAGE_CLUSTER_ADMIN,
+    PRODUCT_ID_OSD,
+    PRODUCT_ID_ROSA,
     ClusterDetails,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
@@ -314,13 +316,20 @@ def test_build_spec_from_config_missing_group(
     assert len(specs[0].errors) == 1
 
 
-def test_build_spec_from_config_cluster_admin_without_capability(
-    cluster: ClusterDetails, mock_group_member_provider: MockGroupMemberProvider
+@pytest.mark.parametrize(
+    "cluster_product, errors", [(PRODUCT_ID_OSD, True), (PRODUCT_ID_ROSA, False)]
+)
+def test_build_spec_from_config_osd_cluster_admin_without_capability(
+    cluster: ClusterDetails,
+    mock_group_member_provider: MockGroupMemberProvider,
+    cluster_product: str,
+    errors: int,
 ) -> None:
     """
-    A cluster without the manage cluster admin capability should NOT be able to
-    have cluster admins defined.
+    An OSD cluster without the manage cluster admin capability should NOT be able to
+    have cluster admins defined. But for ROSA clusters, this is allowed.
     """
+    cluster.ocm_cluster.product.id = cluster_product
     provider = "mock"
     org_config = build_org_config(
         cluster=cluster,
@@ -340,9 +349,12 @@ def test_build_spec_from_config_cluster_admin_without_capability(
         },
     )
     assert len(specs) == 1
-    assert specs[0].roles == {}
-    assert specs[0].cluster == cluster
-    assert len(specs[0].errors) == 1
+    if errors:
+        assert specs[0].roles == {}
+        assert len(specs[0].errors) == 1
+    else:
+        assert specs[0].roles[OCMClusterGroupId.CLUSTER_ADMINS] != {}
+        assert len(specs[0].errors) == 0
 
 
 def test_build_spec_from_config_cluster_admin_with_capability(

--- a/reconcile/utils/ocm/clusters.py
+++ b/reconcile/utils/ocm/clusters.py
@@ -61,6 +61,10 @@ class OCMClusterVersion(BaseModel):
     raw_id: str
 
 
+PRODUCT_ID_OSD = "osd"
+PRODUCT_ID_ROSA = "rosa"
+
+
 class OCMCluster(BaseModel):
 
     kind: str = "Cluster"
@@ -84,6 +88,17 @@ class OCMCluster(BaseModel):
     aws: Optional[OCMClusterAWSSettings]
 
     version: OCMClusterVersion
+
+    hypershift: OCMClusterFlag
+
+    def is_osd(self) -> bool:
+        return self.product.id == PRODUCT_ID_OSD
+
+    def is_rosa_classic(self) -> bool:
+        return self.product.id == PRODUCT_ID_ROSA and not self.hypershift.enabled
+
+    def is_rosa_hypershift(self) -> bool:
+        return self.product.id == PRODUCT_ID_ROSA and self.hypershift.enabled
 
 
 class ClusterDetails(BaseModel):
@@ -277,5 +292,5 @@ def cluster_ready_for_app_interface() -> Filter:
         Filter()
         .eq("managed", "true")
         .eq("state", OCMClusterState.READY.value)
-        .is_in("product.id", ["osd", "rosa"])
+        .is_in("product.id", [PRODUCT_ID_OSD, PRODUCT_ID_ROSA])
     )


### PR DESCRIPTION
currently, the user-mgmt capability refuses to manage cluster-admins groups on clusters without the respective AMS capability. that is the right behaviour for OSD but not for ROSA. for ROSA clusters, the AMS capability is not required.

fix for https://issues.redhat.com/browse/APPSRE-7709