### PR TITLE
expose cluster upgrade state via metrics

### DIFF
--- a/grafana-dashboards/sre-capability-aus.configmap.yaml
+++ b/grafana-dashboards/sre-capability-aus.configmap.yaml
@@ -249,7 +249,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "label_join(aus_cluster_version_remaining_soak_days * on (cluster_uuid, soaking_version) (clamp_max(changes(min(aus_cluster_version_remaining_soak_days) by(cluster_uuid, soaking_version)[1h:1m]), 1) > 0) * on (cluster_uuid) group_left(cluster_name, current_version, workloads, schedule, sector, soak_days) aus_cluster_upgrade_policy_info{workloads=~\".*$workloads.*\", org_id=~\".*$org_id.*\"}, \"cluster_soaking_version\", \"-\", \"cluster_uuid\", \"soaking_version\")",
+              "expr": "label_join((aus_cluster_version_remaining_soak_days >= 0) * on (cluster_uuid, soaking_version) (clamp_max(changes(min(aus_cluster_version_remaining_soak_days) by(cluster_uuid, soaking_version)[1h:1m]), 1) > 0) * on (cluster_uuid) group_left(cluster_name, current_version, workloads, schedule, sector, soak_days) aus_cluster_upgrade_policy_info{workloads=~\".*$workloads.*\", org_id=~\".*$org_id.*\"}, \"cluster_soaking_version\", \"-\", \"cluster_uuid\", \"soaking_version\")",
               "format": "table",
               "instant": true,
               "interval": "5m",
@@ -264,7 +264,7 @@ data:
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "label_join(delta(min(aus_cluster_version_remaining_soak_days) by(cluster_uuid, soaking_version)[1h:1m]) * -24 * on (cluster_uuid) group_left aus_cluster_upgrade_policy_info{workloads=~\".*$workloads.*\", org_id=~\".*$org_id.*\"} > 0, \"cluster_soaking_version\", \"-\", \"cluster_uuid\", \"soaking_version\") > 0",
+              "expr": "label_join(delta(min((aus_cluster_version_remaining_soak_days >= 0)) by(cluster_uuid, soaking_version)[1h:1m]) * -24 * on (cluster_uuid) group_left aus_cluster_upgrade_policy_info{workloads=~\".*$workloads.*\", org_id=~\".*$org_id.*\"} > 0, \"cluster_soaking_version\", \"-\", \"cluster_uuid\", \"soaking_version\") > 0",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -366,7 +366,25 @@ data:
                 "filterable": false,
                 "inspect": false
               },
-              "mappings": [],
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "index": 0,
+                      "text": "🎉"
+                    },
+                    "-1": {
+                      "index": 1,
+                      "text": "⏰"
+                    },
+                    "-2": {
+                      "index": 2,
+                      "text": "💫"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [

--- a/grafana-dashboards/sre-capability-aus.configmap.yaml
+++ b/grafana-dashboards/sre-capability-aus.configmap.yaml
@@ -355,6 +355,7 @@ data:
             "type": "prometheus",
             "uid": "P2C3F6ECC774D80E6"
           },
+          "description": "A numeric value represents the remaining soak days per version and cluster.\nA 🎉 is displayed for versions which have soaked enough and are ready to be\nupgraded to.\nA ⏰ is displayed for versions scheduled to be upgraded to.\nA 💫 is displayed for versions which are being upgraded to. Upgrades taking\nmore than 6 hours will be highlighted.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -202,6 +202,7 @@ class AdvancedUpgradeSchedulerBaseIntegration(
                     cluster_uuid=cluster_upgrade_spec.cluster_uuid,
                     org_id=cluster_upgrade_spec.org.org_id,
                     org_name=org_upgrade_spec.org.name,
+                    channel=cluster_upgrade_spec.cluster.version.channel_group,
                     current_version=cluster_upgrade_spec.current_version,
                     cluster_name=cluster_upgrade_spec.name,
                     schedule=cluster_upgrade_spec.upgrade_policy.schedule,
@@ -241,6 +242,7 @@ class AbstractUpgradePolicy(ABC, BaseModel):
     schedule: Optional[str]
     schedule_type: str
     version: str
+    state: Optional[str]
 
     @abstractmethod
     def create(self, ocm_api: OCMBaseClient) -> None:

--- a/reconcile/aus/metrics.py
+++ b/reconcile/aus/metrics.py
@@ -15,6 +15,10 @@ class AUSBaseMetric(BaseModel):
     ocm_env: str
 
 
+UPGRADE_SCHEDULED_METRIC_VALUE = -1.0
+UPGRADE_STARTED_METRIC_VALUE = -2.0
+
+
 class AUSClusterVersionRemainingSoakDaysGauge(AUSBaseMetric, GaugeMetric):
     "Remaining days a version needs to soak for a cluster"
 
@@ -32,6 +36,7 @@ class AUSClusterUpgradePolicyInfoMetric(AUSBaseMetric, InfoMetric):
     cluster_uuid: str
     org_id: str
     org_name: str
+    channel: str
     current_version: str
     cluster_name: str
     schedule: str

--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -143,9 +143,11 @@ class OCMClusterUpgradeSchedulerIntegration(
                 current_version_upgrade = current_cluster_version_upgrade_policies.get(
                     (spec.cluster.external_id, version)
                 )
-                # the metric value encodes the days remaining for the soak while the cluster is soaking the version
+                # the metric value encodes the days remaining for the soak while the cluster is soaking the version.
                 # once an upgrade is scheduled or started for the specific version, negative values will be used
-                # to catch that state in the metric
+                # to catch that state in the metric.
+                # there are other states than `scheduled` and `started` but the `UpgradePolicy` vanishes too quickly
+                # to observe them reliably, when such states are reached.
                 if (
                     current_version_upgrade
                     and current_version_upgrade.state == "scheduled"

--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -3,7 +3,11 @@ from typing import Optional
 
 from reconcile.aus import base as aus
 from reconcile.aus.cluster_version_data import VersionData
-from reconcile.aus.metrics import AUSClusterVersionRemainingSoakDaysGauge
+from reconcile.aus.metrics import (
+    UPGRADE_SCHEDULED_METRIC_VALUE,
+    UPGRADE_STARTED_METRIC_VALUE,
+    AUSClusterVersionRemainingSoakDaysGauge,
+)
 from reconcile.aus.models import (
     ClusterUpgradeSpec,
     OrganizationUpgradeSpec,
@@ -61,6 +65,7 @@ class OCMClusterUpgradeSchedulerIntegration(
             version_data=version_data_map.get(
                 org_upgrade_spec.org.environment.name, org_upgrade_spec.org.org_id
             ),
+            current_state=current_state,
         )
 
         diffs = aus.calculate_diff(
@@ -119,7 +124,11 @@ class OCMClusterUpgradeSchedulerIntegration(
         ocm_env: str,
         org_upgrade_spec: OrganizationUpgradeSpec,
         version_data: VersionData,
+        current_state: list[aus.AbstractUpgradePolicy],
     ) -> None:
+        current_cluster_version_upgrade_policies = {
+            (p.cluster.external_id, p.version): p for p in current_state
+        }
         for spec in org_upgrade_spec.specs:
             upgrades = spec.cluster.version.available_upgrades or []
             if not upgrades:
@@ -131,6 +140,28 @@ class OCMClusterUpgradeSchedulerIntegration(
             ]
             for version in upgrades or []:
                 soaks = [s.get(version, 0) for s in workload_soaking_upgrades]
+                current_version_upgrade = current_cluster_version_upgrade_policies.get(
+                    (spec.cluster.external_id, version)
+                )
+                # the metric value encodes the days remaining for the soak while the cluster is soaking the version
+                # once an upgrade is scheduled or started for the specific version, negative values will be used
+                # to catch that state in the metric
+                if (
+                    current_version_upgrade
+                    and current_version_upgrade.state == "scheduled"
+                ):
+                    metric_value = UPGRADE_SCHEDULED_METRIC_VALUE
+                elif (
+                    current_version_upgrade
+                    and current_version_upgrade.state == "started"
+                ):
+                    metric_value = UPGRADE_STARTED_METRIC_VALUE
+                else:
+                    metric_value = max(
+                        (spec.upgrade_policy.conditions.soak_days or 0)
+                        - (min(soaks) or 0),
+                        0,
+                    )
                 metrics.set_gauge(
                     AUSClusterVersionRemainingSoakDaysGauge(
                         integration=self.name,
@@ -138,9 +169,5 @@ class OCMClusterUpgradeSchedulerIntegration(
                         cluster_uuid=spec.cluster.external_id,
                         soaking_version=version,
                     ),
-                    max(
-                        (spec.upgrade_policy.conditions.soak_days or 0)
-                        - (min(soaks) or 0),
-                        0,
-                    ),
+                    metric_value,
                 )

--- a/reconcile/utils/ocm/upgrades.py
+++ b/reconcile/utils/ocm/upgrades.py
@@ -37,11 +37,27 @@ def get_addon_upgrade_policies(
     ):
         if addon_id and policy["addon_id"] != addon_id:
             continue
-        results.append(
-            {k: v for k, v in policy.items() if k in ADDON_UPGRADE_POLICY_DESIRED_KEYS}
+        policy_data = {
+            k: v for k, v in policy.items() if k in ADDON_UPGRADE_POLICY_DESIRED_KEYS
+        }
+        policy_data["state"] = get_addon_upgrade_policy_state(
+            ocm_api, cluster_id, policy["id"]
         )
+        results.append(policy_data)
 
     return results
+
+
+def get_addon_upgrade_policy_state(
+    ocm_api: OCMBaseClient, cluster_id: str, addon_upgrade_policy_id: str
+) -> Optional[str]:
+    try:
+        state_data = ocm_api.get(
+            f"{build_cluster_url(cluster_id)}/addon_upgrade_policies/{addon_upgrade_policy_id}/state"
+        )
+        return state_data.get("value")
+    except Exception:
+        return None
 
 
 def create_addon_upgrade_policy(
@@ -85,10 +101,27 @@ def get_upgrade_policies(
     ):
         if schedule_type and policy["schedule_type"] != schedule_type:
             continue
-        results.append(
-            {k: v for k, v in policy.items() if k in UPGRADE_POLICY_DESIRED_KEYS}
+        policy_data = {
+            k: v for k, v in policy.items() if k in UPGRADE_POLICY_DESIRED_KEYS
+        }
+        policy_data["state"] = get_upgrade_policy_state(
+            ocm_api, cluster_id, policy["id"]
         )
+        results.append(policy_data)
+
     return results
+
+
+def get_upgrade_policy_state(
+    ocm_api: OCMBaseClient, cluster_id: str, upgrade_policy_id: str
+) -> Optional[str]:
+    try:
+        state_data = ocm_api.get(
+            f"{build_cluster_url(cluster_id)}/upgrade_policies/{upgrade_policy_id}/state"
+        )
+        return state_data.get("value")
+    except Exception:
+        return None
 
 
 def create_upgrade_policy(ocm_api: OCMBaseClient, cluster_id: str, spec: dict) -> None:
@@ -124,9 +157,11 @@ def get_control_plane_upgrade_policies(
     ):
         if schedule_type and policy["schedule_type"] != schedule_type:
             continue
-        results.append(
-            {k: v for k, v in policy.items() if k in UPGRADE_POLICY_DESIRED_KEYS}
-        )
+        policy_data = {
+            k: v for k, v in policy.items() if k in UPGRADE_POLICY_DESIRED_KEYS
+        }
+        policy_data["state"] = policy.get("state", {}).get("value")
+        results.append(policy_data)
     return results
 
 


### PR DESCRIPTION
we lack upcoming and ongoing upgrade information on the AUS dashboards.

this patch encodes such data as negative values in the `aus_cluster_version_remaining_soak_days` metric. this is safe since the metric currently has a min value of 0.

we will use
* -1 for scheduled upgrades (upgrade policy created in OCM)
* -2 for started/ongoing upgrades.

the dashboard tile for "currently soaking" has been adapted to deal with negative numbers (ignore them) and the matrix now shows the well known icons for ready, scheduled and ongoing.

part of https://issues.redhat.com/browse/APPSRE-7878

additionally the channel group of a cluster is exposed in the AUS info metric for dashboarding purposes.

part of https://issues.redhat.com/browse/APPSRE-7877