### PR TITLE
[ocmmap] basic cluster filtering during CS request

### DIFF
--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -745,7 +745,11 @@ class OCM:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     def _ready_for_app_interface(cluster: dict[str, Any]) -> bool:
-        return cluster["state"] == STATUS_READY
+        return (
+            cluster["managed"]
+            and cluster["state"] == STATUS_READY
+            and cluster["product"]["id"] in OCM_PRODUCTS_IMPL
+        )
 
     def _init_clusters(self, init_provision_shards: bool):
         api = f"{CS_API_BASE}/v1/clusters"

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -745,15 +745,14 @@ class OCM:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     def _ready_for_app_interface(cluster: dict[str, Any]) -> bool:
-        return (
-            cluster["managed"]
-            and cluster["state"] == STATUS_READY
-            and cluster["product"]["id"] in OCM_PRODUCTS_IMPL
-        )
+        return cluster["state"] == STATUS_READY
 
     def _init_clusters(self, init_provision_shards: bool):
         api = f"{CS_API_BASE}/v1/clusters"
-        params = {"search": f"organization.id='{self.org_id}'"}
+        product_csv = ",".join([f"'{p}'" for p in OCM_PRODUCTS_IMPL])
+        params = {
+            "search": f"organization.id='{self.org_id}' and managed='true' and product.id in ({product_csv})"
+        }
         clusters = self._get_json(api, params=params).get("items", [])
         self.cluster_ids = {c["name"]: c["id"] for c in clusters}
 


### PR DESCRIPTION
filter for `managed` clusters and filtering on the `product` (OSD/ROSA/Hypershift) is now done as part of the CS request instead of filtering the raw result afterwards. this reduces the number of queries a lot in big organizations with clusters that dod not fit those filters.

filtering for state `ready` is still on the raw result because certain code relies on knowing about non-ready clusters. we can reconsider this in a later PR.

part of https://issues.redhat.com/browse/APPSRE-8152