### PR TITLE
[slack-usergroups] use enterprise_user id as lookup key

### DIFF
--- a/reconcile/test/utils/test_slack_api.py
+++ b/reconcile/test/utils/test_slack_api.py
@@ -275,6 +275,49 @@ def test_create_usergroup(slack_api):
     )
 
 
+@pytest.mark.parametrize(
+    "user,ids,expected",
+    [
+        (
+            {
+                "id": "ID_A",
+                "name": "user_a",
+            },
+            ["ID_A"],
+            {"ID_A": "user_a"},
+        ),
+        (
+            {
+                "id": "ID_A",
+                "name": "user_a",
+                "enterprise_user": {"id": "ENTERPRISE_ID_A"},
+            },
+            ["ENTERPRISE_ID_A"],
+            {"ENTERPRISE_ID_A": "user_a"},
+        ),
+        (
+            {
+                "id": "ID_A",
+                "name": "user_a",
+                "enterprise_user": {"id": "ENTERPRISE_ID_A"},
+            },
+            ["ID_A"],
+            {},
+        ),
+    ],
+)
+def test_get_users_by_ids(slack_api, user, ids, expected):
+    slack_response = new_slack_response(
+        {
+            "members": [user],
+            "response_metadata": {"next_cursor": ""},
+        }
+    )
+    slack_api.mock_slack_client.return_value.api_call.return_value = slack_response
+
+    assert slack_api.client.get_users_by_ids(ids) == expected
+
+
 def test_update_usergroup_users(slack_api):
     slack_api.client.update_usergroup_users("ABCD", ["USERA", "USERB"])
 

--- a/reconcile/test/utils/test_slack_api.py
+++ b/reconcile/test/utils/test_slack_api.py
@@ -1,9 +1,6 @@
 import json
 from collections import namedtuple
-from typing import (
-    Optional,
-    Union,
-)
+from typing import Any
 from unittest.mock import (
     MagicMock,
     call,
@@ -91,9 +88,7 @@ def test_slack_api_config_from_dict():
     assert slack_api_config.timeout == 5
 
 
-def new_slack_response(
-    data: dict[str, Optional[Union[bool, int, str, dict[str, str]]]]
-):
+def new_slack_response(data: dict[str, Any]):
     return SlackResponse(
         client="",
         http_verb="",

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -392,7 +392,19 @@ class SlackApi:
         }
 
     def get_users_by_ids(self, users_ids: Iterable[str]) -> dict[str, str]:
-        return {k: v["name"] for k, v in self._get("users").items() if k in users_ids}
+        return {
+            user_id: user["name"]
+            for user_id in users_ids
+            if (user := self._get("users").get(user_id))
+        }
+
+    @staticmethod
+    def _default_id_key(data: Mapping) -> str:
+        return data["id"]
+
+    @staticmethod
+    def _user_id_key(data: Mapping) -> str:
+        return data.get("enterprise_user", {}).get("id") or data["id"]
 
     def _get(self, resource: str) -> dict[str, Any]:
         """
@@ -402,13 +414,14 @@ class SlackApi:
         :param resource: resource type
         :return: data from API call
         """
+        if resource in self._results:
+            return self._results[resource]
+
         result_key = "members" if resource == "users" else resource
+        key_func = self._user_id_key if resource == "users" else self._default_id_key
         api_key = "conversations" if resource == "channels" else resource
         results = {}
         additional_kwargs: dict[str, Union[str, int]] = {"cursor": ""}
-
-        if resource in self._results:
-            return self._results[resource]
 
         method_config = self.config.get_method_config(f"{api_key}.list")
         if method_config:
@@ -420,7 +433,7 @@ class SlackApi:
             )
 
             for r in result[result_key]:
-                results[r["id"]] = r
+                results[key_func(r)] = r
 
             cursor = result["response_metadata"]["next_cursor"]
 


### PR DESCRIPTION
According to Slack API doc for [user](https://api.slack.com/types/user), `enterprise_user.id`

>This user's ID - some Grid users have a kind of dual identity — a local, workspace-centric user ID as well as a Grid-wise user ID, called the Enterprise user ID. In most cases these IDs can be used interchangeably, but when it is provided, we strongly recommend using this Enterprise user id over the root level user id field.

Currently use root level user id field is causing reconcile loops for [user group](https://api.slack.com/types/usergroup), `users` value returned as `enterprise_user.id` after some time. The same user group will be updated to use the other id field, but result in no op as both ids are linked to the same user.

More context on id [migration](https://api.slack.com/methods/migration.exchange#migration.exchange__additional-nuance).

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c77da6d</samp>

This pull request enhances the `SlackApi` class and its tests in the `reconcile/utils/slack_api.py` and `reconcile/test/utils/test_slack_api.py` modules. It reduces the number of slack API calls, handles different user id formats, and simplifies the code logic. It also adds a new test function to verify the `get_users_by_ids` method.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c77da6d</samp>

* Optimize and improve the `get_users_by_ids` and `_get` methods of the `SlackApi` class in `reconcile/utils/slack_api.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L395-R408), [link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L405-R425), [link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L423-R436))
  - Use list comprehension, conditional expression, and walrus operator to filter and map user ids and names from the cached users data ([link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L395-R408))
  - Use a helper method `_user_id_key` to get the user id from either the `enterprise_user` or the `id` field of the user data ([link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L395-R408), [link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L405-R425))
  - Check the `_results` cache before making the API call and return the cached data if available ([link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L405-R425))
  - Define two helper methods `_default_id_key` and `_user_id_key` to get the id key from the data depending on the resource type ([link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L405-R425))
  - Use the `key_func` variable to get the id key from the data instead of hardcoding the `id` field ([link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L423-R436))
  - Reorder some variable assignments to group them by their logical function ([link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L405-R425))
* Add a new test function `test_get_users_by_ids` to the `test_slack_api.py` module to test the `get_users_by_ids` method of the `SlackApi` class ([link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-cb6ed3e3795546037c4c49893fbad618e574046827c6e8da193c942f6b573d22R278-R320))
  - Use the `pytest.mark.parametrize` decorator to run the test with different inputs and expected outputs ([link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-cb6ed3e3795546037c4c49893fbad618e574046827c6e8da193c942f6b573d22R278-R320))
  - Mock the `slack_api` fixture and the `api_call` method of the `mock_slack_client` attribute to return a fake slack response with a given user ([link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-cb6ed3e3795546037c4c49893fbad618e574046827c6e8da193c942f6b573d22R278-R320))
  - Assert that the `get_users_by_ids` method of the `slack_api.client` returns the expected dictionary of user ids and names ([link](https://github.com/app-sre/qontract-reconcile/pull/3926/files?diff=unified&w=0#diff-cb6ed3e3795546037c4c49893fbad618e574046827c6e8da193c942f6b573d22R278-R320))