### PR TITLE
APPSRE-7307 validate promotion via publisher uid

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -188,6 +188,7 @@ def run(
         gitlab=gl,
         jenkins_map=jenkins_map,
         state=init_state(integration=QONTRACT_INTEGRATION, secret_reader=secret_reader),
+        all_saas_files=saas_file_list.saas_files,
     )
     if defer:
         defer(saasherder.cleanup)

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -911,6 +911,7 @@ class TestConfigHashPromotionsValidation(TestCase):
             hash_length=24,
             repo_url="https://repo-url.com",
         )
+        self.saasherder._all_saas_files = self.all_saas_files
 
         # IMPORTANT: Populating desired state modify self.saas_files within
         # saasherder object.

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -880,8 +880,6 @@ class TestConfigHashPromotionsValidation(TestCase):
         self.saas_file = self.gql_class_factory(  # type: ignore[attr-defined] # it's set in the fixture
             SaasFile, Fixtures("saasherder").get_anymarkup("saas.gql.yml")
         )
-        self.all_saas_files = [self.saas_file]
-
         self.state_patcher = patch("reconcile.utils.state.State", autospec=True)
         self.state_mock = self.state_patcher.start().return_value
 
@@ -910,8 +908,8 @@ class TestConfigHashPromotionsValidation(TestCase):
             integration_version="",
             hash_length=24,
             repo_url="https://repo-url.com",
+            all_saas_files=[self.saas_file],
         )
-        self.saasherder._all_saas_files = self.all_saas_files
 
         # IMPORTANT: Populating desired state modify self.saas_files within
         # saasherder object.
@@ -1009,10 +1007,8 @@ class TestConfigHashTrigger(TestCase):
 
     def setUp(self) -> None:
         self.saas_file = self.gql_class_factory(  # type: ignore[attr-defined] # it's set in the fixture
-            SaasFileV2, Fixtures("saasherder").get_anymarkup("saas.gql.yml")
+            SaasFile, Fixtures("saasherder").get_anymarkup("saas.gql.yml")
         )
-        self.all_saas_files = [self.saas_file]
-
         self.state_patcher = patch("reconcile.utils.state.State", autospec=True)
         self.state_mock = self.state_patcher.start().return_value
 
@@ -1036,6 +1032,7 @@ class TestConfigHashTrigger(TestCase):
             integration_version="",
             hash_length=24,
             repo_url="https://repo-url.com",
+            all_saas_files=[self.saas_file],
         )
 
     def tearDown(self) -> None:

--- a/reconcile/utils/saasherder/interfaces.py
+++ b/reconcile/utils/saasherder/interfaces.py
@@ -273,6 +273,11 @@ class SaasResourceTemplateTargetPromotion(Protocol):
         ...
 
 
+class Channel(Protocol):
+    name: str
+    publisher_uids: list[str]
+
+
 @runtime_checkable
 class SaasPromotion(Protocol):
     commit_sha: str
@@ -280,12 +285,15 @@ class SaasPromotion(Protocol):
     target_config_hash: str
     auto: Optional[bool] = None
     publish: Optional[list[str]] = None
-    subscribe: Optional[list[str]] = None
     saas_file_paths: Optional[list[str]] = None
     target_paths: Optional[list[str]] = None
 
     @property
     def promotion_data(self) -> Optional[Sequence[SaasPromotionData]]:
+        ...
+
+    @property
+    def subscribe(self) -> Optional[list[Channel]]:
         ...
 
     def dict(self, *, by_alias: bool = False) -> dict[str, Any]:

--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -166,6 +166,11 @@ class PromotionData(BaseModel):
     data: Optional[list[Union[ParentSaasPromotion, PromotionChannelData]]] = None
 
 
+class Channel(BaseModel):
+    name: str
+    publisher_uids: list[str]
+
+
 class Promotion(BaseModel):
     """Implementation of the SaasPromotion interface for saasherder and AutoPromoter."""
 
@@ -175,7 +180,7 @@ class Promotion(BaseModel):
     saas_target_uid: str
     auto: Optional[bool] = None
     publish: Optional[list[str]] = None
-    subscribe: Optional[list[str]] = None
+    subscribe: Optional[list[Channel]] = None
     promotion_data: Optional[list[PromotionData]] = None
     saas_file_paths: Optional[list[str]] = None
     target_paths: Optional[list[str]] = None

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -71,6 +71,7 @@ from reconcile.utils.saasherder.interfaces import (
     SaasSecretParameters,
 )
 from reconcile.utils.saasherder.models import (
+    Channel,
     ImageAuth,
     Namespace,
     Promotion,
@@ -119,6 +120,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         state: Optional[State] = None,
         validate: bool = False,
         include_trigger_trace: bool = False,
+        all_saas_files: Optional[Iterable[SaasFile]] = None,
     ):
         self.error_registered = False
         self.saas_files = saas_files
@@ -140,6 +142,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         self.include_trigger_trace = include_trigger_trace
         self.state = state
         self._promotion_state = PromotionState(state=state) if state else None
+        self._all_saas_files = all_saas_files
 
         # each namespace is in fact a target,
         # so we can use it to calculate.
@@ -1036,10 +1039,11 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
 
         target_promotion = None
         if target.promotion:
+            channels = self._assemble_channels(channel_names=target.promotion.subscribe)
             target_promotion = Promotion(
                 auto=target.promotion.auto,
                 publish=target.promotion.publish,
-                subscribe=target.promotion.subscribe,
+                subscribe=channels,
                 promotion_data=target.promotion.promotion_data,
                 commit_sha=commit_sha,
                 saas_file=saas_file_name,
@@ -1050,6 +1054,37 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 ),
             )
         return resources, html_url, target_promotion
+
+    def _assemble_channels(
+        self, channel_names: Optional[Iterable[str]]
+    ) -> list[Channel]:
+        """
+        We need to assemble all publisher_uids that are publishing to a channel.
+        These uids are required to validate correctness of promotions.
+        """
+        channel_names_set = set(channel_names or [])
+        channel_map: dict[str, Channel] = {}
+        if not self._all_saas_files:
+            raise RuntimeError("Must set self._all_saas_files at saasherder init")
+        for saas_file in self._all_saas_files:
+            for tmpl in saas_file.resource_templates:
+                for target in tmpl.targets:
+                    if not target.promotion:
+                        continue
+                    for publish in target.promotion.publish or []:
+                        if publish not in channel_names_set:
+                            continue
+                        publisher_uid = target.uid(
+                            parent_saas_file_name=saas_file.name,
+                            parent_resource_template_name=tmpl.name,
+                        )
+                        if publish not in channel_map:
+                            channel_map[publish] = Channel(
+                                name=publish,
+                                publisher_uids=[],
+                            )
+                        channel_map[publish].publisher_uids.append(publisher_uid)
+        return list(channel_map.values())
 
     @staticmethod
     def _collect_images(resource: Resource) -> set[str]:
@@ -1836,23 +1871,26 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             # was successfully published to the subscribed channel(s)
             if promotion.subscribe:
                 for channel in promotion.subscribe:
-                    info = self._promotion_state.get_promotion_data(
-                        sha=promotion.commit_sha,
-                        channel=channel,
-                        target_uid=promotion.saas_target_uid,
-                        local_lookup=False,
-                    )
-                    if not (info and info.success):
-                        logging.error(
-                            f"Commit {promotion.commit_sha} was not "
-                            + f"published with success to channel {channel}"
+                    config_hashes: set[str] = set()
+                    for target_uid in channel.publisher_uids:
+                        deployment = self._promotion_state.get_promotion_data(
+                            sha=promotion.commit_sha,
+                            channel=channel.name,
+                            target_uid=target_uid,
+                            local_lookup=False,
                         )
-                        return False
-                    state_config_hash = info.target_config_hash
+                        if not (deployment and deployment.success):
+                            logging.error(
+                                f"Commit {promotion.commit_sha} was not "
+                                + f"published with success to channel {channel}"
+                            )
+                            return False
+                        if deployment.target_config_hash:
+                            config_hashes.add(deployment.target_config_hash)
 
                     # This code supports current saas targets that does
                     # not have promotion_data yet
-                    if not state_config_hash or not promotion.promotion_data:
+                    if not config_hashes or not promotion.promotion_data:
                         logging.info(
                             "Promotion data is missing; rely on the success "
                             "state only"
@@ -1864,7 +1902,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     # promotion_data type by now.
                     parent_saas_config = None
                     for pd in promotion.promotion_data:
-                        if pd.channel == channel:
+                        if pd.channel == channel.name:
                             for data in pd.data or []:
                                 if isinstance(data, SaasParentSaasPromotion):
                                     parent_saas_config = data
@@ -1882,7 +1920,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
 
                     # Validate that the state config_hash set by the parent
                     # matches with the hash set in promotion_data
-                    if parent_saas_config.target_config_hash == state_config_hash:
+                    if parent_saas_config.target_config_hash in config_hashes:
                         return True
 
                     logging.error(
@@ -1890,7 +1928,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         "configuration and the same commit (ref). "
                         "Check if other MR exists for this target, "
                         f"or update {parent_saas_config.target_config_hash} "
-                        f"to {state_config_hash} for channel {channel}"
+                        f"to any in {config_hashes} for channel {channel}"
                     )
                     return False
         return True

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1882,7 +1882,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         if not (deployment and deployment.success):
                             logging.error(
                                 f"Commit {promotion.commit_sha} was not "
-                                + f"published with success to channel {channel}"
+                                + f"published with success to channel {channel.name}"
                             )
                             return False
                         if deployment.target_config_hash:
@@ -1928,7 +1928,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         "configuration and the same commit (ref). "
                         "Check if other MR exists for this target, "
                         f"or update {parent_saas_config.target_config_hash} "
-                        f"to any in {config_hashes} for channel {channel}"
+                        f"to any in {config_hashes} for channel {channel.name}"
                     )
                     return False
         return True


### PR DESCRIPTION
This is a prerequisite to switch to promotions_v2 in saasherder, which is needed to allow multi-publisher channels.

A subscriber needs a relation to all publisher target uids in order to validate promotions from multiple different publishers towards the same publisher channel.

This PR mainly introduces a method to introduce a channel class to the saas file class. The channel object holds all publisher uids.

Saasherder gets a full list of saas files from openshift-saas-deploy. This list is required to resolve publisher -> channel -> subscriber relations. Currently only openshift-saas-deploy uses validate_promotions, so this should be fine.

Note, that saasherder is still primarily using promotions_v1 to validate promotions.
If this change does not lead to issues, we will switch to promotions_v2 in a follow-up PR and cross fingers.

**Test**

Ran openshift-saas-deploy locally