### PR TITLE
Extended early exit cache management

### DIFF
--- a/reconcile/test/utils/test_early_exit_cache.py
+++ b/reconcile/test/utils/test_early_exit_cache.py
@@ -12,18 +12,12 @@ from reconcile.utils.early_exit_cache import (
     CacheValue,
     EarlyExitCache,
 )
-from reconcile.utils.secret_reader import SecretReaderBase
 from reconcile.utils.state import State
 
 
 @pytest.fixture
 def state() -> Any:
     return create_autospec(State)
-
-
-@pytest.fixture
-def secret_reader() -> Any:
-    return create_autospec(SecretReaderBase)
 
 
 def test_early_exit_cache_build(

--- a/reconcile/test/utils/test_early_exit_cache.py
+++ b/reconcile/test/utils/test_early_exit_cache.py
@@ -1,0 +1,185 @@
+import datetime
+from typing import Any
+from unittest.mock import create_autospec
+
+import pytest
+from deepdiff import DeepHash
+from pytest_mock import MockerFixture
+
+from reconcile.utils.early_exit_cache import (
+    CacheKey,
+    CacheStatus,
+    CacheValue,
+    EarlyExitCache,
+)
+from reconcile.utils.secret_reader import SecretReaderBase
+from reconcile.utils.state import State
+
+
+@pytest.fixture
+def state() -> Any:
+    return create_autospec(State)
+
+
+@pytest.fixture
+def secret_reader() -> Any:
+    return create_autospec(SecretReaderBase)
+
+
+def test_early_exit_cache_build(
+    mocker: MockerFixture,
+    state: Any,
+    secret_reader: Any,
+) -> None:
+    mocked_init_state = mocker.patch(
+        "reconcile.utils.early_exit_cache.init_state",
+        return_value=state,
+    )
+
+    with EarlyExitCache.build(secret_reader):
+        pass
+
+    mocked_init_state.assert_called_once_with("early-exit-cache", secret_reader)
+    state.cleanup.assert_called_once_with()
+
+
+@pytest.fixture
+def early_exit_cache(state: Any) -> EarlyExitCache:
+    return EarlyExitCache(state)
+
+
+@pytest.mark.parametrize(
+    "integration, integration_version, dry_run, cache_desired_state, expected",
+    [
+        (
+            "some-integration",
+            "some-version",
+            False,
+            "state",
+            f"some-integration/some-version/no-dry-run/{DeepHash('state')['state']}",
+        ),
+        (
+            "some-integration",
+            "some-version",
+            True,
+            "state",
+            f"some-integration/some-version/dry-run/{DeepHash('state')['state']}",
+        ),
+    ],
+)
+def test_cache_key_string(
+    integration: str,
+    integration_version: str,
+    dry_run: bool,
+    cache_desired_state: Any,
+    expected: str,
+) -> None:
+    cache_key = CacheKey(
+        integration=integration,
+        integration_version=integration_version,
+        dry_run=dry_run,
+        cache_desired_state=cache_desired_state,
+    )
+
+    assert str(cache_key) == expected
+
+
+@pytest.fixture
+def cache_key() -> CacheKey:
+    return CacheKey(
+        integration="some-integration",
+        integration_version="some-integration-version",
+        dry_run=False,
+        cache_desired_state={"k": "v"},
+    )
+
+
+@pytest.fixture
+def cache_value() -> CacheValue:
+    return CacheValue(
+        desired_state={"k": "v"},
+        log_output="some-log-output",
+        applied_count=1,
+    )
+
+
+def test_early_exit_cache_get(
+    early_exit_cache: EarlyExitCache,
+    state: Any,
+    cache_key: CacheKey,
+    cache_value: CacheValue,
+) -> None:
+    state.get.return_value = cache_value.dict()
+
+    value = early_exit_cache.get(cache_key)
+
+    assert value == cache_value
+    state.get.assert_called_once_with(str(cache_key))
+
+
+def test_early_exit_cache_set(
+    mocker: MockerFixture,
+    early_exit_cache: EarlyExitCache,
+    state: Any,
+    cache_key: CacheKey,
+    cache_value: CacheValue,
+) -> None:
+    mock_datetime = mocker.patch(
+        "reconcile.utils.early_exit_cache.datetime",
+    )
+    now = datetime.datetime.now(tz=datetime.UTC)
+    mock_datetime.now.return_value = now
+
+    early_exit_cache.set(cache_key, cache_value, 100)
+
+    expected_expire_at = str(int((now + datetime.timedelta(seconds=100)).timestamp()))
+    state.add.assert_called_once_with(
+        str(cache_key),
+        cache_value.dict(),
+        metadata={"expire-at": expected_expire_at},
+        force=True,
+    )
+
+
+def test_early_exit_cache_head_miss(
+    early_exit_cache: EarlyExitCache,
+    state: Any,
+    cache_key: CacheKey,
+) -> None:
+    state.head.return_value = (False, {})
+
+    status = early_exit_cache.head(cache_key)
+
+    assert status == CacheStatus.MISS
+
+
+@pytest.mark.parametrize(
+    "expire_at_offset, expected_status",
+    [
+        (-1, CacheStatus.EXPIRED),
+        (0, CacheStatus.EXPIRED),
+        (1, CacheStatus.HIT),
+    ],
+)
+def test_early_exit_cache_head(
+    mocker: MockerFixture,
+    early_exit_cache: EarlyExitCache,
+    state: Any,
+    cache_key: CacheKey,
+    expire_at_offset: int,
+    expected_status: CacheStatus,
+) -> None:
+    now = datetime.datetime.now(tz=datetime.UTC)
+    mock_datetime = mocker.patch(
+        "reconcile.utils.early_exit_cache.datetime",
+    )
+    mock_datetime.now.return_value = now
+    mock_datetime.fromtimestamp.side_effect = datetime.datetime.fromtimestamp
+    state.head.return_value = (
+        True,
+        {"expire-at": str(int(now.timestamp()) + expire_at_offset)},
+    )
+
+    status = early_exit_cache.head(cache_key)
+
+    assert status == expected_status

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -107,5 +107,5 @@ def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
         data=promotion_info,
     )
     deployment_state._state.add.assert_called_once_with(  # type: ignore[attr-defined]
-        "promotions_v2/channel/uid/sha", promotion_info.dict(), True
+        "promotions_v2/channel/uid/sha", promotion_info.dict(), force=True
     )

--- a/reconcile/test/utils/test_state.py
+++ b/reconcile/test/utils/test_state.py
@@ -187,6 +187,22 @@ def test_exists_for_missing_bucket(s3_client: S3Client) -> None:
         )
 
 
+def test_add_without_metadata(integration_state: State) -> None:
+    integration_state.add("k", "v", force=True)
+
+    assert integration_state.head("k") == (True, {})
+    assert integration_state.get("k") == "v"
+
+
+def test_add_with_metadata(integration_state: State) -> None:
+    metadata = {"a": "b"}
+
+    integration_state.add("k", "v", metadata=metadata, force=True)
+
+    assert integration_state.head("k") == (True, metadata)
+    assert integration_state.get("k") == "v"
+
+
 #
 # aquire settings
 #

--- a/reconcile/utils/early_exit_cache.py
+++ b/reconcile/utils/early_exit_cache.py
@@ -1,0 +1,86 @@
+from datetime import UTC, datetime, timedelta
+from enum import Enum
+from typing import Any, Optional, Self
+
+from deepdiff import DeepHash
+from pydantic import BaseModel
+
+from reconcile.utils.secret_reader import SecretReaderBase
+from reconcile.utils.state import State, init_state
+
+STATE_INTEGRATION = "early-exit-cache"
+EXPIRE_AT_METADATA_KEY = "expire-at"
+
+
+class CacheKey(BaseModel):
+    integration: str
+    integration_version: str
+    dry_run: bool
+    cache_desired_state: object
+
+    def __str__(self) -> str:
+        return "/".join([
+            self.integration,
+            self.integration_version,
+            "dry-run" if self.dry_run else "no-dry-run",
+            DeepHash(self.cache_desired_state)[self.cache_desired_state],
+        ])
+
+
+class CacheValue(BaseModel):
+    desired_state: object
+    log_output: str
+    applied_count: int
+
+
+class CacheStatus(Enum):
+    MISS = "MISS"
+    HIT = "HIT"
+    EXPIRED = "EXPIRED"
+
+
+class EarlyExitCache:
+    def __init__(self, state: State):
+        self.state = state
+
+    @classmethod
+    def build(
+        cls,
+        secret_reader: Optional[SecretReaderBase] = None,
+    ) -> Self:
+        state = init_state(STATE_INTEGRATION, secret_reader)
+        return cls(state)
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.cleanup()
+
+    def cleanup(self) -> None:
+        self.state.cleanup()
+
+    def get(self, key: CacheKey) -> CacheValue:
+        value = self.state.get(str(key))
+        return CacheValue.parse_obj(value)
+
+    def set(self, key: CacheKey, value: CacheValue, ttl_seconds: int) -> None:
+        expire_at = datetime.now(tz=UTC) + timedelta(seconds=ttl_seconds)
+        metadata = {EXPIRE_AT_METADATA_KEY: str(int(expire_at.timestamp()))}
+        self.state.add(
+            str(key),
+            value.dict(),
+            metadata=metadata,
+            force=True,
+        )
+
+    def head(self, key: CacheKey) -> CacheStatus:
+        exists, metadata = self.state.head(str(key))
+        if not exists:
+            return CacheStatus.MISS
+
+        expire_at = datetime.fromtimestamp(
+            int(metadata[EXPIRE_AT_METADATA_KEY]),
+            tz=UTC,
+        )
+        return CacheStatus.HIT if datetime.now(UTC) < expire_at else CacheStatus.EXPIRED

--- a/reconcile/utils/early_exit_cache.py
+++ b/reconcile/utils/early_exit_cache.py
@@ -83,4 +83,5 @@ class EarlyExitCache:
             int(metadata[EXPIRE_AT_METADATA_KEY]),
             tz=UTC,
         )
-        return CacheStatus.HIT if datetime.now(UTC) < expire_at else CacheStatus.EXPIRED
+        now = datetime.now(UTC)
+        return CacheStatus.HIT if now < expire_at else CacheStatus.EXPIRED

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         # this is really needed only in lint and type validations.
         # Is there any better place to put this in?
         "packaging~=23.1",
-        "deepdiff==6.4.1",
+        "deepdiff==6.7.1",
         "jsonpath-ng==1.5.3",
         "networkx~=2.8",
         "mypy-boto3-s3~=1.24.94",

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2419,7 +2419,7 @@ def early_exit_cache(ctx):
     pass
 
 
-@early_exit_cache.command(name="head")  # type: ignore
+@early_exit_cache.command(name="head")
 @click.option(
     "-i",
     "--integration",
@@ -2462,7 +2462,7 @@ def early_exit_cache_head(
         print(status)
 
 
-@early_exit_cache.command(name="get")  # type: ignore
+@early_exit_cache.command(name="get")
 @click.option(
     "-i",
     "--integration",

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -83,6 +83,7 @@ from reconcile.utils import (
     gql,
 )
 from reconcile.utils.aws_api import AWSApi
+from reconcile.utils.early_exit_cache import CacheKey, CacheValue, EarlyExitCache
 from reconcile.utils.environ import environ
 from reconcile.utils.external_resources import (
     PROVIDER_AWS,
@@ -2409,6 +2410,176 @@ def state_set(ctx, integration, key, value):
 def rm(ctx, integration, key):
     state = init_state(integration=integration)
     state.rm(key)
+
+
+@root.group()
+@environ(["APP_INTERFACE_STATE_BUCKET"])
+@click.pass_context
+def early_exit_cache(ctx):
+    pass
+
+
+@early_exit_cache.command(name="head")  # type: ignore
+@click.option(
+    "-i",
+    "--integration",
+    help="Integration name.",
+    required=True,
+)
+@click.option(
+    "-v",
+    "--integration-version",
+    help="Integration version.",
+    required=True,
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    help="",
+    default=False,
+)
+@click.option(
+    "-c",
+    "--cache-desired-state",
+    help="Cache desired state. It should be a JSON string.",
+    required=True,
+)
+@click.pass_context
+def early_exit_cache_head(
+    ctx,
+    integration,
+    integration_version,
+    dry_run,
+    cache_desired_state,
+):
+    with EarlyExitCache.build() as cache:
+        cache_key = CacheKey(
+            integration=integration,
+            integration_version=integration_version,
+            dry_run=dry_run,
+            cache_desired_state=json.loads(cache_desired_state),
+        )
+        status = cache.head(cache_key)
+        print(status)
+
+
+@early_exit_cache.command(name="get")  # type: ignore
+@click.option(
+    "-i",
+    "--integration",
+    help="Integration name.",
+    required=True,
+)
+@click.option(
+    "-v",
+    "--integration-version",
+    help="Integration version.",
+    required=True,
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    help="",
+    default=False,
+)
+@click.option(
+    "-c",
+    "--cache-desired-state",
+    help="Cache desired state. It should be a JSON string.",
+    required=True,
+)
+@click.pass_context
+def early_exit_cache_get(
+    ctx,
+    integration,
+    integration_version,
+    dry_run,
+    cache_desired_state,
+):
+    with EarlyExitCache.build() as cache:
+        cache_key = CacheKey(
+            integration=integration,
+            integration_version=integration_version,
+            dry_run=dry_run,
+            cache_desired_state=json.loads(cache_desired_state),
+        )
+        value = cache.get(cache_key)
+        print(value)
+
+
+@early_exit_cache.command(name="set")
+@click.option(
+    "-i",
+    "--integration",
+    help="Integration name.",
+    required=True,
+)
+@click.option(
+    "-v",
+    "--integration-version",
+    help="Integration version.",
+    required=True,
+)
+@click.option(
+    "--dry-run/--no-dry-run",
+    help="",
+    default=False,
+)
+@click.option(
+    "-c",
+    "--cache-desired-state",
+    help="Cache desired state. It should be a JSON string.",
+    required=True,
+)
+@click.option(
+    "-d",
+    "--desired-state",
+    help="Desired state. It should be a JSON string.",
+    required=True,
+)
+@click.option(
+    "-l",
+    "--log-output",
+    help="Log output.",
+    default="",
+)
+@click.option(
+    "-a",
+    "--applied-count",
+    help="Log output.",
+    default=0,
+    type=int,
+)
+@click.option(
+    "-t",
+    "--ttl",
+    help="TTL, in seconds.",
+    default=60,
+    type=int,
+)
+@click.pass_context
+def early_exit_cache_set(
+    ctx,
+    integration,
+    integration_version,
+    dry_run,
+    cache_desired_state,
+    desired_state,
+    log_output,
+    applied_count,
+    ttl,
+):
+    with EarlyExitCache.build() as cache:
+        cache_key = CacheKey(
+            integration=integration,
+            integration_version=integration_version,
+            dry_run=dry_run,
+            cache_desired_state=json.loads(cache_desired_state),
+        )
+        cache_value = CacheValue(
+            desired_state=json.loads(desired_state),
+            log_output=log_output,
+            applied_count=applied_count,
+        )
+        cache.set(cache_key, cache_value, ttl)
 
 
 @root.command()


### PR DESCRIPTION
Extended early exit cache management, with `qontract-cli` methods to test.

Support 3 methods:

* `head` check cache status
* `get` get cache value
* `set` set cache value

Local test via `localstack`

```shell
# start localstack
$ make localstack

# set envs to point to localstack s3
$ export $(cat ./dev/localstack/.env.local | xargs)

# check cache status
$ qontract-cli --config config.toml early-exit-cache head -i a -v b --dry-run -c {}
CacheStatus.MISS

# set cache with 30s ttl
$ qontract-cli --config config.debug.toml early-exit-cache set -i a -v b --dry-run -c {} -d {} --ttl 30

# check cache status
$ qontract-cli --config config.toml early-exit-cache head -i a -v b --dry-run -c {}
CacheStatus.HIT

# get cache value
$ qontract-cli --config config.toml early-exit-cache get -i a -v b --dry-run -c {}
desired_state={} log_output='' applied_count=0

# wait for 30s then check cache status
$ qontract-cli --config config.toml early-exit-cache head -i a -v b --dry-run -c {}
CacheStatus.EXPIRED
```

[APPSRE-8725](https://issues.redhat.com/browse/APPSRE-8725)