### PR TITLE
[qontract-cli] sso-client management command

### DIFF
--- a/reconcile/test/utils/test_keycloak.py
+++ b/reconcile/test/utils/test_keycloak.py
@@ -53,7 +53,7 @@ def test_keycloak_register_client(
 ) -> None:
     httpretty.register_uri(
         httpretty.POST,
-        f"{keycloak_api._openid_configuration['registration_endpoint']}",
+        f"{keycloak_api._openid_configuration['registration_endpoint']}",  # type: ignore[index]
         body=json.dumps(
             {
                 "client_id": "test-client",

--- a/reconcile/utils/keycloak.py
+++ b/reconcile/utils/keycloak.py
@@ -1,4 +1,5 @@
 from typing import (
+    Any,
     Iterable,
     Optional,
     Sequence,
@@ -35,14 +36,21 @@ class KeycloakInstance(BaseModel):
 
 class KeycloakAPI:
     def __init__(
-        self, url: str, initial_access_token: Optional[str] = None, timeout: int = 30
+        self,
+        url: str | None = None,
+        initial_access_token: str | None = None,
+        timeout: int = 30,
     ) -> None:
         self.url = url
         self.initial_access_token = initial_access_token
         self.timeout = timeout
-        self._init_openid_configuration()
+        self._openid_configuration: dict[str, Any] | None = None
+        if self.url:
+            self._init_openid_configuration()
 
     def _init_openid_configuration(self) -> None:
+        if not self.url:
+            raise ValueError("url is required")
         self._openid_configuration = requests.get(
             f"{self.url}/.well-known/openid-configuration",
             timeout=self.timeout,
@@ -59,6 +67,8 @@ class KeycloakAPI:
         """Create a new SSO client."""
         if not self.initial_access_token:
             raise ValueError("initial_access_token is required")
+        if not self._openid_configuration:
+            raise ValueError("openid_configuration is required")
 
         response = requests.post(
             self._openid_configuration["registration_endpoint"],

--- a/reconcile/utils/keycloak.py
+++ b/reconcile/utils/keycloak.py
@@ -44,14 +44,12 @@ class KeycloakAPI:
         self.url = url
         self.initial_access_token = initial_access_token
         self.timeout = timeout
-        self._openid_configuration: dict[str, Any] | None = None
-        if self.url:
-            self._init_openid_configuration()
+        self._openid_configuration = self._init_openid_configuration()
 
-    def _init_openid_configuration(self) -> None:
+    def _init_openid_configuration(self) -> dict[str, Any] | None:
         if not self.url:
-            raise ValueError("url is required")
-        self._openid_configuration = requests.get(
+            return None
+        return requests.get(
             f"{self.url}/.well-known/openid-configuration",
             timeout=self.timeout,
         ).json()

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2868,7 +2868,6 @@ def test_change_type(change_type_name: str, role_name: str, app_interface_path: 
 @click.pass_context
 def sso_client(ctx):
     """SSO client commands"""
-    pass
 
 
 @sso_client.command()

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -91,6 +91,10 @@ from reconcile.utils.gitlab_api import (
 )
 from reconcile.utils.gql import GqlApiSingleton
 from reconcile.utils.jjb_client import JJB
+from reconcile.utils.keycloak import (
+    KeycloakAPI,
+    SSOClient,
+)
 from reconcile.utils.mr.labels import (
     SAAS_FILE_UPDATE,
     SELF_SERVICEABLE,
@@ -2858,6 +2862,99 @@ def test_change_type(change_type_name: str, role_name: str, app_interface_path: 
 
     # tester.test_change_type(change_type_name, datafile_path)
     tester.test_change_type_in_context(change_type_name, role_name, app_interface_path)
+
+
+@root.group()
+@click.pass_context
+def sso_client(ctx):
+    """SSO client commands"""
+    pass
+
+
+@sso_client.command()
+@click.argument("client-name", required=True)
+@click.option(
+    "--contact-email",
+    default="sd-app-sre+auth@redhat.com",
+    help="Specify the contact email address",
+    required=True,
+    show_default=True,
+)
+@click.option(
+    "--keycloak-instance-vault-path",
+    help="Path to the keycloak secret in vault",
+    default="app-sre/creds/rhidp/auth.redhat.com",
+    required=True,
+    show_default=True,
+)
+@click.option(
+    "--request-uri",
+    help="Specify an allowed request URL; first one will be used as the initial one URL. Can be specified multiple times",
+    multiple=True,
+    required=True,
+    prompt=True,
+)
+@click.option(
+    "--redirect-uri",
+    help="Specify an allowed redirect URL. Can be specified multiple times",
+    multiple=True,
+    required=True,
+    prompt=True,
+)
+@click.pass_context
+def create(
+    ctx,
+    client_name: str,
+    contact_email: str,
+    keycloak_instance_vault_path: str,
+    request_uri: tuple[str],
+    redirect_uri: tuple[str],
+) -> None:
+    """Create a new SSO client"""
+    vault_settings = get_app_interface_vault_settings()
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+
+    keycloak_secret = secret_reader.read_all({"path": keycloak_instance_vault_path})
+    keycloak_api = KeycloakAPI(
+        url=keycloak_secret["url"],
+        initial_access_token=keycloak_secret["initial-access-token"],
+    )
+    sso_client = keycloak_api.register_client(
+        client_name=client_name,
+        redirect_uris=redirect_uri,
+        initiate_login_uri=request_uri[0],
+        request_uris=request_uri,
+        contacts=[contact_email],
+    )
+    click.secho(
+        "SSO client created successfully. Please save the following JSON in Vault!",
+        bg="red",
+        fg="white",
+    )
+    print(sso_client.json(by_alias=True, indent=2))
+
+
+@sso_client.command()
+@click.argument("sso-client-vault-secret-path", required=True)
+@click.pass_context
+def remove(ctx, sso_client_vault_secret_path: str):
+    """Remove an existing SSO client"""
+    vault_settings = get_app_interface_vault_settings()
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+
+    sso_client = SSOClient(
+        **secret_reader.read_all({"path": sso_client_vault_secret_path})
+    )
+    keycloak_api = KeycloakAPI()
+    keycloak_api.delete_client(
+        registration_client_uri=sso_client.registration_client_uri,
+        registration_access_token=sso_client.registration_access_token,
+    )
+    click.secho(
+        "SSO client removed successfully. Please remove the secret from Vault!",
+        bg="red",
+        fg="white",
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Create/Remove SSO clients via `qontract-cli`.

Ticket: [APPSRE-8203](https://issues.redhat.com/browse/APPSRE-8203)

### Create an SSO client
```
$ qontract-cli --config $CONFIG sso-client create --help                                                                                                         
Usage: qontract-cli sso-client create [OPTIONS] CLIENT_NAME

  Create a new SSO client

Options:
  --contact-email TEXT            Specify the contact email address  [default:
                                  sd-app-sre+auth@redhat.com; required]
  --keycloak-instance-vault-path TEXT
                                  Path to the keycloak secret in vault
                                  [default: app-
                                  sre/creds/rhidp/auth.redhat.com; required]
  --request-uri TEXT              Specify an allowed request URL; first one
                                  will be used as the initial one URL. Can be
                                  specified multiple times  [required]
  --redirect-uri TEXT             Specify an allowed redirect URL. Can be
                                  specified multiple times  [required]
  --help                          Show this message and exit.
```

For example:

```
$ qontract-cli --config $CONFIG sso-client create --request-uri https://just-an-example.org --redirect-uri https://just-an-example.org/login  just-test                     
SSO client created successfully. Please save the following JSON in Vault!
{
  "client_id": "1234567890",
  "client_id_issued_at": 1693832008,
  "client_name": "just-test",
  "client_secret": "*****",
  "client_secret_expires_at": 0,
  "grant_types": [
    "authorization_code",
    "refresh_token"
  ],
  "redirect_uris": [
    "https://just-an-example.org/login"
  ],
  "registration_access_token": "****",
  "registration_client_uri": "https://****",
  "request_uris": [
    "https://just-an-example.org"
  ],
  "response_types": [
    "code",
    "none"
  ],
  "subject_type": "public",
  "tls_client_certificate_bound_access_tokens": false,
  "token_endpoint_auth_method": "client_secret_basic",
  "issuer": "https://****"
}
```

### Remove an SSO client

```
$ qontract-cli --config $CONFIG sso-client remove --help                                                                                                          
Usage: qontract-cli sso-client remove [OPTIONS] SSO_CLIENT_VAULT_SECRET_PATH

  Remove an existing SSO client

Options:
  --help  Show this message and exit.
```

For example

```
$ qontract-cli --config $CONFIG sso-client remove app-sre/creds/ca-test                                                                                                              
SSO client removed successfully. Please remove the secret from Vault!
```