### PR TITLE
minimize pylint ignore rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ ignore = [
     "PLR0915", # Too many statements
     "PLR0917", # Too many positional arguments
     "PLR2004", # Magic value used in comparison
-    "PLR5501", # Use `elif` instead of `else` then `if`, to reduce indentation
     "PLR6201", # Use a `set` literal when testing for membership
     "PLR6301", # Method XXX could be a function, class method, or static method
     "PLW0602", # Using global for %r but no assigment is done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ ignore = [
     "PLR0917", # Too many positional arguments
     "PLR2004", # Magic value used in comparison
     "PLR6301", # Method XXX could be a function, class method, or static method
-    "PLW1514", # `open` in text mode without explicit `encoding` argument
     "PLW1641", # Object does not implement `__hash__` method
     "PLW2901", # `for` loop variable `v` overwritten by assignment target
     "PLW3201", # Bad or misspelled dunder method name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ ignore = [
     "PLR6301", # Method XXX could be a function, class method, or static method
     "PLW1641", # Object does not implement `__hash__` method
     "PLW2901", # `for` loop variable `v` overwritten by assignment target
-    "PLW3201", # Bad or misspelled dunder method name
 ]
 [tool.ruff.format]
 preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ ignore = [
     "PLR0917", # Too many positional arguments
     "PLR2004", # Magic value used in comparison
     "PLR6301", # Method XXX could be a function, class method, or static method
-    "PLW1510", # `subprocess.run` without explicit `check` argument
     "PLW1514", # `open` in text mode without explicit `encoding` argument
     "PLW1641", # Object does not implement `__hash__` method
     "PLW2901", # `for` loop variable `v` overwritten by assignment target

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ ignore = [
     "PLR0917", # Too many positional arguments
     "PLR2004", # Magic value used in comparison
     "PLR6301", # Method XXX could be a function, class method, or static method
-    "PLW0602", # Using global for %r but no assigment is done
     "PLW0603", # global-statement
     "PLW1510", # `subprocess.run` without explicit `check` argument
     "PLW1514", # `open` in text mode without explicit `encoding` argument

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ ignore = [
     "PLR0913", # Too many arguments
     "PLR0915", # Too many statements
     "PLR0917", # Too many positional arguments
-    "PLR1704", # Redefining argument with the local name
     "PLR2004", # Magic value used in comparison
     "PLR5501", # Use `elif` instead of `else` then `if`, to reduce indentation
     "PLR6201", # Use a `set` literal when testing for membership

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ extend-select = [
 
 ]
 ignore = [
-    "PLC0415", # `import` should be at the top-level of a file
     "PLC1901", # ... can be simplified to `...` as an empty string is falsey
     "PLR0904", # Too many public methods
     "PLR0911", # Too many return statements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ ignore = [
     "PLR0915", # Too many statements
     "PLR0917", # Too many positional arguments
     "PLR2004", # Magic value used in comparison
-    "PLR6201", # Use a `set` literal when testing for membership
     "PLR6301", # Method XXX could be a function, class method, or static method
     "PLW0602", # Using global for %r but no assigment is done
     "PLW0603", # global-statement

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ extend-select = [
 
 ]
 ignore = [
-    "PLC1901", # ... can be simplified to `...` as an empty string is falsey
     "PLR0904", # Too many public methods
     "PLR0911", # Too many return statements
     "PLR0912", # Too many branches

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ ignore = [
     "PLR0917", # Too many positional arguments
     "PLR2004", # Magic value used in comparison
     "PLR6301", # Method XXX could be a function, class method, or static method
-    "PLW0603", # global-statement
     "PLW1510", # `subprocess.run` without explicit `check` argument
     "PLW1514", # `open` in text mode without explicit `encoding` argument
     "PLW1641", # Object does not implement `__hash__` method

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 line-length = 88
 target-version = 'py311'
-required-version = "0.1.7"
+required-version = "0.1.8"
 
 src = ["reconcile", "tools", "release", "dockerfiles/hack", "setup.py"]
 extend-exclude = ["reconcile/gql_definitions"]

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -1137,7 +1137,7 @@ def remaining_soak_day_metric_values_for_cluster(
         if current_upgrade and current_upgrade.version == version:
             if current_upgrade.state == "scheduled":
                 remaining_soakdays[idx] = UPGRADE_SCHEDULED_METRIC_VALUE
-            elif current_upgrade.state in ("started", "delayed"):
+            elif current_upgrade.state in {"started", "delayed"}:
                 remaining_soakdays[idx] = UPGRADE_STARTED_METRIC_VALUE
                 if current_upgrade.next_run:
                     # if an upgrade runs for over 6 hours, we mark it as a long running upgrade
@@ -1157,12 +1157,12 @@ def remaining_soak_day_metric_values_for_cluster(
         # for an upgrade over the older one anyways.
         if remaining_soakdays[idx] >= 0 and any(
             later_version_remaining_soak_days
-            in (
+            in {
                 0,
                 UPGRADE_SCHEDULED_METRIC_VALUE,
                 UPGRADE_STARTED_METRIC_VALUE,
                 UPGRADE_LONG_RUNNING_METRIC_VALUE,
-            )
+            }
             for later_version_remaining_soak_days in remaining_soakdays[idx + 1 :]
         ):
             continue

--- a/reconcile/aws_iam_keys.py
+++ b/reconcile/aws_iam_keys.py
@@ -26,7 +26,7 @@ def get_keys_to_delete(accounts) -> dict[str, list[str]]:
     return {
         account["name"]: account["deleteKeys"]
         for account in accounts
-        if account["deleteKeys"] not in (None, [])
+        if account["deleteKeys"]
     }
 
 

--- a/reconcile/aws_support_cases_sos.py
+++ b/reconcile/aws_support_cases_sos.py
@@ -20,7 +20,7 @@ def get_deleted_keys(accounts):
     return {
         account["name"]: account["deleteKeys"]
         for account in accounts
-        if account["deleteKeys"] not in (None, [])
+        if account["deleteKeys"]
     }
 
 

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -383,13 +383,12 @@ def run(
 
             if mr_management_enabled:
                 gl.set_labels_on_merge_request(merge_request, labels)
-            else:
+            elif SELF_SERVICEABLE in labels:
                 # if MR management is disabled, we need to make sure the self-serviceable
                 # labels is not present, because other integration react to them
                 # e.g. gitlab-housekeeper rejects direct lgtm labels and the review-queue
                 # skips MRs with this label
-                if SELF_SERVICEABLE in labels:
-                    gl.remove_label(merge_request, SELF_SERVICEABLE)
+                gl.remove_label(merge_request, SELF_SERVICEABLE)
 
     except BaseException:
         logging.error(traceback.format_exc())

--- a/reconcile/change_owners/diff.py
+++ b/reconcile/change_owners/diff.py
@@ -60,7 +60,7 @@ class Diff:
         )
 
     def get_context_data_copy(self) -> Optional[Any]:
-        if self.diff_type in [DiffType.ADDED, DiffType.CHANGED]:
+        if self.diff_type in {DiffType.ADDED, DiffType.CHANGED}:
             return copy.deepcopy(self.new)
         if self.diff_type == DiffType.REMOVED:
             return copy.deepcopy(self.old)

--- a/reconcile/change_owners/tester.py
+++ b/reconcile/change_owners/tester.py
@@ -151,7 +151,7 @@ class AppInterfaceRepo:
             for file in files:
                 if file.endswith(".yml") or file.endswith(".yaml"):
                     filepath = os.path.join(root, file)
-                    with open(filepath, "r") as f:
+                    with open(filepath, "r", encoding="locale") as f:
                         parsed_yaml = yaml.safe_load(f)
                         if parsed_yaml.get("$schema") == schema:
                             relative_path = filepath[len(self.data_dir()) :]
@@ -166,7 +166,7 @@ class AppInterfaceRepo:
         self, file_type: BundleFileType, path: str
     ) -> BundleFileChange:
         if file_type == BundleFileType.DATAFILE:
-            with open(f"{self.data_dir()}{path}", "r") as f:
+            with open(f"{self.data_dir()}{path}", "r", encoding="locale") as f:
                 parsed_yaml = yaml.safe_load(f)
                 return BundleFileChange(
                     fileref=FileRef(
@@ -181,7 +181,7 @@ class AppInterfaceRepo:
                     diffs=[],
                 )
         elif file_type == BundleFileType.RESOURCEFILE:
-            with open(f"{self.resource_dir()}{path}", "r") as f:
+            with open(f"{self.resource_dir()}{path}", "r", encoding="locale") as f:
                 content = f.read()
                 parsed_content, schema = parse_resource_file_content(content)
                 return BundleFileChange(

--- a/reconcile/checkpoint.py
+++ b/reconcile/checkpoint.py
@@ -87,7 +87,7 @@ def render_template(
     template: Path, name: str, path: str, field: str, bad_value: str
 ) -> str:
     """Render the template with all its fields."""
-    with open(template) as f:
+    with open(template, encoding="locale") as f:
         t = Template(f.read(), keep_trailing_newline=True, trim_blocks=True)
         return t.render(
             app_name=name, app_path=path, field=field, field_value=bad_value

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1,3 +1,4 @@
+# ruff: noqa: PLC0415 - `import` should be at the top-level of a file
 import faulthandler
 import json
 import logging

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -590,7 +590,7 @@ def run_class_integration(
     finally:
         if dump_schemas_file:
             gqlapi = gql.get_api()
-            with open(dump_schemas_file, "w") as f:
+            with open(dump_schemas_file, "w", encoding="locale") as f:
                 f.write(json.dumps(gqlapi.get_queried_schemas()))
 
 

--- a/reconcile/closedbox_endpoint_monitoring_base.py
+++ b/reconcile/closedbox_endpoint_monitoring_base.py
@@ -85,7 +85,7 @@ class Endpoint:
 
 def parse_prober_url(url: str) -> dict[str, str]:
     parsed_url = urlparse(url)
-    if parsed_url.scheme not in ["http", "https"]:
+    if parsed_url.scheme not in {"http", "https"}:
         raise ValueError(
             "the prober URL needs to be an http:// or https:// one " f"but is {url}"
         )

--- a/reconcile/cna/state.py
+++ b/reconcile/cna/state.py
@@ -85,7 +85,7 @@ class State:
                 if asset_name not in self._assets[kind]:
                     continue
                 asset = self._assets[kind][asset_name]
-                if asset.status in (AssetStatus.TERMINATED, AssetStatus.PENDING):
+                if asset.status in {AssetStatus.TERMINATED, AssetStatus.PENDING}:
                     continue
                 if asset == other_asset:
                     # There is no diff - no need to update
@@ -106,7 +106,7 @@ class State:
         ans = State()
         for kind in AssetType:
             for asset_name, asset in self._assets[kind].items():
-                if asset.status in (AssetStatus.TERMINATED, AssetStatus.PENDING):
+                if asset.status in {AssetStatus.TERMINATED, AssetStatus.PENDING}:
                     continue
                 if other_asset := other._assets[kind].get(asset_name):
                     if other_asset.status == AssetStatus.TERMINATED:

--- a/reconcile/dashdotdb_base.py
+++ b/reconcile/dashdotdb_base.py
@@ -149,9 +149,9 @@ class DashdotdbBase:
         if token:
             headers["Authorization"] = f"Bearer {token}"
         elif username and password:
-            headers[
-                "Authorization"
-            ] = f"Basic {b64encode(f'{username}:{password}'.encode()).decode('utf-8')}"
+            headers["Authorization"] = (
+                f"Basic {b64encode(f'{username}:{password}'.encode()).decode('utf-8')}"
+            )
         response = requests.get(
             url, params=params, headers=headers, verify=ssl_verify, timeout=(5, 120)
         )

--- a/reconcile/dynatrace_token_provider.py
+++ b/reconcile/dynatrace_token_provider.py
@@ -169,9 +169,9 @@ class DynatraceTokenProviderIntegration(
                                 continue
 
                             if tenant_id not in existing_dtp_tokens:
-                                existing_dtp_tokens[
-                                    tenant_id
-                                ] = self.get_all_dtp_tokens(dt_clients[tenant_id])
+                                existing_dtp_tokens[tenant_id] = (
+                                    self.get_all_dtp_tokens(dt_clients[tenant_id])
+                                )
 
                             self.process_cluster(
                                 dry_run,

--- a/reconcile/dynatrace_token_provider.py
+++ b/reconcile/dynatrace_token_provider.py
@@ -285,11 +285,10 @@ class DynatraceTokenProviderIntegration(
                         logging.info(
                             f"Operator token created in Dynatrace for cluster {cluster.ocm_cluster.external_id}."
                         )
-                else:
-                    if token_name == DYNATRACE_INGESTION_TOKEN_NAME:
-                        ingestion_token = ApiTokenCreated(raw_element=token)
-                    elif token_name == DYNATRACE_OPERATOR_TOKEN_NAME:
-                        operator_token = ApiTokenCreated(raw_element=token)
+                elif token_name == DYNATRACE_INGESTION_TOKEN_NAME:
+                    ingestion_token = ApiTokenCreated(raw_element=token)
+                elif token_name == DYNATRACE_OPERATOR_TOKEN_NAME:
+                    operator_token = ApiTokenCreated(raw_element=token)
             if need_patching:
                 if not dry_run:
                     patch_syncset_payload = self.construct_base_syncset(

--- a/reconcile/gcr_mirror.py
+++ b/reconcile/gcr_mirror.py
@@ -221,7 +221,7 @@ class QuayMirror:
         control_file_name = "qontract-reconcile-gcr-mirror.timestamp"
         control_file_path = os.path.join(tempfile.gettempdir(), control_file_name)
         try:
-            with open(control_file_path, "r") as file_obj:
+            with open(control_file_path, "r", encoding="locale") as file_obj:
                 last_deep_sync = float(file_obj.read())
         except FileNotFoundError:
             self._record_timestamp(control_file_path)
@@ -236,7 +236,7 @@ class QuayMirror:
 
     @staticmethod
     def _record_timestamp(path):
-        with open(path, "w") as file_object:
+        with open(path, "w", encoding="locale") as file_object:
             file_object.write(str(time.time()))
 
     def _get_push_creds(self):

--- a/reconcile/github_org.py
+++ b/reconcile/github_org.py
@@ -198,7 +198,7 @@ def fetch_desired_state(infer_clusters=True):
     for role in roles:
         permissions = list(
             filter(
-                lambda p: p.get("service") in ["github-org", "github-org-team"],
+                lambda p: p.get("service") in {"github-org", "github-org-team"},
                 role["permissions"],
             )
         )
@@ -238,7 +238,7 @@ def fetch_desired_state(infer_clusters=True):
     )
     for cluster in clusters:
         for auth in cluster["auth"]:
-            if auth["service"] not in ["github-org", "github-org-team"]:
+            if auth["service"] not in {"github-org", "github-org-team"}:
                 continue
 
             cluster_name = cluster["name"]

--- a/reconcile/github_owners.py
+++ b/reconcile/github_owners.py
@@ -48,7 +48,7 @@ def fetch_desired_state():
         permissions = [
             p
             for p in role["permissions"]
-            if p.get("service") in ["github-org", "github-org-team"]
+            if p.get("service") in {"github-org", "github-org-team"}
             and p.get("role") == "owner"
         ]
         if not permissions:

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -129,7 +129,7 @@ def get_timed_out_pipelines(
 ) -> list[dict]:
     now = datetime.utcnow()
 
-    pending_pipelines = [p for p in pipelines if p["status"] in ["pending", "running"]]
+    pending_pipelines = [p for p in pipelines if p["status"] in {"pending", "running"}]
 
     if not pending_pipelines:
         return []
@@ -299,10 +299,10 @@ def preprocess_merge_requests(
 ) -> list[dict[str, Any]]:
     results = []
     for mr in project_merge_requests:
-        if mr.merge_status in [
+        if mr.merge_status in {
             MRStatus.CANNOT_BE_MERGED,
             MRStatus.CANNOT_BE_MERGED_RECHECK,
-        ]:
+        }:
             continue
         if mr.work_in_progress:
             continue

--- a/reconcile/gitlab_labeler.py
+++ b/reconcile/gitlab_labeler.py
@@ -68,12 +68,11 @@ def guess_onboarding_status(
                 else:
                     app = apps[app_name]
                     labels.add(app["onboardingStatus"])
+            elif app_name in apps:
+                app = apps[app_name]
+                labels.add(app["onboardingStatus"])
             else:
-                if app_name in apps:
-                    app = apps[app_name]
-                    labels.add(app["onboardingStatus"])
-                else:
-                    logging.debug("Error getting app name " + path)
+                logging.debug("Error getting app name " + path)
 
     if len(labels) == 1:
         return labels.pop()

--- a/reconcile/glitchtip/reconciler.py
+++ b/reconcile/glitchtip/reconciler.py
@@ -81,9 +81,9 @@ class GlitchtipReconciler:
                     name=project.name,
                     platform=project.platform,
                 )
-                organization_projects[
-                    organization_projects.index(project)
-                ] = updated_project
+                organization_projects[organization_projects.index(project)] = (
+                    updated_project
+                )
 
         for desired_project in desired_projects:
             current_project = organization_projects[

--- a/reconcile/glitchtip_project_alerts/integration.py
+++ b/reconcile/glitchtip_project_alerts/integration.py
@@ -236,9 +236,9 @@ class GlitchtipProjectAlertsIntegration(
         glitchtip_instances = glitchtip_instance_query(
             query_func=gqlapi.query
         ).instances
-        glitchtip_projects_by_instance: dict[
-            str, list[GlitchtipProjectsV1]
-        ] = defaultdict(list)
+        glitchtip_projects_by_instance: dict[str, list[GlitchtipProjectsV1]] = (
+            defaultdict(list)
+        )
         for glitchtip_project in self.get_projects(query_func=gqlapi.query):
             glitchtip_projects_by_instance[
                 glitchtip_project.organization.instance.name

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -163,17 +163,17 @@ def get_app_interface_spec_updates(
         desired_spec.spec.disable_user_workload_monitoring is None
         and current_spec.spec.disable_user_workload_monitoring
     ):
-        ocm_spec_updates[
-            ocmmod.SPEC_ATTR_DISABLE_UWM
-        ] = current_spec.spec.disable_user_workload_monitoring
+        ocm_spec_updates[ocmmod.SPEC_ATTR_DISABLE_UWM] = (
+            current_spec.spec.disable_user_workload_monitoring
+        )
 
     if (
         current_spec.spec.provision_shard_id is not None
         and desired_spec.spec.provision_shard_id != current_spec.spec.provision_shard_id
     ):
-        ocm_spec_updates[
-            ocmmod.SPEC_ATTR_PROVISION_SHARD_ID
-        ] = current_spec.spec.provision_shard_id
+        ocm_spec_updates[ocmmod.SPEC_ATTR_PROVISION_SHARD_ID] = (
+            current_spec.spec.provision_shard_id
+        )
 
     if isinstance(current_spec.spec, ROSAClusterSpec) and isinstance(
         desired_spec.spec, ROSAClusterSpec
@@ -183,9 +183,9 @@ def get_app_interface_spec_updates(
             and desired_spec.spec.oidc_endpoint_url
             != current_spec.spec.oidc_endpoint_url
         ):
-            ocm_spec_updates[
-                ocmmod.SPEC_ATTR_OIDC_ENDPONT_URL
-            ] = current_spec.spec.oidc_endpoint_url
+            ocm_spec_updates[ocmmod.SPEC_ATTR_OIDC_ENDPONT_URL] = (
+                current_spec.spec.oidc_endpoint_url
+            )
 
     if current_spec.server_url and desired_spec.server_url != current_spec.server_url:
         root_updates[ocmmod.SPEC_ATTR_SERVER_URL] = current_spec.server_url

--- a/reconcile/ocm_github_idp.py
+++ b/reconcile/ocm_github_idp.py
@@ -63,7 +63,7 @@ def fetch_desired_state(clusters, vault_input_path, settings):
 
 
 def sanitize(state):
-    return {k: v for k, v in state.items() if k not in ["client_secret", "id"]}
+    return {k: v for k, v in state.items() if k not in {"client_secret", "id"}}
 
 
 def act(dry_run, ocm_map, current_state, desired_state):

--- a/reconcile/ocm_groups.py
+++ b/reconcile/ocm_groups.py
@@ -85,7 +85,7 @@ def run(dry_run, thread_pool_size=10):
 
     for diff in diffs:
         # we do not need to create/delete groups in OCM
-        if diff["action"] in ["create_group", "delete_group"]:
+        if diff["action"] in {"create_group", "delete_group"}:
             continue
         logging.info(list(diff.values()))
 

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -416,7 +416,7 @@ def apply(
         except FieldIsImmutableError:
             # Add more resources types to the list when you're
             # sure they're safe.
-            if resource_type not in ["Route", "Service", "Secret"]:
+            if resource_type not in {"Route", "Service", "Secret"}:
                 raise
             oc.delete(namespace=namespace, kind=resource_type, name=resource.name)
             oc.apply(namespace=namespace, resource=annotated)
@@ -470,7 +470,7 @@ def apply(
                 obsolete_rs["metadata"]["ownerReferences"] = owner_references
                 oc.apply(namespace=namespace, resource=OR(obsolete_rs, "", ""))
         except (MayNotChangeOnceSetError, PrimaryClusterIPCanNotBeUnsetError):
-            if resource_type not in ["Service"]:
+            if resource_type not in {"Service"}:
                 raise
 
             oc.delete(namespace=namespace, kind=resource_type, name=resource.name)
@@ -1075,10 +1075,10 @@ def _validate_resources_used_exist(
                 )
                 # we found one! does it's value (secret name) match the
                 # using resource's?
-                if used_name in (
+                if used_name in {
                     serving_cert_alpha_secret_name,
                     serving_cert_beta_secret_name,
-                ):
+                }:
                     # found a match. we assume the serving cert secret will
                     # be present at some point soon after the Service is deployed
                     resource = service
@@ -1115,7 +1115,7 @@ def validate_planned_data(ri: ResourceInventory, oc_map: ClusterMap) -> None:
         oc = oc_map.get_cluster(cluster)
 
         for name, d_item in data["desired"].items():
-            if kind in ("Deployment", "DeploymentConfig"):
+            if kind in {"Deployment", "DeploymentConfig"}:
                 spec = d_item.body["spec"]["template"]["spec"]
                 _validate_resources_used_exist(
                     ri, oc, spec, cluster, namespace, kind, name, "Secret"
@@ -1162,7 +1162,7 @@ def validate_realized_data(actions: Iterable[dict[str, str]], oc_map: ClusterMap
             if not status:
                 raise ValidationError("status")
             # add elif to validate additional resource kinds
-            if kind in ["Deployment", "DeploymentConfig", "StatefulSet"]:
+            if kind in {"Deployment", "DeploymentConfig", "StatefulSet"}:
                 desired_replicas = resource["spec"]["replicas"]
                 if desired_replicas == 0:
                     continue

--- a/reconcile/openshift_clusterrolebindings.py
+++ b/reconcile/openshift_clusterrolebindings.py
@@ -89,7 +89,7 @@ def fetch_desired_state(ri, oc_map):
         permissions = [
             {"cluster": a["cluster"], "cluster_role": a["clusterRole"]}
             for a in role["access"] or []
-            if None not in [a["cluster"], a["clusterRole"]]
+            if None not in {a["cluster"], a["clusterRole"]}
         ]
         if not permissions:
             continue

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -233,7 +233,7 @@ def validate_diffs(diffs: Iterable[Mapping[str, Optional[str]]]) -> None:
 
 
 def sort_diffs(diff: Mapping[str, Optional[str]]) -> int:
-    if diff["action"] in ["create_group", "del_user_from_group"]:
+    if diff["action"] in {"create_group", "del_user_from_group"}:
         return 1
     return 2
 

--- a/reconcile/openshift_namespace_labels.py
+++ b/reconcile/openshift_namespace_labels.py
@@ -182,18 +182,18 @@ class LabelInventory:
                     if k not in managed:
                         self.update_managed_keys(cluster, ns, k)
                     changed[k] = v
-                else:  # k in current:
-                    if k not in managed:  # conflicting labels
-                        self.add_error(
-                            cluster,
-                            ns,
-                            "Label conflict:"
-                            + f"desired {k}={v} vs "
-                            + f"current {k}={current[k]}",
-                        )
-                    else:
-                        if v != current[k]:
-                            changed[k] = v
+
+                elif k not in managed:  # conflicting labels
+                    self.add_error(
+                        cluster,
+                        ns,
+                        "Label conflict:"
+                        + f"desired {k}={v} vs "
+                        + f"current {k}={current[k]}",
+                    )
+
+                elif v != current[k]:
+                    changed[k] = v
 
             # remove old labels
             for k, v in current.items():

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -539,9 +539,9 @@ def fetch_provider_resource(
                         if not annotations:
                             continue
                         # TODO(mafriedm): make this better
-                        rule["annotations"][
-                            "html_url"
-                        ] = f"{APP_INT_BASE_URL}/blob/master/resources{path}"
+                        rule["annotations"]["html_url"] = (
+                            f"{APP_INT_BASE_URL}/blob/master/resources{path}"
+                        )
             except Exception:
                 logging.warning(
                     "could not add html_url annotation to" + body["metadata"]["name"]

--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -97,7 +97,7 @@ def fetch_desired_state(ri, oc_map, enforced_user_keys=None):
                 "role": a["role"],
             }
             for a in role["access"] or []
-            if None not in [a["namespace"], a["role"]]
+            if None not in {a["namespace"], a["role"]}
             and a["namespace"].get("managedRoles")
             and not ob.is_namespace_deleted(a["namespace"])
         ]

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -316,7 +316,7 @@ def run(
         emails = " ".join([o.email for o in owners])
         file, url = saasherder.get_archive_info(saas_file, trigger_reason)
         sast_file = os.path.join(io_dir, "sast")
-        with open(sast_file, "w") as f:
+        with open(sast_file, "w", encoding="locale") as f:
             f.write(file + "\n")
             f.write(url + "\n")
             f.write(emails + "\n")

--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -349,7 +349,7 @@ class QuayMirror:
     @staticmethod
     def check_compare_tags_elapsed_time(path, interval) -> bool:
         try:
-            with open(path, "r") as file_obj:
+            with open(path, "r", encoding="locale") as file_obj:
                 last_compare_tags = float(file_obj.read())
         except FileNotFoundError:
             return True
@@ -362,7 +362,7 @@ class QuayMirror:
 
     @staticmethod
     def record_timestamp(path) -> None:
-        with open(path, "w") as file_object:
+        with open(path, "w", encoding="locale") as file_object:
             file_object.write(str(time.time()))
 
     def _get_push_creds(self):

--- a/reconcile/rhidp/common.py
+++ b/reconcile/rhidp/common.py
@@ -66,10 +66,10 @@ class ClusterAuth(BaseModel):
 
     @property
     def oidc_enabled(self) -> bool:
-        return self.status not in (
+        return self.status not in {
             StatusValue.DISABLED.value,
             StatusValue.RHIDP_ONLY.value,
-        )
+        }
 
     @property
     def enforced(self) -> bool:

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
@@ -237,10 +237,10 @@ class MergeRequestManager:
             for sub in subs:
                 if sub.target_file_path not in content_by_path:
                     try:
-                        content_by_path[
-                            sub.target_file_path
-                        ] = self._vcs.get_file_content_from_app_interface_master(
-                            file_path=sub.target_file_path
+                        content_by_path[sub.target_file_path] = (
+                            self._vcs.get_file_content_from_app_interface_master(
+                                file_path=sub.target_file_path
+                            )
                         )
                     except GitlabGetError as e:
                         if e.response_code == 404:
@@ -251,11 +251,11 @@ class MergeRequestManager:
                             has_error = True
                             break
                         raise e
-                content_by_path[
-                    sub.target_file_path
-                ] = self._renderer.render_merge_request_content(
-                    subscriber=sub,
-                    current_content=content_by_path[sub.target_file_path],
+                content_by_path[sub.target_file_path] = (
+                    self._renderer.render_merge_request_content(
+                        subscriber=sub,
+                        current_content=content_by_path[sub.target_file_path],
+                    )
                 )
             if has_error:
                 continue

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -114,7 +114,7 @@ class State(BaseModel):
     usergroup_id: Optional[str] = None
 
     def __bool__(self) -> bool:
-        return self.workspace != ""
+        return self.workspace != ""  # noqa: PLC1901
 
 
 SlackState = dict[str, dict[str, State]]

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -235,7 +235,7 @@ def get_usernames_from_pagerduty(
     pagerduty_map: PagerDutyMap,
 ) -> list[str]:
     """Return list of usernames from all pagerduties."""
-    global error_occurred
+    global error_occurred  # noqa: PLW0603
     all_output_usernames = []
     all_pagerduty_names = [get_pagerduty_name(u) for u in users]
     for pagerduty in pagerduties:
@@ -544,7 +544,7 @@ def _create_usergroups(
     dry_run: bool = True,
 ) -> None:
     """Create Slack usergroups."""
-    global error_occurred
+    global error_occurred  # noqa: PLW0603
     if current_ug_state:
         logging.debug(
             f"[{desired_ug_state.workspace}] Usergroup exists and will not be created {desired_ug_state.usergroup}"
@@ -572,7 +572,7 @@ def _update_usergroup_users_from_state(
     dry_run: bool = True,
 ) -> None:
     """Update the users in a Slack usergroup."""
-    global error_occurred
+    global error_occurred  # noqa: PLW0603
     if current_ug_state.users == desired_ug_state.users:
         logging.debug(
             f"No usergroup user changes detected for {desired_ug_state.usergroup}"
@@ -622,7 +622,7 @@ def _update_usergroup_from_state(
     dry_run: bool = True,
 ) -> None:
     """Update a Slack usergroup."""
-    global error_occurred
+    global error_occurred  # noqa: PLW0603
     if (
         current_ug_state.channels == desired_ug_state.channels
         and current_ug_state.description == desired_ug_state.description
@@ -735,7 +735,7 @@ def run(
     workspace_name: Optional[str] = None,
     usergroup_name: Optional[str] = None,
 ) -> None:
-    global error_occurred
+    global error_occurred  # noqa: PLW0603
     error_occurred = False
 
     gqlapi = gql.get_api()

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -477,9 +477,9 @@ def get_desired_state_cluster_usergroups(
 ) -> SlackState:
     """Get the desired state of Slack usergroups."""
     desired_state: SlackState = {}
-    openshift_users_desired_state: list[
-        dict[str, str]
-    ] = openshift_users.fetch_desired_state(oc_map=None)
+    openshift_users_desired_state: list[dict[str, str]] = (
+        openshift_users.fetch_desired_state(oc_map=None)
+    )
     for cluster in clusters:
         if not integration_is_enabled(QONTRACT_INTEGRATION, cluster):
             logging.debug(

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -356,7 +356,7 @@ def make_mysql_command(sqlqueries_file: str) -> str:
 
 
 def make_output_cmd(output: str, recipient: str) -> str:
-    if output in ("filesystem", "encrypted"):
+    if output in {"filesystem", "encrypted"}:
         command = filesystem_redir_stdout()
     else:
         # stdout

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -681,10 +681,9 @@ def _get_query_status(
         # CronJob
         if query.get("delete"):
             return QueryStatus.PENDING_DELETION
-    else:
+    elif time.time() >= query_state + JOB_TTL:
         # Job
-        if time.time() >= query_state + JOB_TTL:
-            return QueryStatus.PENDING_DELETION
+        return QueryStatus.PENDING_DELETION
     return QueryStatus.ACTIVE
 
 

--- a/reconcile/terraform_aws_route53.py
+++ b/reconcile/terraform_aws_route53.py
@@ -87,7 +87,7 @@ def build_desired_state(
                 # get_a_record is used here to validate the record and reused later
                 target_cluster_elb_value = dnsutils.get_a_records(target_cluster_elb)
 
-                if target_cluster_elb is None or target_cluster_elb == "":
+                if not target_cluster_elb:
                     msg = (
                         f"{zone_name}: field `_target_cluster` for record "
                         f"{record_name} of type {record_type} points to a "

--- a/reconcile/terraform_cloudflare_users.py
+++ b/reconcile/terraform_cloudflare_users.py
@@ -304,13 +304,13 @@ def get_cloudflare_users(
                                 user.cloudflare_user
                             ].roles.update(set(cf_role.roles))
                         else:
-                            users[cf_role.account.name][
-                                user.cloudflare_user
-                            ] = CloudflareUser(
-                                user.cloudflare_user,
-                                cf_role.account.name,
-                                user.org_username,
-                                set(cf_role.roles),
+                            users[cf_role.account.name][user.cloudflare_user] = (
+                                CloudflareUser(
+                                    user.cloudflare_user,
+                                    cf_role.account.name,
+                                    user.org_username,
+                                    set(cf_role.roles),
+                                )
                             )
 
                     else:

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -166,7 +166,9 @@ class TerraformRepoIntegration(
 
         if self.params.output_file:
             try:
-                with open(self.params.output_file, "w") as output_file:
+                with open(
+                    self.params.output_file, "w", encoding="locale"
+                ) as output_file:
                     yaml.safe_dump(
                         data=output.dict(),
                         stream=output_file,

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -298,10 +298,10 @@ def build_desired_state_vpc_mesh_single_cluster(
         if provided_assume_role:
             account["assume_role"] = provided_assume_role
         elif ocm is not None:
-            account[
-                "assume_role"
-            ] = ocm.get_aws_infrastructure_access_terraform_assume_role(
-                cluster, account["uid"], account["terraformUsername"]
+            account["assume_role"] = (
+                ocm.get_aws_infrastructure_access_terraform_assume_role(
+                    cluster, account["uid"], account["terraformUsername"]
+                )
             )
         account["assume_region"] = requester["region"]
         account["assume_cidr"] = requester["cidr_block"]
@@ -418,12 +418,12 @@ def build_desired_state_vpc_single_cluster(
         if provided_assume_role:
             account["assume_role"] = provided_assume_role
         elif ocm is not None:
-            account[
-                "assume_role"
-            ] = ocm.get_aws_infrastructure_access_terraform_assume_role(
-                cluster,
-                peer_vpc["account"]["uid"],
-                peer_vpc["account"]["terraformUsername"],
+            account["assume_role"] = (
+                ocm.get_aws_infrastructure_access_terraform_assume_role(
+                    cluster,
+                    peer_vpc["account"]["uid"],
+                    peer_vpc["account"]["terraformUsername"],
+                )
             )
         else:
             raise KeyError(

--- a/reconcile/test/fixtures.py
+++ b/reconcile/test/fixtures.py
@@ -14,7 +14,7 @@ class Fixtures:
         )
 
     def get(self, fixture):
-        with open(self.path(fixture), "r") as f:
+        with open(self.path(fixture), "r", encoding="locale") as f:
             return f.read().strip()
 
     def get_anymarkup(self, fixture):

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/renderer/conftest.py
@@ -30,10 +30,10 @@ def file_contents() -> Callable[[str], tuple[str, str]]:
             "files",
         )
 
-        with open(f"{path}/{case}.yml", "r") as f:
+        with open(f"{path}/{case}.yml", "r", encoding="locale") as f:
             a = f.read().strip()
 
-        with open(f"{path}/{case}.result.yml", "r") as f:
+        with open(f"{path}/{case}.result.yml", "r", encoding="locale") as f:
             b = f.read().strip()
 
         return (a, b)

--- a/reconcile/test/test_jump_host.py
+++ b/reconcile/test/test_jump_host.py
@@ -55,7 +55,7 @@ def test_base_jumphost(fs: Any, parameters: JumphostParameters, expected_port: i
     jumphost = JumpHostBase(parameters=parameters)
     assert os.path.exists(jumphost._identity_file)
 
-    with open(jumphost._identity_file, "r") as f:
+    with open(jumphost._identity_file, "r", encoding="locale") as f:
         assert f.read() == parameters.key
 
     assert jumphost._port == expected_port
@@ -113,5 +113,5 @@ def test_ssh_jumphost(
     if local_port:
         assert jumphost._local_port == local_port
 
-    with open(known_hosts_file, "r") as f:
+    with open(known_hosts_file, "r", encoding="locale") as f:
         assert f.read() == EXPECTED_KNOWN_HOSTS_CONTENT

--- a/reconcile/test/test_quay_mirror.py
+++ b/reconcile/test/test_quay_mirror.py
@@ -51,7 +51,9 @@ class TestIsCompareTags:
         self.tmp_dir = (
             tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
         )
-        with open(os.path.join(self.tmp_dir.name, CONTROL_FILE_NAME), "w") as fh:
+        with open(
+            os.path.join(self.tmp_dir.name, CONTROL_FILE_NAME), "w", encoding="locale"
+        ) as fh:
             fh.write(str(NOW - 100.0))
 
     def teardown_method(self):

--- a/reconcile/test/test_quay_mirror_org.py
+++ b/reconcile/test/test_quay_mirror_org.py
@@ -33,7 +33,9 @@ class TestIsCompareTags:
         self.tmp_dir = (
             tempfile.TemporaryDirectory()  # pylint: disable=consider-using-with
         )
-        with open(os.path.join(self.tmp_dir.name, CONTROL_FILE_NAME), "w") as fh:
+        with open(
+            os.path.join(self.tmp_dir.name, CONTROL_FILE_NAME), "w", encoding="locale"
+        ) as fh:
             fh.write(str(NOW - 100.0))
 
     def teardown_method(self):

--- a/reconcile/test/test_terraform_repo.py
+++ b/reconcile/test/test_terraform_repo.py
@@ -339,7 +339,7 @@ def test_output_correct_statefile(
     assert diff
     integration.print_output(diff, True)
 
-    with open(f"{tmp_path}/tf-repo.yaml", "r") as output:
+    with open(f"{tmp_path}/tf-repo.yaml", "r", encoding="locale") as output:
         yaml_rep = yaml.safe_load(output)
 
         assert expected_output == yaml_rep
@@ -366,7 +366,7 @@ def test_output_correct_no_statefile(
     assert diff
     integration.print_output(diff, True)
 
-    with open(f"{tmp_path}/tf-repo.yaml", "r") as output:
+    with open(f"{tmp_path}/tf-repo.yaml", "r", encoding="locale") as output:
         yaml_rep = yaml.safe_load(output)
 
         assert expected_output == yaml_rep

--- a/reconcile/test/utils/test_external_resources.py
+++ b/reconcile/test/utils/test_external_resources.py
@@ -254,24 +254,24 @@ def test_resource_value_resolver_overrides_and_defaults(mocker):
 
 def test_get_inventory_count_combinations():
     inventory: ExternalResourceSpecInventory = {}
-    inventory[
-        ExternalResourceUniqueKey("pp1", "pn1", "id1", "rds")
-    ] = ExternalResourceSpec("pp1", {}, {}, {})
-    inventory[
-        ExternalResourceUniqueKey("pp1", "pn1", "id2", "rds")
-    ] = ExternalResourceSpec("pp1", {}, {}, {})
-    inventory[
-        ExternalResourceUniqueKey("pp2", "pn2", "id3", "rds")
-    ] = ExternalResourceSpec("pp2", {}, {}, {})
-    inventory[
-        ExternalResourceUniqueKey("pp2", "pn3", "id4", "s3")
-    ] = ExternalResourceSpec("pp2", {}, {}, {})
-    inventory[
-        ExternalResourceUniqueKey("pp3", "pn4", "id5", "s3")
-    ] = ExternalResourceSpec("pp3", {}, {}, {})
-    inventory[
-        ExternalResourceUniqueKey("pp3", "pn4", "id6", "asg")
-    ] = ExternalResourceSpec("pp3", {}, {}, {})
+    inventory[ExternalResourceUniqueKey("pp1", "pn1", "id1", "rds")] = (
+        ExternalResourceSpec("pp1", {}, {}, {})
+    )
+    inventory[ExternalResourceUniqueKey("pp1", "pn1", "id2", "rds")] = (
+        ExternalResourceSpec("pp1", {}, {}, {})
+    )
+    inventory[ExternalResourceUniqueKey("pp2", "pn2", "id3", "rds")] = (
+        ExternalResourceSpec("pp2", {}, {}, {})
+    )
+    inventory[ExternalResourceUniqueKey("pp2", "pn3", "id4", "s3")] = (
+        ExternalResourceSpec("pp2", {}, {}, {})
+    )
+    inventory[ExternalResourceUniqueKey("pp3", "pn4", "id5", "s3")] = (
+        ExternalResourceSpec("pp3", {}, {}, {})
+    )
+    inventory[ExternalResourceUniqueKey("pp3", "pn4", "id6", "asg")] = (
+        ExternalResourceSpec("pp3", {}, {}, {})
+    )
 
     count_combinations = uer.get_inventory_count_combinations(inventory)
     expected_count_combinations = Counter({

--- a/reconcile/test/utils/test_lean_terraform_client.py
+++ b/reconcile/test/utils/test_lean_terraform_client.py
@@ -172,7 +172,7 @@ def test_show_json(mocker: MockerFixture) -> None:
 
 def test_terraform_component() -> None:
     with tempfile.TemporaryDirectory() as working_dir:
-        with open(os.path.join(working_dir, "main.tf"), "w"):
+        with open(os.path.join(working_dir, "main.tf"), "w", encoding="locale"):
             pass
         assert lean_terraform_client.init(working_dir)[0] == 0
         assert lean_terraform_client.output(working_dir)[0] == 0

--- a/reconcile/test/utils/test_terrascript_cloudflare_client.py
+++ b/reconcile/test/utils/test_terrascript_cloudflare_client.py
@@ -374,7 +374,9 @@ def test_terrascript_cloudflare_client_dump(mocker):
     cloudflare_client.dump()
 
     patch_mkdtemp.assert_called_once()
-    mock_builtins_open.assert_called_once_with("/tmp/test/config.tf.json", "w")
+    mock_builtins_open.assert_called_once_with(
+        "/tmp/test/config.tf.json", "w", encoding="locale"
+    )
     mock_builtins_open.return_value.write.assert_called_once_with("some data")
 
 
@@ -396,7 +398,9 @@ def test_terrascript_cloudflare_client_dump_existing_dir(mocker):
     cloudflare_client.dump(existing_dir="/tmp/existing-dir")
 
     patch_mkdtemp.assert_not_called()
-    mock_builtins_open.assert_called_once_with("/tmp/existing-dir/config.tf.json", "w")
+    mock_builtins_open.assert_called_once_with(
+        "/tmp/existing-dir/config.tf.json", "w", encoding="locale"
+    )
     mock_builtins_open.return_value.write.assert_called_once_with("some data")
 
 

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -95,9 +95,9 @@ class SaasResourceTemplate(ConfiguredBaseModel):
     provider: Optional[str] = Field(..., alias="provider")
     hash_length: Optional[int] = Field(..., alias="hash_length")
     parameters: Optional[Json] = Field(..., alias="parameters")
-    secret_parameters: Optional[
-        list[SaasResourceTemplateV2_SaasSecretParametersV1]
-    ] = Field(..., alias="secretParameters")
+    secret_parameters: Optional[list[SaasResourceTemplateV2_SaasSecretParametersV1]] = (
+        Field(..., alias="secretParameters")
+    )
     targets: list[SaasResourceTemplateTarget] = Field(..., alias="targets")
 
 

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -308,7 +308,7 @@ class SaasFileList:
 def convert_parameters_to_json_string(root: dict[str, Any]) -> dict[str, Any]:
     """Find all parameter occurrences and convert them to a json string."""
     for key, value in root.items():
-        if key in ["parameters", "labels"]:
+        if key in {"parameters", "labels"}:
             root[key] = json.dumps(value) if value is not None else None
         elif isinstance(value, dict):
             root[key] = convert_parameters_to_json_string(value)

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -279,7 +279,7 @@ class SaasFileList:
         if name is None and env_name is None and app_name is None:
             return self.saas_files
 
-        if name == "" or env_name == "" or app_name == "":
+        if name == "" or env_name == "" or app_name == "":  # noqa: PLC1901
             return []
 
         filtered: list[SaasFile] = []

--- a/reconcile/utils/amtool.py
+++ b/reconcile/utils/amtool.py
@@ -25,7 +25,7 @@ class AmtoolResult:
 def check_config(yaml_config: str) -> AmtoolResult:
     """Run amtool check rules on the given yaml string"""
 
-    with tempfile.NamedTemporaryFile(mode="w+") as fp:
+    with tempfile.NamedTemporaryFile(mode="w+", encoding="locale") as fp:
         fp.write(yaml_config)
         fp.flush()
         cmd = ["amtool", "check-config", fp.name]
@@ -36,7 +36,7 @@ def check_config(yaml_config: str) -> AmtoolResult:
 
 def config_routes_test(yaml_config: str, labels: Mapping[str, str]) -> AmtoolResult:
     labels_lst = [f"{key}={value}" for key, value in labels.items()]
-    with tempfile.NamedTemporaryFile(mode="w+") as fp:
+    with tempfile.NamedTemporaryFile(mode="w+", encoding="locale") as fp:
         fp.write(yaml_config)
         fp.flush()
         cmd = ["amtool", "config", "routes", "test", "--config.file", fp.name]

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -58,37 +58,13 @@ if TYPE_CHECKING:
         ResourceRecordTypeDef,
     )
 else:
-    EC2Client = (
-        EC2ServiceResource
-    ) = (
-        RouteTableTypeDef
-    ) = (
-        SubnetTypeDef
-    ) = (
+    EC2Client = EC2ServiceResource = RouteTableTypeDef = SubnetTypeDef = (
         TransitGatewayTypeDef
-    ) = (
-        TransitGatewayVpcAttachmentTypeDef
-    ) = (
-        VpcTypeDef
-    ) = (
-        IAMClient
-    ) = (
+    ) = TransitGatewayVpcAttachmentTypeDef = VpcTypeDef = IAMClient = (
         AccessKeyMetadataTypeDef
-    ) = (
-        ImageTypeDef
-    ) = (
-        TagTypeDef
-    ) = (
-        LaunchPermissionModificationsTypeDef
-    ) = (
+    ) = ImageTypeDef = TagTypeDef = LaunchPermissionModificationsTypeDef = (
         FilterTypeDef
-    ) = (
-        Route53Client
-    ) = (
-        ResourceRecordSetTypeDef
-    ) = (
-        ResourceRecordTypeDef
-    ) = (
+    ) = Route53Client = ResourceRecordSetTypeDef = ResourceRecordTypeDef = (
         HostedZoneTypeDef
     ) = RDSClient = DBInstanceMessageTypeDef = UpgradeTargetTypeDef = object
 

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -866,7 +866,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         self, account_name: str, assume_role: str, assume_region: str, client_type="ec2"
     ) -> EC2Client:
         session = self.get_session(account_name)
-        if assume_role == "":
+        if not assume_role:
             return self.get_session_client(
                 session, client_type, region_name=assume_region
             )

--- a/reconcile/utils/config.py
+++ b/reconcile/utils/config.py
@@ -16,7 +16,7 @@ def get_config():
 
 
 def init(config):
-    global _config
+    global _config  # noqa: PLW0603
     _config = config
     return _config
 

--- a/reconcile/utils/config.py
+++ b/reconcile/utils/config.py
@@ -12,7 +12,6 @@ class SecretNotFound(Exception):
 
 
 def get_config():
-    global _config
     return _config
 
 

--- a/reconcile/utils/environ.py
+++ b/reconcile/utils/environ.py
@@ -11,7 +11,7 @@ def environ(variables=None):
         @wraps(f)
         def f_environ(*args, **kwargs):
             for e in variables:
-                if e not in os.environ or os.environ[e] == "":
+                if not os.environ.get(e):
                     raise KeyError("Could not find environment variable: {}".format(e))
             f(*args, **kwargs)
 

--- a/reconcile/utils/git.py
+++ b/reconcile/utils/git.py
@@ -9,7 +9,9 @@ class GitError(Exception):
 def clone(repo_url, wd):
     # pylint: disable=subprocess-run-check
     cmd = ["git", "clone", repo_url, wd]
-    result = subprocess.run(cmd, cwd=wd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result = subprocess.run(
+        cmd, cwd=wd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+    )
     if result.returncode != 0:
         raise GitError(f"git clone failed: {repo_url}")
 
@@ -17,7 +19,9 @@ def clone(repo_url, wd):
 def checkout(commit, wd):
     # pylint: disable=subprocess-run-check
     cmd = ["git", "checkout", commit]
-    result = subprocess.run(cmd, cwd=wd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    result = subprocess.run(
+        cmd, cwd=wd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
+    )
     if result.returncode != 0:
         raise GitError(f"git checkout failed: {commit}")
 
@@ -28,7 +32,7 @@ def is_file_in_git_repo(file_path):
     # pylint: disable=subprocess-run-check
     cmd = ["git", "rev-parse", "--is-inside-work-tree"]
     result = subprocess.run(
-        cmd, cwd=dir_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        cmd, cwd=dir_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
     )
     return result.returncode == 0
 

--- a/reconcile/utils/git_secrets.py
+++ b/reconcile/utils/git_secrets.py
@@ -38,7 +38,7 @@ def scan_history(repo_url, existing_keys):
 def get_suspected_files(error):
     suspects = []
     for e in error.split("\n"):
-        if e == "":
+        if not e:
             break
         if e.startswith("warning"):
             continue

--- a/reconcile/utils/git_secrets.py
+++ b/reconcile/utils/git_secrets.py
@@ -55,7 +55,7 @@ def get_leaked_keys(repo_wd, suspected_files, existing_keys):
         commit, file_relative_path = s[0], s[1]
         git.checkout(commit, repo_wd)
         file_path = os.path.join(repo_wd, file_relative_path)
-        with open(file_path, "r") as f:
+        with open(file_path, "r", encoding="locale") as f:
             content = f.read()
         leaked_keys = [key for key in existing_keys if key in content]
         all_leaked_keys.extend(leaked_keys)

--- a/reconcile/utils/helm.py
+++ b/reconcile/utils/helm.py
@@ -25,7 +25,7 @@ class JSONEncoder(json.JSONEncoder):
 
 def template(values: Mapping[str, Any]) -> Mapping[str, Any]:
     try:
-        with tempfile.NamedTemporaryFile(mode="w+") as values_file:
+        with tempfile.NamedTemporaryFile(mode="w+", encoding="locale") as values_file:
             values_file.write(json.dumps(values, cls=JSONEncoder))
             values_file.flush()
             cmd = [

--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -64,7 +64,7 @@ class JJB:  # pylint: disable=too-many-public-methods
                 ini = ini.replace('"', "")
                 ini = ini.replace("false", "False")
             ini_file_path = "{}/{}.ini".format(wd, name)
-            with open(ini_file_path, "w") as f:
+            with open(ini_file_path, "w", encoding="locale") as f:
                 f.write(ini)
                 f.write("\n")
             working_dirs[name] = wd
@@ -81,12 +81,12 @@ class JJB:  # pylint: disable=too-many-public-methods
                 if c["type"] == "jobs":
                     for item in content:
                         item["project"]["app_name"] = c["app"]["name"]
-                with open(config_file_path, "a") as f:
+                with open(config_file_path, "a", encoding="locale") as f:
                     yaml.dump(content, f)
                     f.write("\n")
             else:
                 config = c["config_path"]["content"]
-                with open(config_file_path, "a") as f:
+                with open(config_file_path, "a", encoding="locale") as f:
                     f.write(config)
                     f.write("\n")
 
@@ -100,7 +100,7 @@ class JJB:  # pylint: disable=too-many-public-methods
         the supplied configs"""
         for name, wd in self.working_dirs.items():
             config_path = "{}/config.yaml".format(wd)
-            with open(config_path, "w") as f:
+            with open(config_path, "w", encoding="locale") as f:
                 f.write(configs[name])
 
     def sort(self, configs):
@@ -136,7 +136,7 @@ class JJB:  # pylint: disable=too-many-public-methods
         configs = {}
         for name, wd in self.working_dirs.items():
             config_path = "{}/config.yaml".format(wd)
-            with open(config_path, "r") as f:
+            with open(config_path, "r", encoding="locale") as f:
                 configs[name] = f.read()
 
         return configs
@@ -196,7 +196,7 @@ class JJB:  # pylint: disable=too-many-public-methods
             logging.info([action, item_type, instance, item])
 
             if action == "update":
-                with open(ft) as c, open(f) as d:
+                with open(ft, encoding="locale") as c, open(f, encoding="locale") as d:
                     clines = c.readlines()
                     dlines = d.readlines()
 

--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -247,7 +247,7 @@ class JJB:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     def get_jjb(args):
-        from jenkins_jobs.cli.entry import JenkinsJobs
+        from jenkins_jobs.cli.entry import JenkinsJobs  # noqa: PLC0415
 
         return JenkinsJobs(args)
 

--- a/reconcile/utils/jump_host.py
+++ b/reconcile/utils/jump_host.py
@@ -45,7 +45,7 @@ class JumpHostBase:
         self._identity_dir = tempfile.mkdtemp()
 
         identity_file = self._identity_dir + "/id"
-        with open(identity_file, "w") as f:
+        with open(identity_file, "w", encoding="locale") as f:
             f.write(self._identity)
         os.chmod(identity_file, 0o600)
         self._identity_file = identity_file
@@ -96,7 +96,7 @@ class JumpHostSSH(JumpHostBase):
 
     def _init_known_hosts_file(self) -> None:
         known_hosts_file = self._identity_dir + "/known_hosts"
-        with open(known_hosts_file, "w") as f:
+        with open(known_hosts_file, "w", encoding="locale") as f:
             f.write(self._known_hosts)
         os.chmod(known_hosts_file, 0o600)
         self.known_hosts_file = known_hosts_file

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -187,9 +187,9 @@ class MetricsContainer:
         self._gauges: dict[Type[GaugeMetric], dict[Sequence[str], float]] = defaultdict(
             dict
         )
-        self._counters: dict[
-            Type[CounterMetric], dict[Sequence[str], float]
-        ] = defaultdict(dict)
+        self._counters: dict[Type[CounterMetric], dict[Sequence[str], float]] = (
+            defaultdict(dict)
+        )
 
         self._scopes: dict[Hashable, MetricsContainer] = {}
 

--- a/reconcile/utils/models.py
+++ b/reconcile/utils/models.py
@@ -29,56 +29,52 @@ def data_default_none(
             # Settings defaults
             if field.allow_none:
                 data[field.alias] = None
-            else:
-                if isinstance(field.type_, type) and issubclass(field.type_, str):
-                    data[field.alias] = DEFAULT_STRING
-                elif isinstance(field.type_, type) and issubclass(field.type_, bool):
-                    data[field.alias] = False
-                elif isinstance(field.type_, type) and issubclass(field.type_, int):
-                    data[field.alias] = DEFAULT_INT
-        else:
-            if isinstance(field.type_, type) and issubclass(field.type_, BaseModel):
-                if isinstance(data[field.alias], dict):
-                    data[field.alias] = data_default_none(
-                        field.type_, data[field.alias]
-                    )
-                if isinstance(data[field.alias], list):
-                    data[field.alias] = [
-                        data_default_none(field.type_, item)
-                        for item in data[field.alias]
-                        if isinstance(item, dict)
-                    ]
-            elif field.sub_fields:
-                if all(
-                    isinstance(sub_field.type_, type)
-                    and issubclass(sub_field.type_, BaseModel)
-                    for sub_field in field.sub_fields
-                ):
-                    # Union[ClassA, ClassB] field
-                    for sub_field in field.sub_fields:
-                        if isinstance(data[field.alias], dict):
-                            try:
-                                d = dict(data[field.alias])
-                                d.update(data_default_none(sub_field.type_, d))
-                                # Lets confirm we found a matching union class
-                                sub_field.type_(**d)
-                                data[field.alias] = d
-                                break
-                            except ValidationError:
-                                continue
-                elif isinstance(data[field.alias], list) and len(field.sub_fields) == 1:
-                    # list[Union[ClassA, ClassB]] field
-                    for sub_data in data[field.alias]:
-                        for sub_field in field.sub_fields[0].sub_fields or []:
-                            try:
-                                d = dict(sub_data)
-                                d.update(data_default_none(sub_field.type_, d))
-                                # Lets confirm we found a matching union class
-                                sub_field.type_(**d)
-                                sub_data.update(d)
-                                break
-                            except ValidationError:
-                                continue
+            elif isinstance(field.type_, type) and issubclass(field.type_, str):
+                data[field.alias] = DEFAULT_STRING
+            elif isinstance(field.type_, type) and issubclass(field.type_, bool):
+                data[field.alias] = False
+            elif isinstance(field.type_, type) and issubclass(field.type_, int):
+                data[field.alias] = DEFAULT_INT
+        elif isinstance(field.type_, type) and issubclass(field.type_, BaseModel):
+            if isinstance(data[field.alias], dict):
+                data[field.alias] = data_default_none(field.type_, data[field.alias])
+            if isinstance(data[field.alias], list):
+                data[field.alias] = [
+                    data_default_none(field.type_, item)
+                    for item in data[field.alias]
+                    if isinstance(item, dict)
+                ]
+        elif field.sub_fields:
+            if all(
+                isinstance(sub_field.type_, type)
+                and issubclass(sub_field.type_, BaseModel)
+                for sub_field in field.sub_fields
+            ):
+                # Union[ClassA, ClassB] field
+                for sub_field in field.sub_fields:
+                    if isinstance(data[field.alias], dict):
+                        try:
+                            d = dict(data[field.alias])
+                            d.update(data_default_none(sub_field.type_, d))
+                            # Lets confirm we found a matching union class
+                            sub_field.type_(**d)
+                            data[field.alias] = d
+                            break
+                        except ValidationError:
+                            continue
+            elif isinstance(data[field.alias], list) and len(field.sub_fields) == 1:
+                # list[Union[ClassA, ClassB]] field
+                for sub_data in data[field.alias]:
+                    for sub_field in field.sub_fields[0].sub_fields or []:
+                        try:
+                            d = dict(sub_data)
+                            d.update(data_default_none(sub_field.type_, d))
+                            # Lets confirm we found a matching union class
+                            sub_field.type_(**d)
+                            sub_data.update(d)
+                            break
+                        except ValidationError:
+                            continue
 
     return data
 

--- a/reconcile/utils/models.py
+++ b/reconcile/utils/models.py
@@ -86,7 +86,7 @@ class CSV(list[str]):
     """
 
     @classmethod
-    def __get_validators__(cls) -> Generator[Callable, None, None]:
+    def __get_validators__(cls) -> Generator[Callable, None, None]:  # noqa: PLW3201
         yield cls.validate
         yield cls.length_validator
 

--- a/reconcile/utils/mr/aws_access.py
+++ b/reconcile/utils/mr/aws_access.py
@@ -57,7 +57,7 @@ class CreateDeleteAwsAccessKey(MergeRequestBase):
         )
 
         # add a new email to be picked up by email-sender
-        with open(BODY_TEMPLATE) as file_obj:
+        with open(BODY_TEMPLATE, encoding="locale") as file_obj:
             body_template = Template(
                 file_obj.read(), keep_trailing_newline=True, trim_blocks=True
             )

--- a/reconcile/utils/mr/base.py
+++ b/reconcile/utils/mr/base.py
@@ -232,7 +232,7 @@ def app_interface_email(
     apps: Optional[list[str]] = None,
 ) -> str:
     """Render app-interface-email template."""
-    with open(EMAIL_TEMPLATE) as file_obj:
+    with open(EMAIL_TEMPLATE, encoding="locale") as file_obj:
         email_template = Template(
             file_obj.read(), keep_trailing_newline=True, trim_blocks=True
         )

--- a/reconcile/utils/mr/user_maintenance.py
+++ b/reconcile/utils/mr/user_maintenance.py
@@ -36,7 +36,7 @@ class CreateDeleteUserAppInterface(MergeRequestBase):
         for path_spec in self.paths:
             path_type = path_spec["type"]
             path = path_spec["path"]
-            if path_type in [PathTypes.USER, PathTypes.REQUEST, PathTypes.QUERY]:
+            if path_type in {PathTypes.USER, PathTypes.REQUEST, PathTypes.QUERY}:
                 gitlab_cli.delete_file(
                     branch_name=self.branch, file_path=path, commit_message=self.title
                 )

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1117,7 +1117,7 @@ class OCCli:  # pylint: disable=too-many-public-methods
             find = False
             for gv in self.api_resources[kind]:
                 if apigroup_override == gv.group:
-                    if gv.group == "":
+                    if not gv.group:
                         group_version = gv.api_version
                     else:
                         group_version = f"{gv.group}/{gv.api_version}"

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -382,7 +382,7 @@ class OCCli:  # pylint: disable=too-many-public-methods
 
         self.is_log_slow_oc_reconcile = os.environ.get(
             "LOG_SLOW_OC_RECONCILE", ""
-        ).lower() in ["true", "yes"]
+        ).lower() in {"true", "yes"}
 
     def _init(
         self,
@@ -454,7 +454,7 @@ class OCCli:  # pylint: disable=too-many-public-methods
 
         self.is_log_slow_oc_reconcile = os.environ.get(
             "LOG_SLOW_OC_RECONCILE", ""
-        ).lower() in ["true", "yes"]
+        ).lower() in {"true", "yes"}
 
     def whoami(self):
         return self._run(["whoami"])
@@ -719,7 +719,7 @@ class OCCli:  # pylint: disable=too-many-public-methods
         ready_pods = [
             pod
             for pod in pods
-            if pod["status"].get("phase") in ("Running", "Succeeded")
+            if pod["status"].get("phase") in {"Running", "Succeeded"}
         ]
 
         if not ready_pods:
@@ -983,7 +983,7 @@ class OCCli:  # pylint: disable=too-many-public-methods
         kind: str,
         include_optional: bool = True,
     ) -> dict[str, set[str]]:
-        if kind not in ("Secret", "ConfigMap"):
+        if kind not in {"Secret", "ConfigMap"}:
             raise KeyError(f"unsupported resource kind: {kind}")
         optional = "optional"
         if kind == "Secret":
@@ -1389,7 +1389,7 @@ class OC:
         use_native_env = os.environ.get("USE_NATIVE_CLIENT", "")
         use_native = True
         if len(use_native_env) > 0:
-            use_native = use_native_env.lower() in ["true", "yes"]
+            use_native = use_native_env.lower() in {"true", "yes"}
         else:
             enable_toggle = "openshift-resources-native-client"
             use_native = get_feature_toggle_state(
@@ -1756,7 +1756,7 @@ def validate_labels(labels: dict[str, str]) -> Iterable[str]:
                     f"Label key prefix is invalid, it needs to match "
                     f"'{k_prefix_pattern}'': {prefix}"
                 )
-            if prefix in ("kubernetes.io", "k8s.io"):
+            if prefix in {"kubernetes.io", "k8s.io"}:
                 err.append(f"Label key prefix is reserved: {prefix}")
 
     return err

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -731,7 +731,7 @@ class OCCli:  # pylint: disable=too-many-public-methods
         if follow:
             cmd.append("-f")
         # pylint: disable=consider-using-with
-        output_file = open(os.path.join(output, name), "w")
+        output_file = open(os.path.join(output, name), "w", encoding="locale")
         # collect logs to file async
         Popen(self.oc_base_cmd + cmd, stdout=output_file)
 

--- a/reconcile/utils/oc_connection_parameters.py
+++ b/reconcile/utils/oc_connection_parameters.py
@@ -153,20 +153,19 @@ class OCConnectionParameters:
                 logging.debug(
                     f"No admin automation token set for cluster '{cluster.name}', but privileged access requested."
                 )
+        elif cluster.automation_token:
+            try:
+                automation_token = OCConnectionParameters._get_automation_token(
+                    secret_reader, cluster.automation_token, cluster
+                )
+            except SecretNotFound:
+                logging.error(
+                    f"[{cluster.name}] automation token {cluster.automation_token} not found"
+                )
         else:
-            if cluster.automation_token:
-                try:
-                    automation_token = OCConnectionParameters._get_automation_token(
-                        secret_reader, cluster.automation_token, cluster
-                    )
-                except SecretNotFound:
-                    logging.error(
-                        f"[{cluster.name}] automation token {cluster.automation_token} not found"
-                    )
-            else:
-                # Note, that currently OCMap uses OCLogMsg if a token is missing, i.e.,
-                # for now this is valid behavior.
-                logging.debug(f"No automation token for cluster '{cluster.name}'.")
+            # Note, that currently OCMap uses OCLogMsg if a token is missing, i.e.,
+            # for now this is valid behavior.
+            logging.debug(f"No automation token for cluster '{cluster.name}'.")
 
         disabled_integrations = []
         if cluster.disable:

--- a/reconcile/utils/ocm/base.py
+++ b/reconcile/utils/ocm/base.py
@@ -207,7 +207,7 @@ class OCMCluster(BaseModel):
         return (
             self.managed
             and self.state == OCMClusterState.READY
-            and self.product.id in [PRODUCT_ID_OSD, PRODUCT_ID_ROSA]
+            and self.product.id in {PRODUCT_ID_OSD, PRODUCT_ID_ROSA}
         )
 
     @property

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -510,9 +510,9 @@ class OCMProductRosa(OCMProduct):
 
         if isinstance(cluster.spec, ROSAClusterSpec):
             ocm_spec.setdefault("properties", {})
-            ocm_spec["properties"][
-                "rosa_creator_arn"
-            ] = cluster.spec.account.rosa.creator_role_arn
+            ocm_spec["properties"]["rosa_creator_arn"] = (
+                cluster.spec.account.rosa.creator_role_arn
+            )
 
             if not cluster.spec.account.rosa.sts:
                 raise ParameterError("STS is required for ROSA clusters")
@@ -536,14 +536,14 @@ class OCMProductRosa(OCMProduct):
             }
 
             if cluster.spec.account.rosa.sts.controlplane_role_arn:
-                rosa_spec["aws"]["sts"]["instance_iam_roles"][
-                    "master_role_arn"
-                ] = cluster.spec.account.rosa.sts.controlplane_role_arn
+                rosa_spec["aws"]["sts"]["instance_iam_roles"]["master_role_arn"] = (
+                    cluster.spec.account.rosa.sts.controlplane_role_arn
+                )
 
             if cluster.spec.hypershift:
-                ocm_spec["nodes"][
-                    "availability_zones"
-                ] = cluster.spec.availability_zones
+                ocm_spec["nodes"]["availability_zones"] = (
+                    cluster.spec.availability_zones
+                )
                 rosa_spec["aws"]["subnet_ids"] = cluster.spec.subnet_ids
 
         ocm_spec.update(rosa_spec)

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -444,7 +444,7 @@ class OpenshiftResource:
                     tls.pop("key", None)
                     tls.pop("certificate", None)
             subdomain = body["spec"].get("subdomain", None)
-            if subdomain == "":
+            if not subdomain:
                 body["spec"].pop("subdomain", None)
 
         if body["kind"] == "ServiceAccount":
@@ -497,8 +497,7 @@ class OpenshiftResource:
                 if "namespace" in subject:
                     subject.pop("namespace")
                 if "apiGroup" in subject and (
-                    subject["apiGroup"] == ""
-                    or subject["apiGroup"] in body["apiVersion"]
+                    not subject["apiGroup"] or subject["apiGroup"] in body["apiVersion"]
                 ):
                     subject.pop("apiGroup")
             # TODO: remove this once we have no 3.11 clusters
@@ -714,6 +713,6 @@ def build_secret(
 
 
 def base64_encode_secret_field_value(value: str) -> str:
-    if value == "":
+    if not value:
         return ""
     return base64.b64encode(str(value).encode()).decode("utf-8")

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -104,7 +104,7 @@ class OpenshiftResource:
             for obj1_k, obj1_v in obj1.items():
                 obj2_v = obj2.get(obj1_k, None)
                 if obj2_v is None:
-                    if obj1_v not in [None, ""]:
+                    if obj1_v:
                         return False
                 if self.ignorable_field(obj1_k):
                     pass
@@ -123,7 +123,7 @@ class OpenshiftResource:
                     ]
                     if diff or not self.obj_intersect_equal(obj1_v, obj2_v, depth + 1):
                         return False
-                elif obj1_k in ["data", "matchLabels"]:
+                elif obj1_k in {"data", "matchLabels"}:
                     diff = [
                         k
                         for k in obj2_v
@@ -244,12 +244,12 @@ class OpenshiftResource:
             )
             raise ConstructResourceError(msg)
 
-        if self.kind not in [
+        if self.kind not in {
             "Role",
             "RoleBinding",
             "ClusterRole",
             "ClusterRoleBinding",
-        ] and (
+        } and (
             not DNS_SUBDOMAIN_RE.match(self.name)
             or not len(self.name) <= DNS_SUBDOMAIN_MAX_LENGTH
         ):
@@ -414,7 +414,7 @@ class OpenshiftResource:
 
         # Default fields for specific resource types
         # ConfigMaps and Secrets are by default Opaque
-        if body["kind"] in ("ConfigMap", "Secret") and body.get("type") == "Opaque":
+        if body["kind"] in {"ConfigMap", "Secret"} and body.get("type") == "Opaque":
             body.pop("type")
 
         if body["kind"] == "Secret":

--- a/reconcile/utils/parse_dhms_duration.py
+++ b/reconcile/utils/parse_dhms_duration.py
@@ -58,7 +58,7 @@ def dhms_to_seconds(time_str: str) -> int:
         if s.isnumeric():
             previous_number += s
         else:
-            if previous_number == "":
+            if not previous_number:
                 raise BadHDMSDurationError(f"Invalid time duration {time_str}")
 
             if s in HANDLE_UNIT_MAP:

--- a/reconcile/utils/runtime/sharding.py
+++ b/reconcile/utils/runtime/sharding.py
@@ -110,7 +110,7 @@ class StaticShardingStrategy:
     def create_sub_shards(
         base_shard: ShardSpec, sub_sharding: SubShardingV1
     ) -> list[ShardSpec]:
-        if base_shard.shard_id != "" or base_shard.shards != "":
+        if base_shard.shard_id or base_shard.shards:
             raise ValueError(
                 "Static sub_sharding can only be applied to Key based sharding"
             )

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1803,9 +1803,9 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 )
 
                 # add managed resource types to target config
-                desired_target_config[
-                    "saas_file_managed_resource_types"
-                ] = saas_file.managed_resource_types
+                desired_target_config["saas_file_managed_resource_types"] = (
+                    saas_file.managed_resource_types
+                )
                 desired_target_config["url"] = rt.url
                 desired_target_config["path"] = rt.path
                 # before the GQL classes are introduced, the parameters attribute

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -2027,8 +2027,8 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
     @staticmethod
     def resolve_templated_parameters(saas_files: Iterable[SaasFile]) -> None:
         """Resolve templated target parameters in saas files."""
-        from reconcile.openshift_resources_base import (
-            compile_jinja2_template,  # avoid circular import
+        from reconcile.openshift_resources_base import (  # noqa: PLC0415 - # avoid circular import
+            compile_jinja2_template,
         )
 
         for saas_file in saas_files:

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -429,7 +429,7 @@ class SlackApi:
 
             cursor = result["response_metadata"]["next_cursor"]
 
-            if cursor == "":
+            if not cursor:
                 break
 
             additional_kwargs["cursor"] = cursor
@@ -478,7 +478,7 @@ class SlackApi:
                 break
 
             cursor = response["response_metadata"]["next_cursor"]
-            if cursor == "":
+            if not cursor:
                 break
 
         return responses

--- a/reconcile/utils/terraform/config_client.py
+++ b/reconcile/utils/terraform/config_client.py
@@ -122,7 +122,7 @@ class TerraformConfigClientCollection:
             working_dirs[account_name] = client.dump()
 
             if print_to_file:
-                with open(print_to_file, "a") as f:
+                with open(print_to_file, "a", encoding="locale") as f:
                     f.write(f"##### {account_name} #####\n")
                     f.write(client.dumps())
                     f.write("\n")

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -439,9 +439,9 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                 replica_source_name = f'{replica_src}-{tf_resource.get("provider")}'
                 # Creating a dict that is convenient to use inside the
                 # loop processing the formatted_output
-                replicas_info[spec.provisioner_name][
-                    spec.output_prefix
-                ] = replica_source_name
+                replicas_info[spec.provisioner_name][spec.output_prefix] = (
+                    replica_source_name
+                )
 
         return replicas_info
 

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -502,10 +502,10 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                 data[resource_name] = {}
             data[resource_name][field_key] = field_value
 
-        if len(data) == 1 and type in (
+        if len(data) == 1 and type in {
             self.OUTPUT_TYPE_PASSWORDS,
             self.OUTPUT_TYPE_CONSOLEURLS,
-        ):
+        }:
             return data[list(data.keys())[0]]
         return data
 

--- a/reconcile/utils/terrascript/cloudflare_client.py
+++ b/reconcile/utils/terrascript/cloudflare_client.py
@@ -171,7 +171,9 @@ class TerrascriptCloudflareClient(TerraformConfigClient):
             working_dir = tempfile.mkdtemp(prefix=TMP_DIR_PREFIX)
         else:
             working_dir = existing_dir
-        with open(working_dir + "/config.tf.json", "w") as terraform_config_file:
+        with open(
+            working_dir + "/config.tf.json", "w", encoding="locale"
+        ) as terraform_config_file:
             terraform_config_file.write(self.dumps())
 
         return working_dir

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -3796,7 +3796,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         for name, ts in self.tss.items():
             if print_to_file:
-                with open(print_to_file, "a") as f:
+                with open(print_to_file, "a", encoding="locale") as f:
                     f.write(f"##### {name} #####\n")
                     f.write(str(ts))
                     f.write("\n")
@@ -3804,7 +3804,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 wd = tempfile.mkdtemp(prefix=TMP_DIR_PREFIX)
             else:
                 wd = working_dirs[name]
-            with open(wd + "/config.tf.json", "w") as f:
+            with open(wd + "/config.tf.json", "w", encoding="locale") as f:
                 f.write(str(ts))
             working_dirs[name] = wd
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -2432,9 +2432,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         specs = common_values.get("specs")
         all_queues_per_spec = []
         kms_keys = set()
-        for spec in specs:
-            defaults = self.get_values(spec["defaults"])
-            queues = spec.pop("queues", [])
+        for _spec in specs:
+            defaults = self.get_values(_spec["defaults"])
+            queues = _spec.pop("queues", [])
             all_queues = []
             for queue_kv in queues:
                 queue_key = queue_kv["key"]
@@ -2624,10 +2624,10 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         region = common_values.get("region") or self.default_regions.get(account)
         specs = common_values.get("specs")
         all_tables = []
-        for spec in specs:
-            defaults = self.get_values(spec["defaults"])
+        for _spec in specs:
+            defaults = self.get_values(_spec["defaults"])
             attributes = defaults.pop("attributes")
-            tables = spec["tables"]
+            tables = _spec["tables"]
             for table_kv in tables:
                 table_key = table_kv["key"]
                 table = table_kv["value"]

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1056,7 +1056,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     "Name": connection_name,
                 },
             }
-            if connection_provider in ["account-vpc", "account-vpc-mesh"]:
+            if connection_provider in {"account-vpc", "account-vpc-mesh"}:
                 if self._multiregion_account(acc_account_name):
                     values["provider"] = "aws." + accepter["region"]
             else:
@@ -1075,7 +1075,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                         + identifier
                         + ".id}",
                     }
-                    if connection_provider in ["account-vpc", "account-vpc-mesh"]:
+                    if connection_provider in {"account-vpc", "account-vpc-mesh"}:
                         if self._multiregion_account(acc_account_name):
                             values["provider"] = "aws." + accepter["region"]
                     else:
@@ -5281,7 +5281,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         lambda_managed_policy_arn = (
             "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         )
-        if region in ("us-gov-west-1", "us-gov-east-1"):
+        if region in {"us-gov-west-1", "us-gov-east-1"}:
             lambda_managed_policy_arn = "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
         vpc_id = common_values.get("vpc_id")
         subnet_ids = common_values.get("subnet_ids")

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -603,10 +603,10 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             with self.jenkins_lock:
                 # this may have already happened, so we check again
                 if not self.jenkins_map.get(instance_name):
-                    self.jenkins_map[
-                        instance_name
-                    ] = JenkinsApi.init_jenkins_from_secret(
-                        SecretReader(self.settings), instance["token"]
+                    self.jenkins_map[instance_name] = (
+                        JenkinsApi.init_jenkins_from_secret(
+                            SecretReader(self.settings), instance["token"]
+                        )
                     )
         return self.jenkins_map[instance_name]
 
@@ -1796,9 +1796,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             common_values.get("server_side_encryption_configuration")
             or DEFAULT_S3_SSE_CONFIGURATION
         )
-        values[
-            "server_side_encryption_configuration"
-        ] = server_side_encryption_configuration
+        values["server_side_encryption_configuration"] = (
+            server_side_encryption_configuration
+        )
         # Support static website hosting [rosa-authenticator]
         website = common_values.get("website")
         if website:
@@ -3604,9 +3604,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     "starting_position_timestamp", None
                 )
                 if not starting_position_timestamp:
-                    source_vaules[
-                        "starting_position_timestamp"
-                    ] = starting_position_timestamp
+                    source_vaules["starting_position_timestamp"] = (
+                        starting_position_timestamp
+                    )
 
             batch_size = common_values.get("batch_size", 100)
             source_vaules["batch_size"] = batch_size
@@ -4353,19 +4353,19 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         auth_options = values.get("auth", {})
         # TODO: @fishi0x01 make mandatory after migration APPSRE-3409
         if auth_options:
-            es_values[
-                "advanced_security_options"
-            ] = self._build_es_advanced_security_options(auth_options)
+            es_values["advanced_security_options"] = (
+                self._build_es_advanced_security_options(auth_options)
+            )
 
         # TODO: @fishi0x01 remove after migration APPSRE-3409
         # ++++++++ START: REMOVE +++++++++
         else:
             advanced_security_options = values.get("advanced_security_options", {})
             if advanced_security_options:
-                es_values[
-                    "advanced_security_options"
-                ] = self._build_es_advanced_security_options_deprecated(
-                    advanced_security_options
+                es_values["advanced_security_options"] = (
+                    self._build_es_advanced_security_options_deprecated(
+                        advanced_security_options
+                    )
                 )
         # ++++++++ END: REMOVE ++++++++++
 
@@ -4624,12 +4624,12 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         account = self.accounts[account_name]
         cluster = namespace_info["cluster"]
         ocm = ocm_map.get(cluster["name"])
-        account[
-            "assume_role"
-        ] = ocm.get_aws_infrastructure_access_terraform_assume_role(
-            cluster["name"],
-            account["uid"],
-            account["terraformUsername"],
+        account["assume_role"] = (
+            ocm.get_aws_infrastructure_access_terraform_assume_role(
+                cluster["name"],
+                account["uid"],
+                account["terraformUsername"],
+            )
         )
         account["assume_region"] = cluster["spec"]["region"]
         service_name = f"{namespace_info['name']}/{openshift_service}"
@@ -5198,9 +5198,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         if instance_requirements:
             override += [{"instance_requirements": instance_requirements}]
         if override:
-            asg_value["mixed_instances_policy"]["launch_template"][
-                "override"
-            ] = override
+            asg_value["mixed_instances_policy"]["launch_template"]["override"] = (
+                override
+            )
 
         asg_value["tags"] = [
             {"key": k, "value": v, "propagate_at_launch": True} for k, v in tags.items()
@@ -6219,9 +6219,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             del values["logging_info"]["broker_logs"]["cloudwatch_logs"][
                 "retention_in_days"
             ]
-            values["logging_info"]["broker_logs"]["cloudwatch_logs"][
-                "log_group"
-            ] = log_group_tf_resource.name
+            values["logging_info"]["broker_logs"]["cloudwatch_logs"]["log_group"] = (
+                log_group_tf_resource.name
+            )
 
         # resource - secret manager for SCRAM client credentials
         if scram_enabled and scram_users:

--- a/reconcile/utils/three_way_diff_strategy.py
+++ b/reconcile/utils/three_way_diff_strategy.py
@@ -95,7 +95,7 @@ def is_empty_env_value(current: OR, desired: OR, patch: Mapping[str, Any]) -> bo
     pointer = patch["path"]
     if (
         patch["op"] == "add"
-        and patch["value"] == ""
+        and not patch["value"]
         and re.match(EMPTY_ENV_VALUE, pointer)
     ):
         return True

--- a/reconcile/utils/three_way_diff_strategy.py
+++ b/reconcile/utils/three_way_diff_strategy.py
@@ -105,7 +105,7 @@ def is_empty_env_value(current: OR, desired: OR, patch: Mapping[str, Any]) -> bo
 
 def is_valid_change(current: OR, desired: OR, patch: Mapping[str, Any]) -> bool:
     # Only consider added or replaced values on the Desired object
-    if patch["op"] not in ["add", "replace"]:
+    if patch["op"] not in {"add", "replace"}:
         return False
 
     # Check known mutations. Replaced values can happen if values have been

--- a/reconcile/utils/unleash.py
+++ b/reconcile/utils/unleash.py
@@ -65,7 +65,7 @@ class EnableClusterStrategy(ClusterStrategy):
 
 
 def _get_unleash_api_client(api_url: str, auth_head: str) -> UnleashClient:
-    global client
+    global client  # noqa: PLW0603
     with client_lock:
         if client is None:
             logging.getLogger("apscheduler").setLevel(logging.ERROR)

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -151,7 +151,7 @@ class _VaultClient:
     def _refresh_client_auth(self):
         if self.kube_auth_enabled:
             # must read each time to account for sa token refresh
-            with open(self.kube_sa_token_path) as f:
+            with open(self.kube_sa_token_path, encoding="locale") as f:
                 try:
                     self._client.auth_kubernetes(
                         role=self.kube_auth_role,

--- a/reconcile/vpc_peerings_validator.py
+++ b/reconcile/vpc_peerings_validator.py
@@ -58,10 +58,10 @@ def validate_no_cidr_overlap(
                         "cidr_block": cidr_block,
                     }
                     peerings_entries.append(vpc_peering_info)
-                if peering.provider in (
+                if peering.provider in {
                     "cluster-vpc-requester",
                     "cluster-vpc-accepter",
-                ):
+                }:
                     vpc_peering_info = {
                         "provider": peering.provider,
                         "vpc_name": peering.cluster.name,  # type: ignore[union-attr]
@@ -101,10 +101,10 @@ def validate_no_internal_to_public_peerings(
         if not cluster.internal or not cluster.peering:
             continue
         for connection in cluster.peering.connections:
-            if connection.provider not in [
+            if connection.provider not in {
                 "cluster-vpc-accepter",
                 "cluster-vpc-requester",
-            ]:
+            }:
                 continue
             connection = cast(
                 Union[
@@ -144,10 +144,10 @@ def validate_no_public_to_public_peerings(
         ):
             continue
         for connection in cluster.peering.connections:
-            if connection.provider not in [
+            if connection.provider not in {
                 "cluster-vpc-accepter",
                 "cluster-vpc-requester",
-            ]:
+            }:
                 continue
             connection = cast(
                 Union[

--- a/release/version.py
+++ b/release/version.py
@@ -26,13 +26,17 @@ def git() -> str:
         # tox is running setup.py sdist from the git repo, and then runs again outside
         # of the git repo. At this second step, we cannot run git commands.
         # So we save the git version in a file and include it in the source distribution
-        with open(GIT_VERSION_FILE, "w", encoding=locale.getpreferredencoding(False)) as f:
+        with open(
+            GIT_VERSION_FILE, "w", encoding=locale.getpreferredencoding(False)
+        ) as f:
             f.write(v)
         return v
     except subprocess.CalledProcessError as e:
         # if we're not in a git repo, try reading out from the GIT_VERSION file
         if os.path.exists(GIT_VERSION_FILE):
-            with open(GIT_VERSION_FILE, "r", encoding=locale.getpreferredencoding(False)) as f:
+            with open(
+                GIT_VERSION_FILE, "r", encoding=locale.getpreferredencoding(False)
+            ) as f:
                 return f.read()
         print(e.stderr)
         raise e

--- a/release/version.py
+++ b/release/version.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import locale
 import os
 import re
 import subprocess
@@ -25,13 +26,13 @@ def git() -> str:
         # tox is running setup.py sdist from the git repo, and then runs again outside
         # of the git repo. At this second step, we cannot run git commands.
         # So we save the git version in a file and include it in the source distribution
-        with open(GIT_VERSION_FILE, "w") as f:
+        with open(GIT_VERSION_FILE, "w", encoding=locale.getpreferredencoding(False)) as f:
             f.write(v)
         return v
     except subprocess.CalledProcessError as e:
         # if we're not in a git repo, try reading out from the GIT_VERSION file
         if os.path.exists(GIT_VERSION_FILE):
-            with open(GIT_VERSION_FILE, "r") as f:
+            with open(GIT_VERSION_FILE, "r", encoding=locale.getpreferredencoding(False)) as f:
                 return f.read()
         print(e.stderr)
         raise e

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -13,4 +13,4 @@ MarkupSafe==2.1.1
 smtpdfix==0.3.3
 pyfakefs~=5.1
 botocore==1.29.139
-ruff==0.1.7
+ruff==0.1.8

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -443,7 +443,7 @@ def main(
             except FileExistsError:
                 pass
 
-            with open(report_file, "w") as f:
+            with open(report_file, "w", encoding="locale") as f:
                 f.write(report["content"])
 
     if not dry_run:

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -387,9 +387,9 @@ def get_build_history(job):
 
 def get_build_history_pool(jenkins_map, jobs, timestamp_limit, thread_pool_size):
     history_to_get = []
-    for instance, jobs in jobs.items():
+    for instance, _jobs in jobs.items():
         jenkins = jenkins_map[instance]
-        for job in jobs:
+        for job in _jobs:
             job["jenkins"] = jenkins
             job["timestamp_limit"] = timestamp_limit
             history_to_get.append(job)

--- a/tools/cli_commands/gpg_encrypt.py
+++ b/tools/cli_commands/gpg_encrypt.py
@@ -100,7 +100,7 @@ class GPGEncryptCommand:
         return GPGEncryptCommand._format(secret)
 
     def _fetch_local_file_secret(self) -> str:
-        with open(self._command_data.secret_file_path) as f:
+        with open(self._command_data.secret_file_path, encoding="locale") as f:
             return f.read()
 
     def _fetch_secret(self) -> str:
@@ -140,7 +140,7 @@ class GPGEncryptCommand:
         if not output:
             print(content)
             return
-        with open(output, "w") as f:
+        with open(output, "w", encoding="locale") as f:
             f.write(content)
 
     def execute(self):

--- a/tools/cli_commands/test/test_gpg_encrypt.py
+++ b/tools/cli_commands/test/test_gpg_encrypt.py
@@ -184,7 +184,7 @@ def test_gpg_encrypt_from_local_file(
 
     captured = capsys.readouterr()
     assert captured.out == f"{encrypted_content}\n"
-    mock_file.assert_called_once_with(file_path)
+    mock_file.assert_called_once_with(file_path, encoding="locale")
     secret_reader_mock.read_all.assert_not_called()
 
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2208,9 +2208,9 @@ def slo_document_services(ctx, status_board_instance):
         print(f"Status-board instance '{status_board_instance}' not found.")
         sys.exit(1)
 
-    desired_product_apps: dict[
-        str, set[str]
-    ] = StatusBoardExporterIntegration.get_product_apps(sb)
+    desired_product_apps: dict[str, set[str]] = (
+        StatusBoardExporterIntegration.get_product_apps(sb)
+    )
 
     slodocs = []
     for slodoc in get_slo_documents():

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# ruff: noqa: PLC0415 - `import` should be at the top-level of a file
 
 import base64
 import json

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1782,10 +1782,10 @@ def app_interface_review_queue(ctx) -> None:
                 continue
             if len(mr.commits()) == 0:
                 continue
-            if mr.merge_status in [
+            if mr.merge_status in {
                 MRStatus.CANNOT_BE_MERGED,
                 MRStatus.CANNOT_BE_MERGED_RECHECK,
-            ]:
+            }:
                 continue
 
             labels = mr.attributes.get("labels")
@@ -2621,7 +2621,7 @@ def alert_to_receiver(
 @click.option("--env-name", default=None, help="environment to use for parameters.")
 @click.pass_context
 def saas_dev(ctx, app_name=None, saas_file_name=None, env_name=None) -> None:
-    if env_name in [None, ""]:
+    if not env_name:
         print("env-name must be defined")
         return
     saas_files = get_saas_files(saas_file_name, env_name, app_name)


### PR DESCRIPTION
Remove/Move pylint ignore rules:
- remove PLC0415: import should be at the top-level of a file
- remove PLC1901: ... can be simplified to `...` as an empty string is falsey
- remove PLR1704: Redefining argument with the local name
- remove PLR5501: Use `elif` instead of `else` then `if`, to reduce indentation
- remove PLR6201: Use a `set` literal when testing for membership
- remove PLW0602: Using global for `...` but no assignment is done
- move PLW0603 (usage of global) to occurences instead of having it global
- remove PLW1510: `subprocess.run` without explicit `check` argument
- remove PLW1514: `open` in text mode without explicit `encoding` argument
- move PLW3201 (Bad or misspelled dunder method name) to occurrence instead of having it globally


Please review it commit by commit.

Ticket: [APPSRE-8624](https://issues.redhat.com/browse/APPSRE-8624)