### PR TITLE
Log warn and error from terraform run

### DIFF
--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -561,12 +561,13 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         stdout, stderr = self.split_to_lines(stdout, stderr)
         with self._log_lock:
             for line in stdout:
-                if line.startswith("[WARN]"):
-                    logging.warning(line_format.format(name, cmd, line))
-                elif line.startswith("[ERROR]"):
-                    logging.error(line_format.format(name, cmd, line))
-                else:
-                    logging.debug(line_format.format(name, cmd, line))
+                match line.split():
+                    case ["[WARN]", *_]:
+                        logging.warning(line_format.format(name, cmd, line))
+                    case ["[ERROR]", *_]:
+                        logging.error(line_format.format(name, cmd, line))
+                    case _:
+                        logging.debug(line_format.format(name, cmd, line))
             if error_occured:
                 for line in stderr:
                     logging.error(line_format.format(name, cmd, line))


### PR DESCRIPTION
Log `[WARN]` and `[ERROR]` from terraform output, so we can get more details from unexpected errors.

[APPSRE-7884](https://issues.redhat.com/browse/APPSRE-7884)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f9f4e97</samp>

Added logging features and tests for `TerraformClient` class. This improves the visibility and error handling of the terraform operations performed by the class and its methods. The logging captures both the terraform log output and the provider logs. The tests cover the new `check_output` method that parses the log output.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f9f4e97</samp>

*  Add context manager to capture and handle terraform log output in `terraform_init`, `terraform_output`, `terraform_plan`, and `terraform_apply` methods of `TerraformClient` class ([link](https://github.com/app-sre/qontract-reconcile/pull/3689/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL116-R144), [link](https://github.com/app-sre/qontract-reconcile/pull/3689/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL135-R160), [link](https://github.com/app-sre/qontract-reconcile/pull/3689/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL175-R204), [link](https://github.com/app-sre/qontract-reconcile/pull/3689/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL383-R414))
*  Modify `check_output` method of `TerraformClient` class to accept log argument, split it into lines, match provider logs with warnings or errors, and simplify error flag logic ([link](https://github.com/app-sre/qontract-reconcile/pull/3689/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL556-R603))
*  Add constants for provider log regex pattern and terraform log level in `terraform_client.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3689/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfR48-R49))
*  Update imports in `terraform_client.py` and `test_utils_terraform_client.py` to include new modules and classes ([link](https://github.com/app-sre/qontract-reconcile/pull/3689/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL3-R14), [link](https://github.com/app-sre/qontract-reconcile/pull/3689/files?diff=unified&w=0#diff-9ce65893311aef81c9bbccde0dcc4c1d44037684b52fe82331cb5376cd4c95daL2-R17))
*  Extract account name as constant in `test_utils_terraform_client.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3689/files?diff=unified&w=0#diff-9ce65893311aef81c9bbccde0dcc4c1d44037684b52fe82331cb5376cd4c95daL22-R37))
*  Add tests for `check_output` method of `TerraformClient` class in `test_utils_terraform_client.py` using different scenarios of return code, stdout, stderr, and log ([link](https://github.com/app-sre/qontract-reconcile/pull/3689/files?diff=unified&w=0#diff-9ce65893311aef81c9bbccde0dcc4c1d44037684b52fe82331cb5376cd4c95daR653-R883))