### PR TITLE
[terraform-repo] option to ignore statefile loading errors

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1604,14 +1604,21 @@ def ldap_groups(ctx):
     "--output-file",
     help="Specify where to place the output of the integration",
 )
+@click.option(
+    "--ignore-state-errors",
+    is_flag=True,
+    help="Instructs terraform-repo to ignore state load errors and re-create repo states",
+)
 @click.pass_context
-def terraform_repo(ctx, output_file):
+def terraform_repo(ctx, output_file, ignore_state_errors):
     from reconcile import terraform_repo
 
     run_class_integration(
         integration=terraform_repo.TerraformRepoIntegration(
             terraform_repo.TerraformRepoIntegrationParams(
-                output_file=output_file, validate_git=True
+                output_file=output_file,
+                validate_git=True,
+                ignore_state_errors=ignore_state_errors,
             )
         ),
         ctx=ctx.obj,

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -65,6 +65,7 @@ class OutputFile(BaseModel):
 class TerraformRepoIntegrationParams(PydanticRunParams):
     output_file: Optional[str]
     validate_git: bool
+    ignore_state_errors: bool
 
 
 class TerraformRepoIntegration(
@@ -181,9 +182,11 @@ class TerraformRepoIntegration(
                     repo = TerraformRepoV1.parse_obj(value)
                     repo_list.append(repo)
                 except ValidationError as err:
-                    logging.warning(
-                        f"{err}\nUnable to parse existing state for repo: '{key}', terraform apply will be re-run on this and new version of state will be saved"
+                    logging.error(
+                        f"{err}\nUnable to parse existing state for repo: '{key}'"
                     )
+                    if self.params.ignore_state_errors:
+                        logging.info("Ignoring state load error")
 
         return repo_list
 
@@ -294,6 +297,13 @@ class TerraformRepoIntegration(
         diff = diff_iterables(existing_state, desired_state, lambda x: x.name)
 
         merged = self.merge_results(diff)
+
+        # validate that only one repo is being modified in each MR
+        # this lets us fail early and avoid multiple GL requests we don't need to make
+        if dry_run and len(merged) > 1 and not self.params.ignore_state_errors:
+            raise Exception(
+                "Only one repository can be modified per merge request, please split your change out into multiple MRs. Hint: try rebasing your merge request"
+            )
 
         # added repos: do standard validation that SHA is valid
         if self.params.validate_git:

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -181,8 +181,8 @@ class TerraformRepoIntegration(
                     repo = TerraformRepoV1.parse_obj(value)
                     repo_list.append(repo)
                 except ValidationError as err:
-                    logging.error(
-                        f"{err}\nUnable to parse existing state for repo: '{key}', skipping"
+                    logging.warning(
+                        f"{err}\nUnable to parse existing state for repo: '{key}', terraform apply will be re-run on this and new version of state will be saved"
                     )
 
         return repo_list
@@ -294,13 +294,6 @@ class TerraformRepoIntegration(
         diff = diff_iterables(existing_state, desired_state, lambda x: x.name)
 
         merged = self.merge_results(diff)
-
-        # validate that only one repo is being modified in each MR
-        # this lets us fail early and avoid multiple GL requests we don't need to make
-        if dry_run and len(merged) > 1:
-            raise Exception(
-                "Only one repository can be modified per merge request, please split your change out into multiple MRs. Hint: try rebasing your merge request"
-            )
 
         # added repos: do standard validation that SHA is valid
         if self.params.validate_git:

--- a/reconcile/test/test_terraform_repo.py
+++ b/reconcile/test/test_terraform_repo.py
@@ -136,13 +136,17 @@ def aws_account_no_state(automation_token) -> AWSAccountV1:
 
 @pytest.fixture
 def int_params() -> TerraformRepoIntegrationParams:
-    return TerraformRepoIntegrationParams(output_file=None, validate_git=False)
+    return TerraformRepoIntegrationParams(
+        output_file=None, validate_git=False, ignore_state_errors=False
+    )
 
 
 @pytest.fixture
 def int_params_print_to_tmp(tmp_path) -> TerraformRepoIntegrationParams:
     return TerraformRepoIntegrationParams(
-        output_file=f"{tmp_path}/tf-repo.yaml", validate_git=False
+        output_file=f"{tmp_path}/tf-repo.yaml",
+        validate_git=False,
+        ignore_state_errors=False,
     )
 
 


### PR DESCRIPTION
When trying to update terraform-repo in FedRamp where there are a number of different statefiles already saved in S3, I ran into many validation errors:

```
[2023-09-15 14:37:43] [ERROR] [DRY-RUN] [terraform_repo.py:get_existing_state:184] - 1 validation error for TerraformRepoV1
account -> terraformState
  field required (type=value_error.missing)
Unable to parse existing state for repo: '/app-sre-base-networking', skipping
```

This is due to the updates to the GQL syntax updates done in a previous MR: https://github.com/app-sre/qontract-reconcile/pull/3777/files#diff-07306e78e084b1597025733d9c9787506f617028ba6ebe1cb240937c39ed8f34R11

It seems that Pydantic expects the terraformState attribute to be defined, just as `null` so it's unable to parse. To fix this, I've added a CLI flag to the command instructing terraform repo to ignore statefile errors and proceed with statefile recreation. Note that this is only recreating the statefiles stored in AWS S3 for the QR integration, not the actual terraform .tfstate files. This will result in some extra `terraform apply` calls if the flag is enabled.

I'll add an SOP detailing this into App Interface. Shouldn't be an option we need to use often, just if there are breaking GQL schema changes.