### PR TITLE
Review queue, escape pipes in titles

### DIFF
--- a/reconcile/utils/output.py
+++ b/reconcile/utils/output.py
@@ -53,6 +53,8 @@ def format_table(content, columns, table_format="simple") -> str:
                     cell = "<br />".join(cell)
                 else:
                     cell = "\n".join(cell)
+            if table_format == "github" and isinstance(cell, str):
+                cell = cell.replace("|", "&#124;")
             row_data.append(cell)
         table_data.append(row_data)
     return tabulate(table_data, headers=headers, tablefmt=table_format)


### PR DESCRIPTION
Pipes in content can break the review queue, see: https://gitlab.cee.redhat.com/service/app-interface-output/-/blob/249d7417ff9e9552589ba65614f35aab26b810bb/app-interface-review-queue.md

