### PR TITLE
Fix/Openshift-clusterRoleBindings crb spec

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -649,8 +649,11 @@ def three_way_merge_patch_diff_using_hash(c_item: OR, d_item: OR) -> bool:
     for item in patch.patch:
         if item["op"] == "add" or item["op"] == "replace":
             # Add or Replace from DESIRED Over CURRENT
+            log_items = [
+                item for item in patch.patch if item["op"] in ["add", "replace"]
+            ]
             logging.info("Desired and Current objects differ -> Apply")
-            logging.info(patch.patch)
+            logging.info(log_items)
             return False
 
     return True

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -70,7 +70,6 @@ def construct_sa_oc_resource(role, namespace, sa_name):
         "subjects": [
             {"kind": "ServiceAccount", "name": sa_name, "namespace": namespace}
         ],
-        "userNames": [f"system:serviceaccount:{namespace}:{sa_name}"],
     }
     return (
         OR(
@@ -123,7 +122,7 @@ def fetch_desired_state(ri, oc_map):
                         ri.add_desired(
                             cluster,
                             namespace_cluster_scope,
-                            "ClusterRoleBinding",
+                            "ClusterRoleBinding.rbac.authorization.k8s.io",
                             resource_name,
                             oc_resource,
                         )
@@ -142,7 +141,7 @@ def fetch_desired_state(ri, oc_map):
                     ri.add_desired(
                         cluster,
                         namespace_cluster_scope,
-                        "ClusterRoleBinding",
+                        "ClusterRoleBinding.rbac.authorization.k8s.io",
                         resource_name,
                         oc_resource,
                     )
@@ -166,7 +165,7 @@ def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True, defer=N
         thread_pool_size=thread_pool_size,
         integration=QONTRACT_INTEGRATION,
         integration_version=QONTRACT_INTEGRATION_VERSION,
-        override_managed_types=["ClusterRoleBinding"],
+        override_managed_types=["ClusterRoleBinding.rbac.authorization.k8s.io"],
         internal=internal,
         use_jump_host=use_jump_host,
     )

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
         # Is there any better place to put this in?
         "packaging~=23.1",
         "deepdiff==6.4.1",
-        "jsonpath-ng~=1.5",
+        "jsonpath-ng==1.5.3",
         "networkx~=2.8",
         "mypy-boto3-s3~=1.24.94",
         "rich>=13.3.0,<14.0.0",


### PR DESCRIPTION
This issue has surfaced because of the new 3-way diff strategy: 

* Ensure the ClusterRoleBindings use the `rbac.authorization.k8s.io` API. It's not the default in Openshift 4.x
* userNames is a thing with `authorization.openshift.io` not in `rbac.authorization.k8s.io`

`userNames` is being discarded by Kube and ignored silently in the reconciliation. 