### PR TITLE
[AUS] expose metrics for addon upgrades

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -12,6 +12,8 @@ from datetime import (
 from typing import (
     Callable,
     Optional,
+    Protocol,
+    Sequence,
     cast,
 )
 
@@ -27,6 +29,10 @@ from reconcile.aus.cluster_version_data import (
     get_version_data,
 )
 from reconcile.aus.metrics import (
+    UPGRADE_BLOCKED_METRIC_VALUE,
+    UPGRADE_LONG_RUNNING_METRIC_VALUE,
+    UPGRADE_SCHEDULED_METRIC_VALUE,
+    UPGRADE_STARTED_METRIC_VALUE,
     AUSClusterUpgradePolicyInfoMetric,
     AUSOCMEnvironmentError,
     AUSOrganizationErrorRate,
@@ -187,6 +193,44 @@ class AdvancedUpgradeSchedulerBaseIntegration(
             else None,
         ).environments
 
+    def expose_remaining_soak_day_metrics(
+        self,
+        org_upgrade_spec: OrganizationUpgradeSpec,
+        version_data: VersionData,
+        current_state: Sequence["AbstractUpgradePolicy"],
+        metrics_builder: "RemainingSoakDayMetricsBuilder",
+    ) -> None:
+        current_cluster_upgrade_policies = {
+            p.cluster.external_id: p for p in current_state
+        }
+        for spec in org_upgrade_spec.specs:
+            upgrades = spec.get_available_upgrades()
+            if not upgrades:
+                continue
+
+            # calculate the amount every version has soaked. if a version has soaked for
+            # multiple workloads, we will pick the minimum soak day value of all workloads
+            # relevant on the cluster.
+            soaked_versions: dict[str, float] = {}
+            for workload in spec.upgrade_policy.workloads:
+                for version, soak_days in soaking_days(
+                    version_data, upgrades, workload, False
+                ).items():
+                    soaked_versions[version] = min(
+                        soak_days, soaked_versions.get(version, soak_days)
+                    )
+
+            current_upgrade = current_cluster_upgrade_policies.get(spec.cluster_uuid)
+            for version, metric_value in remaining_soak_day_metric_values_for_cluster(
+                spec, soaked_versions, current_upgrade
+            ).items():
+                metrics.set_gauge(
+                    metrics_builder(
+                        cluster_uuid=spec.cluster.external_id, soaking_version=version
+                    ),
+                    metric_value,
+                )
+
     @abstractmethod
     def process_upgrade_policies_in_org(
         self, dry_run: bool, org_upgrade_spec: OrganizationUpgradeSpec
@@ -267,6 +311,11 @@ class GateAgreement(BaseModel):
                 "Unexpected response while creating version "
                 f"agreement with id {self.gate.id} for cluster {cluster.name} (id={cluster.id})"
             )
+
+
+class RemainingSoakDayMetricsBuilder(Protocol):
+    def __call__(self, cluster_uuid: str, soaking_version: str) -> metrics.GaugeMetric:
+        ...
 
 
 class AbstractUpgradePolicy(ABC, BaseModel):
@@ -735,7 +784,7 @@ def upgradeable_version(
 
 
 def verify_current_should_skip(
-    current_state: list[AbstractUpgradePolicy],
+    current_state: Sequence[AbstractUpgradePolicy],
     desired: ClusterUpgradeSpec,
     now: datetime,
     addon_id: str = "",
@@ -861,7 +910,7 @@ def _calculate_node_pool_diffs(
 
 
 def calculate_diff(
-    current_state: list[AbstractUpgradePolicy],
+    current_state: Sequence[AbstractUpgradePolicy],
     desired_state: OrganizationUpgradeSpec,
     ocm_api: OCMBaseClient,
     version_data: VersionData,
@@ -1042,3 +1091,76 @@ def get_orgs_for_environment(
             or org.org_id not in excluded_ocm_organization_ids
         )
     ]
+
+
+def remaining_soak_day_metric_values_for_cluster(
+    spec: ClusterUpgradeSpec,
+    soaked_versions: dict[str, float],
+    current_upgrade: Optional[AbstractUpgradePolicy],
+) -> dict[str, float]:
+    """
+    Calculate what versions and metric values to report for `AUS*VersionRemainingSoakDaysGauge` metrics.
+    Usually, the remaining soak days for a version are reported but there are some special cases
+    where we report negative values to indicate that a version is blocked or an upgrade has been
+    scheduled or started.
+
+    Additionally certain versions are not reported when it is not meaningful (e.g. an upgrade will never happen)
+    to prevent metric clutter.
+    """
+    upgrades = spec.get_available_upgrades()
+    if not upgrades:
+        return {}
+
+    # calculate the remaining soakdays for each upgrade version candidate of the cluster.
+    # when a version is soaking, it has a value > 0 and when it soaked enough, the value is 0.
+    remaining_soakdays: list[float] = [
+        max(
+            (spec.upgrade_policy.conditions.soak_days or 0) - soaked_versions.get(v, 0),
+            0,
+        )
+        for v in upgrades
+    ]
+
+    # under certain conditions, the remaining soak day value for a version needs to be
+    # replaced with special marker values
+    version_metrics: dict[str, float] = {}
+    for idx, version in reversed(list(enumerate(upgrades))):
+        # if an upgrade is `scheduled` or `started`` for the specific version, their respective negative
+        # marker values will be used instead of their actual soak days. there are other states than `scheduled`
+        # and `started` but the `UpgradePolicy` vanishes too quickly to observe them reliably, when such
+        # states are reached.
+        if current_upgrade and current_upgrade.version == version:
+            if current_upgrade.state == "scheduled":
+                remaining_soakdays[idx] = UPGRADE_SCHEDULED_METRIC_VALUE
+            elif current_upgrade.state in ("started", "delayed"):
+                remaining_soakdays[idx] = UPGRADE_STARTED_METRIC_VALUE
+                if current_upgrade.next_run:
+                    # if an upgrade runs for over 6 hours, we mark it as a long running upgrade
+                    next_run = datetime.strptime(
+                        current_upgrade.next_run, "%Y-%m-%dT%H:%M:%SZ"
+                    )
+                    now = datetime.utcnow()
+                    hours_ago = (now - next_run).total_seconds() / 3600
+                    if hours_ago >= 6:
+                        remaining_soakdays[idx] = UPGRADE_LONG_RUNNING_METRIC_VALUE
+        elif spec.version_blocked(version):
+            # if a version is blocked, we will still report it but with a dedicated negative marker value
+            remaining_soakdays[idx] = UPGRADE_BLOCKED_METRIC_VALUE
+
+        # we are intentionally not reporting versions that still soak or soaked enough when
+        # there is a later version that also soaked enough. the later one will be picked
+        # for an upgrade over the older one anyways.
+        if remaining_soakdays[idx] >= 0 and any(
+            later_version_remaining_soak_days
+            in (
+                0,
+                UPGRADE_SCHEDULED_METRIC_VALUE,
+                UPGRADE_STARTED_METRIC_VALUE,
+                UPGRADE_LONG_RUNNING_METRIC_VALUE,
+            )
+            for later_version_remaining_soak_days in remaining_soakdays[idx + 1 :]
+        ):
+            continue
+        version_metrics[version] = remaining_soakdays[idx]
+
+    return version_metrics

--- a/reconcile/aus/metrics.py
+++ b/reconcile/aus/metrics.py
@@ -42,6 +42,16 @@ class AUSClusterVersionRemainingSoakDaysGauge(AUSBaseMetric, GaugeMetric):
         return "aus_cluster_version_remaining_soak_days"
 
 
+class AUSAddonVersionRemainingSoakDaysGauge(AUSClusterVersionRemainingSoakDaysGauge):
+    "Remaining days a version needs to soak for an addon on a cluster"
+
+    addon: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "aus_addon_version_remaining_soak_days"
+
+
 class AUSClusterUpgradePolicyInfoMetric(AUSBaseMetric, InfoMetric):
     "Info metric for clusters under AUS upgrade control"
 
@@ -60,6 +70,18 @@ class AUSClusterUpgradePolicyInfoMetric(AUSBaseMetric, InfoMetric):
     @classmethod
     def name(cls) -> str:
         return "aus_cluster_upgrade_policy_info"
+
+
+class AUSAddonUpgradePolicyInfoMetric(
+    AUSClusterUpgradePolicyInfoMetric
+):  # pylint: disable=R0901
+    "Info metric for cluster addons under AUS upgrade control"
+
+    addon: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "aus_addon_upgrade_policy_info"
 
 
 class AUSOrganizationValidationErrorsGauge(AUSBaseMetric, GaugeMetric):

--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -1,22 +1,13 @@
+import functools
 from abc import ABC
-from datetime import datetime
-from typing import Optional
 
 from reconcile.aus import base as aus
 from reconcile.aus.cluster_version_data import VersionData
 from reconcile.aus.metrics import (
-    UPGRADE_BLOCKED_METRIC_VALUE,
-    UPGRADE_LONG_RUNNING_METRIC_VALUE,
-    UPGRADE_SCHEDULED_METRIC_VALUE,
-    UPGRADE_STARTED_METRIC_VALUE,
     AUSClusterVersionRemainingSoakDaysGauge,
     AUSOrganizationVersionDataGauge,
 )
-from reconcile.aus.models import (
-    ClusterUpgradeSpec,
-    OrganizationUpgradeSpec,
-)
-from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
+from reconcile.aus.models import OrganizationUpgradeSpec
 from reconcile.utils import metrics
 from reconcile.utils.ocm import (
     OCM_PRODUCT_OSD,
@@ -63,25 +54,20 @@ class OCMClusterUpgradeSchedulerIntegration(
             version_data=version_data,
         )
         self.expose_remaining_soak_day_metrics(
-            ocm_env=org_upgrade_spec.org.environment.name,
             org_upgrade_spec=org_upgrade_spec,
             version_data=version_data,
             current_state=current_state,
+            metrics_builder=functools.partial(
+                AUSClusterVersionRemainingSoakDaysGauge,
+                integration=self.name,
+                ocm_env=org_upgrade_spec.org.environment.name,
+            ),
         )
 
         diffs = aus.calculate_diff(
             current_state, org_upgrade_spec, ocm_api, version_data
         )
         aus.act(dry_run, diffs, ocm_api)
-
-    def get_ocm_env_upgrade_specs(
-        self, ocm_env: OCMEnvironment
-    ) -> dict[str, OrganizationUpgradeSpec]:
-        raise NotImplementedError(
-            "Don't use ocm-upgrade-scheduler anymore but use: \n"
-            "* ocm-label to transfer upgrade policies to OCM subscription labels \n"
-            "* advanced-upgrade-service to drive upgrade policies based on OCM subscription labels"
-        )
 
     def expose_version_data_metrics(
         self,
@@ -101,117 +87,3 @@ class OCMClusterUpgradeSchedulerIntegration(
                     ),
                     workload_history.soak_days,
                 )
-
-    def expose_remaining_soak_day_metrics(
-        self,
-        ocm_env: str,
-        org_upgrade_spec: OrganizationUpgradeSpec,
-        version_data: VersionData,
-        current_state: list[aus.AbstractUpgradePolicy],
-    ) -> None:
-        current_cluster_upgrade_policies = {
-            p.cluster.external_id: p for p in current_state
-        }
-        for spec in org_upgrade_spec.specs:
-            upgrades = spec.get_available_upgrades()
-            if not upgrades:
-                continue
-
-            # calculate the amount every version has soaked. if a version has soaked for
-            # multiple workloads, we will pick the minimum soak day value of all workloads
-            # relevant on the cluster.
-            soaked_versions: dict[str, float] = {}
-            for workload in spec.upgrade_policy.workloads:
-                for version, soak_days in aus.soaking_days(
-                    version_data, upgrades, workload, False
-                ).items():
-                    soaked_versions[version] = min(
-                        soak_days, soaked_versions.get(version, soak_days)
-                    )
-
-            current_upgrade = current_cluster_upgrade_policies.get(spec.cluster_uuid)
-            for version, metric_value in remaining_soak_day_metric_values_for_cluster(
-                spec, soaked_versions, current_upgrade
-            ).items():
-                metrics.set_gauge(
-                    AUSClusterVersionRemainingSoakDaysGauge(
-                        integration=self.name,
-                        ocm_env=ocm_env,
-                        cluster_uuid=spec.cluster.external_id,
-                        soaking_version=version,
-                    ),
-                    metric_value,
-                )
-
-
-def remaining_soak_day_metric_values_for_cluster(
-    spec: ClusterUpgradeSpec,
-    soaked_versions: dict[str, float],
-    current_upgrade: Optional[aus.AbstractUpgradePolicy],
-) -> dict[str, float]:
-    """
-    Calculate what versions and metric values to report for `AUSClusterVersionRemainingSoakDaysGauge`.
-    Usually, the remaining soak days for a version are reported but there are some special cases
-    where we report negative values to indicate that a version is blocked or an upgrade has been
-    scheduled or started.
-
-    Additionally certain versions are not reported when it is not meaningful (e.g. an upgrade will never happen)
-    to prevent metric clutter.
-    """
-    upgrades = spec.get_available_upgrades()
-    if not upgrades:
-        return {}
-
-    # calculate the remaining soakdays for each upgrade version candidate of the cluster.
-    # when a version is soaking, it has a value > 0 and when it soaked enough, the value is 0.
-    remaining_soakdays: list[float] = [
-        max(
-            (spec.upgrade_policy.conditions.soak_days or 0) - soaked_versions.get(v, 0),
-            0,
-        )
-        for v in upgrades
-    ]
-
-    # under certain conditions, the remaining soak day value for a version needs to be
-    # replaced with special marker values
-    version_metrics: dict[str, float] = {}
-    for idx, version in reversed(list(enumerate(upgrades))):
-        # if an upgrade is `scheduled` or `started`` for the specific version, their respective negative
-        # marker values will be used instead of their actual soak days. there are other states than `scheduled`
-        # and `started` but the `UpgradePolicy` vanishes too quickly to observe them reliably, when such
-        # states are reached.
-        if current_upgrade and current_upgrade.version == version:
-            if current_upgrade.state == "scheduled":
-                remaining_soakdays[idx] = UPGRADE_SCHEDULED_METRIC_VALUE
-            elif current_upgrade.state in ("started", "delayed"):
-                remaining_soakdays[idx] = UPGRADE_STARTED_METRIC_VALUE
-                if current_upgrade.next_run:
-                    # if an upgrade runs for over 6 hours, we mark it as a long running upgrade
-                    next_run = datetime.strptime(
-                        current_upgrade.next_run, "%Y-%m-%dT%H:%M:%SZ"
-                    )
-                    now = datetime.utcnow()
-                    hours_ago = (now - next_run).total_seconds() / 3600
-                    if hours_ago >= 6:
-                        remaining_soakdays[idx] = UPGRADE_LONG_RUNNING_METRIC_VALUE
-        elif spec.version_blocked(version):
-            # if a version is blocked, we will still report it but with a dedicated negative marker value
-            remaining_soakdays[idx] = UPGRADE_BLOCKED_METRIC_VALUE
-
-        # we are intentionally not reporting versions that still soak or soaked enough when
-        # there is a later version that also soaked enough. the later one will be picked
-        # for an upgrade over the older one anyways.
-        if remaining_soakdays[idx] >= 0 and any(
-            later_version_remaining_soak_days
-            in (
-                0,
-                UPGRADE_SCHEDULED_METRIC_VALUE,
-                UPGRADE_STARTED_METRIC_VALUE,
-                UPGRADE_LONG_RUNNING_METRIC_VALUE,
-            )
-            for later_version_remaining_soak_days in remaining_soakdays[idx + 1 :]
-        ):
-            continue
-        version_metrics[version] = remaining_soakdays[idx]
-
-    return version_metrics

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -1056,7 +1056,7 @@ def run(
         namespace_name=namespace_name,
     )
     if not namespaces:
-        logging.info(
+        logging.debug(
             "No namespaces found when filtering for "
             f"cluster={cluster_name}, namespace={namespace_name}. "
             "Exiting."

--- a/reconcile/test/ocm/aus/test_expose_metrics.py
+++ b/reconcile/test/ocm/aus/test_expose_metrics.py
@@ -3,14 +3,12 @@ from datetime import (
     timedelta,
 )
 
+from reconcile.aus.base import remaining_soak_day_metric_values_for_cluster
 from reconcile.aus.metrics import (
     UPGRADE_BLOCKED_METRIC_VALUE,
     UPGRADE_LONG_RUNNING_METRIC_VALUE,
     UPGRADE_SCHEDULED_METRIC_VALUE,
     UPGRADE_STARTED_METRIC_VALUE,
-)
-from reconcile.aus.ocm_upgrade_scheduler import (
-    remaining_soak_day_metric_values_for_cluster,
 )
 from reconcile.test.ocm.aus.fixtures import (
     build_cluster_upgrade_policy,


### PR DESCRIPTION
expose metrics for addon upgrades

* `aus_addon_upgrade_policy_info` - cluster and addon metadata, including upgrade policy details
* `aus_addon_version_remaining_soak_days` - remaining soak days for a addon version on a cluster

they have the same set of labels as their cluster upgrade counterparts but have an additional one called `addon` to distinguish between addons managed on the same cluster.

part of [APPSRE-8524](https://issues.redhat.com/browse/APPSRE-8524)