### PR TITLE
Add default tags to aws provider for cost management

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -255,6 +255,12 @@ SUPPORTED_ALB_LISTENER_RULE_CONDITION_TYPE_MAPPING = {
     "source-ip": "source_ip",
 }
 
+DEFAULT_TAGS = {
+    "tags": {
+        "app": "app-sre-infra",
+    },
+}
+
 
 class StateInaccessibleException(Exception):
     pass
@@ -382,6 +388,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                         region=region,
                         alias=region,
                         skip_region_validation=True,
+                        default_tags=DEFAULT_TAGS,
                     )
 
             # Add default region, which will be in resourcesDefaultRegion
@@ -391,6 +398,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 version=self.versions.get(name),
                 region=config["resourcesDefaultRegion"],
                 skip_region_validation=True,
+                default_tags=DEFAULT_TAGS,
             )
 
             # the time provider can be removed if all AWS accounts
@@ -875,6 +883,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     alias=alias,
                     assume_role={"role_arn": assume_role},
                     skip_region_validation=True,
+                    default_tags=DEFAULT_TAGS,
                 )
 
     def populate_route53(


### PR DESCRIPTION
Some resources created by integrations don't have `app` tag set, they will appear as `no-app` in cost management, this change adds a default `app-sre-infra` as `app` so these resources can be tracked.

[APPSRE-8193](https://issues.redhat.com/browse/APPSRE-8193)


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26f8b1b</samp>

This pull request enhances the AWS resource tagging functionality and testing for the `TerrascriptClient` class in the `qontract-reconcile` repository. It refactors the default tagging logic and adds fixtures to the test module `test_terrascript_aws_client.py`.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 26f8b1b</samp>

*  Implement default tagging feature for AWS resources ([link](https://github.com/app-sre/qontract-reconcile/pull/3836/files?diff=unified&w=0#diff-4db367e141fd1992ae5a98872e6101dde4bf61a460c1bd0097176c6fbc849ac2L258-R264), [link](https://github.com/app-sre/qontract-reconcile/pull/3836/files?diff=unified&w=0#diff-4db367e141fd1992ae5a98872e6101dde4bf61a460c1bd0097176c6fbc849ac2R391), [link](https://github.com/app-sre/qontract-reconcile/pull/3836/files?diff=unified&w=0#diff-4db367e141fd1992ae5a98872e6101dde4bf61a460c1bd0097176c6fbc849ac2R401), [link](https://github.com/app-sre/qontract-reconcile/pull/3836/files?diff=unified&w=0#diff-4db367e141fd1992ae5a98872e6101dde4bf61a460c1bd0097176c6fbc849ac2R886))
* Add fixtures to test module `test_terrascript_aws_client.py` to improve test coverage and readability ([link](https://github.com/app-sre/qontract-reconcile/pull/3836/files?diff=unified&w=0#diff-2b85c4eca6f7f6cf05b1628a161c3b67760eaaf718b0c590e15c2bbdb17703ecR18-R156))