### PR TITLE
Unleash should always use the default fallback function

### DIFF
--- a/reconcile/test/test_gabi_authorized_users.py
+++ b/reconcile/test/test_gabi_authorized_users.py
@@ -18,6 +18,9 @@ fixture = Fixtures("gabi_authorized_users").get_anymarkup("api.yml")
 
 def test_gabi_authorized_users_apply(mocker: MockerFixture) -> None:
     ri = ResourceInventory()
+    # This can be removed once the three_way_diff strategy is the default
+    # mechanism. Without the feature flag.
+    ri.clusters_3way_diff_strategy = {"server": True}
     ri.initialize_resource_type("server", "gabi-db", "ConfigMap")
     gabi_instance = fixture["gql_response"][0]
     gabi_u.fetch_desired_state([gabi_instance], ri)

--- a/reconcile/test/test_unleash.py
+++ b/reconcile/test/test_unleash.py
@@ -1,0 +1,184 @@
+import json
+import os
+
+import httpretty
+import pytest
+from UnleashClient.features import Feature
+
+import reconcile.utils.unleash
+from reconcile.utils.unleash import (
+    _get_unleash_api_client,
+    _shutdown_client,
+    get_feature_toggle_default,
+    get_feature_toggle_state,
+    get_feature_toggles,
+)
+
+
+@pytest.fixture
+def reset_client():
+    reconcile.utils.unleash.client = None
+
+
+def test__get_unleash_api_client(mocker):
+    a = mocker.patch("UnleashClient.UnleashClient.initialize_client")
+    c = _get_unleash_api_client("https://u/api", "foo")
+
+    assert a.call_count == 1
+    assert reconcile.utils.unleash.client == c
+
+
+def test__get_unleash_api_client_skip_create(mocker):
+    u = mocker.patch("UnleashClient.UnleashClient")
+    reconcile.utils.unleash.client = u
+    a = mocker.patch("UnleashClient.UnleashClient.initialize_client")
+    c = _get_unleash_api_client("https://u/api", "foo")
+
+    assert a.call_count == 0
+    assert reconcile.utils.unleash.client == c == u
+
+
+def test_get_feature_toggle_default():
+    assert get_feature_toggle_default(None, None)
+
+
+def test_get_feature_toggle_state_env_missing():
+    assert get_feature_toggle_state("foo")
+
+
+def test_get_feature_toggle_state_env_missing_default_false():
+    assert not get_feature_toggle_state("foo", default=False)
+
+
+def test_get_feature_toggle_state(mocker, monkeypatch):
+    def enabled_func(feature, context, fallback_function):
+        return feature == "enabled"
+
+    os.environ["UNLEASH_API_URL"] = "foo"
+    os.environ["UNLEASH_CLIENT_ACCESS_TOKEN"] = "bar"
+
+    defaultfunc = mocker.patch(
+        "reconcile.utils.unleash.get_feature_toggle_default", return_value=True
+    )
+    monkeypatch.setattr(
+        "reconcile.utils.unleash.client",
+        mocker.patch("UnleashClient.UnleashClient", autospec=True),
+    )
+    mocker.patch(
+        "UnleashClient.UnleashClient.is_enabled",
+        side_effect=enabled_func,
+    )
+
+    assert get_feature_toggle_state("enabled")
+    assert get_feature_toggle_state("disabled") is False
+    assert defaultfunc.call_count == 0
+
+
+def test_get_feature_toggles(mocker, monkeypatch):
+    c = mocker.patch("UnleashClient.UnleashClient")
+    c.features = {
+        "foo": Feature("foo", False, []),
+        "bar": Feature("bar", True, []),
+    }
+
+    monkeypatch.setattr("reconcile.utils.unleash.client", c)
+    toggles = get_feature_toggles("api", "token")
+
+    assert toggles["foo"] == "disabled"
+    assert toggles["bar"] == "enabled"
+
+
+def setup_unleash_disable_cluster_strategy_httpretty(enabled: bool):
+    features = {
+        "version": 2,
+        "features": [
+            {
+                "strategies": [
+                    {
+                        "name": "disableCluster",
+                        "constraints": [],
+                        "parameters": {"cluster_name": "foo"},
+                    },
+                ],
+                "impressionData": False,
+                "enabled": enabled,
+                "name": "test-strategies",
+                "description": "",
+                "project": "default",
+                "stale": False,
+                "type": "release",
+                "variants": [],
+            }
+        ],
+    }
+
+    feature_param = (httpretty.GET, "http://unleash/api/client/features")
+    httpretty.register_uri(*feature_param, body=json.dumps(features), status=200)
+
+    register_param = (httpretty.POST, "http://unleash/api/client/register")
+    httpretty.register_uri(*register_param, status=202)
+
+
+@httpretty.activate(allow_net_connect=False)
+def test_get_feature_toggle_state_with_strategy(reset_client):
+    os.environ["UNLEASH_API_URL"] = "http://unleash/api"
+    os.environ["UNLEASH_CLIENT_ACCESS_TOKEN"] = "bar"
+    setup_unleash_disable_cluster_strategy_httpretty(True)
+    assert not get_feature_toggle_state(
+        "test-strategies", context={"cluster_name": "foo"}
+    )
+    assert get_feature_toggle_state("test-strategies", context={"cluster_name": "bar"})
+    _shutdown_client()
+
+
+@httpretty.activate(allow_net_connect=False)
+def test_get_feature_toggle_state_disabled_with_strategy(reset_client):
+    os.environ["UNLEASH_API_URL"] = "http://unleash/api"
+    os.environ["UNLEASH_CLIENT_ACCESS_TOKEN"] = "bar"
+    setup_unleash_disable_cluster_strategy_httpretty(False)
+    assert not get_feature_toggle_state(
+        "test-strategies", context={"cluster_name": "bar"}
+    )
+    _shutdown_client()
+
+
+def setup_unleash_enable_cluster_strategy_httpretty(enabled: bool):
+    features = {
+        "version": 2,
+        "features": [
+            {
+                "strategies": [
+                    {
+                        "name": "enableCluster",
+                        "constraints": [],
+                        "parameters": {"cluster_name": "enabled-cluster"},
+                    },
+                ],
+                "impressionData": False,
+                "enabled": enabled,
+                "name": "test-strategies",
+                "description": "",
+                "project": "default",
+                "stale": False,
+                "type": "release",
+                "variants": [],
+            }
+        ],
+    }
+
+    feature_param = (httpretty.GET, "http://unleash/api/client/features")
+    httpretty.register_uri(*feature_param, body=json.dumps(features), status=200)
+
+    register_param = (httpretty.POST, "http://unleash/api/client/register")
+    httpretty.register_uri(*register_param, status=202)
+
+
+@httpretty.activate(allow_net_connect=False)
+def test_get_feature_toggle_state_with_enable_cluster_strategy(reset_client):
+    os.environ["UNLEASH_API_URL"] = "http://unleash/api"
+    os.environ["UNLEASH_CLIENT_ACCESS_TOKEN"] = "bar"
+    setup_unleash_enable_cluster_strategy_httpretty(True)
+    assert get_feature_toggle_state(
+        "test-strategies", context={"cluster_name": "enabled-cluster"}
+    )
+    _shutdown_client()

--- a/reconcile/utils/unleash/client.py
+++ b/reconcile/utils/unleash/client.py
@@ -95,16 +95,17 @@ def get_feature_toggle_state(
 ) -> bool:
     api_url = os.environ.get("UNLEASH_API_URL")
     client_access_token = os.environ.get("UNLEASH_CLIENT_ACCESS_TOKEN")
+
+    fallback_func = (
+        get_feature_toggle_default if default else get_feature_toggle_default_false
+    )
+
     if not (api_url and client_access_token):
-        return get_feature_toggle_default("", {})
+        return fallback_func("", {})
 
     c = _get_unleash_api_client(
         api_url,
         client_access_token,
-    )
-
-    fallback_func = (
-        get_feature_toggle_default if default else get_feature_toggle_default_false
     )
 
     return c.is_enabled(


### PR DESCRIPTION
`get_feature_toggle_state` should always consider the default return value, even if the unleash configuration is missing. 
Without this change, environments without unleash have all the feature flags enabled. 