### PR TITLE
[rhidp-sso-client] do not depend on cluster OCM relation

### DIFF
--- a/reconcile/rhidp/common.py
+++ b/reconcile/rhidp/common.py
@@ -99,7 +99,10 @@ def build_cluster_obj(
 
 
 def get_clusters(
-    integration_name: str, query_func: Callable, default_issuer_url: str
+    integration_name: str,
+    query_func: Callable,
+    default_issuer_url: str,
+    exclude_clusters_without_ocm: bool = True,
 ) -> list[ClusterV1]:
     """Get all clusters from AppInterface."""
     data = cluster_query(query_func, variables={})
@@ -109,7 +112,7 @@ def get_clusters(
         if not integration_is_enabled(integration_name, c):
             # integration disabled for this particular cluster
             continue
-        if c.ocm is None:
+        if c.ocm is None and exclude_clusters_without_ocm:
             # no ocm relation
             continue
         if not [auth for auth in c.auth if isinstance(auth, ClusterAuthOIDCV1)]:

--- a/reconcile/rhidp/sso_client/base.py
+++ b/reconcile/rhidp/sso_client/base.py
@@ -151,15 +151,11 @@ def fetch_desired_state(
     desired_sso_clients = {}
     for cluster in clusters:
         for auth in cluster.auth:
-            if (
-                not isinstance(auth, ClusterAuthOIDCV1)
-                or not auth.issuer
-                or not cluster.ocm
-            ):
+            if not isinstance(auth, ClusterAuthOIDCV1) or not auth.issuer:
                 # this cannot happen, these attributes are set via cluster retrieval method - just make mypy happy
                 continue
             cid = cluster_vault_secret_id(
-                org_id=cluster.ocm.org_id,
+                org_id=cluster.ocm.org_id if cluster.ocm else "unknown",
                 cluster_name=cluster.name,
                 auth_name=auth.name,
             )
@@ -216,7 +212,7 @@ def create_sso_client(
     vault_input_path: str,
 ) -> None:
     """Create an SSO client and store SSO client data in Vault."""
-    if not auth.issuer or not cluster.ocm:
+    if not auth.issuer:
         # this cannot happen, these attributes are set via cluster retrieval method - just make mypy happy
         return
 

--- a/reconcile/rhidp/sso_client/integration.py
+++ b/reconcile/rhidp/sso_client/integration.py
@@ -58,7 +58,12 @@ class SSOClientIntegration(
         )
 
     def get_clusters(self, query_func: Callable) -> list[ClusterV1]:
-        return get_clusters(self.name, query_func, self.params.default_auth_issuer_url)
+        return get_clusters(
+            self.name,
+            query_func,
+            self.params.default_auth_issuer_url,
+            exclude_clusters_without_ocm=False,
+        )
 
     def get_early_exit_desired_state(self) -> Optional[dict[str, Any]]:
         gqlapi = gql.get_api()

--- a/reconcile/test/fixtures/rhidp/clusters.yml
+++ b/reconcile/test/fixtures/rhidp/clusters.yml
@@ -145,7 +145,7 @@ clusters:
     disable: null
     auth:
       - service: github-org-team
-  # no ocm - must be ignored
+  # no ocm - must be ignored by ocm-oidc-idp but not by rhidp-sso-client
   - name: cluster-5
     ocm: null
     consoleUrl: "https://console.url.com"

--- a/reconcile/test/rhidp/conftest.py
+++ b/reconcile/test/rhidp/conftest.py
@@ -8,6 +8,7 @@ from pytest_mock import MockerFixture
 from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.gql_definitions.rhidp.clusters import ClusterV1
+from reconcile.gql_definitions.rhidp.clusters import query as cluster_query
 from reconcile.ocm.types import OCMOidcIdp
 from reconcile.rhidp import common
 from reconcile.rhidp.ocm_oidc_idp import integration
@@ -41,8 +42,26 @@ def clusters(cluster_query_func: Callable) -> list[ClusterV1]:
 
 
 @pytest.fixture
-def clusters_to_act_on(clusters: list[ClusterV1]) -> list[ClusterV1]:
-    return [c for c in clusters if c.name in ["cluster-1", "cluster-2", "cluster-3"]]
+def all_clusters(cluster_query_func: Callable) -> list[ClusterV1]:
+    return cluster_query(cluster_query_func).clusters or []
+
+
+@pytest.fixture
+def ocm_oidc_idp_clusters_to_act_on(all_clusters: list[ClusterV1]) -> list[ClusterV1]:
+    return [
+        c for c in all_clusters if c.name in ["cluster-1", "cluster-2", "cluster-3"]
+    ]
+
+
+@pytest.fixture
+def rhidp_sso_client_clusters_to_act_on(
+    all_clusters: list[ClusterV1],
+) -> list[ClusterV1]:
+    return [
+        c
+        for c in all_clusters
+        if c.name in ["cluster-1", "cluster-2", "cluster-3", "cluster-5"]
+    ]
 
 
 @pytest.fixture

--- a/reconcile/test/rhidp/test_ocm_oidc_idp_integration.py
+++ b/reconcile/test/rhidp/test_ocm_oidc_idp_integration.py
@@ -8,11 +8,11 @@ from reconcile.rhidp.ocm_oidc_idp.integration import (
 
 
 def test_ocm_oidc_idp_integration_get_clusters(
-    cluster_query_func: Callable, clusters_to_act_on: list[ClusterV1]
+    cluster_query_func: Callable, ocm_oidc_idp_clusters_to_act_on: list[ClusterV1]
 ) -> None:
     intg = OCMOidcIdpIntegration(
         OCMOidcIdpIntegrationParams(
             vault_input_path="foo/bar", default_auth_issuer_url="https://issuer.com"
         )
     )
-    assert intg.get_clusters(cluster_query_func) == clusters_to_act_on
+    assert intg.get_clusters(cluster_query_func) == ocm_oidc_idp_clusters_to_act_on

--- a/reconcile/test/rhidp/test_sso_client_integration.py
+++ b/reconcile/test/rhidp/test_sso_client_integration.py
@@ -7,8 +7,8 @@ from reconcile.rhidp.sso_client.integration import (
 )
 
 
-def test_ocm_oidc_idp_integration_get_clusters(
-    cluster_query_func: Callable, clusters_to_act_on: list[ClusterV1]
+def test_rhidp_sso_client_integration_get_clusters(
+    cluster_query_func: Callable, rhidp_sso_client_clusters_to_act_on: list[ClusterV1]
 ) -> None:
     intg = SSOClientIntegration(
         SSOClientIntegrationParams(
@@ -18,4 +18,4 @@ def test_ocm_oidc_idp_integration_get_clusters(
             contacts=["email@foobar.com"],
         )
     )
-    assert intg.get_clusters(cluster_query_func) == clusters_to_act_on
+    assert intg.get_clusters(cluster_query_func) == rhidp_sso_client_clusters_to_act_on


### PR DESCRIPTION
The `rhidp-sso-client` doesn't act on OCM; it just uses the `cluster.ocm.org_id` to store the SSO client data in a unique Vault path. We want to use the app-interface flavor for clusters w/o an OCM relation; all cluster names are unique within an app-interface instance; therefore, we can use a static "fake" ocm org id instead.

Ticket: [APPSRE-7986](https://issues.redhat.com/browse/APPSRE-7986)