### PR TITLE
[terraform-resources] add support for aws-iam-role role policy

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -38400,6 +38400,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "role_policy",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "output_resource_name",
                             "description": null,
                             "args": [],

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
@@ -108,6 +108,7 @@ query TerraformResourcesNamespaces {
                 assume_condition
                 assume_action
                 inline_policy
+                role_policy
                 output_resource_name
                 annotations
             }

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
@@ -165,6 +165,7 @@ query TerraformResourcesNamespaces {
                 assume_condition
                 assume_action
                 inline_policy
+                role_policy
                 output_resource_name
                 annotations
             }
@@ -619,6 +620,7 @@ class NamespaceTerraformResourceRoleV1(NamespaceTerraformResourceAWSV1):
     assume_condition: Optional[str] = Field(..., alias="assume_condition")
     assume_action: Optional[str] = Field(..., alias="assume_action")
     inline_policy: Optional[str] = Field(..., alias="inline_policy")
+    role_policy: Optional[str] = Field(..., alias="role_policy")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
 
@@ -970,7 +972,7 @@ class NamespaceTerraformResourceMskV1(NamespaceTerraformResourceAWSV1):
 
 
 class NamespaceTerraformProviderResourceAWSV1(NamespaceExternalResourceV1):
-    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
+    resources: list[Union[NamespaceTerraformResourceRDSV1, NamespaceTerraformResourceRosaAuthenticatorV1, NamespaceTerraformResourceALBV1, NamespaceTerraformResourceS3V1, NamespaceTerraformResourceASGV1, NamespaceTerraformResourceRoleV1, NamespaceTerraformResourceSNSTopicV1, NamespaceTerraformResourceElastiCacheV1, NamespaceTerraformResourceServiceAccountV1, NamespaceTerraformResourceS3SQSV1, NamespaceTerraformResourceCloudWatchV1, NamespaceTerraformResourceRosaAuthenticatorVPCEV1, NamespaceTerraformResourceS3CloudFrontV1, NamespaceTerraformResourceKMSV1, NamespaceTerraformResourceElasticSearchV1, NamespaceTerraformResourceACMV1, NamespaceTerraformResourceKinesisV1, NamespaceTerraformResourceRoute53ZoneV1, NamespaceTerraformResourceMskV1, NamespaceTerraformResourceSQSV1, NamespaceTerraformResourceDynamoDBV1, NamespaceTerraformResourceECRV1, NamespaceTerraformResourceS3CloudFrontPublicKeyV1, NamespaceTerraformResourceSecretsManagerV1, NamespaceTerraformResourceSecretsManagerServiceAccountV1, NamespaceTerraformResourceAWSV1]] = Field(..., alias="resources")
 
 
 class EnvironmentV1(ConfiguredBaseModel):

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -2469,6 +2469,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 name=identifier,
                 policy=role_policy,
                 depends_on=self.get_dependencies([role_tf_resource]),
+                tags=common_values["tags"],
             )
             tf_resources.append(tf_aws_iam_policy)
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -221,6 +221,7 @@ VARIABLE_KEYS = [
     "image",
     "assume_role",
     "inline_policy",
+    "role_policy",
     "assume_condition",
     "assume_action",
     "api_proxy_uri",
@@ -2460,6 +2461,24 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         role_tf_resource = aws_iam_role(identifier, **values)
         tf_resources.append(role_tf_resource)
+
+        role_policy = common_values.get("role_policy")
+        if role_policy:
+            tf_aws_iam_policy = aws_iam_policy(
+                identifier,
+                name=identifier,
+                policy=role_policy,
+                depends_on=self.get_dependencies([role_tf_resource]),
+            )
+            tf_resources.append(tf_aws_iam_policy)
+
+            tf_aws_iam_policy_attachment = aws_iam_role_policy_attachment(
+                identifier,
+                role=role_tf_resource.name,
+                policy_arn=f"${{{tf_aws_iam_policy.arn}}}",
+                depends_on=self.get_dependencies([role_tf_resource, tf_aws_iam_policy]),
+            )
+            tf_resources.append(tf_aws_iam_policy_attachment)
 
         # output role arn
         output_name_0_13 = output_prefix + "__role_arn"

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -2462,8 +2462,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         role_tf_resource = aws_iam_role(identifier, **values)
         tf_resources.append(role_tf_resource)
 
-        role_policy = common_values.get("role_policy")
-        if role_policy:
+        if role_policy := common_values.get("role_policy"):
             tf_aws_iam_policy = aws_iam_policy(
                 identifier,
                 name=identifier,


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-8794

depends on https://github.com/app-sre/qontract-schemas/pull/580

this PR adds support to define a policy to be created and attached to a role, instead or in addition to an inline policy.

this change is quite similar to https://github.com/app-sre/qontract-reconcile/blob/94db30819eceadcb38e99d107eb2c1f1f163b321/reconcile/utils/terrascript_aws_client.py#L2328-L2342