### PR TITLE
[glitchtip-project-alerts] add urlSecret attribute

### DIFF
--- a/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.gql
+++ b/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.gql
@@ -19,11 +19,13 @@ query GlitchtipProjectsWithAlerts {
         provider
         ... on GlitchtipProjectAlertRecipientWebhook_v1 {
           url
+          urlSecret {
+            ...VaultSecret
+          }
         }
         ... on GlitchtipProjectAlertRecipientEmail_v1 {
           provider
         }
-
       }
     }
   }

--- a/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.py
+++ b/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.py
@@ -17,8 +17,17 @@ from pydantic import (  # noqa: F401 # pylint: disable=W0611
     Json,
 )
 
+from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
+
 
 DEFINITION = """
+fragment VaultSecret on VaultSecret_v1 {
+    path
+    field
+    version
+    format
+}
+
 query GlitchtipProjectsWithAlerts {
   glitchtip_projects: glitchtip_projects_v1 {
     name
@@ -38,11 +47,13 @@ query GlitchtipProjectsWithAlerts {
         provider
         ... on GlitchtipProjectAlertRecipientWebhook_v1 {
           url
+          urlSecret {
+            ...VaultSecret
+          }
         }
         ... on GlitchtipProjectAlertRecipientEmail_v1 {
           provider
         }
-
       }
     }
   }
@@ -70,7 +81,8 @@ class GlitchtipProjectAlertRecipientV1(ConfiguredBaseModel):
 
 
 class GlitchtipProjectAlertRecipientWebhookV1(GlitchtipProjectAlertRecipientV1):
-    url: str = Field(..., alias="url")
+    url: Optional[str] = Field(..., alias="url")
+    url_secret: Optional[VaultSecret] = Field(..., alias="urlSecret")
 
 
 class GlitchtipProjectAlertRecipientEmailV1(GlitchtipProjectAlertRecipientV1):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -40680,13 +40680,21 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "urlSecret",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "VaultSecret_v1",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/test/fixtures/glitchtip/project_alerts.yml
+++ b/reconcile/test/fixtures/glitchtip/project_alerts.yml
@@ -15,13 +15,19 @@ glitchtip_projects:
     - provider: email-project-members
     - provider: webhook
       url: https://example.com
+      urlSecret: null
   - name: example-2
     description: Example alert 1
     quantity: 2
     timespanMinutes: 2
     recipients:
     - provider: webhook
-      url: https://example.com
+      url: null
+      urlSecret:
+        path: ecret/glitchtip/webhook-url
+        field: url
+        version: 1
+        format: null
 
 - name: no-alerts
   projectId: null


### PR DESCRIPTION
A webhook URL may contain credentials, e.g. slack webhooks. Add an `urlSecret` attribute to retrieve a URL via Vault as well.

Depends on: https://github.com/app-sre/qontract-schemas/pull/514
Ticket: [[glitchtip project-alerts] Webhook URL from vault](https://issues.redhat.com/browse/APPSRE-8288)