### PR TITLE
[AUS] show delayed upgrade policies as long running upgrades

### DIFF
--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -203,7 +203,7 @@ def remaining_soak_day_metric_values_for_cluster(
         if current_upgrade and current_upgrade.version == version:
             if current_upgrade.state == "scheduled":
                 remaining_soakdays[idx] = UPGRADE_SCHEDULED_METRIC_VALUE
-            elif current_upgrade.state == "started":
+            elif current_upgrade.state in ("started", "delayed"):
                 remaining_soakdays[idx] = UPGRADE_STARTED_METRIC_VALUE
                 if current_upgrade.next_run:
                     # if an upgrade runs for over 6 hours, we mark it as a long running upgrade


### PR DESCRIPTION
if an upgrade gets delayed for too long, it is not in state `running` anymore but in state `delayed`. we can report such cluster upgrades as `long running` as well, as we do for `running` ones that run for > 6h already.