### PR TITLE
[terraform-resources] availability zone validation

### DIFF
--- a/requirements/requirements-type.txt
+++ b/requirements/requirements-type.txt
@@ -11,5 +11,5 @@ types-setuptools
 types-tabulate
 types-toml
 types-dateparser
-boto3-stubs[ec2,s3,rds,iam,route53]==1.24.71
+boto3-stubs[ec2,s3,rds,iam,route53,elasticache]==1.24.71
 qenerate==0.6.1


### PR DESCRIPTION
with this PR, whenever we create/update an elasticache instance, we will validate the subnet group availability zones.

example for a fix that would have been detected: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/73198

terraform error:
```
InvalidVPCNetworkStateFault: No subnet is present in the cache subnet group for availability zone
```