### PR TITLE
[saas-file-validator] validate targets in app may include parent app

### DIFF
--- a/reconcile/gql_definitions/common/saas_files.gql
+++ b/reconcile/gql_definitions/common/saas_files.gql
@@ -6,6 +6,9 @@ query SaasFiles {
     name
     app {
       name
+      parentApp {
+        name
+      }
     }
     pipelinesProvider {
       name

--- a/reconcile/gql_definitions/common/saas_files.py
+++ b/reconcile/gql_definitions/common/saas_files.py
@@ -75,6 +75,9 @@ fragment SaasTargetNamespace on Namespace_v1 {
   }
   app {
     name
+    parentApp {
+      name
+    }
     labels
   }
   cluster {
@@ -98,6 +101,9 @@ query SaasFiles {
     name
     app {
       name
+      parentApp {
+        name
+      }
     }
     pipelinesProvider {
       name
@@ -268,8 +274,13 @@ class ConfiguredBaseModel(BaseModel):
         extra = Extra.forbid
 
 
+class AppV1_AppV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+
+
 class AppV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+    parent_app: Optional[AppV1_AppV1] = Field(..., alias="parentApp")
 
 
 class PipelinesProviderV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/common/saas_target_namespaces.py
+++ b/reconcile/gql_definitions/common/saas_target_namespaces.py
@@ -71,6 +71,9 @@ fragment SaasTargetNamespace on Namespace_v1 {
   }
   app {
     name
+    parentApp {
+      name
+    }
     labels
   }
   cluster {

--- a/reconcile/gql_definitions/fragments/saas_target_namespace.gql
+++ b/reconcile/gql_definitions/fragments/saas_target_namespace.gql
@@ -18,6 +18,9 @@ fragment SaasTargetNamespace on Namespace_v1 {
   }
   app {
     name
+    parentApp {
+      name
+    }
     labels
   }
   cluster {

--- a/reconcile/gql_definitions/fragments/saas_target_namespace.py
+++ b/reconcile/gql_definitions/fragments/saas_target_namespace.py
@@ -43,8 +43,13 @@ class EnvironmentV1(ConfiguredBaseModel):
     )
 
 
+class AppV1_AppV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+
+
 class AppV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+    parent_app: Optional[AppV1_AppV1] = Field(..., alias="parentApp")
     labels: Optional[Json] = Field(..., alias="labels")
 
 

--- a/reconcile/test/test_typed_queries/test_saas_files.py
+++ b/reconcile/test/test_typed_queries/test_saas_files.py
@@ -321,7 +321,7 @@ PIPELINE_PROVIDER = {
                 {
                     "path": "path1",
                     "name": "saas-file-01",
-                    "app": {"name": "app-01"},
+                    "app": {"name": "app-01", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
                     "imagePatterns": [],
@@ -341,7 +341,7 @@ PIPELINE_PROVIDER = {
                                             "name": "test",
                                             "parameters": '{"ENV_PARAM": "foobar"}',
                                         },
-                                        "app": {"name": "app-01"},
+                                        "app": {"name": "app-01", "parentApp": None},
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "main",
@@ -352,7 +352,7 @@ PIPELINE_PROVIDER = {
                                         "name": "namespace-prod",
                                         "path": "some-path",
                                         "environment": {"name": "prod"},
-                                        "app": {"name": "app-01"},
+                                        "app": {"name": "app-01", "parentApp": None},
                                         "cluster": CLUSTER,
                                     },
                                     "provider": "static",
@@ -373,7 +373,7 @@ PIPELINE_PROVIDER = {
                 {
                     "path": "path2",
                     "name": "saas-file-02",
-                    "app": {"name": "app-02"},
+                    "app": {"name": "app-02", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
                     "imagePatterns": [],
@@ -388,7 +388,7 @@ PIPELINE_PROVIDER = {
                                         "name": "namespace-test",
                                         "path": "some-path",
                                         "environment": {"name": "test"},
-                                        "app": {"name": "app-02"},
+                                        "app": {"name": "app-02", "parentApp": None},
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "main",
@@ -398,7 +398,7 @@ PIPELINE_PROVIDER = {
                                         "name": "namespace-prod",
                                         "path": "some-path",
                                         "environment": {"name": "prod"},
-                                        "app": {"name": "app-02"},
+                                        "app": {"name": "app-02", "parentApp": None},
                                         "cluster": CLUSTER,
                                     },
                                     "provider": "static",
@@ -419,7 +419,7 @@ PIPELINE_PROVIDER = {
                 {
                     "path": "path2",
                     "name": "saas-file-02",
-                    "app": {"name": "app-02"},
+                    "app": {"name": "app-02", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
                     "imagePatterns": [],
@@ -434,7 +434,7 @@ PIPELINE_PROVIDER = {
                                         "name": "namespace-test",
                                         "path": "some-path",
                                         "environment": {"name": "test"},
-                                        "app": {"name": "app-02"},
+                                        "app": {"name": "app-02", "parentApp": None},
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "main",
@@ -454,7 +454,7 @@ PIPELINE_PROVIDER = {
                 {
                     "path": "path1",
                     "name": "saas-file-01",
-                    "app": {"name": "app-01"},
+                    "app": {"name": "app-01", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
                     "imagePatterns": [],
@@ -474,7 +474,7 @@ PIPELINE_PROVIDER = {
                                             "name": "test",
                                             "parameters": '{"ENV_PARAM": "foobar"}',
                                         },
-                                        "app": {"name": "app-01"},
+                                        "app": {"name": "app-01", "parentApp": None},
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "main",
@@ -487,7 +487,7 @@ PIPELINE_PROVIDER = {
                 {
                     "path": "path2",
                     "name": "saas-file-02",
-                    "app": {"name": "app-02"},
+                    "app": {"name": "app-02", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
                     "imagePatterns": [],
@@ -502,7 +502,7 @@ PIPELINE_PROVIDER = {
                                         "name": "namespace-test",
                                         "path": "some-path",
                                         "environment": {"name": "test"},
-                                        "app": {"name": "app-02"},
+                                        "app": {"name": "app-02", "parentApp": None},
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "main",
@@ -523,7 +523,7 @@ PIPELINE_PROVIDER = {
                 {
                     "path": "path3",
                     "name": "saas-file-03",
-                    "app": {"name": "example"},
+                    "app": {"name": "example", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
                     "imagePatterns": [],
@@ -538,7 +538,7 @@ PIPELINE_PROVIDER = {
                                         "name": "example-01",
                                         "path": "some-path",
                                         "environment": {"name": "production"},
-                                        "app": {"name": "example"},
+                                        "app": {"name": "example", "parentApp": None},
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "1234567890123456789012345678901234567890",
@@ -548,7 +548,7 @@ PIPELINE_PROVIDER = {
                                         "name": "example-02",
                                         "path": "some-path",
                                         "environment": {"name": "stage"},
-                                        "app": {"name": "example"},
+                                        "app": {"name": "example", "parentApp": None},
                                         "cluster": CLUSTER,
                                     },
                                     "ref": "1234567890123456789012345678901234567890",
@@ -615,7 +615,7 @@ def test_export_model(
         {
             "path": "path1",
             "name": "saas-file-01",
-            "app": {"name": "app-01"},
+            "app": {"name": "app-01", "parentApp": None},
             "pipelinesProvider": {
                 "name": "pipeline-provider-01",
                 "provider": "tekton",
@@ -685,7 +685,11 @@ def test_export_model(
                                     "parameters": '{"ENV_PARAM": "foobar"}',
                                     "secretParameters": None,
                                 },
-                                "app": {"name": "app-01", "labels": None},
+                                "app": {
+                                    "name": "app-01",
+                                    "labels": None,
+                                    "parentApp": None,
+                                },
                                 "cluster": {
                                     "name": "appint-ex-01",
                                     "serverUrl": "https://cluster-url",
@@ -726,7 +730,11 @@ def test_export_model(
                                     "parameters": None,
                                     "secretParameters": None,
                                 },
-                                "app": {"name": "app-01", "labels": None},
+                                "app": {
+                                    "name": "app-01",
+                                    "labels": None,
+                                    "parentApp": None,
+                                },
                                 "cluster": {
                                     "name": "appint-ex-01",
                                     "serverUrl": "https://cluster-url",
@@ -761,7 +769,7 @@ def test_export_model(
         {
             "path": "path2",
             "name": "saas-file-02",
-            "app": {"name": "app-02"},
+            "app": {"name": "app-02", "parentApp": None},
             "pipelinesProvider": {
                 "name": "pipeline-provider-01",
                 "provider": "tekton",
@@ -831,7 +839,11 @@ def test_export_model(
                                     "parameters": None,
                                     "secretParameters": None,
                                 },
-                                "app": {"name": "app-02", "labels": None},
+                                "app": {
+                                    "name": "app-02",
+                                    "labels": None,
+                                    "parentApp": None,
+                                },
                                 "cluster": {
                                     "name": "appint-ex-01",
                                     "serverUrl": "https://cluster-url",
@@ -872,7 +884,11 @@ def test_export_model(
                                     "parameters": None,
                                     "secretParameters": None,
                                 },
-                                "app": {"name": "app-02", "labels": None},
+                                "app": {
+                                    "name": "app-02",
+                                    "labels": None,
+                                    "parentApp": None,
+                                },
                                 "cluster": {
                                     "name": "appint-ex-01",
                                     "serverUrl": "https://cluster-url",
@@ -907,7 +923,7 @@ def test_export_model(
         {
             "path": "path3",
             "name": "saas-file-03",
-            "app": {"name": "example"},
+            "app": {"name": "example", "parentApp": None},
             "pipelinesProvider": {
                 "name": "pipeline-provider-01",
                 "provider": "tekton",
@@ -977,7 +993,11 @@ def test_export_model(
                                     "parameters": None,
                                     "secretParameters": None,
                                 },
-                                "app": {"name": "example", "labels": None},
+                                "app": {
+                                    "name": "example",
+                                    "parentApp": None,
+                                    "labels": None,
+                                },
                                 "cluster": {
                                     "name": "appint-ex-01",
                                     "serverUrl": "https://cluster-url",
@@ -1018,7 +1038,11 @@ def test_export_model(
                                     "parameters": None,
                                     "secretParameters": None,
                                 },
-                                "app": {"name": "example", "labels": None},
+                                "app": {
+                                    "name": "example",
+                                    "parentApp": None,
+                                    "labels": None,
+                                },
                                 "cluster": {
                                     "name": "appint-ex-01",
                                     "serverUrl": "https://cluster-url",

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -47,11 +47,15 @@ class HasSecretParameters(Protocol):
         ...
 
 
+class SaasParentApp(Protocol):
+    name: str
+
+
 class SaasApp(Protocol):
     name: str
 
     @property
-    def parent_app(self) -> Optional[SaasApp]:
+    def parent_app(self) -> Optional[SaasParentApp]:
         ...
 
 

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -50,6 +50,10 @@ class HasSecretParameters(Protocol):
 class SaasApp(Protocol):
     name: str
 
+    @property
+    def parent_app(self) -> Optional[SaasApp]:
+        ...
+
 
 class SaasPipelinesProvider(Protocol):
     name: str

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -312,9 +312,11 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     )
                     if saas_file.validate_targets_in_app:
                         valid_app_names = {saas_file.app.name}
+                        if saas_file.app.parent_app:
+                            valid_app_names.add(saas_file.app.parent_app.name)
                         if target.namespace.app.name not in valid_app_names:
                             logging.error(
-                                f"[{saas_file.name}] targets must be within app {valid_app_names}"
+                                f"[{saas_file.name}] targets must be within app(s) {valid_app_names}"
                             )
                             self.valid = False
 

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -232,6 +232,19 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     f"secret parameter path '{sp.secret.path}' does not match any of allowedSecretParameterPaths"
                 )
 
+    def _validate_target_in_app(
+        self, saas_file: SaasFile, target: SaasResourceTemplateTarget
+    ) -> None:
+        if saas_file.validate_targets_in_app:
+            valid_app_names = {saas_file.app.name}
+            if saas_file.app.parent_app:
+                valid_app_names.add(saas_file.app.parent_app.name)
+            if target.namespace.app.name not in valid_app_names:
+                logging.error(
+                    f"[{saas_file.name}] targets must be within app(s) {valid_app_names}"
+                )
+                self.valid = False
+
     def _validate_saas_files(self) -> None:
         self.valid = True
         saas_file_name_path_map: dict[str, list[str]] = {}
@@ -310,15 +323,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         target.namespace.environment.secret_parameters or [],
                         saas_file.allowed_secret_parameter_paths or [],
                     )
-                    if saas_file.validate_targets_in_app:
-                        valid_app_names = {saas_file.app.name}
-                        if saas_file.app.parent_app:
-                            valid_app_names.add(saas_file.app.parent_app.name)
-                        if target.namespace.app.name not in valid_app_names:
-                            logging.error(
-                                f"[{saas_file.name}] targets must be within app(s) {valid_app_names}"
-                            )
-                            self.valid = False
+                    self._validate_target_in_app(saas_file, target)
 
                     if target.promotion:
                         rt_ref = (

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -311,9 +311,10 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         saas_file.allowed_secret_parameter_paths or [],
                     )
                     if saas_file.validate_targets_in_app:
-                        if saas_file.app.name != target.namespace.app.name:
+                        valid_app_names = {saas_file.app.name}
+                        if target.namespace.app.name not in valid_app_names:
                             logging.error(
-                                f"[{saas_file.name}] targets must be within app {saas_file.app.name}"
+                                f"[{saas_file.name}] targets must be within app {valid_app_names}"
                             )
                             self.valid = False
 


### PR DESCRIPTION
with this PR, `validateTargetsInApp` now allows saas file targets (namespaces) to reference a parent app of it's own app.