### PR TITLE
[gitlab-housekeeping] add priority label to time_to_merge histogram

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -343,7 +343,7 @@ def get_merge_requests(
         if not is_good_to_merge(labels):
             continue
 
-        label_priotiry = min(
+        label_priority = min(
             MERGE_LABELS_PRIORITY.index(merge_label)
             for merge_label in MERGE_LABELS_PRIORITY
             if merge_label in labels
@@ -352,8 +352,8 @@ def get_merge_requests(
         item = {
             "mr": mr,
             "labels": labels,
-            "label_priority": label_priotiry,
-            "priority": f"{label_priotiry} - {MERGE_LABELS_PRIORITY[label_priotiry]}",
+            "label_priority": label_priority,
+            "priority": f"{label_priority} - {MERGE_LABELS_PRIORITY[label_priority]}",
             "approved_at": approved_at,
             "approved_by": approved_by,
         }

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -506,7 +506,7 @@ def merge_merge_requests(
                     auto_merge=AUTO_MERGE in labels,
                     app_sre=mr.author["username"] in app_sre_usernames,
                 ).inc()
-                time_to_merge.labels(mr.target_project_id).observe(
+                time_to_merge.labels(project_id=mr.target_project_id).observe(
                     _calculate_time_since_approval(merge_request_approved_at[mr])
                 )
                 if rebase:


### PR DESCRIPTION
this is an attempt to be able to visualize the average time it takes to merge a MR per priority.