### PR TITLE
Fix S3 -> SQS Notifications 

### DIFF
--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
@@ -56,7 +56,7 @@ query TerraformResourcesNamespaces {
                 overrides
                 sqs_identifier
                 s3_events
-                sns_event_notifications: event_notifications {
+                event_notifications {
                     destination_type
                     destination
                     event_type

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
@@ -95,7 +95,7 @@ query TerraformResourcesNamespaces {
                 overrides
                 sqs_identifier
                 s3_events
-                sns_event_notifications: event_notifications {
+                event_notifications {
                     destination_type
                     destination
                     event_type
@@ -560,8 +560,8 @@ class NamespaceTerraformResourceS3V1(NamespaceTerraformResourceAWSV1):
     overrides: Optional[str] = Field(..., alias="overrides")
     sqs_identifier: Optional[str] = Field(..., alias="sqs_identifier")
     s3_events: Optional[list[str]] = Field(..., alias="s3_events")
-    sns_event_notifications: Optional[list[AWSS3EventNotificationV1]] = Field(
-        ..., alias="sns_event_notifications"
+    event_notifications: Optional[list[AWSS3EventNotificationV1]] = Field(
+        ..., alias="event_notifications"
     )
     bucket_policy: Optional[str] = Field(..., alias="bucket_policy")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")


### PR DESCRIPTION
Ticket: https://issues.redhat.com/browse/APPSRE-8351

A GQL change broke the event_notifications functionality of S3 buckets due to an alias being used in GQL. This MR removes that alias and adds a test for this functionality specifically for sending notifications to SQS from S3.

I also ran QR locally against App Interface production and noted that the output indicates that the bucket notification objects are being created now.

[2023-09-20 09:27:11] [INFO] [DRY-RUN] [terraform_client.py:log_plan_diff:332] - ['create', 'app-sre-stage', 'aws_s3_bucket_notification', 'a-stage-event-notifications', set()]
[2023-09-20 09:27:11] [INFO] [DRY-RUN] [terraform_client.py:log_plan_diff:332] - ['create', 'app-sre-stage', 'aws_s3_bucket_notification', 'b-stage-event-notifications', set()]

Slack discussion here: https://redhat-internal.slack.com/archives/GGC2A0MS8/p1695144541954949

(Take two because I forgot to push my tests :facepalm: )
