### PR TITLE
Log warning for terraform_resources empty run

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -220,6 +220,11 @@ def setup(
     # build a resource inventory for all the kube secrets managed by the
     # app-interface managed terraform resources
     tf_namespaces = get_tf_namespaces(account_names)
+    if not tf_namespaces:
+        logging.warning(
+            "No terraform namespaces found, consider disabling this integration, account names: "
+            f"{', '.join(account_names)}"
+        )
     ri, oc_map = fetch_current_state(
         dry_run, tf_namespaces, thread_pool_size, internal, use_jump_host, account_names
     )


### PR DESCRIPTION
Log warning for terraform_resources empty run, so we can disable the integration to save resource.

Similar to https://github.com/app-sre/qontract-reconcile/pull/3602

[APPSRE-7624](https://issues.redhat.com/browse/APPSRE-7624)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a986ed1</samp>

Add logging and testing for empty terraform namespaces. This pull request adds a warning log message to `reconcile/terraform_resources.py` and a corresponding test case to `reconcile/test/test_terraform_resources.py` to handle the case when no terraform namespaces are found for the given account names.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at a986ed1</samp>

* Add a warning log message when no terraform namespaces are found ([link](https://github.com/app-sre/qontract-reconcile/pull/3635/files?diff=unified&w=0#diff-0e9f20c0944ab8088807c726d964c2df24b5c33b873c4c4ef1a4a78c5fe86517R223-R227))
* Import pytest_mock fixture for mocking objects and functions in test cases ([link](https://github.com/app-sre/qontract-reconcile/pull/3635/files?diff=unified&w=0#diff-aa3407e2884577fb05f6ed1925376a267ff8655228672c67c899a3bafe4c7497R9))