### PR TITLE
[oc] try to get all managed resource names at once

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -487,8 +487,7 @@ class OCCli:  # pylint: disable=too-many-public-methods
         if resource_names:
             items = []
             try:
-                resource_cmd = cmd + resource_names
-                items_list = self._run_json(resource_cmd, allow_not_found=True)
+                items_list = self._run_json(cmd + resource_names, allow_not_found=True)
             except ForbiddenError:
                 for resource_name in resource_names:
                     resource_cmd = cmd + [resource_name]

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -486,12 +486,16 @@ class OCCli:  # pylint: disable=too-many-public-methods
         resource_names = kwargs.get("resource_names")
         if resource_names:
             items = []
-            for resource_name in resource_names:
-                resource_cmd = cmd + [resource_name]
-                item = self._run_json(resource_cmd, allow_not_found=True)
-                if item:
-                    items.append(item)
-            items_list = {"items": items}
+            try:
+                resource_cmd = cmd + ' '.join(resource_names)
+                items_list = self._run_json(resource_cmd, allow_not_found=True)
+            except ForbiddenError:
+                for resource_name in resource_names:
+                    resource_cmd = cmd + [resource_name]
+                    item = self._run_json(resource_cmd, allow_not_found=True)
+                    if item:
+                        items.append(item)
+                items_list = {"items": items}
         else:
             items_list = self._run_json(cmd)
 

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -487,7 +487,7 @@ class OCCli:  # pylint: disable=too-many-public-methods
         if resource_names:
             items = []
             try:
-                resource_cmd = cmd + ' '.join(resource_names)
+                resource_cmd = cmd + resource_names
                 items_list = self._run_json(resource_cmd, allow_not_found=True)
             except ForbiddenError:
                 for resource_name in resource_names:


### PR DESCRIPTION
when `managedResourceNames` is used, it is assumed we operate within a restricted namespace. this means the logic tries to get one resource at a time.

but what if we are not in a restricted namespace?

this PR introduces an attempt to get all the resources by names once, and only go one by one in case the attempt it forbidden.