### PR TITLE
[rosa-authenticator] redact sensitive field in CloudWatch

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -6022,6 +6022,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     "${aws_cloudwatch_log_group.waf_log_group.arn}"
                 ],
                 resource_arn="${aws_wafv2_web_acl.api_waf.arn}",
+                redacted_fields={"single_header": {"name": "authorization"}},
             )
         )
 


### PR DESCRIPTION
Ensure that we aren't logging sensitive info into CloudWatch when a user interacts with rosa-authenticator.