### PR TITLE
ROSA TGW attachments and peerings without osd-experience

### DIFF
--- a/reconcile/gql_definitions/common/clusters_with_peering.gql
+++ b/reconcile/gql_definitions/common/clusters_with_peering.gql
@@ -24,6 +24,12 @@ query ClustersWithPeering {
 
     spec {
       region
+      ... on ClusterSpecROSA_v1 {
+        account {
+          name
+          uid
+        }
+      }
     }
     network {
       vpc

--- a/reconcile/gql_definitions/common/clusters_with_peering.py
+++ b/reconcile/gql_definitions/common/clusters_with_peering.py
@@ -99,6 +99,12 @@ query ClustersWithPeering {
 
     spec {
       region
+      ... on ClusterSpecROSA_v1 {
+        account {
+          name
+          uid
+        }
+      }
     }
     network {
       vpc
@@ -207,6 +213,15 @@ class ClusterSpecV1(ConfiguredBaseModel):
     region: str = Field(..., alias="region")
 
 
+class AWSAccountV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+    uid: str = Field(..., alias="uid")
+
+
+class ClusterSpecROSAV1(ClusterSpecV1):
+    account: Optional[AWSAccountV1] = Field(..., alias="account")
+
+
 class ClusterNetworkV1(ConfiguredBaseModel):
     vpc: str = Field(..., alias="vpc")
 
@@ -224,7 +239,7 @@ class ClusterPeeringConnectionAccountV1(ClusterPeeringConnectionV1):
     manage_account_routes: Optional[bool] = Field(..., alias="manageAccountRoutes")
 
 
-class AWSAccountV1(ConfiguredBaseModel):
+class ClusterPeeringConnectionAccountVPCMeshV1_AWSAccountV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     uid: str = Field(..., alias="uid")
     terraform_username: Optional[str] = Field(..., alias="terraformUsername")
@@ -232,7 +247,7 @@ class AWSAccountV1(ConfiguredBaseModel):
 
 
 class ClusterPeeringConnectionAccountVPCMeshV1(ClusterPeeringConnectionV1):
-    account: AWSAccountV1 = Field(..., alias="account")
+    account: ClusterPeeringConnectionAccountVPCMeshV1_AWSAccountV1 = Field(..., alias="account")
     tags: Optional[Json] = Field(..., alias="tags")
 
 
@@ -312,7 +327,7 @@ class ClusterV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     ocm: Optional[OpenShiftClusterManagerV1] = Field(..., alias="ocm")
     aws_infrastructure_management_accounts: Optional[list[AWSInfrastructureManagementAccount]] = Field(..., alias="awsInfrastructureManagementAccounts")
-    spec: Optional[ClusterSpecV1] = Field(..., alias="spec")
+    spec: Optional[Union[ClusterSpecROSAV1, ClusterSpecV1]] = Field(..., alias="spec")
     network: Optional[ClusterNetworkV1] = Field(..., alias="network")
     peering: Optional[ClusterPeeringV1] = Field(..., alias="peering")
     disable: Optional[DisableClusterAutomationsV1] = Field(..., alias="disable")

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1073,6 +1073,19 @@ CLUSTER_PEERING_QUERY = """
       region
       private
       hypershift
+      ... on ClusterSpecROSA_v1 {
+        account {
+          name
+          uid
+          terraformUsername
+          automationToken {
+            path
+            field
+            version
+            format
+          }
+        }
+      }
     }
     network {
       vpc
@@ -1147,6 +1160,19 @@ CLUSTER_PEERING_QUERY = """
               region
               private
               hypershift
+              ... on ClusterSpecROSA_v1 {
+                account {
+                  name
+                  uid
+                  terraformUsername
+                  automationToken {
+                    path
+                    field
+                    version
+                    format
+                  }
+                }
+              }
             }
             awsInfrastructureManagementAccounts {
               account {
@@ -1174,6 +1200,21 @@ CLUSTER_PEERING_QUERY = """
                   name
                   cluster {
                     name
+                    spec {
+                      ... on ClusterSpecROSA_v1 {
+                        account {
+                          name
+                          uid
+                          terraformUsername
+                          automationToken {
+                            path
+                            field
+                            version
+                            format
+                          }
+                        }
+                      }
+                    }
                   }
                   assumeRole
                   awsInfrastructureManagementAccount {

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -311,7 +311,7 @@ def _populate_tgw_attachments_working_dirs(
         )
     for infra_account_name, accounts in accounts_by_infra_account_name.items():
         ts.populate_additional_providers(infra_account_name, accounts)
-    ts.populate_tgw_attachments([item.dict(by_alias=True) for item in desired_state])
+    ts.populate_tgw_attachments(desired_state)
     working_dirs = ts.dump(print_to_file=print_to_file)
     return working_dirs
 

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -372,7 +372,6 @@ def _fetch_desired_state_data_source(
     clusters = get_clusters_with_peering(gql.get_api())
     tgw_clusters = _filter_tgw_clusters(clusters, account_name)
     all_accounts = get_aws_accounts(gql.get_api())
-    # tgw_accounts = _filter_tgw_accounts(accounts, tgw_clusters)
     return DesiredStateDataSource(
         clusters=tgw_clusters,
         accounts=all_accounts,

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -61,6 +61,7 @@ def test_c2c_all_clusters(mocker):
         {
             "connection_provider": "cluster-vpc-requester",
             "connection_name": "peername",
+            "infra_account_name": "acc",
             "requester": {
                 "cidr_block": "requester_vpc",
                 "region": "region",
@@ -226,6 +227,7 @@ def test_c2c_hcp(
         {
             "connection_provider": "cluster-vpc-requester",
             "connection_name": "peername",
+            "infra_account_name": "acc",
             "requester": {
                 "cidr_block": "requester_vpc",
                 "region": "region",
@@ -326,6 +328,7 @@ def test_c2c_base(mocker):
         {
             "connection_provider": "cluster-vpc-requester",
             "connection_name": "peername",
+            "infra_account_name": "acc",
             "requester": {
                 "cidr_block": "requester_vpc",
                 "region": "region",
@@ -798,6 +801,7 @@ class TestBuildDesiredStateVpcMeshSingleCluster(testslide.TestCase):
             {
                 "connection_provider": "account-vpc-mesh",
                 "connection_name": "peername_peer_account-vpc1",
+                "infra_account_name": self.peer_account["name"],
                 "requester": {
                     "vpc_id": "vpc_id",
                     "route_table_ids": ["route_table_id"],
@@ -818,6 +822,7 @@ class TestBuildDesiredStateVpcMeshSingleCluster(testslide.TestCase):
             {
                 "connection_provider": "account-vpc-mesh",
                 "connection_name": "peername_peer_account-vpc2",
+                "infra_account_name": self.peer_account["name"],
                 "requester": {
                     "vpc_id": "vpc_id",
                     "route_table_ids": ["route_table_id"],
@@ -870,6 +875,7 @@ class TestBuildDesiredStateVpcMeshSingleCluster(testslide.TestCase):
             {
                 "connection_provider": "account-vpc-mesh",
                 "connection_name": "peername_peer_account-vpc1",
+                "infra_account_name": self.peer_account["name"],
                 "requester": {
                     "vpc_id": "vpc_id",
                     "route_table_ids": ["route_table_id"],
@@ -890,6 +896,7 @@ class TestBuildDesiredStateVpcMeshSingleCluster(testslide.TestCase):
             {
                 "connection_provider": "account-vpc-mesh",
                 "connection_name": "peername_peer_account-vpc2",
+                "infra_account_name": self.peer_account["name"],
                 "requester": {
                     "vpc_id": "vpc_id",
                     "route_table_ids": ["route_table_id"],
@@ -1203,6 +1210,7 @@ class TestBuildDesiredStateVpcSingleCluster(testslide.TestCase):
                 },
                 "connection_name": "peername",
                 "connection_provider": "account-vpc",
+                "infra_account_name": "accountname",
                 "deleted": False,
                 "requester": {
                     "account": {
@@ -1269,6 +1277,7 @@ class TestBuildDesiredStateVpcSingleCluster(testslide.TestCase):
                 },
                 "connection_name": "peername",
                 "connection_provider": "account-vpc",
+                "infra_account_name": "accountname",
                 "deleted": False,
                 "requester": {
                     "account": {


### PR DESCRIPTION
Trying to remove the need for osd-experience/network-mgmt role for TGW attachments and peerings. This is done by using directly the cluster account terraform user instead of relying on a remote terraform user and assuming role onto the network-mgmt role.

The review should be easier one commit at a time.

The basic idea is to add an `infra_account_name` field in desired state items. This field represents the account against which we run terraform (basically the one holding the state). This allows to have requester/accepter cluster account which do not use this central account + assume_role for their provider, but can directly be targeted with their own terraform user.

The aim here is that running the integration outputs a TF script which is fully identical if we keep the `assumeRole` fields in peering connections.
When we remove those `assumeRole`:
- renamed aliases for ROSA cluster accounts where `assumeRole` is not set, and use of direct terraform user in there
- use of those aliases in TGW/Peering related resources