### PR TITLE
Add validation setps

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1871,7 +1871,9 @@ def template_validator(ctx, bundle_file):
     from reconcile.templating import validator
 
     run_class_integration(
-        integration=validator.TemplateValidatorIntegration(TemplateValidatorIntegrationParams(bundle_file=bundle_file)),
+        integration=validator.TemplateValidatorIntegration(
+            TemplateValidatorIntegrationParams(bundle_file=bundle_file)
+        ),
         ctx=ctx.obj,
     )
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -20,6 +20,7 @@ from reconcile.status import (
     ExitCodes,
     RunningState,
 )
+from reconcile.templating.validator import TemplateValidatorIntegrationParams
 from reconcile.utils import gql
 from reconcile.utils.aggregated_list import RunnerException
 from reconcile.utils.binary import (
@@ -1859,12 +1860,18 @@ def terraform_repo(ctx, output_file, gitlab_project_id, gitlab_merge_request_id)
 
 
 @integration.command(short_help="Test app-interface templates.")
+@click.option(
+    "--bundle-file",
+    help="Bundle to use during schema validation.",
+    required=False,
+    envvar="BUNDLE_FILE",
+)
 @click.pass_context
-def template_validator(ctx):
+def template_validator(ctx, bundle_file):
     from reconcile.templating import validator
 
     run_class_integration(
-        integration=validator.TemplateValidatorIntegration(PydanticRunParams()),
+        integration=validator.TemplateValidatorIntegration(TemplateValidatorIntegrationParams(bundle_file=bundle_file)),
         ctx=ctx.obj,
     )
 

--- a/reconcile/templating/rendering.py
+++ b/reconcile/templating/rendering.py
@@ -21,7 +21,9 @@ class Renderer(ABC):
         self.jinja_env = SandboxedEnvironment()
 
     def _jinja2_render_kwargs(self) -> dict[str, Any]:
-        return {**self.data.variables, "current": self.data.current}
+        return {**self.data.variables,
+                ""
+                "current": self.data.current}
 
     def _render_template(self, template: str) -> str:
         return self.jinja_env.from_string(template).render(

--- a/reconcile/templating/rendering.py
+++ b/reconcile/templating/rendering.py
@@ -21,9 +21,7 @@ class Renderer(ABC):
         self.jinja_env = SandboxedEnvironment()
 
     def _jinja2_render_kwargs(self) -> dict[str, Any]:
-        return {**self.data.variables,
-                ""
-                "current": self.data.current}
+        return {**self.data.variables, "" "current": self.data.current}
 
     def _render_template(self, template: str) -> str:
         return self.jinja_env.from_string(template).render(

--- a/reconcile/templating/validator.py
+++ b/reconcile/templating/validator.py
@@ -51,7 +51,7 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
     def run(self, dry_run: bool) -> None:
         for template in get_templates():
             for test in template.template_test:
-                logging.info(f"Running test {test.name} for template {template.name}")
+                logging.debug(f"Running test {test.name} for template {template.name}")
 
                 r = create_renderer(
                     template,

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,7 @@ setup(
         "dt==1.1.61",
         "jsonpatch~=1.33",
         "jsonpointer~=2.4",
+        "yamllint==1.34.0",
     ],
     test_suite="tests",
     classifiers=[


### PR DESCRIPTION
- This adds yamllint to the template validation integration. This requires moving the yamllint configuration file into the resources directory and also updating the hack scripts.
- This also adds validation using `qontract-valdation`, for this the following is required: https://github.com/app-sre/qontract-validator/pull/59

[APPSRE-8796](https://issues.redhat.com/browse/APPSRE-8796)