### PR TITLE
[ldap-groups] ignore "deleted users"

### DIFF
--- a/reconcile/test/ldap_groups/test_ldap_groups_integration.py
+++ b/reconcile/test/ldap_groups/test_ldap_groups_integration.py
@@ -164,8 +164,32 @@ def test_ldap_groups_integration_reconcile(
             Entity(type=EntityType.USER, id="spock - christine"),
         ],
     )
-    desired_groups = [officers, medical_crew, love_couples_new]
-    current_groups = [officers, cerritos_crew, love_couples]
+    # must be a noop for DELETED_USERs
+    nx_01_crew = Group(
+        name="the-deleted-ones",
+        description="Managed by qontract-reconcile",
+        contact_list="email@example.org",
+        owners=[Entity(type=EntityType.SERVICE_ACCOUNT, id="enterprise-lcars-1")],
+        display_name="Star Trek - New Strange Worlds: Medical Crew",
+        members=[
+            Entity(type=EntityType.USER, id="archer"),
+            Entity(type=EntityType.USER, id="t'pol"),
+        ],
+    )
+    nx_01_crew_deleted = Group(
+        name="the-deleted-ones",
+        description="Managed by qontract-reconcile",
+        contact_list="email@example.org",
+        owners=[Entity(type=EntityType.SERVICE_ACCOUNT, id="enterprise-lcars-1")],
+        display_name="Star Trek - New Strange Worlds: Medical Crew",
+        members=[
+            Entity(type=EntityType.DELETED_USER, id="archer"),
+            Entity(type=EntityType.DELETED_USER, id="t'pol"),
+        ],
+    )
+
+    desired_groups = [officers, medical_crew, love_couples_new, nx_01_crew_deleted]
+    current_groups = [officers, cerritos_crew, love_couples, nx_01_crew]
     intg.reconcile(
         dry_run=dry_run,
         internal_groups_client=internal_groups_client,
@@ -183,7 +207,7 @@ def test_ldap_groups_integration_reconcile(
     internal_groups_client.update_group.assert_called_once_with(love_couples_new)
 
     assert sorted(intg._managed_groups) == sorted(
-        ["officers", "medical-crew", "love-couples"]
+        ["officers", "medical-crew", "love-couples", "the-deleted-ones"]
     )
 
 

--- a/reconcile/test/utils/internal_groups/test_internal_groups_models.py
+++ b/reconcile/test/utils/internal_groups/test_internal_groups_models.py
@@ -9,9 +9,9 @@ from reconcile.utils.internal_groups.models import (
 )
 
 USER_1 = Entity(id="user-1", type=EntityType.USER)
+USER_1_DELETED = Entity(id="user-1", type=EntityType.DELETED_USER)
 USER_2 = Entity(id="user-2", type=EntityType.USER)
-SERVICE_ACCOUNT_1 = Entity(id="user-1", type=EntityType.SERVICE_ACCOUNT)
-SERVICE_ACCOUNT_2 = Entity(id="service-account-2", type=EntityType.SERVICE_ACCOUNT)
+SERVICE_ACCOUNT_1 = Entity(id="service-account-1", type=EntityType.SERVICE_ACCOUNT)
 
 GROUP = Group(
     name="group",
@@ -99,9 +99,9 @@ GROUP_MEMBERS_CHANGED = Group(
     "a, b, expected",
     [
         (USER_1, USER_1, True),
+        (USER_1, USER_1_DELETED, True),
         (USER_1, USER_2, False),
         (USER_1, SERVICE_ACCOUNT_1, False),
-        (USER_1, SERVICE_ACCOUNT_2, False),
     ],
 )
 def test_internal_groups_models_entity_eq(a: Entity, b: Entity, expected: bool) -> None:

--- a/reconcile/utils/internal_groups/models.py
+++ b/reconcile/utils/internal_groups/models.py
@@ -12,14 +12,20 @@ from pydantic import (
 class EntityType(str, Enum):
     USER = "user"
     SERVICE_ACCOUNT = "serviceaccount"
+    DELETED_USER = "deleteduser"
 
 
 class Entity(BaseModel):
     type: EntityType
     id: str
 
-    class Config:
-        frozen = True
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, Entity):
+            raise NotImplementedError("Cannot compare to non Entity objects.")
+        return self.id == other.id
+
+    def __hash__(self) -> int:
+        return hash(self.id)
 
 
 class Group(BaseModel):


### PR DESCRIPTION
Deleted LDAP users are flagged as type `deleteduser`. Do not use the entity type to compare the member lists.

Ticket: [APPSRE-8259](https://issues.redhat.com/browse/APPSRE-8259)