### PR TITLE
[aws-version-sync] show not auto-merge MRs in AppSRE review queue

### DIFF
--- a/reconcile/aws_version_sync/merge_request_manager/merge_request_manager.py
+++ b/reconcile/aws_version_sync/merge_request_manager/merge_request_manager.py
@@ -15,7 +15,10 @@ from reconcile.aws_version_sync.merge_request_manager.merge_request import (
 )
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.mr.base import MergeRequestBase
-from reconcile.utils.mr.labels import AUTO_MERGE
+from reconcile.utils.mr.labels import (
+    AUTO_MERGE,
+    SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE,
+)
 from reconcile.utils.vcs import VCS
 
 
@@ -223,6 +226,8 @@ class MergeRequestManager:
         mr_labels = [AVS_LABEL]
         if self._auto_merge_enabled:
             mr_labels.append(AUTO_MERGE)
+        else:
+            mr_labels.append(SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE)
         self._vcs.open_app_interface_merge_request(
             mr=AVSMR(
                 path=namespace_file,

--- a/reconcile/test/aws_version_sync/merge_request_manager/test_merge_request_manager.py
+++ b/reconcile/test/aws_version_sync/merge_request_manager/test_merge_request_manager.py
@@ -26,7 +26,10 @@ from reconcile.aws_version_sync.merge_request_manager.merge_request_manager impo
     OpenMergeRequest,
 )
 from reconcile.utils.gitlab_api import GitLabApi
-from reconcile.utils.mr.labels import AUTO_MERGE
+from reconcile.utils.mr.labels import (
+    AUTO_MERGE,
+    SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE,
+)
 from reconcile.utils.vcs import VCS
 
 
@@ -340,5 +343,6 @@ def test_merge_request_manager_create_avs_merge_request_auto_merge_off(
 
     vcs_mock.close_app_interface_mr.assert_not_called()
     assert vcs_mock.open_app_interface_merge_request.call_args.kwargs["mr"].labels == [
-        AVS_LABEL
+        AVS_LABEL,
+        SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE,
     ]

--- a/reconcile/utils/mr/labels.py
+++ b/reconcile/utils/mr/labels.py
@@ -20,3 +20,8 @@ def prioritized_approval_label(priority: str) -> str:
 
 def change_owner_label(label: str) -> str:
     return f"change-owner/{label}"
+
+
+SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE = change_owner_label(
+    "show-self-serviceable-in-review-queue"
+)

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -102,7 +102,7 @@ from reconcile.utils.keycloak import (
 from reconcile.utils.mr.labels import (
     SAAS_FILE_UPDATE,
     SELF_SERVICEABLE,
-    change_owner_label,
+    SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE,
 )
 from reconcile.utils.oc import (
     OC_Map,
@@ -1819,8 +1819,7 @@ def app_interface_review_queue(ctx) -> None:
                 continue
             if (
                 SELF_SERVICEABLE in labels
-                and change_owner_label("show-self-serviceable-in-review-queue")
-                not in labels
+                and SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE not in labels
             ):
                 continue
 


### PR DESCRIPTION
... otherwise, we don't see such MRs because the `engine_version` field is `self-serviceable`.