### PR TITLE
APPSRE8701 retain last successed builds for CI

### DIFF
--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -33,9 +33,10 @@ def delete_builds(jenkins, builds_todel, dry_run=True):
                 msg = f"failed to delete {job_name}/{build_id}"
                 logging.exception(msg)
 
+
 def get_last_build_ids(builds):
     builds_to_keep = []
-    #FIXME need to explicitly sort and not rely on order API returns
+    # FIXME need to explicitly sort and not rely on order API returns
 
     good_build_timestamp = 0
     for build in builds:
@@ -51,6 +52,7 @@ def get_last_build_ids(builds):
                 good_build_timestamp = build["timestamp"]
     return builds_to_keep
 
+
 def find_builds(jenkins, job_names, rules):
     # Current time in ms
     time_ms = time.time() * 1000
@@ -61,10 +63,12 @@ def find_builds(jenkins, job_names, rules):
             if rule["name_re"].search(job_name):
                 builds = jenkins.get_builds(job_name)
                 # We need to keep last [|successful] build (https://issues.redhat.com/browse/APPSRE-8701)
-                builds_to_keep =  get_last_build_ids(builds)                      
+                builds_to_keep = get_last_build_ids(builds)
                 for build in builds:
                     if build["id"] in builds_to_keep:
-                        logging.debug(f"{jenkins.url}: {job_name} build: {build['id']} will be kept")
+                        logging.debug(
+                            f"{jenkins.url}: {job_name} build: {build['id']} will be kept"
+                        )
                         continue
                     if time_ms - rule["keep_ms"] > build["timestamp"]:
                         builds_found.append({

--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -36,20 +36,14 @@ def delete_builds(jenkins, builds_todel, dry_run=True):
 
 def get_last_build_ids(builds):
     builds_to_keep = []
-    # FIXME need to explicitly sort and not rely on order API returns
+    if builds != []:
+        last_build = sorted(builds, key=lambda b: b["timestamp"], reverse=True)[0]
+        builds_to_keep.append(last_build["id"])
 
-    good_build_timestamp = 0
-    for build in builds:
-        if build["timestamp"] > good_build_timestamp:
-            builds_to_keep.append(build["id"])
-            good_build_timestamp = build["timestamp"]
-
-    good_build_timestamp = 0
-    for build in builds:
+    for build in sorted(builds, key=lambda b: b["timestamp"], reverse=True):
         if build["result"] == "SUCCESS":
-            if build["timestamp"] > good_build_timestamp:
-                builds_to_keep.append(build["id"])
-                good_build_timestamp = build["timestamp"]
+            builds_to_keep.append(build["id"])
+            break
     return builds_to_keep
 
 

--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -36,11 +36,11 @@ def delete_builds(jenkins, builds_todel, dry_run=True):
 
 def get_last_build_ids(builds):
     builds_to_keep = []
-    if builds != []:
+    if builds:
         last_build = sorted(builds, key=lambda b: b["timestamp"], reverse=True)[0]
         builds_to_keep.append(last_build["id"])
 
-    for build in sorted(builds, key=lambda b: b["timestamp"], reverse=True):
+    for build in builds:
         if build["result"] == "SUCCESS":
             builds_to_keep.append(build["id"])
             break
@@ -56,7 +56,7 @@ def find_builds(jenkins, job_names, rules):
         for rule in rules:
             if rule["name_re"].search(job_name):
                 builds = jenkins.get_builds(job_name)
-                # We need to keep last [|successful] build (https://issues.redhat.com/browse/APPSRE-8701)
+                # We need to keep last and last successful builds (https://issues.redhat.com/browse/APPSRE-8701)
                 builds_to_keep = get_last_build_ids(builds)
                 for build in builds:
                     if build["id"] in builds_to_keep:

--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -36,11 +36,12 @@ def delete_builds(jenkins, builds_todel, dry_run=True):
 
 def get_last_build_ids(builds):
     builds_to_keep = []
-    if builds:
-        last_build = sorted(builds, key=lambda b: b["timestamp"], reverse=True)[0]
+    sorted_builds = sorted(builds, key=lambda b: b["timestamp"], reverse=True)
+    if sorted_builds:
+        last_build = sorted_builds[0]
         builds_to_keep.append(last_build["id"])
 
-    for build in builds:
+    for build in sorted_builds:
         if build["result"] == "SUCCESS":
             builds_to_keep.append(build["id"])
             break

--- a/reconcile/jenkins_job_builds_cleaner.py
+++ b/reconcile/jenkins_job_builds_cleaner.py
@@ -33,6 +33,23 @@ def delete_builds(jenkins, builds_todel, dry_run=True):
                 msg = f"failed to delete {job_name}/{build_id}"
                 logging.exception(msg)
 
+def get_last_build_ids(builds):
+    builds_to_keep = []
+    #FIXME need to explicitly sort and not rely on order API returns
+
+    good_build_timestamp = 0
+    for build in builds:
+        if build["timestamp"] > good_build_timestamp:
+            builds_to_keep.append(build["id"])
+            good_build_timestamp = build["timestamp"]
+
+    good_build_timestamp = 0
+    for build in builds:
+        if build["result"] == "SUCCESS":
+            if build["timestamp"] > good_build_timestamp:
+                builds_to_keep.append(build["id"])
+                good_build_timestamp = build["timestamp"]
+    return builds_to_keep
 
 def find_builds(jenkins, job_names, rules):
     # Current time in ms
@@ -43,16 +60,11 @@ def find_builds(jenkins, job_names, rules):
         for rule in rules:
             if rule["name_re"].search(job_name):
                 builds = jenkins.get_builds(job_name)
-                # We need to keep last successful build (https://issues.redhat.com/browse/APPSRE-8701)
-                good_build_timestamp = 0
+                # We need to keep last [|successful] build (https://issues.redhat.com/browse/APPSRE-8701)
+                builds_to_keep =  get_last_build_ids(builds)                      
                 for build in builds:
-                    if build["result"] == "SUCCESS":
-                        if build["timestamp"] > good_build_timestamp:
-                            build_to_keep = build["id"]
-                            good_build_timestamp = build["timestamp"]
-                for build in builds:
-                    if build["id"] == build_to_keep:
-                        logging.info(f"{jenkins.url}: {job_name} build: {build_to_keep} will be kept")
+                    if build["id"] in builds_to_keep:
+                        logging.debug(f"{jenkins.url}: {job_name} build: {build['id']} will be kept")
                         continue
                     if time_ms - rule["keep_ms"] > build["timestamp"]:
                         builds_found.append({


### PR DESCRIPTION
If last build is cleaned then SCM that pools git consider as it newer built last commit and initiates new (duplicated) build.

We should preserve last SUCCESSFUL built even if cleanup rules matches it.