### PR TITLE
[AUS] frozen condition for cluster upgrade policies

### DIFF
--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -306,6 +306,7 @@ class ClusterUpgradePolicyLabelSet(BaseModel):
     schedule: str = Field(alias=aus_label_key("schedule"))
     mutexes: Optional[CSV] = Field(alias=aus_label_key("mutexes"))
     sector: Optional[str] = Field(alias=aus_label_key("sector"))
+    frozen: Optional[bool] = Field(alias=aus_label_key("frozen"))
     _schedule_validator = validator("schedule", allow_reuse=True)(cron_validator)
 
 
@@ -323,6 +324,7 @@ def _build_policy_from_labels(labels: LabelContainer) -> ClusterUpgradePolicy:
             soakDays=policy_labelset.soak_days,
             mutexes=policy_labelset.mutexes,
             sector=policy_labelset.sector,
+            frozen=policy_labelset.frozen or False,
         ),
     )
 

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -654,6 +654,8 @@ def upgradeable_version(
     addon_id: str = "",
 ) -> Optional[str]:
     """Get the highest next version we can upgrade to, fulfilling all conditions"""
+    if policy.conditions.frozen:
+        return None
     for version in reversed(sort_versions(upgrades)):
         if addon_id and ocm.addon_version_blocked(version, addon_id):
             continue

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -71,6 +71,7 @@ class ConfiguredUpgradePolicyConditions(BaseModel):
     mutexes: Optional[list[str]]
     soakDays: int
     sector: Optional[Sector]
+    frozen: bool = False
 
     def get_mutexes(self) -> list[str]:
         return self.mutexes or []
@@ -111,6 +112,8 @@ class ConfiguredAddonUpgradePolicy(ConfiguredUpgradePolicy):
             conditions=ConfiguredUpgradePolicyConditions(
                 mutexes=ous.upgrade_policy.conditions.mutexes,
                 soakDays=ous.upgrade_policy.conditions.soak_days,
+                sector=ous.upgrade_policy.conditions.sector,
+                frozen=ous.upgrade_policy.conditions.frozen or False,
             ),
             schedule=ous.upgrade_policy.schedule,
             workloads=ous.upgrade_policy.workloads,
@@ -145,6 +148,8 @@ class ConfiguredClusterUpgradePolicy(ConfiguredUpgradePolicy):
             conditions=ConfiguredUpgradePolicyConditions(
                 mutexes=ous.upgrade_policy.conditions.mutexes,
                 soakDays=ous.upgrade_policy.conditions.soak_days,
+                sector=ous.upgrade_policy.conditions.sector,
+                frozen=ous.upgrade_policy.conditions.frozen or False,
             ),
             schedule=ous.upgrade_policy.schedule,
             workloads=ous.upgrade_policy.workloads,

--- a/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.py
+++ b/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.py
@@ -82,6 +82,7 @@ fragment ClusterUpgradePolicy on ClusterUpgradePolicy_v1 {
     mutexes
     soakDays
     sector
+    frozen
   }
 }
 

--- a/reconcile/gql_definitions/advanced_upgrade_service/aus_organization.py
+++ b/reconcile/gql_definitions/advanced_upgrade_service/aus_organization.py
@@ -81,6 +81,7 @@ fragment ClusterUpgradePolicy on ClusterUpgradePolicy_v1 {
     mutexes
     soakDays
     sector
+    frozen
   }
 }
 

--- a/reconcile/gql_definitions/common/clusters.gql
+++ b/reconcile/gql_definitions/common/clusters.gql
@@ -130,6 +130,7 @@ query Clusters($name: String) {
         soakDays
         mutexes
         sector
+        frozen
       }
     }
     additionalRouters {

--- a/reconcile/gql_definitions/common/clusters.py
+++ b/reconcile/gql_definitions/common/clusters.py
@@ -200,6 +200,7 @@ query Clusters($name: String) {
         soakDays
         mutexes
         sector
+        frozen
       }
     }
     additionalRouters {
@@ -510,6 +511,7 @@ class ClusterUpgradePolicyConditionsV1(ConfiguredBaseModel):
     soak_days: Optional[int] = Field(..., alias="soakDays")
     mutexes: Optional[list[str]] = Field(..., alias="mutexes")
     sector: Optional[str] = Field(..., alias="sector")
+    frozen: Optional[bool] = Field(..., alias="frozen")
 
 
 class ClusterUpgradePolicyV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/fragments/upgrade_policy.gql
+++ b/reconcile/gql_definitions/fragments/upgrade_policy.gql
@@ -7,5 +7,6 @@ fragment ClusterUpgradePolicy on ClusterUpgradePolicy_v1 {
     mutexes
     soakDays
     sector
+    frozen
   }
 }

--- a/reconcile/gql_definitions/fragments/upgrade_policy.py
+++ b/reconcile/gql_definitions/fragments/upgrade_policy.py
@@ -28,6 +28,7 @@ class ClusterUpgradePolicyConditionsV1(ConfiguredBaseModel):
     mutexes: Optional[list[str]] = Field(..., alias="mutexes")
     soak_days: Optional[int] = Field(..., alias="soakDays")
     sector: Optional[str] = Field(..., alias="sector")
+    frozen: Optional[bool] = Field(..., alias="frozen")
 
 
 class ClusterUpgradePolicy(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -10822,6 +10822,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "frozen",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -13040,6 +13052,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "jiraComponent",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "nextEscalationPolicy",
                             "description": null,
                             "args": [],
@@ -14221,6 +14245,26 @@
                                 "kind": "SCALAR",
                                 "name": "String",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "escalationPolicies",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "AppEscalationPolicy_v1",
+                                        "ofType": null
+                                    }
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -778,6 +778,7 @@ CLUSTERS_QUERY = """
         soakDays
         mutexes
         sector
+        frozen
       }
     }
     additionalRouters {
@@ -1277,6 +1278,7 @@ OCM_QUERY = """
           sector
           soakDays
           mutexes
+          frozen
         }
       }
       upgradePolicyTemplate {
@@ -1297,6 +1299,7 @@ OCM_QUERY = """
           soakDays
           mutexes
           sector
+          frozen
         }
       }
     }

--- a/reconcile/test/test_ocm_upgrade_scheduler.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler.py
@@ -347,6 +347,13 @@ class TestUpgradeableVersion:
         x = aus.upgradeable_version(upgrade_policy, version_data_map, ocm, upgrades)
         assert x == "4.4.1"
 
+    @staticmethod
+    def test_upgradeable_version_frozen(upgrade_policy, ocm):
+        upgrade_policy.conditions.frozen = True
+        upgrades = ocm.get_available_upgrades()
+        x = aus.upgradeable_version(upgrade_policy, {}, ocm, upgrades)
+        assert x is None
+
 
 class TestVersionGateAgreement:
     @staticmethod


### PR DESCRIPTION
Sometimes an upgrade for a cluster needs to prevented. The current ways of setting high soakdays or removing the policy are not nice because for both the fact that the cluster is just temporary frozen is not apparent.

Adding a new `frozen` condition to upgrade policies allows to define explicit upgrade freeze.

depends on https://github.com/app-sre/qontract-schemas/pull/479
part of https://issues.redhat.com/browse/APPSRE-7870