### PR TITLE
[ocm-oidc-idp-standalone] do not delete manually configured IDPs

### DIFF
--- a/reconcile/rhidp/ocm_oidc_idp/standalone.py
+++ b/reconcile/rhidp/ocm_oidc_idp/standalone.py
@@ -71,6 +71,7 @@ class OCMOidcIdpStandalone(QontractReconcileIntegration[OCMOidcIdpStandalonePara
                 secret_reader=self.secret_reader,
                 vault_input_path=f"{self.params.vault_input_path}/{ocm_env.name}",
                 dry_run=dry_run,
+                managed_idps=[self.params.auth_name],
             )
 
     def get_clusters(


### PR DESCRIPTION
Enable `ocm-oidc-idp-standalone` (OCM labeled clusters) to leave other manually configured IDPs untouched. This doesn't apply to AppInterface managed clusters!