### PR TITLE
[reqs-dev] pin response package to 0.23.1

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -5,7 +5,7 @@ kubernetes~=24.0
 pytest~=7.2
 pytest-cov~=4.0.0
 pytest-mock~=3.6
-responses
+responses==0.23.1
 testslide~=2.7
 typeguard==2.13.3
 moto~=2.2


### PR DESCRIPTION
Newer [response](https://github.com/getsentry/responses/releases/tag/0.23.2) requires `requests >= 2.30.0`, but we are currently on `2.22.0`