### PR TITLE
[dashdotdb-slo] early exit

### DIFF
--- a/reconcile/dashdotdb_slo.py
+++ b/reconcile/dashdotdb_slo.py
@@ -2,7 +2,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import (
     Any,
-    Callable,
     Optional,
 )
 

--- a/reconcile/dashdotdb_slo.py
+++ b/reconcile/dashdotdb_slo.py
@@ -2,6 +2,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import (
     Any,
+    Callable,
     Optional,
 )
 
@@ -193,3 +194,7 @@ def run(dry_run: bool = False, thread_pool_size: int = 10) -> None:
         dry_run=dry_run, thread_pool_size=thread_pool_size, secret_reader=secret_reader
     )
     dashdotdb_slo.run()
+
+
+def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    return {doc.name: doc.dict() for doc in get_slo_documents()}


### PR DESCRIPTION
implement early-exit for dashdotdb-slo. the integration queries several schemas but most of the data in those schemas is not part of the relevant desired state.

part of https://issues.redhat.com/browse/APPSRE-8526