### PR TITLE
 terraform-state-1.yml support for Terraform Repo #3766 

### DIFF
--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
@@ -12,6 +12,10 @@ query TerraformRepo {
         provider
         bucket
         region
+        integrations {
+          integration
+          key
+        }
       }
     }
     name

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
@@ -8,6 +8,11 @@ query TerraformRepo {
       automationToken {
         ...VaultSecret
       }
+      terraformState {
+        provider
+        bucket
+        region
+      }
     }
     name
     repository

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.py
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.py
@@ -40,6 +40,10 @@ query TerraformRepo {
         provider
         bucket
         region
+        integrations {
+          integration
+          key
+        }
       }
     }
     name
@@ -58,10 +62,18 @@ class ConfiguredBaseModel(BaseModel):
         extra = Extra.forbid
 
 
+class AWSTerraformStateIntegrationsV1(ConfiguredBaseModel):
+    integration: str = Field(..., alias="integration")
+    key: str = Field(..., alias="key")
+
+
 class TerraformStateAWSV1(ConfiguredBaseModel):
     provider: str = Field(..., alias="provider")
     bucket: str = Field(..., alias="bucket")
     region: str = Field(..., alias="region")
+    integrations: list[AWSTerraformStateIntegrationsV1] = Field(
+        ..., alias="integrations"
+    )
 
 
 class AWSAccountV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.py
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.py
@@ -36,6 +36,11 @@ query TerraformRepo {
       automationToken {
         ...VaultSecret
       }
+      terraformState {
+        provider
+        bucket
+        region
+      }
     }
     name
     repository
@@ -53,10 +58,17 @@ class ConfiguredBaseModel(BaseModel):
         extra = Extra.forbid
 
 
+class TerraformStateAWSV1(ConfiguredBaseModel):
+    provider: str = Field(..., alias="provider")
+    bucket: str = Field(..., alias="bucket")
+    region: str = Field(..., alias="region")
+
+
 class AWSAccountV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     uid: str = Field(..., alias="uid")
     automation_token: VaultSecret = Field(..., alias="automationToken")
+    terraform_state: Optional[TerraformStateAWSV1] = Field(..., alias="terraformState")
 
 
 class TerraformRepoV1(ConfiguredBaseModel):

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -102,7 +102,7 @@ class TerraformRepoIntegration(
         if repo_diff_result:
             self.print_output(repo_diff_result, dry_run)
 
-    def print_output(self, diff: list[TerraformRepoV1], dry_run: bool):
+    def print_output(self, diff: list[TerraformRepoV1], dry_run: bool) -> None:
         """Parses and prints the output of a Terraform Repo diff for the executor
 
         :param diff: list of terraform repos to be acted on

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -100,50 +100,57 @@ class TerraformRepoIntegration(
         )
 
         if repo_diff_result:
-            # put together output to pass to executor
-            actions_list: list[RepoOutput] = []
+            self.print_output(repo_diff_result, dry_run)
 
-            for repo in repo_diff_result:
-                out_repo = RepoOutput(
-                    repository=repo.repository,
-                    name=repo.name,
-                    ref=repo.ref,
-                    project_path=repo.project_path,
-                    delete=repo.delete or False,
-                    secret=RepoSecret(
-                        path=repo.account.automation_token.path,
-                        version=repo.account.automation_token.version,
-                    ),
-                )
-                # terraform-repo will store its statefiles in a specified directory if there is a
-                # terraform-state yaml file associated with the AWS account and a configuration is
-                # listed for terraform-repo, otherwise it will default to loading this information
-                # from the automation_token secret in Vault
-                if repo.account.terraform_state:
-                    for integration in repo.account.terraform_state.integrations:
-                        if integration.integration == "terraform-repo":
-                            out_repo.bucket = repo.account.terraform_state.bucket
-                            out_repo.region = repo.account.terraform_state.region
-                            out_repo.bucket_path = integration.key
+    def print_output(self, diff: list[TerraformRepoV1], dry_run: bool):
+        """Parses and prints the output of a Terraform Repo diff for the executor
 
-                actions_list.append(out_repo)
+        :param diff: list of terraform repos to be acted on
+        :type diff: list[TerraformRepoV1]
+        :param dry_run: whether the executor should perform a tf apply
+        :type dry_run: bool
+        """
+        actions_list: list[RepoOutput] = []
 
-            output = OutputFile(dry_run=dry_run, repos=actions_list)
+        for repo in diff:
+            out_repo = RepoOutput(
+                repository=repo.repository,
+                name=repo.name,
+                ref=repo.ref,
+                project_path=repo.project_path,
+                delete=repo.delete or False,
+                secret=RepoSecret(
+                    path=repo.account.automation_token.path,
+                    version=repo.account.automation_token.version,
+                ),
+            )
+            # terraform-repo will store its statefiles in a specified directory if there is a
+            # terraform-state yaml file associated with the AWS account and a configuration is
+            # listed for terraform-repo, otherwise it will default to loading this information
+            # from the automation_token secret in Vault
+            if repo.account.terraform_state:
+                for integration in repo.account.terraform_state.integrations:
+                    if integration.integration == "terraform-repo":
+                        out_repo.bucket = repo.account.terraform_state.bucket
+                        out_repo.region = repo.account.terraform_state.region
+                        out_repo.bucket_path = integration.key
 
-            if self.params.output_file:
-                try:
-                    with open(self.params.output_file, "w") as output_file:
-                        yaml.safe_dump(
-                            data=output.dict(),
-                            stream=output_file,
-                            explicit_start=True,
-                        )
-                except FileNotFoundError:
-                    raise ParameterError(
-                        f"Unable to write to '{self.params.output_file}'"
+            actions_list.append(out_repo)
+
+        output = OutputFile(dry_run=dry_run, repos=actions_list)
+
+        if self.params.output_file:
+            try:
+                with open(self.params.output_file, "w") as output_file:
+                    yaml.safe_dump(
+                        data=output.dict(),
+                        stream=output_file,
+                        explicit_start=True,
                     )
-            else:
-                print(yaml.safe_dump(data=output.dict(), explicit_start=True))
+            except FileNotFoundError:
+                raise ParameterError(f"Unable to write to '{self.params.output_file}'")
+        else:
+            print(yaml.safe_dump(data=output.dict(), explicit_start=True))
 
     def get_repos(self, query_func: Callable) -> list[TerraformRepoV1]:
         """Gets a list of terraform repos defined in App Interface

--- a/reconcile/test/test_terraform_repo.py
+++ b/reconcile/test/test_terraform_repo.py
@@ -1,12 +1,10 @@
-from os import path
 from unittest.mock import MagicMock
 
 import pytest
-from tomlkit import key
+
 from reconcile.gql_definitions.fragments.terraform_state import (
     AWSTerraformStateIntegrationsV1,
 )
-
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.gql_definitions.terraform_repo.terraform_repo import (
     AWSAccountV1,

--- a/reconcile/test/test_terraform_repo.py
+++ b/reconcile/test/test_terraform_repo.py
@@ -321,13 +321,12 @@ def test_output_correct_statefile(
     )
 
     assert diff
-    if diff:
-        integration.print_output(diff, True)
+    integration.print_output(diff, True)
 
-        with open(f"{tmp_path}/tf-repo.yaml", "r") as output:
-            yaml_rep = yaml.safe_load(output)
+    with open(f"{tmp_path}/tf-repo.yaml", "r") as output:
+        yaml_rep = yaml.safe_load(output)
 
-            assert expected_output == yaml_rep
+        assert expected_output == yaml_rep
 
 
 def test_output_correct_no_statefile(
@@ -348,13 +347,12 @@ def test_output_correct_no_statefile(
     )
 
     assert diff
-    if diff:
-        integration.print_output(diff, True)
+    integration.print_output(diff, True)
 
-        with open(f"{tmp_path}/tf-repo.yaml", "r") as output:
-            yaml_rep = yaml.safe_load(output)
+    with open(f"{tmp_path}/tf-repo.yaml", "r") as output:
+        yaml_rep = yaml.safe_load(output)
 
-            assert expected_output == yaml_rep
+        assert expected_output == yaml_rep
 
 
 def test_fail_on_multiple_repos_dry_run(int_params, existing_repo, new_repo):


### PR DESCRIPTION
[APPSRE-8242](https://issues.redhat.com/browse/APPSRE-8242)

Allows Terraform Repo to work with [terraform-state-1.yml](https://github.com/app-sre/qontract-schemas/blob/main/schemas/dependencies/terraform-state-1.yml) files. terraform-state files are separate from the actual Terraform state and allow you to specify where state files for specific AppSRE integrations are stored within AWS rather than relying on hard-coded paths and Vault secret values. This is a key step to getting terraform-repo in commercial.

Here's what a terraform state file would look like for Terraform Repo:

```
$schema: /dependencies/terraform-state-1.yml
provider: s3
bucket: tf-state
region: us-east-1 
integrations:
- integration: terraform-repo
  key: tf-repo
```

So then, if you created a terraform repo named "my-cool-repo" in an AWS account with this state attached, it would be stored in the following location on S3:

`s3://tf-state/tf-repo/my-cool-repo-tf-repo.tfstate`

Additionally adds new tests to validate outputs are correct for the executor. Executor PR: https://github.com/app-sre/terraform-repo-executor/pull/14

Example of expected output from terraform-repo QR integration now:
```yaml
dry_run: true
repos:
- repository: https://git-example/tf-repo-example
  name: a_repo
  ref: a390f5cb20322c90861d6d80e9b70c6a579be1d0
  project_path: tf
  delete: false
  secret:
    path: aws-secrets/terraform/foo
    version: 1
  bucket: app-sre
  region: us-east-1
  bucket_path: tf-repo
```