### PR TITLE
[rhidp app-interface flavor] skip cluster with an empyt console url

### DIFF
--- a/reconcile/rhidp/common.py
+++ b/reconcile/rhidp/common.py
@@ -111,6 +111,9 @@ def get_clusters(
     clusters: list[ClusterV1] = []
 
     for c in data.clusters or []:
+        if not c.console_url:
+            # without a console url we can't calculate the redirect url ... skip it for a moment
+            continue
         if not integration_is_enabled(integration_name, c):
             # integration disabled for this particular cluster
             continue


### PR DESCRIPTION
The integration can only calculate the redirect URL with a cluster console URL. Otherwise skip the cluster.