### PR TITLE
APPSRE-8300: Optionally silence successful deploy notices

### DIFF
--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -109,6 +109,9 @@ class SaasFile(ConfiguredBaseModel):
     pipelines_provider: Union[PipelinesProviderTektonV1, PipelinesProviderV1] = Field(
         ..., alias="pipelinesProvider"
     )
+    skip_successful_deploy_notifications: Optional[bool] = Field(
+        ..., alias="skipSuccessfulDeployNotifications"
+    )
     deploy_resources: Optional[DeployResourcesV1] = Field(..., alias="deployResources")
     slack: Optional[SlackOutputV1] = Field(..., alias="slack")
     managed_resource_types: list[str] = Field(..., alias="managedResourceTypes")


### PR DESCRIPTION
Sometimes teams might want to be notified only on successful notifications. This allows for that.

There is a companion schemas PR to come shorlty.