### PR TITLE
Reduce gitlab api calls for gitlab_housekeeping

### DIFF
--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -7,13 +7,16 @@ from unittest.mock import (
     patch,
 )
 
+import pytest
 from gitlab import Gitlab
 from gitlab.v4.objects import (
     Project,
     ProjectCommit,
     ProjectCommitManager,
     ProjectMergeRequest,
+    ProjectMergeRequestResourceLabelEvent,
 )
+from pytest_mock import MockerFixture
 
 import reconcile.gitlab_housekeeping as gl_h
 from reconcile.test.fixtures import Fixtures
@@ -126,3 +129,157 @@ def test_is_rebase():
         expected_sha,
         expected_head,
     )
+
+
+@pytest.fixture
+def repo_gitlab_housekeeping() -> dict:
+    return {
+        "url": "https://gitlab.com/org/repo",
+        "housekeeping": {
+            "enabled": True,
+            "rebase": False,
+            "enable_closing": True,
+        },
+    }
+
+
+def test_dry_run(
+    mocker: MockerFixture,
+    repo_gitlab_housekeeping: dict,
+) -> None:
+    mocked_queries = mocker.patch("reconcile.gitlab_housekeeping.queries")
+    mocked_queries.get_repos_gitlab_housekeeping.return_value = [
+        repo_gitlab_housekeeping,
+    ]
+    mocked_gitlab_api = mocker.patch(
+        "reconcile.gitlab_housekeeping.GitLabApi", autospec=True
+    ).return_value.__enter__.return_value
+
+    gl_h.run(True, False)
+
+    mocked_gitlab_api.get_issues.assert_called_once_with(state="opened")
+    mocked_gitlab_api.get_merge_requests.assert_called_once_with(state="opened")
+
+
+@pytest.fixture
+def project() -> Project:
+    project = create_autospec(Project)
+    project.id = "some-id"
+    project.name = "some-name"
+    return project
+
+
+@pytest.fixture
+def can_be_merged_merge_request() -> ProjectMergeRequest:
+    mr = create_autospec(ProjectMergeRequest)
+    mr.merge_status = "can_be_merged"
+    mr.work_in_progress = False
+    mr.commits.return_value = [create_autospec(ProjectCommit)]
+    mr.attributes = {
+        "labels": ["lgtm"],
+    }
+    mr.iid = 1
+    mr.target_project_id = 3
+    mr.author = {"username": "user"}
+    return mr
+
+
+@pytest.fixture
+def add_lgtm_merge_request_resource_label_event() -> (
+    ProjectMergeRequestResourceLabelEvent
+):
+    event = create_autospec(ProjectMergeRequestResourceLabelEvent)
+    event.action = "add"
+    event.label = {"name": "lgtm"}
+    event.user = {"username": "user"}
+    event.created_at = "2023-01-01T00:00:00.0Z"
+    return event
+
+
+@pytest.fixture
+def success_merge_request_pipeline() -> dict:
+    return {
+        "status": "success",
+    }
+
+
+def test_merge_merge_requests(
+    project: Project,
+    can_be_merged_merge_request: ProjectMergeRequest,
+    add_lgtm_merge_request_resource_label_event: ProjectMergeRequestResourceLabelEvent,
+    success_merge_request_pipeline: dict,
+) -> None:
+    mocked_gl = create_autospec(GitLabApi)
+    mocked_gl.project = project
+    mocked_gl.get_merge_request_label_events.return_value = [
+        add_lgtm_merge_request_resource_label_event
+    ]
+    mocked_gl.get_merge_request_pipelines.return_value = [
+        success_merge_request_pipeline
+    ]
+
+    gl_h.merge_merge_requests(
+        False,
+        mocked_gl,
+        [can_be_merged_merge_request],
+        gl_h.ReloadToggle(reload=False),
+        1,
+        False,
+        pipeline_timeout=None,
+        insist=True,
+        wait_for_pipeline=False,
+        gl_instance=None,
+        gl_settings=None,
+        users_allowed_to_label=None,
+    )
+
+    can_be_merged_merge_request.merge.assert_called_once()
+
+
+@pytest.fixture
+def running_merge_request_pipeline() -> dict:
+    return {
+        "status": "running",
+    }
+
+
+def test_merge_merge_requests_with_retry(
+    mocker: MockerFixture,
+    project: Project,
+    can_be_merged_merge_request: ProjectMergeRequest,
+    add_lgtm_merge_request_resource_label_event: ProjectMergeRequestResourceLabelEvent,
+    running_merge_request_pipeline: dict,
+) -> None:
+    mocker.patch("time.sleep")
+    mocked_gl = create_autospec(GitLabApi)
+    mocked_gl.project = project
+    mocked_gl.get_merge_requests.return_value = [can_be_merged_merge_request]
+    mocked_gl.get_merge_request_label_events.return_value = [
+        add_lgtm_merge_request_resource_label_event
+    ]
+    mocked_gl.get_merge_request_pipelines.return_value = [
+        running_merge_request_pipeline
+    ]
+
+    with pytest.raises(gl_h.InsistOnPipelineError) as e:
+        gl_h.merge_merge_requests(
+            False,
+            mocked_gl,
+            [can_be_merged_merge_request],
+            gl_h.ReloadToggle(reload=False),
+            1,
+            False,
+            pipeline_timeout=None,
+            insist=True,
+            wait_for_pipeline=True,
+            gl_instance=None,
+            gl_settings=None,
+            users_allowed_to_label=None,
+        )
+
+    assert (
+        f"Pipelines for merge request have not completed yet: {can_be_merged_merge_request.iid}"
+        == str(e.value)
+    )
+
+    assert mocked_gl.get_merge_requests.call_count == 9

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -159,6 +159,7 @@ def test_dry_run(
 
     mocked_gitlab_api.get_issues.assert_called_once_with(state="opened")
     mocked_gitlab_api.get_merge_requests.assert_called_once_with(state="opened")
+    mocked_gitlab_api.get_app_sre_group_users.assert_called_once_with()
 
 
 @pytest.fixture
@@ -225,6 +226,7 @@ def test_merge_merge_requests(
         gl_h.ReloadToggle(reload=False),
         1,
         False,
+        app_sre_usernames=set(),
         pipeline_timeout=None,
         insist=True,
         wait_for_pipeline=False,
@@ -269,6 +271,7 @@ def test_merge_merge_requests_with_retry(
             gl_h.ReloadToggle(reload=False),
             1,
             False,
+            app_sre_usernames=set(),
             pipeline_timeout=None,
             insist=True,
             wait_for_pipeline=True,
@@ -278,7 +281,7 @@ def test_merge_merge_requests_with_retry(
         )
 
     assert (
-        f"Pipelines for merge request have not completed yet: {can_be_merged_merge_request.iid}"
+        f"Pipelines for merge request in project 'some-name' have not completed yet: {can_be_merged_merge_request.iid}"
         == str(e.value)
     )
 


### PR DESCRIPTION
* fetch merge requests only once for project in happy path
* fetch app_sre_usernames only once per run


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8ffb800</samp>

Improved the gitlab housekeeping feature by refactoring the main logic, reducing API calls, and adding more tests.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 8ffb800</samp>

*  Refactor `run` function to query issues and merge requests only once and pass them to other functions as arguments ([link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L540-R603), [link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L549-R613), [link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L565-R632))
*  Refactor `merge_merge_requests` function to accept a list of project merge requests, a reload toggle, and a set of app-sre usernames as arguments, and to set the reload toggle to True after a successful merge ([link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L183-R203), [link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L449-R485), [link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520R519), [link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520R544))
*  Define a new dataclass `ReloadToggle` to store a boolean flag for reloading merge requests ([link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L2-R6), [link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520R104-R110))
*  Define a new function `preprocess_merge_requests` to extract the logic of preprocessing the merge requests from `get_merge_requests` function ([link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L278-R306))
*  Define a new function `get_app_sre_usernames` to return a set of usernames of the app-sre group users and cache the result ([link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L2-R6), [link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520R551-R554))
*  Add new imports to support the new features and refactoring of the code ([link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L2-R6), [link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-cfe12becadfed2850e5224ff99c1708b3c677b7bb6199636436dfa9c72e8474cL5-R22))
*  Add a new test function `test_dry_run` to test the behavior of the `run` function in dry-run mode ([link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-cfe12becadfed2850e5224ff99c1708b3c677b7bb6199636436dfa9c72e8474cR101-R257))
*  Define a new fixture `repo_gitlab_housekeeping` to return a sample repository configuration for the gitlab housekeeping feature ([link](https://github.com/app-sre/qontract-reconcile/pull/3682/files?diff=unified&w=0#diff-cfe12becadfed2850e5224ff99c1708b3c677b7bb6199636436dfa9c72e8474cR101-R257))
