### PR TITLE
[change-owners] resourcefile backrefs for ownership expansion

### DIFF
--- a/reconcile/change_owners/bundle.py
+++ b/reconcile/change_owners/bundle.py
@@ -101,6 +101,15 @@ def _clean_datafile_content(data: Optional[dict[str, Any]]) -> Optional[dict[str
     return {k: v for k, v in data.items() if k not in DATAFILE_CONTENT_CLEANUP_FIELDS}
 
 
+class QontractServerResourcefileBackref(BaseModel):
+    """
+    Represents a backref from a resourcefile to a datafile
+    """
+
+    path: str
+    datafileschema: str = Field(..., alias="datafileSchema")
+
+
 class QontractServerResourcefileDiffState(BaseModel):
     """
     Represents the old or new state of a resourcefile returned by the qontract-server /diff endpoint.
@@ -110,6 +119,7 @@ class QontractServerResourcefileDiffState(BaseModel):
     content: str
     resourcefileschema: Optional[str] = Field(..., alias="$schema")
     sha256sum: str
+    backrefs: Optional[list[QontractServerResourcefileBackref]]
 
 
 class QontractServerResourcefileDiff(BaseModel):

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -276,7 +276,7 @@ def run(
         f"build_time {comparison_gql_api.commit_timestamp_utc})"
     )
     change_type_processors = fetch_change_type_processors(
-        comparison_gql_api, file_diff_resolver
+        gql.get_api(), file_diff_resolver
     )
 
     # an error while trying to cover changes will not fail the integration

--- a/reconcile/change_owners/implicit_ownership.py
+++ b/reconcile/change_owners/implicit_ownership.py
@@ -4,6 +4,7 @@ from reconcile.change_owners.approver import ApproverResolver
 from reconcile.change_owners.change_types import (
     ChangeTypeContext,
     ChangeTypeProcessor,
+    FileChange,
 )
 from reconcile.change_owners.changes import BundleFileChange
 from reconcile.gql_definitions.change_owners.queries.change_types import (
@@ -37,7 +38,12 @@ def change_type_contexts_for_implicit_ownership(
     for ctp in processors_with_implicit_ownership:
         for bc in bundle_changes:
             for ownership in ctp.find_context_file_refs(
-                bc.fileref, bc.old, bc.new, set()
+                change=FileChange(
+                    file_ref=bc.fileref,
+                    old=bc.old,
+                    new=bc.new,
+                ),
+                expansion_trail=set(),
             ):
                 for io in ctp.implicit_ownership:
                     if isinstance(io, ChangeTypeImplicitOwnershipJsonPathProviderV1):

--- a/reconcile/change_owners/self_service_roles.py
+++ b/reconcile/change_owners/self_service_roles.py
@@ -10,6 +10,7 @@ from reconcile.change_owners.change_types import (
     Approver,
     ChangeTypeContext,
     ChangeTypeProcessor,
+    FileChange,
 )
 from reconcile.change_owners.changes import BundleFileChange
 from reconcile.gql_definitions.change_owners.queries import self_service_roles
@@ -119,7 +120,14 @@ def change_type_contexts_for_self_service_roles(
     for bc in bundle_changes:
         for ctp in change_type_processors:
             for ownership in ctp.find_context_file_refs(
-                bc.fileref, bc.old, bc.new, set()
+                change=FileChange(
+                    file_ref=bc.fileref,
+                    old=bc.old,
+                    new=bc.new,
+                    old_backrefs=bc.old_backrefs,
+                    new_backrefs=bc.new_backrefs,
+                ),
+                expansion_trail=set(),
             ):
                 # if the context file is bound with the change type in
                 # a role, build a changetypecontext

--- a/reconcile/gql_definitions/change_owners/queries/change_types.gql
+++ b/reconcile/gql_definitions/change_owners/queries/change_types.gql
@@ -16,6 +16,7 @@ query ChangeTypes($name: String) {
         context {
           selector
           when
+          where
         }
       }
       ... on ChangeTypeChangeDetectorChangeTypeProvider_v1 {
@@ -26,6 +27,7 @@ query ChangeTypes($name: String) {
         ownership_context: context {
           selector
           when
+          where
         }
       }
     }

--- a/reconcile/gql_definitions/change_owners/queries/change_types.py
+++ b/reconcile/gql_definitions/change_owners/queries/change_types.py
@@ -35,6 +35,7 @@ query ChangeTypes($name: String) {
         context {
           selector
           when
+          where
         }
       }
       ... on ChangeTypeChangeDetectorChangeTypeProvider_v1 {
@@ -45,6 +46,7 @@ query ChangeTypes($name: String) {
         ownership_context: context {
           selector
           when
+          where
         }
       }
     }
@@ -76,6 +78,7 @@ class ChangeTypeChangeDetectorV1(ConfiguredBaseModel):
 class ChangeTypeChangeDetectorContextSelectorV1(ConfiguredBaseModel):
     selector: str = Field(..., alias="selector")
     when: Optional[str] = Field(..., alias="when")
+    where: Optional[str] = Field(..., alias="where")
 
 
 class ChangeTypeChangeDetectorJsonPathProviderV1(ChangeTypeChangeDetectorV1):
@@ -95,6 +98,7 @@ class ChangeTypeChangeDetectorChangeTypeProviderV1_ChangeTypeChangeDetectorConte
 ):
     selector: str = Field(..., alias="selector")
     when: Optional[str] = Field(..., alias="when")
+    where: Optional[str] = Field(..., alias="where")
 
 
 class ChangeTypeChangeDetectorChangeTypeProviderV1(ChangeTypeChangeDetectorV1):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -12198,6 +12198,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "where",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "when",
                             "description": null,
                             "args": [],

--- a/reconcile/test/change_owners/fixtures.py
+++ b/reconcile/test/change_owners/fixtures.py
@@ -20,6 +20,7 @@ from reconcile.change_owners.bundle import (
     FileRef,
     QontractServerDatafileDiff,
     QontractServerDiff,
+    QontractServerResourcefileBackref,
     QontractServerResourcefileDiff,
     QontractServerResourcefileDiffState,
 )
@@ -99,6 +100,8 @@ class QontractServerBundleDiffDataBuilder:
         old_content: Any,
         new_content: Any,
         schema: Optional[str] = None,
+        old_backrefs: Optional[list[QontractServerResourcefileBackref]] = None,
+        new_backrefs: Optional[list[QontractServerResourcefileBackref]] = None,
     ) -> "QontractServerBundleDiffDataBuilder":
 
         entry = QontractServerResourcefileDiff(resourcepath=path)
@@ -109,6 +112,7 @@ class QontractServerBundleDiffDataBuilder:
                     "content": old_content,
                     "$schema": schema,
                     "sha256sum": _sha256_sum(old_content),
+                    "backrefs": old_backrefs,
                 }
             )
         if new_content:
@@ -118,6 +122,7 @@ class QontractServerBundleDiffDataBuilder:
                     "content": new_content,
                     "$schema": schema,
                     "sha256sum": _sha256_sum(new_content),
+                    "backrefs": new_backrefs,
                 }
             )
         self._diff.resources[path] = entry
@@ -314,10 +319,13 @@ def build_jsonpath_change(
     schema: Optional[str] = None,
     context_selector: Optional[str] = None,
     context_when: Optional[str] = None,
+    context_where: Optional[str] = None,
 ) -> ChangeTypeChangeDetectorJsonPathProviderV1:
     if context_selector:
         context = ChangeTypeChangeDetectorContextSelectorV1(
-            selector=context_selector, when=context_when
+            selector=context_selector,
+            when=context_when,
+            where=context_where,
         )
     else:
         context = None
@@ -333,7 +341,8 @@ def build_change_type_change(
     schema: str,
     change_type_names: list[str],
     context_selector: str,
-    context_when: Optional[str],
+    context_when: Optional[str] = None,
+    context_where: Optional[str] = None,
 ) -> ChangeTypeChangeDetectorChangeTypeProviderV1:
     return ChangeTypeChangeDetectorChangeTypeProviderV1(
         provider="changeType",
@@ -348,6 +357,7 @@ def build_change_type_change(
         ownership_context=ChangeTypeChangeDetectorChangeTypeProviderV1_ChangeTypeChangeDetectorContextSelectorV1(
             selector=context_selector,
             when=context_when,
+            where=context_where,
         ),
     )
 

--- a/reconcile/test/change_owners/test_change_type_context.py
+++ b/reconcile/test/change_owners/test_change_type_context.py
@@ -2,6 +2,7 @@ from reconcile.change_owners.bundle import (
     BundleFileType,
     FileRef,
 )
+from reconcile.change_owners.change_types import FileChange
 from reconcile.gql_definitions.change_owners.queries.change_types import ChangeTypeV1
 from reconcile.test.change_owners.fixtures import (
     StubFile,
@@ -27,7 +28,12 @@ def test_extract_context_file_refs_from_bundle_change(
     )
     ctp = change_type_to_processor(saas_file_changetype)
     file_refs = ctp.find_context_file_refs(
-        bundle_change.fileref, bundle_change.old, bundle_change.new, set()
+        FileChange(
+            file_ref=bundle_change.fileref,
+            old=bundle_change.old,
+            new=bundle_change.new,
+        ),
+        set(),
     )
     assert [o.context_file_ref for o in file_refs] == [saas_file.file_ref()]
 
@@ -45,7 +51,12 @@ def test_extract_context_file_refs_from_bundle_change_schema_mismatch(
     )
     ctp = change_type_to_processor(saas_file_changetype)
     file_refs = ctp.find_context_file_refs(
-        bundle_change.fileref, bundle_change.old, bundle_change.new, set()
+        FileChange(
+            file_ref=bundle_change.fileref,
+            old=bundle_change.old,
+            new=bundle_change.new,
+        ),
+        set(),
     )
     assert not file_refs
 
@@ -76,7 +87,12 @@ def test_extract_context_file_refs_selector(
     assert namespace_change
     ctp = change_type_to_processor(cluster_owner_change_type)
     file_refs = ctp.find_context_file_refs(
-        namespace_change.fileref, namespace_change.old, namespace_change.new, set()
+        FileChange(
+            file_ref=namespace_change.fileref,
+            old=namespace_change.old,
+            new=namespace_change.new,
+        ),
+        set(),
     )
     assert [o.context_file_ref for o in file_refs] == [
         FileRef(
@@ -112,7 +128,12 @@ def test_extract_context_file_refs_in_list_added_selector(
     assert user_change
     ctp = change_type_to_processor(role_member_change_type)
     file_refs = ctp.find_context_file_refs(
-        user_change.fileref, user_change.old, user_change.new, set()
+        FileChange(
+            file_ref=user_change.fileref,
+            old=user_change.old,
+            new=user_change.new,
+        ),
+        set(),
     )
     assert [o.context_file_ref for o in file_refs] == [
         FileRef(
@@ -146,7 +167,12 @@ def test_extract_context_file_refs_in_list_removed_selector(
     assert user_change
     ctp = change_type_to_processor(role_member_change_type)
     file_refs = ctp.find_context_file_refs(
-        user_change.fileref, user_change.old, user_change.new, set()
+        FileChange(
+            file_ref=user_change.fileref,
+            old=user_change.old,
+            new=user_change.new,
+        ),
+        set(),
     )
     assert [o.context_file_ref for o in file_refs] == [
         FileRef(
@@ -173,6 +199,11 @@ def test_extract_context_file_refs_in_list_selector_change_schema_mismatch(
     assert datafile_change
     ctp = change_type_to_processor(role_member_change_type)
     file_refs = ctp.find_context_file_refs(
-        datafile_change.fileref, datafile_change.old, datafile_change.new, set()
+        FileChange(
+            file_ref=datafile_change.fileref,
+            old=datafile_change.old,
+            new=datafile_change.new,
+        ),
+        set(),
     )
     assert not file_refs

--- a/reconcile/test/change_owners/test_change_type_implicit_ownership.py
+++ b/reconcile/test/change_owners/test_change_type_implicit_ownership.py
@@ -6,7 +6,7 @@ import pytest
 from reconcile.change_owners.approver import Approver
 from reconcile.change_owners.change_types import (
     ChangeTypeProcessor,
-    OwnershipContext,
+    ForwardrefOwnershipContext,
 )
 from reconcile.change_owners.implicit_ownership import (
     change_type_contexts_for_implicit_ownership,
@@ -187,8 +187,8 @@ def test_find_implict_change_type_context_jsonpath_provider_invalid_context_file
     change_schema = "change-schema-1.yml"
 
     change_type.change_detectors[0].change_schema = change_schema
-    change_type.change_detectors[0].context = OwnershipContext(
-        selector=jsonpath_ng.ext.parse("$.approver"), when=None
+    change_type.change_detectors[0].context = ForwardrefOwnershipContext(
+        selector=jsonpath_ng.ext.parse("$.approver")
     )
 
     bc = build_test_datafile(

--- a/reconcile/test/fixtures/change_owners/changetype_cluster_owner.yml
+++ b/reconcile/test/fixtures/change_owners/changetype_cluster_owner.yml
@@ -19,3 +19,4 @@ changes:
   context:
     selector: cluster.'$ref'
     when: null
+    where: null

--- a/reconcile/test/fixtures/change_owners/changetype_role_member.yaml
+++ b/reconcile/test/fixtures/change_owners/changetype_role_member.yaml
@@ -23,3 +23,4 @@ changes:
   context:
     selector: roles[*].'$ref'
     when: added
+    where: null


### PR DESCRIPTION
this PR introduces ownership expansions for resource files based on their usage (backref). if a resourcefile is used within datafile, ownership of the datafile can expand to ownership of the resourcefile with the following configuration, showcasing it for namespaces and RDS default files.

```yaml
$schema: /app-interface/change-type-1.yml
name: namespace-owner
contextType: datafile
contextSchema: /openshift/namespace-1.yml

changes:
- provider: change-type
  changeTypes:
  - $ref: /app-interface/changetype/rds-defaults-maintainer.yaml
  context:
    where: backrefs (1)
    selector: externalResources[?(@.provider=="aws")].resources[?(@.provider=="rds")].defaults (2)
```

(1) `where: backrefs` defines that the backrefs of a resourcefile need to be inspected in order to relate it back to the owned namespace file
(2) ... but to be more restrictive, the RDS resource file must be used in a very specific location within the namespace file

this way, certain resourcefiles don't need to be owned explicitely anymoe via the `resource-owner` change-type but can be automatically owned based on context

disclaimer: if a resourcefile is used in multiple datafiles (e.g. shared RDS default files), ownership is expaned to all datafiles using the resourcefile, which ultimatly ends up granting owners of ALL datafiles approval permissions.

depends on schema https://github.com/app-sre/qontract-schemas/pull/470
part of https://issues.redhat.com/browse/APPSRE-7812