### PR TITLE
APPSRE-8505 allow to fetch latest pipeline state

### DIFF
--- a/reconcile/test/utils/vcs/conftest.py
+++ b/reconcile/test/utils/vcs/conftest.py
@@ -1,0 +1,46 @@
+from collections.abc import (
+    Callable,
+    Mapping,
+)
+from unittest.mock import create_autospec
+
+import pytest
+
+from reconcile.utils.gitlab_api import GitLabApi
+from reconcile.utils.secret_reader import SecretReaderBase
+from reconcile.utils.vcs import VCS
+
+
+@pytest.fixture
+def gitlab_api_builder() -> Callable[[Mapping], GitLabApi]:
+    def builder(data: Mapping) -> GitLabApi:
+        gitlab_api = create_autospec(spec=GitLabApi)
+        gitlab_api.get_merge_request_pipelines.side_effect = [
+            data.get("MR_PIPELINES", [])
+        ]
+        return gitlab_api
+
+    return builder
+
+
+@pytest.fixture
+def vcs_builder(
+    gitlab_api_builder: Callable[[Mapping], GitLabApi], secret_reader: SecretReaderBase
+) -> Callable[[Mapping], VCS]:
+    def builder(data: Mapping) -> VCS:
+        gitlab_api = gitlab_api_builder(data)
+        vcs = VCS(
+            allow_deleting_mrs=False,
+            allow_opening_mrs=False,
+            app_interface_api=gitlab_api,
+            app_interface_repo_url="",
+            default_gh_token="some-token",
+            github_orgs=[],
+            gitlab_instance=gitlab_api,
+            secret_reader=secret_reader,
+            dry_run=True,
+            gitlab_instances=[],
+        )
+        return vcs
+
+    return builder

--- a/reconcile/test/utils/vcs/test_vcs.py
+++ b/reconcile/test/utils/vcs/test_vcs.py
@@ -1,0 +1,30 @@
+from collections.abc import Callable, Mapping
+from unittest.mock import create_autospec
+
+import pytest
+from gitlab.v4.objects import ProjectMergeRequest
+
+from reconcile.utils.vcs import VCS, MRCheckStatus
+
+
+# https://docs.gitlab.com/ee/api/pipelines.html
+@pytest.mark.parametrize(
+    "pipelines, expected_status",
+    [
+        ([{"status": "success"}], MRCheckStatus.SUCCESS),
+        ([{"status": "failed"}], MRCheckStatus.FAILED),
+        ([{"status": "canceled"}], MRCheckStatus.NONE),
+        ([], MRCheckStatus.NONE),
+    ],
+)
+def test_gitlab_mr_check_status(
+    vcs_builder: Callable[[Mapping], VCS],
+    pipelines: list[Mapping],
+    expected_status: MRCheckStatus,
+) -> None:
+    vcs = vcs_builder({
+        "MR_PIPELINES": pipelines,
+    })
+
+    mr = create_autospec(spec=ProjectMergeRequest)
+    assert vcs.get_gitlab_mr_check_status(mr=mr) == expected_status


### PR DESCRIPTION
Lets allow our VCS layer to fetch latest pipeline state. The logic is taken from gitlab_housekeeping integration.

Further, this adds a builder pattern to allow tests for VCS functions. The builder pattern can be easily extended for other VCS functions too in the future.

This will be required by SAPM to properly unbatch MRs that are failing, so they do not block each other.