### PR TITLE
[AUS] catch and report missing sector on organization level

### DIFF
--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -360,10 +360,7 @@ def _build_org_upgrade_spec(
                     c.ocm_cluster.external_id, f"label {e['loc'][0]}: {e['msg']}"
                 )
         except Exception as ex:
-            org_upgrade_spec.add_cluster_error(
-                c.ocm_cluster.external_id,
-                str(ex)
-            )
+            org_upgrade_spec.add_cluster_error(c.ocm_cluster.external_id, str(ex))
 
     # register organization errors
     if (

--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -359,6 +359,11 @@ def _build_org_upgrade_spec(
                 org_upgrade_spec.add_cluster_error(
                     c.ocm_cluster.external_id, f"label {e['loc'][0]}: {e['msg']}"
                 )
+        except Exception as ex:
+            org_upgrade_spec.add_cluster_error(
+                c.ocm_cluster.external_id,
+                str(ex)
+            )
 
     # register organization errors
     if (

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -130,11 +130,15 @@ class OrganizationUpgradeSpec(BaseModel):
         return self._sectors
 
     def add_spec(self, spec: ClusterUpgradeSpec) -> None:
-        self._specs.append(spec)
-        self._specs.sort(key=upgrade_spec_sort_key)
         # add clusters to their sectors
         if spec.upgrade_policy.conditions.sector:
+            if spec.upgrade_policy.conditions.sector not in self._sectors:
+                raise ValueError(
+                    f"sector {spec.upgrade_policy.conditions.sector} not found in organization"
+                )
             self._sectors[spec.upgrade_policy.conditions.sector].add_spec(spec)
+        self._specs.append(spec)
+        self._specs.sort(key=upgrade_spec_sort_key)
 
     @property
     def specs(self) -> Sequence[ClusterUpgradeSpec]:

--- a/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
+++ b/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
@@ -272,6 +272,31 @@ def test_build_org_upgrade_spec_with_version_inheritance_no_publish(
     assert len(org_upgrade_spec.specs) == 1
 
 
+def test_build_org_upgrade_spec_missing_sector(
+    ocm_env: OCMEnvironment, org_labels: LabelContainer
+) -> None:
+    org_upgrade_spec = _build_org_upgrade_spec(
+        ocm_env=ocm_env,
+        org=OCMOrganization(
+            id="org-id",
+            name="org-name",
+        ),
+        clusters=[
+            build_cluster_details(
+                "cluster-1",
+                build_cluster_upgrade_policy_labels(
+                    sector="i-am-a-sector-missing-in-the-org"
+                ),
+            ),
+        ],
+        org_labels=org_labels,
+        version_data_inheritance=None,
+    )
+    assert len(org_upgrade_spec.cluster_errors) == 1
+    assert len(org_upgrade_spec.organization_errors) == 0
+    assert len(org_upgrade_spec.specs) == 0
+
+
 #
 # build_org_upgrade_specs_for_ocm_env
 #


### PR DESCRIPTION
catch sectors defined on clusters but missing on the organization level.

there will be a companion MR on the aus-cli project to prevent this situation client side.