### PR TITLE
APPSRE-7307 remove publish promotion_v1

### DIFF
--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -116,9 +116,6 @@ def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
         target_uid="uid",
         data=promotion_info,
     )
-    deployment_state._state.add.assert_any_call(  # type: ignore[attr-defined]
-        "promotions/channel/sha", promotion_info.dict(), True
-    )
-    deployment_state._state.add.assert_any_call(  # type: ignore[attr-defined]
+    deployment_state._state.add.assert_called_once_with(  # type: ignore[attr-defined]
         "promotions_v2/channel/uid/sha", promotion_info.dict(), True
     )

--- a/reconcile/utils/promotion_state.py
+++ b/reconcile/utils/promotion_state.py
@@ -104,11 +104,6 @@ class PromotionState:
     def publish_promotion_data(
         self, sha: str, channel: str, target_uid: str, data: PromotionData
     ) -> None:
-        # TODO: this will be deprecated once we fully moved to promotions_v2
-        state_key = f"promotions/{channel}/{sha}"
-        self._state.add(state_key, data.dict(), force=True)
-        logging.info("Uploaded %s to %s", data, state_key)
-
         state_key_v2 = f"promotions_v2/{channel}/{target_uid}/{sha}"
         self._state.add(state_key_v2, data.dict(), force=True)
         logging.info("Uploaded %s to %s", data, state_key_v2)

--- a/reconcile/utils/promotion_state.py
+++ b/reconcile/utils/promotion_state.py
@@ -87,7 +87,7 @@ class PromotionState:
             return PromotionData(**data)
         except KeyError:
             pass
-        
+
         # BACKWARDS-COMPAT BLOCK
         # Keep for backwards-compatibility with v1 promotions
         # We wait a couple of months to be sure all pipelines have

--- a/reconcile/utils/promotion_state.py
+++ b/reconcile/utils/promotion_state.py
@@ -81,6 +81,13 @@ class PromotionState:
             # Lets reduce unecessary calls to S3
             return None
 
+        path_v2 = f"promotions_v2/{channel}/{target_uid}/{sha}"
+        try:
+            data = self._state.get(path_v2)
+            return PromotionData(**data)
+        except KeyError:
+            pass
+        
         # BACKWARDS-COMPAT BLOCK
         # Keep for backwards-compatibility with v1 promotions
         # We wait a couple of months to be sure all pipelines have
@@ -91,15 +98,8 @@ class PromotionState:
             data = self._state.get(path_v1)
             return PromotionData(**data)
         except KeyError:
-            pass
-        # / BACKWARDS-COMPAT BLOCK
-
-        path_v2 = f"promotions_v2/{channel}/{target_uid}/{sha}"
-        try:
-            data = self._state.get(path_v2)
-            return PromotionData(**data)
-        except KeyError:
             return None
+        # / BACKWARDS-COMPAT BLOCK
 
     def publish_promotion_data(
         self, sha: str, channel: str, target_uid: str, data: PromotionData


### PR DESCRIPTION
Our promotions do not rely on the v1 path any longer:

- https://github.com/app-sre/qontract-reconcile/pull/3650
- https://github.com/app-sre/qontract-reconcile/pull/3653

This PR stops publishing promotions to our v1 path.