### PR TITLE
Add user deletion to DBAM

### DIFF
--- a/reconcile/database_access_manager.py
+++ b/reconcile/database_access_manager.py
@@ -77,6 +77,9 @@ class PSQLScriptGenerator(BaseModel):
     def _get_user(self) -> str:
         return self.db_access.username
 
+    def _get_admin_user(self) -> str:
+        return self.admin_connection_parameter.user
+
     def _generate_create_user(self) -> str:
         return f"""
 \\set ON_ERROR_STOP on
@@ -94,8 +97,22 @@ select 'CREATE ROLE "{self._get_user()}"  WITH LOGIN PASSWORD ''{self.connection
 WHERE NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '{self._get_db()}');\\gexec
 
 -- rds specific, grant role to admin or create schema fails
-GRANT "{self._get_user()}" to "{self.admin_connection_parameter.user}";
+GRANT "{self._get_user()}" to "{self._get_admin_user()}";
 CREATE SCHEMA IF NOT EXISTS "{self._get_user()}" AUTHORIZATION "{self._get_user()}";"""
+
+    def _generate_delete_user(self) -> str:
+        return f"""
+\\set ON_ERROR_STOP on
+\\c "{self._get_db()}"
+REASSIGN OWNED BY "{self._get_user()}" TO "{self._get_admin_user()}";
+DROP ROLE IF EXISTS "{self._get_user()}";\\gexec"""
+
+    def _generate_revoke_db_access(self) -> str:
+        statements: list[str] = ["\n"]
+        for access in self.db_access.access or []:
+            statement = f'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA "{access.target.dbschema}" FROM "{self._get_user()}";\n'
+            statements.append(statement)
+        return "".join(statements)
 
     def _generate_db_access(self) -> str:
         statements: list[str] = ["\n"]
@@ -105,8 +122,13 @@ CREATE SCHEMA IF NOT EXISTS "{self._get_user()}" AUTHORIZATION "{self._get_user(
         return "".join(statements)
 
     def generate_script(self) -> str:
-        x = self._generate_create_user() + "\n" + self._generate_db_access()
-        return x
+        if not self.db_access.delete:
+            script = self._generate_create_user() + "\n" + self._generate_db_access()
+        else:
+            script = (
+                self._generate_revoke_db_access() + "\n" + self._generate_delete_user()
+            )
+        return script
 
 
 def secret_head(name: str) -> dict[str, Any]:

--- a/reconcile/database_access_manager.py
+++ b/reconcile/database_access_manager.py
@@ -108,27 +108,29 @@ REASSIGN OWNED BY "{self._get_user()}" TO "{self._get_admin_user()}";
 DROP ROLE IF EXISTS "{self._get_user()}";\\gexec"""
 
     def _generate_revoke_db_access(self) -> str:
-        statements: list[str] = ["\n"]
-        for access in self.db_access.access or []:
-            statement = f'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA "{access.target.dbschema}" FROM "{self._get_user()}";\n'
-            statements.append(statement)
-        return "".join(statements)
+        statements = [
+            f'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA "{access.target.dbschema}" FROM "{self._get_user()}";'
+            for access in self.db_access.access or []
+        ]
+        return "\n".join(statements)
 
     def _generate_db_access(self) -> str:
-        statements: list[str] = ["\n"]
-        for access in self.db_access.access or []:
-            statement = f"GRANT {','.join(access.grants)} ON ALL TABLES IN SCHEMA \"{access.target.dbschema}\" TO \"{self._get_user()}\";\n"
-            statements.append(statement)
-        return "".join(statements)
+        statements = [
+            f"GRANT {','.join(access.grants)} ON ALL TABLES IN SCHEMA \"{access.target.dbschema}\" TO \"{self._get_user()}\";"
+            for access in self.db_access.access or []
+        ]
+        return "\n".join(statements)
+
+    def _provision_script(self) -> str:
+        return self._generate_create_user() + "\n" + self._generate_db_access()
+
+    def _deprovision_script(self) -> str:
+        return self._generate_revoke_db_access() + "\n" + self._generate_delete_user()
 
     def generate_script(self) -> str:
-        if not self.db_access.delete:
-            script = self._generate_create_user() + "\n" + self._generate_db_access()
-        else:
-            script = (
-                self._generate_revoke_db_access() + "\n" + self._generate_delete_user()
-            )
-        return script
+        if self.db_access.delete:
+            return self._deprovision_script()
+        return self._provision_script()
 
 
 def secret_head(name: str) -> dict[str, Any]:

--- a/reconcile/test/test_database_access_manager.py
+++ b/reconcile/test/test_database_access_manager.py
@@ -145,7 +145,9 @@ def _assert_delete_script(script: str) -> None:
 
 
 def _assert_revoke_access(script: str) -> None:
-    assert '\nREVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA "foo" FROM "test";\n' in script
+    assert (
+        '\nREVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA "foo" FROM "test";\n' in script
+    )
 
 
 def test_generate_create_user(

--- a/reconcile/test/test_database_access_manager.py
+++ b/reconcile/test/test_database_access_manager.py
@@ -137,6 +137,17 @@ def _assert_grant_access(script: str) -> None:
     assert 'GRANT insert,select ON ALL TABLES IN SCHEMA "foo" TO "test"' in script
 
 
+def _assert_delete_script(script: str) -> None:
+    assert (
+        '\n\\set ON_ERROR_STOP on\n\\c "test"\nREASSIGN OWNED BY "test" TO "admin";\nDROP ROLE IF EXISTS "test";\\gexec'
+        in script
+    )
+
+
+def _assert_revoke_access(script: str) -> None:
+    assert '\nREVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA "foo" FROM "test";\n'
+
+
 def test_generate_create_user(
     db_access: DatabaseAccessV1,
     db_connection_parameter: DatabaseConnectionParameters,
@@ -150,6 +161,21 @@ def test_generate_create_user(
     )
     script = s._generate_create_user()
     _assert_create_script(script)
+
+
+def test_generate_delete_user(
+    db_access: DatabaseAccessV1,
+    db_connection_parameter: DatabaseConnectionParameters,
+    db_admin_connection_parameter: DatabaseConnectionParameters,
+) -> None:
+    s = PSQLScriptGenerator(
+        db_access=db_access,
+        connection_parameter=db_connection_parameter,
+        admin_connection_parameter=db_admin_connection_parameter,
+        engine="postgres",
+    )
+    script = s._generate_delete_user()
+    _assert_delete_script(script)
 
 
 def test_generate_access(
@@ -170,6 +196,24 @@ def test_generate_access(
     _assert_grant_access(script)
 
 
+def test_generate_revoke_access(
+    db_access: DatabaseAccessV1,
+    db_access_access: DatabaseAccessAccessV1,
+    db_connection_parameter: DatabaseConnectionParameters,
+    db_admin_connection_parameter: DatabaseConnectionParameters,
+):
+    db_access.access = [db_access_access]
+
+    s = PSQLScriptGenerator(
+        db_access=db_access,
+        connection_parameter=db_connection_parameter,
+        admin_connection_parameter=db_connection_parameter,
+        engine="postgres",
+    )
+    script = s._generate_revoke_db_access()
+    _assert_revoke_access(script)
+
+
 def test_generate_complete(
     db_access_complete: DatabaseAccessV1,
     db_connection_parameter: DatabaseConnectionParameters,
@@ -184,6 +228,23 @@ def test_generate_complete(
     script = s.generate_script()
     _assert_create_script(script)
     _assert_grant_access(script)
+
+
+def test_generate_delete_complete(
+    db_access_complete: DatabaseAccessV1,
+    db_connection_parameter: DatabaseConnectionParameters,
+    db_admin_connection_parameter: DatabaseConnectionParameters,
+):
+    db_access_complete.delete = True
+    s = PSQLScriptGenerator(
+        db_access=db_access_complete,
+        connection_parameter=db_connection_parameter,
+        admin_connection_parameter=db_admin_connection_parameter,
+        engine="postgres",
+    )
+    script = s.generate_script()
+    _assert_delete_script(script)
+    _assert_revoke_access(script)
 
 
 def test_job_completion():

--- a/reconcile/test/test_database_access_manager.py
+++ b/reconcile/test/test_database_access_manager.py
@@ -145,7 +145,7 @@ def _assert_delete_script(script: str) -> None:
 
 
 def _assert_revoke_access(script: str) -> None:
-    assert '\nREVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA "foo" FROM "test";\n'
+    assert '\nREVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA "foo" FROM "test";\n' in script
 
 
 def test_generate_create_user(

--- a/reconcile/test/test_database_access_manager.py
+++ b/reconcile/test/test_database_access_manager.py
@@ -145,9 +145,7 @@ def _assert_delete_script(script: str) -> None:
 
 
 def _assert_revoke_access(script: str) -> None:
-    assert (
-        '\nREVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA "foo" FROM "test";\n' in script
-    )
+    assert 'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA "foo" FROM "test";' in script
 
 
 def test_generate_create_user(


### PR DESCRIPTION
This enables the deletion of provisioned users.
Content created by these users will not be deleted, but ownership transferred to the admin user. Schemas are retained as well.