### PR TITLE
Review queue, escape pipes in titles

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1895,7 +1895,7 @@ def app_interface_review_queue(ctx) -> None:
             item = {
                 "id": f"[{mr.iid}]({mr.web_url})",
                 "repo": repo,
-                "title": mr.title,
+                "title": mr.title.replace("|", "&#124;"),
                 "onboarding": "onboarding" in labels,
                 "updated_at": mr.updated_at,
                 "author": author,


### PR DESCRIPTION
Pipes in titles can break the review queue, see: https://gitlab.cee.redhat.com/service/app-interface-output/-/blob/249d7417ff9e9552589ba65614f35aab26b810bb/app-interface-review-queue.md