### PR TITLE
Add integration for RHACS rbac configuration

### DIFF
--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -168,8 +168,6 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         """
         Get current ACS roles and associated users from ACS api
 
-        :param acs: ACS api client
-        :param auth_id: id of auth provider within ACS instance to target for reconciliation
         :return: list of current AcsRole associated with specified auth provider
         """
         current_roles: dict[str, AcsRole] = {}
@@ -256,9 +254,6 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         Creates desired ACS roles as well as associated access scopes and rules
 
         :param to_add: result of 'diff_iterables(current, desired).add' for ACS roles
-        :param acs: ACS api client
-        :param auth_id: id of auth provider within ACS instance to target for reconciliation
-        :param dry_run: run in dry-run mode
         """
         access_scope_id_map = {s.name: s.id for s in self.acs.get_access_scopes()}
         permission_sets_id_map = {
@@ -336,9 +331,6 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         Deletes desired ACS roles as well as associated access scopes and rules
 
         :param to_delete: result of 'diff_iterables(current, desired).delete' for ACS roles
-        :param acs: ACS api client
-        :param auth_id: id of auth provider within ACS instance to target for reconciliation
-        :param dry_run: run in dry-run mode
         """
         access_scope_id_map = {s.name: s.id for s in self.acs.get_access_scopes()}
         role_group_mappings: dict[str, list[str]] = {}
@@ -387,9 +379,6 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         Updates desired ACS roles as well as associated access scopes and rules
 
         :param to_update: result of 'diff_iterables(current, desired).change' for ACS roles
-        :param acs: ACS api client
-        :param auth_id: id of auth provider within ACS instance to target for reconciliation
-        :param dry_run: run in dry-run mode
         """
         access_scope_id_map = {s.name: s.id for s in self.acs.get_access_scopes()}
         permission_sets_id_map = {

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -59,7 +59,7 @@ class AcsAccessScope(BaseModel):
 
 
 class Permission(OidcPermissionAcsV1):
-    def __hash__(self):
+    def __hash__(self) -> str:
         return hash(self.name)
 
 
@@ -209,7 +209,10 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                     access_scope = acs.get_access_scope_by_id(role.access_scope_id)
                 except Exception as e:
                     logging.error(
-                        f"Failed to retrieve current access scope: {role.access_scope_id} for role: {role.name}\t\n{e}"
+                        "Failed to retrieve current access scope: %s for role: %s\n\t%s",
+                        role.access_scope_id,
+                        role.name,
+                        e,
                     )
                     continue
 
@@ -219,7 +222,10 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                     )
                 except Exception as e:
                     logging.error(
-                        f"Failed to retrieve current permission set: {role.permission_set_id} for role: {role.name}\t\n{e}"
+                        "Failed to retrieve current permission set: %s for role: %s\n\t%s",
+                        role.permission_set_id,
+                        role.name,
+                        e,
                     )
                     continue
 
@@ -299,7 +305,10 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                         )
                     except Exception as e:
                         logging.error(
-                            f"Failed to create access scope: {role.access_scope.name} for role: {role.name}\t\n{e}"
+                            "Failed to create access scope: %s for role: %s\n\t%s",
+                            role.access_scope.name,
+                            role.name,
+                            e,
                         )
                         continue
                     logging.info("Created access scope: %s", role.access_scope.name)
@@ -315,7 +324,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                         else as_id,
                     )
                 except Exception as e:
-                    logging.error(f"Failed to create role: {role.name}\t\n{e}")
+                    logging.error("Failed to create role: %s\n\t%s", role.name, e)
                     continue
             logging.info("Created role: %s", role.name)
 
@@ -333,7 +342,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                     acs.create_group_batch(additions)
                 except Exception as e:
                     logging.error(
-                        f"Failed to create group(s) for role: {role.name}\t\n{e}"
+                        "Failed to create group(s) for role: %s\n\t%s", role.name, e
                     )
                     continue
             logging.info(
@@ -366,7 +375,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                     acs.delete_group_batch(role_group_mappings[role.name])
                 except Exception as e:
                     logging.error(
-                        f"Failed to delete group(s) for role: {role.name}\t\n{e}"
+                        "Failed to delete group(s) for role: %s\n\t%s", role.name, e
                     )
                     continue
             logging.info(
@@ -382,7 +391,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                 try:
                     acs.delete_role(role.name)
                 except Exception as e:
-                    logging.error(f"Failed to delete role: {role.name}\t\n{e}")
+                    logging.error("Failed to delete role: %s\n\t%s", role.name, e)
                     continue
             logging.info("Deleted role: %s", role.name)
             if not dry_run:
@@ -390,7 +399,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                     acs.delete_access_scope(access_scope_id_map[role.access_scope.name])
                 except Exception as e:
                     logging.error(
-                        f"Failed to delete access scope for role: {role.name}\t\n{e}"
+                        "Failed to delete access scope for role: %s\n\t%s", role.name, e
                     )
                     continue
             logging.info("Deleted access scope: %s", role.access_scope.name)
@@ -448,7 +457,9 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                         acs.patch_group_batch(old, new)
                     except Exception as e:
                         logging.error(
-                            f"Failed to update rules for role: {role_diff_pair.desired.name}\t\n{e}"
+                            "Failed to update rules for role: %s\n\t%s",
+                            role_diff_pair.desired.name,
+                            e,
                         )
                         continue
                 logging.info(
@@ -478,7 +489,9 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                         )
                     except Exception as e:
                         logging.error(
-                            f"Failed to update access scope: {role_diff_pair.desired.access_scope.name}\t\n{e}"
+                            "Failed to update access scope: %s\n\t%s",
+                            role_diff_pair.desired.access_scope.name,
+                            e,
                         )
                         continue
                 logging.info(
@@ -505,7 +518,9 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                         )
                     except Exception as e:
                         logging.error(
-                            f"Failed to update role: {role_diff_pair.desired.name}\t\n{e}"
+                            "Failed to update role: %s\n\t%s",
+                            role_diff_pair.desired.name,
+                            e,
                         )
                         continue
                 logging.info("Updated role: %s", role_diff_pair.desired.name)

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -21,7 +21,10 @@ from reconcile.utils.secret_reader import (
 from reconcile.utils.acs_api import AcsApi, Group
 from reconcile.utils.exceptions import AppInterfaceSettingsError
 from reconcile.utils import gql
-from reconcile.utils.differ import diff_iterables, DiffPair
+from reconcile.utils.differ import (
+    diff_iterables,
+    DiffPair,
+)
 from reconcile.utils.runtime.integration import (
     PydanticRunParams,
     QontractReconcileIntegration,
@@ -161,7 +164,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
 
         return list(desired_roles.values())
 
-    def get_current_state(self, acs: AcsApi, auth_id: str) -> list[AcsRole]:
+    def get_current_state(self) -> list[AcsRole]:
         """
         Get current ACS roles and associated users from ACS api
 
@@ -171,16 +174,16 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         """
         current_roles: dict[str, AcsRole] = {}
         try:
-            roles = acs.get_roles()
+            roles = self.acs.get_roles()
         except Exception as e:
             raise Exception(f"Failed to retrieve current roles: {e}")
 
         try:
-            groups = acs.get_groups()
+            groups = self.acs.get_groups()
         except Exception as e:
             raise Exception(f"Failed to retrieve current role assignments: {e}")
 
-        role_assignments: RoleAssignments = self.build_role_assignments(auth_id, groups)
+        role_assignments: RoleAssignments = self.build_role_assignments(groups)
 
         for role in roles:
             # process roles that are not system default
@@ -191,7 +194,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                 role.name in role_assignments and role.name != "None"
             ):
                 try:
-                    access_scope = acs.get_access_scope_by_id(role.access_scope_id)
+                    access_scope = self.acs.get_access_scope_by_id(role.access_scope_id)
                 except Exception as e:
                     logging.error(
                         f"Failed to retrieve current access scope: {role.access_scope_id} for role: {role.name}\t\n{e}"
@@ -199,7 +202,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                     continue
 
                 try:
-                    permission_set = acs.get_permission_set_by_id(
+                    permission_set = self.acs.get_permission_set_by_id(
                         role.permission_set_id
                     )
                 except Exception as e:
@@ -224,9 +227,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
 
         return list(current_roles.values())
 
-    def build_role_assignments(
-        self, auth_id: str, groups: list[Group]
-    ) -> RoleAssignments:
+    def build_role_assignments(self, groups: list[Group]) -> RoleAssignments:
         """
         Processes Groups returned by ACS api and maps roles to users
         A "group" in ACS api is a rule that assigns a user to a role
@@ -239,7 +240,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         auth_rules: RoleAssignments = {}
         for group in groups:
             # part of auth provider specified in A-I to reconcile (internal SSO)
-            if group.auth_provider_id == auth_id:
+            if group.auth_provider_id == self.auth_provider_id:
                 if group.role_name in auth_rules:
                     auth_rules[group.role_name].append(
                         AssignmentPair(key=group.key, value=group.value)
@@ -250,9 +251,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                     ]
         return auth_rules
 
-    def add_rbac(
-        self, to_add: dict[str, AcsRole], acs: AcsApi, auth_id: str, dry_run: bool
-    ) -> None:
+    def add_rbac(self, to_add: dict[str, AcsRole]) -> None:
         """
         Creates desired ACS roles as well as associated access scopes and rules
 
@@ -261,9 +260,9 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         :param auth_id: id of auth provider within ACS instance to target for reconciliation
         :param dry_run: run in dry-run mode
         """
-        access_scope_id_map = {s.name: s.id for s in acs.get_access_scopes()}
+        access_scope_id_map = {s.name: s.id for s in self.acs.get_access_scopes()}
         permission_sets_id_map = {
-            ps.name.lower(): ps.id for ps in acs.get_permission_sets()
+            ps.name.lower(): ps.id for ps in self.acs.get_permission_sets()
         }
 
         for role in to_add.values():
@@ -281,9 +280,9 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
             else:
                 # recall that a desired role and access scope are derived from a single oidc-permission-1
                 # therefore, items in diff.add require creation of dependency access scope first and then role
-                if not dry_run:
+                if not self.dry_run:
                     try:
-                        as_id = acs.create_access_scope(
+                        as_id = self.acs.create_access_scope(
                             role.access_scope.name,
                             role.access_scope.description,
                             role.access_scope.clusters,
@@ -296,9 +295,9 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                         continue
                 logging.info(f"Created access_scope '{role.access_scope.name}'")
 
-            if not dry_run:
+            if not self.dry_run:
                 try:
-                    acs.create_role(
+                    self.acs.create_role(
                         role.name,
                         role.description,
                         permission_sets_id_map[role.permission_set_name],
@@ -311,18 +310,18 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                     continue
             logging.info(f"Created role '{role.name}'")
 
-            if not dry_run:
+            if not self.dry_run:
                 additions = [
                     AcsApi.GroupAdd(
                         role_name=role.name,
                         key=a.key,
                         value=a.value,
-                        auth_provider_id=auth_id,
+                        auth_provider_id=self.auth_provider_id,
                     )
                     for a in role.assignments
                 ]
                 try:
-                    acs.create_group_batch(additions)
+                    self.acs.create_group_batch(additions)
                 except Exception as e:
                     logging.error(
                         f"Failed to create group(s) for role: {role.name}\t\n{e}"
@@ -332,9 +331,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                 f"Added users to role '{role.name}': {[a.value for a in role.assignments]}"
             )
 
-    def delete_rbac(
-        self, to_delete: dict[str, AcsRole], acs: AcsApi, auth_id: str, dry_run: bool
-    ) -> None:
+    def delete_rbac(self, to_delete: dict[str, AcsRole]) -> None:
         """
         Deletes desired ACS roles as well as associated access scopes and rules
 
@@ -343,19 +340,19 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         :param auth_id: id of auth provider within ACS instance to target for reconciliation
         :param dry_run: run in dry-run mode
         """
-        access_scope_id_map = {s.name: s.id for s in acs.get_access_scopes()}
+        access_scope_id_map = {s.name: s.id for s in self.acs.get_access_scopes()}
         role_group_mappings: dict[str, list[str]] = {}
-        for group in acs.get_groups():
-            if group.auth_provider_id == auth_id:
+        for group in self.acs.get_groups():
+            if group.auth_provider_id == self.auth_provider_id:
                 if group.role_name not in role_group_mappings:
                     role_group_mappings[group.role_name] = []
                 role_group_mappings[group.role_name].append(group)
 
         # role and associated resources must be deleted in the proceeding order
         for role in to_delete.values():
-            if not dry_run:
+            if not self.dry_run:
                 try:
-                    acs.delete_group_batch(role_group_mappings[role.name])
+                    self.acs.delete_group_batch(role_group_mappings[role.name])
                 except Exception as e:
                     logging.error(
                         f"Failed to delete group(s) for role: {role.name}\t\n{e}"
@@ -368,16 +365,16 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
             # do not continue to deletion of the role and associated access scope
             if role.system_default:
                 continue
-            if not dry_run:
+            if not self.dry_run:
                 try:
-                    acs.delete_role(role.name)
+                    self.acs.delete_role(role.name)
                 except Exception as e:
                     logging.error(f"Failed to delete role: {role.name}\t\n{e}")
                     continue
             logging.info(f"Deleted role '{role.name}'")
-            if not dry_run:
+            if not self.dry_run:
                 try:
-                    acs.delete_access_scope(access_scope_id_map[role.access_scope.name])
+                    self.acs.delete_access_scope(access_scope_id_map[role.access_scope.name])
                 except Exception as e:
                     logging.error(
                         f"Failed to delete access scope for role: {role.name}\t\n{e}"
@@ -385,13 +382,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                     continue
             logging.info(f"Deleted access scope '{role.access_scope.name}'")
 
-    def update_rbac(
-        self,
-        to_update: dict[str, DiffPair[AcsRole, AcsRole]],
-        acs: AcsApi,
-        auth_id: str,
-        dry_run: bool,
-    ):
+    def update_rbac(self, to_update: dict[str, DiffPair[AcsRole, AcsRole]]):
         """
         Updates desired ACS roles as well as associated access scopes and rules
 
@@ -400,12 +391,12 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         :param auth_id: id of auth provider within ACS instance to target for reconciliation
         :param dry_run: run in dry-run mode
         """
-        access_scope_id_map = {s.name: s.id for s in acs.get_access_scopes()}
+        access_scope_id_map = {s.name: s.id for s in self.acs.get_access_scopes()}
         permission_sets_id_map = {
-            ps.name.lower(): ps.id for ps in acs.get_permission_sets()
+            ps.name.lower(): ps.id for ps in self.acs.get_permission_sets()
         }
         role_group_mappings: dict[str[dict[str, str]]] = {}
-        for group in acs.get_groups():
+        for group in self.acs.get_groups():
             if group.role_name not in role_group_mappings:
                 role_group_mappings[group.role_name] = {}
             role_group_mappings[group.role_name][group.value] = group
@@ -431,13 +422,13 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                         role_name=role_diff_pair.desired.name,
                         key=a.key,
                         value=a.value,
-                        auth_provider_id=auth_id,
+                        auth_provider_id=self.auth_provider_id,
                     )
                     for a in diff.add.values()
                 ]
-                if not dry_run:
+                if not self.dry_run:
                     try:
-                        acs.patch_group_batch(old, new)
+                        self.acs.patch_group_batch(old, new)
                     except Exception as e:
                         logging.error(
                             f"Failed to update rules for role: {role_diff_pair.current.name}\t\n{e}"
@@ -458,9 +449,9 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                 and role_diff_pair.current.access_scope
                 != role_diff_pair.desired.access_scope
             ):
-                if not dry_run:
+                if not self.dry_run:
                     try:
-                        acs.update_access_scope(
+                        self.acs.update_access_scope(
                             access_scope_id_map[
                                 role_diff_pair.current.access_scope.name
                             ],
@@ -488,9 +479,9 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                 or role_diff_pair.current.description
                 != role_diff_pair.desired.description
             ):
-                if not dry_run:
+                if not self.dry_run:
                     try:
-                        acs.update_role(
+                        self.acs.update_role(
                             role_diff_pair.current.access_scope.name,
                             role_diff_pair.current.access_scope.description,
                             permission_sets_id_map[
@@ -507,10 +498,21 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                         continue
                 logging.info(f"Updated role '{role_diff_pair.current.name}'")
 
+    def reconcile(self, desired: list[AcsRole], current: list[AcsRole]):
+        diff = diff_iterables(current, desired, lambda x: x.name)
+        if len(diff.add) > 0:
+            self.add_rbac(diff.add)
+        if len(diff.delete) > 0:
+            self.delete_rbac(diff.delete)
+        if len(diff.change) > 0:
+            self.update_rbac(diff.change)
+
     def run(
         self,
         dry_run: bool,
     ) -> None:
+        self.dry_run = dry_run
+
         gqlapi = gql.get_api()
         instance = self.get_acs_instance(gqlapi.query)
 
@@ -518,17 +520,13 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         secret_reader = create_secret_reader(use_vault=vault_settings.vault)
         token = secret_reader.read_all_secret(instance.credentials)
 
-        acs = AcsApi(
+        self.acs = AcsApi(
             instance={"url": instance.url, "token": token[instance.credentials.field]}
         )
+        # id of auth provider within ACS instance to target for all rbac reconciliation
+        self.auth_provider_id = instance.auth_provider.q_id
 
         desired = self.get_desired_state(gqlapi.query)
-        current = self.get_current_state(acs, auth_id=instance.auth_provider.q_id)
+        current = self.get_current_state()
 
-        diff = diff_iterables(current, desired, lambda x: x.name)
-        if len(diff.add) > 0:
-            self.add_rbac(diff.add, acs, instance.auth_provider.q_id, dry_run)
-        if len(diff.delete) > 0:
-            self.delete_rbac(diff.delete, acs, instance.auth_provider.q_id, dry_run)
-        if len(diff.change) > 0:
-            self.update_rbac(diff.change, acs, instance.auth_provider.q_id, dry_run)
+        self.reconcile(desired, current)

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -436,7 +436,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         """
         access_scope_id_map = {s.name: s.id for s in acs.get_access_scopes()}
         permission_sets_id_map = {ps.name: ps.id for ps in acs.get_permission_sets()}
-        role_group_mappings: dict[str[dict[str, Group]]] = {}
+        role_group_mappings: dict[str, dict[str, Group]] = {}
         for group in acs.get_groups():
             if group.role_name not in role_group_mappings:
                 role_group_mappings[group.role_name] = {}

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -434,7 +434,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
             # it will appear as one entry to delete and one entry to add
             # ex: desired value = foo. current value = bar
             # output will be an entry to delete bar and an entry to add foo
-            if any(len(lst) > 0 for lst in [diff.add, diff.delete, diff.change]):  # type: ignore
+            if any((diff.add, diff.delete)):
                 old = [
                     role_group_mappings[role_diff_pair.current.name][d.value]
                     for d in diff.delete.values()

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -32,7 +32,6 @@ from reconcile.utils.runtime.integration import (
 from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.semver_helper import make_semver
 
-
 DEFAULT_ADMIN_SCOPE_NAME = "Unrestricted"
 DEFAULT_ADMIN_SCOPE_DESC = "Access to all clusters and namespaces"
 # map enum values defined in oidc-permission schema to system default ACS values

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -1,5 +1,4 @@
 import logging
-from collections import defaultdict
 from collections.abc import Callable
 from typing import Optional
 
@@ -7,7 +6,7 @@ from pydantic import BaseModel
 
 from reconcile.gql_definitions.acs.acs_instances import AcsInstanceV1
 from reconcile.gql_definitions.acs.acs_instances import query as acs_instances_query
-from reconcile.gql_definitions.acs.acs_rbac import OidcPermissionAcsV1, UserV1
+from reconcile.gql_definitions.acs.acs_rbac import OidcPermissionAcsV1
 from reconcile.gql_definitions.acs.acs_rbac import query as acs_rbac_query
 from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,
@@ -84,7 +83,7 @@ class AcsRole(BaseModel):
         usernames: list[str]
 
     @classmethod
-    def build(cls, pu: PermissionWithUsers):
+    def build(cls, pu: PermissionWithUsers) -> "AcsRole":
         assignments = [
             AssignmentPair(
                 # https://github.com/app-sre/qontract-schemas/blob/main/schemas/access/user-1.yml#L16

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -551,11 +551,12 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         secret_reader = create_secret_reader(use_vault=vault_settings.vault)
         token = secret_reader.read_all_secret(instance.credentials)
 
-        acs = AcsApi(
-            instance={"url": instance.url, "token": token[instance.credentials.field]}
-        )
-
         desired = self.get_desired_state(gqlapi.query)
-        current = self.get_current_state(acs, instance.auth_provider.q_id)
 
-        self.reconcile(desired, current, acs, instance.auth_provider.q_id, dry_run)
+        with AcsApi(
+            instance={"url": instance.url, "token": token[instance.credentials.field]}
+        ) as acs_api:
+            current = self.get_current_state(acs_api, instance.auth_provider.q_id)
+            self.reconcile(
+                desired, current, acs_api, instance.auth_provider.q_id, dry_run
+            )

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -44,16 +44,6 @@ class AcsAccessScope(BaseModel):
     clusters: list[str]
     namespaces: list[dict[str, str]]
 
-    def __eq__(self, other: object) -> bool:
-        if isinstance(other, AcsAccessScope):
-            return (
-                self.name == other.name
-                and self.description == other.description
-                and self.clusters == other.clusters
-                and self.namespaces == other.namespaces
-            )
-        return False
-
 
 DEFAULT_ADMIN_SCOPE_NAME = "Unrestricted"
 DEFAULT_ADMIN_SCOPE_DESC = "Access to all clusters and namespaces"

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -481,7 +481,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
             ):
                 if not dry_run:
                     try:
-                        acs.update_access_scope(
+                        acs.patch_access_scope(
                             access_scope_id_map[
                                 role_diff_pair.current.access_scope.name
                             ],
@@ -511,7 +511,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
             ):
                 if not dry_run:
                     try:
-                        acs.update_role(
+                        acs.patch_role(
                             role_diff_pair.current.access_scope.name,
                             role_diff_pair.current.access_scope.description,
                             permission_sets_id_map[

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -59,7 +59,7 @@ class AcsAccessScope(BaseModel):
 
 
 class Permission(OidcPermissionAcsV1):
-    def __hash__(self) -> str:
+    def __hash__(self) -> int:
         return hash(self.name)
 
 

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -62,6 +62,12 @@ class AcsAccessScope(BaseModel):
 
 
 DEFAULT_ADMIN_SCOPE_NAME = "Unrestricted"
+# map enum values defined in oidc-permission schema to system default ACS values
+PERMISSION_SET_NAMES = {
+    "admin": "Admin",
+    "analyst": "Analyst",
+    "vuln-admin": "Vulnerability Management Admin"
+}
 
 
 class AcsRole(BaseModel):
@@ -136,7 +142,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                                         key="org_username", value=user.org_username
                                     )
                                 ],
-                                permission_set_name=permission.permission_set,
+                                permission_set_name=PERMISSION_SET_NAMES[permission.permission_set],
                                 access_scope=AcsAccessScope(
                                     name=permission.name,
                                     description=permission.description,
@@ -217,7 +223,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                     name=role.name,
                     description=role.description,
                     assignments=role_assignments.get(role.name, []),
-                    permission_set_name=permission_set.name.lower(),
+                    permission_set_name=permission_set.name,
                     system_default=role.system_default,
                     access_scope=AcsAccessScope(
                         name=access_scope.name,
@@ -268,7 +274,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         """
         access_scope_id_map = {s.name: s.id for s in acs.get_access_scopes()}
         permission_sets_id_map = {
-            ps.name.lower(): ps.id for ps in acs.get_permission_sets()
+            ps.name: ps.id for ps in acs.get_permission_sets()
         }
 
         for role in to_add.values():
@@ -407,7 +413,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         """
         access_scope_id_map = {s.name: s.id for s in acs.get_access_scopes()}
         permission_sets_id_map = {
-            ps.name.lower(): ps.id for ps in acs.get_permission_sets()
+            ps.name: ps.id for ps in acs.get_permission_sets()
         }
         role_group_mappings: dict[str[dict[str, str]]] = {}
         for group in acs.get_groups():

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -311,7 +311,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                             f"Failed to create access scope: {role.access_scope.name} for role: {role.name}\t\n{e}"
                         )
                         continue
-                logging.info(f"Created access_scope '{role.access_scope.name}'")
+                    logging.info("Created access scope: %s", role.access_scope.name)
 
             if not dry_run:
                 try:
@@ -326,7 +326,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                 except Exception as e:
                     logging.error(f"Failed to create role: {role.name}\t\n{e}")
                     continue
-            logging.info(f"Created role '{role.name}'")
+            logging.info("Created role: %s", role.name)
 
             if not dry_run:
                 additions = [
@@ -346,7 +346,9 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                     )
                     continue
             logging.info(
-                f"Added users to role '{role.name}': {[a.value for a in role.assignments]}"
+                "Added users to role %s: %s",
+                role.name,
+                [a.value for a in role.assignments],
             )
 
     def delete_rbac(
@@ -379,7 +381,9 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                     )
                     continue
             logging.info(
-                f"Deleted users from role '{role.name}': {[a.value for a in role.assignments]}"
+                "Deleted users from role %s: %s",
+                role.name,
+                [a.value for a in role.assignments],
             )
             # only delete rules associated with a system default roles
             # do not continue to deletion of the role and associated access scope
@@ -391,7 +395,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                 except Exception as e:
                     logging.error(f"Failed to delete role: {role.name}\t\n{e}")
                     continue
-            logging.info(f"Deleted role '{role.name}'")
+            logging.info("Deleted role: %s", role.name)
             if not dry_run:
                 try:
                     acs.delete_access_scope(access_scope_id_map[role.access_scope.name])
@@ -400,7 +404,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                         f"Failed to delete access scope for role: {role.name}\t\n{e}"
                     )
                     continue
-            logging.info(f"Deleted access scope '{role.access_scope.name}'")
+            logging.info("Deleted access scope: %s", role.access_scope.name)
 
     def update_rbac(
         self,
@@ -459,9 +463,10 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                         )
                         continue
                 logging.info(
-                    f"Updated rules for role '{role_diff_pair.desired.name}':\n\t"
-                    + f"Added: {[n.value for n in new]}\n\t"
-                    + f"Deleted: {[o.value for o in old]}"
+                    "Updated rules for role '%s':\n\t" "Added: %s\n\t" "Deleted: %s",
+                    role_diff_pair.desired.name,
+                    [n.value for n in new],
+                    [o.value for o in old],
                 )
 
             # access scope portion
@@ -486,7 +491,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                         )
                         continue
                 logging.info(
-                    f"Updated access scope '{role_diff_pair.desired.access_scope.name}'"
+                    "Updated access scope %s", role_diff_pair.desired.access_scope.name
                 )
 
             # role portion
@@ -519,7 +524,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                             f"Failed to update role: {role_diff_pair.desired.name}\t\n{e}"
                         )
                         continue
-                logging.info(f"Updated role '{role_diff_pair.desired.name}'")
+                logging.info("Updated role: %s", role_diff_pair.desired.name)
 
     def reconcile(
         self,

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from collections.abc import Callable
 from typing import Optional
 
@@ -255,18 +256,13 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         :return: dict in which keys are role names and values are list of
                 user attributes assigned to role
         """
-        auth_rules: RoleAssignments = {}
+        auth_rules: RoleAssignments = defaultdict(list)
         for group in groups:
             # part of auth provider specified in A-I to reconcile (internal SSO)
             if group.auth_provider_id == auth_id:
-                if group.role_name in auth_rules:
-                    auth_rules[group.role_name].append(
-                        AssignmentPair(key=group.key, value=group.value)
-                    )
-                else:
-                    auth_rules[group.role_name] = [
-                        AssignmentPair(key=group.key, value=group.value)
-                    ]
+                auth_rules[group.role_name].append(
+                    AssignmentPair(key=group.key, value=group.value)
+                )
         return auth_rules
 
     def add_rbac(

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -459,7 +459,9 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                         )
                         continue
                 logging.info(
-                    "Updated rules for role '%s':\n\t" "Added: %s\n\t" "Deleted: %s",
+                    "Updated rules for role '%s':\n"
+                    + "\tAdded: %s\n"
+                    + "\tDeleted: %s",
                     role_diff_pair.desired.name,
                     [n.value for n in new],
                     [o.value for o in old],

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -1,38 +1,31 @@
 import logging
-
 from collections.abc import Callable
 from typing import Optional
 
-from pydantic import (
-    BaseModel,
-)
+from pydantic import BaseModel
 
-from reconcile.gql_definitions.acs.acs_rbac import (
-    query as acs_rbac_query,
-    OidcPermissionAcsV1,
-)
 from reconcile.gql_definitions.acs.acs_instances import AcsInstanceV1
-from reconcile.gql_definitions.acs.acs_instances import (
-    query as acs_instances_query,
-)
-
+from reconcile.gql_definitions.acs.acs_instances import query as acs_instances_query
+from reconcile.gql_definitions.acs.acs_rbac import OidcPermissionAcsV1
+from reconcile.gql_definitions.acs.acs_rbac import query as acs_rbac_query
 from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,
 )
-from reconcile.utils.secret_reader import (
-    create_secret_reader,
-)
-from reconcile.utils.acs_api import AcsApi, Group
-from reconcile.utils.exceptions import AppInterfaceSettingsError
 from reconcile.utils import gql
-from reconcile.utils.differ import (
-    diff_iterables,
-    DiffPair,
+from reconcile.utils.acs_api import (
+    AcsApi,
+    Group,
 )
+from reconcile.utils.differ import (
+    DiffPair,
+    diff_iterables,
+)
+from reconcile.utils.exceptions import AppInterfaceSettingsError
 from reconcile.utils.runtime.integration import (
     PydanticRunParams,
     QontractReconcileIntegration,
 )
+from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.semver_helper import make_semver
 
 

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -359,11 +359,9 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         :param dry_run: run in dry-run mode
         """
         access_scope_id_map = {s.name: s.id for s in acs.get_access_scopes()}
-        role_group_mappings: dict[str, list[Group]] = {}
+        role_group_mappings: dict[str, list[Group]] = defaultdict(list)
         for group in acs.get_groups():
             if group.auth_provider_id == auth_id:
-                if group.role_name not in role_group_mappings:
-                    role_group_mappings[group.role_name] = []
                 role_group_mappings[group.role_name].append(group)
 
         # role and associated resources must be deleted in the proceeding order

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -194,16 +194,9 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
         :return: list of current AcsRole associated with specified auth provider
         """
         current_roles: dict[str, AcsRole] = {}
-        try:
-            roles = acs.get_roles()
-        except Exception as e:
-            raise Exception(f"Failed to retrieve current roles: {e}")
 
-        try:
-            groups = acs.get_groups()
-        except Exception as e:
-            raise Exception(f"Failed to retrieve current role assignments: {e}")
-
+        roles = acs.get_roles()
+        groups = acs.get_groups()
         role_assignments: RoleAssignments = self.build_role_assignments(
             auth_provider_id, groups
         )

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -192,7 +192,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[NoParams]):
         :param auth_id: id of auth provider within ACS instance to target for reconciliation
         :return: list of current AcsRole associated with specified auth provider
         """
-        current_roles: dict[str, AcsRole] = {}
+        current_roles: list[AcsRole] = []
 
         roles = acs.get_roles()
         groups = acs.get_groups()
@@ -232,21 +232,23 @@ class AcsRbacIntegration(QontractReconcileIntegration[NoParams]):
                     )
                     continue
 
-                current_roles[role.name] = AcsRole(
-                    name=role.name,
-                    description=role.description,
-                    assignments=role_assignments.get(role.name, []),
-                    permission_set_name=permission_set.name,
-                    system_default=role.system_default,
-                    access_scope=AcsAccessScope(
-                        name=access_scope.name,
-                        description=access_scope.description,
-                        clusters=access_scope.clusters,
-                        namespaces=access_scope.namespaces,
-                    ),
+                current_roles.append(
+                    AcsRole(
+                        name=role.name,
+                        description=role.description,
+                        assignments=role_assignments.get(role.name, []),
+                        permission_set_name=permission_set.name,
+                        system_default=role.system_default,
+                        access_scope=AcsAccessScope(
+                            name=access_scope.name,
+                            description=access_scope.description,
+                            clusters=access_scope.clusters,
+                            namespaces=access_scope.namespaces,
+                        ),
+                    )
                 )
 
-        return list(current_roles.values())
+        return current_roles
 
     def build_role_assignments(
         self, auth_id: str, groups: list[Group]

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -454,7 +454,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
                 ]
                 if not dry_run:
                     try:
-                        acs.patch_group_batch(old, new)
+                        acs.update_group_batch(old, new)
                     except Exception as e:
                         logging.error(
                             "Failed to update rules for role: %s\n\t%s",
@@ -478,7 +478,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
             ):
                 if not dry_run:
                     try:
-                        acs.patch_access_scope(
+                        acs.update_access_scope(
                             access_scope_id_map[
                                 role_diff_pair.desired.access_scope.name
                             ],
@@ -506,7 +506,7 @@ class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams])
             if role_diff_pair.current.diff_role(role_diff_pair.desired):
                 if not dry_run:
                     try:
-                        acs.patch_role(
+                        acs.update_role(
                             role_diff_pair.desired.name,
                             role_diff_pair.desired.description,
                             permission_sets_id_map[

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -1,7 +1,10 @@
 import logging
 from collections import defaultdict
 from collections.abc import Callable
-from typing import Optional, Self
+from typing import (
+    Optional,
+    Self,
+)
 
 from pydantic import BaseModel
 

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -3,6 +3,10 @@ import logging
 from collections.abc import Callable
 from typing import Optional
 
+from pydantic import (
+    BaseModel,
+)
+
 from reconcile.gql_definitions.acs.acs_rbac import (
     query as acs_rbac_query,
     OidcPermissionAcsV1,
@@ -30,10 +34,6 @@ from reconcile.utils.runtime.integration import (
     QontractReconcileIntegration,
 )
 from reconcile.utils.semver_helper import make_semver
-
-from pydantic import (
-    BaseModel,
-)
 
 
 class AssignmentPair(BaseModel):

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -94,8 +94,8 @@ class AcsRole(BaseModel):
         ]
 
         is_unrestricted_scope = (
-            pu.permission.clusters is None or len(pu.permission.clusters) == 0
-        ) and (pu.permission.namespaces is None or len(pu.permission.namespaces) == 0)
+            not pu.permission.clusters and not pu.permission.namespaces
+        )
 
         return cls(
             name=pu.permission.name,

--- a/reconcile/acs_rbac.py
+++ b/reconcile/acs_rbac.py
@@ -26,7 +26,7 @@ from reconcile.utils.differ import (
 )
 from reconcile.utils.exceptions import AppInterfaceSettingsError
 from reconcile.utils.runtime.integration import (
-    PydanticRunParams,
+    NoParams,
     QontractReconcileIntegration,
 )
 from reconcile.utils.secret_reader import create_secret_reader
@@ -134,13 +134,9 @@ class AcsRole(BaseModel):
         return not self.access_scope.clusters and not self.access_scope.namespaces
 
 
-class AcsRbacIntegrationParams(PydanticRunParams):
-    thread_pool_size: int
-
-
-class AcsRbacIntegration(QontractReconcileIntegration[AcsRbacIntegrationParams]):
-    def __init__(self, params: AcsRbacIntegrationParams) -> None:
-        super().__init__(params)
+class AcsRbacIntegration(QontractReconcileIntegration[NoParams]):
+    def __init__(self) -> None:
+        super().__init__(NoParams())
         self.qontract_integration = "acs_rbac"
         self.qontract_integration_version = make_semver(0, 1, 0)
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2892,7 +2892,7 @@ def acs_rbac(ctx, thread_pool_size):
 
     run_class_integration(
         integration=acs_rbac.AcsRbacIntegration(
-            acs_rbac.AcsRbacIntegrationParams(thread_pool_size)
+            acs_rbac.AcsRbacIntegrationParams(thread_pool_size=thread_pool_size)
         ),
         ctx=ctx.obj,
     )

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2885,13 +2885,14 @@ def ocm_labels(ctx, managed_label_prefixes):
 
 
 @integration.command(short_help="Manages RHACS rbac configuration")
+@threaded()
 @click.pass_context
-def acs_rbac(ctx):
+def acs_rbac(ctx, thread_pool_size):
     from reconcile import acs_rbac
 
     run_class_integration(
         integration=acs_rbac.AcsRbacIntegration(
-            acs_rbac.AcsRbacIntegrationParams(thread_pool_size=10)
+            acs_rbac.AcsRbacIntegrationParams(thread_pool_size)
         ),
         ctx=ctx.obj,
     )

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2885,15 +2885,12 @@ def ocm_labels(ctx, managed_label_prefixes):
 
 
 @integration.command(short_help="Manages RHACS rbac configuration")
-@threaded()
 @click.pass_context
-def acs_rbac(ctx, thread_pool_size):
+def acs_rbac(ctx):
     from reconcile import acs_rbac
 
     run_class_integration(
-        integration=acs_rbac.AcsRbacIntegration(
-            acs_rbac.AcsRbacIntegrationParams(thread_pool_size=thread_pool_size)
-        ),
+        integration=acs_rbac.AcsRbacIntegration(),
         ctx=ctx.obj,
     )
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2891,9 +2891,7 @@ def acs_rbac(ctx):
 
     run_class_integration(
         integration=acs_rbac.AcsRbacIntegration(
-            acs_rbac.AcsRbacIntegrationParams(
-                thread_pool_size=10
-            )
+            acs_rbac.AcsRbacIntegrationParams(thread_pool_size=10)
         ),
         ctx=ctx.obj,
     )

--- a/reconcile/gql_definitions/acs/acs_instances.gql
+++ b/reconcile/gql_definitions/acs/acs_instances.gql
@@ -7,10 +7,8 @@ query AcsInstance {
       ... VaultSecret
     }
     authProvider {
-      ... on AcsInstanceAuthProvider_v1 {
-        name
-        id
-      }
+      name
+      id      
     }
   }
 }

--- a/reconcile/gql_definitions/acs/acs_instances.gql
+++ b/reconcile/gql_definitions/acs/acs_instances.gql
@@ -8,7 +8,7 @@ query AcsInstance {
     }
     authProvider {
       name
-      id      
+      id
     }
   }
 }

--- a/reconcile/gql_definitions/acs/acs_instances.py
+++ b/reconcile/gql_definitions/acs/acs_instances.py
@@ -35,10 +35,8 @@ query AcsInstance {
       ... VaultSecret
     }
     authProvider {
-      ... on AcsInstanceAuthProvider_v1 {
-        name
-        id
-      }
+      name
+      id      
     }
   }
 }
@@ -52,10 +50,6 @@ class ConfiguredBaseModel(BaseModel):
 
 
 class AcsInstanceAuthProviderV1(ConfiguredBaseModel):
-    ...
-
-
-class AcsInstanceAuthProviderV1_AcsInstanceAuthProviderV1(AcsInstanceAuthProviderV1):
     name: str = Field(..., alias="name")
     q_id: str = Field(..., alias="id")
 
@@ -63,9 +57,7 @@ class AcsInstanceAuthProviderV1_AcsInstanceAuthProviderV1(AcsInstanceAuthProvide
 class AcsInstanceV1(ConfiguredBaseModel):
     url: str = Field(..., alias="url")
     credentials: VaultSecret = Field(..., alias="credentials")
-    auth_provider: Union[
-        AcsInstanceAuthProviderV1_AcsInstanceAuthProviderV1, AcsInstanceAuthProviderV1
-    ] = Field(..., alias="authProvider")
+    auth_provider: AcsInstanceAuthProviderV1 = Field(..., alias="authProvider")
 
 
 class AcsInstanceQueryData(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/acs/acs_instances.py
+++ b/reconcile/gql_definitions/acs/acs_instances.py
@@ -36,7 +36,7 @@ query AcsInstance {
     }
     authProvider {
       name
-      id      
+      id
     }
   }
 }

--- a/reconcile/gql_definitions/acs/acs_rbac.gql
+++ b/reconcile/gql_definitions/acs/acs_rbac.gql
@@ -2,7 +2,7 @@
 
 query AcsRbac  {
   acs_rbacs: users_v1 {
-    org_username
+    acs_user
     roles {
       name
       oidc_permissions {

--- a/reconcile/gql_definitions/acs/acs_rbac.gql
+++ b/reconcile/gql_definitions/acs/acs_rbac.gql
@@ -2,7 +2,7 @@
 
 query AcsRbac  {
   acs_rbacs: users_v1 {
-    acs_user
+    org_username
     roles {
       name
       oidc_permissions {

--- a/reconcile/gql_definitions/acs/acs_rbac.py
+++ b/reconcile/gql_definitions/acs/acs_rbac.py
@@ -21,7 +21,7 @@ from pydantic import (  # noqa: F401 # pylint: disable=W0611
 DEFINITION = """
 query AcsRbac  {
   acs_rbacs: users_v1 {
-    acs_user
+    org_username
     roles {
       name
       oidc_permissions {
@@ -86,7 +86,7 @@ class RoleV1(ConfiguredBaseModel):
 
 
 class UserV1(ConfiguredBaseModel):
-    acs_user: Optional[str] = Field(..., alias="acs_user")
+    org_username: str = Field(..., alias="org_username")
     roles: Optional[list[RoleV1]] = Field(..., alias="roles")
 
 

--- a/reconcile/gql_definitions/acs/acs_rbac.py
+++ b/reconcile/gql_definitions/acs/acs_rbac.py
@@ -21,7 +21,7 @@ from pydantic import (  # noqa: F401 # pylint: disable=W0611
 DEFINITION = """
 query AcsRbac  {
   acs_rbacs: users_v1 {
-    org_username
+    acs_user
     roles {
       name
       oidc_permissions {
@@ -86,7 +86,7 @@ class RoleV1(ConfiguredBaseModel):
 
 
 class UserV1(ConfiguredBaseModel):
-    org_username: str = Field(..., alias="org_username")
+    acs_user: Optional[str] = Field(..., alias="acs_user")
     roles: Optional[list[RoleV1]] = Field(..., alias="roles")
 
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -9450,6 +9450,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "acs_user",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "public_gpg_key",
                             "description": null,
                             "args": [],

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -9450,18 +9450,6 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "acs_user",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
-                                "ofType": null
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        },
-                        {
                             "name": "public_gpg_key",
                             "description": null,
                             "args": [],

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -29,7 +29,7 @@ def query_data_desired_state() -> AcsRbacQueryData:
     return AcsRbacQueryData(
         acs_rbacs=[
             UserV1(
-                acs_user="foo@redhat.com",
+                org_username="foo",
                 roles=[
                     RoleV1(
                         name="app-sre-admin",
@@ -47,7 +47,7 @@ def query_data_desired_state() -> AcsRbacQueryData:
                 ],
             ),
             UserV1(
-                acs_user="bar@redhat.com",
+                org_username="bar",
                 roles=[
                     RoleV1(
                         name="app-sre-admin",
@@ -65,7 +65,7 @@ def query_data_desired_state() -> AcsRbacQueryData:
                 ],
             ),
             UserV1(
-                acs_user="foofoo@redhat.com",
+                org_username="foofoo",
                 roles=[
                     RoleV1(
                         name="tenant-role-a",
@@ -86,7 +86,7 @@ def query_data_desired_state() -> AcsRbacQueryData:
                 ],
             ),
             UserV1(
-                acs_user="barbar@redhat.com",
+                org_username="barbar",
                 roles=[
                     RoleV1(
                         name="tenant-role-a",
@@ -107,7 +107,7 @@ def query_data_desired_state() -> AcsRbacQueryData:
                 ],
             ),
             UserV1(
-                acs_user="foobar@redhat.com",
+                org_username="foobar",
                 roles=[
                     RoleV1(
                         name="tenant-role-b",
@@ -148,8 +148,8 @@ def modeled_acs_roles() -> list[AcsRole]:
             name="app-sre-acs-admin",
             description="admin access to acs instance",
             assignments=[
-                AssignmentPair(key="email", value="foo@redhat.com"),
-                AssignmentPair(key="email", value="bar@redhat.com"),
+                AssignmentPair(key="userid", value="foo"),
+                AssignmentPair(key="userid", value="bar"),
             ],
             permission_set_name="Admin",
             access_scope=AcsAccessScope(
@@ -164,8 +164,8 @@ def modeled_acs_roles() -> list[AcsRole]:
             name="cluster-analyst",
             description="analyst access to clusters in acs instance",
             assignments=[
-                AssignmentPair(key="email", value="foofoo@redhat.com"),
-                AssignmentPair(key="email", value="barbar@redhat.com"),
+                AssignmentPair(key="userid", value="foofoo"),
+                AssignmentPair(key="userid", value="barbar"),
             ],
             permission_set_name="Analyst",
             access_scope=AcsAccessScope(
@@ -179,7 +179,7 @@ def modeled_acs_roles() -> list[AcsRole]:
         AcsRole(
             name="service-vuln-admin",
             description="vuln-admin access to service namespaces in acs instance",
-            assignments=[AssignmentPair(key="email", value="foobar@redhat.com")],
+            assignments=[AssignmentPair(key="userid", value="foobar")],
             permission_set_name="Vulnerability Management Admin",
             access_scope=AcsAccessScope(
                 name="service-vuln-admin",
@@ -237,8 +237,8 @@ def api_response_groups() -> list[acs_api.Group]:
                 "props": {
                     "id": "1",
                     "authProviderId": AUTH_PROVIDER_ID,
-                    "key": "email",
-                    "value": "foo@redhat.com",
+                    "key": "userid",
+                    "value": "foo",
                 },
             }
         ),
@@ -248,8 +248,8 @@ def api_response_groups() -> list[acs_api.Group]:
                 "props": {
                     "id": "2",
                     "authProviderId": AUTH_PROVIDER_ID,
-                    "key": "email",
-                    "value": "bar@redhat.com",
+                    "key": "userid",
+                    "value": "bar",
                 },
             }
         ),
@@ -259,8 +259,8 @@ def api_response_groups() -> list[acs_api.Group]:
                 "props": {
                     "id": "3",
                     "authProviderId": AUTH_PROVIDER_ID,
-                    "key": "email",
-                    "value": "foofoo@redhat.com",
+                    "key": "userid",
+                    "value": "foofoo",
                 },
             }
         ),
@@ -270,8 +270,8 @@ def api_response_groups() -> list[acs_api.Group]:
                 "props": {
                     "id": "4",
                     "authProviderId": AUTH_PROVIDER_ID,
-                    "key": "email",
-                    "value": "barbar@redhat.com",
+                    "key": "userid",
+                    "value": "barbar",
                 },
             }
         ),
@@ -281,8 +281,8 @@ def api_response_groups() -> list[acs_api.Group]:
                 "props": {
                     "id": "5",
                     "authProviderId": AUTH_PROVIDER_ID,
-                    "key": "email",
-                    "value": "foobar@redhat.com",
+                    "key": "userid",
+                    "value": "foobar",
                 },
             }
         ),
@@ -660,8 +660,8 @@ def test_full_reconcile(
             name="new-role",
             description="add me",
             assignments=[
-                AssignmentPair(key="email", value="elsa@redhat.com"),
-                AssignmentPair(key="email", value="anna@redhat.com"),
+                AssignmentPair(key="userid", value="elsa"),
+                AssignmentPair(key="userid", value="anna"),
             ],
             permission_set_name="Admin",
             access_scope=AcsAccessScope(
@@ -786,8 +786,8 @@ def test_full_reconcile_with_errors(
             name="new-role",
             description="add me",
             assignments=[
-                AssignmentPair(key="email", value="elsa@redhat.com"),
-                AssignmentPair(key="email", value="anna@redhat.com"),
+                AssignmentPair(key="userid", value="elsa"),
+                AssignmentPair(key="userid", value="anna"),
             ],
             permission_set_name="Admin",
             access_scope=AcsAccessScope(

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -29,7 +29,7 @@ def query_data_desired_state() -> AcsRbacQueryData:
     return AcsRbacQueryData(
         acs_rbacs=[
             UserV1(
-                org_username="foo",
+                acs_user="foo@redhat.com",
                 roles=[
                     RoleV1(
                         name="app-sre-admin",
@@ -47,7 +47,7 @@ def query_data_desired_state() -> AcsRbacQueryData:
                 ],
             ),
             UserV1(
-                org_username="bar",
+                acs_user="bar@redhat.com",
                 roles=[
                     RoleV1(
                         name="app-sre-admin",
@@ -65,7 +65,7 @@ def query_data_desired_state() -> AcsRbacQueryData:
                 ],
             ),
             UserV1(
-                org_username="foofoo",
+                acs_user="foofoo@redhat.com",
                 roles=[
                     RoleV1(
                         name="tenant-role-a",
@@ -86,7 +86,7 @@ def query_data_desired_state() -> AcsRbacQueryData:
                 ],
             ),
             UserV1(
-                org_username="barbar",
+                acs_user="barbar@redhat.com",
                 roles=[
                     RoleV1(
                         name="tenant-role-a",
@@ -107,7 +107,7 @@ def query_data_desired_state() -> AcsRbacQueryData:
                 ],
             ),
             UserV1(
-                org_username="foobar",
+                acs_user="foobar@redhat.com",
                 roles=[
                     RoleV1(
                         name="tenant-role-b",
@@ -148,8 +148,8 @@ def modeled_acs_roles() -> list[AcsRole]:
             name="app-sre-acs-admin",
             description="admin access to acs instance",
             assignments=[
-                AssignmentPair(key="org_username", value="foo"),
-                AssignmentPair(key="org_username", value="bar"),
+                AssignmentPair(key="email", value="foo@redhat.com"),
+                AssignmentPair(key="email", value="bar@redhat.com"),
             ],
             permission_set_name="Admin",
             access_scope=AcsAccessScope(
@@ -164,8 +164,8 @@ def modeled_acs_roles() -> list[AcsRole]:
             name="cluster-analyst",
             description="analyst access to clusters in acs instance",
             assignments=[
-                AssignmentPair(key="org_username", value="foofoo"),
-                AssignmentPair(key="org_username", value="barbar"),
+                AssignmentPair(key="email", value="foofoo@redhat.com"),
+                AssignmentPair(key="email", value="barbar@redhat.com"),
             ],
             permission_set_name="Analyst",
             access_scope=AcsAccessScope(
@@ -179,7 +179,7 @@ def modeled_acs_roles() -> list[AcsRole]:
         AcsRole(
             name="service-vuln-admin",
             description="vuln-admin access to service namespaces in acs instance",
-            assignments=[AssignmentPair(key="org_username", value="foobar")],
+            assignments=[AssignmentPair(key="email", value="foobar@redhat.com")],
             permission_set_name="Vulnerability Management Admin",
             access_scope=AcsAccessScope(
                 name="service-vuln-admin",
@@ -237,8 +237,8 @@ def api_response_groups() -> list[acs_api.Group]:
                 "props": {
                     "id": "1",
                     "authProviderId": AUTH_PROVIDER_ID,
-                    "key": "org_username",
-                    "value": "foo",
+                    "key": "email",
+                    "value": "foo@redhat.com",
                 },
             }
         ),
@@ -248,8 +248,8 @@ def api_response_groups() -> list[acs_api.Group]:
                 "props": {
                     "id": "2",
                     "authProviderId": AUTH_PROVIDER_ID,
-                    "key": "org_username",
-                    "value": "bar",
+                    "key": "email",
+                    "value": "bar@redhat.com",
                 },
             }
         ),
@@ -259,8 +259,8 @@ def api_response_groups() -> list[acs_api.Group]:
                 "props": {
                     "id": "3",
                     "authProviderId": AUTH_PROVIDER_ID,
-                    "key": "org_username",
-                    "value": "foofoo",
+                    "key": "email",
+                    "value": "foofoo@redhat.com",
                 },
             }
         ),
@@ -270,8 +270,8 @@ def api_response_groups() -> list[acs_api.Group]:
                 "props": {
                     "id": "4",
                     "authProviderId": AUTH_PROVIDER_ID,
-                    "key": "org_username",
-                    "value": "barbar",
+                    "key": "email",
+                    "value": "barbar@redhat.com",
                 },
             }
         ),
@@ -281,8 +281,8 @@ def api_response_groups() -> list[acs_api.Group]:
                 "props": {
                     "id": "5",
                     "authProviderId": AUTH_PROVIDER_ID,
-                    "key": "org_username",
-                    "value": "foobar",
+                    "key": "email",
+                    "value": "foobar@redhat.com",
                 },
             }
         ),
@@ -610,8 +610,8 @@ def test_full_reconcile(
             name="new-role",
             description="add me",
             assignments=[
-                AssignmentPair(key="org_username", value="elsa"),
-                AssignmentPair(key="org_username", value="anna"),
+                AssignmentPair(key="email", value="elsa@redhat.com"),
+                AssignmentPair(key="email", value="anna@redhat.com"),
             ],
             permission_set_name="Admin",
             access_scope=AcsAccessScope(

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -420,7 +420,7 @@ def test_add_rbac_dry_run(
     mocker.patch.object(acs_mock, "create_group_batch")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(
+    integration.reconcile(
         desired=desired,
         current=current,
         rbac_api_resources=rbac_api_resources,
@@ -432,8 +432,6 @@ def test_add_rbac_dry_run(
     acs_mock.create_access_scope.assert_not_called()
     acs_mock.create_role.assert_not_called()
     acs_mock.create_group_batch.assert_not_called()
-
-    assert not errs
 
 
 def test_add_rbac(
@@ -463,7 +461,7 @@ def test_add_rbac(
     mocker.patch.object(acs_mock, "create_group_batch")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(
+    integration.reconcile(
         desired=desired,
         current=current,
         rbac_api_resources=rbac_api_resources,
@@ -508,8 +506,6 @@ def test_add_rbac(
         ]
     )
 
-    assert not errs
-
 
 def test_delete_rbac_dry_run(
     mocker: MockerFixture,
@@ -534,7 +530,7 @@ def test_delete_rbac_dry_run(
     mocker.patch.object(acs_mock, "delete_access_scope")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(
+    integration.reconcile(
         desired=desired,
         current=current,
         rbac_api_resources=rbac_api_resources,
@@ -546,8 +542,6 @@ def test_delete_rbac_dry_run(
     acs_mock.delete_role.assert_not_called()
     acs_mock.delete_group_batch.assert_not_called()
     acs_mock.delete_access_scope.assert_not_called()
-
-    assert not errs
 
 
 def test_delete_rbac(
@@ -575,7 +569,7 @@ def test_delete_rbac(
     mocker.patch.object(acs_mock, "delete_access_scope")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(
+    integration.reconcile(
         desired=desired,
         current=current,
         rbac_api_resources=rbac_api_resources,
@@ -591,8 +585,6 @@ def test_delete_rbac(
     acs_mock.delete_access_scope.assert_has_calls(
         [mocker.call(api_response_access_scopes[1].id)]
     )
-
-    assert not errs
 
 
 def test_update_rbac_groups_only(
@@ -624,7 +616,7 @@ def test_update_rbac_groups_only(
     mocker.patch.object(acs_mock, "update_role")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(
+    integration.reconcile(
         desired=desired,
         current=current,
         rbac_api_resources=rbac_api_resources,
@@ -651,8 +643,6 @@ def test_update_rbac_groups_only(
 
     acs_mock.update_access_scope.assert_not_called()
     acs_mock.update_role.assert_not_called()
-
-    assert not errs
 
 
 def test_full_reconcile(
@@ -711,7 +701,7 @@ def test_full_reconcile(
     mocker.patch.object(acs_mock, "update_role")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(
+    integration.reconcile(
         desired=desired,
         current=current,
         rbac_api_resources=rbac_api_resources,
@@ -781,8 +771,6 @@ def test_full_reconcile(
     acs_mock.create_access_scope.assert_not_called()
     acs_mock.update_group_batch.assert_not_called()
 
-    assert not errs
-
 
 def test_full_reconcile_with_errors(
     mocker: MockerFixture,
@@ -843,14 +831,15 @@ def test_full_reconcile_with_errors(
     mocker.patch.object(acs_mock, "update_role")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(
-        desired=desired,
-        current=current,
-        rbac_api_resources=rbac_api_resources,
-        acs=acs_mock,
-        auth_provider_id=AUTH_PROVIDER_ID,
-        dry_run=dry_run,
-    )
+    with pytest.raises(ExceptionGroup) as exc_info:
+        integration.reconcile(
+            desired=desired,
+            current=current,
+            rbac_api_resources=rbac_api_resources,
+            acs=acs_mock,
+            auth_provider_id=AUTH_PROVIDER_ID,
+            dry_run=dry_run,
+        )
 
     # call to 'create_role' failed. remaining create logic should be skipped
     acs_mock.create_role.assert_has_calls(
@@ -899,4 +888,4 @@ def test_full_reconcile_with_errors(
     acs_mock.create_access_scope.assert_not_called()
     acs_mock.update_group_batch.assert_not_called()
 
-    assert errs
+    assert "Reconcile errors occurred" in str(exc_info.value)

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -6,7 +6,6 @@ import pytest
 from reconcile.acs_rbac import (
     AcsAccessScope,
     AcsRbacIntegration,
-    AcsRbacIntegrationParams,
     AcsRole,
     AssignmentPair,
 )
@@ -362,7 +361,7 @@ def test_get_desired_state(mocker, query_data_desired_state, modeled_acs_roles):
     query_func = mocker.patch("reconcile.acs_rbac.acs_rbac_query", autospec=True)
     query_func.return_value = query_data_desired_state
 
-    integration = AcsRbacIntegration(AcsRbacIntegrationParams(thread_pool_size=10))
+    integration = AcsRbacIntegration()
     result = integration.get_desired_state(query_func)
 
     assert result == modeled_acs_roles
@@ -382,7 +381,7 @@ def test_get_current_state(
     acs_mock.get_access_scope_by_id.side_effect = api_response_access_scopes
     acs_mock.get_permission_set_by_id.side_effect = api_response_permission_sets
 
-    integration = AcsRbacIntegration(AcsRbacIntegrationParams(thread_pool_size=10))
+    integration = AcsRbacIntegration()
     result = integration.get_current_state(acs_mock, AUTH_PROVIDER_ID)
 
     assert result == modeled_acs_roles
@@ -410,7 +409,7 @@ def test_add_rbac_dry_run(
     mocker.patch.object(acs_mock, "create_role")
     mocker.patch.object(acs_mock, "create_group_batch")
 
-    integration = AcsRbacIntegration(AcsRbacIntegrationParams(thread_pool_size=10))
+    integration = AcsRbacIntegration()
     integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
 
     acs_mock.get_access_scopes.assert_called_once()
@@ -443,7 +442,7 @@ def test_add_rbac(
     mocker.patch.object(acs_mock, "create_role")
     mocker.patch.object(acs_mock, "create_group_batch")
 
-    integration = AcsRbacIntegration(AcsRbacIntegrationParams(thread_pool_size=10))
+    integration = AcsRbacIntegration()
     integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
 
     acs_mock.get_access_scopes.assert_called_once()
@@ -501,7 +500,7 @@ def test_delete_rbac_dry_run(
     mocker.patch.object(acs_mock, "delete_group_batch")
     mocker.patch.object(acs_mock, "delete_access_scope")
 
-    integration = AcsRbacIntegration(AcsRbacIntegrationParams(thread_pool_size=10))
+    integration = AcsRbacIntegration()
     integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
 
     acs_mock.get_access_scopes.assert_called_once()
@@ -530,7 +529,7 @@ def test_delete_rbac(
     mocker.patch.object(acs_mock, "delete_group_batch")
     mocker.patch.object(acs_mock, "delete_access_scope")
 
-    integration = AcsRbacIntegration(AcsRbacIntegrationParams(thread_pool_size=10))
+    integration = AcsRbacIntegration()
     integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
 
     acs_mock.get_access_scopes.assert_called_once()
@@ -569,7 +568,7 @@ def test_update_rbac_groups_only(
     mocker.patch.object(acs_mock, "update_access_scope")
     mocker.patch.object(acs_mock, "update_role")
 
-    integration = AcsRbacIntegration(AcsRbacIntegrationParams(thread_pool_size=10))
+    integration = AcsRbacIntegration()
     integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
 
     acs_mock.get_access_scopes.assert_called_once()
@@ -647,7 +646,7 @@ def test_full_reconcile(
     mocker.patch.object(acs_mock, "update_access_scope")
     mocker.patch.object(acs_mock, "update_role")
 
-    integration = AcsRbacIntegration(AcsRbacIntegrationParams(thread_pool_size=10))
+    integration = AcsRbacIntegration()
     integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
 
     acs_mock.create_role.assert_has_calls(

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -1,5 +1,4 @@
 import pytest
-import copy
 
 from unittest.mock import Mock
 

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -397,10 +397,8 @@ def test_add_rbac_dry_run(
     dry_run = True
     desired = modeled_acs_roles
 
-    current = copy.deepcopy(modeled_acs_roles)
-    current.pop()
-    current_access_scopes = copy.deepcopy(api_response_access_scopes)
-    current_access_scopes.pop()
+    current = modeled_acs_roles[:-1]
+    current_access_scopes = api_response_access_scopes[:-1]
 
     acs_mock = Mock()
 
@@ -418,9 +416,9 @@ def test_add_rbac_dry_run(
     acs_mock.get_access_scopes.assert_called_once()
     acs_mock.get_permission_sets.assert_called_once()
 
-    assert not acs_mock.create_access_scope.called
-    assert not acs_mock.create_role.called
-    assert not acs_mock.create_group_batch.called
+    acs_mock.create_access_scope.assert_not_called()
+    acs_mock.create_role.assert_not_called()
+    acs_mock.create_group_batch.assert_not_called()
 
 
 def test_add_rbac(
@@ -432,11 +430,8 @@ def test_add_rbac(
     dry_run = False
     desired = modeled_acs_roles
 
-    current = copy.deepcopy(modeled_acs_roles)
-    # trigger creation of 'service-vuln-admin' role and dependencies
-    current.pop()
-    current_access_scopes = copy.deepcopy(api_response_access_scopes)
-    current_access_scopes.pop()
+    current = modeled_acs_roles[:-1]
+    current_access_scopes = api_response_access_scopes[:-1]
 
     acs_mock = Mock()
 
@@ -496,8 +491,7 @@ def test_delete_rbac_dry_run(
     dry_run = True
     current = modeled_acs_roles
 
-    desired = copy.deepcopy(modeled_acs_roles)
-    desired.pop(1)  # remove 'cluster-analyst' role
+    desired = modeled_acs_roles[:-1]  # remove 'cluster-analyst' role
 
     acs_mock = Mock()
 
@@ -513,9 +507,9 @@ def test_delete_rbac_dry_run(
     acs_mock.get_access_scopes.assert_called_once()
     acs_mock.get_groups.assert_called_once()
 
-    assert not acs_mock.delete_role.called
-    assert not acs_mock.delete_group_batch.called
-    assert not acs_mock.delete_access_scope.called
+    acs_mock.delete_role.assert_not_called()
+    acs_mock.delete_group_batch.assert_not_called()
+    acs_mock.delete_access_scope.assert_not_called()
 
 
 def test_delete_rbac(
@@ -524,8 +518,9 @@ def test_delete_rbac(
     dry_run = False
     current = modeled_acs_roles
 
-    desired = copy.deepcopy(modeled_acs_roles)
-    desired.pop(1)  # remove 'cluster-analyst' role
+    desired = (
+        modeled_acs_roles[:1] + modeled_acs_roles[2:]
+    )  # remove 'cluster-analyst' role
 
     acs_mock = Mock()
 
@@ -597,8 +592,8 @@ def test_update_rbac_groups_only(
         ]
     )
 
-    assert not acs_mock.patch_access_scope.called
-    assert not acs_mock.patch_role.called
+    acs_mock.patch_access_scope.assert_not_called()
+    acs_mock.patch_role.assert_not_called()
 
 
 def test_full_reconcile(
@@ -720,5 +715,5 @@ def test_full_reconcile(
     assert acs_mock.get_permission_sets.call_count == 2
     assert acs_mock.get_groups.call_count == 2
     # new desired role is admin scope. Should use existing 'Unrestricted' system default
-    assert not acs_mock.create_access_scope.called
-    assert not acs_mock.patch_group_batch.called
+    acs_mock.create_access_scope.assert_not_called()
+    acs_mock.patch_group_batch.assert_not_called()

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -565,9 +565,9 @@ def test_update_rbac_groups_only(
     acs_mock.get_access_scopes.return_value = api_response_access_scopes
     acs_mock.get_permission_sets.return_value = api_response_permission_sets
     acs_mock.get_groups.return_value = current_groups
-    mocker.patch.object(acs_mock, "patch_group_batch")
-    mocker.patch.object(acs_mock, "patch_access_scope")
-    mocker.patch.object(acs_mock, "patch_role")
+    mocker.patch.object(acs_mock, "update_group_batch")
+    mocker.patch.object(acs_mock, "update_access_scope")
+    mocker.patch.object(acs_mock, "update_role")
 
     integration = AcsRbacIntegration(AcsRbacIntegrationParams(thread_pool_size=10))
     integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
@@ -576,7 +576,7 @@ def test_update_rbac_groups_only(
     acs_mock.get_permission_sets.assert_called_once()
     acs_mock.get_groups.assert_called_once()
 
-    acs_mock.patch_group_batch.assert_has_calls(
+    acs_mock.update_group_batch.assert_has_calls(
         [
             mocker.call(
                 [current_groups[0]],
@@ -592,8 +592,8 @@ def test_update_rbac_groups_only(
         ]
     )
 
-    acs_mock.patch_access_scope.assert_not_called()
-    acs_mock.patch_role.assert_not_called()
+    acs_mock.update_access_scope.assert_not_called()
+    acs_mock.update_role.assert_not_called()
 
 
 def test_full_reconcile(
@@ -647,9 +647,9 @@ def test_full_reconcile(
     mocker.patch.object(acs_mock, "delete_role")
     mocker.patch.object(acs_mock, "delete_group_batch")
     mocker.patch.object(acs_mock, "delete_access_scope")
-    mocker.patch.object(acs_mock, "patch_group_batch")
-    mocker.patch.object(acs_mock, "patch_access_scope")
-    mocker.patch.object(acs_mock, "patch_role")
+    mocker.patch.object(acs_mock, "update_group_batch")
+    mocker.patch.object(acs_mock, "update_access_scope")
+    mocker.patch.object(acs_mock, "update_role")
 
     integration = AcsRbacIntegration(AcsRbacIntegrationParams(thread_pool_size=10))
     integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
@@ -688,7 +688,7 @@ def test_full_reconcile(
         [mocker.call(api_response_access_scopes[2].id)]
     )
 
-    acs_mock.patch_role.assert_has_calls(
+    acs_mock.update_role.assert_has_calls(
         [
             mocker.call(
                 desired[1].name,
@@ -699,7 +699,7 @@ def test_full_reconcile(
             )
         ]
     )
-    acs_mock.patch_access_scope.assert_has_calls(
+    acs_mock.update_access_scope.assert_has_calls(
         [
             mocker.call(
                 api_response_access_scopes[1].id,
@@ -716,4 +716,4 @@ def test_full_reconcile(
     assert acs_mock.get_groups.call_count == 2
     # new desired role is admin scope. Should use existing 'Unrestricted' system default
     acs_mock.create_access_scope.assert_not_called()
-    acs_mock.patch_group_batch.assert_not_called()
+    acs_mock.update_group_batch.assert_not_called()

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -1,0 +1,392 @@
+import pytest
+import copy
+
+from unittest.mock import Mock
+
+from reconcile.acs_rbac import (
+    AcsRbacIntegration,
+    AcsRbacIntegrationParams,
+    AcsRole,
+    AcsAccessScope,
+    AssignmentPair,
+)
+
+from reconcile.gql_definitions.acs.acs_rbac import (
+    AcsRbacQueryData,
+    UserV1,
+    RoleV1,
+    OidcPermissionAcsV1,
+    NamespaceV1,
+    NamespaceV1_ClusterV1,
+    ClusterV1,
+)
+
+import reconcile.utils.acs_api as acs_api
+
+
+AUTH_PROVIDER_ID = "6a41743c-792b-11ee-b962-0242ac120002"
+
+
+@pytest.fixture
+def query_data_desired_state() -> AcsRbacQueryData:
+    return AcsRbacQueryData(
+        acs_rbacs=[
+            UserV1(
+                org_username="foo",
+                roles=[
+                    RoleV1(
+                        name="app-sre-admin",
+                        oidc_permissions=[
+                            OidcPermissionAcsV1(
+                                name="app-sre-acs-admin",
+                                description="admin access to acs instance",
+                                service="acs",
+                                permission_set="admin",
+                                clusters=[],
+                                namespaces=[],
+                            )
+                        ],
+                    )
+                ],
+            ),
+            UserV1(
+                org_username="bar",
+                roles=[
+                    RoleV1(
+                        name="app-sre-admin",
+                        oidc_permissions=[
+                            OidcPermissionAcsV1(
+                                name="app-sre-acs-admin",
+                                description="admin access to acs instance",
+                                service="acs",
+                                permission_set="admin",
+                                clusters=[],
+                                namespaces=[],
+                            )
+                        ],
+                    )
+                ],
+            ),
+            UserV1(
+                org_username="foofoo",
+                roles=[
+                    RoleV1(
+                        name="tenant-role-a",
+                        oidc_permissions=[
+                            OidcPermissionAcsV1(
+                                name="cluster-analyst",
+                                description="analyst access to clusters in acs instance",
+                                service="acs",
+                                permission_set="analyst",
+                                clusters=[
+                                    ClusterV1(name="clusterA"),
+                                    ClusterV1(name="clusterB"),
+                                ],
+                                namespaces=[],
+                            )
+                        ],
+                    )
+                ],
+            ),
+            UserV1(
+                org_username="barbar",
+                roles=[
+                    RoleV1(
+                        name="tenant-role-a",
+                        oidc_permissions=[
+                            OidcPermissionAcsV1(
+                                name="cluster-analyst",
+                                description="analyst access to clusters in acs instance",
+                                service="acs",
+                                permission_set="analyst",
+                                clusters=[
+                                    ClusterV1(name="clusterA"),
+                                    ClusterV1(name="clusterB"),
+                                ],
+                                namespaces=[],
+                            )
+                        ],
+                    )
+                ],
+            ),
+            UserV1(
+                org_username="foobar",
+                roles=[
+                    RoleV1(
+                        name="tenant-role-b",
+                        oidc_permissions=[
+                            OidcPermissionAcsV1(
+                                name="service-vuln-admin",
+                                description="vuln-admin access to service namespaces in acs instance",
+                                service="acs",
+                                permission_set="vuln-admin",
+                                clusters=[],
+                                namespaces=[
+                                    NamespaceV1(
+                                        name="serviceA-stage",
+                                        cluster=NamespaceV1_ClusterV1(
+                                            name="stage-cluster"
+                                        ),
+                                    ),
+                                    NamespaceV1(
+                                        name="serviceA-prod",
+                                        cluster=NamespaceV1_ClusterV1(
+                                            name="prod-cluster"
+                                        ),
+                                    ),
+                                ],
+                            )
+                        ],
+                    )
+                ],
+            ),
+        ]
+    )
+
+
+@pytest.fixture
+def modeled_acs_roles() -> list[AcsRole]:
+    return [
+        AcsRole(
+            name="app-sre-acs-admin",
+            description="admin access to acs instance",
+            assignments=[
+                AssignmentPair(key="org_username", value="foo"),
+                AssignmentPair(key="org_username", value="bar"),
+            ],
+            permission_set_name="Admin",
+            access_scope=AcsAccessScope(
+                name="Unrestricted",
+                description="Access to all clusters and namespaces",
+                clusters=[],
+                namespaces=[],
+            ),
+            system_default=False,
+        ),
+        AcsRole(
+            name="cluster-analyst",
+            description="analyst access to clusters in acs instance",
+            assignments=[
+                AssignmentPair(key="org_username", value="foofoo"),
+                AssignmentPair(key="org_username", value="barbar"),
+            ],
+            permission_set_name="Analyst",
+            access_scope=AcsAccessScope(
+                name="cluster-analyst",
+                description="analyst access to clusters in acs instance",
+                clusters=["clusterA", "clusterB"],
+                namespaces=[],
+            ),
+            system_default=False,
+        ),
+        AcsRole(
+            name="service-vuln-admin",
+            description="vuln-admin access to service namespaces in acs instance",
+            assignments=[AssignmentPair(key="org_username", value="foobar")],
+            permission_set_name="Vulnerability Management Admin",
+            access_scope=AcsAccessScope(
+                name="service-vuln-admin",
+                description="vuln-admin access to service namespaces in acs instance",
+                clusters=[],
+                namespaces=[
+                    {"clusterName": "stage-cluster", "namespaceName": "serviceA-stage"},
+                    {"clusterName": "prod-cluster", "namespaceName": "serviceA-prod"},
+                ],
+            ),
+            system_default=False,
+        ),
+    ]
+
+
+@pytest.fixture
+def api_response_roles() -> list[acs_api.Role]:
+    return [
+        acs_api.Role(
+            api_data={
+                "name": "app-sre-acs-admin",
+                "permissionSetId": "1",
+                "accessScopeId": "1",
+                "description": "admin access to acs instance",
+                "system_default": False,
+            }
+        ),
+        acs_api.Role(
+            api_data={
+                "name": "cluster-analyst",
+                "permissionSetId": "2",
+                "accessScopeId": "2",
+                "description": "analyst access to clusters in acs instance",
+                "system_default": False,
+            }
+        ),
+        acs_api.Role(
+            api_data={
+                "name": "service-vuln-admin",
+                "permissionSetId": "3",
+                "accessScopeId": "3",
+                "description": "vuln-admin access to service namespaces in acs instance",
+                "system_default": False,
+            }
+        ),
+    ]
+
+
+@pytest.fixture
+def api_response_groups() -> list[acs_api.Group]:
+    return [
+        acs_api.Group(
+            api_data={
+                "roleName": "app-sre-acs-admin",
+                "props": {
+                    "id": "1",
+                    "authProviderId": AUTH_PROVIDER_ID,
+                    "key": "org_username",
+                    "value": "foo",
+                },
+            }
+        ),
+        acs_api.Group(
+            api_data={
+                "roleName": "app-sre-acs-admin",
+                "props": {
+                    "id": "2",
+                    "authProviderId": AUTH_PROVIDER_ID,
+                    "key": "org_username",
+                    "value": "bar",
+                },
+            }
+        ),
+        acs_api.Group(
+            api_data={
+                "roleName": "cluster-analyst",
+                "props": {
+                    "id": "3",
+                    "authProviderId": AUTH_PROVIDER_ID,
+                    "key": "org_username",
+                    "value": "foofoo",
+                },
+            }
+        ),
+        acs_api.Group(
+            api_data={
+                "roleName": "cluster-analyst",
+                "props": {
+                    "id": "4",
+                    "authProviderId": AUTH_PROVIDER_ID,
+                    "key": "org_username",
+                    "value": "barbar",
+                },
+            }
+        ),
+        acs_api.Group(
+            api_data={
+                "roleName": "service-vuln-admin",
+                "props": {
+                    "id": "5",
+                    "authProviderId": AUTH_PROVIDER_ID,
+                    "key": "org_username",
+                    "value": "foobar",
+                },
+            }
+        ),
+    ]
+
+
+@pytest.fixture
+def api_response_access_scopes() -> list[acs_api.AccessScope]:
+    return [
+        acs_api.AccessScope(
+            api_data={
+                "id": "1",
+                "name": "Unrestricted",
+                "description": "Access to all clusters and namespaces",
+                "rules": None,
+            }
+        ),
+        acs_api.AccessScope(
+            api_data={
+                "id": "2",
+                "name": "cluster-analyst",
+                "description": "analyst access to clusters in acs instance",
+                "rules": {
+                    "includedClusters": ["clusterA", "clusterB"],
+                    "includedNamespaces": [],
+                },
+            }
+        ),
+        acs_api.AccessScope(
+            api_data={
+                "id": "3",
+                "name": "service-vuln-admin",
+                "description": "vuln-admin access to service namespaces in acs instance",
+                "rules": {
+                    "includedClusters": [],
+                    "includedNamespaces": [
+                        {
+                            "clusterName": "stage-cluster",
+                            "namespaceName": "serviceA-stage",
+                        },
+                        {
+                            "clusterName": "prod-cluster",
+                            "namespaceName": "serviceA-prod",
+                        },
+                    ],
+                },
+            }
+        ),
+    ]
+
+
+@pytest.fixture
+def api_response_permission_sets() -> list[acs_api.PermissionSet]:
+    return [
+        acs_api.PermissionSet(
+            api_data={
+                "id": "1",
+                "name": "Admin",
+            }
+        ),
+        acs_api.PermissionSet(
+            api_data={
+                "id": "2",
+                "name": "Analyst",
+            }
+        ),
+        acs_api.PermissionSet(
+            api_data={
+                "id": "3",
+                "name": "Vulnerability Management Admin",
+            }
+        ),
+    ]
+
+
+def test_get_desired_state(mocker, query_data_desired_state, modeled_acs_roles):
+    integration = AcsRbacIntegration(AcsRbacIntegrationParams(thread_pool_size=10))
+
+    query_func = mocker.patch("reconcile.acs_rbac.acs_rbac_query", autospec=True)
+    query_func.return_value = query_data_desired_state
+
+    result = integration.get_desired_state(query_func)
+
+    assert result == modeled_acs_roles
+
+
+def test_get_current_state(
+    modeled_acs_roles,
+    api_response_roles,
+    api_response_groups,
+    api_response_access_scopes,
+    api_response_permission_sets,
+):
+    acs_mock = Mock()
+
+    acs_mock.get_roles.return_value = api_response_roles
+    acs_mock.get_groups.return_value = api_response_groups
+    acs_mock.get_access_scope_by_id.side_effect = api_response_access_scopes
+    acs_mock.get_permission_set_by_id.side_effect = api_response_permission_sets
+
+    integration = AcsRbacIntegration(AcsRbacIntegrationParams(thread_pool_size=10))
+    result = integration.get_current_state(acs_mock, AUTH_PROVIDER_ID)
+
+    assert result == modeled_acs_roles

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -605,11 +605,7 @@ def test_full_reconcile(
 ):
     dry_run = False
 
-    desired = copy.deepcopy(modeled_acs_roles)
-    # trigger deletion of 'service-vuln-admin' rbac
-    desired.pop()
-    # create new admin rbac
-    desired.append(
+    desired = modeled_acs_roles[:-1] + [
         AcsRole(
             name="new-role",
             description="add me",
@@ -626,7 +622,7 @@ def test_full_reconcile(
             ),
             system_default=False,
         )
-    )
+    ]
 
     current = copy.deepcopy(modeled_acs_roles)
     # change permission set to trigger update to existing 'cluster-analyst' role

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -1,6 +1,6 @@
-import pytest
-
 from unittest.mock import Mock
+
+import pytest
 
 from reconcile.acs_rbac import (
     AcsRbacIntegration,
@@ -20,7 +20,7 @@ from reconcile.gql_definitions.acs.acs_rbac import (
     ClusterV1,
 )
 
-import reconcile.utils.acs_api as acs_api
+from reconcile.utils import acs_api
 
 
 AUTH_PROVIDER_ID = "6a41743c-792b-11ee-b962-0242ac120002"

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -2,6 +2,7 @@ import copy
 from unittest.mock import Mock
 
 import pytest
+from pytest_mock import MockerFixture
 
 from reconcile.acs_rbac import (
     AcsAccessScope,
@@ -357,7 +358,11 @@ def api_response_permission_sets() -> list[acs_api.PermissionSet]:
     ]
 
 
-def test_get_desired_state(mocker, query_data_desired_state, modeled_acs_roles):
+def test_get_desired_state(
+    mocker: MockerFixture,
+    query_data_desired_state: AcsRbacQueryData,
+    modeled_acs_roles: list[AcsRole],
+):
     query_func = mocker.patch("reconcile.acs_rbac.acs_rbac_query", autospec=True)
     query_func.return_value = query_data_desired_state
 
@@ -368,11 +373,11 @@ def test_get_desired_state(mocker, query_data_desired_state, modeled_acs_roles):
 
 
 def test_get_current_state(
-    modeled_acs_roles,
-    api_response_roles,
-    api_response_groups,
-    api_response_access_scopes,
-    api_response_permission_sets,
+    modeled_acs_roles: list[AcsRole],
+    api_response_roles: list[acs_api.Role],
+    api_response_groups: list[acs_api.Group],
+    api_response_access_scopes: list[acs_api.AccessScope],
+    api_response_permission_sets: list[acs_api.PermissionSet],
 ):
     acs_mock = Mock()
 
@@ -388,10 +393,10 @@ def test_get_current_state(
 
 
 def test_add_rbac_dry_run(
-    mocker,
-    modeled_acs_roles,
-    api_response_access_scopes,
-    api_response_permission_sets,
+    mocker: MockerFixture,
+    modeled_acs_roles: list[AcsRole],
+    api_response_access_scopes: list[acs_api.AccessScope],
+    api_response_permission_sets: list[acs_api.PermissionSet],
 ):
     dry_run = True
     desired = modeled_acs_roles
@@ -421,10 +426,10 @@ def test_add_rbac_dry_run(
 
 
 def test_add_rbac(
-    mocker,
-    modeled_acs_roles,
-    api_response_access_scopes,
-    api_response_permission_sets,
+    mocker: MockerFixture,
+    modeled_acs_roles: list[AcsRole],
+    api_response_access_scopes: list[acs_api.AccessScope],
+    api_response_permission_sets: list[acs_api.PermissionSet],
 ):
     dry_run = False
     desired = modeled_acs_roles
@@ -485,11 +490,13 @@ def test_add_rbac(
 
 
 def test_delete_rbac_dry_run(
-    mocker, modeled_acs_roles, api_response_access_scopes, api_response_groups
+    mocker: MockerFixture,
+    modeled_acs_roles: list[AcsRole],
+    api_response_access_scopes: list[acs_api.AccessScope],
+    api_response_groups: list[acs_api.Group],
 ):
     dry_run = True
     current = modeled_acs_roles
-
     desired = modeled_acs_roles[:-1]  # remove 'cluster-analyst' role
 
     acs_mock = Mock()
@@ -512,11 +519,13 @@ def test_delete_rbac_dry_run(
 
 
 def test_delete_rbac(
-    mocker, modeled_acs_roles, api_response_access_scopes, api_response_groups
+    mocker: MockerFixture,
+    modeled_acs_roles: list[AcsRole],
+    api_response_access_scopes: list[acs_api.AccessScope],
+    api_response_groups: list[acs_api.Group],
 ):
     dry_run = False
     current = modeled_acs_roles
-
     desired = (
         modeled_acs_roles[:1] + modeled_acs_roles[2:]
     )  # remove 'cluster-analyst' role
@@ -544,11 +553,11 @@ def test_delete_rbac(
 
 
 def test_update_rbac_groups_only(
-    mocker,
-    modeled_acs_roles,
-    api_response_access_scopes,
-    api_response_permission_sets,
-    api_response_groups,
+    mocker: MockerFixture,
+    modeled_acs_roles: list[AcsRole],
+    api_response_access_scopes: list[acs_api.AccessScope],
+    api_response_permission_sets: list[acs_api.PermissionSet],
+    api_response_groups: list[acs_api.Group],
 ):
     dry_run = False
     desired = modeled_acs_roles
@@ -596,11 +605,11 @@ def test_update_rbac_groups_only(
 
 
 def test_full_reconcile(
-    mocker,
-    modeled_acs_roles,
-    api_response_access_scopes,
-    api_response_permission_sets,
-    api_response_groups,
+    mocker: MockerFixture,
+    modeled_acs_roles: list[AcsRole],
+    api_response_access_scopes: list[acs_api.AccessScope],
+    api_response_permission_sets: list[acs_api.PermissionSet],
+    api_response_groups: list[acs_api.Group],
 ):
     dry_run = False
 

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -3,25 +3,22 @@ from unittest.mock import Mock
 import pytest
 
 from reconcile.acs_rbac import (
+    AcsAccessScope,
     AcsRbacIntegration,
     AcsRbacIntegrationParams,
     AcsRole,
-    AcsAccessScope,
     AssignmentPair,
 )
-
 from reconcile.gql_definitions.acs.acs_rbac import (
     AcsRbacQueryData,
-    UserV1,
-    RoleV1,
-    OidcPermissionAcsV1,
+    ClusterV1,
     NamespaceV1,
     NamespaceV1_ClusterV1,
-    ClusterV1,
+    OidcPermissionAcsV1,
+    RoleV1,
+    UserV1,
 )
-
 from reconcile.utils import acs_api
-
 
 AUTH_PROVIDER_ID = "6a41743c-792b-11ee-b962-0242ac120002"
 

--- a/reconcile/test/test_acs_rbac.py
+++ b/reconcile/test/test_acs_rbac.py
@@ -379,15 +379,16 @@ def test_get_current_state(
     api_response_access_scopes: list[acs_api.AccessScope],
     api_response_permission_sets: list[acs_api.PermissionSet],
 ):
-    acs_mock = Mock()
-
-    acs_mock.get_roles.return_value = api_response_roles
-    acs_mock.get_groups.return_value = api_response_groups
-    acs_mock.get_access_scope_by_id.side_effect = api_response_access_scopes
-    acs_mock.get_permission_set_by_id.side_effect = api_response_permission_sets
-
     integration = AcsRbacIntegration()
-    result = integration.get_current_state(acs_mock, AUTH_PROVIDER_ID)
+    result = integration.get_current_state(
+        AUTH_PROVIDER_ID,
+        acs_api.RbacResources(
+            roles=api_response_roles,
+            access_scopes=api_response_access_scopes,
+            groups=api_response_groups,
+            permission_sets=api_response_permission_sets,
+        ),
+    )
 
     assert result == modeled_acs_roles
 
@@ -406,8 +407,12 @@ def test_add_rbac_dry_run(
 
     acs_mock = Mock()
 
-    acs_mock.get_access_scopes.return_value = current_access_scopes
-    acs_mock.get_permission_sets.return_value = api_response_permission_sets
+    rbac_api_resources = acs_api.RbacResources(
+        roles=[],
+        access_scopes=current_access_scopes,
+        groups=[],
+        permission_sets=api_response_permission_sets,
+    )
     mocker.patch.object(
         acs_mock, "create_access_scope", side_effect=[api_response_access_scopes[2].id]
     )
@@ -415,10 +420,14 @@ def test_add_rbac_dry_run(
     mocker.patch.object(acs_mock, "create_group_batch")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
-
-    acs_mock.get_access_scopes.assert_called_once()
-    acs_mock.get_permission_sets.assert_called_once()
+    errs = integration.reconcile(
+        desired=desired,
+        current=current,
+        rbac_api_resources=rbac_api_resources,
+        acs=acs_mock,
+        auth_provider_id=AUTH_PROVIDER_ID,
+        dry_run=dry_run,
+    )
 
     acs_mock.create_access_scope.assert_not_called()
     acs_mock.create_role.assert_not_called()
@@ -441,8 +450,12 @@ def test_add_rbac(
 
     acs_mock = Mock()
 
-    acs_mock.get_access_scopes.return_value = current_access_scopes
-    acs_mock.get_permission_sets.return_value = api_response_permission_sets
+    rbac_api_resources = acs_api.RbacResources(
+        roles=[],
+        access_scopes=current_access_scopes,
+        groups=[],
+        permission_sets=api_response_permission_sets,
+    )
     mocker.patch.object(
         acs_mock, "create_access_scope", side_effect=[api_response_access_scopes[2].id]
     )
@@ -450,10 +463,15 @@ def test_add_rbac(
     mocker.patch.object(acs_mock, "create_group_batch")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
+    errs = integration.reconcile(
+        desired=desired,
+        current=current,
+        rbac_api_resources=rbac_api_resources,
+        acs=acs_mock,
+        auth_provider_id=AUTH_PROVIDER_ID,
+        dry_run=dry_run,
+    )
 
-    acs_mock.get_access_scopes.assert_called_once()
-    acs_mock.get_permission_sets.assert_called_once()
     acs_mock.create_access_scope.assert_has_calls(
         [
             mocker.call(
@@ -505,17 +523,25 @@ def test_delete_rbac_dry_run(
 
     acs_mock = Mock()
 
-    acs_mock.get_access_scopes.return_value = api_response_access_scopes
-    acs_mock.get_groups.return_value = api_response_groups
+    rbac_api_resources = acs_api.RbacResources(
+        roles=[],
+        access_scopes=api_response_access_scopes,
+        groups=api_response_groups,
+        permission_sets=[],
+    )
     mocker.patch.object(acs_mock, "delete_role")
     mocker.patch.object(acs_mock, "delete_group_batch")
     mocker.patch.object(acs_mock, "delete_access_scope")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
-
-    acs_mock.get_access_scopes.assert_called_once()
-    acs_mock.get_groups.assert_called_once()
+    errs = integration.reconcile(
+        desired=desired,
+        current=current,
+        rbac_api_resources=rbac_api_resources,
+        acs=acs_mock,
+        auth_provider_id=AUTH_PROVIDER_ID,
+        dry_run=dry_run,
+    )
 
     acs_mock.delete_role.assert_not_called()
     acs_mock.delete_group_batch.assert_not_called()
@@ -538,17 +564,26 @@ def test_delete_rbac(
 
     acs_mock = Mock()
 
-    acs_mock.get_access_scopes.return_value = api_response_access_scopes
-    acs_mock.get_groups.return_value = api_response_groups
+    rbac_api_resources = acs_api.RbacResources(
+        roles=[],
+        access_scopes=api_response_access_scopes,
+        groups=api_response_groups,
+        permission_sets=[],
+    )
     mocker.patch.object(acs_mock, "delete_role")
     mocker.patch.object(acs_mock, "delete_group_batch")
     mocker.patch.object(acs_mock, "delete_access_scope")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
+    errs = integration.reconcile(
+        desired=desired,
+        current=current,
+        rbac_api_resources=rbac_api_resources,
+        acs=acs_mock,
+        auth_provider_id=AUTH_PROVIDER_ID,
+        dry_run=dry_run,
+    )
 
-    acs_mock.get_access_scopes.assert_called_once()
-    acs_mock.get_groups.assert_called_once()
     acs_mock.delete_role.assert_has_calls([mocker.call(current[1].name)])
     acs_mock.delete_group_batch.assert_has_calls(
         [mocker.call([api_response_groups[2], api_response_groups[3]])]
@@ -578,19 +613,25 @@ def test_update_rbac_groups_only(
 
     acs_mock = Mock()
 
-    acs_mock.get_access_scopes.return_value = api_response_access_scopes
-    acs_mock.get_permission_sets.return_value = api_response_permission_sets
-    acs_mock.get_groups.return_value = current_groups
+    rbac_api_resources = acs_api.RbacResources(
+        roles=[],
+        access_scopes=api_response_access_scopes,
+        groups=current_groups,
+        permission_sets=api_response_permission_sets,
+    )
     mocker.patch.object(acs_mock, "update_group_batch")
     mocker.patch.object(acs_mock, "update_access_scope")
     mocker.patch.object(acs_mock, "update_role")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
-
-    acs_mock.get_access_scopes.assert_called_once()
-    acs_mock.get_permission_sets.assert_called_once()
-    acs_mock.get_groups.assert_called_once()
+    errs = integration.reconcile(
+        desired=desired,
+        current=current,
+        rbac_api_resources=rbac_api_resources,
+        acs=acs_mock,
+        auth_provider_id=AUTH_PROVIDER_ID,
+        dry_run=dry_run,
+    )
 
     acs_mock.update_group_batch.assert_has_calls(
         [
@@ -653,9 +694,12 @@ def test_full_reconcile(
 
     acs_mock = Mock()
 
-    acs_mock.get_access_scopes.return_value = current_access_scopes
-    acs_mock.get_permission_sets.return_value = api_response_permission_sets
-    acs_mock.get_groups.return_value = api_response_groups
+    rbac_api_resources = acs_api.RbacResources(
+        roles=[],
+        access_scopes=current_access_scopes,
+        groups=api_response_groups,
+        permission_sets=api_response_permission_sets,
+    )
     mocker.patch.object(acs_mock, "create_access_scope")
     mocker.patch.object(acs_mock, "create_role")
     mocker.patch.object(acs_mock, "create_group_batch")
@@ -667,7 +711,14 @@ def test_full_reconcile(
     mocker.patch.object(acs_mock, "update_role")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
+    errs = integration.reconcile(
+        desired=desired,
+        current=current,
+        rbac_api_resources=rbac_api_resources,
+        acs=acs_mock,
+        auth_provider_id=AUTH_PROVIDER_ID,
+        dry_run=dry_run,
+    )
 
     acs_mock.create_role.assert_has_calls(
         [
@@ -726,9 +777,6 @@ def test_full_reconcile(
         ]
     )
 
-    assert acs_mock.get_access_scopes.call_count == 3
-    assert acs_mock.get_permission_sets.call_count == 2
-    assert acs_mock.get_groups.call_count == 2
     # new desired role is admin scope. Should use existing 'Unrestricted' system default
     acs_mock.create_access_scope.assert_not_called()
     acs_mock.update_group_batch.assert_not_called()
@@ -774,9 +822,12 @@ def test_full_reconcile_with_errors(
 
     acs_mock = Mock()
 
-    acs_mock.get_access_scopes.return_value = current_access_scopes
-    acs_mock.get_permission_sets.return_value = api_response_permission_sets
-    acs_mock.get_groups.return_value = api_response_groups
+    rbac_api_resources = acs_api.RbacResources(
+        roles=[],
+        access_scopes=current_access_scopes,
+        groups=api_response_groups,
+        permission_sets=api_response_permission_sets,
+    )
     mocker.patch.object(acs_mock, "create_access_scope")
     mocker.patch.object(
         acs_mock, "create_role", side_effect=Exception("Simulated error")
@@ -792,7 +843,14 @@ def test_full_reconcile_with_errors(
     mocker.patch.object(acs_mock, "update_role")
 
     integration = AcsRbacIntegration()
-    errs = integration.reconcile(desired, current, acs_mock, AUTH_PROVIDER_ID, dry_run)
+    errs = integration.reconcile(
+        desired=desired,
+        current=current,
+        rbac_api_resources=rbac_api_resources,
+        acs=acs_mock,
+        auth_provider_id=AUTH_PROVIDER_ID,
+        dry_run=dry_run,
+    )
 
     # call to 'create_role' failed. remaining create logic should be skipped
     acs_mock.create_role.assert_has_calls(
@@ -837,9 +895,6 @@ def test_full_reconcile_with_errors(
         ]
     )
 
-    assert acs_mock.get_access_scopes.call_count == 3
-    assert acs_mock.get_permission_sets.call_count == 2
-    assert acs_mock.get_groups.call_count == 2
     # new desired role is admin scope. Should use existing 'Unrestricted' system default
     acs_mock.create_access_scope.assert_not_called()
     acs_mock.update_group_batch.assert_not_called()

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -216,6 +216,18 @@ class AcsApi:
 
         self.generic_post_request(f"/v1/roles/{name}", json)
 
+    def update_role(
+        self, name: str, desc: str, permission_set_id: str, access_scope_id: str
+    ):
+        json = {
+            "name": name,
+            "description": desc,
+            "permissionSetId": permission_set_id,
+            "accessScopeId": access_scope_id,
+        }
+
+        self.generic_put_request(f"/v1/roles/{name}", json)
+
     def delete_role(self, name: str):
         self.generic_delete_request(f"/v1/roles/{name}")
 

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -127,9 +127,9 @@ class AcsApi:
     ) -> requests.Response:
         url = (f"{self.url}{path}",)
         headers = {
-                "Authorization": f"Bearer {self.token}",
-                "Content-Type": "application/json",
-            }
+            "Authorization": f"Bearer {self.token}",
+            "Content-Type": "application/json",
+        }
 
         if verb == "GET":
             response = requests.get(url, headers=headers, timeout=self.timeout)

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -142,20 +142,13 @@ class AcsApi:
             "Content-Type": "application/json",
         }
 
-        if verb == "GET":
-            response = self.session.get(url, headers=headers, timeout=self.timeout)
-        elif verb == "DELETE":
-            response = self.session.delete(url, headers=headers, timeout=self.timeout)
-        elif verb == "POST":
-            response = self.session.put(
-                url, headers=headers, json=json, timeout=self.timeout
-            )
-        elif verb == "PUT":
-            response = self.session.post(
-                url, headers=headers, json=json, timeout=self.timeout
-            )
-        else:
-            raise ValueError(f"Unsupported request type: {verb}")
+        response = self.session.request(
+            verb,
+            url,
+            headers=headers,
+            json=json,
+            timeout=self.timeout,
+        )
 
         response.raise_for_status()
         return response

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -74,10 +74,10 @@ class AccessScope(BaseModel):
         # attributes defined within stackrox(ACS) API for GET /v1/simpleaccessscopes/{id}
         unrestricted = False
         check_len_attributes(["id", "name"], api_data)
+
         # it is valid for the default Unrestricted access scope to have null 'rules'
-        if api_data["name"] == "Unrestricted":
-            unrestricted = True
-        else:
+        unrestricted = api_data["name"] == "Unrestricted"
+        if not unrestricted:
             check_len_attributes(["rules"], api_data)
 
         super().__init__(

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -104,6 +104,13 @@ class PermissionSet(BaseModel):
         super().__init__(id=api_data["id"], name=api_data["name"])
 
 
+class RbacResources(BaseModel):
+    roles: list[Role]
+    access_scopes: list[AccessScope]
+    groups: list[Group]
+    permission_sets: list[PermissionSet]
+
+
 def check_len_attributes(attrs: list[Any], api_data: Any) -> None:
     # generic attribute check function for expected types with valid len()
     for attr in attrs:
@@ -259,10 +266,6 @@ class AcsApi:
         }
         self.generic_request("/v1/groupsbatch", "POST", json)
 
-    def get_access_scope_by_id(self, id: str) -> AccessScope:
-        response = self.generic_request(f"/v1/simpleaccessscopes/{id}", "GET")
-        return AccessScope(response.json())
-
     def get_access_scopes(self) -> list[AccessScope]:
         response = self.generic_request("/v1/simpleaccessscopes", "GET")
         return [AccessScope(a) for a in response.json()["accessScopes"]]
@@ -310,10 +313,14 @@ class AcsApi:
 
         self.generic_request(f"/v1/simpleaccessscopes/{id}", "PUT", json)
 
-    def get_permission_set_by_id(self, id: str) -> PermissionSet:
-        response = self.generic_request(f"/v1/permissionsets/{id}", "GET")
-        return PermissionSet(response.json())
-
     def get_permission_sets(self) -> list[PermissionSet]:
         response = self.generic_request("/v1/permissionsets", "GET")
         return [PermissionSet(p) for p in response.json()["permissionSets"]]
+
+    def get_rbac_resources(self) -> RbacResources:
+        return RbacResources(
+            roles=self.get_roles(),
+            access_scopes=self.get_access_scopes(),
+            groups=self.get_groups(),
+            permission_sets=self.get_permission_sets(),
+        )

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -1,4 +1,7 @@
-from typing import Any, Optional
+from typing import (
+    Any,
+    Optional,
+)
 
 import requests
 from pydantic import BaseModel

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -1,4 +1,8 @@
-from typing import Any, Optional, Self
+from typing import (
+    Any,
+    Optional,
+    Self,
+)
 
 import requests
 from pydantic import BaseModel

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -124,6 +124,10 @@ class AcsApi:
         self.base_url = instance["url"]
         self.token = instance["token"]
         self.timeout = timeout
+        self.session = requests.Session()
+
+    def __exit__(self) -> None:
+        self.session.close()
 
     def generic_request(
         self, path: str, verb: str, json: Optional[Any] = None
@@ -135,15 +139,15 @@ class AcsApi:
         }
 
         if verb == "GET":
-            response = requests.get(url, headers=headers, timeout=self.timeout)
+            response = self.session.get(url, headers=headers, timeout=self.timeout)
         elif verb == "DELETE":
-            response = requests.delete(url, headers=headers, timeout=self.timeout)
+            response = self.session.delete(url, headers=headers, timeout=self.timeout)
         elif verb == "POST":
-            response = requests.put(
+            response = self.session.put(
                 url, headers=headers, json=json, timeout=self.timeout
             )
         elif verb == "PUT":
-            response = requests.post(
+            response = self.session.post(
                 url, headers=headers, json=json, timeout=self.timeout
             )
         else:

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -174,7 +174,7 @@ class AcsApi:
 
     def get_roles(self) -> list[Role]:
         response = self.generic_get_request("/v1/roles")
-        return list(response.json()["roles"])
+        return [Role(r) for r in response.json()["roles"]]
 
     def create_role(
         self, name: str, desc: str, permission_set_id: str, access_scope_id: str
@@ -205,7 +205,7 @@ class AcsApi:
 
     def get_groups(self) -> list[Group]:
         response = self.generic_get_request("/v1/groups")
-        return list(response.json()["groups"])
+        return [Group(g) for g in response.json()["groups"]]
 
     class GroupAdd(BaseModel):
         role_name: str
@@ -286,7 +286,7 @@ class AcsApi:
 
     def get_access_scopes(self) -> list[AccessScope]:
         response = self.generic_get_request("/v1/simpleaccessscopes")
-        return list(response.json()["accessScopes"])
+        return [AccessScope(a) for a in response.json()["accessScopes"]]
 
     def create_access_scope(
         self,
@@ -337,4 +337,4 @@ class AcsApi:
 
     def get_permission_sets(self) -> list[PermissionSet]:
         response = self.generic_get_request("/v1/permissionsets")
-        return list(response.json()["permissionSets"])
+        return [PermissionSet(p) for p in response.json()["permissionSets"]]

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -215,7 +215,7 @@ class AcsApi:
 
         self.generic_post_request(f"/v1/roles/{name}", json)
 
-    def update_role(
+    def patch_role(
         self, name: str, desc: str, permission_set_id: str, access_scope_id: str
     ) -> None:
         json = {
@@ -350,7 +350,7 @@ class AcsApi:
     def delete_access_scope(self, id: str) -> None:
         self.generic_delete_request(f"/v1/simpleaccessscopes/{id}")
 
-    def update_access_scope(
+    def patch_access_scope(
         self,
         id: str,
         name: str,

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -1,6 +1,6 @@
 from typing import Any
-import requests
 
+import requests
 from pydantic import BaseModel
 
 

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -1,7 +1,7 @@
+from typing import Any
 import requests
 
 from pydantic import BaseModel
-from typing import Any
 
 
 class Role(BaseModel):

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -1,7 +1,7 @@
 import requests
 
 from pydantic import BaseModel
-from typing import Any, Optional
+from typing import Any
 
 
 class Role(BaseModel):
@@ -235,7 +235,6 @@ class AcsApi:
 
     def delete_group_batch(self, removals: list[Group]):
         json = {
-            "requiredGroups": [],
             "previousGroups": [
                 {
                     "roleName": group.role_name,
@@ -248,9 +247,13 @@ class AcsApi:
                 }
                 for group in removals
             ],
+            "requiredGroups": [],
         }
 
         self.generic_post_request("/v1/groupsbatch", json)
+
+    def patch_group_batch(self, current: list[Group], removals: list[Group]):
+        pass
 
     def get_access_scope_by_id(self, id: str) -> AccessScope:
         response = self.generic_get_request(f"/v1/simpleaccessscopes/{id}")

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -174,7 +174,7 @@ class AcsApi:
 
     def get_roles(self) -> list[Role]:
         response = self.generic_get_request("/v1/roles")
-        return [role for role in response.json()["roles"]]
+        return list(response.json()["roles"])
 
     def create_role(
         self, name: str, desc: str, permission_set_id: str, access_scope_id: str
@@ -205,7 +205,7 @@ class AcsApi:
 
     def get_groups(self) -> list[Group]:
         response = self.generic_get_request("/v1/groups")
-        return [group for group in response.json()["groups"]]
+        return list(response.json()["groups"])
 
     class GroupAdd(BaseModel):
         role_name: str
@@ -286,7 +286,7 @@ class AcsApi:
 
     def get_access_scopes(self) -> list[AccessScope]:
         response = self.generic_get_request("/v1/simpleaccessscopes")
-        return [scope for scope in response.json()["accessScopes"]]
+        return list(response.json()["accessScopes"])
 
     def create_access_scope(
         self,
@@ -337,4 +337,4 @@ class AcsApi:
 
     def get_permission_sets(self) -> list[PermissionSet]:
         response = self.generic_get_request("/v1/permissionsets")
-        return [ps for ps in response.json()["permissionSets"]]
+        return list(response.json()["permissionSets"])

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -252,8 +252,34 @@ class AcsApi:
 
         self.generic_post_request("/v1/groupsbatch", json)
 
-    def patch_group_batch(self, current: list[Group], removals: list[Group]):
-        pass
+    def patch_group_batch(self, old: list[Group], new: list[GroupAdd]):
+        json = {
+            "previousGroups": [
+                {
+                    "roleName": o.role_name,
+                    "props": {
+                        "id": o.id,
+                        "authProviderId": o.auth_provider_id,
+                        "key": o.key,
+                        "value": o.value,
+                    },
+                }
+                for o in old
+            ],
+            "requiredGroups": [
+                {
+                    "roleName": n.role_name,
+                    "props": {
+                        "id": "",
+                        "authProviderId": n.auth_provider_id,
+                        "key": n.key,
+                        "value": n.value,
+                    },
+                }
+                for n in new
+            ],
+        }
+        self.generic_post_request("/v1/groupsbatch", json)
 
     def get_access_scope_by_id(self, id: str) -> AccessScope:
         response = self.generic_get_request(f"/v1/simpleaccessscopes/{id}")

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -123,36 +123,34 @@ class AcsApi:
         self.timeout = timeout
 
     def generic_request(
-        self, path, request_type, json: Optional[Any]
+        self, path: str, verb: str, json: Optional[Any]
     ) -> requests.Response:
         url = (f"{self.url}{path}",)
-        headers = (
-            {
+        headers = {
                 "Authorization": f"Bearer {self.token}",
                 "Content-Type": "application/json",
-            },
-        )
+            }
 
-        if request_type == "GET":
+        if verb == "GET":
             response = requests.get(url, headers=headers, timeout=self.timeout)
-        elif request_type == "DELETE":
+        elif verb == "DELETE":
             response = requests.delete(url, headers=headers, timeout=self.timeout)
-        elif request_type == "POST":
+        elif verb == "POST":
             response = requests.put(
                 url, headers=headers, json=json, timeout=self.timeout
             )
-        elif request_type == "PUT":
+        elif verb == "PUT":
             response = requests.post(
                 url, headers=headers, json=json, timeout=self.timeout
             )
         else:
-            raise ValueError(f"Unsupported request type: {request_type}")
+            raise ValueError(f"Unsupported request type: {verb}")
 
         response.raise_for_status()
         return response
 
     def get_roles(self) -> list[Role]:
-        response = self.generic_request("/v1/roles", "GET")
+        response = self.generic_request(path="/v1/roles", verb="GET")
         return [Role(r) for r in response.json()["roles"]]
 
     def create_role(

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -46,14 +46,13 @@ class Group(BaseModel):
     def __init__(self, api_data: Any) -> None:
         # attributes defined within stackrox(ACS) API for GET /v1/groups
         check_len_attributes(["roleName", "props"], api_data)
-        try:
+        if api_data["roleName"] != "None":
             check_len_attributes(
                 ["id", "authProviderId", "key", "value"], api_data["props"]
             )
-        except ValueError as e:
+        else:
             # it is valid for the default None group to contain empty key/value
-            if api_data["roleName"] != "None":
-                raise e
+            check_len_attributes(["id", "authProviderId"], api_data["props"])
 
         super().__init__(
             role_name=api_data["roleName"],

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -197,11 +197,7 @@ class AcsApi:
 
     def get_roles(self) -> list[Role]:
         response = self.generic_get_request("/v1/roles")
-
-        roles = []
-        for role in response.json()["roles"]:
-            roles.append(Role(role))
-        return roles
+        return [role for role in response.json()["roles"]]
 
     def create_role(
         self, name: str, desc: str, permission_set_id: str, access_scope_id: str
@@ -232,12 +228,7 @@ class AcsApi:
 
     def get_groups(self) -> list[Group]:
         response = self.generic_get_request("/v1/groups")
-
-        groups = []
-        for group in response.json()["groups"]:
-            groups.append(Group(group))
-
-        return groups
+        return [group for group in response.json()["groups"]]
 
     class GroupAdd(BaseModel):
         role_name: str
@@ -314,17 +305,11 @@ class AcsApi:
 
     def get_access_scope_by_id(self, id: str) -> AccessScope:
         response = self.generic_get_request(f"/v1/simpleaccessscopes/{id}")
-
         return AccessScope(response.json())
 
     def get_access_scopes(self) -> list[AccessScope]:
         response = self.generic_get_request("/v1/simpleaccessscopes")
-
-        access_scopes = []
-        for scope in response.json()["accessScopes"]:
-            access_scopes.append(AccessScope(scope))
-
-        return access_scopes
+        return [scope for scope in response.json()["accessScopes"]]
 
     def create_access_scope(
         self,
@@ -371,14 +356,8 @@ class AcsApi:
 
     def get_permission_set_by_id(self, id: str) -> PermissionSet:
         response = self.generic_get_request(f"/v1/permissionsets/{id}")
-
         return PermissionSet(response.json())
 
     def get_permission_sets(self) -> list[PermissionSet]:
         response = self.generic_get_request("/v1/permissionsets")
-
-        permission_sets = []
-        for ps in response.json()["permissionSets"]:
-            permission_sets.append(PermissionSet(ps))
-
-        return permission_sets
+        return [ps for ps in response.json()["permissionSets"]]

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -128,12 +128,7 @@ class AcsApi:
             headers={"Authorization": f"Bearer {self.token}"},
             timeout=self.timeout,
         )
-        try:
-            response.raise_for_status()
-        except requests.exceptions.RequestException as details:
-            raise requests.exceptions.RequestException(
-                f"Failed to perform GET request:\n\t{details}\n\t{response.text}"
-            )
+        response.raise_for_status()
 
         return response
 
@@ -147,13 +142,7 @@ class AcsApi:
             timeout=self.timeout,
             json=json,
         )
-
-        try:
-            response.raise_for_status()
-        except requests.exceptions.RequestException as details:
-            raise requests.exceptions.RequestException(
-                f"Failed to perform POST request with body:\n\t{json}\n\t{details}\n\t{response.text}"
-            )
+        response.raise_for_status()
 
         return response
 
@@ -167,13 +156,7 @@ class AcsApi:
             timeout=self.timeout,
             json=json,
         )
-
-        try:
-            response.raise_for_status()
-        except requests.exceptions.RequestException as details:
-            raise requests.exceptions.RequestException(
-                f"Failed to perform PUT request with body:\n\t{json}\n\t{details}\n\t{response.text}"
-            )
+        response.raise_for_status()
 
         return response
 
@@ -185,13 +168,7 @@ class AcsApi:
             },
             timeout=self.timeout,
         )
-
-        try:
-            response.raise_for_status()
-        except requests.exceptions.RequestException as details:
-            raise requests.exceptions.RequestException(
-                f"Failed to perform DELETE request:\n\t{details}\n\t{response.text}"
-            )
+        response.raise_for_status()
 
         return response
 

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -73,13 +73,12 @@ class AccessScope(BaseModel):
     def __init__(self, api_data: Any) -> None:
         # attributes defined within stackrox(ACS) API for GET /v1/simpleaccessscopes/{id}
         unrestricted = False
-        try:
-            check_len_attributes(["id", "name", "rules"], api_data)
-        except ValueError as e:
-            # it is valid for the default Unrestricted access scope to have null `rules`
-            if api_data.get("name") != "Unrestricted":
-                raise e
+        check_len_attributes(["id", "name"], api_data)
+        # it is valid for the default Unrestricted access scope to have null 'rules'
+        if api_data["name"] == "Unrestricted":
             unrestricted = True
+        else:
+            check_len_attributes(["rules"], api_data)
 
         super().__init__(
             id=api_data["id"],

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -118,14 +118,14 @@ class AcsApi:
         instance: Any,
         timeout: int = 30,
     ) -> None:
-        self.url = instance["url"]
+        self.base_url = instance["url"]
         self.token = instance["token"]
         self.timeout = timeout
 
     def generic_request(
-        self, path: str, verb: str, json: Optional[Any]
+        self, path: str, verb: str, json: Optional[Any] = None
     ) -> requests.Response:
-        url = (f"{self.url}{path}",)
+        url = f"{self.base_url}{path}"
         headers = {
             "Authorization": f"Bearer {self.token}",
             "Content-Type": "application/json",
@@ -150,7 +150,7 @@ class AcsApi:
         return response
 
     def get_roles(self) -> list[Role]:
-        response = self.generic_request(path="/v1/roles", verb="GET")
+        response = self.generic_request("/v1/roles", "GET")
         return [Role(r) for r in response.json()["roles"]]
 
     def create_role(
@@ -207,7 +207,7 @@ class AcsApi:
             ],
         }
 
-        self.generic_post_request("/v1/groupsbatch", "POST", json)
+        self.generic_request("/v1/groupsbatch", "POST", json)
 
     def delete_group_batch(self, removals: list[Group]) -> None:
         json = {

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -1,7 +1,4 @@
-from typing import (
-    Any,
-    Optional,
-)
+from typing import Any, Optional, Self
 
 import requests
 from pydantic import BaseModel
@@ -126,7 +123,10 @@ class AcsApi:
         self.timeout = timeout
         self.session = requests.Session()
 
-    def __exit__(self) -> None:
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         self.session.close()
 
     def generic_request(

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -201,7 +201,6 @@ class AcsApi:
         roles = []
         for role in response.json()["roles"]:
             roles.append(Role(role))
-
         return roles
 
     def create_role(

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -157,6 +157,26 @@ class AcsApi:
 
         return response
 
+    def generic_put_request(self, path: str, json: Any) -> requests.Response:
+        response = requests.put(
+            url=f"{self.url}{path}",
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+            },
+            timeout=self.timeout,
+            json=json,
+        )
+
+        try:
+            response.raise_for_status()
+        except requests.exceptions.RequestException as details:
+            raise requests.exceptions.RequestException(
+                f"Failed to perform PUT request with body:\n\t{json}\n\t{details}\n\t{response.text}"
+            )
+
+        return response
+
     def generic_delete_request(self, path: str) -> requests.Response:
         response = requests.delete(
             url=f"{self.url}{path}",
@@ -318,6 +338,25 @@ class AcsApi:
 
     def delete_access_scope(self, id: str):
         self.generic_delete_request(f"/v1/simpleaccessscopes/{id}")
+
+    def update_access_scope(
+        self,
+        id: str,
+        name: str,
+        desc: str,
+        clusters: list[str],
+        namespaces: list[dict[str, str]],
+    ):
+        json = {
+            "name": name,
+            "description": desc,
+            "rules": {
+                "includedClusters": clusters,
+                "includedNamespaces": namespaces,
+            },
+        }
+
+        self.generic_put_request(f"/v1/simpleaccessscopes/{id}")
 
     def get_permission_set_by_id(self, id: str) -> PermissionSet:
         response = self.generic_get_request(f"/v1/permissionsets/{id}")

--- a/reconcile/utils/acs_api.py
+++ b/reconcile/utils/acs_api.py
@@ -206,7 +206,7 @@ class AcsApi:
 
     def create_role(
         self, name: str, desc: str, permission_set_id: str, access_scope_id: str
-    ):
+    ) -> None:
         json = {
             "name": name,
             "description": desc,
@@ -218,7 +218,7 @@ class AcsApi:
 
     def update_role(
         self, name: str, desc: str, permission_set_id: str, access_scope_id: str
-    ):
+    ) -> None:
         json = {
             "name": name,
             "description": desc,
@@ -228,7 +228,7 @@ class AcsApi:
 
         self.generic_put_request(f"/v1/roles/{name}", json)
 
-    def delete_role(self, name: str):
+    def delete_role(self, name: str) -> None:
         self.generic_delete_request(f"/v1/roles/{name}")
 
     def get_groups(self) -> list[Group]:
@@ -246,7 +246,7 @@ class AcsApi:
         value: str
         auth_provider_id: str
 
-    def create_group_batch(self, additions: list[GroupAdd]):
+    def create_group_batch(self, additions: list[GroupAdd]) -> None:
         json = {
             "previousGroups": [],
             "requiredGroups": [
@@ -265,7 +265,7 @@ class AcsApi:
 
         self.generic_post_request("/v1/groupsbatch", json)
 
-    def delete_group_batch(self, removals: list[Group]):
+    def delete_group_batch(self, removals: list[Group]) -> None:
         json = {
             "previousGroups": [
                 {
@@ -284,7 +284,7 @@ class AcsApi:
 
         self.generic_post_request("/v1/groupsbatch", json)
 
-    def patch_group_batch(self, old: list[Group], new: list[GroupAdd]):
+    def patch_group_batch(self, old: list[Group], new: list[GroupAdd]) -> None:
         json = {
             "previousGroups": [
                 {
@@ -348,7 +348,7 @@ class AcsApi:
 
         return response.json()["id"]
 
-    def delete_access_scope(self, id: str):
+    def delete_access_scope(self, id: str) -> None:
         self.generic_delete_request(f"/v1/simpleaccessscopes/{id}")
 
     def update_access_scope(
@@ -358,7 +358,7 @@ class AcsApi:
         desc: str,
         clusters: list[str],
         namespaces: list[dict[str, str]],
-    ):
+    ) -> None:
         json = {
             "name": name,
             "description": desc,
@@ -368,7 +368,7 @@ class AcsApi:
             },
         }
 
-        self.generic_put_request(f"/v1/simpleaccessscopes/{id}")
+        self.generic_put_request(f"/v1/simpleaccessscopes/{id}", json)
 
     def get_permission_set_by_id(self, id: str) -> PermissionSet:
         response = self.generic_get_request(f"/v1/permissionsets/{id}")


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-8467
https://issues.redhat.com/browse/APPSRE-7607

Dependencies:
*  https://github.com/app-sre/qontract-schemas/pull/539

This integration will be responsible for reconciling [RH ACS rbac resources](https://docs.openshift.com/acs/4.2/operating/manage-user-access/manage-role-based-access-control-3630.html) . The integration will derive necessary rbac resources via oidc-permissions (see [expansion to oidc-permission-1 schema](https://github.com/app-sre/qontract-schemas/pull/539/files#diff-7a842619b2728c197543a91c51fc7eb0b944b2cb85b43900c981ce6522073faaR71-R96)) associated with App Interface roles that users reference.

`acs` variants of the oidc-permission are defined like so:
```yaml
---
$schema: /access/oidc-permission-1.yml

name: app-sre-cluster-scope

description: example of assigning permission at cluster scope

service: acs

permission_set: admin

clusters: 
- $ref: /clusters/appsres05ue1/cluster.yml
- $ref: /clusters/appint-ex-01/cluster.yml
```

These permissions are then referenced in the existing `oidc_permissions` attribute of the `role-1` schema:
```yaml
---
$schema: /access/role-1.yml

name: team-member-role

permissions:
- $ref: /teams/example-team/permissions/team-slack-permissions.yml

oidc_permissions:
- $ref: /dependencies/acs/permissions/app-sre-cluster-scope.yml
```

After defining an acs oidc-permission and referencing it within a role used by App Interface users, the integration becomes responsible for reconciling the ACS RBAC resources necessary to grant the desired access.

The `acs` oidc-permission defined within App Interface corresponds to two ACS rbac api resources: `role` and `access scope`. These two resources will share the same name (derived from name of the oidc-permission).
* note: `role` is derived from the oidc-permission definition instead of the App Interface role(s) the permission is referenced by due ability for A-I roles to reference multiple `oidc_permissions`. There would be potential for multiple ACS roles with same name.

`permission_set` is a enum with values that directly correspond to system default `permission sets` within ACS. ACS provides ample `permission set` options by default that cover our use cases. The enum list can be expanded to cover additional system default options if deemed necessary.

Finally, the link between an App Interface user that references a role with an `acs` oidc-permission attached corresponds to an ACS api `group`. Each `group` resource creates a rule within the ACS auth provider for assignment of permission to an authenticated user.
Example of one `group` represented in list of auth rules:
![image](https://github.com/app-sre/qontract-reconcile/assets/100163026/13fd320e-746a-486c-990d-35d97d5b2667)

