### PR TITLE
[openshift-saas-deploy] publish metrics

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1091,6 +1091,11 @@ def openshift_resources(
 @click.option("--env-name", default=None, help="environment to deploy to.")
 @trigger_integration
 @trigger_reason
+@click.option(
+    "--publish-metrics-only/--no-publish-metrics-only",
+    default=False,
+    help="if set, publishes metrics and exits (no deployment).",
+)
 @click.pass_context
 def openshift_saas_deploy(
     ctx,
@@ -1101,6 +1106,7 @@ def openshift_saas_deploy(
     env_name,
     trigger_integration,
     trigger_reason,
+    publish_metrics_only,
 ):
     import reconcile.openshift_saas_deploy
 
@@ -1114,6 +1120,7 @@ def openshift_saas_deploy(
         env_name=env_name,
         trigger_integration=trigger_integration,
         trigger_reason=trigger_reason,
+        publish_metrics_only=publish_metrics_only,
     )
 
 

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -101,6 +101,7 @@ def run(
     trigger_integration: Optional[str] = None,
     trigger_reason: Optional[str] = None,
     saas_file_list: Optional[SaasFileList] = None,
+    publish_metrics_only: Optional[bool] = False,
     defer: Optional[Callable] = None,
 ) -> None:
     vault_settings = get_app_interface_vault_settings()
@@ -208,6 +209,10 @@ def run(
     if defer:  # defer is provided by the method decorator. this makes just mypy happy
         defer(oc_map.cleanup)
     saasherder.populate_desired_state(ri)
+
+    if publish_metrics_only:
+        ob.publish_metrics(ri, QONTRACT_INTEGRATION)
+        sys.exit(ExitCodes.SUCCESS)
 
     # validate that this deployment is valid
     # based on promotion information in targets


### PR DESCRIPTION
The [AppSRE Overview dashboard](https://grafana.app-sre.devshift.net/d/xNTPSl-Vk/appsre-overview) currently shows OpenShift resources that do not include resources managed via saas files.

With this PR, we add an option for `openshift-saas-deploy` to run as a metrics exporter, acting just like each `openshift-saas-deploy` deployment (tekton), but instead of deploying - publishing metrics.

The intention is to run this integration as an exporter just like any other integration.