### PR TITLE
Support COMMAND_NAME for Deployment in helm

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -247,6 +247,10 @@ objects:
           {{- end }}
           - name: DRY_RUN
             value: ${DRY_RUN}
+          {{- if $integration.command }}
+          - name: COMMAND_NAME
+            value: {{ $integration.command }}
+          {{- end }}
           {{- if eq $integration.name "integrations-manager" }}
           - name: MANAGER_DRY_RUN
             value: ${MANAGER_DRY_RUN}

--- a/reconcile/test/fixtures/helm/command.yml
+++ b/reconcile/test/fixtures/helm/command.yml
@@ -103,6 +103,8 @@ objects:
             value: "0"
           - name: DRY_RUN
             value: ${DRY_RUN}
+          - name: COMMAND_NAME
+            value: app-interface-metrics-exporter
           - name: INTEGRATION_NAME
             value: integ
           - name: SLEEP_DURATION_SECS

--- a/reconcile/test/utils/test_helm.py
+++ b/reconcile/test/utils/test_helm.py
@@ -65,7 +65,7 @@ def test_template_cache(helm_integration_specs: Sequence[HelmIntegrationSpec]):
 
 
 def test_template_command(helm_integration_specs: Sequence[HelmIntegrationSpec]):
-    helm_integration_specs[0].command = "app-interface-reporter"
+    helm_integration_specs[0].command = "app-interface-metrics-exporter"
     template = helm.template(build_helm_values(helm_integration_specs))
     expected = yaml.safe_load(fxt.get("command.yml"))
     assert template == expected


### PR DESCRIPTION
Follow up on https://github.com/app-sre/qontract-reconcile/pull/3898#pullrequestreview-1692859265, `COMMAND_NAME` was supported in `CronJob` only, this change make it work for `Deployment` too.