### PR TITLE
APPSRE-7307 remove prom v1 publishing

### DIFF
--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -116,6 +116,6 @@ def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
         target_uid="uid",
         data=promotion_info,
     )
-    deployment_state._state.add.assert_called_with(  # type: ignore[attr-defined]
+    deployment_state._state.add.assert_called_once_with(  # type: ignore[attr-defined]
         "promotions_v2/channel/uid/sha", promotion_info.dict(), True
     )

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -116,9 +116,6 @@ def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
         target_uid="uid",
         data=promotion_info,
     )
-    deployment_state._state.add.assert_any_call(  # type: ignore[attr-defined]
-        "promotions/channel/sha", promotion_info.dict(), True
-    )
-    deployment_state._state.add.assert_any_call(  # type: ignore[attr-defined]
+    deployment_state._state.add.assert_called_with(  # type: ignore[attr-defined]
         "promotions_v2/channel/uid/sha", promotion_info.dict(), True
     )

--- a/reconcile/utils/promotion_state.py
+++ b/reconcile/utils/promotion_state.py
@@ -75,11 +75,6 @@ class PromotionState:
     def publish_promotion_data(
         self, sha: str, channel: str, target_uid: str, data: PromotionData
     ) -> None:
-        # TODO: this will be deprecated once we fully moved to promotions_v2
-        state_key = f"promotions/{channel}/{sha}"
-        self._state.add(state_key, data.dict(), force=True)
-        logging.info("Uploaded %s to %s", data, state_key)
-
         state_key_v2 = f"promotions_v2/{channel}/{target_uid}/{sha}"
         self._state.add(state_key_v2, data.dict(), force=True)
         logging.info("Uploaded %s to %s", data, state_key_v2)


### PR DESCRIPTION
saasherder now fully relies on promotion v2. We can stop publishing promotion v1 states to s3.