### PR TITLE
Rename template test integration

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2628,10 +2628,10 @@ def prometheus_rules_tester(ctx, thread_pool_size, cluster_name):
 
 @integration.command(short_help="Tests templating of resources.")
 @click.pass_context
-def template_tester(ctx):
-    import reconcile.template_tester
+def resource_template_tester(ctx):
+    import reconcile.resource_template_tester
 
-    run_integration(reconcile.template_tester, ctx.obj)
+    run_integration(reconcile.resource_template_tester, ctx.obj)
 
 
 @integration.command(

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -2453,7 +2453,7 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "template_tests_v1",
+                            "name": "resource_template_tests_v1",
                             "description": null,
                             "args": [
                                 {
@@ -2485,7 +2485,7 @@
                                     "name": null,
                                     "ofType": {
                                         "kind": "OBJECT",
-                                        "name": "TemplateTest_v1",
+                                        "name": "ResourceTemplateTest_v1",
                                         "ofType": null
                                     }
                                 }
@@ -27212,7 +27212,7 @@
                 },
                 {
                     "kind": "OBJECT",
-                    "name": "TemplateTest_v1",
+                    "name": "ResourceTemplateTest_v1",
                     "description": null,
                     "fields": [
                         {

--- a/reconcile/resource_template_tester.py
+++ b/reconcile/resource_template_tester.py
@@ -11,13 +11,13 @@ from reconcile.status import ExitCodes
 from reconcile.utils import gql
 from reconcile.utils.semver_helper import make_semver
 
-QONTRACT_INTEGRATION = "template-tester"
+QONTRACT_INTEGRATION = "resource-template-tester"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
 TEMPLATE_TESTS_QUERY = """
 {
-  tests: template_tests_v1 {
+  tests: resource_template_tests_v1 {
     name
     resourcePath
     expectedResult

--- a/reconcile/resource_template_tester.py
+++ b/reconcile/resource_template_tester.py
@@ -30,7 +30,7 @@ def load_resource(path: str) -> dict:
     return yaml.safe_load(gql.get_resource(path)["content"])
 
 
-def run(dry_run):
+def run(dry_run: bool) -> None:
     gqlapi = gql.get_api()
     template_tests = gqlapi.query(TEMPLATE_TESTS_QUERY)["tests"]
     settings = queries.get_app_interface_settings()


### PR DESCRIPTION
Rename it to resource template test, cause it's testing resource templates. Template Test would collide with future addition of templating

[APPSRE-8710](https://issues.redhat.com/browse/APPSRE-8710)