### PR TITLE
Apply session and timeout to quay mirror integrations

### DIFF
--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -38,10 +38,9 @@ _LOG = logging.getLogger(__name__)
 
 QONTRACT_INTEGRATION = "quay-mirror"
 CONTROL_FILE_NAME = "qontract-reconcile-quay-mirror.timestamp"
+REQUEST_TIMEOUT = 60
 
 OrgKey = namedtuple("OrgKey", ["instance", "org_name"])
-
-REQUEST_TIMEOUT = 60
 
 
 class QuayMirror:

--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -12,8 +12,10 @@ from collections.abc import Iterable
 from typing import (
     Any,
     Optional,
+    Self,
 )
 
+import requests
 from requests import Response
 from sretoolbox.container.image import (
     ImageComparisonError,
@@ -38,6 +40,8 @@ QONTRACT_INTEGRATION = "quay-mirror"
 CONTROL_FILE_NAME = "qontract-reconcile-quay-mirror.timestamp"
 
 OrgKey = namedtuple("OrgKey", ["instance", "org_name"])
+
+REQUEST_TIMEOUT = 60
 
 
 class QuayMirror:
@@ -111,6 +115,13 @@ class QuayMirror:
             )
 
         self._has_enough_time_passed_since_last_compare_tags: Optional[bool] = None
+        self.session = requests.Session()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self.session.close()
 
     def run(self) -> None:
         sync_tasks = self.process_sync_tasks()
@@ -134,6 +145,8 @@ class QuayMirror:
         cls,
         repository_urls: Optional[Iterable[str]] = None,
         exclude_repository_urls: Optional[Iterable[str]] = None,
+        session: requests.Session | None = None,
+        timeout: int = REQUEST_TIMEOUT,
     ) -> defaultdict[OrgKey, list[dict[str, Any]]]:
         apps = queries.get_quay_repos()
 
@@ -171,7 +184,12 @@ class QuayMirror:
                     ):
                         continue
 
-                    mirror_image = Image(mirror_url, response_cache=cls.response_cache)
+                    mirror_image = Image(
+                        mirror_url,
+                        response_cache=cls.response_cache,
+                        session=session,
+                        timeout=timeout,
+                    )
                     if mirror_image.registry == "docker.io" and item["public"]:
                         _LOG.error(
                             "Image %s can't be mirrored to a public "
@@ -224,6 +242,8 @@ class QuayMirror:
                     username=push_creds[0],
                     password=push_creds[1],
                     response_cache=self.response_cache,
+                    session=self.session,
+                    timeout=REQUEST_TIMEOUT,
                 )
 
                 mirror_url = item["mirror"]["url"]
@@ -243,6 +263,8 @@ class QuayMirror:
                     username=username,
                     password=password,
                     response_cache=self.response_cache,
+                    session=self.session,
+                    timeout=REQUEST_TIMEOUT,
                 )
 
                 tags = item["mirror"].get("tags")
@@ -391,20 +413,20 @@ def run(
     repository_urls: Optional[Iterable[str]],
     exclude_repository_urls: Optional[Iterable[str]],
 ):
-    quay_mirror = QuayMirror(
+    with QuayMirror(
         dry_run,
         control_file_dir,
         compare_tags,
         compare_tags_interval,
         repository_urls,
         exclude_repository_urls,
-    )
-    quay_mirror.run()
+    ) as quay_mirror:
+        quay_mirror.run()
 
 
 def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
-    quay_mirror = QuayMirror(dry_run=True)
-    return {
-        "repos": quay_mirror.process_repos_query(),
-        "orgs": quay_mirror.push_creds,
-    }
+    with QuayMirror(dry_run=True) as quay_mirror:
+        return {
+            "repos": quay_mirror.process_repos_query(session=quay_mirror.session),
+            "orgs": quay_mirror.push_creds,
+        }

--- a/reconcile/test/test_gcr_mirror.py
+++ b/reconcile/test/test_gcr_mirror.py
@@ -1,0 +1,14 @@
+from pytest_mock import MockerFixture
+
+from reconcile.gcr_mirror import QuayMirror
+
+
+def test_gcr_mirror_session(mocker: MockerFixture) -> None:
+    mocker.patch("reconcile.gcr_mirror.gql")
+    mocker.patch("reconcile.gcr_mirror.queries")
+    mocked_request = mocker.patch("reconcile.gcr_mirror.requests")
+
+    with QuayMirror() as gcr_mirror:
+        assert gcr_mirror.session == mocked_request.Session.return_value
+
+    mocked_request.Session.return_value.close.assert_called_once_with()

--- a/reconcile/test/test_quay_mirror.py
+++ b/reconcile/test/test_quay_mirror.py
@@ -176,4 +176,4 @@ def test_quay_mirror_session(mocker):
     with QuayMirror() as quay_mirror:
         assert quay_mirror.session == mocked_request.Session.return_value
 
-    mocked_request.Session.return_value.close.assert_called_once()
+    mocked_request.Session.return_value.close.assert_called_once_with()

--- a/reconcile/test/test_quay_mirror_org.py
+++ b/reconcile/test/test_quay_mirror_org.py
@@ -70,3 +70,13 @@ class TestIsCompareTags:
             compare_tags=True,
         )
         assert qm.is_compare_tags
+
+
+def test_quay_mirror_org_session(mocker):
+    mocker.patch("reconcile.quay_mirror_org.get_quay_api_store")
+    mocked_request = mocker.patch("reconcile.quay_mirror_org.requests")
+
+    with QuayMirrorOrg() as quay_mirror_org:
+        assert quay_mirror_org.session == mocked_request.Session.return_value
+
+    mocked_request.Session.return_value.close.assert_called_once_with()

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(exclude=("tests",)),
     package_data={"reconcile": ["templates/*.j2", "gql_queries/*/*.gql"]},
     install_requires=[
-        "sretoolbox~=2.4.3",
+        "sretoolbox~=2.5.0",
         "Click>=7.0,<9.0",
         "gql==3.1.0",
         "toml>=0.10.0,<0.11.0",


### PR DESCRIPTION
Quay mirror started OOM kill after urllib3 upgrade in https://github.com/app-sre/qontract-reconcile/pull/4002, main change is from this commit https://github.com/urllib3/urllib3/commit/a80c248c34a77e106551bf997e726457b03f42b5.

We need to avoid creating too many connections. This change applies `session` and `timeout` to integrations using `Image`.

* quay-mirror
* quay-mirror-org
* gcr-mirror

Depends on https://github.com/app-sre/sretoolbox/pull/103, need to bump version after merged.

[APPSRE-8176](https://issues.redhat.com/browse/APPSRE-8176)