### PR TITLE
[AUS] cluster level blocked versions

### DIFF
--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -304,6 +304,7 @@ class ClusterUpgradePolicyLabelSet(BaseModel):
     schedule: str = Field(alias=aus_label_key("schedule"))
     mutexes: Optional[CSV] = Field(alias=aus_label_key("mutexes"))
     sector: Optional[str] = Field(alias=aus_label_key("sector"))
+    blocked_versions: Optional[CSV] = Field(alias=aus_label_key("blocked-versions"))
     _schedule_validator = validator("schedule", allow_reuse=True)(cron_validator)
 
 
@@ -321,6 +322,7 @@ def _build_policy_from_labels(labels: LabelContainer) -> ClusterUpgradePolicyV1:
             soakDays=policy_labelset.soak_days,
             mutexes=policy_labelset.mutexes,
             sector=policy_labelset.sector,
+            blockedVersions=policy_labelset.blocked_versions,
         ),
     )
 

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -45,7 +45,9 @@ class ClusterUpgradeSpec(BaseModel):
 
     @property
     def blocked_versions(self) -> set[str]:
-        return set(self.org.blocked_versions or [])
+        return set(self.org.blocked_versions or []) | set(
+            self.upgrade_policy.conditions.blocked_versions or []
+        )
 
     def version_blocked(self, version: str) -> bool:
         return any(re.search(b, version) for b in self.blocked_versions)

--- a/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.py
+++ b/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.py
@@ -82,6 +82,7 @@ fragment ClusterUpgradePolicyV1 on ClusterUpgradePolicy_v1 {
     mutexes
     soakDays
     sector
+    blockedVersions
   }
 }
 

--- a/reconcile/gql_definitions/advanced_upgrade_service/aus_organization.py
+++ b/reconcile/gql_definitions/advanced_upgrade_service/aus_organization.py
@@ -81,6 +81,7 @@ fragment ClusterUpgradePolicyV1 on ClusterUpgradePolicy_v1 {
     mutexes
     soakDays
     sector
+    blockedVersions
   }
 }
 

--- a/reconcile/gql_definitions/common/clusters.py
+++ b/reconcile/gql_definitions/common/clusters.py
@@ -50,6 +50,7 @@ fragment ClusterUpgradePolicyV1 on ClusterUpgradePolicy_v1 {
     mutexes
     soakDays
     sector
+    blockedVersions
   }
 }
 

--- a/reconcile/gql_definitions/fragments/upgrade_policy.gql
+++ b/reconcile/gql_definitions/fragments/upgrade_policy.gql
@@ -7,5 +7,6 @@ fragment ClusterUpgradePolicyV1 on ClusterUpgradePolicy_v1 {
     mutexes
     soakDays
     sector
+    blockedVersions
   }
 }

--- a/reconcile/gql_definitions/fragments/upgrade_policy.py
+++ b/reconcile/gql_definitions/fragments/upgrade_policy.py
@@ -28,6 +28,7 @@ class ClusterUpgradePolicyConditionsV1(ConfiguredBaseModel):
     mutexes: Optional[list[str]] = Field(..., alias="mutexes")
     soak_days: Optional[int] = Field(..., alias="soakDays")
     sector: Optional[str] = Field(..., alias="sector")
+    blocked_versions: Optional[list[str]] = Field(..., alias="blockedVersions")
 
 
 class ClusterUpgradePolicyV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/rhidp/clusters.py
+++ b/reconcile/gql_definitions/rhidp/clusters.py
@@ -30,6 +30,7 @@ fragment ClusterUpgradePolicyV1 on ClusterUpgradePolicy_v1 {
     mutexes
     soakDays
     sector
+    blockedVersions
   }
 }
 

--- a/reconcile/test/fixtures/oc_connection_parameters/cluster_custom_token.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/cluster_custom_token.yml
@@ -87,5 +87,6 @@ upgradePolicy:
     mutexes: null
     sector: null
     soakDays: 7
+    blockedVersions: null
   schedule: 0 12 * * 1-5
   workloads: []

--- a/reconcile/test/fixtures/oc_connection_parameters/cluster_no_jumphost.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/cluster_no_jumphost.yml
@@ -87,5 +87,6 @@ upgradePolicy:
     mutexes: null
     sector: null
     soakDays: 7
+    blockedVersions: null
   schedule: 0 12 * * 1-5
   workloads: []

--- a/reconcile/test/fixtures/oc_connection_parameters/cluster_with_jumphost.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/cluster_with_jumphost.yml
@@ -97,5 +97,6 @@ upgradePolicy:
     mutexes: null
     sector: null
     soakDays: 7
+    blockedVersions: null
   schedule: 0 12 * * 1-5
   workloads: []

--- a/reconcile/test/fixtures/openshift_upgrade_watcher/cluster1.yml
+++ b/reconcile/test/fixtures/openshift_upgrade_watcher/cluster1.yml
@@ -87,5 +87,6 @@ upgradePolicy:
     mutexes: null
     sector: null
     soakDays: 7
+    blockedVersions: null
   schedule: 0 12 * * 1-5
   workloads: []

--- a/reconcile/test/ocm/aus/fixtures.py
+++ b/reconcile/test/ocm/aus/fixtures.py
@@ -32,6 +32,7 @@ def build_upgrade_policy(
     schedule: Optional[str] = None,
     sector: Optional[str] = None,
     mutexes: Optional[list[str]] = None,
+    blocked_versions: Optional[list[str]] = None,
 ) -> ClusterUpgradePolicyV1:
     return ClusterUpgradePolicyV1(
         schedule=schedule or "* * * * *",
@@ -40,6 +41,7 @@ def build_upgrade_policy(
             soakDays=soak_days,
             sector=sector,
             mutexes=mutexes,
+            blockedVersions=blocked_versions,
         ),
     )
 


### PR DESCRIPTION
add support to block versions on cluster level

part of https://issues.redhat.com/browse/APPSRE-7870
depends on https://github.com/app-sre/qontract-schemas/pull/479