### PR TITLE
[openshift-update-watcher] fix HCP control plane upgrade notification

### DIFF
--- a/reconcile/openshift_upgrade_watcher.py
+++ b/reconcile/openshift_upgrade_watcher.py
@@ -86,7 +86,7 @@ def _get_start_hypershift(
     ocm_api: OCMBaseClient, cluster_id: str
 ) -> tuple[Optional[str], Optional[str]]:
     schedules = get_control_plane_upgrade_policies(ocm_api, cluster_id)
-    schedule = [s for s in schedules if s["state"]["value"] == "started"]
+    schedule = [s for s in schedules if s["state"] == "started"]
     if not schedule:
         return None, None
 

--- a/reconcile/test/test_openshift_upgrade_watcher.py
+++ b/reconcile/test/test_openshift_upgrade_watcher.py
@@ -182,7 +182,7 @@ def test__get_start_hypershift_started(mocker):
         {
             "next_run": upgrade_at,
             "version": upgrade_version,
-            "state": {"value": "started"},
+            "state": "started",
         }
     ]
     ocm_api_mock = mocker.patch(


### PR DESCRIPTION
fix the place where the upgrade policy state can be found in the dict

```
^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/reconcile/openshift_upgrade_watcher.py", line 89, in _get_start_hypershift
schedule = [s for s in schedules if s["state"]["value"] == "started"]
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.11/site-packages/reconcile/openshift_upgrade_watcher.py", line 89, in <listcomp>
schedule = [s for s in schedules if s["state"]["value"] == "started"]
```