### PR TITLE
[ocm-machine-pools] Update deletable check for OSD and ROSA HCP

### DIFF
--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -274,8 +274,7 @@ class NodePool(AbstractPool):
         return None
 
     def deletable(self) -> bool:
-        # As of now, you can not delete the first worker pool(s)
-        return not self.id.startswith("workers")
+        return True
 
     @classmethod
     def create_from_gql(

--- a/reconcile/test/test_ocm_machine_pools.py
+++ b/reconcile/test/test_ocm_machine_pools.py
@@ -19,6 +19,7 @@ from reconcile.gql_definitions.common.clusters import (
 from reconcile.ocm_machine_pools import (
     AbstractPool,
     AWSNodePool,
+    ClusterType,
     DesiredMachinePool,
     InvalidUpdateError,
     MachinePool,
@@ -63,7 +64,7 @@ def test_pool() -> TestPool:
         labels=None,
         taints=None,
         cluster="cluster1",
-        cluster_product="osd",
+        cluster_type=ClusterType.OSD,
     )
 
 
@@ -78,7 +79,7 @@ def current_with_pool() -> Mapping[str, list[AbstractPool]]:
                 labels=None,
                 taints=None,
                 cluster="cluster1",
-                cluster_product="osd",
+                cluster_type=ClusterType.OSD,
             )
         ]
     }
@@ -92,7 +93,7 @@ def node_pool() -> NodePool:
         labels=None,
         taints=None,
         cluster="cluster1",
-        cluster_product="rosa",
+        cluster_type=ClusterType.ROSA_HCP,
         subnet="subnet1",
         aws_node_pool=AWSNodePool(
             instance_type="m5.xlarge",
@@ -108,8 +109,7 @@ def machine_pool() -> MachinePool:
         labels=None,
         taints=None,
         cluster="cluster1",
-        cluster_product="osd",
-        subnet="subnet1",
+        cluster_type=ClusterType.OSD,
         instance_type="m5.xlarge",
     )
 
@@ -133,7 +133,7 @@ def ocm_mock():
 
 
 def test_diff__has_diff_autoscale(cluster_machine_pool: ClusterMachinePoolV1):
-    pool = TestPool(id="pool1", cluster="cluster1", cluster_product="osd")
+    pool = TestPool(id="pool1", cluster="cluster1", cluster_type=ClusterType.OSD)
 
     assert cluster_machine_pool.autoscale is None
     assert not pool._has_diff_autoscale(cluster_machine_pool)
@@ -169,8 +169,7 @@ def test_calculate_diff_create():
     desired = {
         "cluster1": DesiredMachinePool(
             cluster_name="cluster1",
-            cluster_product="osd",
-            hypershift=False,
+            cluster_type=ClusterType.OSD,
             pools=[
                 ClusterMachinePoolV1(
                     id="pool1",
@@ -195,8 +194,7 @@ def test_calculate_diff_noop(current_with_pool):
     desired = {
         "cluster1": DesiredMachinePool(
             cluster_name="cluster1",
-            cluster_product="osd",
-            hypershift=False,
+            cluster_type=ClusterType.OSD,
             pools=[
                 ClusterMachinePoolV1(
                     id="pool1",
@@ -219,8 +217,7 @@ def test_calculate_diff_update(current_with_pool):
     desired = {
         "cluster1": DesiredMachinePool(
             cluster_name="cluster1",
-            cluster_product="osd",
-            hypershift=False,
+            cluster_type=ClusterType.OSD,
             pools=[
                 ClusterMachinePoolV1(
                     id="pool1",
@@ -252,7 +249,7 @@ def current_with_2_pools() -> Mapping[str, list[AbstractPool]]:
                 labels=None,
                 taints=None,
                 cluster="cluster1",
-                cluster_product="osd",
+                cluster_type=ClusterType.OSD,
             ),
             MachinePool(
                 id="workers",
@@ -261,7 +258,7 @@ def current_with_2_pools() -> Mapping[str, list[AbstractPool]]:
                 labels=None,
                 taints=None,
                 cluster="cluster1",
-                cluster_product="osd",
+                cluster_type=ClusterType.OSD,
             ),
         ]
     }
@@ -271,8 +268,7 @@ def test_calculate_diff_delete(current_with_2_pools):
     desired = {
         "cluster1": DesiredMachinePool(
             cluster_name="cluster1",
-            cluster_product="osd",
-            hypershift=False,
+            cluster_type=ClusterType.OSD,
             pools=[
                 ClusterMachinePoolV1(
                     id="pool1",
@@ -297,8 +293,7 @@ def test_calculate_diff_delete_all_fail_validation(current_with_pool):
     desired = {
         "cluster1": DesiredMachinePool(
             cluster_name="cluster1",
-            cluster_product="osd",
-            hypershift=False,
+            cluster_type=ClusterType.OSD,
             pools=[],
         ),
     }
@@ -905,6 +900,7 @@ def hypershift_cluster_builder(
                     },
                 },
                 "spec": {
+                    "product": "rosa",
                     "hypershift": True,
                 },
                 "machinePools": machine_pools,

--- a/reconcile/test/test_ocm_machine_pools.py
+++ b/reconcile/test/test_ocm_machine_pools.py
@@ -1094,7 +1094,7 @@ def existing_multiple_hypershift_node_pools_with_defaults() -> list[dict]:
     ]
 
 
-def test_run_delete_node_pool_skip_workers_ones(
+def test_run_delete_default_node_pool(
     mocker: MockerFixture,
     hypershift_cluster_without_default_worker_machine_pools: ClusterV1,
     existing_multiple_hypershift_node_pools_with_defaults: list[dict],
@@ -1107,4 +1107,4 @@ def test_run_delete_node_pool_skip_workers_ones(
 
     run(False)
 
-    mocks["OCM"].delete_node_pool.assert_not_called()
+    mocks["OCM"].delete_node_pool.assert_called()


### PR DESCRIPTION
OSD NON CCS clusters can't delete default `worker` machine pool, ROSA HCP clusters can delete default `workers*` node pools.

This change updates deletable check to fail for OSD delete default machine pool, pass for ROSA HCP delete default node pools.


[APPSRE-8556](https://issues.redhat.com/browse/APPSRE-8556)