### PR TITLE
APPSRE-8280: added code to fix multiple sns subscription for terraform

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -2620,7 +2620,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         if "subscriptions" in common_values.keys():
             subscriptions = common_values.get("subscriptions")
-            for index,sub in enumerate(subscriptions):
+            for index, sub in enumerate(subscriptions):
                 sub_values = {}
                 sub_values["topic_arn"] = "${aws_sns_topic" + "." + identifier + ".arn}"
                 protocol = sub["protocol"]

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -2620,7 +2620,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         if "subscriptions" in common_values.keys():
             subscriptions = common_values.get("subscriptions")
-            for sub in subscriptions:
+            for index,sub in enumerate(subscriptions):
                 sub_values = {}
                 sub_values["topic_arn"] = "${aws_sns_topic" + "." + identifier + ".arn}"
                 protocol = sub["protocol"]
@@ -2630,7 +2630,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     raise ValueError(msg)
                 sub_values["protocol"] = protocol
                 sub_values["endpoint"] = endpoint
-                sub_identifier = f"{identifier}_{protocol}_aws_sns_topic_subscription"
+                sub_identifier = f"{identifier}_{protocol}_aws_sns_topic_subscription_{index}"
                 sub_tf_resource = aws_sns_topic_subscription(
                     sub_identifier, **sub_values
                 )

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -2630,8 +2630,10 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     raise ValueError(msg)
                 sub_values["protocol"] = protocol
                 sub_values["endpoint"] = endpoint
+                # append suffix only in case there are multiple subscriptions
+                suffix=f"_{index+1}" if len(subscriptions)>1 else ""
                 sub_identifier = (
-                    f"{identifier}_{protocol}_aws_sns_topic_subscription_{index}"
+                    f"{identifier}_{protocol}_aws_sns_topic_subscription{suffix}"
                 )
                 sub_tf_resource = aws_sns_topic_subscription(
                     sub_identifier, **sub_values

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -2630,7 +2630,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     raise ValueError(msg)
                 sub_values["protocol"] = protocol
                 sub_values["endpoint"] = endpoint
-                sub_identifier = f"{identifier}_{protocol}_aws_sns_topic_subscription_{index}"
+                sub_identifier = (
+                    f"{identifier}_{protocol}_aws_sns_topic_subscription_{index}"
+                )
                 sub_tf_resource = aws_sns_topic_subscription(
                     sub_identifier, **sub_values
                 )

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -2631,7 +2631,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 sub_values["protocol"] = protocol
                 sub_values["endpoint"] = endpoint
                 # append suffix only in case there are multiple subscriptions
-                suffix=f"_{index+1}" if len(subscriptions)>1 else ""
+                suffix = f"_{index + 1}" if len(subscriptions) > 1 else ""
                 sub_identifier = (
                     f"{identifier}_{protocol}_aws_sns_topic_subscription{suffix}"
                 )


### PR DESCRIPTION
This consists of code to fix the issue - [APPSRE-8280](https://issues.redhat.com/browse/APPSRE-8280)

Problem - The parsing logic created the same identifier for `"aws_sns_topic_subscription`. Hence  the terrascipt only used to render the resource considering the last subscription added

Now with the new code every subscription for an sns topic will have a unique  identifier. As a result all the subscription for a particular topic will be created.


Local Testing
For the following configuration
<img width="348" alt="image" src="https://github.com/app-sre/qontract-reconcile/assets/10884640/d75bdc64-ee4f-43f3-8ea5-d0bccc07a986">
The terrascript created the following plan
 
<img width="606" alt="image" src="https://github.com/app-sre/qontract-reconcile/assets/10884640/839a1581-d552-41da-9b5a-84b56e79361f">

With single subscription the output is like
<img width="435" alt="image" src="https://github.com/app-sre/qontract-reconcile/assets/10884640/56c68f95-a6e8-4b6c-a4f8-364735df9df8">

the output we get is as follows
<img width="527" alt="Screenshot 2024-01-08 at 2 38 40 PM" src="https://github.com/app-sre/qontract-reconcile/assets/10884640/07bcd5f0-be47-45ce-9894-8429167b8013">
