### PR TITLE
APPSRE-9803: add support for AWS ALB Listener Rule Redirect action

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -40875,6 +40875,11 @@
                             "kind": "OBJECT",
                             "name": "NamespaceTerraformResourceALBActionFixedResponse_v1",
                             "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
+                            "name": "NamespaceTerraformResourceALBActionRedirect_v1",
+                            "ofType": null
                         }
                     ]
                 },
@@ -41934,6 +41939,138 @@
                                     "name": "String",
                                     "ofType": null
                                 }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "NamespaceTerraformResourceALBActionRedirect_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "type",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "redirect",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "NamespaceTerraformResourceALBActionRedirectSettings_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "NamespaceTerraformResourceALBAction_v1",
+                            "ofType": null
+                        }
+                    ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "NamespaceTerraformResourceALBActionRedirectSettings_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "host",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "port",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Int",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "protocol",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "query",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "status_code",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.gql
@@ -289,6 +289,16 @@ query TerraformResourcesNamespaces {
                                 status_code
                             }
                         }
+                        ... on NamespaceTerraformResourceALBActionRedirect_v1 {
+                            redirect {
+                                host
+                                path
+                                port
+                                protocol
+                                query
+                                status_code
+                            }
+                        }
                     }
                 }
                 output_resource_name

--- a/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
+++ b/reconcile/gql_definitions/terraform_resources/terraform_resources_namespaces.py
@@ -346,6 +346,16 @@ query TerraformResourcesNamespaces {
                                 status_code
                             }
                         }
+                        ... on NamespaceTerraformResourceALBActionRedirect_v1 {
+                            redirect {
+                                host
+                                path
+                                port
+                                protocol
+                                query
+                                status_code
+                            }
+                        }
                     }
                 }
                 output_resource_name
@@ -831,9 +841,22 @@ class NamespaceTerraformResourceALBActionFixedResponseV1(NamespaceTerraformResou
     fixed_response: NamespaceTerraformResourceALBActionFixedResponseSettingsV1 = Field(..., alias="fixed_response")
 
 
+class NamespaceTerraformResourceALBActionRedirectSettingsV1(ConfiguredBaseModel):
+    host: Optional[str] = Field(..., alias="host")
+    path: Optional[str] = Field(..., alias="path")
+    port: Optional[int] = Field(..., alias="port")
+    protocol: Optional[str] = Field(..., alias="protocol")
+    query: Optional[str] = Field(..., alias="query")
+    status_code: Optional[str] = Field(..., alias="status_code")
+
+
+class NamespaceTerraformResourceALBActionRedirectV1(NamespaceTerraformResourceALBActionV1):
+    redirect: NamespaceTerraformResourceALBActionRedirectSettingsV1 = Field(..., alias="redirect")
+
+
 class NamespaceTerraformResourceALBRulesV1(ConfiguredBaseModel):
     condition: list[Union[NamespaceTerraformResourceALBConditionHostHeaderV1, NamespaceTerraformResourceALBConditionHTTPRequestMethodV1, NamespaceTerraformResourceALBConditionPathPatternV1, NamespaceTerraformResourceALBConditionSourceIPV1, NamespaceTerraformResourceALBConditionV1]] = Field(..., alias="condition")
-    action: Union[NamespaceTerraformResourceALBActionForwardV1, NamespaceTerraformResourceALBActionFixedResponseV1, NamespaceTerraformResourceALBActionV1] = Field(..., alias="action")
+    action: Union[NamespaceTerraformResourceALBActionForwardV1, NamespaceTerraformResourceALBActionFixedResponseV1, NamespaceTerraformResourceALBActionRedirectV1, NamespaceTerraformResourceALBActionV1] = Field(..., alias="action")
 
 
 class NamespaceTerraformResourceALBV1(NamespaceTerraformResourceAWSV1):

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5126,6 +5126,19 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                         "status_code": fr_data.get("status_code"),
                     },
                 }
+            elif action_type == "redirect":
+                redirect_data = action.get("redirect", {})
+                action_values = {
+                    "type": "redirect",
+                    "redirect": {
+                        "host": redirect_data.get("host"),
+                        "path": redirect_data.get("path"),
+                        "port": redirect_data.get("port"),
+                        "protocol": redirect_data.get("protocol"),
+                        "query": redirect_data.get("query"),
+                        "status_code": redirect_data.get("status_code"),
+                    },
+                }
             else:
                 raise KeyError(f"unknown alb rule action type {action_type}")
 


### PR DESCRIPTION
Support AWS ALB Listener Rule action type "Redirect" following arguments in the [provider docs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lb_listener_rule#redirect)

Depends on https://github.com/app-sre/qontract-schemas/pull/589