### PR TITLE
Revert "Clusters-network for CCS/ROSA clusters (#3638)"

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -735,16 +735,7 @@ CLUSTERS_QUERY = """
         subnet_ids
         availability_zones
         account {
-          name
           uid
-          terraformUsername
-          resourcesDefaultRegion
-          automationToken {
-            path
-            field
-            version
-            format
-          }
           rosa {
             ocm_environments {
               ocm {

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -846,8 +846,6 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         self, account_name: str, assume_role: str, assume_region: str, client_type="ec2"
     ) -> EC2Client:
         session = self.get_session(account_name)
-        if assume_role == "":
-            return self.get_session_client(session, client_type)
         sts = self.get_session_client(session, "sts")
         assumed_session = self._get_assume_role_session(
             sts, account_name, assume_role, assume_region
@@ -932,14 +930,12 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
         return vpc_id, route_table_ids, subnets_id_az
 
-    def get_cluster_nat_gateways_egress_ips(self, account: dict[str, Any], vpc_id: str):
+    def get_cluster_nat_gateways_egress_ips(self, account):
         assumed_role_data = self._get_account_assume_data(account)
         assumed_ec2 = self._get_assumed_role_client(*assumed_role_data)
         nat_gateways = assumed_ec2.describe_nat_gateways()
         egress_ips = set()
-        for nat in nat_gateways.get("NatGateways") or []:
-            if nat["VpcId"] != vpc_id:
-                continue
+        for nat in nat_gateways.get("NatGateways"):
             for address in nat["NatGatewayAddresses"]:
                 egress_ips.add(address["PublicIp"])
 


### PR DESCRIPTION
Reverting #3638 as this causes Pydantic issues in OCMSpec:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/reconcile/cli.py", line 513, in run_class_integration
    run_integration_cfg(
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/runtime/runner.py", line 158, in run_integration_cfg
    _integration_dry_run(run_cfg.integration, desired_state_diff)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/runtime/runner.py", line 229, in _integration_dry_run
    integration.run(True)
  File "/usr/local/lib/python3.9/site-packages/reconcile/utils/runtime/integration.py", line 318, in run
    self.params.module.run(dry_run, *self.params.args, **self.params.kwargs)
  File "/usr/local/lib/python3.9/site-packages/reconcile/ocm_clusters.py", line 302, in run
    desired_state = fetch_desired_state(clusters)
  File "/usr/local/lib/python3.9/site-packages/reconcile/ocm_clusters.py", line 67, in fetch_desired_state
    desired_state[name] = OCMSpec(**c)
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 12 validation errors for OCMSpec
spec -> load_balancers
  field required (type=value_error.missing)
spec -> storage
  field required (type=value_error.missing)
spec -> account
  extra fields not permitted (type=value_error.extra)
spec -> availability_zones
  extra fields not permitted (type=value_error.extra)
spec -> subnet_ids
  extra fields not permitted (type=value_error.extra)
spec -> account -> automationToken
  extra fields not permitted (type=value_error.extra)
spec -> account -> name
  extra fields not permitted (type=value_error.extra)
spec -> account -> resourcesDefaultRegion
  extra fields not permitted (type=value_error.extra)
spec -> account -> terraformUsername
  extra fields not permitted (type=value_error.extra)
spec -> account
  extra fields not permitted (type=value_error.extra)
spec -> availability_zones
  extra fields not permitted (type=value_error.extra)
spec -> subnet_ids
  extra fields not permitted (type=value_error.extra)
```

The fix may take some time, so I prefer reverting