### PR TITLE
Move condition inside matching log group regex name

### DIFF
--- a/reconcile/aws_cloudwatch_log_retention/integration.py
+++ b/reconcile/aws_cloudwatch_log_retention/integration.py
@@ -98,16 +98,16 @@ def run(dry_run: bool, thread_pool_size: int, defer: Optional[Callable] = None) 
                                 awsapi.create_cloudwatch_tag(
                                     aws_acct, group_name, MANAGED_TAG
                                 )
-                    if (
-                        retention_days
-                        != cloudwatch_cleanup_entry.log_retention_day_length
-                    ):
-                        logging.info(
-                            f" Setting {group_name} retention days to {cloudwatch_cleanup_entry.log_retention_day_length}"
-                        )
-                        if not dry_run:
-                            awsapi.set_cloudwatch_log_retention(
-                                aws_acct,
-                                group_name,
-                                cloudwatch_cleanup_entry.log_retention_day_length,
+                        if (
+                            retention_days
+                            != cloudwatch_cleanup_entry.log_retention_day_length
+                        ):
+                            logging.info(
+                                f" Setting {group_name} retention days to {cloudwatch_cleanup_entry.log_retention_day_length}"
                             )
+                            if not dry_run:
+                                awsapi.set_cloudwatch_log_retention(
+                                    aws_acct,
+                                    group_name,
+                                    cloudwatch_cleanup_entry.log_retention_day_length,
+                                )


### PR DESCRIPTION
Follow up to https://github.com/app-sre/qontract-reconcile/pull/3587

The retention day condition is currently sitting outside of the regex log name match condition and so the regex logic is not functioning as intended.

Part of [APPSRE-7249]( https://issues.redhat.com/browse/APPSRE-7249)