### PR TITLE
[job-controller] support secret data for jobs

### DIFF
--- a/reconcile/test/utils/jobcontroller/conftest.py
+++ b/reconcile/test/utils/jobcontroller/conftest.py
@@ -1,0 +1,57 @@
+from typing import Any, Callable
+
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.utils.jobcontroller.controller import K8sJobController
+from reconcile.utils.oc import OCCli
+
+
+@pytest.fixture
+def oc(mocker: MockerFixture) -> OCCli:
+    oc = mocker.create_autospec(OCCli)
+    oc.get_items.side_effect = [[]]
+    return oc
+
+
+OCItemSetter = Callable[[list[list[dict[str, Any]]]], None]
+
+
+@pytest.fixture
+def set_oc_get_items_side_effect(
+    oc: OCCli,
+) -> OCItemSetter:
+    def _set_oc_get_items_side_effect(
+        item_sequence: list[list[dict[str, Any]]],
+    ) -> None:
+        oc.get_items.side_effect = item_sequence  # type: ignore[attr-defined]
+
+    return _set_oc_get_items_side_effect
+
+
+@pytest.fixture
+def controller(oc: OCCli, mocker: MockerFixture) -> K8sJobController:
+    controller = K8sJobController(
+        oc=oc,
+        cluster="some-cluster",
+        namespace="some-ns",
+        integration="some-integration",
+        integration_version="0.1",
+        dry_run=False,
+        time_module=TimeMock(),
+    )
+    mocker.patch.object(controller, "_lookup_job_uid", return_value="some-uid")
+    return controller
+
+
+class TimeMock:
+    def __init__(self) -> None:
+        self.current_time = 0.0
+
+    def time(self) -> float:
+        return self.current_time
+
+    def sleep(self, seconds: float) -> None:
+        if seconds < 0:
+            raise ValueError("Negative value for sleep seconds not allowed")
+        self.current_time += seconds

--- a/reconcile/test/utils/jobcontroller/fixtures.py
+++ b/reconcile/test/utils/jobcontroller/fixtures.py
@@ -1,5 +1,4 @@
 from typing import Any, Optional
-from unittest.mock import create_autospec
 
 from kubernetes.client import (  # type: ignore[attr-defined]
     ApiClient,
@@ -8,14 +7,13 @@ from kubernetes.client import (  # type: ignore[attr-defined]
 )
 from pydantic import BaseModel
 
-from reconcile.utils.jobcontroller.controller import K8sJobController
 from reconcile.utils.jobcontroller.models import K8sJob
-from reconcile.utils.oc import OCCli
 
 
 class SomeJob(K8sJob, BaseModel):
     identifying_attribute: str
     backoff_limit: int = 0
+    credentials: Optional[dict[str, str]] = None
 
     def name_prefix(self) -> str:
         return "some-job"
@@ -30,9 +28,13 @@ class SomeJob(K8sJob, BaseModel):
             template=V1PodTemplateSpec(),
         )
 
+    def secret_data(self) -> dict[str, str]:
+        return self.credentials or {}
+
 
 class SomeJobV2(K8sJob, BaseModel):
     identifying_attribute: str
+    credentials: Optional[dict[str, str]] = None
 
     def name_prefix(self) -> str:
         return "some-job"
@@ -65,34 +67,3 @@ def build_job_resource(
     if status:
         job_resource["status"] = status
     return job_resource
-
-
-def build_oc_fixture(job_specs: Optional[list[list[dict[str, Any]]]] = None) -> OCCli:
-    mocked_oc_client = create_autospec(OCCli)
-    mocked_oc_client.get_items.side_effect = job_specs or [[]]
-    return mocked_oc_client
-
-
-def build_job_controller_fixture(oc: OCCli, dry_run: bool) -> K8sJobController:
-    return K8sJobController(
-        oc=oc,
-        cluster="some-cluster",
-        namespace="some-ns",
-        integration="some-integration",
-        integration_version="0.1",
-        dry_run=dry_run,
-        time_module=TimeMock(),
-    )
-
-
-class TimeMock:
-    def __init__(self) -> None:
-        self.current_time = 0.0
-
-    def time(self) -> float:
-        return self.current_time
-
-    def sleep(self, seconds: float) -> None:
-        if seconds < 0:
-            raise ValueError("Negative value for sleep seconds not allowed")
-        self.current_time += seconds

--- a/reconcile/test/utils/jobcontroller/test_controller.py
+++ b/reconcile/test/utils/jobcontroller/test_controller.py
@@ -3,13 +3,13 @@ from unittest.mock import patch
 
 import pytest
 
+from reconcile.test.utils.jobcontroller.conftest import OCItemSetter
 from reconcile.test.utils.jobcontroller.fixtures import (
     SomeJob,
-    build_job_controller_fixture,
     build_job_resource,
     build_job_status,
-    build_oc_fixture,
 )
+from reconcile.utils.jobcontroller.controller import K8sJobController
 from reconcile.utils.jobcontroller.models import JobConcurrencyPolicy, JobStatus
 
 #
@@ -17,14 +17,8 @@ from reconcile.utils.jobcontroller.models import JobConcurrencyPolicy, JobStatus
 #
 
 
-def test_controller_enqueue_new_job() -> None:
-    job = SomeJob(identifying_attribute="some-id", description="some-description")
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture(
-            [[]],
-        ),
-        dry_run=False,
-    )
+def test_controller_enqueue_new_job(controller: K8sJobController) -> None:
+    job = SomeJob(identifying_attribute="some-id")
     assert controller.enqueue_job(job)
 
 
@@ -47,16 +41,13 @@ def test_controller_enqueue_job_in_progress_job_exists(
     concurrency_policy: JobConcurrencyPolicy,
     delete_expected: bool,
     create_expected: bool,
+    controller: K8sJobController,
+    set_oc_get_items_side_effect: OCItemSetter,
 ) -> None:
-    job = SomeJob(identifying_attribute="some-id", description="some-description")
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture(
-            [
-                [build_job_resource(job, build_job_status(active=1))],
-            ],
-        ),
-        dry_run=False,
-    )
+    job = SomeJob(identifying_attribute="some-id")
+    set_oc_get_items_side_effect([
+        [build_job_resource(job, build_job_status(active=1))],
+    ])
     with patch.object(controller, "delete_job") as mock_delete_job:
         assert create_expected == controller.enqueue_job(
             job=job, concurrency_policy=concurrency_policy
@@ -83,16 +74,13 @@ def test_controller_enqueue_job_finished_job_exists(
     concurrency_policy: JobConcurrencyPolicy,
     delete_expected: bool,
     create_expected: bool,
+    controller: K8sJobController,
+    set_oc_get_items_side_effect: OCItemSetter,
 ) -> None:
     job = SomeJob(identifying_attribute="some-id", description="some-description")
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture(
-            [
-                [build_job_resource(job, build_job_status(succeeded=1))],
-            ],
-        ),
-        dry_run=False,
-    )
+    set_oc_get_items_side_effect([
+        [build_job_resource(job, build_job_status(succeeded=1))],
+    ])
     with patch.object(controller, "delete_job") as mock_delete_job:
         assert create_expected == controller.enqueue_job(
             job=job, concurrency_policy=concurrency_policy
@@ -119,16 +107,13 @@ def test_controller_enqueue_job_failed_job_exists(
     concurrency_policy: JobConcurrencyPolicy,
     delete_expected: bool,
     create_expected: bool,
+    controller: K8sJobController,
+    set_oc_get_items_side_effect: OCItemSetter,
 ) -> None:
     job = SomeJob(identifying_attribute="some-id", description="some-description")
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture(
-            [
-                [build_job_resource(job, build_job_status(failed=1))],
-            ],
-        ),
-        dry_run=False,
-    )
+    set_oc_get_items_side_effect([
+        [build_job_resource(job, build_job_status(failed=1))],
+    ])
     with patch.object(controller, "delete_job") as mock_delete_job:
         assert create_expected == controller.enqueue_job(
             job=job, concurrency_policy=concurrency_policy
@@ -150,20 +135,18 @@ def test_controller_enqueue_job_failed_job_exists(
     ],
 )
 def test_controller_wait_for_completion(
-    status: dict[str, Any], timeout: int, expected: bool
+    status: dict[str, Any],
+    timeout: int,
+    expected: bool,
+    controller: K8sJobController,
+    set_oc_get_items_side_effect: OCItemSetter,
 ) -> None:
     job = SomeJob(identifying_attribute="some-id", description="some-description")
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture(
-            [
-                [build_job_resource(job, build_job_status(active=1))],  # 0 seconds
-                [build_job_resource(job, build_job_status(active=1))],  # 5 seconds
-                [build_job_resource(job, status)],  # 10 seconds
-            ],
-        ),
-        dry_run=False,
-    )
-
+    set_oc_get_items_side_effect([
+        [build_job_resource(job, build_job_status(active=1))],  # 0 seconds
+        [build_job_resource(job, build_job_status(active=1))],  # 5 seconds
+        [build_job_resource(job, status)],  # 10 seconds
+    ])
     assert (
         controller.wait_for_job_completion(
             job.name(), check_interval_seconds=5, timeout_seconds=timeout
@@ -173,16 +156,13 @@ def test_controller_wait_for_completion(
     assert controller.time_module.time() == 10
 
 
-def test_controller_wait_for_completion_instant() -> None:
+def test_controller_wait_for_completion_instant(
+    controller: K8sJobController, set_oc_get_items_side_effect: OCItemSetter
+) -> None:
     job = SomeJob(identifying_attribute="some-id", description="some-description")
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture(
-            [
-                [build_job_resource(job, build_job_status(succeeded=1))],  # 0 seconds
-            ],
-        ),
-        dry_run=False,
-    )
+    set_oc_get_items_side_effect([
+        [build_job_resource(job, build_job_status(succeeded=1))],  # 0 seconds
+    ])
 
     assert controller.wait_for_job_completion(
         job.name(), check_interval_seconds=5, timeout_seconds=0
@@ -190,18 +170,15 @@ def test_controller_wait_for_completion_instant() -> None:
     assert controller.time_module.time() == 0
 
 
-def test_controller_wait_for_completion_timeout() -> None:
+def test_controller_wait_for_completion_timeout(
+    controller: K8sJobController, set_oc_get_items_side_effect: OCItemSetter
+) -> None:
     job = SomeJob(identifying_attribute="some-id", description="some-description")
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture(
-            [
-                [build_job_resource(job, build_job_status(active=1))],  # 0 seconds
-                [build_job_resource(job, build_job_status(active=1))],  # 5 seconds
-                [build_job_resource(job, build_job_status(active=1))],  # 10 seconds
-            ],
-        ),
-        dry_run=False,
-    )
+    set_oc_get_items_side_effect([
+        [build_job_resource(job, build_job_status(active=1))],  # 0 seconds
+        [build_job_resource(job, build_job_status(active=1))],  # 5 seconds
+        [build_job_resource(job, build_job_status(active=1))],  # 10 seconds
+    ])
 
     with pytest.raises(TimeoutError):
         controller.wait_for_job_completion(
@@ -214,26 +191,23 @@ def test_controller_wait_for_completion_timeout() -> None:
 #
 
 
-def test_controller_wait_for_job_list_completion() -> None:
+def test_controller_wait_for_job_list_completion(
+    controller: K8sJobController, set_oc_get_items_side_effect: OCItemSetter
+) -> None:
     job1 = SomeJob(identifying_attribute="some-id-1", description="some-description")
     job2 = SomeJob(identifying_attribute="some-id-2", description="some-description")
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture(
-            [
-                # 0 seconds
-                [
-                    build_job_resource(job1, build_job_status(active=1)),
-                    build_job_resource(job2, build_job_status(active=1)),
-                ],
-                # 5 seconds
-                [
-                    build_job_resource(job1, build_job_status(succeeded=1)),
-                    build_job_resource(job2, build_job_status(succeeded=1)),
-                ],
-            ],
-        ),
-        dry_run=False,
-    )
+    set_oc_get_items_side_effect([
+        # 0 seconds
+        [
+            build_job_resource(job1, build_job_status(active=1)),
+            build_job_resource(job2, build_job_status(active=1)),
+        ],
+        # 5 seconds
+        [
+            build_job_resource(job1, build_job_status(succeeded=1)),
+            build_job_resource(job2, build_job_status(succeeded=1)),
+        ],
+    ])
 
     expected = {
         job1.name(): JobStatus.SUCCESS,
@@ -247,31 +221,28 @@ def test_controller_wait_for_job_list_completion() -> None:
     assert controller.time_module.time() == 5
 
 
-def test_controller_wait_for_job_list_completion_partial() -> None:
+def test_controller_wait_for_job_list_completion_partial(
+    controller: K8sJobController, set_oc_get_items_side_effect: OCItemSetter
+) -> None:
     job1 = SomeJob(identifying_attribute="some-id-1", description="some-description")
     job2 = SomeJob(identifying_attribute="some-id-2", description="some-description")
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture(
-            [
-                # 0 seconds
-                [
-                    build_job_resource(job1, build_job_status(active=1)),
-                    build_job_resource(job2, build_job_status(active=1)),
-                ],
-                # 5 seconds
-                [
-                    build_job_resource(job1, build_job_status(succeeded=1)),
-                    build_job_resource(job2, build_job_status(active=1)),
-                ],
-                # 10 seconds - we don't reach this before the timeout
-                [
-                    build_job_resource(job1, build_job_status(succeeded=1)),
-                    build_job_resource(job2, build_job_status(succeeded=1)),
-                ],
-            ],
-        ),
-        dry_run=False,
-    )
+    set_oc_get_items_side_effect([
+        # 0 seconds
+        [
+            build_job_resource(job1, build_job_status(active=1)),
+            build_job_resource(job2, build_job_status(active=1)),
+        ],
+        # 5 seconds
+        [
+            build_job_resource(job1, build_job_status(succeeded=1)),
+            build_job_resource(job2, build_job_status(active=1)),
+        ],
+        # 10 seconds - we don't reach this before the timeout
+        [
+            build_job_resource(job1, build_job_status(succeeded=1)),
+            build_job_resource(job2, build_job_status(succeeded=1)),
+        ],
+    ])
 
     expected = {
         job1.name(): JobStatus.SUCCESS,
@@ -286,25 +257,24 @@ def test_controller_wait_for_job_list_completion_partial() -> None:
     assert controller.time_module.time() == 5
 
 
-def test_controller_wait_for_job_list_completion_no_timeout() -> None:
+def test_controller_wait_for_job_list_completion_no_timeout(
+    controller: K8sJobController, set_oc_get_items_side_effect: OCItemSetter
+) -> None:
     job1 = SomeJob(identifying_attribute="some-id-1", description="some-description")
     job2 = SomeJob(identifying_attribute="some-id-2", description="some-description")
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture(
+    set_oc_get_items_side_effect(
+        [
+            # 0 seconds
             [
-                # 0 seconds
-                [
-                    build_job_resource(job1, build_job_status(active=1)),
-                    build_job_resource(job2, build_job_status(active=1)),
-                ],
-                # 5 seconds
-                [
-                    build_job_resource(job1, build_job_status(succeeded=1)),
-                    build_job_resource(job2, build_job_status(succeeded=1)),
-                ],
+                build_job_resource(job1, build_job_status(active=1)),
+                build_job_resource(job2, build_job_status(active=1)),
             ],
-        ),
-        dry_run=False,
+            # 5 seconds
+            [
+                build_job_resource(job1, build_job_status(succeeded=1)),
+                build_job_resource(job2, build_job_status(succeeded=1)),
+            ],
+        ],
     )
 
     expected = {
@@ -320,21 +290,60 @@ def test_controller_wait_for_job_list_completion_no_timeout() -> None:
 
 
 #
+# build secret
+#
+
+
+def test_build_secret(controller: K8sJobController) -> None:
+    job = SomeJob(identifying_attribute="some-id", credentials={"super": "secret"})
+    job_secret = controller.build_secret(job)
+    assert job_secret
+    assert job_secret.kind == "Secret"
+    assert job_secret.metadata and job_secret.metadata.name == job.name()
+    assert job_secret.string_data == job.secret_data()
+
+
+#
+# create job
+#
+
+
+@pytest.mark.parametrize(
+    "job, expected_applied_kinds",
+    [
+        (
+            SomeJob(identifying_attribute="some-id", credentials={"super": "secret"}),
+            ["Job", "Secret"],
+        ),
+        (
+            SomeJob(identifying_attribute="some-id"),
+            ["Job"],
+        ),
+    ],
+)
+def test_create_job(
+    job: SomeJob, expected_applied_kinds: list[str], controller: K8sJobController
+) -> None:
+    controller.create_job(job)
+
+    applied_kinds = [
+        call.kwargs["resource"].kind for call in controller.oc.apply.call_args_list
+    ]
+    assert applied_kinds == expected_applied_kinds
+
+
+#
 # get job generation annotation
 #
 
 
-def test_get_job_generation() -> None:
+def test_get_job_generation(
+    controller: K8sJobController, set_oc_get_items_side_effect: OCItemSetter
+) -> None:
     job = SomeJob(identifying_attribute="some-id", description="some-description")
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture(
-            [
-                [build_job_resource(job, build_job_status(active=1))],
-            ],
-        ),
-        dry_run=False,
-    )
-
+    set_oc_get_items_side_effect([
+        [build_job_resource(job, build_job_status(active=1))],
+    ])
     assert controller.get_job_generation(job.name())
 
 
@@ -351,7 +360,10 @@ def test_get_job_generation() -> None:
     ],
 )
 def test_get_job_status_backoff_limit(
-    backoff_limit: int, expected_job_status: JobStatus
+    backoff_limit: int,
+    expected_job_status: JobStatus,
+    controller: K8sJobController,
+    set_oc_get_items_side_effect: OCItemSetter,
 ) -> None:
     """
     Verify that backoff_limit is honored when determining the job status.
@@ -359,27 +371,19 @@ def test_get_job_status_backoff_limit(
     not exceeded yet.
     """
     job = SomeJob(identifying_attribute="some-id", backoff_limit=backoff_limit)
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture(
-            [[build_job_resource(job, build_job_status(failed=1))]],
-        ),
-        dry_run=False,
-    )
+    set_oc_get_items_side_effect([
+        [build_job_resource(job, build_job_status(failed=1))]
+    ])
     assert controller.get_job_status(job_name=job.name()) == expected_job_status
 
 
-def test_get_job_status_not_exists() -> None:
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture(),
-        dry_run=False,
-    )
+def test_get_job_status_not_exists(controller: K8sJobController) -> None:
     assert controller.get_job_status(job_name="foo bar") == JobStatus.NOT_EXISTS
 
 
-def test_get_job_status_no_job_resource_status() -> None:
+def test_get_job_status_no_job_resource_status(
+    controller: K8sJobController, set_oc_get_items_side_effect: OCItemSetter
+) -> None:
     job = SomeJob(identifying_attribute="some-id")
-    controller = build_job_controller_fixture(
-        oc=build_oc_fixture([[build_job_resource(job)]]),
-        dry_run=False,
-    )
+    set_oc_get_items_side_effect([[build_job_resource(job)]])
     assert controller.get_job_status(job_name=job.name()) == JobStatus.IN_PROGRESS

--- a/reconcile/utils/jobcontroller/controller.py
+++ b/reconcile/utils/jobcontroller/controller.py
@@ -2,7 +2,13 @@ import logging
 import time
 from typing import Optional, Protocol
 
-from kubernetes.client import ApiClient, V1Job  # type: ignore[attr-defined]
+from kubernetes.client import (  # type: ignore[attr-defined]
+    ApiClient,
+    V1Job,
+    V1ObjectMeta,
+    V1OwnerReference,
+    V1Secret,
+)
 
 from reconcile.typed_queries.clusters_minimal import get_clusters_minimal
 from reconcile.utils.jobcontroller.models import (
@@ -242,6 +248,41 @@ class K8sJobController:
             return True
         return False
 
+    def _lookup_job_uid(self, job_name: str) -> Optional[str]:
+        job_resource = self.oc.get(
+            self.namespace, "Job", job_name, allow_not_found=True
+        )
+        if not job_resource:
+            return None
+        return job_resource.get("metadata", {}).get("uid")
+
+    def build_secret(self, job: K8sJob) -> Optional[V1Secret]:
+        secret_data = job.secret_data()
+        if not secret_data:
+            return None
+        job_name = job.name()
+        job_uid = self._lookup_job_uid(job_name)
+        if not job_uid:
+            raise Exception(f"Failed to lookup job uid for {job_name}")
+        return V1Secret(
+            api_version="v1",
+            kind="Secret",
+            metadata=V1ObjectMeta(
+                name=job_name,
+                annotations=job.annotations(),
+                labels=job.labels(),
+                owner_references=[
+                    V1OwnerReference(
+                        api_version="batch/v1",
+                        kind="Job",
+                        name=job_name,
+                        uid=job_uid,
+                    )
+                ],
+            ),
+            string_data=secret_data,
+        )
+
     def create_job(self, job: K8sJob) -> None:
         """
         Creates the K8S job on the cluster and namespace.
@@ -249,12 +290,27 @@ class K8sJobController:
         job_spec = job.build_job()
         self.validate_job(job_spec)
         api = ApiClient()
-        res = OpenshiftResource(
-            api.sanitize_for_serialization(job.build_job()),
-            self.integration,
-            self.integration_version,
+        self.oc.apply(
+            namespace=self.namespace,
+            resource=OpenshiftResource(
+                api.sanitize_for_serialization(job.build_job()),
+                self.integration,
+                self.integration_version,
+            ).annotate(),
         )
-        self.oc.apply(self.namespace, res.annotate())
+
+        # if the job defines secret data, we need to create the secret
+        # with proper owner reference
+        job_secret = self.build_secret(job)
+        if job_secret:
+            self.oc.apply(
+                namespace=self.namespace,
+                resource=OpenshiftResource(
+                    api.sanitize_for_serialization(job_secret),
+                    self.integration,
+                    self.integration_version,
+                ).annotate(),
+            )
 
     def validate_job(self, job: V1Job) -> None:
         if not job.spec:

--- a/reconcile/utils/jobcontroller/models.py
+++ b/reconcile/utils/jobcontroller/models.py
@@ -118,3 +118,10 @@ class K8sJob(ABC):
         hash_object = hashlib.sha256(job_spec_source_code.encode())
         hash = hash_object.hexdigest()
         return hash[:length]
+
+    def secret_data(self) -> dict[str, str]:
+        """
+        If a job relies on some secret data, it should return it here. The
+        job controller will manage the lifecycle of a kubernetes Secret.
+        """
+        return {}


### PR DESCRIPTION
the `K8sJob` class can define secret data it relies on and the job controller will manage the lifecycle of a kubernetes Secret based on that data.

```python

class MyJob(K8sJob):

   ...

   def secret_data(self) -> dict[str: str]:
     return {
       "super": "secret"
     }

```

the resulting secret has an `ownerReference` towards the job, which implies that the secret gets cleaned up when the job gets cleaned up.
