### PR TITLE
[openshift-rolebindings] remove userNames from openshift resource

### DIFF
--- a/reconcile/openshift_rolebindings.py
+++ b/reconcile/openshift_rolebindings.py
@@ -74,7 +74,7 @@ def construct_sa_oc_resource(role, namespace, sa_name):
         "roleRef": {"name": role},
         "subjects": [
             {"kind": "ServiceAccount", "name": sa_name, "namespace": namespace}
-        ]
+        ],
     }
     return (
         OR(


### PR DESCRIPTION
additional fix on top of #4067 to prevent a never ending reconcile:
```
[DEBUG] [DRY-RUN] [three_way_diff_strategy.py:three_way_diff_using_hash:150] - Desired and Current objects differ -> Apply: [{'op': 'add', 'path': '/userNames', 'value': ['system:serviceaccount:namespace:sa-name']}]
```