### PR TITLE
Add `eval` filter to jinja2

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -329,6 +329,10 @@ def hash_list(input: Iterable) -> str:
     return m.hexdigest()
 
 
+def eval_filter(input, **kwargs) -> str:
+    return jinja2.Template(input).render(**kwargs)
+
+
 def json_to_dict(input):
     """Jinja2 filter to parse JSON strings into dictionaries.
        This becomes useful to access Graphql queries data (labels)
@@ -401,6 +405,7 @@ def compile_jinja2_template(body, extra_curly: bool = False):
             "json_to_dict": json_to_dict,
             "urlescape": urlescape,
             "urlunescape": urlunescape,
+            "eval": eval_filter,
         }
     )
 

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -330,6 +330,15 @@ def hash_list(input: Iterable) -> str:
 
 
 def eval_filter(input, **kwargs) -> str:
+    """Jinja2 filter be used when the string
+    is in itself a jinja2 template that must be
+    evaluated with kwargs. For example in the case
+    of the slo-document expression fields.
+    :param input: template string
+    :kwargs: variables that will be used to evaluate the
+             input string
+    :return: rendered string
+    """
     return jinja2.Template(input).render(**kwargs)
 
 


### PR DESCRIPTION
We have a use case where we want to render the slo documents into PrometheusAlerts.

The fields in the slo-documents datafile do contain Jinja2 parameters, for example:

```
expr: |
    sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route="api.repository",status!~"5[0-9][0-9]",method="GET"}[{{window}}]))
    /
    sum(increase(aggregation:quay_request_duration_seconds_count:rate1m:sum{route="api.repository",method="GET"}[{{window}}]))
```

The `{{window}}` parameter must be evaluated inside the jinja2 expression:

```
{{% set expr = slo.expr | eval(window=slo.SLOParameters.window) | trim + ' <= ' + slo.SLOTarget | string %}}
```

In order for the `eval` part to work, this filter is required.