### PR TITLE
fix get labels for app_interface_merge_queue

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1772,7 +1772,7 @@ def app_interface_merge_queue(ctx):
             ).total_seconds()
             / 60,
             "approved_by": mr["approved_by"],
-            "labels": ", ".join(mr["labels"]),
+            "labels": ", ".join(mr["mr"].labels),
         }
         merge_queue_data.append(item)
 


### PR DESCRIPTION
follow up fix of https://github.com/app-sre/qontract-reconcile/pull/3711#discussion_r1280907271