### PR TITLE
Set page size to 1 when get head commit

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -249,7 +249,7 @@ def is_good_to_merge(labels):
 
 def is_rebased(mr, gl: GitLabApi) -> bool:
     target_branch = mr.target_branch
-    head = gl.project.commits.list(ref_name=target_branch)[0].id
+    head = gl.project.commits.list(ref_name=target_branch, per_page=1)[0].id
     result = gl.project.repository_compare(mr.sha, head)
     return len(result["commits"]) == 0
 

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -814,7 +814,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             if not self.gitlab:
                 raise Exception("gitlab is not initialized")
             project = self.gitlab.get_project(url)
-            commits = project.commits.list(ref_name=ref)
+            commits = project.commits.list(ref_name=ref, per_page=1)
             commit_sha = commits[0].id
 
         return commit_sha

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5020,7 +5020,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         if "gitlab" in url:
             gitlab = self.init_gitlab()
             project = gitlab.get_project(url)
-            commits = project.commits.list(ref_name=ref)
+            commits = project.commits.list(ref_name=ref, per_page=1)
             return commits[0].id
 
         return ""


### PR DESCRIPTION
To get head commit sha in gitlab, we only need to fetch 1 commit instead of default 10, set `per_page=1`. Same as https://github.com/app-sre/qontract-reconcile/blob/4ec79143580995ef9fc245d973611b5e0a41bab9/reconcile/utils/gitlab_api.py#L681

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 386b513</samp>

This pull request optimizes the performance of several functions that use the `commits.list` method from the GitLab API by fetching only the latest commit instead of the default 20 commits. It also adds unit tests for the `gitlab_housekeeping` integration. The affected files are `reconcile/test/test_gitlab_housekeeping.py`, `reconcile/gitlab_housekeeping.py`, `reconcile/utils/saasherder/saasherder.py`, and `reconcile/utils/terrascript_aws_client.py`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 386b513</samp>

*  Optimize the performance of fetching the latest commit from a given ref by adding the `per_page=1` parameter to the `commits.list` method call in three functions: `is_rebased` ([link](https://github.com/app-sre/qontract-reconcile/pull/3677/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L252-R252)), `_get_commit_sha` ([link](https://github.com/app-sre/qontract-reconcile/pull/3677/files?diff=unified&w=0#diff-52a815feb4bcd8276212403b5f0ae22e3a3d9508acb5b7a75a5134dcf2657bbcL817-R817)), and `get_commit_sha` ([link](https://github.com/app-sre/qontract-reconcile/pull/3677/files?diff=unified&w=0#diff-4db367e141fd1992ae5a98872e6101dde4bf61a460c1bd0097176c6fbc849ac2L5070-R5070)). These functions are defined in the modules `gitlab_housekeeping.py`, `saasherder.py`, and `terrascript_aws_client.py`, respectively. The context of this optimization is to improve the efficiency of the integrations that use these functions to manage GitLab merge requests, SaaS deployments, and AWS resources.