### PR TITLE
[rosa] utilities for ROSA cli usage in q-r

### DIFF
--- a/reconcile/test/utils/rosa/conftest.py
+++ b/reconcile/test/utils/rosa/conftest.py
@@ -1,0 +1,133 @@
+import json
+from typing import Callable
+from unittest.mock import MagicMock
+
+import httpretty as httpretty_module
+import pytest
+from boto3 import Session
+
+from reconcile.utils.aws_api import AWSTemporaryCredentials
+from reconcile.utils.jobcontroller.controller import K8sJobController
+from reconcile.utils.jobcontroller.models import JobStatus
+from reconcile.utils.rosa.model import ROSACluster
+from reconcile.utils.rosa.session import RosaSessionContextManager, rosa_session_ctx
+from reconcile.utils.secret_reader import SecretReaderBase
+
+
+@pytest.fixture
+def access_token_url() -> str:
+    return "https://sso/get_token"
+
+
+@pytest.fixture
+def ocm_url() -> str:
+    return "http://ocm"
+
+
+@pytest.fixture(autouse=True)
+def ocm_auth_mock(httpretty: httpretty_module, access_token_url: str) -> None:
+    httpretty.register_uri(
+        httpretty.POST,
+        access_token_url,
+        body=json.dumps({"access_token": "1234567890"}),
+        content_type="text/json",
+    )
+
+
+@pytest.fixture
+def account_automation_token() -> tuple[str, str]:
+    return "acc_path", "acc_field"
+
+
+@pytest.fixture
+def rosa_cluster(
+    access_token_url: str,
+    ocm_url: str,
+    account_automation_token: tuple[str, str],
+    gql_class_factory: Callable[..., ROSACluster],
+) -> ROSACluster:
+    return gql_class_factory(
+        ROSACluster,
+        {
+            "name": "cluster",
+            "spec": {
+                "id": "cluster",
+                "account": {
+                    "name": "account",
+                    "uid": "uid",
+                    "automationToken": {
+                        "path": account_automation_token[0],
+                        "field": account_automation_token[1],
+                    },
+                },
+                "product": "rosa",
+                "channel": "candidate",
+                "region": "us-east-1",
+            },
+            "ocm": {
+                "environment": {
+                    "url": ocm_url,
+                    "accessTokenClientId": "env_client_id",
+                    "accessTokenUrl": access_token_url,
+                    "accessTokenClientSecret": {
+                        "path": "env_path",
+                        "field": "env_field",
+                    },
+                },
+                "orgId": "org_id",
+                "accessTokenClientId": "org_client_id",
+                "accessTokenUrl": access_token_url,
+                "accessTokenClientSecret": {
+                    "path": "org_path",
+                    "field": "org_field",
+                },
+            },
+        },
+    )
+
+
+@pytest.fixture
+def job_controller() -> K8sJobController:
+    jc = MagicMock(
+        spec=K8sJobController,
+        autospec=True,
+    )
+    jc.store_job_logs.return_value = None
+    jc.enqueue_job_and_wait_for_completion.return_value = JobStatus.SUCCESS
+    return jc
+
+
+@pytest.fixture
+def secret_reader() -> SecretReaderBase:
+    return MagicMock(
+        spec=SecretReaderBase,
+        autospec=True,
+    )
+
+
+class MockAWSSessionBuilder:
+    def build(self) -> Session:
+        return MagicMock(spec=Session, autospec=True)
+
+    def build_temporary_credentials(self) -> AWSTemporaryCredentials:
+        return AWSTemporaryCredentials(
+            access_key_id="access_key_id",
+            secret_access_key="secret_access_key",
+            session_token="session_token",
+            region="region",
+        )
+
+
+@pytest.fixture
+def rosa_session_ctx_manager(
+    rosa_cluster: ROSACluster,
+    job_controller: K8sJobController,
+    secret_reader: SecretReaderBase,
+) -> RosaSessionContextManager:
+    ctx_mgnr = rosa_session_ctx(
+        cluster=rosa_cluster,
+        job_controller=job_controller,
+        secret_reader=secret_reader,
+    )
+    ctx_mgnr.aws_session_builder = MockAWSSessionBuilder()
+    return ctx_mgnr

--- a/reconcile/test/utils/rosa/conftest.py
+++ b/reconcile/test/utils/rosa/conftest.py
@@ -1,15 +1,16 @@
 import json
-from typing import Callable
+import tempfile
+from typing import Callable, Generator
 from unittest.mock import MagicMock
 
 import httpretty as httpretty_module
 import pytest
-from boto3 import Session
 
-from reconcile.utils.aws_api import AWSTemporaryCredentials
+from reconcile.utils.aws_api import AWSStaticCredentials
 from reconcile.utils.jobcontroller.controller import K8sJobController
 from reconcile.utils.jobcontroller.models import JobStatus
 from reconcile.utils.rosa.model import ROSACluster
+from reconcile.utils.rosa.rosa_cli import LogHandle, RosaJob
 from reconcile.utils.rosa.session import RosaSessionContextManager, rosa_session_ctx
 from reconcile.utils.secret_reader import SecretReaderBase
 
@@ -99,23 +100,23 @@ def job_controller() -> K8sJobController:
 
 @pytest.fixture
 def secret_reader() -> SecretReaderBase:
-    return MagicMock(
+    sr = MagicMock(
         spec=SecretReaderBase,
         autospec=True,
     )
+    sr.read_all_secret.return_value = {
+        "aws_access_key_id": "access_key_id",
+        "aws_secret_access_key": "secret_access_key",
+    }
+    return sr
 
 
-class MockAWSSessionBuilder:
-    def build(self) -> Session:
-        return MagicMock(spec=Session, autospec=True)
+ROSA_CLI_IMAGE = "registry.ci.openshift.org/ci/rosa-aws-cli:latest"
 
-    def build_temporary_credentials(self) -> AWSTemporaryCredentials:
-        return AWSTemporaryCredentials(
-            access_key_id="access_key_id",
-            secret_access_key="secret_access_key",
-            session_token="session_token",
-            region="region",
-        )
+
+@pytest.fixture
+def rosa_cli_image() -> str:
+    return ROSA_CLI_IMAGE
 
 
 @pytest.fixture
@@ -123,11 +124,47 @@ def rosa_session_ctx_manager(
     rosa_cluster: ROSACluster,
     job_controller: K8sJobController,
     secret_reader: SecretReaderBase,
+    rosa_cli_image: str,
 ) -> RosaSessionContextManager:
     ctx_mgnr = rosa_session_ctx(
         cluster=rosa_cluster,
         job_controller=job_controller,
         secret_reader=secret_reader,
+        image=rosa_cli_image,
     )
-    ctx_mgnr.aws_session_builder = MockAWSSessionBuilder()
+    ctx_mgnr.aws_credentials = AWSStaticCredentials(
+        access_key_id="access_key_id",
+        secret_access_key="secret_access_key",
+        region="us-east-1",
+    )
     return ctx_mgnr
+
+
+@pytest.fixture
+def log_file() -> Generator[str, None, None]:
+    with tempfile.NamedTemporaryFile(delete=False) as f:
+        f.write(b"line1\nline2\nline3\nline4\nline5\n")
+        f.flush()
+        yield f.name
+
+
+@pytest.fixture
+def log_handle(log_file: str) -> LogHandle:
+    return LogHandle(log_file)
+
+
+@pytest.fixture
+def rosa_job() -> RosaJob:
+    return RosaJob(
+        account_name="account",
+        cluster_name="cluster",
+        org_id="org_id",
+        cmd="rosa whoami",
+        image=ROSA_CLI_IMAGE,
+        aws_credentials=AWSStaticCredentials(
+            access_key_id="access_key_id",
+            secret_access_key="secret_access_key",
+            region="us-east-1",
+        ),
+        ocm_token="1234567890",
+    )

--- a/reconcile/test/utils/rosa/test_log_handler.py
+++ b/reconcile/test/utils/rosa/test_log_handler.py
@@ -1,0 +1,43 @@
+import pytest
+
+from reconcile.utils.rosa.rosa_cli import LogHandle
+
+#
+# LogHandler
+#
+
+
+@pytest.mark.parametrize(
+    "max_lines, expected_lines",
+    [
+        (2, 2),
+        (6, 5),
+        (5, 5),
+        (0, 0),
+        (-1, 0),
+    ],
+)
+def test_log_handle_get_log_lines(
+    max_lines: int, expected_lines: int, log_handle: LogHandle
+) -> None:
+    lines = log_handle.get_log_lines(max_lines=max_lines)
+    assert len(lines) == expected_lines
+    for line in lines:
+        assert not line.endswith("\n")
+
+
+def test_log_handle_write_logs_to_logger(log_handle: LogHandle) -> None:
+    content = ""
+
+    def append(line: str) -> None:
+        nonlocal content
+        content += line
+
+    log_handle.write_logs_to_logger(append)
+    assert content.rstrip().split("\n") == log_handle.get_log_lines(5)
+
+
+def test_log_handler_cleanup(log_handle: LogHandle) -> None:
+    assert log_handle.exists()
+    log_handle.cleanup()
+    assert not log_handle.exists()

--- a/reconcile/test/utils/rosa/test_rosa_cli.py
+++ b/reconcile/test/utils/rosa/test_rosa_cli.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+import pytest
+
+from reconcile.utils.rosa.rosa_cli import RosaJob
+
+
+@pytest.mark.parametrize(
+    "change, expect_identity_to_change",
+    [
+        ({"cmd": "other cmd"}, True),
+        ({"account_name": "another_account"}, True),
+        ({"cluster_name": "another_cluster"}, True),
+        ({"org_id": "123"}, True),
+        ({"dry_run": True}, True),
+        ({"image": "another_image:latest"}, True),
+        ({"aws_credentials": {"access_key_id": "another_access_key"}}, False),
+        ({"ocm_token": "another_ocm_token"}, False),
+    ],
+)
+def test_rosa_job_identity(
+    change: dict[str, Any], expect_identity_to_change: bool, rosa_job: RosaJob
+) -> None:
+    other_job = rosa_job.copy(deep=True, update=change)
+    identity_digest_changed = (
+        rosa_job.unit_of_work_digest() != other_job.unit_of_work_digest()
+    )
+    assert identity_digest_changed == expect_identity_to_change
+
+
+def test_rosa_job_secret_data(rosa_job: RosaJob) -> None:
+    secret_data = rosa_job.secret_data()
+    assert set(secret_data.keys()) == {
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_REGION",
+        "OCM_TOKEN",
+    }
+
+
+def test_rosa_job_spec(rosa_job: RosaJob) -> None:
+    job_spec = rosa_job.job_spec()
+    container = job_spec.template.spec.containers[0]  # type: ignore
+    assert container.image == rosa_job.image
+    assert container.args == [rosa_job.cmd]
+    assert {e.name for e in container.env or []} == {
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_REGION",
+        "OCM_TOKEN",
+    }

--- a/reconcile/test/utils/rosa/test_session.py
+++ b/reconcile/test/utils/rosa/test_session.py
@@ -1,0 +1,46 @@
+import pytest
+
+from reconcile.utils.jobcontroller.controller import K8sJobController
+from reconcile.utils.jobcontroller.models import JobStatus
+from reconcile.utils.rosa.rosa_cli import RosaCliException
+from reconcile.utils.rosa.session import RosaSessionContextManager
+
+
+def test_rosa_session_ctx(rosa_session_ctx_manager: RosaSessionContextManager) -> None:
+    with rosa_session_ctx_manager as rosa_session:
+        assert not rosa_session.is_closed()
+        assert rosa_session is not None
+        assert rosa_session.aws_session_builder is not None
+        assert rosa_session.ocm_api is not None
+    assert rosa_session.is_closed()
+
+
+def test_rosa_session_ctx_exit(
+    rosa_session_ctx_manager: RosaSessionContextManager,
+) -> None:
+    with pytest.raises(Exception):
+        with rosa_session_ctx_manager as rosa_session:
+            assert not rosa_session.is_closed()
+            assert rosa_session is not None
+            assert rosa_session.aws_session_builder is not None
+            assert rosa_session.ocm_api is not None
+            raise Exception("boom!")
+    assert rosa_session.is_closed()
+
+
+def test_rosa_session_cli_execute(
+    rosa_session_ctx_manager: RosaSessionContextManager,
+) -> None:
+    with rosa_session_ctx_manager as rosa_session:
+        result = rosa_session.cli_execute("rosa whoami")
+        assert result.status == JobStatus.SUCCESS
+
+
+def test_rosa_session_cli_execute_fail(
+    rosa_session_ctx_manager: RosaSessionContextManager,
+    job_controller: K8sJobController,
+) -> None:
+    job_controller.enqueue_job_and_wait_for_completion.return_value = JobStatus.ERROR  # type: ignore[attr-defined]
+    with rosa_session_ctx_manager as rosa_session:
+        with pytest.raises(RosaCliException):
+            rosa_session.cli_execute("rosa whoami")

--- a/reconcile/test/utils/test_aws_api.py
+++ b/reconcile/test/utils/test_aws_api.py
@@ -10,6 +10,8 @@ from pytest_mock import MockerFixture
 from reconcile.utils.aws_api import (
     AmiTag,
     AWSApi,
+    AWSStaticCredentials,
+    AWSTemporaryCredentials,
 )
 
 
@@ -377,3 +379,80 @@ def test_get_cluster_vpc_details_aws_error(
             "name": "some-account",
             "assume_region": "us-east-1",
         })
+
+
+#
+# AWS credential dataclasses
+#
+
+
+@pytest.fixture
+def aws_static_credentials():
+    return AWSStaticCredentials(
+        access_key_id="access-key-id",
+        secret_access_key="secret-access-key",
+        region="us-east-1",
+    )
+
+
+def test_static_credentials_as_env_vars(
+    aws_static_credentials: AWSStaticCredentials,
+) -> None:
+    assert aws_static_credentials.as_env_vars() == {
+        "AWS_ACCESS_KEY_ID": aws_static_credentials.access_key_id,
+        "AWS_SECRET_ACCESS_KEY": aws_static_credentials.secret_access_key,
+        "AWS_REGION": aws_static_credentials.region,
+    }
+
+
+@pytest.mark.parametrize(
+    "profile_name",
+    [
+        "default",
+        "some-profile",
+    ],
+)
+def test_static_credentials_as_file(
+    profile_name, aws_static_credentials: AWSStaticCredentials
+) -> None:
+    expected_file = f"""[{profile_name}]\naws_access_key_id = {aws_static_credentials.access_key_id}\naws_secret_access_key = {aws_static_credentials.secret_access_key}\nregion = {aws_static_credentials.region}\n"""
+    creds_file = aws_static_credentials.as_credentials_file(profile_name=profile_name)
+    assert creds_file == expected_file
+
+
+@pytest.fixture
+def aws_temporary_credentials():
+    return AWSTemporaryCredentials(
+        access_key_id="access-key-id",
+        secret_access_key="secret-access-key",
+        session_token="session-token",
+        region="us-east-1",
+    )
+
+
+def test_temporary_credentials_as_env_vars(
+    aws_temporary_credentials: AWSTemporaryCredentials,
+) -> None:
+    assert aws_temporary_credentials.as_env_vars() == {
+        "AWS_ACCESS_KEY_ID": aws_temporary_credentials.access_key_id,
+        "AWS_SECRET_ACCESS_KEY": aws_temporary_credentials.secret_access_key,
+        "AWS_SESSION_TOKEN": aws_temporary_credentials.session_token,
+        "AWS_REGION": aws_temporary_credentials.region,
+    }
+
+
+@pytest.mark.parametrize(
+    "profile_name",
+    [
+        "default",
+        "some-profile",
+    ],
+)
+def test_temporary_credentials_as_file(
+    profile_name, aws_temporary_credentials: AWSTemporaryCredentials
+) -> None:
+    expected_file = f"""[{profile_name}]\naws_access_key_id = {aws_temporary_credentials.access_key_id}\naws_secret_access_key = {aws_temporary_credentials.secret_access_key}\naws_session_token = {aws_temporary_credentials.session_token}\nregion = {aws_temporary_credentials.region}\n"""
+    creds_file = aws_temporary_credentials.as_credentials_file(
+        profile_name=profile_name
+    )
+    assert creds_file == expected_file

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -93,7 +93,7 @@ class AWSTemporaryCredentials(BaseModel):
     access_key_id: str
     secret_access_key: str
     session_token: str
-    region: Optional[str]
+    region: str
 
 
 def build_temporary_aws_credentials_from_session(

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1,7 +1,9 @@
 import logging
 import os
 import re
+import textwrap
 import time
+from abc import ABC, abstractmethod
 from collections.abc import (
     Iterable,
     Iterator,
@@ -16,7 +18,6 @@ from typing import (
     Any,
     Literal,
     Optional,
-    Protocol,
     Union,
 )
 
@@ -85,73 +86,116 @@ KeyStatus = Union[Literal["Active"], Literal["Inactive"]]
 GOVCLOUD_PARTITION = "aws-us-gov"
 
 
-class AWSTemporaryCredentials(BaseModel):
+class AWSCredentials(ABC):
+    @abstractmethod
+    def as_env_vars(self) -> dict[str, str]:
+        """
+        Returns a dictionary of environment variables that can be used to authenticate with AWS.
+        """
+        ...
+
+    @abstractmethod
+    def as_credentials_file(self, profile_name: str = "default") -> str:
+        """
+        Returns a string that can be used to write an AWS credentials file.
+        """
+        ...
+
+    @abstractmethod
+    def build_session(self) -> Session:
+        """
+        Builds an AWS session using these credentials.
+        """
+        ...
+
+    def get_temporary_credentials(
+        self, duration_seconds: int = 900
+    ) -> "AWSTemporaryCredentials":
+        """
+        Builds temporary AWS credentials from a session. This is similar to assuming a role,
+        in the sense that the credentials will expire after a certain amount of time.
+
+        These temporary credentials have the same permissions as the session they were built from, except:
+        - they can't be used for anything IAM related
+        - for the STS API only the AssumeRole and GetSessionToken actions are allowed
+        """
+        session = self.build_session()
+        response = session.client("sts").get_session_token(
+            DurationSeconds=duration_seconds
+        )
+        tmp_creds = response["Credentials"]
+        return AWSTemporaryCredentials(
+            access_key_id=tmp_creds["AccessKeyId"],
+            secret_access_key=tmp_creds["SecretAccessKey"],
+            session_token=tmp_creds["SessionToken"],
+            region=session.region_name,
+        )
+
+
+class AWSStaticCredentials(BaseModel, AWSCredentials):
     """
-    A model representing temporary AWS credentials.
+    A model representing AWS credentials.
     """
 
     access_key_id: str
     secret_access_key: str
-    session_token: str
     region: str
 
+    def as_env_vars(self) -> dict[str, str]:
+        return {
+            "AWS_ACCESS_KEY_ID": self.access_key_id,
+            "AWS_SECRET_ACCESS_KEY": self.secret_access_key,
+            "AWS_REGION": self.region,
+        }
 
-def build_temporary_aws_credentials_from_session(
-    session: Session, duration_seconds: int = 900
-) -> AWSTemporaryCredentials:
-    """
-    Builds temporary AWS credentials from an existing session. This is similar to assuming a role,
-    in the sense that the credentials will expire after a certain amount of time.
-    """
-    response = session.client("sts").get_session_token(DurationSeconds=duration_seconds)
-    tmp_creds = response["Credentials"]
-    return AWSTemporaryCredentials(
-        access_key_id=tmp_creds["AccessKeyId"],
-        secret_access_key=tmp_creds["SecretAccessKey"],
-        session_token=tmp_creds["SessionToken"],
-        region=session.region_name,
-    )
+    def as_credentials_file(self, profile_name: str = "default") -> str:
+        return textwrap.dedent(
+            f"""\
+            [{profile_name}]
+            aws_access_key_id = {self.access_key_id}
+            aws_secret_access_key = {self.secret_access_key}
+            region = {self.region}
+            """
+        )
 
-
-class AWSSessionBuilder(Protocol):
-    """
-    A generic protocol for building AWS sessions.
-    """
-
-    def build(self) -> Session:
-        """
-        Builds an AWS session.
-        """
-        ...
-
-    def build_temporary_credentials(self) -> AWSTemporaryCredentials:
-        """
-        Builds temporary AWS credentials based und the session built by the `build` method.
-        """
-        ...
-
-
-class AWSStaticCredsSessionBuilder:
-    """
-    An implementation of the AWSSessionBuilder protocol that builds a session with static credentials.
-    """
-
-    def __init__(
-        self, access_key_id: str, secret_access_key: str, region: Optional[str]
-    ) -> None:
-        self.access_key_id = access_key_id
-        self.secret_access_key = secret_access_key
-        self.region = region
-
-    def build(self) -> Session:
+    def build_session(self) -> Session:
         return Session(
             aws_access_key_id=self.access_key_id,
             aws_secret_access_key=self.secret_access_key,
             region_name=self.region,
         )
 
-    def build_temporary_credentials(self) -> AWSTemporaryCredentials:
-        return build_temporary_aws_credentials_from_session(self.build())
+
+class AWSTemporaryCredentials(AWSStaticCredentials):
+    """
+    A model representing temporary AWS credentials.
+    """
+
+    session_token: str
+
+    def as_env_vars(self) -> dict[str, str]:
+        env_vars = super().as_env_vars()
+        env_vars["AWS_SESSION_TOKEN"] = self.session_token
+        return env_vars
+
+    def as_credentials_file(self, profile_name: str = "default") -> str:
+        return textwrap.dedent(
+            f"""\
+            [{profile_name}]
+            aws_access_key_id = {self.access_key_id}
+            aws_secret_access_key = {self.secret_access_key}
+            aws_session_token = {self.session_token}
+            region = {self.region}
+            """
+        )
+
+    def build_session(self) -> Session:
+        return Session(
+            aws_access_key_id=self.access_key_id,
+            aws_secret_access_key=self.secret_access_key,
+            aws_session_token=self.session_token,
+            region_name=self.region,
+        )
 
 
 class AmiTag(BaseModel):

--- a/reconcile/utils/jobcontroller/controller.py
+++ b/reconcile/utils/jobcontroller/controller.py
@@ -368,7 +368,7 @@ class K8sJobController:
         Stores the logs of a job in the given output directory.
         The filename will be the name of the job.
         """
-        self.oc.job_logs(
+        self.oc.job_logs_latest_pod(
             namespace=self.namespace,
             follow=False,
             name=job_name,

--- a/reconcile/utils/jobcontroller/controller.py
+++ b/reconcile/utils/jobcontroller/controller.py
@@ -370,7 +370,6 @@ class K8sJobController:
         """
         self.oc.job_logs_latest_pod(
             namespace=self.namespace,
-            follow=False,
             name=job_name,
             output=output_dir_path,
         )

--- a/reconcile/utils/jobcontroller/models.py
+++ b/reconcile/utils/jobcontroller/models.py
@@ -5,7 +5,14 @@ from enum import Enum, IntFlag
 from typing import Any
 
 from deepdiff import DeepHash
-from kubernetes.client import V1Job, V1JobSpec, V1ObjectMeta
+from kubernetes.client import (
+    V1EnvVar,
+    V1EnvVarSource,
+    V1Job,
+    V1JobSpec,
+    V1ObjectMeta,
+    V1SecretKeySelector,
+)
 
 
 class JobStatus(str, Enum):
@@ -125,3 +132,18 @@ class K8sJob(ABC):
         job controller will manage the lifecycle of a kubernetes Secret.
         """
         return {}
+
+    def secret_data_to_env_vars_secret_refs(self) -> list[V1EnvVar]:
+        secret_name = self.name()
+        return [
+            V1EnvVar(
+                name=secret_key_name,
+                value_from=V1EnvVarSource(
+                    secret_key_ref=V1SecretKeySelector(
+                        name=secret_name,
+                        key=secret_key_name,
+                    )
+                ),
+            )
+            for secret_key_name in self.secret_data().keys()
+        ]

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -754,7 +754,6 @@ class OCCli:  # pylint: disable=too-many-public-methods
             namespace,
             f"pod/{latest_pod['metadata']['name']}",
         ]
-        # pylint: disable=consider-using-with
         output_file = open(os.path.join(output, name), "w", encoding="locale")
         # collect logs to file async
         Popen(self.oc_base_cmd + cmd, stdout=output_file)

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -735,7 +735,7 @@ class OCCli:  # pylint: disable=too-many-public-methods
         # collect logs to file async
         Popen(self.oc_base_cmd + cmd, stdout=output_file)
 
-    def job_logs_latest_pod(self, namespace, name, follow, output):
+    def job_logs_latest_pod(self, namespace, name, output):
         pods = self.get_items("Pod", namespace=namespace, labels={"job-name": name})
 
         finished_pods = [
@@ -754,8 +754,6 @@ class OCCli:  # pylint: disable=too-many-public-methods
             namespace,
             f"pod/{latest_pod['metadata']['name']}",
         ]
-        if follow:
-            cmd.append("-f")
         # pylint: disable=consider-using-with
         output_file = open(os.path.join(output, name), "w", encoding="locale")
         # collect logs to file async

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -735,6 +735,32 @@ class OCCli:  # pylint: disable=too-many-public-methods
         # collect logs to file async
         Popen(self.oc_base_cmd + cmd, stdout=output_file)
 
+    def job_logs_latest_pod(self, namespace, name, follow, output):
+        pods = self.get_items("Pod", namespace=namespace, labels={"job-name": name})
+
+        finished_pods = [
+            pod for pod in pods if pod["status"].get("phase") in {"Failed", "Succeeded"}
+        ]
+        if not finished_pods:
+            raise JobNotRunningError(name)
+
+        latest_pod = sorted(
+            finished_pods, key=lambda pod: pod["metadata"]["creationTimestamp"]
+        )[-1]
+        cmd = [
+            "logs",
+            "--all-containers=true",
+            "-n",
+            namespace,
+            f"pod/{latest_pod['metadata']['name']}",
+        ]
+        if follow:
+            cmd.append("-f")
+        # pylint: disable=consider-using-with
+        output_file = open(os.path.join(output, name), "w", encoding="locale")
+        # collect logs to file async
+        Popen(self.oc_base_cmd + cmd, stdout=output_file)
+
     @staticmethod
     def get_service_account_username(user):
         namespace = user.split("/")[0]

--- a/reconcile/utils/ocm_base_client.py
+++ b/reconcile/utils/ocm_base_client.py
@@ -148,6 +148,9 @@ class OCMBaseClient:
         r = self._session.delete(f"{self._url}{api_path}", timeout=REQUEST_TIMEOUT_SEC)
         r.raise_for_status()
 
+    def close(self):
+        self._session.close()
+
 
 class OCMAPIClientConfigurationProtocol(Protocol):
     url: str

--- a/reconcile/utils/rosa/model.py
+++ b/reconcile/utils/rosa/model.py
@@ -1,0 +1,56 @@
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
+
+"""
+These models reflect an app-interface ROSA cluster including its
+- spec details
+- account details
+- ocm details
+
+without any Optionals
+
+This allows for easier handling with AppInterface ROSA cluster assets because
+there is no need to constantly check for None values.
+"""
+
+
+class AWSAccount(BaseModel):
+    name: str = Field(..., alias="name")
+    uid: str = Field(..., alias="uid")
+    automation_token: VaultSecret = Field(..., alias="automationToken")
+
+
+class ROSAClusterSpec(BaseModel):
+    q_id: Optional[str] = Field(..., alias="id")
+    product: str = Field(..., alias="product")
+    channel: str = Field(..., alias="channel")
+    region: str = Field(..., alias="region")
+    account: AWSAccount = Field(..., alias="account")
+
+
+class OCMEnvironment(BaseModel):
+    url: str = Field(..., alias="url")
+    access_token_client_id: str = Field(..., alias="accessTokenClientId")
+    access_token_url: str = Field(..., alias="accessTokenUrl")
+    access_token_client_secret: VaultSecret = Field(
+        ..., alias="accessTokenClientSecret"
+    )
+
+
+class OCMOrganization(BaseModel):
+    environment: OCMEnvironment = Field(..., alias="environment")
+    org_id: str = Field(..., alias="orgId")
+    access_token_client_id: Optional[str] = Field(..., alias="accessTokenClientId")
+    access_token_url: Optional[str] = Field(..., alias="accessTokenUrl")
+    access_token_client_secret: Optional[VaultSecret] = Field(
+        ..., alias="accessTokenClientSecret"
+    )
+
+
+class ROSACluster(BaseModel):
+    name: str = Field(..., alias="name")
+    spec: ROSAClusterSpec = Field(..., alias="spec")
+    ocm: OCMOrganization = Field(..., alias="ocm")

--- a/reconcile/utils/rosa/rosa_cli.py
+++ b/reconcile/utils/rosa/rosa_cli.py
@@ -104,6 +104,7 @@ class RosaJob(K8sJob, BaseModel, frozen=True):
     cluster_name: str
     org_id: str
     cmd: str
+    image: str
 
     aws_credentials: AWSTemporaryCredentials
     ocm_token: str
@@ -123,6 +124,7 @@ class RosaJob(K8sJob, BaseModel, frozen=True):
             "cluster_name": self.cluster_name,
             "org_id": self.org_id,
             "dry_run": self.dry_run,
+            "image": self.image,
         }
 
     def annotations(self) -> dict[str, str]:
@@ -143,8 +145,8 @@ class RosaJob(K8sJob, BaseModel, frozen=True):
                 spec=V1PodSpec(
                     containers=[
                         V1Container(
-                            name="outputs",
-                            image="registry.ci.openshift.org/ci/rosa-aws-cli:latest",
+                            name="rosa-cli",
+                            image=self.image,
                             command=["/bin/bash", "-c"],
                             args=[self.cmd],
                             image_pull_policy="Always",

--- a/reconcile/utils/rosa/rosa_cli.py
+++ b/reconcile/utils/rosa/rosa_cli.py
@@ -1,0 +1,193 @@
+import itertools
+import os
+from typing import Any, Callable, Optional
+
+from kubernetes.client import (
+    V1Container,
+    V1EmptyDirVolumeSource,
+    V1EnvVar,
+    V1JobSpec,
+    V1ObjectMeta,
+    V1PodSpec,
+    V1PodTemplateSpec,
+    V1Volume,
+    V1VolumeMount,
+)
+from pydantic import BaseModel
+
+from reconcile.utils.aws_api import (
+    AWSTemporaryCredentials,
+)
+from reconcile.utils.jobcontroller.models import JobStatus, K8sJob
+
+
+class LogHandle:
+    """
+    Represents a handle to a log file and offers convenience methods to consume
+    the log content in an efficient manner.
+    """
+
+    def __init__(self, log_file: str) -> None:
+        self.log_file = log_file
+
+    def get_log_lines(self, max_lines: int = 5) -> list[str]:
+        with open(self.log_file, "r", encoding="utf-8") as f:
+            return list(itertools.islice(f, max_lines))
+
+    def write_logs_to_logger(self, logger: Callable[..., None]) -> None:
+        with open(self.log_file, "r", encoding="utf-8") as f:
+            logger(f.read())
+
+    def cleanup(self) -> None:
+        os.remove(self.log_file)
+
+
+class RosaCliResult:
+    """
+    Represents the result of a ROSA CLI execution.
+    """
+
+    def __init__(
+        self,
+        status: JobStatus,
+        command: str,
+        log_handle: Optional[LogHandle] = None,
+    ) -> None:
+        self.status = status
+        self.command = command
+        self.log_handle = log_handle
+
+    def get_log_lines(self, max_lines: int = 5) -> list[str]:
+        if self.log_handle:
+            return self.log_handle.get_log_lines(max_lines)
+        return []
+
+    def write_logs_to_logger(self, logger: Callable[..., None]) -> None:
+        if self.log_handle:
+            self.log_handle.write_logs_to_logger(logger)
+
+
+class RosaCliException(Exception, RosaCliResult):
+    """
+    Represents an exception that occurred during a ROSA CLI execution.
+    """
+
+    def __init__(
+        self,
+        status: JobStatus,
+        command: str,
+        log_handle: Optional[LogHandle] = None,
+    ) -> None:
+        Exception.__init__(
+            self, f"ROSA CLI execution failed with status: {status}, cmd: {command}"
+        )
+        RosaCliResult.__init__(self, status, command, log_handle)
+
+
+class RosaJob(K8sJob, BaseModel, frozen=True):
+    """
+    Represents a ROSA CLI job. It leverages the reconcile.utils.jobcontroller module
+    functionality to execute ROSA CLI commands in a Kubernetes cluster.
+
+    Since the ROSA CLI requires access to both AWS and OCM, the job is executed
+    with the required credentials and tokens.
+
+    The credentials used for AWS are as temporary ones that expire after a
+    defined amount of time, usually 15 minutes. The OCM access token is provided
+    as a JWT with an expiration of 15 minutes.
+
+    Since both credential types are of temporary nature, they are passed to the
+    Kubernetes job as environment variables.
+    """
+
+    account_name: str
+    cluster_name: str
+    org_id: str
+    cmd: str
+
+    aws_credentials: AWSTemporaryCredentials
+    ocm_token: str
+
+    dry_run: bool = False
+
+    def name_prefix(self) -> str:
+        prefix = "rosa-cli"
+        if self.dry_run:
+            prefix += "-dry-run"
+        return prefix
+
+    def unit_of_work_identity(self) -> Any:
+        return {
+            "cmd": self.cmd,
+            "account_name": self.account_name,
+            "cluster_name": self.cluster_name,
+            "org_id": self.org_id,
+            "dry_run": self.dry_run,
+        }
+
+    def annotations(self) -> dict[str, str]:
+        return {
+            "qontract.rosa.account_name": self.account_name,
+            "qontract.rosa.cluster_name": self.cluster_name,
+            "qontract.rosa.org_id": self.org_id,
+        }
+
+    def job_spec(self) -> V1JobSpec:
+        return V1JobSpec(
+            backoff_limit=1,
+            ttl_seconds_after_finished=3600,
+            template=V1PodTemplateSpec(
+                metadata=V1ObjectMeta(
+                    annotations=self.annotations(), labels=self.labels()
+                ),
+                spec=V1PodSpec(
+                    containers=[
+                        V1Container(
+                            name="outputs",
+                            image="registry.ci.openshift.org/ci/rosa-aws-cli:latest",
+                            command=["/bin/bash", "-c"],
+                            args=[self.cmd],
+                            image_pull_policy="Always",
+                            env=[
+                                V1EnvVar(
+                                    name="AWS_ACCESS_KEY_ID",
+                                    value=self.aws_credentials.access_key_id,
+                                ),
+                                V1EnvVar(
+                                    name="AWS_SECRET_ACCESS_KEY",
+                                    value=self.aws_credentials.secret_access_key,
+                                ),
+                                V1EnvVar(
+                                    name="AWS_SESSION_TOKEN",
+                                    value=self.aws_credentials.session_token,
+                                ),
+                                V1EnvVar(
+                                    name="AWS_REGION",
+                                    value=self.aws_credentials.region,
+                                ),
+                                V1EnvVar(
+                                    name="OCM_TOKEN",
+                                    value=self.ocm_token,
+                                ),
+                            ],
+                            volume_mounts=[
+                                V1VolumeMount(
+                                    name="workdir",
+                                    mount_path="/.config",
+                                )
+                            ],
+                        )
+                    ],
+                    restart_policy="Never",
+                    service_account_name="default",
+                    volumes=[
+                        V1Volume(
+                            name="workdir",
+                            empty_dir=V1EmptyDirVolumeSource(
+                                size_limit="10Mi",
+                            ),
+                        )
+                    ],
+                ),
+            ),
+        )

--- a/reconcile/utils/rosa/rosa_cli.py
+++ b/reconcile/utils/rosa/rosa_cli.py
@@ -95,13 +95,6 @@ class RosaJob(K8sJob, BaseModel, frozen=True, arbitrary_types_allowed=True):
 
     Since the ROSA CLI requires access to both AWS and OCM, the job is executed
     with the required credentials and tokens.
-
-    The credentials used for AWS are as temporary ones that expire after a
-    defined amount of time, usually 15 minutes. The OCM access token is provided
-    as a JWT with an expiration of 15 minutes.
-
-    Since both credential types are of temporary nature, they are passed to the
-    Kubernetes job as environment variables.
     """
 
     account_name: str

--- a/reconcile/utils/rosa/session.py
+++ b/reconcile/utils/rosa/session.py
@@ -56,7 +56,7 @@ class RosaSession:
         """
         Execute CLI commands in the context of a valid ROSA session (rosa login not required).
         The provided cmd needs to be a single command. If multiple commands are required, they
-        need to be combined into a single command with /bin/bash -c.
+        need to be combined delimited with a ;
         """
         aws_tmp_creds = self.aws_session_builder.build_temporary_credentials()
         job = RosaJob(
@@ -75,9 +75,9 @@ class RosaSession:
             timeout_seconds=60,
             concurrency_policy=JobConcurrencyPolicy.REPLACE_FAILED,
         )
-        log_dir = tempfile.TemporaryDirectory()
-        self.job_controller.store_job_logs(job.name(), log_dir.name)
-        log_file = f"{log_dir.name}/{job.name()}"
+        log_dir = tempfile.mkdtemp()
+        self.job_controller.store_job_logs(job.name(), log_dir)
+        log_file = f"{log_dir}/{job.name()}"
         if status != JobStatus.SUCCESS:
             raise RosaCliException(status, cmd, LogHandle(log_file))
         return RosaCliResult(status, cmd, LogHandle(log_file))

--- a/reconcile/utils/rosa/session.py
+++ b/reconcile/utils/rosa/session.py
@@ -1,0 +1,182 @@
+import tempfile
+from types import TracebackType
+from typing import Optional, Type
+
+from reconcile.utils.aws_api import (
+    AWSSessionBuilder,
+    AWSStaticCredsSessionBuilder,
+)
+from reconcile.utils.jobcontroller.controller import K8sJobController
+from reconcile.utils.jobcontroller.models import JobConcurrencyPolicy, JobStatus
+from reconcile.utils.ocm_base_client import (
+    OCMAPIClientConfiguration,
+    OCMAPIClientConfigurationProtocol,
+    OCMBaseClient,
+    init_ocm_base_client,
+)
+from reconcile.utils.rosa.model import ROSACluster
+from reconcile.utils.rosa.rosa_cli import (
+    LogHandle,
+    RosaCliException,
+    RosaCliResult,
+    RosaJob,
+)
+from reconcile.utils.secret_reader import SecretReaderBase
+
+
+class RosaSession:
+    """
+    A ROSA session contains the required context to interact with OCM and AWS
+    for a specific cluster.
+    """
+
+    def __init__(
+        self,
+        cluster: ROSACluster,
+        aws_session_builder: AWSSessionBuilder,
+        ocm_api: OCMBaseClient,
+        job_controller: K8sJobController,
+    ):
+        self.cluster = cluster
+        self.aws_session_builder = aws_session_builder
+        self.ocm_api = ocm_api
+        self.job_controller = job_controller
+        self._closed = False
+
+    def close(self) -> None:
+        self._closed = True
+        self.ocm_api.close()
+
+    def is_closed(self) -> bool:
+        return self._closed
+
+    def cli_execute(self, cmd: str) -> RosaCliResult:
+        """
+        Execute CLI commands in the context of a valid ROSA session (rosa login not required).
+        The provided cmd needs to be a single command. If multiple commands are required, they
+        need to be combined into a single command with /bin/bash -c.
+        """
+        aws_tmp_creds = self.aws_session_builder.build_temporary_credentials()
+        job = RosaJob(
+            account_name=self.cluster.spec.account.name,
+            cluster_name=self.cluster.name,
+            org_id=self.cluster.ocm.org_id,
+            cmd=f"rosa login > /dev/null && {cmd}",
+            aws_credentials=aws_tmp_creds,
+            ocm_token=self.ocm_api._access_token,
+        )
+
+        status = self.job_controller.enqueue_job_and_wait_for_completion(
+            job,
+            check_interval_seconds=2,
+            timeout_seconds=60,
+            concurrency_policy=JobConcurrencyPolicy.REPLACE_FAILED,
+        )
+        log_dir = tempfile.TemporaryDirectory()
+        self.job_controller.store_job_logs(job.name(), log_dir.name)
+        log_file = f"{log_dir.name}/{job.name()}"
+        if status != JobStatus.SUCCESS:
+            raise RosaCliException(status, cmd, LogHandle(log_file))
+        return RosaCliResult(status, cmd, LogHandle(log_file))
+
+    def upgrade_account_roles(
+        self, role_prefix: str, minor_version: str, dry_run: bool
+    ) -> None:
+        if not dry_run:
+            self.cli_execute(
+                f"rosa upgrade account-roles --prefix {role_prefix} --version {minor_version} --channel-group {self.cluster.spec.channel} -y -m=auto"
+            )
+
+    def upgrade_operator_roles(
+        self, role_prefix: str, minor_version: str, dry_run: bool
+    ) -> None:
+        cluster_id = self.cluster.spec.q_id
+        if not cluster_id:
+            raise Exception(
+                f"Can't upgrade operator roles. Cluster {self.cluster.name} does not define spec.cluster_id"
+            )
+        if not dry_run:
+            self.cli_execute(
+                f"rosa upgrade operator-roles --cluster {cluster_id} --prefix {role_prefix} --version {minor_version}.z --channel-group {self.cluster.spec.channel} -y -m=auto"
+            )
+
+
+class RosaSessionContextManager:
+    """
+    A context manager providing a fresh ROSA session when entering.
+    """
+
+    def __init__(
+        self,
+        cluster: ROSACluster,
+        aws_session_builder: AWSSessionBuilder,
+        ocm_config: OCMAPIClientConfigurationProtocol,
+        secret_reader: SecretReaderBase,
+        job_controller: K8sJobController,
+    ):
+        self.cluster = cluster
+        self.aws_session_builder = aws_session_builder
+        self.ocm_config = ocm_config
+        self.secret_reader = secret_reader
+        self.job_controller = job_controller
+
+        self._rosa_session: Optional[RosaSession] = None
+
+    def __enter__(self) -> RosaSession:
+        self._rosa_session = RosaSession(
+            cluster=self.cluster,
+            aws_session_builder=self.aws_session_builder,
+            ocm_api=init_ocm_base_client(self.ocm_config, self.secret_reader),
+            job_controller=self.job_controller,
+        )
+        return self._rosa_session
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> None:
+        if self._rosa_session:
+            self._rosa_session.close()
+            self._rosa_session = None
+
+
+def rosa_session_ctx(
+    cluster: ROSACluster,
+    secret_reader: SecretReaderBase,
+    job_controller: K8sJobController,
+) -> RosaSessionContextManager:
+    """
+    Creates a context manager for a ROSA session. The ROSA session
+    itself is managed by the context manager and no AWS session nor
+    OCM session is created at this point.
+    """
+
+    # build aws config
+    aws_secret = secret_reader.read_all_secret(cluster.spec.account.automation_token)
+    aws_session_builder = AWSStaticCredsSessionBuilder(
+        access_key_id=aws_secret["aws_access_key_id"],
+        secret_access_key=aws_secret["aws_secret_access_key"],
+        region=cluster.spec.region,
+    )
+
+    # build OCM config
+    ocm_config = OCMAPIClientConfiguration(
+        url=cluster.ocm.environment.url,
+        access_token_client_id=cluster.ocm.access_token_client_id
+        or cluster.ocm.environment.access_token_client_id,
+        access_token_client_secret=cluster.ocm.access_token_client_secret
+        or cluster.ocm.environment.access_token_client_secret,
+        access_token_url=cluster.ocm.access_token_url
+        or cluster.ocm.environment.access_token_url,
+    )
+
+    rosa_session_builder = RosaSessionContextManager(
+        cluster=cluster,
+        aws_session_builder=aws_session_builder,
+        ocm_config=ocm_config,
+        secret_reader=secret_reader,
+        job_controller=job_controller,
+    )
+    return rosa_session_builder


### PR DESCRIPTION
several ROSA operations are offered via the ROSA CLI only. the utilities in the new `reconcile.utils.rosa` module offer a way to setup the required sessions towards OCM and AWS and integrates into the `reconcile.utils.jobcontroller` to run CLI commands as K8S jobs.

```python
with rosa_session_ctx(cluster, job_controller, secret_reader) as rosa:
  result = rosa.cli_execute("rosa whoami")
  assert result.status == JobStatus.SUCCESS
  print(result.get_log_lines(5))
```