### PR TITLE
Clusters-network for CCS/ROSA clusters

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -735,7 +735,16 @@ CLUSTERS_QUERY = """
         subnet_ids
         availability_zones
         account {
+          name
           uid
+          terraformUsername
+          resourcesDefaultRegion
+          automationToken {
+            path
+            field
+            version
+            format
+          }
           rosa {
             ocm_environments {
               ocm {

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -846,6 +846,8 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         self, account_name: str, assume_role: str, assume_region: str, client_type="ec2"
     ) -> EC2Client:
         session = self.get_session(account_name)
+        if assume_role is None:
+            return self.get_session_client(session, client_type)
         sts = self.get_session_client(session, "sts")
         assumed_session = self._get_assume_role_session(
             sts, account_name, assume_role, assume_region

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -846,7 +846,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         self, account_name: str, assume_role: str, assume_region: str, client_type="ec2"
     ) -> EC2Client:
         session = self.get_session(account_name)
-        if assume_role is None:
+        if assume_role == "":
             return self.get_session_client(session, client_type)
         sts = self.get_session_client(session, "sts")
         assumed_session = self._get_assume_role_session(

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -932,12 +932,14 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
         return vpc_id, route_table_ids, subnets_id_az
 
-    def get_cluster_nat_gateways_egress_ips(self, account):
+    def get_cluster_nat_gateways_egress_ips(self, account: dict[str, Any], vpc_id: str):
         assumed_role_data = self._get_account_assume_data(account)
         assumed_ec2 = self._get_assumed_role_client(*assumed_role_data)
         nat_gateways = assumed_ec2.describe_nat_gateways()
         egress_ips = set()
-        for nat in nat_gateways.get("NatGateways"):
+        for nat in nat_gateways.get("NatGateways") or []:
+            if nat["VpcId"] != vpc_id:
+                continue
             for address in nat["NatGatewayAddresses"]:
                 egress_ips.add(address["PublicIp"])
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1014,11 +1014,13 @@ def clusters_network(ctx, name):
                 ocm_map.get(cluster_name),
                 provided_assume_role=None,
             )
-            account["resourcesDefaultRegion"] = management_account["resourcesDefaultRegion"]
+            account["resourcesDefaultRegion"] = management_account[
+                "resourcesDefaultRegion"
+            ]
         with AWSApi(1, [account], settings=settings, init_users=False) as aws_api:
             vpc_id, _, _ = aws_api.get_cluster_vpc_details(account)
             cluster["vpc_id"] = vpc_id
-            egress_ips = aws_api.get_cluster_nat_gateways_egress_ips(account)
+            egress_ips = aws_api.get_cluster_nat_gateways_egress_ips(account, vpc_id)
             cluster["egress_ips"] = ", ".join(sorted(egress_ips))
 
     # TODO(mafriedm): fix this
@@ -1081,41 +1083,6 @@ def ocm_aws_infrastructure_access_switch_role_links(ctx):
         print("")
         print(f"# {user}")
         print_output(ctx.obj["options"], by_user[user], columns)
-
-
-@get.command()
-@click.pass_context
-def clusters_egress_ips(ctx):
-    settings = queries.get_app_interface_settings()
-    clusters = queries.get_clusters()
-    clusters = [
-        c
-        for c in clusters
-        if c.get("ocm") is not None
-        and c.get("awsInfrastructureManagementAccounts") is not None
-    ]
-    ocm_map = OCMMap(clusters=clusters, settings=settings)
-
-    results = []
-    for cluster in clusters:
-        cluster_name = cluster["name"]
-        management_account = tfvpc._get_default_management_account(cluster)
-        account = tfvpc._build_infrastructure_assume_role(
-            management_account,
-            cluster,
-            ocm_map.get(cluster_name),
-            provided_assume_role=None,
-        )
-        if not account:
-            continue
-        account["resourcesDefaultRegion"] = management_account["resourcesDefaultRegion"]
-        with AWSApi(1, [account], settings=settings, init_users=False) as aws_api:
-            egress_ips = aws_api.get_cluster_nat_gateways_egress_ips(account)
-        item = {"cluster": cluster_name, "egress_ips": ", ".join(sorted(egress_ips))}
-        results.append(item)
-
-    columns = ["cluster", "egress_ips"]
-    print_output(ctx.obj["options"], results, columns)
 
 
 @get.command()

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1002,7 +1002,7 @@ def clusters_network(ctx, name):
             account = cluster["spec"]["account"]
             account.update(
                 {
-                    "assume_role": None,
+                    "assume_role": "",
                     "assume_region": cluster["spec"]["region"],
                     "assume_cidr": cluster["network"]["vpc"],
                 }


### PR DESCRIPTION
Include CCS/Rosa clusters in `qontract-cli clusters-network`

https://issues.redhat.com/browse/APPSRE-7848

Those clusters don't rely on OCM infrastructure access to retrieve their network info. Instead, we'll use the direct access to their account (no `assume_role`).