### PR TITLE
Fluentd error log filtering for Google Chat

### DIFF
--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -32,6 +32,7 @@ from reconcile.utils.runtime.environment import (
 SHARDS = int(os.environ.get("SHARDS", 1))
 SHARD_ID = int(os.environ.get("SHARD_ID", 0))
 SHARD_ID_LABEL = os.environ.get("SHARD_KEY", f"{SHARD_ID}-{SHARDS}")
+PREFIX_LOG_LEVEL = os.environ.get("PREFIX_LOG_LEVEL", "false")
 
 INTEGRATION_NAME = os.environ["INTEGRATION_NAME"]
 COMMAND_NAME = os.environ.get("COMMAND_NAME", "qontract-reconcile")
@@ -63,7 +64,10 @@ HANDLERS = [STREAM_HANDLER]
 # Messages to the log file
 if LOG_FILE is not None:
     FILE_HANDLER = logging.FileHandler(LOG_FILE)
-    FILE_HANDLER.setFormatter(logging.Formatter(fmt="%(message)s"))
+    logFileFormat = "%(message)s"
+    if PREFIX_LOG_LEVEL == "true":
+        logFileFormat = "[%(levelname)s] %(message)s"
+    FILE_HANDLER.setFormatter(logging.Formatter(fmt=logFileFormat))
     HANDLERS.append(FILE_HANDLER)  # type: ignore
 
 # Setting up the root logger

--- a/helm/README.md
+++ b/helm/README.md
@@ -35,6 +35,7 @@ https://github.com/helm/helm/releases
 | logs                      | ship logs to providers                                                   | cloudwatch is enabled by default                                        |
 | logs.slack                | ship logs to slack                                                       | false                                                                   |
 | logs.googleChat           | ship logs to google chat                                                 | false                                                                   |
+| logs.errorsOnly           | filter shipped logs to only include errors (anything not INFO level)     | false                                                                   |
 | resources                 | CPU/Memory resource requests/limits                                      |                                                                         |
 | fluentdResources          | CPU/Memory resource requests/limits for Fluentd                          | {requests: {memory: 30Mi, cpu: 15m}, limits: {memory: 120Mi, cpu: 25m}} |
 | shards                    | number of shards to run integration with                                 | 1                                                                       |
@@ -48,7 +49,6 @@ https://github.com/helm/helm/releases
 | restartPolicy             | restarts of the integration                                              | OnFailure                                                               |
 | successfulJobHistoryLimit | number of history records reserved for successful integration executions | 3                                                                       |
 | failedJobHistoryLimit     | number of history records reserved for failed integration executions     | 1                                                                       |
-
 ## Logging
 
 ### Usage of "teams" plugin for Google Chat support

--- a/helm/README.md
+++ b/helm/README.md
@@ -34,8 +34,7 @@ https://github.com/helm/helm/releases
 | internalCertificates      | integration requires internal certificates to execute                    | false                                                                   |
 | logs                      | ship logs to providers                                                   | cloudwatch is enabled by default                                        |
 | logs.slack                | ship logs to slack                                                       | false                                                                   |
-| logs.googleChat           | ship logs to google chat                                                 | false                                                                   |
-| logs.errorsOnly           | filter shipped logs to only include errors (anything not INFO level)     | false                                                                   |
+| logs.googleChat           | ship any error logs to google chat (anything not INFO level)             | false                                                                   |
 | resources                 | CPU/Memory resource requests/limits                                      |                                                                         |
 | fluentdResources          | CPU/Memory resource requests/limits for Fluentd                          | {requests: {memory: 30Mi, cpu: 15m}, limits: {memory: 120Mi, cpu: 25m}} |
 | shards                    | number of shards to run integration with                                 | 1                                                                       |
@@ -48,7 +47,7 @@ https://github.com/helm/helm/releases
 | concurrencyPolicy         | how to treat concurrent executions of the integration                    | Allow                                                                   |
 | restartPolicy             | restarts of the integration                                              | OnFailure                                                               |
 | successfulJobHistoryLimit | number of history records reserved for successful integration executions | 3                                                                       |
-| failedJobHistoryLimit     | number of history records reserved for failed integration executions     | 1                                                                       |
+| failedJobHistoryLimit     | number of history records reserved for failed integration executions     | 1                                                                       |                                                                     |
 ## Logging
 
 ### Usage of "teams" plugin for Google Chat support

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -158,16 +158,6 @@ objects:
               </exclude>
             </filter>
 
-            {{- if $logs.errorsOnly }}
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /\[INFO\]/
-              </exclude>
-            </filter>
-            {{- end }}
-
             <match integration>
               @type copy
               {{- if $logs.slack }}
@@ -185,34 +175,48 @@ objects:
                 message "\`\`\`[{{ $integration.name }}] %s\`\`\`"
               </store>
               {{- end }}
-              {{- if $logs.googleChat }}
-              <store>
-                @type teams
-                webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=${POD_NAME}"
-                text "<%= Time.at(time) %> [${POD_NAME}] <%= record['message'] %>\n\n"
-                buffered true
-                <buffer>
-                  @type file
-                  path /fluentd/buffer
-
-                  flush_mode interval
-                  flush_interval 15s
-                  flush_at_shutdown true
-
-                  retry_max_times 5
-                  retry_wait 30
-
-                  disable_chunk_backup true
-                </buffer>
-              </store>
-              {{- end }}
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
                 log_stream_name {{ $integration.name }}
                 auto_create_stream true
               </store>
+              {{- if $logs.googleChat }}
+              # only ship errors and warnings to Google Chat
+              <store>
+                @type rewrite_tag_filter
+                <rule>
+                  key message
+                  pattern /\[INFO\]/
+                  invert true
+                  tag gchat
+                </rule>
+              </store>
+              {{- end}}
             </match>
+
+            {{- if $logs.googleChat }}
+            <match gchat>
+              @type teams
+              webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=${POD_NAME}"
+              text "<%= Time.at(time) %> [${POD_NAME}] <%= record['message'] %>\n\n"
+              buffered true
+              <buffer>
+                @type file
+                path /fluentd/buffer
+
+                flush_mode interval
+                flush_interval 15s
+                flush_at_shutdown true
+
+                retry_max_times 0
+                retry_wait 30
+
+                disable_chunk_backup true
+              </buffer>
+            </match>
+            {{- end }}
+            
             EOF
           volumeMounts:
           - name: fluentd-config
@@ -230,7 +234,7 @@ objects:
             - name: http
               containerPort: 9090
           env:
-          {{- if $logs.errorsOnly }}
+          {{- if $logs.googleChat }}
           - name: PREFIX_LOG_LEVEL
             value: "true"
           {{- end }}

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -216,7 +216,6 @@ objects:
               </buffer>
             </match>
             {{- end }}
-            
             EOF
           volumeMounts:
           - name: fluentd-config

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -96,6 +96,10 @@ objects:
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           {{- end }}
+          {{- if $logs.errorsOnly }}
+          - name: PREFIX_LOG_LEVEL
+            value: "true"
+          {{- end }}
           {{- if $logs.googleChat }}
 
           {{- /*
@@ -157,6 +161,16 @@ objects:
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>
+
+            {{- if $logs.errorsOnly }}
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /\[INFO\]/
+              </exclude>
+            </filter>
+            {{- end }}
 
             <match integration>
               @type copy

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -96,10 +96,6 @@ objects:
           - name: SLACK_ICON_EMOJI
             value: ${SLACK_ICON_EMOJI}
           {{- end }}
-          {{- if $logs.errorsOnly }}
-          - name: PREFIX_LOG_LEVEL
-            value: "true"
-          {{- end }}
           {{- if $logs.googleChat }}
 
           {{- /*
@@ -234,6 +230,10 @@ objects:
             - name: http
               containerPort: 9090
           env:
+          {{- if $logs.errorsOnly }}
+          - name: PREFIX_LOG_LEVEL
+            value: "true"
+          {{- end }}
           {{- if $shard.shard_id }}
           - name: SHARDS
             value: "{{ $shard.shards }}"

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -187,7 +187,7 @@ objects:
                 @type rewrite_tag_filter
                 <rule>
                   key message
-                  pattern /\[INFO\]/
+                  pattern /^\[INFO\]/
                   invert true
                   tag gchat
                 </rule>

--- a/helm/qontract-reconcile/values-manager-fedramp.yaml
+++ b/helm/qontract-reconcile/values-manager-fedramp.yaml
@@ -19,7 +19,6 @@ integrations:
   logs:
     slack: false
     googleChat: true
-    errorsOnly: true
   disableUnleash: true
   shard_specs:
   - shard_id: 0

--- a/helm/qontract-reconcile/values-manager-fedramp.yaml
+++ b/helm/qontract-reconcile/values-manager-fedramp.yaml
@@ -19,6 +19,7 @@ integrations:
   logs:
     slack: false
     googleChat: true
+    errorsOnly: true
   disableUnleash: true
   shard_specs:
   - shard_id: 0

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -85,41 +85,44 @@ objects:
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>
-            <filter integration>
-              @type grep
-              <exclude>
-                key message
-                pattern /\[INFO\]/
-              </exclude>
-            </filter>
 
             <match integration>
               @type copy
-              <store>
-                @type teams
-                webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=${POD_NAME}"
-                text "<%= Time.at(time) %> [${POD_NAME}] <%= record['message'] %>\n\n"
-                buffered true
-                <buffer>
-                  @type file
-                  path /fluentd/buffer
-
-                  flush_mode interval
-                  flush_interval 15s
-                  flush_at_shutdown true
-
-                  retry_max_times 5
-                  retry_wait 30
-
-                  disable_chunk_backup true
-                </buffer>
-              </store>
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
                 log_stream_name integrations-manager
                 auto_create_stream true
               </store>
+              # only ship errors and warnings to Google Chat
+              <store>
+                @type rewrite_tag_filter
+                <rule>
+                  key message
+                  pattern /\[INFO\]/
+                  invert true
+                  tag gchat
+                </rule>
+              </store>
+            </match>
+            <match gchat>
+              @type teams
+              webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=${POD_NAME}"
+              text "<%= Time.at(time) %> [${POD_NAME}] <%= record['message'] %>\n\n"
+              buffered true
+              <buffer>
+                @type file
+                path /fluentd/buffer
+
+                flush_mode interval
+                flush_interval 15s
+                flush_at_shutdown true
+
+                retry_max_times 0
+                retry_wait 30
+
+                disable_chunk_backup true
+              </buffer>
             </match>
             EOF
           volumeMounts:

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -85,6 +85,13 @@ objects:
                 pattern /Certificate did not match expected hostname/
               </exclude>
             </filter>
+            <filter integration>
+              @type grep
+              <exclude>
+                key message
+                pattern /\[INFO\]/
+              </exclude>
+            </filter>
 
             <match integration>
               @type copy
@@ -125,6 +132,8 @@ objects:
             - name: http
               containerPort: 9090
           env:
+          - name: PREFIX_LOG_LEVEL
+            value: "true"
           - name: DRY_RUN
             value: ${DRY_RUN}
           - name: MANAGER_DRY_RUN

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -99,7 +99,7 @@ objects:
                 @type rewrite_tag_filter
                 <rule>
                   key message
-                  pattern /\[INFO\]/
+                  pattern /^\[INFO\]/
                   invert true
                   tag gchat
                 </rule>

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -89,30 +89,40 @@ objects:
             <match integration>
               @type copy
               <store>
-                @type teams
-                webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=${POD_NAME}"
-                text "<%= Time.at(time) %> [${POD_NAME}] <%= record['message'] %>\n\n"
-                buffered true
-                <buffer>
-                  @type file
-                  path /fluentd/buffer
-
-                  flush_mode interval
-                  flush_interval 15s
-                  flush_at_shutdown true
-
-                  retry_max_times 5
-                  retry_wait 30
-
-                  disable_chunk_backup true
-                </buffer>
-              </store>
-              <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name integ
+                log_stream_name integrations-manager
                 auto_create_stream true
               </store>
+              # only ship errors and warnings to Google Chat
+              <store>
+                @type rewrite_tag_filter
+                <rule>
+                  key message
+                  pattern /\[INFO\]/
+                  invert true
+                  tag gchat
+                </rule>
+              </store>
+            </match>
+            <match gchat>
+              @type teams
+              webhook_url "${GOOGLE_CHAT_WEBHOOK_URL}&threadKey=${POD_NAME}"
+              text "<%= Time.at(time) %> [${POD_NAME}] <%= record['message'] %>\n\n"
+              buffered true
+              <buffer>
+                @type file
+                path /fluentd/buffer
+
+                flush_mode interval
+                flush_interval 15s
+                flush_at_shutdown true
+
+                retry_max_times 0
+                retry_wait 30
+
+                disable_chunk_backup true
+              </buffer>
             </match>
             EOF
           volumeMounts:
@@ -125,6 +135,8 @@ objects:
             - name: http
               containerPort: 9090
           env:
+          - name: PREFIX_LOG_LEVEL
+            value: "true"
           - name: SHARDS
             value: "1"
           - name: SHARD_ID

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -99,7 +99,7 @@ objects:
                 @type rewrite_tag_filter
                 <rule>
                   key message
-                  pattern /\[INFO\]/
+                  pattern /^\[INFO\]/
                   invert true
                   tag gchat
                 </rule>

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -91,7 +91,7 @@ objects:
               <store>
                 @type cloudwatch_logs
                 log_group_name ${LOG_GROUP_NAME}
-                log_stream_name integrations-manager
+                log_stream_name integ
                 auto_create_stream true
               </store>
               # only ship errors and warnings to Google Chat


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-7881

We make use of Fluentd for shipping logs to Cloudwatch, Slack, and Google Chat (within FedRamp). Unfortunately, Google Chat isn't well suited for displaying tons of log messages and the UI performance becomes atrocious if we're shipping every single info message to gchat. So instead, let's just send non-INFO (warning, error) to gchat within FedRamp.

## What's going on here?
- A new environment variable `PREFIX_LOG_LEVEL`, is set to true which triggers QR to format log messages prefixed with their log level `INFO`, `ERROR`, etc.
- The fluentd config is updated for FedRamp such that [rewrite_tag_filter](https://docs.fluentd.org/output/rewrite_tag_filter) is used to rewrite error and warning log events to `gchat`
- A new `match` statement is added for `gchat`, meaning that these newly tagged events get sent to Google Chat
- The filtering is done in such a way that `INFO` level logs are still sent to AWS CloudWatch as expected
