### PR TITLE
Introduce mutation controls to the 3way-diff strategy

### DIFF
--- a/reconcile/test/fixtures/openshift_resource/deployment.yml
+++ b/reconcile/test/fixtures/openshift_resource/deployment.yml
@@ -22,3 +22,10 @@ spec:
         image: nginx:1.14.2
         ports:
         - containerPort: 80
+        resources:
+          requests:
+            memory: 1000Mi
+            cpu: "1"
+          limits:
+            memory: 2000Mi
+            cpu: "2"

--- a/reconcile/test/test_openshift_resource.py
+++ b/reconcile/test/test_openshift_resource.py
@@ -1,6 +1,5 @@
 import pytest
 
-from reconcile.openshift_base import three_way_merge_patch_diff_using_hash
 from reconcile.utils.openshift_resource import ConstructResourceError
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.openshift_resource import (
@@ -32,48 +31,6 @@ def build_resource(kind: str, api_version: str, name: str):
 #
 # OpenshiftResource tests
 #
-
-
-@pytest.fixture
-def deployment():
-    resource = fxt.get_anymarkup("deployment.yml")
-    yield resource
-
-
-def test_3wpd_equal_objects_should_not_apply(deployment):
-    d_item = OR(deployment, "", "")
-
-    # sha256 Hash is calculated over the DESIRED object
-    c_item = d_item.annotate(canonicalize=False)
-    assert three_way_merge_patch_diff_using_hash(c_item, d_item) is True
-
-
-def test_3wpd_change_desired_should_apply(deployment):
-    d_item = OR(deployment, "", "")
-    c_item = d_item.annotate(canonicalize=False)
-
-    del d_item.body["metadata"]["annotations"]
-    assert three_way_merge_patch_diff_using_hash(c_item, d_item) is False
-
-
-# Changes in current objects over attributes defined in desired
-def test_3wpd_change_current_should_apply(deployment):
-    d_item = OR(deployment, "", "")
-    c_item = d_item.annotate(canonicalize=False)
-
-    c_item.body["spec"]["replicas"] = 5
-    assert three_way_merge_patch_diff_using_hash(c_item, d_item) is False
-
-
-# Changes in current objects on attributes *NOT* defined in desired
-def test_3wpd_change_current_not_in_desired_should_not_apply(deployment):
-    d_item = OR(deployment, "", "")
-    c_item = d_item.annotate(canonicalize=False)
-
-    c_item.body["spec"]["manual_added_attr"] = 5
-    assert three_way_merge_patch_diff_using_hash(c_item, d_item) is True
-
-
 def test_obj_intersect_equal_status_depth_0_current():
     desired = {
         "kind": "kind",

--- a/reconcile/test/test_three_way_diff_strategy.py
+++ b/reconcile/test/test_three_way_diff_strategy.py
@@ -1,0 +1,92 @@
+import pytest
+
+from reconcile.utils.openshift_resource import OpenshiftResource as OR
+from reconcile.utils.three_way_diff_strategy import (
+    is_cpu_mutation,
+    three_way_diff_using_hash,
+)
+
+from .fixtures import Fixtures
+
+fxt = Fixtures("openshift_resource")
+
+
+@pytest.fixture
+def deployment():
+    resource = fxt.get_anymarkup("deployment.yml")
+    yield resource
+
+
+def test_3wpd_change_current_not_in_desired_should_not_apply(deployment):
+    d_item = OR(deployment, "", "")
+    c_item = d_item.annotate(canonicalize=False)
+
+    c_item.body["spec"]["manual_added_attr"] = 5
+    assert three_way_diff_using_hash(c_item, d_item) is True
+
+
+def test_3wpd_equal_objects_should_not_apply(deployment):
+    d_item = OR(deployment, "", "")
+
+    # sha256 Hash is calculated over the DESIRED object
+    c_item = d_item.annotate(canonicalize=False)
+    assert three_way_diff_using_hash(c_item, d_item) is True
+
+
+def test_3wpd_change_desired_should_apply(deployment):
+    d_item = OR(deployment, "", "")
+    c_item = d_item.annotate(canonicalize=False)
+
+    del d_item.body["metadata"]["annotations"]
+    assert three_way_diff_using_hash(c_item, d_item) is False
+
+
+# Changes in current objects over attributes defined in desired
+def test_3wpd_change_current_should_apply(deployment):
+    d_item = OR(deployment, "", "")
+    c_item = d_item.annotate(canonicalize=False)
+
+    c_item.body["spec"]["replicas"] = 5
+    assert three_way_diff_using_hash(c_item, d_item) is False
+
+
+def test_is_a_cpu_mutation(deployment):
+    patch = {
+        "op": "replace",
+        "path": "/spec/template/spec/containers/0/resources/requests/cpu",
+        "value": "2000m",
+    }
+    deployment["spec"]["template"]["spec"]["containers"][0]["resources"]["requests"][
+        "cpu"
+    ] = "2"
+    current = OR(deployment, "", "")
+    desired = OR(deployment, "", "")  # Not used to check cpu mutation
+    assert is_cpu_mutation(current, desired, patch) is True
+
+
+def test_is_not_a_cpu_mutation(deployment):
+    patch = {
+        "op": "replace",
+        "path": "/spec/template/spec/containers/0/resources/requests/cpu",
+        "value": "20m",
+    }
+    deployment["spec"]["template"]["spec"]["containers"][0]["resources"]["requests"][
+        "cpu"
+    ] = "2"
+    current = OR(deployment, "", "")
+    desired = OR(deployment, "", "")  # Not used to check cpu mutation
+    assert is_cpu_mutation(current, desired, patch) is False
+
+
+def test_3wpd_change_valid_mutation_not_apply(deployment):
+    d_item = OR(deployment, "", "")
+    d_item.body["spec"]["template"]["spec"]["containers"][0]["resources"]["requests"][
+        "cpu"
+    ] = "1000m"
+
+    c_item = d_item.annotate(canonicalize=False)
+    c_item.body["spec"]["template"]["spec"]["containers"][0]["resources"]["requests"][
+        "cpu"
+    ] = "1"
+
+    assert three_way_diff_using_hash(c_item, d_item) is True

--- a/reconcile/test/test_three_way_diff_strategy.py
+++ b/reconcile/test/test_three_way_diff_strategy.py
@@ -90,3 +90,22 @@ def test_3wpd_change_valid_mutation_not_apply(deployment):
     ] = "1"
 
     assert three_way_diff_using_hash(c_item, d_item) is True
+
+
+def test_3wpd_change_empty_env_value_should_not_apply(deployment):
+    d_item = OR(deployment, "", "")
+    d_item.body["spec"]["template"]["spec"]["containers"][0]["env"] = [
+        {
+            "name": "test_env",
+            "value": "",
+        }
+    ]
+
+    c_item = d_item.annotate(canonicalize=False)
+    c_item.body["spec"]["template"]["spec"]["containers"][0]["env"] = [
+        {
+            "name": "test_env",
+        }
+    ]
+
+    assert three_way_diff_using_hash(c_item, d_item) is True

--- a/reconcile/utils/three_way_diff_strategy.py
+++ b/reconcile/utils/three_way_diff_strategy.py
@@ -1,0 +1,134 @@
+import base64
+import logging
+import re
+from collections.abc import Mapping
+from typing import Any
+
+import jsonpatch  # type: ignore
+from jsonpointer import resolve_pointer  # type: ignore
+
+from reconcile.utils.openshift_resource import QONTRACT_ANNOTATIONS
+from reconcile.utils.openshift_resource import OpenshiftResource as OR
+
+NORMALIZE_COMPARE_EXCLUDED_ATTRS = {
+    "creationTimestamp",
+    "resourceVersion",
+    "generation",
+    "selfLink",
+    "uid",
+    "fieldRef",
+    "managedFields",
+    "namespace",
+}
+
+
+def _normalize_secret(secret: OR) -> None:
+    body = secret.body
+    string_data = body.get("stringData")
+
+    if string_data:
+        data = body.get("data") or {}
+        body["data"] = data | {
+            k: base64.b64encode(str(v).encode()).decode("utf-8")
+            for k, v in string_data.items()
+        }
+        secret.body = {k: v for k, v in body.items() if k != "stringData"}
+
+
+def _normalize_noop(item: OR) -> None:
+    pass
+
+
+NORMALIZERS = {"Secret": _normalize_secret}
+
+
+def normalize_object(item: OR) -> OR:
+    # Remove K8s managed attributes not needed to compare objects
+    metadata = {
+        k: v
+        for k, v in item.body["metadata"].items()
+        if k not in NORMALIZE_COMPARE_EXCLUDED_ATTRS
+    }
+
+    n = OR(
+        body=item.body | {"metadata": metadata},
+        integration=item.integration,
+        integration_version=item.integration_version,
+        error_details=item.error_details,
+        caller_name=item.caller_name,
+        validate_k8s_object=False,
+    )
+
+    annotations = n.body.get("annotations", {})
+    metadata["annotations"] = {
+        k: v for k, v in annotations.items() if k not in QONTRACT_ANNOTATIONS
+    }
+
+    # Run normalizers on Kinds with special needs
+    NORMALIZERS.get(n.body["kind"], _normalize_noop)(n)
+    return n
+
+
+CPU_REGEX = re.compile(r"/.*/(requests|limits)/cpu$")
+
+
+def is_cpu_mutation(current: OR, desired: OR, patch: Mapping[str, Any]) -> bool:
+    pointer = patch["path"]
+    if re.match(CPU_REGEX, pointer):
+        current_value = resolve_pointer(current.body, pointer)
+        desired_value = patch["value"]
+        return OR.cpu_equal(current_value, desired_value)
+
+    return False
+
+
+def is_valid_change(current: OR, desired: OR, patch: Mapping[str, Any]) -> bool:
+    # Only consider added or replaced values on the Desired object
+    if patch["op"] not in ["add", "replace"]:
+        return False
+
+    # Check known mutations. Replaced values can happen if values have been
+    # mutated by the API server
+    if is_cpu_mutation(current, desired, patch):
+        return False
+
+    return True
+
+
+def three_way_diff_using_hash(c_item: OR, d_item: OR) -> bool:
+    # Get the ORIGINAL object hash
+    # This needs to be improved in OR, by now is just a PoC
+    c_item_sha256 = ""
+    try:
+        annotations = c_item.body["metadata"]["annotations"]
+        c_item_sha256 = annotations["qontract.sha256sum"]
+    except KeyError:
+        logging.info("Current object QR hash is missing -> Apply")
+        return False
+
+    # Original object does not match Desired -> Apply
+    # Current object is not recalculated!
+    # d_item_sha256 = OR.calculate_sha256sum(OR.serialize(d_item.body))
+    # if c_item_sha256 != d_item_sha256:
+    if c_item_sha256 != d_item.sha256sum():
+        logging.info("Original and Desired objects hash differs -> Apply")
+        return False
+
+    # If there are differences between current and desired -> Apply
+    # The patch only detects changes with attributes defined in the desired state.
+    # Values in the current state added by operators or other actors are not taken
+    # into account
+
+    current = normalize_object(c_item)
+    desired = normalize_object(d_item)
+
+    patch = jsonpatch.JsonPatch.from_diff(current.body, desired.body)
+    valid_changes = [
+        item for item in patch.patch if is_valid_change(current, desired, item)
+    ]
+    if len(valid_changes) > 0:
+        logging.info("Desired and Current objects differ -> Apply")
+        logging.info(valid_changes)
+        return False
+
+    return True

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         "requests-oauthlib~=1.3",
         "dt==1.1.61",
         "jsonpatch~=1.33",
+        "jsonpointer~=2.4",
     ],
     test_suite="tests",
     classifiers=[


### PR DESCRIPTION
* Code reorg: 3-way diff strategy code + tests have been moved to their own files 
* Added an extensible logic to control object mutations. 
  * For now, only cpu mutations are checked. K8s mutates cpu values. e.g: "1000m" becomes "1" 