### PR TITLE
[terraform-resources] publish external resource invetory metrics

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -41,6 +41,7 @@ from reconcile.utils.external_resources import (
     PROVIDER_AWS,
     get_external_resource_specs,
     managed_external_resources,
+    publish_metrics,
 )
 from reconcile.utils.oc import StatusCodeError
 from reconcile.utils.oc_map import (
@@ -399,6 +400,7 @@ def run(
         account_names,
         exclude_accounts,
     )
+    publish_metrics(resource_specs)
 
     if not dry_run and oc_map and defer:
         defer(oc_map.cleanup)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -400,7 +400,7 @@ def run(
         account_names,
         exclude_accounts,
     )
-    publish_metrics(resource_specs)
+    publish_metrics(resource_specs, QONTRACT_INTEGRATION.replace("_", "-"))
 
     if not dry_run and oc_map and defer:
         defer(oc_map.cleanup)

--- a/reconcile/test/utils/test_external_resources.py
+++ b/reconcile/test/utils/test_external_resources.py
@@ -1,9 +1,14 @@
 import json
+from collections import Counter
 
 import pytest
 
 import reconcile.utils.external_resources as uer
-from reconcile.utils.external_resource_spec import ExternalResourceSpec
+from reconcile.utils.external_resource_spec import (
+    ExternalResourceSpec,
+    ExternalResourceSpecInventory,
+    ExternalResourceUniqueKey,
+)
 
 
 @pytest.fixture
@@ -245,3 +250,37 @@ def test_resource_value_resolver_overrides_and_defaults(mocker):
         "default_2": "override_data2",
         "default_3": "default_data3",
     }
+
+
+def test_get_inventory_count_combinations():
+    inventory: ExternalResourceSpecInventory = {}
+    inventory[
+        ExternalResourceUniqueKey("pp1", "pn1", "id1", "rds")
+    ] = ExternalResourceSpec("pp1", {}, {}, {})
+    inventory[
+        ExternalResourceUniqueKey("pp1", "pn1", "id2", "rds")
+    ] = ExternalResourceSpec("pp1", {}, {}, {})
+    inventory[
+        ExternalResourceUniqueKey("pp2", "pn2", "id3", "rds")
+    ] = ExternalResourceSpec("pp2", {}, {}, {})
+    inventory[
+        ExternalResourceUniqueKey("pp2", "pn3", "id4", "s3")
+    ] = ExternalResourceSpec("pp2", {}, {}, {})
+    inventory[
+        ExternalResourceUniqueKey("pp3", "pn4", "id5", "s3")
+    ] = ExternalResourceSpec("pp3", {}, {}, {})
+    inventory[
+        ExternalResourceUniqueKey("pp3", "pn4", "id6", "asg")
+    ] = ExternalResourceSpec("pp3", {}, {}, {})
+
+    count_combinations = uer.get_inventory_count_combinations(inventory)
+    expected_count_combinations = Counter(
+        {
+            ("pp1", "pn1", "rds"): 2,
+            ("pp2", "pn2", "rds"): 1,
+            ("pp2", "pn3", "s3"): 1,
+            ("pp3", "pn4", "s3"): 1,
+            ("pp3", "pn4", "asg"): 1,
+        }
+    )
+    assert expected_count_combinations == count_combinations

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -12,9 +12,11 @@ from typing import (
 )
 
 import yaml
+from pydantic import BaseModel
 from pydantic.dataclasses import dataclass
 
 from reconcile import openshift_resources_base
+from reconcile.utils.metrics import GaugeMetric
 from reconcile.utils.openshift_resource import (
     SECRET_MAX_KEY_LENGTH,
     OpenshiftResource,
@@ -186,6 +188,24 @@ class ExternalResourceUniqueKey:
             identifier=spec.identifier,
             provider=spec.provider,
         )
+
+
+class ExternalResourceBaseMetric(BaseModel):
+    "Base class External Resource metrics"
+
+    integration: str
+
+
+class ExternalResourceInventoryGauge(ExternalResourceBaseMetric, GaugeMetric):
+    "Inventory Gauge"
+
+    provision_provider: str
+    provisioner_name: str
+    provider: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "external_resource_inventory"
 
 
 ExternalResourceSpecInventory = MutableMapping[

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -69,10 +69,16 @@ def managed_external_resources(namespace_info: Mapping[str, Any]) -> bool:
     return False
 
 
-def publish_metrics(inventory: ExternalResourceSpecInventory, integration: str) -> None:
-    count_combinations = Counter(
+def get_inventory_count_combinations(
+    inventory: ExternalResourceSpecInventory,
+) -> Counter[tuple]:
+    return Counter(
         (k.provision_provider, k.provisioner_name, k.provider) for k in inventory
     )
+
+
+def publish_metrics(inventory: ExternalResourceSpecInventory, integration: str) -> None:
+    count_combinations = get_inventory_count_combinations(inventory)
     for combination, count in count_combinations.items():
         provision_provider, provisioner_name, provider = combination
         metrics.set_gauge(

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -12,7 +12,10 @@ import anymarkup
 
 from reconcile.utils import gql
 from reconcile.utils.exceptions import FetchResourceError
-from reconcile.utils.external_resource_spec import ExternalResourceSpec
+from reconcile.utils.external_resource_spec import (
+    ExternalResourceSpec,
+    ExternalResourceSpecInventory,
+)
 
 PROVIDER_AWS = "aws"
 PROVIDER_CLOUDFLARE = "cloudflare"
@@ -59,6 +62,10 @@ def managed_external_resources(namespace_info: Mapping[str, Any]) -> bool:
         return True
 
     return False
+
+
+def publish_metrics(inventory: ExternalResourceSpecInventory):
+    raise NotImplementedError()
 
 
 class ResourceValueResolver:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-8184

this PR attempts to add a metric to describe the inventory of external resources managed by `terraform-resources`.
nice to have: make it re-usable between other integrations managing external resources.