### PR TITLE
extend gabi expiration max days to 365 days

### DIFF
--- a/reconcile/gabi_authorized_users.py
+++ b/reconcile/gabi_authorized_users.py
@@ -29,7 +29,7 @@ from reconcile.utils.semver_helper import make_semver
 
 QONTRACT_INTEGRATION = "gabi-authorized-users"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
-EXPIRATION_DAYS_MAX = 90
+EXPIRATION_DAYS_MAX = 365
 
 
 def construct_gabi_oc_resource(


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-8298

the origin of the 90 days limitation is unclear.

design doc: https://docs.google.com/document/d/1rQBCGFy2rc6A9RdeqOkTEXsr0kZlRwXTer5qarabjbA

extending this to 1 year, as even compliance training are only done once per year.

we can argue over making this number parameterized, but i don't think it is worth the effort.