### PR TITLE
FIPS Validation for Terraform Repos

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -28325,6 +28325,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "requireFips",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
@@ -23,5 +23,6 @@ query TerraformRepo {
     ref
     projectPath
     delete
+    requireFips
   }
 }

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.py
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.py
@@ -51,6 +51,7 @@ query TerraformRepo {
     ref
     projectPath
     delete
+    requireFips
   }
 }
 """
@@ -90,6 +91,7 @@ class TerraformRepoV1(ConfiguredBaseModel):
     ref: str = Field(..., alias="ref")
     project_path: str = Field(..., alias="projectPath")
     delete: Optional[bool] = Field(..., alias="delete")
+    require_fips: Optional[bool] = Field(..., alias="requireFips")
 
 
 class TerraformRepoQueryData(ConfiguredBaseModel):

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -50,6 +50,7 @@ class RepoOutput(BaseModel):
     bucket: Optional[str]
     region: Optional[str]
     bucket_path: Optional[str]
+    require_fips: bool
 
 
 class OutputFile(BaseModel):
@@ -122,6 +123,7 @@ class TerraformRepoIntegration(
                 ref=repo.ref,
                 project_path=repo.project_path,
                 delete=repo.delete or False,
+                require_fips=repo.require_fips or False,
                 secret=RepoSecret(
                     path=repo.account.automation_token.path,
                     version=repo.account.automation_token.version,

--- a/reconcile/test/test_terraform_repo.py
+++ b/reconcile/test/test_terraform_repo.py
@@ -39,6 +39,7 @@ def existing_repo(aws_account) -> TerraformRepoV1:
         account=aws_account,
         projectPath="tf",
         delete=False,
+        requireFips=True,
     )
 
 
@@ -58,6 +59,7 @@ def existing_repo_output() -> str:
           bucket: {STATE_BUCKET}
           region: {STATE_REGION}
           bucket_path: tf-repo
+          require_fips: true
     """
 
 
@@ -70,6 +72,7 @@ def new_repo(aws_account_no_state) -> TerraformRepoV1:
         account=aws_account_no_state,
         projectPath="tf",
         delete=False,
+        requireFips=False,
     )
 
 
@@ -89,6 +92,7 @@ def new_repo_output() -> str:
           bucket: null
           region: null
           bucket_path: null
+          require_fips: false
     """
 
 
@@ -255,6 +259,7 @@ def test_get_repo_state(s3_state_builder, int_params, existing_repo):
                     "ref": A_REPO_SHA,
                     "projectPath": "tf",
                     "delete": False,
+                    "requireFips": True,
                     "account": {
                         "name": "foo",
                         "uid": AWS_UID,


### PR DESCRIPTION
[APPSRE-8520](https://issues.redhat.com/browse/APPSRE-8520)

Corresponds with the following PRs:
- Schemas: https://github.com/app-sre/qontract-schemas/pull/554
- Executor: https://github.com/app-sre/terraform-repo-executor/pull/16

Basically updates what tf-repo expects as integration input and the output it feeds to the executor to include this new validation flag.