### PR TITLE
[Terraform] Skip log plan diff when plan failed

### DIFF
--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -208,6 +208,8 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
             )
             log = f.read().decode("utf-8")
         error = self.check_output(spec.name, "plan", return_code, stdout, stderr, log)
+        if error:
+            return False, [], error
         disabled_deletion_detected, created_users = self.log_plan_diff(
             spec, enable_deletion
         )


### PR DESCRIPTION
When `terraform plan` failed, plan file is not created, later `terraform show` in `log_plan_diff` will fail like

```
Error loading statefile: open xxxx: no such file or directory
```

This change skips `log_plan_diff` when plan failed to avoid messy error messages in log.


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23f037a</samp>

This pull request adds error handling and testing for the `terraform_plan` method of the `TerraformClient` class. It modifies the `reconcile/utils/terraform_client.py` module and the `reconcile/test/utils/test_terraform_client.py` module.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 23f037a</samp>

*  Add a new test case to verify the error handling of `terraform_plan` ([link](https://github.com/app-sre/qontract-reconcile/pull/3719/files?diff=unified&w=0#diff-b3ecbf5e85f99cd579b16e0340930eb7183e47033610cf8a42fa7cc71e45c54aR877-R907))
*  Add a new conditional branch to handle the error scenario in `terraform_plan` ([link](https://github.com/app-sre/qontract-reconcile/pull/3719/files?diff=unified&w=0#diff-5d6f3e1e250b0217592c7e87cd1048ac0f03e7f9ae07e979d540bb9170803bbfR211-R212))
