### PR TITLE
Fix s3 bucket policy with region config

### DIFF
--- a/reconcile/test/utils/test_terrascript_aws_client.py
+++ b/reconcile/test/utils/test_terrascript_aws_client.py
@@ -1,4 +1,9 @@
 import pytest
+from pytest_mock import MockerFixture
+from terrascript.resource import (
+    aws_s3_bucket,
+    aws_s3_bucket_policy,
+)
 
 import reconcile.utils.terrascript_aws_client as tsclient
 from reconcile.utils.aws_api import AmiTag
@@ -275,3 +280,191 @@ def test_terraform_state_when_not_present_error(ts):
         )
     except ValueError:
         pass
+
+
+def build_s3_spec(
+    resource: dict,
+) -> ExternalResourceSpec:
+    provider = "aws"
+    provisioner = {"name": "a"}
+    namespace = {
+        "name": "n",
+        "managedExternalResources": True,
+        "externalResources": [
+            {
+                "provider": provider,
+                "provisioner": provisioner,
+                "resources": [resource],
+            },
+        ],
+        "cluster": {"name": "c"},
+        "environment": {
+            "name": "e",
+        },
+        "app": {"name": "app"},
+    }
+    return ExternalResourceSpec(
+        provision_provider=provider,
+        provisioner=provisioner,
+        resource=resource,
+        namespace=namespace,
+    )
+
+
+@pytest.fixture
+def s3_default_spec() -> ExternalResourceSpec:
+    resource = {
+        "identifier": "s3-bucket",
+        "provider": "s3",
+    }
+    return build_s3_spec(resource)
+
+
+@pytest.fixture
+def expected_s3_default_bucket() -> aws_s3_bucket:
+    return aws_s3_bucket(
+        "s3-bucket",
+        **{
+            "bucket": "s3-bucket",
+            "versioning": {"enabled": True},
+            "tags": {
+                "managed_by_integration": "",
+                "cluster": "c",
+                "namespace": "n",
+                "environment": "e",
+                "app": "app",
+            },
+            "lifecycle": {"ignore_changes": ["grant"]},
+            "server_side_encryption_configuration": {
+                "rule": {
+                    "apply_server_side_encryption_by_default": {
+                        "sse_algorithm": "AES256"
+                    }
+                }
+            },
+        },
+    )
+
+
+def test_populate_tf_resource_s3(
+    ts: tsclient.TerrascriptClient,
+    s3_default_spec: ExternalResourceSpec,
+    expected_s3_default_bucket: aws_s3_bucket,
+) -> None:
+    bucket_tf_resource = ts.populate_tf_resource_s3(s3_default_spec)
+
+    assert bucket_tf_resource == expected_s3_default_bucket
+
+
+@pytest.fixture
+def s3_spec_with_bucket_policy() -> ExternalResourceSpec:
+    resource = {
+        "identifier": "s3-bucket",
+        "provider": "s3",
+        "bucket_policy": "some-bucket-policy",
+    }
+    return build_s3_spec(resource)
+
+
+@pytest.fixture
+def expected_s3_bucket_policy() -> aws_s3_bucket_policy:
+    return aws_s3_bucket_policy(
+        "s3-bucket",
+        **{
+            "bucket": "s3-bucket",
+            "policy": "some-bucket-policy",
+            "depends_on": ["aws_s3_bucket.s3-bucket"],
+        },
+    )
+
+
+def test_populate_tf_resource_s3_with_bucket_policy(
+    mocker: MockerFixture,
+    ts: tsclient.TerrascriptClient,
+    s3_spec_with_bucket_policy: ExternalResourceSpec,
+    expected_s3_default_bucket: aws_s3_bucket,
+    expected_s3_bucket_policy: aws_s3_bucket_policy,
+) -> None:
+    mocked_add_resources = mocker.patch.object(ts, "add_resources")
+
+    bucket_tf_resource = ts.populate_tf_resource_s3(s3_spec_with_bucket_policy)
+
+    assert bucket_tf_resource == expected_s3_default_bucket
+
+    mocked_add_resources.assert_called_once()
+    identifier, tf_resources = mocked_add_resources.call_args.args
+    assert identifier == "a"
+    assert expected_s3_bucket_policy in tf_resources
+
+
+@pytest.fixture
+def s3_spec_with_bucket_policy_and_region() -> ExternalResourceSpec:
+    resource = {
+        "identifier": "s3-bucket",
+        "provider": "s3",
+        "bucket_policy": "some-bucket-policy",
+        "region": "us-west-2",
+    }
+    return build_s3_spec(resource)
+
+
+@pytest.fixture
+def expected_s3_bucket_with_region() -> aws_s3_bucket:
+    return aws_s3_bucket(
+        "s3-bucket",
+        **{
+            "bucket": "s3-bucket",
+            "versioning": {"enabled": True},
+            "tags": {
+                "managed_by_integration": "",
+                "cluster": "c",
+                "namespace": "n",
+                "environment": "e",
+                "app": "app",
+            },
+            "lifecycle": {"ignore_changes": ["grant"]},
+            "server_side_encryption_configuration": {
+                "rule": {
+                    "apply_server_side_encryption_by_default": {
+                        "sse_algorithm": "AES256"
+                    }
+                }
+            },
+            "provider": "aws.us-west-2",
+        },
+    )
+
+
+@pytest.fixture
+def expected_s3_bucket_policy_with_region() -> aws_s3_bucket_policy:
+    return aws_s3_bucket_policy(
+        "s3-bucket",
+        **{
+            "bucket": "s3-bucket",
+            "policy": "some-bucket-policy",
+            "depends_on": ["aws_s3_bucket.s3-bucket"],
+            "provider": "aws.us-west-2",
+        },
+    )
+
+
+def test_populate_tf_resource_s3_with_bucket_policy_and_different_region(
+    mocker: MockerFixture,
+    ts: tsclient.TerrascriptClient,
+    s3_spec_with_bucket_policy_and_region: ExternalResourceSpec,
+    expected_s3_bucket_with_region: aws_s3_bucket,
+    expected_s3_bucket_policy_with_region: aws_s3_bucket_policy,
+) -> None:
+    mocked_add_resources = mocker.patch.object(ts, "add_resources")
+    mocker.patch.object(ts, "_multiregion_account", return_value=True)
+
+    bucket_tf_resource = ts.populate_tf_resource_s3(
+        s3_spec_with_bucket_policy_and_region
+    )
+
+    assert bucket_tf_resource == expected_s3_bucket_with_region
+
+    mocked_add_resources.assert_called_once()
+    identifier, tf_resources = mocked_add_resources.call_args.args
+    assert identifier == "a"
+    assert expected_s3_bucket_policy_with_region in tf_resources

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -2067,6 +2067,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 "policy": bucket_policy,
                 "depends_on": self.get_dependencies([bucket_tf_resource]),
             }
+            if self._multiregion_account(account):
+                values["provider"] = "aws." + region
             bucket_policy_tf_resource = aws_s3_bucket_policy(identifier, **values)
             tf_resources.append(bucket_policy_tf_resource)
 


### PR DESCRIPTION
When s3 bucket policy defined with a region, the generated tf config is missing `provider`, causing error:

```
Error: Error putting S3 policy: AuthorizationHeaderMalformed: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'us-east-2'
```

This fix added `provider` to tf resource, same logic as https://github.com/app-sre/qontract-reconcile/blob/3e2dc2c348306a49a01dd47c33ba267f9852b7aa/reconcile/utils/terrascript_aws_client.py#L2841


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b0aee5</samp>

This pull request adds support for S3 buckets in different regions for multiregion accounts and improves the test coverage for the `populate_tf_resource_s3` method in `reconcile/utils/terrascript_aws_client.py` and `reconcile/test/utils/test_terrascript_aws_client.py`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 0b0aee5</samp>

*  Add conditional statement to set region-specific provider for S3 bucket resource in multiregion accounts ([link](https://github.com/app-sre/qontract-reconcile/pull/3811/files?diff=unified&w=0#diff-4db367e141fd1992ae5a98872e6101dde4bf61a460c1bd0097176c6fbc849ac2R2070-R2071))
*  Import modules and classes for testing S3 bucket resource population ([link](https://github.com/app-sre/qontract-reconcile/pull/3811/files?diff=unified&w=0#diff-2b85c4eca6f7f6cf05b1628a161c3b67760eaaf718b0c590e15c2bbdb17703ecR2-R6))
*  Add test functions and fixtures to check different scenarios for S3 bucket resource population, such as default bucket, bucket with policy, and bucket with policy and region ([link](https://github.com/app-sre/qontract-reconcile/pull/3811/files?diff=unified&w=0#diff-2b85c4eca6f7f6cf05b1628a161c3b67760eaaf718b0c590e15c2bbdb17703ecR283-R470))
*  Use `pytest_mock` fixture to mock `add_resources` and `_multiregion_account` methods of `TerrascriptClient` class ([link](https://github.com/app-sre/qontract-reconcile/pull/3811/files?diff=unified&w=0#diff-2b85c4eca6f7f6cf05b1628a161c3b67760eaaf718b0c590e15c2bbdb17703ecR283-R470))
*  Use `assert` statement to compare actual and expected outputs of `populate_tf_resource_s3` method ([link](https://github.com/app-sre/qontract-reconcile/pull/3811/files?diff=unified&w=0#diff-2b85c4eca6f7f6cf05b1628a161c3b67760eaaf718b0c590e15c2bbdb17703ecR283-R470))