### PR TITLE
Fix jvmOptions case sensitive field name

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -10443,15 +10443,15 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "credentialsId",
+                            "name": "sshConnector",
                             "description": null,
                             "args": [],
                             "type": {
                                 "kind": "NON_NULL",
                                 "name": null,
                                 "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
+                                    "kind": "OBJECT",
+                                    "name": "JenkinsSSHConnector_v1",
                                     "ofType": null
                                 }
                             },
@@ -10553,6 +10553,105 @@
                             "type": {
                                 "kind": "SCALAR",
                                 "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "JenkinsSSHConnector_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "credentialsId",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "jvmOptions",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "launchTimeoutSeconds",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "maxNumRetries",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "port",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "retryWaitTime",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "sshHostKeyVerificationStrategy",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
                                 "ofType": null
                             },
                             "isDeprecated": false,

--- a/reconcile/jenkins/types.py
+++ b/reconcile/jenkins/types.py
@@ -26,7 +26,7 @@ class SSHConnector(BaseModel):
     max_num_retries: Optional[int] = Field(None, alias="maxNumRetries")
     retry_wait_time: Optional[int] = Field(None, alias="retryWaitTime")
     port: Optional[int] = 22
-    jvm_options: Optional[str] = Field(None, alias="JVMOptions")
+    jvm_options: Optional[str] = Field(None, alias="jvmOptions")
     ssh_host_key_verification_strategy: SSHHostKeyVerificationStrategy = Field(
         SSHHostKeyVerificationStrategy.NON_VERIFYING_KEY_VERIFICATION_STRATEGY,
         alias="sshHostKeyVerificationStrategy",

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -325,7 +325,7 @@ JENKINS_INSTANCES_QUERY = """
       identifier
       sshConnector {
         credentialsId
-        JVMOptions
+        jvmOptions
         launchTimeoutSeconds
         maxNumRetries
         port

--- a/reconcile/test/fixtures/jenkins_worker_fleets/gql-queries.yml
+++ b/reconcile/test/fixtures/jenkins_worker_fleets/gql-queries.yml
@@ -101,7 +101,7 @@ gql_response:
       identifier: test-add-sshConnector-JVMOpts
       sshConnector:
         credentialsId: jenkins
-        JVMOptions: "-djava.jenkinsci.iloveyou=false"
+        jvmOptions: "-djava.jenkinsci.iloveyou=false"
       fsRoot: "/var/lib/jenkins"
       labelString: rhel7
       numExecutors: 3
@@ -117,6 +117,27 @@ gql_response:
           - provider: aws-iam-service-account
           - provider: asg
             identifier: test-add-sshConnector-JVMOpts
+            defaults: "/terraform/resources/asg-1.yml"
+    - account: app-sre
+      identifier: test-same-sshConnector-JVMOpts
+      sshConnector:
+        credentialsId: jenkins
+        jvmOptions: "-djava.jenkinsci.iloveyou=false"
+      fsRoot: "/var/lib/jenkins"
+      labelString: rhel7
+      numExecutors: 3
+      namespace:
+        name: app-sre
+        managedExternalResources: true
+        externalResources:
+        - provider: aws
+          provisioner:
+            name: app-sre
+            resourcesDefaultRegion: us-east-1
+          resources:
+          - provider: aws-iam-service-account
+          - provider: asg
+            identifier: test-same-sshConnector-JVMOpts
             defaults: "/terraform/resources/asg-1.yml"
 
   - name: ci-ext

--- a/reconcile/test/fixtures/jenkins_worker_fleets/jcasc-apply.yml
+++ b/reconcile/test/fixtures/jenkins_worker_fleets/jcasc-apply.yml
@@ -108,7 +108,30 @@ jenkins:
           credentialsId: jenkins
           port: 22
           sshHostKeyVerificationStrategy: nonVerifyingKeyVerificationStrategy
-          JVMOptions: "-djava.jenkinsci.iloveyou=false"
+          jvmOptions: "-djava.jenkinsci.iloveyou=false"
+      fsRoot: "/var/lib/jenkins"
+      labelString: rhel7
+      numExecutors: 3
+      idleMinutes: 30
+      minSpareSize: 0
+      maxTotalUses: -1
+      noDelayProvision: false
+      addNodeOnlyIfRunning: true
+      alwaysReconnect: true
+      privateIpUsed: true
+      restrictUsage: true
+  - eC2Fleet:
+      name: test-same-sshConnector-JVMOpts
+      fleet: test-same-sshConnector-JVMOpts
+      region: us-east-1
+      minSize: 1
+      maxSize: 1
+      computerConnector:
+        sSHConnector:
+          credentialsId: jenkins
+          port: 22
+          sshHostKeyVerificationStrategy: nonVerifyingKeyVerificationStrategy
+          jvmOptions: "-djava.jenkinsci.iloveyou=false"
       fsRoot: "/var/lib/jenkins"
       labelString: rhel7
       numExecutors: 3

--- a/reconcile/test/fixtures/jenkins_worker_fleets/jcasc-export.yml
+++ b/reconcile/test/fixtures/jenkins_worker_fleets/jcasc-export.yml
@@ -152,3 +152,32 @@ jenkins:
       region: "us-east-1"
       restrictUsage: true
       scaleExecutorsByWeight: false
+  - eC2Fleet:
+      addNodeOnlyIfRunning: true
+      alwaysReconnect: true
+      cloudStatusIntervalSec: 10
+      computerConnector:
+        sSHConnector:
+          credentialsId: "jenkins"
+          port: 22
+          sshHostKeyVerificationStrategy: "nonVerifyingKeyVerificationStrategy"
+          jvmOptions: "-djava.jenkinsci.iloveyou=false"
+      disableTaskResubmit: false
+      fleet: "test-same-sshConnector-JVMOpts"
+      fsRoot: "/var/lib/jenkins"
+      idleMinutes: 30
+      initOnlineCheckIntervalSec: 15
+      initOnlineTimeoutSec: 180
+      labelString: "rhel7"
+      maxSize: 1
+      maxTotalUses: -1
+      minSize: 1
+      minSpareSize: 0
+      name: "test-same-sshConnector-JVMOpts"
+      noDelayProvision: false
+      numExecutors: 3
+      oldId: "a7833fe6-f643-4d5f-8178-a7109fecc9b7"
+      privateIpUsed: true
+      region: "us-east-1"
+      restrictUsage: true
+      scaleExecutorsByWeight: false


### PR DESCRIPTION
Fix reconcile loop caused by wrong case name for `jvmOptions`

schema changes in https://github.com/app-sre/qontract-schemas/pull/527

Follow up for https://github.com/app-sre/qontract-reconcile/pull/3838