### PR TITLE
Fix cloudflare logpush/logpull data lookup identifier

### DIFF
--- a/reconcile/test/utils/test_terrascript_cloudflare_client.py
+++ b/reconcile/test/utils/test_terrascript_cloudflare_client.py
@@ -140,7 +140,7 @@ def test_create_cloudflare_resources_terraform_json(account_config, backend_conf
         {
             "provider": "logpush_ownership_challenge",
             "identifier": "logpush_ownership_challenge_zone",
-            "zone_name": "test-zone",
+            "zone_name": "test.zone",
             "destination_conf": "s3://bucket/logs?region=us-east-1&sse=AES256",
         },
         {},
@@ -162,7 +162,7 @@ def test_create_cloudflare_resources_terraform_json(account_config, backend_conf
             "provider": "logpush_job",
             "identifier": "logpush_job_zone",
             "enabled": True,
-            "zone_name": "test-zone",
+            "zone_name": "test.zone",
             "logpull_options": "fields=RayID,ClientIP,EdgeStartTimestamp&timestamps=rfc3339",
             "destination_conf": "s3://bucket/logs?region=us-east-1&sse=AES256",
             "ownership_challenge": "some-challenge",
@@ -195,7 +195,7 @@ def test_create_cloudflare_resources_terraform_json(account_config, backend_conf
         {
             "provider": "logpull_retention",
             "identifier": "test",
-            "zone": "test-zone",
+            "zone": "test.zone",
             "enabled_flag": True,
         },
         {},
@@ -241,7 +241,7 @@ def test_create_cloudflare_resources_terraform_json(account_config, backend_conf
                 "cloudflare-account": {"account_id": "${var.account_id}"}
             },
             "cloudflare_zone": {
-                "test-zone": {"account_id": "${var.account_id}", "name": "test-zone"}
+                "test_zone": {"account_id": "${var.account_id}", "name": "test.zone"}
             },
         },
         "variable": {"account_id": {"default": "account_id", "type": "string"}},
@@ -309,7 +309,7 @@ def test_create_cloudflare_resources_terraform_json(account_config, backend_conf
             "cloudflare_logpush_ownership_challenge": {
                 "logpush_ownership_challenge_zone": {
                     "destination_conf": "s3://bucket/logs?region=us-east-1&sse=AES256",
-                    "zone_id": "${data.cloudflare_zone.test-zone.id}",
+                    "zone_id": "${data.cloudflare_zone.test_zone.id}",
                 },
                 "logpush_ownership_challenge_account": {
                     "account_id": "${var.account_id}",
@@ -318,7 +318,7 @@ def test_create_cloudflare_resources_terraform_json(account_config, backend_conf
             },
             "cloudflare_logpush_job": {
                 "logpush_job_zone": {
-                    "zone_id": "${data.cloudflare_zone.test-zone.id}",
+                    "zone_id": "${data.cloudflare_zone.test_zone.id}",
                     "dataset": "http_requests",
                     "destination_conf": "s3://bucket/logs?region=us-east-1&sse=AES256",
                     "enabled": True,
@@ -342,7 +342,7 @@ def test_create_cloudflare_resources_terraform_json(account_config, backend_conf
             "cloudflare_logpull_retention": {
                 "test": {
                     "enabled": True,
-                    "zone_id": "${data.cloudflare_zone.test-zone.id}",
+                    "zone_id": "${data.cloudflare_zone.test_zone.id}",
                 }
             },
         },

--- a/reconcile/utils/terrascript/cloudflare_resources.py
+++ b/reconcile/utils/terrascript/cloudflare_resources.py
@@ -310,7 +310,9 @@ class CloudflareLogpushJob(TerrascriptResource):
 
         if zone:
             resources.append(
-                self.cloudflare_zone(safe_resource_id(zone), name=zone, account_id="${var.account_id}")
+                self.cloudflare_zone(
+                    safe_resource_id(zone), name=zone, account_id="${var.account_id}"
+                )
             )
             values["zone_id"] = f"${{data.cloudflare_zone.{safe_resource_id(zone)}.id}}"
         else:
@@ -337,7 +339,9 @@ class CloudflareLogpushOwnershipChallengeResource(TerrascriptResource):
         zone = values.get("zone_name")
         if zone:
             resources.append(
-                self.cloudflare_zone(safe_resource_id(zone), name=zone, account_id="${var.account_id}")
+                self.cloudflare_zone(
+                    safe_resource_id(zone), name=zone, account_id="${var.account_id}"
+                )
             )
             resources.append(
                 cloudflare_logpush_ownership_challenge(
@@ -372,13 +376,15 @@ class CloudflareLogpullRetention(TerrascriptResource):
         values = ResourceValueResolver(self._spec).resolve()
 
         zone = values.get("zone")
-        
+
         # this is to appease mypy
         if not zone:
             return []
 
         resources.append(
-            self.cloudflare_zone(safe_resource_id(zone), name=zone, account_id="${var.account_id}")
+            self.cloudflare_zone(
+                safe_resource_id(zone), name=zone, account_id="${var.account_id}"
+            )
         )
         cf_logpull_retention = cloudflare_logpull_retention(
             self._spec.identifier,

--- a/reconcile/utils/terrascript/cloudflare_resources.py
+++ b/reconcile/utils/terrascript/cloudflare_resources.py
@@ -310,9 +310,9 @@ class CloudflareLogpushJob(TerrascriptResource):
 
         if zone:
             resources.append(
-                self.cloudflare_zone(zone, name=zone, account_id="${var.account_id}")
+                self.cloudflare_zone(safe_resource_id(zone), name=zone, account_id="${var.account_id}")
             )
-            values["zone_id"] = f"${{data.cloudflare_zone.{zone}.id}}"
+            values["zone_id"] = f"${{data.cloudflare_zone.{safe_resource_id(zone)}.id}}"
         else:
             values["account_id"] = "${var.account_id}"
 
@@ -337,12 +337,12 @@ class CloudflareLogpushOwnershipChallengeResource(TerrascriptResource):
         zone = values.get("zone_name")
         if zone:
             resources.append(
-                self.cloudflare_zone(zone, name=zone, account_id="${var.account_id}")
+                self.cloudflare_zone(safe_resource_id(zone), name=zone, account_id="${var.account_id}")
             )
             resources.append(
                 cloudflare_logpush_ownership_challenge(
                     self._spec.identifier,
-                    zone_id=f"${{data.cloudflare_zone.{zone}.id}}",
+                    zone_id=f"${{data.cloudflare_zone.{safe_resource_id(zone)}.id}}",
                     destination_conf=destination_conf,
                 )
             )
@@ -373,11 +373,11 @@ class CloudflareLogpullRetention(TerrascriptResource):
 
         zone = values.get("zone")
         resources.append(
-            self.cloudflare_zone(zone, name=zone, account_id="${var.account_id}")
+            self.cloudflare_zone(safe_resource_id(zone), name=zone, account_id="${var.account_id}")
         )
         cf_logpull_retention = cloudflare_logpull_retention(
             self._spec.identifier,
-            zone_id=f"${{data.cloudflare_zone.{zone}.id}}",
+            zone_id=f"${{data.cloudflare_zone.{safe_resource_id(zone)}.id}}",
             enabled=values.get("enabled_flag"),
         )
         resources.append(cf_logpull_retention)

--- a/reconcile/utils/terrascript/cloudflare_resources.py
+++ b/reconcile/utils/terrascript/cloudflare_resources.py
@@ -372,6 +372,11 @@ class CloudflareLogpullRetention(TerrascriptResource):
         values = ResourceValueResolver(self._spec).resolve()
 
         zone = values.get("zone")
+        
+        # this is to appease mypy
+        if not zone:
+            return []
+
         resources.append(
             self.cloudflare_zone(safe_resource_id(zone), name=zone, account_id="${var.account_id}")
         )


### PR DESCRIPTION
We need to use `safe_resource_id` in the terraform resource identifier because zone can contain dots for e.g `stage.quay.io` 