### PR TITLE
[tf-repo] update behavior to recreate state on error

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1701,17 +1701,10 @@ def aws_version_sync(
     "--output-file",
     help="Specify where to place the output of the integration",
 )
-@click.option(
-    "--ignore-state-errors",
-    is_flag=True,
-    help="Instructs terraform-repo to ignore state load errors and re-create repo states",
-)
 @click.argument("gitlab-project-id", required=False)
 @click.argument("gitlab-merge-request-id", required=False)
 @click.pass_context
-def terraform_repo(
-    ctx, output_file, ignore_state_errors, gitlab_project_id, gitlab_merge_request_id
-):
+def terraform_repo(ctx, output_file, gitlab_project_id, gitlab_merge_request_id):
     from reconcile import terraform_repo
 
     run_class_integration(
@@ -1719,7 +1712,6 @@ def terraform_repo(
             terraform_repo.TerraformRepoIntegrationParams(
                 output_file=output_file,
                 validate_git=True,
-                ignore_state_errors=ignore_state_errors,
                 gitlab_project_id=gitlab_project_id,
                 gitlab_merge_request_id=gitlab_merge_request_id,
             )

--- a/reconcile/test/test_terraform_repo.py
+++ b/reconcile/test/test_terraform_repo.py
@@ -140,17 +140,13 @@ def aws_account_no_state(automation_token) -> AWSAccountV1:
 
 @pytest.fixture
 def int_params() -> TerraformRepoIntegrationParams:
-    return TerraformRepoIntegrationParams(
-        output_file=None, validate_git=False, ignore_state_errors=False
-    )
+    return TerraformRepoIntegrationParams(output_file=None, validate_git=False)
 
 
 @pytest.fixture
 def int_params_print_to_tmp(tmp_path) -> TerraformRepoIntegrationParams:
     return TerraformRepoIntegrationParams(
-        output_file=f"{tmp_path}/tf-repo.yaml",
-        validate_git=False,
-        ignore_state_errors=False,
+        output_file=f"{tmp_path}/tf-repo.yaml", validate_git=False
     )
 
 
@@ -165,7 +161,11 @@ def test_addition_to_existing_repo(existing_repo, new_repo, int_params, state_mo
 
     integration = TerraformRepoIntegration(params=int_params)
     diff = integration.calculate_diff(
-        existing_state=existing, desired_state=desired, dry_run=False, state=state_mock
+        existing_state=existing,
+        desired_state=desired,
+        dry_run=False,
+        state=state_mock,
+        recreate_state=False,
     )
 
     assert diff == [new_repo]
@@ -187,6 +187,7 @@ def test_updating_repo_ref(existing_repo, int_params, state_mock):
         desired_state=[updated_repo],
         dry_run=False,
         state=state_mock,
+        recreate_state=False,
     )
 
     assert diff == [updated_repo]
@@ -213,6 +214,7 @@ def test_fail_on_update_invalid_repo_params(existing_repo, int_params):
             desired_state=[updated_repo],
             dry_run=True,
             state=None,
+            recreate_state=False,
         )
 
 
@@ -228,6 +230,7 @@ def test_delete_repo(existing_repo, int_params, state_mock):
         desired_state=[updated_repo],
         dry_run=False,
         state=state_mock,
+        recreate_state=False,
     )
 
     assert diff == [updated_repo]
@@ -242,7 +245,11 @@ def test_delete_repo_without_flag(existing_repo, int_params):
 
     with pytest.raises(ParameterError):
         integration.calculate_diff(
-            existing_state=existing, desired_state=[], dry_run=True, state=None
+            existing_state=existing,
+            desired_state=[],
+            dry_run=True,
+            state=None,
+            recreate_state=False,
         )
 
 
@@ -303,6 +310,7 @@ def test_update_repo_state(int_params, existing_repo, state_mock):
         desired_state=desired_state,
         dry_run=False,
         state=state_mock,
+        recreate_state=False,
     )
 
     state_mock.add.assert_called_once_with(
@@ -327,6 +335,7 @@ def test_output_correct_statefile(
         desired_state=desired_state,
         dry_run=True,
         state=state_mock,
+        recreate_state=False,
     )
 
     assert diff
@@ -353,6 +362,7 @@ def test_output_correct_no_statefile(
         desired_state=desired_state,
         dry_run=True,
         state=state_mock,
+        recreate_state=False,
     )
 
     assert diff
@@ -371,7 +381,11 @@ def test_fail_on_multiple_repos_dry_run(int_params, existing_repo, new_repo):
 
     with pytest.raises(Exception):
         integration.calculate_diff(
-            existing_state=[], desired_state=desired_state, dry_run=True, state=None
+            existing_state=[],
+            desired_state=desired_state,
+            dry_run=True,
+            state=None,
+            recreate_state=False,
         )
 
 
@@ -381,7 +395,11 @@ def test_succeed_on_multiple_repos_non_dry_run(int_params, existing_repo, new_re
     desired_state = [existing_repo, new_repo]
 
     diff = integration.calculate_diff(
-        existing_state=[], desired_state=desired_state, dry_run=False, state=None
+        existing_state=[],
+        desired_state=desired_state,
+        dry_run=False,
+        state=None,
+        recreate_state=False,
     )
 
     assert diff
@@ -397,7 +415,11 @@ def test_no_op_succeeds(int_params, existing_repo):
     state = [existing_repo]
 
     diff = integration.calculate_diff(
-        existing_state=state, desired_state=state, dry_run=True, state=None
+        existing_state=state,
+        desired_state=state,
+        dry_run=True,
+        state=None,
+        recreate_state=False,
     )
 
     assert diff is None


### PR DESCRIPTION
Start here for some context: https://github.com/app-sre/qontract-reconcile/pull/3799

TLDR is that Pydantic has issues when updating schemas for terraform-repo causing the `load_existing_state` part of the tf-repo reconcile operation to fail. This PR updates that behavior such that if a state load error is encountered, tf-repo just re-creates its own representation of states based on what is in app interface. 

This means that no plan is output to the executor and no infrastructure is updated once the failing MR is merged, only terraform-repo's state is updated (not the actual .tfstate backend files). We could cause more issues if we go in and re-apply every single Terraform Repo in a particular App Interface instance so this PR removes that behavior.

Validated this locally against our FR App Interface.