### PR TITLE
APPSRE-8164 set tekton taskrun timeouts according to saas files settings

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -397,7 +397,10 @@ def _construct_tekton_trigger_resource(
                 f"timeout {timeout} is smaller than 60 minutes"
             )
 
-        body["spec"]["timeout"] = timeout
+        body["spec"]["timeouts"] = {
+            "pipeline": "0",
+            "tasks": timeout,
+        }
 
     return (
         OR(body, integration, integration_version, error_details=name),

--- a/reconcile/openshift_tekton_resources.py
+++ b/reconcile/openshift_tekton_resources.py
@@ -48,6 +48,7 @@ SAAS_FILES_QUERY = """
       name
       provider
     }
+    timeout
     deployResources {
       requests {
         cpu
@@ -280,6 +281,8 @@ def build_one_per_saas_file_pipeline(
         pipeline_template_config["name"], saas_file["name"]
     )
 
+    timeout = saas_file.get("timeout")
+
     for section in ["tasks", "finally"]:
         for task in pipeline["spec"].get(section, []):
             if task["name"] not in task_templates_types:
@@ -296,6 +299,9 @@ def build_one_per_saas_file_pipeline(
                 task["taskRef"]["name"] = build_one_per_saas_file_tkn_task_name(
                     task["name"], saas_file["name"]
                 )
+
+            if timeout:
+                task["timeout"] = timeout
 
     return pipeline
 


### PR DESCRIPTION
[APPSRE-8164](https://issues.redhat.com/browse/APPSRE-8164)

PipelineRun `.spec.timeout` is [deprecated](https://tekton.dev/docs/pipelines/pipelineruns/#configuring-a-failure-timeout) and replaced by `.spec.timeouts`: 
> ⚠️ ** timeout is deprecated and will be removed in future versions. Consider using timeouts instead.

In this new field:
* `.spec.timeouts.tasks` sets the timeout globally for all tasks in the pipeline.
* `.spec.timeouts.pipeline` needs to be greater or equal to `.spec.timeouts.tasks + .spec.timeouts.finally`.

So we set `.spec.timeouts.pipeline = 0` and `.spec.timeouts.tasks = ${saas-file-timeout}`, allowing tasks to benefit from that timeout, and all finally tasks to run successfuly, even in case of timeout.

However, that is not sufficient. If we only set values in PipelineRun, each individual TaskRun gets the default timeout of `1h`.
So we also need to set each task timeout.
That is done in Pipeline, adding a `timeout` field in each `.spec.tasks[*]` and `.spec.finally[*]` definition.
