### PR TITLE
Send unleash auth token without Bearer prefix

### DIFF
--- a/reconcile/utils/unleash.py
+++ b/reconcile/utils/unleash.py
@@ -70,7 +70,7 @@ def _get_unleash_api_client(api_url: str, auth_head: str) -> UnleashClient:
         if client is None:
             logging.getLogger("apscheduler").setLevel(logging.ERROR)
             logging.getLogger("UnleashClient").setLevel(logging.ERROR)
-            headers = {"Authorization": f"Bearer {auth_head}"}
+            headers = {"Authorization": auth_head}
             client = UnleashClient(
                 url=api_url,
                 app_name="qontract-reconcile",


### PR DESCRIPTION
New unleash version (v5.x) handles token management, token format in request header has to be exactly match, example in [unleash-client-python](https://github.com/Unleash/unleash-client-python). Current AppSRE unleash supports both with and without `Bearer`, code [here](https://github.com/app-sre/unleash/blob/aa873f6533886930fbfe49ba3b902aab714f6c54/app.js#L130), so this is a compatible change.

[APPSRE-7691](https://issues.redhat.com/browse/APPSRE-7691)


<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3bc3077</samp>

This pull request fixes a bug in the Unleash feature flag integration and adds custom strategies for cluster-based toggling. It also improves the test coverage and readability of the `reconcile/utils/unleash.py` and `reconcile/test/test_unleash.py` files.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 3bc3077</samp>

* Fix a bug in the `_get_unleash_api_client` function that caused 401 errors from the Unleash API by removing the `Bearer` prefix from the `Authorization` header ([link](https://github.com/app-sre/qontract-reconcile/pull/3925/files?diff=unified&w=0#diff-263b940603506b66e174ee504120a23a094b54493dbc9e1bd4c14b93a017c1b6L73-R73))
* Import and use two custom strategies, `DisableClusterStrategy` and `EnableClusterStrategy`, to toggle feature flags based on cluster names in the `UnleashClient` constructor ([link](https://github.com/app-sre/qontract-reconcile/pull/3925/files?diff=unified&w=0#diff-3ae7ddfe78ce95d0a20eb2c29f93d854ef3d8491212a13e93989af48b7d9490bR10-R11), [link](https://github.com/app-sre/qontract-reconcile/pull/3925/files?diff=unified&w=0#diff-3ae7ddfe78ce95d0a20eb2c29f93d854ef3d8491212a13e93989af48b7d9490bL24-R61))
* Refactor the tests for the `_get_unleash_api_client` function to use `mocker.patch` with `autospec=True` to mock the `UnleashClient` and `CacheDict` classes and assert their calls and arguments in `reconcile/test/test_unleash.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3925/files?diff=unified&w=0#diff-3ae7ddfe78ce95d0a20eb2c29f93d854ef3d8491212a13e93989af48b7d9490bL24-R61))