### PR TITLE
[openshift-resources] add environment to query

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -169,6 +169,10 @@ NAMESPACES_QUERY = """
     openshiftResources {
       %s
     }
+    environment {
+      name
+      parameters
+    }
     cluster {
       name
       labels


### PR DESCRIPTION
to be able to facilitate data from environments in resources, openshift-resources should query for environment information.

part of https://issues.redhat.com/browse/OSD-20607

required for https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/95166