### PR TITLE
Pin botocore to same version as in setup.py

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -15,3 +15,4 @@ MarkupSafe==2.1.1
 smtpdfix==0.3.3
 isort~=5.10
 pyfakefs~=5.1
+botocore==1.29.139


### PR DESCRIPTION
Found, that pip will download every minor version to determine fitting version. This drasticaly slows down builds. Pin version to same as in setup.py to speed up builds