### PR TITLE
Sync introspection for run_order

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -26150,6 +26150,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "run_order",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,


### PR DESCRIPTION
No logic change, just sync `introspection.json` for https://github.com/app-sre/qontract-schemas/pull/582

[APPSRE-8759](https://issues.redhat.com/browse/APPSRE-8759)