### PR TITLE
Add filter option to get_cluster_addons

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -411,7 +411,9 @@ def fetch_upgrade_policies(
             sector = ocm.sectors[cluster.upgrade_policy.conditions.sector]
 
         if addons:
-            cluster_addons = ocm.get_cluster_addons(cluster_name, with_version=True)
+            cluster_addons = ocm.get_cluster_addons(
+                cluster_name, with_version=True, required_state="ready"
+            )
             for addon in cluster_addons:
                 ccaup = ConfiguredAddonUpgradePolicy.from_cluster_upgrade_spec(
                     cluster,

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -1655,7 +1655,10 @@ class OCM:  # pylint: disable=too-many-public-methods
         return self._post(api, {"version_gate": {"id": gate_id}})
 
     def get_cluster_addons(
-        self, cluster: str, with_version: bool = False
+        self,
+        cluster: str,
+        with_version: bool = False,
+        required_state: Optional[str] = None,
     ) -> list[dict[str, str]]:
         """Returns a list of Addons installed on a cluster
 
@@ -1673,6 +1676,9 @@ class OCM:  # pylint: disable=too-many-public-methods
             return results
 
         for item in items:
+            if required_state:
+                if item["state"] != required_state:
+                    continue
             result = {k: v for k, v in item.items() if k in CLUSTER_ADDON_DESIRED_KEYS}
             parameters = result.pop("parameters", None)
             if parameters is not None:


### PR DESCRIPTION
Make it possible to filter returned addons by state. Add filter to aus addon upgrade scheduler

Fixes bug: https://issues.redhat.com/browse/APPSRE-8011
