### PR TITLE
native deepdiff 6.7.x path parsing and tf-res sharded pr check fix

### DIFF
--- a/reconcile/change_owners/diff.py
+++ b/reconcile/change_owners/diff.py
@@ -1,6 +1,5 @@
 import copy
 import json
-import re
 from dataclasses import dataclass
 from enum import Enum
 from functools import reduce
@@ -237,9 +236,6 @@ def extract_diffs(old_file_content: Any, new_file_content: Any) -> list[Diff]:
         )
 
     return diffs
-
-
-DEEP_DIFF_RE = re.compile(r"\['?(.*?)'?\]")
 
 
 def deepdiff_path_to_jsonpath(deep_diff_path: str) -> jsonpath_ng.JSONPath:

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -563,7 +563,7 @@ def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:
 
     return {
         "accounts": queries.get_aws_accounts(terraform_state=True),
-        "namespaces": namespaces,
+        "namespaces": [ns.dict(by_alias=True) for ns in namespaces],
         "resources": resources,
     }
 

--- a/reconcile/test/change_owners/test_change_type_diff.py
+++ b/reconcile/test/change_owners/test_change_type_diff.py
@@ -21,10 +21,16 @@ from reconcile.test.change_owners.fixtures import (
 @pytest.mark.parametrize(
     "deep_diff_path,expected_json_path",
     [
+        # the old deepdiff format before 6.7.x, with square bracket notation
         ("root['one']['two']['three']", "one.two.three"),
         (
             "root['resourceTemplates'][0]['targets'][0]['ref']",
             "resourceTemplates.[0].targets.[0].ref",
+        ),
+        # the new deepdiff format 6.7.x onwards, with dot notation
+        (
+            "root['namespaces'][353].external_resources[0].resources[0].overrides",
+            "namespaces.[353].external_resources.[0].resources.[0].overrides",
         ),
         ("root", "$"),
     ],

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
         # this is really needed only in lint and type validations.
         # Is there any better place to put this in?
         "packaging~=23.1",
-        "deepdiff==6.4.1",
+        "deepdiff==6.7.1",
         "jsonpath-ng==1.5.3",
         "networkx~=2.8",
         "mypy-boto3-s3~=1.24.94",


### PR DESCRIPTION
the deepdiff 6.7.x library yields different path formats for the found diffs. our custom parse logic was not able to deal with that but deepdiff now also offers a native way to parse paths.

this PR uses the deepdiff path parse logic instead of our own. additionally a bug in the produced early exit desired state was fixed. the state can only contain dicts and not dataclasses.