### PR TITLE
[AUS] OCM sharding and ocm-upgrade-scheduler deprecation

### DIFF
--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -201,7 +201,7 @@ def discover_clusters(
     for c in clusters:
         is_sts_cluster = c.ocm_cluster.aws and c.ocm_cluster.aws.sts_enabled
         passed_sts_filter = not ignore_sts_clusters or not is_sts_cluster
-        passed_ocm_filters = org_ids is None or c.organization_id in org_ids
+        passed_ocm_filters = not org_ids or c.organization_id in org_ids
         if passed_ocm_filters and passed_sts_filter:
             clusters_by_org[c.organization_id].append(c)
 

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -1000,17 +1000,29 @@ def get_orgs_for_environment(
     excluded_ocm_organization_ids: Optional[set[str]] = None,
     only_addon_managed_upgrades: bool = False,
 ) -> list[AUSOCMOrganization]:
+    """
+    Returns a list of organizations for the given OCM environment, applying
+    filters based on the provided arguments.
+
+    Args:
+        ocm_env_name (str): OCM environment name to filter
+        ocm_organization_ids (Optional[set[str]]): if any organization IDs are provided, any other organizations are excluded from the results
+        excluded_ocm_organization_ids (Optional[set[str]]): if any organization IDs are provided, these organizations are excluded from the results
+        only_addon_managed_upgrades (bool): if True, organizations without enabled addon management are excluded from the results
+        query_func (Callable): function to query organizations via GQL
+
+    Returns:
+        list[AUSOCMOrganization]: list of organizations matching the given filters
+    """
     orgs = aus_organizations_query(query_func=query_func).organizations or []
     return [
         org
         for org in orgs or []
         if org.environment.name == ocm_env_name
         and (not only_addon_managed_upgrades or org.addon_managed_upgrades)
+        and (not ocm_organization_ids or org.org_id in ocm_organization_ids)
         and (
-            (not ocm_organization_ids or org.org_id in ocm_organization_ids)
-            and (
-                not excluded_ocm_organization_ids
-                or org.org_id not in excluded_ocm_organization_ids
-            )
+            not excluded_ocm_organization_ids
+            or org.org_id not in excluded_ocm_organization_ids
         )
     ]

--- a/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
@@ -104,7 +104,6 @@ class OCMAddonsUpgradeSchedulerOrgIntegration(
         Build the upgrade specs for all relevant organizations. Each org spec contains
         one spec per cluster and addon.
         """
-        # query all OCM organizations from app-interface and filter by and orgs
         organizations = self.get_orgs_for_environment(
             ocm_env, only_addon_managed_upgrades=True
         )

--- a/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from pydantic import BaseModel
 
 from reconcile.aus import base as aus
@@ -14,15 +12,9 @@ from reconcile.aus.models import (
     ClusterUpgradeSpec,
     OrganizationUpgradeSpec,
 )
-from reconcile.gql_definitions.advanced_upgrade_service.aus_organization import (
-    query as aus_organizations_query,
-)
 from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
 from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
-from reconcile.utils import (
-    gql,
-    metrics,
-)
+from reconcile.utils import metrics
 from reconcile.utils.ocm.addons import (
     OCMAddonInstallation,
     get_addon_latest_versions,
@@ -106,23 +98,16 @@ class OCMAddonsUpgradeSchedulerOrgIntegration(
             )
 
     def get_ocm_env_upgrade_specs(
-        self, ocm_env: OCMEnvironment, org_ids: Optional[set[str]]
+        self, ocm_env: OCMEnvironment
     ) -> dict[str, OrganizationUpgradeSpec]:
         """
         Build the upgrade specs for all relevant organizations. Each org spec contains
         one spec per cluster and addon.
         """
         # query all OCM organizations from app-interface and filter by and orgs
-        organizations = [
-            org
-            for org in aus_organizations_query(
-                query_func=gql.get_api().query
-            ).organizations
-            or []
-            if org.environment.name == ocm_env.name
-            and org.addon_managed_upgrades
-            and (org_ids is None or org.org_id in org_ids)
-        ]
+        organizations = self.get_orgs_for_environment(
+            ocm_env, only_addon_managed_upgrades=True
+        )
         if not organizations:
             return {}
 

--- a/reconcile/aus/ocm_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_upgrade_scheduler_org.py
@@ -22,7 +22,6 @@ class OCMClusterUpgradeSchedulerOrgIntegration(OCMClusterUpgradeSchedulerIntegra
     def get_ocm_env_upgrade_specs(
         self, ocm_env: OCMEnvironment
     ) -> dict[str, OrganizationUpgradeSpec]:
-        # query all OCM organizations from app-interface and filter by and orgs
         organizations = self.get_orgs_for_environment(ocm_env)
         if not organizations:
             return {}

--- a/reconcile/aus/ocm_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_upgrade_scheduler_org.py
@@ -1,16 +1,10 @@
-from typing import Optional
-
 from reconcile.aus.models import (
     ClusterUpgradeSpec,
     OrganizationUpgradeSpec,
 )
 from reconcile.aus.ocm_upgrade_scheduler import OCMClusterUpgradeSchedulerIntegration
-from reconcile.gql_definitions.advanced_upgrade_service.aus_organization import (
-    query as aus_organizations_query,
-)
 from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
 from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
-from reconcile.utils import gql
 from reconcile.utils.ocm.clusters import (
     OCMCluster,
     discover_clusters_for_organizations,
@@ -26,18 +20,10 @@ class OCMClusterUpgradeSchedulerOrgIntegration(OCMClusterUpgradeSchedulerIntegra
         return QONTRACT_INTEGRATION
 
     def get_ocm_env_upgrade_specs(
-        self, ocm_env: OCMEnvironment, org_ids: Optional[set[str]]
+        self, ocm_env: OCMEnvironment
     ) -> dict[str, OrganizationUpgradeSpec]:
         # query all OCM organizations from app-interface and filter by and orgs
-        organizations = [
-            org
-            for org in aus_organizations_query(
-                query_func=gql.get_api().query
-            ).organizations
-            or []
-            if org.environment.name == ocm_env.name
-            and (org_ids is None or org.org_id in org_ids)
-        ]
+        organizations = self.get_orgs_for_environment(ocm_env)
         if not organizations:
             return {}
 

--- a/reconcile/test/ocm/aus/fixtures.py
+++ b/reconcile/test/ocm/aus/fixtures.py
@@ -72,6 +72,7 @@ def build_organization(
     publish_version_data_from_org_ids: Optional[list[str]] = None,
     blocked_versions: Optional[list[str]] = None,
     sector_dependencies: Optional[dict[str, Optional[list[str]]]] = None,
+    addonManagedUpgrades: bool = False,
 ) -> AUSOCMOrganization:
     org_id = org_id or "org-1-id"
     return AUSOCMOrganization(
@@ -104,7 +105,7 @@ def build_organization(
         accessTokenClientSecret=None,
         upgradePolicyClusters=None,
         upgradePolicyAllowedWorkloads=None,
-        addonManagedUpgrades=False,
+        addonManagedUpgrades=addonManagedUpgrades,
         addonUpgradeTests=None,
         sectors=[
             OpenShiftClusterManagerSectorV1(

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -559,8 +559,18 @@ def ocm_fleet_upgrade_policies(
 )
 @click.pass_context
 def aus_fleet_upgrade_policies(ctx, ocm_env, ocm_org_ids, ignore_sts_clusters):
-    print(
-        "https://grafana.app-sre.devshift.net/d/ukLXCSwVz/aus-cluster-upgrade-overview"
+    from reconcile.aus.advanced_upgrade_service import AdvancedUpgradeServiceIntegration
+
+    parsed_ocm_org_ids = set(ocm_org_ids.split(",")) if ocm_org_ids else None
+    generate_fleet_upgrade_policices_report(
+        ctx,
+        AdvancedUpgradeServiceIntegration(
+            AdvancedUpgradeSchedulerBaseIntegrationParams(
+                ocm_environment=ocm_env,
+                ocm_organization_ids=parsed_ocm_org_ids,
+                ignore_sts_clusters=ignore_sts_clusters,
+            )
+        ),
     )
 
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -509,98 +509,9 @@ def cluster_upgrade_policies(
     show_only_soaking_upgrades=False,
     by_workload=False,
 ):
-    from reconcile.aus.ocm_upgrade_scheduler import (
-        OCMClusterUpgradeSchedulerIntegration,
+    print(
+        "https://grafana.app-sre.devshift.net/d/ukLXCSwVz/aus-cluster-upgrade-overview"
     )
-
-    integration = OCMClusterUpgradeSchedulerIntegration(
-        AdvancedUpgradeSchedulerBaseIntegrationParams()
-    )
-    generate_cluster_upgrade_policies_report(
-        ctx,
-        integration=integration,
-        cluster=cluster,
-        workload=workload,
-        show_only_soaking_upgrades=show_only_soaking_upgrades,
-        by_workload=by_workload,
-    )
-
-
-def generate_cluster_upgrade_policies_report(
-    ctx,
-    integration: AdvancedUpgradeSchedulerBaseIntegration,
-    cluster: Optional[str],
-    workload: Optional[str],
-    show_only_soaking_upgrades: bool,
-    by_workload: bool,
-) -> None:
-    md_output = ctx.obj["options"]["output"] == "md"
-
-    org_upgrade_specs = []
-    for orgs in integration.get_upgrade_specs().values():
-        for org_spec in orgs.values():
-            filtered_specs = org_spec.specs
-            if cluster:
-                filtered_specs = [s for s in filtered_specs if cluster == s.name]
-            if workload:
-                filtered_specs = [
-                    s for s in filtered_specs if workload in s.upgrade_policy.workloads
-                ]
-            if filtered_specs:
-                org_upgrade_specs.append(
-                    OrganizationUpgradeSpec(org=org_spec.org, specs=filtered_specs)
-                )
-
-    results = get_upgrade_policies_data(
-        org_upgrade_specs,
-        md_output,
-        integration.name,
-        workload,
-        show_only_soaking_upgrades,
-        by_workload,
-    )
-
-    if md_output:
-        fields = [
-            {"key": "cluster", "sortable": True},
-            {"key": "version", "sortable": True},
-            {"key": "channel", "sortable": True},
-            {"key": "schedule"},
-            {"key": "sector", "sortable": True},
-            {"key": "mutexes", "sortable": True},
-            {"key": "soak_days", "sortable": True},
-            {"key": "workload"},
-            {"key": "soaking_upgrades"},
-        ]
-        md = """
-{}
-
-```json:table
-{}
-```
-        """
-        md = md.format(
-            upgrade_policies_output_description,
-            json.dumps(
-                {"fields": fields, "items": results, "filter": True, "caption": ""},
-                indent=1,
-            ),
-        )
-        print(md)
-    else:
-        columns = [
-            "cluster",
-            "version",
-            "channel",
-            "schedule",
-            "sector",
-            "mutexes",
-            "soak_days",
-            "workload",
-            "soaking_upgrades",
-        ]
-        ctx.obj["options"]["to_string"] = True
-        print_output(ctx.obj["options"], results, columns)
 
 
 def inherit_version_data_text(org: AUSOCMOrganization) -> str:
@@ -648,18 +559,8 @@ def ocm_fleet_upgrade_policies(
 )
 @click.pass_context
 def aus_fleet_upgrade_policies(ctx, ocm_env, ocm_org_ids, ignore_sts_clusters):
-    from reconcile.aus.advanced_upgrade_service import AdvancedUpgradeServiceIntegration
-
-    parsed_ocm_org_ids = set(ocm_org_ids.split(",")) if ocm_org_ids else None
-    generate_fleet_upgrade_policices_report(
-        ctx,
-        AdvancedUpgradeServiceIntegration(
-            AdvancedUpgradeSchedulerBaseIntegrationParams(
-                ocm_environment=ocm_env,
-                ocm_organization_ids=parsed_ocm_org_ids,
-                ignore_sts_clusters=ignore_sts_clusters,
-            )
-        ),
+    print(
+        "https://grafana.app-sre.devshift.net/d/ukLXCSwVz/aus-cluster-upgrade-overview"
     )
 
 


### PR DESCRIPTION
* add compatibility for the integrations-manager OCM org sharding functionality to AUS (relies on `--org-id` and `--exclude-org-id` parameters)
* deprecate reporting for `ocm-upgrade-scheduler` and `advanced-upgrade-service` and link to the AUS dashboard instead

part of https://issues.redhat.com/browse/APPSRE-8414