### PR TITLE
Log terraform provider warn and error in the right way

### DIFF
--- a/reconcile/test/utils/test_lean_terraform_client.py
+++ b/reconcile/test/utils/test_lean_terraform_client.py
@@ -1,0 +1,139 @@
+from subprocess import CompletedProcess
+
+from pytest_mock import MockerFixture
+from reconcile.utils import lean_terraform_client
+
+
+def test_init(mocker: MockerFixture) -> None:
+    mocked_subprocess = mocker.patch("reconcile.utils.lean_terraform_client.subprocess")
+    mocked_subprocess.run.return_value = CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=b"out",
+        stderr=b"err",
+    )
+
+    return_code, stdout, stderr = lean_terraform_client.init("working_dir")
+
+    assert return_code == 0
+    assert stdout == "out"
+    assert stderr == "err"
+    mocked_subprocess.run.assert_called_once_with(
+        ["terraform", "init", "-input=false", "-no-color"],
+        capture_output=True,
+        check=False,
+        cwd="working_dir",
+    )
+
+
+def test_output(mocker: MockerFixture) -> None:
+    mocked_subprocess = mocker.patch("reconcile.utils.lean_terraform_client.subprocess")
+    mocked_subprocess.run.return_value = CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=b"out",
+        stderr=b"err",
+    )
+
+    return_code, stdout, stderr = lean_terraform_client.output("working_dir")
+
+    assert return_code == 0
+    assert stdout == "out"
+    assert stderr == "err"
+    mocked_subprocess.run.assert_called_once_with(
+        ["terraform", "output", "-json"],
+        capture_output=True,
+        check=False,
+        cwd="working_dir",
+    )
+
+
+def test_plan(mocker: MockerFixture) -> None:
+    mocked_subprocess = mocker.patch("reconcile.utils.lean_terraform_client.subprocess")
+    mocked_subprocess.run.return_value = CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=b"out",
+        stderr=b"err",
+    )
+
+    return_code, stdout, stderr = lean_terraform_client.plan(
+        working_dir="working_dir",
+        out="tfplan",
+    )
+
+    assert return_code == 0
+    assert stdout == "out"
+    assert stderr == "err"
+    mocked_subprocess.run.assert_called_once_with(
+        [
+            "terraform",
+            "plan",
+            "-out=tfplan",
+            "-input=false",
+            "-no-color",
+        ],
+        capture_output=True,
+        check=False,
+        cwd="working_dir",
+    )
+
+
+def test_apply(mocker: MockerFixture) -> None:
+    mocked_subprocess = mocker.patch("reconcile.utils.lean_terraform_client.subprocess")
+    mocked_subprocess.run.return_value = CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=b"out",
+        stderr=b"err",
+    )
+
+    return_code, stdout, stderr = lean_terraform_client.apply(
+        working_dir="working_dir",
+        dir_or_plan="tfplan",
+    )
+
+    assert return_code == 0
+    assert stdout == "out"
+    assert stderr == "err"
+    mocked_subprocess.run.assert_called_once_with(
+        [
+            "terraform",
+            "apply",
+            "-input=false",
+            "-no-color",
+            "tfplan",
+        ],
+        capture_output=True,
+        check=False,
+        cwd="working_dir",
+    )
+
+
+def test_show_json(mocker: MockerFixture) -> None:
+    mocked_subprocess = mocker.patch("reconcile.utils.lean_terraform_client.subprocess")
+    mocked_subprocess.run.return_value = CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout=b"{}",
+        stderr=b"",
+    )
+
+    result = lean_terraform_client.show_json(
+        working_dir="working_dir",
+        path="tfplan",
+    )
+
+    assert result == {}
+    mocked_subprocess.run.assert_called_once_with(
+        [
+            "terraform",
+            "show",
+            "-no-color",
+            "-json",
+            "tfplan",
+        ],
+        capture_output=True,
+        check=False,
+        cwd="working_dir",
+    )

--- a/reconcile/test/utils/test_lean_terraform_client.py
+++ b/reconcile/test/utils/test_lean_terraform_client.py
@@ -1,3 +1,5 @@
+import os
+import tempfile
 from subprocess import CompletedProcess
 
 from pytest_mock import MockerFixture
@@ -166,3 +168,14 @@ def test_show_json(mocker: MockerFixture) -> None:
         cwd="working_dir",
         env={},
     )
+
+
+def test_terraform_component() -> None:
+    with tempfile.TemporaryDirectory() as working_dir:
+        with open(os.path.join(working_dir, "main.tf"), "w"):
+            pass
+        assert lean_terraform_client.init(working_dir)[0] == 0
+        assert lean_terraform_client.output(working_dir)[0] == 0
+        assert lean_terraform_client.plan(working_dir, "tfplan")[0] == 0
+        assert lean_terraform_client.show_json(working_dir, "tfplan") is not None
+        assert lean_terraform_client.apply(working_dir, "tfplan")[0] == 0

--- a/reconcile/test/utils/test_lean_terraform_client.py
+++ b/reconcile/test/utils/test_lean_terraform_client.py
@@ -6,6 +6,9 @@ from reconcile.utils import lean_terraform_client
 
 
 def test_init(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "reconcile.utils.lean_terraform_client.os"
+    ).environ.copy.return_value = {}
     mocked_subprocess = mocker.patch("reconcile.utils.lean_terraform_client.subprocess")
     mocked_subprocess.run.return_value = CompletedProcess(
         args=[],
@@ -14,7 +17,10 @@ def test_init(mocker: MockerFixture) -> None:
         stderr=b"err",
     )
 
-    return_code, stdout, stderr = lean_terraform_client.init("working_dir")
+    return_code, stdout, stderr = lean_terraform_client.init(
+        "working_dir",
+        env={"TF_LOG": "INFO"},
+    )
 
     assert return_code == 0
     assert stdout == "out"
@@ -24,10 +30,14 @@ def test_init(mocker: MockerFixture) -> None:
         capture_output=True,
         check=False,
         cwd="working_dir",
+        env={"TF_LOG": "INFO"},
     )
 
 
 def test_output(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "reconcile.utils.lean_terraform_client.os"
+    ).environ.copy.return_value = {}
     mocked_subprocess = mocker.patch("reconcile.utils.lean_terraform_client.subprocess")
     mocked_subprocess.run.return_value = CompletedProcess(
         args=[],
@@ -36,7 +46,10 @@ def test_output(mocker: MockerFixture) -> None:
         stderr=b"err",
     )
 
-    return_code, stdout, stderr = lean_terraform_client.output("working_dir")
+    return_code, stdout, stderr = lean_terraform_client.output(
+        "working_dir",
+        env={"TF_LOG": "INFO"},
+    )
 
     assert return_code == 0
     assert stdout == "out"
@@ -46,10 +59,14 @@ def test_output(mocker: MockerFixture) -> None:
         capture_output=True,
         check=False,
         cwd="working_dir",
+        env={"TF_LOG": "INFO"},
     )
 
 
 def test_plan(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "reconcile.utils.lean_terraform_client.os"
+    ).environ.copy.return_value = {}
     mocked_subprocess = mocker.patch("reconcile.utils.lean_terraform_client.subprocess")
     mocked_subprocess.run.return_value = CompletedProcess(
         args=[],
@@ -61,6 +78,7 @@ def test_plan(mocker: MockerFixture) -> None:
     return_code, stdout, stderr = lean_terraform_client.plan(
         working_dir="working_dir",
         out="tfplan",
+        env={"TF_LOG": "INFO"},
     )
 
     assert return_code == 0
@@ -77,10 +95,14 @@ def test_plan(mocker: MockerFixture) -> None:
         capture_output=True,
         check=False,
         cwd="working_dir",
+        env={"TF_LOG": "INFO"},
     )
 
 
 def test_apply(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "reconcile.utils.lean_terraform_client.os"
+    ).environ.copy.return_value = {}
     mocked_subprocess = mocker.patch("reconcile.utils.lean_terraform_client.subprocess")
     mocked_subprocess.run.return_value = CompletedProcess(
         args=[],
@@ -92,6 +114,7 @@ def test_apply(mocker: MockerFixture) -> None:
     return_code, stdout, stderr = lean_terraform_client.apply(
         working_dir="working_dir",
         dir_or_plan="tfplan",
+        env={"TF_LOG": "INFO"},
     )
 
     assert return_code == 0
@@ -108,10 +131,14 @@ def test_apply(mocker: MockerFixture) -> None:
         capture_output=True,
         check=False,
         cwd="working_dir",
+        env={"TF_LOG": "INFO"},
     )
 
 
 def test_show_json(mocker: MockerFixture) -> None:
+    mocker.patch(
+        "reconcile.utils.lean_terraform_client.os"
+    ).environ.copy.return_value = {}
     mocked_subprocess = mocker.patch("reconcile.utils.lean_terraform_client.subprocess")
     mocked_subprocess.run.return_value = CompletedProcess(
         args=[],
@@ -137,4 +164,5 @@ def test_show_json(mocker: MockerFixture) -> None:
         capture_output=True,
         check=False,
         cwd="working_dir",
+        env={},
     )

--- a/reconcile/test/utils/test_lean_terraform_client.py
+++ b/reconcile/test/utils/test_lean_terraform_client.py
@@ -1,6 +1,7 @@
 from subprocess import CompletedProcess
 
 from pytest_mock import MockerFixture
+
 from reconcile.utils import lean_terraform_client
 
 

--- a/reconcile/test/utils/test_terraform_client.py
+++ b/reconcile/test/utils/test_terraform_client.py
@@ -1,10 +1,13 @@
 import base64
+import tempfile
+from collections.abc import Callable
 from logging import DEBUG
 from operator import itemgetter
 from unittest.mock import create_autospec
 
 import pytest
 from botocore.errorfactory import ClientError
+from pytest_mock import MockerFixture
 
 import reconcile.utils.terraform_client as tfclient
 from reconcile.utils.aws_api import AWSApi
@@ -19,9 +22,12 @@ def aws_api():
     return create_autospec(AWSApi)
 
 
+ACCOUNT_NAME = "a1"
+
+
 @pytest.fixture
 def tf(aws_api):
-    account = {"name": "a1", "deletionApprovals": []}
+    account = {"name": ACCOUNT_NAME, "deletionApprovals": []}
     return tfclient.TerraformClient(
         "integ", "v1", "integ_pfx", [account], {}, 1, aws_api
     )
@@ -636,4 +642,265 @@ def test_validate_db_upgrade_with_empty_valid_upgrade_targe_and_not_allow_major_
         "allow_major_version_upgrade is not enabled for upgrading RDS instance: "
         "test-database-1 to a new version when there is no valid upgrade target available."
         == str(error.value)
+    )
+
+
+def test_check_output_debug(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    result = tf.check_output("name", "cmd", 0, "out", "", "")
+
+    assert result is False
+    mocked_logging.debug.assert_called_once_with("[name - cmd] out")
+    mocked_logging.warning.assert_not_called()
+    mocked_logging.error.assert_not_called()
+
+
+def test_check_output_warning(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    result = tf.check_output("name", "cmd", 0, "out", "error", "")
+
+    assert result is False
+    mocked_logging.debug.assert_called_once_with("[name - cmd] out")
+    mocked_logging.warning.assert_called_once_with("[name - cmd] error")
+    mocked_logging.error.assert_not_called()
+
+
+def test_check_output_from_terraform_log(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    log = "2023-07-20T15:49:09.681+1000 [INFO] doing something"
+
+    result = tf.check_output("name", "cmd", 0, "", "", log)
+
+    assert result is False
+    mocked_logging.debug.assert_not_called()
+    mocked_logging.warning.assert_not_called()
+    mocked_logging.error.assert_not_called()
+
+
+def test_check_output_warning_from_provider_warn_log(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    log = (
+        "2023-07-20T15:49:09.681+1000 [INFO]  plugin.terraform-provider-aws_v3.76.0_x5: 2023/07/20 15:49:09 "
+        "[WARN] DB Instance (xxx) not found, removing from state: timestamp=2023-07-20T15:49:09.673+1000"
+    )
+
+    result = tf.check_output("name", "cmd", 0, "", "", log)
+
+    assert result is False
+    mocked_logging.debug.assert_not_called()
+    mocked_logging.warning.assert_called_once_with(f"[name - cmd] {log}")
+    mocked_logging.error.assert_not_called()
+
+
+def test_check_output_warning_from_provider_error_log(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    log = (
+        "2023-07-20T15:49:09.681+1000 [INFO]  plugin.terraform-provider-aws_v3.76.0_x5: 2023/07/20 15:49:09 "
+        "[ERROR] something is wrong: timestamp=2023-07-20T15:49:09.673+1000"
+    )
+
+    result = tf.check_output("name", "cmd", 0, "", "", log)
+
+    assert result is False
+    mocked_logging.debug.assert_not_called()
+    mocked_logging.warning.assert_called_once_with(f"[name - cmd] {log}")
+    mocked_logging.error.assert_not_called()
+
+
+def test_check_output_warning_ignore_from_provider_warning_log(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    log = (
+        "2023-07-20T15:49:09.681+1000 [INFO]  plugin.terraform-provider-aws_v3.76.0_x5: 2023/07/20 15:49:09 "
+        "[WARN] ObjectLockConfigurationNotFoundError: timestamp=2023-07-20T15:49:09.673+1000"
+    )
+
+    result = tf.check_output("name", "cmd", 0, "", "", log)
+
+    assert result is False
+    mocked_logging.debug.assert_not_called()
+    mocked_logging.warning.assert_not_called()
+    mocked_logging.error.assert_not_called()
+
+
+def test_check_output_error(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+) -> None:
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+
+    result = tf.check_output("name", "cmd", 1, "", "error", "")
+
+    assert result is True
+    mocked_logging.debug.assert_not_called()
+    mocked_logging.warning.assert_not_called()
+    mocked_logging.error.assert_called_once_with("[name - cmd] error")
+
+
+@pytest.fixture
+def terraform_spec_builder() -> Callable[..., tfclient.TerraformSpec]:
+    def builder(name: str, working_dir: str) -> tfclient.TerraformSpec:
+        return tfclient.TerraformSpec(
+            name=name,
+            working_dir=working_dir,
+        )
+
+    return builder
+
+
+def test_terraform_init(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+    terraform_spec_builder: Callable[..., tfclient.TerraformSpec],
+) -> None:
+    mocked_lean_tf = mocker.patch("reconcile.utils.terraform_client.lean_tf")
+    mocked_lean_tf.init.return_value = (0, "", "")
+    mocked_tempfile = mocker.patch("reconcile.utils.terraform_client.tempfile")
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+    warning_log = "a [INFO] b [WARN] c"
+    with mocked_tempfile.NamedTemporaryFile.return_value as f:
+        f.name = "temp-name"
+        f.read.return_value.decode.return_value = warning_log
+
+    with tempfile.TemporaryDirectory() as working_dir:
+        init_spec = terraform_spec_builder(ACCOUNT_NAME, working_dir)
+
+        tf.terraform_init(init_spec)
+
+    mocked_lean_tf.init.assert_called_once_with(
+        working_dir,
+        env={
+            "TF_LOG": "TRACE",
+            "TF_LOG_PATH": "temp-name",
+        },
+    )
+    mocked_logging.warning.assert_called_once_with(
+        f"[{ACCOUNT_NAME} - init] {warning_log}"
+    )
+
+
+def test_terraform_output(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+    terraform_spec_builder: Callable[..., tfclient.TerraformSpec],
+) -> None:
+    mocked_lean_tf = mocker.patch("reconcile.utils.terraform_client.lean_tf")
+    mocked_lean_tf.output.return_value = (0, "{}", "")
+    mocked_tempfile = mocker.patch("reconcile.utils.terraform_client.tempfile")
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+    warning_log = "a [INFO] b [WARN] c"
+    with mocked_tempfile.NamedTemporaryFile.return_value as f:
+        f.name = "temp-name"
+        f.read.return_value.decode.return_value = warning_log
+
+    with tempfile.TemporaryDirectory() as working_dir:
+        spec = terraform_spec_builder(ACCOUNT_NAME, working_dir)
+
+        name, output = tf.terraform_output(spec)
+
+    assert name == ACCOUNT_NAME
+    assert output == {}
+    mocked_lean_tf.output.assert_called_once_with(
+        working_dir,
+        env={
+            "TF_LOG": "TRACE",
+            "TF_LOG_PATH": "temp-name",
+        },
+    )
+    mocked_logging.warning.assert_called_once_with(
+        f"[{ACCOUNT_NAME} - output] {warning_log}"
+    )
+
+
+def test_terraform_plan(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+    terraform_spec_builder: Callable[..., tfclient.TerraformSpec],
+) -> None:
+    mocked_lean_tf = mocker.patch("reconcile.utils.terraform_client.lean_tf")
+    mocked_lean_tf.show_json.return_value = {"format_version": "0.1"}
+    mocked_lean_tf.plan.return_value = (0, "", "")
+    mocked_tempfile = mocker.patch("reconcile.utils.terraform_client.tempfile")
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+    warning_log = "a [INFO] b [WARN] c"
+    with mocked_tempfile.NamedTemporaryFile.return_value as f:
+        f.name = "temp-name"
+        f.read.return_value.decode.return_value = warning_log
+
+    with tempfile.TemporaryDirectory() as working_dir:
+        spec = terraform_spec_builder(ACCOUNT_NAME, working_dir)
+
+        disabled_deletion_detected, created_users, error = tf.terraform_plan(
+            spec,
+            False,
+        )
+
+    assert disabled_deletion_detected is False
+    assert created_users == []
+    assert error is False
+    mocked_lean_tf.plan.assert_called_once_with(
+        working_dir,
+        ACCOUNT_NAME,
+        env={
+            "TF_LOG": "TRACE",
+            "TF_LOG_PATH": "temp-name",
+        },
+    )
+    mocked_logging.warning.assert_called_once_with(
+        f"[{ACCOUNT_NAME} - plan] {warning_log}"
+    )
+
+
+def test_terraform_apply(
+    tf: tfclient.TerraformClient,
+    mocker: MockerFixture,
+    terraform_spec_builder: Callable[..., tfclient.TerraformSpec],
+) -> None:
+    mocked_lean_tf = mocker.patch("reconcile.utils.terraform_client.lean_tf")
+    mocked_lean_tf.apply.return_value = (0, "", "")
+    mocked_tempfile = mocker.patch("reconcile.utils.terraform_client.tempfile")
+    mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
+    warning_log = " a [INFO] b [WARN] c"
+    with mocked_tempfile.NamedTemporaryFile.return_value as f:
+        f.name = "temp-name"
+        f.read.return_value.decode.return_value = warning_log
+
+    with tempfile.TemporaryDirectory() as working_dir:
+        spec = terraform_spec_builder(ACCOUNT_NAME, working_dir)
+        error = tf.terraform_apply(spec)
+
+    assert error is False
+    mocked_lean_tf.apply.assert_called_once_with(
+        working_dir,
+        ACCOUNT_NAME,
+        env={
+            "TF_LOG": "TRACE",
+            "TF_LOG_PATH": "temp-name",
+        },
+    )
+    mocked_logging.warning.assert_called_once_with(
+        f"[{ACCOUNT_NAME} - apply] {warning_log}"
     )

--- a/reconcile/utils/lean_terraform_client.py
+++ b/reconcile/utils/lean_terraform_client.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import subprocess
+from typing import Any
 
 
 def state_rm_access_key(working_dirs, account, user):
@@ -13,15 +14,87 @@ def state_rm_access_key(working_dirs, account, user):
     return result.returncode == 0
 
 
-def show_json(working_dir, out_file):
+def _terraform_command(args: list[str], working_dir: str) -> (int, str, str):
     result = subprocess.run(
-        ["terraform", "show", "-no-color", "-json", out_file],
+        args,
         capture_output=True,
         check=False,
         cwd=working_dir,
     )
-    if result.returncode != 0:
-        msg = f"[{out_file}] terraform show failed: {result.stderr.decode('utf-8')}"
+    return_code = result.returncode
+    stdout = result.stdout.decode("utf-8")
+    stderr = result.stderr.decode("utf-8")
+    return return_code, stdout, stderr
+
+
+def show_json(working_dir: str, path: str) -> dict[str, Any]:
+    """
+    Run terraform show -no-color -json <path>.
+
+    :param working_dir: The directory where the terraform files are located
+    :param path: The path to the plan file
+    :return: Deserialized JSON from the terraform show command
+    """
+    return_code, stdout, stderr = _terraform_command(
+        args=["terraform", "show", "-no-color", "-json", path],
+        working_dir=working_dir,
+    )
+    if return_code != 0:
+        msg = f"[{path}] terraform show failed: {stderr}"
         logging.warning(msg)
         raise Exception(msg)
-    return json.loads(result.stdout)
+    return json.loads(stdout)
+
+
+def init(working_dir: str) -> (int, str, str):
+    """
+    Run terraform init -input=false -no-color.
+
+    :param working_dir: The directory where the terraform files are located
+    :return: (return_code, stdout, stderr)
+    """
+    return _terraform_command(
+        args=["terraform", "init", "-input=false", "-no-color"],
+        working_dir=working_dir,
+    )
+
+
+def output(working_dir: str) -> (int, str, str):
+    """
+    Run terraform output -json.
+
+    :param working_dir: The directory where the terraform files are located
+    :return: (return_code, stdout, stderr)
+    """
+    return _terraform_command(
+        args=["terraform", "output", "-json"],
+        working_dir=working_dir,
+    )
+
+
+def plan(working_dir: str, out: str):
+    """
+    Run terraform plan -out=<out> -input=false -no-color.
+
+    :param working_dir: The directory where the terraform files are located
+    :param out: The path to the plan file
+    :return: (return_code, stdout, stderr)
+    """
+    return _terraform_command(
+        args=["terraform", "plan", f"-out={out}", "-input=false", "-no-color"],
+        working_dir=working_dir,
+    )
+
+
+def apply(working_dir: str, dir_or_plan: str):
+    """
+    Run terraform apply -input=false -no-color <dir_or_plan>.
+
+    :param working_dir: The directory where the terraform files are located
+    :param dir_or_plan: The path to the directory or plan file
+    :return: (return_code, stdout, stderr)
+    """
+    return _terraform_command(
+        args=["terraform", "apply", "-input=false", "-no-color", dir_or_plan],
+        working_dir=working_dir,
+    )

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup(
         "anymarkup>=0.7.0,<0.9.0",
         "python-gitlab>=1.11.0,<1.12.0",
         "semver~=2.13",
-        "python-terraform>=0.10.0,<0.11.0",
         "boto3==1.26.139",
         "botocore==1.29.139",
         "urllib3>=1.25.4,<1.27.0",


### PR DESCRIPTION
Previous changes reverted in https://github.com/app-sre/qontract-reconcile/pull/3707 because monkey patch can't work with already multithreaded environment.

In this change, `python-terraform` is removed and replaced by [lean_terraform_client](https://github.com/app-sre/qontract-reconcile/blob/2e931bfcbd4c4da8387c55edc8699b651f507380/reconcile/utils/lean_terraform_client.py), then reapply extract terraform provider logs logic from previous PRs:

* https://github.com/app-sre/qontract-reconcile/pull/3689
* https://github.com/app-sre/qontract-reconcile/pull/3705

[APPSRE-7884](https://issues.redhat.com/browse/APPSRE-7884)

Doc [Running Terraform in Automation](https://developer.hashicorp.com/terraform/tutorials/automation/automate-terraform)


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e931bf</samp>

This pull request replaces the python_terraform package with the lean_tf module for the TerraformClient class, and adds unit tests and documentation for the terraform-related modules. It also removes the unused python_terraform dependency from the setup.py file.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2e931bf</samp>

*  Refactor the TerraformClient class to use the lean_terraform_client module instead of the python_terraform package, and add a new dataclass TerraformSpec and a new exception class TerraformCommandError ([link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL14-R21), [link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL22-L26), [link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfR43-R49), [link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfR58-R67), [link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL84-R112), [link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL112-R155), [link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL132-R166), [link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL145-R177), [link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL171-R212), [link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL219-R255), [link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfL231-R263))
*  Add type annotations, docstrings, and refactor the show_json function in the lean_terraform_client module, which provides a wrapper for the terraform commands using the subprocess module ([link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-f5b40651f6729aefce87470bb42a7bd4d4131e0955abd85a4c9e83f4f45b5b0fL3-R10), [link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-f5b40651f6729aefce87470bb42a7bd4d4131e0955abd85a4c9e83f4f45b5b0fL16-R140))
*  Remove the python_terraform package from the install_requires list in the setup.py file ([link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7L32))
*  Add unit tests for the check_output method of the TerraformClient class, which logs the output of the terraform commands based on the return code and the log level ([link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-b3ecbf5e85f99cd579b16e0340930eb7183e47033610cf8a42fa7cc71e45c54aR646-R906))
*  Add import statements, constants, and a pytest_mock fixture for the unit tests in the test_terraform_client.py file ([link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-b3ecbf5e85f99cd579b16e0340930eb7183e47033610cf8a42fa7cc71e45c54aR2-R3), [link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-b3ecbf5e85f99cd579b16e0340930eb7183e47033610cf8a42fa7cc71e45c54aR10), [link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-b3ecbf5e85f99cd579b16e0340930eb7183e47033610cf8a42fa7cc71e45c54aL22-R30))
*  Add import statements for the unit tests in the test_lean_terraform_client.py file ([link](https://github.com/app-sre/qontract-reconcile/pull/3708/files?diff=unified&w=0#diff-f1162b13b774db976e0022ff57e3c8cfa9406dab21e11a3e31ad21bf6431bb77R1-R181))