### PR TITLE
Log close_item only when enable_closing

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -179,15 +179,25 @@ def close_item(
     item_type: str,
     item: Union[ProjectIssue, ProjectMergeRequest],
 ):
-    logging.info(["close_item", gl.project.name, item_type, item.attributes.get("iid")])
     if enable_closing:
+        logging.info(
+            [
+                "close_item",
+                gl.project.name,
+                item_type,
+                item.attributes.get("iid"),
+            ]
+        )
         if not dry_run:
             gl.close(item)
     else:
         logging.debug(
-            "'close_item' action is not enabled. "
-            + "Please run the integration manually "
-            + "with the '--enable-deletion' flag."
+            [
+                "'enable_closing' is not enabled to close item",
+                gl.project.name,
+                item_type,
+                item.attributes.get("iid"),
+            ]
         )
 
 


### PR DESCRIPTION
`close_item` is logged even `enable_closing` is not True, appears as repeated logs.
This change moved info log to only run when `enable_closing` is True.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0116b41</samp>

Refactor and test `close_item` function in gitlab housekeeping. This improves the logging and the test coverage of the function that closes stale issues and merge requests.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0116b41</samp>

*  Refactor `close_item` function to log item details and closing action consistently ([link](https://github.com/app-sre/qontract-reconcile/pull/3693/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L182-R200))
* Add test cases for `close_item` function with different `enable_closing` values ([link](https://github.com/app-sre/qontract-reconcile/pull/3693/files?diff=unified&w=0#diff-cfe12becadfed2850e5224ff99c1708b3c677b7bb6199636436dfa9c72e8474cR16), [link](https://github.com/app-sre/qontract-reconcile/pull/3693/files?diff=unified&w=0#diff-cfe12becadfed2850e5224ff99c1708b3c677b7bb6199636436dfa9c72e8474cR290-R327))