### PR TITLE
trigger sast scan for image build

### DIFF
--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -7,6 +7,8 @@ from typing import Optional
 import reconcile.openshift_base as ob
 from reconcile import (
     jenkins_base,
+    openshift_saas_deploy_trigger_images,
+    openshift_saas_deploy_trigger_upstream_jobs,
     queries,
 )
 from reconcile.gql_definitions.common.saas_files import PipelinesProviderTektonV1
@@ -302,12 +304,16 @@ def run(
     # we only do this if:
     # - this is not a dry run
     # - there is a single saas file deployed
-    # - saas-deploy triggered by upstream-job
+    # - saas-deploy triggered by upstream job or image build
+    allowed_integration = [
+        openshift_saas_deploy_trigger_upstream_jobs.QONTRACT_INTEGRATION,
+        openshift_saas_deploy_trigger_images.QONTRACT_INTEGRATION,
+    ]
     sast = (
         not dry_run
         and len(saas_files) == 1
         and trigger_integration
-        and trigger_integration == "openshift-saas-deploy-trigger-upstream-jobs"
+        and trigger_integration in allowed_integration
         and trigger_reason
     )
     if sast:

--- a/reconcile/test/fixtures/saasherder/saas-trigger.gql.yml
+++ b/reconcile/test/fixtures/saasherder/saas-trigger.gql.yml
@@ -1,0 +1,117 @@
+---
+path: /services/test-saas-deployment-pipelines/cicd/deploy.yml
+name: test-saas-deployments-deploy
+app:
+  name: app-interface
+  selfServiceRoles:
+  - name: test
+  serviceOwners:
+  - name: AppSRE
+    email: owners@example.com
+  - name: AppSRE-1
+    email: owners-1@example.com
+
+pipelinesProvider:
+  name: tekton-app-sre-pipelines-appsres03ue1
+  provider: tekton
+  namespace:
+    name: app-sre-pipelines
+    cluster:
+      name: appsres03ue1
+      serverUrl: 'https://api.appsres03ue1.5nvu.p1.openshiftapps.com:6443'
+      consoleUrl: 'https://console.appsres03ue1.5nvu.p1.openshiftapps.com:6443'
+      internal: true
+  defaults:
+    pipelineTemplates:
+      openshiftSaasDeploy:
+        name: saas-deploy
+  pipelineTemplates:
+    openshiftSaasDeploy:
+      name: saas-deploy
+
+slack:
+  workspace:
+    name: coreos
+    integrations:
+    - name: openshift-upgrade-watcher
+      token:
+        path: app-sre/creds/slack-app-sre-groups
+        field: bot_token
+      channel: sd-app-sre
+      icon_emoji: openshift
+      username: OpenShift
+    - name: qontract-cli
+      token:
+        path: app-sre/creds/slack-app-sre-groups
+        field: bot_token
+      channel: sd-app-sre
+      icon_emoji: app-sre
+      username: AppSRE
+  channel: sd-app-sre-info
+
+managedResourceTypes:
+- Job
+
+publishJobLogs: true
+
+imagePatterns:
+- 'quay.io/centos/centos:centos8'
+
+allowedSecretParameterPaths: []
+
+resourceTemplates:
+- name: test-saas-deployments
+  url: 'https://github.com/app-sre/test-saas-deployments'
+  path: /openshift/deploy-template.yml
+  parameters: '{"PARAM":"test"}'
+  targets:
+  - namespace:
+      name: test-moving-commit-trigger
+      environment:
+        name: App-SRE
+        parameters: '{"CHANNEL":"staging"}'
+      app:
+        name: test-saas-deployments
+      cluster:
+        name: appsres03ue1
+        serverUrl: 'https://api.appsres03ue1.5nvu.p1.openshiftapps.com:6443'
+        internal: true
+    ref: main
+    path: openshift/deploy-template.yml
+  - namespace:
+      name: test-upstream-job-trigger
+      environment:
+        name: App-SRE-stage
+        parameters: '{"CHANNEL":"staging"}'
+      app:
+        name: test-saas-deployments
+      cluster:
+        name: appsres03ue1
+        serverUrl: 'https://api.appsres03ue1.5nvu.p1.openshiftapps.com:6443'
+        internal: true
+    ref: main
+    path: openshift/deploy-template.yml
+    upstream:
+      instance:
+        name: ci
+        serverUrl: 'https://jenkins.com'
+      name: job
+  - namespace:
+      name: test-image-trigger
+      environment:
+        name: App-SRE-stage
+        parameters: '{"CHANNEL":"staging"}'
+      app:
+        name: test-saas-deployments
+      cluster:
+        name: appsres03ue1
+        serverUrl: 'https://api.appsres03ue1.5nvu.p1.openshiftapps.com:6443'
+        internal: true
+    ref: main
+    path: openshift/deploy-template.yml
+    image:
+      org:
+        instance:
+          url: quay.io
+        name: centos
+      name: centos

--- a/reconcile/test/fixtures/saasherder/saas_deploy.state.json
+++ b/reconcile/test/fixtures/saasherder/saas_deploy.state.json
@@ -16,7 +16,6 @@
     "subscribe": null
   },
   "parameters": null,
-  "upstream": null,
   "disable": null,
   "delete": null,
   "saas_file_parameters": null,

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1686,7 +1686,9 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         state_content=desired_image_tag,
                     )
                     if self.include_trigger_trace:
-                        trigger_spec.reason = image_uri
+                        trigger_spec.reason = (
+                            f"{rt.url}/commit/{commit_sha} build {image_uri}"
+                        )
                     if not self.state:
                         raise Exception("state is not initialized")
                     current_image_tag = self.state.get(trigger_spec.state_key, None)


### PR DESCRIPTION
This is a missing part of [APPSRE-8072](https://issues.redhat.com/browse/APPSRE-8072). Deploy services built by RHTAP would be triggered by image build, We should also allow triggering sast scan in this case. I revisit this feature as I would like to use the same logic for triggering malware detection scan.