### PR TITLE
Revert changes to helm template run

### DIFF
--- a/reconcile/utils/helm.py
+++ b/reconcile/utils/helm.py
@@ -1,7 +1,6 @@
 import json
 import tempfile
 from collections.abc import Mapping
-from pathlib import Path
 from subprocess import (
     CalledProcessError,
     run,
@@ -38,8 +37,7 @@ def template(values: Mapping[str, Any]) -> Mapping[str, Any]:
                 "-f",
                 values_file.name,
             ]
-            cwd = Path(__file__).parent.parent.parent
-            result = run(cmd, capture_output=True, check=True, cwd=cwd)
+            result = run(cmd, capture_output=True, check=True)
     except CalledProcessError as e:
         msg = f'Error running helm template [{" ".join(cmd)}]'
         if e.stdout:


### PR DESCRIPTION
Revert changes in https://github.com/app-sre/qontract-reconcile/pull/3750/files#diff-b1dab64139515cc76cf5052912473f2813d58c19c3dd54cac4e718fb7318b637,

`./helm/qontract-reconcile` is outside of package, so path won't be the same as local run, error in pipeline

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/helm.py", line 42, in template
    result = run(cmd, capture_output=True, check=True, cwd=cwd)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['helm', 'template', './helm/qontract-reconcile', '-n', 'qontract-reconcile', '-f', '/tmp/tmp0aohl31b']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/reconcile/cli.py", line 515, in run_class_integration
    run_integration_cfg(
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 158, in run_integration_cfg
    _integration_dry_run(run_cfg.integration, desired_state_diff)
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 229, in _integration_dry_run
    integration.run(True)
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/integration.py", line 318, in run
    self.params.module.run(dry_run, *self.params.args, **self.params.kwargs)
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/defer.py", line 13, in func_wrapper
    return func(*args, defer=stack.callback, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/integrations_manager.py", line 287, in run
    fetch_desired_state(
  File "/usr/local/lib/python3.11/site-packages/reconcile/integrations_manager.py", line 205, in fetch_desired_state
    oc_resources = construct_oc_resources(ie, upstream, image, image_tag_from_ref)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/integrations_manager.py", line 174, in construct_oc_resources
    template = helm.template(values)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/helm.py", line 49, in template
    raise HelmTemplateError(msg)
reconcile.utils.helm.HelmTemplateError: Error running helm template [helm template ./helm/qontract-reconcile -n qontract-reconcile -f /tmp/tmp0aohl31b] Error: path "./helm/qontract-reconcile" not found
```

`helm.template` will only work by running command in the right current working dir.