### PR TITLE
[AUS] remove deprecated --ocm-org-ids CLI flag

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2096,12 +2096,6 @@ def ocm_addons_upgrade_scheduler_org(
     required=False,
     envvar="AUS_OCM_ENV",
 )
-@click.option(
-    "--ocm-org-ids",
-    help="A comma seperated list of OCM organization IDs AUS should operator on. If none is specified, all organizations are considered.",
-    required=False,
-    envvar="AUS_OCM_ORG_IDS",
-)
 @org_id_multiple
 @exclude_org_id
 @click.option(


### PR DESCRIPTION
in the course of enabling AUS to shard on OCM orgs, the new `--org-id` flag has been introduced, which deprecated the `--ocm-org-ids` flag. this MR cleans up the old one.

background: singular-named flags that can be repeated are used on cluster and AWS account based sharding already and the PR check scripts know how to deal with these

follows up on https://github.com/app-sre/qontract-reconcile/pull/3883
part of https://issues.redhat.com/browse/APPSRE-8414