### PR TITLE
Revert deepdiff version to 6.4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         # this is really needed only in lint and type validations.
         # Is there any better place to put this in?
         "packaging~=23.1",
-        "deepdiff==6.7.1",
+        "deepdiff==6.4.1",
         "jsonpath-ng==1.5.3",
         "networkx~=2.8",
         "mypy-boto3-s3~=1.24.94",


### PR DESCRIPTION
`deepdiff` diff paths format is different, break shard check, revert back to `6.4.1`