### PR TITLE
APPSRE-8505 allow hash/channel concatenation

### DIFF
--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
@@ -12,7 +12,7 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request 
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
     CHANNELS_REF,
-    CONTENT_HASH,
+    CONTENT_HASHES,
     PROMOTION_DATA_SEPARATOR,
     SAPM_LABEL,
     SAPM_VERSION,
@@ -51,7 +51,7 @@ class MergeRequestManager:
         self._vcs = vcs
         self._renderer = renderer
         self._version_ref_regex = re.compile(rf"{VERSION_REF}: (.*)$", re.MULTILINE)
-        self._content_hash_regex = re.compile(rf"{CONTENT_HASH}: (.*)$", re.MULTILINE)
+        self._content_hash_regex = re.compile(rf"{CONTENT_HASHES}: (.*)$", re.MULTILINE)
         self._channels_regex = re.compile(rf"{CHANNELS_REF}: (.*)$", re.MULTILINE)
         self._open_mrs: list[OpenMergeRequest] = []
         self._open_mrs_with_problems: list[OpenMergeRequest] = []
@@ -140,11 +140,11 @@ class MergeRequestManager:
             if not content_hash:
                 logging.info(
                     "Bad %s format. Closing %s",
-                    CONTENT_HASH,
+                    CONTENT_HASHES,
                     mr.attributes.get("web_url", "NO_WEBURL"),
                 )
                 self._vcs.close_app_interface_mr(
-                    mr, f"Closing this MR because of bad {CONTENT_HASH} format."
+                    mr, f"Closing this MR because of bad {CONTENT_HASHES} format."
                 )
                 continue
 
@@ -196,7 +196,7 @@ class MergeRequestManager:
         return any(
             True
             for mr in self._open_mrs
-            if mr.content_hash == content_hash and mr.channels == channels
+            if content_hash in mr.content_hash and channels in mr.channels
         )
 
     def create_promotion_merge_requests(
@@ -221,9 +221,9 @@ class MergeRequestManager:
                 )
                 continue
             for mr in self._open_mrs:
-                if mr.channels != channel_combo:
+                if channel_combo not in mr.channels:
                     continue
-                if mr.content_hash != combined_content_hash:
+                if combined_content_hash not in mr.content_hash:
                     logging.info(
                         "Closing MR %s because it has out-dated content",
                         mr.raw.attributes.get("web_url", "NO_WEBURL"),

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
@@ -18,9 +18,9 @@ from reconcile.saas_auto_promotions_manager.subscriber import Subscriber
 PROMOTION_DATA_SEPARATOR = (
     "**SAPM Data - DO NOT MANUALLY CHANGE ANYTHING BELOW THIS LINE**"
 )
-SAPM_VERSION = "1.0.0"
+SAPM_VERSION = "1.1.0"
 SAPM_LABEL = "SAPM"
-CONTENT_HASH = "content_hash"
+CONTENT_HASHES = "content_hashes"
 CHANNELS_REF = "channels"
 VERSION_REF = "sapm_version"
 SAPM_DESC = f"""
@@ -142,13 +142,13 @@ class Renderer:
 
 {CHANNELS_REF}: {channels}
 
-{CONTENT_HASH}: {content_hash}
+{CONTENT_HASHES}: {content_hash}
 
 {VERSION_REF}: {SAPM_VERSION}
         """
 
     def render_title(self, channels: str) -> str:
-        return f"[auto-promotion] event for channel(s) {channels}"
+        return f"[SAPM] auto-promotion for {channels}"
 
 
 def _parse_expression(expression: str) -> Any:

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/conftest.py
@@ -12,7 +12,7 @@ from reconcile.gql_definitions.fragments.saas_target_namespace import (
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
     CHANNELS_REF,
-    CONTENT_HASH,
+    CONTENT_HASHES,
     PROMOTION_DATA_SEPARATOR,
     SAPM_LABEL,
     SAPM_VERSION,
@@ -43,7 +43,7 @@ from .data_keys import (
 def mr_builder() -> Callable[[Mapping], ProjectMergeRequest]:
     def builder(data: Mapping) -> ProjectMergeRequest:
         mr = create_autospec(spec=ProjectMergeRequest)
-        if CONTENT_HASH in data:
+        if CONTENT_HASHES in data:
             # Generate with valid defaults
             mr.attributes = {
                 "labels": [SAPM_LABEL],
@@ -51,7 +51,7 @@ def mr_builder() -> Callable[[Mapping], ProjectMergeRequest]:
                 {PROMOTION_DATA_SEPARATOR}
                 {VERSION_REF}: {data.get(VERSION_REF, SAPM_VERSION)}
                 {CHANNELS_REF}: {data.get(SUBSCRIBER_CHANNELS, "some_channel")}
-                {CONTENT_HASH}: {data.get(SUBSCRIBER_CONTENT_HASH, "content_hash")}
+                {CONTENT_HASHES}: {data.get(SUBSCRIBER_CONTENT_HASH, "content_hash")}
                 """,
                 "web_url": "http://localhost",
                 "has_conflicts": False,

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/data_keys.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/data_keys.py
@@ -1,7 +1,11 @@
+from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
+    CONTENT_HASHES,
+)
+
 OPEN_MERGE_REQUESTS = "open_merge_requests"
 LABELS = "labels"
 DESCRIPTION = "description"
-SUBSCRIBER_CONTENT_HASH = "content_hash"
+SUBSCRIBER_CONTENT_HASH = CONTENT_HASHES
 SUBSCRIBER_TARGET_PATH = "target_path"
 SUBSCRIBER_DESIRED_CONFIG_HASHES = "config_hashes"
 SUBSCRIBER_DESIRED_REF = "desired_ref"

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_housekeeping.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_housekeeping.py
@@ -8,7 +8,7 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request_
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
     CHANNELS_REF,
-    CONTENT_HASH,
+    CONTENT_HASHES,
     PROMOTION_DATA_SEPARATOR,
     SAPM_LABEL,
     SAPM_VERSION,
@@ -56,7 +56,7 @@ def test_valid_description(vcs_builder: Callable[[Mapping], VCS], renderer: Rend
                     {PROMOTION_DATA_SEPARATOR}
                     {VERSION_REF}: {SAPM_VERSION}
                     {CHANNELS_REF}: some-channel
-                    {CONTENT_HASH}: some_hash
+                    {CONTENT_HASHES}: some_hash
                 """,
             }
         ]
@@ -81,7 +81,7 @@ def test_bad_mrs(vcs_builder: Callable[[Mapping], VCS], renderer: Renderer):
                     {PROMOTION_DATA_SEPARATOR}
                     missing-version: some_version
                     {CHANNELS_REF}: some-channel
-                    {CONTENT_HASH}: hash_1
+                    {CONTENT_HASHES}: hash_1
                 """,
             },
             {
@@ -100,7 +100,7 @@ def test_bad_mrs(vcs_builder: Callable[[Mapping], VCS], renderer: Renderer):
                     Blabla
                     missing-data-separator
                     {VERSION_REF}: {SAPM_VERSION}
-                    {CONTENT_HASH}: hash_3
+                    {CONTENT_HASHES}: hash_3
                 """,
             },
             {
@@ -110,7 +110,7 @@ def test_bad_mrs(vcs_builder: Callable[[Mapping], VCS], renderer: Renderer):
                     {VERSION_REF}: {SAPM_VERSION}
                     {PROMOTION_DATA_SEPARATOR}
                     {CHANNELS_REF}: some-channel
-                    {CONTENT_HASH}: hash_4
+                    {CONTENT_HASHES}: hash_4
                 """,
             },
             {
@@ -122,7 +122,7 @@ def test_bad_mrs(vcs_builder: Callable[[Mapping], VCS], renderer: Renderer):
                     {PROMOTION_DATA_SEPARATOR}
                     {VERSION_REF}: {SAPM_VERSION}
                     {CHANNELS_REF}: some-channel
-                    {CONTENT_HASH}: hash_5
+                    {CONTENT_HASHES}: hash_5
                 """,
             },
             {
@@ -132,7 +132,7 @@ def test_bad_mrs(vcs_builder: Callable[[Mapping], VCS], renderer: Renderer):
                     {PROMOTION_DATA_SEPARATOR}
                     {VERSION_REF}: outdated-version
                     {CHANNELS_REF}: some-channel
-                    {CONTENT_HASH}: hash_6
+                    {CONTENT_HASHES}: hash_6
                 """,
             },
             {
@@ -142,7 +142,7 @@ def test_bad_mrs(vcs_builder: Callable[[Mapping], VCS], renderer: Renderer):
                     {PROMOTION_DATA_SEPARATOR}
                     {VERSION_REF}: {SAPM_VERSION}
                     bad_channel_ref: some-channel
-                    {CONTENT_HASH}: hash_7
+                    {CONTENT_HASHES}: hash_7
                 """,
             },
         ]
@@ -167,7 +167,7 @@ def test_remove_duplicates(vcs_builder: Callable[[Mapping], VCS], renderer: Rend
                     {PROMOTION_DATA_SEPARATOR}
                     {VERSION_REF}: {SAPM_VERSION}
                     {CHANNELS_REF}: some_channel
-                    {CONTENT_HASH}: same_hash
+                    {CONTENT_HASHES}: same_hash
                 """,
             },
             {
@@ -177,7 +177,7 @@ def test_remove_duplicates(vcs_builder: Callable[[Mapping], VCS], renderer: Rend
                     {PROMOTION_DATA_SEPARATOR}
                     {VERSION_REF}: {SAPM_VERSION}
                     {CHANNELS_REF}: some_channel
-                    {CONTENT_HASH}: same_hash
+                    {CONTENT_HASHES}: same_hash
                 """,
             },
         ]

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_merge_request_manager.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_merge_request_manager.py
@@ -3,6 +3,8 @@ from collections.abc import (
     Mapping,
 )
 
+import pytest
+
 from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request_manager import (
     MergeRequestManager,
 )
@@ -61,18 +63,34 @@ def test_close_old_content(
     vcs.open_app_interface_merge_request.assert_called_once()  # type: ignore[attr-defined]
 
 
+@pytest.mark.parametrize(
+    "hash_prefix, hash_suffix, channel_prefix, channel_suffix",
+    [
+        ("", "", "", ""),
+        ("hashprefix,", "", "", ""),
+        ("", ",hashsuffix", "", ""),
+        ("", "", "channelprefix,", ""),
+        ("", "", "", ",channelsuffix"),
+        ("a,", ",b", "c,", ",d"),
+    ],
+)
 def test_merge_request_already_opened(
     vcs_builder: Callable[[Mapping], VCS],
     renderer: Renderer,
     subscriber_builder: Callable[[Mapping], Subscriber],
+    hash_prefix: str,
+    hash_suffix: str,
+    channel_prefix: str,
+    channel_suffix: str,
 ):
+    subscriber_channel = "channel-a"
     subscribers = [
         subscriber_builder({
             SUBSCRIBER_TARGET_NAMESPACE: {"path": "namespace1"},
             SUBSCRIBER_TARGET_PATH: "target1",
             SUBSCRIBER_DESIRED_REF: "new_sha",
             SUBSCRIBER_DESIRED_CONFIG_HASHES: [],
-            SUBSCRIBER_CHANNELS: ["channel-a"],
+            SUBSCRIBER_CHANNELS: [subscriber_channel],
         })
     ]
     content_hash = Subscriber.combined_content_hash(subscribers=subscribers)
@@ -80,8 +98,12 @@ def test_merge_request_already_opened(
     vcs = vcs_builder({
         OPEN_MERGE_REQUESTS: [
             {
-                SUBSCRIBER_CONTENT_HASH: content_hash,
-                SUBSCRIBER_CHANNELS: "channel-a",
+                # Note, that the hash/channel can be embedded within a concatenated string.
+                # This is required to allow aggregating multiple MRs into a single MR,
+                # while still keeping track of whether the desired content is already part
+                # of an MR or not.
+                SUBSCRIBER_CONTENT_HASH: f"{hash_prefix}{content_hash}{hash_suffix}",
+                SUBSCRIBER_CHANNELS: f"{channel_prefix}{subscriber_channel}{channel_suffix}",
             }
         ]
     })
@@ -100,10 +122,25 @@ def test_merge_request_already_opened(
     vcs.open_app_interface_merge_request.assert_not_called()  # type: ignore[attr-defined]
 
 
+@pytest.mark.parametrize(
+    "hash_prefix, hash_suffix, channel_prefix, channel_suffix",
+    [
+        ("", "", "", ""),
+        ("hashprefix,", "", "", ""),
+        ("", ",hashsuffix", "", ""),
+        ("", "", "channelprefix,", ""),
+        ("", "", "", ",channelsuffix"),
+        ("a,", ",b", "c,", ",d"),
+    ],
+)
 def test_ignore_unrelated_channels(
     vcs_builder: Callable[[Mapping], VCS],
     renderer: Renderer,
     subscriber_builder: Callable[[Mapping], Subscriber],
+    hash_prefix: str,
+    hash_suffix: str,
+    channel_prefix: str,
+    channel_suffix: str,
 ):
     subscribers = [
         subscriber_builder({
@@ -119,8 +156,12 @@ def test_ignore_unrelated_channels(
     vcs = vcs_builder({
         OPEN_MERGE_REQUESTS: [
             {
-                SUBSCRIBER_CONTENT_HASH: content_hash,
-                SUBSCRIBER_CHANNELS: "other-channel",
+                # Note, that the hash/channel can be embedded within a concatenated string.
+                # This is required to allow aggregating multiple MRs into a single MR,
+                # while still keeping track of whether the desired content is already part
+                # of an MR or not.
+                SUBSCRIBER_CONTENT_HASH: f"{hash_prefix}{content_hash}{hash_suffix}",
+                SUBSCRIBER_CHANNELS: f"{channel_prefix}other-channel{channel_suffix}",
             }
         ]
     })
@@ -134,6 +175,6 @@ def test_ignore_unrelated_channels(
     merge_request_manager.create_promotion_merge_requests(subscribers=subscribers)
 
     # There is already an open merge request for this subscriber content
-    # Do not open another one
+    # Do not open another one, because the channels do not match
     vcs.close_app_interface_mr.assert_not_called()  # type: ignore[attr-defined]
     vcs.open_app_interface_merge_request.assert_called_once()  # type: ignore[attr-defined]


### PR DESCRIPTION
This is the first step in allowing SAPM to aggregate promotions into a single MR.

SAPM is difficult to test with all edge cases locally - for that reason we do small incremental steps and observe.

In this first step, we allow the metadata in the MR description to be a concatenation of multiple MRs. The idea is to touch as less as possible to finish this critical issue quickly. By simply aggregating strings, we can keep the data types as is and still hold the state of multiple MRs within a single MR.

In a follow-up MR, we will implement the actual aggregation logic.