### PR TITLE
Revert "[utils.output] escape md pipe char"

### DIFF
--- a/reconcile/utils/output.py
+++ b/reconcile/utils/output.py
@@ -9,10 +9,6 @@ import yaml
 from tabulate import tabulate
 
 
-def md_escape(text: str) -> str:
-    return text.replace("|", "\\|")
-
-
 def print_output(
     options: Mapping[str, Union[str, bool]],
     content: list[dict],
@@ -57,7 +53,7 @@ def format_table(content, columns, table_format="simple") -> str:
                     cell = "<br />".join(cell)
                 else:
                     cell = "\n".join(cell)
-            row_data.append(md_escape(cell))
+            row_data.append(cell)
         table_data.append(row_data)
     return tabulate(table_data, headers=headers, tablefmt=table_format)
 


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#3804

```
[2023-09-19 08:12:59] [INFO] [DRY-RUN] [change_owners.py:run:253] - running in `limited` mode that prevents full self-service MR 81094 contains changes other than datafiles, resources, docs or testdata
[2023-09-19 08:13:03] [INFO] [DRY-RUN] [change_owners.py:run:286] - fetching change types and permissions from comparison bundle (sha=c9dad9d48217430e9663f9ecbd03ad7bebd70b25bb312842a1a307e5a82be30b, commit_id=5d3b60e70ffa5e47b62146d2470e1d0aaab7b97a, build_time 2023-09-19T08:10:29+00:00)
[2023-09-19 08:13:04] [INFO] [DRY-RUN] [change_owners.py:run:302] - detected 4 changed files with 4 differences and 0 metadata-only changes
[2023-09-19 08:13:29] [ERROR] [DRY-RUN] [change_owners.py:run:398] - Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/reconcile/change_owners/change_owners.py", line 345, in run
    write_coverage_report_to_mr(
  File "/usr/local/lib/python3.11/site-packages/reconcile/change_owners/change_owners.py", line 156, in write_coverage_report_to_mr
    coverage_report = format_table(
                      ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/output.py", line 60, in format_table
    row_data.append(md_escape(cell))
                    ^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/output.py", line 13, in md_escape
    return text.replace("|", "\\|")
           ^^^^^^^^^^^^
AttributeError: 'Child' object has no attribute 'replace'
```