### PR TITLE
Log tf warn error with monkey patch

### DIFF
--- a/reconcile/test/utils/test_terraform_client.py
+++ b/reconcile/test/utils/test_terraform_client.py
@@ -1,10 +1,20 @@
 import base64
+import tempfile
+from collections.abc import Callable
 from logging import DEBUG
 from operator import itemgetter
-from unittest.mock import create_autospec
+from unittest.mock import (
+    MagicMock,
+    create_autospec,
+)
 
 import pytest
 from botocore.errorfactory import ClientError
+from pytest_mock import MockerFixture
+from python_terraform import (
+    IsFlagged,
+    Terraform,
+)
 
 import reconcile.utils.terraform_client as tfclient
 from reconcile.utils.aws_api import AWSApi
@@ -19,9 +29,12 @@ def aws_api():
     return create_autospec(AWSApi)
 
 
+ACCOUNT_NAME = "a1"
+
+
 @pytest.fixture
 def tf(aws_api):
-    account = {"name": "a1", "deletionApprovals": []}
+    account = {"name": ACCOUNT_NAME, "deletionApprovals": []}
     return tfclient.TerraformClient(
         "integ", "v1", "integ_pfx", [account], {}, 1, aws_api
     )
@@ -636,4 +649,235 @@ def test_validate_db_upgrade_with_empty_valid_upgrade_targe_and_not_allow_major_
         "allow_major_version_upgrade is not enabled for upgrading RDS instance: "
         "test-database-1 to a new version when there is no valid upgrade target available."
         == str(error.value)
+    )
+
+
+def test_check_output_debug(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    result = tf.check_output("name", "cmd", 0, "out", "", "")
+
+    assert result is False
+    mocked_logging.debug.assert_called_once_with("[name - cmd] out")
+    mocked_logging.warning.assert_not_called()
+    mocked_logging.error.assert_not_called()
+
+
+def test_check_output_warning(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    result = tf.check_output("name", "cmd", 0, "out", "error", "")
+
+    assert result is False
+    mocked_logging.debug.assert_called_once_with("[name - cmd] out")
+    mocked_logging.warning.assert_called_once_with("[name - cmd] error")
+    mocked_logging.error.assert_not_called()
+
+
+def test_check_output_from_terraform_log(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    log = "2023-07-20T15:49:09.681+1000 [INFO] doing something"
+
+    result = tf.check_output("name", "cmd", 0, "", "", log)
+
+    assert result is False
+    mocked_logging.debug.assert_not_called()
+    mocked_logging.warning.assert_not_called()
+    mocked_logging.error.assert_not_called()
+
+
+def test_check_output_warning_from_provider_warn_log(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    log = (
+        "2023-07-20T15:49:09.681+1000 [INFO]  plugin.terraform-provider-aws_v3.76.0_x5: 2023/07/20 15:49:09 "
+        "[WARN] DB Instance (xxx) not found, removing from state: timestamp=2023-07-20T15:49:09.673+1000"
+    )
+
+    result = tf.check_output("name", "cmd", 0, "", "", log)
+
+    assert result is False
+    mocked_logging.debug.assert_not_called()
+    mocked_logging.warning.assert_called_once_with(f"[name - cmd] {log}")
+    mocked_logging.error.assert_not_called()
+
+
+def test_check_output_error_from_provider_error_log(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    log = (
+        "2023-07-20T15:49:09.681+1000 [INFO]  plugin.terraform-provider-aws_v3.76.0_x5: 2023/07/20 15:49:09 "
+        "[ERROR] something is wrong: timestamp=2023-07-20T15:49:09.673+1000"
+    )
+
+    result = tf.check_output("name", "cmd", 0, "", "", log)
+
+    assert result is False
+    mocked_logging.debug.assert_not_called()
+    mocked_logging.warning.assert_called_once_with(f"[name - cmd] {log}")
+    mocked_logging.error.assert_not_called()
+
+
+def test_check_output_error(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    result = tf.check_output("name", "cmd", 1, "", "error", "")
+
+    assert result is True
+    mocked_logging.debug.assert_not_called()
+    mocked_logging.warning.assert_not_called()
+    mocked_logging.error.assert_called_once_with("[name - cmd] error")
+
+
+@pytest.fixture
+def init_spec_builder() -> Callable[..., dict]:
+    def builder(name: str, working_dir: str) -> dict:
+        return {
+            "name": name,
+            "wd": working_dir,
+        }
+
+    return builder
+
+
+def test_terraform_init(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+    init_spec_builder: Callable[..., dict],
+) -> None:
+    mocked_tf = mocker.patch("reconcile.utils.terraform_client.Terraform")
+    mocked_tf.return_value.init.return_value = (0, "", "")
+    mocked_tempfile = mocker.patch("reconcile.utils.terraform_client.tempfile")
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+    warning_log = "[INFO] a [WARN]"
+    with mocked_tempfile.NamedTemporaryFile.return_value as f:
+        f.name = "temp-name"
+        f.read.return_value.decode.return_value = warning_log
+
+    with tempfile.TemporaryDirectory() as working_dir:
+        init_spec = init_spec_builder(ACCOUNT_NAME, working_dir)
+
+        tf.terraform_init(init_spec)
+
+    mocked_tf.assert_called_once_with(
+        working_dir=working_dir, is_env_vars_included=True
+    )
+    mocked_tf.return_value.init.assert_called_once_with()
+    mocked_logging.warning.assert_called_once_with(
+        f"[{ACCOUNT_NAME} - init] {warning_log}"
+    )
+
+
+@pytest.fixture
+def terraform_spec_builder() -> Callable[..., dict]:
+    def builder(name: str, working_dir: str) -> dict:
+        return {
+            "name": name,
+            "tf": create_autospec(Terraform, working_dir=working_dir),
+        }
+
+    return builder
+
+
+def test_terraform_output(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+    terraform_spec_builder: Callable[..., dict],
+) -> None:
+    mocked_tempfile = mocker.patch("reconcile.utils.terraform_client.tempfile")
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+    warning_log = "[INFO] a [WARN]"
+    with mocked_tempfile.NamedTemporaryFile.return_value as f:
+        f.name = "temp-name"
+        f.read.return_value.decode.return_value = warning_log
+
+    with tempfile.TemporaryDirectory() as working_dir:
+        spec = terraform_spec_builder(ACCOUNT_NAME, working_dir)
+        spec["tf"].output_cmd = MagicMock(return_value=(0, "{}", ""))
+
+        name, output = tf.terraform_output(spec)
+
+    assert name == ACCOUNT_NAME
+    assert output == {}
+    spec["tf"].output_cmd.assert_called_once_with(json=IsFlagged)
+    mocked_logging.warning.assert_called_once_with(
+        f"[{ACCOUNT_NAME} - output] {warning_log}"
+    )
+
+
+def test_terraform_plan(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+    terraform_spec_builder,
+) -> None:
+    mocked_lean_tf = mocker.patch("reconcile.utils.terraform_client.lean_tf")
+    mocked_lean_tf.show_json.return_value = {"format_version": "0.1"}
+    mocked_tempfile = mocker.patch("reconcile.utils.terraform_client.tempfile")
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+    warning_log = "[INFO] a [WARN]"
+    with mocked_tempfile.NamedTemporaryFile.return_value as f:
+        f.name = "temp-name"
+        f.read.return_value.decode.return_value = warning_log
+
+    with tempfile.TemporaryDirectory() as working_dir:
+        spec = terraform_spec_builder(ACCOUNT_NAME, working_dir)
+        spec["tf"].plan.return_value = (0, "", "")
+
+        disabled_deletion_detected, created_users, error = tf.terraform_plan(
+            spec,
+            False,
+        )
+
+    assert disabled_deletion_detected is False
+    assert created_users == []
+    assert error is False
+    spec["tf"].plan.assert_called_once_with(
+        detailed_exitcode=False, parallelism=tf.parallelism, out=ACCOUNT_NAME
+    )
+    mocked_logging.warning.assert_called_once_with(
+        f"[{ACCOUNT_NAME} - plan] {warning_log}"
+    )
+
+
+def test_terraform_apply(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+    terraform_spec_builder,
+) -> None:
+    mocked_tempfile = mocker.patch("reconcile.utils.terraform_client.tempfile")
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+    warning_log = "[INFO] a [WARN]"
+    with mocked_tempfile.NamedTemporaryFile.return_value as f:
+        f.name = "temp-name"
+        f.read.return_value.decode.return_value = warning_log
+
+    with tempfile.TemporaryDirectory() as working_dir:
+        spec = terraform_spec_builder(ACCOUNT_NAME, working_dir)
+        spec["tf"].apply.return_value = (0, "", "")
+
+        error = tf.terraform_apply(spec)
+
+    assert error is False
+    spec["tf"].apply.assert_called_once_with(dir_or_plan=ACCOUNT_NAME, var=None)
+    mocked_logging.warning.assert_called_once_with(
+        f"[{ACCOUNT_NAME} - apply] {warning_log}"
     )

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -1,11 +1,17 @@
 import json
 import logging
+import os
+import re
 import shutil
+import tempfile
+import typing
 from collections import defaultdict
 from collections.abc import (
+    Generator,
     Iterable,
     Mapping,
 )
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import (
     datetime,
@@ -39,6 +45,8 @@ from reconcile.utils.external_resource_spec import (
 
 ALLOWED_TF_SHOW_FORMAT_VERSION = "0.1"
 DATE_FORMAT = "%Y-%m-%d"
+PROVIDER_LOG_REGEX = r""".*(?:\[INFO]|\[WARN]|\[ERROR]).+(?:\[WARN]|\[ERROR]).*"""
+TERRAFORM_LOG_LEVEL = "TRACE"  # can change to INFO after tf 0.15
 
 
 @dataclass
@@ -113,13 +121,27 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         results = threaded.run(self.terraform_init, wd_specs, self.thread_pool_size)
         self.specs = [{"name": name, "tf": tf} for name, tf in results]
 
+    @staticmethod
+    @contextmanager
+    def _terraform_log_file(working_dir: str) -> Generator[typing.IO, None, None]:
+        with tempfile.NamedTemporaryFile(dir=working_dir) as f:
+            os.environ["TF_LOG"] = TERRAFORM_LOG_LEVEL
+            os.environ["TF_LOG_PATH"] = f.name
+            try:
+                yield f
+            finally:
+                del os.environ["TF_LOG"]
+                del os.environ["TF_LOG_PATH"]
+
     @retry(exceptions=TerraformCommandError)
     def terraform_init(self, init_spec):
         name = init_spec["name"]
         wd = init_spec["wd"]
-        tf = Terraform(working_dir=wd)
-        return_code, stdout, stderr = tf.init()
-        error = self.check_output(name, "init", return_code, stdout, stderr)
+        tf = Terraform(working_dir=wd, is_env_vars_included=True)
+        with self._terraform_log_file(tf.working_dir) as f:
+            return_code, stdout, stderr = tf.init()
+            log = f.read().decode("utf-8")
+        error = self.check_output(name, "init", return_code, stdout, stderr, log)
         if error:
             raise TerraformCommandError(return_code, "init", out=stdout, err=stderr)
         return name, tf
@@ -132,8 +154,10 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
     def terraform_output(self, spec):
         name = spec["name"]
         tf = spec["tf"]
-        return_code, stdout, stderr = tf.output_cmd(json=IsFlagged)
-        error = self.check_output(name, "output", return_code, stdout, stderr)
+        with self._terraform_log_file(tf.working_dir) as f:
+            return_code, stdout, stderr = tf.output_cmd(json=IsFlagged)
+            log = f.read().decode("utf-8")
+        error = self.check_output(name, "output", return_code, stdout, stderr, log)
         no_output_error = (
             "The module root could not be found. There is nothing to output."
         )
@@ -172,10 +196,12 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
     ) -> tuple[bool, list[AccountUser], bool]:
         name = plan_spec["name"]
         tf = plan_spec["tf"]
-        return_code, stdout, stderr = tf.plan(
-            detailed_exitcode=False, parallelism=self.parallelism, out=name
-        )
-        error = self.check_output(name, "plan", return_code, stdout, stderr)
+        with self._terraform_log_file(tf.working_dir) as f:
+            return_code, stdout, stderr = tf.plan(
+                detailed_exitcode=False, parallelism=self.parallelism, out=name
+            )
+            log = f.read().decode("utf-8")
+        error = self.check_output(name, "plan", return_code, stdout, stderr, log)
         disabled_deletion_detected, created_users = self.log_plan_diff(
             name, tf, enable_deletion
         )
@@ -380,10 +406,12 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
     def terraform_apply(self, apply_spec):
         name = apply_spec["name"]
         tf = apply_spec["tf"]
-        # adding var=None to allow applying the saved plan
-        # https://github.com/beelit94/python-terraform/issues/67
-        return_code, stdout, stderr = tf.apply(dir_or_plan=name, var=None)
-        error = self.check_output(name, "apply", return_code, stdout, stderr)
+        with self._terraform_log_file(tf.working_dir) as f:
+            # adding var=None to allow applying the saved plan
+            # https://github.com/beelit94/python-terraform/issues/67
+            return_code, stdout, stderr = tf.apply(dir_or_plan=name, var=None)
+            log = f.read().decode("utf-8")
+        error = self.check_output(name, "apply", return_code, stdout, stderr, log)
         return error
 
     def get_terraform_output_secrets(self) -> dict[str, dict[str, dict[str, str]]]:
@@ -553,22 +581,26 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         name: str,
         cmd: str,
         return_code: int,
-        stdout: list[str],
-        stderr: list[str],
+        stdout: str,
+        stderr: str,
+        log: str,
     ) -> bool:
-        error_occured = False
+        error_occured = return_code != 0
         line_format = "[{} - {}] {}"
-        stdout, stderr = self.split_to_lines(stdout, stderr)
+        stdout, stderr, log = self.split_to_lines(stdout, stderr, log)
+        provider_log_re = re.compile(PROVIDER_LOG_REGEX)
         with self._log_lock:
             for line in stdout:
                 logging.debug(line_format.format(name, cmd, line))
-            if return_code == 0:
-                for line in stderr:
-                    logging.warning(line_format.format(name, cmd, line))
-            else:
+            if error_occured:
                 for line in stderr:
                     logging.error(line_format.format(name, cmd, line))
-                error_occured = True
+            else:
+                for line in stderr:
+                    logging.warning(line_format.format(name, cmd, line))
+            for line in log:
+                if provider_log_re.match(line):
+                    logging.warning(line_format.format(name, cmd, line))
         return error_occured
 
     @staticmethod


### PR DESCRIPTION
Fix errors when used in multi-threaded env, main changes are from https://github.com/app-sre/qontract-reconcile/pull/3689, new monkey patch is in https://github.com/app-sre/qontract-reconcile/pull/3699/commits/400df23ca297615baf80feb08b7d018c25ca45c4.

To support this without monkey patch, we either have to change how `python-terraform` inject env or implement all methods in https://github.com/app-sre/qontract-reconcile/blob/24a81aa7a578d28795b37cf835207df3c0142406/reconcile/utils/lean_terraform_client.py

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 400df23</samp>

This pull request improves the testing and implementation of the `TerraformClient` class, which is used to run terraform commands and manage the terraform state for various integrations. It uses the `python_terraform` module to simplify the command execution and logging, and adds more tests for the `check_output` method in `reconcile/test/utils/test_terraform_client.py`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 400df23</samp>

*  Add new imports for modules and classes used in the new features and test cases ([link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-b3ecbf5e85f99cd579b16e0340930eb7183e47033610cf8a42fa7cc71e45c54aL2-R17), [link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL3-R14), [link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfR27))
* Define constants for the terraform log regex and log level ([link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfR49-R50))
* Add a lock attribute to the TerraformClient class to synchronize the access to the environment variables ([link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfR84))
* Modify the `init_specs`, `init_outputs`, and `plan` methods to use the `_monkey_patch_terraform_env` context manager, which patches the `os.environ.copy` method to release the lock before copying the environment variables ([link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL113-R173), [link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL128-R182), [link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL153-R215))
* Modify the `terraform_init`, `terraform_output`, `terraform_plan`, and `terraform_apply` methods to use the `_terraform_log_file` context manager, which creates a temporary file for the terraform log, sets the environment variables, and reads the log file after the command. It also passes the `is_env_vars_included` argument to the `Terraform` constructor, and the log file content to the `check_output` method ([link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL135-R192), [link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL175-R237), [link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL383-R450), [link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL556-R639))
* Modify the `check_output` method to accept the log file content as an argument, and to use the regex to match the log lines that contain warnings or errors from the terraform providers. It also changes the logging logic to only log errors if the return code is not zero, and to log warnings otherwise. It also changes the input types from lists to strings ([link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL556-R639))
* Define the `ACCOUNT_NAME` constant and use it in the `tf` fixture to avoid repeating the same string literal ([link](https://github.com/app-sre/qontract-reconcile/pull/3699/files?diff=unified&w=0#diff-b3ecbf5e85f99cd579b16e0340930eb7183e47033610cf8a42fa7cc71e45c54aL22-R37))