### PR TITLE
Update DashdotSLO, allow configuration of external reference

### DIFF
--- a/reconcile/dashdotdb_slo.py
+++ b/reconcile/dashdotdb_slo.py
@@ -100,8 +100,6 @@ class DashdotdbSLO(DashdotdbBase):
         result: list[ServiceSLO] = []
         for pa in slo_document.namespaces:
             ns = pa.namespace
-            if not ns:
-                continue
             if pa.external:
                 promurl = pa.external.url
                 promtoken = self._get_automation_token(pa.external.token)

--- a/reconcile/dashdotdb_slo.py
+++ b/reconcile/dashdotdb_slo.py
@@ -118,9 +118,7 @@ class DashdotdbSLO(DashdotdbBase):
                 window = slo.slo_parameters.window
                 promquery = template.render({"window": window})
                 prom_response = self._promget(
-                    url=promurl,
-                    params={"query": (f"{promquery}")},
-                    token=promtoken if promtoken else None,
+                    url=promurl, params={"query": (f"{promquery}")}, token=promtoken
                 )
                 prom_result = prom_response["data"]["result"]
                 if not prom_result:

--- a/reconcile/dashdotdb_slo.py
+++ b/reconcile/dashdotdb_slo.py
@@ -98,11 +98,11 @@ class DashdotdbSLO(DashdotdbBase):
     def _get_service_slo(self, slo_document: SLODocumentV1) -> list[ServiceSLO]:
         LOG.debug("SLO: processing %s", slo_document.name)
         result: list[ServiceSLO] = []
-        for pa in slo_document.namespaces:
-            ns = pa.namespace
-            if pa.external:
-                promurl = pa.external.url
-                promtoken = self._get_automation_token(pa.external.token)
+        for namespace_access in slo_document.namespaces:
+            ns = namespace_access.namespace
+            promtoken: Optional[str] = None
+            if namespace_access.prometheus_access:
+                promurl = namespace_access.prometheus_access.url
             else:
                 promurl = ns.cluster.prometheus_url
                 if not ns.cluster.automation_token:
@@ -120,7 +120,7 @@ class DashdotdbSLO(DashdotdbBase):
                 prom_response = self._promget(
                     url=promurl,
                     params={"query": (f"{promquery}")},
-                    token=promtoken,
+                    token=promtoken if promtoken else None,
                 )
                 prom_result = prom_response["data"]["result"]
                 if not prom_result:

--- a/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.gql
+++ b/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.gql
@@ -4,11 +4,8 @@ query SLODocuments {
   slo_documents: slo_document_v1 {
     name
     namespaces {
-      external {
+      prometheusAccess {
          url
-         token {
-         ... VaultSecret
-        }
       }
       namespace {
         name

--- a/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.gql
+++ b/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.gql
@@ -4,18 +4,26 @@ query SLODocuments {
   slo_documents: slo_document_v1 {
     name
     namespaces {
-      name
-      app {
-        name
-      }
-      cluster {
-        name
-        automationToken {
-          ... VaultSecret
+      external {
+         url
+         token {
+         ... VaultSecret
         }
-        prometheusUrl
-        spec {
-          private
+      }
+      namespace {
+        name
+        app {
+          name
+        }
+        cluster {
+          name
+          automationToken {
+          ... VaultSecret
+          }
+          prometheusUrl
+          spec {
+            private
+          }
         }
       }
     }

--- a/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.py
+++ b/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.py
@@ -32,11 +32,8 @@ query SLODocuments {
   slo_documents: slo_document_v1 {
     name
     namespaces {
-      external {
+      prometheusAccess {
          url
-         token {
-         ... VaultSecret
-        }
       }
       namespace {
         name
@@ -78,7 +75,6 @@ class ConfiguredBaseModel(BaseModel):
 
 class SLOExternalPrometheusAccessV1(ConfiguredBaseModel):
     url: str = Field(..., alias="url")
-    token: VaultSecret = Field(..., alias="token")
 
 
 class AppV1(ConfiguredBaseModel):
@@ -103,7 +99,9 @@ class NamespaceV1(ConfiguredBaseModel):
 
 
 class SLONamespacesV1(ConfiguredBaseModel):
-    external: Optional[SLOExternalPrometheusAccessV1] = Field(..., alias="external")
+    prometheus_access: Optional[SLOExternalPrometheusAccessV1] = Field(
+        ..., alias="prometheusAccess"
+    )
     namespace: NamespaceV1 = Field(..., alias="namespace")
 
 

--- a/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.py
+++ b/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.py
@@ -32,18 +32,26 @@ query SLODocuments {
   slo_documents: slo_document_v1 {
     name
     namespaces {
-      name
-      app {
-        name
-      }
-      cluster {
-        name
-        automationToken {
-          ... VaultSecret
+      external {
+         url
+         token {
+         ... VaultSecret
         }
-        prometheusUrl
-        spec {
-          private
+      }
+      namespace {
+        name
+        app {
+          name
+        }
+        cluster {
+          name
+          automationToken {
+          ... VaultSecret
+          }
+          prometheusUrl
+          spec {
+            private
+          }
         }
       }
     }
@@ -68,6 +76,11 @@ class ConfiguredBaseModel(BaseModel):
         extra = Extra.forbid
 
 
+class SLOExternalPrometheusAccessV1(ConfiguredBaseModel):
+    url: str = Field(..., alias="url")
+    token: VaultSecret = Field(..., alias="token")
+
+
 class AppV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
 
@@ -89,6 +102,11 @@ class NamespaceV1(ConfiguredBaseModel):
     cluster: ClusterV1 = Field(..., alias="cluster")
 
 
+class SLONamespacesV1(ConfiguredBaseModel):
+    external: Optional[SLOExternalPrometheusAccessV1] = Field(..., alias="external")
+    namespace: NamespaceV1 = Field(..., alias="namespace")
+
+
 class SLODocumentSLOSLOParametersV1(ConfiguredBaseModel):
     window: str = Field(..., alias="window")
 
@@ -104,7 +122,7 @@ class SLODocumentSLOV1(ConfiguredBaseModel):
 
 class SLODocumentV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    namespaces: list[NamespaceV1] = Field(..., alias="namespaces")
+    namespaces: list[SLONamespacesV1] = Field(..., alias="namespaces")
     slos: Optional[list[SLODocumentSLOV1]] = Field(..., alias="slos")
 
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -1899,37 +1899,6 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "ocp_release_mirror_v1",
-                            "description": null,
-                            "args": [
-                                {
-                                    "name": "path",
-                                    "description": null,
-                                    "type": {
-                                        "kind": "SCALAR",
-                                        "name": "String",
-                                        "ofType": null
-                                    },
-                                    "defaultValue": null
-                                }
-                            ],
-                            "type": {
-                                "kind": "LIST",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "NON_NULL",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "OBJECT",
-                                        "name": "OcpReleaseMirror_v1",
-                                        "ofType": null
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
                             "name": "slo_document_v1",
                             "description": null,
                             "args": [
@@ -2431,6 +2400,37 @@
                                     "ofType": {
                                         "kind": "OBJECT",
                                         "name": "StatusBoard_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "dynatrace_environment_v1",
+                            "description": null,
+                            "args": [
+                                {
+                                    "name": "path",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                }
+                            ],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "DynatraceEnvironment_v1",
                                         "ofType": null
                                     }
                                 }
@@ -3849,6 +3849,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "dynatraceEnvironment",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "DynatraceEnvironment_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "spec",
                             "description": null,
                             "args": [],
@@ -4507,6 +4519,18 @@
                         },
                         {
                             "name": "delete",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "enableDynatraceLogging",
                             "description": null,
                             "args": [],
                             "type": {
@@ -14343,6 +14367,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "issueType",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "issueResolveState",
                             "description": null,
                             "args": [],
@@ -17703,7 +17739,7 @@
                                         "name": null,
                                         "ofType": {
                                             "kind": "OBJECT",
-                                            "name": "Namespace_v1",
+                                            "name": "SLONamespaces_v1",
                                             "ofType": null
                                         }
                                     }
@@ -17741,6 +17777,152 @@
                             "ofType": null
                         }
                     ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "SLONamespaces_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "namespace",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "Namespace_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "external",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "SLOExternalPrometheusAccess_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "SLOExternalPrometheusAccess_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "url",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "token",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "VaultSecret_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
                 },
@@ -19625,6 +19807,97 @@
                                 "kind": "SCALAR",
                                 "name": "JSON",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "DynatraceEnvironment_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "schema",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "description",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "environmentUrl",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
@@ -25770,129 +26043,6 @@
                                 "kind": "SCALAR",
                                 "name": "String",
                                 "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "OcpReleaseMirror_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "hiveCluster",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "Cluster_v1",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "ecrResourcesNamespace",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "Namespace_v1",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "ocpReleaseEcrIdentifier",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "ocpArtDevEcrIdentifier",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "quayTargetOrgs",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "LIST",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "NON_NULL",
-                                        "name": null,
-                                        "ofType": {
-                                            "kind": "OBJECT",
-                                            "name": "QuayOrg_v1",
-                                            "ofType": null
-                                        }
-                                    }
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "mirrorChannels",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "LIST",
-                                    "name": null,
-                                    "ofType": {
-                                        "kind": "NON_NULL",
-                                        "name": null,
-                                        "ofType": {
-                                            "kind": "SCALAR",
-                                            "name": "String",
-                                            "ofType": null
-                                        }
-                                    }
-                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -17834,7 +17834,7 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "external",
+                            "name": "prometheusAccess",
                             "description": null,
                             "args": [],
                             "type": {
@@ -17898,22 +17898,6 @@
                                 "ofType": {
                                     "kind": "SCALAR",
                                     "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
-                            "name": "token",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "OBJECT",
-                                    "name": "VaultSecret_v1",
                                     "ofType": null
                                 }
                             },


### PR DESCRIPTION
Update DashdotSLO, and allow it to use an external reference for getting SLO data from Prometheus.

Related schema change: https://github.com/app-sre/qontract-schemas/pull/501

https://issues.redhat.com/browse/APPSRE-8197