### PR TITLE
[glitchtip] throttle project event ingest

### DIFF
--- a/reconcile/glitchtip/integration.py
+++ b/reconcile/glitchtip/integration.py
@@ -100,6 +100,7 @@ def fetch_desired_state(
             name=glitchtip_project.name,
             platform=glitchtip_project.platform,
             slug=glitchtip_project.project_id if glitchtip_project.project_id else "",
+            event_throttle_rate=glitchtip_project.event_throttle_rate or 0,
         )
         # Check project is unique within an organization
         if project.name in [p.name for p in organization.projects]:

--- a/reconcile/gql_definitions/glitchtip/glitchtip_project.gql
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_project.gql
@@ -5,6 +5,7 @@ query Projects {
     name
     platform
     projectId
+    eventThrottleRate
     teams {
       name
       roles {

--- a/reconcile/gql_definitions/glitchtip/glitchtip_project.py
+++ b/reconcile/gql_definitions/glitchtip/glitchtip_project.py
@@ -45,6 +45,7 @@ query Projects {
     name
     platform
     projectId
+    eventThrottleRate
     teams {
       name
       roles {
@@ -183,6 +184,7 @@ class GlitchtipProjectsV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     platform: str = Field(..., alias="platform")
     project_id: Optional[str] = Field(..., alias="projectId")
+    event_throttle_rate: Optional[int] = Field(..., alias="eventThrottleRate")
     teams: list[GlitchtipTeamV1] = Field(..., alias="teams")
     organization: GlitchtipProjectsV1_GlitchtipOrganizationV1 = Field(..., alias="organization")
     namespaces: list[NamespaceV1] = Field(..., alias="namespaces")

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -20731,12 +20731,12 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "acceptEvents",
+                            "name": "eventThrottleRate",
                             "description": null,
                             "args": [],
                             "type": {
                                 "kind": "SCALAR",
-                                "name": "Boolean",
+                                "name": "Int",
                                 "ofType": null
                             },
                             "isDeprecated": false,

--- a/reconcile/test/fixtures/glitchtip/current_state_expected.yml
+++ b/reconcile/test/fixtures/glitchtip/current_state_expected.yml
@@ -6,6 +6,7 @@
     pk: 10
     platform: python
     slug: rosetta-flight-control
+    event_throttle_rate: 0
     teams:
     - name: esa-flight-control
       pk: 7
@@ -16,6 +17,7 @@
     pk: 9
     platform: python
     slug: rosetta-spacecraft
+    event_throttle_rate: 0
     teams:
     - name: esa-pilots
       pk: 6
@@ -84,6 +86,7 @@
     pk: 8
     platform: python
     slug: apollo-11-flight-control
+    event_throttle_rate: 0
     teams:
     - name: nasa-flight-control
       pk: 4
@@ -94,6 +97,7 @@
     pk: 7
     platform: python
     slug: apollo-11-spacecraft
+    event_throttle_rate: 0
     teams:
     - name: nasa-pilots
       pk: 2

--- a/reconcile/test/fixtures/glitchtip/desire_state_expected.yml
+++ b/reconcile/test/fixtures/glitchtip/desire_state_expected.yml
@@ -6,6 +6,7 @@
     pk: null
     platform: python
     slug: rosetta-spacecraft
+    event_throttle_rate: 0
     teams:
     - name: esa-pilots
       pk: null
@@ -36,6 +37,7 @@
     pk: null
     platform: python
     slug: rosetta-flight-control
+    event_throttle_rate: 0
     teams:
     - name: esa-flight-control
       pk: null
@@ -104,6 +106,7 @@
     pk: null
     platform: python
     slug: apollo-11-spacecraft
+    event_throttle_rate: 0
     teams:
     - name: nasa-pilots
       pk: null
@@ -134,6 +137,7 @@
     pk: null
     platform: python
     slug: apollo-11-flight-control
+    event_throttle_rate: 0
     teams:
     - name: nasa-flight-control
       pk: null

--- a/reconcile/utils/glitchtip/models.py
+++ b/reconcile/utils/glitchtip/models.py
@@ -154,6 +154,10 @@ class Project(BaseModel):
     platform: Optional[str]
     teams: list[Team] = []
     alerts: list[ProjectAlert] = []
+    event_throttle_rate: int = Field(0, alias="eventThrottleRate")
+
+    class Config:
+        allow_population_by_field_name = True
 
     @root_validator
     def slugify(  # pylint: disable=no-self-argument
@@ -174,7 +178,11 @@ class Project(BaseModel):
         return self.slug == other.slug
 
     def diff(self, other: Project) -> bool:
-        return self.name != other.name or self.platform != other.platform
+        return (
+            self.name != other.name
+            or self.platform != other.platform
+            or self.event_throttle_rate != other.event_throttle_rate
+        )
 
     def __hash__(self) -> int:
         return hash(self.slug)


### PR DESCRIPTION
Implement a feature to throttle the event ingest on glitchtip project level. This will be the last resort to throttle/disable incoming events on top talkers.

Ticket: [APPSRE-9732](https://issues.redhat.com/browse/APPSRE-9732)
Depends on: https://github.com/app-sre/qontract-schemas/pull/586