### PR TITLE
Fix tekton retention days

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_cleaner.py
+++ b/reconcile/openshift_saas_deploy_trigger_cleaner.py
@@ -36,7 +36,7 @@ def within_retention_days(resource: dict[str, Any], days: int) -> bool:
     now_date = datetime.now(timezone.utc)
     interval = now_date.timestamp() - creation_date.timestamp()
 
-    return interval < timedelta(days=days).seconds
+    return interval < timedelta(days=days).total_seconds()
 
 
 @defer


### PR DESCRIPTION
the `timedelta.seconds` attribute does not return the delta in seconds but the portions of seconds in there.
Since we create teh delta only with the attribute `days`, `seconds` will always be `0`.

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6be86e6</samp>

Fixed a bug in the `openshift_saas_deploy_trigger_cleaner` script that could delete triggers too early. Changed the `within_retention_days` function to use `total_seconds` instead of `seconds` for timedelta comparison.