### PR TITLE
[terraform-msk] fix identifiers and scram_secret_associations

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -33632,7 +33632,7 @@
                                     "name": null,
                                     "ofType": {
                                         "kind": "OBJECT",
-                                        "name": "SaasSecretParameters_v1",
+                                        "name": "MskSecretParameters_v1",
                                         "ofType": null
                                     }
                                 }
@@ -33649,6 +33649,49 @@
                             "ofType": null
                         }
                     ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "MskSecretParameters_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "secret",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "VaultSecret_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
                 },

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
@@ -1022,7 +1022,7 @@ class NamespaceTerraformResourceRosaAuthenticatorVPCEV1(
     defaults: str = Field(..., alias="defaults")
 
 
-class SaasSecretParametersV1(ConfiguredBaseModel):
+class MskSecretParametersV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     secret: VaultSecret = Field(..., alias="secret")
 
@@ -1033,7 +1033,7 @@ class NamespaceTerraformResourceMskV1(NamespaceTerraformResourceAWSV1):
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     defaults: str = Field(..., alias="defaults")
     annotations: Optional[str] = Field(..., alias="annotations")
-    users: Optional[list[SaasSecretParametersV1]] = Field(..., alias="users")
+    users: Optional[list[MskSecretParametersV1]] = Field(..., alias="users")
 
 
 class NamespaceTerraformProviderResourceAWSV1(NamespaceExternalResourceV1):


### PR DESCRIPTION
* make all AWS resource identifiers unique based on the external resource identifier
* create just one KMS for all scram secrets (save some AWS costs)
* add a human readable KMS alias
* fix scram secret association - it must be just one per MSK cluster

Depends on: https://github.com/app-sre/qontract-schemas/pull/469
Ticket: [APPSRE-7534](https://issues.redhat.com/browse/APPSRE-7534)