### PR TITLE
[Terraform] Handle empty ValidUpgradeTarget for RDS upgrade

### DIFF
--- a/reconcile/test/test_utils_aws_api.py
+++ b/reconcile/test/test_utils_aws_api.py
@@ -5,6 +5,7 @@ from moto import (
     mock_iam,
     mock_route53,
 )
+from pytest_mock import MockerFixture
 
 from reconcile.utils.aws_api import (
     AmiTag,
@@ -238,3 +239,60 @@ def test_get_image_id(ec2_client, aws_api: AWSApi):
         aws_api.get_image_id(
             "some-account", "us-east-1", tags=[AmiTag(name="foo", value="bar")]
         )
+
+
+def test_get_db_valid_upgrade_target(
+    aws_api: AWSApi,
+    accounts: list,
+    mocker: MockerFixture,
+) -> None:
+    # should patch Session object, but here aws_api is already created, require bigger refactor to do proper mock
+    mocker.patch.object(aws_api, "get_session_client", autospec=True)
+    mocked_rds_client = aws_api.get_session_client.return_value
+    expected_valid_upgrade_target = [
+        {
+            "Engine": "postgres",
+            "EngineVersion": "12.9",
+            "IsMajorVersionUpgrade": False,
+        },
+    ]
+    mocked_rds_client.describe_db_engine_versions.return_value = {
+        "DBEngineVersions": [{"ValidUpgradeTarget": expected_valid_upgrade_target}]
+    }
+
+    engine = "postgres"
+    engine_version = "12.8"
+
+    result = aws_api.get_db_valid_upgrade_target(
+        accounts[0]["name"],
+        engine,
+        engine_version,
+    )
+
+    assert result == expected_valid_upgrade_target
+
+    mocked_rds_client.describe_db_engine_versions.assert_called_once_with(
+        Engine=engine,
+        EngineVersion=engine_version,
+    )
+
+
+def test_get_db_valid_upgrade_target_with_empty_db_engine_versions(
+    aws_api: AWSApi,
+    accounts: list,
+    mocker: MockerFixture,
+) -> None:
+    # should patch Session object, but here aws_api is already created, require bigger refactor to do proper mock
+    mocker.patch.object(aws_api, "get_session_client", autospec=True)
+    mocked_rds_client = aws_api.get_session_client.return_value
+    mocked_rds_client.describe_db_engine_versions.return_value = {
+        "DBEngineVersions": []
+    }
+
+    result = aws_api.get_db_valid_upgrade_target(
+        accounts[0]["name"],
+        "postgres",
+        "12.8",
+    )
+
+    assert result == []

--- a/reconcile/test/test_utils_aws_api.py
+++ b/reconcile/test/test_utils_aws_api.py
@@ -248,7 +248,7 @@ def test_get_db_valid_upgrade_target(
 ) -> None:
     # should patch Session object, but here aws_api is already created, require bigger refactor to do proper mock
     mocker.patch.object(aws_api, "get_session_client", autospec=True)
-    mocked_rds_client = aws_api.get_session_client.return_value
+    mocked_rds_client = aws_api.get_session_client.return_value  # type: ignore[attr-defined]
     expected_valid_upgrade_target = [
         {
             "Engine": "postgres",
@@ -284,7 +284,7 @@ def test_get_db_valid_upgrade_target_with_empty_db_engine_versions(
 ) -> None:
     # should patch Session object, but here aws_api is already created, require bigger refactor to do proper mock
     mocker.patch.object(aws_api, "get_session_client", autospec=True)
-    mocked_rds_client = aws_api.get_session_client.return_value
+    mocked_rds_client = aws_api.get_session_client.return_value  # type: ignore[attr-defined]
     mocked_rds_client.describe_db_engine_versions.return_value = {
         "DBEngineVersions": []
     }

--- a/reconcile/test/test_utils_terraform_client.py
+++ b/reconcile/test/test_utils_terraform_client.py
@@ -464,12 +464,12 @@ def test__can_skip_rds_modifications_with_exception(aws_api, tf):
     assert "a-test-exception" in str(error.value)
 
 
-def test__validate_db_upgrade_no_upgrade(aws_api, tf):
+def test_validate_db_upgrade_no_upgrade(aws_api, tf):
     aws_api.get_db_valid_upgrade_target.return_value = [
         {"Engine": "postgres", "EngineVersion": "11.17", "IsMajorVersionUpgrade": False}
     ]
 
-    tf._validate_db_upgrade(
+    tf.validate_db_upgrade(
         account_name="a1",
         resource_name="test-database-1",
         resource_change={
@@ -485,12 +485,12 @@ def test__validate_db_upgrade_no_upgrade(aws_api, tf):
     )
 
 
-def test__validate_db_upgrade(aws_api, tf):
+def test_validate_db_upgrade(aws_api, tf):
     aws_api.get_db_valid_upgrade_target.return_value = [
         {"Engine": "postgres", "EngineVersion": "11.17", "IsMajorVersionUpgrade": False}
     ]
 
-    tf._validate_db_upgrade(
+    tf.validate_db_upgrade(
         account_name="a1",
         resource_name="test-database-1",
         resource_change={
@@ -507,12 +507,12 @@ def test__validate_db_upgrade(aws_api, tf):
     )
 
 
-def test__validate_db_upgrade_major_version_upgrade(aws_api, tf):
+def test_validate_db_upgrade_major_version_upgrade(aws_api, tf):
     aws_api.get_db_valid_upgrade_target.return_value = [
         {"Engine": "postgres", "EngineVersion": "13.3", "IsMajorVersionUpgrade": True}
     ]
 
-    tf._validate_db_upgrade(
+    tf.validate_db_upgrade(
         account_name="a1",
         resource_name="test-database-1",
         resource_change={
@@ -530,13 +530,13 @@ def test__validate_db_upgrade_major_version_upgrade(aws_api, tf):
     )
 
 
-def test__validate_db_upgrade_cannot_upgrade(aws_api, tf):
+def test_validate_db_upgrade_cannot_upgrade(aws_api, tf):
     aws_api.get_db_valid_upgrade_target.return_value = [
         {"Engine": "postgres", "EngineVersion": "13.3", "IsMajorVersionUpgrade": True}
     ]
 
     with pytest.raises(ValueError) as error:
-        tf._validate_db_upgrade(
+        tf.validate_db_upgrade(
             account_name="a1",
             resource_name="test-database-1",
             resource_change={
@@ -557,13 +557,13 @@ def test__validate_db_upgrade_cannot_upgrade(aws_api, tf):
     )
 
 
-def test__validate_db_upgrade_major_version_upgrade_not_allow(aws_api, tf):
+def test_validate_db_upgrade_major_version_upgrade_not_allow(aws_api, tf):
     aws_api.get_db_valid_upgrade_target.return_value = [
         {"Engine": "postgres", "EngineVersion": "13.3", "IsMajorVersionUpgrade": True}
     ]
 
     with pytest.raises(ValueError) as error:
-        tf._validate_db_upgrade(
+        tf.validate_db_upgrade(
             account_name="a1",
             resource_name="test-database-1",
             resource_change={

--- a/reconcile/test/test_utils_terraform_client.py
+++ b/reconcile/test/test_utils_terraform_client.py
@@ -589,7 +589,7 @@ def test_validate_db_upgrade_with_empty_valid_upgrade_targe_and_allow_major_vers
     aws_api: AWSApi,
     tf: tfclient.TerraformClient,
 ) -> None:
-    aws_api.get_db_valid_upgrade_target.return_value = []
+    aws_api.get_db_valid_upgrade_target.return_value = []  # type: ignore[attr-defined]
 
     tf.validate_db_upgrade(
         account_name="a1",
@@ -613,7 +613,7 @@ def test_validate_db_upgrade_with_empty_valid_upgrade_targe_and_not_allow_major_
     aws_api: AWSApi,
     tf: tfclient.TerraformClient,
 ) -> None:
-    aws_api.get_db_valid_upgrade_target.return_value = []
+    aws_api.get_db_valid_upgrade_target.return_value = []  # type: ignore[attr-defined]
 
     with pytest.raises(ValueError) as error:
         tf.validate_db_upgrade(

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1493,6 +1493,10 @@ class AWSApi:  # pylint: disable=too-many-public-methods
             optional_kwargs["region_name"] = region_name
 
         rds = self._account_rds_client(account_name, **optional_kwargs)
-        return rds.describe_db_engine_versions(
+        response = rds.describe_db_engine_versions(
             Engine=engine, EngineVersion=engine_version
-        )["DBEngineVersions"][0]["ValidUpgradeTarget"]
+        )
+
+        if versions := response["DBEngineVersions"]:
+            return versions[0]["ValidUpgradeTarget"]
+        return []

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -706,27 +706,39 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         if after_version == before_version:
             return
 
+        allow_major_version_upgrade = after.get("allow_major_version_upgrade", False)
         region_name = get_region_from_availability_zone(before["availability_zone"])
         if self._aws_api is not None:
             valid_upgrade_target = self._aws_api.get_db_valid_upgrade_target(
                 account_name, engine, before_version, region_name=region_name
             )
-            found = False
-            for t in valid_upgrade_target:
-                if t["EngineVersion"] == after_version:
-                    found = True
-                    if t["IsMajorVersionUpgrade"] and not after.get(
-                        "allow_major_version_upgrade", False
-                    ):
-                        raise ValueError(
-                            "allow_major_version_upgrade is not enabled for upgrading RDS instance: "
-                            f"{resource_name} to a new major version."
-                        )
-
-            if not found:
+            if not valid_upgrade_target:
+                # valid_upgrade_target can be empty when current version is no longer supported by AWS.
+                # In this case, we can't validate it, so treat it as major version upgrade for safety.
+                # Skip validation if allow_major_version_upgrade is enabled.
+                if not allow_major_version_upgrade:
+                    raise ValueError(
+                        "allow_major_version_upgrade is not enabled for upgrading RDS instance: "
+                        f"{resource_name} to a new version when there is no valid upgrade target available."
+                    )
+                return
+            target = next(
+                (
+                    t
+                    for t in valid_upgrade_target
+                    if t["EngineVersion"] == after_version
+                ),
+                None,
+            )
+            if target is None:
                 raise ValueError(
                     f"Cannot upgrade RDS instance: {resource_name} "
                     f"from {before_version} to {after_version}"
+                )
+            if target["IsMajorVersionUpgrade"] and not allow_major_version_upgrade:
+                raise ValueError(
+                    "allow_major_version_upgrade is not enabled for upgrading RDS instance: "
+                    f"{resource_name} to a new major version."
                 )
 
 

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -281,7 +281,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                     logging.debug([action, name, resource_type, resource_name])
                     continue
                 if action == "update" and resource_type == "aws_db_instance":
-                    self._validate_db_upgrade(name, resource_name, resource_change)
+                    self.validate_db_upgrade(name, resource_name, resource_change)
                     # Ignore RDS modifications that are going to occur during the next
                     # maintenance window. This can be up to 7 days away and will cause
                     # unnecessary Terraform state updates until they complete.
@@ -683,7 +683,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
             return not set(changed_resource_arguments) - set(changed_values)
         return False
 
-    def _validate_db_upgrade(
+    def validate_db_upgrade(
         self, account_name: str, resource_name: str, resource_change: Mapping[str, Any]
     ):
         """


### PR DESCRIPTION
Handle validation error when current RDS version is no longer supported, `describe_db_engine_versions` will return empty response in this case.

We can't validate it, so treat it as major version upgrade for safety.

Skip validation if `allow_major_version_upgrade` is enabled.

[APPSRE-7777](https://issues.redhat.com/browse/APPSRE-7777)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a798c8c</samp>

This pull request adds and updates tests for the `AWSApi` and `TerraformClient` classes, and refactors the `validate_db_upgrade` and `get_db_valid_upgrade_target` methods to handle empty lists of DB engine versions. These changes improve the functionality and reliability of the `qontract-reconcile` tool for managing AWS RDS resources.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a798c8c</samp>

*  Rename and expose the `_validate_db_upgrade` method of the `TerraformClient` class as `validate_db_upgrade` and update its calls in the `log_plan_diff` method and the test functions ([link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-9ce65893311aef81c9bbccde0dcc4c1d44037684b52fe82331cb5376cd4c95daL467-R472), [link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-9ce65893311aef81c9bbccde0dcc4c1d44037684b52fe82331cb5376cd4c95daL488-R493), [link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-9ce65893311aef81c9bbccde0dcc4c1d44037684b52fe82331cb5376cd4c95daL510-R515), [link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-9ce65893311aef81c9bbccde0dcc4c1d44037684b52fe82331cb5376cd4c95daL533-R533), [link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-9ce65893311aef81c9bbccde0dcc4c1d44037684b52fe82331cb5376cd4c95daL539-R539), [link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-9ce65893311aef81c9bbccde0dcc4c1d44037684b52fe82331cb5376cd4c95daL560-R560), [link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-9ce65893311aef81c9bbccde0dcc4c1d44037684b52fe82331cb5376cd4c95daL566-R566), [link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL284-R284), [link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL686-R686))
*  Add a new variable `allow_major_version_upgrade` to the `validate_db_upgrade` method and use it to check if the major version upgrade is allowed or not in the validation logic ([link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfR709), [link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL714-R742))
*  Modify the `get_db_valid_upgrade_target` method of the `AWSApi` class to return an empty list when there are no DB engine versions available and handle this case in the `validate_db_upgrade` method ([link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-fa53225044580356ab5fbddd2d4f182e37bfeef41768289fa3f6e185e5f87302L1496-R1502), [link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL714-R742))
*  Add two new test functions to test the `get_db_valid_upgrade_target` method of the `AWSApi` class with an empty list of DB engine versions ([link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-beca72090e9edd535f6373be0d7d5f8b77621fe8472f05c504af5561ef39a6faR8), [link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-beca72090e9edd535f6373be0d7d5f8b77621fe8472f05c504af5561ef39a6faR242-R298))
*  Add two new test functions to test the `validate_db_upgrade` method of the `TerraformClient` class with an empty list of valid upgrade targets ([link](https://github.com/app-sre/qontract-reconcile/pull/3576/files?diff=unified&w=0#diff-9ce65893311aef81c9bbccde0dcc4c1d44037684b52fe82331cb5376cd4c95daR586-R639))