### PR TITLE
[mypy/requests] code fixes because of types-requests changes

### DIFF
--- a/reconcile/utils/internal_groups/client.py
+++ b/reconcile/utils/internal_groups/client.py
@@ -46,7 +46,7 @@ class InternalGroupsApi:
         try:
             resp.raise_for_status()
         except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 404:
+            if e.response is not None and e.response.status_code == 404:
                 raise NotFound
             raise
 


### PR DESCRIPTION
`types-requests` now allows `requests.exceptions.HTTPError.response` to be `None` and in order to make mypy happy, we need to check for it

see https://github.com/python/typeshed/pull/10875