### PR TITLE
[openshift-serviceaccount-tokens] ignore deleted namespace

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1524,6 +1524,7 @@ SERVICEACCOUNT_TOKENS_QUERY = """
 {
   namespaces: namespaces_v1 {
     name
+    delete
     cluster {
       name
       serverUrl


### PR DESCRIPTION
follow up on #2942 and #3010

openshift-serviceaccount-tokens currently does not handle deleted namespaces. with this PR, we add the `delete` field to the query, allowing the proper handle of this scenario.