### PR TITLE
Log warning for terraform_aws_route53 empty run

### DIFF
--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -216,10 +216,16 @@ def run(
     zones = queries.get_dns_zones(account_name=account_name)
 
     all_accounts = queries.get_aws_accounts(terraform_state=True)
-    participating_account_names = [z["account"]["name"] for z in zones]
+    participating_account_names = {z["account"]["name"] for z in zones}
     participating_accounts = [
         a for a in all_accounts if a["name"] in participating_account_names
     ]
+
+    if not participating_accounts:
+        logging.warning(
+            f"No participating AWS accounts found, consider disabling this integration, account name: {account_name}"
+        )
+        return
 
     ts = Terrascript(
         QONTRACT_INTEGRATION,

--- a/reconcile/test/test_terraform_aws_route53.py
+++ b/reconcile/test/test_terraform_aws_route53.py
@@ -1,0 +1,29 @@
+import pytest
+from pytest_mock import MockerFixture
+
+import reconcile.terraform_aws_route53 as integ
+
+
+@pytest.fixture
+def aws_accounts() -> list[dict]:
+    return [
+        {
+            "name": "test-account",
+        }
+    ]
+
+
+def test_empty_run(
+    mocker: MockerFixture,
+    aws_accounts: list[dict],
+) -> None:
+    mocked_logging = mocker.patch("reconcile.terraform_aws_route53.logging")
+    mocked_queries = mocker.patch("reconcile.terraform_aws_route53.queries")
+    mocked_queries.get_dns_zones.return_value = []
+    mocked_queries.get_aws_accounts.return_value = aws_accounts
+
+    integ.run(False)
+
+    mocked_logging.warning.assert_called_once_with(
+        "No participating AWS accounts found, consider disabling this integration, account name: None"
+    )


### PR DESCRIPTION
Log warning for empty run in terraform_aws_route53, so we can disable the integration to save resource.

Similar to https://github.com/app-sre/qontract-reconcile/pull/3602

[APPSRE-7624](https://issues.redhat.com/browse/APPSRE-7624)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08d0d66</samp>

Add a warning for empty participating accounts in `terraform_aws_route53` integration and a corresponding test case. This is to improve the user feedback and the test coverage of the integration.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 08d0d66</samp>

*  Add a check for empty participating accounts and log a warning message ([link](https://github.com/app-sre/qontract-reconcile/pull/3626/files?diff=unified&w=0#diff-80cb36d6e315332cdc81adda629952b07124bea9bbaf507f8d49699dc28a79caL219-R229))
* Add a test case for the empty participating accounts scenario ([link](https://github.com/app-sre/qontract-reconcile/pull/3626/files?diff=unified&w=0#diff-84594b78b3c8403cb0de5b4a9e41cd5ad4a3a75525055b798445b28b15f50e91R1-R29))