### PR TITLE
[gitlab-housekeeping] add self-service label to qontract_reconcile_merged_merge_requests counter

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -68,7 +68,7 @@ DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 merged_merge_requests = Counter(
     name="qontract_reconcile_merged_merge_requests",
     documentation="Number of merge requests that have been successfully merged in a repository",
-    labelnames=["project_id"],
+    labelnames=["project_id", "self_service"],
 )
 
 rebased_merge_requests = Counter(
@@ -496,7 +496,10 @@ def merge_merge_requests(
         if not dry_run and merges < merge_limit:
             try:
                 mr.merge()
-                merged_merge_requests.labels(mr.target_project_id).inc()
+                merged_merge_requests.labels(
+                    project_id=mr.target_project_id,
+                    self_service=SELF_SERVICEABLE in get_labels(mr, gl),
+                ).inc()
                 time_to_merge.labels(mr.target_project_id).observe(
                     _calculate_time_since_approval(merge_request_approved_at[mr])
                 )


### PR DESCRIPTION
with this new label, we can distinguish between self-serviceable and not-self-serviceable MRs.
this will allow us to visualize our self-service frequency, and also to establish internal SLOs for percentage of self-serviceable MRs (if we want).

example of the current metric: https://prometheus.appsrep05ue1.devshift.net/graph?g0.expr=qontract_reconcile_merged_merge_requests_total&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h