### PR TITLE
[openshift-resources] enforce managed-resources names

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -197,7 +197,9 @@ def init_specs_to_fetch(
             for kind in managed_types:
                 managed_names = resource_names.get(kind)
                 kind_to_use = resource_type_overrides.get(kind, kind)
-                ri.initialize_resource_type(cluster, namespace, kind_to_use)
+                ri.initialize_resource_type(
+                    cluster, namespace, kind_to_use, managed_names
+                )
                 state_specs.append(
                     CurrentStateSpec(
                         oc=oc,

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -56,6 +56,7 @@ from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.openshift_resource import (
     ResourceInventory,
     ResourceKeyExistsError,
+    ResourceNotManagedError,
 )
 from reconcile.utils.runtime.integration import DesiredStateShardConfig
 from reconcile.utils.secret_reader import SecretReader
@@ -843,6 +844,15 @@ def fetch_desired_state(
         # the same type was already added previously
         ri.register_error()
         msg = ("[{}/{}] desired item already exists: {}/{}.").format(
+            cluster, namespace, openshift_resource.kind, openshift_resource.name
+        )
+        _locked_error_log(msg)
+        return
+    except ResourceNotManagedError:
+        # This is failing because the resource name is
+        # not in the list of resource names that are managed
+        ri.register_error()
+        msg = "[{}/{}] desired item is not managed: {}/{}.".format(
             cluster, namespace, openshift_resource.kind, openshift_resource.name
         )
         _locked_error_log(msg)


### PR DESCRIPTION
it seems that we lost the ability to enforce managedResourceNames for openshift resource in namespaces (or it never was enforced, who knows).

this PR manages the allowed resources names as part of the `ResourceInventory`. the allowed names are registered along with the allowed resource types during clusteR/namespace/type registration. if a desired resources is added to the inventory with a name that is not managed, an error is raised. the resource inventory will be marked as failed, so the execution will fail (important for PR checks).

the managedResourcesNames remain optional. if none are defined, the resource inventory acts as before, allowing all names.

i'm unsure if we should also fail adding current state resources to the inventory if their name is not managed. i believe it is not necessary right now because if managed resource names are defined, the fetching processes for a namespace/kind takes care of filtering already.

https://issues.redhat.com/browse/APPSRE-7811