### PR TITLE
Update terraform provider log filter

### DIFF
--- a/reconcile/test/utils/test_terraform_client.py
+++ b/reconcile/test/utils/test_terraform_client.py
@@ -715,7 +715,7 @@ def test_check_output_warning_from_provider_warn_log(
     mocked_logging.error.assert_not_called()
 
 
-def test_check_output_error_from_provider_error_log(
+def test_check_output_warning_from_provider_error_log(
     tf: tfclient.TerraformClient,
     mocker: MockerFixture,
 ) -> None:
@@ -731,6 +731,25 @@ def test_check_output_error_from_provider_error_log(
     assert result is False
     mocked_logging.debug.assert_not_called()
     mocked_logging.warning.assert_called_once_with(f"[name - cmd] {log}")
+    mocked_logging.error.assert_not_called()
+
+
+def test_check_output_warning_ignore_from_provider_warning_log(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    log = (
+        "2023-07-20T15:49:09.681+1000 [INFO]  plugin.terraform-provider-aws_v3.76.0_x5: 2023/07/20 15:49:09 "
+        "[WARN] ObjectLockConfigurationNotFoundError: timestamp=2023-07-20T15:49:09.673+1000"
+    )
+
+    result = tf.check_output("name", "cmd", 0, "", "", log)
+
+    assert result is False
+    mocked_logging.debug.assert_not_called()
+    mocked_logging.warning.assert_not_called()
     mocked_logging.error.assert_not_called()
 
 

--- a/reconcile/test/utils/test_terraform_client.py
+++ b/reconcile/test/utils/test_terraform_client.py
@@ -773,7 +773,7 @@ def test_terraform_init(
     mocked_tf.return_value.init.side_effect = init_side_effect
     mocked_tempfile = mocker.patch("reconcile.utils.terraform_client.tempfile")
     mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
-    warning_log = "[INFO] a [WARN]"
+    warning_log = "a [INFO] b [WARN] c"
     with mocked_tempfile.NamedTemporaryFile.return_value as f:
         f.name = "temp-name"
         f.read.return_value.decode.return_value = warning_log
@@ -810,7 +810,7 @@ def test_terraform_output(
 ) -> None:
     mocked_tempfile = mocker.patch("reconcile.utils.terraform_client.tempfile")
     mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
-    warning_log = "[INFO] a [WARN]"
+    warning_log = "a [INFO] b [WARN] c"
     with mocked_tempfile.NamedTemporaryFile.return_value as f:
         f.name = "temp-name"
         f.read.return_value.decode.return_value = warning_log
@@ -842,7 +842,7 @@ def test_terraform_plan(
     mocked_lean_tf.show_json.return_value = {"format_version": "0.1"}
     mocked_tempfile = mocker.patch("reconcile.utils.terraform_client.tempfile")
     mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
-    warning_log = "[INFO] a [WARN]"
+    warning_log = "a [INFO] b [WARN] c"
     with mocked_tempfile.NamedTemporaryFile.return_value as f:
         f.name = "temp-name"
         f.read.return_value.decode.return_value = warning_log
@@ -878,7 +878,7 @@ def test_terraform_apply(
 ) -> None:
     mocked_tempfile = mocker.patch("reconcile.utils.terraform_client.tempfile")
     mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
-    warning_log = "[INFO] a [WARN]"
+    warning_log = " a [INFO] b [WARN] c"
     with mocked_tempfile.NamedTemporaryFile.return_value as f:
         f.name = "temp-name"
         f.read.return_value.decode.return_value = warning_log

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -49,6 +49,9 @@ DATE_FORMAT = "%Y-%m-%d"
 PROVIDER_LOG_REGEX = (
     r""".*\s(?:\[INFO]|\[WARN]|\[ERROR])\s.+\s(?:\[WARN]|\[ERROR])\s.*"""
 )
+PROVIDER_LOG_IGNORE_REGEX = (
+    r""".*(?:ObjectLockConfigurationNotFoundError|WaitForState).*"""
+)
 TERRAFORM_LOG_LEVEL = "TRACE"  # can change to INFO after tf 0.15
 
 
@@ -627,6 +630,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         line_format = "[{} - {}] {}"
         stdout, stderr, log = self.split_to_lines(stdout, stderr, log)
         provider_log_re = re.compile(PROVIDER_LOG_REGEX)
+        provider_log_ignore_re = re.compile(PROVIDER_LOG_IGNORE_REGEX)
         with self._log_lock:
             for line in stdout:
                 logging.debug(line_format.format(name, cmd, line))
@@ -637,7 +641,9 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                 for line in stderr:
                     logging.warning(line_format.format(name, cmd, line))
             for line in log:
-                if provider_log_re.match(line):
+                if provider_log_re.match(line) and not provider_log_ignore_re.match(
+                    line
+                ):
                     logging.warning(line_format.format(name, cmd, line))
         return error_occured
 

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -46,7 +46,9 @@ from reconcile.utils.external_resource_spec import (
 
 ALLOWED_TF_SHOW_FORMAT_VERSION = "0.1"
 DATE_FORMAT = "%Y-%m-%d"
-PROVIDER_LOG_REGEX = r""".*(?:\[INFO]|\[WARN]|\[ERROR]).+(?:\[WARN]|\[ERROR]).*"""
+PROVIDER_LOG_REGEX = (
+    r""".*\s(?:\[INFO]|\[WARN]|\[ERROR])\s.+\s(?:\[WARN]|\[ERROR])\s.*"""
+)
 TERRAFORM_LOG_LEVEL = "TRACE"  # can change to INFO after tf 0.15
 
 


### PR DESCRIPTION
* Ensure log level like `[INFO]` has space around it, avoid debug log like `[INFO]  plugin.terraform-provider-cloudflare_v3.32.0: 2023-07-26T05:25:09.315215043Z [DEBUG] cloudflare[WARN] ` to be printed
* Ignore noisy warnings like
  * `WaitForState timeout after 2m0s`
  * `WaitForState starting 30s refresh grace period`
  * `Object Lock Configuration: ObjectLockConfigurationNotFoundError: Object Lock configuration does not exist for this bucket`.

[APPSRE-7884](https://issues.redhat.com/browse/APPSRE-7884)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 75f3e53</samp>

Improved the testing and filtering of provider logs in the `check_output` method of the `TerraformClient` class. Added and modified test functions in `reconcile/test/utils/test_terraform_client.py` and updated the regex pattern for ignored logs in `reconcile/utils/terraform_client.py`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 75f3e53</samp>

*  Add a constant and a variable to define and compile a regex pattern for ignoring some provider warning logs ([link](https://github.com/app-sre/qontract-reconcile/pull/3705/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL49-R54), [link](https://github.com/app-sre/qontract-reconcile/pull/3705/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfR633))
* Modify the `check_output` method to filter out provider warning logs that match the ignore pattern and only log those that do not ([link](https://github.com/app-sre/qontract-reconcile/pull/3705/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL638-R646))
* Rename a test function to reflect the expected behavior of `check_output` when encountering a provider error log ([link](https://github.com/app-sre/qontract-reconcile/pull/3705/files?diff=unified&w=0#diff-b3ecbf5e85f99cd579b16e0340930eb7183e47033610cf8a42fa7cc71e45c54aL718-R718))
* Add a test function to check the behavior of `check_output` when encountering a provider warning log that matches the ignore pattern ([link](https://github.com/app-sre/qontract-reconcile/pull/3705/files?diff=unified&w=0#diff-b3ecbf5e85f99cd579b16e0340930eb7183e47033610cf8a42fa7cc71e45c54aR737-R755))
* Modify the `warning_log` variables in four test functions (`test_terraform_init`, `test_terraform_output`, `test_terraform_plan`, and `test_terraform_apply`) to include more realistic text between the log level tags ([link](https://github.com/app-sre/qontract-reconcile/pull/3705/files?diff=unified&w=0#diff-b3ecbf5e85f99cd579b16e0340930eb7183e47033610cf8a42fa7cc71e45c54aL776-R795), [link](https://github.com/app-sre/qontract-reconcile/pull/3705/files?diff=unified&w=0#diff-b3ecbf5e85f99cd579b16e0340930eb7183e47033610cf8a42fa7cc71e45c54aL813-R832), [link](https://github.com/app-sre/qontract-reconcile/pull/3705/files?diff=unified&w=0#diff-b3ecbf5e85f99cd579b16e0340930eb7183e47033610cf8a42fa7cc71e45c54aL845-R864), [link](https://github.com/app-sre/qontract-reconcile/pull/3705/files?diff=unified&w=0#diff-b3ecbf5e85f99cd579b16e0340930eb7183e47033610cf8a42fa7cc71e45c54aL881-R900))