### PR TITLE
[change-owners] place change-owners role labels from self-service roles on MRs

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -40,6 +40,7 @@ from reconcile.utils.mr.labels import (
     HOLD,
     NOT_SELF_SERVICEABLE,
     SELF_SERVICEABLE,
+    change_owner_label,
     prioritized_approval_label,
 )
 from reconcile.utils.output import format_table
@@ -94,7 +95,7 @@ def manage_conditional_label(
     current_labels: list[str],
     conditional_labels: dict[str, bool],
     dry_run: bool = True,
-) -> list[str]:
+) -> set[str]:
     new_labels = current_labels.copy()
     for label, condition in conditional_labels.items():
         if condition and label not in new_labels:
@@ -105,7 +106,7 @@ def manage_conditional_label(
             logging.info(f"removing label {label}")
             if not dry_run:
                 new_labels.remove(label)
-    return new_labels
+    return set(new_labels)
 
 
 def write_coverage_report_to_mr(
@@ -377,6 +378,12 @@ def run(
                 conditional_labels=conditional_labels,
                 dry_run=False,
             )
+
+            # change-owner labels
+            for bc in changes:
+                for label in bc.change_owner_labels:
+                    labels.add(change_owner_label(label))
+
             if mr_management_enabled:
                 gl.set_labels_on_merge_request(merge_request, labels)
             else:

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -79,6 +79,16 @@ class DiffCoverage:
 
     parent: Optional["DiffCoverage"] = None
 
+    @property
+    def change_owner_labels(self) -> set[str]:
+        """
+        Returns a list of change-owner labels of all involved change-type contexts.
+        """
+        labels = {label for c in self.coverage for label in c.change_owner_labels or {}}
+        for _split in self._split_into:
+            labels.update(_split.change_owner_labels)
+        return labels
+
     def relative_path(self) -> jsonpath_ng.JSONPath:
         if self.parent:
             path = remove_prefix_from_path(self.diff.path, self.parent.diff.path)
@@ -831,6 +841,7 @@ class ChangeTypeContext:
     context_file: FileRef
     approvers: list[Approver]
     approver_reachability: Optional[list[ApproverReachability]] = None
+    change_owner_labels: Optional[set[str]] = None
 
     @property
     def disabled(self) -> bool:

--- a/reconcile/change_owners/changes.py
+++ b/reconcile/change_owners/changes.py
@@ -196,6 +196,17 @@ class BundleFileChange:
             coverages.extend(dc.fine_grained_diff_coverages().values())
         return coverages
 
+    @property
+    def change_owner_labels(self) -> set[str]:
+        """
+        returns the set of change owner labels that are attached to the
+        BundleFileChanges DiffCoverage
+        """
+        labels = set()
+        for dc in self.diff_coverage:
+            labels.update(dc.change_owner_labels)
+        return labels
+
     def involved_change_types(self) -> list[ChangeTypeProcessor]:
         """
         returns all the change-types that are involved in the coverage

--- a/reconcile/change_owners/self_service_roles.py
+++ b/reconcile/change_owners/self_service_roles.py
@@ -21,6 +21,8 @@ from reconcile.gql_definitions.change_owners.queries.self_service_roles import (
 )
 from reconcile.utils import gql
 
+CHANGE_OWNERS_LABELS_LABEL = "change-owners-labels"
+
 
 class NoApproversInSelfServiceRoleError(Exception):
     """
@@ -201,11 +203,19 @@ def change_type_contexts_for_self_service_roles(
                                 approver_reachability=approver_reachability_from_role(
                                     role
                                 ),
+                                change_owner_labels=change_type_labels_from_role(role),
                                 context_file=ownership.context_file_ref,
                             ),
                         )
                     )
     return change_type_contexts
+
+
+def change_type_labels_from_role(role: RoleV1) -> set[str]:
+    change_owner_labels = (
+        role.labels.get(CHANGE_OWNERS_LABELS_LABEL, "") if role.labels else ""
+    )
+    return {label.strip() for label in change_owner_labels.split(",")}
 
 
 def approver_reachability_from_role(role: RoleV1) -> list[ApproverReachability]:

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.gql
@@ -3,6 +3,7 @@
 query SelfServiceRolesQuery($name: String) {
   roles: roles_v1(name: $name) {
     name
+    labels
     path
     self_service {
       change_type {

--- a/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
+++ b/reconcile/gql_definitions/change_owners/queries/self_service_roles.py
@@ -22,6 +22,7 @@ DEFINITION = """
 query SelfServiceRolesQuery($name: String) {
   roles: roles_v1(name: $name) {
     name
+    labels
     path
     self_service {
       change_type {
@@ -107,6 +108,7 @@ class PermissionGitlabGroupMembershipV1(PermissionV1):
 
 class RoleV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+    labels: Optional[Json] = Field(..., alias="labels")
     path: str = Field(..., alias="path")
     self_service: Optional[list[SelfServiceConfigV1]] = Field(..., alias="self_service")
     users: list[UserV1] = Field(..., alias="users")

--- a/reconcile/test/change_owners/fixtures.py
+++ b/reconcile/test/change_owners/fixtures.py
@@ -9,6 +9,7 @@ from typing import (
 
 import jsonpath_ng
 import jsonpath_ng.ext
+from pydantic import Json
 from pydantic.dataclasses import dataclass
 
 from reconcile.change_owners.bundle import (
@@ -286,6 +287,7 @@ def build_role(
     slack_groups: Optional[list[str]] = None,
     slack_workspace: Optional[str] = "workspace",
     gitlab_groups: Optional[list[str]] = None,
+    labels: Optional[Json] = None,
 ) -> self_service_roles.RoleV1:
     permissions: list[PermissionV1] = [
         PermissionSlackUsergroupV1(
@@ -310,6 +312,7 @@ def build_role(
         ],
         bots=[BotV1(org_username=b) for b in bots or []],
         permissions=permissions,
+        labels=labels,
     )
 
 

--- a/reconcile/test/change_owners/test_change_type_various.py
+++ b/reconcile/test/change_owners/test_change_type_various.py
@@ -18,11 +18,11 @@ from reconcile.change_owners.changes import parse_resource_file_content
 
 
 def test_label_management_add() -> None:
-    assert [
+    assert {
         "existing-label",
         "true-label",
         "another-true-label",
-    ] == manage_conditional_label(
+    } == manage_conditional_label(
         current_labels=["existing-label"],
         conditional_labels={
             "true-label": True,
@@ -33,7 +33,7 @@ def test_label_management_add() -> None:
     )
 
     # dry-run
-    assert ["existing-label"] == manage_conditional_label(
+    assert {"existing-label"} == manage_conditional_label(
         current_labels=["existing-label"],
         conditional_labels={
             "true-label": True,
@@ -45,7 +45,7 @@ def test_label_management_add() -> None:
 
 
 def test_label_management_remove() -> None:
-    assert ["existing-label"] == manage_conditional_label(
+    assert {"existing-label"} == manage_conditional_label(
         current_labels=["existing-label", "false-label"],
         conditional_labels={
             "false-label": False,
@@ -54,7 +54,7 @@ def test_label_management_remove() -> None:
     )
 
     # dry-run
-    assert ["existing-label", "false-label"] == manage_conditional_label(
+    assert {"existing-label", "false-label"} == manage_conditional_label(
         current_labels=["existing-label", "false-label"],
         conditional_labels={
             "false-label": False,
@@ -64,7 +64,7 @@ def test_label_management_remove() -> None:
 
 
 def test_label_management_add_and_remove() -> None:
-    assert ["existing-label", "true-label"] == manage_conditional_label(
+    assert {"existing-label", "true-label"} == manage_conditional_label(
         current_labels=["existing-label", "false-label"],
         conditional_labels={
             "true-label": True,

--- a/reconcile/utils/mr/labels.py
+++ b/reconcile/utils/mr/labels.py
@@ -15,3 +15,7 @@ NOT_SELF_SERVICEABLE = "not-self-serviceable"
 
 def prioritized_approval_label(priority: str) -> str:
     return f"{APPROVED}: {priority}"
+
+
+def change_owner_label(label: str) -> str:
+    return f"change-owner/{label}"

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -98,6 +98,7 @@ from reconcile.utils.keycloak import (
 from reconcile.utils.mr.labels import (
     SAAS_FILE_UPDATE,
     SELF_SERVICEABLE,
+    change_owner_label,
 )
 from reconcile.utils.oc import (
     OC_Map,
@@ -1847,7 +1848,11 @@ def app_interface_review_queue(ctx) -> None:
                 continue
             if SAAS_FILE_UPDATE in labels:
                 continue
-            if SELF_SERVICEABLE in labels:
+            if (
+                SELF_SERVICEABLE in labels
+                and change_owner_label("show-self-serviceable-in-review-queue")
+                not in labels
+            ):
                 continue
 
             pipelines = mr.pipelines()


### PR DESCRIPTION
self-serviceable MRs intentionally do not show up in the review queue. but if an MR is self-serviceable and the approvers are AppSRE, we would still love to see such MRs in the review queue, so IC is aware and can review and approve.

to fix this we will:
* include MRs with the label "change-owner/show-self-serviceable-in-review-queue" in the review-queue, regardless of its self-serviceable state
* change-owners will apply additional labels to MRs based on the "change-owners-label" label of the involved self-service roles (prefixing them with `change-owners` to ensure uniqueness and avoid conflict)

E.g. if the following role is approver on an MR, the `change-owner/show-self-serviceable-in-review-queue` label will be added the the MR.

```yaml
---
$schema: /access/role-1.yml
labels:
  change-owners-labels: show-self-serviceable-in-review-queue
```

the qontract-cli app-interface-review-queue command will react to this label and show respective MRs in the review queue report regardless of their self-service state

part of https://issues.redhat.com/browse/APPSRE-8322