### PR TITLE
Bump UnleashClient version to 5.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
         "ruamel.yaml>=0.17.22,<0.18.0",
         "terrascript==0.9.0",
         "tabulate>=0.8.6,<0.9.0",
-        "UnleashClient~=5.3",
+        "UnleashClient~=5.11",
         "prometheus-client~=0.8",
         "sentry-sdk~=0.14",
         "jenkins-job-builder~=4.3.0",


### PR DESCRIPTION
No difference in prod run as `UnleashClient~=5.3` will install latest `5.x` version client, bump to `UnleashClient~=5.11` to make it explicit.

[APPSRE-7691](https://issues.redhat.com/browse/APPSRE-7691)