### PR TITLE
terraform-state-1.yml support for Terraform Repo

### DIFF
--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
@@ -12,6 +12,10 @@ query TerraformRepo {
         provider
         bucket
         region
+        integrations {
+          integration
+          key
+        }
       }
     }
     name

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
@@ -8,6 +8,11 @@ query TerraformRepo {
       automationToken {
         ...VaultSecret
       }
+      terraformState {
+        provider
+        bucket
+        region
+      }
     }
     name
     repository

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.py
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.py
@@ -40,6 +40,10 @@ query TerraformRepo {
         provider
         bucket
         region
+        integrations {
+          integration
+          key
+        }
       }
     }
     name
@@ -58,10 +62,18 @@ class ConfiguredBaseModel(BaseModel):
         extra = Extra.forbid
 
 
+class AWSTerraformStateIntegrationsV1(ConfiguredBaseModel):
+    integration: str = Field(..., alias="integration")
+    key: str = Field(..., alias="key")
+
+
 class TerraformStateAWSV1(ConfiguredBaseModel):
     provider: str = Field(..., alias="provider")
     bucket: str = Field(..., alias="bucket")
     region: str = Field(..., alias="region")
+    integrations: list[AWSTerraformStateIntegrationsV1] = Field(
+        ..., alias="integrations"
+    )
 
 
 class AWSAccountV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.py
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.py
@@ -36,6 +36,11 @@ query TerraformRepo {
       automationToken {
         ...VaultSecret
       }
+      terraformState {
+        provider
+        bucket
+        region
+      }
     }
     name
     repository
@@ -53,10 +58,17 @@ class ConfiguredBaseModel(BaseModel):
         extra = Extra.forbid
 
 
+class TerraformStateAWSV1(ConfiguredBaseModel):
+    provider: str = Field(..., alias="provider")
+    bucket: str = Field(..., alias="bucket")
+    region: str = Field(..., alias="region")
+
+
 class AWSAccountV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     uid: str = Field(..., alias="uid")
     automation_token: VaultSecret = Field(..., alias="automationToken")
+    terraform_state: Optional[TerraformStateAWSV1] = Field(..., alias="terraformState")
 
 
 class TerraformRepoV1(ConfiguredBaseModel):


### PR DESCRIPTION
[APPSRE-8242](https://issues.redhat.com/browse/APPSRE-8242)

Allows Terraform Repo to work with [terraform-state-1.yml](https://github.com/app-sre/qontract-schemas/blob/main/schemas/dependencies/terraform-state-1.yml) files. terraform-state files are separate from the actual Terraform state and allow you to specify where state files for specific AppSRE integrations are stored within AWS rather than relying on hard-coded paths and Vault secret values. This is a key step to getting terraform-repo in commercial. 

Here's what a terraform state file would look like for Terraform Repo: 

```yml
$schema: /dependencies/terraform-state-1.yml
provider: s3
bucket: tf-state
region: us-east-1 
integrations:
- integration: terraform-repo
  key: tf-repo
```

So then, if you created a terraform repo named "my-cool-repo" in an AWS account with this state attached, it would be stored in the following location on S3:

`s3://tf-state/tf-repo/my-cool-repo-tf-repo.tfstate`

Executor update coming as well to deal with this output change in tf-repo.