### PR TITLE
[aws-cloudwatch-log-retention] performance optimization part 1

### DIFF
--- a/reconcile/aws_cloudwatch_log_retention/integration.py
+++ b/reconcile/aws_cloudwatch_log_retention/integration.py
@@ -1,6 +1,7 @@
 import logging
 import re
 import typing
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 from botocore.exceptions import ClientError
@@ -26,7 +27,7 @@ class AWSCloudwatchLogRetention(BaseModel):
     retention_in_days: int
 
 
-def get_app_interface_cloudwatch_retention_period(
+def get_desired_retentions(
     aws_acct: dict,
 ) -> list[AWSCloudwatchLogRetention]:
     if cleanup := aws_acct.get("cleanup"):
@@ -41,95 +42,103 @@ def get_app_interface_cloudwatch_retention_period(
     return []
 
 
-def check_cloudwatch_log_group_tag(
-    log_groups: list, client: CloudWatchLogsClient
-) -> list:
-    log_group_list = []
-    for log_group in log_groups:
-        log_group_name = log_group.get("logGroupName")
-        tag_result = client.list_tags_log_group(logGroupName=log_group_name)
-        tag_list = tag_result.get("tags", {})
-        tag_match = any(
-            k == MANAGED_BY_INTEGRATION_KEY and v != QONTRACT_INTEGRATION
-            for k, v in tag_list.items()
-        )
-        if not tag_match:
-            log_group_tag_info = {**log_group, "tags": tag_list}
-            log_group_list.append(log_group_tag_info)
-    return log_group_list
-
-
 def create_awsapi_client(accounts: list, thread_pool_size: int) -> AWSApi:
     settings = queries.get_secret_reader_settings()
     return AWSApi(thread_pool_size, accounts, settings=settings, init_users=False)
 
 
-def get_log_group_list(awsapi: AWSApi, aws_acct: dict) -> list:
-    log_groups = awsapi.get_cloudwatch_logs(aws_acct)
+def get_log_group_tags(awsapi: AWSApi, aws_acct: dict, log_group: dict) -> dict:
     session = awsapi.get_session(aws_acct["name"])
     region = aws_acct["resourcesDefaultRegion"]
     log_client = awsapi.get_session_client(session, "logs", region)
-    log_group_list = check_cloudwatch_log_group_tag(log_groups, log_client)
-    return log_group_list
+    log_group_name = log_group.get("logGroupName")
+    tag_result = log_client.list_tags_log_group(logGroupName=log_group_name)
+    tag_list = tag_result.get("tags", {})
+    return tag_list
+
+
+def _reconcile_log_group(
+    dry_run: bool,
+    aws_log_group: dict,
+    desired_retentions: Iterable[AWSCloudwatchLogRetention],
+    aws_account: dict,
+    awsapi: AWSApi,
+) -> None:
+    current_retention_in_days = aws_log_group.get("retentionInDays")
+    group_name = aws_log_group["logGroupName"]
+    desired_retention_days = next(
+        (c.retention_in_days for c in desired_retentions if c.regex.match(group_name)),
+        DEFAULT_RETENTION_IN_DAYS,
+    )
+    if current_retention_in_days == desired_retention_days:
+        return
+
+    log_group_tags = get_log_group_tags(awsapi, aws_account, aws_log_group)
+    if managed_by_integration := log_group_tags.get(MANAGED_BY_INTEGRATION_KEY):
+        if managed_by_integration != QONTRACT_INTEGRATION:
+            return
+    else:
+        logging.info(
+            "Setting tag %s for log group %s",
+            MANAGED_TAG,
+            group_name,
+        )
+        if not dry_run:
+            awsapi.create_cloudwatch_tag(aws_account, group_name, MANAGED_TAG)
+
+    logging.info(
+        "Setting %s retention days to %d",
+        group_name,
+        desired_retention_days,
+    )
+    if not dry_run:
+        awsapi.set_cloudwatch_log_retention(
+            aws_account, group_name, desired_retention_days
+        )
+
+
+def _reconcile_log_groups(
+    dry_run: bool,
+    aws_account: dict,
+    awsapi: AWSApi,
+) -> None:
+    aws_account_name = aws_account["name"]
+    try:
+        aws_log_groups = awsapi.get_cloudwatch_logs(aws_account)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "AccessDeniedException":
+            logging.info(
+                "Access denied for aws account %s. Skipping...",
+                aws_account_name,
+            )
+        else:
+            logging.error(
+                "Error getting log groups for %s: %s",
+                aws_account_name,
+                e,
+            )
+        return
+
+    desired_retentions = get_desired_retentions(aws_account)
+    for aws_log_group in aws_log_groups:
+        try:
+            _reconcile_log_group(
+                dry_run=dry_run,
+                aws_log_group=aws_log_group,
+                desired_retentions=desired_retentions,
+                aws_account=aws_account,
+                awsapi=awsapi,
+            )
+        except ClientError as e:
+            logging.error(
+                "Error reconciling log group retention for %s: %s",
+                aws_log_group["logGroupName"],
+                e,
+            )
 
 
 def run(dry_run: bool, thread_pool_size: int) -> None:
     aws_accounts = get_aws_accounts(cleanup=True)
     with create_awsapi_client(aws_accounts, thread_pool_size) as awsapi:
         for aws_account in aws_accounts:
-            aws_account_name = aws_account["name"]
-            cloudwatch_cleanup_list = get_app_interface_cloudwatch_retention_period(
-                aws_account
-            )
-            try:
-                aws_log_group_list = get_log_group_list(awsapi, aws_account)
-            except ClientError as e:
-                if e.response["Error"]["Code"] == "AccessDeniedException":
-                    logging.info(
-                        "Access denied for aws account %s. Skipping...",
-                        aws_account_name,
-                    )
-                else:
-                    logging.error(
-                        "Error getting log groups for %s: %s",
-                        aws_account_name,
-                        e,
-                    )
-                continue
-
-            for aws_log_group in aws_log_group_list:
-                group_name = aws_log_group["logGroupName"]
-                retention_days = aws_log_group.get("retentionInDays")
-
-                log_group_tags = aws_log_group["tags"]
-                if (
-                    log_group_tags.get(MANAGED_BY_INTEGRATION_KEY)
-                    != QONTRACT_INTEGRATION
-                ):
-                    logging.info(
-                        "Setting tag %s for log group %s",
-                        MANAGED_TAG,
-                        group_name,
-                    )
-                    if not dry_run:
-                        awsapi.create_cloudwatch_tag(
-                            aws_account, group_name, MANAGED_TAG
-                        )
-                desired_retention_days = next(
-                    (
-                        c.retention_in_days
-                        for c in cloudwatch_cleanup_list
-                        if c.regex.match(group_name)
-                    ),
-                    DEFAULT_RETENTION_IN_DAYS,
-                )
-                if retention_days != desired_retention_days:
-                    logging.info(
-                        "Setting %s retention days to %d",
-                        group_name,
-                        desired_retention_days,
-                    )
-                    if not dry_run:
-                        awsapi.set_cloudwatch_log_retention(
-                            aws_account, group_name, desired_retention_days
-                        )
+            _reconcile_log_groups(dry_run, aws_account, awsapi)

--- a/reconcile/test/test_aws_cloudwatch_log_retention.py
+++ b/reconcile/test/test_aws_cloudwatch_log_retention.py
@@ -1,13 +1,18 @@
 from collections.abc import Generator
-from typing import TYPE_CHECKING
+from typing import (
+    TYPE_CHECKING,
+    Any,
+)
 
 import boto3
 import pytest
 from moto import mock_logs
+from pytest_mock import MockerFixture
 
 from reconcile.aws_cloudwatch_log_retention.integration import (
     check_cloudwatch_log_group_tag,
     get_app_interface_cloudwatch_retention_period,
+    run,
 )
 
 if TYPE_CHECKING:
@@ -45,27 +50,34 @@ def log_group_tf_tag(cloudwatchlogs_client: CloudWatchLogsClient) -> list:
     return log_output_list
 
 
-def test_get_app_interface_cloudwatch_retention_period() -> None:
-    test_cloudwatch_acct = {
+@pytest.fixture
+def test_cloudwatch_account() -> dict[str, Any]:
+    return {
         "accountOwners": [{"email": "some-email@email.com", "name": "Some Team"}],
         "cleanup": [
             {
                 "provider": "cloudwatch",
-                "regex": "some/path*",
-                "retention_in_days": "90",
+                "regex": "some-path*",
+                "retention_in_days": "30",
             },
             {
                 "provider": "cloudwatch",
-                "regex": "some/other/path*",
-                "retention_in_days": "90",
+                "regex": "some-other-path*",
+                "retention_in_days": "60",
             },
         ],
         "consoleUrl": "https://some-url.com/console",
         "name": "some-account-name",
         "uid": "0123456789",
+        "resourcesDefaultRegion": "us-east-1",
     }
+
+
+def test_get_app_interface_cloudwatch_retention_period(
+    test_cloudwatch_account: dict,
+) -> None:
     refined_cloudwatch_list = get_app_interface_cloudwatch_retention_period(
-        test_cloudwatch_acct
+        test_cloudwatch_account
     )
     assert len(refined_cloudwatch_list) == 2
 
@@ -76,3 +88,193 @@ def test_get_log_tag_groups(
     tag_result = log_group_tf_tag
     result = check_cloudwatch_log_group_tag(tag_result, cloudwatchlogs_client)
     assert len(result) == 1
+
+
+def setup_mocks(
+    mocker: MockerFixture,
+    aws_accounts: list[dict],
+    log_groups: list[dict],
+    tags: dict[str, Any],
+) -> dict[str, Any]:
+    mocker.patch(
+        "reconcile.aws_cloudwatch_log_retention.integration.get_aws_accounts",
+        return_value=aws_accounts,
+    )
+    mocker.patch(
+        "reconcile.aws_cloudwatch_log_retention.integration.queries.get_secret_reader_settings",
+        return_value={},
+    )
+    aws_api = mocker.patch(
+        "reconcile.aws_cloudwatch_log_retention.integration.AWSApi",
+        autospec=True,
+    )
+    mocked_aws_api = aws_api.return_value.__enter__.return_value
+    mocked_aws_api.get_cloudwatch_logs.return_value = log_groups
+    mocked_log_client = mocked_aws_api.get_session_client.return_value
+    mocked_log_client.list_tags_log_group.return_value = tags
+    return {
+        "aws_api": mocked_aws_api,
+        "log_client": mocked_log_client,
+    }
+
+
+@pytest.fixture
+def log_group_with_unset_retention() -> dict[str, Any]:
+    return {
+        "logGroupName": "group-without-retention",
+        "storedBytes": 123,
+        "creationTime": 1433189500783,
+        "arn": "arn:aws:logs:us-west-2:0123456789012:log-group:group-without-retention:*",
+    }
+
+
+@pytest.fixture
+def empty_tags() -> dict[str, Any]:
+    return {"tags": {}}
+
+
+@pytest.fixture
+def managed_by_aws_cloudwatch_log_retention_tags() -> dict[str, Any]:
+    return {
+        "tags": {
+            "managed_by_integration": "aws_cloudwatch_log_retention",
+        }
+    }
+
+
+@pytest.fixture
+def managed_by_terraform_resources_tags() -> dict[str, Any]:
+    return {
+        "tags": {
+            "managed_by_integration": "terraform_resources",
+        }
+    }
+
+
+def test_run_with_unset_retention_log_group_and_default_cleanup(
+    mocker: MockerFixture,
+    test_cloudwatch_account: dict[str, Any],
+    log_group_with_unset_retention: dict[str, Any],
+    empty_tags: dict[str, Any],
+) -> None:
+    mocks = setup_mocks(
+        mocker,
+        aws_accounts=[test_cloudwatch_account],
+        log_groups=[log_group_with_unset_retention],
+        tags=empty_tags,
+    )
+
+    run(dry_run=False, thread_pool_size=1)
+
+    mocks["log_client"].list_tags_log_group.assert_called_once_with(
+        logGroupName="group-without-retention"
+    )
+
+    mocks["aws_api"].create_cloudwatch_tag.assert_called_once_with(
+        test_cloudwatch_account,
+        "group-without-retention",
+        {"managed_by_integration": "aws_cloudwatch_log_retention"},
+    )
+
+    mocks["aws_api"].set_cloudwatch_log_retention.assert_called_once_with(
+        test_cloudwatch_account,
+        "group-without-retention",
+        90,
+    )
+
+
+@pytest.fixture
+def log_group_with_unset_retention_and_matching_name() -> dict[str, Any]:
+    return {
+        "logGroupName": "some-path-group-without-retention",
+        "storedBytes": 123,
+        "creationTime": 1433189500783,
+        "arn": "arn:aws:logs:us-west-2:0123456789012:log-group:some-path-group-without-retention:*",
+    }
+
+
+def test_run_with_unset_retention_log_group_and_matching_cleanup(
+    mocker: MockerFixture,
+    test_cloudwatch_account: dict[str, Any],
+    log_group_with_unset_retention_and_matching_name: dict[str, Any],
+    empty_tags: dict[str, Any],
+) -> None:
+    mocks = setup_mocks(
+        mocker,
+        aws_accounts=[test_cloudwatch_account],
+        log_groups=[log_group_with_unset_retention_and_matching_name],
+        tags=empty_tags,
+    )
+
+    run(dry_run=False, thread_pool_size=1)
+
+    mocks["log_client"].list_tags_log_group.assert_called_once_with(
+        logGroupName="some-path-group-without-retention"
+    )
+
+    mocks["aws_api"].create_cloudwatch_tag.assert_called_once_with(
+        test_cloudwatch_account,
+        "some-path-group-without-retention",
+        {"managed_by_integration": "aws_cloudwatch_log_retention"},
+    )
+
+    mocks["aws_api"].set_cloudwatch_log_retention.assert_called_once_with(
+        test_cloudwatch_account,
+        "some-path-group-without-retention",
+        30,
+    )
+
+
+@pytest.fixture
+def log_group_with_desired_retention() -> dict[str, Any]:
+    return {
+        "logGroupName": "group-with-desired-retention",
+        "retentionInDays": 90,
+        "storedBytes": 123,
+        "creationTime": 1433189500783,
+        "arn": "arn:aws:logs:us-west-2:0123456789012:log-group:group-with-desired-retention:*",
+    }
+
+
+def test_run_with_matching_retention_log_group(
+    mocker: MockerFixture,
+    test_cloudwatch_account: dict[str, Any],
+    log_group_with_desired_retention: dict[str, Any],
+    managed_by_aws_cloudwatch_log_retention_tags: dict[str, Any],
+) -> None:
+    mocks = setup_mocks(
+        mocker,
+        aws_accounts=[test_cloudwatch_account],
+        log_groups=[log_group_with_desired_retention],
+        tags=managed_by_aws_cloudwatch_log_retention_tags,
+    )
+
+    run(dry_run=False, thread_pool_size=1)
+
+    mocks["log_client"].list_tags_log_group.assert_called_once_with(
+        logGroupName="group-with-desired-retention"
+    )
+    mocks["aws_api"].create_cloudwatch_tag.assert_not_called()
+    mocks["aws_api"].set_cloudwatch_log_retention.assert_not_called()
+
+
+def test_run_with_log_group_managed_by_terraform_resources(
+    mocker: MockerFixture,
+    test_cloudwatch_account: dict[str, Any],
+    log_group_with_unset_retention: dict[str, Any],
+    managed_by_terraform_resources_tags: dict[str, Any],
+) -> None:
+    mocks = setup_mocks(
+        mocker,
+        aws_accounts=[test_cloudwatch_account],
+        log_groups=[log_group_with_unset_retention],
+        tags=managed_by_terraform_resources_tags,
+    )
+
+    run(dry_run=False, thread_pool_size=1)
+
+    mocks["log_client"].list_tags_log_group.assert_called_once_with(
+        logGroupName="group-without-retention"
+    )
+    mocks["aws_api"].create_cloudwatch_tag.assert_not_called()
+    mocks["aws_api"].set_cloudwatch_log_retention.assert_not_called()

--- a/reconcile/test/test_aws_cloudwatch_log_retention.py
+++ b/reconcile/test/test_aws_cloudwatch_log_retention.py
@@ -10,8 +10,7 @@ from moto import mock_logs
 from pytest_mock import MockerFixture
 
 from reconcile.aws_cloudwatch_log_retention.integration import (
-    check_cloudwatch_log_group_tag,
-    get_app_interface_cloudwatch_retention_period,
+    get_desired_retentions,
     run,
 )
 
@@ -73,21 +72,11 @@ def test_cloudwatch_account() -> dict[str, Any]:
     }
 
 
-def test_get_app_interface_cloudwatch_retention_period(
+def test_get_desired_retentions(
     test_cloudwatch_account: dict,
 ) -> None:
-    refined_cloudwatch_list = get_app_interface_cloudwatch_retention_period(
-        test_cloudwatch_account
-    )
+    refined_cloudwatch_list = get_desired_retentions(test_cloudwatch_account)
     assert len(refined_cloudwatch_list) == 2
-
-
-def test_get_log_tag_groups(
-    log_group_tf_tag: list, cloudwatchlogs_client: CloudWatchLogsClient
-) -> None:
-    tag_result = log_group_tf_tag
-    result = check_cloudwatch_log_group_tag(tag_result, cloudwatchlogs_client)
-    assert len(result) == 1
 
 
 def setup_mocks(
@@ -251,9 +240,7 @@ def test_run_with_matching_retention_log_group(
 
     run(dry_run=False, thread_pool_size=1)
 
-    mocks["log_client"].list_tags_log_group.assert_called_once_with(
-        logGroupName="group-with-desired-retention"
-    )
+    mocks["log_client"].list_tags_log_group.assert_not_called()
     mocks["aws_api"].create_cloudwatch_tag.assert_not_called()
     mocks["aws_api"].set_cloudwatch_log_retention.assert_not_called()
 

--- a/reconcile/test/test_aws_cloudwatch_log_retention.py
+++ b/reconcile/test/test_aws_cloudwatch_log_retention.py
@@ -58,12 +58,12 @@ def test_cloudwatch_account() -> dict[str, Any]:
             {
                 "provider": "cloudwatch",
                 "regex": "some-path*",
-                "retention_in_days": "30",
+                "retention_in_days": 30,
             },
             {
                 "provider": "cloudwatch",
                 "regex": "some-other-path*",
-                "retention_in_days": "60",
+                "retention_in_days": 60,
             },
         ],
         "consoleUrl": "https://some-url.com/console",

--- a/reconcile/test/test_aws_cloudwatch_log_retention.py
+++ b/reconcile/test/test_aws_cloudwatch_log_retention.py
@@ -98,7 +98,7 @@ def setup_mocks(
         autospec=True,
     )
     mocked_aws_api = aws_api.return_value.__enter__.return_value
-    mocked_aws_api.get_cloudwatch_logs.return_value = log_groups
+    mocked_aws_api.get_cloudwatch_log_groups.return_value = iter(log_groups)
     mocked_log_client = mocked_aws_api.get_session_client.return_value
     mocked_log_client.list_tags_log_group.return_value = tags
     return {

--- a/reconcile/test/utils/test_aws_api.py
+++ b/reconcile/test/utils/test_aws_api.py
@@ -311,7 +311,7 @@ def test_get_cloudwatch_log_group_tags(
         }
     }
 
-    result = aws_api.get_cloudwatch_log_group_tags(accounts[0], "some-arn")
+    result = aws_api.get_cloudwatch_log_group_tags(accounts[0], "some-arn:*")
 
     assert result == {"tag1": "value1"}
     mocked_cloudwatch_client.list_tags_for_resource.assert_called_once_with(
@@ -326,9 +326,9 @@ def test_create_cloudwatch_tag(
 ) -> None:
     mocker.patch.object(aws_api, "get_session_client", autospec=True)
     mocked_cloudwatch_client = aws_api.get_session_client.return_value  # type: ignore[attr-defined]
-    new_tag = {"tag1: value1"}
+    new_tag = {"tag1": "value1"}
 
-    aws_api.create_cloudwatch_tag(accounts[0], "some-arn", new_tag)
+    aws_api.create_cloudwatch_tag(accounts[0], "some-arn:*", new_tag)
 
     mocked_cloudwatch_client.tag_resource.assert_called_once_with(
         resourceArn="some-arn",

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -5,6 +5,7 @@ import time
 from collections.abc import (
     Iterable,
     Mapping,
+    Iterator,
 )
 from datetime import datetime
 from functools import lru_cache
@@ -1031,13 +1032,12 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         cloudwatch_logs = self._account_cloudwatch_client(account["name"])
         cloudwatch_logs.tag_log_group(logGroupName=group_name, tags=new_tag)
 
-    def get_cloudwatch_logs(self, account):
-        log_group_list = []
-        cloudwatch_logs = self._account_cloudwatch_client(account["name"])
-        paginator = cloudwatch_logs.get_paginator("describe_log_groups")
+    def get_cloudwatch_log_groups(self, account) -> Iterator[dict]:
+        client = self._account_cloudwatch_client(account["name"])
+        paginator = client.get_paginator("describe_log_groups")
         for page in paginator.paginate():
-            log_group_list.extend(page["logGroups"])
-        return log_group_list
+            for log_group in page["logGroups"]:
+                yield log_group
 
     def set_cloudwatch_log_retention(self, account, group_name, retention_days):
         cloudwatch_logs = self._account_cloudwatch_client(account["name"])

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -4,8 +4,8 @@ import re
 import time
 from collections.abc import (
     Iterable,
-    Mapping,
     Iterator,
+    Mapping,
 )
 from datetime import datetime
 from functools import lru_cache
@@ -1028,9 +1028,14 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         }
         image.modify_attribute(LaunchPermission=launch_permission)
 
-    def create_cloudwatch_tag(self, account, group_name, new_tag):
-        cloudwatch_logs = self._account_cloudwatch_client(account["name"])
-        cloudwatch_logs.tag_log_group(logGroupName=group_name, tags=new_tag)
+    def create_cloudwatch_tag(
+        self,
+        account: dict[str, Any],
+        arn: str,
+        new_tag: dict[str, str],
+    ) -> None:
+        client = self._account_cloudwatch_client(account["name"])
+        client.tag_resource(resourceArn=arn, tags=new_tag)
 
     def get_cloudwatch_log_groups(self, account) -> Iterator[dict]:
         client = self._account_cloudwatch_client(account["name"])
@@ -1039,9 +1044,14 @@ class AWSApi:  # pylint: disable=too-many-public-methods
             for log_group in page["logGroups"]:
                 yield log_group
 
+    def get_cloudwatch_log_group_tags(self, account, arn) -> dict[str, str]:
+        client = self._account_cloudwatch_client(account["name"])
+        tags = client.list_tags_for_resource(resourceArn=arn)
+        return tags.get("tags", {})
+
     def set_cloudwatch_log_retention(self, account, group_name, retention_days):
-        cloudwatch_logs = self._account_cloudwatch_client(account["name"])
-        cloudwatch_logs.put_retention_policy(
+        client = self._account_cloudwatch_client(account["name"])
+        client.put_retention_policy(
             logGroupName=group_name, retentionInDays=retention_days
         )
 


### PR DESCRIPTION
Currently `aws-cloudwatch-log-retention` is being rate limited as there are too many requests to AWS. This change optmizes:

* do tag filter only after current retention days is not equal to desired retention days, so for log groups managed by this integration, it won’t request it again.
* streaming process log groups instead of get all log groups then filter and process all, so even rate limit exceeded, there are some log groups can be processed in each run, and eventually all got cleaned up.

Further improvement like empty log group deletion and `terraform_resources` integration managed log group exclusion via gql will be added later based on the effectiveness of this optimization.

[APPSRE-8425](https://issues.redhat.com/browse/APPSRE-8425)


<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 71a2aad</samp>

This pull request enhances the `aws_cloudwatch_log_retention` integration and its tests by using more reliable and consistent identifiers, simplifying the data model, and improving readability and error handling. It also improves the `AWSApi` class and its tests by using log group ARNs for tagging and fetching, and by returning an iterator of log groups.

<!--
copilot:walkthrough
-->
### <samp>🤖 Generated by Copilot at 71a2aad</samp>

*  Simplify the `AWSCloudwatchLogRetention` model and rename the `get_app_interface_cloudwatch_retention_period` function to `get_desired_retentions` ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-773495110cdde5ed044f7f1bbf0eb68bf7ba5d387c6e3985cedaea64ec613760L19-R44))
* Import the `Iterable` type and use it as an annotation for the `desired_retentions` parameter in the `_reconcile_log_group` function ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-773495110cdde5ed044f7f1bbf0eb68bf7ba5d387c6e3985cedaea64ec613760R4))
* Refactor the `run` function and extract some helper functions to improve readability and modularity ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-773495110cdde5ed044f7f1bbf0eb68bf7ba5d387c6e3985cedaea64ec613760L70-R129))
  * Use the log group ARN instead of the name for tagging and normalize the ARN by removing the trailing `:*` ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-773495110cdde5ed044f7f1bbf0eb68bf7ba5d387c6e3985cedaea64ec613760L70-R129), [link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-fa53225044580356ab5fbddd2d4f182e37bfeef41768289fa3f6e185e5f87302L1030-R1064))
  * Add error handling and logging for the `ClientError` exception ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-773495110cdde5ed044f7f1bbf0eb68bf7ba5d387c6e3985cedaea64ec613760L70-R129))
  * Use the `get_desired_retentions` function to get the retention periods from the `AWSCloudwatchLogRetention` model ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-773495110cdde5ed044f7f1bbf0eb68bf7ba5d387c6e3985cedaea64ec613760L70-R129), [link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-773495110cdde5ed044f7f1bbf0eb68bf7ba5d387c6e3985cedaea64ec613760L19-R44))
  * Use the `get_cloudwatch_log_group_tags` and `create_cloudwatch_tag` methods of the `AWSApi` class to get and set the tags for the log groups ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-773495110cdde5ed044f7f1bbf0eb68bf7ba5d387c6e3985cedaea64ec613760L70-R129), [link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-fa53225044580356ab5fbddd2d4f182e37bfeef41768289fa3f6e185e5f87302L1030-R1064), [link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-3cab48a56e9a56706a9d7595e6491747721b507aec2327de8fa510699638ebdeR299-R336))
  * Use the `get_cloudwatch_log_groups` method of the `AWSApi` class to get an iterator over the log groups ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-773495110cdde5ed044f7f1bbf0eb68bf7ba5d387c6e3985cedaea64ec613760L70-R129), [link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-fa53225044580356ab5fbddd2d4f182e37bfeef41768289fa3f6e185e5f87302R7), [link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-fa53225044580356ab5fbddd2d4f182e37bfeef41768289fa3f6e185e5f87302L1030-R1064))
  * Extract the `_get_log_group_retention` and `_set_log_group_retention` functions to handle the logic of getting and setting the retention period for a log group ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-773495110cdde5ed044f7f1bbf0eb68bf7ba5d387c6e3985cedaea64ec613760L70-R129))
* Update the imports in the test module to reflect the changes in the integration module and add some imports for the new test fixtures and mocks ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-e81c808723c9a0cdf47d10ebd03eea5c9f7fd0acad9693fae992a1079c94735eL2-R15))
* Modify the `test_cloudwatch_account` fixture to use different regex and retention values and convert it to a pytest fixture with a decorator ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-e81c808723c9a0cdf47d10ebd03eea5c9f7fd0acad9693fae992a1079c94735eL48-R66))
* Add several new test functions and fixtures to test the new logic and behavior of the `run` function and the helper functions ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-e81c808723c9a0cdf47d10ebd03eea5c9f7fd0acad9693fae992a1079c94735eL66-R263))
  * Use the `setup_mocks` function to mock the AWS API calls and responses ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-e81c808723c9a0cdf47d10ebd03eea5c9f7fd0acad9693fae992a1079c94735eL66-R263))
  * Test the `_reconcile_log_group` function with different scenarios of matching and non-matching regex and retention values ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-e81c808723c9a0cdf47d10ebd03eea5c9f7fd0acad9693fae992a1079c94735eL66-R263))
  * Test the `_get_log_group_retention` and `_set_log_group_retention` functions with different scenarios of existing and non-existing tags and retention periods ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-e81c808723c9a0cdf47d10ebd03eea5c9f7fd0acad9693fae992a1079c94735eL66-R263))
* Add two new test functions to test the `get_cloudwatch_log_group_tags` and `create_cloudwatch_tag` methods of the `AWSApi` class ([link](https://github.com/app-sre/qontract-reconcile/pull/3882/files?diff=unified&w=0#diff-3cab48a56e9a56706a9d7595e6491747721b507aec2327de8fa510699638ebdeR299-R336))