### PR TITLE
Pass in Admin connection to Script generator

### DIFF
--- a/reconcile/database_access_manager.py
+++ b/reconcile/database_access_manager.py
@@ -67,6 +67,7 @@ class DatabaseConnectionParameters(BaseModel):
 class PSQLScriptGenerator(BaseModel):
     db_access: DatabaseAccessV1
     connection_parameter: DatabaseConnectionParameters
+    admin_connection_parameter: DatabaseConnectionParameters
     engine: str
 
     def _get_db(self) -> str:
@@ -92,7 +93,7 @@ select 'CREATE ROLE "{self._get_user()}"  WITH LOGIN PASSWORD ''{self.connection
 WHERE NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '{self._get_db()}');\\gexec
 
 -- rds specific, grant role to admin or create schema fails
-grant "{self._get_user()}" to postgres;
+GRANT "{self._get_user()}" to "{self.admin_connection_parameter.user}";
 CREATE SCHEMA IF NOT EXISTS "{self._get_user()}" AUTHORIZATION "{self._get_user()}";"""
 
     def _generate_db_access(self) -> str:
@@ -357,7 +358,8 @@ def _populate_resources(
     admin_secret_name: str,
     resource_prefix: str,
     settings: dict[Any, Any],
-    database_connection: DatabaseConnectionParameters,
+    user_connection: DatabaseConnectionParameters,
+    admin_connection: DatabaseConnectionParameters,
 ) -> list[DBAMResource]:
     managed_resources: list[DBAMResource] = []
     # create service account
@@ -371,7 +373,8 @@ def _populate_resources(
     # create script secret
     generator = PSQLScriptGenerator(
         db_access=db_access,
-        connection_parameter=database_connection,
+        connection_parameter=user_connection,
+        admin_connection_parameter=admin_connection,
         engine=engine,
     )
     script_secret_name = f"{resource_prefix}-script"
@@ -387,7 +390,7 @@ def _populate_resources(
     # create user secret
     managed_resources.append(
         DBAMResource(
-            resource=generate_user_secret_spec(resource_prefix, database_connection),
+            resource=generate_user_secret_spec(resource_prefix, user_connection),
             clean_up=False,
         )
     )
@@ -439,16 +442,24 @@ def _create_database_connection_parameter(
     oc: OCClient,
     admin_secret_name: str,
     user_secret_name: str,
-) -> DatabaseConnectionParameters:
+) -> dict[str, DatabaseConnectionParameters]:
     def _decode_secret_value(value: str) -> str:
         return base64.b64decode(value).decode("utf-8")
 
+    print("creating database connection parameter")
     user_secret = oc.get(
         namespace_name,
         "Secret",
         user_secret_name,
         allow_not_found=True,
     )
+    admin_secret = oc.get(
+        namespace_name,
+        "Secret",
+        admin_secret_name,
+        allow_not_found=False,
+    )
+    print(f"admin_secret: {admin_secret}")
     if user_secret:
         password = _decode_secret_value(user_secret["data"]["db.password"])
         host = _decode_secret_value(user_secret["data"]["db.host"])
@@ -456,25 +467,27 @@ def _create_database_connection_parameter(
         port = _decode_secret_value(user_secret["data"]["db.port"])
         database = _decode_secret_value(user_secret["data"]["db.name"])
     else:
-        admin_secret = oc.get(
-            namespace_name,
-            "Secret",
-            admin_secret_name,
-            allow_not_found=False,
-        )
         host = _decode_secret_value(admin_secret["data"]["db.host"])
         port = _decode_secret_value(admin_secret["data"]["db.port"])
         user = db_access.username
         password = _generate_password()
         database = db_access.database
-    database_connection = DatabaseConnectionParameters(
-        host=host,
-        port=port,
-        user=user,
-        password=password,
-        database=database,
-    )
-    return database_connection
+    return {
+        "user": DatabaseConnectionParameters(
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            database=database,
+        ),
+        "admin": DatabaseConnectionParameters(
+            host=_decode_secret_value(admin_secret["data"]["db.host"]),
+            port=_decode_secret_value(admin_secret["data"]["db.port"]),
+            user=_decode_secret_value(admin_secret["data"]["db.user"]),
+            password=_decode_secret_value(admin_secret["data"]["db.password"]),
+            database=_decode_secret_value(admin_secret["data"]["db.name"]),
+        ),
+    }
 
 
 class JobFailedError(Exception):
@@ -526,7 +539,8 @@ def _process_db_access(
             admin_secret_name,
             resource_prefix,
             settings,
-            database_connection,
+            database_connection["user"],
+            database_connection["admin"],
         )
 
         # create job, delete old, failed job first

--- a/reconcile/database_access_manager.py
+++ b/reconcile/database_access_manager.py
@@ -446,7 +446,6 @@ def _create_database_connection_parameter(
     def _decode_secret_value(value: str) -> str:
         return base64.b64decode(value).decode("utf-8")
 
-    print("creating database connection parameter")
     user_secret = oc.get(
         namespace_name,
         "Secret",
@@ -459,7 +458,7 @@ def _create_database_connection_parameter(
         admin_secret_name,
         allow_not_found=False,
     )
-    print(f"admin_secret: {admin_secret}")
+
     if user_secret:
         password = _decode_secret_value(user_secret["data"]["db.password"])
         host = _decode_secret_value(user_secret["data"]["db.host"])

--- a/reconcile/test/test_database_access_manager.py
+++ b/reconcile/test/test_database_access_manager.py
@@ -16,6 +16,7 @@ from reconcile.database_access_manager import (
     JobStatusCondition,
     PSQLScriptGenerator,
     _create_database_connection_parameter,
+    _DBDonnections,
     _generate_password,
     _populate_resources,
     _process_db_access,
@@ -315,10 +316,10 @@ def dbam_process_mocks(
     expected_resource = DBAMResource(resource=openshift_resource_secet, clean_up=True)
     mocker.patch(
         "reconcile.database_access_manager._create_database_connection_parameter",
-        return_value={
-            "user": db_connection_parameter,
-            "admin": db_admin_connection_parameter,
-        },
+        return_value=_DBDonnections(
+            user=db_connection_parameter,
+            admin=db_admin_connection_parameter,
+        ),
     )
     mocker.patch(
         "reconcile.database_access_manager._populate_resources",


### PR DESCRIPTION
Need to pass in admin permission to Script Generator. Terraform-resources allows it to change the username of the admin connection. Need to pass the admin connection in to be able to create a managed user