### PR TITLE
APPSRE-8505 run V2 in non-draft mode

### DIFF
--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request.py
@@ -1,9 +1,8 @@
 import logging
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.mr.base import MergeRequestBase
-from reconcile.utils.mr.labels import AUTO_MERGE
 
 LOG = logging.getLogger(__name__)
 
@@ -23,13 +22,13 @@ class SAPMMR(MergeRequestBase):
         content_by_path: Mapping[str, str],
         description: str,
         title: str,
-        sapm_label: str,
+        labels: Iterable[str],
     ):
         super().__init__()
         self._content_by_path = content_by_path
         self._title = title
         self._description = description
-        self.labels = [AUTO_MERGE, sapm_label]
+        self.labels = labels
 
     @property
     def title(self) -> str:

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
@@ -20,11 +20,23 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer impor
     Renderer,
 )
 from reconcile.saas_auto_promotions_manager.subscriber import Subscriber
+from reconcile.utils.mr.labels import AUTO_MERGE
 from reconcile.utils.vcs import VCS
 
 ITEM_SEPARATOR = ","
 
 SAPM_LABEL = "SAPM"
+SAPM_MR_LABELS = [SAPM_LABEL, AUTO_MERGE]
+
+MR_DESC = """
+This is an auto-promotion triggered by app-interface's [saas-auto-promotions-manager](https://github.com/app-sre/qontract-reconcile/tree/master/reconcile/saas_auto_promotions_manager) (SAPM).
+The channel(s) mentioned in the MR title had an event.
+This MR promotes all subscribers with auto-promotions for these channel(s).
+
+Please **do not remove or change any label** from this MR.
+
+Parts of this description are used by SAPM to manage auto-promotions.
+"""
 
 
 class MergeRequestManager:
@@ -156,6 +168,7 @@ class MergeRequestManager:
                 continue
 
             description = self._renderer.render_description(
+                message=MR_DESC,
                 content_hashes=combined_content_hash,
                 channels=channel_combo,
                 is_batchable=combined_content_hash not in self._unbatchable_hashes,
@@ -167,7 +180,7 @@ class MergeRequestManager:
             )
             self._vcs.open_app_interface_merge_request(
                 mr=SAPMMR(
-                    sapm_label=SAPM_LABEL,
+                    labels=SAPM_MR_LABELS,
                     content_by_path=content_by_path,
                     title=title,
                     description=description,

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager_v2.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager_v2.py
@@ -19,10 +19,21 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer impor
     Renderer,
 )
 from reconcile.saas_auto_promotions_manager.subscriber import Subscriber
+from reconcile.utils.mr.labels import DO_NOT_MERGE_HOLD
 from reconcile.utils.vcs import VCS
 
 BATCH_SIZE_LIMIT = 5
 SAPM_LABEL = "SAPMCanary"
+SAPM_MR_LABELS = [SAPM_LABEL, DO_NOT_MERGE_HOLD]
+
+MR_DESC = """
+:warning: **THIS IS A TEST MR - DO NOT MERGE OR CHANGE THIS!**
+
+If you witness any issues with this MR, please reach out to @kfischer from AppSRE.
+
+Please **do not remove or change any label** from this MR.
+
+"""
 
 
 class MergeRequestManagerV2:
@@ -103,12 +114,13 @@ class MergeRequestManagerV2:
         description_channels = ",".join(addition.channels)
 
         description = self._renderer.render_description(
+            message=MR_DESC,
             content_hashes=description_hashes,
             channels=description_channels,
             is_batchable=addition.batchable,
         )
         title = self._renderer.render_title(
-            is_draft=True, channels=description_channels
+            is_draft=False, channels=description_channels
         )
         logging.info(
             "Open MR for update in channel(s) %s",
@@ -116,7 +128,7 @@ class MergeRequestManagerV2:
         )
         self._sapm_mrs.append(
             SAPMMR(
-                sapm_label=SAPM_LABEL,
+                labels=SAPM_MR_LABELS,
                 content_by_path=content_by_path,
                 title=title,
                 description=description,

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
@@ -24,15 +24,6 @@ CONTENT_HASHES = "content_hashes"
 CHANNELS_REF = "channels"
 IS_BATCHABLE = "is_batchable"
 VERSION_REF = "sapm_version"
-SAPM_DESC = """
-This is an auto-promotion triggered by app-interface's [saas-auto-promotions-manager](https://github.com/app-sre/qontract-reconcile/tree/master/reconcile/saas_auto_promotions_manager) (SAPM).
-The channel(s) mentioned in the MR title had an event.
-This MR promotes all subscribers with auto-promotions for these channel(s).
-
-Please **do not remove or change any label** from this MR.
-
-Parts of this description are used by SAPM to manage auto-promotions.
-"""
 
 
 class Renderer:
@@ -136,10 +127,10 @@ class Renderer:
         return new_content
 
     def render_description(
-        self, content_hashes: str, channels: str, is_batchable: bool
+        self, message: str, content_hashes: str, channels: str, is_batchable: bool
     ) -> str:
         return f"""
-{SAPM_DESC}
+{message}
 
 {PROMOTION_DATA_SEPARATOR}
 


### PR DESCRIPTION
SAPM MergeRequestManagerV2 has been opening MRs in Draft mode and the MRs looked good.

In this PR we allow V2 to open MRs in non-draft mode, but with the do-not-merge label. By doing so, we allow CI checks to run. We want to observe the behavior of V2 on failed MR checks, i.e., if it properly unbatches MRs if an MR check fails.
Since we apply the do-not-merge label, nothing will be merged. The MR description also indicates that this MR must not be merged.