### PR TITLE
Update threaded to max 10

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -981,7 +981,7 @@ def aws_support_cases_sos(ctx, gitlab_project_id, thread_pool_size):
 
 
 @integration.command(short_help="Manages OpenShift Resources.")
-@threaded(default=20)
+@threaded()
 @binary(["oc", "ssh", "amtool"])
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
 @internal()
@@ -1557,7 +1557,7 @@ def terraform_repo(ctx, output_file):
 @integration.command(short_help="Manage AWS Resources using Terraform.")
 @print_to_file
 @vault_output_path
-@threaded(default=20)
+@threaded()
 @binary(["terraform", "oc", "git"])
 @binary_version("terraform", ["version"], TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSION)
@@ -1606,7 +1606,7 @@ def terraform_resources(
 @integration.command(short_help="Manage Cloudflare Resources using Terraform.")
 @print_to_file
 @enable_deletion(default=False)
-@threaded(default=20)
+@threaded()
 @binary(["terraform"])
 @binary_version("terraform", ["version"], TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @account_name
@@ -1642,7 +1642,7 @@ def terraform_cloudflare_resources(
 @integration.command(short_help="Manage Cloudflare DNS using Terraform.")
 @print_to_file
 @enable_deletion(default=False)
-@threaded(default=10)
+@threaded()
 @binary(["terraform"])
 @binary_version("terraform", ["version"], TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @account_name
@@ -1670,7 +1670,7 @@ def terraform_cloudflare_dns(
 @integration.command(short_help="Manage Cloudflare Users using Terraform.")
 @print_to_file
 @binary(["terraform"])
-@threaded(default=20)
+@threaded()
 @binary_version("terraform", ["version"], TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @account_name
 @enable_deletion(default=True)
@@ -1700,7 +1700,7 @@ def terraform_cloudflare_users(
     short_help="Manage Cloud Resources using Cloud Native Assets (CNA)."
 )
 @enable_deletion(default=False)
-@threaded(default=20)
+@threaded()
 @click.pass_context
 def cna_resources(
     ctx,
@@ -1718,7 +1718,7 @@ def cna_resources(
 
 
 @integration.command(short_help="Manage auto-promotions defined in SaaS files")
-@threaded(default=10)
+@threaded()
 @click.pass_context
 def saas_auto_promotions_manager(
     ctx,
@@ -1735,7 +1735,7 @@ def saas_auto_promotions_manager(
 
 @integration.command(short_help="Manage AWS users using Terraform.")
 @print_to_file
-@threaded(default=20)
+@threaded()
 @binary(["terraform", "gpg", "git"])
 @binary_version("terraform", ["version"], TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
 @enable_deletion(default=True)

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1124,12 +1124,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         )
 
         base_url = os.environ.get("GITHUB_API", "https://api.github.com")
-        # This is a threaded world. Let's define a big
-        # connections pool to live in that world
-        # (this avoids the warning "Connection pool is
-        # full, discarding connection: api.github.com")
-        pool_size = 100
-        return Github(token, base_url=base_url, pool_size=pool_size)
+        return Github(token, base_url=base_url)
 
     def _initiate_image_auth(self, saas_file: SaasFile) -> ImageAuth:
         """

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -96,12 +96,9 @@ class _VaultClient:
         self._get_mount_version = lru_cache(maxsize=128)(self.__get_mount_version)
         self._read_all_v2 = lru_cache(maxsize=2048)(self.__read_all_v2)
 
-        # This is a threaded world. Let's define a big
-        # connections pool to live in that world
-        # (this avoids the warning "Connection pool is
-        # full, discarding connection: vault.devshift.net")
         session = requests.Session()
-        adapter = HTTPAdapter(pool_connections=100, pool_maxsize=100)
+        # There are at most 10 working threads in reconcile, plus 1 daemon thread for auto refresh
+        adapter = HTTPAdapter(pool_maxsize=11)
         session.mount("https://", adapter)
         self._client = hvac.Client(url=server, session=session)
         self._close_lock = threading.Lock()


### PR DESCRIPTION
This change updates all `@threaded` to use max 10 (default), according to [ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ThreadPoolExecutor):
>Changed in version 3.8: Default value of max_workers is changed to min(32, os.cpu_count() + 4). This default value preserves at least 5 workers for I/O bound tasks. It utilizes at most 32 CPU cores for CPU bound tasks which release the GIL. And it avoids using very large resources implicitly on many-core machines.

We are using 4-8 cpu cores, 10 is a proper value since we already sharded integrations, this will reduce CPU throttle and make it easier to introduce session usages for other api clients like https://github.com/app-sre/qontract-reconcile/pull/3741

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2640560</samp>

This pull request improves the performance and configurability of the qontract-reconcile tool by adjusting the number of threads and connections to external services. It refactors the `@threaded` decorator usage in `reconcile/cli.py`, removes the pool_size argument from the Github constructor in `reconcile/utils/saasherder/saasherder.py`, and modifies the HTTPAdapter arguments in the `_VaultClient` class constructor in `reconcile/utils/vault.py`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 2640560</samp>

*  Remove default values for `@threaded` decorator in various commands to make the number of threads configurable ([link](https://github.com/app-sre/qontract-reconcile/pull/3742/files?diff=unified&w=0#diff-2ac404c3a4f4d289c1811816c94253a70cc6559b8de427388de06546141f1f43L984-R984), [link](https://github.com/app-sre/qontract-reconcile/pull/3742/files?diff=unified&w=0#diff-2ac404c3a4f4d289c1811816c94253a70cc6559b8de427388de06546141f1f43L1560-R1560), [link](https://github.com/app-sre/qontract-reconcile/pull/3742/files?diff=unified&w=0#diff-2ac404c3a4f4d289c1811816c94253a70cc6559b8de427388de06546141f1f43L1609-R1609), [link](https://github.com/app-sre/qontract-reconcile/pull/3742/files?diff=unified&w=0#diff-2ac404c3a4f4d289c1811816c94253a70cc6559b8de427388de06546141f1f43L1645-R1645), [link](https://github.com/app-sre/qontract-reconcile/pull/3742/files?diff=unified&w=0#diff-2ac404c3a4f4d289c1811816c94253a70cc6559b8de427388de06546141f1f43L1673-R1673), [link](https://github.com/app-sre/qontract-reconcile/pull/3742/files?diff=unified&w=0#diff-2ac404c3a4f4d289c1811816c94253a70cc6559b8de427388de06546141f1f43L1703-R1703), [link](https://github.com/app-sre/qontract-reconcile/pull/3742/files?diff=unified&w=0#diff-2ac404c3a4f4d289c1811816c94253a70cc6559b8de427388de06546141f1f43L1721-R1721), [link](https://github.com/app-sre/qontract-reconcile/pull/3742/files?diff=unified&w=0#diff-2ac404c3a4f4d289c1811816c94253a70cc6559b8de427388de06546141f1f43L1738-R1738)) in `reconcile/cli.py`