### PR TITLE
Add shard to early exit cache and avoid stale cache

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -419,6 +419,7 @@ def run(
             integration_version=QONTRACT_INTEGRATION_VERSION,
             dry_run=dry_run,
             cache_source=ts.terraform_configurations(),
+            shard="_".join(account_name) if account_name else "",
             ttl_seconds=extended_early_exit_cache_ttl_seconds,
             logger=logging.getLogger(),
             runner=runner,

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -376,6 +376,7 @@ def test_run_with_extended_early_exit_run_enabled(
         integration_version=integ.QONTRACT_INTEGRATION_VERSION,
         dry_run=True,
         cache_source=mocks["ts"].terraform_configurations.return_value,
+        shard="a",
         ttl_seconds=60,
         logger=mocks["logging"].getLogger.return_value,
         runner=integ.runner,

--- a/reconcile/test/utils/test_early_exit_cache.py
+++ b/reconcile/test/utils/test_early_exit_cache.py
@@ -24,6 +24,7 @@ DRY_RUN_CACHE_KEY = CacheKey(
     integration_version=INTEGRATION_VERSION,
     dry_run=True,
     cache_source=CACHE_SOURCE,
+    shard="",
 )
 
 DRY_RUN_CACHE_VALUE = CacheValue(
@@ -37,8 +38,8 @@ NO_DRY_RUN_CACHE_KEY = CacheKey(
     integration_version=INTEGRATION_VERSION,
     dry_run=False,
     cache_source=CACHE_SOURCE,
+    shard="",
 )
-
 
 NO_DRY_RUN_CACHE_VALUE = CacheValue(
     payload={"k2": "v2"},
@@ -75,21 +76,39 @@ def early_exit_cache(state: Any) -> EarlyExitCache:
 
 
 @pytest.mark.parametrize(
-    "integration, integration_version, dry_run, cache_source, expected",
+    "integration, integration_version, dry_run, cache_source, shard, expected",
     [
         (
             INTEGRATION_NAME,
             INTEGRATION_VERSION,
             False,
             CACHE_SOURCE,
+            "",
             f"{INTEGRATION_NAME}/{INTEGRATION_VERSION}/no-dry-run/latest",
+        ),
+        (
+            INTEGRATION_NAME,
+            INTEGRATION_VERSION,
+            False,
+            CACHE_SOURCE,
+            "shard-1",
+            f"{INTEGRATION_NAME}/{INTEGRATION_VERSION}/no-dry-run/shard-1/latest",
         ),
         (
             INTEGRATION_NAME,
             INTEGRATION_VERSION,
             True,
             CACHE_SOURCE,
+            "",
             f"{INTEGRATION_NAME}/{INTEGRATION_VERSION}/dry-run/{CACHE_SOURCE_DIGEST}",
+        ),
+        (
+            INTEGRATION_NAME,
+            INTEGRATION_VERSION,
+            True,
+            CACHE_SOURCE,
+            "shard-1",
+            f"{INTEGRATION_NAME}/{INTEGRATION_VERSION}/dry-run/shard-1/{CACHE_SOURCE_DIGEST}",
         ),
     ],
 )
@@ -98,6 +117,7 @@ def test_cache_key_string(
     integration_version: str,
     dry_run: bool,
     cache_source: Any,
+    shard: str,
     expected: str,
 ) -> None:
     cache_key = CacheKey(
@@ -105,6 +125,7 @@ def test_cache_key_string(
         integration_version=integration_version,
         dry_run=dry_run,
         cache_source=cache_source,
+        shard=shard,
     )
     assert str(cache_key) == expected
 

--- a/reconcile/test/utils/test_extended_early_exit.py
+++ b/reconcile/test/utils/test_extended_early_exit.py
@@ -7,6 +7,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from reconcile.utils.early_exit_cache import (
+    CacheHeadResult,
     CacheKey,
     CacheStatus,
     CacheValue,
@@ -28,6 +29,7 @@ TTLS_SECONDS = 100
 RUNNER_PARAMS = {"some_param": "some-value"}
 CACHE_SOURCE = {"k": "v"}
 SHARD = "some-shard"
+LATEST_CACHE_SOURCE_DIGEST = "some-digest"
 
 
 @pytest.fixture
@@ -73,7 +75,10 @@ def test_extended_early_exit_run_miss_or_expired(
         autospec=True,
     )
     mock_early_exit_cache.build.return_value.__enter__.return_value = early_exit_cache
-    early_exit_cache.head.return_value = cache_status
+    early_exit_cache.head.return_value = CacheHeadResult(
+        status=cache_status,
+        latest_cache_source_digest=LATEST_CACHE_SOURCE_DIGEST,
+    )
     mock_inc_counter = mocker.patch("reconcile.utils.extended_early_exit.inc_counter")
     mock_set_gauge = mocker.patch("reconcile.utils.extended_early_exit.set_gauge")
     runner = MagicMock()
@@ -131,6 +136,7 @@ def test_extended_early_exit_run_miss_or_expired(
             applied_count=applied_count,
         ),
         expected_ttl,
+        LATEST_CACHE_SOURCE_DIGEST,
     )
     mock_inc_counter.assert_called_once_with(
         ExtendedEarlyExitCounter(
@@ -172,7 +178,10 @@ def test_extended_early_exit_run_hit_when_not_log_cached_log_output(
         autospec=True,
     )
     mock_early_exit_cache.build.return_value.__enter__.return_value = early_exit_cache
-    early_exit_cache.head.return_value = CacheStatus.HIT
+    early_exit_cache.head.return_value = CacheHeadResult(
+        status=CacheStatus.HIT,
+        latest_cache_source_digest=LATEST_CACHE_SOURCE_DIGEST,
+    )
     mock_inc_counter = mocker.patch("reconcile.utils.extended_early_exit.inc_counter")
     mock_set_gauge = mocker.patch("reconcile.utils.extended_early_exit.set_gauge")
     runner = MagicMock()
@@ -244,7 +253,10 @@ def test_extended_early_exit_run_hit_when_log_cached_log_output(
         autospec=True,
     )
     mock_early_exit_cache.build.return_value.__enter__.return_value = early_exit_cache
-    early_exit_cache.head.return_value = CacheStatus.HIT
+    early_exit_cache.head.return_value = CacheHeadResult(
+        status=CacheStatus.HIT,
+        latest_cache_source_digest=LATEST_CACHE_SOURCE_DIGEST,
+    )
     early_exit_cache.get.return_value = CacheValue(
         payload=CACHE_SOURCE,
         log_output="log-output",
@@ -313,7 +325,10 @@ def test_extended_early_exit_run_when_error(
         autospec=True,
     )
     mock_early_exit_cache.build.return_value.__enter__.return_value = early_exit_cache
-    early_exit_cache.head.return_value = CacheStatus.MISS
+    early_exit_cache.head.return_value = CacheHeadResult(
+        status=CacheStatus.MISS,
+        latest_cache_source_digest=LATEST_CACHE_SOURCE_DIGEST,
+    )
     mock_inc_counter = mocker.patch("reconcile.utils.extended_early_exit.inc_counter")
     mock_set_gauge = mocker.patch("reconcile.utils.extended_early_exit.set_gauge")
     runner = MagicMock()

--- a/reconcile/test/utils/test_extended_early_exit.py
+++ b/reconcile/test/utils/test_extended_early_exit.py
@@ -26,6 +26,8 @@ INTEGRATION_VERSION = "some-integration-version"
 SHORT_TTL_SECONDS = 0
 TTLS_SECONDS = 100
 RUNNER_PARAMS = {"some_param": "some-value"}
+CACHE_SOURCE = {"k": "v"}
+SHARD = "some-shard"
 
 
 @pytest.fixture
@@ -43,9 +45,6 @@ def mock_logger() -> Any:
 @pytest.fixture
 def early_exit_cache() -> Any:
     return create_autospec(EarlyExitCache)
-
-
-CACHE_SOURCE = {"k": "v"}
 
 
 @pytest.mark.parametrize(
@@ -107,6 +106,7 @@ def test_extended_early_exit_run_miss_or_expired(
         integration_version=INTEGRATION_VERSION,
         dry_run=dry_run,
         cache_source=CACHE_SOURCE,
+        shard=SHARD,
         ttl_seconds=TTLS_SECONDS,
         logger=logger,
         runner=runner,
@@ -119,6 +119,7 @@ def test_extended_early_exit_run_miss_or_expired(
         integration_version=INTEGRATION_VERSION,
         dry_run=dry_run,
         cache_source=CACHE_SOURCE,
+        shard=SHARD,
     )
     early_exit_cache.head.assert_called_once_with(expected_cache_key)
     runner.assert_called_once_with(**RUNNER_PARAMS)
@@ -137,6 +138,7 @@ def test_extended_early_exit_run_miss_or_expired(
             integration_version=INTEGRATION_VERSION,
             dry_run=dry_run,
             cache_status=cache_status.value,
+            shard=SHARD,
         ),
     )
     mock_set_gauge.assert_called_once_with(
@@ -145,6 +147,7 @@ def test_extended_early_exit_run_miss_or_expired(
             integration_version=INTEGRATION_VERSION,
             dry_run=dry_run,
             cache_status=cache_status.value,
+            shard=SHARD,
         ),
         applied_count,
     )
@@ -179,6 +182,7 @@ def test_extended_early_exit_run_hit_when_not_log_cached_log_output(
         integration_version=INTEGRATION_VERSION,
         dry_run=dry_run,
         cache_source=CACHE_SOURCE,
+        shard=SHARD,
         ttl_seconds=TTLS_SECONDS,
         logger=mock_logger,
         runner=runner,
@@ -192,6 +196,7 @@ def test_extended_early_exit_run_hit_when_not_log_cached_log_output(
         integration_version=INTEGRATION_VERSION,
         dry_run=dry_run,
         cache_source=CACHE_SOURCE,
+        shard=SHARD,
     )
     early_exit_cache.head.assert_called_once_with(expected_cache_key)
     runner.assert_not_called()
@@ -205,6 +210,7 @@ def test_extended_early_exit_run_hit_when_not_log_cached_log_output(
             integration_version=INTEGRATION_VERSION,
             dry_run=dry_run,
             cache_status=CacheStatus.HIT.value,
+            shard=SHARD,
         ),
     )
     mock_set_gauge.assert_called_once_with(
@@ -213,6 +219,7 @@ def test_extended_early_exit_run_hit_when_not_log_cached_log_output(
             integration_version=INTEGRATION_VERSION,
             dry_run=dry_run,
             cache_status=CacheStatus.HIT.value,
+            shard=SHARD,
         ),
         0,
     )
@@ -252,6 +259,7 @@ def test_extended_early_exit_run_hit_when_log_cached_log_output(
         integration_version=INTEGRATION_VERSION,
         dry_run=dry_run,
         cache_source=CACHE_SOURCE,
+        shard=SHARD,
         ttl_seconds=TTLS_SECONDS,
         logger=mock_logger,
         runner=runner,
@@ -265,6 +273,7 @@ def test_extended_early_exit_run_hit_when_log_cached_log_output(
         integration_version=INTEGRATION_VERSION,
         dry_run=dry_run,
         cache_source=CACHE_SOURCE,
+        shard=SHARD,
     )
     early_exit_cache.head.assert_called_once_with(expected_cache_key)
     early_exit_cache.get.assert_called_once_with(expected_cache_key)
@@ -278,6 +287,7 @@ def test_extended_early_exit_run_hit_when_log_cached_log_output(
             integration_version=INTEGRATION_VERSION,
             dry_run=dry_run,
             cache_status=CacheStatus.HIT.value,
+            shard=SHARD,
         ),
     )
     mock_set_gauge.assert_called_once_with(
@@ -286,6 +296,7 @@ def test_extended_early_exit_run_hit_when_log_cached_log_output(
             integration_version=INTEGRATION_VERSION,
             dry_run=dry_run,
             cache_status=CacheStatus.HIT.value,
+            shard=SHARD,
         ),
         0,
     )
@@ -314,6 +325,7 @@ def test_extended_early_exit_run_when_error(
             integration_version=INTEGRATION_VERSION,
             dry_run=False,
             cache_source=CACHE_SOURCE,
+            shard=SHARD,
             ttl_seconds=TTLS_SECONDS,
             logger=mock_logger,
             runner=runner,

--- a/reconcile/utils/extended_early_exit.py
+++ b/reconcile/utils/extended_early_exit.py
@@ -32,6 +32,7 @@ class ExtendedEarlyExitBaseMetric(BaseModel):
     integration_version: str
     dry_run: bool
     cache_status: str
+    shard: str
 
 
 class ExtendedEarlyExitCounter(ExtendedEarlyExitBaseMetric, CounterMetric):
@@ -57,6 +58,7 @@ def _publish_metrics(
             integration_version=cache_key.integration_version,
             dry_run=cache_key.dry_run,
             cache_status=cache_status.value,
+            shard=cache_key.shard,
         ),
     )
     set_gauge(
@@ -65,6 +67,7 @@ def _publish_metrics(
             integration_version=cache_key.integration_version,
             dry_run=cache_key.dry_run,
             cache_status=cache_status.value,
+            shard=cache_key.shard,
         ),
         applied_count,
     )
@@ -111,6 +114,7 @@ def extended_early_exit_run(
     integration_version: str,
     dry_run: bool,
     cache_source: object,
+    shard: str,
     ttl_seconds: int,
     logger: Logger,
     runner: Callable[..., ExtendedEarlyExitRunnerResult],
@@ -130,6 +134,7 @@ def extended_early_exit_run(
     :param integration_version: The integration version
     :param dry_run: True if the run is in dry run mode, False otherwise
     :param cache_source: The cache source, usually the static desired state
+    :param shard: The shard name
     :param ttl_seconds: A ttl in seconds
     :param logger: A Logger
     :param runner: A runner can return ExtendedEarlyExitRunnerResult when called
@@ -144,6 +149,7 @@ def extended_early_exit_run(
             integration_version=integration_version,
             dry_run=dry_run,
             cache_source=cache_source,
+            shard=shard,
         )
         cache_status = cache.head(key)
         logger.debug("Early exit cache status for key=%s: %s", key, cache_status)

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2450,6 +2450,12 @@ def early_exit_cache(ctx):
     help="Cache source. It should be a JSON string.",
     required=True,
 )
+@click.option(
+    "-s",
+    "--shard",
+    help="Shard",
+    default="",
+)
 @click.pass_context
 def early_exit_cache_head(
     ctx,
@@ -2457,6 +2463,7 @@ def early_exit_cache_head(
     integration_version,
     dry_run,
     cache_source,
+    shard,
 ):
     with EarlyExitCache.build() as cache:
         cache_key = CacheKey(
@@ -2464,6 +2471,7 @@ def early_exit_cache_head(
             integration_version=integration_version,
             dry_run=dry_run,
             cache_source=json.loads(cache_source),
+            shard=shard,
         )
         status = cache.head(cache_key)
         print(status)
@@ -2493,6 +2501,12 @@ def early_exit_cache_head(
     help="Cache source. It should be a JSON string.",
     required=True,
 )
+@click.option(
+    "-s",
+    "--shard",
+    help="Shard",
+    default="",
+)
 @click.pass_context
 def early_exit_cache_get(
     ctx,
@@ -2500,6 +2514,7 @@ def early_exit_cache_get(
     integration_version,
     dry_run,
     cache_source,
+    shard,
 ):
     with EarlyExitCache.build() as cache:
         cache_key = CacheKey(
@@ -2507,6 +2522,7 @@ def early_exit_cache_get(
             integration_version=integration_version,
             dry_run=dry_run,
             cache_source=json.loads(cache_source),
+            shard=shard,
         )
         value = cache.get(cache_key)
         print(value)
@@ -2535,6 +2551,12 @@ def early_exit_cache_get(
     "--cache-source",
     help="Cache source. It should be a JSON string.",
     required=True,
+)
+@click.option(
+    "-s",
+    "--shard",
+    help="Shard",
+    default="",
 )
 @click.option(
     "-p",
@@ -2569,6 +2591,7 @@ def early_exit_cache_set(
     integration_version,
     dry_run,
     cache_source,
+    shard,
     payload,
     log_output,
     applied_count,
@@ -2580,6 +2603,7 @@ def early_exit_cache_set(
             integration_version=integration_version,
             dry_run=dry_run,
             cache_source=json.loads(cache_source),
+            shard=shard,
         )
         cache_value = CacheValue(
             payload=json.loads(payload),

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2473,8 +2473,8 @@ def early_exit_cache_head(
             cache_source=json.loads(cache_source),
             shard=shard,
         )
-        status = cache.head(cache_key)
-        print(status)
+        result = cache.head(cache_key)
+        print(result)
 
 
 @early_exit_cache.command(name="get")
@@ -2584,6 +2584,12 @@ def early_exit_cache_get(
     default=60,
     type=int,
 )
+@click.option(
+    "-d",
+    "--latest-cache-source-digest",
+    help="Latest cache source digest.",
+    default="",
+)
 @click.pass_context
 def early_exit_cache_set(
     ctx,
@@ -2596,6 +2602,7 @@ def early_exit_cache_set(
     log_output,
     applied_count,
     ttl,
+    latest_cache_source_digest,
 ):
     with EarlyExitCache.build() as cache:
         cache_key = CacheKey(
@@ -2610,7 +2617,7 @@ def early_exit_cache_set(
             log_output=log_output,
             applied_count=applied_count,
         )
-        cache.set(cache_key, cache_value, ttl)
+        cache.set(cache_key, cache_value, ttl, latest_cache_source_digest)
 
 
 @root.command()

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -73,7 +73,7 @@ def test_early_exit_cache_get(env_vars, mock_queries, mock_early_exit_cache):
     )
 
     result = runner.invoke(
-        qontract_cli.early_exit_cache, "get -i a -v b --dry-run -c {}"
+        qontract_cli.early_exit_cache, "get -i a -v b --dry-run -c {} -s shard-1"
     )
     assert result.exit_code == 0
     assert result.output == "some value\n"
@@ -84,7 +84,7 @@ def test_early_exit_cache_set(env_vars, mock_queries, mock_early_exit_cache):
 
     result = runner.invoke(
         qontract_cli.early_exit_cache,
-        "set -i a -v b --no-dry-run -c {} -p {} -l log -t 30",
+        "set -i a -v b --no-dry-run -c {} -s shard-1 -p {} -l log -t 30",
     )
     assert result.exit_code == 0
     mock_early_exit_cache.build.return_value.__enter__.return_value.set.assert_called()
@@ -96,7 +96,7 @@ def test_early_exit_cache_head(env_vars, mock_queries, mock_early_exit_cache):
     mock_early_exit_cache.build.return_value.__enter__.return_value.head.return_value = CacheStatus.HIT
 
     result = runner.invoke(
-        qontract_cli.early_exit_cache, "head -i a -v b --dry-run -c {}"
+        qontract_cli.early_exit_cache, "head -i a -v b --dry-run -c {} -s shard-1"
     )
     assert result.exit_code == 0
     assert result.output == f"{CacheStatus.HIT}\n"

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -1,7 +1,7 @@
 import pytest
 from click.testing import CliRunner
 
-from reconcile.utils.early_exit_cache import CacheStatus
+from reconcile.utils.early_exit_cache import CacheHeadResult, CacheStatus
 from tools import qontract_cli
 
 
@@ -84,7 +84,7 @@ def test_early_exit_cache_set(env_vars, mock_queries, mock_early_exit_cache):
 
     result = runner.invoke(
         qontract_cli.early_exit_cache,
-        "set -i a -v b --no-dry-run -c {} -s shard-1 -p {} -l log -t 30",
+        "set -i a -v b --no-dry-run -c {} -s shard-1 -p {} -l log -t 30 -d digest",
     )
     assert result.exit_code == 0
     mock_early_exit_cache.build.return_value.__enter__.return_value.set.assert_called()
@@ -93,10 +93,14 @@ def test_early_exit_cache_set(env_vars, mock_queries, mock_early_exit_cache):
 def test_early_exit_cache_head(env_vars, mock_queries, mock_early_exit_cache):
     runner = CliRunner()
 
-    mock_early_exit_cache.build.return_value.__enter__.return_value.head.return_value = CacheStatus.HIT
+    cache_head_result = CacheHeadResult(
+        status=CacheStatus.HIT,
+        latest_cache_source_digest="some-digest",
+    )
+    mock_early_exit_cache.build.return_value.__enter__.return_value.head.return_value = cache_head_result
 
     result = runner.invoke(
         qontract_cli.early_exit_cache, "head -i a -v b --dry-run -c {} -s shard-1"
     )
     assert result.exit_code == 0
-    assert result.output == f"{CacheStatus.HIT}\n"
+    assert result.output == f"{cache_head_result}\n"


### PR DESCRIPTION
Current early exit cache can't handle stale cache, for example in `terraform-resources`:

* MR1: modify resource A
* MR2: revert MR1

Expect MR2 to show some diff, but due to cache hit for MR2 same as state before MR1, pr check will show nothing, prod run will skip until cache expire.

From terraform config point of view, the config after MR2 is the same as before MR1, but the real current state already changed due to MR1, we need to let cache aware of it.

New design is to let `no-dry-run` mode have one cache item per shard, bump cache hash when set cache so old cache won't be reused. `dry-run` mode will additionally check `no-dry-run` latest cache to determine if it's stale.

This change redesign the cache key path:

* dry-run path: `/<integration>/<integration_version>/dry-run(/<shard>)/<cache_source_digest>`
* no-dry-run path: ` /<integration>/<integration_version>/no-dry-run(/<shard>)/latest`

cache item will have 2 new metadata:

* `cache-source-digest`, value is the consistent hash of `key.cache_source` (terraform config for `terraform-resources`).
* `latest-cache-source-digest`, value is the latest `cache-source-digest` in `no-dry-run` during cache lookup time.

`no-dry-run` will use the `cache-source-digest` to determine if the cache is HIT, each integration shard will have at most 1 `latest` cache in `no-dry-run` mode.

`dry-run` mode will additional locate the matching `no-dry-run` latest cache, if `cache-source-digest` is not same as `latest-cache-source-digest` saved in `dry-run` cache, then something changed in current state, we shouldn't use this cache anymore, mark it as stale.

Test this change locally:

```shell
# start localstack
$ make localstack

# set envs
$ export $(cat ./dev/localstack/.env.local | xargs)

# check head dry run cache miss
$ qontract-cli --config config.toml early-exit-cache head -i a -v b --dry-run -c '{"k": "v"}' -s shard-1
status=<CacheStatus.MISS: 'MISS'> latest_cache_source_digest=''

# check head no dry run cache miss
$ qontract-cli --config config.toml early-exit-cache head -i a -v b --no-dry-run -c '{"k": "v"}' -s shard-1
status=<CacheStatus.MISS: 'MISS'> latest_cache_source_digest=''

# set dry-run cache
$ qontract-cli --config config.toml early-exit-cache set -i a -v b --dry-run -c '{"k": "v"}' -s shard-1 -p {} --ttl 3600

# check dry-run HIT
$ qontract-cli --config config.toml early-exit-cache head -i a -v b --dry-run -c '{"k": "v"}' -s shard-1
status=<CacheStatus.HIT: 'HIT'> latest_cache_source_digest=''

# set no-dry-run cache
$ qontract-cli --config config.toml early-exit-cache set -i a -v b --no-dry-run -c '{"k": "v"}' -s shard-1 -p {} --ttl 3600

# check no-dry-run HIT
$ qontract-cli --config config.toml early-exit-cache head -i a -v b --no-dry-run -c '{"k": "v"}' -s shard-1
status=<CacheStatus.HIT: 'HIT'> latest_cache_source_digest='d3f1f34d36332ded8721468ff57cdaf988f91a68837ef59a3a16aaf2b03e0443'

# now dry-run cache should be stale since new no-dry-run cache updated
$ qontract-cli --config config.toml early-exit-cache head -i a -v b --dry-run -c '{"k": "v"}' -s shard-1
status=<CacheStatus.STALE: 'STALE'> latest_cache_source_digest='d3f1f34d36332ded8721468ff57cdaf988f91a68837ef59a3a16aaf2b03e0443'

# simulate dry-run run again to set cache
$ qontract-cli --config config.toml early-exit-cache set -i a -v b --dry-run -c '{"k": "v"}' -s shard-1 -p {} --ttl 3600

# check again, should HIT
$ qontract-cli --config config.toml early-exit-cache head -i a -v b --dry-run -c '{"k": "v"}' -s shard-1
status=<CacheStatus.HIT: 'HIT'> latest_cache_source_digest='d3f1f34d36332ded8721468ff57cdaf988f91a68837ef59a3a16aaf2b03e0443'

# set a new no-dry-run cache to simulate changes in MR1
$ qontract-cli --config config.toml early-exit-cache set -i a -v b --no-dry-run -c '{"k": "v2"}' -s shard-1 -p {} --ttl 3600

# now check both old caches again
$ qontract-cli --config config.toml early-exit-cache head -i a -v b --dry-run -c '{"k": "v"}' -s shard-1
status=<CacheStatus.STALE: 'STALE'> latest_cache_source_digest='29ec39a1e5d350154aa53702f1b79240a5dbeece159a67ecae4fbd4c25510412'

$ qontract-cli --config config.toml early-exit-cache head -i a -v b --no-dry-run -c '{"k": "v"}' -s shard-1
status=<CacheStatus.MISS: 'MISS'> latest_cache_source_digest='29ec39a1e5d350154aa53702f1b79240a5dbeece159a67ecae4fbd4c25510412'
```