### PR TITLE
fix qontract-cli upgrade-cluster-addon 

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -973,7 +973,7 @@ def upgrade_cluster_addon(
             "cluster_id": ocm.cluster_ids[cluster],
             "upgrade_type": "ADDON",
         }
-        create_addon_upgrade_policy(ocm._ocm_client, cluster, spec)
+        create_addon_upgrade_policy(ocm._ocm_client, ocm.cluster_ids[cluster], spec)
 
 
 def has_cluster_account_access(cluster: dict[str, Any]):


### PR DESCRIPTION
We need to use the cluster id instead of the cluster name