### PR TITLE
[tf-repo] Fix for loading state

### DIFF
--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -149,7 +149,7 @@ class TerraformRepoIntegration(
         for key in keys:
             if value := state.get(key.lstrip("/"), None):
                 try:
-                    repo = TerraformRepoV1.parse_raw(value)
+                    repo = TerraformRepoV1.parse_obj(value)
                     repo_list.append(repo)
                 except ValidationError as err:
                     logging.error(

--- a/reconcile/test/test_terraform_repo.py
+++ b/reconcile/test/test_terraform_repo.py
@@ -66,30 +66,6 @@ def int_params() -> TerraformRepoIntegrationParams:
 
 
 @pytest.fixture()
-def a_repo_json() -> str:
-    # terraform repo expects a JSON string not a dict so we have to encode a multi-line JSON string
-    return f"""
-            {{
-                "name": "a_repo",
-                "repository": "{A_REPO}",
-                "ref": "{A_REPO_SHA}",
-                "projectPath": "tf",
-                "delete": false,
-                "account": {{
-                    "name": "foo",
-                    "uid": "{AWS_UID}",
-                    "automationToken": {{
-                        "path": "{AUTOMATION_TOKEN_PATH}",
-                        "field": "all",
-                        "version": 1,
-                        "format": null
-                    }}
-                }}
-            }}
-            """
-
-
-@pytest.fixture()
 def state_mock() -> MagicMock:
     return MagicMock(spec=State)
 
@@ -181,13 +157,31 @@ def test_delete_repo_without_flag(existing_repo, int_params):
         )
 
 
-def test_get_repo_state(s3_state_builder, int_params, existing_repo, a_repo_json):
+def test_get_repo_state(s3_state_builder, int_params, existing_repo):
     state = s3_state_builder(
         {
             "ls": [
                 "/a_repo",
             ],
-            "get": {"a_repo": a_repo_json},
+            "get": {
+                "a_repo": {
+                    "name": "a_repo",
+                    "repository": A_REPO,
+                    "ref": A_REPO_SHA,
+                    "projectPath": "tf",
+                    "delete": False,
+                    "account": {
+                        "name": "foo",
+                        "uid": AWS_UID,
+                        "automationToken": {
+                            "path": AUTOMATION_TOKEN_PATH,
+                            "field": "all",
+                            "version": 1,
+                            "format": None,
+                        },
+                    },
+                }
+            },
         }
     )
 


### PR DESCRIPTION
Fix `get_existing_state` for terraform repo. I was under the impression that `state.get()` would return a JSON string but instead it returns a Python object. Therefore, I'm switching to `parse_obj()`. See https://docs.pydantic.dev/latest/usage/models/#helper-functions for reference.