### PR TITLE
qontract-cli get clusters-aws-account-ids take account id from spec.account if exists

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1078,6 +1078,13 @@ def clusters_aws_account_ids(ctx):
     results = []
     for cluster in clusters:
         cluster_name = cluster["name"]
+        if cluster["spec"].get("account"):
+            item = {
+                "cluster": cluster_name,
+                "aws_account_id": cluster["spec"]["account"]["uid"],
+            }
+            results.append(item)
+            continue
         ocm = ocm_map.get(cluster_name)
         aws_account_id = ocm.get_cluster_aws_account_id(cluster_name)
         item = {


### PR DESCRIPTION
fixes some of the empty cells: https://gitlab.cee.redhat.com/service/app-interface-output/-/blob/e50fe385afdc72ef9ffc877c2eb3944171b7b2ea/clusters-aws-account-ids.md