### PR TITLE
Log warning for terraform_vpc_peerings empty run

### DIFF
--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -536,8 +536,13 @@ def run(
 
     participating_accounts = [item["requester"]["account"] for item in desired_state]
     participating_accounts += [item["accepter"]["account"] for item in desired_state]
-    participating_account_names = [a["name"] for a in participating_accounts]
+    participating_account_names = {a["name"] for a in participating_accounts}
     accounts = [a for a in accounts if a["name"] in participating_account_names]
+    if not accounts:
+        logging.warning(
+            f"No participating AWS accounts found, consider disabling this integration, account name: {account_name}"
+        )
+        return
 
     with terrascript.TerrascriptClient(
         QONTRACT_INTEGRATION, "", thread_pool_size, accounts, settings=settings


### PR DESCRIPTION
Log warning for empty run in terraform_vpc_peerings, so we can disable the integration to save resource. Similar to https://github.com/app-sre/qontract-reconcile/pull/3602 [APPSRE-7624](https://issues.redhat.com/browse/APPSRE-7624)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3bd4755</samp>

Add a check and a test for empty accounts in `reconcile/terraform_vpc_peerings.py`. This improves the efficiency and logging of the VPC peering integration.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 3bd4755</samp>

*  Add a check for empty accounts list before creating a Terrascript client ([link](https://github.com/app-sre/qontract-reconcile/pull/3605/files?diff=unified&w=0#diff-79f381a7c684c7a6788d3410826abaa6412cd5767ee6694e8e06154fe8e0268fL539-R545))
* Add a test case for the empty accounts scenario ([link](https://github.com/app-sre/qontract-reconcile/pull/3605/files?diff=unified&w=0#diff-a1cc2e3e64ba1590b7a93f30c3cf9614316a8f00d31aa1109d51c14d6e86458aR346-R369))