### PR TITLE
[AUS] expect at least one version gate for a minor version

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -1025,7 +1025,7 @@ def calculate_diff(
                             GateAgreement(gate=g)
                             for g in gates_to_agree(
                                 minor_version_gates,
-                                spec.cluster,
+                                spec.cluster.id,
                                 ocm_api,
                             )
                         ],

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -735,12 +735,12 @@ def gates_to_agree(
     """Check via OCM if a version is agreed
 
     Args:
-        gates (OCMVersionGate): list of OCMVersionGate objects that need an
+        gates (OCMVersionGate): list of OCMVersionGate objects to check for agreements
         cluster_id (str): the cluster that needs gate agreements
         ocm_api (OCMBaseClient): used to fetch infos from OCM
 
     Returns:
-        list[OCMVersionGate]: list of gates to agree
+        list[OCMVersionGate]: list of gates a cluster has not agreed on yet
     """
     applicable_gates = [
         g

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -720,43 +720,42 @@ def version_conditions_met(
     return True
 
 
+def gates_for_minor_version(
+    gates: list[OCMVersionGate],
+    target_version_prefix: str,
+) -> list[OCMVersionGate]:
+    return [g for g in gates if g.version_raw_id_prefix == target_version_prefix]
+
+
 def gates_to_agree(
     gates: list[OCMVersionGate],
-    version_prefix: str,
-    cluster: OCMCluster,
+    cluster_id: str,
     ocm_api: OCMBaseClient,
 ) -> list[OCMVersionGate]:
     """Check via OCM if a version is agreed
 
     Args:
-        gates: list of OCMVersionGate objects
-        version_prefix (string): major.minor version prefix
-        cluster (string)
-        cluster_version (string): current version of the cluster
-        sts (bool): is the cluster a STS cluster
+        gates (OCMVersionGate): list of OCMVersionGate objects that need an
+        cluster_id (str): the cluster that needs gate agreements
         ocm_api (OCMBaseClient): used to fetch infos from OCM
 
     Returns:
         list[OCMVersionGate]: list of gates to agree
     """
-    semver_cluster = parse_semver(f"{cluster.version.raw_id}")
-
     applicable_gates = [
         g
         for g in gates
-        if g.version_raw_id_prefix == version_prefix
         # todo: sts version gates need special handling - https://issues.redhat.com/browse/APPSRE-7949
         #       until this is solved, we can't do automated upgrades for STS clusters that cross a version gate
         #       once we have proper and secure handling get gate agreements for STS clusters, we can use this condition:
         #       `and (not g.sts_only or g.sts_only == cluster.is_sts())`
-        and not g.sts_only
-        and semver_cluster.match(f"<{g.version_raw_id_prefix}.0")
+        if not g.sts_only
     ]
 
     if applicable_gates:
         current_agreements = {
             agreement["version_gate"]["id"]
-            for agreement in get_version_agreement(ocm_api, cluster.id)
+            for agreement in get_version_agreement(ocm_api, cluster_id)
         }
         return [gate for gate in applicable_gates if gate.id not in current_agreements]
     return []
@@ -1002,6 +1001,22 @@ def calculate_diff(
                     )
                 )
             else:
+                target_version_prefix = get_version_prefix(version)
+                minor_version_gates = gates_for_minor_version(
+                    gates, target_version_prefix
+                )
+                # skipping upgrades when there are no version gates is a safety
+                # precaution to prevent cluster upgrades being scheduled.
+                # missing version gates are an indicator that the version has not yet gone
+                # through SREP gap analysis and is not yet ready for upgrades.
+                #
+                # this might change in the future - revisite for 4.16
+                if not minor_version_gates:
+                    logging.warning(
+                        f"[{spec.org.org_id}/{spec.cluster.name}] no gates found for {target_version_prefix}. "
+                        "Skip creation of an upgrade policy."
+                    )
+                    continue
                 diffs.append(
                     UpgradePolicyHandler(
                         action="create",
@@ -1009,8 +1024,7 @@ def calculate_diff(
                         gates_to_agree=[
                             GateAgreement(gate=g)
                             for g in gates_to_agree(
-                                gates,
-                                get_version_prefix(version),
+                                minor_version_gates,
                                 spec.cluster,
                                 ocm_api,
                             )

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -1012,7 +1012,7 @@ def calculate_diff(
                 #
                 # this might change in the future - revisite for 4.16
                 if not minor_version_gates:
-                    logging.warning(
+                    logging.debug(
                         f"[{spec.org.org_id}/{spec.cluster.name}] no gates found for {target_version_prefix}. "
                         "Skip creation of an upgrade policy."
                     )

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -133,10 +133,11 @@ class OrganizationUpgradeSpec(BaseModel):
         # add clusters to their sectors
         if spec.upgrade_policy.conditions.sector:
             if spec.upgrade_policy.conditions.sector not in self._sectors:
-                raise ValueError(
+                self.add_organization_error(
                     f"sector {spec.upgrade_policy.conditions.sector} not found in organization"
                 )
-            self._sectors[spec.upgrade_policy.conditions.sector].add_spec(spec)
+            else:
+                self._sectors[spec.upgrade_policy.conditions.sector].add_spec(spec)
         self._specs.append(spec)
         self._specs.sort(key=upgrade_spec_sort_key)
 

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -136,8 +136,11 @@ class OrganizationUpgradeSpec(BaseModel):
                 self.add_organization_error(
                     f"sector {spec.upgrade_policy.conditions.sector} not found in organization"
                 )
-            else:
-                self._sectors[spec.upgrade_policy.conditions.sector].add_spec(spec)
+                self.add_cluster_error(
+                    f"cluster {spec.cluster_uuid} references unknown sector {spec.upgrade_policy.conditions.sector}"
+                )
+                return
+            self._sectors[spec.upgrade_policy.conditions.sector].add_spec(spec)
         self._specs.append(spec)
         self._specs.sort(key=upgrade_spec_sort_key)
 

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -137,6 +137,7 @@ class OrganizationUpgradeSpec(BaseModel):
                     f"sector {spec.upgrade_policy.conditions.sector} not found in organization"
                 )
                 self.add_cluster_error(
+                    spec.cluster_uuid,
                     f"cluster {spec.cluster_uuid} references unknown sector {spec.upgrade_policy.conditions.sector}"
                 )
                 return

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -138,7 +138,7 @@ class OrganizationUpgradeSpec(BaseModel):
                 )
                 self.add_cluster_error(
                     spec.cluster_uuid,
-                    f"cluster {spec.cluster_uuid} references unknown sector {spec.upgrade_policy.conditions.sector}"
+                    f"cluster {spec.cluster_uuid} references unknown sector {spec.upgrade_policy.conditions.sector}",
                 )
                 return
             self._sectors[spec.upgrade_policy.conditions.sector].add_spec(spec)

--- a/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
+++ b/reconcile/test/ocm/aus/test_advanced_upgrade_service.py
@@ -293,7 +293,7 @@ def test_build_org_upgrade_spec_missing_sector(
         version_data_inheritance=None,
     )
     assert len(org_upgrade_spec.cluster_errors) == 1
-    assert len(org_upgrade_spec.organization_errors) == 0
+    assert len(org_upgrade_spec.organization_errors) == 1
     assert len(org_upgrade_spec.specs) == 0
 
 

--- a/reconcile/test/ocm/aus/test_base.py
+++ b/reconcile/test/ocm/aus/test_base.py
@@ -37,7 +37,6 @@ from reconcile.test.ocm.aus.fixtures import (
     build_upgrade_policy,
 )
 from reconcile.test.ocm.fixtures import build_ocm_cluster
-from reconcile.utils.ocm.base import OCMVersionGate
 from reconcile.utils.ocm.clusters import OCMCluster
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
@@ -76,14 +75,14 @@ def now(mocker: MockerFixture) -> datetime:
 @pytest.fixture
 def version_gates() -> list[dict[str, Any]]:
     return [
-        OCMVersionGate(**{
+        {
             "kind": "VersionGate",
             "id": "gate_id",
             "version_raw_id_prefix": "4.12",
             "label": "api.openshift.com/some-gate",
             "value": "4.12",
             "sts_only": False,
-        })
+        }
     ]
 
 

--- a/reconcile/test/ocm/aus/test_base.py
+++ b/reconcile/test/ocm/aus/test_base.py
@@ -37,6 +37,7 @@ from reconcile.test.ocm.aus.fixtures import (
     build_upgrade_policy,
 )
 from reconcile.test.ocm.fixtures import build_ocm_cluster
+from reconcile.utils.ocm.base import OCMVersionGate
 from reconcile.utils.ocm.clusters import OCMCluster
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
@@ -72,14 +73,32 @@ def now(mocker: MockerFixture) -> datetime:
 #
 
 
+@pytest.fixture
+def version_gates() -> list[dict[str, Any]]:
+    return [
+        OCMVersionGate(**{
+            "kind": "VersionGate",
+            "id": "gate_id",
+            "version_raw_id_prefix": "4.12",
+            "label": "api.openshift.com/some-gate",
+            "value": "4.12",
+            "sts_only": False,
+        })
+    ]
+
+
 def test_calculate_diff_no_lock(
     ocm_api: OCMBaseClient,
     cluster_1: OCMCluster,
     now: datetime,
+    mocker: MockerFixture,
 ) -> None:
     """
     Test case: there is no other upgrade lock, so the cluster upgrade can be scheduled
     """
+    gates_to_agree_mock = mocker.patch("reconcile.aus.base.gates_to_agree")
+    gates_to_agree_mock.return_value = []
+
     org_upgrade_spec = build_organization_upgrade_spec(
         specs=[
             (
@@ -142,11 +161,15 @@ def test_calculate_diff_inter_lock(
     cluster_1: OCMCluster,
     cluster_2: OCMCluster,
     now: datetime,
+    mocker: MockerFixture,
 ) -> None:
     """
     Test case: two clusters need an upgrade, but define the same mutex.
     only the first one will be upgraded
     """
+    gates_to_agree_mock = mocker.patch("reconcile.aus.base.gates_to_agree")
+    gates_to_agree_mock.return_value = []
+
     upgrade_policy_spec = build_upgrade_policy(
         workloads=["workload1"], soak_days=0, mutexes=["mutex1"]
     )

--- a/reconcile/test/ocm/aus/test_version_gates.py
+++ b/reconcile/test/ocm/aus/test_version_gates.py
@@ -138,9 +138,10 @@ def test_gates_to_agree_same_version(
     ocm_api: OCMBaseClient,
 ) -> None:
     gates = base.gates_to_agree(
-        gates=[OCMVersionGate(**g) for g in version_gates],
-        version_prefix="4.12",
-        cluster=cluster,
+        gates=base.gates_for_minor_version(
+            [OCMVersionGate(**g) for g in version_gates], "4.12"
+        ),
+        cluster_id=cluster.id,
         ocm_api=ocm_api,
     )
     assert gates == []
@@ -156,9 +157,10 @@ def test_gates_to_agree_ocp_agreement_required(
     cluster.version.available_upgrades = ["4.13.2"]
     cluster.aws.sts.enabled = False  # type: ignore
     gates = base.gates_to_agree(
-        gates=[OCMVersionGate(**g) for g in version_gates],
-        version_prefix="4.13",
-        cluster=cluster,
+        gates=base.gates_for_minor_version(
+            [OCMVersionGate(**g) for g in version_gates], "4.13"
+        ),
+        cluster_id=cluster.id,
         ocm_api=ocm_api,
     )
     assert {g.id for g in gates} == {version_gate_4_13_ocp_id}
@@ -174,9 +176,10 @@ def test_gates_to_agree_ocp_agreement_present(
     cluster.version.available_upgrades = ["4.13.2"]
     cluster.aws.sts.enabled = False  # type: ignore
     gates = base.gates_to_agree(
-        gates=[OCMVersionGate(**g) for g in version_gates],
-        version_prefix="4.13",
-        cluster=cluster,
+        gates=base.gates_for_minor_version(
+            [OCMVersionGate(**g) for g in version_gates], "4.13"
+        ),
+        cluster_id=cluster.id,
         ocm_api=ocm_api,
     )
     assert gates == []
@@ -193,9 +196,10 @@ def test_gates_to_agree_sts_cluster_agreement_required(
     cluster.version.available_upgrades = ["4.13.2"]
     cluster.aws.sts.enabled = True  # type: ignore
     gates = base.gates_to_agree(
-        gates=[OCMVersionGate(**g) for g in version_gates],
-        version_prefix="4.13",
-        cluster=cluster,
+        gates=base.gates_for_minor_version(
+            [OCMVersionGate(**g) for g in version_gates], "4.13"
+        ),
+        cluster_id=cluster.id,
         ocm_api=ocm_api,
     )
     # version gate for sts is not present becaues we don't want to agree to them automatically for now
@@ -213,9 +217,10 @@ def test_gates_to_agree_sts_agreement_present(
     cluster.version.available_upgrades = ["4.13.2"]
     cluster.aws.sts.enabled = True  # type: ignore
     gates = base.gates_to_agree(
-        gates=[OCMVersionGate(**g) for g in version_gates],
-        version_prefix="4.13",
-        cluster=cluster,
+        gates=base.gates_for_minor_version(
+            [OCMVersionGate(**g) for g in version_gates], "4.13"
+        ),
+        cluster_id=cluster.id,
         ocm_api=ocm_api,
     )
     assert {g.id for g in gates} == {version_gate_4_13_ocp_id}


### PR DESCRIPTION
change: if a minor version has no version gates, upgrades to that minor versions are skipped.

reasoning: usually every minor version has at least one version gate in place. this is not technically necessary but practically speaking this has been the case for every minor version of the last couple of years. we want to skip scheduling an upgrade in such situations because missing version gates might be an indicator that the gap analysis has not been conducted yet from the platform team. such upgrades bear many unknowns and are not considered safe. this mostly happens early during pre-GA, e.g. for RCs.

https://issues.redhat.com/browse/APPSRE-8694