### PR TITLE
[sql-query] Publish sql-query metrics for qontract_reconcile_openshift_resource_inventory

### DIFF
--- a/reconcile/test/change_owners/fixtures.py
+++ b/reconcile/test/change_owners/fixtures.py
@@ -160,12 +160,8 @@ def build_bundle_resourcefile_change(
     builder = QontractServerBundleDiffDataBuilder().add_resource_file(
         path=path,
         schema=schema,
-        old_content=json.dumps(old_content)
-        if old_content and isinstance(old_content, dict)
-        else old_content,
-        new_content=json.dumps(new_content)
-        if new_content and isinstance(new_content, dict)
-        else new_content,
+        old_content=old_content,
+        new_content=new_content,
     )
     parsed_changes = parse_bundle_changes(builder.diff)
     bundle_file_change = parsed_changes[0] if parsed_changes else None

--- a/reconcile/test/test_sql_query.py
+++ b/reconcile/test/test_sql_query.py
@@ -1,6 +1,14 @@
-import pytest
+from collections.abc import Callable
+from unittest.mock import create_autospec
 
+import pytest
+from pytest_mock import MockFixture
+
+import reconcile.sql_query as intg
+from reconcile.gql_definitions.common.smtp_client_settings import SmtpSettingsV1
 from reconcile.sql_query import split_long_query
+from reconcile.utils.oc import OCCli
+from reconcile.utils.state import State
 
 
 @pytest.mark.parametrize(
@@ -17,3 +25,191 @@ from reconcile.sql_query import split_long_query
 )
 def test_split_long_query(q, size, expected):
     assert split_long_query(q, size) == expected
+
+
+@pytest.fixture
+def smtp_settings(
+    gql_class_factory: Callable[..., SmtpSettingsV1],
+) -> SmtpSettingsV1:
+    return gql_class_factory(
+        SmtpSettingsV1,
+        {
+            "mailAddress": "some_address",
+            "timeout": 30,
+            "credentials": {
+                "path": "some-path",
+            },
+        },
+    )
+
+
+@pytest.fixture
+def smtp_server_connection_info() -> dict:
+    return {
+        "server": "some-host",
+        "port": 1234,
+        "username": "some-username",
+        "password": "some-password",
+    }
+
+
+@pytest.fixture
+def sql_query() -> dict:
+    return {
+        "name": "some-query",
+        "delete": None,
+        "identifier": "rds-id",
+        "query": None,
+        "queries": ["SELECT * FROM table;"],
+        "namespace": {
+            "name": "some-namespace",
+            "managedExternalResources": True,
+            "externalResources": [
+                {
+                    "provider": "aws",
+                    "provisioner": {
+                        "name": "some-provisioner",
+                    },
+                    "resources": [
+                        {
+                            "provider": "rds",
+                            "identifier": "rds-id",
+                        }
+                    ],
+                }
+            ],
+            "app": {
+                "name": "some-app",
+            },
+            "environment": {
+                "name": "some-env",
+            },
+            "cluster": {
+                "name": "some-cluster",
+            },
+        },
+        "overrides": None,
+        "output": "stdout",
+    }
+
+
+def setup_mocks(
+    mocker: MockFixture,
+    smtp_settings: SmtpSettingsV1,
+    smtp_server_connection_info: dict,
+    sql_query: dict,
+    state: dict,
+    time: float = 0.0,
+    current_items: dict[str, list[str]] | None = None,
+) -> dict:
+    mocked_queries = mocker.patch("reconcile.sql_query.queries")
+    mocked_queries.get_app_interface_settings.return_value = {}
+    mocked_queries.get_app_interface_sql_queries.return_value = [sql_query]
+    mocked_state = create_autospec(State)
+    mocked_state.ls.return_value = [f"/{k}" for k in state.keys()]
+    mocked_state.__getitem__.side_effect = lambda x: state[x]
+    mocked_secret_reader = mocker.patch("reconcile.sql_query.SecretReader")
+    mocked_secret_reader.return_value.read_all_secret.return_value = (
+        smtp_server_connection_info
+    )
+    mocker.patch("reconcile.sql_query.init_state", return_value=mocked_state)
+    mocker.patch(
+        "reconcile.sql_query.typed_queries.smtp.settings", return_value=smtp_settings
+    )
+    mocked_ts = mocker.patch("reconcile.sql_query.Terrascript")
+    mocked_ts.return_value.init_values.return_value = {}
+    mocked_ob = mocker.patch("reconcile.sql_query.openshift_base")
+
+    mocked_oc_map = mocker.patch("reconcile.sql_query.OC_Map", autospec=True)
+    mocked_oc_client = create_autospec(OCCli)
+    mocked_oc_client.get_items.side_effect = lambda kind, **_: [
+        {"kind": kind, "metadata": {"name": name}}
+        for name in current_items.get(kind, [])
+    ]
+    mocked_oc_map.return_value.__enter__.return_value.get_cluster.return_value = (
+        mocked_oc_client
+    )
+
+    mocked_time = mocker.patch("reconcile.sql_query.time")
+    mocked_time.time.return_value = time
+
+    return {
+        "mocked_queries": mocked_queries,
+        "mocked_state": mocked_state,
+        "mocked_ob": mocked_ob,
+    }
+
+
+def test_run_with_new_sql_query(
+    mocker: MockFixture,
+    smtp_settings: SmtpSettingsV1,
+    smtp_server_connection_info: dict,
+    sql_query: dict,
+) -> None:
+    mocks = setup_mocks(
+        mocker=mocker,
+        smtp_settings=smtp_settings,
+        smtp_server_connection_info=smtp_server_connection_info,
+        sql_query=sql_query,
+        state={},
+    )
+
+    intg.run(False)
+
+    mocks["mocked_ob"].apply.assert_called()
+    assert mocks["mocked_ob"].apply.call_count == 4
+    mocks["mocked_ob"].delete.assert_not_called()
+
+
+def test_run_with_done_sql_query(
+    mocker: MockFixture,
+    smtp_settings: SmtpSettingsV1,
+    smtp_server_connection_info: dict,
+    sql_query: dict,
+) -> None:
+    mocks = setup_mocks(
+        mocker=mocker,
+        smtp_settings=smtp_settings,
+        smtp_server_connection_info=smtp_server_connection_info,
+        sql_query=sql_query,
+        state={"some-query": "DONE"},
+    )
+
+    intg.run(False)
+
+    mocks["mocked_ob"].apply.assert_not_called()
+    mocks["mocked_ob"].delete.assert_not_called()
+
+
+@pytest.fixture
+def current_items() -> dict[str, list[str]]:
+    return {
+        "ConfigMap": ["some-query-gpg-key", "some-query-q00000c00000"],
+        "ServiceAccount": ["some-query"],
+        "Job": ["some-query"],
+    }
+
+
+def test_run_with_sql_query_need_cleanup(
+    mocker: MockFixture,
+    smtp_settings: SmtpSettingsV1,
+    smtp_server_connection_info: dict,
+    sql_query: dict,
+    current_items: dict[str, list[str]],
+) -> None:
+    mocks = setup_mocks(
+        mocker=mocker,
+        smtp_settings=smtp_settings,
+        smtp_server_connection_info=smtp_server_connection_info,
+        sql_query=sql_query,
+        state={"some-query": 0},
+        time=6048000.0,
+        current_items=current_items,
+    )
+
+    intg.run(False, enable_deletion=True)
+
+    mocks["mocked_ob"].apply.assert_not_called()
+    mocks["mocked_ob"].delete.assert_called()
+    assert mocks["mocked_ob"].delete.call_count == 4
+    mocks["mocked_state"].__setitem__.assert_called_once_with("some-query", "DONE")


### PR DESCRIPTION
Follow up on #3858, `sql-query` integration `qontract_reconcile_openshift_resource_inventory` metric is a special one.

This integration is using state bucket to do conditional operations without populating all current and desired states. This change handles metrics in the following logic:

* For new query, populate `desired` from constructed openshift resources
* For existing query:
  * If state is `DONE`, publish current and desired with 0 as all resources are already deleted
  * If pending deletion (explicit delete or TTL expired), publish current openshift resources to be deleted
  * If still active, reconstruct desired openshift resources and use them as both desired and current


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6676e4</samp>

Added and updated tests for `sql_query` integration. The tests cover various scenarios of querying data from different sources and handling errors. The test file also has updated imports to reflect the changes in the integration code.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at b6676e4</samp>

*  Add imports for modules and classes used in new tests ([link](https://github.com/app-sre/qontract-reconcile/pull/3871/files?diff=unified&w=0#diff-7c15e1482046349edcc507e8edf0a26d896111ff958613cf3ff79c75d06dc1b4L1-R12))
*  Add tests for `run` function of `sql_query` integration ([link](https://github.com/app-sre/qontract-reconcile/pull/3871/files?diff=unified&w=0#diff-7c15e1482046349edcc507e8edf0a26d896111ff958613cf3ff79c75d06dc1b4R29-R316))