### PR TITLE
Fixing compare block to better check log retention day amount set

### DIFF
--- a/reconcile/aws_cloudwatch_log_retention/integration.py
+++ b/reconcile/aws_cloudwatch_log_retention/integration.py
@@ -1,5 +1,6 @@
 import logging
 import re
+import sys
 from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
@@ -9,6 +10,7 @@ from typing import (
 from pydantic import BaseModel
 
 from reconcile import queries
+from reconcile.status import ExitCodes
 from reconcile.queries import get_aws_accounts
 from reconcile.utils.aws_api import AWSApi
 
@@ -113,3 +115,4 @@ def run(dry_run: bool, thread_pool_size: int, defer: Optional[Callable] = None) 
                                         cloudwatch_cleanup_entry.log_retention_day_length
                                     ),
                                 )
+    sys.exit(ExitCodes.SUCCESS)

--- a/reconcile/aws_cloudwatch_log_retention/integration.py
+++ b/reconcile/aws_cloudwatch_log_retention/integration.py
@@ -100,9 +100,8 @@ def run(dry_run: bool, thread_pool_size: int, defer: Optional[Callable] = None) 
                                 awsapi.create_cloudwatch_tag(
                                     aws_acct, group_name, MANAGED_TAG
                                 )
-                        if (
-                            retention_days
-                            != cloudwatch_cleanup_entry.log_retention_day_length
+                        if int(retention_days) != int(
+                            cloudwatch_cleanup_entry.log_retention_day_length
                         ):
                             logging.info(
                                 f" Setting {group_name} retention days to {cloudwatch_cleanup_entry.log_retention_day_length}"
@@ -115,4 +114,3 @@ def run(dry_run: bool, thread_pool_size: int, defer: Optional[Callable] = None) 
                                         cloudwatch_cleanup_entry.log_retention_day_length
                                     ),
                                 )
-    sys.exit(ExitCodes.SUCCESS)

--- a/reconcile/aws_cloudwatch_log_retention/integration.py
+++ b/reconcile/aws_cloudwatch_log_retention/integration.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import sys
 from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
@@ -10,7 +9,6 @@ from typing import (
 from pydantic import BaseModel
 
 from reconcile import queries
-from reconcile.status import ExitCodes
 from reconcile.queries import get_aws_accounts
 from reconcile.utils.aws_api import AWSApi
 


### PR DESCRIPTION
The condition to compare the log retention value in AWS and what is set in app-interface is not working as expected. This PR will fix that conditional so log retentions that are set in app-interface won't continuously reset and reconcile like that.

Part of [APPSRE-7249](https://issues.redhat.com/browse/APPSRE-7249)