### PR TITLE
integration-manager template optional unleash secret

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -540,11 +540,13 @@ objects:
                   secretKeyRef:
                     name: unleash
                     key: API_URL
+                    optional: true
               - name: UNLEASH_CLIENT_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: unleash
                     key: CLIENT_ACCESS_TOKEN
+                    optional: true
               {{- end }}
               {{- with $integration.extraEnv }}
               {{- range $i, $env := . }}

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -297,11 +297,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           {{- end }}
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -146,11 +146,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
@@ -126,11 +126,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE
@@ -319,11 +321,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
@@ -126,11 +126,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
@@ -321,11 +321,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/aws_account_shards.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shards.yml
@@ -126,11 +126,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/aws_account_shards.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shards.yml
@@ -321,11 +321,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/basic.yml
+++ b/reconcile/test/fixtures/helm/basic.yml
@@ -124,11 +124,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/cache.yml
+++ b/reconcile/test/fixtures/helm/cache.yml
@@ -133,11 +133,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/command.yml
+++ b/reconcile/test/fixtures/helm/command.yml
@@ -124,11 +124,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/concurrency_policy.yml
+++ b/reconcile/test/fixtures/helm/concurrency_policy.yml
@@ -41,11 +41,13 @@ objects:
                   secretKeyRef:
                     name: unleash
                     key: API_URL
+                    optional: true
               - name: UNLEASH_CLIENT_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: unleash
                     key: CLIENT_ACCESS_TOKEN
+                    optional: true
               - name: KUBE_SA_TOKEN_PATH
                 value: "${KUBE_SA_TOKEN_MOUNT_PATH}/${KUBE_SA_TOKEN_FILENAME}"
               volumeMounts:

--- a/reconcile/test/fixtures/helm/cron.yml
+++ b/reconcile/test/fixtures/helm/cron.yml
@@ -41,11 +41,13 @@ objects:
                   secretKeyRef:
                     name: unleash
                     key: API_URL
+                    optional: true
               - name: UNLEASH_CLIENT_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: unleash
                     key: CLIENT_ACCESS_TOKEN
+                    optional: true
               - name: KUBE_SA_TOKEN_PATH
                 value: "${KUBE_SA_TOKEN_MOUNT_PATH}/${KUBE_SA_TOKEN_FILENAME}"
               volumeMounts:

--- a/reconcile/test/fixtures/helm/dashdotdb.yml
+++ b/reconcile/test/fixtures/helm/dashdotdb.yml
@@ -41,11 +41,13 @@ objects:
                   secretKeyRef:
                     name: unleash
                     key: API_URL
+                    optional: true
               - name: UNLEASH_CLIENT_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: unleash
                     key: CLIENT_ACCESS_TOKEN
+                    optional: true
               - name: DASHDOTDB_SECRET
                 valueFrom:
                   secretKeyRef:

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -163,11 +163,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/enable_pushgateway.yml
+++ b/reconcile/test/fixtures/helm/enable_pushgateway.yml
@@ -41,11 +41,13 @@ objects:
                   secretKeyRef:
                     name: unleash
                     key: API_URL
+                    optional: true
               - name: UNLEASH_CLIENT_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: unleash
                     key: CLIENT_ACCESS_TOKEN
+                    optional: true
               - name: KUBE_SA_TOKEN_PATH
                 value: "${KUBE_SA_TOKEN_MOUNT_PATH}/${KUBE_SA_TOKEN_FILENAME}"
               - name: PUSHGATEWAY_ENABLED

--- a/reconcile/test/fixtures/helm/environment_aware.yml
+++ b/reconcile/test/fixtures/helm/environment_aware.yml
@@ -124,11 +124,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/exclude_service.yml
+++ b/reconcile/test/fixtures/helm/exclude_service.yml
@@ -124,11 +124,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/extra_args.yml
+++ b/reconcile/test/fixtures/helm/extra_args.yml
@@ -126,11 +126,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/extra_env.yml
+++ b/reconcile/test/fixtures/helm/extra_env.yml
@@ -124,11 +124,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/failure_history.yml
+++ b/reconcile/test/fixtures/helm/failure_history.yml
@@ -41,11 +41,13 @@ objects:
                   secretKeyRef:
                     name: unleash
                     key: API_URL
+                    optional: true
               - name: UNLEASH_CLIENT_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: unleash
                     key: CLIENT_ACCESS_TOKEN
+                    optional: true
               - name: KUBE_SA_TOKEN_PATH
                 value: "${KUBE_SA_TOKEN_MOUNT_PATH}/${KUBE_SA_TOKEN_FILENAME}"
               volumeMounts:

--- a/reconcile/test/fixtures/helm/integrations_manager.yml
+++ b/reconcile/test/fixtures/helm/integrations_manager.yml
@@ -132,11 +132,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/internal_certificates.yml
+++ b/reconcile/test/fixtures/helm/internal_certificates.yml
@@ -141,11 +141,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/logs_slack.yml
+++ b/reconcile/test/fixtures/helm/logs_slack.yml
@@ -142,11 +142,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/restart_policy.yml
+++ b/reconcile/test/fixtures/helm/restart_policy.yml
@@ -41,11 +41,13 @@ objects:
                   secretKeyRef:
                     name: unleash
                     key: API_URL
+                    optional: true
               - name: UNLEASH_CLIENT_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: unleash
                     key: CLIENT_ACCESS_TOKEN
+                    optional: true
               - name: KUBE_SA_TOKEN_PATH
                 value: "${KUBE_SA_TOKEN_MOUNT_PATH}/${KUBE_SA_TOKEN_FILENAME}"
               volumeMounts:

--- a/reconcile/test/fixtures/helm/shards.yml
+++ b/reconcile/test/fixtures/helm/shards.yml
@@ -124,11 +124,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE
@@ -315,11 +317,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/sleep_duration.yml
+++ b/reconcile/test/fixtures/helm/sleep_duration.yml
@@ -124,11 +124,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/state.yml
+++ b/reconcile/test/fixtures/helm/state.yml
@@ -131,11 +131,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/storage.yml
+++ b/reconcile/test/fixtures/helm/storage.yml
@@ -124,11 +124,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE

--- a/reconcile/test/fixtures/helm/success_history.yml
+++ b/reconcile/test/fixtures/helm/success_history.yml
@@ -41,11 +41,13 @@ objects:
                   secretKeyRef:
                     name: unleash
                     key: API_URL
+                    optional: true
               - name: UNLEASH_CLIENT_ACCESS_TOKEN
                 valueFrom:
                   secretKeyRef:
                     name: unleash
                     key: CLIENT_ACCESS_TOKEN
+                    optional: true
               - name: KUBE_SA_TOKEN_PATH
                 value: "${KUBE_SA_TOKEN_MOUNT_PATH}/${KUBE_SA_TOKEN_FILENAME}"
               volumeMounts:

--- a/reconcile/test/fixtures/helm/trigger.yml
+++ b/reconcile/test/fixtures/helm/trigger.yml
@@ -124,11 +124,13 @@ objects:
               secretKeyRef:
                 name: unleash
                 key: API_URL
+                optional: true
           - name: UNLEASH_CLIENT_ACCESS_TOKEN
             valueFrom:
               secretKeyRef:
                 name: unleash
                 key: CLIENT_ACCESS_TOKEN
+                optional: true
           - name: SLOW_OC_RECONCILE_THRESHOLD
             value: "${SLOW_OC_RECONCILE_THRESHOLD}"
           - name: LOG_SLOW_OC_RECONCILE


### PR DESCRIPTION
to run an integrationsmanager without unleash interaction, we make the unleash secretKeyRef in the template optional. a missing unleash secret in the namespace will then disable the unleash feature for the integrations-manager.

part of https://issues.redhat.com/browse/APPSRE-8161