### PR TITLE
gitlab-housekeeping add app_sre_bot label to qontract_reconcile_merged_merge_requests

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -75,7 +75,14 @@ DATE_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
 merged_merge_requests = Counter(
     name="qontract_reconcile_merged_merge_requests",
     documentation="Number of merge requests that have been successfully merged in a repository",
-    labelnames=["project_id", "self_service", "auto_merge", "app_sre", "onboarding"],
+    labelnames=[
+        "project_id",
+        "self_service",
+        "auto_merge",
+        "app_sre",
+        "app_sre_bot",
+        "onboarding",
+    ],
 )
 
 rebased_merge_requests = Counter(
@@ -523,11 +530,13 @@ def merge_merge_requests(
             try:
                 mr.merge()
                 labels = mr.labels
+                author = mr.author["username"]
                 merged_merge_requests.labels(
                     project_id=mr.target_project_id,
                     self_service=SELF_SERVICEABLE in labels,
                     auto_merge=AUTO_MERGE in labels,
-                    app_sre=mr.author["username"] in app_sre_usernames,
+                    app_sre=author in app_sre_usernames,
+                    app_sre_bot=author == gl.user.username,
                     onboarding=ONBOARDING in labels,
                 ).inc()
                 time_to_merge.labels(


### PR DESCRIPTION
with this label we can differentiate between MRs submitted by the bot or not.

this will allow us to measure increase in AppSRE productivity by seeing an increase in bot MRs and a decrease in team members MRs.