### PR TITLE
[gitlab] Move refresh_labels closer to request

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -372,7 +372,6 @@ def run(
                     for p in ChangeTypePriority
                 }
             )
-            GitLabApi.refresh_labels(merge_request)
             labels = manage_conditional_label(
                 current_labels=merge_request.labels,
                 conditional_labels=conditional_labels,

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -215,13 +215,18 @@ def test_set_labels_on_merge_request(
     mocked_gitlab_request = mocker.patch("reconcile.utils.gitlab_api.gitlab_request")
     existing_label = "a"
     new_label = "b"
+    extra_existing_label = "c"
+    refreshed_mr = create_autospec(ProjectMergeRequest)
+    refreshed_mr.labels = [existing_label, extra_existing_label]
     mr = create_autospec(ProjectMergeRequest)
     mr.labels = [existing_label]
+    mr.manager = create_autospec(ProjectMergeRequestManager)
+    mr.manager.get.return_value = refreshed_mr
 
     GitLabApi.set_labels_on_merge_request(mr, [new_label])
 
-    mocked_gitlab_request.labels.return_value.inc.assert_called_once()
-    assert mr.labels == [new_label]
+    assert mocked_gitlab_request.labels.return_value.inc.call_count == 2
+    assert set(mr.labels) == {extra_existing_label, new_label}
     mr.save.assert_called_once()
 
 


### PR DESCRIPTION
There can be concurrent requests to gitlab to update labels, move refresh call closer to new request to reduce the possibility of labels overwriting.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at adb4b82</samp>

This pull request improves the label update process for merge requests in the `change_owners` integration, by moving the label refresh logic to the `set_labels_on_merge_request` method in the `GitLabApi` class, and by avoiding unnecessary or conflicting label changes. It also updates the corresponding test case to reflect the new logic.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at adb4b82</samp>

*  Rewrite `set_labels_on_merge_request` method to avoid overwriting existing labels, refresh labels before setting them, and only save changes if needed ([link](https://github.com/app-sre/qontract-reconcile/pull/3731/files?diff=unified&w=0#diff-1d5ab1abb6ecb1d8c243a9e8c04d4cf6505e6be2c8932df654ea9a11c6c1b64bL460-R479))
* Remove unnecessary call to `refresh_labels` from `run` function in `change_owners` integration ([link](https://github.com/app-sre/qontract-reconcile/pull/3731/files?diff=unified&w=0#diff-985fa2d09f658257b01c55b453e714cf8e726d025fab87d818ca0f04e34484e9L375))
* Update test case for `set_labels_on_merge_request` method to reflect new logic and handle label additions and removals ([link](https://github.com/app-sre/qontract-reconcile/pull/3731/files?diff=unified&w=0#diff-0b89eef785c5d5eafddc4849caf0ebfd6e028bbe73d43cd6abe234f4cd95f1eeL218-R229))