### PR TITLE
[glitchtip] fix project deletion error

### DIFF
--- a/reconcile/glitchtip/reconciler.py
+++ b/reconcile/glitchtip/reconciler.py
@@ -35,8 +35,6 @@ class GlitchtipReconciler:
             if not self.dry_run:
                 self.client.delete_project(
                     organization_slug=organization_slug,
-                    # there is always at least one team
-                    team_slug=project.teams[0].slug,
                     slug=project.slug,
                 )
 

--- a/reconcile/test/fixtures/glitchtip/reconciler/projects/mixed.yml
+++ b/reconcile/test/fixtures/glitchtip/reconciler/projects/mixed.yml
@@ -81,7 +81,7 @@ expected_return_value:
 
 glitchtip_urls:
   - name: delete rosetta-old
-    uri: /api/0/teams/esa/esa-flight-control/projects/rosetta-old/
+    uri: /api/0/projects/esa/rosetta-old/
     method: delete
 
   - name: create rosetta-spacecraft

--- a/reconcile/test/fixtures/glitchtip/reconciler/projects/no_desired_projects.yml
+++ b/reconcile/test/fixtures/glitchtip/reconciler/projects/no_desired_projects.yml
@@ -48,8 +48,8 @@ expected_return_value: []
 
 glitchtip_urls:
   - name: delete rosetta-old
-    uri: /api/0/teams/esa/esa-flight-control/projects/rosetta-old/
+    uri: /api/0/projects/esa/rosetta-old/
     method: delete
   - name: delete rosetta-flight-control
-    uri: /api/0/teams/esa/esa-pilots/projects/rosetta-flight-control/
+    uri: /api/0/projects/esa/rosetta-flight-control/
     method: delete

--- a/reconcile/test/glitchtip/conftest.py
+++ b/reconcile/test/glitchtip/conftest.py
@@ -61,12 +61,12 @@ def glitchtip_server_full_api_response(
         "api/0/organizations/nasa/members/29/",
         "api/0/organizations/nasa/members/29/teams/nasa-pilots/",
         "api/0/projects/nasa/science-tools/teams/nasa-flight-control/",
+        "api/0/projects/nasa/science-tools/",
         "api/0/teams/esa/esa-pilots/",
         "api/0/teams/esa/esa-pilots/members/",
         "api/0/teams/esa/esa-flight-control/members/",
         "api/0/teams/nasa/nasa-pilots/members/",
         "api/0/teams/nasa/nasa-pilots/projects/",
-        "api/0/teams/nasa/nasa-pilots/projects/science-tools/",
         "api/0/teams/nasa/nasa-flight-control/members/",
         # glitchtip-project-dsn
         "api/0/projects/nasa/apollo-11-flight-control/keys/",

--- a/reconcile/test/glitchtip/test_utils_glitchtip_client.py
+++ b/reconcile/test/glitchtip/test_utils_glitchtip_client.py
@@ -247,9 +247,7 @@ def test_glitchtip_create_project(glitchtip_client: GlitchtipClient) -> None:
 
 
 def test_glitchtip_delete_project(glitchtip_client: GlitchtipClient) -> None:
-    glitchtip_client.delete_project(
-        organization_slug="nasa", team_slug="nasa-pilots", slug="science-tools"
-    )
+    glitchtip_client.delete_project(organization_slug="nasa", slug="science-tools")
 
 
 def test_glitchtip_add_project_to_team(glitchtip_client: GlitchtipClient) -> None:

--- a/reconcile/utils/glitchtip/client.py
+++ b/reconcile/utils/glitchtip/client.py
@@ -145,10 +145,10 @@ class GlitchtipClient:
             )
         )
 
-    def delete_project(self, organization_slug: str, team_slug: str, slug: str) -> None:
+    def delete_project(self, organization_slug: str, slug: str) -> None:
         """Delete a project."""
         self._delete(
-            f"/api/0/teams/{organization_slug}/{team_slug}/projects/{slug}/",
+            f"/api/0/projects/{organization_slug}/{slug}/",
         )
 
     def project_key(self, organization_slug: str, project_slug: str) -> ProjectKey:


### PR DESCRIPTION
Fix the deletion of a project together with its related team. The Glitchtip API offers several endpoints for the same operation 🤷, use the team independent to delete a project. 

Ticket: [APPSRE-7871](https://issues.redhat.com/browse/APPSRE-7871)