### PR TITLE
Reduce requests to gitlab api

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -348,7 +348,7 @@ def run(
             #   L A B E L I N G
             #
 
-            labels = gl.get_merge_request_labels(gitlab_merge_request_id)
+            labels = merge_request.labels
 
             # base labels
             conditional_labels = {

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -321,7 +321,7 @@ def run(
                 approver_decisions,
                 {
                     gl.user.username,
-                    gl.get_merge_request_author_username(gitlab_merge_request_id),
+                    gl.get_merge_request_author_username(merge_request),
                 },
             )
             hold = any(d.is_held() for d in change_decisions)

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -313,9 +313,7 @@ def run(
         with init_gitlab(gitlab_project_id) as gl:
             merge_request = gl.get_merge_request(gitlab_merge_request_id)
             approver_decisions = get_approver_decisions_from_mr_comments(
-                gl.get_merge_request_comments(
-                    gitlab_merge_request_id, include_description=True
-                )
+                gl.get_merge_request_comments(merge_request, include_description=True)
             )
             change_decisions = apply_decisions_to_changes(
                 changes,

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -123,7 +123,8 @@ def write_coverage_report_to_mr(
     change_coverage_report_header = "Change coverage report"
     # delete previous report comment
     gl.delete_merge_request_comments(
-        merge_request.iid, startswith=change_coverage_report_header
+        merge_request,
+        startswith=change_coverage_report_header,
     )
 
     # add new report comment

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -348,8 +348,6 @@ def run(
             #   L A B E L I N G
             #
 
-            labels = merge_request.labels
-
             # base labels
             conditional_labels = {
                 SELF_SERVICEABLE: self_serviceable,
@@ -367,8 +365,9 @@ def run(
                     for p in ChangeTypePriority
                 }
             )
+            GitLabApi.refresh_labels(merge_request)
             labels = manage_conditional_label(
-                current_labels=labels,
+                current_labels=merge_request.labels,
                 conditional_labels=conditional_labels,
                 dry_run=False,
             )

--- a/reconcile/gitlab_fork_compliance.py
+++ b/reconcile/gitlab_fork_compliance.py
@@ -78,8 +78,7 @@ class GitlabForkCompliance:
 
         # Last but not least, we remove the blocked label, in case
         # it is set
-        mr_labels = self.gl_cli.get_merge_request_labels(self.mr.iid)
-        if BLOCKED_BOT_ACCESS in mr_labels:
+        if BLOCKED_BOT_ACCESS in self.mr.labels:
             self.gl_cli.remove_label(self.mr, BLOCKED_BOT_ACCESS)
 
         sys.exit(self.exit_code)

--- a/reconcile/gitlab_fork_compliance.py
+++ b/reconcile/gitlab_fork_compliance.py
@@ -113,7 +113,7 @@ class GitlabForkCompliance:
 
     def handle_error(self, log_msg, mr_msg):
         LOG.error([log_msg.format(bot=self.gl_cli.user.username)])
-        self.gl_cli.add_label_to_merge_request(self.mr.iid, BLOCKED_BOT_ACCESS)
+        self.gl_cli.add_label_to_merge_request(self.mr, BLOCKED_BOT_ACCESS)
         comment = mr_msg.format(
             user=self.mr.author["username"],
             bot=self.gl_cli.user.username,

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -229,7 +229,7 @@ def handle_stale_items(
             if LABEL not in item.labels:
                 logging.info(["add_label", gl.project.name, item_type, item_iid, LABEL])
                 if not dry_run:
-                    gl.add_label(item, LABEL)
+                    gl.add_label_with_note(item, LABEL)
             # if item has 'stale' label - close it
             else:
                 close_item(dry_run, gl, enable_closing, item_type, item)

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -460,7 +460,7 @@ def merge_merge_requests(
     reload_toggle: ReloadToggle,
     merge_limit,
     rebase,
-    app_sre_usernames: set[str],
+    app_sre_usernames: Set[str],
     pipeline_timeout=None,
     insist=False,
     wait_for_pipeline=False,

--- a/reconcile/gitlab_labeler.py
+++ b/reconcile/gitlab_labeler.py
@@ -1,6 +1,9 @@
 import logging
 import os
-from collections.abc import Iterable, Set
+from collections.abc import (
+    Iterable,
+    Set,
+)
 from typing import Optional
 
 from reconcile import queries
@@ -125,7 +128,7 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None) -> None:
     instance = queries.get_gitlab_instance()
     settings = queries.get_app_interface_settings()
     with GitLabApi(instance, project_id=gitlab_project_id, settings=settings) as gl:
-        project_labels = set(gl.get_project_labels())
+        project_labels = gl.get_project_labels()
         merge_request = gl.get_merge_request(gitlab_merge_request_id)
         changed_paths = gl.get_merge_request_changed_paths(gitlab_merge_request_id)
         guessed_labels = guess_labels(project_labels, changed_paths)

--- a/reconcile/gitlab_labeler.py
+++ b/reconcile/gitlab_labeler.py
@@ -126,6 +126,7 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None) -> None:
     settings = queries.get_app_interface_settings()
     with GitLabApi(instance, project_id=gitlab_project_id, settings=settings) as gl:
         project_labels = gl.get_project_labels()
+        merge_request = gl.get_merge_request(gitlab_merge_request_id)
         labels = gl.get_merge_request_labels(gitlab_merge_request_id)
         changed_paths = gl.get_merge_request_changed_paths(gitlab_merge_request_id)
         guessed_labels = guess_labels(project_labels, changed_paths)
@@ -141,4 +142,4 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None) -> None:
 
         if labels_to_add:
             logging.info(["add_labels", labels_to_add])
-            gl.add_labels_to_merge_request(gitlab_merge_request_id, labels_to_add)
+            gl.add_labels_to_merge_request(merge_request, labels_to_add)

--- a/reconcile/gitlab_labeler.py
+++ b/reconcile/gitlab_labeler.py
@@ -130,7 +130,7 @@ def run(dry_run, gitlab_project_id=None, gitlab_merge_request_id=None) -> None:
     with GitLabApi(instance, project_id=gitlab_project_id, settings=settings) as gl:
         project_labels = gl.get_project_labels()
         merge_request = gl.get_merge_request(gitlab_merge_request_id)
-        changed_paths = gl.get_merge_request_changed_paths(gitlab_merge_request_id)
+        changed_paths = gl.get_merge_request_changed_paths(merge_request)
         guessed_labels = guess_labels(project_labels, changed_paths)
         labels_to_add = guessed_labels - set(merge_request.labels)
         labels_to_create = labels_to_add - project_labels

--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -76,7 +76,7 @@ class MRApproval:
         Collects the usernames of all the '/lgtm' comments.
         """
         lgtms = []
-        comments = self.gitlab.get_merge_request_comments(self.mr.iid)
+        comments = self.gitlab.get_merge_request_comments(self.mr)
         for comment in comments:
             # Only interested in '/lgtm' comments
             if comment["body"] != "/lgtm":
@@ -146,7 +146,7 @@ class MRApproval:
         # Now, since we have a report, let's check if that report was
         # already used for a comment
         formatted_report = self.format_report(report)
-        comments = self.gitlab.get_merge_request_comments(self.mr.iid)
+        comments = self.gitlab.get_merge_request_comments(self.mr)
         for comment in comments:
             # Only interested on our own comments
             if comment["username"] != self.gitlab.user.username:

--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -189,8 +189,7 @@ class MRApproval:
         return approval_status
 
     def has_approval_label(self):
-        labels = self.gitlab.get_merge_request_labels(self.mr.iid)
-        return APPROVED in labels
+        return APPROVED in self.mr.labels
 
     @staticmethod
     def format_report(report):

--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -171,7 +171,7 @@ class MRApproval:
                     ]
                 )
                 if not self.dry_run:
-                    self.gitlab.delete_gitlab_comment(comment["note"])
+                    self.gitlab.delete_comment(comment["note"])
                 continue
 
             # At this point, we've found an approval comment comment

--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -51,7 +51,7 @@ class MRApproval:
         that change.
         """
         change_owners_map = {}
-        paths = self.gitlab.get_merge_request_changed_paths(self.mr.iid)
+        paths = self.gitlab.get_merge_request_changed_paths(self.mr)
         for path in paths:
             owners = self.owners.get_path_owners(path)
             path_approvers = owners["approvers"]

--- a/reconcile/gitlab_owners.py
+++ b/reconcile/gitlab_owners.py
@@ -358,7 +358,7 @@ def act(repo, dry_run, instance, settings, defer=None):
                 ]
             )
             if not dry_run:
-                gitlab_cli.add_label_to_merge_request(mr.iid, APPROVED)
+                gitlab_cli.add_label_to_merge_request(mr, APPROVED)
             continue
 
         if not dry_run:

--- a/reconcile/openshift_saas_deploy_change_tester.py
+++ b/reconcile/openshift_saas_deploy_change_tester.py
@@ -197,9 +197,7 @@ def update_mr_with_ref_diffs(
             compare_diffs_comment_body = "Diffs:\n" + "\n".join(
                 [f"- {d}" for d in compare_diffs]
             )
-            gl.delete_merge_request_comments(
-                gitlab_merge_request_id, startswith="Diffs:"
-            )
+            gl.delete_merge_request_comments(merge_request, startswith="Diffs:")
             gl.add_comment_to_merge_request(merge_request, compare_diffs_comment_body)
 
 

--- a/reconcile/openshift_saas_deploy_change_tester.py
+++ b/reconcile/openshift_saas_deploy_change_tester.py
@@ -189,7 +189,7 @@ def update_mr_with_ref_diffs(
         settings=queries.get_secret_reader_settings(),
     ) as gl:
         merge_request = gl.get_merge_request(gitlab_merge_request_id)
-        changed_paths = gl.get_merge_request_changed_paths(gitlab_merge_request_id)
+        changed_paths = gl.get_merge_request_changed_paths(merge_request)
         compare_diffs = collect_compare_diffs(
             current_state, desired_state, changed_paths
         )

--- a/reconcile/openshift_saas_deploy_change_tester.py
+++ b/reconcile/openshift_saas_deploy_change_tester.py
@@ -188,6 +188,7 @@ def update_mr_with_ref_diffs(
         project_id=gitlab_project_id,
         settings=queries.get_secret_reader_settings(),
     ) as gl:
+        merge_request = gl.get_merge_request(gitlab_merge_request_id)
         changed_paths = gl.get_merge_request_changed_paths(gitlab_merge_request_id)
         compare_diffs = collect_compare_diffs(
             current_state, desired_state, changed_paths
@@ -199,9 +200,7 @@ def update_mr_with_ref_diffs(
             gl.delete_merge_request_comments(
                 gitlab_merge_request_id, startswith="Diffs:"
             )
-            gl.add_comment_to_merge_request(
-                gitlab_merge_request_id, compare_diffs_comment_body
-            )
+            gl.add_comment_to_merge_request(merge_request, compare_diffs_comment_body)
 
 
 def run(

--- a/reconcile/saas_auto_promotions_manager/utils/vcs.py
+++ b/reconcile/saas_auto_promotions_manager/utils/vcs.py
@@ -116,9 +116,9 @@ class VCS:
 
     def close_app_interface_mr(self, mr: ProjectMergeRequest, comment: str) -> None:
         if not self._dry_run and self._allow_deleting_mrs:
-            self._app_interface_api.add_comment_on_merge_request(
+            self._app_interface_api.add_comment_to_merge_request(
                 merge_request=mr,
-                comment=comment,
+                body=comment,
             )
             self._app_interface_api.close(mr)
 

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -137,7 +137,6 @@ def test_add_label_to_merge_request(
 
 
 def test_add_labels_to_merge_request(
-    instance: dict,
     mocker: MockerFixture,
 ) -> None:
     mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
@@ -154,7 +153,6 @@ def test_add_labels_to_merge_request(
 
 
 def test_set_labels_on_merge_request(
-    instance: dict,
     mocker: MockerFixture,
 ) -> None:
     mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
@@ -168,3 +166,21 @@ def test_set_labels_on_merge_request(
     mocked_gitlab_request.labels.return_value.inc.assert_called_once()
     assert mr.labels == [new_label]
     mr.save.assert_called_once()
+
+
+def test_add_comment_to_merge_request(
+    mocker: MockerFixture,
+) -> None:
+    mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
+    mr = create_autospec(ProjectMergeRequest)
+    mr.notes = create_autospec(ProjectMergeRequestNoteManager)
+    body = "some body"
+
+    GitLabApi.add_comment_to_merge_request(mr, body)
+
+    mocked_gitlab_request.labels.return_value.inc.assert_called_once()
+    mr.notes.create.assert_called_once_with(
+        {
+            "body": body,
+        }
+    )

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -190,3 +190,26 @@ def test_add_labels_to_merge_request(
     mocked_gitlab_request.labels.return_value.inc.assert_called_once()
     assert mr.labels == [existing_label, new_label]
     mr.save.assert_called_once()
+
+
+def test_set_labels_on_merge_request(
+    instance: dict,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("reconcile.utils.gitlab_api.gitlab")
+    mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
+    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
+
+    existing_label = "a"
+    new_label = "b"
+    mr = create_autospec(ProjectMergeRequest)
+    mr.labels = [existing_label]
+
+    gitlab_api = GitLabApi(instance, project_id=1)
+    mocked_gitlab_request.reset_mock()
+
+    gitlab_api.set_labels_on_merge_request(mr, [new_label])
+
+    mocked_gitlab_request.labels.return_value.inc.assert_called_once()
+    assert mr.labels == [new_label]
+    mr.save.assert_called_once()

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -290,3 +290,23 @@ def test_get_project_labels(
 
     assert labels == {"a"}
     mocked_gitlab_request.labels.return_value.inc.assert_called_once()
+
+
+def test_get_merge_request_changed_paths(
+    mocker: MockerFixture,
+) -> None:
+    mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
+    mr = create_autospec(ProjectMergeRequest)
+    mr.changes.return_value = {
+        "changes": [
+            {
+                "old_path": "path",
+                "new_path": "path",
+            }
+        ]
+    }
+
+    paths = GitLabApi.get_merge_request_changed_paths(mr)
+
+    mocked_gitlab_request.labels.return_value.inc.assert_called_once()
+    assert paths == ["path"]

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -83,6 +83,44 @@ def test_remove_label_from_issue(
     issue.save.assert_called_once()
 
 
+def test_remove_labels_from_merge_request(
+    mocker: MockerFixture,
+) -> None:
+    mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
+    expected_label = "a"
+    to_be_removed_label = "b"
+    current_labels = [expected_label, to_be_removed_label]
+    mr = create_autospec(ProjectMergeRequest)
+    mr.manager = create_autospec(ProjectMergeRequestManager)
+    mr.manager.get.return_value = mr
+    mr.labels = current_labels
+
+    GitLabApi.remove_labels(mr, [to_be_removed_label])
+
+    assert mocked_gitlab_request.labels.return_value.inc.call_count == 2
+    assert mr.labels == [expected_label]
+    mr.save.assert_called_once()
+
+
+def test_remove_labels_from_issue(
+    mocker: MockerFixture,
+) -> None:
+    mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
+    expected_label = "a"
+    to_be_removed_label = "b"
+    current_labels = [expected_label, to_be_removed_label]
+    issue = create_autospec(ProjectIssue)
+    issue.manager = create_autospec(ProjectIssueManager)
+    issue.manager.get.return_value = issue
+    issue.labels = current_labels
+
+    GitLabApi.remove_labels(issue, [to_be_removed_label])
+
+    assert mocked_gitlab_request.labels.return_value.inc.call_count == 2
+    assert issue.labels == [expected_label]
+    issue.save.assert_called_once()
+
+
 def test_add_label_with_note_to_merge_request(
     mocker: MockerFixture,
 ) -> None:

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -39,23 +39,16 @@ def instance() -> dict:
 
 
 def test_remove_label_from_merge_request(
-    instance: dict,
     mocker: MockerFixture,
 ) -> None:
-    mocker.patch("reconcile.utils.gitlab_api.gitlab")
     mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
-    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
-
     expected_label = "a"
     to_be_removed_label = "b"
     current_labels = [expected_label, to_be_removed_label]
     mr = create_autospec(ProjectMergeRequest)
     mr.labels = current_labels
 
-    gitlab_api = GitLabApi(instance, project_id=1)
-    mocked_gitlab_request.reset_mock()
-
-    gitlab_api.remove_label(mr, to_be_removed_label)
+    GitLabApi.remove_label(mr, to_be_removed_label)
 
     mocked_gitlab_request.labels.return_value.inc.assert_called_once()
     assert mr.labels == [expected_label]
@@ -63,23 +56,16 @@ def test_remove_label_from_merge_request(
 
 
 def test_remove_label_from_issue(
-    instance: dict,
     mocker: MockerFixture,
 ) -> None:
-    mocker.patch("reconcile.utils.gitlab_api.gitlab")
     mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
-    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
-
     expected_label = "a"
     to_be_removed_label = "b"
     current_labels = [expected_label, to_be_removed_label]
     issue = create_autospec(ProjectIssue)
     issue.labels = current_labels
 
-    gitlab_api = GitLabApi(instance, project_id=1)
-    mocked_gitlab_request.reset_mock()
-
-    gitlab_api.remove_label(issue, to_be_removed_label)
+    GitLabApi.remove_label(issue, to_be_removed_label)
 
     mocked_gitlab_request.labels.return_value.inc.assert_called_once()
     assert issue.labels == [expected_label]
@@ -87,23 +73,16 @@ def test_remove_label_from_issue(
 
 
 def test_add_label_with_note_to_merge_request(
-    instance: dict,
     mocker: MockerFixture,
 ) -> None:
-    mocker.patch("reconcile.utils.gitlab_api.gitlab")
     mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
-    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
-
     existing_label = "a"
     new_label = "b"
     mr = create_autospec(ProjectMergeRequest)
     mr.labels = [existing_label]
     mr.notes = create_autospec(ProjectMergeRequestNoteManager)
 
-    gitlab_api = GitLabApi(instance, project_id=1)
-    mocked_gitlab_request.reset_mock()
-
-    gitlab_api.add_label_with_note(mr, new_label)
+    GitLabApi.add_label_with_note(mr, new_label)
 
     assert mocked_gitlab_request.labels.return_value.inc.call_count == 2
     assert mr.labels == [existing_label, new_label]
@@ -117,23 +96,18 @@ def test_add_label_with_note_to_merge_request(
 
 
 def test_add_label_with_note_to_issue(
-    instance: dict,
     mocker: MockerFixture,
 ) -> None:
-    mocker.patch("reconcile.utils.gitlab_api.gitlab")
     mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
-    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
-
     existing_label = "a"
     new_label = "b"
     issue = create_autospec(ProjectIssue)
     issue.labels = [existing_label]
     issue.notes = create_autospec(ProjectIssueNoteManager)
 
-    gitlab_api = GitLabApi(instance, project_id=1)
     mocked_gitlab_request.reset_mock()
 
-    gitlab_api.add_label_with_note(issue, new_label)
+    GitLabApi.add_label_with_note(issue, new_label)
 
     assert mocked_gitlab_request.labels.return_value.inc.call_count == 2
     assert issue.labels == [existing_label, new_label]
@@ -147,22 +121,15 @@ def test_add_label_with_note_to_issue(
 
 
 def test_add_label_to_merge_request(
-    instance: dict,
     mocker: MockerFixture,
 ) -> None:
-    mocker.patch("reconcile.utils.gitlab_api.gitlab")
     mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
-    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
-
     existing_label = "a"
     new_label = "b"
     mr = create_autospec(ProjectMergeRequest)
     mr.labels = [existing_label]
 
-    gitlab_api = GitLabApi(instance, project_id=1)
-    mocked_gitlab_request.reset_mock()
-
-    gitlab_api.add_label_to_merge_request(mr, new_label)
+    GitLabApi.add_label_to_merge_request(mr, new_label)
 
     mocked_gitlab_request.labels.return_value.inc.assert_called_once()
     assert mr.labels == [existing_label, new_label]
@@ -173,19 +140,13 @@ def test_add_labels_to_merge_request(
     instance: dict,
     mocker: MockerFixture,
 ) -> None:
-    mocker.patch("reconcile.utils.gitlab_api.gitlab")
     mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
-    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
-
     existing_label = "a"
     new_label = "b"
     mr = create_autospec(ProjectMergeRequest)
     mr.labels = [existing_label]
 
-    gitlab_api = GitLabApi(instance, project_id=1)
-    mocked_gitlab_request.reset_mock()
-
-    gitlab_api.add_labels_to_merge_request(mr, [new_label])
+    GitLabApi.add_labels_to_merge_request(mr, [new_label])
 
     mocked_gitlab_request.labels.return_value.inc.assert_called_once()
     assert mr.labels == [existing_label, new_label]
@@ -196,19 +157,13 @@ def test_set_labels_on_merge_request(
     instance: dict,
     mocker: MockerFixture,
 ) -> None:
-    mocker.patch("reconcile.utils.gitlab_api.gitlab")
     mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
-    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
-
     existing_label = "a"
     new_label = "b"
     mr = create_autospec(ProjectMergeRequest)
     mr.labels = [existing_label]
 
-    gitlab_api = GitLabApi(instance, project_id=1)
-    mocked_gitlab_request.reset_mock()
-
-    gitlab_api.set_labels_on_merge_request(mr, [new_label])
+    GitLabApi.set_labels_on_merge_request(mr, [new_label])
 
     mocked_gitlab_request.labels.return_value.inc.assert_called_once()
     assert mr.labels == [new_label]

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -52,10 +52,7 @@ def test_remove_label_from_merge_request(
     mr = create_autospec(ProjectMergeRequest)
     mr.labels = current_labels
 
-    gitlab_api = GitLabApi(
-        instance,
-        project_id=1,
-    )
+    gitlab_api = GitLabApi(instance, project_id=1)
     mocked_gitlab_request.reset_mock()
 
     gitlab_api.remove_label(mr, to_be_removed_label)
@@ -79,10 +76,7 @@ def test_remove_label_from_issue(
     issue = create_autospec(ProjectIssue)
     issue.labels = current_labels
 
-    gitlab_api = GitLabApi(
-        instance,
-        project_id=1,
-    )
+    gitlab_api = GitLabApi(instance, project_id=1)
     mocked_gitlab_request.reset_mock()
 
     gitlab_api.remove_label(issue, to_be_removed_label)
@@ -106,10 +100,7 @@ def test_add_label_with_note_to_merge_request(
     mr.labels = [existing_label]
     mr.notes = create_autospec(ProjectMergeRequestNoteManager)
 
-    gitlab_api = GitLabApi(
-        instance,
-        project_id=1,
-    )
+    gitlab_api = GitLabApi(instance, project_id=1)
     mocked_gitlab_request.reset_mock()
 
     gitlab_api.add_label_with_note(mr, new_label)
@@ -139,10 +130,7 @@ def test_add_label_with_note_to_issue(
     issue.labels = [existing_label]
     issue.notes = create_autospec(ProjectIssueNoteManager)
 
-    gitlab_api = GitLabApi(
-        instance,
-        project_id=1,
-    )
+    gitlab_api = GitLabApi(instance, project_id=1)
     mocked_gitlab_request.reset_mock()
 
     gitlab_api.add_label_with_note(issue, new_label)
@@ -156,3 +144,26 @@ def test_add_label_with_note_to_issue(
         }
     )
     issue.save.assert_called_once()
+
+
+def test_add_label_to_merge_request(
+    instance: dict,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("reconcile.utils.gitlab_api.gitlab")
+    mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
+    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
+
+    existing_label = "a"
+    new_label = "b"
+    mr = create_autospec(ProjectMergeRequest)
+    mr.labels = [existing_label]
+
+    gitlab_api = GitLabApi(instance, project_id=1)
+    mocked_gitlab_request.reset_mock()
+
+    gitlab_api.add_label_to_merge_request(mr, new_label)
+
+    mocked_gitlab_request.labels.return_value.inc.assert_called_once()
+    assert mr.labels == [existing_label, new_label]
+    mr.save.assert_called_once()

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -310,3 +310,16 @@ def test_get_merge_request_changed_paths(
 
     mocked_gitlab_request.labels.return_value.inc.assert_called_once()
     assert paths == ["path"]
+
+
+def test_get_merge_request_author_username(
+    mocker: MockerFixture,
+) -> None:
+    mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
+    mr = create_autospec(ProjectMergeRequest)
+    mr.author = {"username": "author_a"}
+
+    username = GitLabApi.get_merge_request_author_username(mr)
+
+    assert username == "author_a"
+    mocked_gitlab_request.labels.return_value.inc.assert_not_called()

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -92,7 +92,7 @@ def test_remove_label_from_issue(
     issue.save.assert_called_once()
 
 
-def test_add_label_to_merge_request(
+def test_add_label_with_note_to_merge_request(
     instance: dict,
     mocker: MockerFixture,
 ) -> None:
@@ -112,7 +112,7 @@ def test_add_label_to_merge_request(
     )
     mocked_gitlab_request.reset_mock()
 
-    gitlab_api.add_label(mr, new_label)
+    gitlab_api.add_label_with_note(mr, new_label)
 
     assert mocked_gitlab_request.labels.return_value.inc.call_count == 2
     assert mr.labels == [existing_label, new_label]
@@ -125,7 +125,7 @@ def test_add_label_to_merge_request(
     mr.save.assert_called_once()
 
 
-def test_add_label_to_issue(
+def test_add_label_with_note_to_issue(
     instance: dict,
     mocker: MockerFixture,
 ) -> None:
@@ -145,7 +145,7 @@ def test_add_label_to_issue(
     )
     mocked_gitlab_request.reset_mock()
 
-    gitlab_api.add_label(issue, new_label)
+    gitlab_api.add_label_with_note(issue, new_label)
 
     assert mocked_gitlab_request.labels.return_value.inc.call_count == 2
     assert issue.labels == [existing_label, new_label]

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -167,3 +167,26 @@ def test_add_label_to_merge_request(
     mocked_gitlab_request.labels.return_value.inc.assert_called_once()
     assert mr.labels == [existing_label, new_label]
     mr.save.assert_called_once()
+
+
+def test_add_labels_to_merge_request(
+    instance: dict,
+    mocker: MockerFixture,
+) -> None:
+    mocker.patch("reconcile.utils.gitlab_api.gitlab")
+    mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
+    mocker.patch("reconcile.utils.gitlab_api.SecretReader", autospec=True)
+
+    existing_label = "a"
+    new_label = "b"
+    mr = create_autospec(ProjectMergeRequest)
+    mr.labels = [existing_label]
+
+    gitlab_api = GitLabApi(instance, project_id=1)
+    mocked_gitlab_request.reset_mock()
+
+    gitlab_api.add_labels_to_merge_request(mr, [new_label])
+
+    mocked_gitlab_request.labels.return_value.inc.assert_called_once()
+    assert mr.labels == [existing_label, new_label]
+    mr.save.assert_called_once()

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -6,6 +6,7 @@ from gitlab.v4.objects import (
     ProjectIssueNoteManager,
     ProjectMergeRequest,
     ProjectMergeRequestNoteManager,
+    ProjectMergeRequestNote,
 )
 from pytest_mock import MockerFixture
 from requests.exceptions import ConnectTimeout
@@ -184,3 +185,15 @@ def test_add_comment_to_merge_request(
             "body": body,
         }
     )
+
+
+def test_delete_comment(
+    mocker: MockerFixture,
+) -> None:
+    mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
+    note = create_autospec(ProjectMergeRequestNote)
+
+    GitLabApi.delete_comment(note)
+
+    mocked_gitlab_request.labels.return_value.inc.assert_called_once()
+    note.delete.assert_called_once_with()

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -1,6 +1,9 @@
 import logging
 import os
-from collections.abc import Iterable
+from collections.abc import (
+    Iterable,
+    Set,
+)
 from operator import (
     attrgetter,
     itemgetter,
@@ -415,8 +418,8 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             if c["username"] == self.user.username and body.startswith(startswith):
                 self.delete_comment(c["note"])
 
-    def get_project_labels(self):
-        return [ln.name for ln in self.get_items(self.project.labels.list)]
+    def get_project_labels(self) -> Set[str]:
+        return {ln.name for ln in self.get_items(self.project.labels.list)}
 
     @staticmethod
     def add_label_to_merge_request(

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -529,6 +529,24 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         item.save()
 
     @staticmethod
+    def remove_labels(
+        item: ProjectMergeRequest | ProjectIssue,
+        labels: Iterable[str],
+    ):
+        # item maybe stale, refresh it to reduce the possibility of labels overwriting
+        GitLabApi.refresh_labels(item)
+
+        current_labels = set(item.labels)
+        to_be_removed = set(labels) & current_labels
+
+        if not to_be_removed:
+            return
+        item.labels = list(current_labels - to_be_removed)
+
+        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
+        item.save()
+
+    @staticmethod
     def close(item):
         item.state_event = "close"
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -418,11 +418,6 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
     def get_project_labels(self):
         return [ln.name for ln in self.get_items(self.project.labels.list)]
 
-    def get_merge_request_labels(self, mr_id):
-        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        merge_request = self.project.mergerequests.get(mr_id)
-        return merge_request.labels
-
     @staticmethod
     def add_label_to_merge_request(
         merge_request: ProjectMergeRequest,

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -410,12 +410,6 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             if c["username"] == self.user.username and body.startswith(startswith):
                 self.delete_gitlab_comment(c["note"])
 
-    def add_comment_on_merge_request(
-        self, merge_request: ProjectMergeRequest, comment: str
-    ) -> None:
-        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        merge_request.notes.create({"body": comment})
-
     def add_merge_request_comment(self, mr_id, comment):
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         merge_request = self.project.mergerequests.get(mr_id)
@@ -465,9 +459,12 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         merge_request.save()
 
-    def add_comment_to_merge_request(self, mr_id, body):
+    @staticmethod
+    def add_comment_to_merge_request(
+        merge_request: ProjectMergeRequest,
+        body: str,
+    ) -> None:
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        merge_request = self.project.mergerequests.get(mr_id)
         merge_request.notes.create({"body": body})
 
     @staticmethod

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -429,12 +429,17 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         merge_request = self.project.mergerequests.get(mr_id)
         return merge_request.labels
 
-    def add_label_to_merge_request(self, mr_id, label):
-        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        merge_request = self.project.mergerequests.get(mr_id)
-        labels = merge_request.attributes.get("labels")
+    @staticmethod
+    def add_label_to_merge_request(
+        merge_request: ProjectMergeRequest,
+        label: str,
+    ) -> None:
+        labels = merge_request.labels
+        if label in labels:
+            return
         labels.append(label)
-        self.update_labels(merge_request, "merge-request", labels)
+        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
+        merge_request.save()
 
     def add_labels_to_merge_request(self, mr_id, labels):
         """Adds labels to a Merge Request"""

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -404,8 +404,11 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         note.delete()
 
-    def delete_merge_request_comments(self, mr_id: int, startswith: str) -> None:
-        merge_request = self.get_merge_request(mr_id)
+    def delete_merge_request_comments(
+        self,
+        merge_request: ProjectMergeRequest,
+        startswith: str,
+    ) -> None:
         comments = self.get_merge_request_comments(merge_request)
         for c in comments:
             body = c["body"] or ""

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -415,12 +415,6 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             if c["username"] == self.user.username and body.startswith(startswith):
                 self.delete_comment(c["note"])
 
-    def add_merge_request_comment(self, mr_id, comment):
-        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        merge_request = self.project.mergerequests.get(mr_id)
-        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        merge_request.notes.create({"body": comment})
-
     def get_project_labels(self):
         return [ln.name for ln in self.get_items(self.project.labels.list)]
 

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -517,21 +517,6 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         item.save()
 
-    def update_labels(self, item, item_type, labels):
-        if item_type == "issue":
-            gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-            editable_item = self.project.issues.get(
-                item.attributes.get("iid"), lazy=True
-            )
-        elif item_type == "merge-request":
-            gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-            editable_item = self.project.mergerequests.get(
-                item.attributes.get("iid"), lazy=True
-            )
-        editable_item.labels = labels
-        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        editable_item.save()
-
     @staticmethod
     def close(item):
         item.state_event = "close"

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -196,15 +196,9 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
 
     def mr_exists(self, title):
         mrs = self.get_merge_requests(state=MRState.OPENED)
-        for mr in mrs:
-            # since we are using a naming convention for these MRs
-            # we can determine if a pending MR exists based on the title
-            if mr.attributes.get("title") != title:
-                continue
-
-            return True
-
-        return False
+        # since we are using a naming convention for these MRs
+        # we can determine if a pending MR exists based on the title
+        return any(mr.title == title for mr in mrs)
 
     @retry()
     def get_project_maintainers(self, repo_url=None):

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -474,7 +474,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         self.project.labels.create({"name": label_text, "color": label_color})
 
     @staticmethod
-    def add_label(
+    def add_label_with_note(
         item: ProjectMergeRequest | ProjectIssue,
         label: str,
     ):

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -455,11 +455,15 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         merge_request.save()
 
-    def set_labels_on_merge_request(self, mr_id, labels):
+    @staticmethod
+    def set_labels_on_merge_request(
+        merge_request: ProjectMergeRequest,
+        labels: Iterable[str],
+    ) -> None:
         """Set labels to a Merge Request"""
+        merge_request.labels = labels
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        merge_request = self.project.mergerequests.get(mr_id)
-        self.update_labels(merge_request, "merge-request", labels)
+        merge_request.save()
 
     def add_comment_to_merge_request(self, mr_id, body):
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -356,9 +356,11 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             self.get_items(mr.pipelines), key=lambda x: x["created_at"], reverse=True
         )
 
-    def get_merge_request_changed_paths(self, mr_id: int) -> list[str]:
+    @staticmethod
+    def get_merge_request_changed_paths(
+        merge_request: ProjectMergeRequest,
+    ) -> list[str]:
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        merge_request = self.project.mergerequests.get(mr_id)
         changes = merge_request.changes()["changes"]
         changed_paths = set()
         for change in changes:

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -94,8 +94,10 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             if project_url is not None:
                 parsed_project_url = urlparse(project_url)
                 name_with_namespace = parsed_project_url.path.strip("/")
+                gitlab_request.labels(integration=INTEGRATION_NAME).inc()
                 self.project = self.gl.projects.get(name_with_namespace)
         else:
+            gitlab_request.labels(integration=INTEGRATION_NAME).inc()
             self.project = self.gl.projects.get(project_id)
         self.saas_files = saas_files
 
@@ -221,6 +223,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         return self.get_items(app_sre_group.members.list)
 
     def get_group_if_exists(self, group_name):
+        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         try:
             return self.gl.groups.get(group_name)
         except gitlab.exceptions.GitlabGetError:
@@ -231,7 +234,6 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         if not group:
             logging.error(group_name + " group not found")
             return []
-        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         return [
             {
                 "user": m.username,
@@ -257,7 +259,6 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         if not group:
             logging.error(group_name + " group not found")
         else:
-            gitlab_request.labels(integration=INTEGRATION_NAME).inc()
             user = self.get_user(username)
             access_level = self.get_access_level(access)
             if user is not None:
@@ -286,6 +287,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         member = group.members.get(user.id)
         member.access_level = self.get_access_level(access)
+        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         member.save()
 
     @staticmethod

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -399,7 +399,8 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             )
         return comments
 
-    def delete_gitlab_comment(self, note: ProjectMergeRequestNote) -> None:
+    @staticmethod
+    def delete_comment(note: ProjectMergeRequestNote) -> None:
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         note.delete()
 
@@ -408,7 +409,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         for c in comments:
             body = c["body"] or ""
             if c["username"] == self.user.username and body.startswith(startswith):
-                self.delete_gitlab_comment(c["note"])
+                self.delete_comment(c["note"])
 
     def add_merge_request_comment(self, mr_id, comment):
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -370,9 +370,10 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             changed_paths.add(new_path)
         return list(changed_paths)
 
-    def get_merge_request_author_username(self, mr_id: int) -> str:
-        gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        merge_request = self.project.mergerequests.get(mr_id)
+    @staticmethod
+    def get_merge_request_author_username(
+        merge_request: ProjectMergeRequest,
+    ) -> str:
         return merge_request.author["username"]
 
     @staticmethod


### PR DESCRIPTION
`merge_request` info is fetched multiple times for the same merge request, because some methods are using `iid` of `merger_request` instead of `merge_request` object. This change mainly refactored those methods to reused already fetched `merger_request` object.

To avoid concurrent 
 `labels` update in `issue` and `merge request`, those items are refreshed before update.

Also fixed some missing or wrong `gitlab_request` metrics.

Affected integrations:

* `change_owners`
* `gitlab_fork_compliance`
* `gitlab_housekeeping`
* `gitlab_labeler`
* `gitlab_owners`
* `openshift_saas_deploy_change_tester`
* `saas_auto_promotions_manager`

[APPSRE-8068](https://issues.redhat.com/browse/APPSRE-8068)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f52e1d7</samp>

This pull request refactors and improves the code that interacts with the GitLab API in various modules, by using the `merge_request` object instead of the `mr_id` integer, simplifying the logic, avoiding redundant or unnecessary calls, and adding new methods and features. It also updates the tests and type annotations accordingly.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at f52e1d7</samp>

*  Simplify and optimize the interface and implementation of the GitLabApi class methods by using the merge request objects directly instead of the IDs, and adding notes to the items when labels are added or removed ([link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-985fa2d09f658257b01c55b453e714cf8e726d025fab87d818ca0f04e34484e9R5-R6), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-985fa2d09f658257b01c55b453e714cf8e726d025fab87d818ca0f04e34484e9L113-R115), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-985fa2d09f658257b01c55b453e714cf8e726d025fab87d818ca0f04e34484e9L123-R128), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-985fa2d09f658257b01c55b453e714cf8e726d025fab87d818ca0f04e34484e9L165-R170), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-985fa2d09f658257b01c55b453e714cf8e726d025fab87d818ca0f04e34484e9L309-R383), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-78e09dfbaefeb1d4369c6ad29ed3315083f6394b3e495f2591664cb0288fe8e3L81-R81), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-78e09dfbaefeb1d4369c6ad29ed3315083f6394b3e495f2591664cb0288fe8e3L116-R115), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L232-R232), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L311-R311), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L352-R364), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L374), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-36fc33e36c6c75f4740d29326cae1f20567af41c6deb6f17b0a908aaeb83d520L463-R463), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1526fa129701470ff8934a7d1b1d53a16fb2ccea5456dbcae9fab1f74bffae46L82-R85), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1526fa129701470ff8934a7d1b1d53a16fb2ccea5456dbcae9fab1f74bffae46L129-R136), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1526fa129701470ff8934a7d1b1d53a16fb2ccea5456dbcae9fab1f74bffae46L144-R147), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-299b14c9cd7227766a3ca80d4217d6b03ee6eaa21f8c8bbb3ba58a1db5eabcf0L54-R54), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-299b14c9cd7227766a3ca80d4217d6b03ee6eaa21f8c8bbb3ba58a1db5eabcf0L79-R79), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-299b14c9cd7227766a3ca80d4217d6b03ee6eaa21f8c8bbb3ba58a1db5eabcf0L149-R149), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-299b14c9cd7227766a3ca80d4217d6b03ee6eaa21f8c8bbb3ba58a1db5eabcf0L174-R174), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-299b14c9cd7227766a3ca80d4217d6b03ee6eaa21f8c8bbb3ba58a1db5eabcf0L192-R192), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-299b14c9cd7227766a3ca80d4217d6b03ee6eaa21f8c8bbb3ba58a1db5eabcf0L361-R360), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-44a063da69274e91106df288ed1776358efa6f48c729be06668b81eee7ef22d8L191-R192), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-44a063da69274e91106df288ed1776358efa6f48c729be06668b81eee7ef22d8L199-R201), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-5ed4d11275484235791ada4163ca7858de639790346178ed141054b5f8fc4e11L119-R121), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bR3-R6), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL93-R100), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL193-R202), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bR220), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL230), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL256), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bR284), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL355-R359), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL367-R380), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL387-R390), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL401-R469), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL477-R503), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bR521-R523), [link](https://github.com/app-sre/qontract-reconcile/pull/3711/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL505-R547))