### PR TITLE
APPSRE-7561 pass resource labels to jinja template

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -143,6 +143,7 @@ NAMESPACES_QUERY = """
 {
   namespaces: namespaces_v1 {
     name
+    labels
     delete
     clusterAdmin
     managedResourceTypes
@@ -164,6 +165,7 @@ NAMESPACES_QUERY = """
     }
     cluster {
       name
+      labels
       serverUrl
         auth {
           service


### PR DESCRIPTION
For the dynatrace effort we need labels for `cluster` and `namespace` available in our jinja2 templates, to do things like 

```
{%- set cluster_labels = resource.namespace.cluster.labels | json_to_dict -%}
```

That way we can use labels for configuration w/o schema changes - especially useful during PoC phases