### PR TITLE
Bring back S3 -> SQS Notifications MR

### DIFF
--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
@@ -56,7 +56,7 @@ query TerraformResourcesNamespaces {
                 overrides
                 sqs_identifier
                 s3_events
-                sns_event_notifications: event_notifications {
+                event_notifications {
                     destination_type
                     destination
                     event_type

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
@@ -95,7 +95,7 @@ query TerraformResourcesNamespaces {
                 overrides
                 sqs_identifier
                 s3_events
-                sns_event_notifications: event_notifications {
+                event_notifications {
                     destination_type
                     destination
                     event_type
@@ -560,8 +560,8 @@ class NamespaceTerraformResourceS3V1(NamespaceTerraformResourceAWSV1):
     overrides: Optional[str] = Field(..., alias="overrides")
     sqs_identifier: Optional[str] = Field(..., alias="sqs_identifier")
     s3_events: Optional[list[str]] = Field(..., alias="s3_events")
-    sns_event_notifications: Optional[list[AWSS3EventNotificationV1]] = Field(
-        ..., alias="sns_event_notifications"
+    event_notifications: Optional[list[AWSS3EventNotificationV1]] = Field(
+        ..., alias="event_notifications"
     )
     bucket_policy: Optional[str] = Field(..., alias="bucket_policy")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")


### PR DESCRIPTION
Un-revert the revert...

Brings back this change: https://github.com/app-sre/qontract-reconcile/pull/3818

After some further discussion, the code is sound however the errors that showed up in App Interface were due to a tenant specifying multiple destionations for an event notification. See the AWS docs here: https://docs.aws.amazon.com/AmazonS3/latest/userguide/notification-how-to-event-types-and-destinations.html

My plan is to re-introduce this fix into QR and remove one of the tenant's queues as well as update our README docs to inform tenants of this limitation. It's not very feasible to validate this limitation at `plan` time.