### PR TITLE
[localstack] use qontract-development-cli network

### DIFF
--- a/dev/localstack/docker-compose.yml
+++ b/dev/localstack/docker-compose.yml
@@ -15,3 +15,5 @@ services:
     volumes:
       - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
       - ./init:/etc/localstack/init/ready.d
+    networks:
+    - qontract-development


### PR DESCRIPTION
Host the localstack container in the `qontract-development-cli` network to enable service connectivity.

Ticket: [APPSRE-8749](https://issues.redhat.com/browse/APPSRE-8749)
Depends on: https://github.com/app-sre/qontract-development-cli/pull/39