### PR TITLE
fix missing slash in url

### DIFF
--- a/reconcile/utils/ocm/upgrades.py
+++ b/reconcile/utils/ocm/upgrades.py
@@ -60,7 +60,9 @@ def delete_addon_upgrade_policy(
     """
     Deletes an existing Addon Upgrade Policy
     """
-    ocm_api.delete(f"{build_cluster_url(cluster_id)}/addon_upgrade_policies{policy_id}")
+    ocm_api.delete(
+        f"{build_cluster_url(cluster_id)}/addon_upgrade_policies/{policy_id}"
+    )
 
 
 #


### PR DESCRIPTION
```
qontract-reconcile-ocm-addons-upgrade-scheduler-org Traceback (most recent call last):
qontract-reconcile-ocm-addons-upgrade-scheduler-org   File "/usr/local/lib/python3.11/site-packages/reconcile/cli.py", line 514, in run_class_integration
qontract-reconcile-ocm-addons-upgrade-scheduler-org     run_integration_cfg(
qontract-reconcile-ocm-addons-upgrade-scheduler-org   File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 161, in run_integration_cfg
qontract-reconcile-ocm-addons-upgrade-scheduler-org     _integration_wet_run(run_cfg.integration)
qontract-reconcile-ocm-addons-upgrade-scheduler-org   File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 170, in _integration_wet_run
qontract-reconcile-ocm-addons-upgrade-scheduler-org     integration.run(False)
qontract-reconcile-ocm-addons-upgrade-scheduler-org   File "/usr/local/lib/python3.11/site-packages/reconcile/aus/base.py", line 116, in run
qontract-reconcile-ocm-addons-upgrade-scheduler-org     raise ReconcileErrorSummary(unhandled_exceptions)
qontract-reconcile-ocm-addons-upgrade-scheduler-org reconcile.aus.base.ReconcileErrorSummary: Reconcile exceptions:
qontract-reconcile-ocm-addons-upgrade-scheduler-org - ocm-integration/osd-fleet-manager-ocm-integration: 404 Client Error: Not Found for url: https://api.integration.openshift.com/api/clusters_mgmt/v1/clusters/xxxxx/addon_upgrade_policies903e5223-3120-11ee-b6d3-xxxxxxx
```