### PR TITLE
[AUS] fix addon spec duplication error + use correct SA

### DIFF
--- a/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
@@ -35,6 +35,7 @@ from reconcile.utils.ocm.clusters import (
 from reconcile.utils.ocm_base_client import (
     OCMBaseClient,
     init_ocm_base_client,
+    init_ocm_base_client_for_org,
 )
 
 QONTRACT_INTEGRATION = "ocm-addons-upgrade-scheduler-org"
@@ -56,9 +57,7 @@ class OCMAddonsUpgradeSchedulerOrgIntegration(
     def process_upgrade_policies_in_org(
         self, dry_run: bool, org_upgrade_spec: OrganizationUpgradeSpec
     ) -> None:
-        ocm_api = init_ocm_base_client(
-            org_upgrade_spec.org.environment, self.secret_reader
-        )
+        ocm_api = init_ocm_base_client_for_org(org_upgrade_spec.org, self.secret_reader)
 
         current_state = aus.fetch_current_state(
             ocm_api,

--- a/reconcile/utils/ocm_base_client.py
+++ b/reconcile/utils/ocm_base_client.py
@@ -179,8 +179,8 @@ def init_ocm_base_client_for_org(
             secret_reader,
             session,
         )
-    else:
-        return init_ocm_base_client(org.environment, secret_reader, session)
+
+    return init_ocm_base_client(org.environment, secret_reader, session)
 
 
 def init_ocm_base_client(

--- a/reconcile/utils/ocm_base_client.py
+++ b/reconcile/utils/ocm_base_client.py
@@ -16,6 +16,7 @@ from requests import (
 )
 from sretoolbox.utils import retry
 
+from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
 from reconcile.utils.secret_reader import (
     HasSecret,
     SecretReaderBase,
@@ -160,6 +161,26 @@ class OCMAPIClientConfiguration(BaseModel, arbitrary_types_allowed=True):
     access_token_client_id: str
     access_token_url: str
     access_token_client_secret: HasSecret
+
+
+def init_ocm_base_client_for_org(
+    org: AUSOCMOrganization,
+    secret_reader: SecretReaderBase,
+    session: Optional[Session] = None,
+) -> OCMBaseClient:
+    if org.access_token_client_id:
+        return init_ocm_base_client(
+            OCMAPIClientConfiguration(
+                url=org.environment.url,
+                access_token_client_id=org.access_token_client_id,
+                access_token_url=org.access_token_url,
+                access_token_client_secret=org.access_token_client_secret,
+            ),
+            secret_reader,
+            session,
+        )
+    else:
+        return init_ocm_base_client(org.environment, secret_reader, session)
 
 
 def init_ocm_base_client(


### PR DESCRIPTION
due to a bug, the current state for addon upgrade policies had duplicates, which then failed duplicate check during reconciling.

also use the correct service account for addon related work - the one on the org if it exists and only if not the one from the env