### PR TITLE
Fix password leak

### DIFF
--- a/reconcile/database_access_manager.py
+++ b/reconcile/database_access_manager.py
@@ -102,8 +102,12 @@ REVOKE ALL ON DATABASE "{self._get_db()}" FROM public;
 
 \\c "{self._get_db()}"
 
-select 'CREATE ROLE "{self._get_user()}"  WITH LOGIN PASSWORD ''{self.connection_parameter.password}'' VALID UNTIL ''infinity'''
+select 'CREATE ROLE "{self._get_user()}"'
 WHERE NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '{self._get_db()}');\\gexec
+
+ALTER ROLE "{self._get_user()}" WITH LOGIN  PASSWORD '{self.connection_parameter.password}' VALID UNTIL 'infinity';
+
+GRANT CONNECT ON DATABASE "{self._get_db()}" to "{self._get_user()}";
 
 -- rds specific, grant role to admin or create schema fails
 GRANT "{self._get_user()}" to "{self._get_admin_user()}";
@@ -272,7 +276,7 @@ def get_job_spec(job_data: JobData) -> OpenshiftResource:
                                 command,
                             ],
                             "args": [
-                                "-ae",
+                                "-b",
                                 "--host=$(db.host)",
                                 "--port=$(db.port)",
                                 "--username=$(db.user)",

--- a/reconcile/test/test_database_access_manager.py
+++ b/reconcile/test/test_database_access_manager.py
@@ -131,7 +131,9 @@ def openshift_resource_secet() -> OpenshiftResource:
 def _assert_create_script(script: str) -> None:
     assert 'CREATE DATABASE "test"' in script
     assert "REVOKE ALL ON DATABASE" in script
-    assert 'CREATE ROLE "test"  WITH LOGIN PASSWORD' in script
+    assert 'CREATE ROLE "test"' in script
+    assert 'ALTER ROLE "test" WITH LOGIN' in script
+    assert 'GRANT CONNECT ON DATABASE "test" to "test"' in script
     assert "CREATE SCHEMA IF NOT EXISTS" in script
     assert 'GRANT "test" to "admin";' in script
 


### PR DESCRIPTION
Do not print statements (changed psql flag to -b)
Alter password after user creation, removes extra print of create role statement containing the password

Example output of the job:
```
?column?
----------------------------------
CREATE DATABASE "jboll-testfcbd"
(1 row)
CREATE DATABASE
REVOKE
You are now connected to database "jboll-testfcbd" as user "unleash".
?column?
------------------------------
CREATE ROLE "jboll-testfcbd"
(1 row)
CREATE ROLE
ALTER ROLE
GRANT
GRANT ROLE
CREATE SCHEMA
```