### PR TITLE
chore: use __test__ = False to drop warnings

### DIFF
--- a/reconcile/test/test_ocm_machine_pools.py
+++ b/reconcile/test/test_ocm_machine_pools.py
@@ -33,6 +33,7 @@ from reconcile.utils.ocm import OCM
 
 
 class TestPool(AbstractPool):
+    __test__ = False
     created = False
     deleted = False
     updated = False

--- a/reconcile/test/test_status_board.py
+++ b/reconcile/test/test_status_board.py
@@ -19,6 +19,7 @@ from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
 class TestStatusBoard(AbstractStatusBoard):
+    __test__ = False
     created: Optional[bool] = False
     deleted: Optional[bool] = False
     summarized: Optional[bool] = False


### PR DESCRIPTION
some helper classes match the test class names but are not tests
