### PR TITLE
openshift resource inventory metrics

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1521,7 +1521,7 @@ def get_namespace_resource_names(
 
 def publish_metrics(ri: ResourceInventory, integration: str) -> None:
     for cluster, namespace, kind, data in ri:
-        for state in {"current", "desired"}:
+        for state in ("current", "desired"):
             metrics.set_gauge(
                 OpenshiftResourceInventoryGauge(
                     integration=integration,

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -24,7 +24,10 @@ from sretoolbox.utils import (
 )
 
 from reconcile import queries
-from reconcile.utils import differ
+from reconcile.utils import (
+    differ,
+    metrics,
+)
 from reconcile.utils.oc import (
     DeploymentFieldIsImmutableError,
     FieldIsImmutableError,
@@ -41,7 +44,10 @@ from reconcile.utils.oc import (
     UnsupportedMediaTypeError,
 )
 from reconcile.utils.openshift_resource import OpenshiftResource as OR
-from reconcile.utils.openshift_resource import ResourceInventory
+from reconcile.utils.openshift_resource import (
+    OpenshiftResourceInventoryGauge,
+    ResourceInventory,
+)
 from reconcile.utils.three_way_diff_strategy import three_way_diff_using_hash
 
 ACTION_APPLIED = "applied"
@@ -1511,3 +1517,18 @@ def get_namespace_resource_names(
         ref += item["resourceNames"]
 
     return rnames
+
+
+def publish_metrics(ri: ResourceInventory, integration: str) -> None:
+    for cluster, namespace, kind, data in ri:
+        for state in {"current", "desired"}:
+            metrics.set_gauge(
+                OpenshiftResourceInventoryGauge(
+                    integration=integration,
+                    cluster=cluster,
+                    namespace=namespace,
+                    kind=kind,
+                    state=state,
+                ),
+                len(data[state]),
+            )

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -171,6 +171,7 @@ def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True, defer=N
     )
     defer(oc_map.cleanup)
     fetch_desired_state(ri, oc_map)
+    ob.publish_metrics(ri, QONTRACT_INTEGRATION)
     ob.realize_data(dry_run, oc_map, ri, thread_pool_size)
 
     if ri.has_error_registered():

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -275,7 +275,7 @@ def publish_metrics(
     current_state: Iterable[Mapping[str, str]],
     desired_state: Iterable[Mapping[str, str]],
 ) -> None:
-    for state, state_type in {(current_state, "current"), (desired_state, "desired")}:
+    for state, state_type in ((current_state, "current"), (desired_state, "desired")):
         for cluster, count in get_state_count_combinations(state).items():
             metrics.set_gauge(
                 OpenshiftResourceInventoryGauge(

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -267,7 +267,7 @@ def act(diff: Mapping[str, Optional[str]], oc_map: ClusterMap) -> None:
         raise Exception("invalid action: {}".format(action))
 
 
-def get_state_count_combinations(state: Iterable[Mapping[str, str]]) -> Counter[tuple]:
+def get_state_count_combinations(state: Iterable[Mapping[str, str]]) -> Counter[str]:
     return Counter(s["cluster"] for s in state)
 
 

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -1075,6 +1075,7 @@ def run(
         if error:
             sys.exit(1)
 
+    ob.publish_metrics(ri, QONTRACT_INTEGRATION)
     ob.realize_data(dry_run, oc_map, ri, thread_pool_size)
 
     if ri.has_error_registered():

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -195,6 +195,7 @@ def run(dry_run, thread_pool_size=10, internal=None, use_jump_host=True, defer=N
     )
     defer(oc_map.cleanup)
     fetch_desired_state(ri, oc_map)
+    ob.publish_metrics(ri, QONTRACT_INTEGRATION)
     ob.realize_data(dry_run, oc_map, ri, thread_pool_size)
 
     if ri.has_error_registered():

--- a/reconcile/test/test_openshift_groups.py
+++ b/reconcile/test/test_openshift_groups.py
@@ -1,0 +1,13 @@
+from reconcile import openshift_groups as og
+
+
+def test_get_state_count_combinations():
+    state = [
+        {"cluster": "c1"},
+        {"cluster": "c2"},
+        {"cluster": "c1"},
+        {"cluster": "c3"},
+        {"cluster": "c2"},
+    ]
+    expected = {"c1": 2, "c2": 2, "c3": 1}
+    assert expected == og.get_state_count_combinations(state)

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -12,7 +12,9 @@ from typing import (
 )
 
 import semver
+from pydantic import BaseModel
 
+from reconcile.utils.metrics import GaugeMetric
 from reconcile.utils.unleash import get_feature_toggle_state
 
 SECRET_MAX_KEY_LENGTH = 253
@@ -546,6 +548,25 @@ def fully_qualified_kind(kind: str, api_version: str) -> str:
         group = api_version.split("/")[0]
         return f"{kind}.{group}"
     return kind
+
+
+class OpenshiftResourceBaseMetric(BaseModel):
+    "Base class Openshift Resource metrics"
+
+    integration: str
+
+
+class OpenshiftResourceInventoryGauge(OpenshiftResourceBaseMetric, GaugeMetric):
+    "Inventory Gauge"
+
+    cluster: str
+    namespace: str
+    kind: str
+    state: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "qontract_reconcile_openshift_resource_inventory"
 
 
 class ResourceInventory:


### PR DESCRIPTION
this PR adds a new `qontract_reconcile_openshift_resource_inventory` metric, a guage which describes the number of resources managed per cluster, namespace, kind and state (current/desired).