### PR TITLE
[openshift-saas-deploy-change-tester] re-use get_saas_files

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -99,6 +99,7 @@ def run(
     env_name: Optional[str] = None,
     trigger_integration: Optional[str] = None,
     trigger_reason: Optional[str] = None,
+    all_saas_files: Optional[list[SaasFile]] = None,
     defer: Optional[Callable] = None,
 ) -> None:
     vault_settings = get_app_interface_vault_settings()

--- a/reconcile/openshift_saas_deploy_change_tester.py
+++ b/reconcile/openshift_saas_deploy_change_tester.py
@@ -58,6 +58,7 @@ def osd_run_wrapper(
     dry_run: bool,
     available_thread_pool_size: int,
     use_jump_host: bool,
+    all_saas_files: Optional[list[SaasFile]],
 ) -> int:
     saas_file_name, env_name = spec
     exit_code = 0
@@ -68,6 +69,7 @@ def osd_run_wrapper(
             use_jump_host=use_jump_host,
             saas_file_name=saas_file_name,
             env_name=env_name,
+            all_saas_files=all_saas_files,
         )
     except SystemExit as e:
         exit_code = e.code if isinstance(e.code, int) else 1
@@ -214,7 +216,8 @@ def run(
     comparison_saas_file_state = collect_state(
         get_saas_files(query_func=comparison_gql_api.query)
     )
-    desired_saas_file_state = collect_state(get_saas_files())
+    all_saas_files = get_saas_files()
+    desired_saas_file_state = collect_state(all_saas_files)
     # compare dicts against dicts which is much faster than comparing BaseModel objects
     comparison_saas_file_state_dicts = [s.dict() for s in comparison_saas_file_state]
     saas_file_state_diffs = [
@@ -246,6 +249,7 @@ def run(
         dry_run=dry_run,
         available_thread_pool_size=available_thread_pool_size,
         use_jump_host=use_jump_host,
+        all_saas_files=all_saas_files,
     )
 
     if [ec for ec in exit_codes if ec]:

--- a/reconcile/test/test_typed_queries/test_saas_files.py
+++ b/reconcile/test/test_typed_queries/test_saas_files.py
@@ -571,7 +571,7 @@ PIPELINE_PROVIDER = {
         ),
         # missing provider
         pytest.param(
-            "saas-file-04",
+            "saas-file-04-missing-provider",
             None,
             None,
             "saas_files-missing-provider.yml",

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -234,8 +234,11 @@ def get_saas_files(
     if not namespaces:
         namespaces = namespaces_query(query_func).namespaces or []
 
+    data_saas_files = list(data.saas_files or [])
+    if name:
+        data_saas_files = [sf for sf in data_saas_files if sf.name == name]
     # resolve namespaceSelectors to real namespaces
-    for saas_file_gql in list(data.saas_files or []):
+    for saas_file_gql in data_saas_files:
         for rt_gql in saas_file_gql.resource_templates:
             for target_gql in rt_gql.targets[:]:
                 # either namespace or namespaceSelector must be set


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-8352

it was observed that runs of the integration were taking a long time. by re-using the results of the first `get_saas_files` call we avoid multiple processing of dynamic namespace selectors.