### PR TITLE
[openshift-resources] Switch out hard-coded App Interface Git URL for dynamic one

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -6,55 +6,32 @@ import logging
 import re
 import sys
 from collections import defaultdict
-from collections.abc import (
-    Iterable,
-    Mapping,
-    Sequence,
-)
+from collections.abc import Iterable, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import cache
 from textwrap import indent
 from threading import Lock
-from typing import (
-    Any,
-    Optional,
-    Protocol,
-    Tuple,
-)
+from typing import Any, Optional, Protocol, Tuple
 from urllib import parse
 
 import anymarkup
 import jinja2
 import jinja2.sandbox
 from deepdiff import DeepHash
-from sretoolbox.utils import (
-    retry,
-    threaded,
-)
+from sretoolbox.utils import retry, threaded
 
 import reconcile.openshift_base as ob
 from reconcile import queries
 from reconcile.change_owners.diff import IDENTIFIER_FIELD_NAME
 from reconcile.checkpoint import url_makes_sense
 from reconcile.github_users import init_github
-from reconcile.utils import (
-    amtool,
-    gql,
-    openssl,
-)
+from reconcile.typed_queries.app_interface_repo_url import get_app_interface_repo_url
+from reconcile.utils import amtool, gql, openssl
 from reconcile.utils.defer import defer
 from reconcile.utils.exceptions import FetchResourceError
-from reconcile.utils.jinja2_ext import (
-    B64EncodeExtension,
-    RaiseErrorExtension,
-)
-from reconcile.utils.oc import (
-    OC_Map,
-    OCClient,
-    OCLogMsg,
-    StatusCodeError,
-)
+from reconcile.utils.jinja2_ext import B64EncodeExtension, RaiseErrorExtension
+from reconcile.utils.oc import OC_Map, OCClient, OCLogMsg, StatusCodeError
 from reconcile.utils.openshift_resource import (
     ConstructResourceError,
     ResourceInventory,
@@ -67,10 +44,7 @@ from reconcile.utils.runtime.integration import DesiredStateShardConfig
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.sharding import is_in_shard
-from reconcile.utils.vault import (
-    SecretVersionIsNone,
-    SecretVersionNotFound,
-)
+from reconcile.utils.vault import SecretVersionIsNone, SecretVersionNotFound
 
 # +-----------------------+-------------------------+-------------+
 # |   Current / Desired   |         Present         | Not Present |
@@ -224,7 +198,6 @@ NAMESPACES_QUERY = """
 QONTRACT_INTEGRATION = "openshift_resources_base"
 QONTRACT_INTEGRATION_VERSION = make_semver(1, 9, 2)
 QONTRACT_BASE64_SUFFIX = "_qb64"
-APP_INT_BASE_URL = "https://gitlab.cee.redhat.com/service/app-interface"
 KUBERNETES_SECRET_DATA_KEY_RE = "^[-._a-zA-Z0-9]+$"
 
 _log_lock = Lock()
@@ -488,6 +461,8 @@ def fetch_provider_resource(
 ) -> OR:
     path = resource["path"]
     content = resource["content"]
+    gqlapi = gql.get_api()
+    app_int_base_url = get_app_interface_repo_url(query_func=gqlapi.query)
     if tfunc:
         content = tfunc(body=content, vars=tvars, settings=settings)
 
@@ -544,9 +519,8 @@ def fetch_provider_resource(
                         annotations = rule.get("annotations")
                         if not annotations:
                             continue
-                        # TODO(mafriedm): make this better
                         rule["annotations"]["html_url"] = (
-                            f"{APP_INT_BASE_URL}/blob/master/resources{path}"
+                            f"{app_int_base_url}/blob/master/resources{path}"
                         )
             except Exception:
                 logging.warning(

--- a/reconcile/test/test_prometheus_rules_tester.py
+++ b/reconcile/test/test_prometheus_rules_tester.py
@@ -1,20 +1,17 @@
 from typing import Any
-from unittest.mock import (
-    create_autospec,
-    patch,
-)
+from unittest.mock import create_autospec, patch
 
 import pytest
 
+from reconcile.gql_definitions.common.app_interface_repo_settings import (
+    DEFINITION as SETTINGS_QUERY,
+)
 from reconcile.gql_definitions.common.app_interface_vault_settings import (
     AppInterfaceSettingsV1,
 )
 from reconcile.openshift_resources_base import NAMESPACES_QUERY
 from reconcile.prometheus_rules_tester.integration import Test as PTest
-from reconcile.prometheus_rules_tester.integration import (
-    check_rules_and_tests,
-    run,
-)
+from reconcile.prometheus_rules_tester.integration import check_rules_and_tests, run
 from reconcile.status import ExitCodes
 from reconcile.utils import gql
 
@@ -42,6 +39,12 @@ class TestPrometheusRulesTester:
         """Mock for GqlApi.query using test_data set in setup_method."""
         if query == NAMESPACES_QUERY:
             return {"namespaces": self.ns_data}
+        if query == SETTINGS_QUERY:
+            return {
+                "settings": [
+                    {"repoUrl": "https://gitlab.cee.redhat.com/service/app-interface"}
+                ]
+            }
 
         raise TstUnsupportedGqlQueryError("Unsupported query")
 


### PR DESCRIPTION
Noticed that in App Interface FedRamp, all of our alert `html_url` values were pointing to commercial App Interface. This change updates such alerts to get the `html_url` base value from App Interface settings.

Some of the changes are updates from ruff formatting.