### PR TITLE
Add tests to ocm cluster and machine pools

### DIFF
--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from abc import (
     ABC,
     abstractmethod,
@@ -21,8 +20,7 @@ from reconcile.gql_definitions.common.clusters import (
     ClusterMachinePoolV1_ClusterSpecAutoScaleV1,
     ClusterV1,
 )
-from reconcile.gql_definitions.common.clusters import query as clusters_query
-from reconcile.utils import gql
+from reconcile.typed_queries.clusters import get_clusters
 from reconcile.utils.disabled_integrations import integration_is_enabled
 from reconcile.utils.ocm import (
     OCM,
@@ -471,7 +469,7 @@ def _cluster_is_compatible(cluster: ClusterV1) -> bool:
 
 
 def run(dry_run: bool):
-    clusters = clusters_query(query_func=gql.get_api().query).clusters or []
+    clusters = get_clusters()
 
     filtered_clusters = [
         c
@@ -480,7 +478,7 @@ def run(dry_run: bool):
     ]
     if not filtered_clusters:
         logging.debug("No machinePools definitions found in app-interface")
-        sys.exit(0)
+        return
 
     settings = queries.get_app_interface_settings()
     cluster_like_objects = [
@@ -501,4 +499,4 @@ def run(dry_run: bool):
     if errors:
         for err in errors:
             logging.error(err)
-        sys.exit(1)
+        raise ExceptionGroup("InvalidUpdateErrors", errors)

--- a/reconcile/test/fixtures/clusters/osd_spec_post.json
+++ b/reconcile/test/fixtures/clusters/osd_spec_post.json
@@ -1,0 +1,40 @@
+{
+  "api": {
+    "listening": "external"
+  },
+  "cloud_provider": {
+    "id": "aws"
+  },
+  "disable_user_workload_monitoring": true,
+  "load_balancer_quota": 4,
+  "multi_az": true,
+  "name": "test-cluster",
+  "network": {
+    "machine_cidr": "10.112.0.0/16",
+    "pod_cidr": "10.128.0.0/14",
+    "service_cidr": "10.120.0.0/16",
+    "type": "OpenShiftSDN"
+  },
+  "nodes": {
+    "autoscale_compute": {
+      "max_replicas": 30,
+      "min_replicas": 21
+    },
+    "compute_machine_type": {
+      "id": "m5.2xlarge"
+    }
+  },
+  "properties": {
+    "provision_shard_id": "provision_shard_id"
+  },
+  "region": {
+    "id": "us-east-1"
+  },
+  "storage_quota": {
+    "value": 4402341478400.0
+  },
+  "version": {
+    "channel_group": "candidate",
+    "id": "openshift-v4.8.10"
+  }
+}

--- a/reconcile/test/fixtures/clusters/rosa_spec_post.json
+++ b/reconcile/test/fixtures/clusters/rosa_spec_post.json
@@ -1,0 +1,59 @@
+{
+  "api": {
+    "listening": "external"
+  },
+  "aws": {
+    "account_id": "249118421612",
+    "sts": {
+      "auto_mode": true,
+      "enabled": true,
+      "instance_iam_roles": {
+        "master_role_arn": "arn:aws:iam::249118421612:role/ManagedOpenShift-ControlPlane-Role",
+        "worker_role_arn": "arn:aws:iam::249118421612:role/ManagedOpenShift-Worker-Role"
+      },
+      "operator_role_prefix": "tst-jpr-rosa-cnzy",
+      "role_arn": "arn:aws:iam::249118421612:role/ManagedOpenShift-Installer-Role",
+      "support_role_arn": "arn:aws:iam::249118421612:role/ManagedOpenShift-Support-Role"
+    }
+  },
+  "ccs": {
+    "enabled": true
+  },
+  "cloud_provider": {
+    "id": "aws"
+  },
+  "disable_user_workload_monitoring": true,
+  "hypershift": {
+    "enabled": null
+  },
+  "multi_az": false,
+  "name": "tst-jpr-rosa",
+  "network": {
+    "machine_cidr": "10.0.0.0/16",
+    "pod_cidr": "10.128.0.0/14",
+    "service_cidr": "172.30.0.0/16",
+    "type": "OpenShiftSDN"
+  },
+  "nodes": {
+    "autoscale_compute": {
+      "max_replicas": 30,
+      "min_replicas": 21
+    },
+    "compute_machine_type": {
+      "id": "m5.xlarge"
+    }
+  },
+  "product": {
+    "id": "rosa"
+  },
+  "properties": {
+    "provision_shard_id": "provision_shard_id",
+    "rosa_creator_arn": "arn:aws:iam::249118421612:role/ManagedOpenShift-OCM-Role-12147054"
+  },
+  "region": {
+    "id": "us-east-1"
+  },
+  "version": {
+    "channel_group": "2", "id": "openshift-v4.8.10"
+  }
+}

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -459,7 +459,7 @@ class OCMProductRosa(OCMProduct):
     @staticmethod
     def _get_create_cluster_spec(cluster_name: str, cluster: OCMSpec) -> dict[str, Any]:
         operator_roles_prefix = "".join(
-            "".join(random.choices(string.ascii_lowercase + string.digits, k=4))
+            random.choices(string.ascii_lowercase + string.digits, k=4)
         )
 
         ocm_spec: dict[str, Any] = {


### PR DESCRIPTION
Prepare for changes regarding switch default machine pool handling from `ocm-clusters` to `ocm-machine-pools`, this change adds some end to end tests for current behaviours, with some minor refactorings.

[APPSRE-8258](https://issues.redhat.com/browse/APPSRE-8258)

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a6c200</samp>

Improved the code quality and test coverage of the modules that reconcile OCM clusters and machine pools. Fixed a bug in the creation of ROSA clusters. Added fixtures for the expected payloads of OSD and ROSA clusters.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 5a6c200</samp>

*  Remove unused `sys` module from imports ([link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-eeceffbceb8fdf008edf0e87f095e168a636b2c2c9081be6eb6c4fe766a071cbL2))
*  Replace `gql_definitions.common.clusters.query` and `utils.gql` modules with `typed_queries.clusters.get_clusters` module for typed queries ([link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-eeceffbceb8fdf008edf0e87f095e168a636b2c2c9081be6eb6c4fe766a071cbL24-R23), [link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-eeceffbceb8fdf008edf0e87f095e168a636b2c2c9081be6eb6c4fe766a071cbL474-R472))
*  Replace `sys.exit` statements with `return` and `raise ExceptionGroup` statements for better error handling ([link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-eeceffbceb8fdf008edf0e87f095e168a636b2c2c9081be6eb6c4fe766a071cbL483-R481), [link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-eeceffbceb8fdf008edf0e87f095e168a636b2c2c9081be6eb6c4fe766a071cbL504-R502))
*  Add expected payloads for creating OSD and ROSA clusters using OCM API ([link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-a9e6cc3c12c86d82e90d06493e784a9325e8f17a9b08ec5a1c4ee01ace042d64R1-R40), [link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-d1cd6670fd8c217ed8f94fa9ecfbb3f537efd8c577b1d1f742aab07f18c8673bR1-R59))
*  Modify `ocm_mock` fixture to remove `autospec=True` argument to avoid mock error ([link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-d0912ff22700e3c850b8665bbaadaf510cdbdf0db83371f2998680b7e31509c5L316-R326))
*  Modify `test_ocm_osd_create_cluster` and `test_ocm_rosa_create_cluster` functions to use expected payloads and mock `random.choices` function ([link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-d0912ff22700e3c850b8665bbaadaf510cdbdf0db83371f2998680b7e31509c5L463-R489), [link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-d0912ff22700e3c850b8665bbaadaf510cdbdf0db83371f2998680b7e31509c5L482-R517))
*  Add imports, mocks, fixtures, and tests for `reconcile/ocm_machine_pools.py` module ([link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-933fdf578ee97e851969466a47ba03cb50e7dec326689144c172795ec7718200L1-R14), [link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-933fdf578ee97e851969466a47ba03cb50e7dec326689144c172795ec7718200R21), [link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-933fdf578ee97e851969466a47ba03cb50e7dec326689144c172795ec7718200R27), [link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-933fdf578ee97e851969466a47ba03cb50e7dec326689144c172795ec7718200L116-R123), [link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-933fdf578ee97e851969466a47ba03cb50e7dec326689144c172795ec7718200L320-R329), [link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-933fdf578ee97e851969466a47ba03cb50e7dec326689144c172795ec7718200L331-R336), [link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-933fdf578ee97e851969466a47ba03cb50e7dec326689144c172795ec7718200L347-R351), [link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-933fdf578ee97e851969466a47ba03cb50e7dec326689144c172795ec7718200R368-R722))
*  Fix bug in `operator_roles_prefix` assignment in `OCMProductRosa` class ([link](https://github.com/app-sre/qontract-reconcile/pull/3787/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L462-R462))