### PR TITLE
[glitchtip-project-alerts] support custom jira labels

### DIFF
--- a/reconcile/glitchtip_project_alerts/integration.py
+++ b/reconcile/glitchtip_project_alerts/integration.py
@@ -118,14 +118,12 @@ class GlitchtipProjectAlertsIntegration(
                         "Either jira.project or jira.board must be set for Jira integration"
                     )
 
-                params = []
+                params: dict[str, str | list] = {}
                 if gjb_token:
-                    params.append(("token", gjb_token))
+                    params["token"] = gjb_token
                 if glitchtip_project.jira.labels:
-                    params += [
-                        ("labels", label) for label in glitchtip_project.jira.labels
-                    ]
-                url = f"{gjb_alert_url}/{jira_project_key}?{urlencode(params)}"
+                    params["labels"] = glitchtip_project.jira.labels
+                url = f"{gjb_alert_url}/{jira_project_key}?{urlencode(params, True)}"
                 alerts.append(
                     ProjectAlert(
                         name=GJB_ALERT_NAME,

--- a/reconcile/glitchtip_project_alerts/integration.py
+++ b/reconcile/glitchtip_project_alerts/integration.py
@@ -8,7 +8,7 @@ from typing import (
     Any,
     Optional,
 )
-from urllib.parse import quote
+from urllib.parse import urlencode
 
 from reconcile.gql_definitions.glitchtip.glitchtip_instance import (
     query as glitchtip_instance_query,
@@ -118,10 +118,14 @@ class GlitchtipProjectAlertsIntegration(
                         "Either jira.project or jira.board must be set for Jira integration"
                     )
 
-                url = f"{gjb_alert_url}/{jira_project_key}"
+                params = []
                 if gjb_token:
-                    url += f"?token={quote(gjb_token)}"
-
+                    params.append(("token", gjb_token))
+                if glitchtip_project.jira.labels:
+                    params += [
+                        ("labels", label) for label in glitchtip_project.jira.labels
+                    ]
+                url = f"{gjb_alert_url}/{jira_project_key}?{urlencode(params)}"
                 alerts.append(
                     ProjectAlert(
                         name=GJB_ALERT_NAME,

--- a/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.gql
+++ b/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.gql
@@ -33,6 +33,7 @@ query GlitchtipProjectsWithAlerts {
       board {
         name
       }
+      labels
     }
   }
 }

--- a/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.py
+++ b/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.py
@@ -61,6 +61,7 @@ query GlitchtipProjectsWithAlerts {
       board {
         name
       }
+      labels
     }
   }
 }
@@ -116,6 +117,7 @@ class JiraBoardV1(ConfiguredBaseModel):
 class GlitchtipProjectJiraV1(ConfiguredBaseModel):
     project: Optional[str] = Field(..., alias="project")
     board: Optional[JiraBoardV1] = Field(..., alias="board")
+    labels: Optional[list[str]] = Field(..., alias="labels")
 
 
 class GlitchtipProjectsV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -18637,6 +18637,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "skipSuccessfulDeployNotifications",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "timeout",
                             "description": null,
                             "args": [],
@@ -20843,6 +20855,26 @@
                                 "kind": "OBJECT",
                                 "name": "JiraBoard_v1",
                                 "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "labels",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/test/fixtures/glitchtip/project_alerts.yml
+++ b/reconcile/test/fixtures/glitchtip/project_alerts.yml
@@ -49,6 +49,9 @@ glitchtip_projects:
     project: null
     board:
       name: JIRA-VIA-BOARD
+    labels:
+    - example-label-1
+    - example-label-2
   alerts:
   - name: example-1
     description: Example alert 1
@@ -66,4 +69,5 @@ glitchtip_projects:
   jira:
     board: null
     project: JIRA-VIA-PROJECT
+    labels: null
   alerts: null

--- a/reconcile/test/glitchtip/test_glitchtip_project_alerts.py
+++ b/reconcile/test/glitchtip/test_glitchtip_project_alerts.py
@@ -6,6 +6,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from reconcile.glitchtip_project_alerts.integration import (
+    GJB_ALERT_NAME,
     GlitchtipProjectAlertsIntegration,
     GlitchtipProjectAlertsIntegrationParams,
 )
@@ -134,7 +135,9 @@ def test_glitchtip_project_alerts_get_projects(
                 )
             ],
             jira=GlitchtipProjectJiraV1(
-                project=None, board=JiraBoardV1(name="JIRA-VIA-BOARD")
+                project=None,
+                board=JiraBoardV1(name="JIRA-VIA-BOARD"),
+                labels=["example-label-1", "example-label-2"],
             ),
         ),
         GlitchtipProjectsV1(
@@ -144,7 +147,9 @@ def test_glitchtip_project_alerts_get_projects(
                 name="NASA", instance=GlitchtipInstanceV1(name="glitchtip-dev")
             ),
             alerts=None,
-            jira=GlitchtipProjectJiraV1(project="JIRA-VIA-PROJECT", board=None),
+            jira=GlitchtipProjectJiraV1(
+                project="JIRA-VIA-PROJECT", board=None, labels=None
+            ),
         ),
     ]
 
@@ -207,14 +212,14 @@ def test_glitchtip_project_alerts_fetch_desire_state(
         ),
         ProjectAlert(
             pk=None,
-            name="Jira integration",
+            name=GJB_ALERT_NAME,
             timespan_minutes=1,
             quantity=1,
             recipients=[
                 ProjectAlertRecipient(
                     pk=None,
                     recipient_type=RecipientType.WEBHOOK,
-                    url="http://gjb.com/JIRA-VIA-BOARD?token=secret",
+                    url="http://gjb.com/JIRA-VIA-BOARD?token=secret&labels=example-label-1&labels=example-label-2",
                 )
             ],
         ),
@@ -223,7 +228,7 @@ def test_glitchtip_project_alerts_fetch_desire_state(
     assert project_4.alerts == [
         ProjectAlert(
             pk=None,
-            name="Jira integration",
+            name=GJB_ALERT_NAME,
             timespan_minutes=1,
             quantity=1,
             recipients=[


### PR DESCRIPTION
Add support for custom labels on glitchtip Jira alert tickets.

Ticket: [APPSRE-8523](https://issues.redhat.com/browse/APPSRE-8523)
Depends on: https://github.com/app-sre/qontract-schemas/pull/553