### PR TITLE
skip namespaces with targetNS in dashdotdb-slo

### DIFF
--- a/reconcile/dashdotdb_slo.py
+++ b/reconcile/dashdotdb_slo.py
@@ -99,10 +99,9 @@ class DashdotdbSLO(DashdotdbBase):
         LOG.debug("SLO: processing %s", slo_document.name)
         result: list[ServiceSLO] = []
         for namespace_access in slo_document.namespaces:
-            # skip if there is a `targetNamespace` defined. in this case we
-            # don't know which is the prometheus that must evaluate the query.
-            # This functionlity is implemented here instead:
-            # app-interface/docs/status-board/statusboard-alertmanager-receiver.md
+            # TODO: APPSRE-8513 Dashdotdb SLO collector should deal with
+            # namespaceTargets This `if` is a temporary workaround until
+            # APPSRE-8513 is implemented.
             if namespace_access.target_namespace:
                 continue
 

--- a/reconcile/dashdotdb_slo.py
+++ b/reconcile/dashdotdb_slo.py
@@ -100,7 +100,7 @@ class DashdotdbSLO(DashdotdbBase):
         result: list[ServiceSLO] = []
         for namespace_access in slo_document.namespaces:
             # TODO: APPSRE-8513 Dashdotdb SLO collector should deal with
-            # namespaceTargets This `if` is a temporary workaround until
+            # namespaceTargets. This `if` is a temporary workaround until
             # APPSRE-8513 is implemented.
             if namespace_access.target_namespace:
                 continue

--- a/reconcile/dashdotdb_slo.py
+++ b/reconcile/dashdotdb_slo.py
@@ -102,7 +102,7 @@ class DashdotdbSLO(DashdotdbBase):
             # TODO: APPSRE-8513 Dashdotdb SLO collector should deal with
             # namespaceTargets. This `if` is a temporary workaround until
             # APPSRE-8513 is implemented.
-            if namespace_access.target_namespace:
+            if namespace_access.slo_namespace:
                 continue
 
             ns = namespace_access.namespace

--- a/reconcile/dashdotdb_slo.py
+++ b/reconcile/dashdotdb_slo.py
@@ -99,6 +99,13 @@ class DashdotdbSLO(DashdotdbBase):
         LOG.debug("SLO: processing %s", slo_document.name)
         result: list[ServiceSLO] = []
         for namespace_access in slo_document.namespaces:
+            # skip if there is a `targetNamespace` defined. in this case we
+            # don't know which is the prometheus that must evaluate the query.
+            # This functionlity is implemented here instead:
+            # app-interface/docs/status-board/statusboard-alertmanager-receiver.md
+            if namespace_access.target_namespace:
+                continue
+
             ns = namespace_access.namespace
             promtoken: Optional[str] = None
             username: Optional[str] = None

--- a/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.gql
+++ b/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.gql
@@ -29,7 +29,7 @@ query SLODocuments {
           }
         }
       }
-      targetNamespace {
+      SLONamespace {
         name
       }
     }

--- a/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.gql
+++ b/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.gql
@@ -29,6 +29,9 @@ query SLODocuments {
           }
         }
       }
+      targetNamespace {
+        name
+      }
     }
     slos {
       name

--- a/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.py
+++ b/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.py
@@ -57,6 +57,9 @@ query SLODocuments {
           }
         }
       }
+      targetNamespace {
+        name
+      }
     }
     slos {
       name
@@ -106,11 +109,18 @@ class NamespaceV1(ConfiguredBaseModel):
     cluster: ClusterV1 = Field(..., alias="cluster")
 
 
+class SLONamespacesV1_NamespaceV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+
+
 class SLONamespacesV1(ConfiguredBaseModel):
     prometheus_access: Optional[SLOExternalPrometheusAccessV1] = Field(
         ..., alias="prometheusAccess"
     )
     namespace: NamespaceV1 = Field(..., alias="namespace")
+    target_namespace: Optional[SLONamespacesV1_NamespaceV1] = Field(
+        ..., alias="targetNamespace"
+    )
 
 
 class SLODocumentSLOSLOParametersV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.py
+++ b/reconcile/gql_definitions/dashdotdb_slo/slo_documents_query.py
@@ -57,7 +57,7 @@ query SLODocuments {
           }
         }
       }
-      targetNamespace {
+      SLONamespace {
         name
       }
     }
@@ -118,8 +118,8 @@ class SLONamespacesV1(ConfiguredBaseModel):
         ..., alias="prometheusAccess"
     )
     namespace: NamespaceV1 = Field(..., alias="namespace")
-    target_namespace: Optional[SLONamespacesV1_NamespaceV1] = Field(
-        ..., alias="targetNamespace"
+    slo_namespace: Optional[SLONamespacesV1_NamespaceV1] = Field(
+        ..., alias="SLONamespace"
     )
 
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -18983,7 +18983,7 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "targetNamespace",
+                            "name": "SLONamespace",
                             "description": null,
                             "args": [],
                             "type": {


### PR DESCRIPTION
Renames `namespaceTarget` to `SLONamespace` according to:
https://github.com/app-sre/qontract-schemas/pull/548

In addition it adds a temporary workaround that skips namespaces with `SLONamespace` defined until https://issues.redhat.com/browse/APPSRE-8513 is implemented.
