### PR TITLE
sendgrid teammates dirty hack for paging

### DIFF
--- a/reconcile/sendgrid_teammates.py
+++ b/reconcile/sendgrid_teammates.py
@@ -46,7 +46,12 @@ def fetch_current_state(sg_client):
     state = []
 
     # pending invites
-    invites = sg_client.teammates.pending.get().to_dict["result"]
+    limit = 300
+    invites = sg_client.teammates.pending.get({"limit": limit}).to_dict["result"]
+    if len(invites) == limit:
+        raise RuntimeError(
+            "too many pending invites and i was too lazy to implement paging. take that future me"
+        )
     for invite in invites:
         t = Teammate(invite["email"], pending_token=invite["token"])
         state.append(t)


### PR DESCRIPTION
the sendgrid teammates integration run into an API paging issue hiding certain pendinv invites and generating new ones over and over again. for a quick resolution this PR queries the pending invites with a big page of 300 which should resolve the issue for now.