### PR TITLE
enabling pagination for the log retention integration

### DIFF
--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1035,8 +1035,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         cloudwatch_logs = self._account_cloudwatch_client(account["name"])
         paginator = cloudwatch_logs.get_paginator("describe_log_groups")
         for page in paginator.paginate():
-            for log_group in page["logGroups"]:
-                log_group_list.append(log_group)
+            log_group_list.extend(page["logGroups"])
         return log_group_list
 
     def set_cloudwatch_log_retention(self, account, group_name, retention_days):

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1031,9 +1031,13 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         cloudwatch_logs.tag_log_group(logGroupName=group_name, tags=new_tag)
 
     def get_cloudwatch_logs(self, account):
+        log_group_list = []
         cloudwatch_logs = self._account_cloudwatch_client(account["name"])
-        log_groups = cloudwatch_logs.describe_log_groups()["logGroups"]
-        return log_groups
+        paginator = cloudwatch_logs.get_paginator('describe_log_groups')
+        for page in paginator.paginate():
+            for log_group in page["logGroups"]:
+                log_group_list.append(log_group)
+        return log_group_list
 
     def set_cloudwatch_log_retention(self, account, group_name, retention_days):
         cloudwatch_logs = self._account_cloudwatch_client(account["name"])

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1033,7 +1033,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
     def get_cloudwatch_logs(self, account):
         log_group_list = []
         cloudwatch_logs = self._account_cloudwatch_client(account["name"])
-        paginator = cloudwatch_logs.get_paginator('describe_log_groups')
+        paginator = cloudwatch_logs.get_paginator("describe_log_groups")
         for page in paginator.paginate():
             for log_group in page["logGroups"]:
                 log_group_list.append(log_group)


### PR DESCRIPTION
The current log retention integration does not take pagination into account when setting a retention period. This PR will enable pagination in order to target all log groups in an AWS account.

[APPSRE-8375](https://issues.redhat.com/browse/APPSRE-8375)