### PR TITLE
[qontract-cli] get network-connections

### DIFF
--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -84,6 +84,7 @@ class Accepter(BaseModel):
     route_table_ids: Optional[list[str]]
     subnets_id_az: Optional[list[dict]]
     account: AccountWithAssumeRole
+    cluster_name: str
 
 
 class DesiredStateItem(BaseModel):
@@ -161,6 +162,7 @@ def _build_desired_state_tgw_connection(
         cluster_region,
         cluster_cidr_block,
         awsapi,
+        cluster_name,
     )
     if accepter.vpc_id is None:
         logging.error(f"[{cluster_name}] could not find VPC ID for cluster")
@@ -223,6 +225,7 @@ def _build_accepter(
     region: str,
     cidr_block: str,
     awsapi: AWSApi,
+    cluster_name: str,
 ) -> Accepter:
     (vpc_id, route_table_ids, subnets_id_az) = awsapi.get_cluster_vpc_details(
         account.dict(by_alias=True),
@@ -236,6 +239,7 @@ def _build_accepter(
         route_table_ids=route_table_ids,
         subnets_id_az=subnets_id_az,
         account=account,
+        cluster_name=cluster_name,
     )
 
 

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -213,6 +213,7 @@ def build_desired_state_single_cluster(
             "vpc_id": requester_vpc_id,
             "route_table_ids": requester_route_table_ids,
             "account": req_aws,
+            "cluster_name": cluster_name,
         }
 
         accepter_vpc_id, accepter_route_table_ids, _ = awsapi.get_cluster_vpc_details(
@@ -230,6 +231,7 @@ def build_desired_state_single_cluster(
             "vpc_id": accepter_vpc_id,
             "route_table_ids": accepter_route_table_ids,
             "account": acc_aws,
+            "cluster_name": peer_cluster_name,
         }
 
         item = {
@@ -290,6 +292,7 @@ def build_desired_state_vpc_mesh_single_cluster(
         requester = {
             "cidr_block": cluster_info["network"]["vpc"],
             "region": cluster_info["spec"]["region"],
+            "cluster_name": cluster,
         }
 
         # assume_role is the role to assume to provision the peering
@@ -390,6 +393,7 @@ def build_desired_state_vpc_single_cluster(
         requester = {
             "cidr_block": cluster_info["network"]["vpc"],
             "region": cluster_info["spec"]["region"],
+            "cluster_name": cluster,
         }
         connection_name = peer_connection["name"]
         peer_vpc = peer_connection["vpc"]

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2299,8 +2299,7 @@ def network_connections(ctx):
             continue
         r = item.requester
         source = f"{r.account.name}/{r.region}/{r.tgw_id}"
-        a = item.accepter
-        target = f"{a.account.name}/{a.region}/{a.vpc_id}"
+        target = item.accepter.cluster_name
         print(f"    {source} --> {target}")
 
     # terraform-vpc-peerings

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2295,6 +2295,8 @@ def network_connections(ctx):
 
     print("graph LR")
     for item in desired_state:
+        if item.deleted:
+            continue
         r = item.requester
         source = f"{r.account.name}/{r.region}/{r.tgw_id}"
         a = item.accepter
@@ -2332,6 +2334,8 @@ def network_connections(ctx):
     desired_state.extend(desired_state_cluster)
 
     for item in desired_state:
+        if item["deleted"]:
+            continue
         r = item["requester"]
         source = f"{r['account']['name']}/{r['region']}/{r['vpc_id']}"
         a = item["accepter"]

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -38,6 +38,7 @@ import reconcile.openshift_base as ob
 import reconcile.openshift_resources_base as orb
 import reconcile.prometheus_rules_tester.integration as ptr
 import reconcile.terraform_resources as tfr
+import reconcile.terraform_tgw_attachments as tftgw
 import reconcile.terraform_users as tfu
 import reconcile.terraform_vpc_peerings as tfvpc
 from reconcile import queries
@@ -2273,8 +2274,7 @@ def slo_document_services(ctx, status_board_instance):
 @get.command()
 @click.pass_context
 def network_connections(ctx):
-    import reconcile.terraform_tgw_attachments as tftgw
-
+    # terraform-tgw-attachments
     desired_state_data_source = tftgw._fetch_desired_state_data_source()
     accounts = [a.dict(by_alias=True) for a in desired_state_data_source.accounts]
 
@@ -2303,9 +2303,7 @@ def network_connections(ctx):
         target = f"{a.account.name}/{a.region}/{a.vpc_id}"
         print(f"    {source} --> {target}")
 
-
-    import reconcile.terraform_vpc_peerings as tfvpc
-
+    # terraform-vpc-peerings
     settings = queries.get_secret_reader_settings()
     clusters = queries.get_clusters_with_peering_settings()
     ocm_map = ocm.OCMMap(

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2334,9 +2334,9 @@ def network_connections(ctx):
         if item["deleted"]:
             continue
         r = item["requester"]
-        source = f"{r['account']['name']}/{r['region']}/{r['vpc_id']}"
+        source = r.get("cluster_name") or f"{r['account']['name']}/{r['region']}/{r['vpc_id']}"
         a = item["accepter"]
-        target = f"{a['account']['name']}/{a['region']}/{a['vpc_id']}"
+        target = a.get("cluster_name") or f"{a['account']['name']}/{a['region']}/{a['vpc_id']}"
         print(f"    {source} --> {target}")
 
 


### PR DESCRIPTION
this command outputs a [mermaid](https://mermaid.js.org/) output with a list of network connections managed via app-interface. this includes everything managed by `terraform-tgw-attachments` and `terraform-vpc-peerings`.

the output can be found here: https://gitlab.cee.redhat.com/service/app-interface-output/-/snippets/7332

why `mermaid`? to possibly be used with a Grafana [diagram](https://grafana.com/grafana/plugins/jdbranham-diagram-panel/) plugin.

a demo dashboard can be found here: https://grafana.dev.devshift.net/d/8QA350y4k/new-dashboard

while this PR is quite raw, it is immediately usable. you can also call it a PoC. as long as this gets thoughts out of you, success.