### PR TITLE
Fix Markdown error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Release version are calculated from git tags of the form X.Y.Z.
 - If the current commit has such a tag, it will be used as is
 - Otherwise the latest tag of that format is used and:
   - the patch label (Z) is incremented
-  - the string `.pre<count>+<commitid>` is appended. `<count>` is the number of commits since the X.Y.Z tag. `<commitid> is... the current commitid.
+  - the string `.pre<count>+<commitid>` is appended. `<count>` is the number of commits since the X.Y.Z tag. `<commitid>` is... the current commitid.
 
 After the PR is merged, a CI job will be triggered that will publish the package to pypi: https://pypi.org/project/qontract-reconcile.
 


### PR DESCRIPTION
A trailing \` was missing causing `<commitid>` to not render properly.