### PR TITLE
[tf-repo] update to allow multi repo execution in non dry run

### DIFF
--- a/reconcile/test/test_terraform_repo.py
+++ b/reconcile/test/test_terraform_repo.py
@@ -79,7 +79,7 @@ def test_addition_to_existing_repo(existing_repo, new_repo, int_params, state_mo
         existing_state=existing, desired_state=desired, dry_run=False, state=state_mock
     )
 
-    assert diff == new_repo
+    assert diff == [new_repo]
 
     # ensure that the state is saved for the new repo
     state_mock.add.assert_called_once_with(
@@ -100,7 +100,7 @@ def test_updating_repo_ref(existing_repo, int_params, state_mock):
         state=state_mock,
     )
 
-    assert diff == updated_repo
+    assert diff == [updated_repo]
 
     state_mock.add.assert_called_once_with(
         updated_repo.name, updated_repo.dict(by_alias=True), force=True
@@ -141,7 +141,7 @@ def test_delete_repo(existing_repo, int_params, state_mock):
         state=state_mock,
     )
 
-    assert diff == updated_repo
+    assert diff == [updated_repo]
 
     state_mock.rm.assert_called_once_with(updated_repo.name)
 
@@ -209,7 +209,7 @@ def test_update_repo_state(int_params, existing_repo, state_mock):
     )
 
 
-def test_fail_on_multiple_repos(int_params, existing_repo, new_repo):
+def test_fail_on_multiple_repos_dry_run(int_params, existing_repo, new_repo):
     integration = TerraformRepoIntegration(params=int_params)
 
     desired_state = [existing_repo, new_repo]
@@ -217,6 +217,22 @@ def test_fail_on_multiple_repos(int_params, existing_repo, new_repo):
     with pytest.raises(Exception):
         integration.calculate_diff(
             existing_state=[], desired_state=desired_state, dry_run=True, state=None
+        )
+
+
+def test_succeed_on_multiple_repos_non_dry_run(int_params, existing_repo, new_repo):
+    integration = TerraformRepoIntegration(params=int_params)
+
+    desired_state = [existing_repo, new_repo]
+
+    diff = integration.calculate_diff(
+        existing_state=[], desired_state=desired_state, dry_run=False, state=None
+    )
+
+    assert diff
+    if diff:
+        assert diff.sort(key=lambda r: r.name) == desired_state.sort(
+            key=lambda r: r.name
         )
 
 


### PR DESCRIPTION
In #3569, I refactored the QR integration to enforce a strict limit of one repo being acted on at a time. This was to cut down on executor complexity and enforce smaller and easier to parse merge requests. However, while we can and should gate tenants to only update one repo at once, there isn't a guarantee that tf-repo will only ever work on one repo at a time.

There could possibly be edge cases due to:
- state loss/network issues causing int to be unable to get existing desired state
- pipeline execution delays causing multiple repos to be acted on in one pipeline

Therefore, this merge request keeps the enforcement of one repo per MR, but allows multiple repos to be acted on when in production. This coincides with a logic change for: https://github.com/app-sre/terraform-repo-executor/pull/9