### PR TITLE
Include Jenkins SSHConnector Options with fleet-manager

### DIFF
--- a/reconcile/jenkins/types.py
+++ b/reconcile/jenkins/types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Optional
 
 from pydantic import (
     BaseModel,
@@ -21,7 +22,11 @@ class SSHHostKeyVerificationStrategy(Enum):
 
 class SSHConnector(BaseModel):
     credentials_id: str = Field(..., alias="credentialsId")
-    port: int = 22
+    launch_timeout_seconds: Optional[int] = Field(None, alias="launchTimeoutSeconds")
+    max_num_retries: Optional[int] = Field(None, alias="maxNumRetries")
+    retry_wait_time: Optional[int] = Field(None, alias="retryWaitTime")
+    port: Optional[int] = 22
+    jvm_options: Optional[str] = Field(None, alias="JVMOptions")
     ssh_host_key_verification_strategy: SSHHostKeyVerificationStrategy = Field(
         SSHHostKeyVerificationStrategy.NON_VERIFYING_KEY_VERIFICATION_STRATEGY,
         alias="sshHostKeyVerificationStrategy",

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -323,7 +323,15 @@ JENKINS_INSTANCES_QUERY = """
     workerFleets {
       account
       identifier
-      credentialsId
+      sshConnector {
+        credentialsId
+        JVMOptions
+        launchTimeoutSeconds
+        maxNumRetries
+        port
+        retryWaitTime
+        sshHostKeyVerificationStrategy
+      }
       fsRoot
       labelString
       numExecutors

--- a/reconcile/test/fixtures/jenkins_worker_fleets/gql-queries.yml
+++ b/reconcile/test/fixtures/jenkins_worker_fleets/gql-queries.yml
@@ -4,7 +4,12 @@ gql_response:
     workerFleets:
     - account: app-sre
       identifier: ci-int-jenkins-worker-app-interface
-      credentialsId: jenkins
+      sshConnector:
+        credentialsId: jenkins
+        launchTimeoutSeconds: 60
+        maxNumRetries: 10
+        port: 22
+        retryWaitTime: 15
       fsRoot: "/var/lib/jenkins"
       labelString: app-interface
       numExecutors: 3
@@ -26,7 +31,12 @@ gql_response:
             overrides: '{"min_size":0,"max_size":10}'
     - account: app-sre
       identifier: ci-int-jenkins-worker-app-sre
-      credentialsId: jenkins
+      sshConnector:
+        credentialsId: jenkins
+        launchTimeoutSeconds: 60
+        maxNumRetries: 10
+        port: 22
+        retryWaitTime: 15
       fsRoot: "/var/lib/jenkins"
       labelString: app-sre app-interface-long-running
       numExecutors: 3
@@ -45,7 +55,12 @@ gql_response:
             defaults: "/terraform/resources/asg-1.yml"
     - account: app-sre
       identifier: ci-int-jenkins-worker-rhel7
-      credentialsId: jenkins
+      sshConnector:
+        credentialsId: jenkins
+        launchTimeoutSeconds: 60
+        maxNumRetries: 10
+        port: 22
+        retryWaitTime: 15
       fsRoot: "/var/lib/jenkins"
       labelString: rhel7
       numExecutors: 3
@@ -62,11 +77,54 @@ gql_response:
           - provider: asg
             identifier: ci-int-jenkins-worker-rhel7
             defaults: "/terraform/resources/asg-1.yml"
+    - account: app-sre
+      identifier: test-remove-sshConnector-attrs
+      sshConnector:
+        credentialsId: jenkins
+      fsRoot: "/var/lib/jenkins"
+      labelString: rhel7
+      numExecutors: 3
+      namespace:
+        name: app-sre
+        managedExternalResources: true
+        externalResources:
+        - provider: aws
+          provisioner:
+            name: app-sre
+            resourcesDefaultRegion: us-east-1
+          resources:
+          - provider: aws-iam-service-account
+          - provider: asg
+            identifier: test-remove-sshConnector-attrs
+            defaults: "/terraform/resources/asg-1.yml"
+    - account: app-sre
+      identifier: test-add-sshConnector-JVMOpts
+      sshConnector:
+        credentialsId: jenkins
+        JVMOptions: "-djava.jenkinsci.iloveyou=false"
+      fsRoot: "/var/lib/jenkins"
+      labelString: rhel7
+      numExecutors: 3
+      namespace:
+        name: app-sre
+        managedExternalResources: true
+        externalResources:
+        - provider: aws
+          provisioner:
+            name: app-sre
+            resourcesDefaultRegion: us-east-1
+          resources:
+          - provider: aws-iam-service-account
+          - provider: asg
+            identifier: test-add-sshConnector-JVMOpts
+            defaults: "/terraform/resources/asg-1.yml"
+
   - name: ci-ext
     workerFleets:
     - account: app-sre
       identifier: ci-int-jenkins-worker-app-interface
-      credentialsId: jenkins
+      sshConnector:
+        credentialsId: jenkins
       fsRoot: "/var/lib/jenkins"
       labelString: app-interface
       numExecutors: 2

--- a/reconcile/test/fixtures/jenkins_worker_fleets/jcasc-apply.yml
+++ b/reconcile/test/fixtures/jenkins_worker_fleets/jcasc-apply.yml
@@ -9,7 +9,10 @@ jenkins:
       computerConnector:
         sSHConnector:
           credentialsId: jenkins
+          launchTimeoutSeconds: 60
+          maxNumRetries: 10
           port: 22
+          retryWaitTime: 15
           sshHostKeyVerificationStrategy: nonVerifyingKeyVerificationStrategy
       fsRoot: "/var/lib/jenkins"
       labelString: app-interface
@@ -31,7 +34,10 @@ jenkins:
       computerConnector:
         sSHConnector:
           credentialsId: jenkins
+          launchTimeoutSeconds: 60
+          maxNumRetries: 10
           port: 22
+          retryWaitTime: 15
           sshHostKeyVerificationStrategy: nonVerifyingKeyVerificationStrategy
       fsRoot: "/var/lib/jenkins"
       labelString: app-sre app-interface-long-running
@@ -53,8 +59,56 @@ jenkins:
       computerConnector:
         sSHConnector:
           credentialsId: jenkins
+          launchTimeoutSeconds: 60
+          maxNumRetries: 10
+          port: 22
+          retryWaitTime: 15
+          sshHostKeyVerificationStrategy: nonVerifyingKeyVerificationStrategy
+      fsRoot: "/var/lib/jenkins"
+      labelString: rhel7
+      numExecutors: 3
+      idleMinutes: 30
+      minSpareSize: 0
+      maxTotalUses: -1
+      noDelayProvision: false
+      addNodeOnlyIfRunning: true
+      alwaysReconnect: true
+      privateIpUsed: true
+      restrictUsage: true
+  - eC2Fleet:
+      name: test-remove-sshConnector-attrs
+      fleet: test-remove-sshConnector-attrs
+      region: us-east-1
+      minSize: 1
+      maxSize: 1
+      computerConnector:
+        sSHConnector:
+          credentialsId: jenkins
           port: 22
           sshHostKeyVerificationStrategy: nonVerifyingKeyVerificationStrategy
+      fsRoot: "/var/lib/jenkins"
+      labelString: rhel7
+      numExecutors: 3
+      idleMinutes: 30
+      minSpareSize: 0
+      maxTotalUses: -1
+      noDelayProvision: false
+      addNodeOnlyIfRunning: true
+      alwaysReconnect: true
+      privateIpUsed: true
+      restrictUsage: true
+  - eC2Fleet:
+      name: test-add-sshConnector-JVMOpts
+      fleet: test-add-sshConnector-JVMOpts
+      region: us-east-1
+      minSize: 1
+      maxSize: 1
+      computerConnector:
+        sSHConnector:
+          credentialsId: jenkins
+          port: 22
+          sshHostKeyVerificationStrategy: nonVerifyingKeyVerificationStrategy
+          JVMOptions: "-djava.jenkinsci.iloveyou=false"
       fsRoot: "/var/lib/jenkins"
       labelString: rhel7
       numExecutors: 3

--- a/reconcile/test/fixtures/jenkins_worker_fleets/jcasc-export.yml
+++ b/reconcile/test/fixtures/jenkins_worker_fleets/jcasc-export.yml
@@ -93,3 +93,62 @@ jenkins:
       region: "us-east-1"
       restrictUsage: true
       scaleExecutorsByWeight: false
+  - eC2Fleet:
+      addNodeOnlyIfRunning: true
+      alwaysReconnect: true
+      cloudStatusIntervalSec: 10
+      computerConnector:
+        sSHConnector:
+          credentialsId: "jenkins"
+          launchTimeoutSeconds: 60
+          maxNumRetries: 10
+          port: 22
+          retryWaitTime: 15
+          sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
+      disableTaskResubmit: false
+      fleet: "test-remove-sshConnector-attrs"
+      fsRoot: "/var/lib/jenkins"
+      idleMinutes: 30
+      initOnlineCheckIntervalSec: 15
+      initOnlineTimeoutSec: 180
+      labelString: "rhel7"
+      maxSize: 1
+      maxTotalUses: -1
+      minSize: 1
+      minSpareSize: 0
+      name: "test-remove-sshConnector-attrs"
+      noDelayProvision: false
+      numExecutors: 3
+      oldId: "a7833fe6-f643-4d5f-8178-a7109fecc9b7"
+      privateIpUsed: true
+      region: "us-east-1"
+      restrictUsage: true
+      scaleExecutorsByWeight: false
+  - eC2Fleet:
+      addNodeOnlyIfRunning: true
+      alwaysReconnect: true
+      cloudStatusIntervalSec: 10
+      computerConnector:
+        sSHConnector:
+          credentialsId: "jenkins"
+          port: 22
+          sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
+      disableTaskResubmit: false
+      fleet: "test-add-sshConnector-JVMOpts"
+      fsRoot: "/var/lib/jenkins"
+      idleMinutes: 30
+      initOnlineCheckIntervalSec: 15
+      initOnlineTimeoutSec: 180
+      labelString: "rhel7"
+      maxSize: 1
+      maxTotalUses: -1
+      minSize: 1
+      minSpareSize: 0
+      name: "test-add-sshConnector-JVMOpts"
+      noDelayProvision: false
+      numExecutors: 3
+      oldId: "a7833fe6-f643-4d5f-8178-a7109fecc9b7"
+      privateIpUsed: true
+      region: "us-east-1"
+      restrictUsage: true
+      scaleExecutorsByWeight: false

--- a/reconcile/test/test_jenkins_worker_fleets.py
+++ b/reconcile/test/test_jenkins_worker_fleets.py
@@ -38,11 +38,15 @@ def test_jenkins_worker_fleets(mocker: MockerFixture, caplog):
         act(False, instance["name"], current_state, desired_state, jenkins)
     mock_apply.assert_called_with(fixture.get_anymarkup("jcasc-apply.yml"))
 
-    assert [rec.message for rec in caplog.records] == [
-        "['create_jenkins_worker_fleet', 'ci-int', 'ci-int-jenkins-worker-app-interface']",
-        "['delete_jenkins_worker_fleet', 'ci-int', 'ci-int-jenkins-worker-rhel8']",
-        "['update_jenkins_worker_fleet', 'ci-int', 'ci-int-jenkins-worker-app-sre']",
-    ]
+    assert sorted([rec.message for rec in caplog.records]) == sorted(
+        [
+            "['create_jenkins_worker_fleet', 'ci-int', 'ci-int-jenkins-worker-app-interface']",
+            "['delete_jenkins_worker_fleet', 'ci-int', 'ci-int-jenkins-worker-rhel8']",
+            "['update_jenkins_worker_fleet', 'ci-int', 'ci-int-jenkins-worker-app-sre']",
+            "['update_jenkins_worker_fleet', 'ci-int', 'test-remove-sshConnector-attrs']",
+            "['update_jenkins_worker_fleet', 'ci-int', 'test-add-sshConnector-JVMOpts']",
+        ]
+    )
 
 
 def test_jenkins_worker_fleets_error():


### PR DESCRIPTION
This PR enhances fleet manager configuration to enable the sshConnector configuration. With this we will be able to set JVM_OPTS in the remote agents and other ssh options as well. 

Notes: 
* Requires: https://github.com/app-sre/qontract-schemas/pull/524 
* Fixes: https://issues.redhat.com/browse/APPSRE-7529