### PR TITLE
Allow restricting resources by name in saas files

### DIFF
--- a/reconcile/gql_definitions/common/saas_files.gql
+++ b/reconcile/gql_definitions/common/saas_files.gql
@@ -68,6 +68,10 @@ query SaasFiles {
       }
     }
     managedResourceTypes
+    managedResourceNames {
+      resource
+      resourceNames
+    }
     takeover
     deprecated
     compare

--- a/reconcile/gql_definitions/common/saas_files.py
+++ b/reconcile/gql_definitions/common/saas_files.py
@@ -188,6 +188,10 @@ query SaasFiles {
       }
     }
     managedResourceTypes
+    managedResourceNames {
+      resource
+      resourceNames
+    }
     takeover
     deprecated
     compare
@@ -405,6 +409,11 @@ class SlackOutputV1(ConfiguredBaseModel):
     )
 
 
+class ManagedResourceNamesV1(ConfiguredBaseModel):
+    resource: str = Field(..., alias="resource")
+    resource_names: list[str] = Field(..., alias="resourceNames")
+
+
 class SaasFileAuthenticationV1(ConfiguredBaseModel):
     code: Optional[VaultSecret] = Field(..., alias="code")
     image: Optional[VaultSecret] = Field(..., alias="image")
@@ -532,6 +541,9 @@ class SaasFileV2(ConfiguredBaseModel):
     deploy_resources: Optional[DeployResourcesV1] = Field(..., alias="deployResources")
     slack: Optional[SlackOutputV1] = Field(..., alias="slack")
     managed_resource_types: list[str] = Field(..., alias="managedResourceTypes")
+    managed_resource_names: Optional[list[ManagedResourceNamesV1]] = Field(
+        ..., alias="managedResourceNames"
+    )
     takeover: Optional[bool] = Field(..., alias="takeover")
     deprecated: Optional[bool] = Field(..., alias="deprecated")
     compare: Optional[bool] = Field(..., alias="compare")

--- a/reconcile/test/test_openshift_saas_deploy.py
+++ b/reconcile/test/test_openshift_saas_deploy.py
@@ -31,6 +31,7 @@ def saas_file_builder(
                     },
                 },
                 "managedResourceTypes": [],
+                "managedResourceNames": None,
                 "imagePatterns": [],
                 "resourceTemplates": [],
             },

--- a/reconcile/test/test_saasherder_allowed_secret_paths.py
+++ b/reconcile/test/test_saasherder_allowed_secret_paths.py
@@ -40,6 +40,7 @@ def test_saasherder_allowed_secret_paths(
                 "path": "path1",
                 "name": "a1",
                 "managedResourceTypes": [],
+                "managedResourceNames": None,
                 "allowedSecretParameterPaths": [allowed_secret_parameter_path],
                 "app": {"name": "app1", "selfServiceRoles": [{"name": "test"}]},
                 "pipelinesProvider": {

--- a/reconcile/test/test_typed_queries/test_saas_files.py
+++ b/reconcile/test/test_typed_queries/test_saas_files.py
@@ -322,6 +322,7 @@ PIPELINE_PROVIDER = {
                     "app": {"name": "app-01", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
+                    "managedResourceNames": None,
                     "imagePatterns": [],
                     "parameters": '{ "SAAS_PARAM": "foobar" }',
                     "resourceTemplates": [
@@ -374,6 +375,7 @@ PIPELINE_PROVIDER = {
                     "app": {"name": "app-02", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
+                    "managedResourceNames": None,
                     "imagePatterns": [],
                     "resourceTemplates": [
                         {
@@ -420,6 +422,7 @@ PIPELINE_PROVIDER = {
                     "app": {"name": "app-02", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
+                    "managedResourceNames": None,
                     "imagePatterns": [],
                     "resourceTemplates": [
                         {
@@ -455,6 +458,7 @@ PIPELINE_PROVIDER = {
                     "app": {"name": "app-01", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
+                    "managedResourceNames": None,
                     "imagePatterns": [],
                     "parameters": '{ "SAAS_PARAM": "foobar" }',
                     "resourceTemplates": [
@@ -488,6 +492,7 @@ PIPELINE_PROVIDER = {
                     "app": {"name": "app-02", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
+                    "managedResourceNames": None,
                     "imagePatterns": [],
                     "resourceTemplates": [
                         {
@@ -524,6 +529,7 @@ PIPELINE_PROVIDER = {
                     "app": {"name": "example", "parentApp": None},
                     "pipelinesProvider": PIPELINE_PROVIDER,
                     "managedResourceTypes": [],
+                    "managedResourceNames": None,
                     "imagePatterns": [],
                     "resourceTemplates": [
                         {
@@ -646,6 +652,7 @@ def test_export_model(
             "deployResources": None,
             "slack": None,
             "managedResourceTypes": [],
+            "managedResourceNames": None,
             "takeover": None,
             "deprecated": None,
             "compare": None,
@@ -808,6 +815,7 @@ def test_export_model(
             "deployResources": None,
             "slack": None,
             "managedResourceTypes": [],
+            "managedResourceNames": None,
             "takeover": None,
             "deprecated": None,
             "compare": None,
@@ -970,6 +978,7 @@ def test_export_model(
             "deployResources": None,
             "slack": None,
             "managedResourceTypes": [],
+            "managedResourceNames": None,
             "takeover": None,
             "deprecated": None,
             "compare": None,

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -20,6 +20,7 @@ from reconcile.gql_definitions.common.saas_files import (
     AppV1,
     ConfiguredBaseModel,
     DeployResourcesV1,
+    ManagedResourceNamesV1,
     PipelinesProviderTektonV1,
     PipelinesProviderV1,
     RoleV1,
@@ -130,6 +131,9 @@ class SaasFile(ConfiguredBaseModel):
         ..., alias="secretParameters"
     )
     validate_targets_in_app: Optional[bool] = Field(..., alias="validateTargetsInApp")
+    managed_resource_names: Optional[list[ManagedResourceNamesV1]] = Field(
+        ..., alias="managedResourceNames"
+    )
     resource_templates: list[SaasResourceTemplate] = Field(
         ..., alias="resourceTemplates"
     )

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -380,6 +380,12 @@ class SaasRole(Protocol):
 SaasPipelinesProviders = Union[SaasPipelinesProviderTekton, SaasPipelinesProvider]
 
 
+@runtime_checkable
+class ManagedResourceName(Protocol):
+    resource: str
+    resource_names: list[str]
+
+
 class SaasFile(HasParameters, HasSecretParameters, Protocol):
     path: str
     name: str
@@ -421,4 +427,8 @@ class SaasFile(HasParameters, HasSecretParameters, Protocol):
 
     @property
     def self_service_roles(self) -> Optional[Sequence[SaasRole]]:
+        ...
+
+    @property
+    def managed_resource_names(self) -> Optional[Sequence[ManagedResourceName]]:
         ...

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import (
     Any,
     Optional,
+    Sequence,
     Union,
 )
 
@@ -15,6 +16,7 @@ from pydantic import (
 
 from reconcile.utils.oc_connection_parameters import Cluster
 from reconcile.utils.saasherder.interfaces import (
+    ManagedResourceName,
     SaasApp,
     SaasEnvironment,
     SaasPipelinesProviders,
@@ -134,6 +136,9 @@ class Namespace(BaseModel):
     app: SaasApp
     cluster: Cluster
     managed_resource_types: list[str] = Field(..., alias="managedResourceTypes")
+    managed_resource_names: Optional[Sequence[ManagedResourceName]] = Field(
+        ..., alias="managedResourceNames"
+    )
 
     class Config:
         arbitrary_types_allowed = True
@@ -191,6 +196,7 @@ class TargetSpec:
     cluster: str
     namespace: str
     managed_resource_types: Iterable[str]
+    managed_resource_names: Optional[Sequence[ManagedResourceName]]
     delete: bool
     privileged: bool
     image_auth: ImageAuth


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-4355

in this PR we leverage the `managedResourceNames` field in saas files (currently unused) to create an experience similar to using that field in namespace files. we override that field of the namespace with the same field coming from the saas file (like we do for `managedResourceTypes`) and let the core openshift_base logic take over.

this is basically sufficient and will create an identical experience to namespace files - an exception and failure in case a desired item is not defined in `managedResourceNames`.

in saas files, differently, we want to allow the openshift template to contain other resources, and simply filter them. for that, we except `ResourceNotManagedError`. the approach of excepting and handling the error out of the core logic is following lessons learned in #1622.