### PR TITLE
disable timeout for glitchtip client DELETE requests

### DIFF
--- a/reconcile/utils/glitchtip/client.py
+++ b/reconcile/utils/glitchtip/client.py
@@ -94,7 +94,7 @@ class GlitchtipClient:
         return response.json()
 
     def _delete(self, url: str) -> None:
-        self._session.delete(urljoin(self.host, url), timeout=self.read_timeout)
+        self._session.delete(urljoin(self.host, url), timeout=None)
 
     def organizations(self) -> list[Organization]:
         """List organizations."""


### PR DESCRIPTION
Deleting Glitchtip resources (projects, teams, ...) is a synchronous API call. When deleting a project with many issues/events, this API call easily exceeds the default 30 seconds timeout. 