### PR TITLE
Add the assumed role name into each terraform provider name.

### DIFF
--- a/reconcile/test/test_utils_aws_helper.py
+++ b/reconcile/test/test_utils_aws_helper.py
@@ -4,10 +4,10 @@ import reconcile.utils.aws_helper as awsh
 from reconcile.utils.secret_reader import SecretReader
 
 
-def test_get_user_id_from_arn():
+def test_get_id_from_arn():
     user_id = "id"
     arn = f"arn:aws:iam::12345:user/{user_id}"
-    result = awsh.get_user_id_from_arn(arn)
+    result = awsh.get_id_from_arn(arn)
     assert result == user_id
 
 

--- a/reconcile/utils/aws_helper.py
+++ b/reconcile/utils/aws_helper.py
@@ -11,8 +11,8 @@ class AccountNotFoundError(Exception):
 Account = dict[str, Any]
 
 
-def get_user_id_from_arn(arn):
-    # arn:aws:iam::12345:user/id --> id
+def get_id_from_arn(arn):
+    # arn:aws:iam::12345:<arntype>/id --> id
     return arn.split("/")[1]
 
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -854,7 +854,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
     @staticmethod
     def get_alias_name_from_assume_role(assume_role):
         uid = awsh.get_account_uid_from_arn(assume_role)
-        return f"account-{uid}"
+        role_name = awsh.get_id_from_arn(assume_role)
+        return f"account-{uid}-{role_name}"
 
     def populate_additional_providers(self, accounts):
         for account in accounts:
@@ -2315,7 +2316,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 role_grants = ocm.get_aws_infrastructure_access_role_grants(cluster)
                 for user_arn, _, state, switch_role_link in role_grants:
                     # find correct user by identifier
-                    user_id = awsh.get_user_id_from_arn(user_arn)
+                    user_id = awsh.get_id_from_arn(user_arn)
                     # output will only be added once
                     # terraform-resources created the user
                     # and ocm-aws-infrastructure-access granted it the role


### PR DESCRIPTION
This allows to not share providers when 2 clusters are running on the same account. This is especially important when different assume role and/or region need to be used.

Note: this will rename all providers and add some. We checked with @maorfr and terraform accepts that without wanting to reapply everything.

The same function `get_alias_name_from_assume_role` is used to set the provider name and reference that provider from resources (as far as we could see).