### PR TITLE
[jenkins-job-builder] generate app_name field for each job

### DIFF
--- a/reconcile/jenkins_job_builder.py
+++ b/reconcile/jenkins_job_builder.py
@@ -20,6 +20,9 @@ QUERY = """
 {
   jenkins_configs: jenkins_configs_v1 {
     name
+    app {
+      name
+    }
     instance {
       name
       serverUrl

--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -77,8 +77,12 @@ class JJB:  # pylint: disable=too-many-public-methods
             config = c["config"]
             config_file_path = "{}/config.yaml".format(working_dirs[instance_name])
             if config:
+                content = yaml.load(config, Loader=yaml.FullLoader)
+                if c["type"] == "jobs":
+                    for item in content:
+                        item["project"]["app_name"] = c["app"]["name"]
                 with open(config_file_path, "a") as f:
-                    yaml.dump(yaml.load(config, Loader=yaml.FullLoader), f)
+                    yaml.dump(content, f)
                     f.write("\n")
             else:
                 config = c["config_path"]["content"]


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-7990

this PR adds an automatic generation of an `app_name` field that will be added to each job definition. this means that job templates can use the `app_name` to template content.