### PR TITLE
APPSRE-7307 promotion state get_v2

### DIFF
--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -116,6 +116,9 @@ def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
         target_uid="uid",
         data=promotion_info,
     )
-    deployment_state._state.add.assert_called_once_with(  # type: ignore[attr-defined]
+    deployment_state._state.add.assert_any_call(  # type: ignore[attr-defined]
+        "promotions/channel/sha", promotion_info.dict(), True
+    )
+    deployment_state._state.add.assert_any_call(  # type: ignore[attr-defined]
         "promotions_v2/channel/uid/sha", promotion_info.dict(), True
     )

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -10,7 +10,7 @@ from reconcile.utils.promotion_state import (
 from reconcile.utils.state import State
 
 
-def test_key_exists(s3_state_builder: Callable[[Mapping], State]):
+def test_key_exists_v1(s3_state_builder: Callable[[Mapping], State]):
     state = s3_state_builder(
         {
             "ls": ["/promotions/channel/sha"],
@@ -25,7 +25,34 @@ def test_key_exists(s3_state_builder: Callable[[Mapping], State]):
     )
     deployment_state = PromotionState(state=state)
     deployment_state.cache_commit_shas_from_s3()
-    deployment_info = deployment_state.get_promotion_data(channel="channel", sha="sha")
+    deployment_info = deployment_state.get_promotion_data(
+        channel="channel", sha="sha", target_uid="uid"
+    )
+    assert deployment_info == PromotionData(
+        success=True,
+        target_config_hash="hash",
+        saas_file="saas_file",
+    )
+
+
+def test_key_exists_v2(s3_state_builder: Callable[[Mapping], State]):
+    state = s3_state_builder(
+        {
+            "ls": ["/promotions_v2/channel/uid/sha"],
+            "get": {
+                "promotions_v2/channel/uid/sha": {
+                    "success": True,
+                    "target_config_hash": "hash",
+                    "saas_file": "saas_file",
+                }
+            },
+        }
+    )
+    deployment_state = PromotionState(state=state)
+    deployment_state.cache_commit_shas_from_s3()
+    deployment_info = deployment_state.get_promotion_data(
+        channel="channel", sha="sha", target_uid="uid"
+    )
     assert deployment_info == PromotionData(
         success=True,
         target_config_hash="hash",
@@ -42,7 +69,9 @@ def test_key_does_not_exist(s3_state_builder: Callable[[Mapping], State]):
     )
     deployment_state = PromotionState(state=state)
     deployment_state.cache_commit_shas_from_s3()
-    deployment_info = deployment_state.get_promotion_data(channel="channel", sha="sha")
+    deployment_info = deployment_state.get_promotion_data(
+        channel="channel", sha="sha", target_uid="uid"
+    )
     assert deployment_info is None
 
 
@@ -61,7 +90,7 @@ def test_key_does_not_exist_locally(s3_state_builder: Callable[[Mapping], State]
     )
     deployment_state = PromotionState(state=state)
     deployment_info = deployment_state.get_promotion_data(
-        channel="channel", sha="sha", local_lookup=False
+        channel="channel", sha="sha", target_uid="uid", local_lookup=False
     )
     assert deployment_info == PromotionData(
         success=True, target_config_hash="hash", saas_file="saas_file"
@@ -87,9 +116,6 @@ def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
         target_uid="uid",
         data=promotion_info,
     )
-    deployment_state._state.add.assert_any_call(  # type: ignore[attr-defined]
-        "promotions/channel/sha", promotion_info.dict(), True
-    )
-    deployment_state._state.add.assert_any_call(  # type: ignore[attr-defined]
+    deployment_state._state.add.assert_called_once_with(  # type: ignore[attr-defined]
         "promotions_v2/channel/uid/sha", promotion_info.dict(), True
     )

--- a/reconcile/utils/promotion_state.py
+++ b/reconcile/utils/promotion_state.py
@@ -39,6 +39,9 @@ class PromotionState:
         self._state = state
         self._commits_by_channel: dict[str, set[str]] = defaultdict(set)
 
+    def _target_key(self, channel: str, target_uid: str) -> str:
+        return f"{channel}/{target_uid}"
+
     def cache_commit_shas_from_s3(self) -> None:
         """
         Caching commit shas locally - this is used
@@ -47,24 +50,56 @@ class PromotionState:
         """
         all_keys = self._state.ls()
         for commit in all_keys:
+            # BACKWARDS-COMPAT BLOCK
             # Format: /promotions/{channel}/{commit-sha}
-            if not commit.startswith("/promotions/"):
+            if commit.startswith("/promotions/"):
+                # Keep this for backwards-compatibility with v1 promotions
+                # We wait a couple of months to be sure all pipelines have
+                # been triggered since.
+                # This can be deleted after 30.09.2023
+                _, _, channel_name, commit_sha = commit.split("/")
+                self._commits_by_channel[channel_name].add(commit_sha)
+            # / BACKWARDS-COMPAT BLOCK
+
+            # Format: /promotions_v2/{channel}/{publisher-target-uid}/{commit-sha}
+            if not commit.startswith("/promotions_v2/"):
                 continue
-            _, _, channel_name, commit_sha = commit.split("/")
-            self._commits_by_channel[channel_name].add(commit_sha)
+            _, _, channel_name, publisher_uid, commit_sha = commit.split("/")
+            key = self._target_key(channel=channel_name, target_uid=publisher_uid)
+            self._commits_by_channel[key].add(commit_sha)
 
     def get_promotion_data(
-        self, sha: str, channel: str, local_lookup: bool = True
+        self, sha: str, channel: str, target_uid: str = "", local_lookup: bool = True
     ) -> Optional[PromotionData]:
-        if local_lookup and sha not in self._commits_by_channel[channel]:
+        cache_key_v1 = channel
+        cache_key_v2 = self._target_key(channel=channel, target_uid=target_uid)
+        if (
+            local_lookup
+            and sha not in self._commits_by_channel[cache_key_v1]
+            and sha not in self._commits_by_channel[cache_key_v2]
+        ):
             # Lets reduce unecessary calls to S3
             return None
-        key = f"promotions/{channel}/{sha}"
+
+        # BACKWARDS-COMPAT BLOCK
+        # Keep for backwards-compatibility with v1 promotions
+        # We wait a couple of months to be sure all pipelines have
+        # been triggered since.
+        # This can be deleted after 30.09.2023
+        path_v1 = f"promotions/{channel}/{sha}"
         try:
-            data = self._state.get(key)
+            data = self._state.get(path_v1)
+            return PromotionData(**data)
+        except KeyError:
+            pass
+        # / BACKWARDS-COMPAT BLOCK
+
+        path_v2 = f"promotions_v2/{channel}/{target_uid}/{sha}"
+        try:
+            data = self._state.get(path_v2)
+            return PromotionData(**data)
         except KeyError:
             return None
-        return PromotionData(**data)
 
     def publish_promotion_data(
         self, sha: str, channel: str, target_uid: str, data: PromotionData


### PR DESCRIPTION
`promotion_state` now tries to fetch data from `promotions_v2` path. This is fully backwards-compatible, as saasherder and SAPM are still not passing any `target_uid` to the get call.

This is a follow-up on https://github.com/app-sre/qontract-reconcile/pull/3639

A follow-up PR will adjust saasherder to pass the target_uid and fetch from v2.
Another follow-up PR will adjust SAPM to fetch from v2.
A third final follow-up PR will adjust SAPMs logic to calculate refs/hashes.