### PR TITLE
Fix: ShardSpecOverrides do not pick the imageRef

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -221,8 +221,8 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          {{- if and ($shard.shard_spec_overrides) ($shard.shard_spec_overrides.image_ref) }}
-          image: ${IMAGE}:{{$shard.shard_spec_overrides.image_ref }}
+          {{- if and ($shard.shard_spec_overrides) ($shard.shard_spec_overrides.imageRef) }}
+          image: ${IMAGE}:{{$shard.shard_spec_overrides.imageRef }}
           {{- else if $integration.imageRef}}
           image: ${IMAGE}:{{$integration.imageRef}}
           {{- else }}

--- a/reconcile/gql_definitions/integrations/integrations.gql
+++ b/reconcile/gql_definitions/integrations/integrations.gql
@@ -28,6 +28,7 @@ query Integrations {
         cache
         command
         disableUnleash
+        environmentAware
         extraArgs
         extraEnv {
           secretName

--- a/reconcile/gql_definitions/integrations/integrations.py
+++ b/reconcile/gql_definitions/integrations/integrations.py
@@ -82,6 +82,7 @@ query Integrations {
         cache
         command
         disableUnleash
+        environmentAware
         extraArgs
         extraEnv {
           secretName
@@ -219,6 +220,7 @@ class IntegrationSpecV1(ConfiguredBaseModel):
     cache: Optional[bool] = Field(..., alias="cache")
     command: Optional[str] = Field(..., alias="command")
     disable_unleash: Optional[bool] = Field(..., alias="disableUnleash")
+    environment_aware: Optional[bool] = Field(..., alias="environmentAware")
     extra_args: Optional[str] = Field(..., alias="extraArgs")
     extra_env: Optional[list[IntegrationSpecExtraEnvV1]] = Field(..., alias="extraEnv")
     internal_certificates: Optional[bool] = Field(..., alias="internalCertificates")

--- a/reconcile/integrations_manager.py
+++ b/reconcile/integrations_manager.py
@@ -123,14 +123,15 @@ class HelmValues(BaseModel):
     cronjobs: list[HelmIntegrationSpec] = []
 
 
-def build_helm_values(specs: Iterable[HelmIntegrationSpec]):
+def build_helm_values(specs: Iterable[HelmIntegrationSpec]) -> dict:
     values = HelmValues()
     for s in specs:
         if s.cron:
             values.cronjobs.append(s)
         else:
             values.integrations.append(s)
-    return values
+
+    return values.dict(exclude_none=True, by_alias=True)
 
 
 class IntegrationsEnvironment(BaseModel):
@@ -170,7 +171,7 @@ def construct_oc_resources(
     # Generate the openshift template with the helm chart. The resulting template
     # contains all the integrations in the environment
     values = build_helm_values(integrations_environment.integration_specs)
-    template = helm.template(values.dict(exclude_none=True, by_alias=True))
+    template = helm.template(values)
 
     parameters = collect_parameters(
         template,

--- a/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
@@ -92,7 +92,7 @@ objects:
             mountPath: /fluentd/etc/
         containers:
         - name: int
-          image: ${IMAGE}:oofrab
+          image: ${IMAGE}:${IMAGE_TAG}
           ports:
             - name: http
               containerPort: 9090

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -210,7 +210,7 @@ def test_build_helm_values_empty():
         "cronjobs": [],
     }
     values = intop.build_helm_values(integrations_specs)
-    assert values.dict(exclude_none=True) == expected
+    assert values == expected
 
 
 def test_build_helm_values(
@@ -227,7 +227,7 @@ def test_build_helm_values(
         "integrations": [
             {
                 "name": "basic-integration",
-                "extra_args": "integ-extra-arg",
+                "extraArgs": "integ-extra-arg",
                 "resources": resources,
                 "shard_specs": [],
             },
@@ -236,14 +236,14 @@ def test_build_helm_values(
             {
                 "name": "cron1",
                 "cron": "yup",
-                "extra_args": "integ-extra-arg",
+                "extraArgs": "integ-extra-arg",
                 "resources": resources,
                 "shard_specs": [],
             },
         ],
     }
     values = intop.build_helm_values(integrations_specs)
-    assert values.dict(exclude_none=True) == expected
+    assert values == expected
 
 
 # Per-AWS-account Tests

--- a/reconcile/test/test_utils_helm.py
+++ b/reconcile/test/test_utils_helm.py
@@ -1,6 +1,21 @@
+from collections.abc import (
+    Callable,
+    Sequence,
+)
+
 import pytest
 import yaml
 
+from reconcile.gql_definitions.integrations.integrations import (
+    AWSAccountShardSpecOverrideV1,
+    IntegrationSpecExtraEnvV1,
+    IntegrationSpecLogsV1,
+)
+from reconcile.integrations_manager import (
+    HelmIntegrationSpec,
+    ShardSpec,
+    build_helm_values,
+)
 from reconcile.utils import helm
 
 from .fixtures import Fixtures
@@ -9,305 +24,395 @@ fxt = Fixtures("helm")
 
 
 @pytest.fixture
-def values():
-    return {
-        "integrations": [
-            {
-                "name": "integ",
-                "resources": {
-                    "requests": {
-                        "cpu": "123",
-                        "memory": "45Mi",
-                    },
-                    "limits": {
-                        "cpu": "678",
-                        "memory": "90Mi",
-                    },
+def helm_integration_specs(
+    gql_class_factory: Callable[..., HelmIntegrationSpec]
+) -> list[HelmIntegrationSpec]:
+    i1 = gql_class_factory(
+        HelmIntegrationSpec,
+        {
+            "name": "integ",
+            "resources": {
+                "requests": {
+                    "cpu": "123",
+                    "memory": "45Mi",
                 },
-                "shard_specs": [
-                    {
-                        "shard_id": "0",
-                        "shards": "1",
-                        "shard_name_suffix": "",
-                    }
-                ],
-            }
-        ]
-    }
+                "limits": {
+                    "cpu": "678",
+                    "memory": "90Mi",
+                },
+            },
+            "shard_specs": [
+                {
+                    "shard_id": "0",
+                    "shards": "1",
+                    "shard_name_suffix": "",
+                }
+            ],
+        },
+    )
+    return [i1]
 
 
-def test_template_basic(values):
-    template = helm.template(values)
+def test_template_basic(helm_integration_specs: Sequence[HelmIntegrationSpec]):
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("basic.yml"))
     assert template == expected
 
 
-def test_template_cache(values):
-    values["integrations"][0]["cache"] = True
-    template = helm.template(values)
+def test_template_cache(helm_integration_specs: Sequence[HelmIntegrationSpec]):
+    helm_integration_specs[0].cache = True
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("cache.yml"))
     assert template == expected
 
 
-def test_template_command(values):
-    values["integrations"][0]["command"] = "app-interface-reporter"
-    template = helm.template(values)
+def test_template_command(helm_integration_specs: Sequence[HelmIntegrationSpec]):
+    helm_integration_specs[0].command = "app-interface-reporter"
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("command.yml"))
     assert template == expected
 
 
-def test_template_disable_unleash(values):
-    values["integrations"][0]["disableUnleash"] = True
-    template = helm.template(values)
+def test_template_disable_unleash(
+    helm_integration_specs: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs[0].disable_unleash = True
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("disable_unleash.yml"))
     assert template == expected
 
 
-def test_template_enable_google_chat(values):
-    values["integrations"][0]["logs"] = {"googleChat": True}
-    template = helm.template(values)
+def test_template_enable_google_chat(
+    helm_integration_specs: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs[0].logs = IntegrationSpecLogsV1(slack=None, googleChat=True)
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("enable_google_chat.yml"))
     assert template == expected
 
 
-def test_template_extra_args(values):
-    values["integrations"][0]["shard_specs"][0]["extra_args"] = "--test-extra-args"
-    template = helm.template(values)
+def test_template_extra_args(helm_integration_specs: Sequence[HelmIntegrationSpec]):
+    helm_integration_specs[0].shard_specs[0].extra_args = "--test-extra-args"
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("extra_args.yml"))
     assert template == expected
 
 
-def test_template_extra_env(values):
-    values["integrations"][0]["extraEnv"] = [
-        {
-            "secretName": "secret",
-            "secretKey": "key",
-        },
-        {
-            "name": "name",
-            "value": "value",
-        },
+def test_template_extra_env(helm_integration_specs: Sequence[HelmIntegrationSpec]):
+    helm_integration_specs[0].extra_env = [
+        IntegrationSpecExtraEnvV1(
+            name=None, value=None, secretName="secret", secretKey="key"
+        ),
+        IntegrationSpecExtraEnvV1(
+            name="name",
+            value="value",
+            secretName=None,
+            secretKey=None,
+        ),
     ]
-    template = helm.template(values)
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("extra_env.yml"))
     assert template == expected
 
 
-def test_template_internal_certificates(values):
-    values["integrations"][0]["internalCertificates"] = True
-    template = helm.template(values)
+def test_template_internal_certificates(
+    helm_integration_specs: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs[0].internal_certificates = True
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("internal_certificates.yml"))
     assert template == expected
 
 
-def test_template_logs_slack(values):
-    values["integrations"][0]["logs"] = {"slack": True}
-    template = helm.template(values)
+def test_template_logs_slack(helm_integration_specs: Sequence[HelmIntegrationSpec]):
+    helm_integration_specs[0].logs = IntegrationSpecLogsV1(slack=True, googleChat=None)
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("logs_slack.yml"))
     assert template == expected
 
 
-def test_template_shards(values):
-    values["integrations"][0]["shard_specs"] = [
-        {
-            "shard_id": "0",
-            "shards": "2",
-            "shard_name_suffix": "-0",
-        },
-        {
-            "shard_id": "1",
-            "shards": "2",
-            "shard_name_suffix": "-1",
-        },
+def test_template_shards(
+    gql_class_factory: Callable[..., ShardSpec],
+    helm_integration_specs: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs[0].shard_specs = [
+        gql_class_factory(
+            ShardSpec,
+            {
+                "shard_id": "0",
+                "shards": "2",
+                "shard_name_suffix": "-0",
+            },
+        ),
+        gql_class_factory(
+            ShardSpec,
+            {
+                "shard_id": "1",
+                "shards": "2",
+                "shard_name_suffix": "-1",
+            },
+        ),
     ]
-    template = helm.template(values)
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("shards.yml"))
     assert template == expected
 
 
-def test_template_aws_account_shards(values):
-    values["integrations"][0]["shard_specs"] = [
-        {
-            "shard_id": "0",
-            "shards": "2",
-            "shard_name_suffix": "-acc-1",
-            "extra_args": "--account-name acc-1",
-        },
-        {
-            "shard_id": "1",
-            "shards": "2",
-            "shard_name_suffix": "-acc-2",
-            "extra_args": "--account-name acc-2",
-        },
+def test_template_aws_account_shards(
+    gql_class_factory: Callable[..., ShardSpec],
+    helm_integration_specs: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs[0].shard_specs = [
+        gql_class_factory(
+            ShardSpec,
+            {
+                "shard_id": "0",
+                "shards": "2",
+                "shard_name_suffix": "-acc-1",
+                "extra_args": "--account-name acc-1",
+            },
+        ),
+        gql_class_factory(
+            ShardSpec,
+            {
+                "shard_id": "1",
+                "shards": "2",
+                "shard_name_suffix": "-acc-2",
+                "extra_args": "--account-name acc-2",
+            },
+        ),
     ]
-    template = helm.template(values)
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("aws_account_shards.yml"))
     assert template == expected
 
 
-def test_template_aws_account_shard_spec_override(values):
-    values["integrations"][0]["imageRef"] = "oofrab"
-    values["integrations"][0]["shard_specs"] = [
+@pytest.fixture
+def aws_shard_spec_override(
+    gql_class_factory: Callable[..., AWSAccountShardSpecOverrideV1]
+) -> AWSAccountShardSpecOverrideV1:
+    return gql_class_factory(
+        AWSAccountShardSpecOverrideV1,
         {
-            "shard_id": "0",
-            "shards": "2",
-            "shard_name_suffix": "-acc-1",
-            "extra_args": "--account-name acc-1",
-        },
-        {
-            "shard_id": "1",
-            "shards": "2",
-            "shard_name_suffix": "-acc-2",
-            "extra_args": "--account-name acc-2",
-            "shard_spec_overrides": {
-                "image_ref": "foobar",
-                "resources": {
-                    "requests": {"cpu": "200m", "memory": "200Mi"},
-                    "limits": {"cpu": "300m", "memory": "300Mi"},
-                },
+            "shard": {"name": "acc-2"},
+            "imageRef": "foobar",
+            "resources": {
+                "requests": {"cpu": "200m", "memory": "200Mi"},
+                "limits": {"cpu": "300m", "memory": "300Mi"},
             },
         },
+    )
+
+
+def test_template_aws_account_shard_spec_override(
+    aws_shard_spec_override,
+    gql_class_factory: Callable[..., ShardSpec],
+    helm_integration_specs: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs[0].shard_specs = [
+        gql_class_factory(
+            ShardSpec,
+            {
+                "shard_id": "0",
+                "shards": "2",
+                "shard_name_suffix": "-acc-1",
+                "extra_args": "--account-name acc-1",
+            },
+        ),
+        gql_class_factory(
+            ShardSpec,
+            {
+                "shard_id": "1",
+                "shards": "2",
+                "shard_name_suffix": "-acc-2",
+                "extra_args": "--account-name acc-2",
+            },
+        ),
     ]
-    template = helm.template(values)
+
+    helm_integration_specs[0].shard_specs[
+        1
+    ].shard_spec_overrides = aws_shard_spec_override
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("aws_account_shard_spec_override.yml"))
     assert template == expected
 
 
-def test_template_aws_account_shard_disabled(values):
-    values["integrations"][0]["shard_specs"] = [
-        {
-            "shard_id": "0",
-            "shards": "2",
-            "shard_name_suffix": "-acc-1",
-            "extra_args": "--account-name acc-1",
-        },
-        {
-            "shard_id": "1",
-            "shards": "2",
-            "shard_name_suffix": "-acc-2",
-            "extra_args": "--account-name acc-2",
-            "shard_spec_overrides": {"disabled": True},
-        },
+def test_template_aws_account_shard_disabled(
+    aws_shard_spec_override: AWSAccountShardSpecOverrideV1,
+    gql_class_factory: Callable[..., ShardSpec],
+    helm_integration_specs: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs[0].shard_specs = [
+        gql_class_factory(
+            ShardSpec,
+            {
+                "shard_id": "0",
+                "shards": "2",
+                "shard_name_suffix": "-acc-1",
+                "extra_args": "--account-name acc-1",
+            },
+        ),
+        gql_class_factory(
+            ShardSpec,
+            {
+                "shard_id": "1",
+                "shards": "2",
+                "shard_name_suffix": "-acc-2",
+                "extra_args": "--account-name acc-2",
+            },
+        ),
     ]
-    template = helm.template(values)
+    aws_shard_spec_override.image_ref = None
+    aws_shard_spec_override.resources = None
+    aws_shard_spec_override.disabled = True
+
+    helm_integration_specs[0].shard_specs[
+        1
+    ].shard_spec_overrides = aws_shard_spec_override
+
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("aws_account_shard_disabled.yml"))
     assert template == expected
 
 
-def test_template_sleep_duration(values):
-    values["integrations"][0]["sleepDurationSecs"] = 29
-    template = helm.template(values)
+def test_template_sleep_duration(helm_integration_specs: Sequence[HelmIntegrationSpec]):
+    helm_integration_specs[0].sleep_duration_secs = "29"
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("sleep_duration.yml"))
     assert template == expected
 
 
-def test_template_state(values):
-    values["integrations"][0]["state"] = True
-    template = helm.template(values)
+def test_template_state(helm_integration_specs: Sequence[HelmIntegrationSpec]):
+    helm_integration_specs[0].state = True
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("state.yml"))
     assert template == expected
 
 
-def test_template_storage(values):
-    values["integrations"][0]["storage"] = "13Mi"
-    template = helm.template(values)
+def test_template_storage(helm_integration_specs: Sequence[HelmIntegrationSpec]):
+    helm_integration_specs[0].storage = "13Mi"
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("storage.yml"))
     assert template == expected
 
 
-def test_template_trigger(values):
-    values["integrations"][0]["trigger"] = True
-    template = helm.template(values)
+def test_template_trigger(helm_integration_specs: Sequence[HelmIntegrationSpec]):
+    helm_integration_specs[0].trigger = True
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("trigger.yml"))
     assert template == expected
 
 
-def test_template_exclude_service(values):
+def test_template_exclude_service(
+    helm_integration_specs: Sequence[HelmIntegrationSpec],
+):
+    values = build_helm_values(helm_integration_specs)
     values["excludeService"] = True
     template = helm.template(values)
     expected = yaml.safe_load(fxt.get("exclude_service.yml"))
     assert template == expected
 
 
-def test_template_integrations_manager(values):
-    values["integrations"][0]["name"] = "integrations-manager"
-    template = helm.template(values)
+def test_template_integrations_manager(
+    helm_integration_specs: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs[0].name = "integrations-manager"
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("integrations_manager.yml"))
     assert template == expected
 
 
-def test_template_environment_aware(values):
-    values["integrations"][0]["environmentAware"] = True
-    template = helm.template(values)
+def test_template_environment_aware(
+    helm_integration_specs: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs[0].environment_aware = True
+    template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("environment_aware.yml"))
     assert template == expected
 
 
 @pytest.fixture
-def values_cron():
-    return {
-        "cronjobs": [
-            {
-                "name": "integ",
-                "resources": {
-                    "requests": {
-                        "cpu": "123",
-                        "memory": "45Mi",
-                    },
-                    "limits": {
-                        "cpu": "678",
-                        "memory": "90Mi",
-                    },
+def helm_integration_specs_cron(
+    gql_class_factory: Callable[..., HelmIntegrationSpec]
+) -> list[HelmIntegrationSpec]:
+    c1 = gql_class_factory(
+        HelmIntegrationSpec,
+        {
+            "name": "integ",
+            "resources": {
+                "requests": {
+                    "cpu": "123",
+                    "memory": "45Mi",
                 },
-                "cron": "* * * * *",
-            }
-        ]
-    }
+                "limits": {
+                    "cpu": "678",
+                    "memory": "90Mi",
+                },
+            },
+            "cron": "* * * * *",
+        },
+    )
+    return [c1]
 
 
-def test_template_cron(values_cron):
-    template = helm.template(values_cron)
+def test_template_cron(
+    helm_integration_specs_cron: Sequence[HelmIntegrationSpec],
+):
+    template = helm.template(build_helm_values(helm_integration_specs_cron))
     expected = yaml.safe_load(fxt.get("cron.yml"))
     assert template == expected
 
 
-def test_template_cron_dashdotdb(values_cron):
-    values_cron["cronjobs"][0]["dashdotdb"] = True
-    template = helm.template(values_cron)
+def test_template_cron_dashdotdb(
+    helm_integration_specs_cron: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs_cron[0].dashdotdb = True
+    template = helm.template(build_helm_values(helm_integration_specs_cron))
     expected = yaml.safe_load(fxt.get("dashdotdb.yml"))
     assert template == expected
 
 
-def test_template_cron_concurrency_policy(values_cron):
-    values_cron["cronjobs"][0]["concurrencyPolicy"] = "Forbid"
-    template = helm.template(values_cron)
+def test_template_cron_concurrency_policy(
+    helm_integration_specs_cron: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs_cron[0].concurrency_policy = "Forbid"
+    template = helm.template(build_helm_values(helm_integration_specs_cron))
     expected = yaml.safe_load(fxt.get("concurrency_policy.yml"))
     assert template == expected
 
 
-def test_template_cron_restart_policy(values_cron):
-    values_cron["cronjobs"][0]["restartPolicy"] = "Always"
-    template = helm.template(values_cron)
+def test_template_cron_restart_policy(
+    helm_integration_specs_cron: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs_cron[0].restart_policy = "Always"
+    template = helm.template(build_helm_values(helm_integration_specs_cron))
     expected = yaml.safe_load(fxt.get("restart_policy.yml"))
     assert template == expected
 
 
-def test_template_cron_success_history(values_cron):
-    values_cron["cronjobs"][0]["successfulJobHistoryLimit"] = 42
-    template = helm.template(values_cron)
+def test_template_cron_success_history(
+    helm_integration_specs_cron: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs_cron[0].successful_job_history_limit = 42
+    template = helm.template(build_helm_values(helm_integration_specs_cron))
     expected = yaml.safe_load(fxt.get("success_history.yml"))
     assert template == expected
 
 
-def test_template_cron_failure_history(values_cron):
-    values_cron["cronjobs"][0]["failedJobHistoryLimit"] = 24
-    template = helm.template(values_cron)
+def test_template_cron_failure_history(
+    helm_integration_specs_cron: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs_cron[0].failed_job_history_limit = 24
+    template = helm.template(build_helm_values(helm_integration_specs_cron))
     expected = yaml.safe_load(fxt.get("failure_history.yml"))
     assert template == expected
 
 
-def test_template_cron_enable_pushgateway(values_cron):
-    values_cron["cronjobs"][0]["enablePushgateway"] = True
-    template = helm.template(values_cron)
+def test_template_cron_enable_pushgateway(
+    helm_integration_specs_cron: Sequence[HelmIntegrationSpec],
+):
+    helm_integration_specs_cron[0].enable_pushgateway = True
+    template = helm.template(build_helm_values(helm_integration_specs_cron))
     expected = yaml.safe_load(fxt.get("enable_pushgateway.yml"))
     assert template == expected


### PR DESCRIPTION
This fix addresses a bug where the `shardSpecOverride.imageRef` is not picked up to as the image for a shard. The main problem is that the helm template uses AWSShardSpecOverride.image_ref attribute instead of the alias `imageRef`. 

This change also includes a refactor over all the helm tests using the generated pedantic classes instead of dictionaries. This issue was not caught in the tests because of that. 

APPSRE-7982
