### PR TITLE
[qontract-cli] fix NotRenderableError on saas-targets subcommand

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2512,7 +2512,7 @@ def saas_targets(
                 if target.parameters:
                     param_table = Table("Key", "Value", box=box.MINIMAL)
                     for k, v in target.parameters.items():
-                        param_table.add_row(k, v)
+                        param_table.add_row(k, str(v))
                     info.add_row("Parameters", param_table)
 
                 if target.secret_parameters:


### PR DESCRIPTION
A `saas.resource_template.target.parameter` can be a JSON object which can't be rendered in a rich table. Cast all parameters to string.