### PR TITLE
[saas-file-owners] validate saas file app self-service instead of saas file

### DIFF
--- a/reconcile/gql_definitions/common/saas_files.gql
+++ b/reconcile/gql_definitions/common/saas_files.gql
@@ -9,6 +9,9 @@ query SaasFiles {
       parentApp {
         name
       }
+      selfServiceRoles {
+        name
+      }
     }
     pipelinesProvider {
       name
@@ -160,13 +163,7 @@ query SaasFiles {
       }
     }
     selfServiceRoles {
-      users {
-        org_username
-        tag_on_merge_requests
-      }
-      bots {
-        org_username
-      }
+      name
     }
   }
 }

--- a/reconcile/gql_definitions/common/saas_files.py
+++ b/reconcile/gql_definitions/common/saas_files.py
@@ -79,6 +79,9 @@ fragment SaasTargetNamespace on Namespace_v1 {
       name
     }
     labels
+    selfServiceRoles {
+      name
+    }
   }
   cluster {
     ...OcConnectionCluster
@@ -102,6 +105,9 @@ query SaasFiles {
     app {
       name
       parentApp {
+        name
+      }
+      selfServiceRoles {
         name
       }
     }
@@ -255,13 +261,7 @@ query SaasFiles {
       }
     }
     selfServiceRoles {
-      users {
-        org_username
-        tag_on_merge_requests
-      }
-      bots {
-        org_username
-      }
+      name
     }
   }
 }
@@ -278,9 +278,14 @@ class AppV1_AppV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
 
 
+class RoleV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+
+
 class AppV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     parent_app: Optional[AppV1_AppV1] = Field(..., alias="parentApp")
+    self_service_roles: Optional[list[RoleV1]] = Field(..., alias="selfServiceRoles")
 
 
 class PipelinesProviderV1(ConfiguredBaseModel):
@@ -491,18 +496,8 @@ class SaasResourceTemplateV2(ConfiguredBaseModel):
     targets: list[SaasResourceTemplateTargetV2] = Field(..., alias="targets")
 
 
-class UserV1(ConfiguredBaseModel):
-    org_username: str = Field(..., alias="org_username")
-    tag_on_merge_requests: Optional[bool] = Field(..., alias="tag_on_merge_requests")
-
-
-class BotV1(ConfiguredBaseModel):
-    org_username: Optional[str] = Field(..., alias="org_username")
-
-
-class RoleV1(ConfiguredBaseModel):
-    users: list[UserV1] = Field(..., alias="users")
-    bots: list[BotV1] = Field(..., alias="bots")
+class SaasFileV2_RoleV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
 
 
 class SaasFileV2(ConfiguredBaseModel):
@@ -539,7 +534,9 @@ class SaasFileV2(ConfiguredBaseModel):
     resource_templates: list[SaasResourceTemplateV2] = Field(
         ..., alias="resourceTemplates"
     )
-    self_service_roles: Optional[list[RoleV1]] = Field(..., alias="selfServiceRoles")
+    self_service_roles: Optional[list[SaasFileV2_RoleV1]] = Field(
+        ..., alias="selfServiceRoles"
+    )
 
 
 class SaasFilesQueryData(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/common/saas_target_namespaces.py
+++ b/reconcile/gql_definitions/common/saas_target_namespaces.py
@@ -75,6 +75,9 @@ fragment SaasTargetNamespace on Namespace_v1 {
       name
     }
     labels
+    selfServiceRoles {
+      name
+    }
   }
   cluster {
     ...OcConnectionCluster

--- a/reconcile/gql_definitions/fragments/saas_target_namespace.gql
+++ b/reconcile/gql_definitions/fragments/saas_target_namespace.gql
@@ -22,6 +22,9 @@ fragment SaasTargetNamespace on Namespace_v1 {
       name
     }
     labels
+    selfServiceRoles {
+      name
+    }
   }
   cluster {
     ...OcConnectionCluster

--- a/reconcile/gql_definitions/fragments/saas_target_namespace.py
+++ b/reconcile/gql_definitions/fragments/saas_target_namespace.py
@@ -47,10 +47,15 @@ class AppV1_AppV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
 
 
+class RoleV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+
+
 class AppV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     parent_app: Optional[AppV1_AppV1] = Field(..., alias="parentApp")
     labels: Optional[Json] = Field(..., alias="labels")
+    self_service_roles: Optional[list[RoleV1]] = Field(..., alias="selfServiceRoles")
 
 
 class NamespaceSkupperSiteConfigV1(ConfiguredBaseModel):

--- a/reconcile/test/fixtures/saasherder/saas.gql.yml
+++ b/reconcile/test/fixtures/saasherder/saas.gql.yml
@@ -3,6 +3,8 @@ path: /services/test-saas-deployment-pipelines/cicd/deploy.yml
 name: test-saas-deployments-deploy
 app:
   name: app-interface
+  selfServiceRoles:
+  - name: test
 
 pipelinesProvider:
   name: tekton-app-sre-pipelines-appsres03ue1
@@ -100,10 +102,3 @@ resourceTemplates:
         - type: parent_saas_config
           parent_saas: test-saas-deployments-deploy
           target_config_hash: ed2af38cf21f268c
-
-selfServiceRoles:
-- users:
-  - org_username: user1
-  - org_username: user2
-    tag_on_merge_requests: true
-  bots: []

--- a/reconcile/test/test_saasherder_allowed_secret_paths.py
+++ b/reconcile/test/test_saasherder_allowed_secret_paths.py
@@ -41,7 +41,7 @@ def test_saasherder_allowed_secret_paths(
                 "name": "a1",
                 "managedResourceTypes": [],
                 "allowedSecretParameterPaths": [allowed_secret_parameter_path],
-                "app": {"name": "app1"},
+                "app": {"name": "app1", "selfServiceRoles": [{"name": "test"}]},
                 "pipelinesProvider": {
                     "name": "tekton-app-sre-pipelines-appsres03ue1",
                     "provider": "tekton",
@@ -105,9 +105,6 @@ def test_saasherder_allowed_secret_paths(
                             },
                         ],
                     },
-                ],
-                "selfServiceRoles": [
-                    {"users": [{"org_username": "theirname"}], "bots": []}
                 ],
             },
         )

--- a/reconcile/test/test_typed_queries/test_saas_files.py
+++ b/reconcile/test/test_typed_queries/test_saas_files.py
@@ -613,7 +613,7 @@ def test_export_model(
         {
             "path": "path1",
             "name": "saas-file-01",
-            "app": {"name": "app-01", "parentApp": None},
+            "app": {"name": "app-01", "parentApp": None, "selfServiceRoles": None},
             "pipelinesProvider": {
                 "name": "pipeline-provider-01",
                 "provider": "tekton",
@@ -687,6 +687,7 @@ def test_export_model(
                                     "name": "app-01",
                                     "labels": None,
                                     "parentApp": None,
+                                    "selfServiceRoles": None,
                                 },
                                 "cluster": {
                                     "name": "appint-ex-01",
@@ -732,6 +733,7 @@ def test_export_model(
                                     "name": "app-01",
                                     "labels": None,
                                     "parentApp": None,
+                                    "selfServiceRoles": None,
                                 },
                                 "cluster": {
                                     "name": "appint-ex-01",
@@ -767,7 +769,7 @@ def test_export_model(
         {
             "path": "path2",
             "name": "saas-file-02",
-            "app": {"name": "app-02", "parentApp": None},
+            "app": {"name": "app-02", "parentApp": None, "selfServiceRoles": None},
             "pipelinesProvider": {
                 "name": "pipeline-provider-01",
                 "provider": "tekton",
@@ -841,6 +843,7 @@ def test_export_model(
                                     "name": "app-02",
                                     "labels": None,
                                     "parentApp": None,
+                                    "selfServiceRoles": None,
                                 },
                                 "cluster": {
                                     "name": "appint-ex-01",
@@ -886,6 +889,7 @@ def test_export_model(
                                     "name": "app-02",
                                     "labels": None,
                                     "parentApp": None,
+                                    "selfServiceRoles": None,
                                 },
                                 "cluster": {
                                     "name": "appint-ex-01",
@@ -921,7 +925,7 @@ def test_export_model(
         {
             "path": "path3",
             "name": "saas-file-03",
-            "app": {"name": "example", "parentApp": None},
+            "app": {"name": "example", "parentApp": None, "selfServiceRoles": None},
             "pipelinesProvider": {
                 "name": "pipeline-provider-01",
                 "provider": "tekton",
@@ -994,6 +998,7 @@ def test_export_model(
                                 "app": {
                                     "name": "example",
                                     "parentApp": None,
+                                    "selfServiceRoles": None,
                                     "labels": None,
                                 },
                                 "cluster": {
@@ -1039,6 +1044,7 @@ def test_export_model(
                                 "app": {
                                     "name": "example",
                                     "parentApp": None,
+                                    "selfServiceRoles": None,
                                     "labels": None,
                                 },
                                 "cluster": {

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -58,6 +58,10 @@ class SaasApp(Protocol):
     def parent_app(self) -> Optional[SaasParentApp]:
         ...
 
+    @property
+    def self_service_roles(self) -> Optional[Sequence[SaasRole]]:
+        ...
+
 
 class SaasPipelinesProvider(Protocol):
     name: str

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -364,15 +364,6 @@ class SaasResourceTemplate(HasParameters, HasSecretParameters, Protocol):
         ...
 
 
-class SaasUser(Protocol):
-    org_username: str
-    tag_on_merge_requests: Optional[bool]
-
-
-class SaasBot(Protocol):
-    org_username: Optional[str]
-
-
 class SaasRole(Protocol):
     name: str
 

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -374,13 +374,7 @@ class SaasBot(Protocol):
 
 
 class SaasRole(Protocol):
-    @property
-    def users(self) -> Sequence[SaasUser]:
-        ...
-
-    @property
-    def bots(self) -> Sequence[SaasBot]:
-        ...
+    name: str
 
 
 SaasPipelinesProviders = Union[SaasPipelinesProviderTekton, SaasPipelinesProvider]

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -256,14 +256,9 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             saas_file_name_path_map.setdefault(saas_file.name, [])
             saas_file_name_path_map[saas_file.name].append(saas_file.path)
 
-            saas_file_owners = [
-                u.org_username
-                for r in saas_file.self_service_roles or []
-                for u in list(r.users) + list(r.bots)
-            ]
-            if not saas_file_owners:
+            if not saas_file.app.self_service_roles:
                 logging.error(
-                    f"saas file {saas_file.name} has no owners: {saas_file.path}"
+                    f"app {saas_file.app.name} has no self-service roles (saas file {saas_file.name})"
                 )
                 self.valid = False
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-7939

alternative for #3661

following up on #3485, we no longer need to validate saas file ownership to the user/bot level.

this PR changes the validation so we validate the app file is self-serviceable, as we are going to include the saas file self-service as part of app ownership in https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/73509