### PR TITLE
Add geo_restrictions to cloudflare resources custom ssl certificate

### DIFF
--- a/reconcile/utils/terrascript/cloudflare_resources.py
+++ b/reconcile/utils/terrascript/cloudflare_resources.py
@@ -201,11 +201,12 @@ class CloudflareZoneTerrascriptResource(TerrascriptResource):
             certificate_secret = cert_values.pop("certificate_secret")
             certificate = secret_reader.read(certificate_secret.pop("certificate"))
             key = secret_reader.read(certificate_secret.pop("key"))
+            bundle_method = cert_values.pop("bundle_method") or "ubiquitous"
             custom_ssl_values: dict[Any, Any] = {
                 "zone_id": f"${{{zone.id}}}",
                 "depends_on": self._get_dependencies([zone]),
                 "custom_ssl_options": {
-                    "bundle_method": cert_values.pop("bundle_method", "ubiquitous"),
+                    "bundle_method": bundle_method,
                     "type": cert_values.pop("type"),
                     "certificate": certificate,
                     "private_key": key,

--- a/reconcile/utils/terrascript/cloudflare_resources.py
+++ b/reconcile/utils/terrascript/cloudflare_resources.py
@@ -208,6 +208,7 @@ class CloudflareZoneTerrascriptResource(TerrascriptResource):
                 "custom_ssl_options": {
                     "bundle_method": bundle_method,
                     "type": cert_values.pop("type"),
+                    "geo_restrictions": cert_values.pop("geo_restrictions"),
                     "certificate": certificate,
                     "private_key": key,
                 },


### PR DESCRIPTION
I'm trying to avoid errors like this one on a terraform apply run:
```
Error: failed to create custom ssl cert: Could not complete the requested operation. Invalid or missing parameters. (2001)
```

I'm not aware of a way to test this with an apply run.