### PR TITLE
[OCM service logs] switch to cluster specific service log list endpoint

### DIFF
--- a/reconcile/test/ocm/test_utils_ocm_search_filters.py
+++ b/reconcile/test/ocm/test_utils_ocm_search_filters.py
@@ -364,3 +364,8 @@ def test_search_filter_equals() -> None:
     f3 = Filter().eq("some_field", "a").is_in("some_field", ["b", "c"])
     f4 = Filter().eq("some_field", "a").eq("some_field", "c").eq("some_field", "b")
     assert f3 == f4
+
+
+def test_empty_filter() -> None:
+    with pytest.raises(InvalidFilterError):
+        assert Filter().render()

--- a/reconcile/utils/ocm/service_log.py
+++ b/reconcile/utils/ocm/service_log.py
@@ -12,16 +12,22 @@ from reconcile.utils.ocm.base import (
 from reconcile.utils.ocm.search_filters import Filter
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
+CLUSTER_SERVICE_LOGS_LIST_ENDPOINT = "/api/service_logs/v1/clusters/cluster_logs"
+CLUSTER_SERVICE_LOGS_CREATE_ENDPOINT = "/api/service_logs/v1/cluster_logs"
 
-def get_service_logs(
-    ocm_api: OCMBaseClient, filter: Filter
+
+def get_service_logs_for_cluster_uuid(
+    ocm_api: OCMBaseClient, cluster_uuid: str, filter: Optional[Filter] = None
 ) -> Generator[OCMClusterServiceLog, None, None]:
     """
-    Returns a list of service logs matching the given filter.
+    Returns a list of service logs for a cluster, matching the optional filter.
     """
+    params = {"cluster_uuid": cluster_uuid}
+    if filter:
+        params["search"] = filter.render()
     for log_dict in ocm_api.get_paginated(
-        api_path="/api/service_logs/v1/cluster_logs",
-        params={"search": filter.render()},
+        api_path=CLUSTER_SERVICE_LOGS_LIST_ENDPOINT,
+        params=params,
         max_page_size=100,
     ):
         yield OCMClusterServiceLog(**log_dict)
@@ -33,21 +39,25 @@ def create_service_log(
     dedup_interval: Optional[timedelta] = None,
 ) -> OCMClusterServiceLog:
     if dedup_interval:
-        for previous_log in get_service_logs(
-            ocm_api=ocm_api,
-            filter=Filter()
-            .eq("cluster_uuid", service_log.cluster_uuid)
-            .eq("service_name", service_log.service_name)
-            .eq("severity", service_log.severity.value)
-            .eq("summary", service_log.summary)
-            .eq("description", service_log.description)
-            .after("created_at", datetime.utcnow() - dedup_interval),
-        ):
+        previous_log = next(
+            get_service_logs_for_cluster_uuid(
+                ocm_api=ocm_api,
+                cluster_uuid=service_log.cluster_uuid,
+                filter=Filter()
+                .eq("service_name", service_log.service_name)
+                .eq("severity", service_log.severity.value)
+                .eq("summary", service_log.summary)
+                .eq("description", service_log.description)
+                .after("created_at", datetime.utcnow() - dedup_interval),
+            ),
+            None,
+        )
+        if previous_log:
             return previous_log
 
     return OCMClusterServiceLog(
         **ocm_api.post(
-            api_path="/api/service_logs/v1/cluster_logs",
+            api_path=CLUSTER_SERVICE_LOGS_CREATE_ENDPOINT,
             data=service_log.dict(by_alias=True),
         )
     )


### PR DESCRIPTION
the service log LIST endpoint `/api/service_logs/v1/cluster_logs` is being deprecated and we need to switch to the `/api/service_logs/v1/clusters/cluster_logs` one.

the new endpoint is cluster specific and not org specific anymore, but since we were fetching service logs for specific cluster anyways (filtering server side via `search`) the change has low impact to the overall usage of service logs in qontract-reconcile.

part of https://issues.redhat.com/browse/APPSRE-8422