### PR TITLE
Extended early exit for terraform resources

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -507,6 +507,30 @@ def trigger_integration(function):
     return function
 
 
+def enable_extended_early_exit(function):
+    return click.option(
+        "--enable-extended-early-exit/--no-enable-extended-early-exit",
+        default=False,
+        help="enable extended early exit.",
+    )(function)
+
+
+def extended_early_exit_cache_ttl_seconds(function):
+    return click.option(
+        "--extended-early-exit-cache-ttl-seconds",
+        default=3600,
+        help="TTL of extended early exit cache in seconds.",
+    )(function)
+
+
+def log_cached_log_output(function):
+    return click.option(
+        "--log-cached-log-output/--no-log-cached-log-output",
+        default=False,
+        help="log the cached log output.",
+    )(function)
+
+
 def register_faulthandler(fileobj=sys.__stderr__):
     if fileobj:
         if not faulthandler.is_enabled():
@@ -1738,6 +1762,9 @@ def terraform_repo(ctx, output_file, gitlab_project_id, gitlab_merge_request_id)
 @enable_deletion(default=False)
 @account_name_multiple
 @exclude_aws_accounts
+@enable_extended_early_exit
+@extended_early_exit_cache_ttl_seconds
+@log_cached_log_output
 @click.option(
     "--light/--full",
     default=False,
@@ -1755,6 +1782,9 @@ def terraform_resources(
     vault_output_path,
     account_name,
     exclude_accounts,
+    enable_extended_early_exit,
+    extended_early_exit_cache_ttl_seconds,
+    log_cached_log_output,
 ):
     import reconcile.terraform_resources
 
@@ -1772,6 +1802,9 @@ def terraform_resources(
         vault_output_path,
         account_name=account_name,
         exclude_accounts=exclude_accounts,
+        enable_extended_early_exit=enable_extended_early_exit,
+        extended_early_exit_cache_ttl_seconds=extended_early_exit_cache_ttl_seconds,
+        log_cached_log_output=log_cached_log_output,
     )
 
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -453,11 +453,13 @@ def runner(
     populate_desired_state(ri, ts.resource_spec_inventory)
 
     ob.publish_metrics(ri, QONTRACT_INTEGRATION)
-    actions = []
-    if oc_map:
-        actions = ob.realize_data(
-            dry_run, oc_map, ri, thread_pool_size, caller=acc_name
-        )
+    actions = ob.realize_data(
+        dry_run,
+        oc_map,
+        ri,
+        thread_pool_size,
+        caller=acc_name,
+    )
 
     if actions and vault_output_path:
         write_outputs_to_vault(vault_output_path, ts.resource_spec_inventory)

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -181,8 +181,7 @@ def exclude_accounts_by_name(
 def validate_account_names(
     accounts: Collection[Mapping[str, Any]], names: Collection[str]
 ) -> None:
-    missing_names = set(names) - {a["name"] for a in accounts}
-    if missing_names:
+    if missing_names := set(names) - {a["name"] for a in accounts}:
         raise ValueError(
             f"Accounts {missing_names} were provided as arguments, but not found in app-interface. Check your input for typos or for missing AWS account definitions."
         )
@@ -214,7 +213,7 @@ def get_aws_accounts(
     if exclude_accounts:
         validate_account_names(accounts, exclude_accounts)
         filtered_accounts = exclude_accounts_by_name(accounts, exclude_accounts)
-        if len(filtered_accounts) == 0:
+        if not filtered_accounts:
             raise ValueError("You have excluded all aws accounts, verify your input")
         return filtered_accounts
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -9,10 +9,10 @@ from typing import (
     Collection,
     Optional,
     Sequence,
+    TypedDict,
     cast,
 )
 
-from pydantic import BaseModel
 from sretoolbox.utils import (
     retry,
     threaded,
@@ -392,7 +392,7 @@ def run(
     if print_to_file:
         return
 
-    runner_params = RunnerParams(
+    runner_params: RunnerParams = dict(
         accounts=accounts,
         account_names=account_names,
         tf_namespaces=tf_namespaces,
@@ -423,10 +423,10 @@ def run(
             log_cached_log_output=log_cached_log_output,
         )
     else:
-        runner(**runner_params.dict())
+        runner(**runner_params)
 
 
-class RunnerParams(BaseModel):
+class RunnerParams(TypedDict):
     accounts: list[dict[str, Any]]
     account_names: set[str]
     tf_namespaces: list[NamespaceV1]
@@ -441,9 +441,6 @@ class RunnerParams(BaseModel):
     light: bool
     vault_output_path: str
     defer: Optional[Callable]
-
-    class Config:
-        arbitrary_types_allowed = True
 
 
 def runner(

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -60,6 +60,7 @@ from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.terraform_client import TerraformClient as Terraform
 from reconcile.utils.terrascript_aws_client import TerrascriptClient
 from reconcile.utils.terrascript_aws_client import TerrascriptClient as Terrascript
+from reconcile.utils.unleash import get_feature_toggle_state
 from reconcile.utils.vault import (
     VaultClient,
     _VaultClient,
@@ -409,7 +410,10 @@ def run(
         defer=defer,
     )
 
-    if enable_extended_early_exit:
+    if enable_extended_early_exit and get_feature_toggle_state(
+        "terraform-resources-extended-early-exit",
+        default=False,
+    ):
         extended_early_exit_run(
             integration=QONTRACT_INTEGRATION,
             integration_version=QONTRACT_INTEGRATION_VERSION,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -361,8 +361,8 @@ def run(
     vault_output_path: str = "",
     account_name: Optional[Sequence[str]] = None,
     exclude_accounts: Optional[Sequence[str]] = None,
-    extended_early_exit: bool = False,
-    extended_early_exit_cache_ttl_seconds: int = 600,
+    enable_extended_early_exit: bool = False,
+    extended_early_exit_cache_ttl_seconds: int = 3600,
     log_cached_log_output: bool = False,
     defer: Optional[Callable] = None,
 ) -> None:
@@ -409,7 +409,7 @@ def run(
         defer=defer,
     )
 
-    if extended_early_exit:
+    if enable_extended_early_exit:
         extended_early_exit_run(
             integration=QONTRACT_INTEGRATION,
             integration_version=QONTRACT_INTEGRATION_VERSION,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -1,6 +1,4 @@
 import logging
-import shutil
-import sys
 from collections.abc import (
     Callable,
     Iterable,
@@ -117,16 +115,13 @@ def populate_oc_resources(
 
 
 def fetch_current_state(
-    dry_run: bool,
     namespaces: Iterable[NamespaceV1],
     thread_pool_size: int,
     internal: Optional[bool],
     use_jump_host: bool,
     account_names: Optional[Iterable[str]],
-) -> tuple[ResourceInventory, Optional[OCMap]]:
+) -> tuple[ResourceInventory, OCMap]:
     ri = ResourceInventory()
-    if dry_run:
-        return ri, None
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
     oc_map = init_oc_map_from_namespaces(
@@ -172,64 +167,72 @@ def init_working_dirs(
 
 
 def filter_accounts_by_name(
-    accounts: Iterable[Mapping[str, Any]], filter: Iterable[str]
-) -> Collection[Mapping[str, Any]]:
-    return [ac for ac in accounts if ac["name"] in filter]
+    accounts: Iterable[dict[str, Any]], names: Iterable[str]
+) -> list[dict[str, Any]]:
+    return [ac for ac in accounts if ac["name"] in names]
 
 
 def exclude_accounts_by_name(
-    accounts: Iterable[Mapping[str, Any]], filter: Iterable[str]
-) -> Collection[Mapping[str, Any]]:
-    return [ac for ac in accounts if ac["name"] not in filter]
+    accounts: Iterable[dict[str, Any]], names: Iterable[str]
+) -> list[dict[str, Any]]:
+    return [ac for ac in accounts if ac["name"] not in names]
 
 
 def validate_account_names(
     accounts: Collection[Mapping[str, Any]], names: Collection[str]
 ) -> None:
-    if len(accounts) != len(names):
-        missing_names = set(names) - {a["name"] for a in accounts}
+    missing_names = set(names) - {a["name"] for a in accounts}
+    if missing_names:
         raise ValueError(
             f"Accounts {missing_names} were provided as arguments, but not found in app-interface. Check your input for typos or for missing AWS account definitions."
         )
 
 
-def setup(
+def get_aws_accounts(
     dry_run: bool,
-    print_to_file: Optional[str],
-    thread_pool_size: int,
-    internal: Optional[bool],
-    use_jump_host: bool,
     include_accounts: Optional[Collection[str]],
     exclude_accounts: Optional[Collection[str]],
-) -> tuple[
-    ResourceInventory, Optional[OCMap], Terraform, ExternalResourceSpecInventory
-]:
+) -> list[dict[str, Any]]:
+    if exclude_accounts and not dry_run:
+        message = "--exclude-accounts is only supported in dry-run mode"
+        logging.error(message)
+        raise ExcludeAccountsAndDryRunException(message)
+
+    if exclude_accounts and include_accounts:
+        message = "Using --exclude-accounts and --account-name at the same time is not allowed"
+        logging.error(message)
+        raise ExcludeAccountsAndAccountNameException(message)
+
+    # If we are not running in dry run we don't want to run with more than one account
+    if include_accounts and len(include_accounts) > 1 and not dry_run:
+        message = "Running with multiple accounts is only supported in dry-run mode"
+        logging.error(message)
+        raise MultipleAccountNamesInDryRunException(message)
+
     accounts = queries.get_aws_accounts(terraform_state=True)
-    if not include_accounts and exclude_accounts:
-        excluding = filter_accounts_by_name(accounts, exclude_accounts)
-        validate_account_names(excluding, exclude_accounts)
-        accounts = exclude_accounts_by_name(accounts, exclude_accounts)
-        if len(accounts) == 0:
+
+    if exclude_accounts:
+        validate_account_names(accounts, exclude_accounts)
+        filtered_accounts = exclude_accounts_by_name(accounts, exclude_accounts)
+        if len(filtered_accounts) == 0:
             raise ValueError("You have excluded all aws accounts, verify your input")
-        account_names = tuple(ac["name"] for ac in accounts)
-    elif include_accounts:
-        accounts = filter_accounts_by_name(accounts, include_accounts)
+        return filtered_accounts
+
+    if include_accounts:
         validate_account_names(accounts, include_accounts)
-    account_names = tuple(a["name"] for a in accounts)
+        return filter_accounts_by_name(accounts, include_accounts)
+
+    return accounts
+
+
+def setup(
+    accounts: list[dict[str, Any]],
+    account_names: set[str],
+    tf_namespaces: list[NamespaceV1],
+    print_to_file: Optional[str],
+    thread_pool_size: int,
+) -> tuple[Terraform, Terrascript]:
     settings = queries.get_app_interface_settings()
-
-    # build a resource inventory for all the kube secrets managed by the
-    # app-interface managed terraform resources
-    tf_namespaces = get_tf_namespaces(account_names)
-    if not tf_namespaces:
-        logging.warning(
-            "No terraform namespaces found, consider disabling this integration, account names: "
-            f"{', '.join(account_names)}"
-        )
-    ri, oc_map = fetch_current_state(
-        dry_run, tf_namespaces, thread_pool_size, internal, use_jump_host, account_names
-    )
-
     # initialize terrascript (scripting engine to generate terraform manifests)
     ts, working_dirs = init_working_dirs(accounts, thread_pool_size, settings=settings)
 
@@ -260,7 +263,7 @@ def setup(
     ts.populate_resources(ocm_map=ocm_map)
     ts.dump(print_to_file, existing_dirs=working_dirs)
 
-    return ri, oc_map, tf, ts.resource_spec_inventory
+    return tf, ts
 
 
 def filter_tf_namespaces(
@@ -288,21 +291,6 @@ def filter_tf_namespaces(
                 break
 
     return tf_namespaces
-
-
-def cleanup_and_exit(
-    tf: Optional[Terraform] = None,
-    status: bool = False,
-    working_dirs: Optional[Mapping[str, str]] = None,
-) -> None:
-    if working_dirs is None:
-        working_dirs = {}
-    if tf is None:
-        for wd in working_dirs.values():
-            shutil.rmtree(wd)
-    else:
-        tf.cleanup()
-    sys.exit(status)
 
 
 @retry()
@@ -368,63 +356,79 @@ def run(
     exclude_accounts: Optional[Sequence[str]] = None,
     defer: Optional[Callable] = None,
 ) -> None:
-    if exclude_accounts and not dry_run:
-        message = "--exclude-accounts is only supported in dry-run mode"
-        logging.error(message)
-        raise ExcludeAccountsAndDryRunException(message)
-
-    if exclude_accounts and account_name:
-        message = "Using --exclude-accounts and --account-name at the same time is not allowed"
-        logging.error(message)
-        raise ExcludeAccountsAndAccountNameException(message)
-
     # account_name is a tuple of account names for more detail go to
     # https://click.palletsprojects.com/en/8.1.x/options/#multiple-options
-    account_names = account_name
+    accounts = get_aws_accounts(dry_run, account_name, exclude_accounts)
+    account_names = {a["name"] for a in accounts}
+    tf_namespaces = get_tf_namespaces(account_names)
+    if not tf_namespaces:
+        logging.warning(
+            "No terraform namespaces found, consider disabling this integration, account names: "
+            f"{', '.join(account_names)}"
+        )
 
-    # acc_name will prevent type error since account_name is not a str
-    acc_name: Optional[str] = account_names[0] if account_names else None
-
-    # If we are not running in dry run we don't want to run with more than one account
-    if account_names and len(account_names) > 1 and not dry_run:
-        message = "Running with multiple accounts is only supported in dry-run mode"
-        logging.error(message)
-        raise MultipleAccountNamesInDryRunException(message)
-
-    ri, oc_map, tf, resource_specs = setup(
-        dry_run,
+    tf, ts = setup(
+        accounts,
+        account_names,
+        tf_namespaces,
         print_to_file,
         thread_pool_size,
-        internal,
-        use_jump_host,
-        account_names,
-        exclude_accounts,
     )
-    publish_metrics(resource_specs, QONTRACT_INTEGRATION)
+    if defer:
+        defer(tf.cleanup)
 
-    if not dry_run and oc_map and defer:
-        defer(oc_map.cleanup)
+    publish_metrics(ts.resource_spec_inventory, QONTRACT_INTEGRATION)
 
     if print_to_file:
-        cleanup_and_exit(tf)
-    if tf is None:
-        err = True
-        cleanup_and_exit(tf, err)
+        return
 
+    runner(
+        accounts=accounts,
+        account_names=account_names,
+        tf_namespaces=tf_namespaces,
+        tf=tf,
+        ts=ts,
+        dry_run=dry_run,
+        enable_deletion=enable_deletion,
+        thread_pool_size=thread_pool_size,
+        internal=internal,
+        use_jump_host=use_jump_host,
+        light=light,
+        vault_output_path=vault_output_path,
+        defer=defer,
+    )
+
+
+def runner(
+    accounts: list[dict[str, Any]],
+    account_names: set[str],
+    tf_namespaces: list[NamespaceV1],
+    tf: Terraform,
+    ts: Terrascript,
+    dry_run: bool,
+    enable_deletion: bool = False,
+    thread_pool_size: int = 10,
+    internal: Optional[bool] = None,
+    use_jump_host: bool = True,
+    light: bool = False,
+    vault_output_path: str = "",
+    defer: Optional[Callable] = None,
+) -> None:
     if not light:
         disabled_deletions_detected, err = tf.plan(enable_deletion)
         if err:
-            cleanup_and_exit(tf, err)
+            raise RuntimeError("Terraform plan has errors")
         if disabled_deletions_detected:
-            cleanup_and_exit(tf, disabled_deletions_detected)
+            raise RuntimeError("Terraform plan has disabled deletions detected")
 
     if dry_run:
-        cleanup_and_exit(tf)
+        return
 
+    acc_name = accounts[0]["name"] if accounts else None
     if not light and tf.should_apply:
         err = tf.apply()
         if err:
-            cleanup_and_exit(tf, err)
+            raise RuntimeError("Terraform apply has errors")
 
         if defer:
             defer(
@@ -437,10 +441,16 @@ def run(
 
     # refresh output data after terraform apply
     tf.populate_terraform_output_secrets(
-        resource_specs=resource_specs, init_rds_replica_source=True
+        resource_specs=ts.resource_spec_inventory, init_rds_replica_source=True
     )
+
+    ri, oc_map = fetch_current_state(
+        tf_namespaces, thread_pool_size, internal, use_jump_host, account_names
+    )
+    if defer:
+        defer(oc_map.cleanup)
     # populate the resource inventory with latest output data
-    populate_desired_state(ri, resource_specs)
+    populate_desired_state(ri, ts.resource_spec_inventory)
 
     ob.publish_metrics(ri, QONTRACT_INTEGRATION)
     actions = []
@@ -450,13 +460,10 @@ def run(
         )
 
     if actions and vault_output_path:
-        write_outputs_to_vault(vault_output_path, resource_specs)
+        write_outputs_to_vault(vault_output_path, ts.resource_spec_inventory)
 
     if ri.has_error_registered():
-        err = True
-        cleanup_and_exit(tf, err)
-
-    cleanup_and_exit(tf)
+        raise RuntimeError("Resource inventory has errors registered")
 
 
 def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -71,7 +71,7 @@ def test_cannot_pass_two_aws_account_if_not_dry_run():
 def test_filter_accounts_by_name():
     accounts = [{"name": "a"}, {"name": "b"}, {"name": "c"}]
 
-    filtered = integ.filter_accounts_by_name(accounts, filter=("a", "b"))
+    filtered = integ.filter_accounts_by_name(accounts, names=("a", "b"))
 
     assert filtered == [{"name": "a"}, {"name": "b"}]
 
@@ -79,7 +79,7 @@ def test_filter_accounts_by_name():
 def test_exclude_accounts_by_name():
     accounts = [{"name": "a"}, {"name": "b"}, {"name": "c"}]
 
-    filtered = integ.exclude_accounts_by_name(accounts, filter=("a", "b"))
+    filtered = integ.exclude_accounts_by_name(accounts, names=("a", "b"))
 
     assert filtered == [{"name": "c"}]
 
@@ -273,7 +273,6 @@ def test_empty_run(mocker: MockerFixture) -> None:
     mocked_tf.return_value.should_apply = False
 
     mocker.patch("reconcile.terraform_resources.AWSApi", autospec=True)
-    mocker.patch("reconcile.terraform_resources.sys")
 
     mocked_logging = mocker.patch("reconcile.terraform_resources.logging")
 

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -411,7 +411,7 @@ def test_terraform_resources_runner_dry_run(
 
     defer = MagicMock()
 
-    runner_params = integ.RunnerParams(
+    runner_params = dict(
         accounts=[{"name": "a"}],
         account_names={"a"},
         tf_namespaces=[],
@@ -428,7 +428,7 @@ def test_terraform_resources_runner_dry_run(
         defer=defer,
     )
 
-    result = integ.runner(**runner_params.dict())
+    result = integ.runner(**runner_params)
 
     assert result == integ.ExtendedEarlyExitRunnerResult(
         payload=terraform_configurations,
@@ -456,7 +456,7 @@ def test_terraform_resources_runner_no_dry_run(
     mocked_ob = mocker.patch("reconcile.terraform_resources.ob")
     mocked_ob.realize_data.return_value = [{"action": "applied"}]
 
-    runner_params = integ.RunnerParams(
+    runner_params = dict(
         accounts=[{"name": "a"}],
         account_names={"a"},
         tf_namespaces=[],
@@ -473,7 +473,7 @@ def test_terraform_resources_runner_no_dry_run(
         defer=defer,
     )
 
-    result = integ.runner(**runner_params.dict())
+    result = integ.runner(**runner_params)
 
     assert result == integ.ExtendedEarlyExitRunnerResult(
         payload=terraform_configurations,

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -358,7 +358,7 @@ def test_run_with_extended_early_exit_run_enabled(
     integ.run.__wrapped__(
         True,
         account_name="a",
-        extended_early_exit=True,
+        enable_extended_early_exit=True,
         extended_early_exit_cache_ttl_seconds=60,
         log_cached_log_output=True,
         defer=defer,
@@ -392,7 +392,7 @@ def test_run_with_extended_early_exit_run_disabled(
     integ.run(
         True,
         account_name="a",
-        extended_early_exit=False,
+        enable_extended_early_exit=False,
     )
 
     mocks["extended_early_exit_run"].assert_not_called()

--- a/reconcile/test/utils/test_early_exit_cache.py
+++ b/reconcile/test/utils/test_early_exit_cache.py
@@ -43,7 +43,7 @@ def early_exit_cache(state: Any) -> EarlyExitCache:
 
 
 @pytest.mark.parametrize(
-    "integration, integration_version, dry_run, cache_desired_state, expected",
+    "integration, integration_version, dry_run, cache_source, expected",
     [
         (
             "some-integration",
@@ -65,16 +65,15 @@ def test_cache_key_string(
     integration: str,
     integration_version: str,
     dry_run: bool,
-    cache_desired_state: Any,
+    cache_source: Any,
     expected: str,
 ) -> None:
     cache_key = CacheKey(
         integration=integration,
         integration_version=integration_version,
         dry_run=dry_run,
-        cache_desired_state=cache_desired_state,
+        cache_source=cache_source,
     )
-
     assert str(cache_key) == expected
 
 
@@ -84,14 +83,14 @@ def cache_key() -> CacheKey:
         integration="some-integration",
         integration_version="some-integration-version",
         dry_run=False,
-        cache_desired_state={"k": "v"},
+        cache_source={"k": "v"},
     )
 
 
 @pytest.fixture
 def cache_value() -> CacheValue:
     return CacheValue(
-        desired_state={"k": "v"},
+        payload={"k": "v"},
         log_output="some-log-output",
         applied_count=1,
     )

--- a/reconcile/test/utils/test_extended_early_exit.py
+++ b/reconcile/test/utils/test_extended_early_exit.py
@@ -1,0 +1,296 @@
+import logging
+from logging import Logger
+from typing import Any
+from unittest.mock import MagicMock, call, create_autospec
+
+import pytest
+from pydantic import BaseModel
+from pytest_mock import MockerFixture
+
+from reconcile.utils.early_exit_cache import (
+    CacheKey,
+    CacheStatus,
+    CacheValue,
+    EarlyExitCache,
+)
+from reconcile.utils.extended_early_exit import (
+    ExtendedEarlyExitRunnerResult,
+    extended_early_exit_run,
+)
+from reconcile.utils.secret_reader import SecretReaderBase
+
+INTEGRATION = "some-integration"
+INTEGRATION_VERSION = "some-integration-version"
+SHORT_TTL_SECONDS = 10
+TTLS_SECONDS = 100
+
+
+@pytest.fixture
+def logger() -> Logger:
+    return logging.getLogger("some-logger")
+
+
+class TestRunnerParams(BaseModel):
+    some_param: str
+
+
+RUNNER_PARAMS = TestRunnerParams(some_param="some-value")
+
+
+@pytest.fixture
+def early_exit_cache() -> Any:
+    return create_autospec(EarlyExitCache)
+
+
+CACHE_DESIRED_STATE = {"k": "v"}
+
+
+@pytest.mark.parametrize(
+    "cache_status, applied_count, expected_ttl",
+    [
+        (CacheStatus.MISS, 0, TTLS_SECONDS),
+        (CacheStatus.MISS, 1, SHORT_TTL_SECONDS),
+        (CacheStatus.EXPIRED, 0, TTLS_SECONDS),
+        (CacheStatus.EXPIRED, 1, SHORT_TTL_SECONDS),
+    ],
+)
+def test_extended_early_exit_run_miss_or_expired_when_no_dry_run(
+    mocker: MockerFixture,
+    logger: Logger,
+    secret_reader: SecretReaderBase,
+    early_exit_cache: Any,
+    cache_status: CacheStatus,
+    applied_count: int,
+    expected_ttl: int,
+) -> None:
+    mock_early_exit_cache = mocker.patch(
+        "reconcile.utils.extended_early_exit.EarlyExitCache",
+        autospec=True,
+    )
+    mock_early_exit_cache.build.return_value.__enter__.return_value = early_exit_cache
+    early_exit_cache.head.return_value = cache_status
+    runner = MagicMock()
+    desired_state = {"k": "v2"}
+    runner.return_value = ExtendedEarlyExitRunnerResult(
+        desired_state=desired_state,
+        applied_count=applied_count,
+    )
+
+    extended_early_exit_run(
+        integration=INTEGRATION,
+        integration_version=INTEGRATION_VERSION,
+        dry_run=False,
+        cache_desired_state=CACHE_DESIRED_STATE,
+        short_ttl_seconds=SHORT_TTL_SECONDS,
+        ttl_seconds=TTLS_SECONDS,
+        logger=logger,
+        runner=runner,
+        runner_params=RUNNER_PARAMS,
+        secret_reader=secret_reader,
+    )
+
+    early_exit_cache.head.assert_called_once_with(
+        CacheKey(
+            integration=INTEGRATION,
+            integration_version=INTEGRATION_VERSION,
+            dry_run=False,
+            cache_desired_state=CACHE_DESIRED_STATE,
+        )
+    )
+    runner.assert_called_once_with(**RUNNER_PARAMS.dict())
+    early_exit_cache.set.assert_called_once_with(
+        CacheKey(
+            integration=INTEGRATION,
+            integration_version=INTEGRATION_VERSION,
+            dry_run=False,
+            cache_desired_state=CACHE_DESIRED_STATE,
+        ),
+        CacheValue(
+            desired_state=desired_state,
+            log_output="",
+            applied_count=applied_count,
+        ),
+        expected_ttl,
+    )
+
+
+@pytest.mark.parametrize(
+    "cache_status",
+    [
+        CacheStatus.MISS,
+        CacheStatus.EXPIRED,
+    ],
+)
+def test_extended_early_exit_run_miss_or_expired_in_dry_run_but_hit_in_no_dry_run(
+    mocker: MockerFixture,
+    logger: Logger,
+    secret_reader: SecretReaderBase,
+    early_exit_cache: Any,
+    cache_status: CacheStatus,
+) -> None:
+    mock_early_exit_cache = mocker.patch(
+        "reconcile.utils.extended_early_exit.EarlyExitCache",
+        autospec=True,
+    )
+    mock_early_exit_cache.build.return_value.__enter__.return_value = early_exit_cache
+    early_exit_cache.head.side_effect = [
+        cache_status,
+        CacheStatus.HIT,
+    ]
+    runner = MagicMock()
+
+    extended_early_exit_run(
+        integration=INTEGRATION,
+        integration_version=INTEGRATION_VERSION,
+        dry_run=True,
+        cache_desired_state=CACHE_DESIRED_STATE,
+        short_ttl_seconds=SHORT_TTL_SECONDS,
+        ttl_seconds=TTLS_SECONDS,
+        logger=logger,
+        runner=runner,
+        runner_params=RUNNER_PARAMS,
+        secret_reader=secret_reader,
+    )
+
+    early_exit_cache.head.assert_has_calls([
+        call(
+            CacheKey(
+                integration=INTEGRATION,
+                integration_version=INTEGRATION_VERSION,
+                dry_run=True,
+                cache_desired_state=CACHE_DESIRED_STATE,
+            )
+        ),
+        call(
+            CacheKey(
+                integration=INTEGRATION,
+                integration_version=INTEGRATION_VERSION,
+                dry_run=False,
+                cache_desired_state=CACHE_DESIRED_STATE,
+            )
+        ),
+    ])
+    runner.assert_not_called()
+    early_exit_cache.set.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "cache_status",
+    [
+        CacheStatus.MISS,
+        CacheStatus.EXPIRED,
+    ],
+)
+def test_extended_early_exit_run_miss_or_expired_in_both_dry_run_and_no_dry_run(
+    mocker: MockerFixture,
+    logger: Logger,
+    secret_reader: SecretReaderBase,
+    early_exit_cache: Any,
+    cache_status: CacheStatus,
+) -> None:
+    mock_early_exit_cache = mocker.patch(
+        "reconcile.utils.extended_early_exit.EarlyExitCache",
+        autospec=True,
+    )
+    mock_early_exit_cache.build.return_value.__enter__.return_value = early_exit_cache
+    early_exit_cache.head.return_value = cache_status
+    runner = MagicMock()
+    desired_state = {"k": "v2"}
+    runner.return_value = ExtendedEarlyExitRunnerResult(
+        desired_state=desired_state,
+        applied_count=0,
+    )
+
+    extended_early_exit_run(
+        integration=INTEGRATION,
+        integration_version=INTEGRATION_VERSION,
+        dry_run=True,
+        cache_desired_state=CACHE_DESIRED_STATE,
+        short_ttl_seconds=SHORT_TTL_SECONDS,
+        ttl_seconds=TTLS_SECONDS,
+        logger=logger,
+        runner=runner,
+        runner_params=RUNNER_PARAMS,
+        secret_reader=secret_reader,
+    )
+
+    early_exit_cache.head.assert_has_calls([
+        call(
+            CacheKey(
+                integration=INTEGRATION,
+                integration_version=INTEGRATION_VERSION,
+                dry_run=True,
+                cache_desired_state=CACHE_DESIRED_STATE,
+            )
+        ),
+        call(
+            CacheKey(
+                integration=INTEGRATION,
+                integration_version=INTEGRATION_VERSION,
+                dry_run=False,
+                cache_desired_state=CACHE_DESIRED_STATE,
+            )
+        ),
+    ])
+    runner.assert_called_once_with(**RUNNER_PARAMS.dict())
+    early_exit_cache.set.assert_called_once_with(
+        CacheKey(
+            integration=INTEGRATION,
+            integration_version=INTEGRATION_VERSION,
+            dry_run=True,
+            cache_desired_state=CACHE_DESIRED_STATE,
+        ),
+        CacheValue(
+            desired_state=desired_state,
+            log_output="",
+            applied_count=0,
+        ),
+        TTLS_SECONDS,
+    )
+
+
+@pytest.mark.parametrize(
+    "dry_run",
+    [
+        True,
+        False,
+    ],
+)
+def test_extended_early_exit_run_hit(
+    mocker: MockerFixture,
+    logger: Logger,
+    secret_reader: SecretReaderBase,
+    early_exit_cache: Any,
+    dry_run: bool,
+) -> None:
+    mock_early_exit_cache = mocker.patch(
+        "reconcile.utils.extended_early_exit.EarlyExitCache",
+        autospec=True,
+    )
+    mock_early_exit_cache.build.return_value.__enter__.return_value = early_exit_cache
+    early_exit_cache.head.return_value = CacheStatus.HIT
+    runner = MagicMock()
+
+    extended_early_exit_run(
+        integration=INTEGRATION,
+        integration_version=INTEGRATION_VERSION,
+        dry_run=dry_run,
+        cache_desired_state=CACHE_DESIRED_STATE,
+        short_ttl_seconds=SHORT_TTL_SECONDS,
+        ttl_seconds=TTLS_SECONDS,
+        logger=logger,
+        runner=runner,
+        runner_params=RUNNER_PARAMS,
+        secret_reader=secret_reader,
+    )
+
+    early_exit_cache.head.assert_called_once_with(
+        CacheKey(
+            integration=INTEGRATION,
+            integration_version=INTEGRATION_VERSION,
+            dry_run=dry_run,
+            cache_desired_state=CACHE_DESIRED_STATE,
+        )
+    )
+    runner.assert_not_called()
+    early_exit_cache.set.assert_not_called()

--- a/reconcile/test/utils/test_extended_early_exit.py
+++ b/reconcile/test/utils/test_extended_early_exit.py
@@ -4,7 +4,6 @@ from typing import Any
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
-from pydantic import BaseModel
 from pytest_mock import MockerFixture
 
 from reconcile.utils.early_exit_cache import (
@@ -23,6 +22,7 @@ INTEGRATION = "some-integration"
 INTEGRATION_VERSION = "some-integration-version"
 SHORT_TTL_SECONDS = 0
 TTLS_SECONDS = 100
+RUNNER_PARAMS = {"some_param": "some-value"}
 
 
 @pytest.fixture
@@ -35,13 +35,6 @@ def logger() -> Logger:
 @pytest.fixture
 def mock_logger() -> Any:
     return create_autospec(Logger)
-
-
-class TestRunnerParams(BaseModel):
-    some_param: str
-
-
-RUNNER_PARAMS = TestRunnerParams(some_param="some-value")
 
 
 @pytest.fixture
@@ -124,7 +117,7 @@ def test_extended_early_exit_run_miss_or_expired(
             cache_source=CACHE_SOURCE,
         )
     )
-    runner.assert_called_once_with(**RUNNER_PARAMS.dict())
+    runner.assert_called_once_with(**RUNNER_PARAMS)
     early_exit_cache.set.assert_called_once_with(
         CacheKey(
             integration=INTEGRATION,

--- a/reconcile/test/utils/test_extended_early_exit.py
+++ b/reconcile/test/utils/test_extended_early_exit.py
@@ -21,7 +21,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
 
 INTEGRATION = "some-integration"
 INTEGRATION_VERSION = "some-integration-version"
-SHORT_TTL_SECONDS = 10
+SHORT_TTL_SECONDS = 0
 TTLS_SECONDS = 100
 
 
@@ -106,7 +106,6 @@ def test_extended_early_exit_run_miss_or_expired_when_no_dry_run(
         integration_version=INTEGRATION_VERSION,
         dry_run=False,
         cache_source=CACHE_SOURCE,
-        short_ttl_seconds=SHORT_TTL_SECONDS,
         ttl_seconds=TTLS_SECONDS,
         logger=logger,
         runner=runner,
@@ -175,7 +174,6 @@ def test_extended_early_exit_run_miss_or_expired_in_dry_run_but_hit_in_no_dry_ru
         integration_version=INTEGRATION_VERSION,
         dry_run=True,
         cache_source=CACHE_SOURCE,
-        short_ttl_seconds=SHORT_TTL_SECONDS,
         ttl_seconds=TTLS_SECONDS,
         logger=mock_logger,
         runner=runner,
@@ -247,7 +245,6 @@ def test_extended_early_exit_run_miss_or_expired_in_both_dry_run_and_no_dry_run(
         integration_version=INTEGRATION_VERSION,
         dry_run=True,
         cache_source=CACHE_SOURCE,
-        short_ttl_seconds=SHORT_TTL_SECONDS,
         ttl_seconds=TTLS_SECONDS,
         logger=logger,
         runner=runner,
@@ -309,7 +306,6 @@ def test_extended_early_exit_run_hit_when_not_dry_run(
         integration_version=INTEGRATION_VERSION,
         dry_run=False,
         cache_source=CACHE_SOURCE,
-        short_ttl_seconds=SHORT_TTL_SECONDS,
         ttl_seconds=TTLS_SECONDS,
         logger=logger,
         runner=runner,
@@ -353,7 +349,6 @@ def test_extended_early_exit_run_hit_when_dry_run(
         integration_version=INTEGRATION_VERSION,
         dry_run=True,
         cache_source=CACHE_SOURCE,
-        short_ttl_seconds=SHORT_TTL_SECONDS,
         ttl_seconds=TTLS_SECONDS,
         logger=mock_logger,
         runner=runner,
@@ -404,7 +399,6 @@ def test_extended_early_exit_run_when_error(
             integration_version=INTEGRATION_VERSION,
             dry_run=False,
             cache_source=CACHE_SOURCE,
-            short_ttl_seconds=SHORT_TTL_SECONDS,
             ttl_seconds=TTLS_SECONDS,
             logger=mock_logger,
             runner=runner,

--- a/reconcile/test/utils/test_extended_early_exit.py
+++ b/reconcile/test/utils/test_extended_early_exit.py
@@ -49,7 +49,7 @@ def early_exit_cache() -> Any:
     return create_autospec(EarlyExitCache)
 
 
-CACHE_DESIRED_STATE = {"k": "v"}
+CACHE_SOURCE = {"k": "v"}
 
 
 @pytest.mark.parametrize(
@@ -95,7 +95,7 @@ def test_extended_early_exit_run_miss_or_expired_when_no_dry_run(
         logger.warning(warning_log_output)
         logger.error(error_log_output)
         return ExtendedEarlyExitRunnerResult(
-            desired_state=desired_state,
+            payload=desired_state,
             applied_count=applied_count,
         )
 
@@ -105,7 +105,7 @@ def test_extended_early_exit_run_miss_or_expired_when_no_dry_run(
         integration=INTEGRATION,
         integration_version=INTEGRATION_VERSION,
         dry_run=False,
-        cache_desired_state=CACHE_DESIRED_STATE,
+        cache_source=CACHE_SOURCE,
         short_ttl_seconds=SHORT_TTL_SECONDS,
         ttl_seconds=TTLS_SECONDS,
         logger=logger,
@@ -119,7 +119,7 @@ def test_extended_early_exit_run_miss_or_expired_when_no_dry_run(
             integration=INTEGRATION,
             integration_version=INTEGRATION_VERSION,
             dry_run=False,
-            cache_desired_state=CACHE_DESIRED_STATE,
+            cache_source=CACHE_SOURCE,
         )
     )
     runner.assert_called_once_with(**RUNNER_PARAMS.dict())
@@ -128,10 +128,10 @@ def test_extended_early_exit_run_miss_or_expired_when_no_dry_run(
             integration=INTEGRATION,
             integration_version=INTEGRATION_VERSION,
             dry_run=False,
-            cache_desired_state=CACHE_DESIRED_STATE,
+            cache_source=CACHE_SOURCE,
         ),
         CacheValue(
-            desired_state=desired_state,
+            payload=desired_state,
             log_output=expected_log_output,
             applied_count=applied_count,
         ),
@@ -164,7 +164,7 @@ def test_extended_early_exit_run_miss_or_expired_in_dry_run_but_hit_in_no_dry_ru
     ]
     expected_log_output = "some-log-output"
     early_exit_cache.get.return_value = CacheValue(
-        desired_state=CACHE_DESIRED_STATE,
+        payload=CACHE_SOURCE,
         log_output=expected_log_output,
         applied_count=1,
     )
@@ -174,7 +174,7 @@ def test_extended_early_exit_run_miss_or_expired_in_dry_run_but_hit_in_no_dry_ru
         integration=INTEGRATION,
         integration_version=INTEGRATION_VERSION,
         dry_run=True,
-        cache_desired_state=CACHE_DESIRED_STATE,
+        cache_source=CACHE_SOURCE,
         short_ttl_seconds=SHORT_TTL_SECONDS,
         ttl_seconds=TTLS_SECONDS,
         logger=mock_logger,
@@ -190,7 +190,7 @@ def test_extended_early_exit_run_miss_or_expired_in_dry_run_but_hit_in_no_dry_ru
                 integration=INTEGRATION,
                 integration_version=INTEGRATION_VERSION,
                 dry_run=True,
-                cache_desired_state=CACHE_DESIRED_STATE,
+                cache_source=CACHE_SOURCE,
             )
         ),
         call(
@@ -198,7 +198,7 @@ def test_extended_early_exit_run_miss_or_expired_in_dry_run_but_hit_in_no_dry_ru
                 integration=INTEGRATION,
                 integration_version=INTEGRATION_VERSION,
                 dry_run=False,
-                cache_desired_state=CACHE_DESIRED_STATE,
+                cache_source=CACHE_SOURCE,
             )
         ),
     ])
@@ -207,7 +207,7 @@ def test_extended_early_exit_run_miss_or_expired_in_dry_run_but_hit_in_no_dry_ru
             integration=INTEGRATION,
             integration_version=INTEGRATION_VERSION,
             dry_run=False,
-            cache_desired_state=CACHE_DESIRED_STATE,
+            cache_source=CACHE_SOURCE,
         )
     )
     mock_logger.info.assert_called_once_with(expected_log_output)
@@ -238,7 +238,7 @@ def test_extended_early_exit_run_miss_or_expired_in_both_dry_run_and_no_dry_run(
     runner = MagicMock()
     desired_state = {"k": "v2"}
     runner.return_value = ExtendedEarlyExitRunnerResult(
-        desired_state=desired_state,
+        payload=desired_state,
         applied_count=0,
     )
 
@@ -246,7 +246,7 @@ def test_extended_early_exit_run_miss_or_expired_in_both_dry_run_and_no_dry_run(
         integration=INTEGRATION,
         integration_version=INTEGRATION_VERSION,
         dry_run=True,
-        cache_desired_state=CACHE_DESIRED_STATE,
+        cache_source=CACHE_SOURCE,
         short_ttl_seconds=SHORT_TTL_SECONDS,
         ttl_seconds=TTLS_SECONDS,
         logger=logger,
@@ -261,7 +261,7 @@ def test_extended_early_exit_run_miss_or_expired_in_both_dry_run_and_no_dry_run(
                 integration=INTEGRATION,
                 integration_version=INTEGRATION_VERSION,
                 dry_run=True,
-                cache_desired_state=CACHE_DESIRED_STATE,
+                cache_source=CACHE_SOURCE,
             )
         ),
         call(
@@ -269,7 +269,7 @@ def test_extended_early_exit_run_miss_or_expired_in_both_dry_run_and_no_dry_run(
                 integration=INTEGRATION,
                 integration_version=INTEGRATION_VERSION,
                 dry_run=False,
-                cache_desired_state=CACHE_DESIRED_STATE,
+                cache_source=CACHE_SOURCE,
             )
         ),
     ])
@@ -279,10 +279,10 @@ def test_extended_early_exit_run_miss_or_expired_in_both_dry_run_and_no_dry_run(
             integration=INTEGRATION,
             integration_version=INTEGRATION_VERSION,
             dry_run=True,
-            cache_desired_state=CACHE_DESIRED_STATE,
+            cache_source=CACHE_SOURCE,
         ),
         CacheValue(
-            desired_state=desired_state,
+            payload=desired_state,
             log_output="",
             applied_count=0,
         ),
@@ -308,7 +308,7 @@ def test_extended_early_exit_run_hit_when_not_dry_run(
         integration=INTEGRATION,
         integration_version=INTEGRATION_VERSION,
         dry_run=False,
-        cache_desired_state=CACHE_DESIRED_STATE,
+        cache_source=CACHE_SOURCE,
         short_ttl_seconds=SHORT_TTL_SECONDS,
         ttl_seconds=TTLS_SECONDS,
         logger=logger,
@@ -322,7 +322,7 @@ def test_extended_early_exit_run_hit_when_not_dry_run(
             integration=INTEGRATION,
             integration_version=INTEGRATION_VERSION,
             dry_run=False,
-            cache_desired_state=CACHE_DESIRED_STATE,
+            cache_source=CACHE_SOURCE,
         )
     )
     runner.assert_not_called()
@@ -342,7 +342,7 @@ def test_extended_early_exit_run_hit_when_dry_run(
     mock_early_exit_cache.build.return_value.__enter__.return_value = early_exit_cache
     early_exit_cache.head.return_value = CacheStatus.HIT
     early_exit_cache.get.return_value = CacheValue(
-        desired_state=CACHE_DESIRED_STATE,
+        payload=CACHE_SOURCE,
         log_output="log-output",
         applied_count=1,
     )
@@ -352,7 +352,7 @@ def test_extended_early_exit_run_hit_when_dry_run(
         integration=INTEGRATION,
         integration_version=INTEGRATION_VERSION,
         dry_run=True,
-        cache_desired_state=CACHE_DESIRED_STATE,
+        cache_source=CACHE_SOURCE,
         short_ttl_seconds=SHORT_TTL_SECONDS,
         ttl_seconds=TTLS_SECONDS,
         logger=mock_logger,
@@ -367,7 +367,7 @@ def test_extended_early_exit_run_hit_when_dry_run(
             integration=INTEGRATION,
             integration_version=INTEGRATION_VERSION,
             dry_run=True,
-            cache_desired_state=CACHE_DESIRED_STATE,
+            cache_source=CACHE_SOURCE,
         )
     )
     early_exit_cache.get.assert_called_once_with(
@@ -375,7 +375,7 @@ def test_extended_early_exit_run_hit_when_dry_run(
             integration=INTEGRATION,
             integration_version=INTEGRATION_VERSION,
             dry_run=True,
-            cache_desired_state=CACHE_DESIRED_STATE,
+            cache_source=CACHE_SOURCE,
         )
     )
     mock_logger.info.assert_called_once_with("log-output")

--- a/reconcile/test/utils/test_metrics.py
+++ b/reconcile/test/utils/test_metrics.py
@@ -12,6 +12,7 @@ from reconcile.utils.metrics import (
     MetricsContainer,
     inc_counter,
     join_metric_containers,
+    normalize_integration_name,
     set_gauge,
     transactional_metrics,
 )
@@ -549,3 +550,18 @@ def test_error_rate_metric_set_mixed() -> None:
 
     assert root.get_metric_value(DemoCounter, field="field") == 2
     assert root.get_metric_value(DemoErrorCounter, field="field") == 1
+
+
+@pytest.mark.parametrize(
+    "integration_name, expected",
+    [
+        ("a", "a"),
+        ("a_b", "a-b"),
+        ("a-b", "a-b"),
+    ],
+)
+def test_normalize_integration_name(
+    integration_name: str,
+    expected: str,
+) -> None:
+    assert normalize_integration_name(integration_name) == expected

--- a/reconcile/utils/early_exit_cache.py
+++ b/reconcile/utils/early_exit_cache.py
@@ -16,19 +16,19 @@ class CacheKey(BaseModel):
     integration: str
     integration_version: str
     dry_run: bool
-    cache_desired_state: object
+    cache_source: object
 
     def __str__(self) -> str:
         return "/".join([
             self.integration,
             self.integration_version,
             "dry-run" if self.dry_run else "no-dry-run",
-            DeepHash(self.cache_desired_state)[self.cache_desired_state],
+            DeepHash(self.cache_source)[self.cache_source],
         ])
 
 
 class CacheValue(BaseModel):
-    desired_state: object
+    payload: object
     log_output: str
     applied_count: int
 

--- a/reconcile/utils/early_exit_cache.py
+++ b/reconcile/utils/early_exit_cache.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime, timedelta
 from enum import Enum
-from typing import Any, Optional, Self
+from typing import Any, Self
 
 from deepdiff import DeepHash
 from pydantic import BaseModel
@@ -46,7 +46,7 @@ class EarlyExitCache:
     @classmethod
     def build(
         cls,
-        secret_reader: Optional[SecretReaderBase] = None,
+        secret_reader: SecretReaderBase | None = None,
     ) -> Self:
         state = init_state(STATE_INTEGRATION, secret_reader)
         return cls(state)

--- a/reconcile/utils/extended_early_exit.py
+++ b/reconcile/utils/extended_early_exit.py
@@ -1,0 +1,119 @@
+from collections.abc import Callable
+from logging import Logger
+
+from pydantic import BaseModel
+
+from reconcile.utils.early_exit_cache import (
+    CacheKey,
+    CacheStatus,
+    CacheValue,
+    EarlyExitCache,
+)
+from reconcile.utils.secret_reader import SecretReaderBase
+
+
+class ExtendedEarlyExitRunnerResult(BaseModel):
+    desired_state: object
+    applied_count: int
+
+
+def _no_dry_run_cache_hit(
+    cache: EarlyExitCache,
+    integration: str,
+    integration_version: str,
+    cache_desired_state: object,
+) -> bool:
+    """
+    Check if the cache has a hit for the no-dry-run key.
+    This is used in dry run mode mostly run in CI,
+    if the cache has a hit for the no-dry-run key,
+    then we want to early exit.
+
+    :param cache: The early exit cache
+    :param integration: The integration name
+    :param integration_version: The integration version
+    :param cache_desired_state: The desired state
+    :return: True if the cache has a hit for the no-dry-run key, False otherwise
+    """
+    key = CacheKey(
+        integration=integration,
+        integration_version=integration_version,
+        dry_run=False,
+        cache_desired_state=cache_desired_state,
+    )
+    return cache.head(key) == CacheStatus.HIT
+
+
+def _ttl_seconds(
+    applied_count: int,
+    short_ttl_seconds: int,
+    ttl_seconds: int,
+) -> int:
+    """
+    Pick the ttl based on the applied count.
+    If the applied count is greater than 0, then we want to set a short ttl so that the next run will not hit the cache,
+    this will allow us to easy debug reconcile loops, as we will be able to see the logs of the next run,
+    and check cached value for more details.
+
+    :param applied_count: The number of resources that were applied
+    :param short_ttl_seconds: A short ttl in seconds
+    :param ttl_seconds: A ttl in seconds
+    :return: The ttl in seconds
+    """
+    return short_ttl_seconds if applied_count > 0 else ttl_seconds
+
+
+def extended_early_exit_run(
+    integration: str,
+    integration_version: str,
+    dry_run: bool,
+    cache_desired_state: object,
+    short_ttl_seconds: int,
+    ttl_seconds: int,
+    logger: Logger,
+    runner: Callable[..., ExtendedEarlyExitRunnerResult],
+    runner_params: BaseModel | None = None,
+    secret_reader: SecretReaderBase | None = None,
+) -> None:
+    """
+    Run the runner based on the cache status.
+
+    :param integration: The integration name
+    :param integration_version: The integration version
+    :param dry_run: True if the run is in dry run mode, False otherwise
+    :param cache_desired_state: The desired state
+    :param short_ttl_seconds: A short ttl in seconds
+    :param ttl_seconds: A ttl in seconds
+    :param logger: A Logger
+    :param runner: A runner can return ExtendedEarlyExitRunnerResult when called
+    :param runner_params: Runner params
+    :param secret_reader: A secret reader
+    :return: None
+    """
+    with EarlyExitCache.build(secret_reader) as cache:
+        key = CacheKey(
+            integration=integration,
+            integration_version=integration_version,
+            dry_run=dry_run,
+            cache_desired_state=cache_desired_state,
+        )
+        cache_status = cache.head(key)
+        if cache_status == CacheStatus.HIT:
+            return
+
+        if dry_run and _no_dry_run_cache_hit(
+            cache,
+            integration,
+            integration_version,
+            cache_desired_state,
+        ):
+            return
+
+        result = runner(**runner_params.dict())
+        value = CacheValue(
+            desired_state=result.desired_state,
+            log_output="",
+            applied_count=result.applied_count,
+        )
+        ttl = _ttl_seconds(result.applied_count, short_ttl_seconds, ttl_seconds)
+        cache.set(key, value, ttl)

--- a/reconcile/utils/extended_early_exit.py
+++ b/reconcile/utils/extended_early_exit.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from io import StringIO
 from logging import Logger
@@ -64,7 +64,7 @@ def extended_early_exit_run(
     ttl_seconds: int,
     logger: Logger,
     runner: Callable[..., ExtendedEarlyExitRunnerResult],
-    runner_params: BaseModel | None = None,
+    runner_params: Mapping | None = None,
     secret_reader: SecretReaderBase | None = None,
     log_cached_log_output: bool = False,
 ) -> None:
@@ -83,7 +83,7 @@ def extended_early_exit_run(
     :param ttl_seconds: A ttl in seconds
     :param logger: A Logger
     :param runner: A runner can return ExtendedEarlyExitRunnerResult when called
-    :param runner_params: Runner params
+    :param runner_params: Runner params, will be spread into kwargs when calling runner
     :param secret_reader: A secret reader
     :param log_cached_log_output: Whether to log the cached log output when there is a cache hit
     :return: None
@@ -104,8 +104,7 @@ def extended_early_exit_run(
             return
 
         with log_stream_handler(logger) as log_stream:
-            params = runner_params.dict() if runner_params is not None else {}
-            result = runner(**params)
+            result = runner(**(runner_params or {}))
             log_output = log_stream.getvalue()
 
         value = CacheValue(

--- a/reconcile/utils/extended_early_exit.py
+++ b/reconcile/utils/extended_early_exit.py
@@ -1,4 +1,7 @@
-from collections.abc import Callable
+import logging
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
+from io import StringIO
 from logging import Logger
 
 from pydantic import BaseModel
@@ -17,11 +20,22 @@ class ExtendedEarlyExitRunnerResult(BaseModel):
     applied_count: int
 
 
+def _log_cached_log_output(
+    cache: EarlyExitCache,
+    key: CacheKey,
+    logger: Logger,
+) -> None:
+    value = cache.get(key)
+    logger.info(value.log_output)
+
+
 def _no_dry_run_cache_hit(
     cache: EarlyExitCache,
     integration: str,
     integration_version: str,
     cache_desired_state: object,
+    logger: Logger,
+    log_cached_log_output: bool,
 ) -> bool:
     """
     Check if the cache has a hit for the no-dry-run key.
@@ -33,6 +47,8 @@ def _no_dry_run_cache_hit(
     :param integration: The integration name
     :param integration_version: The integration version
     :param cache_desired_state: The desired state
+    :param logger: A logger
+    :param log_cached_log_output: True if we want to log the cached log output, False otherwise
     :return: True if the cache has a hit for the no-dry-run key, False otherwise
     """
     key = CacheKey(
@@ -41,7 +57,10 @@ def _no_dry_run_cache_hit(
         dry_run=False,
         cache_desired_state=cache_desired_state,
     )
-    return cache.head(key) == CacheStatus.HIT
+    hit = cache.head(key) == CacheStatus.HIT
+    if hit and log_cached_log_output:
+        _log_cached_log_output(cache, key, logger)
+    return hit
 
 
 def _ttl_seconds(
@@ -63,6 +82,25 @@ def _ttl_seconds(
     return short_ttl_seconds if applied_count > 0 else ttl_seconds
 
 
+@contextmanager
+def log_stream_handler(
+    logger: Logger,
+) -> Generator[StringIO, None, None]:
+    """
+    Add a stream handler to the logger, and return the stream generator, automatically remove the handler when done.
+
+    :param logger: A logger
+    :return: A stream generator
+    """
+    log_stream = StringIO()
+    log_handler = logging.StreamHandler(log_stream)
+    logger.addHandler(log_handler)
+    try:
+        yield log_stream
+    finally:
+        logger.removeHandler(log_handler)
+
+
 def extended_early_exit_run(
     integration: str,
     integration_version: str,
@@ -74,9 +112,16 @@ def extended_early_exit_run(
     runner: Callable[..., ExtendedEarlyExitRunnerResult],
     runner_params: BaseModel | None = None,
     secret_reader: SecretReaderBase | None = None,
+    log_cached_log_output: bool = False,
 ) -> None:
     """
-    Run the runner based on the cache status.
+    Run the runner based on the cache status. Early exit when cache hit.
+    If not hit in dry-run mode, will check no-dry-run cache additionally.
+    Runner log output will be extracted and stored in cache value,
+    and will be logged when hit if log_cached_log_output is True,
+    this is mainly used to show all log output from different integrations in one place (CI).
+    When runner returns no applies (applied_count is 0), the ttl will be set to ttl_seconds,
+    otherwise it will be set to short_ttl_seconds.
 
     :param integration: The integration name
     :param integration_version: The integration version
@@ -88,6 +133,7 @@ def extended_early_exit_run(
     :param runner: A runner can return ExtendedEarlyExitRunnerResult when called
     :param runner_params: Runner params
     :param secret_reader: A secret reader
+    :param log_cached_log_output: Whether to log the cached log output when there is a cache hit
     :return: None
     """
     with EarlyExitCache.build(secret_reader) as cache:
@@ -98,7 +144,10 @@ def extended_early_exit_run(
             cache_desired_state=cache_desired_state,
         )
         cache_status = cache.head(key)
+
         if cache_status == CacheStatus.HIT:
+            if log_cached_log_output:
+                _log_cached_log_output(cache, key, logger)
             return
 
         if dry_run and _no_dry_run_cache_hit(
@@ -106,13 +155,18 @@ def extended_early_exit_run(
             integration,
             integration_version,
             cache_desired_state,
+            logger,
+            log_cached_log_output,
         ):
             return
 
-        result = runner(**runner_params.dict())
+        with log_stream_handler(logger) as log_stream:
+            result = runner(**runner_params.dict())
+            log_output = log_stream.getvalue()
+
         value = CacheValue(
             desired_state=result.desired_state,
-            log_output="",
+            log_output=log_output,
             applied_count=result.applied_count,
         )
         ttl = _ttl_seconds(result.applied_count, short_ttl_seconds, ttl_seconds)

--- a/reconcile/utils/extended_early_exit.py
+++ b/reconcile/utils/extended_early_exit.py
@@ -16,7 +16,7 @@ from reconcile.utils.secret_reader import SecretReaderBase
 
 
 class ExtendedEarlyExitRunnerResult(BaseModel):
-    desired_state: object
+    payload: object
     applied_count: int
 
 
@@ -33,7 +33,7 @@ def _no_dry_run_cache_hit(
     cache: EarlyExitCache,
     integration: str,
     integration_version: str,
-    cache_desired_state: object,
+    cache_source: object,
     logger: Logger,
     log_cached_log_output: bool,
 ) -> bool:
@@ -46,7 +46,7 @@ def _no_dry_run_cache_hit(
     :param cache: The early exit cache
     :param integration: The integration name
     :param integration_version: The integration version
-    :param cache_desired_state: The desired state
+    :param cache_source: The cache source
     :param logger: A logger
     :param log_cached_log_output: True if we want to log the cached log output, False otherwise
     :return: True if the cache has a hit for the no-dry-run key, False otherwise
@@ -55,7 +55,7 @@ def _no_dry_run_cache_hit(
         integration=integration,
         integration_version=integration_version,
         dry_run=False,
-        cache_desired_state=cache_desired_state,
+        cache_source=cache_source,
     )
     hit = cache.head(key) == CacheStatus.HIT
     if hit and log_cached_log_output:
@@ -105,7 +105,7 @@ def extended_early_exit_run(
     integration: str,
     integration_version: str,
     dry_run: bool,
-    cache_desired_state: object,
+    cache_source: object,
     short_ttl_seconds: int,
     ttl_seconds: int,
     logger: Logger,
@@ -126,7 +126,7 @@ def extended_early_exit_run(
     :param integration: The integration name
     :param integration_version: The integration version
     :param dry_run: True if the run is in dry run mode, False otherwise
-    :param cache_desired_state: The desired state
+    :param cache_source: The cache source, usually the static desired state
     :param short_ttl_seconds: A short ttl in seconds
     :param ttl_seconds: A ttl in seconds
     :param logger: A Logger
@@ -141,7 +141,7 @@ def extended_early_exit_run(
             integration=integration,
             integration_version=integration_version,
             dry_run=dry_run,
-            cache_desired_state=cache_desired_state,
+            cache_source=cache_source,
         )
         cache_status = cache.head(key)
 
@@ -154,7 +154,7 @@ def extended_early_exit_run(
             cache,
             integration,
             integration_version,
-            cache_desired_state,
+            cache_source,
             logger,
             log_cached_log_output,
         ):
@@ -165,7 +165,7 @@ def extended_early_exit_run(
             log_output = log_stream.getvalue()
 
         value = CacheValue(
-            desired_state=result.desired_state,
+            payload=result.payload,
             log_output=log_output,
             applied_count=result.applied_count,
         )

--- a/reconcile/utils/extended_early_exit.py
+++ b/reconcile/utils/extended_early_exit.py
@@ -161,7 +161,8 @@ def extended_early_exit_run(
             return
 
         with log_stream_handler(logger) as log_stream:
-            result = runner(**runner_params.dict())
+            params = runner_params.dict() if runner_params is not None else {}
+            result = runner(**params)
             log_output = log_stream.getvalue()
 
         value = CacheValue(

--- a/reconcile/utils/extended_early_exit.py
+++ b/reconcile/utils/extended_early_exit.py
@@ -57,7 +57,9 @@ def _no_dry_run_cache_hit(
         dry_run=False,
         cache_source=cache_source,
     )
-    hit = cache.head(key) == CacheStatus.HIT
+    cache_status = cache.head(key)
+    logger.debug("Early exit cache status for key=%s: %s", key, cache_status)
+    hit = cache_status == CacheStatus.HIT
     if hit and log_cached_log_output:
         _log_cached_log_output(cache, key, logger)
     return hit
@@ -140,6 +142,7 @@ def extended_early_exit_run(
             cache_source=cache_source,
         )
         cache_status = cache.head(key)
+        logger.debug("Early exit cache status for key=%s: %s", key, cache_status)
 
         if cache_status == CacheStatus.HIT:
             if log_cached_log_output:
@@ -167,4 +170,5 @@ def extended_early_exit_run(
             applied_count=result.applied_count,
         )
         ttl = _ttl_seconds(result.applied_count, ttl_seconds)
+        logger.debug("Set early exit cache for key=%s with ttl=%d", key, ttl)
         cache.set(key, value, ttl)

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -79,11 +79,12 @@ def get_inventory_count_combinations(
 
 def publish_metrics(inventory: ExternalResourceSpecInventory, integration: str) -> None:
     count_combinations = get_inventory_count_combinations(inventory)
+    integration_name = metrics.normalize_integration_name(integration)
     for combination, count in count_combinations.items():
         provision_provider, provisioner_name, provider = combination
         metrics.set_gauge(
             ExternalResourceInventoryGauge(
-                integration=integration.replace("_", "-"),
+                integration=integration_name,
                 provision_provider=provision_provider,
                 provisioner_name=provisioner_name,
                 provider=provider,

--- a/reconcile/utils/metrics.py
+++ b/reconcile/utils/metrics.py
@@ -563,3 +563,10 @@ class ErrorRateMetricSet:
         if exc_value:
             self.fail(exc_value)
         inc_counter(self._error_counter, by=(1 if self._errors else 0))
+
+
+def normalize_integration_name(integration: str) -> str:
+    """
+    Normalize the integration name to be used in prometheus.
+    """
+    return integration.replace("_", "-")

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -3890,21 +3890,29 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             if os.path.isfile(print_to_file):
                 os.remove(print_to_file)
 
-        for name, ts in self.tss.items():
+        for name, ts in self.terraform_configurations():
             if print_to_file:
                 with open(print_to_file, "a", encoding="locale") as f:
                     f.write(f"##### {name} #####\n")
-                    f.write(str(ts))
+                    f.write(ts)
                     f.write("\n")
             if existing_dirs is None:
                 wd = tempfile.mkdtemp(prefix=TMP_DIR_PREFIX)
             else:
                 wd = working_dirs[name]
             with open(wd + "/config.tf.json", "w", encoding="locale") as f:
-                f.write(str(ts))
+                f.write(ts)
             working_dirs[name] = wd
 
         return working_dirs
+
+    def terraform_configurations(self) -> dict[str, str]:
+        """
+        Return the Terraform configurations (in JSON format) for each AWS account.
+
+        :return: key is AWS account name and value is terraform configuration
+        """
+        return {name: str(ts) for name, ts in self.tss.items()}
 
     def init_values(self, spec: ExternalResourceSpec, init_tags: bool = True) -> dict:
         """

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -3890,7 +3890,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             if os.path.isfile(print_to_file):
                 os.remove(print_to_file)
 
-        for name, ts in self.terraform_configurations():
+        for name, ts in self.terraform_configurations().items():
             if print_to_file:
                 with open(print_to_file, "a", encoding="locale") as f:
                     f.write(f"##### {name} #####\n")

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2446,8 +2446,8 @@ def early_exit_cache(ctx):
 )
 @click.option(
     "-c",
-    "--cache-desired-state",
-    help="Cache desired state. It should be a JSON string.",
+    "--cache-source",
+    help="Cache source. It should be a JSON string.",
     required=True,
 )
 @click.pass_context
@@ -2456,14 +2456,14 @@ def early_exit_cache_head(
     integration,
     integration_version,
     dry_run,
-    cache_desired_state,
+    cache_source,
 ):
     with EarlyExitCache.build() as cache:
         cache_key = CacheKey(
             integration=integration,
             integration_version=integration_version,
             dry_run=dry_run,
-            cache_desired_state=json.loads(cache_desired_state),
+            cache_source=json.loads(cache_source),
         )
         status = cache.head(cache_key)
         print(status)
@@ -2489,8 +2489,8 @@ def early_exit_cache_head(
 )
 @click.option(
     "-c",
-    "--cache-desired-state",
-    help="Cache desired state. It should be a JSON string.",
+    "--cache-source",
+    help="Cache source. It should be a JSON string.",
     required=True,
 )
 @click.pass_context
@@ -2499,14 +2499,14 @@ def early_exit_cache_get(
     integration,
     integration_version,
     dry_run,
-    cache_desired_state,
+    cache_source,
 ):
     with EarlyExitCache.build() as cache:
         cache_key = CacheKey(
             integration=integration,
             integration_version=integration_version,
             dry_run=dry_run,
-            cache_desired_state=json.loads(cache_desired_state),
+            cache_source=json.loads(cache_source),
         )
         value = cache.get(cache_key)
         print(value)
@@ -2532,14 +2532,14 @@ def early_exit_cache_get(
 )
 @click.option(
     "-c",
-    "--cache-desired-state",
-    help="Cache desired state. It should be a JSON string.",
+    "--cache-source",
+    help="Cache source. It should be a JSON string.",
     required=True,
 )
 @click.option(
-    "-d",
-    "--desired-state",
-    help="Desired state. It should be a JSON string.",
+    "-p",
+    "--payload",
+    help="Payload in Cache value. It should be a JSON string.",
     required=True,
 )
 @click.option(
@@ -2568,8 +2568,8 @@ def early_exit_cache_set(
     integration,
     integration_version,
     dry_run,
-    cache_desired_state,
-    desired_state,
+    cache_source,
+    payload,
     log_output,
     applied_count,
     ttl,
@@ -2579,10 +2579,10 @@ def early_exit_cache_set(
             integration=integration,
             integration_version=integration_version,
             dry_run=dry_run,
-            cache_desired_state=json.loads(cache_desired_state),
+            cache_source=json.loads(cache_source),
         )
         cache_value = CacheValue(
-            desired_state=json.loads(desired_state),
+            payload=json.loads(payload),
             log_output=log_output,
             applied_count=applied_count,
         )

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -84,7 +84,7 @@ def test_early_exit_cache_set(env_vars, mock_queries, mock_early_exit_cache):
 
     result = runner.invoke(
         qontract_cli.early_exit_cache,
-        "set -i a -v b --no-dry-run -c {} -d {} -l log -t 30",
+        "set -i a -v b --no-dry-run -c {} -p {} -l log -t 30",
     )
     assert result.exit_code == 0
     mock_early_exit_cache.build.return_value.__enter__.return_value.set.assert_called()


### PR DESCRIPTION
Extended early exit for terraform resources.

* Refactored terraform resources for easy split desired state and apply result
* Add `extended_early_exit_run` to use cache to do early exit
* `extended_early_exit_run` applied in terraform resources to achieve early exit
* export metrics `qontract_reconcile_extended_early_exit_count`

Test locally:

```shell
# start localstack
$ make localstack

# setup envs to use local s3
$ export $(cat ./dev/localstack/.env.local | xargs)

# run multiple times to verify early exit
$ qontract-reconcile --config config.toml \
    --log-level DEBUG \
    --dry-run \
    terraform-resources \
    --enable-extended-early-exit \
    --extended-early-exit-cache-ttl-seconds 3600 \
    --log-cached-log-output \
    --account-name YOUR_ACCOUNT_NAME
```

[APPSRE-8725](https://issues.redhat.com/browse/APPSRE-8725)