### PR TITLE
APPSRE-8804 better SAPM metrics

### DIFF
--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/metrics.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/metrics.py
@@ -16,6 +16,8 @@ class SAPMOpenedMRsCounter(SAPMBaseMetric, CounterMetric):
     "Counter for the number of opened auto-promotion MRs"
 
     is_batchable: bool
+    # We do not expect batches >10, i.e., cardinality will stay in check here.
+    batch_size: int
 
     @classmethod
     def name(cls) -> str:


### PR DESCRIPTION
- properly calculate parallel open MRs
- add batch size as dimension for open MR counter -> batch sizes are limited, so cardinality will stay low