### PR TITLE
[rhidp] fix OCM KeyError

### DIFF
--- a/reconcile/rhidp/common.py
+++ b/reconcile/rhidp/common.py
@@ -81,7 +81,7 @@ def build_cluster_obj(
         name=cluster.ocm_cluster.name,
         consoleUrl=cluster.ocm_cluster.console.url,
         ocm=OpenShiftClusterManagerV1(
-            name="",
+            name=cluster.organization_id,
             environment=ocm_env,
             orgId=cluster.organization_id,
             # unused values

--- a/reconcile/test/rhidp/test_common.py
+++ b/reconcile/test/rhidp/test_common.py
@@ -134,7 +134,7 @@ def test_rhidp_common_build_cluster_obj(
         name="cluster_name",
         consoleUrl="https://console.foobar.com",
         ocm=OpenShiftClusterManagerV1(
-            name="",
+            name="org_id",
             environment=OCMEnvironment(
                 name="env",
                 url="https://ocm",


### PR DESCRIPTION
Our OCM implementation needs to have a unique OCM name