### PR TITLE
add rosa/hypershift fields to openshift-resources namespaces query

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -194,8 +194,14 @@ NAMESPACES_QUERY = """
         %s
       }
       spec {
+        ... on ClusterSpecROSA_v1 {
+          account {
+            uid
+          }
+        }
         version
         region
+        hypershift
       }
       network {
         pod


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-9783

in order to template resources with the cluster's aws account - we need to query for this information.
also add `hypershift` to the query since it should be useful.