### PR TITLE
Refactor repo filtering in quay-mirror

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1482,14 +1482,27 @@ def gcr_mirror(ctx):
     default=86400,
 )
 @click.option(
-    "-i",
-    "--image",
-    help="Only considers this image to mirror. It can be specified multiple times.",
+    "-r",
+    "--repository-url",
+    help="Only considers this repository to mirror. It can be specified multiple times.",
+    multiple=True,
+)
+@click.option(
+    "-e",
+    "--exclude-repository-url",
+    help="excludes this repository  to mirror. It can be specified multiple times.",
     multiple=True,
 )
 @click.pass_context
 @binary(["skopeo"])
-def quay_mirror(ctx, control_file_dir, compare_tags, compare_tags_interval, image):
+def quay_mirror(
+    ctx,
+    control_file_dir,
+    compare_tags,
+    compare_tags_interval,
+    repository_url,
+    exclude_repository_url,
+):
     import reconcile.quay_mirror
 
     run_integration(
@@ -1498,7 +1511,8 @@ def quay_mirror(ctx, control_file_dir, compare_tags, compare_tags_interval, imag
         control_file_dir,
         compare_tags,
         compare_tags_interval,
-        image,
+        repository_url,
+        exclude_repository_url,
     )
 
 

--- a/reconcile/test/fixtures/quay_mirror/get_quay_repos_ok.yaml
+++ b/reconcile/test/fixtures/quay_mirror/get_quay_repos_ok.yaml
@@ -1,0 +1,75 @@
+- quayRepos:
+  - items:
+    - mirror: null
+      name: cloud-connector
+      public: true
+    - mirror:
+        pullCredentials:
+          field: all
+          format: null
+          path: app-sre/creds/mirror-images/docker.io-sdappsre
+          version: null
+        tags:
+        - latest
+        tagsExclude: null
+        url: docker.io/library/eclipse-mosquitto
+      name: eclipse-mosquitto
+      public: false
+    - mirror: null
+      name: tenant-utils
+      public: true
+    - mirror: null
+      name: cloud-connector-frontend
+      public: true
+    org:
+      instance:
+        name: quay.io
+        url: quay.io
+      name: cloudservices
+
+- quayRepos:
+  - items:
+    - mirror:
+        pullCredentials:
+          field: all
+          format: null
+          path: app-sre/creds/mirror-images/docker.io-sdappsre
+          version: null
+        tags: null
+        tagsExclude: null
+        url: docker.io/redis
+      name: redis
+      public: false
+    - mirror: null
+      name: kube-scripts
+      public: true
+    - mirror: null
+      name: miniop
+      public: true
+    - mirror: null
+      name: selenium-standalone-chrome
+      public: true
+    org:
+      instance:
+        name: quay.io
+        url: quay.io
+      name: cloudservices
+
+- quayRepos:
+  - items:
+    - mirror: null
+      name: acs-fleet-manager
+      public: true
+    - mirror:
+        pullCredentials: null
+        tags:
+        - v0.9.5
+        tagsExclude: null
+        url: ghcr.io/external-secrets/external-secrets
+      name: external-secrets
+      public: true
+    org:
+      instance:
+        name: quay.io
+        url: quay.io
+      name: app-sre

--- a/reconcile/test/fixtures/quay_mirror/get_quay_repos_public_dockerhub.yaml
+++ b/reconcile/test/fixtures/quay_mirror/get_quay_repos_public_dockerhub.yaml
@@ -1,0 +1,28 @@
+- quayRepos:
+  - items:
+    - mirror: null
+      name: cloud-connector
+      public: true
+    - mirror:
+        pullCredentials:
+          field: all
+          format: null
+          path: app-sre/creds/mirror-images/docker.io-sdappsre
+          version: null
+        tags:
+        - latest
+        tagsExclude: null
+        url: docker.io/library/eclipse-mosquitto
+      name: eclipse-mosquitto
+      public: true
+    - mirror: null
+      name: tenant-utils
+      public: true
+    - mirror: null
+      name: cloud-connector-frontend
+      public: true
+    org:
+      instance:
+        name: quay.io
+        url: quay.io
+      name: cloudservices


### PR DESCRIPTION
The previous option (--image) was not very intuitive to understand. It is clearer now with --repository-url what we mean when we want to filter repositories. This patch also includes an exclude option

part of APPSRE-8401