### PR TITLE
Log warning for terraform_users empty run

### DIFF
--- a/reconcile/test/conftest.py
+++ b/reconcile/test/conftest.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel
 from pydantic.error_wrappers import ValidationError
 
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
+from reconcile.utils.gql import GqlApi
 from reconcile.utils.models import data_default_none
 from reconcile.utils.state import State
 
@@ -132,3 +133,13 @@ def gql_class_factory() -> (
             raise GQLClassFactoryError(msg) from e
 
     return _gql_class_factory
+
+
+@pytest.fixture
+def gql_api_builder() -> Callable[[Optional[Mapping]], GqlApi]:
+    def builder(data: Optional[Mapping] = None) -> GqlApi:
+        gql_api = create_autospec(GqlApi)
+        gql_api.query.return_value = data
+        return gql_api
+
+    return builder

--- a/reconcile/test/test_terraform_users.py
+++ b/reconcile/test/test_terraform_users.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from unittest.mock import create_autospec
 
 import pytest
 from pytest_mock import MockerFixture
@@ -113,9 +112,9 @@ def test_setup(
     mocker: MockerFixture,
     test_aws_account: dict,
     test_aws_account_role: dict,
+    gql_api_builder: Callable[..., GqlApi],
 ) -> None:
-    mocked_gql_api = create_autospec(GqlApi)
-    mocked_gql_api.query.return_value = {"roles": [test_aws_account_role]}
+    mocked_gql_api = gql_api_builder({"roles": [test_aws_account_role]})
     mocker.patch("reconcile.terraform_users.gql").get_api.return_value = mocked_gql_api
     mocked_queries = mocker.patch("reconcile.terraform_users.queries")
     mocked_queries.get_aws_accounts.return_value = [test_aws_account]
@@ -157,9 +156,9 @@ def test_empty_run(
     mocker: MockerFixture,
     pgp_reencryption_settings: PgpReencryptionSettingsQueryData,
     test_aws_account: dict,
+    gql_api_builder: Callable[..., GqlApi],
 ) -> None:
-    mocked_gql_api = create_autospec(GqlApi)
-    mocked_gql_api.query.return_value = {"roles": []}
+    mocked_gql_api = gql_api_builder({"roles": []})
     mocker.patch("reconcile.terraform_users.gql").get_api.return_value = mocked_gql_api
     mocker.patch(
         "reconcile.terraform_users.query"

--- a/reconcile/test/test_terraform_users.py
+++ b/reconcile/test/test_terraform_users.py
@@ -1,9 +1,18 @@
-import pytest
+from collections.abc import Callable
+from unittest.mock import create_autospec
 
+import pytest
+from pytest_mock import MockerFixture
+
+import reconcile.terraform_users as integ
+from reconcile.gql_definitions.common.pgp_reencryption_settings import (
+    PgpReencryptionSettingsQueryData,
+)
 from reconcile.terraform_users import (
     send_email_invites,
     write_user_to_vault,
 )
+from reconcile.utils.gql import GqlApi
 
 
 @pytest.fixture
@@ -55,3 +64,116 @@ def test_send_email_invites_skip(mocker, new_users):
     sm = mocker.patch("reconcile.terraform_users.SmtpClient", autospec=True)
     send_email_invites(new_users, sm, [])
     sm.send_mails.assert_not_called()
+
+
+@pytest.fixture
+def pgp_reencryption_settings(
+    gql_class_factory: Callable[..., PgpReencryptionSettingsQueryData],
+) -> PgpReencryptionSettingsQueryData:
+    return gql_class_factory(
+        PgpReencryptionSettingsQueryData,
+        {
+            "pgp_reencryption_settings": [],
+        },
+    )
+
+
+@pytest.fixture
+def test_aws_account_role() -> dict:
+    return {
+        "name": "test_aws_account",
+        "users": [{"name": "test-user"}],
+        "aws_groups": [
+            {
+                "name": "test-group",
+                "account": {
+                    "name": "test-account",
+                },
+            }
+        ],
+        "user_policies": [
+            {
+                "name": "test-policy",
+                "account": {
+                    "name": "test-account",
+                },
+            },
+        ],
+    }
+
+
+@pytest.fixture
+def test_aws_account() -> dict:
+    return {
+        "name": "test-account",
+    }
+
+
+def test_setup(
+    mocker: MockerFixture,
+    test_aws_account: dict,
+    test_aws_account_role: dict,
+) -> None:
+    mocked_gql_api = create_autospec(GqlApi)
+    mocked_gql_api.query.return_value = {"roles": [test_aws_account_role]}
+    mocker.patch("reconcile.terraform_users.gql").get_api.return_value = mocked_gql_api
+    mocked_queries = mocker.patch("reconcile.terraform_users.queries")
+    mocked_queries.get_aws_accounts.return_value = [test_aws_account]
+    mocked_queries.get_app_interface_settings.return_value = None
+    mocked_ts = mocker.patch("reconcile.terraform_users.Terrascript", autospec=True)
+    mocked_aws = mocker.patch("reconcile.terraform_users.AWSApi", autospec=True)
+    thread_pool_size = 1
+
+    accounts, working_dirs, setup_err, aws_api = integ.setup(
+        False, thread_pool_size, []
+    )
+
+    assert accounts == [test_aws_account]
+    assert working_dirs == mocked_ts.return_value.dump.return_value
+    assert setup_err == mocked_ts.return_value.populate_users.return_value
+    assert aws_api == mocked_aws.return_value
+
+    mocked_ts.assert_called_once_with(
+        integ.QONTRACT_INTEGRATION,
+        integ.QONTRACT_TF_PREFIX,
+        thread_pool_size,
+        [test_aws_account],
+        settings=None,
+    )
+    mocked_ts.return_value.populate_users.assert_called_once_with(
+        [test_aws_account_role],
+        [],
+        appsre_pgp_key=None,
+    )
+    mocked_aws.assert_called_once_with(
+        1,
+        [test_aws_account],
+        settings=None,
+        init_users=False,
+    )
+
+
+def test_empty_run(
+    mocker: MockerFixture,
+    pgp_reencryption_settings: PgpReencryptionSettingsQueryData,
+    test_aws_account: dict,
+) -> None:
+    mocked_gql_api = create_autospec(GqlApi)
+    mocked_gql_api.query.return_value = {"roles": []}
+    mocker.patch("reconcile.terraform_users.gql").get_api.return_value = mocked_gql_api
+    mocker.patch(
+        "reconcile.terraform_users.query"
+    ).return_value = pgp_reencryption_settings
+    mocker.patch("reconcile.terraform_users.sys")
+    mocked_queries = mocker.patch("reconcile.terraform_users.queries")
+    mocked_queries.get_aws_accounts.return_value = [test_aws_account]
+    mocked_queries.get_app_interface_settings.return_value = None
+    mocker.patch("reconcile.terraform_users.Terrascript", autospec=True)
+    mocker.patch("reconcile.terraform_users.AWSApi", autospec=True)
+    mocked_logging = mocker.patch("reconcile.terraform_users.logging")
+
+    integ.run(False, send_mails=False)
+
+    mocked_logging.warning.assert_called_once_with(
+        "No participating AWS accounts found, consider disabling this integration, account name: None"
+    )

--- a/reconcile/test/test_typed_queries/conftest.py
+++ b/reconcile/test/test_typed_queries/conftest.py
@@ -2,15 +2,9 @@ from collections.abc import (
     Callable,
     Mapping,
 )
-from typing import (
-    Any,
-    Optional,
-)
-from unittest.mock import create_autospec
+from typing import Any
 
 import pytest
-
-from reconcile.utils.gql import GqlApi
 
 
 @pytest.fixture
@@ -20,15 +14,5 @@ def query_func() -> Callable[[Mapping], Callable]:
             return data
 
         return query_func
-
-    return builder
-
-
-@pytest.fixture
-def gql_api_builder() -> Callable[[Optional[Mapping]], GqlApi]:
-    def builder(data: Optional[Mapping] = None) -> GqlApi:
-        gql_api = create_autospec(GqlApi)
-        gql_api.query.return_value = data
-        return gql_api
 
     return builder


### PR DESCRIPTION
Log warning for terraform_users empty run, so we can disable the integration to save resource.
One special about this integration is `participating_aws_accounts` is not calculated before, added in this change for filtering.

Similar to https://github.com/app-sre/qontract-reconcile/pull/3602

[APPSRE-7624](https://issues.redhat.com/browse/APPSRE-7624)


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7f6d4cf</samp>

This pull request enhances the `terraform_users` integration and its tests by improving performance, logging, and code quality. It also cleans up some code in the `test_typed_queries` module and adds a new fixture for mocking GraphQL API calls.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 7f6d4cf</samp>

*  Import logging module and add new function to filter participating AWS accounts in `reconcile/terraform_users.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3640/files?diff=unified&w=0#diff-ec7136886984ae2be2e6061bbfbf26eadbdf0f9c76f3a7b47cc1738674e2412aR1), [link](https://github.com/app-sre/qontract-reconcile/pull/3640/files?diff=unified&w=0#diff-ec7136886984ae2be2e6061bbfbf26eadbdf0f9c76f3a7b47cc1738674e2412aR93-R105))
*  Use filtered accounts and avoid duplicate call to `get_tf_roles` in `setup` function in `reconcile/terraform_users.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3640/files?diff=unified&w=0#diff-ec7136886984ae2be2e6061bbfbf26eadbdf0f9c76f3a7b47cc1738674e2412aR118-R120), [link](https://github.com/app-sre/qontract-reconcile/pull/3640/files?diff=unified&w=0#diff-ec7136886984ae2be2e6061bbfbf26eadbdf0f9c76f3a7b47cc1738674e2412aL109-R137))
*  Add warning and early return for empty accounts list in `run` function in `reconcile/terraform_users.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3640/files?diff=unified&w=0#diff-ec7136886984ae2be2e6061bbfbf26eadbdf0f9c76f3a7b47cc1738674e2412aR252-R257))
*  Import `GqlApi` class and add new fixture `gql_api_builder` in `reconcile/test/conftest.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3640/files?diff=unified&w=0#diff-d95b64d0d71775e869a296652b83fb00da405610a4793eedc7cc22d0bdb3977fR19), [link](https://github.com/app-sre/qontract-reconcile/pull/3640/files?diff=unified&w=0#diff-d95b64d0d71775e869a296652b83fb00da405610a4793eedc7cc22d0bdb3977fR136-R145))
*  Add new fixtures and tests for `setup` and `run` functions in `reconcile/test/test_terraform_users.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3640/files?diff=unified&w=0#diff-549cf967114d1300c5b51794e971184efe19242d8abda287d9ec22db28351f1eL1-R14), [link](https://github.com/app-sre/qontract-reconcile/pull/3640/files?diff=unified&w=0#diff-549cf967114d1300c5b51794e971184efe19242d8abda287d9ec22db28351f1eR66-R178))
*  Remove unused import and duplicate fixture in `reconcile/test/test_typed_queries/conftest.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3640/files?diff=unified&w=0#diff-ac7c35eca775bdf26d855586b181d5856fc5852966d809f7da5da7edc6b916d0L5-R9), [link](https://github.com/app-sre/qontract-reconcile/pull/3640/files?diff=unified&w=0#diff-ac7c35eca775bdf26d855586b181d5856fc5852966d809f7da5da7edc6b916d0L25-L34))