### PR TITLE
Refactor jinja env and add extract_jsonpath and matches_jsonpath filters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,6 @@ module = [
     "reconcile.utils.imap_client",
     "reconcile.utils.instrumented_wrappers",
     "reconcile.utils.jenkins_api",
-    "reconcile.utils.jinja2_ext",
     "reconcile.utils.jjb_client",
     "reconcile.utils.ldap_client",
     "reconcile.utils.lean_terraform_client",

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -12,7 +12,7 @@ from reconcile import (
     mr_client_gateway,
     queries,
 )
-from reconcile.openshift_resources_base import process_jinja2_template
+from reconcile.utils.jinja2.utils import process_jinja2_template
 from reconcile.utils.ocm import (
     OCMMap,
     OCMSpec,

--- a/reconcile/prometheus_rules_tester/integration.py
+++ b/reconcile/prometheus_rules_tester/integration.py
@@ -29,6 +29,7 @@ from reconcile.utils import (
     gql,
     promtool,
 )
+from reconcile.utils.jinja2.utils import process_extracurlyjinja2_template
 from reconcile.utils.runtime.integration import DesiredStateShardConfig
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.structs import CommandExecutionResult
@@ -91,7 +92,7 @@ def fetch_rule_and_tests(
         test_raw_yaml = gql.get_resource(test_path)["content"]
 
         if rule.resource["type"] == "resource-template-extracurlyjinja2":
-            test_raw_yaml = orb.process_extracurlyjinja2_template(
+            test_raw_yaml = process_extracurlyjinja2_template(
                 body=test_raw_yaml,
                 vars=variables,
                 settings=vault_settings.dict(by_alias=True),

--- a/reconcile/test/test_ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/test/test_ocm_upgrade_scheduler_org_updater.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from reconcile.ocm_upgrade_scheduler_org_updater import render_policy
-from reconcile.openshift_resources_base import Jinja2TemplateError
+from reconcile.utils.jinja2.utils import Jinja2TemplateError
 from reconcile.utils.ocm import (
     OCMClusterNetwork,
     OCMSpec,

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -17,7 +17,6 @@ from reconcile.openshift_resources_base import (
 )
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils import oc
-from reconcile.utils.jinja2.filters import hash_list
 from reconcile.utils.openshift_resource import ResourceInventory
 
 fxt = Fixtures("namespaces")
@@ -439,36 +438,6 @@ def test_check_cluster_scoped_resources_duplicated(
 def test_check_error():
     e = orb.CheckError("message")
     print(e)
-
-
-def test_hash_list_empty():
-    assert hash_list([])[:6] == "ca9781"
-
-
-def test_hash_list_string():
-    assert hash_list(["a", "b"])[:6] == "38760e"
-    assert hash_list(["b", "a"])[:6] == "38760e"
-
-
-def test_hash_list_int():
-    assert hash_list([1, 2])[:6] == "f37508"
-    assert hash_list([2, 1])[:6] == "f37508"
-
-
-def test_hash_list_bool():
-    assert hash_list([True, False])[:6] == "e0ca28"
-    assert hash_list([False, True])[:6] == "e0ca28"
-
-
-def test_hash_list_error():
-    with pytest.raises(RuntimeError):
-        hash_list([{}])
-
-    with pytest.raises(RuntimeError):
-        hash_list([[]])
-
-    with pytest.raises(RuntimeError):
-        hash_list(["a", {}])
 
 
 def test_cluster_params():

--- a/reconcile/test/test_openshift_resources_base.py
+++ b/reconcile/test/test_openshift_resources_base.py
@@ -13,11 +13,11 @@ from reconcile.openshift_base import CurrentStateSpec
 from reconcile.openshift_resources_base import (
     CheckClusterScopedResourceDuplicates,
     canonicalize_namespaces,
-    hash_list,
     ob,
 )
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils import oc
+from reconcile.utils.jinja2.filters import hash_list
 from reconcile.utils.openshift_resource import ResourceInventory
 
 fxt = Fixtures("namespaces")

--- a/reconcile/test/test_utils_jinja2.py
+++ b/reconcile/test/test_utils_jinja2.py
@@ -1,0 +1,123 @@
+import pytest
+from jsonpath_ng.exceptions import JsonPathParserError
+
+from reconcile.utils.jinja2.filters import (
+    extract_jsonpath,
+    hash_list,
+    json_pointers,
+    matches_jsonpath,
+)
+
+
+def test_hash_list_empty() -> None:
+    assert hash_list([])[:6] == "ca9781"
+
+
+def test_hash_list_string() -> None:
+    assert hash_list(["a", "b"])[:6] == "38760e"
+    assert hash_list(["b", "a"])[:6] == "38760e"
+
+
+def test_hash_list_int() -> None:
+    assert hash_list([1, 2])[:6] == "f37508"
+    assert hash_list([2, 1])[:6] == "f37508"
+
+
+def test_hash_list_bool() -> None:
+    assert hash_list([True, False])[:6] == "e0ca28"
+    assert hash_list([False, True])[:6] == "e0ca28"
+
+
+def test_hash_list_error() -> None:
+    with pytest.raises(RuntimeError):
+        hash_list([{}])
+
+    with pytest.raises(RuntimeError):
+        hash_list([[]])
+
+    with pytest.raises(RuntimeError):
+        hash_list(["a", {}])
+
+
+def test_extract_jsonpath_dict_basic() -> None:
+    input = {"a": "A", "b": {"b1": "B1", "b2": ["B", 2]}}
+    assert extract_jsonpath(input, "a") == ["A"]
+    assert extract_jsonpath(input, "b.b1") == ["B1"]
+    assert extract_jsonpath(input, "b.b2") == [["B", 2]]
+    assert extract_jsonpath(input, "b.b2[0]") == ["B"]
+    assert extract_jsonpath(input, "c") == []
+
+
+def test_extract_jsonpath_dict_multiple() -> None:
+    input = {
+        "items": [
+            {"name": "a", "value": "A"},
+            {"name": "b", "value": "B1"},
+            {"name": "b", "value": "B2"},
+        ]
+    }
+    assert extract_jsonpath(input, "items[0]") == [{"name": "a", "value": "A"}]
+    assert extract_jsonpath(input, "items[?(@.name=='a')]") == [
+        {"name": "a", "value": "A"}
+    ]
+    assert extract_jsonpath(input, "items[?(@.name=='a')].value") == ["A"]
+    assert extract_jsonpath(input, "items[?(@.name=='b')]") == [
+        {"name": "b", "value": "B1"},
+        {"name": "b", "value": "B2"},
+    ]
+    assert extract_jsonpath(input, "items[?(@.name=='b')].value") == ["B1", "B2"]
+    assert extract_jsonpath(input, "items[?(@.name=='c')].value") == []
+
+
+def test_extract_jsonpath_list() -> None:
+    input = ["a", "b"]
+    assert extract_jsonpath(input, "[0]") == ["a"]
+
+
+def test_extract_jsonpath_str() -> None:
+    assert extract_jsonpath("a", "[0]") == ["a"]
+    assert extract_jsonpath("a", "something") == []
+
+
+def test_extract_jsonpath_none() -> None:
+    assert extract_jsonpath(None, "a") == []
+
+
+def test_extract_jsonpath_errors() -> None:
+    input = {"a": "A", "b": "B"}
+    with pytest.raises(JsonPathParserError):
+        extract_jsonpath(input, "THIS IS AN INVALID JSONPATH]")
+    with pytest.raises(AssertionError):
+        extract_jsonpath("a", "")
+
+
+def test_matches_jsonpath() -> None:
+    input = {"a": "A", "b": "B"}
+    assert matches_jsonpath(input, "a")
+    assert not matches_jsonpath(input, "c")
+    with pytest.raises(JsonPathParserError):
+        matches_jsonpath(input, "THIS IS AN INVALID JSONPATH]")
+    with pytest.raises(AssertionError):
+        matches_jsonpath("a", "")
+    with pytest.raises(AssertionError):
+        matches_jsonpath("a", None)
+
+
+def test_json_pointers() -> None:
+    input = {
+        "items": [
+            {"name": "a", "value": "A"},
+            {"name": "b", "value": "B1"},
+            {"name": "b", "value": "B2"},
+        ]
+    }
+    assert json_pointers(input, "items") == ["/items"]
+    assert json_pointers(input, "items[*]") == ["/items/0", "/items/1", "/items/2"]
+    assert json_pointers(input, "items[0]") == ["/items/0"]
+    assert json_pointers(input, "items[0].name") == ["/items/0/name"]
+    assert json_pointers(input, "items[4]") == []
+    assert json_pointers(input, "items[4].name") == []
+
+    assert json_pointers(input, "items[?@.name=='a']") == ["/items/0"]
+    assert json_pointers(input, "items[?@.name=='b']") == ["/items/1", "/items/2"]
+    assert json_pointers(input, "items[?@.name=='c']") == []

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -15,7 +15,7 @@ import yaml
 from pydantic import BaseModel
 from pydantic.dataclasses import dataclass
 
-from reconcile import openshift_resources_base
+from reconcile.utils.jinja2.utils import process_jinja2_template
 from reconcile.utils.metrics import GaugeMetric
 from reconcile.utils.openshift_resource import (
     SECRET_MAX_KEY_LENGTH,
@@ -58,9 +58,7 @@ class GenericSecretOutputFormatConfig(OutputFormatProcessor):
         if self.data:
             # the jinja2 rendering has the capabilitiy to change the passed
             # vars dict - make a copy to protect against it
-            rendered_data = openshift_resources_base.process_jinja2_template(
-                self.data, dict(vars)
-            )
+            rendered_data = process_jinja2_template(self.data, dict(vars))
             parsed_data = yaml.safe_load(rendered_data)
             self.validate_k8s_secret_data(parsed_data)
             return cast(dict[str, str], parsed_data)

--- a/reconcile/utils/jinja2/extensions.py
+++ b/reconcile/utils/jinja2/extensions.py
@@ -1,15 +1,17 @@
 import base64
 import textwrap
+from typing import Callable
 
 from jinja2 import nodes
 from jinja2.exceptions import TemplateRuntimeError
 from jinja2.ext import Extension
+from jinja2.parser import Parser
 
 
 class B64EncodeExtension(Extension):
     tags = {"b64encode"}
 
-    def parse(self, parser):
+    def parse(self, parser: Parser) -> nodes.CallBlock:
         lineno = next(parser.stream).lineno
 
         body = parser.parse_statements(["name:endb64encode"], drop_needle=True)
@@ -19,7 +21,7 @@ class B64EncodeExtension(Extension):
         ).set_lineno(lineno)
 
     @staticmethod
-    def _b64encode(caller):
+    def _b64encode(caller: Callable) -> str:
         content = caller()
         content = textwrap.dedent(content)
         return base64.b64encode(content.encode()).decode("utf-8")
@@ -28,7 +30,7 @@ class B64EncodeExtension(Extension):
 class RaiseErrorExtension(Extension):
     tags = {"raise_error"}
 
-    def parse(self, parser):
+    def parse(self, parser: Parser) -> nodes.CallBlock:
         lineno = next(parser.stream).lineno
 
         msg = parser.parse_expression()
@@ -42,5 +44,5 @@ class RaiseErrorExtension(Extension):
         )
 
     @staticmethod
-    def _raise_error(msg, caller):
+    def _raise_error(msg: str, caller: Callable) -> None:
         raise TemplateRuntimeError(msg)

--- a/reconcile/utils/jinja2/filters.py
+++ b/reconcile/utils/jinja2/filters.py
@@ -1,0 +1,87 @@
+import hashlib
+import json
+from collections.abc import Iterable
+from typing import Any, Optional
+from urllib import parse
+
+import jinja2
+
+
+def json_to_dict(input: str) -> Any:
+    """Jinja2 filter to parse JSON strings into dictionaries.
+       This becomes useful to access Graphql queries data (labels)
+    :param input: json string
+    :return: dict with the parsed inputs contents
+    """
+    data = json.loads(input)
+    return data
+
+
+def urlescape(string: str, safe: str = "/", encoding: Optional[str] = None) -> str:
+    """Jinja2 filter that is a simple wrapper around urllib's URL quoting
+    functions that takes a string value and makes it safe for use as URL
+    components escaping any reserved characters using URL encoding. See:
+    urllib.parse.quote() and urllib.parse.quote_plus() for reference.
+
+    :param str string: String value to escape.
+    :param str safe: Optional characters that should not be escaped.
+    :param encoding: Encoding to apply to the string to be escaped. Defaults
+        to UTF-8. Unsupported characters raise a UnicodeEncodeError error.
+    :type encoding: typing.Optional[str]
+    :returns: A string with reserved characters escaped.
+    :rtype: str
+    """
+    return parse.quote(string, safe=safe, encoding=encoding)
+
+
+def urlunescape(string: str, encoding: Optional[str] = None) -> str:
+    """Jinja2 filter that is a simple wrapper around urllib's URL unquoting
+    functions that takes an URL-encoded string value and unescapes it
+    replacing any URL-encoded values with their character equivalent. See:
+    urllib.parse.unquote() and urllib.parse.unquote_plus() for reference.
+
+    :param str string: String value to unescape.
+    :param encoding: Encoding to apply to the string to be unescaped. Defaults
+        to UTF-8. Unsupported characters are replaced by placeholder values.
+    :type encoding: typing.Optional[str]
+    :returns: A string with URL-encoded sequences unescaped.
+    :rtype: str
+    """
+    if encoding is None:
+        encoding = "utf-8"
+    return parse.unquote(string, encoding=encoding)
+
+
+def eval_filter(input: str, **kwargs: dict[str, Any]) -> str:
+    """Jinja2 filter be used when the string
+    is in itself a jinja2 template that must be
+    evaluated with kwargs. For example in the case
+    of the slo-document expression fields.
+    :param input: template string
+    :kwargs: variables that will be used to evaluate the
+             input string
+    :return: rendered string
+    """
+    return jinja2.Template(input).render(**kwargs)
+
+
+def hash_list(input: Iterable) -> str:
+    """
+    Deterministic hash of a list for jinja2 templates.
+    The order of the list doesn't matter as it is sorted
+    before hashing. Note, that the list elements
+    must be flat primitives (no dicts/lists).
+    """
+    lst = list(input)
+    str_lst = []
+    for el in lst:
+        if isinstance(el, (list, dict)):
+            raise RuntimeError(
+                f"jinja2 hash_list function received non-primitive value {el}. All values received {lst}"
+            )
+        str_lst.append(str(el))
+    msg = "a"  # keep non-empty for hashing empty list
+    msg += "".join(sorted(str_lst))
+    m = hashlib.sha256()
+    m.update(msg.encode("utf-8"))
+    return m.hexdigest()

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -11,8 +11,11 @@ from reconcile.utils import gql
 from reconcile.utils.jinja2.extensions import B64EncodeExtension, RaiseErrorExtension
 from reconcile.utils.jinja2.filters import (
     eval_filter,
+    extract_jsonpath,
     hash_list,
+    json_pointers,
     json_to_dict,
+    matches_jsonpath,
     urlescape,
     urlunescape,
 )
@@ -47,6 +50,9 @@ def compile_jinja2_template(body: str, extra_curly: bool = False) -> Any:
         "urlescape": urlescape,
         "urlunescape": urlunescape,
         "eval": eval_filter,
+        "extract_jsonpath": extract_jsonpath,
+        "matches_jsonpath": matches_jsonpath,
+        "json_pointers": json_pointers,
     })
 
     return jinja_env.from_string(body)

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -1,0 +1,182 @@
+from functools import cache
+from typing import Any, Optional
+
+import jinja2
+from jinja2.sandbox import SandboxedEnvironment
+from sretoolbox.utils import retry
+
+from reconcile.checkpoint import url_makes_sense
+from reconcile.github_users import init_github
+from reconcile.utils import gql
+from reconcile.utils.jinja2.extensions import B64EncodeExtension, RaiseErrorExtension
+from reconcile.utils.jinja2.filters import (
+    eval_filter,
+    hash_list,
+    json_to_dict,
+    urlescape,
+    urlunescape,
+)
+from reconcile.utils.secret_reader import SecretNotFound, SecretReader, SecretReaderBase
+
+
+class Jinja2TemplateError(Exception):
+    def __init__(self, msg: Any):
+        super().__init__("error processing jinja2 template: " + str(msg))
+
+
+@cache
+def compile_jinja2_template(body: str, extra_curly: bool = False) -> Any:
+    env: dict = {}
+    if extra_curly:
+        env = {
+            "block_start_string": "{{%",
+            "block_end_string": "%}}",
+            "variable_start_string": "{{{",
+            "variable_end_string": "}}}",
+            "comment_start_string": "{{#",
+            "comment_end_string": "#}}",
+        }
+
+    jinja_env = SandboxedEnvironment(
+        extensions=[B64EncodeExtension, RaiseErrorExtension],
+        undefined=jinja2.StrictUndefined,
+        **env,
+    )
+    jinja_env.filters.update({
+        "json_to_dict": json_to_dict,
+        "urlescape": urlescape,
+        "urlunescape": urlunescape,
+        "eval": eval_filter,
+    })
+
+    return jinja_env.from_string(body)
+
+
+def lookup_github_file_content(
+    repo: str,
+    path: str,
+    ref: str,
+    tvars: Optional[dict[str, Any]] = None,
+    settings: Optional[dict[str, Any]] = None,
+    secret_reader: Optional[SecretReaderBase] = None,
+) -> str:
+    if tvars is not None:
+        repo = process_jinja2_template(
+            body=repo, vars=tvars, settings=settings, secret_reader=secret_reader
+        )
+        path = process_jinja2_template(
+            body=path, vars=tvars, settings=settings, secret_reader=secret_reader
+        )
+        ref = process_jinja2_template(
+            body=ref, vars=tvars, settings=settings, secret_reader=secret_reader
+        )
+
+    gh = init_github()
+    c = gh.get_repo(repo).get_contents(path, ref).decoded_content
+    return c.decode("utf-8")
+
+
+def lookup_graphql_query_results(query: str, **kwargs: dict[str, Any]) -> list[Any]:
+    gqlapi = gql.get_api()
+    resource = gqlapi.get_resource(query)["content"]
+    rendered_resource = jinja2.Template(resource).render(**kwargs)
+    results = list(gqlapi.query(rendered_resource).values())[0]
+    return results
+
+
+@retry()
+def lookup_secret(
+    path: str,
+    key: str,
+    version: Optional[str] = None,
+    tvars: Optional[dict[str, Any]] = None,
+    allow_not_found: bool = False,
+    settings: Optional[dict[str, Any]] = None,
+    secret_reader: Optional[SecretReaderBase] = None,
+) -> Optional[str]:
+    if tvars is not None:
+        path = process_jinja2_template(
+            body=path, vars=tvars, settings=settings, secret_reader=secret_reader
+        )
+        key = process_jinja2_template(
+            body=key, vars=tvars, settings=settings, secret_reader=secret_reader
+        )
+        if version and not isinstance(version, int):
+            version = process_jinja2_template(
+                body=version, vars=tvars, settings=settings, secret_reader=secret_reader
+            )
+    secret = {"path": path, "field": key, "version": version}
+    try:
+        if not secret_reader:
+            secret_reader = SecretReader(settings)
+        return secret_reader.read(secret)
+    except SecretNotFound as e:
+        if allow_not_found:
+            return None
+        raise FetchSecretError(e)
+    except Exception as e:
+        raise FetchSecretError(e)
+
+
+def process_jinja2_template(
+    body: str,
+    vars: Optional[dict[str, Any]] = None,
+    extra_curly: bool = False,
+    settings: Optional[dict[str, Any]] = None,
+    secret_reader: Optional[SecretReaderBase] = None,
+) -> Any:
+    if vars is None:
+        vars = {}
+    vars.update({
+        "vault": lambda p, k, v=None: lookup_secret(
+            path=p,
+            key=k,
+            version=v,
+            tvars=vars,
+            allow_not_found=False,
+            settings=settings,
+            secret_reader=secret_reader,
+        ),
+        "github": lambda u, p, r, v=None: lookup_github_file_content(
+            repo=u,
+            path=p,
+            ref=r,
+            tvars=vars,
+            settings=settings,
+            secret_reader=secret_reader,
+        ),
+        "urlescape": lambda u, s="/", e=None: urlescape(string=u, safe=s, encoding=e),
+        "urlunescape": lambda u, e=None: urlunescape(string=u, encoding=e),
+        "hash_list": hash_list,
+        "query": lookup_graphql_query_results,
+        "url": url_makes_sense,
+    })
+    try:
+        template = compile_jinja2_template(body, extra_curly)
+        r = template.render(vars)
+    except Exception as e:
+        raise Jinja2TemplateError(e)
+    return r
+
+
+def process_extracurlyjinja2_template(
+    body: str,
+    vars: Optional[dict[str, Any]] = None,
+    extra_curly: bool = True,
+    settings: Optional[dict[str, Any]] = None,
+    secret_reader: Optional[SecretReaderBase] = None,
+) -> Any:
+    if vars is None:
+        vars = {}
+    return process_jinja2_template(
+        body,
+        vars=vars,
+        extra_curly=True,
+        settings=settings,
+        secret_reader=secret_reader,
+    )
+
+
+class FetchSecretError(Exception):
+    def __init__(self, msg: Any):
+        super().__init__("error fetching secret: " + str(msg))

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -2031,7 +2031,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
     @staticmethod
     def resolve_templated_parameters(saas_files: Iterable[SaasFile]) -> None:
         """Resolve templated target parameters in saas files."""
-        from reconcile.openshift_resources_base import (  # noqa: PLC0415 - # avoid circular import
+        from reconcile.utils.jinja2.utils import (  # noqa: PLC0415 - # avoid circular import
             compile_jinja2_template,
         )
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -140,7 +140,6 @@ from terrascript.resource import (
     random_id,
 )
 
-import reconcile.openshift_resources_base as orb
 import reconcile.utils.aws_helper as awsh
 from reconcile import queries
 from reconcile.github_org import get_default_config
@@ -176,6 +175,7 @@ from reconcile.utils.external_resources import (
 from reconcile.utils.git import is_file_in_git_repo
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.jenkins_api import JenkinsApi
+from reconcile.utils.jinja2.utils import process_extracurlyjinja2_template
 from reconcile.utils.ocm import OCMMap
 from reconcile.utils.password_validator import (
     PasswordPolicy,
@@ -5342,7 +5342,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             part = []
             for c in cloudinit_configs:
                 raw = self.get_raw_values(c["content"])
-                content = orb.process_extracurlyjinja2_template(
+                content = process_extracurlyjinja2_template(
                     body=raw["content"], vars=vars, secret_reader=self.secret_reader
                 )
                 # https://www.terraform.io/docs/language/expressions/strings.html#escape-sequences


### PR DESCRIPTION
The first commit is a refactoring which will make the jinja templating more usable for non openshift resources, like the ongoing templating.

The second commit adds new filters which allow templates to check for existence of some items in the input object.

For example in a role, checking if a datafile is already present:
```
{% set up_to_date = (role | matches_jsonpath('self_service[?(@.change_type["$ref"]=="' + change_type_path + '")].datafiles[?(@["$ref"]=="' + data_file_path + '")]')) %}
```

`json_pointers` allows to retrieve [RFC6901](https://www.rfc-editor.org/rfc/rfc6901)  JSON pointers. Those are useful to create [JSONPatches](https://www.rfc-editor.org/rfc/rfc6902.html)