### PR TITLE
Speed up saas-file parsing

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -20,7 +20,7 @@ from reconcile.typed_queries.app_interface_vault_settings import (
 )
 from reconcile.typed_queries.saas_files import (
     SaasFile,
-    get_saas_files,
+    SaasFileList,
     get_saasherder_settings,
 )
 from reconcile.utils.defer import defer
@@ -100,18 +100,22 @@ def run(
     env_name: Optional[str] = None,
     trigger_integration: Optional[str] = None,
     trigger_reason: Optional[str] = None,
-    all_saas_files: Optional[list[SaasFile]] = None,
+    saas_file_list: Optional[SaasFileList] = None,
     defer: Optional[Callable] = None,
 ) -> None:
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
 
-    if not all_saas_files:
-        all_saas_files = get_saas_files()
-    saas_files = get_saas_files(saas_file_name, env_name)
+    if not saas_file_list:
+        saas_file_list = SaasFileList()
+    all_saas_files = saas_file_list.saas_files
+    saas_files = saas_file_list.where(name=saas_file_name, env_name=env_name)
+
     if not saas_files:
         logging.error("no saas files found")
         raise RuntimeError("no saas files found")
+
+    #sys.exit(0)
 
     # notify different outputs (publish results, slack notifications)
     # we only do this if:

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -115,8 +115,6 @@ def run(
         logging.error("no saas files found")
         raise RuntimeError("no saas files found")
 
-    #sys.exit(0)
-
     # notify different outputs (publish results, slack notifications)
     # we only do this if:
     # - this is not a dry run

--- a/reconcile/openshift_saas_deploy_change_tester.py
+++ b/reconcile/openshift_saas_deploy_change_tester.py
@@ -18,7 +18,7 @@ from reconcile.gql_definitions.common.saas_files import (
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.typed_queries.saas_files import (
     SaasFile,
-    get_saas_files,
+    SaasFileList,
 )
 from reconcile.utils import gql
 from reconcile.utils.gitlab_api import GitLabApi
@@ -58,7 +58,7 @@ def osd_run_wrapper(
     dry_run: bool,
     available_thread_pool_size: int,
     use_jump_host: bool,
-    all_saas_files: Optional[list[SaasFile]],
+    saas_file_list: Optional[SaasFileList],
 ) -> int:
     saas_file_name, env_name = spec
     exit_code = 0
@@ -69,7 +69,7 @@ def osd_run_wrapper(
             use_jump_host=use_jump_host,
             saas_file_name=saas_file_name,
             env_name=env_name,
-            all_saas_files=all_saas_files,
+            saas_file_list=saas_file_list,
         )
     except SystemExit as e:
         exit_code = e.code if isinstance(e.code, int) else 1
@@ -214,10 +214,10 @@ def run(
     )
     # find the differences in saas-file state
     comparison_saas_file_state = collect_state(
-        get_saas_files(query_func=comparison_gql_api.query)
+        SaasFileList(query_func=comparison_gql_api.query).saas_files
     )
-    all_saas_files = get_saas_files()
-    desired_saas_file_state = collect_state(all_saas_files)
+    saas_file_list = SaasFileList()
+    desired_saas_file_state = collect_state(saas_file_list.saas_files)
     # compare dicts against dicts which is much faster than comparing BaseModel objects
     comparison_saas_file_state_dicts = [s.dict() for s in comparison_saas_file_state]
     saas_file_state_diffs = [
@@ -249,7 +249,7 @@ def run(
         dry_run=dry_run,
         available_thread_pool_size=available_thread_pool_size,
         use_jump_host=use_jump_host,
-        all_saas_files=all_saas_files,
+        saas_file_list=saas_file_list,
     )
 
     if [ec for ec in exit_codes if ec]:

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -8,7 +8,6 @@ from typing import (
 )
 
 from jsonpath_ng.exceptions import JsonPathParserError
-from jsonpath_ng.ext import parser
 from pydantic import (
     BaseModel,
     Extra,
@@ -51,6 +50,7 @@ from reconcile.utils.exceptions import (
     AppInterfaceSettingsError,
     ParameterError,
 )
+from reconcile.utils.jsonpath import parse_jsonpath
 
 
 class SaasResourceTemplateTarget(ConfiguredBaseModel):
@@ -164,7 +164,7 @@ def get_namespaces_by_selector(
 
     try:
         for include in namespace_selector.json_path_selectors.include:
-            for match in parser.parse(include).find(namespaces_as_dict):
+            for match in parse_jsonpath(include).find(namespaces_as_dict):
                 cluster_name = match.value["cluster"]["name"]
                 ns_name = match.value["name"]
                 filtered_namespaces[
@@ -177,7 +177,7 @@ def get_namespaces_by_selector(
 
     try:
         for exclude in namespace_selector.json_path_selectors.exclude or []:
-            for match in parser.parse(exclude).find(namespaces_as_dict):
+            for match in parse_jsonpath(exclude).find(namespaces_as_dict):
                 cluster_name = match.value["cluster"]["name"]
                 ns_name = match.value["name"]
                 filtered_namespaces.pop(f"{cluster_name}-{ns_name}", None)

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -141,6 +141,95 @@ class SaasFile(ConfiguredBaseModel):
     self_service_roles: Optional[list[RoleV1]] = Field(..., alias="selfServiceRoles")
 
 
+class SaasFileList:
+    def __init__(
+        self,
+        name: Optional[str] = None,
+        query_func: Optional[Callable] = None,
+        namespaces: Optional[list[SaasTargetNamespace]] = None,
+    ) -> None:
+        # query_func and namespaces are optional args mostly used in tests
+        if not query_func:
+            query_func = gql.get_api().query
+        if not namespaces:
+            namespaces = namespaces_query(query_func).namespaces or []
+
+        self.saas_files_v2 = saas_files_query(query_func).saas_files or []
+        if name:
+            self.saas_files_v2 = [sf for sf in self.saas_files_v2 if sf.name == name]
+        self.saas_files = self._resolve_namespace_selectors(namespaces)
+
+    def _resolve_namespace_selectors(
+        self, namespaces: list[SaasTargetNamespace]
+    ) -> list[SaasFile]:
+        saas_files: list[SaasFile] = []
+        # resolve namespaceSelectors to real namespaces
+        for sfv2 in self.saas_files_v2:
+            for rt_gql in sfv2.resource_templates:
+                for target_gql in rt_gql.targets[:]:
+                    # either namespace or namespaceSelector must be set
+                    if target_gql.namespace and target_gql.namespace_selector:
+                        raise ParameterError(
+                            f"SaasFile {sfv2.name}: namespace and namespaceSelector are mutually exclusive"
+                        )
+                    if not target_gql.provider:
+                        target_gql.provider = "static"
+
+                    if (
+                        target_gql.namespace_selector
+                        and target_gql.provider != "dynamic"
+                    ):
+                        raise ParameterError(
+                            f"SaasFile {sfv2.name}: namespaceSelector can only be used with 'provider: dynamic'"
+                        )
+                    if (
+                        target_gql.namespace_selector
+                        and target_gql.provider == "dynamic"
+                    ):
+                        rt_gql.targets.remove(target_gql)
+                        rt_gql.targets += create_targets_for_namespace_selector(
+                            target_gql, namespaces, target_gql.namespace_selector
+                        )
+            # convert SaasFileV2 (with optional resource_templates.targets.namespace field)
+            # to SaasFile (with required resource_templates.targets.namespace field)
+            saas_files.append(SaasFile(**export_model(sfv2)))
+        return saas_files
+
+    def where(
+        self,
+        name: Optional[str] = None,
+        env_name: Optional[str] = None,
+        app_name: Optional[str] = None,
+    ) -> list[SaasFile]:
+        if name is None and env_name is None and app_name is None:
+            return self.saas_files
+
+        if name == "" or env_name == "" or app_name == "":
+            return []
+
+        filtered: list[SaasFile] = []
+        for saas_file in self.saas_files[:]:
+            if name and saas_file.name != name:
+                continue
+
+            if app_name and saas_file.app.name != app_name:
+                continue
+
+            sf = saas_file.copy(deep=True)
+            if env_name:
+                for rt in sf.resource_templates[:]:
+                    for target in rt.targets[:]:
+                        if target.namespace.environment.name != env_name:
+                            rt.targets.remove(target)
+                    if not rt.targets:
+                        sf.resource_templates.remove(rt)
+                if not sf.resource_templates:
+                    continue
+            filtered.append(sf)
+
+        return filtered
+
+
 def get_namespaces_by_selector(
     namespaces: list[SaasTargetNamespace],
     namespace_selector: SaasResourceTemplateTargetNamespaceSelectorV1,
@@ -226,73 +315,13 @@ def get_saas_files(
     app_name: Optional[str] = None,
     query_func: Optional[Callable] = None,
     namespaces: Optional[list[SaasTargetNamespace]] = None,
+    saas_file_list: Optional[SaasFileList] = None,
 ) -> list[SaasFile]:
-    if not query_func:
-        query_func = gql.get_api().query
-    data = saas_files_query(query_func)
-    saas_files: list[SaasFile] = []
-    if not namespaces:
-        namespaces = namespaces_query(query_func).namespaces or []
-
-    data_saas_files = list(data.saas_files or [])
-    if name:
-        data_saas_files = [sf for sf in data_saas_files if sf.name == name]
-    # resolve namespaceSelectors to real namespaces
-    for saas_file_gql in data_saas_files:
-        for rt_gql in saas_file_gql.resource_templates:
-            for target_gql in rt_gql.targets[:]:
-                # either namespace or namespaceSelector must be set
-                if target_gql.namespace and target_gql.namespace_selector:
-                    raise ParameterError(
-                        f"SaasFile {saas_file_gql.name}: namespace and namespaceSelector are mutually exclusive"
-                    )
-                if not target_gql.provider:
-                    target_gql.provider = "static"
-
-                if (
-                    target_gql.namespace_selector
-                    and not target_gql.provider == "dynamic"
-                ):
-                    raise ParameterError(
-                        f"SaasFile {saas_file_gql.name}: namespaceSelector can only be used with 'provider: dynamic'"
-                    )
-                if target_gql.namespace_selector and target_gql.provider == "dynamic":
-                    rt_gql.targets.remove(target_gql)
-                    rt_gql.targets += create_targets_for_namespace_selector(
-                        target_gql, namespaces, target_gql.namespace_selector
-                    )
-        # convert SaasFileV2 (with optional resource_templates.targets.namespace field)
-        # to SaasFile (with required resource_templates.targets.namespace field)
-        saas_files.append(SaasFile(**export_model(saas_file_gql)))
-
-    if name is None and env_name is None and app_name is None:
-        return saas_files
-    if name == "" or env_name == "" or app_name == "":
-        return []
-
-    for saas_file in saas_files[:]:
-        if name:
-            if saas_file.name != name:
-                saas_files.remove(saas_file)
-                continue
-
-        if env_name:
-            for rt in saas_file.resource_templates[:]:
-                for target in rt.targets[:]:
-                    if target.namespace.environment.name != env_name:
-                        rt.targets.remove(target)
-                if not rt.targets:
-                    saas_file.resource_templates.remove(rt)
-            if not saas_file.resource_templates:
-                saas_files.remove(saas_file)
-                continue
-
-        if app_name:
-            if saas_file.app.name != app_name:
-                saas_files.remove(saas_file)
-                continue
-
-    return saas_files
+    if not saas_file_list:
+        saas_file_list = SaasFileList(
+            name=name, query_func=query_func, namespaces=namespaces
+        )
+    return saas_file_list.where(env_name=env_name, app_name=app_name)
 
 
 def get_saasherder_settings(


### PR DESCRIPTION
Further improvement on top of https://github.com/app-sre/qontract-reconcile/pull/3837

Linked to https://issues.redhat.com/browse/APPSRE-8352

- cache namespaceselectors result
- convert pydantic namespaces to dict only once
- avoid calling multiple time gql and parsing namespaceselectors by reusing all_saas_files when filtering by name. Note we now need to deep copy individual `saas_file` to not mutate `all_saas_files`

This PR will be easier to review 1 commit at a time.

On my machine, retrieving saas-files in openshift-saas-deploy (without param) goes from 24s to 7s

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 19bba5e</samp>

Refactored the code for querying and filtering saas files using a new `SaasFileList` class. This improves the performance, readability, and error handling of the code. Updated the tests and the `openshift_saas_deploy` and `openshift_saas_deploy_change_tester` integrations to use the new class.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 19bba5e</samp>

*  Replace `get_saas_files` function with `SaasFileList` class for querying, filtering, and resolving saas files and their targets ([link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-304fd1216ea8201e3242ba749fcc1bebbe71e61fd70851f7ed266e7318ed40b2L23-R23), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-304fd1216ea8201e3242ba749fcc1bebbe71e61fd70851f7ed266e7318ed40b2L103-R103), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-304fd1216ea8201e3242ba749fcc1bebbe71e61fd70851f7ed266e7318ed40b2L109-R113), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-44a063da69274e91106df288ed1776358efa6f48c729be06668b81eee7ef22d8L21-R21), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-44a063da69274e91106df288ed1776358efa6f48c729be06668b81eee7ef22d8L61-R61), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-44a063da69274e91106df288ed1776358efa6f48c729be06668b81eee7ef22d8L72-R72), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-44a063da69274e91106df288ed1776358efa6f48c729be06668b81eee7ef22d8L217-R220), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-44a063da69274e91106df288ed1776358efa6f48c729be06668b81eee7ef22d8L252-R252), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-9370abc558624c8cf8a2f663fb5a2f33a5c7ce4dead045b85c80beaefe50f8b3L22-R23), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-9370abc558624c8cf8a2f663fb5a2f33a5c7ce4dead045b85c80beaefe50f8b3L242-R250), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-9370abc558624c8cf8a2f663fb5a2f33a5c7ce4dead045b85c80beaefe50f8b3L256-R267), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-9370abc558624c8cf8a2f663fb5a2f33a5c7ce4dead045b85c80beaefe50f8b3L266), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-3012d36711b8ad8eebee61149b345fb0aa6004426b84a287b191d5ed46f41e31L11), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-3012d36711b8ad8eebee61149b345fb0aa6004426b84a287b191d5ed46f41e31L144-R304), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-3012d36711b8ad8eebee61149b345fb0aa6004426b84a287b191d5ed46f41e31L210-L222), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-3012d36711b8ad8eebee61149b345fb0aa6004426b84a287b191d5ed46f41e31L229-R338))
  * Add `SaasFileList` class in `reconcile/typed_queries/saas_files.py` to encapsulate the logic of creating a list of saas files from a query function and optional name and namespaces arguments, filtering the saas files by name, environment name, and app name, resolving the namespace selectors to actual namespaces, creating targets for namespace selectors, and getting namespaces by selectors using cached jsonpath expressions and namespaces ([link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-3012d36711b8ad8eebee61149b345fb0aa6004426b84a287b191d5ed46f41e31L144-R304))
  * Import `threading` module and `reconcile.utils.jsonpath` module in `reconcile/typed_queries/saas_files.py` to use the `Lock` class for thread-safe caching of namespaces and jsonpath expressions in the `SaasFileList` class, and the `parse_jsonpath` function for parsing and evaluating jsonpath expressions ([link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-3012d36711b8ad8eebee61149b345fb0aa6004426b84a287b191d5ed46f41e31R4), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-3012d36711b8ad8eebee61149b345fb0aa6004426b84a287b191d5ed46f41e31R54))
  * Remove `jsonpath_ng.ext` module from `reconcile/typed_queries/saas_files.py` as it is no longer used by the `get_namespaces_by_selector` function, which was moved to the `SaasFileList` class and replaced by the `reconcile.utils.jsonpath` module ([link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-3012d36711b8ad8eebee61149b345fb0aa6004426b84a287b191d5ed46f41e31L11))
  * Remove `create_targets_for_namespace_selector` function from `reconcile/typed_queries/saas_files.py` as it was moved to the `SaasFileList` class as a method ([link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-3012d36711b8ad8eebee61149b345fb0aa6004426b84a287b191d5ed46f41e31L210-L222))
  * Modify `get_saas_files` function in `reconcile/typed_queries/saas_files.py` to use the `SaasFileList` class and its methods, instead of duplicating the logic of querying, filtering, and resolving saas files. The function accepts an optional `saas_file_list` argument, which can be used to reuse an existing `SaasFileList` object, or create a new one if not provided. The function returns the result of calling the `where` method of the `SaasFileList` object with the given name, environment name, and app name arguments ([link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-3012d36711b8ad8eebee61149b345fb0aa6004426b84a287b191d5ed46f41e31L229-R338))
  * Modify `run` function in `reconcile/openshift_saas_deploy.py` to accept a `saas_file_list` argument instead of `all_saas_files`, to use the `SaasFileList` class for filtering and resolving saas files. The function creates a `SaasFileList` object if not provided, and uses its methods to get the saas files by name and environment name ([link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-304fd1216ea8201e3242ba749fcc1bebbe71e61fd70851f7ed266e7318ed40b2L23-R23), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-304fd1216ea8201e3242ba749fcc1bebbe71e61fd70851f7ed266e7318ed40b2L103-R103), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-304fd1216ea8201e3242ba749fcc1bebbe71e61fd70851f7ed266e7318ed40b2L109-R113))
  * Modify `osd_run_wrapper` function in `reconcile/openshift_saas_deploy_change_tester.py` to accept a `saas_file_list` argument instead of `all_saas_files`, to use the `SaasFileList` class for filtering and resolving saas files. The function passes the `saas_file_list` argument to the `openshift_saas_deploy.run` function ([link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-44a063da69274e91106df288ed1776358efa6f48c729be06668b81eee7ef22d8L21-R21), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-44a063da69274e91106df288ed1776358efa6f48c729be06668b81eee7ef22d8L61-R61), [link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-44a063da69274e91106df288ed1776358efa6f48c729be06668b81eee7ef22d8L72-R72))
  * Modify `run` function in `reconcile/openshift_saas_deploy_change_tester.py` to create a `SaasFileList` object with a custom query function for the comparison saas files, and use its methods to get the saas files by name and environment name, instead of calling the `get_saas_files` function ([link](https://github.com/app-sre/qontract-reconcile/pull/3846/files?diff=unified&w=0#diff-44a063da69274e91106df288ed1776358efa6f48c729be06668b81eee7ef22d8L217-R220))
