### PR TITLE
[terraform-resources] aws-iam-role add support for lifecycle

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -36370,6 +36370,61 @@
                 },
                 {
                     "kind": "OBJECT",
+                    "name": "NamespaceTerraformResourceLifecycle_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "create_before_destroy",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "prevent_destroy",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "ignore_changes",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
                     "name": "NamespaceTerraformResourceASG_v1",
                     "description": null,
                     "fields": [
@@ -38442,6 +38497,18 @@
                             "type": {
                                 "kind": "SCALAR",
                                 "name": "JSON",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "lifecycle",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "NamespaceTerraformResourceLifecycle_v1",
                                 "ofType": null
                             },
                             "isDeprecated": false,

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
@@ -111,6 +111,11 @@ query TerraformResourcesNamespaces {
                 role_policy
                 output_resource_name
                 annotations
+                lifecycle {
+                  create_before_destroy
+                  prevent_destroy
+                  ignore_changes
+                }
             }
             ... on NamespaceTerraformResourceSQS_v1 {
                 region

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
@@ -168,6 +168,11 @@ query TerraformResourcesNamespaces {
                 role_policy
                 output_resource_name
                 annotations
+                lifecycle {
+                  create_before_destroy
+                  prevent_destroy
+                  ignore_changes
+                }
             }
             ... on NamespaceTerraformResourceSQS_v1 {
                 region
@@ -614,6 +619,12 @@ class AssumeRoleV1(ConfiguredBaseModel):
     federated: Optional[str] = Field(..., alias="Federated")
 
 
+class NamespaceTerraformResourceLifecycleV1(ConfiguredBaseModel):
+    create_before_destroy: Optional[bool] = Field(..., alias="create_before_destroy")
+    prevent_destroy: Optional[bool] = Field(..., alias="prevent_destroy")
+    ignore_changes: Optional[list[str]] = Field(..., alias="ignore_changes")
+
+
 class NamespaceTerraformResourceRoleV1(NamespaceTerraformResourceAWSV1):
     identifier: str = Field(..., alias="identifier")
     assume_role: AssumeRoleV1 = Field(..., alias="assume_role")
@@ -623,6 +634,7 @@ class NamespaceTerraformResourceRoleV1(NamespaceTerraformResourceAWSV1):
     role_policy: Optional[str] = Field(..., alias="role_policy")
     output_resource_name: Optional[str] = Field(..., alias="output_resource_name")
     annotations: Optional[str] = Field(..., alias="annotations")
+    lifecycle: Optional[NamespaceTerraformResourceLifecycleV1] = Field(..., alias="lifecycle")
 
 
 class KeyValueV1(ConfiguredBaseModel):

--- a/reconcile/test/utils/test_terrascript_aws_client.py
+++ b/reconcile/test/utils/test_terrascript_aws_client.py
@@ -720,7 +720,7 @@ def test_get_resource_lifecycle_none(
 def test_get_resource_lifecycle_default(
     ts: tsclient.TerrascriptClient,
 ) -> None:
-    common_values = {
+    common_values: dict = {
         "lifecycle": {
             "create_before_destroy": None,
             "prevent_destroy": None,

--- a/reconcile/test/utils/test_terrascript_aws_client.py
+++ b/reconcile/test/utils/test_terrascript_aws_client.py
@@ -707,3 +707,43 @@ def test_s3_bucket_event_notifications(
     identifier, tf_resources = mocked_add_resources.call_args.args
     assert identifier == "a"
     assert expected_s3_bucket_notification in tf_resources
+
+
+def test_get_resource_lifecycle_none(
+    ts: tsclient.TerrascriptClient,
+) -> None:
+    common_values = {"lifecycle": None}
+    lifecycle = ts.get_resource_lifecycle(common_values)
+    assert lifecycle is None
+
+
+def test_get_resource_lifecycle_default(
+    ts: tsclient.TerrascriptClient,
+) -> None:
+    common_values = {
+        "lifecycle": {
+            "create_before_destroy": None,
+            "prevent_destroy": None,
+            "ignore_changes": [],
+        }
+    }
+    lifecycle = ts.get_resource_lifecycle(common_values)
+    expected = {
+        "create_before_destroy": False,
+        "prevent_destroy": False,
+        "ignore_changes": [],
+    }
+    assert lifecycle == expected
+
+
+def test_get_resource_lifecycle_all(
+    ts: tsclient.TerrascriptClient,
+) -> None:
+    common_values = {"lifecycle": {"ignore_changes": ["all"]}}
+    lifecycle = ts.get_resource_lifecycle(common_values)
+    expected = {
+        "create_before_destroy": False,
+        "prevent_destroy": False,
+        "ignore_changes": "all",
+    }
+    assert lifecycle == expected

--- a/reconcile/test/utils/test_terrascript_aws_client.py
+++ b/reconcile/test/utils/test_terrascript_aws_client.py
@@ -739,7 +739,13 @@ def test_get_resource_lifecycle_default(
 def test_get_resource_lifecycle_all(
     ts: tsclient.TerrascriptClient,
 ) -> None:
-    common_values = {"lifecycle": {"ignore_changes": ["all"]}}
+    common_values: dict = {
+        "lifecycle": {
+            "create_before_destroy": None,
+            "prevent_destroy": None,
+            "ignore_changes": ["all"],
+        }
+    }
     lifecycle = ts.get_resource_lifecycle(common_values)
     expected = {
         "create_before_destroy": False,

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -143,6 +143,9 @@ import reconcile.openshift_resources_base as orb
 import reconcile.utils.aws_helper as awsh
 from reconcile import queries
 from reconcile.github_org import get_default_config
+from reconcile.gql_definitions.terraform_resources.terraform_resources_namespaces import (
+    NamespaceTerraformResourceLifecycleV1,
+)
 from reconcile.utils import gql
 from reconcile.utils.aws_api import (
     AmiTag,
@@ -876,15 +879,16 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         common_values: dict[str, Any],
     ) -> Optional[dict[str, Any]]:
         if lifecycle := common_values.get("lifecycle"):
-            if lifecycle.get("create_before_destroy") is None:
-                lifecycle["create_before_destroy"] = False
-            if lifecycle.get("prevent_destroy") is None:
-                lifecycle["prevent_destroy"] = False
-            if lifecycle.get("ignore_changes") is None:
-                lifecycle["ignore_changes"] = []
-            if "all" in lifecycle["ignore_changes"]:
-                lifecycle["ignore_changes"] = "all"
-            return lifecycle
+            lifecycle = NamespaceTerraformResourceLifecycleV1(**lifecycle)
+            if lifecycle.create_before_destroy is None:
+                lifecycle.create_before_destroy = False
+            if lifecycle.prevent_destroy is None:
+                lifecycle.prevent_destroy = False
+            if lifecycle.ignore_changes is None:
+                lifecycle.ignore_changes = []
+            if "all" in lifecycle.ignore_changes:
+                lifecycle.ignore_changes = "all"
+            return lifecycle.dict(by_alias=True)
         return None
 
     def populate_additional_providers(self, infra_account_name: str, accounts):


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-8799

depends on https://github.com/app-sre/qontract-schemas/pull/583

this PR adds logic to consider a `lifecycle` attribute on an `aws-iam-role`.