### PR TITLE
[ocm-upgrade-scheduler] use the org creds for OCM interaction if available

### DIFF
--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -22,7 +22,7 @@ from reconcile.utils.ocm import (
     OCM_PRODUCT_ROSA,
 )
 from reconcile.utils.ocm.clusters import discover_clusters_for_organizations
-from reconcile.utils.ocm_base_client import init_ocm_base_client
+from reconcile.utils.ocm_base_client import init_ocm_base_client, init_ocm_base_client_for_org
 
 QONTRACT_INTEGRATION = "ocm-upgrade-scheduler"
 SUPPORTED_OCM_PRODUCTS = [OCM_PRODUCT_OSD, OCM_PRODUCT_ROSA]
@@ -38,9 +38,7 @@ class OCMClusterUpgradeSchedulerIntegration(
     def process_upgrade_policies_in_org(
         self, dry_run: bool, org_upgrade_spec: OrganizationUpgradeSpec
     ) -> None:
-        ocm_api = init_ocm_base_client(
-            org_upgrade_spec.org.environment, self.secret_reader
-        )
+        ocm_api = init_ocm_base_client_for_org(org_upgrade_spec.org, self.secret_reader)
         current_state = aus.fetch_current_state(
             ocm_api=ocm_api,
             org_upgrade_spec=org_upgrade_spec,

--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -22,7 +22,10 @@ from reconcile.utils.ocm import (
     OCM_PRODUCT_ROSA,
 )
 from reconcile.utils.ocm.clusters import discover_clusters_for_organizations
-from reconcile.utils.ocm_base_client import init_ocm_base_client, init_ocm_base_client_for_org
+from reconcile.utils.ocm_base_client import (
+    init_ocm_base_client,
+    init_ocm_base_client_for_org,
+)
 
 QONTRACT_INTEGRATION = "ocm-upgrade-scheduler"
 SUPPORTED_OCM_PRODUCTS = [OCM_PRODUCT_OSD, OCM_PRODUCT_ROSA]


### PR DESCRIPTION
if creds are available on an OCM organization, prefer them over the ones from the environment.

mitigates https://issues.redhat.com/browse/APPSRE-8162