### PR TITLE
APPSRE-7307 remove promotions_v1 fetch

### DIFF
--- a/reconcile/test/saas_auto_promotions_manager/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/conftest.py
@@ -17,6 +17,10 @@ from reconcile.gql_definitions.fragments.saas_target_namespace import (
 from reconcile.saas_auto_promotions_manager.utils.vcs import VCS
 from reconcile.typed_queries.saas_files import SaasFile
 from reconcile.utils.gitlab_api import GitLabApi
+from reconcile.utils.promotion_state import (
+    PromotionData,
+    PromotionState,
+)
 
 
 @pytest.fixture
@@ -84,5 +88,15 @@ def saas_target_namespace_builder(
         if "cluster" not in data:
             data["cluster"] = {}
         return gql_class_factory(SaasTargetNamespace, data)
+
+    return builder
+
+
+@pytest.fixture
+def promotion_state_builder() -> Callable[..., PromotionState]:
+    def builder(data: Iterable[PromotionData]) -> PromotionState:
+        promotion_state = create_autospec(spec=PromotionState)
+        promotion_state.get_promotion_data.side_effect = data
+        return promotion_state
 
     return builder

--- a/reconcile/test/saas_auto_promotions_manager/test_integration_test.py
+++ b/reconcile/test/saas_auto_promotions_manager/test_integration_test.py
@@ -17,14 +17,16 @@ from reconcile.saas_auto_promotions_manager.utils.saas_files_inventory import (
 )
 from reconcile.saas_auto_promotions_manager.utils.vcs import VCS
 from reconcile.typed_queries.saas_files import SaasFile
-from reconcile.utils.promotion_state import PromotionState
-from reconcile.utils.state import State
+from reconcile.utils.promotion_state import (
+    PromotionData,
+    PromotionState,
+)
 
 
 def test_integration_test(
     saas_files_builder: Callable[[Iterable[Mapping]], list[SaasFile]],
     vcs_builder: Callable[..., VCS],
-    s3_state_builder: Callable[[Mapping], State],
+    promotion_state_builder: Callable[..., PromotionState],
 ):
     """
     Have all the parts glued together and have one full run.
@@ -86,27 +88,19 @@ def test_integration_test(
         ]
     )
     vcs = vcs_builder()
-    deployment_state = PromotionState(
-        state=s3_state_builder(
-            {
-                "ls": [
-                    "/promotions/channel-1/new_sha",
-                    "/promotions/channel-2/new_sha",
-                ],
-                "get": {
-                    "promotions/channel-1/new_sha": {
-                        "success": True,
-                        "target_config_hash": "new_hash",
-                        "saas_file": "saas_1",
-                    },
-                    "promotions/channel-2/new_sha": {
-                        "success": True,
-                        "target_config_hash": "new_hash",
-                        "saas_file": "saas_1",
-                    },
-                },
-            }
-        )
+    deployment_state = promotion_state_builder(
+        [
+            PromotionData(
+                success=True,
+                target_config_hash="new_hash",
+                saas_file="saas_1",
+            ),
+            PromotionData(
+                success=True,
+                target_config_hash="new_hash",
+                saas_file="saas_1",
+            ),
+        ]
     )
     renderer = create_autospec(spec=Renderer)
     merge_request_manager = MergeRequestManager(

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -13,9 +13,9 @@ from reconcile.utils.state import State
 def test_key_exists_v1(s3_state_builder: Callable[[Mapping], State]):
     state = s3_state_builder(
         {
-            "ls": ["/promotions/channel/sha"],
+            "ls": ["/promotions_v2/channel/uid/sha"],
             "get": {
-                "promotions/channel/sha": {
+                "promotions_v2/channel/uid/sha": {
                     "success": True,
                     "target_config_hash": "hash",
                     "saas_file": "saas_file",
@@ -80,7 +80,7 @@ def test_key_does_not_exist_locally(s3_state_builder: Callable[[Mapping], State]
         {
             "ls": [],
             "get": {
-                "promotions/channel/sha": {
+                "promotions_v2/channel/uid/sha": {
                     "success": True,
                     "target_config_hash": "hash",
                     "saas_file": "saas_file",


### PR DESCRIPTION
Deprecate promotions_v1. Deployment validation logic will not use any data from old promotions storage prefix.

Note, in the meantime we still keep publishing to promotions_v1 path, so that we can easily revert without having lost potential promotion data. Once this PR is confirmed to have worked, we will remove publishing to promotions_v1 in a follow-up PR.