### PR TITLE
Fixing conditional logic and var type in log retention integration

### DIFF
--- a/reconcile/aws_cloudwatch_log_retention/integration.py
+++ b/reconcile/aws_cloudwatch_log_retention/integration.py
@@ -18,7 +18,7 @@ else:
     CloudWatchLogsClient = object
 
 QONTRACT_INTEGRATION = "aws_cloudwatch_log_retention"
-MANAGED_TAG = {"Key": "managed_by_integration", "Value": QONTRACT_INTEGRATION}
+MANAGED_TAG = {"managed_by_integration": QONTRACT_INTEGRATION}
 
 
 class AWSCloudwatchLogRetention(BaseModel):

--- a/reconcile/aws_cloudwatch_log_retention/integration.py
+++ b/reconcile/aws_cloudwatch_log_retention/integration.py
@@ -109,5 +109,7 @@ def run(dry_run: bool, thread_pool_size: int, defer: Optional[Callable] = None) 
                                 awsapi.set_cloudwatch_log_retention(
                                     aws_acct,
                                     group_name,
-                                    int(cloudwatch_cleanup_entry.log_retention_day_length),
+                                    int(
+                                        cloudwatch_cleanup_entry.log_retention_day_length
+                                    ),
                                 )

--- a/reconcile/aws_cloudwatch_log_retention/integration.py
+++ b/reconcile/aws_cloudwatch_log_retention/integration.py
@@ -87,7 +87,7 @@ def run(dry_run: bool, thread_pool_size: int, defer: Optional[Callable] = None) 
                     regex_pattern = re.compile(cloudwatch_cleanup_entry.log_regex)
                     if regex_pattern.match(group_name):
                         log_group_tags = log_group["tags"]
-                        if all(
+                        if not all(
                             item in log_group_tags.items()
                             for item in MANAGED_TAG.items()
                         ):
@@ -109,5 +109,5 @@ def run(dry_run: bool, thread_pool_size: int, defer: Optional[Callable] = None) 
                                 awsapi.set_cloudwatch_log_retention(
                                     aws_acct,
                                     group_name,
-                                    cloudwatch_cleanup_entry.log_retention_day_length,
+                                    int(cloudwatch_cleanup_entry.log_retention_day_length),
                                 )


### PR DESCRIPTION
Whenever a user pushes a log retention value, the following shows up in the integration pod:
```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter retentionInDays, value: 365, type: <class 'str'>, valid types: <class 'int'>
```

This PR fixes the var type as well as fixes the logic to implement integration tagging.