### PR TITLE
[aws-version-sync] no RDS downgrades

### DIFF
--- a/reconcile/aws_version_sync/integration.py
+++ b/reconcile/aws_version_sync/integration.py
@@ -87,7 +87,7 @@ class ExternalResource(BaseModel):
             self.resource_engine,
         )
 
-    @validator("resource_engine_version")
+    @validator("resource_engine_version", pre=True)
     def parse_resource_engine_version(  # pylint: disable=no-self-argument
         cls, v: str | semver.VersionInfo
     ) -> semver.VersionInfo:

--- a/reconcile/aws_version_sync/integration.py
+++ b/reconcile/aws_version_sync/integration.py
@@ -250,6 +250,12 @@ class AVSIntegration(QontractReconcileIntegration[AVSIntegrationParams]):
         for diff_pair in diff.change.values():
             aws_resource = diff_pair.desired
             app_interface_resource = diff_pair.current
+            if (
+                aws_resource.resource_engine_version
+                <= app_interface_resource.resource_engine_version
+            ):
+                # do not downgrade the version
+                continue
             # make mypy happy
             assert app_interface_resource.namespace_file
             assert app_interface_resource.provisioner.path

--- a/reconcile/aws_version_sync/integration.py
+++ b/reconcile/aws_version_sync/integration.py
@@ -5,7 +5,11 @@ from collections.abc import (
 )
 from typing import Any
 
-from pydantic import BaseModel
+import semver
+from pydantic import (
+    BaseModel,
+    validator,
+)
 
 from reconcile.aws_version_sync.merge_request_manager.merge_request import (
     Parser,
@@ -42,6 +46,7 @@ from reconcile.utils.runtime.integration import (
     PydanticRunParams,
     QontractReconcileIntegration,
 )
+from reconcile.utils.semver_helper import parse_semver
 from reconcile.utils.unleash import get_feature_toggle_state
 from reconcile.utils.vcs import VCS
 
@@ -67,7 +72,10 @@ class ExternalResource(BaseModel):
     resource_provider: str
     resource_identifier: str
     resource_engine: str
-    resource_engine_version: str
+    resource_engine_version: semver.VersionInfo | str
+
+    class Config:
+        arbitrary_types_allowed = True
 
     @property
     def key(self) -> tuple:
@@ -78,6 +86,14 @@ class ExternalResource(BaseModel):
             self.resource_identifier,
             self.resource_engine,
         )
+
+    @validator("resource_engine_version")
+    def parse_resource_engine_version(  # pylint: disable=no-self-argument
+        cls, v: str | semver.VersionInfo
+    ) -> semver.VersionInfo:
+        if isinstance(v, semver.VersionInfo):
+            return v
+        return parse_semver(v, optional_minor_and_patch=True)
 
 
 AwsExternalResources = list[ExternalResource]
@@ -228,8 +244,8 @@ class AVSIntegration(QontractReconcileIntegration[AVSIntegrationParams]):
             current=external_resources_app_interface,
             desired=external_resources_aws,
             key=lambda r: r.key,
-            equal=lambda r1, r2: r1.resource_engine_version
-            == r2.resource_engine_version,
+            equal=lambda external_resources_app_interface, external_resources_aws: external_resources_app_interface.resource_engine_version
+            >= external_resources_aws.resource_engine_version,
         )
         for diff_pair in diff.change.values():
             aws_resource = diff_pair.desired

--- a/reconcile/aws_version_sync/integration.py
+++ b/reconcile/aws_version_sync/integration.py
@@ -72,7 +72,7 @@ class ExternalResource(BaseModel):
     resource_provider: str
     resource_identifier: str
     resource_engine: str
-    resource_engine_version: semver.VersionInfo | str
+    resource_engine_version: semver.VersionInfo
 
     class Config:
         arbitrary_types_allowed = True

--- a/reconcile/aws_version_sync/integration.py
+++ b/reconcile/aws_version_sync/integration.py
@@ -245,7 +245,7 @@ class AVSIntegration(QontractReconcileIntegration[AVSIntegrationParams]):
             desired=external_resources_aws,
             key=lambda r: r.key,
             equal=lambda external_resources_app_interface, external_resources_aws: external_resources_app_interface.resource_engine_version
-            >= external_resources_aws.resource_engine_version,
+            == external_resources_aws.resource_engine_version,
         )
         for diff_pair in diff.change.values():
             aws_resource = diff_pair.desired

--- a/reconcile/test/aws_version_sync/test_avs_integration.py
+++ b/reconcile/test/aws_version_sync/test_avs_integration.py
@@ -258,6 +258,26 @@ def test_avs_reconcile(mocker: MockerFixture, intg: AVSIntegration) -> None:
         resource_engine="postgres",
         resource_engine_version="13.5",
     )
+    no_downgrade_aws = ExternalResource(
+        namespace_file=None,
+        provider="aws",
+        provisioner=ExternalResourceProvisioner(uid="no_downgrade", path=None),
+        resource_provider="rds",
+        resource_identifier="no_downgrade",
+        resource_engine="postgres",
+        resource_engine_version="13.5",
+    )
+    no_downgrade_ai = ExternalResource(
+        namespace_file="/no_downgrade_ai-namespace-file.yml",
+        provider="aws",
+        provisioner=ExternalResourceProvisioner(
+            uid="no_downgrade", path="no_downgrade.yml"
+        ),
+        resource_provider="rds",
+        resource_identifier="no_downgrade",
+        resource_engine="postgres",
+        resource_engine_version="13.10",
+    )
     version_update_aws = ExternalResource(
         namespace_file=None,
         provider="aws",
@@ -311,6 +331,7 @@ def test_avs_reconcile(mocker: MockerFixture, intg: AVSIntegration) -> None:
         no_change_aws,
         version_update_aws,
         aws_only,
+        no_downgrade_aws,
     ]
 
     external_resources_app_interface = [
@@ -318,6 +339,7 @@ def test_avs_reconcile(mocker: MockerFixture, intg: AVSIntegration) -> None:
         version_update_ai,
         same_name_different_account,
         ai_only,
+        no_downgrade_ai,
     ]
     # randomize the order of the external resources
     random.shuffle(external_resources_aws)

--- a/reconcile/test/utils/test_semver_helper.py
+++ b/reconcile/test/utils/test_semver_helper.py
@@ -1,3 +1,6 @@
+import pytest
+import semver
+
 import reconcile.utils.semver_helper as svh
 
 
@@ -17,3 +20,43 @@ def test_is_version_bumped_higher():
 
 def test_is_version_bumped_equal():
     assert svh.is_version_bumped("0.5.0", "0.5.0") is False
+
+
+@pytest.mark.parametrize(
+    "version_str, expected, optional_minor_and_patch",
+    [
+        ("0.4.0", semver.VersionInfo(major=0, minor=4, patch=0), False),
+        (
+            "0.4.0-6+gaaaaaaa",
+            semver.VersionInfo(
+                major=0, minor=4, patch=0, prerelease="6", build="gaaaaaaa"
+            ),
+            False,
+        ),
+        ("15", semver.VersionInfo(major=15, minor=0, patch=0), True),
+        ("15.0", semver.VersionInfo(major=15, minor=0, patch=0), True),
+        # no minor and patch
+        pytest.param(
+            "15",
+            None,
+            False,
+            marks=pytest.mark.xfail(raises=ValueError, strict=True),
+        ),
+        pytest.param(
+            "15.0",
+            None,
+            False,
+            marks=pytest.mark.xfail(raises=ValueError, strict=True),
+        ),
+    ],
+)
+def test_parse_semver(
+    version_str: str, optional_minor_and_patch: bool, expected: semver.VersionInfo
+) -> None:
+    assert svh.parse_semver(version_str, optional_minor_and_patch) == expected
+
+
+def test_comparison_with_optional_minor_and_patch() -> None:
+    assert svh.parse_semver("13.0", optional_minor_and_patch=True) < svh.parse_semver(
+        "13.1", optional_minor_and_patch=True
+    )

--- a/reconcile/utils/semver_helper.py
+++ b/reconcile/utils/semver_helper.py
@@ -7,7 +7,16 @@ def make_semver(major: int, minor: int, patch: int) -> str:
     return str(semver.VersionInfo(major=major, minor=minor, patch=patch))
 
 
-def parse_semver(version: str) -> semver.VersionInfo:
+def parse_semver(
+    version: str, optional_minor_and_patch: bool = False
+) -> semver.VersionInfo:
+    if optional_minor_and_patch:
+        # semver3 supports optional minor and patch.
+        # until we upgrade to semver3, we support this by adding a default minor and/or patch
+        if "." not in version:
+            version = f"{version}.0.0"
+        elif version.count(".") == 1:
+            version = f"{version}.0"
     return semver.VersionInfo.parse(version)
 
 


### PR DESCRIPTION
Convert the `engine_version` strings to `semver.VersionInfo` objects to have a proper version comparison to avoid RDS downgrade MRs. 

Additionally, enhance our custom `parse_semver` function with `optional_minor_and_patch` to mimik semver3 [Version.parse](https://python-semver.readthedocs.io/en/latest/api.html#semver.version.Version.parse)