### PR TITLE
[change-owners] don't add empty change-owner/ labels

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -380,6 +380,11 @@ def run(
             )
 
             # change-owner labels
+            labels = {
+                co_label
+                for co_label in labels
+                if not co_label.startswith("change-owner/")
+            }
             for bc in changes:
                 for label in bc.change_owner_labels:
                     labels.add(change_owner_label(label))

--- a/reconcile/change_owners/self_service_roles.py
+++ b/reconcile/change_owners/self_service_roles.py
@@ -213,9 +213,13 @@ def change_type_contexts_for_self_service_roles(
 
 def change_type_labels_from_role(role: RoleV1) -> set[str]:
     change_owner_labels = (
-        role.labels.get(CHANGE_OWNERS_LABELS_LABEL, "") if role.labels else ""
+        role.labels[CHANGE_OWNERS_LABELS_LABEL]
+        if role.labels and CHANGE_OWNERS_LABELS_LABEL in role.labels
+        else None
     )
-    return {label.strip() for label in change_owner_labels.split(",")}
+    if change_owner_labels:
+        return {label.strip() for label in change_owner_labels.split(",")}
+    return set()
 
 
 def approver_reachability_from_role(role: RoleV1) -> list[ApproverReachability]:

--- a/reconcile/test/change_owners/test_change_type_self_service_roles.py
+++ b/reconcile/test/change_owners/test_change_type_self_service_roles.py
@@ -209,3 +209,23 @@ def test_self_service_role_change_owner_labels() -> None:
         labels=json.dumps({CHANGE_OWNERS_LABELS_LABEL: "label1,label2, label3"}),
     )
     assert {"label1", "label2", "label3"} == change_type_labels_from_role(role)
+
+
+def test_self_service_role_no_change_owner_labels() -> None:
+    role = build_role(
+        name="role",
+        datafiles=None,
+        change_type_name="change-type-name",
+        labels=json.dumps({}),
+    )
+    assert not change_type_labels_from_role(role)
+
+
+def test_self_service_role_empty_change_owner_labels() -> None:
+    role = build_role(
+        name="role",
+        datafiles=None,
+        change_type_name="change-type-name",
+        labels=json.dumps({CHANGE_OWNERS_LABELS_LABEL: ""}),
+    )
+    assert not change_type_labels_from_role(role)


### PR DESCRIPTION
due to a bug, empty `change-owner/` labels were added to MRs

followup to https://github.com/app-sre/qontract-reconcile/pull/3796 part of https://issues.redhat.com/browse/APPSRE-8322