### PR TITLE
tgw-attachments: fix early-exit desiredstate

### DIFF
--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -471,7 +471,9 @@ def run(
 
 
 def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:
-    return _fetch_desired_state_data_source().dict(by_alias=True)
+    datasource = _fetch_desired_state_data_source()
+    datasource.accounts = _filter_tgw_accounts(datasource.accounts, datasource.clusters)
+    return datasource.dict(by_alias=True)
 
 
 def desired_state_shard_config() -> DesiredStateShardConfig:

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -1133,7 +1133,7 @@ def test_early_exit_desired_state(
 
     expected_early_exit_desired_state = {
         "clusters": [cluster_with_tgw_connection.dict(by_alias=True)],
-        "accounts": [tgw_account.dict(by_alias=True), vpc_account.dict(by_alias=True)],
+        "accounts": [tgw_account.dict(by_alias=True)],
     }
 
     assert desired_state == expected_early_exit_desired_state


### PR DESCRIPTION
Reducing the list of accounts taken into account for the early exit datasource. This list had been wrongly extended in https://github.com/app-sre/qontract-reconcile/pull/3998