### PR TITLE
[slack-usergroups] Support both user_id and enterprise_user_id

### DIFF
--- a/reconcile/test/utils/test_slack_api.py
+++ b/reconcile/test/utils/test_slack_api.py
@@ -288,7 +288,7 @@ def test_create_usergroup(slack_api):
                 "enterprise_user": {"id": "ENTERPRISE_ID_A"},
             },
             ["ENTERPRISE_ID_A"],
-            {"ENTERPRISE_ID_A": "user_a"},
+            {"ID_A": "user_a"},
         ),
         (
             {
@@ -297,6 +297,15 @@ def test_create_usergroup(slack_api):
                 "enterprise_user": {"id": "ENTERPRISE_ID_A"},
             },
             ["ID_A"],
+            {"ID_A": "user_a"},
+        ),
+        (
+            {
+                "id": "ID_A",
+                "name": "user_a",
+                "enterprise_user": {"id": "ENTERPRISE_ID_A"},
+            },
+            ["ID_NOT_FOUND"],
             {},
         ),
     ],


### PR DESCRIPTION
This is a different fix follow up https://github.com/app-sre/qontract-reconcile/pull/3926

Sometimes `users` returned from slack api are using enterprise user id, sometimes user id, this change covers both cases to consolidate user ids.

<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c7790ce</samp>

This pull request improves the `SlackApi` class to work with both enterprise and regular user ids in Slack. It adds a new attribute and methods to translate the user ids, and updates the existing methods and test cases accordingly. It affects the files `reconcile/utils/slack_api.py` and `reconcile/test/utils/test_slack_api.py`.

<!--
copilot:walkthrough
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at c7790ce</samp>

*  Add and modify methods to translate enterprise user id to user id in `SlackApi` class ([link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6R198), [link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L395-R405), [link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L446-R454), [link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L436-R432), [link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L421))
  * Add a new attribute that maps enterprise user id to user id for each user in the Slack API response ([link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6R198))
  * Use a generator expression to translate input user ids to regular user ids in `get_users_by_ids` method ([link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L395-R405))
  * Add two new helper methods to populate and use the attribute that maps enterprise user id to user id ([link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L446-R454), [link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L436-R432))
  * Remove unnecessary `key_func` variable from `_get` method, since the resource type is always "users" ([link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-651a0cece2ef0746181125b300455482012a7dd7a133fc384373b18a471334f6L421))
* Update and add test cases for `get_users_by_ids` method in `test_slack_api.py` ([link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-cb6ed3e3795546037c4c49893fbad618e574046827c6e8da193c942f6b573d22L291-R291), [link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-cb6ed3e3795546037c4c49893fbad618e574046827c6e8da193c942f6b573d22R300-R308))
  * Replace enterprise user id with user id in expected output of existing test case, to match the new behavior of the method ([link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-cb6ed3e3795546037c4c49893fbad618e574046827c6e8da193c942f6b573d22L291-R291))
  * Add a new test case for the scenario where the input user id is not found in the Slack API response, and the method should return an empty dictionary ([link](https://github.com/app-sre/qontract-reconcile/pull/3928/files?diff=unified&w=0#diff-cb6ed3e3795546037c4c49893fbad618e574046827c6e8da193c942f6b573d22R300-R308))