### PR TITLE
[rhidp] fix idp callback uri for rosa clusters

### DIFF
--- a/reconcile/rhidp/sso_client/base.py
+++ b/reconcile/rhidp/sso_client/base.py
@@ -3,7 +3,11 @@ from collections.abc import (
     Iterable,
     Sequence,
 )
-from urllib.parse import urljoin
+from urllib.parse import (
+    urljoin,
+    urlparse,
+    urlunparse,
+)
 
 import jwt
 
@@ -37,10 +41,16 @@ def console_url_to_oauth_url(console_url: str, auth_name: str) -> str:
     """Convert a console URL to an OAuth callback URL."""
     if console_url.startswith("https://console-openshift-console.apps.rosa."):
         # ROSA cluster
-        return urljoin(
-            console_url.replace("console-openshift-console.apps.rosa", "oauth"),
-            f"/oauth2callback/{auth_name}",
+
+        url = urlparse(
+            urljoin(
+                console_url.replace("console-openshift-console.apps.rosa", "oauth"),
+                f"/oauth2callback/{auth_name}",
+            )
         )
+        if url.port is None:
+            url = url._replace(netloc=url.netloc + ":443")
+        return urlunparse(url)
     # OSD cluster
     return urljoin(
         console_url.replace("console-openshift-console", "oauth-openshift"),

--- a/reconcile/test/rhidp/test_sso_client_base.py
+++ b/reconcile/test/rhidp/test_sso_client_base.py
@@ -27,11 +27,25 @@ from reconcile.utils.keycloak import (
 @pytest.mark.parametrize(
     "console_url, auth_name, expected",
     [
+        # OSD cluster w/o port
+        (
+            "https://console-openshift-console.apps.cluster-name.lalala-land.com/huhu/la/le/lu",
+            "super-dupper-auth",
+            "https://oauth-openshift.apps.cluster-name.lalala-land.com/oauth2callback/super-dupper-auth",
+        ),
+        # OSD cluster with port
         (
             "https://console-openshift-console.apps.cluster-name.lalala-land.com:1234/huhu/la/le/lu",
             "super-dupper-auth",
             "https://oauth-openshift.apps.cluster-name.lalala-land.com:1234/oauth2callback/super-dupper-auth",
         ),
+        # ROSA cluster w/o port
+        (
+            "https://console-openshift-console.apps.rosa.cluster-name.lalala-land.com/huhu/la/le/lu",
+            "super-dupper-auth",
+            "https://oauth.cluster-name.lalala-land.com:443/oauth2callback/super-dupper-auth",
+        ),
+        # ROSA cluster with port
         (
             "https://console-openshift-console.apps.rosa.cluster-name.lalala-land.com:1234/huhu/la/le/lu",
             "super-dupper-auth",


### PR DESCRIPTION
Rosa clusters use `:433` in the redirect URI which was forgotten in the last bug fix #3674. The CRC is also not displaying the OAuth callback URL correctly 🤦 