### PR TITLE
APPSRE-9796: S3 bucket logging lifecycle change must be ignored

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1936,6 +1936,12 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             target_bucket_name = s3_bucket_logging.get("target_bucket_name")
             logging_identifier = f"{identifier}-logging"
 
+            # Logging config will be set out of this resource
+            # the following `ignore_change` allows to avoid conflicts
+            values.setdefault("lifecycle", {}).setdefault("ignore_changes", []).append(
+                "logging"
+            )
+
             logging_values = {
                 "bucket": "${aws_s3_bucket." + identifier + ".id}",
                 "target_bucket": "${aws_s3_bucket." + target_bucket_name + ".id}",


### PR DESCRIPTION
Configuring logging on a bucket adds a logging configuration to the bucket but we don't set that on the bucket resource itself. If we do not ignore it this causes a reconcile loop

Ref.: https://registry.terraform.io/providers/hashicorp/aws/3.76.1/docs/resources/s3_bucket_logging