### PR TITLE
[AUS] customer dashboard currently soaking panel fixes

### DIFF
--- a/grafana-dashboards/sre-capability-aus.configmap.yaml
+++ b/grafana-dashboards/sre-capability-aus.configmap.yaml
@@ -211,7 +211,13 @@ data:
               ],
               "show": false
             },
-            "showHeader": true
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": false,
+                "displayName": "Current Version"
+              }
+            ]
           },
           "pluginVersion": "9.3.8",
           "targets": [
@@ -222,7 +228,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "aus_cluster_version_remaining_soak_days * on (cluster_uuid, soaking_version) (clamp_max(changes(aus_cluster_version_remaining_soak_days[1h]), 1) > 0) * on (cluster_uuid) group_left(cluster_name, current_version, workloads, schedule, sector) aus_cluster_upgrade_policy_info{workloads=~\".*$workloads.*\", org_id=~\".*$org_id.*\"}",
+              "expr": "aus_cluster_version_remaining_soak_days * on (cluster_uuid, soaking_version) (clamp_max(changes(min(aus_cluster_version_remaining_soak_days) by(cluster_uuid, soaking_version)[1h:1m]), 1) > 0) * on (cluster_uuid) group_left(cluster_name, current_version, workloads, schedule, sector) aus_cluster_upgrade_policy_info{workloads=~\".*$workloads.*\", org_id=~\".*$org_id.*\"}",
               "format": "table",
               "instant": true,
               "interval": "5m",
@@ -314,7 +320,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "aus_cluster_version_remaining_soak_days * on (cluster_uuid) group_left(cluster_name, workloads, schedule, sector) aus_cluster_upgrade_policy_info{workloads=~\".*$workloads.*\", org_id=~\".*$org_id.*\"}",
+              "expr": "aus_cluster_version_remaining_soak_days * on (cluster_uuid) group_left(cluster_name, workloads, schedule, sector, cluster_name_version) label_join(aus_cluster_upgrade_policy_info{workloads=~\".*$workloads.*\", org_id=~\".*$org_id.*\"}, \"cluster_name_version\", \" - \", \"cluster_name\", \"current_version\")",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
@@ -339,7 +345,7 @@ data:
               "id": "groupingToMatrix",
               "options": {
                 "columnField": "soaking_version",
-                "rowField": "cluster_name",
+                "rowField": "cluster_name_version",
                 "valueField": "Value"
               }
             }
@@ -387,10 +393,10 @@ data:
             "current": {
               "selected": true,
               "text": [
-                "crc"
+                "All"
               ],
               "value": [
-                "crc"
+                "$__all"
               ]
             },
             "datasource": {


### PR DESCRIPTION
* the "currently soaking versions" panel was throwing errors in situations where target labels changed (e.g. pod restarts)
* show the current version of a cluster in the "remaining soak days" panel
* clean pre-selections for filters (accidentally introduced in earlier dashboard changes)

part of https://issues.redhat.com/browse/APPSRE-7360