### PR TITLE
[openshift-resources] Fix for html_url in Prometheus alerts

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -224,7 +224,6 @@ NAMESPACES_QUERY = """
 QONTRACT_INTEGRATION = "openshift_resources_base"
 QONTRACT_INTEGRATION_VERSION = make_semver(1, 9, 2)
 QONTRACT_BASE64_SUFFIX = "_qb64"
-APP_INT_BASE_URL = "https://gitlab.cee.redhat.com/service/app-interface"
 KUBERNETES_SECRET_DATA_KEY_RE = "^[-._a-zA-Z0-9]+$"
 
 _log_lock = Lock()
@@ -536,6 +535,9 @@ def fetch_provider_resource(
 
     if add_path_to_prom_rules:
         if body["kind"] == "PrometheusRule":
+            app_int_base_url = "https://gitlab.cee.redhat.com/service/app-interface"
+            if settings and "repoUrl" in settings:
+                app_int_base_url = settings["repoUrl"]
             try:
                 groups = body["spec"]["groups"]
                 for group in groups:
@@ -544,9 +546,8 @@ def fetch_provider_resource(
                         annotations = rule.get("annotations")
                         if not annotations:
                             continue
-                        # TODO(mafriedm): make this better
                         rule["annotations"]["html_url"] = (
-                            f"{APP_INT_BASE_URL}/blob/master/resources{path}"
+                            f"{app_int_base_url}/blob/master/resources{path}"
                         )
             except Exception:
                 logging.warning(

--- a/reconcile/test/test_prometheus_rules_tester.py
+++ b/reconcile/test/test_prometheus_rules_tester.py
@@ -1,17 +1,20 @@
 from typing import Any
-from unittest.mock import create_autospec, patch
+from unittest.mock import (
+    create_autospec,
+    patch,
+)
 
 import pytest
 
-from reconcile.gql_definitions.common.app_interface_repo_settings import (
-    DEFINITION as SETTINGS_QUERY,
-)
 from reconcile.gql_definitions.common.app_interface_vault_settings import (
     AppInterfaceSettingsV1,
 )
 from reconcile.openshift_resources_base import NAMESPACES_QUERY
 from reconcile.prometheus_rules_tester.integration import Test as PTest
-from reconcile.prometheus_rules_tester.integration import check_rules_and_tests, run
+from reconcile.prometheus_rules_tester.integration import (
+    check_rules_and_tests,
+    run,
+)
 from reconcile.status import ExitCodes
 from reconcile.utils import gql
 
@@ -39,12 +42,6 @@ class TestPrometheusRulesTester:
         """Mock for GqlApi.query using test_data set in setup_method."""
         if query == NAMESPACES_QUERY:
             return {"namespaces": self.ns_data}
-        if query == SETTINGS_QUERY:
-            return {
-                "settings": [
-                    {"repoUrl": "https://gitlab.cee.redhat.com/service/app-interface"}
-                ]
-            }
 
         raise TstUnsupportedGqlQueryError("Unsupported query")
 


### PR DESCRIPTION
A second attempt at #3990 

Some colleagues pointed out that the earlier attempt resulted in a doubling of qontract-server requests which means more $$$. This take removes that additional GQL call as the function already has a settings dict passed to it which includes the `repoUrl` value I was previously querying for in GQL.