### PR TITLE
[ocm] basic support for rosa non-sts clusters

### DIFF
--- a/reconcile/ocm/types.py
+++ b/reconcile/ocm/types.py
@@ -54,12 +54,19 @@ class OSDClusterSpec(OCMClusterSpec):
         extra = Extra.forbid
 
 
-class ROSAOcmAwsAttrs(BaseModel):
-    creator_role_arn: str
+class ROSAOcmAwsStsAttrs(BaseModel):
     installer_role_arn: str
     support_role_arn: str
     controlplane_role_arn: Optional[str]
     worker_role_arn: str
+
+    class Config:
+        extra = Extra.forbid
+
+
+class ROSAOcmAwsAttrs(BaseModel):
+    creator_role_arn: str
+    sts: Optional[ROSAOcmAwsStsAttrs]
 
     class Config:
         extra = Extra.forbid

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -158,10 +158,12 @@ def rosa_cluster_fxt():
                 "uid": "123123123",
                 "rosa": {
                     "creator_role_arn": "creator_role",
-                    "installer_role_arn": "installer_role",
-                    "support_role_arn": " support_role",
-                    "controlplane_role_arn": "controlplane_role",
-                    "worker_role_arn": "worker_role",
+                    "sts": {
+                        "installer_role_arn": "installer_role",
+                        "support_role_arn": " support_role",
+                        "controlplane_role_arn": "controlplane_role",
+                        "worker_role_arn": "worker_role",
+                    },
                 },
             },
             "id": "the-cluster-id",


### PR DESCRIPTION
This PR adds "read" support for non-sts ROSA clusters (clusters w/o an `aws.sts` attribute). No support for the creation of non-sts rosa clusters! Basically, it makes all arns in the `sts` attribute optional.

Ticket: [APPSRE-8040](https://issues.redhat.com/browse/APPSRE-8040)