### PR TITLE
[AUS] inherit version data feature for label based AUS

### DIFF
--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -369,8 +369,9 @@ def _build_org_upgrade_spec(
             for org in version_data_inheritance.unverified_inheritance_from_orgs
         ]
         org_upgrade_spec.add_organization_error(
-            f"version data inheritance from organizations {', '.join(sorted(unverified_org_ids))} "
-            f"is unverified. ask the owner of these organizations to publish version data to the organization ID {org.id}"
+            f"Version data inheritance from organizations {', '.join(sorted(unverified_org_ids))} "
+            f"are unverified. Ask the owner of these organizations to publish version data to the organization ID {org.id}. "
+            "See https://source.redhat.com/groups/public/sre/wiki/advanced_upgrade_service_aus"
         )
 
     return org_upgrade_spec

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -141,11 +141,11 @@ class AdvancedUpgradeSchedulerBaseIntegration(
             for ocm_env in self.get_ocm_environments()
         }
 
-    def get_ocm_environments(self) -> list[OCMEnvironment]:
+    def get_ocm_environments(self, filter: bool = True) -> list[OCMEnvironment]:
         return ocm_environment_query(
             gql.get_api().query,
             variables={"name": self.params.ocm_environment}
-            if self.params.ocm_environment
+            if self.params.ocm_environment and filter
             else None,
         ).environments
 

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -730,8 +730,6 @@ class OCM:  # pylint: disable=too-many-public-methods
 
         self._init_blocked_versions(blocked_versions)
 
-        self.inheritVersionData = inheritVersionData or []
-
         self.init_version_gates = init_version_gates
         self.version_gates: list[Any] = []
         if init_version_gates:


### PR DESCRIPTION
introduce two new organizations labels to describe publish/inherit intent for version data between organizations.

  ```
  sre-capability.aus.version-data.inherit: CSV of org IDs to inherit version data from
  sre-capability.aus.version-data.publish: CSV of org IDs to publish version data to
  ```

  if an inherit label is not accompanied with a publish label on the other side, the organization trying to inherit is in error mode and a service log is published for each cluster with an upgrade policy in the inheriting org

  part of https://issues.redhat.com/browse/APPSRE-7838