### PR TITLE
APPSRE-7307 multi-publisher support for SAPM

### DIFF
--- a/reconcile/saas_auto_promotions_manager/publisher.py
+++ b/reconcile/saas_auto_promotions_manager/publisher.py
@@ -29,6 +29,7 @@ class Publisher:
         self,
         ref: str,
         repo_url: str,
+        uid: str,
         auth_code: Optional[HasSecret],
     ):
         self._ref = ref
@@ -37,6 +38,7 @@ class Publisher:
         self.channels: set[str] = set()
         self.commit_sha: str = ""
         self.deployment_info_by_channel: dict[str, Optional[DeploymentInfo]] = {}
+        self.uid = uid
 
     def fetch_commit_shas_and_deployment_info(
         self, vcs: VCS, deployment_state: PromotionState
@@ -51,6 +53,7 @@ class Publisher:
             promotion_data = deployment_state.get_promotion_data(
                 sha=self.commit_sha,
                 channel=channel,
+                target_uid=self.uid,
             )
             if not (
                 promotion_data

--- a/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
+++ b/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
@@ -34,25 +34,6 @@ class SaasFilesInventory:
         self._assemble_publishers()
         self._remove_unsupported()
 
-    def _assemble_channels(self) -> None:
-        for saas_file in self._saas_files:
-            for resource_template in saas_file.resource_templates:
-                for target in resource_template.targets:
-                    if not target.promotion:
-                        continue
-                    for publish_channel in target.promotion.publish or []:
-                        if publish_channel not in self._channels_by_name:
-                            self._channels_by_name[publish_channel] = Channel(
-                                name=publish_channel,
-                                publishers=[],
-                            )
-                    for subscribe_channel in target.promotion.subscribe or []:
-                        if subscribe_channel not in self._channels_by_name:
-                            self._channels_by_name[subscribe_channel] = Channel(
-                                name=subscribe_channel,
-                                publishers=[],
-                            )
-
     def _assemble_publishers(self) -> None:
         for saas_file in self._saas_files:
             for resource_template in saas_file.resource_templates:
@@ -66,6 +47,10 @@ class SaasFilesInventory:
                     )
                     publisher = Publisher(
                         ref=target.ref,
+                        uid=target.uid(
+                            parent_saas_file_name=saas_file.name,
+                            parent_resource_template_name=resource_template.name,
+                        ),
                         repo_url=resource_template.url,
                         auth_code=auth_code,
                     )
@@ -149,26 +134,9 @@ class SaasFilesInventory:
         for subscriber in self.subscribers:
             is_supported = True
             for channel in subscriber.channels:
-                if len(channel.publishers) > 1:
-                    logging.error(
-                        "[%s] We do not support multiple publishers for a single channel - blocked by https://issues.redhat.com/browse/APPSRE-7414",
-                        channel.name,
-                    )
-                    is_supported = False
-                    break
                 if not channel.publishers:
                     logging.error(
                         "[%s] There must be at least one publisher per channel.",
-                        channel.name,
-                    )
-                    is_supported = False
-                    break
-                if (
-                    len(subscriber.config_hashes_by_channel_name.get(channel.name, []))
-                    > 1
-                ):
-                    logging.error(
-                        "[%s] We do not support multiple publishers for a single channel - blocked by https://issues.redhat.com/browse/APPSRE-7414",
                         channel.name,
                     )
                     is_supported = False

--- a/reconcile/test/saas_auto_promotions_manager/subscriber/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/subscriber/conftest.py
@@ -41,6 +41,7 @@ def subscriber_builder() -> Callable[[Mapping[str, Any]], Subscriber]:
             for publisher_name, publisher_data in channel_data.items():
                 publisher = Publisher(
                     ref="",
+                    uid="",
                     repo_url="",
                     auth_code=None,
                 )

--- a/reconcile/test/saas_auto_promotions_manager/subscriber/test_multiple_publishers_moving_ref.py
+++ b/reconcile/test/saas_auto_promotions_manager/subscriber/test_multiple_publishers_moving_ref.py
@@ -1,0 +1,137 @@
+from collections.abc import (
+    Callable,
+    Mapping,
+)
+from typing import Any
+
+from reconcile.saas_auto_promotions_manager.subscriber import Subscriber
+
+from .data_keys import (
+    CHANNELS,
+    CUR_CONFIG_HASHES,
+    CUR_SUBSCRIBER_REF,
+    REAL_WORLD_SHA,
+    SUCCESSFUL_DEPLOYMENT,
+    USE_TARGET_CONFIG_HASH,
+)
+
+
+def test_no_change(
+    subscriber_builder: Callable[[Mapping[str, Any]], Subscriber],
+):
+    subscriber = subscriber_builder(
+        {
+            USE_TARGET_CONFIG_HASH: False,
+            CUR_SUBSCRIBER_REF: "current_sha",
+            CUR_CONFIG_HASHES: [],
+            CHANNELS: {
+                "channel-a": {
+                    "publisher_a": {
+                        REAL_WORLD_SHA: "current_sha",
+                    },
+                    "publisher_b": {
+                        REAL_WORLD_SHA: "current_sha",
+                    },
+                },
+                "channel-b": {
+                    "publisher_c": {
+                        REAL_WORLD_SHA: "current_sha",
+                    },
+                },
+            },
+        }
+    )
+    subscriber.compute_desired_state()
+    assert subscriber.desired_ref == "current_sha"
+    assert subscriber.desired_hashes == []
+
+
+def test_moving_ref(
+    subscriber_builder: Callable[[Mapping[str, Any]], Subscriber],
+):
+    subscriber = subscriber_builder(
+        {
+            USE_TARGET_CONFIG_HASH: False,
+            CUR_SUBSCRIBER_REF: "current_sha",
+            CUR_CONFIG_HASHES: [],
+            CHANNELS: {
+                "channel-a": {
+                    "publisher_a": {
+                        REAL_WORLD_SHA: "new_sha",
+                    },
+                    "publisher_b": {
+                        REAL_WORLD_SHA: "new_sha",
+                    },
+                },
+                "channel-b": {
+                    "publisher_c": {
+                        REAL_WORLD_SHA: "new_sha",
+                    }
+                },
+            },
+        }
+    )
+    subscriber.compute_desired_state()
+    assert subscriber.desired_ref == "new_sha"
+    assert subscriber.desired_hashes == []
+
+
+def test_moving_ref_mismatch(
+    subscriber_builder: Callable[[Mapping[str, Any]], Subscriber],
+):
+    subscriber = subscriber_builder(
+        {
+            USE_TARGET_CONFIG_HASH: False,
+            CUR_SUBSCRIBER_REF: "current_sha",
+            CUR_CONFIG_HASHES: [],
+            CHANNELS: {
+                "channel-a": {
+                    "publisher_a": {
+                        REAL_WORLD_SHA: "new_sha",
+                    },
+                    "publisher_b": {
+                        REAL_WORLD_SHA: "other_new_sha",
+                    },
+                },
+                "channel-b": {
+                    "publisher_c": {
+                        REAL_WORLD_SHA: "new_sha",
+                    }
+                },
+            },
+        }
+    )
+    subscriber.compute_desired_state()
+    assert subscriber.desired_ref == "current_sha"
+    assert subscriber.desired_hashes == []
+
+
+def test_moving_ref_bad_deployment(
+    subscriber_builder: Callable[[Mapping[str, Any]], Subscriber],
+):
+    subscriber = subscriber_builder(
+        {
+            USE_TARGET_CONFIG_HASH: False,
+            CUR_SUBSCRIBER_REF: "current_sha",
+            CUR_CONFIG_HASHES: [],
+            CHANNELS: {
+                "channel-a": {
+                    "publisher_a": {
+                        REAL_WORLD_SHA: "new_sha",
+                    },
+                    "publisher_b": {
+                        REAL_WORLD_SHA: "new_sha",
+                        SUCCESSFUL_DEPLOYMENT: False,
+                    },
+                },
+                "channel-b": {
+                    "publisher_c": {
+                        REAL_WORLD_SHA: "new_sha",
+                    }
+                },
+            },
+        }
+    )
+    subscriber.compute_desired_state()
+    assert subscriber.desired_ref == "current_sha"
+    assert subscriber.desired_hashes == []

--- a/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_multiple_publishers_for_single_channel.py
+++ b/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_multiple_publishers_for_single_channel.py
@@ -65,6 +65,4 @@ def test_multiple_publishers_for_single_channel(
     )
     inventory = SaasFilesInventory(saas_files=saas_files)
     assert len(inventory.publishers) == 2
-    # As of now we do not support this, i.e., all
-    # subscribers should be removed from the inventory
-    assert len(inventory.subscribers) == 0
+    assert len(inventory.subscribers) == 1


### PR DESCRIPTION
Introduce multi-publisher support for moving refs.

This is a follow-up on a range of PRs for this effort:
- https://github.com/app-sre/qontract-reconcile/pull/3651
- https://github.com/app-sre/qontract-reconcile/pull/3650
- https://github.com/app-sre/qontract-reconcile/pull/3639

Note, this does not support target-config-hashes yet. They require introduction of publisher_uid into the hash object. Target-config-hashes are subject to further discussion https://issues.redhat.com/browse/APPSRE-7516

Currently only a small set of saas files rely on target-config-hash (saas files dedicated to tests), i.e., this PR will provide multi-publisher support for majority of saas files.