### PR TITLE
[tf-vpc-peerings] allow access to private HCP API VPCE via peering

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1069,7 +1069,10 @@ CLUSTER_PEERING_QUERY = """
     }
 
     spec {
+      id
       region
+      private
+      hypershift
     }
     network {
       vpc
@@ -1140,7 +1143,10 @@ CLUSTER_PEERING_QUERY = """
               vpc
             }
             spec {
+              id
               region
+              private
+              hypershift
             }
             awsInfrastructureManagementAccounts {
               account {

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -199,8 +199,15 @@ def build_desired_state_single_cluster(
                 "are not suppored"
             )
 
-        requester_vpc_id, requester_route_table_ids, _ = awsapi.get_cluster_vpc_details(
-            req_aws, route_tables=requester_manage_routes
+        (
+            requester_vpc_id,
+            requester_route_table_ids,
+            _,
+            api_security_group_id,
+        ) = awsapi.get_cluster_vpc_details(
+            req_aws,
+            route_tables=requester_manage_routes,
+            hcp_vpc_endpoint_sg=_private_hosted_control_plane(cluster_info),
         )
         if requester_vpc_id is None:
             raise BadTerraformPeeringState(
@@ -213,10 +220,18 @@ def build_desired_state_single_cluster(
             "vpc_id": requester_vpc_id,
             "route_table_ids": requester_route_table_ids,
             "account": req_aws,
+            "api_security_group_id": api_security_group_id,
         }
 
-        accepter_vpc_id, accepter_route_table_ids, _ = awsapi.get_cluster_vpc_details(
-            acc_aws, route_tables=accepter_manage_routes
+        (
+            accepter_vpc_id,
+            accepter_route_table_ids,
+            _,
+            api_security_group_id,
+        ) = awsapi.get_cluster_vpc_details(
+            acc_aws,
+            route_tables=accepter_manage_routes,
+            hcp_vpc_endpoint_sg=_private_hosted_control_plane(peer_cluster),
         )
         if accepter_vpc_id is None:
             raise BadTerraformPeeringState(
@@ -230,6 +245,7 @@ def build_desired_state_single_cluster(
             "vpc_id": accepter_vpc_id,
             "route_table_ids": accepter_route_table_ids,
             "account": acc_aws,
+            "api_security_group_id": api_security_group_id,
         }
 
         item = {
@@ -305,8 +321,15 @@ def build_desired_state_vpc_mesh_single_cluster(
             )
         account["assume_region"] = requester["region"]
         account["assume_cidr"] = requester["cidr_block"]
-        requester_vpc_id, requester_route_table_ids, _ = awsapi.get_cluster_vpc_details(
-            account, route_tables=peer_connection.get("manageRoutes")
+        (
+            requester_vpc_id,
+            requester_route_table_ids,
+            _,
+            api_security_group_id,
+        ) = awsapi.get_cluster_vpc_details(
+            account,
+            route_tables=peer_connection.get("manageRoutes"),
+            hcp_vpc_endpoint_sg=_private_hosted_control_plane(cluster_info),
         )
 
         if requester_vpc_id is None:
@@ -317,6 +340,7 @@ def build_desired_state_vpc_mesh_single_cluster(
 
         requester["vpc_id"] = requester_vpc_id
         requester["route_table_ids"] = requester_route_table_ids
+        requester["api_security_group_id"] = api_security_group_id
         requester["account"] = account
 
         account_vpcs = awsapi.get_vpcs_details(
@@ -433,8 +457,15 @@ def build_desired_state_vpc_single_cluster(
             )
         account["assume_region"] = requester["region"]
         account["assume_cidr"] = requester["cidr_block"]
-        requester_vpc_id, requester_route_table_ids, _ = awsapi.get_cluster_vpc_details(
-            account, route_tables=peer_connection.get("manageRoutes")
+        (
+            requester_vpc_id,
+            requester_route_table_ids,
+            _,
+            api_security_group_id,
+        ) = awsapi.get_cluster_vpc_details(
+            account,
+            route_tables=peer_connection.get("manageRoutes"),
+            hcp_vpc_endpoint_sg=_private_hosted_control_plane(cluster_info),
         )
 
         if requester_vpc_id is None:
@@ -444,6 +475,7 @@ def build_desired_state_vpc_single_cluster(
         requester["vpc_id"] = requester_vpc_id
         requester["route_table_ids"] = requester_route_table_ids
         requester["account"] = account
+        requester["api_security_group_id"] = api_security_group_id
         accepter["account"] = account
         item = {
             "connection_provider": peer_connection_provider,
@@ -454,6 +486,12 @@ def build_desired_state_vpc_single_cluster(
         }
         desired_state.append(item)
     return desired_state
+
+
+def _private_hosted_control_plane(cluster_info: dict[str, Any]) -> bool:
+    return cluster_info["spec"].get("hypershift", False) and cluster_info["spec"].get(
+        "private", False
+    )
 
 
 def build_desired_state_vpc(

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -489,8 +489,8 @@ def build_desired_state_vpc_single_cluster(
 
 
 def _private_hosted_control_plane(cluster_info: dict[str, Any]) -> bool:
-    return cluster_info["spec"].get("hypershift", False) and cluster_info["spec"].get(
-        "private", False
+    return bool(
+        cluster_info["spec"].get("hypershift") and cluster_info["spec"].get("private")
     )
 
 

--- a/reconcile/test/test_terraform_vpc_peerings.py
+++ b/reconcile/test/test_terraform_vpc_peerings.py
@@ -50,7 +50,7 @@ class MockOCM:
 
 class MockAWSAPI:
     def __init__(self) -> None:
-        self.vpc_details: dict[str, tuple[str, list[str], str]] = {}
+        self.vpc_details: dict[str, tuple[str, list[str], Optional[str]]] = {}
 
     def register(
         self,
@@ -59,7 +59,11 @@ class MockAWSAPI:
         route_tables: list[str],
         vpce_sg: Optional[str] = None,
     ) -> "MockAWSAPI":
-        self.vpc_details[vpc] = (vpc_id, route_tables, vpce_sg)
+        self.vpc_details[vpc] = (
+            vpc_id,
+            route_tables,
+            vpce_sg,
+        )
         return self
 
     def get_cluster_vpc_details(
@@ -95,7 +99,7 @@ def build_cluster(
     peering_connections: Optional[list[dict[str, Any]]] = None,
     hcp: bool = False,
     private: bool = False,
-    sg: str = None,
+    sg: Optional[str] = None,
 ):
     if not vpc:
         vpc = name

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -893,7 +893,7 @@ class TestBuildDesiredStateVpcMeshSingleCluster(testslide.TestCase):
                 "requester": {
                     "vpc_id": "vpc_id",
                     "route_table_ids": ["route_table_id"],
-                    "api_security_group_id": None,
+                    "api_security_group_id": "sg-vpce",
                     "account": self.peer_account,
                     "region": "mars-plain-1",
                     "cidr_block": "172.16.0.0/12",

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -963,25 +963,6 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
         return vpc_id, route_table_ids, subnets_id_az, api_security_group_id
 
-    @staticmethod
-    # pylint: disable=method-hidden
-    def _create_security_group_on_vpc_endpoint(
-        vpc_endpoint_id: str, security_group_name: str, ec2: EC2Client
-    ) -> str:
-        """
-        Creates a security group on a given VPC endpoint.
-        :param vpc_endpoint_id: VPC endpoint ID
-        :param security_group_name: name of the security group
-        :param ec2: EC2 client
-        :return: ID of the created security group
-        """
-        response = ec2.create_security_group(
-            Description=security_group_name,
-            GroupName=security_group_name,
-            VpcId=vpc_endpoint_id.split("-")[0],
-        )
-        return response["GroupId"]
-
     def get_cluster_nat_gateways_egress_ips(self, account: dict[str, Any], vpc_id: str):
         assumed_role_data = self._get_account_assume_data(account)
         assumed_ec2 = self._get_assumed_role_client(*assumed_role_data)

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1348,7 +1348,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
     # pylint: disable=method-hidden
     def _get_vpc_endpoints(
         filters: Sequence[FilterTypeDef], ec2: EC2Client
-    ) -> list[VpcEndpointTypeDef]:
+    ) -> list["VpcEndpointTypeDef"]:
         atts = ec2.describe_vpc_endpoints(Filters=filters)
         return atts.get("VpcEndpoints", [])
 

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -6,6 +6,7 @@ from collections.abc import (
     Iterable,
     Iterator,
     Mapping,
+    Sequence,
 )
 from datetime import datetime
 from functools import lru_cache
@@ -43,6 +44,7 @@ if TYPE_CHECKING:
         TransitGatewayTypeDef,
         TransitGatewayVpcAttachmentTypeDef,
         VpcTypeDef,
+        VpcEndpointTypeDef,
     )
     from mypy_boto3_iam import IAMClient
     from mypy_boto3_iam.type_defs import AccessKeyMetadataTypeDef
@@ -1344,7 +1346,9 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
     @staticmethod
     # pylint: disable=method-hidden
-    def _get_vpc_endpoints(filters: dict[str, Any], ec2: EC2Client) -> dict[str, Any]:
+    def _get_vpc_endpoints(
+        filters: Sequence[FilterTypeDef], ec2: EC2Client
+    ) -> list[VpcEndpointTypeDef]:
         atts = ec2.describe_vpc_endpoints(Filters=filters)
         return atts.get("VpcEndpoints", [])
 

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -43,8 +43,8 @@ if TYPE_CHECKING:
         TagTypeDef,
         TransitGatewayTypeDef,
         TransitGatewayVpcAttachmentTypeDef,
-        VpcTypeDef,
         VpcEndpointTypeDef,
+        VpcTypeDef,
     )
     from mypy_boto3_iam import IAMClient
     from mypy_boto3_iam.type_defs import AccessKeyMetadataTypeDef

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1048,25 +1048,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             # add security group rules for private hosted controlplane API VPC endpoint service
             api_security_group_id = requester.get("api_security_group_id")
             if api_security_group_id:
-                # security_group_identifier = f"{vpc_endpoint_id}-api-access-from-peerings"
-                # security_group = vpce_security_groups.get(security_group_identifier)
-                # if security_group is None:
-                #    # create security group once
-                #    security_group = aws_security_group(
-                #        security_group_identifier,
-                #        provider="aws." + req_alias,
-                #        description=f"{vpc_endpoint_id} API access from peerings",
-                #        vpc_id=requester['vpc_id'],
-                #        # todo tags
-                #    )
-                #    vpce_security_groups[security_group_identifier] = security_group
-                #    self.add_resource(req_account_name, security_group)
-
-                # create the ingress rule
                 hcp_api_ingress_rule = aws_security_group_rule(
                     f"api-access-from-peering-{connection_name}",
                     type="ingress",
-                    # security_group_id=f"${{{security_group.id}}}",
                     security_group_id=api_security_group_id,
                     cidr_blocks=[accepter["cidr_block"]],
                     from_port=443,


### PR DESCRIPTION
the HCP API is offered via a VPC endpoint in the clusters AWS account. access to this VPCE is per default only granted from within the VPC. when accessing the API via VPC peering, the security group of the VPCE is preventing communication.

this patch will add new rules to the security group of the VPC endpoint. sadly we can't create a dedicated SG and add it to the VPCE because that is only possible with the AWS TF provider > 4 (and we are at 3.7.x). so our only way is to add more rules to the existing SG.

i checked the code of the hypershift operator that reconciling this SG. it is not removing any excessive rules, only adding missing ones. once we upgrade to a newer TF provider, we can add new security groups to existing VPC endpoints. but for now we need to accept this approach.

for the our first HCP private cluster, the output of the integration would be

```
[2023-12-19 02:42:55] [INFO] [DRY-RUN] [terraform_client.py:log_plan_diff:335] - ['create', 'app-sre', 'aws_security_group_rule', 'api-access-from-peering-backplanei03ue1_app-sre-ci-int', set()]
[2023-12-19 02:42:55] [INFO] [DRY-RUN] [terraform_client.py:log_plan_diff:335] - ['create', 'app-sre', 'aws_security_group_rule', 'api-access-from-peering-backplanei03ue1_appsrep05ue1', set()]
[2023-12-19 02:42:55] [INFO] [DRY-RUN] [terraform_client.py:log_plan_diff:335] - ['create', 'app-sre', 'aws_security_group_rule', 'api-access-from-peering-backplanei03ue1_appsres05ue1', set()]
```

part of https://issues.redhat.com/browse/APPSRE-8666