### PR TITLE
Introduce 3way Merge diff for openshift resources

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1,5 +1,4 @@
 import base64
-
 import itertools
 import logging
 from collections.abc import (
@@ -43,9 +42,9 @@ from reconcile.utils.oc import (
     StatusCodeError,
     UnsupportedMediaTypeError,
 )
+from reconcile.utils.openshift_resource import QONTRACT_ANNOTATIONS
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.openshift_resource import ResourceInventory
-from reconcile.utils.openshift_resource import QONTRACT_ANNOTATIONS
 
 ACTION_APPLIED = "applied"
 ACTION_DELETED = "deleted"

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -890,8 +890,6 @@ def _realize_resource_data(
     override_enable_deletion: bool,
     recycle_pods: bool,
 ) -> list[dict[str, Any]]:
-    args = locals()
-
     cluster, _, _, _ = ri_item
 
     options = ApplyOptions(
@@ -914,7 +912,19 @@ def _realize_resource_data(
             ri_item=ri_item, oc_map=oc_map, ri=ri, options=options
         )
 
-    return _realize_resource_data_qr(**args)
+    return _realize_resource_data_qr(
+        unpacked_ri_item=ri_item,
+        dry_run=dry_run,
+        oc_map=oc_map,
+        ri=ri,
+        take_over=take_over,
+        caller=caller,
+        all_callers=all_callers,
+        wait_for_namespace=wait_for_namespace,
+        no_dry_run_skip_compare=no_dry_run_skip_compare,
+        override_enable_deletion=override_enable_deletion,
+        recycle_pods=recycle_pods,
+    )
 
 
 def _realize_resource_data_3way_diff(

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -721,7 +721,7 @@ def should_delete(
 
 
 def handle_new_resources(
-    oc_map: OC_Map,
+    oc_map: ClusterMap,
     ri: ResourceInventory,
     new_resources: Mapping[Any, Any],
     cluster: str,
@@ -757,7 +757,7 @@ def handle_new_resources(
 
 
 def handle_modified_resources(
-    oc_map: OC_Map,
+    oc_map: ClusterMap,
     ri: ResourceInventory,
     modified_resources: Mapping[Any, Any],
     cluster: str,
@@ -801,7 +801,7 @@ def handle_modified_resources(
 
 
 def handle_deleted_resources(
-    oc_map: OC_Map,
+    oc_map: ClusterMap,
     ri: ResourceInventory,
     deleted_resources: Mapping[Any, Any],
     cluster: str,
@@ -845,7 +845,7 @@ def handle_deleted_resources(
 
 
 def apply_action(
-    oc_map: OC_Map,
+    oc_map: ClusterMap,
     ri: ResourceInventory,
     cluster: str,
     namespace: str,
@@ -881,7 +881,7 @@ def apply_action(
 
 
 def delete_action(
-    oc_map: OC_Map,
+    oc_map: ClusterMap,
     ri: ResourceInventory,
     cluster: str,
     namespace: str,
@@ -909,7 +909,7 @@ def delete_action(
 def _realize_resource_data(
     ri_item: tuple[str, str, str, Mapping[str, Any]],
     dry_run: bool,
-    oc_map: OC_Map,
+    oc_map: ClusterMap,
     ri: ResourceInventory,
     take_over: bool,
     caller: str,
@@ -958,7 +958,7 @@ def _realize_resource_data(
 
 def _realize_resource_data_3way_diff(
     ri_item: tuple[str, str, str, Mapping[str, Any]],
-    oc_map: OC_Map,
+    oc_map: ClusterMap,
     ri: ResourceInventory,
     options: ApplyOptions,
 ) -> list[dict[str, Any]]:

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -588,7 +588,7 @@ NORMALIZERS = {"Secret": _normalize_secret}
 
 
 def normalize_object(item: OR) -> OR:
-    # Remove K8s managed attributes not neede to compare objects
+    # Remove K8s managed attributes not needed to compare objects
     metadata = {
         k: v
         for k, v in item.body["metadata"].items()

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -650,6 +650,30 @@ def _realize_resource_data(
     override_enable_deletion,
     recycle_pods,
 ):
+    args = locals()
+
+    cluster, _, _ ,_  = unpacked_ri_item
+    use_3way_diff = ri.clusters_3way_diff_strategy[cluster]
+    if use_3way_diff:
+        return _realize_resource_data_3way_diff(**args)
+    else:
+        return _realize_resource_data_old(**args)
+
+
+
+def _realize_resource_data_3way_diff(
+    unpacked_ri_item,
+    dry_run,
+    oc_map: ClusterMap,
+    ri: ResourceInventory,
+    take_over,
+    caller,
+    all_callers,
+    wait_for_namespace,
+    no_dry_run_skip_compare,
+    override_enable_deletion,
+    recycle_pods,
+):
     cluster, namespace, resource_type, data = unpacked_ri_item
     actions: list[dict] = []
     if ri.has_error_registered(cluster=cluster):
@@ -691,6 +715,186 @@ def _realize_resource_data(
                 # Don't apply if no differences found.
                 elif not three_way_merge_patch_diff_using_hash(c_item, d_item):
                     continue
+
+                logging.debug("CURRENT: " + OR.serialize(OR.canonicalize(c_item.body)))
+        else:
+            logging.debug("CURRENT: None")
+
+        logging.debug("DESIRED: " + OR.serialize(OR.canonicalize(d_item.body)))
+
+        try:
+            privileged = data["use_admin_token"].get(name, False)
+            apply(
+                dry_run,
+                oc_map,
+                cluster,
+                namespace,
+                resource_type,
+                d_item,
+                wait_for_namespace,
+                recycle_pods,
+                privileged,
+            )
+            action = {
+                "action": ACTION_APPLIED,
+                "cluster": cluster,
+                "namespace": namespace,
+                "kind": resource_type,
+                "name": d_item.name,
+                "privileged": privileged,
+            }
+            actions.append(action)
+        except StatusCodeError as e:
+            ri.register_error()
+            err = (
+                str(e)
+                if resource_type != "Secret"
+                else f"error applying Secret {d_item.name}: REDACTED"
+            )
+            msg = (
+                f"[{cluster}/{namespace}] {err} "
+                + f"(error details: {d_item.error_details})"
+            )
+            logging.error(msg)
+
+    # current items
+    for name, c_item in data["current"].items():
+        d_item = data["desired"].get(name)
+        if d_item is not None:
+            continue
+
+        if c_item.has_qontract_annotations():
+            if caller and c_item.caller != caller:
+                continue
+        elif not take_over:
+            # this is reached when the current resources:
+            # - does not have qontract annotations (not managed)
+            # - not taking over all resources of the current kind
+            msg = (
+                f"[{cluster}/{namespace}] skipping " + f"{resource_type}/{c_item.name}"
+            )
+            logging.debug(msg)
+            continue
+
+        if c_item.has_owner_reference():
+            continue
+
+        try:
+            privileged = data["use_admin_token"].get(name, False)
+            delete(
+                dry_run,
+                oc_map,
+                cluster,
+                namespace,
+                resource_type,
+                name,
+                enable_deletion,
+                privileged,
+            )
+            action = {
+                "action": ACTION_DELETED,
+                "cluster": cluster,
+                "namespace": namespace,
+                "kind": resource_type,
+                "name": name,
+                "privileged": privileged,
+            }
+            actions.append(action)
+        except StatusCodeError as e:
+            ri.register_error()
+            msg = "[{}/{}] {}".format(cluster, namespace, str(e))
+            logging.error(msg)
+
+    return actions
+
+
+def _realize_resource_data_old(
+    unpacked_ri_item,
+    dry_run,
+    oc_map: ClusterMap,
+    ri: ResourceInventory,
+    take_over,
+    caller,
+    all_callers,
+    wait_for_namespace,
+    no_dry_run_skip_compare,
+    override_enable_deletion,
+    recycle_pods,
+):
+    cluster, namespace, resource_type, data = unpacked_ri_item
+    actions: list[dict] = []
+    if ri.has_error_registered(cluster=cluster):
+        msg = ("[{}] skipping realize_data for " "cluster with errors").format(cluster)
+        logging.error(msg)
+        return actions
+
+    enable_deletion = False if ri.has_error_registered() else True
+    # only allow to override enable_deletion if no errors were found
+    if enable_deletion is True and override_enable_deletion is False:
+        enable_deletion = False
+
+    # desired items
+    for name, d_item in data["desired"].items():
+        c_item: OR = data["current"].get(name)
+
+        if c_item is not None:
+            if not dry_run and no_dry_run_skip_compare:
+                msg = ("[{}/{}] skipping compare of resource '{}/{}'.").format(
+                    cluster, namespace, resource_type, name
+                )
+                logging.debug(msg)
+            else:
+                # If resource doesn't have annotations, annotate and apply
+                if not c_item.has_qontract_annotations():
+                    msg = (
+                        "[{}/{}] resource '{}/{}' present "
+                        "w/o annotations, annotating and applying"
+                    ).format(cluster, namespace, resource_type, name)
+                    logging.info(msg)
+
+                # don't apply if there is a caller (saas file)
+                # and this is not a take over
+                # and current item caller is different from the current caller
+                elif caller and not take_over and c_item.caller != caller:
+                    # if the current item is owned by a caller that no longer exists,
+                    # do nothing. the condition is nested so we fall into this condition
+                    # so we end up either applying to take ownership, or we error if the
+                    # current caller is still present
+                    if c_item.caller in all_callers:
+                        ri.register_error()
+                        logging.error(
+                            f"[{cluster}/{namespace}] resource '{resource_type}/{name}' present and managed by another caller: {c_item.caller}"
+                        )
+                        continue
+
+                # don't apply if resources match
+                # if there is a caller (saas file) and this is a take over
+                # we skip the equal compare as it's not covering
+                # cases of a removed label (for example)
+                # d_item == c_item is uncommutative
+                elif not (caller and take_over) and d_item == c_item:
+                    msg = (
+                        "[{}/{}] resource '{}/{}' present "
+                        "and matches desired, skipping."
+                    ).format(cluster, namespace, resource_type, name)
+                    logging.debug(msg)
+                    continue
+
+                # don't apply if sha256sum hashes match
+                elif c_item.sha256sum() == d_item.sha256sum():
+                    if c_item.has_valid_sha256sum():
+                        msg = (
+                            "[{}/{}] resource '{}/{}' present "
+                            "and hashes match, skipping."
+                        ).format(cluster, namespace, resource_type, name)
+                        logging.debug(msg)
+                        continue
+
+                    msg = (
+                        "[{}/{}] resource '{}/{}' present and "
+                        "has stale sha256sum due to manual changes."
+                    ).format(cluster, namespace, resource_type, name)
+                    logging.info(msg)
 
                 logging.debug("CURRENT: " + OR.serialize(OR.canonicalize(c_item.body)))
         else:

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1,3 +1,5 @@
+import base64
+import copy
 import itertools
 import logging
 from collections.abc import (
@@ -17,12 +19,8 @@ from typing import (
     runtime_checkable,
 )
 
-import json
-import copy
-import base64
+import jsonpatch  # type: ignore
 import yaml
-import jsonpatch
-
 from sretoolbox.utils import (
     retry,
     threaded,
@@ -652,13 +650,13 @@ def _realize_resource_data(
 ):
     args = locals()
 
-    cluster, _, _ ,_  = unpacked_ri_item
+    cluster, _, _, _ = unpacked_ri_item
     use_3way_diff = ri.clusters_3way_diff_strategy[cluster]
+
     if use_3way_diff:
         return _realize_resource_data_3way_diff(**args)
-    else:
-        return _realize_resource_data_old(**args)
 
+    return _realize_resource_data_old(**args)
 
 
 def _realize_resource_data_3way_diff(

--- a/reconcile/test/fixtures/openshift_resource/deployment.yml
+++ b/reconcile/test/fixtures/openshift_resource/deployment.yml
@@ -1,0 +1,24 @@
+# Example from https://kubernetes.io/docs/concepts/workloads/controllers/deployment/
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+  annotations:
+    test-annotation: test-annotation-value
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80

--- a/reconcile/test/test_gabi_authorized_users.py
+++ b/reconcile/test/test_gabi_authorized_users.py
@@ -29,8 +29,8 @@ def test_gabi_authorized_users_apply(mocker: MockerFixture) -> None:
         gabi_u.QONTRACT_INTEGRATION,
         gabi_u.QONTRACT_INTEGRATION_VERSION,
     )
-    args, _ = mock_apply.call_args
-    assert args[5] == expected
+    _, kwargs = mock_apply.call_args
+    assert kwargs["resource"] == expected
 
 
 def test_gabi_authorized_users_exist(mocker: MockerFixture) -> None:

--- a/reconcile/test/test_openshift_base.py
+++ b/reconcile/test/test_openshift_base.py
@@ -1,5 +1,9 @@
 import logging
-from typing import Any, Optional, Mapping
+from typing import (
+    Any,
+    Mapping,
+    Optional,
+)
 from unittest.mock import patch
 
 import pytest
@@ -12,8 +16,11 @@ import reconcile.openshift_base as sut
 import reconcile.utils.openshift_resource as resource
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils import oc
+from reconcile.utils.differ import (
+    DiffPair,
+    DiffResult,
+)
 from reconcile.utils.semver_helper import make_semver
-from reconcile.utils.differ import DiffResult, DiffPair
 
 fxt = Fixtures("namespaces")
 

--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -1,15 +1,15 @@
 import pytest
 
+from reconcile.openshift_base import three_way_merge_patch_diff_using_hash
 from reconcile.utils.openshift_resource import ConstructResourceError
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
-from reconcile.openshift_base import three_way_merge_patch_diff_using_hash
-from reconcile.utils.semver_helper import make_semver
-
 from reconcile.utils.openshift_resource import (
     ResourceInventory,
     ResourceNotManagedError,
     build_secret,
 )
+from reconcile.utils.semver_helper import make_semver
+
 from .fixtures import Fixtures
 
 fxt = Fixtures("openshift_resource")

--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -45,7 +45,7 @@ def test_3wpd_equal_objects_should_not_apply(deployment):
 
     # sha256 Hash is calculated over the DESIRED object
     c_item = d_item.annotate(canonicalize=False)
-    assert three_way_merge_patch_diff_using_hash(c_item, d_item) is False
+    assert three_way_merge_patch_diff_using_hash(c_item, d_item) is True
 
 
 def test_3wpd_change_desired_should_apply(deployment):
@@ -53,7 +53,7 @@ def test_3wpd_change_desired_should_apply(deployment):
     c_item = d_item.annotate(canonicalize=False)
 
     del d_item.body["metadata"]["annotations"]
-    assert three_way_merge_patch_diff_using_hash(c_item, d_item) is True
+    assert three_way_merge_patch_diff_using_hash(c_item, d_item) is False
 
 
 # Changes in current objects over attributes defined in desired
@@ -62,7 +62,7 @@ def test_3wpd_change_current_should_apply(deployment):
     c_item = d_item.annotate(canonicalize=False)
 
     c_item.body["spec"]["replicas"] = 5
-    assert three_way_merge_patch_diff_using_hash(c_item, d_item) is True
+    assert three_way_merge_patch_diff_using_hash(c_item, d_item) is False
 
 
 # Changes in current objects on attributes *NOT* defined in desired
@@ -71,7 +71,7 @@ def test_3wpd_change_current_not_in_desired_should_not_apply(deployment):
     c_item = d_item.annotate(canonicalize=False)
 
     c_item.body["spec"]["manual_added_attr"] = 5
-    assert three_way_merge_patch_diff_using_hash(c_item, d_item) is False
+    assert three_way_merge_patch_diff_using_hash(c_item, d_item) is True
 
 
 def test_obj_intersect_equal_status_depth_0_current():

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -198,14 +198,6 @@ class OpenshiftResource:
         return val1 == val2
 
     @property
-    def last_applied_configuration(self):
-        try:
-            lac = self.body["metadata"]["annotations"][LAC_ANNOTATION]
-            return lac
-        except KeyError:
-            return None
-
-    @property
     def name(self):
         return self.body["metadata"]["name"]
 

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -10,9 +10,10 @@ from typing import (
     Optional,
     Union,
 )
-from reconcile.utils.unleash import get_feature_toggle_state
 
 import semver
+
+from reconcile.utils.unleash import get_feature_toggle_state
 
 SECRET_MAX_KEY_LENGTH = 253
 LAC_ANNOTATION = "kubectl.kubernetes.io/last-applied-configuration"
@@ -56,6 +57,7 @@ CONTROLLER_MANAGED_LABELS: dict[str, set[Union[str, re.Pattern]]] = {
 }
 
 
+# pylint: disable=R0904
 class OpenshiftResource:
     def __init__(
         self,
@@ -565,7 +567,6 @@ class ResourceInventory:
         # temporary logic to rollout new resources diff mechanism
         self.clusters_3way_diff_strategy = {}
         #
-
 
     def initialize_resource_type(
         self,

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -292,14 +292,6 @@ class OpenshiftResource:
         except KeyError:
             pass
 
-    def remove_qontract_annotations(self):
-        try:
-            annotations = self.body["metadata"]["annotations"]
-            for a in QONTRACT_ANNOTATIONS:
-                annotations.pop(a, None)
-        except KeyError:
-            pass
-
     @staticmethod
     def is_controller_managed_label(kind, label) -> bool:
         for il in CONTROLLER_MANAGED_LABELS.get(kind, []):

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     Union,
 )
+from reconcile.utils.unleash import get_feature_toggle_state
 
 import semver
 
@@ -561,6 +562,11 @@ class ResourceInventory:
         self._error_registered_clusters = {}
         self._lock = Lock()
 
+        # temporary logic to rollout new resources diff mechanism
+        self.clusters_3way_diff_strategy = {}
+        #
+
+
     def initialize_resource_type(
         self,
         cluster,
@@ -568,6 +574,15 @@ class ResourceInventory:
         resource_type,
         managed_names: Optional[list[str]] = None,
     ):
+        # temporary logic to rollout new resources diff mechanism
+        if cluster not in self.clusters_3way_diff_strategy:
+            toggle = "openshift-resources-3way-diff-strategy"
+            use_3way_diff = get_feature_toggle_state(
+                toggle, context={"cluster_name": cluster}, default=False
+            )
+            self.clusters_3way_diff_strategy[cluster] = use_3way_diff
+        #
+
         self._clusters.setdefault(cluster, {})
         self._clusters[cluster].setdefault(namespace, {})
         self._clusters[cluster][namespace].setdefault(

--- a/reconcile/utils/unleash.py
+++ b/reconcile/utils/unleash.py
@@ -50,6 +50,21 @@ class DisableClusterStrategy(Strategy):
 
         return enable
 
+class EnableClusterStrategy(Strategy):
+
+    def load_provisioning(self) -> list:
+        return [x.strip() for x in self.parameters["cluster_name"].split(",")]
+
+    def apply(self, context: Optional[dict] = None) -> bool:
+        enable = False
+
+        if context and "cluster_name" in context.keys():
+            # if cluster in context is in clusters sent from server, enable
+            enable = context["cluster_name"] in self.parsed_provisioning
+
+        return enable
+
+
 
 def _get_unleash_api_client(api_url: str, auth_head: str) -> UnleashClient:
     global client
@@ -63,7 +78,10 @@ def _get_unleash_api_client(api_url: str, auth_head: str) -> UnleashClient:
                 app_name="qontract-reconcile",
                 custom_headers=headers,
                 cache=CacheDict(),
-                custom_strategies={"disableCluster": DisableClusterStrategy},
+                custom_strategies={
+                    "enableCluster": EnableClusterStrategy,
+                    "disableCluster": DisableClusterStrategy,
+                },
             )
             client.initialize_client()
     return client

--- a/reconcile/utils/unleash.py
+++ b/reconcile/utils/unleash.py
@@ -37,10 +37,12 @@ class CacheDict(BaseCache):
         self.cache = {}
 
 
-class DisableClusterStrategy(Strategy):
+class ClusterStrategy(Strategy):
     def load_provisioning(self) -> list:
         return [x.strip() for x in self.parameters["cluster_name"].split(",")]
 
+
+class DisableClusterStrategy(ClusterStrategy):
     def apply(self, context: Optional[dict] = None) -> bool:
         enable = True
 
@@ -51,10 +53,7 @@ class DisableClusterStrategy(Strategy):
         return enable
 
 
-class EnableClusterStrategy(Strategy):
-    def load_provisioning(self) -> list:
-        return [x.strip() for x in self.parameters["cluster_name"].split(",")]
-
+class EnableClusterStrategy(ClusterStrategy):
     def apply(self, context: Optional[dict] = None) -> bool:
         enable = False
 

--- a/reconcile/utils/unleash.py
+++ b/reconcile/utils/unleash.py
@@ -50,8 +50,8 @@ class DisableClusterStrategy(Strategy):
 
         return enable
 
-class EnableClusterStrategy(Strategy):
 
+class EnableClusterStrategy(Strategy):
     def load_provisioning(self) -> list:
         return [x.strip() for x in self.parameters["cluster_name"].split(",")]
 
@@ -63,7 +63,6 @@ class EnableClusterStrategy(Strategy):
             enable = context["cluster_name"] in self.parsed_provisioning
 
         return enable
-
 
 
 def _get_unleash_api_client(api_url: str, auth_head: str) -> UnleashClient:

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         "pyjwt~=2.7",
         "requests-oauthlib~=1.3",
         "dt==1.1.61",
+        "jsonpatch~=1.33",
     ],
     test_suite="tests",
     classifiers=[


### PR DESCRIPTION
# Overview  
This PR changes the way Openshift objects are compared to know if they need to be applied or not. This change affects multiple integrations, like all openshift-related integrations and terraform-resources. 

Currently, QR uses a custom method to compare objects which sometimes is not accurate. For example, removing an annotation from an object is not detected, non-expected attributes in desired objects that are removed by the API server are not detected, etc. 

This PR introduces a 3-way merge strategy to compare objects. 

## How it works

<img width="676" alt="image" src="https://github.com/app-sre/qontract-reconcile/assets/11975365/10b614c6-ab44-49d3-8ace-7227e713c4a2">

### Notes 
* The Original object is represented by the QR hash. It's the last Desired state that was applied 
* The last comparison is made for the desired object attributes only. Changes introduced by operators or other stuff are not considered.

## Rollout 
* A feature toggle to use this strategy has been set. Clusters need to be added to the `openshift-resources-3way-diff-strategy` feature flag in unleash to enable this strategy. 
* The plan is to test this locally before enabling the feature flag in the QR runtime. 