### PR TITLE
Terraform cloudflare resources custom ssl certificate

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -34726,6 +34726,26 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "cloudflare_custom_ssl_certificates",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "OBJECT",
+                                        "name": "CloudflareCustomSSLCertificate_v1",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -35012,6 +35032,132 @@
                                 "kind": "SCALAR",
                                 "name": "Boolean",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "CloudflareCustomSSLCertificate_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "identifier",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "bundle_method",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "geo_restrictions",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "certificate_secret",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "CertificateSecret_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "CertificateSecret_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "certificate",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "VaultSecret_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "key",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "VaultSecret_v1",
+                                    "ofType": null
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -34728,7 +34728,7 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "cloudflare_custom_ssl_certificates",
+                            "name": "custom_ssl_certificates",
                             "description": null,
                             "args": [],
                             "type": {

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.gql
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.gql
@@ -92,10 +92,14 @@ query TerraformCloudflareResources {
               identifier
               type
               bundle_method
-              vault_certificate {
-                path
-                certificate_key
-                private_key_key
+              geo_restrictions
+              certificate_secret {
+                certificate {
+                  ... VaultSecret
+                }
+                key {
+                  ... VaultSecret
+                }
               }
             }
           }

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.gql
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.gql
@@ -88,7 +88,7 @@ query TerraformCloudflareResources {
               cloudflare_branding
               wait_for_active_status
             }
-            cloudflare_custom_ssl_certificates {
+            custom_ssl_certificates {
               identifier
               type
               bundle_method

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.gql
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.gql
@@ -26,6 +26,7 @@ query TerraformCloudflareResources {
     }
     managedExternalResources
     externalResources {
+      provider
       ... on NamespaceTerraformProviderResourceCloudflare_v1 {
         provider
         provisioner {
@@ -86,6 +87,16 @@ query TerraformCloudflareResources {
               certificate_authority
               cloudflare_branding
               wait_for_active_status
+            }
+            cloudflare_custom_ssl_certificates {
+              identifier
+              type
+              bundle_method
+              vault_certificate {
+                path
+                certificate_key
+                private_key_key
+              }
             }
           }
           ... on NamespaceTerraformResourceLogpushOwnershipChallenge_v1

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.py
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.py
@@ -129,7 +129,7 @@ query TerraformCloudflareResources {
               cloudflare_branding
               wait_for_active_status
             }
-            cloudflare_custom_ssl_certificates {
+            custom_ssl_certificates {
               identifier
               type
               bundle_method
@@ -286,9 +286,7 @@ class CloudflareCustomSSLCertificateV1(ConfiguredBaseModel):
     certificate_secret: CertificateSecretV1 = Field(..., alias="certificate_secret")
 
 
-class NamespaceTerraformResourceCloudflareZoneV1(
-    NamespaceTerraformResourceCloudflareV1
-):
+class NamespaceTerraformResourceCloudflareZoneV1(NamespaceTerraformResourceCloudflareV1):
     identifier: str = Field(..., alias="identifier")
     zone: str = Field(..., alias="zone")
     plan: Optional[str] = Field(..., alias="plan")
@@ -299,12 +297,8 @@ class NamespaceTerraformResourceCloudflareZoneV1(
     cache_reserve: Optional[CloudflareZoneCacheReserveV1] = Field(..., alias="cache_reserve")
     records: Optional[list[CloudflareDnsRecordV1]] = Field(..., alias="records")
     workers: Optional[list[CloudflareZoneWorkerV1]] = Field(..., alias="workers")
-    certificates: Optional[list[CloudflareZoneCertificateV1]] = Field(
-        ..., alias="certificates"
-    )
-    cloudflare_custom_ssl_certificates: Optional[
-        list[CloudflareCustomSSLCertificateV1]
-    ] = Field(..., alias="cloudflare_custom_ssl_certificates")
+    certificates: Optional[list[CloudflareZoneCertificateV1]] = Field(..., alias="certificates")
+    custom_ssl_certificates: Optional[list[CloudflareCustomSSLCertificateV1]] = Field(..., alias="custom_ssl_certificates")
 
 
 class NamespaceTerraformResourceLogpushOwnershipChallengeV1(NamespaceTerraformResourceCloudflareV1):

--- a/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.py
+++ b/reconcile/gql_definitions/terraform_cloudflare_resources/terraform_cloudflare_resources.py
@@ -67,6 +67,7 @@ query TerraformCloudflareResources {
     }
     managedExternalResources
     externalResources {
+      provider
       ... on NamespaceTerraformProviderResourceCloudflare_v1 {
         provider
         provisioner {
@@ -127,6 +128,20 @@ query TerraformCloudflareResources {
               certificate_authority
               cloudflare_branding
               wait_for_active_status
+            }
+            cloudflare_custom_ssl_certificates {
+              identifier
+              type
+              bundle_method
+              geo_restrictions
+              certificate_secret {
+                certificate {
+                  ... VaultSecret
+                }
+                key {
+                  ... VaultSecret
+                }
+              }
             }
           }
           ... on NamespaceTerraformResourceLogpushOwnershipChallenge_v1
@@ -190,7 +205,7 @@ class ClusterV1(ConfiguredBaseModel):
 
 
 class NamespaceExternalResourceV1(ConfiguredBaseModel):
-    ...
+    provider: str = Field(..., alias="provider")
 
 
 class CloudflareAccountV1(ConfiguredBaseModel):
@@ -258,7 +273,22 @@ class CloudflareZoneCertificateV1(ConfiguredBaseModel):
     wait_for_active_status: Optional[bool] = Field(..., alias="wait_for_active_status")
 
 
-class NamespaceTerraformResourceCloudflareZoneV1(NamespaceTerraformResourceCloudflareV1):
+class CertificateSecretV1(ConfiguredBaseModel):
+    certificate: VaultSecret = Field(..., alias="certificate")
+    key: VaultSecret = Field(..., alias="key")
+
+
+class CloudflareCustomSSLCertificateV1(ConfiguredBaseModel):
+    identifier: str = Field(..., alias="identifier")
+    q_type: str = Field(..., alias="type")
+    bundle_method: Optional[str] = Field(..., alias="bundle_method")
+    geo_restrictions: Optional[str] = Field(..., alias="geo_restrictions")
+    certificate_secret: CertificateSecretV1 = Field(..., alias="certificate_secret")
+
+
+class NamespaceTerraformResourceCloudflareZoneV1(
+    NamespaceTerraformResourceCloudflareV1
+):
     identifier: str = Field(..., alias="identifier")
     zone: str = Field(..., alias="zone")
     plan: Optional[str] = Field(..., alias="plan")
@@ -269,7 +299,12 @@ class NamespaceTerraformResourceCloudflareZoneV1(NamespaceTerraformResourceCloud
     cache_reserve: Optional[CloudflareZoneCacheReserveV1] = Field(..., alias="cache_reserve")
     records: Optional[list[CloudflareDnsRecordV1]] = Field(..., alias="records")
     workers: Optional[list[CloudflareZoneWorkerV1]] = Field(..., alias="workers")
-    certificates: Optional[list[CloudflareZoneCertificateV1]] = Field(..., alias="certificates")
+    certificates: Optional[list[CloudflareZoneCertificateV1]] = Field(
+        ..., alias="certificates"
+    )
+    cloudflare_custom_ssl_certificates: Optional[
+        list[CloudflareCustomSSLCertificateV1]
+    ] = Field(..., alias="cloudflare_custom_ssl_certificates")
 
 
 class NamespaceTerraformResourceLogpushOwnershipChallengeV1(NamespaceTerraformResourceCloudflareV1):

--- a/reconcile/terraform_cloudflare_resources.py
+++ b/reconcile/terraform_cloudflare_resources.py
@@ -345,8 +345,6 @@ def run(
         logging.info("No cloudflare namespaces were detected, nothing to do.")
         sys.exit(ExitCodes.SUCCESS)
 
-    # _filter_custom_ssl_certificate(cloudflare_namespaces, secret_reader)
-
     # Build Cloudflare clients
     cf_clients = TerraformConfigClientCollection()
     for client in build_clients(secret_reader, query_accounts, selected_account):

--- a/reconcile/terraform_cloudflare_resources.py
+++ b/reconcile/terraform_cloudflare_resources.py
@@ -21,7 +21,6 @@ from reconcile.gql_definitions.terraform_cloudflare_resources.terraform_cloudfla
 )
 from reconcile.gql_definitions.terraform_cloudflare_resources.terraform_cloudflare_resources import (
     NamespaceTerraformProviderResourceCloudflareV1,
-    NamespaceTerraformResourceCloudflareZoneV1,
     NamespaceV1,
     TerraformCloudflareResourcesQueryData,
 )
@@ -306,33 +305,6 @@ def _filter_cloudflare_namespaces(
                     ):
                         cloudflare_namespaces.append(ns)
     return cloudflare_namespaces
-
-
-def _populate_custom_ssl_certificate(
-    namespaces: Iterable[NamespaceV1],
-    secret_reader: SecretReaderBase,
-) -> None:
-    for ns in namespaces:
-        if ns.external_resources:
-            for ext_resource in ns.external_resources:
-                if isinstance(
-                    ext_resource, NamespaceTerraformProviderResourceCloudflareV1
-                ):
-                    zones = [
-                        res for res in ext_resource.resources if res.provider == "zone"
-                    ]
-                    for zone in zones:
-                        if (
-                            isinstance(zone, NamespaceTerraformResourceCloudflareZoneV1)
-                            and zone.custom_ssl_certificates
-                        ):
-                            for cert in zone.custom_ssl_certificates:
-                                cert_data = secret_reader.read_secret(
-                                    cert.certificate_secret.certificate
-                                )
-                                key_data = secret_reader.read_secret(
-                                    cert.certificate_secret.key
-                                )
 
 
 @defer

--- a/reconcile/terraform_cloudflare_resources.py
+++ b/reconcile/terraform_cloudflare_resources.py
@@ -309,7 +309,7 @@ def _filter_cloudflare_namespaces(
     return cloudflare_namespaces
 
 
-def _filter_cloudflare_custom_ssl_certificate(
+def _filter_custom_ssl_certificate(
     namespaces: Iterable[NamespaceV1],
 ) -> list[CloudflareCustomSSLCertificateV1]:
     certificates: list[CloudflareCustomSSLCertificateV1] = []
@@ -326,9 +326,9 @@ def _filter_cloudflare_custom_ssl_certificate(
                     for zone in zones:
                         if (
                             isinstance(zone, NamespaceTerraformResourceCloudflareZoneV1)
-                            and zone.cloudflare_custom_ssl_certificates
+                            and zone.custom_ssl_certificates
                         ):
-                            certificates += zone.cloudflare_custom_ssl_certificates
+                            certificates += zone.custom_ssl_certificates
     return certificates
 
 
@@ -370,7 +370,7 @@ def run(
         logging.info("No cloudflare namespaces were detected, nothing to do.")
         sys.exit(ExitCodes.SUCCESS)
 
-    cloudflare_custom_ssl_certificates = _filter_cloudflare_custom_ssl_certificate(
+    custom_ssl_certificates = _filter_custom_ssl_certificate(
         cloudflare_namespaces
     )
 

--- a/reconcile/terraform_cloudflare_resources.py
+++ b/reconcile/terraform_cloudflare_resources.py
@@ -370,9 +370,7 @@ def run(
         logging.info("No cloudflare namespaces were detected, nothing to do.")
         sys.exit(ExitCodes.SUCCESS)
 
-    custom_ssl_certificates = _filter_custom_ssl_certificate(
-        cloudflare_namespaces
-    )
+    custom_ssl_certificates = _filter_custom_ssl_certificate(cloudflare_namespaces)
 
     # Build Cloudflare clients
     cf_clients = TerraformConfigClientCollection()

--- a/reconcile/test/test_terraform_cloudflare_resources.py
+++ b/reconcile/test/test_terraform_cloudflare_resources.py
@@ -405,4 +405,3 @@ def test_terraform_cloudflare_resources_dry_run(
     assert sample.value.code == ExitCodes.SUCCESS
     assert mock_terraform_client.called is True
     assert call().apply() not in mock_terraform_client.method_calls
-    assert True

--- a/reconcile/test/test_terraform_cloudflare_resources.py
+++ b/reconcile/test/test_terraform_cloudflare_resources.py
@@ -388,6 +388,6 @@ def test_terraform_cloudflare_resources_dry_run(
     with pytest.raises(SystemExit) as sample:
         integ.run(True, None, False, 10)
     assert sample.value.code == ExitCodes.SUCCESS
-    assert mock_terraform_client.called == True
+    assert mock_terraform_client.called is True
     assert call().apply() not in mock_terraform_client.method_calls
     assert True

--- a/reconcile/test/test_terraform_cloudflare_resources.py
+++ b/reconcile/test/test_terraform_cloudflare_resources.py
@@ -18,7 +18,9 @@ from reconcile.gql_definitions.terraform_cloudflare_resources.terraform_cloudfla
     CloudflareAccountV1 as CFAccountV1,
 )
 from reconcile.gql_definitions.terraform_cloudflare_resources.terraform_cloudflare_resources import (
+    CertificateSecretV1,
     CloudflareAccountV1,
+    CloudflareCustomSSLCertificateV1,
     CloudflareDnsRecordV1,
     CloudflareZoneArgoV1,
     CloudflareZoneCacheReserveV1,
@@ -113,6 +115,28 @@ def external_resources(provisioner_config):
                         certificate_authority="lets_encrypt",
                         cloudflare_branding=False,
                         wait_for_active_status=False,
+                    )
+                ],
+                cloudflare_custom_ssl_certificates=[
+                    CloudflareCustomSSLCertificateV1(
+                        identifier="testcustomssl",
+                        type="legacy_custom",
+                        bundle_method="ubiquitous",
+                        geo_restrictions="us",
+                        certificate_secret=CertificateSecretV1(
+                            certificate=VaultSecret(
+                                path="some/path",
+                                field="certificate.crt",
+                                format="plain",
+                                version=1,
+                            ),
+                            key=VaultSecret(
+                                path="another/path",
+                                field="certificate.key",
+                                format="plain",
+                                version=1,
+                            ),
+                        ),
                     )
                 ],
             ),

--- a/reconcile/test/test_terraform_cloudflare_resources.py
+++ b/reconcile/test/test_terraform_cloudflare_resources.py
@@ -78,7 +78,7 @@ def external_resources(provisioner_config):
         provisioner=provisioner_config,
         resources=[
             NamespaceTerraformResourceCloudflareZoneV1(
-                provider="cloudflare_zone",
+                provider="zone",
                 identifier="testzone-com",
                 zone="testzone.com",
                 plan="enterprise",
@@ -228,12 +228,12 @@ def mock_cloudflare_accounts(mocker):
                             format="plain",
                         ),
                         terraformState=TerraformStateAWSV1(
-                            provider="",
-                            bucket="",
-                            region="",
+                            provider="s3",
+                            bucket="app-interface",
+                            region="us-east-1",
                             integrations=[
                                 AWSTerraformStateIntegrationsV1(
-                                    integration="terraform-cloudflare-resources", key=""
+                                    integration="terraform-cloudflare-resources", key="somekey.tfstate"
                                 )
                             ],
                         ),

--- a/reconcile/test/test_terraform_cloudflare_resources.py
+++ b/reconcile/test/test_terraform_cloudflare_resources.py
@@ -233,7 +233,8 @@ def mock_cloudflare_accounts(mocker):
                             region="us-east-1",
                             integrations=[
                                 AWSTerraformStateIntegrationsV1(
-                                    integration="terraform-cloudflare-resources", key="somekey.tfstate"
+                                    integration="terraform-cloudflare-resources",
+                                    key="somekey.tfstate",
                                 )
                             ],
                         ),

--- a/reconcile/utils/terrascript/cloudflare_resources.py
+++ b/reconcile/utils/terrascript/cloudflare_resources.py
@@ -60,15 +60,6 @@ class cloudflare_certificate_pack(Resource):
     """
 
 
-class cloudflare_custom_sll(Resource):
-    """
-    https://registry.terraform.io/providers/cloudflare/cloudflare/3.32.0/docs/resources/custom_ssl
-
-    This resource isn't supported directly by Terrascript, which is why it needs to be
-    defined like this as a Resource.
-    """
-
-
 class cloudflare_tiered_cache(Resource):
     """
     https://registry.terraform.io/providers/cloudflare/cloudflare/latest/docs/resources/tiered_cache
@@ -241,7 +232,7 @@ class CloudflareZoneTerrascriptResource(TerrascriptResource):
         zone_records = values.pop("records", [])
         zone_workers = values.pop("workers", [])
         zone_certs = values.pop("certificates", [])
-        zone_custom_sll = values.pop("custom_ssl_certificates", [])
+        zone_custom_ssl = values.pop("custom_ssl_certificates", [])
 
         zone_values = {
             "account_id": "${var.account_id}",
@@ -308,9 +299,9 @@ class CloudflareZoneTerrascriptResource(TerrascriptResource):
 
         resources.extend(self._create_cloudflare_certificate_pack(zone, zone_certs))
 
-        if zone_custom_sll:
+        if zone_custom_ssl:
             resources.extend(
-                self._create_cloudflare_custom_ssl_certificates(zone, zone_custom_sll)
+                self._create_cloudflare_custom_ssl_certificates(zone, zone_custom_ssl)
             )
 
         return resources

--- a/reconcile/utils/terrascript/cloudflare_resources.py
+++ b/reconcile/utils/terrascript/cloudflare_resources.py
@@ -186,6 +186,14 @@ class CloudflareZoneTerrascriptResource(TerrascriptResource):
 
         return resources
 
+    def _create_cloudflare_custom_ssl_certificates(
+        self, zone: Resource, zone_custom_ssl: Iterable[MutableMapping[str, Any]]
+    ) -> list[Union[Resource, Output]]:
+        resources = []
+        for cert_values in zone_custom_ssl:
+            safe_resource_id(cert_values.pop("identifier"))
+        return resources
+
     def populate(self) -> list[Union[Resource, Output]]:
         resources = []
 
@@ -202,6 +210,7 @@ class CloudflareZoneTerrascriptResource(TerrascriptResource):
         zone_records = values.pop("records", [])
         zone_workers = values.pop("workers", [])
         zone_certs = values.pop("certificates", [])
+        zone_custom_sll = values.pop("custom_ssl_certificates", [])
 
         zone_values = {
             "account_id": "${var.account_id}",
@@ -267,6 +276,9 @@ class CloudflareZoneTerrascriptResource(TerrascriptResource):
             resources.append(cloudflare_worker_route(identifier, **worker_route_values))
 
         resources.extend(self._create_cloudflare_certificate_pack(zone, zone_certs))
+        resources.extend(
+            self._create_cloudflare_custom_ssl_certificates(zone, zone_custom_sll)
+        )
 
         return resources
 


### PR DESCRIPTION
Related to: https://issues.redhat.com/browse/APPSRE-8315
Needs to be tested with: https://github.com/app-sre/qontract-schemas/pull/532

This adds support to create [custom_ssl_certificate](https://registry.terraform.io/providers/cloudflare/cloudflare/3.32.0/docs/resources/custom_ssl) for Cloudflare.
