### PR TITLE
autodetect default branch name for automated MRs

### DIFF
--- a/reconcile/test/utils/test_mr_clusters_updates.py
+++ b/reconcile/test/utils/test_mr_clusters_updates.py
@@ -21,7 +21,6 @@ class TestProcess(TestCase):
         cli = MagicMock()
         c = sut.CreateClustersUpdates({})
         c.branch = "abranch"
-        c.main_branch = "main"
         c.process(cli)
         cancel.assert_called_once()
 
@@ -34,7 +33,6 @@ class TestProcess(TestCase):
             {"cluster1": {"spec": {"id": "42"}, "root": {}, "path": "/a/path"}}
         )
         c.branch = "abranch"
-        c.main_branch = "main"
         c.process(cli)
         self.clusters[0]["spec"]["id"] = "42"
 
@@ -61,7 +59,6 @@ class TestProcess(TestCase):
             }
         )
         c.branch = "abranch"
-        c.main_branch = "main"
         c.process(cli)
         self.clusters[0]["prometheusUrl"] = "aprometheusurl"
 

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -100,6 +100,22 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
             gitlab_request.labels(integration=INTEGRATION_NAME).inc()
             self.project = self.gl.projects.get(project_id)
         self.saas_files = saas_files
+        self._main_branch = None
+
+    @property
+    def main_branch(self) -> str:
+        if self._main_branch is None:
+            self._main_branch = self._determine_main_branch()
+        return self._main_branch or "master"
+
+    def _determine_main_branch(self) -> Optional[str]:
+        if self.project:
+            main_branch_obj = next(
+                (b for b in self.project.branches.list() if b.default), None
+            )
+            if main_branch_obj:
+                return main_branch_obj.name
+        return None
 
     def __enter__(self):
         return self

--- a/reconcile/utils/mr/__init__.py
+++ b/reconcile/utils/mr/__init__.py
@@ -38,7 +38,7 @@ class UnknownMergeRequestType(Exception):
     """
 
 
-def init_from_sqs_message(message):
+def init_from_sqs_message(message) -> MergeRequestBase:
     # First, let's find the classes that are inheriting from
     # MergeRequestBase and create a map where the class.name is
     # the key and the class itself is the value.

--- a/reconcile/utils/mr/app_interface_reporter.py
+++ b/reconcile/utils/mr/app_interface_reporter.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from ruamel.yaml.scalarstring import PreservedScalarString as pss
 
+from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.mr.base import (
     MergeRequestBase,
     app_interface_email,
@@ -34,7 +35,7 @@ class CreateAppInterfaceReporter(MergeRequestBase):
     def description(self) -> str:
         return f"reports for {self.isodate}"
 
-    def process(self, gitlab_cli):
+    def process(self, gitlab_cli: GitLabApi) -> None:
         actions = [
             {
                 "action": "create",

--- a/reconcile/utils/mr/aws_access.py
+++ b/reconcile/utils/mr/aws_access.py
@@ -5,6 +5,7 @@ from ruamel import yaml
 from ruamel.yaml.scalarstring import PreservedScalarString as pss
 
 from reconcile.utils.constants import PROJ_ROOT
+from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.mr.base import (
     MergeRequestBase,
     app_interface_email,
@@ -34,10 +35,10 @@ class CreateDeleteAwsAccessKey(MergeRequestBase):
     def description(self) -> str:
         return f"delete {self.account} access key {self.key}"
 
-    def process(self, gitlab_cli):
+    def process(self, gitlab_cli: GitLabApi) -> None:
         # add key to deleteKeys list to be picked up by aws-iam-keys
         raw_file = gitlab_cli.project.files.get(
-            file_path=self.path, ref=self.main_branch
+            file_path=self.path, ref=gitlab_cli.main_branch
         )
         content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
 

--- a/reconcile/utils/mr/base.py
+++ b/reconcile/utils/mr/base.py
@@ -217,6 +217,7 @@ class MergeRequestBase(ABC):
 
         if isinstance(cli, SQSGateway):
             self.submit_to_sqs(sqs_cli=cli)
+            return None
 
         raise AttributeError(f"client {cli} not supported")
 

--- a/reconcile/utils/mr/base.py
+++ b/reconcile/utils/mr/base.py
@@ -1,10 +1,11 @@
 import json
 import logging
 from abc import (
-    ABCMeta,
+    ABC,
     abstractmethod,
 )
 from typing import (
+    Any,
     Optional,
     Union,
 )
@@ -38,7 +39,7 @@ class MergeRequestProcessingError(Exception):
 MRClient = Union[GitLabApi, SQSGateway]
 
 
-class MergeRequestBase(metaclass=ABCMeta):
+class MergeRequestBase(ABC):
     """
     Base abstract class for all merge request types.
     """
@@ -52,19 +53,17 @@ class MergeRequestBase(metaclass=ABCMeta):
         # of the child class.
         self.sqs_msg_data = {**self.__dict__}
 
-        self.gitlab_cli = None
         self.labels = [DO_NOT_MERGE_HOLD]
 
         random_id = str(uuid4())[:6]
         self.branch = f"{self.name}-{random_id}"
         self.branch_created = False
 
-        self.main_branch = "master"
         self.remove_source_branch = True
 
         self.cancelled = False
 
-    def cancel(self, message):
+    def cancel(self, message: str) -> None:
         self.cancelled = True
         raise CancelMergeRequest(
             f"{self.name} MR canceled for "
@@ -93,7 +92,7 @@ class MergeRequestBase(metaclass=ABCMeta):
         """
 
     @abstractmethod
-    def process(self, gitlab_cli):
+    def process(self, gitlab_cli: GitLabApi) -> None:
         """
         Called by `submit_to_gitlab`, this method is the place for
         user-defined steps to create the commits of a merge request.
@@ -103,7 +102,7 @@ class MergeRequestBase(metaclass=ABCMeta):
         """
 
     @property
-    def sqs_data(self):
+    def sqs_data(self) -> dict[str, Any]:
         """
         The SQS Message payload (MessageBody) generated out of
         the Merge Request class instance.
@@ -113,7 +112,7 @@ class MergeRequestBase(metaclass=ABCMeta):
             **self.sqs_msg_data,
         }
 
-    def submit_to_sqs(self, sqs_cli) -> None:
+    def submit_to_sqs(self, sqs_cli: SQSGateway) -> None:
         """
         Sends the MR message to SQS.
 
@@ -122,21 +121,20 @@ class MergeRequestBase(metaclass=ABCMeta):
         """
         sqs_cli.send_message(self.sqs_data)
 
-    @property
-    def gitlab_data(self):
+    def gitlab_data(self, target_branch: str) -> dict[str, Any]:
         """
         The Gitlab payload for creating the Merge Request.
         """
         return {
             "source_branch": self.branch,
-            "target_branch": self.main_branch,
+            "target_branch": target_branch,
             "title": self.title,
             "description": self.description,
             "remove_source_branch": self.remove_source_branch,
             "labels": self.labels,
         }
 
-    def submit_to_gitlab(self, gitlab_cli):
+    def submit_to_gitlab(self, gitlab_cli: GitLabApi) -> Any:
         """
         Sends the MR to Gitlab.
 
@@ -163,11 +161,13 @@ class MergeRequestBase(metaclass=ABCMeta):
             # Avoiding empty MRs
             if not self.diffs(gitlab_cli):
                 self.cancel(
-                    f"No changes when compared to {self.main_branch}. "
+                    f"No changes when compared to {gitlab_cli.main_branch}. "
                     "Aborting MR creation."
                 )
 
-            return gitlab_cli.project.mergerequests.create(self.gitlab_data)
+            return gitlab_cli.project.mergerequests.create(
+                self.gitlab_data(target_branch=gitlab_cli.main_branch)
+            )
         except CancelMergeRequest as mr_cancel:
             # cancellation is a valid behaviour. it indicates, that the
             # operation is not required, therefore we will not signal
@@ -187,14 +187,14 @@ class MergeRequestBase(metaclass=ABCMeta):
                 f"Reason: {err}"
             ) from err
 
-    def ensure_tmp_branch_exists(self, gitlab_cli):
+    def ensure_tmp_branch_exists(self, gitlab_cli: GitLabApi) -> None:
         if not self.branch_created:
             gitlab_cli.create_branch(
-                new_branch=self.branch, source_branch=self.main_branch
+                new_branch=self.branch, source_branch=gitlab_cli.main_branch
             )
             self.branch_created = True
 
-    def delete_tmp_branch(self, gitlab_cli):
+    def delete_tmp_branch(self, gitlab_cli: GitLabApi) -> None:
         if self.branch_created:
             try:
                 gitlab_cli.delete_branch(branch=self.branch)
@@ -206,17 +206,17 @@ class MergeRequestBase(metaclass=ABCMeta):
                     f"Failed to delete branch {self.branch}. " f"Reason: {gitlab_error}"
                 )
 
-    def diffs(self, gitlab_cli):
+    def diffs(self, gitlab_cli: GitLabApi) -> Any:
         return gitlab_cli.project.repository_compare(
-            from_=self.main_branch, to=self.branch
+            from_=gitlab_cli.main_branch, to=self.branch
         )["diffs"]
 
-    def submit(self, cli: MRClient):
+    def submit(self, cli: MRClient) -> Union[Any, None]:
         if isinstance(cli, GitLabApi):
             return self.submit_to_gitlab(gitlab_cli=cli)
 
         if isinstance(cli, SQSGateway):
-            return self.submit_to_sqs(sqs_cli=cli)
+            self.submit_to_sqs(sqs_cli=cli)
 
         raise AttributeError(f"client {cli} not supported")
 

--- a/reconcile/utils/mr/clusters_updates.py
+++ b/reconcile/utils/mr/clusters_updates.py
@@ -3,6 +3,7 @@ from io import StringIO
 from ruamel.yaml import YAML
 
 from reconcile.change_owners.decision import DecisionCommand
+from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.mr.base import MergeRequestBase
 
 yaml = YAML()
@@ -27,7 +28,7 @@ class CreateClustersUpdates(MergeRequestBase):
     def description(self) -> str:
         return DecisionCommand.APPROVED.value
 
-    def process(self, gitlab_cli):
+    def process(self, gitlab_cli: GitLabApi):
         changes = False
         for cluster_name, cluster_updates in self.clusters_updates.items():
             if not cluster_updates:
@@ -35,7 +36,7 @@ class CreateClustersUpdates(MergeRequestBase):
 
             cluster_path = cluster_updates.pop("path")
             raw_file = gitlab_cli.project.files.get(
-                file_path=cluster_path, ref=self.main_branch
+                file_path=cluster_path, ref=gitlab_cli.main_branch
             )
             content = yaml.load(raw_file.decode())
             if "spec" not in content:

--- a/reconcile/utils/mr/ocm_update_recommended_version.py
+++ b/reconcile/utils/mr/ocm_update_recommended_version.py
@@ -29,7 +29,7 @@ class CreateOCMUpdateRecommendedVersion(MergeRequestBase):
 
     def process(self, gitlab_cli: GitLabApi) -> None:
         raw_file = gitlab_cli.project.files.get(
-            file_path=self.path, ref=self.main_branch
+            file_path=self.path, ref=gitlab_cli.main_branch
         )
         content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
 

--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -1,5 +1,6 @@
 from ruamel import yaml
 
+from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.mr.base import MergeRequestBase
 from reconcile.utils.mr.labels import AUTO_MERGE
 
@@ -22,13 +23,13 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
     def description(self) -> str:
         return f'ocm upgrade scheduler org updates for {self.updates_info["name"]}'
 
-    def process(self, gitlab_cli):
+    def process(self, gitlab_cli: GitLabApi) -> None:
         changes = False
         ocm_path = self.updates_info["path"]
         ocm_name = self.updates_info["name"]
 
         raw_file = gitlab_cli.project.files.get(
-            file_path=ocm_path, ref=self.main_branch
+            file_path=ocm_path, ref=gitlab_cli.main_branch
         )
         content = yaml.load(raw_file.decode(), Loader=yaml.RoundTripLoader)
         upgrade_policy_clusters = content["upgradePolicyClusters"]

--- a/reconcile/utils/mr/user_maintenance.py
+++ b/reconcile/utils/mr/user_maintenance.py
@@ -1,5 +1,6 @@
 from ruamel import yaml
 
+from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.mr.base import MergeRequestBase
 from reconcile.utils.mr.labels import AUTO_MERGE
 
@@ -31,7 +32,7 @@ class CreateDeleteUserAppInterface(MergeRequestBase):
     def description(self) -> str:
         return f"delete user {self.username}"
 
-    def process(self, gitlab_cli):
+    def process(self, gitlab_cli: GitLabApi) -> None:
         for path_spec in self.paths:
             path_type = path_spec["type"]
             path = path_spec["path"]


### PR DESCRIPTION
the a-i default branch name can't be assumed to be "master" for all a-i repos but can be "main" or anything else as well.

this PR introduces main branch name detection.

(also added some typehints along the way, thought it is not comprehensive since the gitlab api does not really expose good typehints on its own 😢 )

https://issues.redhat.com/browse/APPSRE-8420