### PR TITLE
[gabi-authorized-users] add missing users.org_username

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -2515,6 +2515,7 @@ GABI_INSTANCES_QUERY = """
     }
     users{
       github_username
+      org_username
     }
     instances{
       account


### PR DESCRIPTION
Clusters with enabled OIDC authentication use `users.org_username` as the username attribute, which was missing in the gabi instance query.