### PR TITLE
[rhidp] ocm_environment label

### DIFF
--- a/reconcile/rhidp/common.py
+++ b/reconcile/rhidp/common.py
@@ -154,6 +154,7 @@ def cluster_vault_secret(
 def expose_base_metrics(
     metrics_container: MetricsContainer,
     integration_name: str,
+    ocm_environment: str,
     clusters: Iterable[ClusterV1],
 ) -> None:
     clusters_per_org: Counter[str] = Counter()
@@ -168,6 +169,7 @@ def expose_base_metrics(
         metrics_container.set_gauge(
             RhIdpClusterCounter(
                 integration=integration_name,
+                ocm_environment=ocm_environment,
                 org_id=org_id,
             ),
             value=count,

--- a/reconcile/rhidp/metrics.py
+++ b/reconcile/rhidp/metrics.py
@@ -7,6 +7,7 @@ class RhIdpBaseMetric(BaseModel):
     """Base class for RhIdp metrics"""
 
     integration: str
+    ocm_environment: str
 
 
 class RhIdpClusterCounter(RhIdpBaseMetric, GaugeMetric):

--- a/reconcile/rhidp/ocm_oidc_idp/base.py
+++ b/reconcile/rhidp/ocm_oidc_idp/base.py
@@ -33,16 +33,18 @@ DEFAULT_GROUPS_CLAIMS: list[str] = []
 
 def run(
     integration_name: str,
-    flavor: str,
+    ocm_environment: str,
     clusters: Iterable[ClusterV1],
     secret_reader: SecretReaderBase,
     vault_input_path: str,
     dry_run: bool,
     managed_idps: Optional[list[str]] = None,
 ) -> None:
-    with metrics.transactional_metrics(flavor) as metrics_container:
+    with metrics.transactional_metrics(ocm_environment) as metrics_container:
         # metrics
-        expose_base_metrics(metrics_container, integration_name, clusters)
+        expose_base_metrics(
+            metrics_container, integration_name, ocm_environment, clusters
+        )
 
         # APIs
         settings = queries.get_app_interface_settings()
@@ -66,11 +68,15 @@ def run(
                 managed_idps=managed_idps or [],
             )
             metrics_container.inc_counter(
-                RhIdpOCMOidcIdpReconcileCounter(integration=integration_name)
+                RhIdpOCMOidcIdpReconcileCounter(
+                    integration=integration_name, ocm_environment=ocm_environment
+                )
             )
         except Exception:
             metrics_container.inc_counter(
-                RhIdpOCMOidcIdpReconcileErrorCounter(integration=integration_name)
+                RhIdpOCMOidcIdpReconcileErrorCounter(
+                    integration=integration_name, ocm_environment=ocm_environment
+                )
             )
             raise
 

--- a/reconcile/rhidp/ocm_oidc_idp/integration.py
+++ b/reconcile/rhidp/ocm_oidc_idp/integration.py
@@ -45,7 +45,7 @@ class OCMOidcIdpIntegration(
 
         run(
             integration_name=self.name,
-            flavor="app-interface",
+            ocm_environment="all",
             clusters=clusters,
             secret_reader=self.secret_reader,
             vault_input_path=self.params.vault_input_path,

--- a/reconcile/rhidp/ocm_oidc_idp/metrics.py
+++ b/reconcile/rhidp/ocm_oidc_idp/metrics.py
@@ -5,6 +5,8 @@ from reconcile.utils.metrics import CounterMetric
 class RhIdpOCMOidcIdpReconcileErrorCounter(RhIdpBaseMetric, CounterMetric):
     """Counter for the failed reconcile runs."""
 
+    ocm_environment: str
+
     @classmethod
     def name(cls) -> str:
         return "rhidp_ocm_oidc_idp_reconcile_errors"
@@ -12,6 +14,8 @@ class RhIdpOCMOidcIdpReconcileErrorCounter(RhIdpBaseMetric, CounterMetric):
 
 class RhIdpOCMOidcIdpReconcileCounter(RhIdpBaseMetric, CounterMetric):
     """Counter for successful reconcile runs."""
+
+    ocm_environment: str
 
     @classmethod
     def name(cls) -> str:

--- a/reconcile/rhidp/ocm_oidc_idp/standalone.py
+++ b/reconcile/rhidp/ocm_oidc_idp/standalone.py
@@ -66,7 +66,7 @@ class OCMOidcIdpStandalone(QontractReconcileIntegration[OCMOidcIdpStandalonePara
 
             run(
                 integration_name=self.name,
-                flavor=ocm_env.name,
+                ocm_environment=ocm_env.name,
                 clusters=clusters,
                 secret_reader=self.secret_reader,
                 vault_input_path=f"{self.params.vault_input_path}/{ocm_env.name}",

--- a/reconcile/rhidp/sso_client/integration.py
+++ b/reconcile/rhidp/sso_client/integration.py
@@ -48,7 +48,7 @@ class SSOClientIntegration(
 
         run(
             integration_name=self.name,
-            flavor="app-interface",
+            ocm_environment="all",
             clusters=clusters,
             secret_reader=VaultSecretReader(),
             keycloak_vault_paths=self.params.keycloak_vault_paths,

--- a/reconcile/rhidp/sso_client/standalone.py
+++ b/reconcile/rhidp/sso_client/standalone.py
@@ -50,7 +50,7 @@ class SSOClientStandalone(QontractReconcileIntegration[SSOClientStandaloneParams
 
             run(
                 integration_name=self.name,
-                flavor=ocm_env.name,
+                ocm_environment=ocm_env.name,
                 clusters=clusters,
                 secret_reader=secret_reader,
                 keycloak_vault_paths=self.params.keycloak_vault_paths,


### PR DESCRIPTION
Add a unique `ocm_environment` label to all metrics to avoid overrides.