### PR TITLE
DORA LTTC collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Additional tools that use the libraries created by the reconciliations are also 
                                   Assets (CNA).
   dashdotdb-cso                   Collects the ImageManifestVuln CRs from all
                                   the clusters and posts them to Dashdotdb.
+  dashdotdb-dora                  Collects dora metrics.
   dashdotdb-dvo                   Collects the DeploymentValidations from all
                                   the clusters and posts them to Dashdotdb.
   dashdotdb-slo                   Collects the ServiceSloMetrics from all the

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2424,6 +2424,18 @@ def dashdotdb_slo(ctx, thread_pool_size):
     run_integration(reconcile.dashdotdb_slo, ctx.obj, thread_pool_size)
 
 
+@integration.command(short_help="Collects dora metrics.")
+@gitlab_project_id
+@threaded(default=5)
+@click.pass_context
+def dashdotdb_dora(ctx, gitlab_project_id, thread_pool_size):
+    import reconcile.dashdotdb_dora
+
+    run_integration(
+        reconcile.dashdotdb_dora, ctx.obj, gitlab_project_id, thread_pool_size
+    )
+
+
 @integration.command(short_help="Tests prometheus rules using promtool.")
 @threaded(default=5)
 @binary(["promtool"])

--- a/reconcile/dashdotdb_base.py
+++ b/reconcile/dashdotdb_base.py
@@ -52,6 +52,7 @@ class DashdotdbBase:
         self.dashdotdb_pass = self.secret_content["password"]
         self.logmarker = marker
         self.scope = scope
+        self.dashdotdb_token = Optional[str]
 
     def _get_token(self) -> None:
         if self.dry_run:
@@ -105,10 +106,26 @@ class DashdotdbBase:
         data: Mapping[Any, Any],
         timeout: tuple[int, int] = (5, 120),
     ) -> requests.Response:
+        headers: dict[str, str] = {}
+        if self.dashdotdb_token:
+            headers["X-Auth"] = str(self.dashdotdb_token)
         return requests.post(
             url=endpoint,
             json=data,
-            headers={"X-Auth": self.dashdotdb_token},
+            headers=headers,
+            auth=(self.dashdotdb_user, self.dashdotdb_pass),
+            timeout=timeout,
+        )
+
+    def _do_get(
+        self,
+        endpoint: str,
+        params: Mapping[Any, Any],
+        timeout: tuple[int, int] = (5, 120),
+    ) -> requests.Response:
+        return requests.get(
+            url=endpoint,
+            params=params,
             auth=(self.dashdotdb_user, self.dashdotdb_pass),
             timeout=timeout,
         )

--- a/reconcile/dashdotdb_dora.py
+++ b/reconcile/dashdotdb_dora.py
@@ -102,7 +102,7 @@ class DeploymentDB:
         password: str,
     ):
         self.conn = connect(
-            f"host={host} port={port} dbname={name} user={user} password={password}"
+            host=host, port=port, dbname=name, user=user, password=password
         )
         LOG.info("Connected to DeploymentDB")
 

--- a/reconcile/dashdotdb_dora.py
+++ b/reconcile/dashdotdb_dora.py
@@ -1,0 +1,538 @@
+import functools
+import os
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import (
+    datetime,
+    timedelta,
+    timezone,
+)
+from typing import (
+    Any,
+    Optional,
+)
+
+import requests
+import yaml
+from psycopg2 import (
+    connect,
+    sql,
+)
+from sretoolbox.utils import threaded
+
+from reconcile import queries
+from reconcile.dashdotdb_base import (
+    LOG,
+    DashdotdbBase,
+)
+from reconcile.typed_queries.app_interface_vault_settings import (
+    get_app_interface_vault_settings,
+)
+from reconcile.typed_queries.saas_files import get_saas_files
+from reconcile.utils.github_api import GithubRepositoryApi
+from reconcile.utils.gitlab_api import GitLabApi
+from reconcile.utils.secret_reader import create_secret_reader
+
+QONTRACT_INTEGRATION = "dashdotdb-dora"
+
+
+@dataclass
+class DeploymentDBSecret:
+    path: str
+    field: str
+    q_format: Optional[str]
+    version: Optional[int]
+
+
+@dataclass(eq=True, frozen=True)
+class AppEnv:
+    app_name: str
+    env_name: str
+
+
+@dataclass
+class Deployment:
+    trigger_reason: str
+    deployment_time: datetime
+
+
+@dataclass(eq=True, frozen=True)
+class SaasTarget:
+    app_name: str
+    env_name: str
+    path: str
+    resource_template: str
+    namespace: str
+    pipeline: str
+
+    @property
+    def app_env(self) -> AppEnv:
+        return AppEnv(self.app_name, self.env_name)
+
+
+@dataclass(eq=True, frozen=True)
+class RepoChanges:
+    repo_url: Optional[str]
+    ref_from: Optional[str]
+    ref_to: Optional[str]
+
+
+@dataclass(eq=True, frozen=True)
+class SummaryKey:
+    rt_name: str
+    target_ns: str
+
+
+@dataclass(eq=True, frozen=True)
+class SummaryEntry:
+    repo_url: str
+    target_ref: str
+
+
+class DeploymentDB:
+    def __init__(
+        self,
+        host: str,
+        port: str,
+        name: str,
+        user: str,
+        password: str,
+    ):
+        self.conn = connect(
+            "host={} port={} dbname={} user={} password={}".format(
+                host, port, name, user, password
+            ),
+        )
+        LOG.info("Connected to DeploymentDB")
+
+    def deployments(
+        self,
+        trigger_reason_pattern: str,
+        app_env_since_list: list[tuple[AppEnv, datetime]],
+    ) -> list[tuple[AppEnv, Deployment]]:
+        deployments = []
+        with self.conn.cursor() as cur:
+            subq = [
+                sql.SQL(
+                    "(app_name = {} AND env_name = {} AND deployment_time > {})"
+                ).format(
+                    sql.Literal(app_env.app_name),
+                    sql.Literal(app_env.env_name),
+                    sql.Literal(since),
+                )
+                for (app_env, since) in app_env_since_list
+            ]
+
+            query = sql.SQL(
+                """
+                    SELECT app_name, env_name, trigger_reason, deployment_time
+                    FROM deployments
+                    WHERE
+                        succeeded = True
+                        AND trigger_reason LIKE {}
+                        AND ({})
+                    ORDER BY deployment_time ASC;
+                """
+            ).format(sql.Literal(trigger_reason_pattern), sql.SQL(" OR ").join(subq))
+
+            cur.execute(query)
+
+            for record in cur:
+                deployments.append(
+                    (AppEnv(record[0], record[1]), Deployment(record[2], record[3]))
+                )
+
+        if not deployments:
+            LOG.info("No deployments found")
+
+        return deployments
+
+
+@dataclass
+class Commit:
+    repo: str
+    sha: str
+    date: datetime
+
+    def lttc(self, finish_timestamp: datetime) -> int:
+        commit_date_tzaware = self.date
+        finish_timestamp_tzaware = finish_timestamp
+
+        if commit_date_tzaware.tzinfo is None:
+            commit_date_tzaware = commit_date_tzaware.replace(tzinfo=timezone.utc)
+
+        if finish_timestamp_tzaware.tzinfo is None:
+            finish_timestamp_tzaware = finish_timestamp_tzaware.replace(
+                tzinfo=timezone.utc
+            )
+
+        return int((finish_timestamp_tzaware - commit_date_tzaware).total_seconds())
+
+
+class DashdotdbDORA(DashdotdbBase):
+    """DashdotDB DORA collector.
+
+    Definitions:
+
+    * `app_name` is the value of `.name` in the saas-file.
+    * `env_name` is the value of a given
+      `.resourceTemplates.targets.namespace.$ref -> ns file -> environment file
+      -> .name`.
+    * `trigger_reason` is one of the fields registered in DeploymentDB that
+      identifies the promotion event. It looks like:
+      https://gitlab.../service/app-interface/commit/<sha>.
+    * `promotion_sha` is the sha contained in the trigger_reason.
+
+    This collector performs the followig tasks:
+
+    * Get a list of saasfiles that contain the dora field in its labels. The
+      value is a comma-separated list of target env_names. Relevant MR.
+    * Query DashdotDB (over API) to obtain latest registered entry for that
+      app_name and env_name pair.
+    * Query DeploymentDB (over SQL) to obtain the deployments associated to each
+      app_name and env_name pair from the latest registered entry in DashdotDB
+      or from the last 90 days if there are none.
+    * From the DeploymentDB entry trigger_reason, extract the changes: url of
+      the repository, previous commit, promotion commit. This is done by
+      fetching the saas-file from GitLab's API at at the promotion_sha commit,
+      and comparing it with the promotion_sha^ commit (note the ^).
+    * Using GitHub or GitLab's API, obtain the list of commits between
+      promotion_sha^ and promotion_sha.
+    * Build the payload for DashdotDB and submit it as a POST.
+
+    Caveats:
+
+    * This class has been designed to run as a cronjob, so the cleanup code
+      should be reviewed if this changes its execution pattern to a service.
+    """
+
+    def __init__(
+        self, dry_run: bool, gitlab_project_id: str, thread_pool_size: int = 5
+    ) -> None:
+        self.gitlab_project_id = gitlab_project_id
+        self.settings = queries.get_app_interface_settings()
+        vault_settings = get_app_interface_vault_settings()
+        secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+
+        # init dashdotdb
+        super().__init__(
+            dry_run=dry_run,
+            thread_pool_size=thread_pool_size,
+            marker="DDDB_DORA:",
+            scope="dora",
+            secret_reader=secret_reader,
+        )
+
+        # init dep db
+        depdb_secret = secret_reader.read_all_secret(
+            DeploymentDBSecret(
+                field="",
+                path=os.environ["DEPLOYMENT_DB_SECRET"],
+                q_format=None,
+                version=None,
+            )
+        )
+
+        self.dep_db = DeploymentDB(
+            depdb_secret["db.host"],
+            depdb_secret["db.port"],
+            depdb_secret["db.name"],
+            depdb_secret["db.user"],
+            depdb_secret["db.password"],
+        )
+
+        # init GitLab API
+        gl_instance = queries.get_gitlab_instance()
+        self.gl = GitLabApi(
+            gl_instance, project_id=self.gitlab_project_id, settings=self.settings
+        )
+        self.gl_app_interface_get_file = functools.cache(self.gl.get_file)
+
+        # init GitHub API
+        gh_instance = queries.get_github_instance()
+        self.gh_token = secret_reader.read(gh_instance["token"])
+        self._gh_apis: dict[str, GithubRepositoryApi] = {}
+
+    def __enter__(self) -> "DashdotdbDORA":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self.gl.cleanup()
+        for gh in self._gh_apis.values():
+            gh.cleanup()
+
+    def gh_api(self, repo: str) -> GithubRepositoryApi:
+        if repo not in self._gh_apis:
+            self._gh_apis[repo] = GithubRepositoryApi(repo, self.gh_token)
+        return self._gh_apis[repo]
+
+    def run(self) -> None:
+        saastargets = self.get_saastargets()
+
+        # Build unique combination of app_name and env_names
+        # so we can fetch the deployments associated with each one.
+        # We are doing this so we don't fetch the deployments
+        # from the DB for a unique (app_name, env_name) multiple times.
+        app_envs = {s.app_env for s in saastargets}
+
+        since_default = datetime.now() - timedelta(days=90)
+        app_env_since_list: list[tuple[AppEnv, datetime]] = threaded.run(
+            func=functools.partial(self.get_latest_with_default, since_default),
+            iterable=app_envs,
+            thread_pool_size=self.thread_pool_size,
+        )
+
+        trigger_reason_pattern = f"{self.gl.server}/service/app-interface/commit/%"
+        app_env_deployments_list = self.dep_db.deployments(
+            trigger_reason_pattern, app_env_since_list
+        )
+
+        self.app_env_deployments = defaultdict(list)
+        for app_env, deployment in app_env_deployments_list:
+            self.app_env_deployments[app_env].append(deployment)
+
+        repo_changes_iterable = [
+            (saastarget, deployment)
+            for saastarget in saastargets
+            for deployment in self.app_env_deployments[saastarget.app_env]
+        ]
+
+        saastarget_dep_repo_changes: list[
+            tuple[SaasTarget, Deployment, RepoChanges]
+        ] = threaded.run(
+            func=self.get_repo_changes,
+            iterable=repo_changes_iterable,
+            thread_pool_size=self.thread_pool_size,
+        )
+
+        # filter out invalid entries:
+        # - one of the fields (repo, ref_from, ref_to) is null
+        # - ref_from is equal to ref_to. This can happen when there was a happen
+        #   to the saasfile that didn't change the ref, only a parameter for
+        #   example
+        saastarget_dep_repo_changes = [
+            (st, dep, rc)
+            for (st, dep, rc) in saastarget_dep_repo_changes
+            if rc.repo_url and rc.ref_from and rc.ref_to and rc.ref_from != rc.ref_to
+        ]
+
+        unique_repo_changes = {rc for (_, _, rc) in saastarget_dep_repo_changes}
+
+        rc_commits_list = threaded.run(
+            func=self.compare,
+            iterable=unique_repo_changes,
+            thread_pool_size=self.thread_pool_size,
+        )
+
+        rc_commits = dict(rc_commits_list)
+
+        # we want to sort by oldest first, so that if the process crashes
+        # the call to latest_deployment from Dash.DB will return the appropriate
+        # value so that it is possible to continue
+        def sortkey(item: tuple[SaasTarget, Deployment, RepoChanges]) -> datetime:
+            (_, dep, _) = item
+            return dep.deployment_time
+
+        deployments = [
+            self.build_deployment_post(st, dep, rc_commits[rc])
+            for st, dep, rc in sorted(saastarget_dep_repo_changes, key=sortkey)
+        ]
+
+        if deployments:
+            self.post({"deployments": deployments})
+
+    def get_saastargets(self) -> list[SaasTarget]:
+        targets = []
+        for saas_file in get_saas_files():
+            if not saas_file.labels:
+                continue
+
+            if "dora" not in saas_file.labels:
+                continue
+
+            dora_target_env_names = saas_file.labels["dora"].split(",")
+
+            # filter out empty fields, in case there are leading, trailing or doubled commas
+            dora_target_env_names = [e for e in dora_target_env_names if e]
+
+            for rt in saas_file.resource_templates:
+                for target in rt.targets:
+                    ns = target.namespace
+                    target_env_name = ns.environment.name
+                    if target_env_name not in dora_target_env_names:
+                        continue
+
+                    pipeline = f"{rt.name}-{ns.cluster.name}-{ns.name}"
+                    saas_file_path = "data/" + saas_file.path.lstrip("/")
+                    saastarget = SaasTarget(
+                        app_name=saas_file.name,
+                        env_name=target_env_name,
+                        path=saas_file_path,
+                        resource_template=rt.name,
+                        namespace=ns.path,
+                        pipeline=pipeline,
+                    )
+
+                    targets.append(saastarget)
+
+                    LOG.info("marking SaaS file for processing: %s", saastarget)
+        return targets
+
+    def get_repo_changes(
+        self, saastarget_deployment: tuple[SaasTarget, Deployment]
+    ) -> tuple[SaasTarget, Deployment, RepoChanges]:
+        saastarget, deployment = saastarget_deployment
+        LOG.info("Fetching repo changes for %s - %s", saastarget, deployment)
+        # sometimes the trigger_reason ends with '[auto-promotion]', so we keeep
+        # only the first 40 chars.
+        promotion_sha = deployment.trigger_reason.split("/")[-1][:40]
+
+        repo_url, ref_from = self.get_repo_ref_for_sha(saastarget, promotion_sha + "^")
+        _, ref_to = self.get_repo_ref_for_sha(saastarget, promotion_sha)
+
+        return (saastarget, deployment, RepoChanges(repo_url, ref_from, ref_to))
+
+    def get_repo_ref_for_sha(
+        self, saastarget: SaasTarget, sha: str
+    ) -> tuple[Optional[str], Optional[str]]:
+        saas_file_yaml = self.gl_app_interface_get_file(
+            saastarget.path, ref=sha
+        ).decode()
+        saas_file = yaml.safe_load(saas_file_yaml)
+
+        for rt in saas_file["resourceTemplates"]:
+            if saastarget.resource_template != rt["name"]:
+                continue
+
+            for target in rt["targets"]:
+                if saastarget.namespace == target["namespace"]["$ref"]:
+                    return (rt["url"], target["ref"])
+
+        return (None, None)
+
+    def compare(self, rc: RepoChanges) -> tuple[RepoChanges, list[Commit]]:
+        if not rc.repo_url:
+            return rc, []
+
+        LOG.info("Fetching commits %s", rc)
+        if rc.repo_url.startswith("https://github.com"):
+            commits = self._github_compare_commits(rc)
+        elif rc.repo_url.startswith(self.gl.server):
+            commits = self._gitlab_compare_commits(rc)
+        else:
+            raise Exception(f"Unknown git hosting {rc.repo_url}")
+
+        return rc, commits
+
+    def get_latest_with_default(
+        self, since_default: datetime, app_env: AppEnv
+    ) -> tuple[AppEnv, datetime]:
+        endpoint = f"{self.dashdotdb_url}/api/v1/dora/latest"
+        response = self._do_get(
+            endpoint,
+            {
+                "app_name": app_env.app_name,
+                "env_name": app_env.env_name,
+            },
+        )
+
+        if response.status_code == 404:
+            return app_env, since_default
+
+        return app_env, datetime.fromisoformat(response.json()["finish_timestamp"])
+
+    def _gitlab_compare_commits(self, rc: RepoChanges) -> list[Commit]:
+        if not rc.repo_url or not rc.ref_from or not rc.ref_to:
+            return []
+
+        prefix = "https://gitlab.cee.redhat.com/"
+        repo = rc.repo_url[rc.repo_url.startswith(prefix) and len(prefix) :]
+
+        commits = self.gl.repository_compare(repo, rc.ref_from, rc.ref_to)
+
+        return [
+            Commit(
+                rc.repo_url,
+                commit["id"],
+                datetime.fromisoformat(commit["committed_date"]),
+            )
+            for commit in commits
+        ]
+
+    def _github_compare_commits(self, rc: RepoChanges) -> list[Commit]:
+        if not rc.repo_url:
+            return []
+
+        prefix = "https://github.com/"
+        repo = rc.repo_url[rc.repo_url.startswith(prefix) and len(prefix) :]
+
+        return [
+            Commit(rc.repo_url, commit.sha, commit.commit.committer.date)
+            for commit in self.gh_api(repo).compare(rc.ref_from, rc.ref_to)
+        ]
+
+    def post(self, data: dict[str, Any]) -> None:
+        endpoint = f"{self.dashdotdb_url}/api/v1/dora"
+        response = self._do_post(endpoint, data)
+        try:
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as details:
+            LOG.error(
+                "%s error posting DORA - %s - %s",
+                self.logmarker,
+                details,
+                response.text,
+            )
+        else:
+            LOG.info(
+                "Successfully posted to DashdotDB %s deployments.",
+                len(data["deployments"]),
+            )
+
+    @staticmethod
+    def get_saas_file_summary(
+        saas_file: dict[str, Any]
+    ) -> dict[SummaryKey, SummaryEntry]:
+        summary: dict[SummaryKey, SummaryEntry] = {}
+
+        for rt in saas_file["resourceTemplates"]:
+            repo_url = rt["url"]
+            for target in rt["targets"]:
+                rt_name = rt["name"]
+                target_ns = target["namespace"]["$ref"]
+                target_ref = target["ref"]
+
+                summary[SummaryKey(rt_name, target_ns)] = SummaryEntry(
+                    repo_url, target_ref
+                )
+        return summary
+
+    @staticmethod
+    def build_deployment_post(
+        saastarget: SaasTarget, deployment: Deployment, commits: list[Commit]
+    ) -> dict[str, Any]:
+        return {
+            "app_name": saastarget.app_name,
+            "env_name": saastarget.env_name,
+            "pipeline": saastarget.pipeline,
+            "trigger_reason": deployment.trigger_reason,
+            "finish_timestamp": deployment.deployment_time.isoformat(),
+            "commits": [
+                {
+                    "repo": c.repo,
+                    "revision": c.sha,
+                    "timestamp": c.date.isoformat(),
+                    "lttc": c.lttc(deployment.deployment_time),
+                }
+                for c in commits
+            ],
+        }
+
+
+def run(dry_run: bool, gitlab_project_id: str, thread_pool_size: int = 5) -> None:
+    with DashdotdbDORA(
+        dry_run=dry_run,
+        gitlab_project_id=gitlab_project_id,
+        thread_pool_size=thread_pool_size,
+    ) as dashdotdb_dora:
+        dashdotdb_dora.run()

--- a/reconcile/gql_definitions/common/saas_files.gql
+++ b/reconcile/gql_definitions/common/saas_files.gql
@@ -4,6 +4,7 @@ query SaasFiles {
   saas_files: saas_files_v2 {
     path
     name
+    labels
     app {
       name
       parentApp {

--- a/reconcile/gql_definitions/common/saas_files.py
+++ b/reconcile/gql_definitions/common/saas_files.py
@@ -124,6 +124,7 @@ query SaasFiles {
   saas_files: saas_files_v2 {
     path
     name
+    labels
     app {
       name
       parentApp {
@@ -534,6 +535,7 @@ class SaasFileV2_RoleV1(ConfiguredBaseModel):
 class SaasFileV2(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     name: str = Field(..., alias="name")
+    labels: Optional[Json] = Field(..., alias="labels")
     app: AppV1 = Field(..., alias="app")
     pipelines_provider: Union[PipelinesProviderTektonV1, PipelinesProviderV1] = Field(
         ..., alias="pipelinesProvider"

--- a/reconcile/test/test_dashdotdb_dora.py
+++ b/reconcile/test/test_dashdotdb_dora.py
@@ -1,0 +1,292 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import yaml
+from pytest_mock import MockerFixture
+
+from reconcile.dashdotdb_dora import (
+    AppEnv,
+    Commit,
+    DashdotdbDORA,
+    Deployment,
+    RepoChanges,
+    SaasTarget,
+    SummaryEntry,
+    SummaryKey,
+)
+
+
+def test_get_repo_ref_for_sha(mocker: MockerFixture):
+    mocker.patch("reconcile.dashdotdb_dora.DashdotdbDORA.__init__").return_value = None
+    d = DashdotdbDORA(False, "1", 1)
+
+    # mock gl_app_interface_get_file
+    d.gl_app_interface_get_file = MagicMock(
+        return_value=yaml.safe_dump(
+            {
+                "resourceTemplates": [
+                    {
+                        "name": "rt0",
+                        "url": "url0",
+                        "ref": "ref0",
+                        "targets": [
+                            {"namespace": {"$ref": "ns0"}, "ref": "ref0"},
+                            {"namespace": {"$ref": "ns3"}, "ref": "ref3"},
+                        ],
+                    },
+                    {
+                        "name": "rt1",
+                        "url": "url1",
+                        "ref": "ref1",
+                        "targets": [
+                            {"namespace": {"$ref": "ns0"}, "ref": "ref0"},
+                            {"namespace": {"$ref": "ns1"}, "ref": "ref1"},
+                        ],
+                    },
+                ]
+            }
+        ).encode("utf-8")
+    )
+
+    saastarget = SaasTarget("app1", "env1", "/path1", "rt1", "ns1", "pipeline1")
+    info = d.get_repo_ref_for_sha(saastarget, "sha")
+
+    assert info == ("url1", "ref1")
+
+
+def test_get_repo_ref_for_sha_none(mocker: MockerFixture):
+    mocker.patch("reconcile.dashdotdb_dora.DashdotdbDORA.__init__").return_value = None
+    d = DashdotdbDORA(False, "1", 1)
+
+    # mock gl_app_interface_get_file
+    d.gl_app_interface_get_file = MagicMock(
+        return_value=yaml.safe_dump(
+            {
+                "resourceTemplates": [
+                    {
+                        "name": "rt10",
+                        "url": "url0",
+                        "ref": "ref0",
+                        "targets": [
+                            {"namespace": {"$ref": "ns0"}, "ref": "ref0"},
+                            {"namespace": {"$ref": "ns3"}, "ref": "ref3"},
+                        ],
+                    },
+                    {
+                        "name": "rt11",
+                        "url": "url1",
+                        "ref": "ref1",
+                        "targets": [
+                            {"namespace": {"$ref": "ns0"}, "ref": "ref0"},
+                            {"namespace": {"$ref": "ns1"}, "ref": "ref1"},
+                        ],
+                    },
+                ]
+            }
+        ).encode("utf-8")
+    )
+
+    saastarget = SaasTarget("app1", "env1", "/path1", "rt1", "ns1", "pipeline1")
+    info = d.get_repo_ref_for_sha(saastarget, "sha")
+
+    assert info == (None, None)
+
+
+def test_get_saas_file_summary():
+    saas_file = {
+        "resourceTemplates": [
+            {
+                "name": "rt10",
+                "url": "url0",
+                "ref": "ref0",
+                "targets": [
+                    {"namespace": {"$ref": "ns0"}, "ref": "ref0"},
+                    {"namespace": {"$ref": "ns3"}, "ref": "ref3"},
+                ],
+            },
+            {
+                "name": "rt11",
+                "url": "url1",
+                "ref": "ref1",
+                "targets": [
+                    {"namespace": {"$ref": "ns0"}, "ref": "ref0"},
+                    {"namespace": {"$ref": "ns1"}, "ref": "ref1"},
+                ],
+            },
+        ]
+    }
+    summary = DashdotdbDORA.get_saas_file_summary(saas_file)
+
+    assert summary == {
+        SummaryKey(rt_name="rt10", target_ns="ns0"): SummaryEntry(
+            repo_url="url0", target_ref="ref0"
+        ),
+        SummaryKey(rt_name="rt10", target_ns="ns3"): SummaryEntry(
+            repo_url="url0", target_ref="ref3"
+        ),
+        SummaryKey(rt_name="rt11", target_ns="ns0"): SummaryEntry(
+            repo_url="url1", target_ref="ref0"
+        ),
+        SummaryKey(rt_name="rt11", target_ns="ns1"): SummaryEntry(
+            repo_url="url1", target_ref="ref1"
+        ),
+    }
+
+
+def test_compare_gh(mocker: MockerFixture):
+    mocker.patch("reconcile.dashdotdb_dora.DashdotdbDORA.__init__").return_value = None
+    d = DashdotdbDORA(False, "1", 1)
+    ghapi_mock = MagicMock()
+
+    def gl_commit_mock(sha, date):
+        obj = MagicMock()
+        obj.sha = sha
+        obj.commit.committer.date = date
+        return obj
+
+    ghapi_mock.compare.return_value = [
+        gl_commit_mock(
+            "8cfb8408f614e1d0179d75af793f3fddf42d054a", datetime(2023, 9, 1, 0, 0, 0)
+        ),
+        gl_commit_mock(
+            "81677e1bc71324c9fa5c747b494add5a5af5e653", datetime(2023, 9, 2, 0, 0, 0)
+        ),
+        gl_commit_mock(
+            "566f37f8e9985d775e619cc959b806f5a254a380", datetime(2023, 9, 3, 0, 0, 0)
+        ),
+        gl_commit_mock(
+            "adab91701311fec1b0f5405adddaf68f886bba2c", datetime(2023, 9, 4, 0, 0, 0)
+        ),
+    ]
+
+    d._gh_apis = {"my/repo": ghapi_mock}
+
+    repo = "https://github.com/my/repo"
+
+    repo_changes = RepoChanges(
+        repo,
+        "e000dafd2e7bf34be41e7b3a5cb529ce7fbde257",
+        "adab91701311fec1b0f5405adddaf68f886bba2c",
+    )
+    rc, commits = d.compare(repo_changes)
+    assert rc == repo_changes
+    assert commits == [
+        Commit(
+            repo,
+            "8cfb8408f614e1d0179d75af793f3fddf42d054a",
+            datetime(2023, 9, 1, 0, 0, 0),
+        ),
+        Commit(
+            repo,
+            "81677e1bc71324c9fa5c747b494add5a5af5e653",
+            datetime(2023, 9, 2, 0, 0, 0),
+        ),
+        Commit(
+            repo,
+            "566f37f8e9985d775e619cc959b806f5a254a380",
+            datetime(2023, 9, 3, 0, 0, 0),
+        ),
+        Commit(
+            repo,
+            "adab91701311fec1b0f5405adddaf68f886bba2c",
+            datetime(2023, 9, 4, 0, 0, 0),
+        ),
+    ]
+
+
+def test_compare_gl(mocker: MockerFixture):
+    mocker.patch("reconcile.dashdotdb_dora.DashdotdbDORA.__init__").return_value = None
+    d = DashdotdbDORA(False, "1", 1)
+    d.gl = MagicMock()
+    d.gl.server = "https://gitlab.com"
+    d.gl.repository_compare.return_value = [
+        {
+            "id": "8cfb8408f614e1d0179d75af793f3fddf42d054a",
+            "committed_date": "2023-09-01T00:00:00",
+        },
+        {
+            "id": "81677e1bc71324c9fa5c747b494add5a5af5e653",
+            "committed_date": "2023-09-02T00:00:00",
+        },
+        {
+            "id": "566f37f8e9985d775e619cc959b806f5a254a380",
+            "committed_date": "2023-09-03T00:00:00",
+        },
+        {
+            "id": "adab91701311fec1b0f5405adddaf68f886bba2c",
+            "committed_date": "2023-09-04T00:00:00",
+        },
+    ]
+    repo = "https://gitlab.com/my/repo"
+
+    repo_changes = RepoChanges(
+        repo,
+        "e000dafd2e7bf34be41e7b3a5cb529ce7fbde257",
+        "adab91701311fec1b0f5405adddaf68f886bba2c",
+    )
+    rc, commits = d.compare(repo_changes)
+    assert rc == repo_changes
+    assert commits == [
+        Commit(
+            repo,
+            "8cfb8408f614e1d0179d75af793f3fddf42d054a",
+            datetime(2023, 9, 1, 0, 0, 0),
+        ),
+        Commit(
+            repo,
+            "81677e1bc71324c9fa5c747b494add5a5af5e653",
+            datetime(2023, 9, 2, 0, 0, 0),
+        ),
+        Commit(
+            repo,
+            "566f37f8e9985d775e619cc959b806f5a254a380",
+            datetime(2023, 9, 3, 0, 0, 0),
+        ),
+        Commit(
+            repo,
+            "adab91701311fec1b0f5405adddaf68f886bba2c",
+            datetime(2023, 9, 4, 0, 0, 0),
+        ),
+    ]
+
+
+def test_get_latest_with_default(mocker: MockerFixture):
+    mocker.patch("reconcile.dashdotdb_dora.DashdotdbDORA.__init__").return_value = None
+    d = DashdotdbDORA(False, "1", 1)
+    d.dashdotdb_url = "http://localhost"
+
+    date = datetime(2023, 9, 3, 0, 0, 0)
+    appenv = AppEnv("app1", "env1")
+
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {"finish_timestamp": date.isoformat()}
+
+    d._do_get = MagicMock(return_value=response)  # type: ignore[method-assign]
+
+    latest = d.get_latest_with_default(date, appenv)
+    assert latest == (
+        AppEnv(app_name="app1", env_name="env1"),
+        datetime(2023, 9, 3, 0, 0),
+    )
+
+
+def test_get_repo_changes(mocker: MockerFixture):
+    mocker.patch("reconcile.dashdotdb_dora.DashdotdbDORA.__init__").return_value = None
+    d = DashdotdbDORA(False, "1", 1)
+
+    saastarget = SaasTarget("app1", "env1", "/path1", "rt1", "ns1", "pipeline1")
+    date = datetime(2023, 9, 3, 0, 0)
+    deployment = Deployment("trigger1", date)
+    saastarget_deployment = (saastarget, deployment)
+
+    d.get_repo_ref_for_sha = MagicMock(  # type: ignore[method-assign]
+        side_effect=[("repo1", "commitA"), ("repo1", "commitB")]
+    )
+
+    exp_saas_target, exp_deployment, repo_changes = d.get_repo_changes(
+        saastarget_deployment
+    )
+    assert exp_saas_target == saastarget
+    assert exp_deployment == deployment
+    assert repo_changes == RepoChanges("repo1", "commitA", "commitB")

--- a/reconcile/test/test_dashdotdb_dora.py
+++ b/reconcile/test/test_dashdotdb_dora.py
@@ -11,8 +11,6 @@ from reconcile.dashdotdb_dora import (
     Deployment,
     RepoChanges,
     SaasTarget,
-    SummaryEntry,
-    SummaryKey,
 )
 
 
@@ -90,47 +88,6 @@ def test_get_repo_ref_for_sha_none(mocker: MockerFixture):
     info = d.get_repo_ref_for_sha(saastarget, "sha")
 
     assert info == (None, None)
-
-
-def test_get_saas_file_summary():
-    saas_file = {
-        "resourceTemplates": [
-            {
-                "name": "rt10",
-                "url": "url0",
-                "ref": "ref0",
-                "targets": [
-                    {"namespace": {"$ref": "ns0"}, "ref": "ref0"},
-                    {"namespace": {"$ref": "ns3"}, "ref": "ref3"},
-                ],
-            },
-            {
-                "name": "rt11",
-                "url": "url1",
-                "ref": "ref1",
-                "targets": [
-                    {"namespace": {"$ref": "ns0"}, "ref": "ref0"},
-                    {"namespace": {"$ref": "ns1"}, "ref": "ref1"},
-                ],
-            },
-        ]
-    }
-    summary = DashdotdbDORA.get_saas_file_summary(saas_file)
-
-    assert summary == {
-        SummaryKey(rt_name="rt10", target_ns="ns0"): SummaryEntry(
-            repo_url="url0", target_ref="ref0"
-        ),
-        SummaryKey(rt_name="rt10", target_ns="ns3"): SummaryEntry(
-            repo_url="url0", target_ref="ref3"
-        ),
-        SummaryKey(rt_name="rt11", target_ns="ns0"): SummaryEntry(
-            repo_url="url1", target_ref="ref0"
-        ),
-        SummaryKey(rt_name="rt11", target_ns="ns1"): SummaryEntry(
-            repo_url="url1", target_ref="ref1"
-        ),
-    }
 
 
 def test_compare_gh(mocker: MockerFixture):

--- a/reconcile/test/test_typed_queries/test_saas_files.py
+++ b/reconcile/test/test_typed_queries/test_saas_files.py
@@ -319,6 +319,7 @@ PIPELINE_PROVIDER = {
                 {
                     "path": "path1",
                     "name": "saas-file-01",
+                    "labels": None,
                     "app": {"name": "app-01", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
@@ -372,6 +373,7 @@ PIPELINE_PROVIDER = {
                 {
                     "path": "path2",
                     "name": "saas-file-02",
+                    "labels": None,
                     "app": {"name": "app-02", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
@@ -419,6 +421,7 @@ PIPELINE_PROVIDER = {
                 {
                     "path": "path2",
                     "name": "saas-file-02",
+                    "labels": None,
                     "app": {"name": "app-02", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
@@ -455,6 +458,7 @@ PIPELINE_PROVIDER = {
                 {
                     "path": "path1",
                     "name": "saas-file-01",
+                    "labels": None,
                     "app": {"name": "app-01", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
@@ -489,6 +493,7 @@ PIPELINE_PROVIDER = {
                 {
                     "path": "path2",
                     "name": "saas-file-02",
+                    "labels": None,
                     "app": {"name": "app-02", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
@@ -526,6 +531,7 @@ PIPELINE_PROVIDER = {
                 {
                     "path": "path3",
                     "name": "saas-file-03",
+                    "labels": None,
                     "app": {"name": "example", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
@@ -619,6 +625,7 @@ def test_export_model(
         {
             "path": "path1",
             "name": "saas-file-01",
+            "labels": None,
             "app": {"name": "app-01", "parentApp": None, "selfServiceRoles": None},
             "pipelinesProvider": {
                 "name": "pipeline-provider-01",
@@ -782,6 +789,7 @@ def test_export_model(
         {
             "path": "path2",
             "name": "saas-file-02",
+            "labels": None,
             "app": {"name": "app-02", "parentApp": None, "selfServiceRoles": None},
             "pipelinesProvider": {
                 "name": "pipeline-provider-01",
@@ -945,6 +953,7 @@ def test_export_model(
         {
             "path": "path3",
             "name": "saas-file-03",
+            "labels": None,
             "app": {"name": "example", "parentApp": None, "selfServiceRoles": None},
             "pipelinesProvider": {
                 "name": "pipeline-provider-01",

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -103,6 +103,7 @@ class SaasResourceTemplate(ConfiguredBaseModel):
 class SaasFile(ConfiguredBaseModel):
     path: str = Field(..., alias="path")
     name: str = Field(..., alias="name")
+    labels: Optional[Json] = Field(..., alias="labels")
     app: AppV1 = Field(..., alias="app")
     pipelines_provider: Union[PipelinesProviderTektonV1, PipelinesProviderV1] = Field(
         ..., alias="pipelinesProvider"

--- a/reconcile/utils/github_api.py
+++ b/reconcile/utils/github_api.py
@@ -2,7 +2,6 @@ import os
 from pathlib import Path
 from types import TracebackType
 from typing import (
-    List,
     Optional,
     Type,
 )
@@ -85,5 +84,5 @@ class GithubRepositoryApi:
         return self._repo.get_commit(sha=ref).sha
 
     @retry()
-    def compare(self, commit_from: str, commit_to: str) -> List[Commit.Commit]:
+    def compare(self, commit_from: str, commit_to: str) -> list[Commit.Commit]:
         return self._repo.compare(commit_from, commit_to).commits

--- a/reconcile/utils/github_api.py
+++ b/reconcile/utils/github_api.py
@@ -2,12 +2,14 @@ import os
 from pathlib import Path
 from types import TracebackType
 from typing import (
+    List,
     Optional,
     Type,
 )
 from urllib.parse import urlparse
 
 from github import (
+    Commit,
     Github,
     UnknownObjectException,
 )
@@ -81,3 +83,7 @@ class GithubRepositoryApi:
     @retry()
     def get_commit_sha(self, ref: str) -> str:
         return self._repo.get_commit(sha=ref).sha
+
+    @retry()
+    def compare(self, commit_from: str, commit_to: str) -> List[Commit.Commit]:
+        return self._repo.compare(commit_from, commit_to).commits

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -735,3 +735,10 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         project = self.get_project(repo_url)
         commits = project.commits.list(ref_name=ref, per_page=1)
         return commits[0].id
+
+    def repository_compare(
+        self, repo_url: str, ref_from: str, ref_to: str
+    ) -> list[dict[str, Any]]:
+        project = self.get_project(repo_url)
+        response = project.repository_compare(ref_from, ref_to)
+        return response.get("commits", [])

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -11,8 +11,6 @@ from typing import (
     runtime_checkable,
 )
 
-from pydantic import Json
-
 from reconcile.utils import oc_connection_parameters
 from reconcile.utils.secret_reader import HasSecret
 
@@ -391,7 +389,7 @@ class ManagedResourceName(Protocol):
 class SaasFile(HasParameters, HasSecretParameters, Protocol):
     path: str
     name: str
-    labels: Optional[Json]
+    labels: Optional[dict[str, Any]]
     managed_resource_types: list[str]
     takeover: Optional[bool]
     deprecated: Optional[bool]

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -11,6 +11,8 @@ from typing import (
     runtime_checkable,
 )
 
+from pydantic import Json
+
 from reconcile.utils import oc_connection_parameters
 from reconcile.utils.secret_reader import HasSecret
 
@@ -389,6 +391,7 @@ class ManagedResourceName(Protocol):
 class SaasFile(HasParameters, HasSecretParameters, Protocol):
     path: str
     name: str
+    labels: Optional[Json]
     managed_resource_types: list[str]
     takeover: Optional[bool]
     deprecated: Optional[bool]

--- a/requirements/requirements-type.txt
+++ b/requirements/requirements-type.txt
@@ -14,3 +14,4 @@ types-dateparser
 types-oauthlib
 boto3-stubs[ec2,s3,rds,iam,route53]==1.24.71
 qenerate==0.6.1
+types-psycopg2

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "pydantic~=1.10.6",
         "MarkupSafe==2.1.1",
         "filetype~=1.2.0",
+        "psycopg2-binary~=2.9",
         # this is really needed only in lint and type validations.
         # Is there any better place to put this in?
         "packaging~=23.1",

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ setup(
         "pydantic~=1.10.6",
         "MarkupSafe==2.1.1",
         "filetype~=1.2.0",
-        "psycopg2-binary~=2.9",
+        "psycopg2~=2.9",
         # this is really needed only in lint and type validations.
         # Is there any better place to put this in?
         "packaging~=23.1",


### PR DESCRIPTION
As part of the Services Dashboard effort, the DORA LTTC (lead time to change metrics) must be collected.

Definitions:
- `app_name` is the value of `.name` in the saas-file.
- `env_name` is the value of a given `.resourceTemplates.targets.namespace.$ref -> ns file -> environment file -> .name`.
- `trigger_reason` is one of the fields registered in DeploymentDB that identifies the promotion event. It looks like: `https://gitlab.../service/app-interface/commit/<sha>`.
- `promotion_sha` is the `sha` contained in the `trigger_reason`.

The purpose of this MR is to add a new DashdotDB collector that does the following:

* Get a list of saasfiles that contain the `dora` field in its `labels`. The value is a comma-separated list of target `env_name`s. Relevant [MR](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/79454).
* Query DashdotDB (over API) to obtain latest registered entry for that `app_name` and `env_name` pair.
* Query DeploymentDB (over SQL) to obtain the deployments associated to each `app_name` and `env_name` pair from the latest registered entry in DashdotDB or from the last 90 days if there are none.
* From the DeploymentDB entry `trigger_reason`, extract the changes: url of the repository, previous commit, promotion commit. This is done by fetching the saas-file from GitLab's API at at the `promotion_sha` commit, and comparing it with the `promotion_sha^` commit (note the `^`).
* Using GitHub or GitLab's API, obtain the list of commits between `promotion_sha^` and `promotion_sha`.
* Build the payload for DashdotDB and submit it as a `POST`.

Ticket: [OSDEV-1255](https://issues.redhat.com/browse/OSDEV-1255)
