### PR TITLE
APPSRE-8505 titles must have diff

### DIFF
--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager.py
@@ -173,7 +173,9 @@ class MergeRequestManager:
                 channels=channel_combo,
                 is_batchable=combined_content_hash not in self._unbatchable_hashes,
             )
-            title = self._renderer.render_title(is_draft=False, channels=channel_combo)
+            title = self._renderer.render_title(
+                is_draft=False, canary=False, channels=channel_combo
+            )
             logging.info(
                 "Open MR for update in channel(s) %s",
                 channel_combo,

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager_v2.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager_v2.py
@@ -120,7 +120,7 @@ class MergeRequestManagerV2:
             is_batchable=addition.batchable,
         )
         title = self._renderer.render_title(
-            is_draft=False, channels=description_channels
+            is_draft=False, canary=True, channels=description_channels
         )
         logging.info(
             "Open MR for update in channel(s) %s",

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
@@ -143,8 +143,9 @@ class Renderer:
 {VERSION_REF}: {SAPM_VERSION}
         """
 
-    def render_title(self, is_draft: bool, channels: str) -> str:
-        content = f"[SAPM] auto-promotion ID {int(hashlib.sha256(channels.encode('utf-8')).hexdigest(), 16) % 10**8}"
+    def render_title(self, is_draft: bool, canary: bool, channels: str) -> str:
+        canary_suffix = "Canary" if canary else ""
+        content = f"[SAPM{canary_suffix}] auto-promotion ID {int(hashlib.sha256(channels.encode('utf-8')).hexdigest(), 16) % 10**8}"
         if is_draft:
             return f"Draft: {content}"
         return content


### PR DESCRIPTION
The titles of V1 and V2 do not have a diff now -> in our api lib the MR is not opened properly if title already exists.

Without this, the first MR wins. If it comes from V2, then it will never get merged.