### PR TITLE
Bump skip minutes

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -81,7 +81,7 @@ from reconcile.utils.semver_helper import (
 )
 from reconcile.utils.state import init_state
 
-MIN_DELTA_MINUTES = 5
+MIN_DELTA_MINUTES = 6
 
 
 class AdvancedUpgradeSchedulerBaseIntegrationParams(PydanticRunParams):

--- a/reconcile/test/ocm/aus/test_base.py
+++ b/reconcile/test/ocm/aus/test_base.py
@@ -93,7 +93,7 @@ def test_calculate_diff_no_lock(
                 cluster=cluster_1,
                 version="4.12.19",
                 schedule_type="manual",
-                next_run="2021-08-30T18:06:00Z",
+                next_run="2021-08-30T18:07:00Z",
             ),
             gates_to_agree=[],
         )
@@ -160,7 +160,7 @@ def test_calculate_diff_inter_lock(
                 cluster=cluster_1,
                 version="4.12.19",
                 schedule_type="manual",
-                next_run="2021-08-30T18:06:00Z",
+                next_run="2021-08-30T18:07:00Z",
             ),
             gates_to_agree=[],
         )
@@ -780,7 +780,7 @@ def test_verify_lock_should_skip_locked_by_another_cluster() -> None:
 def test_verify_schedule_should_skip_cluster_now() -> None:
     cluster_upgrade_spec = build_cluster_upgrade_spec(name="cluster")
     now = datetime.now()
-    expected = now + timedelta(minutes=6)
+    expected = now + timedelta(minutes=7)
     s = base.verify_schedule_should_skip(
         cluster_upgrade_spec,
         now,

--- a/reconcile/test/ocm/aus/test_calculate_diff.py
+++ b/reconcile/test/ocm/aus/test_calculate_diff.py
@@ -112,7 +112,7 @@ def test_calculate_diff_create_cluster_upgrade_no_gate(
                 cluster=cluster,
                 version="4.12.19",
                 schedule_type="manual",
-                next_run="2021-08-30T18:06:00Z",
+                next_run="2021-08-30T18:07:00Z",
             ),
             gates_to_agree=[],
         )
@@ -152,7 +152,7 @@ def test_calculate_diff_create_control_plane_upgrade_no_gate(
                 cluster=cluster,
                 version="4.12.19",
                 schedule_type="manual",
-                next_run="2021-08-30T18:06:00Z",
+                next_run="2021-08-30T18:07:00Z",
             ),
             gates_to_agree=[],
         )


### PR DESCRIPTION
With only 5 minutes node pool upgrades might fail at times. Increase to 6 minutes