### PR TITLE
APPSRE-7563 start publishing promotions_v2

### DIFF
--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -28,10 +28,11 @@ from reconcile.gql_definitions.common.saas_files import (
     SaasResourceTemplateTargetV2_SaasSecretParametersV1,
     SaasResourceTemplateV2,
 )
+from reconcile.typed_queries.saas_files import SaasFile
 from reconcile.utils.jjb_client import JJB
 from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.saasherder import SaasHerder
-from reconcile.utils.saasherder.interfaces import SaasFile
+from reconcile.utils.saasherder.interfaces import SaasFile as SaasFileInterface
 from reconcile.utils.saasherder.models import TriggerSpecMovingCommit
 from reconcile.utils.secret_reader import SecretReaderBase
 
@@ -761,7 +762,7 @@ class TestConfigHashPromotionsValidation(TestCase):
 
     def setUp(self) -> None:
         self.saas_file = self.gql_class_factory(  # type: ignore[attr-defined] # it's set in the fixture
-            SaasFileV2, Fixtures("saasherder").get_anymarkup("saas.gql.yml")
+            SaasFile, Fixtures("saasherder").get_anymarkup("saas.gql.yml")
         )
         self.all_saas_files = [self.saas_file]
 
@@ -959,7 +960,7 @@ class TestRemoveNoneAttributes(TestCase):
 
 
 def test_render_templated_parameters(
-    gql_class_factory: Callable[..., SaasFile]
+    gql_class_factory: Callable[..., SaasFileInterface]
 ) -> None:
     saas_file = gql_class_factory(
         SaasFileV2,

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -84,8 +84,12 @@ def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
     deployment_state.publish_promotion_data(
         channel="channel",
         sha="sha",
+        target_uid="uid",
         data=promotion_info,
     )
-    deployment_state._state.add.assert_called_once_with(  # type: ignore[attr-defined]
+    deployment_state._state.add.assert_any_call(  # type: ignore[attr-defined]
         "promotions/channel/sha", promotion_info.dict(), True
+    )
+    deployment_state._state.add.assert_any_call(  # type: ignore[attr-defined]
+        "promotions_v2/channel/uid/sha", promotion_info.dict(), True
     )

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 from collections.abc import Callable
 from typing import (
@@ -70,6 +71,15 @@ class SaasResourceTemplateTarget(ConfiguredBaseModel):
     image: Optional[SaasResourceTemplateTargetImageV1] = Field(..., alias="image")
     disable: Optional[bool] = Field(..., alias="disable")
     delete: Optional[bool] = Field(..., alias="delete")
+
+    def uid(
+        self, parent_saas_file_name: str, parent_resource_template_name: str
+    ) -> str:
+        """Returns a unique identifier for a target."""
+        return hashlib.blake2s(
+            f"{parent_saas_file_name}:{parent_resource_template_name}:{self.name if self.name else 'default'}:{self.namespace.cluster.name}:{self.namespace.name}".encode(),
+            digest_size=20,
+        ).hexdigest()
 
     class Config:
         # ignore `namespaceSelector` and 'provider' fields from the GQL schema

--- a/reconcile/utils/promotion_state.py
+++ b/reconcile/utils/promotion_state.py
@@ -67,8 +67,13 @@ class PromotionState:
         return PromotionData(**data)
 
     def publish_promotion_data(
-        self, sha: str, channel: str, data: PromotionData
+        self, sha: str, channel: str, target_uid: str, data: PromotionData
     ) -> None:
+        # TODO: this will be deprecated once we fully moved to promotions_v2
         state_key = f"promotions/{channel}/{sha}"
         self._state.add(state_key, data.dict(), force=True)
         logging.info("Uploaded %s to %s", data, state_key)
+
+        state_key_v2 = f"promotions_v2/{channel}/{target_uid}/{sha}"
+        self._state.add(state_key_v2, data.dict(), force=True)
+        logging.info("Uploaded %s to %s", data, state_key_v2)

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -339,6 +339,11 @@ class SaasResourceTemplateTarget(HasParameters, HasSecretParameters, Protocol):
     def image(self) -> Optional[SaasResourceTemplateTargetImage]:
         ...
 
+    def uid(
+        self, parent_saas_file_name: str, parent_resource_template_name: str
+    ) -> str:
+        ...
+
     def dict(self, *, by_alias: bool = False) -> dict[str, Any]:
         ...
 

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -167,6 +167,7 @@ class Promotion(BaseModel):
     commit_sha: str
     saas_file: str
     target_config_hash: str
+    saas_target_uid: str
     auto: Optional[bool] = None
     publish: Optional[list[str]] = None
     subscribe: Optional[list[str]] = None

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1021,6 +1021,10 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 commit_sha=commit_sha,
                 saas_file=saas_file_name,
                 target_config_hash=target_config_hash,
+                saas_target_uid=target.uid(
+                    parent_resource_template_name=resource_template_name,
+                    parent_saas_file_name=saas_file_name,
+                ),
             )
         return resources, html_url, target_promotion
 
@@ -1877,6 +1881,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     self._promotion_state.publish_promotion_data(
                         sha=promotion.commit_sha,
                         channel=channel,
+                        target_uid=promotion.saas_target_uid,
                         data=PromotionData(
                             saas_file=promotion.saas_file,
                             success=success,


### PR DESCRIPTION
We need a way to support multiple publishers for a single channel.

We already had multiple attempts on this (https://github.com/app-sre/qontract-reconcile/pull/3521). For that reason we chunk this effort into smaller backwards-compatible PRs. You can regard this PR as a subset of https://github.com/app-sre/qontract-reconcile/pull/3521

This PR introduces a new additional publisher path for promotions in the s3 state: `f"promotions_v2/{channel}/{target_uid}/{sha}"`.

The `target_uid` is a uid based on a hash from unique combination of `(saas_file_name, resource_template_name, namespace, cluster)`. That uid allows us to distinguish between multiple publishers for the same channel.

This PR only handles the publishing aspect and is fully backwards compatible. Follow-up PRs will deal with the consumption from the new `promotions_v2` path.

This PR will initially add overhead as we publish promotions to 2 paths now. Future PRs will remove that overhead as we transition towards `promotions_v2`.

**Test**

```
qd profile run prod openshift-saas-deploy-trigger-moving-commits
```

```
# run for saas file uhc-integration after changing a ref locally
qd profile run prod openshift-saas-deploy
```

Note, that testing happened in dry-run. This is very limited, as the publish promotion step only happens in non-dry-run. However, we do not really have a proper way to test this.