### PR TITLE
[rhidp] fix metrics

### DIFF
--- a/reconcile/rhidp/ocm_oidc_idp/base.py
+++ b/reconcile/rhidp/ocm_oidc_idp/base.py
@@ -32,12 +32,13 @@ DEFAULT_GROUPS_CLAIMS: list[str] = []
 
 def run(
     integration_name: str,
+    flavor: str,
     clusters: Iterable[ClusterV1],
     secret_reader: SecretReaderBase,
     vault_input_path: str,
     dry_run: bool,
 ) -> None:
-    with metrics.transactional_metrics(integration_name) as metrics_container:
+    with metrics.transactional_metrics(flavor) as metrics_container:
         # metrics
         expose_base_metrics(metrics_container, integration_name, clusters)
 

--- a/reconcile/rhidp/ocm_oidc_idp/integration.py
+++ b/reconcile/rhidp/ocm_oidc_idp/integration.py
@@ -45,6 +45,7 @@ class OCMOidcIdpIntegration(
 
         run(
             integration_name=self.name,
+            flavor="app-interface",
             clusters=clusters,
             secret_reader=self.secret_reader,
             vault_input_path=self.params.vault_input_path,

--- a/reconcile/rhidp/ocm_oidc_idp/standalone.py
+++ b/reconcile/rhidp/ocm_oidc_idp/standalone.py
@@ -66,6 +66,7 @@ class OCMOidcIdpStandalone(QontractReconcileIntegration[OCMOidcIdpStandalonePara
 
             run(
                 integration_name=self.name,
+                flavor=ocm_env.name,
                 clusters=clusters,
                 secret_reader=self.secret_reader,
                 vault_input_path=f"{self.params.vault_input_path}/{ocm_env.name}",

--- a/reconcile/rhidp/sso_client/base.py
+++ b/reconcile/rhidp/sso_client/base.py
@@ -43,6 +43,7 @@ def console_url_to_oauth_url(console_url: str, auth_name: str) -> str:
 
 def run(
     integration_name: str,
+    flavor: str,
     clusters: Iterable[ClusterV1],
     secret_reader: VaultSecretReader,
     keycloak_vault_paths: Iterable[str],
@@ -50,7 +51,7 @@ def run(
     contacts: Sequence[str],
     dry_run: bool,
 ) -> None:
-    with metrics.transactional_metrics(integration_name) as metrics_container:
+    with metrics.transactional_metrics(flavor) as metrics_container:
         # metrics
         expose_base_metrics(metrics_container, integration_name, clusters)
 

--- a/reconcile/rhidp/sso_client/integration.py
+++ b/reconcile/rhidp/sso_client/integration.py
@@ -48,6 +48,7 @@ class SSOClientIntegration(
 
         run(
             integration_name=self.name,
+            flavor="app-interface",
             clusters=clusters,
             secret_reader=VaultSecretReader(),
             keycloak_vault_paths=self.params.keycloak_vault_paths,

--- a/reconcile/rhidp/sso_client/standalone.py
+++ b/reconcile/rhidp/sso_client/standalone.py
@@ -43,14 +43,16 @@ class SSOClientStandalone(QontractReconcileIntegration[SSOClientStandaloneParams
         return QONTRACT_INTEGRATION
 
     def run(self, dry_run: bool) -> None:
+        secret_reader = VaultSecretReader()
         for ocm_env in self.get_ocm_environments():
             ocm_api = init_ocm_base_client(ocm_env, self.secret_reader)
             clusters = self.get_clusters(ocm_api=ocm_api, ocm_env=ocm_env)
 
             run(
                 integration_name=self.name,
+                flavor=ocm_env.name,
                 clusters=clusters,
-                secret_reader=VaultSecretReader(),
+                secret_reader=secret_reader,
                 keycloak_vault_paths=self.params.keycloak_vault_paths,
                 # put secrets in a subpath per OCM environment to avoid deleting
                 # clusters from other environments


### PR DESCRIPTION
Create unique metric context managers to avoid overriding metrics from another OCM environment.