### PR TITLE
Bump versions for container images

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/qontract-reconcile-builder:0.5.1 as build-image
+FROM quay.io/app-sre/qontract-reconcile-builder:0.5.2 as build-image
 
 WORKDIR /work
 
@@ -14,7 +14,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
     python3 -m pip wheel . --wheel-dir /work/wheels
 
 
-FROM quay.io/app-sre/qontract-reconcile-base:0.10.1 as dev-image
+FROM quay.io/app-sre/qontract-reconcile-base:0.10.2 as dev-image
 
 ARG CONTAINER_UID=1000
 RUN useradd --uid ${CONTAINER_UID} reconcile
@@ -44,7 +44,7 @@ VOLUME ["/work"]
 ENTRYPOINT ["/work/dev/run.sh"]
 
 
-FROM quay.io/app-sre/qontract-reconcile-base:0.10.1 as prod-image
+FROM quay.io/app-sre/qontract-reconcile-base:0.10.2 as prod-image
 
 # Cache mount. We don't need te wheel files in the final image.
 # This COPY will create a layer with all the wheel files to install the app.

--- a/dockerfiles/Dockerfile.publish-release
+++ b/dockerfiles/Dockerfile.publish-release
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/qontract-reconcile-builder:0.5.1 as build-image
+FROM quay.io/app-sre/qontract-reconcile-builder:0.5.2 as build-image
 
 WORKDIR /work
 

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/qontract-reconcile-builder:0.5.1
+FROM quay.io/app-sre/qontract-reconcile-builder:0.5.2
 
 ENV TOX_PARALLEL_NO_SPINNER=1
 


### PR DESCRIPTION
Bump version for container images, changes in https://github.com/app-sre/container-images/pull/88, this is to support https://github.com/app-sre/qontract-reconcile/pull/3793.