### PR TITLE
[ocm-clusters] make controlplane role optional

### DIFF
--- a/reconcile/gql_definitions/common/clusters.py
+++ b/reconcile/gql_definitions/common/clusters.py
@@ -487,7 +487,7 @@ class RosaOcmAwsSpecV1(ConfiguredBaseModel):
     creator_role_arn: str = Field(..., alias="creator_role_arn")
     installer_role_arn: str = Field(..., alias="installer_role_arn")
     support_role_arn: str = Field(..., alias="support_role_arn")
-    controlplane_role_arn: str = Field(..., alias="controlplane_role_arn")
+    controlplane_role_arn: Optional[str] = Field(..., alias="controlplane_role_arn")
     worker_role_arn: str = Field(..., alias="worker_role_arn")
 
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -13220,13 +13220,9 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -55,7 +55,7 @@ def _set_rosa_ocm_attrs(cluster: Mapping[str, Any]):
             sts=ROSAOcmAwsStsAttrs(
                 installer_role_arn=env["installer_role_arn"],
                 support_role_arn=env["support_role_arn"],
-                controlplane_role_arn=env["controlplane_role_arn"],
+                controlplane_role_arn=env.get("controlplane_role_arn"),
                 worker_role_arn=env["worker_role_arn"],
             ),
         ),

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -257,10 +257,11 @@ def rosa_hosted_cp_cluster_fxt():
                 "uid": "123123123",
                 "rosa": {
                     "creator_role_arn": "creator_role",
-                    "installer_role_arn": "installer_role",
-                    "support_role_arn": " support_role",
-                    "controlplane_role_arn": "controlplane_role",
-                    "worker_role_arn": "worker_role",
+                    "sts": {
+                        "installer_role_arn": "installer_role",
+                        "support_role_arn": " support_role",
+                        "worker_role_arn": "worker_role",
+                    },
                 },
             },
             "id": "the-cluster-id",
@@ -363,6 +364,11 @@ def get_json_mock():
 
 def test_ocm_spec_population_rosa(rosa_cluster_fxt):
     n = OCMSpec(**rosa_cluster_fxt)
+    assert isinstance(n.spec, ROSAClusterSpec)
+
+
+def test_ocm_spec_population_hcp(rosa_hosted_cp_cluster_fxt):
+    n = OCMSpec(**rosa_hosted_cp_cluster_fxt)
     assert isinstance(n.spec, ROSAClusterSpec)
 
 


### PR DESCRIPTION
HCP clusters don't have a controlplane account role

part of [APPSRE-8561
](https://issues.redhat.com/browse/APPSRE-8561)

depends on https://github.com/app-sre/qontract-schemas/pull/552/files