### PR TITLE
Temporarily remove insist feature

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -549,7 +549,8 @@ def run(dry_run, wait_for_pipeline):
                     limit,
                     rebase,
                     pipeline_timeout,
-                    insist=True,
+                    # TODO: set insist=True after gitlab issues cleared
+                    insist=False,
                     wait_for_pipeline=wait_for_pipeline,
                     gl_instance=instance,
                     gl_settings=settings,


### PR DESCRIPTION
Waiting for one pipeline requires ~1 minute. Potentially any pipeline in any repo can add to that. 
While this is considered a feature, we might want to disable this behavior while we run in degraded state in order to process app-interface MRs faster.