### PR TITLE
[dev-image] install debugger

### DIFF
--- a/dev/run.sh
+++ b/dev/run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-pip install -r /work/requirements/requirements-debugger.txt
-
 DEBUGPY_PORT=${DEBUGPY_PORT:-5678}
 
 # for backwards compatibility

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -34,6 +34,7 @@ WORKDIR /work
 
 RUN python3 -m pip install --no-cache-dir --no-index --find-links=/tmp/work/wheels qontract-reconcile
 RUN python3 -m pip install -e .
+RUN python3 -m pip install -r /work/requirements/requirements-debugger.txt
 
 RUN chown -R reconcile /work && \
     chown -R reconcile /.terraform.d


### PR DESCRIPTION
Install debug requirements in the dev image instead of installing them at startup. This will speed up the startup of the local development container a little bit.