### PR TITLE
sendgrid API proper paging for invites and teammates

### DIFF
--- a/reconcile/sendgrid_teammates.py
+++ b/reconcile/sendgrid_teammates.py
@@ -44,27 +44,37 @@ def fetch_desired_state(users):
 @retry()
 def fetch_current_state(sg_client):
     state = []
+    limit = 100
 
     # pending invites
-    limit = 300
-    invites = sg_client.teammates.pending.get({"limit": limit}).to_dict["result"]
-    if len(invites) == limit:
-        raise RuntimeError(
-            "too many pending invites and i was too lazy to implement paging. take that future me"
-        )
-    for invite in invites:
-        t = Teammate(invite["email"], pending_token=invite["token"])
-        state.append(t)
+    offset = 0
+    while True:
+        invites = sg_client.teammates.pending.get(
+            query_params={"limit": limit, "offset": offset}
+        ).to_dict["result"]
+        if not invites:
+            break
+        for invite in invites:
+            t = Teammate(invite["email"], pending_token=invite["token"])
+            state.append(t)
+        offset += limit
 
     # current teammates
-    teammates = sg_client.teammates.get().to_dict["result"]
-    for teammate in teammates:
-        if teammate["user_type"] == "owner":
-            # we want to ignore the root account (owner account)
-            continue
+    offset = 0
+    while True:
+        teammates = sg_client.teammates.get(
+            query_params={"limit": limit, "offset": offset}
+        ).to_dict["result"]
+        if not teammates:
+            break
+        for teammate in teammates:
+            if teammate["user_type"] == "owner":
+                # we want to ignore the root account (owner account)
+                continue
 
-        t = Teammate(teammate["email"], username=teammate["username"])
-        state.append(t)
+            t = Teammate(teammate["email"], username=teammate["username"])
+            state.append(t)
+        offset += limit
 
     return state
 


### PR DESCRIPTION
use the proper `limit/offset` combination to page until no new items are returned