### PR TITLE
APPSRE-8127 fix ami cleaner

### DIFF
--- a/reconcile/aws_ami_cleanup/integration.py
+++ b/reconcile/aws_ami_cleanup/integration.py
@@ -211,11 +211,15 @@ def run(dry_run: bool, thread_pool_size: int, defer: Optional[Callable] = None) 
     # cannot still be properly monitored (see https://issues.redhat.com/browse/APPSRE-7674),
     # it's easy that it breaks without being noticed. Once it is properly monitored, this should
     # be moved to a typed query.
-    cleanup_accounts = [
-        a
-        for a in queries.get_aws_accounts(terraform_state=True, cleanup=True)
-        if a.get("cleanup")
-    ]
+    query_data = queries.get_aws_accounts(terraform_state=True, cleanup=True)
+    cleanup_accounts = []
+    for data in query_data:
+        cleanup = data.get("cleanup")
+        if not cleanup:
+            continue
+        if not (cleanup.get("regex") or cleanup.get("age") or cleanup.get("region")):
+            continue
+        cleanup_accounts.append(data)
 
     vault_settings = get_app_interface_vault_settings()
 

--- a/reconcile/aws_ami_cleanup/integration.py
+++ b/reconcile/aws_ami_cleanup/integration.py
@@ -219,7 +219,7 @@ def run(dry_run: bool, thread_pool_size: int, defer: Optional[Callable] = None) 
             continue
         is_ami_related = False
         for cleanup in cleanups:
-            is_ami_related |= not (cleanup.get("regex") or cleanup.get("age") or cleanup.get("region"))
+            is_ami_related |= cleanup.get("provider") == "ami"
         if not is_ami_related:
             continue
         cleanup_accounts.append(data)

--- a/reconcile/aws_ami_cleanup/integration.py
+++ b/reconcile/aws_ami_cleanup/integration.py
@@ -214,10 +214,13 @@ def run(dry_run: bool, thread_pool_size: int, defer: Optional[Callable] = None) 
     query_data = queries.get_aws_accounts(terraform_state=True, cleanup=True)
     cleanup_accounts = []
     for data in query_data:
-        cleanup = data.get("cleanup")
-        if not cleanup:
+        cleanups = data.get("cleanup")
+        if not cleanups:
             continue
-        if not (cleanup.get("regex") or cleanup.get("age") or cleanup.get("region")):
+        is_ami_related = False
+        for cleanup in cleanups:
+            is_ami_related |= not (cleanup.get("regex") or cleanup.get("age") or cleanup.get("region"))
+        if not is_ami_related:
             continue
         cleanup_accounts.append(data)
 


### PR DESCRIPTION
https://github.com/app-sre/qontract-reconcile/pull/3587 introduces a change to the AWS query:

```
 cleanup {
      provider
     # NEW
      ... on AWSAccountCleanupOptionCloudWatch_v1 {
        regex
        retention_in_days
      }
      ... on AWSAccountCleanupOptionAMI_v1 {
        regex
        age
        region
      }
}
```

The AMI cleaner only checks for any cleanup entry, thus also taking cloudwatch entries into account. We need to properly distinguish between the 2.

**Test**

Ran locally

```
qd profile run prod aws-ami-cleanup
```