### PR TITLE
Fix openshift-namespaces cluster and namespace options

### DIFF
--- a/reconcile/openshift_namespaces.py
+++ b/reconcile/openshift_namespaces.py
@@ -4,6 +4,7 @@ from collections.abc import (
     Callable,
     Iterable,
     Mapping,
+    Sequence,
 )
 from typing import (
     Any,
@@ -145,16 +146,16 @@ def run(
     thread_pool_size: int = 10,
     internal: Optional[bool] = None,
     use_jump_host: bool = True,
-    cluster_name: Optional[str] = None,
-    namespace_name: Optional[str] = None,
+    cluster_name: Optional[Sequence[str]] = None,
+    namespace_name: Optional[Sequence[str]] = None,
     defer: Optional[Callable] = None,
 ) -> None:
     all_namespaces = get_namespaces_minimal()
     shard_namespaces, duplicates = get_shard_namespaces(all_namespaces)
     namespaces = filter_namespaces_by_cluster_and_namespace(
         namespaces=shard_namespaces,
-        cluster_name=cluster_name,
-        namespace_name=namespace_name,
+        cluster_names=cluster_name,
+        namespace_names=namespace_name,
     )
 
     desired_state = get_desired_state(namespaces)

--- a/reconcile/test/oc/test_oc_filters.py
+++ b/reconcile/test/oc/test_oc_filters.py
@@ -19,15 +19,15 @@ class Namespace:
 
 
 @pytest.mark.parametrize(
-    "namespaces, cluster_name, namespace_name, expected",
+    "namespaces, cluster_names, namespace_names, expected",
     [
         # Filter single namespace
         (
             [
                 Namespace(name="test-namespace", cluster=Cluster(name="test-cluster")),
             ],
-            "test-cluster",
-            "test-namespace",
+            ("test-cluster",),
+            ("test-namespace",),
             [
                 Namespace(name="test-namespace", cluster=Cluster(name="test-cluster")),
             ],
@@ -40,8 +40,8 @@ class Namespace:
                     name="test-namespace-2", cluster=Cluster(name="test-cluster-2")
                 ),
             ],
-            "test-cluster",
-            "test-namespace",
+            ("test-cluster",),
+            ("test-namespace",),
             [
                 Namespace(name="test-namespace", cluster=Cluster(name="test-cluster")),
             ],
@@ -54,9 +54,41 @@ class Namespace:
                     name="test-namespace", cluster=Cluster(name="test-cluster-2")
                 ),
             ],
-            "test-cluster-3",
-            "test-namespace",
+            ("test-cluster-3",),
+            ("test-namespace",),
             [],
+        ),
+        # Filter multiple clusters and multiple namespaces
+        (
+            [
+                Namespace(name="test-namespace", cluster=Cluster(name="test-cluster")),
+                Namespace(
+                    name="test-namespace-2", cluster=Cluster(name="test-cluster")
+                ),
+                Namespace(
+                    name="test-namespace", cluster=Cluster(name="test-cluster-2")
+                ),
+                Namespace(
+                    name="test-namespace-2", cluster=Cluster(name="test-cluster-2")
+                ),
+                Namespace(
+                    name="test-namespace", cluster=Cluster(name="test-cluster-3")
+                ),
+            ],
+            ("test-cluster", "test-cluster-2"),
+            ("test-namespace", "test-namespace-2"),
+            [
+                Namespace(name="test-namespace", cluster=Cluster(name="test-cluster")),
+                Namespace(
+                    name="test-namespace-2", cluster=Cluster(name="test-cluster")
+                ),
+                Namespace(
+                    name="test-namespace", cluster=Cluster(name="test-cluster-2")
+                ),
+                Namespace(
+                    name="test-namespace-2", cluster=Cluster(name="test-cluster-2")
+                ),
+            ],
         ),
         # Filter with Nones -> return input
         (
@@ -79,14 +111,14 @@ class Namespace:
 )
 def test_filter_namespaces_by_cluster_and_namespace(
     namespaces: Iterable[Namespace],
-    cluster_name: Optional[str],
-    namespace_name: Optional[str],
+    cluster_names: Optional[Iterable[str]],
+    namespace_names: Optional[Iterable[str]],
     expected: Iterable[Namespace],
-):
+) -> None:
     result = filter_namespaces_by_cluster_and_namespace(
         namespaces=namespaces,
-        cluster_name=cluster_name,
-        namespace_name=namespace_name,
+        cluster_names=cluster_names,
+        namespace_names=namespace_names,
     )
 
     def _sort(items: Iterable[Namespace]) -> list[Namespace]:

--- a/reconcile/utils/oc_filters.py
+++ b/reconcile/utils/oc_filters.py
@@ -22,21 +22,21 @@ NS = TypeVar("NS", bound=Namespace)
 
 
 def filter_namespaces_by_cluster(
-    namespaces: Iterable[NS], cluster_name: str
+    namespaces: Iterable[NS], cluster_names: Iterable[str]
 ) -> list[NS]:
-    return [n for n in namespaces if n.cluster.name == cluster_name]
+    return [n for n in namespaces if n.cluster.name in cluster_names]
 
 
 def filter_namespaces_by_name(
-    namespaces: Iterable[NS], namespace_name: str
+    namespaces: Iterable[NS], namespace_names: Iterable[str]
 ) -> list[NS]:
-    return [n for n in namespaces if n.name == namespace_name]
+    return [n for n in namespaces if n.name in namespace_names]
 
 
 def filter_namespaces_by_cluster_and_namespace(
     namespaces: Iterable[NS],
-    cluster_name: Optional[str],
-    namespace_name: Optional[str],
+    cluster_names: Optional[Iterable[str]],
+    namespace_names: Optional[Iterable[str]],
 ) -> list[NS]:
     """
     Filter namespaces by cluster and namespace name.
@@ -45,12 +45,12 @@ def filter_namespaces_by_cluster_and_namespace(
     be empty, no matter if the namespace name exists or not.
     """
     result: list[NS] = list(namespaces)
-    if cluster_name:
+    if cluster_names:
         result = filter_namespaces_by_cluster(
-            namespaces=result, cluster_name=cluster_name
+            namespaces=result, cluster_names=cluster_names
         )
-    if namespace_name:
+    if namespace_names:
         result = filter_namespaces_by_name(
-            namespaces=result, namespace_name=namespace_name
+            namespaces=result, namespace_names=namespace_names
         )
     return result

--- a/setup.cfg
+++ b/setup.cfg
@@ -752,6 +752,10 @@ check_untyped_defs = False
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 
+[mypy-reconcile.test.oc.test_oc_filters.*]
+disallow_untyped_defs = True
+disallow_incomplete_defs = True
+
 ; Below are all of the packages that don't implement stub packages. Mypy will throw an error if we don't ignore the
 ; missing imports. See: https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
 


### PR DESCRIPTION
They're currently broken because cli.py passes a tuple from `--cluster-name` and `--namespace-name` options. Since this is something that is taken into consideration by other integrations, this patch changes the interface of `filter_namespaces_by_cluster_and_namespace` as it is only currently used by `openshift-namespaces`.