### PR TITLE
Consider "needs-rebase" a hold label

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -40,6 +40,7 @@ from reconcile.utils.mr.labels import (
     DO_NOT_MERGE_PENDING_REVIEW,
     HOLD,
     LGTM,
+    NEEDS_REBASE,
     SAAS_FILE_UPDATE,
     SELF_SERVICEABLE,
     prioritized_approval_label,
@@ -59,6 +60,7 @@ HOLD_LABELS = [
     HOLD,
     DO_NOT_MERGE_HOLD,
     DO_NOT_MERGE_PENDING_REVIEW,
+    NEEDS_REBASE,
 ]
 
 QONTRACT_INTEGRATION = "gitlab-housekeeping"

--- a/reconcile/utils/mr/labels.py
+++ b/reconcile/utils/mr/labels.py
@@ -8,7 +8,7 @@ DO_NOT_MERGE_PENDING_REVIEW = "do-not-merge/pending-review"
 HOLD = "bot/hold"
 LGTM = "lgtm"
 SAAS_FILE_UPDATE = "saas-file-update"
-
+NEEDS_REBASE = "needs-rebase"
 SELF_SERVICEABLE = "self-serviceable"
 NOT_SELF_SERVICEABLE = "not-self-serviceable"
 


### PR DESCRIPTION
If an App-SRE member adds the "needs-rebase" label to an MR, then that should be considered a holding tag as it requires actions on the tenant's side. This ensures that these MRs don't block the merge queue.