### PR TITLE
APPSRE-8219 normalize tekton pipeline timeout format

### DIFF
--- a/reconcile/openshift_tekton_resources.py
+++ b/reconcile/openshift_tekton_resources.py
@@ -16,6 +16,10 @@ from reconcile.status import ExitCodes
 from reconcile.utils import gql
 from reconcile.utils.defer import defer
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
+from reconcile.utils.parse_dhms_duration import (
+    dhms_to_seconds,
+    seconds_to_hms,
+)
 from reconcile.utils.saasherder import Providers
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.sharding import is_in_shard
@@ -282,6 +286,9 @@ def build_one_per_saas_file_pipeline(
     )
 
     timeout = saas_file.get("timeout")
+    if timeout:
+        timeout_seconds = dhms_to_seconds(timeout)
+        normalized_timeout = seconds_to_hms(timeout_seconds)
 
     for section in ["tasks", "finally"]:
         for task in pipeline["spec"].get(section, []):
@@ -301,7 +308,7 @@ def build_one_per_saas_file_pipeline(
                 )
 
             if timeout:
-                task["timeout"] = timeout
+                task["timeout"] = normalized_timeout
 
     return pipeline
 

--- a/reconcile/test/utils/test_parse_dhms_duration.py
+++ b/reconcile/test/utils/test_parse_dhms_duration.py
@@ -3,6 +3,7 @@ import pytest
 from reconcile.utils.parse_dhms_duration import (
     BadHDMSDurationError,
     dhms_to_seconds,
+    seconds_to_hms,
 )
 
 
@@ -32,3 +33,23 @@ def test_valid_duration(test_input: str, expected: int) -> None:
 def test_invalid_duration(bad_input: str):
     with pytest.raises(BadHDMSDurationError):
         dhms_to_seconds(bad_input)
+
+
+@pytest.mark.parametrize(
+    "test_input, expected",
+    [
+        ("3s", "3s"),
+        ("2m1s", "2m1s"),
+        ("2m", "2m0s"),
+        ("3h2m1s", "3h2m1s"),
+        ("3h2m", "3h2m0s"),
+        ("3h", "3h0m0s"),
+        ("4d3h2m1s", "99h2m1s"),
+        ("4d3h2m", "99h2m0s"),
+        ("4d3h", "99h0m0s"),
+        ("4d", "96h0m0s"),
+        ("90m", "1h30m0s"),
+    ],
+)
+def test_format_valid_duration(test_input: str, expected: int) -> None:
+    assert seconds_to_hms(dhms_to_seconds(test_input)) == expected

--- a/reconcile/utils/parse_dhms_duration.py
+++ b/reconcile/utils/parse_dhms_duration.py
@@ -31,6 +31,20 @@ HANDLE_UNIT_MAP = {
 }
 
 
+def seconds_to_hms(seconds: int) -> str:
+    s = seconds % 60
+
+    minutes = seconds // 60
+    if minutes == 0:
+        return f"{s}s"
+
+    h, m = divmod(minutes, 60)
+    if h == 0:
+        return f"{m}m{s}s"
+
+    return f"{h}h{m}m{s}s"
+
+
 def dhms_to_seconds(time_str: str) -> int:
     """Parses durations and returns seconds. The format is a subset of Go's
     ParseDuration format, only allowing from days to seconds in resolution,


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-8219

We can define a pipeline timeout with any Golang accepted duration format.
However tekton will update the Pipeline specs with timeouts following the default format XhYmZs. For example, 90m gets updated as 1h30m0s.
To avoid continuous reconciliation due to this discrepency, we need to set the timeout value with the default Golang format