### PR TITLE
Ensure the same SA token is always copied

### DIFF
--- a/reconcile/openshift_serviceaccount_tokens.py
+++ b/reconcile/openshift_serviceaccount_tokens.py
@@ -77,15 +77,6 @@ def fetch_desired_state(namespaces: list[dict], ri: ResourceInventory, oc_map: O
                 sa_token_list = get_tokens_for_service_account(sa_name, all_tokens)
                 sa_token_list.sort(key=lambda t: t["metadata"]["name"])
                 sa_token = sa_token_list[0]["data"]["token"]
-                cur = ri.get_current(
-                    cluster_name, namespace_name, "Secret", oc_resource_name
-                )
-                if cur:
-                    for token in sa_token_list:
-                        if token["data"]["token"] == cur.body.get("data", {}).get(
-                            "token"
-                        ):
-                            sa_token = token["data"]["token"]
             except KeyError:
                 logging.log(
                     level=logging.ERROR,


### PR DESCRIPTION
This patch eliminates the condition that checks if a token is already present in the destination namespace so that it is that one that is copied instead of the first of the list. This made that in case we had multiple tokens associated to an account, we could potentially copy to different tokens to two different clusters if there was already a token copied that it was not the first of the `sa_token_list` list. This also made the Vault shared-resources secret to be updated multiple times in each run if we had different tokens being copied.

fixes APPSRE-8480