### PR TITLE
import OCM cluster OIDC endpoint URL into a-i cluster files

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -16566,6 +16566,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "issueSecurityId",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "escalationPolicies",
                             "description": null,
                             "args": [],
@@ -31675,6 +31687,18 @@
                                         "ofType": null
                                     }
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "oidc_endpoint_url",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/ocm/types.py
+++ b/reconcile/ocm/types.py
@@ -84,6 +84,7 @@ class ROSAClusterSpec(OCMClusterSpec):
     account: ROSAClusterAWSAccount
     subnet_ids: Optional[list[str]]
     availability_zones: Optional[list[str]]
+    oidc_endpoint_url: Optional[str]
 
     class Config:
         extra = Extra.forbid

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -15,6 +15,7 @@ from reconcile import (
 from reconcile.ocm.types import (
     OCMSpec,
     ROSAClusterAWSAccount,
+    ROSAClusterSpec,
     ROSAOcmAwsAttrs,
     ROSAOcmAwsStsAttrs,
 )
@@ -173,6 +174,18 @@ def get_app_interface_spec_updates(
         ocm_spec_updates[
             ocmmod.SPEC_ATTR_PROVISION_SHARD_ID
         ] = current_spec.spec.provision_shard_id
+
+    if isinstance(current_spec.spec, ROSAClusterSpec) and isinstance(
+        desired_spec.spec, ROSAClusterSpec
+    ):
+        if (
+            current_spec.spec.oidc_endpoint_url
+            and desired_spec.spec.oidc_endpoint_url
+            != current_spec.spec.oidc_endpoint_url
+        ):
+            ocm_spec_updates[
+                ocmmod.SPEC_ATTR_OIDC_ENDPONT_URL
+            ] = current_spec.spec.oidc_endpoint_url
 
     if current_spec.server_url and desired_spec.server_url != current_spec.server_url:
         root_updates[ocmmod.SPEC_ATTR_SERVER_URL] = current_spec.server_url

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -747,6 +747,7 @@ CLUSTERS_QUERY = """
       ... on ClusterSpecROSA_v1 {
         subnet_ids
         availability_zones
+        oidc_endpoint_url
         account {
           name
           uid

--- a/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
+++ b/reconcile/test/fixtures/clusters/rosa_spec_ai.yml
@@ -54,6 +54,7 @@ spec:
   private: false
   provision_shard_id: provision_shard_id
   disable_user_workload_monitoring: false
+  oidc_endpoint_url: "https://rh-oidc.s3.us-east-1.amazonaws.com/rosa-cluster-id"
 machinePools:
 - id: worker
   instance_type: m5.xlarge

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -85,6 +85,7 @@ SPEC_ATTR_LOAD_BALANCERS = "load_balancers"
 SPEC_ATTR_STORAGE = "storage"
 SPEC_ATTR_ID = "id"
 SPEC_ATTR_EXTERNAL_ID = "external_id"
+SPEC_ATTR_OIDC_ENDPONT_URL = "oidc_endpoint_url"
 SPEC_ATTR_PROVISION_SHARD_ID = "provision_shard_id"
 SPEC_ATTR_VERSION = "version"
 SPEC_ATTR_INITIAL_VERSION = "initial_version"
@@ -341,6 +342,7 @@ class OCMProductRosa(OCMProduct):
         SPEC_ATTR_HYPERSHIFT,
         SPEC_ATTR_SUBNET_IDS,
         SPEC_ATTR_AVAILABILITY_ZONES,
+        SPEC_ATTR_OIDC_ENDPONT_URL,
     }
 
     @staticmethod
@@ -380,6 +382,7 @@ class OCMProductRosa(OCMProduct):
             provision_shard_id = None
 
         sts = None
+        oidc_endpoint_url = None
         if cluster["aws"].get("sts", None):
             sts = ROSAOcmAwsStsAttrs(
                 installer_role_arn=cluster["aws"]["sts"]["role_arn"],
@@ -391,6 +394,7 @@ class OCMProductRosa(OCMProduct):
                     "worker_role_arn"
                 ],
             )
+            oidc_endpoint_url = cluster["aws"]["sts"]["oidc_endpoint_url"]
         account = ROSAClusterAWSAccount(
             uid=cluster["properties"]["rosa_creator_arn"].split(":")[4],
             rosa=ROSAOcmAwsAttrs(
@@ -417,6 +421,7 @@ class OCMProductRosa(OCMProduct):
             hypershift=cluster["hypershift"]["enabled"],
             subnet_ids=cluster["aws"].get("subnet_ids"),
             availability_zones=cluster["nodes"].get("availability_zones"),
+            oidc_endpoint_url=oidc_endpoint_url,
         )
 
         machine_pools = [


### PR DESCRIPTION
Import the OIDC endpoint URL of ROSA clusters into app-interface cluster files, similar to the ID and external ID of a cluster. It is supposed to be read only information that can be used by people and automation to define trust policies in IAM policies without the need to do OCM lookups. Since this URL is static, "caching" it like this in the cluster file is a legit approach.

part of https://issues.redhat.com/browse/APPSRE-8656

depends on https://github.com/app-sre/qontract-schemas/pull/560