### PR TITLE
remove unused job filter

### DIFF
--- a/reconcile/jenkins_job_cleaner.py
+++ b/reconcile/jenkins_job_cleaner.py
@@ -20,9 +20,7 @@ def get_managed_job_names(job_names, managed_projects):
 
 def get_desired_job_names(instance_name: str, secret_reader: SecretReader):
     jjb = init_jjb(secret_reader)
-    desired_jobs = jjb.get_all_jobs(instance_name=instance_name, include_test=True)[
-        instance_name
-    ]
+    desired_jobs = jjb.get_all_jobs(instance_name=instance_name)[instance_name]
     return [j["name"] for j in desired_jobs]
 
 

--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -347,9 +347,7 @@ class JJB:  # pylint: disable=too-many-public-methods
     def get_ref(job: dict) -> str:
         return job["scm"][0]["git"]["branches"][0]
 
-    def get_all_jobs(
-        self, job_types=None, instance_name=None, include_test=False
-    ) -> dict[str, list[dict]]:
+    def get_all_jobs(self, job_types=None, instance_name=None) -> dict[str, list[dict]]:
         if job_types is None:
             job_types = []
         all_jobs: dict[str, list[dict]] = {}
@@ -362,11 +360,6 @@ class JJB:  # pylint: disable=too-many-public-methods
             for job in jobs:
                 job_name = job["name"]
                 if not any(job_type in job_name for job_type in job_types):
-                    continue
-                if not include_test and "test" in job_name:
-                    continue
-                # temporarily ignore openshift-saas-deploy jobs
-                if job_name.startswith("openshift-saas-deploy"):
                     continue
                 all_jobs[name].append(job)
 


### PR DESCRIPTION
fix https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/79861
test job is for filter [centos](https://github.com/app-sre/qontract-reconcile/pull/479) Jenkins instance which has gone. 
openshift-saas-deploy jobs also have been removed. 
jenkins-job-cleaer is not running.