### PR TITLE
Handle default work machine pool for ocm-clusters and ocm-machine-pools Part 1

### DIFF
--- a/reconcile/ocm/types.py
+++ b/reconcile/ocm/types.py
@@ -99,7 +99,9 @@ class ClusterMachinePool(BaseModel):
 class OCMSpec(BaseModel):
     path: Optional[str]
     spec: Union[OSDClusterSpec, ROSAClusterSpec, OCMClusterSpec]
-    machine_pools: list[ClusterMachinePool] = Field(..., alias="machinePools")
+    machine_pools: list[ClusterMachinePool] = Field(
+        default_factory=list, alias="machinePools"
+    )
     network: OCMClusterNetwork
     domain: Optional[str]
     server_url: str = Field("", alias="serverUrl")

--- a/reconcile/ocm/types.py
+++ b/reconcile/ocm/types.py
@@ -89,9 +89,17 @@ class ROSAClusterSpec(OCMClusterSpec):
         extra = Extra.forbid
 
 
+class ClusterMachinePool(BaseModel):
+    id: str
+    instance_type: str
+    replicas: Optional[int]
+    autoscale: Optional[OCMClusterAutoscale]
+
+
 class OCMSpec(BaseModel):
     path: Optional[str]
     spec: Union[OSDClusterSpec, ROSAClusterSpec, OCMClusterSpec]
+    machine_pools: list[ClusterMachinePool] = Field(..., alias="machinePools")
     network: OCMClusterNetwork
     domain: Optional[str]
     server_url: str = Field("", alias="serverUrl")

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -362,6 +362,9 @@ def run(dry_run: bool, gitlab_project_id=None, thread_pool_size=10):
                     "its manifest to app-interface"
                 )
                 error = True
+            except ocmmod.OCMValidationException as e:
+                logging.error("[%s] Error creating cluster: %s", cluster_name, e)
+                error = True
 
     _app_interface_updates_mr(clusters_updates, gitlab_project_id, dry_run)
     sys.exit(int(error))

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -311,10 +311,12 @@ class DesiredMachinePool(BaseModel):
         action: str,
         pool: ClusterMachinePoolV1,
     ) -> PoolHandler:
-        pool_class = NodePool if self.hypershift else MachinePool
+        pool_builder = (
+            NodePool.create_from_gql if self.hypershift else MachinePool.create_from_gql
+        )
         return PoolHandler(
             action=action,
-            pool=pool_class.create_from_gql(pool, self.cluster_name),
+            pool=pool_builder(pool, self.cluster_name),
         )
 
 

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -21,6 +21,7 @@ from reconcile.gql_definitions.common.clusters import (
     ClusterV1,
 )
 from reconcile.typed_queries.clusters import get_clusters
+from reconcile.utils.differ import diff_mappings
 from reconcile.utils.disabled_integrations import integration_is_enabled
 from reconcile.utils.ocm import (
     OCM,
@@ -123,6 +124,10 @@ class AbstractPool(ABC, BaseModel):
     def invalid_diff(self, pool: ClusterMachinePoolV1) -> Optional[str]:
         pass
 
+    @abstractmethod
+    def deletable(self) -> bool:
+        pass
+
     def _has_diff_autoscale(self, pool):
         match (self.autoscaling, pool.autoscale):
             case (None, None):
@@ -173,6 +178,9 @@ class MachinePool(AbstractPool):
         if self.instance_type != pool.instance_type:
             return "instance_type"
         return None
+
+    def deletable(self) -> bool:
+        return True
 
     @classmethod
     def create_from_gql(cls, pool: ClusterMachinePoolV1, cluster: str):
@@ -245,6 +253,10 @@ class NodePool(AbstractPool):
             return "subnet"
         return None
 
+    def deletable(self) -> bool:
+        # As of now, you can not delete the first worker pool(s)
+        return not self.id.startswith("workers")
+
     @classmethod
     def create_from_gql(cls, pool: ClusterMachinePoolV1, cluster: str):
         autoscaling: Optional[NodePoolAutoscaling] = None
@@ -294,9 +306,16 @@ class DesiredMachinePool(BaseModel):
     hypershift: bool
     pools: list[ClusterMachinePoolV1]
 
-
-class DesiredStateList(BaseModel):
-    cluster_pools: list[DesiredMachinePool]
+    def build_pool_handler(
+        self,
+        action: str,
+        pool: ClusterMachinePoolV1,
+    ) -> PoolHandler:
+        pool_class = NodePool if self.hypershift else MachinePool
+        return PoolHandler(
+            action=action,
+            pool=pool_class.create_from_gql(pool, self.cluster_name),
+        )
 
 
 def fetch_current_state(
@@ -309,8 +328,12 @@ def fetch_current_state(
     }
 
 
+def _is_hypershift(cluster: ClusterV1) -> bool:
+    return bool(cluster.spec and cluster.spec.hypershift)
+
+
 def fetch_current_state_for_cluster(cluster, ocm):
-    if cluster.spec and cluster.spec.hypershift:
+    if _is_hypershift(cluster):
         return [
             NodePool(
                 id=node_pool["id"],
@@ -353,106 +376,81 @@ def fetch_current_state_for_cluster(cluster, ocm):
 
 def create_desired_state_from_gql(
     clusters: Iterable[ClusterV1],
-) -> DesiredStateList:
-    desired_state: DesiredStateList = DesiredStateList(cluster_pools=[])
-    for cluster in clusters:
-        if cluster.machine_pools:
-            is_hypershift = False
-            if cluster.spec:
-                is_hypershift = True if cluster.spec.hypershift else False
-            desired_state.cluster_pools.append(
-                DesiredMachinePool(
-                    cluster_name=cluster.name,
-                    hypershift=is_hypershift,
-                    pools=cluster.machine_pools,
-                )
-            )
-
-    return desired_state
+) -> dict[str, DesiredMachinePool]:
+    return {
+        cluster.name: DesiredMachinePool(
+            cluster_name=cluster.name,
+            hypershift=_is_hypershift(cluster),
+            pools=cluster.machine_pools,
+        )
+        for cluster in clusters
+        if cluster.machine_pools is not None
+    }
 
 
 def calculate_diff(
     current_state: Mapping[str, list[AbstractPool]],
-    desired_state: DesiredStateList,
+    desired_state: Mapping[str, DesiredMachinePool],
 ) -> tuple[list[PoolHandler], list[InvalidUpdateError]]:
+    current_machine_pools = {
+        (cluster_name, machine_pool.id): machine_pool
+        for cluster_name, machine_pools in current_state.items()
+        for machine_pool in machine_pools
+    }
+
+    desired_machine_pools = {
+        (desired.cluster_name, desired_machine_pool.q_id): desired_machine_pool
+        for desired in desired_state.values()
+        for desired_machine_pool in desired.pools
+    }
+
+    diff_result = diff_mappings(
+        current_machine_pools,
+        desired_machine_pools,
+        equal=lambda current, desired: not current.has_diff(desired),
+    )
+
     diffs: list[PoolHandler] = []
     errors: list[InvalidUpdateError] = []
 
-    all_desired_pools: set[tuple[str, str]] = set()
-    for desired in desired_state.cluster_pools:
-        for desired_machine_pool in desired.pools:
-            current_machine_pool = [
-                p
-                for p in current_state.get(desired.cluster_name, [])
-                if p.id == desired_machine_pool.q_id
-            ]
-            all_desired_pools.add((desired_machine_pool.q_id, desired.cluster_name))
-            if not current_machine_pool:
-                if desired.hypershift:
-                    diffs.append(
-                        PoolHandler(
-                            action="create",
-                            pool=NodePool.create_from_gql(
-                                pool=desired_machine_pool,
-                                cluster=desired.cluster_name,
-                            ),
-                        )
-                    )
-                else:
-                    diffs.append(
-                        PoolHandler(
-                            action="create",
-                            pool=MachinePool.create_from_gql(
-                                pool=desired_machine_pool,
-                                cluster=desired.cluster_name,
-                            ),
-                        )
-                    )
-                    continue
-            elif current_machine_pool[0].has_diff(desired_machine_pool):
-                invalid_diff = current_machine_pool[0].invalid_diff(
-                    desired_machine_pool
+    for (cluster_name, _), desired_machine_pool in diff_result.add.items():
+        diffs.append(
+            desired_state[cluster_name].build_pool_handler(
+                "create",
+                desired_machine_pool,
+            )
+        )
+    for (cluster_name, _), diff_pair in diff_result.change.items():
+        invalid_diff = diff_pair.current.invalid_diff(diff_pair.desired)
+        if invalid_diff:
+            errors.append(
+                InvalidUpdateError(
+                    f"can not update {invalid_diff} for existing machine pool"
                 )
-                if invalid_diff:
-                    errors.append(
-                        InvalidUpdateError(
-                            f"can not update {invalid_diff} for existing machine pool"
-                        )
-                    )
-                else:
-                    if desired.hypershift:
-                        diffs.append(
-                            PoolHandler(
-                                action="update",
-                                pool=NodePool.create_from_gql(
-                                    pool=desired_machine_pool,
-                                    cluster=desired.cluster_name,
-                                ),
-                            )
-                        )
-                    else:
-                        diffs.append(
-                            PoolHandler(
-                                action="update",
-                                pool=MachinePool.create_from_gql(
-                                    pool=desired_machine_pool,
-                                    cluster=desired.cluster_name,
-                                ),
-                            )
-                        )
+            )
+        else:
+            diffs.append(
+                desired_state[cluster_name].build_pool_handler(
+                    "update",
+                    diff_pair.desired,
+                )
+            )
 
-    for cluster_name, machine_pools in current_state.items():
-        for pool in machine_pools:
-            if (pool.id, cluster_name) not in all_desired_pools:
-                if pool.id.startswith("workers"):
-                    # As of now, you can not delete the first worker pool(s)
-                    continue
-                diffs.append(
-                    PoolHandler(
-                        action="delete",
-                        pool=pool,
-                    )
+    for (cluster_name, _), current_machine_pool in diff_result.delete.items():
+        if not desired_state[cluster_name].pools:
+            errors.append(
+                InvalidUpdateError(
+                    f"can not delete all machine pools for cluster {cluster_name}"
                 )
+            )
+        elif current_machine_pool.deletable():
+            diffs.append(
+                PoolHandler(
+                    action="delete",
+                    pool=current_machine_pool,
+                )
+            )
+
     return diffs, errors
 
 

--- a/reconcile/test/fixtures/clusters/osd_spec.json
+++ b/reconcile/test/fixtures/clusters/osd_spec.json
@@ -148,7 +148,7 @@
   },
   "etcd_encryption": false,
   "billing_model": "standard",
-  "disable_user_workload_monitoring": true,
+  "disable_user_workload_monitoring": false,
   "managed_service": {
     "enabled": false
   },

--- a/reconcile/test/fixtures/clusters/osd_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/osd_spec_ai.yml
@@ -33,16 +33,18 @@ spec:
   version: 4.10.6
   initial_version: 4.8.10
   multi_az: true
-  instance_type: m5.2xlarge
   storage: 4100
   load_balancers: 4
   private: false
   provision_shard_id: provision_shard_id
+  disable_user_workload_monitoring: true
+  hypershift: null
+machinePools:
+- id: worker
+  instance_type: m5.2xlarge
   autoscale:
     min_replicas: 21
     max_replicas: 30
-  disable_user_workload_monitoring: true
-  hypershift: null
 network:
   type: OpenShiftSDN
   vpc: 10.112.0.0/16

--- a/reconcile/test/fixtures/clusters/osd_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/osd_spec_ai.yml
@@ -37,7 +37,7 @@ spec:
   load_balancers: 4
   private: false
   provision_shard_id: provision_shard_id
-  disable_user_workload_monitoring: true
+  disable_user_workload_monitoring: false
   hypershift: null
 machinePools:
 - id: worker

--- a/reconcile/test/fixtures/clusters/osd_spec_post.json
+++ b/reconcile/test/fixtures/clusters/osd_spec_post.json
@@ -5,7 +5,7 @@
   "cloud_provider": {
     "id": "aws"
   },
-  "disable_user_workload_monitoring": true,
+  "disable_user_workload_monitoring": false,
   "load_balancer_quota": 4,
   "multi_az": true,
   "name": "test-cluster",

--- a/reconcile/test/fixtures/clusters/rosa_spec.json
+++ b/reconcile/test/fixtures/clusters/rosa_spec.json
@@ -206,7 +206,7 @@
   },
   "etcd_encryption": false,
   "billing_model": "standard",
-  "disable_user_workload_monitoring": false,
+  "disable_user_workload_monitoring": true,
   "managed_service": {
     "enabled": false
   },

--- a/reconcile/test/fixtures/clusters/rosa_spec.json
+++ b/reconcile/test/fixtures/clusters/rosa_spec.json
@@ -206,7 +206,7 @@
   },
   "etcd_encryption": false,
   "billing_model": "standard",
-  "disable_user_workload_monitoring": true,
+  "disable_user_workload_monitoring": false,
   "managed_service": {
     "enabled": false
   },

--- a/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
@@ -53,7 +53,7 @@ spec:
   multi_az: false
   private: false
   provision_shard_id: provision_shard_id
-  disable_user_workload_monitoring: true
+  disable_user_workload_monitoring: false
 machinePools:
 - id: worker
   instance_type: m5.xlarge

--- a/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
@@ -47,7 +47,7 @@ spec:
   external_id: "external-id"
   provider: aws
   region: us-east-1
-  channel: 2
+  channel: stable
   version: 4.10.16
   initial_version: 4.8.10
   multi_az: false

--- a/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
@@ -51,13 +51,15 @@ spec:
   version: 4.10.16
   initial_version: 4.8.10
   multi_az: false
-  instance_type: m5.xlarge
   private: false
   provision_shard_id: provision_shard_id
+  disable_user_workload_monitoring: true
+machinePools:
+- id: worker
+  instance_type: m5.xlarge
   autoscale:
     min_replicas: 21
     max_replicas: 30
-  disable_user_workload_monitoring: true
 network:
   type: OpenShiftSDN
   vpc: 10.0.0.0/16

--- a/reconcile/test/fixtures/clusters/rosa_spec_post.json
+++ b/reconcile/test/fixtures/clusters/rosa_spec_post.json
@@ -54,6 +54,7 @@
     "id": "us-east-1"
   },
   "version": {
-    "channel_group": "2", "id": "openshift-v4.8.10"
+    "channel_group": "stable",
+    "id": "openshift-v4.8.10"
   }
 }

--- a/reconcile/test/fixtures/clusters/rosa_spec_post.json
+++ b/reconcile/test/fixtures/clusters/rosa_spec_post.json
@@ -22,7 +22,7 @@
   "cloud_provider": {
     "id": "aws"
   },
-  "disable_user_workload_monitoring": true,
+  "disable_user_workload_monitoring": false,
   "hypershift": {
     "enabled": null
   },

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -617,7 +617,7 @@ def test_ocm_rosa_update_cluster_with_machine_pools_change(
         ]
     }
     get_json_mock.return_value = {"items": [ocm_rosa_cluster_raw_spec]}
-    queries_mock[1].return_value = [ocm_rosa_cluster_ai_spec]
+    queries_mock[1].return_value = [new_spec]
 
     with pytest.raises(SystemExit):
         occ.run(dry_run=False)

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -11,6 +11,7 @@ from reconcile import (
     queries,
 )
 from reconcile.ocm.types import (
+    ClusterMachinePool,
     OCMClusterNetwork,
     OCMSpec,
     OSDClusterSpec,
@@ -86,8 +87,16 @@ def ocm_osd_cluster_spec():
         storage=1100,
         provider="aws",
     )
+    machine_pools = [
+        ClusterMachinePool(
+            id="worker",
+            instance_type="m5.xlarge",
+            replicas=5,
+        )
+    ]
     obj = OCMSpec(
         spec=spec,
+        machine_pools=machine_pools,
         network=n,
         domain="devshift.net",
         server_url="https://api.test-cluster.0000.p1.openshiftapps.com:6443",
@@ -111,12 +120,17 @@ def osd_cluster_fxt():
             "version": "4.10.0",
             "initial_version": "4.9.0-candidate",
             "multi_az": False,
-            "nodes": 5,
-            "instance_type": "m5.xlarge",
             "private": False,
             "provision_shard_id": "the-cluster-provision_shard_id",
             "disable_user_workload_monitoring": True,
         },
+        "machinePools": [
+            {
+                "id": "worker",
+                "instance_type": "m5.xlarge",
+                "replicas": 5,
+            }
+        ],
         "network": {
             "type": None,
             "vpc": "10.112.0.0/16",
@@ -184,12 +198,17 @@ def rosa_cluster_fxt():
             "version": "4.10.0",
             "initial_version": "4.9.0-candidate",
             "multi_az": False,
-            "nodes": 5,
-            "instance_type": "m5.xlarge",
             "private": False,
             "provision_shard_id": "the-cluster-provision_shard_id",
             "disable_user_workload_monitoring": True,
         },
+        "machinePools": [
+            {
+                "id": "worker",
+                "instance_type": "m5.xlarge",
+                "replicas": 5,
+            },
+        ],
         "network": {
             "type": None,
             "vpc": "10.112.0.0/16",

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -495,15 +495,38 @@ def test_ocm_osd_create_cluster(
     get_json_mock.return_value = {"items": []}
     queries_mock[1].return_value = [ocm_osd_cluster_ai_spec]
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as sys_exit:
         occ.run(dry_run=False)
 
+    assert sys_exit.value.code == 0
     _post, _patch = ocm_mock
     _post.assert_called_once_with(
         "/api/clusters_mgmt/v1/clusters",
         ocm_osd_cluster_post_spec,
         {},
     )
+    _patch.assert_not_called()
+    cluster_updates_mr_mock.assert_not_called()
+
+
+def test_ocm_osd_create_cluster_without_machine_pools(
+    get_json_mock,
+    queries_mock,
+    ocm_mock,
+    cluster_updates_mr_mock,
+    ocm_osd_cluster_ai_spec,
+    ocm_osd_cluster_post_spec,
+):
+    get_json_mock.return_value = {"items": []}
+    bad_spec = ocm_osd_cluster_ai_spec | {"machinePools": []}
+    queries_mock[1].return_value = [bad_spec]
+
+    with pytest.raises(SystemExit) as sys_exit:
+        occ.run(dry_run=False)
+
+    assert sys_exit.value.code == 1
+    _post, _patch = ocm_mock
+    _post.assert_not_called()
     _patch.assert_not_called()
     cluster_updates_mr_mock.assert_not_called()
 
@@ -520,16 +543,39 @@ def test_ocm_rosa_create_cluster(
     queries_mock[1].return_value = [ocm_rosa_cluster_ai_spec]
 
     with patch("reconcile.utils.ocm.random.choices", return_value=["c", "n", "z", "y"]):
-        with pytest.raises(SystemExit):
+        with pytest.raises(SystemExit) as sys_exit:
             occ.run(dry_run=False)
 
+    assert sys_exit.value.code == 0
     _post, _patch = ocm_mock
-
     _post.assert_called_once_with(
         "/api/clusters_mgmt/v1/clusters",
         ocm_rosa_cluster_post_spec,
         {},
     )
+    _patch.assert_not_called()
+    cluster_updates_mr_mock.assert_not_called()
+
+
+def test_ocm_rosa_create_cluster_without_machine_pools(
+    get_json_mock,
+    queries_mock,
+    ocm_mock,
+    cluster_updates_mr_mock,
+    ocm_rosa_cluster_ai_spec,
+    ocm_rosa_cluster_post_spec,
+):
+    get_json_mock.return_value = {"items": []}
+    bad_spec = ocm_rosa_cluster_ai_spec | {"machinePools": []}
+    queries_mock[1].return_value = [bad_spec]
+
+    with patch("reconcile.utils.ocm.random.choices", return_value=["c", "n", "z", "y"]):
+        with pytest.raises(SystemExit) as sys_exit:
+            occ.run(dry_run=False)
+
+    assert sys_exit.value.code == 1
+    _post, _patch = ocm_mock
+    _post.assert_not_called()
     _patch.assert_not_called()
     cluster_updates_mr_mock.assert_not_called()
 

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -599,6 +599,35 @@ def test_ocm_rosa_update_cluster(
     assert cluster_updates_mr_mock.call_count == 0
 
 
+def test_ocm_rosa_update_cluster_with_machine_pools_change(
+    get_json_mock,
+    queries_mock,
+    ocm_mock,
+    cluster_updates_mr_mock,
+    ocm_rosa_cluster_raw_spec,
+    ocm_rosa_cluster_ai_spec,
+):
+    new_spec = ocm_rosa_cluster_ai_spec | {
+        "machinePools": [
+            {
+                "id": "new",
+                "instance_type": "m5.xlarge",
+                "replicas": 1,
+            }
+        ]
+    }
+    get_json_mock.return_value = {"items": [ocm_rosa_cluster_raw_spec]}
+    queries_mock[1].return_value = [ocm_rosa_cluster_ai_spec]
+
+    with pytest.raises(SystemExit):
+        occ.run(dry_run=False)
+
+    _post, _patch = ocm_mock
+    _post.assert_not_called()
+    _patch.assert_not_called()
+    cluster_updates_mr_mock.assert_not_called()
+
+
 def test_ocm_osd_update_cluster(
     get_json_mock,
     queries_mock,
@@ -616,6 +645,35 @@ def test_ocm_osd_update_cluster(
     assert _post.call_count == 0
     assert _patch.call_count == 1
     assert cluster_updates_mr_mock.call_count == 0
+
+
+def test_ocm_osd_update_cluster_with_machine_pools_change(
+    get_json_mock,
+    queries_mock,
+    ocm_mock,
+    cluster_updates_mr_mock,
+    ocm_osd_cluster_raw_spec,
+    ocm_osd_cluster_ai_spec,
+):
+    new_spec = ocm_osd_cluster_ai_spec | {
+        "machinePools": [
+            {
+                "id": "new",
+                "instance_type": "m5.xlarge",
+                "replicas": 1,
+            }
+        ]
+    }
+    get_json_mock.return_value = {"items": [ocm_osd_cluster_raw_spec]}
+    queries_mock[1].return_value = [new_spec]
+
+    with pytest.raises(SystemExit):
+        occ.run(dry_run=False)
+
+    _post, _patch = ocm_mock
+    _post.assert_not_called()
+    _patch.assert_not_called()
+    cluster_updates_mr_mock.assert_not_called()
 
 
 def test_ocm_returns_a_rosa_cluster(

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -120,6 +120,10 @@ OCM_PRODUCT_HYPERSHIFT = "hypershift"
 DEFAULT_OCM_MACHINE_POOL_ID = "worker"
 
 
+class OCMValidationException(Exception):
+    pass
+
+
 class OCMProduct:
     ALLOWED_SPEC_UPDATE_FIELDS: set[str]
     EXCLUDED_SPEC_FIELDS: set[str]
@@ -243,7 +247,7 @@ class OCMProductOsd(OCMProduct):
         return ocm_spec
 
     @staticmethod
-    def _get_nodes_spec(cluster: OCMSpec) -> dict[str, Any] | None:
+    def _get_nodes_spec(cluster: OCMSpec) -> dict[str, Any]:
         default_machine_pool = next(
             (
                 mp
@@ -253,7 +257,9 @@ class OCMProductOsd(OCMProduct):
             None,
         )
         if default_machine_pool is None:
-            return None
+            raise OCMValidationException(
+                f"No default machine pool found, id: {DEFAULT_OCM_MACHINE_POOL_ID}"
+            )
 
         spec = {
             "compute_machine_type": {"id": default_machine_pool.instance_type},
@@ -460,7 +466,7 @@ class OCMProductRosa(OCMProduct):
         return ocm_spec
 
     @staticmethod
-    def _get_nodes_spec(cluster: OCMSpec) -> dict[str, Any] | None:
+    def _get_nodes_spec(cluster: OCMSpec) -> dict[str, Any]:
         default_machine_pool = next(
             (
                 mp
@@ -470,7 +476,9 @@ class OCMProductRosa(OCMProduct):
             None,
         )
         if default_machine_pool is None:
-            return None
+            raise OCMValidationException(
+                f"No default machine pool found, id: {DEFAULT_OCM_MACHINE_POOL_ID}"
+            )
 
         spec = {
             "compute_machine_type": {"id": default_machine_pool.instance_type},

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -164,6 +164,10 @@ class OCMProductOsd(OCMProduct):
         SPEC_ATTR_VERSION,
         SPEC_ATTR_INITIAL_VERSION,
         SPEC_ATTR_HYPERSHIFT,
+        # TODO: Remove below fields after schema cleanup
+        SPEC_ATTR_INSTANCE_TYPE,
+        SPEC_ATTR_AUTOSCALE,
+        SPEC_ATTR_NODES,
     }
 
     @staticmethod
@@ -354,6 +358,10 @@ class OCMProductRosa(OCMProduct):
         SPEC_ATTR_HYPERSHIFT,
         SPEC_ATTR_SUBNET_IDS,
         SPEC_ATTR_AVAILABILITY_ZONES,
+        # TODO: Remove below fields after schema cleanup
+        SPEC_ATTR_INSTANCE_TYPE,
+        SPEC_ATTR_AUTOSCALE,
+        SPEC_ATTR_NODES,
     }
 
     @staticmethod

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -18,7 +18,6 @@ import reconcile.utils.aws_helper as awsh
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.ocm.types import (
     ClusterMachinePool,
-    OCMClusterAutoscale,
     OCMClusterNetwork,
     OCMClusterSpec,
     OCMSpec,
@@ -263,7 +262,7 @@ class OCMProductOsd(OCMProduct):
                 f"No default machine pool found, id: {DEFAULT_OCM_MACHINE_POOL_ID}"
             )
 
-        spec = {
+        spec: dict[str, Any] = {
             "compute_machine_type": {"id": default_machine_pool.instance_type},
         }
         if default_machine_pool.autoscale is not None:
@@ -479,7 +478,7 @@ class OCMProductRosa(OCMProduct):
                 f"No default machine pool found, id: {DEFAULT_OCM_MACHINE_POOL_ID}"
             )
 
-        spec = {
+        spec: dict[str, Any] = {
             "compute_machine_type": {"id": default_machine_pool.instance_type},
         }
         if default_machine_pool.autoscale is not None:

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -154,8 +154,6 @@ class OCMProductOsd(OCMProduct):
         SPEC_ATTR_LOAD_BALANCERS,
         SPEC_ATTR_PRIVATE,
         SPEC_ATTR_CHANNEL,
-        SPEC_ATTR_AUTOSCALE,
-        SPEC_ATTR_NODES,
         SPEC_ATTR_DISABLE_UWM,
     }
 
@@ -330,14 +328,6 @@ class OCMProductOsd(OCMProduct):
         if channel is not None:
             ocm_spec["version"] = {"channel_group": channel}
 
-        autoscale = update_spec.get("autoscale")
-        if autoscale is not None:
-            ocm_spec["nodes"] = {"autoscale_compute": autoscale}
-
-        nodes = update_spec.get("nodes")
-        if nodes:
-            ocm_spec["nodes"] = {"compute": update_spec["nodes"]}
-
         disable_uwm = update_spec.get("disable_user_workload_monitoring")
         if disable_uwm is not None:
             ocm_spec["disable_user_workload_monitoring"] = disable_uwm
@@ -348,8 +338,6 @@ class OCMProductOsd(OCMProduct):
 class OCMProductRosa(OCMProduct):
     ALLOWED_SPEC_UPDATE_FIELDS = {
         SPEC_ATTR_CHANNEL,
-        SPEC_ATTR_AUTOSCALE,
-        SPEC_ATTR_NODES,
         SPEC_ATTR_DISABLE_UWM,
     }
 
@@ -570,14 +558,6 @@ class OCMProductRosa(OCMProduct):
         channel = update_spec.get(SPEC_ATTR_CHANNEL)
         if channel is not None:
             ocm_spec["version"] = {"channel_group": channel}
-
-        autoscale = update_spec.get(SPEC_ATTR_AUTOSCALE)
-        if autoscale is not None:
-            ocm_spec["nodes"] = {"autoscale_compute": autoscale}
-
-        nodes = update_spec.get(SPEC_ATTR_NODES)
-        if nodes:
-            ocm_spec["nodes"] = {"compute": update_spec["nodes"]}
 
         disable_uwm = update_spec.get(SPEC_ATTR_DISABLE_UWM)
         if disable_uwm is not None:

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -1116,10 +1116,6 @@ class OCM:  # pylint: disable=too-many-public-methods
             return results
 
         for item in items:
-            # API changed and now returns worker pool, but we do not want to manage that here
-            # APPSRE-8258
-            if item["id"] == "worker":
-                continue
             result = {k: v for k, v in item.items() if k in MACHINE_POOL_DESIRED_KEYS}
             results.append(result)
 

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -287,8 +287,11 @@ class OCMProductOsd(OCMProduct):
                 "pod_cidr": cluster.network.pod,
             },
             "api": {"listening": "internal" if cluster.spec.private else "external"},
-            "disable_user_workload_monitoring": cluster.spec.disable_user_workload_monitoring
-            or True,
+            "disable_user_workload_monitoring": (
+                duwm
+                if (duwm := cluster.spec.disable_user_workload_monitoring) is not None
+                else True
+            ),
         }
 
         # Workaround to enable type checks.
@@ -501,8 +504,11 @@ class OCMProductRosa(OCMProduct):
                 "service_cidr": cluster.network.service,
                 "pod_cidr": cluster.network.pod,
             },
-            "disable_user_workload_monitoring": cluster.spec.disable_user_workload_monitoring
-            or True,
+            "disable_user_workload_monitoring": (
+                duwm
+                if (duwm := cluster.spec.disable_user_workload_monitoring) is not None
+                else True
+            ),
         }
 
         provision_shard_id = cluster.spec.provision_shard_id


### PR DESCRIPTION
OCM API starts to return default worker machine pool (id `worker`) when listing machine pools, this change adapt `ocm-clusters` and `ocm-machine-pools` to handle it properly.

Now `ocm-clusters` will only use `machinePools` in `/openshift/cluster-1.yml` to populate payload for cluster creation, after that all machine pools including the default one is managed by `ocm-machine-pools`.

Fix a bug for cluster creation `disable_user_workload_monitoring` always `True`.

This reverts https://github.com/app-sre/qontract-reconcile/pull/3773

There will be schema and code cleanup in part 2 after part 1 deployed.


[APPSRE-8258](https://issues.redhat.com/browse/APPSRE-8258)


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d1fcc4c</samp>

This pull request adds support for machine pools configuration for OCM clusters, updates the cluster spec structure and the OCM API calls, and fixes some fixture files and tests. It also refactors some code and adds validation and error handling for invalid or unsupported machine pool changes.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at d1fcc4c</samp>

*  Add a new exception class `OCMValidationException` to handle invalid cluster specs ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L119-R125))
*  Remove the `instance_type`, `autoscale`, and `nodes` fields from the `OSDClusterSpec` and `ROSAClusterSpec` classes and replace them with a new `machine_pools` field, which is a list of `ClusterMachinePool` objects that represent the machine pools configuration for OCM clusters ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L20-R20), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L195-L204), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L214), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L220-L221), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6R228-R231), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6R244), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L387-L396), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L427), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L433-L434), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6R442-R445), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6R460))
*  Add a new model class `ClusterMachinePool` to store the machine pool configuration for each cluster ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-37783785076a166eb8f3706bf280dc91a61616a522f5b24c879c29160c9cb8beL92-R104))
*  Add a new static method `_get_nodes_spec` to the `OCMProductOsd` and `OCMProductRosa` classes to create the nodes spec for the OCM API calls from the `machine_pools` field of the cluster spec, and raise an `OCMValidationException` if the default machine pool with the id "worker" is not found ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6R251-R274), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6R467-R490))
*  Modify the `_get_create_cluster_spec` and `_get_update_cluster_spec` functions in the `OCMProductOsd` and `OCMProductRosa` classes to use the `_get_nodes_spec` method to create the nodes spec for the cluster, and simplify the logic for setting the `disable_user_workload_monitoring` field ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L261-R285), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L269-R297), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L288-L293), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L316-L323), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L476-R507), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L483-R518), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L492-L497), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L547-L554))
*  Remove the `SPEC_ATTR_AUTOSCALE` and `SPEC_ATTR_NODES` constants from the `ALLOWED_SPEC_UPDATE_FIELDS` sets in the `OCMProductOsd` and `OCMProductRosa` classes, as they are no longer used or supported by the OCM API for cluster updates, and add the `SPEC_ATTR_INSTANCE_TYPE`, `SPEC_ATTR_AUTOSCALE`, and `SPEC_ATTR_NODES` constants temporarily to avoid breaking the schema validation until the schema is cleaned up ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L150-L151), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6R166-R169), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L334-L335), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6R360-R363))
*  Modify the `get_ocm_spec` function in the `OCMProductOsd` and `OCMProductRosa` classes to create the `machine_pools` list from the `machinePools` field in the cluster data, or an empty list if the field is missing ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6R228-R231), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6R442-R445))
*  Modify the `get_machine_pools` function in the `OCM` class to remove the code that filters out the machine pool with the id "worker", as the OCM API now returns only the machine pools that are managed by the user ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d958fe76bb4d6bd2498eaa126196090836aeb24ffd4a5ba3310a44595c4c2cc6L1106-L1109))
*  Add a new abstract method `deletable` to the `AbstractPool` class and implement it for the `MachinePool` and `NodePool` classes, to check if a machine pool can be deleted or not ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-eeceffbceb8fdf008edf0e87f095e168a636b2c2c9081be6eb6c4fe766a071cbR127-R130), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-eeceffbceb8fdf008edf0e87f095e168a636b2c2c9081be6eb6c4fe766a071cbR182-R184), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-eeceffbceb8fdf008edf0e87f095e168a636b2c2c9081be6eb6c4fe766a071cbR256-R259))
*  Modify the `DesiredMachinePool` class to add a new method `build_pool_handler`, which takes an action and a pool as arguments and returns a `PoolHandler` object, using the `hypershift` attribute of the class to determine whether to create a `NodePool` or a `MachinePool` object ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-eeceffbceb8fdf008edf0e87f095e168a636b2c2c9081be6eb6c4fe766a071cbL297-R322))
*  Modify the `fetch_current_state_for_cluster` function to use a new helper function `_is_hypershift` to check if a cluster is hypershift or not, and use the `build_pool_handler` method to create the `PoolHandler` objects for the current state ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-eeceffbceb8fdf008edf0e87f095e168a636b2c2c9081be6eb6c4fe766a071cbL312-R338))
*  Modify the `create_desired_state_from_gql` function to change the return type from a `DesiredStateList` object to a dictionary mapping cluster names to `DesiredMachinePool` objects, and filter out clusters that have no machine pools defined in the gql schema ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-eeceffbceb8fdf008edf0e87f095e168a636b2c2c9081be6eb6c4fe766a071cbL356-R455))
*  Add a new import statement for the `diff_mappings` function from `reconcile/utils/differ.py`, which is used to compare the current and desired state of machine pools and generate the diff result ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-eeceffbceb8fdf008edf0e87f095e168a636b2c2c9081be6eb6c4fe766a071cbR24))
*  Add a new exception handling case for `OCMValidationException` in the `run` function of `reconcile/ocm_clusters.py`, which logs the error message and sets the `error` flag to True ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-c6864bdf1ca61fad743e15096a363fa2ca01e50383721bef22ceb2a711179419R365-R367))
*  Modify the fixture files in `reconcile/test/fixtures/clusters` to change the structure of the cluster spec, removing the `instance_type`, `autoscale`, and `nodes` fields from the top level and adding a new `machinePools` field as a list of dictionaries, and updating the `channel` and `disable_user_workload_monitoring` fields to match the OCM API ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-26f8d0b7ff46fffa14777df474538db11706f9a485b4f3768c90a9bc6581dccaL151-R151), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-62ad0dfc3095494de50c5ef46b84fac31a33d01ec61072f434da8d4d494a8024L36-R47), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-a9e6cc3c12c86d82e90d06493e784a9325e8f17a9b08ec5a1c4ee01ace042d64L8-R8), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-2e4787783abeb95860fe02768fac8659da0a6b705a445ebcd7165fac2635cfb2L50-R62), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d1cd6670fd8c217ed8f94fa9ecfbb3f537efd8c577b1d1f742aab07f18c8673bL25-R25), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d1cd6670fd8c217ed8f94fa9ecfbb3f537efd8c577b1d1f742aab07f18c8673bL57-R58))
*  Modify the `ocm_osd_cluster_spec` function in `reconcile/test/test_ocm_clusters.py` to add a new argument `machine_pools` to the `OCMSpec` object, and remove the `instance_type` and `nodes` arguments from the `OSDClusterSpec` object ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d0912ff22700e3c850b8665bbaadaf510cdbdf0db83371f2998680b7e31509c5L89-R99))
*  Modify the `osd_cluster_fxt` and `rosa_cluster_fxt` functions in `reconcile/test/test_ocm_clusters.py` to change the structure of the cluster spec fixture, for the same reason as the fixture files ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d0912ff22700e3c850b8665bbaadaf510cdbdf0db83371f2998680b7e31509c5L114-R133), [link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d0912ff22700e3c850b8665bbaadaf510cdbdf0db83371f2998680b7e31509c5L187-R211))
*  Add a new import statement for the `ClusterMachinePool` class from `reconcile/ocm/types.py` in `reconcile/test/test_ocm_clusters.py`, which is used in the test fixtures and functions ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d0912ff22700e3c850b8665bbaadaf510cdbdf0db83371f2998680b7e31509c5R14))
*  Modify the `test_ocm_osd_create_cluster` function in `reconcile/test/test_ocm_clusters.py` to add an assertion on the exit code of the `run` function, and update the `queries_mock` return value to use the `ocm_osd_cluster_ai_spec` fixture ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d0912ff22700e3c850b8665bbaadaf510cdbdf0db83371f2998680b7e31509c5L479-R501))
*  Add a new test function `test_ocm_osd_create_cluster_without_machine_pools` in `reconcile/test/test_ocm_clusters.py`, which tests the scenario where the cluster spec does not have any machine pools defined, and expects the exit code to be 1 and the OCM API methods and the cluster updates MR method to not be called ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d0912ff22700e3c850b8665bbaadaf510cdbdf0db83371f2998680b7e31509c5R512-R533))
*  Add a new test function `test_ocm_rosa_create_cluster` in `reconcile/test/test_ocm_clusters.py`, which tests the scenario where a new ROSA cluster is created from the cluster spec with machine pools, and expects the exit code to be 0 and the OCM API methods to be called with the expected arguments and the cluster updates MR method to not be called ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d0912ff22700e3c850b8665bbaadaf510cdbdf0db83371f2998680b7e31509c5L504-R550))
*  Add a new test function `test_ocm_rosa_create_cluster_without_machine_pools` in `reconcile/test/test_ocm_clusters.py`, which tests the scenario where the cluster spec does not have any machine pools defined, and expects the exit code to be 1 and the OCM API methods and the cluster updates MR method to not be called ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d0912ff22700e3c850b8665bbaadaf510cdbdf0db83371f2998680b7e31509c5R560-R582))
*  Add a new test function `test_ocm_rosa_update_cluster_with_machine_pools_change` in `reconcile/test/test_ocm_clusters.py`, which tests the scenario where the cluster spec has a different machine pool configuration than the current state of the cluster, and expects the exit code to be 0 and the OCM API methods and the cluster updates MR method to not be called ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d0912ff22700e3c850b8665bbaadaf510cdbdf0db83371f2998680b7e31509c5R602-R630))
*  Add a new test function `test_ocm_osd_update_cluster_with_machine_pools_change` in `reconcile/test/test_ocm_clusters.py`, which tests the same scenario as the previous function but for OSD clusters ([link](https://github.com/app-sre/qontract-reconcile/pull/3825/files?diff=unified&w=0#diff-d0912ff22700e3c850b8665bbaadaf510cdbdf0db83371f2998680b7e31509c5R650-R678))