### PR TITLE
[change-owners] detect field type changes

### DIFF
--- a/reconcile/change_owners/diff.py
+++ b/reconcile/change_owners/diff.py
@@ -208,6 +208,19 @@ def extract_diffs(old_file_content: Any, new_file_content: Any) -> list[Diff]:
             ]
         )
 
+        # handle type changes
+        diffs.extend(
+            [
+                Diff(
+                    path=deepdiff_path_to_jsonpath(path),
+                    diff_type=DiffType.CHANGED,
+                    old=change.get("old_value"),
+                    new=change.get("new_value"),
+                )
+                for path, change in deep_diff.get("type_changes", {}).items()
+            ]
+        )
+
     elif old_file_content:
         # file was deleted
         diffs.append(

--- a/reconcile/test/change_owners/test_change_type_diff.py
+++ b/reconcile/test/change_owners/test_change_type_diff.py
@@ -568,6 +568,25 @@ def test_bundle_change_diff_item_reorder() -> None:
     assert bundle_change.old_content_sha != bundle_change.new_content_sha
 
 
+def test_bundle_change_diff_type_changed() -> None:
+    """
+    detect a change in a fields type
+    """
+    bundle_change = build_bundle_datafile_change(
+        path="path",
+        schema="schema",
+        old_content={"field": 10},
+        new_content={"field": "10"},
+    )
+
+    assert bundle_change
+    assert len(bundle_change.diff_coverage) == 1
+    assert str(bundle_change.diff_coverage[0].diff.path) == "field"
+    assert bundle_change.diff_coverage[0].diff.diff_type == DiffType.CHANGED
+    assert bundle_change.diff_coverage[0].diff.old == 10
+    assert bundle_change.diff_coverage[0].diff.new == "10"
+
+
 def test_bundle_change_diff_resourcefile_without_schema_unparsable() -> None:
     bundle_change = build_bundle_resourcefile_change(
         path="path",


### PR DESCRIPTION
field type changes are not reported as proper change, instead they are surfaced as metadata change only (change in SHA for the datafile).

now, type changes are reported as regular changes which can be owned and self-serviced.

https://issues.redhat.com/browse/APPSRE-7934