### PR TITLE
Alerts report crashes on missing message

### DIFF
--- a/reconcile/test/fixtures/slack_api/conversations_history_messages.yaml
+++ b/reconcile/test/fixtures/slack_api/conversations_history_messages.yaml
@@ -1,3 +1,63 @@
+# AlertmanagerReceiverTest rule file does not have "message" set
+# in the rule file, so we have to consider it separately
+# elapsed time: 300s
+- attachments:
+  - actions:
+    - id: '1'
+      style: ''
+      text: 'Query :mag:'
+      type: button
+      url: https://prometheus.app-sre-prod-04.devshift.net/graph?g0.expr=floor%28vector%28time%28%29+%2F+%282+%2A+60%29%29%29+%25+2+%3E+0+%3C+2&g0.tab=1
+    - id: '2'
+      style: ''
+      text: 'Silence :no_bell:'
+      type: button
+      url: https://alertmanager.app-sre-prod-04.devshift.net/#/silences/new?filter=%7Bcluster%3D"app-sre-prod-04"%2C%20environment%3D"production"%2C%20prometheus%3D"openshift-customer-monitoring/app-sre"%2C%20statusBoardService%3D"status-board/status-board/AlertmanagerReceiverTest"%2C%20alertname%3D"AlertmanagerReceiverTest"%7D
+    color: 2eb886
+    fallback: "Alert: AlertmanagerReceiverTest [RESOLVED] \n | <https://alertmanager.app-sre-prod-04.devshift.net/#/alerts?receiver=slack-app-sre-alerts>"
+    id: 1
+    mrkdwn_in:
+    - fallback
+    - pretext
+    - text
+    title: 'Alert: AlertmanagerReceiverTest [RESOLVED]'
+    title_link: https://alertmanager.app-sre-prod-04.devshift.net/#/alerts?receiver=slack-app-sre-alerts
+  bot_id: BFYPB540Z
+  icons:
+    emoji: ':prometheus:'
+  subtype: bot_message
+  text: ''
+  ts: '1686819033.031509'
+  type: message
+  username: app-sre-alerts (app-sre-prod-04)
+- attachments:
+  - actions:
+    - id: '1'
+      style: ''
+      text: 'Query :mag:'
+      type: button
+      url: https://prometheus.app-sre-prod-04.devshift.net/graph?g0.expr=floor%28vector%28time%28%29+%2F+%282+%2A+60%29%29%29+%25+2+%3E+0+%3C+2&g0.tab=1
+    - id: '2'
+      style: ''
+      text: 'Silence :no_bell:'
+      type: button
+      url: https://alertmanager.app-sre-prod-04.devshift.net/#/silences/new?filter=%7Bcluster%3D"app-sre-prod-04"%2C%20environment%3D"production"%2C%20prometheus%3D"openshift-customer-monitoring/app-sre"%2C%20statusBoardService%3D"status-board/status-board/AlertmanagerReceiverTest"%2C%20alertname%3D"AlertmanagerReceiverTest"%7D
+    fallback: 'Alert: AlertmanagerReceiverTest [FIRING:1]  | <https://alertmanager.app-sre-prod-04.devshift.net/#/alerts?receiver=slack-app-sre-alerts>'
+    id: 1
+    mrkdwn_in:
+    - fallback
+    - pretext
+    - text
+    title: 'Alert: AlertmanagerReceiverTest [FIRING:1]'
+    title_link: https://alertmanager.app-sre-prod-04.devshift.net/#/alerts?receiver=slack-app-sre-alerts
+  bot_id: BFYPB540Z
+  icons:
+    emoji: ':prometheus:'
+  subtype: bot_message
+  text: ''
+  ts: '1686818733.031509'
+  type: message
+  username: app-sre-alerts (app-sre-prod-04)
 # PrometheusTargetFlapping alerts
 # Cases to test multiple entries to calculate medians
 ## Target pushgateway-nginx-gate-1/10.131.0.19:9091

--- a/tools/sd_app_sre_alert_report.py
+++ b/tools/sd_app_sre_alert_report.py
@@ -82,6 +82,21 @@ def group_alerts(messages: list[dict]) -> dict[str, list[Alert]]:
                     )
                 )
             else:
+                # This may happen for alerts rules without "message". This can happen
+                # if schema cannot be validated for a certain alert rule because it
+                # is not valid yaml (go templates, jinja templates)
+                if "text" not in at:
+                    alert_state = "FIRING" if "FIRING" in mg.group(2) else mg.group(2)
+                    alerts[alert_name].append(
+                        Alert(
+                            state=alert_state,
+                            message="placeholder",
+                            timestamp=timestamp,
+                            username=m["username"],
+                        )
+                    )
+                    continue
+
                 alert_state = ""
                 for line in at["text"].split("\n"):
                     if "Alerts Firing" in line:

--- a/tools/test/test_sd_app_sre_alert_report.py
+++ b/tools/test/test_sd_app_sre_alert_report.py
@@ -28,16 +28,21 @@ def test_group_alerts():
     assert csopc
     assert len(csopc) == 1
 
+    art = alerts["AlertmanagerReceiverTest"]
+    assert art
+    assert len(art) == 2
+
     # This means one of the list elements has been ignored as it didn't have alertname
-    # as the total alerts we have from the above tests is 11 and the total of messages
-    # from the fixture is 12.
+    # as the total alerts we have from the above tests is 13 and the total of messages
+    # from the fixture is 14.
     assert set(alerts.keys()) == {
         "PrometheusTargetFlapping",
         "SLOMetricAbsent",
         "PatchmanAlertEvalDelay",
         "ContainerSecurityOperatorPodCount",
+        "AlertmanagerReceiverTest",
     }
-    assert len(messages) == 12
+    assert len(messages) == 14
 
 
 def test_alert_stats():
@@ -62,3 +67,8 @@ def test_alert_stats():
     assert csopc.triggered_alerts == 0
     assert csopc.resolved_alerts == 1
     assert not csopc.elapsed_times
+
+    art = alert_stats["AlertmanagerReceiverTest"]
+    assert art.triggered_alerts == 1
+    assert art.resolved_alerts == 1
+    assert median(art.elapsed_times) == 300


### PR DESCRIPTION
It makes an assumption on the shape of the alert slack messages from the prometheus alert schema. But sometimes the schema cannot be validated (if the rules file is a template) and it may have an unexpected shape. We introduce a workaround to be able to count them.

Signed-off-by: Rafa Porres Molina <rporresm@redhat.com>