### PR TITLE
Refactor gitlab label management

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -372,9 +372,8 @@ def run(
             # e.g. gitlab-housekeeper rejects direct lgtm labels and the review-queue
             # skips MRs with this label
             if SELF_SERVICEABLE in labels:
-                gl.remove_label_from_merge_request(
-                    gitlab_merge_request_id, SELF_SERVICEABLE
-                )
+                merge_request = gl.get_merge_request(gitlab_merge_request_id)
+                gl.remove_label_from_merge_request(merge_request, SELF_SERVICEABLE)
 
     except BaseException:
         logging.error(traceback.format_exc())

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -373,7 +373,7 @@ def run(
             # skips MRs with this label
             if SELF_SERVICEABLE in labels:
                 merge_request = gl.get_merge_request(gitlab_merge_request_id)
-                gl.remove_label_from_merge_request(merge_request, SELF_SERVICEABLE)
+                gl.remove_label(merge_request, SELF_SERVICEABLE)
 
     except BaseException:
         logging.error(traceback.format_exc())

--- a/reconcile/gitlab_fork_compliance.py
+++ b/reconcile/gitlab_fork_compliance.py
@@ -80,7 +80,7 @@ class GitlabForkCompliance:
         # it is set
         mr_labels = self.gl_cli.get_merge_request_labels(self.mr.iid)
         if BLOCKED_BOT_ACCESS in mr_labels:
-            self.gl_cli.remove_label_from_merge_request(self.mr.iid, BLOCKED_BOT_ACCESS)
+            self.gl_cli.remove_label_from_merge_request(self.mr, BLOCKED_BOT_ACCESS)
 
         sys.exit(self.exit_code)
 

--- a/reconcile/gitlab_fork_compliance.py
+++ b/reconcile/gitlab_fork_compliance.py
@@ -80,7 +80,7 @@ class GitlabForkCompliance:
         # it is set
         mr_labels = self.gl_cli.get_merge_request_labels(self.mr.iid)
         if BLOCKED_BOT_ACCESS in mr_labels:
-            self.gl_cli.remove_label_from_merge_request(self.mr, BLOCKED_BOT_ACCESS)
+            self.gl_cli.remove_label(self.mr, BLOCKED_BOT_ACCESS)
 
         sys.exit(self.exit_code)
 

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -229,7 +229,7 @@ def handle_stale_items(
             if LABEL not in item.labels:
                 logging.info(["add_label", gl.project.name, item_type, item_iid, LABEL])
                 if not dry_run:
-                    gl.add_label(item, item_type, LABEL)
+                    gl.add_label(item, LABEL)
             # if item has 'stale' label - close it
             else:
                 close_item(dry_run, gl, enable_closing, item_type, item)

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -336,7 +336,7 @@ def preprocess_merge_requests(
                 + "suitable for self serviceable MRs. removing 'lgtm' label"
             )
             if not dry_run:
-                gl.remove_label_from_merge_request(mr.iid, LGTM)
+                gl.remove_label_from_merge_request(mr, LGTM)
             continue
 
         label_events = gl.get_merge_request_label_events(mr)
@@ -375,7 +375,7 @@ def preprocess_merge_requests(
             # Remove bad_label from the cached labels list. Otherwise, we may face a caching bug
             labels.remove(bad_label)
             if not dry_run:
-                gl.remove_label_from_merge_request(mr.iid, bad_label)
+                gl.remove_label_from_merge_request(mr, bad_label)
 
         if not is_good_to_merge(labels):
             continue

--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -370,7 +370,7 @@ def act(repo, dry_run, instance, settings, defer=None):
                         f"- removing approval"
                     ]
                 )
-                gitlab_cli.remove_label_from_merge_request(mr.iid, APPROVED)
+                gitlab_cli.remove_label_from_merge_request(mr, APPROVED)
 
         if approval_status["report"] is not None:
             _LOG.info(
@@ -382,7 +382,7 @@ def act(repo, dry_run, instance, settings, defer=None):
             )
 
             if not dry_run:
-                gitlab_cli.remove_label_from_merge_request(mr.iid, APPROVED)
+                gitlab_cli.remove_label_from_merge_request(mr, APPROVED)
                 mr.notes.create({"body": approval_status["report"]})
             continue
 

--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -370,7 +370,7 @@ def act(repo, dry_run, instance, settings, defer=None):
                         f"- removing approval"
                     ]
                 )
-                gitlab_cli.remove_label_from_merge_request(mr, APPROVED)
+                gitlab_cli.remove_label(mr, APPROVED)
 
         if approval_status["report"] is not None:
             _LOG.info(
@@ -382,7 +382,7 @@ def act(repo, dry_run, instance, settings, defer=None):
             )
 
             if not dry_run:
-                gitlab_cli.remove_label_from_merge_request(mr, APPROVED)
+                gitlab_cli.remove_label(mr, APPROVED)
                 mr.notes.create({"body": approval_status["report"]})
             continue
 

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -177,9 +177,7 @@ def can_be_merged_merge_request() -> ProjectMergeRequest:
     mr.merge_status = "can_be_merged"
     mr.work_in_progress = False
     mr.commits.return_value = [create_autospec(ProjectCommit)]
-    mr.attributes = {
-        "labels": ["lgtm"],
-    }
+    mr.labels = ["lgtm"]
     mr.iid = 1
     mr.target_project_id = 3
     mr.author = {"username": "user"}

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -3,7 +3,9 @@ from unittest.mock import create_autospec
 import pytest
 from gitlab.v4.objects import (
     ProjectIssue,
+    ProjectIssueNoteManager,
     ProjectMergeRequest,
+    ProjectMergeRequestNoteManager,
 )
 from pytest_mock import MockerFixture
 from requests.exceptions import ConnectTimeout
@@ -59,7 +61,7 @@ def test_remove_label_from_merge_request(
     gitlab_api.remove_label(mr, to_be_removed_label)
 
     mocked_gitlab_request.labels.return_value.inc.assert_called_once()
-    assert mr.labels == ["a"]
+    assert mr.labels == [expected_label]
     mr.save.assert_called_once()
 
 
@@ -86,5 +88,71 @@ def test_remove_label_from_issue(
     gitlab_api.remove_label(issue, to_be_removed_label)
 
     mocked_gitlab_request.labels.return_value.inc.assert_called_once()
-    assert issue.labels == ["a"]
+    assert issue.labels == [expected_label]
+    issue.save.assert_called_once()
+
+
+def test_add_label_to_merge_request(
+    instance: dict,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("reconcile.utils.gitlab_api.gitlab")
+    mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
+    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
+
+    existing_label = "a"
+    new_label = "b"
+    mr = create_autospec(ProjectMergeRequest)
+    mr.labels = [existing_label]
+    mr.notes = create_autospec(ProjectMergeRequestNoteManager)
+
+    gitlab_api = GitLabApi(
+        instance,
+        project_id=1,
+    )
+    mocked_gitlab_request.reset_mock()
+
+    gitlab_api.add_label(mr, new_label)
+
+    assert mocked_gitlab_request.labels.return_value.inc.call_count == 2
+    assert mr.labels == [existing_label, new_label]
+    mr.notes.create.assert_called_once_with(
+        {
+            "body": f"item has been marked as {new_label}. "
+            f"to remove say `/{new_label} cancel`",
+        }
+    )
+    mr.save.assert_called_once()
+
+
+def test_add_label_to_issue(
+    instance: dict,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("reconcile.utils.gitlab_api.gitlab")
+    mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
+    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
+
+    existing_label = "a"
+    new_label = "b"
+    issue = create_autospec(ProjectIssue)
+    issue.labels = [existing_label]
+    issue.notes = create_autospec(ProjectIssueNoteManager)
+
+    gitlab_api = GitLabApi(
+        instance,
+        project_id=1,
+    )
+    mocked_gitlab_request.reset_mock()
+
+    gitlab_api.add_label(issue, new_label)
+
+    assert mocked_gitlab_request.labels.return_value.inc.call_count == 2
+    assert issue.labels == [existing_label, new_label]
+    issue.notes.create.assert_called_once_with(
+        {
+            "body": f"item has been marked as {new_label}. "
+            f"to remove say `/{new_label} cancel`",
+        }
+    )
     issue.save.assert_called_once()

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -1,7 +1,10 @@
 from unittest.mock import create_autospec
 
 import pytest
-from gitlab.v4.objects import ProjectMergeRequest
+from gitlab.v4.objects import (
+    ProjectIssue,
+    ProjectMergeRequest,
+)
 from pytest_mock import MockerFixture
 from requests.exceptions import ConnectTimeout
 
@@ -53,8 +56,35 @@ def test_remove_label_from_merge_request(
     )
     mocked_gitlab_request.reset_mock()
 
-    gitlab_api.remove_label_from_merge_request(mr, to_be_removed_label)
+    gitlab_api.remove_label(mr, to_be_removed_label)
 
     mocked_gitlab_request.labels.return_value.inc.assert_called_once()
     assert mr.labels == ["a"]
     mr.save.assert_called_once()
+
+
+def test_remove_label_from_issue(
+    instance: dict,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("reconcile.utils.gitlab_api.gitlab")
+    mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
+    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
+
+    expected_label = "a"
+    to_be_removed_label = "b"
+    current_labels = [expected_label, to_be_removed_label]
+    issue = create_autospec(ProjectIssue)
+    issue.labels = current_labels
+
+    gitlab_api = GitLabApi(
+        instance,
+        project_id=1,
+    )
+    mocked_gitlab_request.reset_mock()
+
+    gitlab_api.remove_label(issue, to_be_removed_label)
+
+    mocked_gitlab_request.labels.return_value.inc.assert_called_once()
+    assert issue.labels == ["a"]
+    issue.save.assert_called_once()

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -1,4 +1,8 @@
+from unittest.mock import create_autospec
+
 import pytest
+from gitlab.v4.objects import ProjectMergeRequest
+from pytest_mock import MockerFixture
 from requests.exceptions import ConnectTimeout
 
 from reconcile.utils.gitlab_api import GitLabApi
@@ -18,3 +22,39 @@ def test_gitlab_client_timeout(mocker, patch_sleep):
 
     with pytest.raises(ConnectTimeout):
         GitLabApi(instance, timeout=0.1)
+
+
+@pytest.fixture
+def instance() -> dict:
+    return {
+        "url": "http://some-url",
+        "token": "some-token",
+        "sslVerify": False,
+    }
+
+
+def test_remove_label_from_merge_request(
+    instance: dict,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("reconcile.utils.gitlab_api.gitlab")
+    mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
+    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
+
+    expected_label = "a"
+    to_be_removed_label = "b"
+    current_labels = [expected_label, to_be_removed_label]
+    mr = create_autospec(ProjectMergeRequest)
+    mr.labels = current_labels
+
+    gitlab_api = GitLabApi(
+        instance,
+        project_id=1,
+    )
+    mocked_gitlab_request.reset_mock()
+
+    gitlab_api.remove_label_from_merge_request(mr, to_be_removed_label)
+
+    mocked_gitlab_request.labels.return_value.inc.assert_called_once()
+    assert mr.labels == ["a"]
+    mr.save.assert_called_once()

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -449,13 +449,16 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         merge_request = self.project.mergerequests.get(mr_id)
         self.update_labels(merge_request, "merge-request", labels)
 
-    def remove_label_from_merge_request(self, mr_id, label):
-        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        merge_request = self.project.mergerequests.get(mr_id)
-        labels = merge_request.attributes.get("labels")
+    @staticmethod
+    def remove_label_from_merge_request(
+        merge_request: ProjectMergeRequest,
+        label: str,
+    ):
+        labels = merge_request.labels
         if label in labels:
             labels.remove(label)
-        self.update_labels(merge_request, "merge-request", labels)
+            gitlab_request.labels(integration=INTEGRATION_NAME).inc()
+            merge_request.save()
 
     def add_comment_to_merge_request(self, mr_id, body):
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()


### PR DESCRIPTION
Refactor gitlab label related logic, remove unnecessary get merge request call by passing `merge_request` object directly.

Docs:

* [Merge requests](https://python-gitlab.readthedocs.io/en/v1.11.0/gl_objects/mrs.html)
* [Issues](https://python-gitlab.readthedocs.io/en/v1.11.0/gl_objects/issues.html)
* [Notes](https://python-gitlab.readthedocs.io/en/v1.11.0/gl_objects/notes.html)


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1dce1eb</samp>

This pull request refactors and optimizes the label management logic in various `qontract-reconcile` modules that interact with GitLab. It uses the new `add_label` and `remove_label` methods in the `GitLabApi` class, and the `labels` attribute of the `item` and `mr` objects, to reduce unnecessary API calls and improve performance and reliability. It also updates the test code and removes some deprecated methods.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 1dce1eb</samp>

*  Refactor label management methods in `GitLabApi` class to use `labels` attribute of `item` object and remove `item_type` argument ([link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL483-R503), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL452-L459), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bR17))
* Update integrations and tests to use the new label management methods and the `labels` attribute of `item` object instead of the deprecated methods and the `attributes` dictionary ([link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-985fa2d09f658257b01c55b453e714cf8e726d025fab87d818ca0f04e34484e9L375-R376), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-78e09dfbaefeb1d4369c6ad29ed3315083f6394b3e495f2591664cb0288fe8e3L83-R83), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L217-R217), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L230-R232), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L239-R238), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L264-R263), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L327-R311), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L339-R323), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L369-R353), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L375-R363), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L543-R526), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-299b14c9cd7227766a3ca80d4217d6b03ee6eaa21f8c8bbb3ba58a1db5eabcf0L373-R373), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-299b14c9cd7227766a3ca80d4217d6b03ee6eaa21f8c8bbb3ba58a1db5eabcf0L385-R385), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-cfe12becadfed2850e5224ff99c1708b3c677b7bb6199636436dfa9c72e8474cL180-R180))
* Remove unused `get_labels` function from `reconcile/gitlab_housekeeping.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L280-L294))
* Add test functions for the new label management methods in `reconcile/test/utils/test_gitlab_api.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-0b89eef785c5d5eafddc4849caf0ebfd6e028bbe73d43cd6abe234f4cd95f1eeL1-R10), [link](https://github.com/app-sre/qontract-reconcile/pull/3702/files?diff=unified&w=0#diff-0b89eef785c5d5eafddc4849caf0ebfd6e028bbe73d43cd6abe234f4cd95f1eeR30-R158))