### PR TITLE
Use FIPS endpoints with AWS for GovCloud Accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ Install build prerequisites for [psycopg2](https://www.psycopg.org/docs/install.
   * The `libpq` header files. They are usually installed in a package such as `libpq-dev`.
   * The `pg_config` program: it is usually installed by the `libpq-dev` package but sometimes it is not in a `PATH` directory.
   * On macOS, can be installed via `brew install libpq`. Make sure the installation path is added to your PATH, otherwise `pg_config` will not be available.
+  * On Fedora, it can be installed with `dnf install libpq-devel`
   
 Note:
 In macOS with M1/M2 `pip` will fail to install in a virtualenvironment unless LDFLAGS reference the openssl library path. It can be fixed with `export LDFLAGS="-I/opt/homebrew/opt/openssl/include -L/opt/homebrew/opt/openssl/lib"`.


### PR DESCRIPTION
[APPSRE-8486](https://issues.redhat.com/browse/APPSRE-8486)

Updates the AWS API wrapper to configure any client for a GovCloud account to use FIPS endpoints in order to comply with FedRamp compliance requirements. GovCloud accounts are determined by checking the `partition` value in the `account.yml` file for each. The reason being is that we have some non GovCloud accounts in FedRamp so we cannot enable FIPS across the board for all accounts.

Tested locally against FedRamp App Interface with a variety of AWS based integrations (terraform-resources, users, etc.). Should not affect commercial at all since we have no us-gov partition accounts there but I will do a rollout to stage before promoting to prod in commercial.

Also adds a note to the README about libpq and Fedora