### PR TITLE
[org-updater] don't query external config labels on HCPs

### DIFF
--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -65,8 +65,10 @@ def run(dry_run, gitlab_project_id):
                 c for c in upgrade_policy_clusters if c["name"] == ocm_cluster_name
             ]
             if not found:
-                ocm_cluster_labels = ocm.get_external_configuration_labels(
-                    ocm_cluster_name
+                ocm_cluster_labels = (
+                    ocm.get_external_configuration_labels(ocm_cluster_name)
+                    if not ocm_cluster_spec.spec.hypershift
+                    else {}
                 )
                 for default in upgrade_policy_defaults:
                     default_name = default["name"]


### PR DESCRIPTION
HCPs don't have external config labels so default to an empty set of labels in the context of the ocm-upgrade-scheduler-org-updater