### PR TITLE
Vault-secrets empty values are not populated

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -60,6 +60,7 @@ from reconcile.utils.openshift_resource import (
     ResourceInventory,
     ResourceKeyExistsError,
     ResourceNotManagedError,
+    base64_encode_secret_field_value,
 )
 from reconcile.utils.runtime.integration import DesiredStateShardConfig
 from reconcile.utils.secret_reader import SecretReader
@@ -577,13 +578,10 @@ def fetch_provider_vault_secret(
 
     # populate data
     for k, v in raw_data.items():
-        if v == "":
-            continue
         if k.lower().endswith(QONTRACT_BASE64_SUFFIX):
             k = k[: -len(QONTRACT_BASE64_SUFFIX)]
             v = v.replace("\n", "")
-        elif v is not None:
-            v = base64.b64encode(v.encode()).decode("utf-8")
+        v = base64_encode_secret_field_value(v)
         body.setdefault("data", {})[k] = v
 
     try:

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -421,7 +421,7 @@ class OpenshiftResource:
             if string_data:
                 body.setdefault("data", {})
                 for k, v in string_data.items():
-                    v = base64.b64encode(str(v).encode()).decode("utf-8")
+                    v = base64_encode_secret_field_value(str(v))
                     body["data"][k] = v
 
         if body["kind"] == "Deployment":
@@ -706,7 +706,7 @@ def build_secret(
     )
 
 
-def base64_encode_secret_field_value(value: str) -> Optional[str]:
+def base64_encode_secret_field_value(value: str) -> str:
     if value == "":
-        return None
+        return ""
     return base64.b64encode(str(value).encode()).decode("utf-8")


### PR DESCRIPTION
As there are cases where empty data entries in Secrets are needed, let's handle all of the options the same way. 


Context:
* https://issues.redhat.com/browse/APPSRE-1448 
* https://github.com/app-sre/qontract-reconcile/pull/1144

