### PR TITLE
Set skip_region_validation to work with not supported regions

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -381,6 +381,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                         version=self.versions.get(name),
                         region=region,
                         alias=region,
+                        skip_region_validation=True,
                     )
 
             # Add default region, which will be in resourcesDefaultRegion
@@ -389,6 +390,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 secret_key=config["aws_secret_access_key"],
                 version=self.versions.get(name),
                 region=config["resourcesDefaultRegion"],
+                skip_region_validation=True,
             )
 
             # the time provider can be removed if all AWS accounts
@@ -872,6 +874,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     region=account["assume_region"],
                     alias=alias,
                     assume_role={"role_arn": assume_role},
+                    skip_region_validation=True,
                 )
 
     def populate_route53(


### PR DESCRIPTION
Our current AWS terraform provider doesn't support `ap-southeast-4` yet, use `skip_region_validation` to bypass validation.

https://github.com/hashicorp/terraform-provider-aws/issues/29231

[APPSRE-8071](https://issues.redhat.com/browse/APPSRE-8071)