### PR TITLE
Add validation cli

### DIFF
--- a/reconcile/templating/rendering.py
+++ b/reconcile/templating/rendering.py
@@ -7,6 +7,7 @@ from ruamel import yaml
 
 from reconcile.utils.jinja2.utils import Jinja2TemplateError, process_jinja2_template
 from reconcile.utils.jsonpath import parse_jsonpath
+from reconcile.utils.ruamel import create_ruamel_instance
 from reconcile.utils.secret_reader import SecretReaderBase
 
 
@@ -40,7 +41,7 @@ class Renderer(ABC):
         self,
         template: Template,
         data: TemplateData,
-        secret_reader: SecretReaderBase,
+        secret_reader: Optional[SecretReaderBase] = None,
     ):
         self.template = template
         self.data = data
@@ -108,7 +109,9 @@ class PatchRenderer(Renderer):
             )
         matched_value = matched_values[0]
 
-        data_to_add = yaml.safe_load(self._render_template(self.template.template))
+        data_to_add = create_ruamel_instance().load(
+            self._render_template(self.template.template)
+        )
 
         if isinstance(matched_value, list):
             if not self.template.patch.identifier:
@@ -142,7 +145,7 @@ class PatchRenderer(Renderer):
 def create_renderer(
     template: Template,
     data: TemplateData,
-    secret_reader: SecretReaderBase,
+    secret_reader: Optional[SecretReaderBase] = None,
 ) -> Renderer:
     if template.patch:
         return PatchRenderer(template=template, data=data, secret_reader=secret_reader)

--- a/reconcile/templating/rendering.py
+++ b/reconcile/templating/rendering.py
@@ -4,7 +4,6 @@ from io import StringIO
 from typing import Any, Optional, Protocol
 
 from pydantic import BaseModel
-from ruamel import yaml
 
 from reconcile.utils.jinja2.utils import Jinja2TemplateError, process_jinja2_template
 from reconcile.utils.jsonpath import parse_jsonpath
@@ -111,7 +110,9 @@ class PatchRenderer(Renderer):
             )
         matched_value = matched_values[0]
 
-        data_to_add = self.ruaml_instace.load(self._render_template(self.template.template))
+        data_to_add = self.ruaml_instace.load(
+            self._render_template(self.template.template)
+        )
 
         if isinstance(matched_value, list):
             if not self.template.patch.identifier:

--- a/reconcile/templating/validator.py
+++ b/reconcile/templating/validator.py
@@ -42,7 +42,9 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
 
     @staticmethod
     def _create_renderer(
-        template: TemplateV1, template_test: TemplateTestV1, secret_reader: SecretReaderBase
+        template: TemplateV1,
+        template_test: TemplateTestV1,
+        secret_reader: SecretReaderBase,
     ) -> Renderer:
         return create_renderer(
             template,
@@ -57,11 +59,15 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
 
     @staticmethod
     def validate_template(
-        template: TemplateV1, template_test: TemplateTestV1, secret_reader: SecretReaderBase
+        template: TemplateV1,
+        template_test: TemplateTestV1,
+        secret_reader: SecretReaderBase,
     ) -> list[TemplateDiff]:
         diffs: list[TemplateDiff] = []
 
-        r = TemplateValidatorIntegration._create_renderer(template, template_test, secret_reader=secret_reader)
+        r = TemplateValidatorIntegration._create_renderer(
+            template, template_test, secret_reader=secret_reader
+        )
 
         # Check target path
         if template_test.expected_target_path:

--- a/reconcile/templating/validator.py
+++ b/reconcile/templating/validator.py
@@ -2,15 +2,20 @@ import logging
 from difflib import context_diff
 from typing import Callable, Optional
 
+from build.lib.reconcile.templating.rendering import Renderer
 from pydantic import BaseModel
 from ruamel import yaml
 
-from reconcile.gql_definitions.templating.templates import TemplateV1, query
+from reconcile.gql_definitions.templating.templates import (
+    TemplateTestV1,
+    TemplateV1,
+    query,
+)
 from reconcile.templating.rendering import TemplateData, create_renderer
 from reconcile.utils import gql
 from reconcile.utils.runtime.integration import (
+    PydanticRunParams,
     QontractReconcileIntegration,
-    RunParamsTypeVar,
 )
 
 QONTRACT_INTEGRATION = "template-validator"
@@ -31,70 +36,91 @@ class TemplateDiff(BaseModel):
 
 
 class TemplateValidatorIntegration(QontractReconcileIntegration):
-    def __init__(self, params: RunParamsTypeVar) -> None:
+    def __init__(self, params: PydanticRunParams) -> None:
         super().__init__(params)
-        self.diffs: list[TemplateDiff] = []
 
-    def diff_result(
-        self, template_name: str, test_name: str, output: str, expected: str
-    ) -> None:
-        diff = list(
-            context_diff(
-                output.splitlines(keepends=True), expected.splitlines(keepends=True)
-            )
+    @staticmethod
+    def _create_renderer(
+        template: TemplateV1, template_test: TemplateTestV1
+    ) -> Renderer:
+        return create_renderer(
+            template,
+            TemplateData(
+                variables=template_test.variables or {},
+                current=yaml.load(
+                    template_test.current or "", Loader=yaml.RoundTripLoader
+                ),
+            ),
         )
-        if diff:
-            self.diffs.append(
-                TemplateDiff(template=template_name, test=test_name, diff="".join(diff))
+
+    @staticmethod
+    def validate_template(
+        template: TemplateV1, template_test: TemplateTestV1
+    ) -> list[TemplateDiff]:
+        diffs: list[TemplateDiff] = []
+
+        r = TemplateValidatorIntegration._create_renderer(template, template_test)
+
+        # Check target path
+        if template_test.expected_target_path:
+            rendered_target_path = r.render_target_path().strip()
+            if rendered_target_path != template_test.expected_target_path.strip():
+                diffs.append(
+                    TemplateDiff(
+                        template=template.name,
+                        test=template_test.name,
+                        diff=f"Target path mismatch, got: {rendered_target_path}, expected: {template_test.expected_target_path}",
+                    )
+                )
+
+        # Check condition
+        should_render = r.render_condition()
+        if (
+            template_test.expected_to_render is not None
+            and template_test.expected_to_render != should_render
+        ):
+            diffs.append(
+                TemplateDiff(
+                    template=template.name,
+                    test=template_test.name,
+                    diff=f"Condition mismatch, got: {should_render}, expected: {template_test.expected_to_render}",
+                )
             )
+
+        # Check template output
+        if should_render:
+            output = r.render_output()
+            diff = list(
+                context_diff(
+                    output.splitlines(keepends=True),
+                    template_test.expected_output.splitlines(keepends=True),
+                )
+            )
+            if diff:
+                diffs.append(
+                    TemplateDiff(
+                        template=template.name,
+                        test=template_test.name,
+                        diff="".join(diff),
+                    )
+                )
+
+        return diffs
 
     def run(self, dry_run: bool) -> None:
+        diffs: list[TemplateDiff] = []
+
         for template in get_templates():
             for test in template.template_test:
                 logging.info(f"Running test {test.name} for template {template.name}")
-                r = create_renderer(
-                    template,
-                    TemplateData(
-                        variables=test.variables or {},
-                        current=yaml.load(
-                            test.current or "", Loader=yaml.RoundTripLoader
-                        ),
-                    ),
-                    secret_reader=self.secret_reader,
-                )
-                if test.expected_target_path:
-                    self.diff_result(
-                        template.name,
-                        test.name,
-                        r.render_target_path().strip(),
-                        test.expected_target_path.strip(),
-                    )
-                should_render = r.render_condition()
-                if (
-                    test.expected_to_render is not None
-                    and test.expected_to_render != should_render
-                ):
-                    self.diffs.append(
-                        TemplateDiff(
-                            template=template.name,
-                            test=test.name,
-                            diff=f"Condition mismatch, got: {should_render}, expected: {test.expected_to_render}",
-                        )
-                    )
-                if should_render:
-                    self.diff_result(
-                        template.name,
-                        test.name,
-                        r.render_output().strip(),
-                        test.expected_output.strip(),
-                    )
+                diffs.extend(self.validate_template(template, test))
 
-        if self.diffs:
-            for diff in self.diffs:
+        if diffs:
+            for diff in diffs:
                 logging.error(
                     f"template: {diff.template}, test: {diff.test}: {diff.diff}"
                 )
-            raise ValueError("Template validation")
+            raise ValueError("Template validation failed")
 
     @property
     def name(self) -> str:

--- a/reconcile/templating/validator.py
+++ b/reconcile/templating/validator.py
@@ -17,6 +17,7 @@ from reconcile.utils.runtime.integration import (
     PydanticRunParams,
     QontractReconcileIntegration,
 )
+from reconcile.utils.secret_reader import SecretReaderBase
 
 QONTRACT_INTEGRATION = "template-validator"
 
@@ -41,7 +42,7 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
 
     @staticmethod
     def _create_renderer(
-        template: TemplateV1, template_test: TemplateTestV1
+        template: TemplateV1, template_test: TemplateTestV1, secret_reader: SecretReaderBase
     ) -> Renderer:
         return create_renderer(
             template,
@@ -51,15 +52,16 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
                     template_test.current or "", Loader=yaml.RoundTripLoader
                 ),
             ),
+            secret_reader=secret_reader,
         )
 
     @staticmethod
     def validate_template(
-        template: TemplateV1, template_test: TemplateTestV1
+        template: TemplateV1, template_test: TemplateTestV1, secret_reader: SecretReaderBase
     ) -> list[TemplateDiff]:
         diffs: list[TemplateDiff] = []
 
-        r = TemplateValidatorIntegration._create_renderer(template, template_test)
+        r = TemplateValidatorIntegration._create_renderer(template, template_test, secret_reader=secret_reader)
 
         # Check target path
         if template_test.expected_target_path:

--- a/reconcile/test/templating/test_validator.py
+++ b/reconcile/test/templating/test_validator.py
@@ -2,13 +2,12 @@ from collections.abc import Callable
 
 import pytest
 
-from reconcile.gql_definitions.templating.template_collection import TemplateV1
-from reconcile.gql_definitions.templating.templates import TemplateTestV1
+from reconcile.gql_definitions.templating.templates import TemplateTestV1, TemplateV1
 from reconcile.templating.validator import TemplateValidatorIntegration
 
 
 @pytest.fixture
-def simple_template(gql_class_factory: Callable):
+def simple_template(gql_class_factory: Callable) -> TemplateV1:
     return gql_class_factory(
         TemplateV1,
         {
@@ -16,12 +15,13 @@ def simple_template(gql_class_factory: Callable):
             "template": "{{foo}}",
             "condition": "{{foo == 'bar'}}",
             "targetPath": "/foo/{{foo}}.yml",
+            "templateTest": [],
         },
     )
 
 
 @pytest.fixture
-def simple_template_test(gql_class_factory: Callable):
+def simple_template_test(gql_class_factory: Callable) -> TemplateTestV1:
     return gql_class_factory(
         TemplateTestV1,
         {
@@ -36,7 +36,7 @@ def simple_template_test(gql_class_factory: Callable):
 
 def test_validate_template(
     simple_template: TemplateV1, simple_template_test: TemplateTestV1
-):
+) -> None:
     assert (
         TemplateValidatorIntegration.validate_template(
             simple_template, simple_template_test
@@ -47,7 +47,7 @@ def test_validate_template(
 
 def test_validate_template_diff(
     simple_template: TemplateV1, simple_template_test: TemplateTestV1
-):
+) -> None:
     simple_template_test.expected_output = "baz"
     diff = TemplateValidatorIntegration.validate_template(
         simple_template, simple_template_test
@@ -61,7 +61,7 @@ def test_validate_template_diff(
 
 def test_validate_output_template(
     simple_template: TemplateV1, simple_template_test: TemplateTestV1
-):
+) -> None:
     assert (
         TemplateValidatorIntegration.validate_template(
             simple_template, simple_template_test
@@ -72,7 +72,7 @@ def test_validate_output_template(
 
 def test_validate_output_condition_diff(
     simple_template: TemplateV1, simple_template_test: TemplateTestV1
-):
+) -> None:
     simple_template.condition = "{{1 == 2}}"
     diff = TemplateValidatorIntegration.validate_template(
         simple_template, simple_template_test
@@ -83,7 +83,7 @@ def test_validate_output_condition_diff(
 
 def test_validate_target_path_diff(
     simple_template: TemplateV1, simple_template_test: TemplateTestV1
-):
+) -> None:
     simple_template.target_path = "/{{foo}}/bar.yml"
     diff = TemplateValidatorIntegration.validate_template(
         simple_template, simple_template_test

--- a/reconcile/test/templating/test_validator.py
+++ b/reconcile/test/templating/test_validator.py
@@ -1,0 +1,95 @@
+from collections.abc import Callable
+
+import pytest
+
+from reconcile.gql_definitions.templating.template_collection import TemplateV1
+from reconcile.gql_definitions.templating.templates import TemplateTestV1
+from reconcile.templating.validator import TemplateValidatorIntegration
+
+
+@pytest.fixture
+def simple_template(gql_class_factory: Callable):
+    return gql_class_factory(
+        TemplateV1,
+        {
+            "name": "valid-template",
+            "template": "{{foo}}",
+            "condition": "{{foo == 'bar'}}",
+            "targetPath": "/foo/{{foo}}.yml",
+        },
+    )
+
+
+@pytest.fixture
+def simple_template_test(gql_class_factory: Callable):
+    return gql_class_factory(
+        TemplateTestV1,
+        {
+            "name": "valid-template",
+            "variables": '{"foo": "bar"}',
+            "expectedOutput": "bar",
+            "expectedToRender": "true",
+            "expectedTargetPath": "/foo/bar.yml",
+        },
+    )
+
+
+def test_validate_template(
+    simple_template: TemplateV1, simple_template_test: TemplateTestV1
+):
+    assert (
+        TemplateValidatorIntegration.validate_template(
+            simple_template, simple_template_test
+        )
+        == []
+    )
+
+
+def test_validate_template_diff(
+    simple_template: TemplateV1, simple_template_test: TemplateTestV1
+):
+    simple_template_test.expected_output = "baz"
+    diff = TemplateValidatorIntegration.validate_template(
+        simple_template, simple_template_test
+    )
+    assert diff
+    assert (
+        diff[0].diff
+        == "*** \n--- \n***************\n*** 1 ****\n! bar--- 1 ----\n! baz"
+    )
+
+
+def test_validate_output_template(
+    simple_template: TemplateV1, simple_template_test: TemplateTestV1
+):
+    assert (
+        TemplateValidatorIntegration.validate_template(
+            simple_template, simple_template_test
+        )
+        == []
+    )
+
+
+def test_validate_output_condition_diff(
+    simple_template: TemplateV1, simple_template_test: TemplateTestV1
+):
+    simple_template.condition = "{{1 == 2}}"
+    diff = TemplateValidatorIntegration.validate_template(
+        simple_template, simple_template_test
+    )
+    assert diff
+    assert diff[0].diff == "Condition mismatch, got: False, expected: True"
+
+
+def test_validate_target_path_diff(
+    simple_template: TemplateV1, simple_template_test: TemplateTestV1
+):
+    simple_template.target_path = "/{{foo}}/bar.yml"
+    diff = TemplateValidatorIntegration.validate_template(
+        simple_template, simple_template_test
+    )
+    assert diff
+    assert (
+        diff[0].diff
+        == "Target path mismatch, got: /bar/bar.yml, expected: /foo/bar.yml"
+    )

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -7,7 +7,6 @@ from sretoolbox.utils import retry
 
 from reconcile.checkpoint import url_makes_sense
 from reconcile.github_users import init_github
-from reconcile.typed_queries.clusters_minimal import get_clusters_minimal
 from reconcile.utils import gql
 from reconcile.utils.jinja2.extensions import B64EncodeExtension, RaiseErrorExtension
 from reconcile.utils.jinja2.filters import (
@@ -20,8 +19,6 @@ from reconcile.utils.jinja2.filters import (
     urlescape,
     urlunescape,
 )
-from reconcile.utils.oc import OCCli
-from reconcile.utils.oc_map import init_oc_map_from_clusters
 from reconcile.utils.secret_reader import SecretNotFound, SecretReader, SecretReaderBase
 
 
@@ -83,24 +80,6 @@ def lookup_github_file_content(
     gh = init_github()
     c = gh.get_repo(repo).get_contents(path, ref).decoded_content
     return c.decode("utf-8")
-
-
-def openshift_namespace_exists(
-    cluster_name: str,
-    namespace: str,
-    secret_reader: Optional[SecretReaderBase],
-) -> bool:
-    if not secret_reader:
-        return False
-    clusters = get_clusters_minimal(name=cluster_name)
-    oc_map = init_oc_map_from_clusters(clusters, secret_reader)
-    oc = oc_map.get(cluster_name)
-    if isinstance(oc, OCCli):
-        namespace_object = oc.get(
-            "default", "Namespace", name=namespace, allow_not_found=True
-        )
-        return namespace_object.get("status", {}).get("phase", "") == "Active"
-    return False
 
 
 def lookup_graphql_query_results(query: str, **kwargs: dict[str, Any]) -> list[Any]:
@@ -177,9 +156,6 @@ def process_jinja2_template(
         "hash_list": hash_list,
         "query": lookup_graphql_query_results,
         "url": url_makes_sense,
-        "openshift_namespace_exists": lambda c, n: openshift_namespace_exists(
-            cluster_name=c, namespace=n, secret_reader=secret_reader
-        ),
     })
     if "_template_mocks" in vars:
         for k, v in vars["_template_mocks"].items():

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -7,6 +7,7 @@ from sretoolbox.utils import retry
 
 from reconcile.checkpoint import url_makes_sense
 from reconcile.github_users import init_github
+from reconcile.typed_queries.clusters_minimal import get_clusters_minimal
 from reconcile.utils import gql
 from reconcile.utils.jinja2.extensions import B64EncodeExtension, RaiseErrorExtension
 from reconcile.utils.jinja2.filters import (
@@ -19,6 +20,7 @@ from reconcile.utils.jinja2.filters import (
     urlescape,
     urlunescape,
 )
+from reconcile.utils.oc_map import init_oc_map_from_clusters
 from reconcile.utils.secret_reader import SecretNotFound, SecretReader, SecretReaderBase
 
 
@@ -80,6 +82,22 @@ def lookup_github_file_content(
     gh = init_github()
     c = gh.get_repo(repo).get_contents(path, ref).decoded_content
     return c.decode("utf-8")
+
+
+def openshift_namespace_exists(
+    cluster_name: str,
+    namespace: str,
+    secret_reader: SecretReaderBase,
+):
+    clusters = get_clusters_minimal(name=cluster_name)
+    oc_map = init_oc_map_from_clusters(clusters, secret_reader)
+    namespace = oc_map.get(cluster_name).get(
+        "default", "Namespace", name=namespace, allow_not_found=True
+    )
+    return (
+        namespace is not None
+        and namespace.get("status", {}).get("phase", "") == "Active"
+    )
 
 
 def lookup_graphql_query_results(query: str, **kwargs: dict[str, Any]) -> list[Any]:
@@ -156,6 +174,13 @@ def process_jinja2_template(
         "hash_list": hash_list,
         "query": lookup_graphql_query_results,
         "url": url_makes_sense,
+        "openshift_namespace_exists": lambda c, n: vars.get("mock", {}).get(
+            "openshift_namespace_exists", None
+        )
+        if vars.get("mock", {})
+        else openshift_namespace_exists(
+            cluster_name=c, namespace=n, secret_reader=secret_reader
+        ),
     })
     if "_template_mocks" in vars:
         for k, v in vars["_template_mocks"].items():

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -20,6 +20,7 @@ from reconcile.utils.jinja2.filters import (
     urlescape,
     urlunescape,
 )
+from reconcile.utils.oc import OCCli
 from reconcile.utils.oc_map import init_oc_map_from_clusters
 from reconcile.utils.secret_reader import SecretNotFound, SecretReader, SecretReaderBase
 
@@ -87,17 +88,19 @@ def lookup_github_file_content(
 def openshift_namespace_exists(
     cluster_name: str,
     namespace: str,
-    secret_reader: SecretReaderBase,
-):
+    secret_reader: Optional[SecretReaderBase],
+) -> bool:
+    if not secret_reader:
+        return False
     clusters = get_clusters_minimal(name=cluster_name)
     oc_map = init_oc_map_from_clusters(clusters, secret_reader)
-    namespace = oc_map.get(cluster_name).get(
-        "default", "Namespace", name=namespace, allow_not_found=True
-    )
-    return (
-        namespace is not None
-        and namespace.get("status", {}).get("phase", "") == "Active"
-    )
+    oc = oc_map.get(cluster_name)
+    if isinstance(oc, OCCli):
+        namespace_object = oc.get(
+            "default", "Namespace", name=namespace, allow_not_found=True
+        )
+        return namespace_object.get("status", {}).get("phase", "") == "Active"
+    return False
 
 
 def lookup_graphql_query_results(query: str, **kwargs: dict[str, Any]) -> list[Any]:
@@ -174,11 +177,7 @@ def process_jinja2_template(
         "hash_list": hash_list,
         "query": lookup_graphql_query_results,
         "url": url_makes_sense,
-        "openshift_namespace_exists": lambda c, n: vars.get("mock", {}).get(
-            "openshift_namespace_exists", None
-        )
-        if vars.get("mock", {})
-        else openshift_namespace_exists(
+        "openshift_namespace_exists": lambda c, n: openshift_namespace_exists(
             cluster_name=c, namespace=n, secret_reader=secret_reader
         ),
     })

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,6 @@ setup(
         "jsonpatch~=1.33",
         "jsonpointer~=2.4",
         "yamllint==1.34.0",
-        "qontract-validator==0.1.0",
     ],
     test_suite="tests",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,8 @@ setup(
         "dt==1.1.61",
         "jsonpatch~=1.33",
         "jsonpointer~=2.4",
+        "yamllint==1.34.0",
+        "qontract-validator==0.1.0",
     ],
     test_suite="tests",
     classifiers=[
@@ -85,6 +87,7 @@ setup(
             "app-interface-metrics-exporter = tools.app_interface_metrics_exporter:main",
             "glitchtip-access-reporter = tools.glitchtip_access_reporter:main",
             "glitchtip-access-revalidation = tools.glitchtip_access_revalidation:main",
+            "template-validation = tools.template_validation:main",
             "qontract-cli = tools.qontract_cli:root",
         ],
     },

--- a/tools/template_validation.py
+++ b/tools/template_validation.py
@@ -4,15 +4,13 @@ import sys
 from pprint import pprint
 
 import click
-
-from yamllint import linter
-from yamllint.config import YamlLintConfig
+from yamllint import linter  # type: ignore
+from yamllint.config import YamlLintConfig  # type: ignore
 
 from reconcile.gql_definitions.templating.templates import TemplateV1
 from reconcile.templating.validator import TemplateDiff, TemplateValidatorIntegration
 from reconcile.utils.models import data_default_none
 from reconcile.utils.ruamel import create_ruamel_instance
-
 
 
 def load_clean_yaml(ai_path: str, path: str) -> dict:
@@ -91,11 +89,9 @@ def main(ai_path: str, template_path: str) -> None:
     for test in template.template_test:
         diffs: list[TemplateDiff] = []
         print("Running tests:", test.name)
-        diffs.extend(
-            TemplateValidatorIntegration.validate_template(template, test, None)
-        )
+        diffs.extend(TemplateValidatorIntegration.validate_template(template, test))
 
-        renderer = TemplateValidatorIntegration._create_renderer(template, test, None)
+        renderer = TemplateValidatorIntegration._create_renderer(template, test)
         if renderer.render_condition():
             output = renderer.render_output()
             lint_problems = list(

--- a/tools/template_validation.py
+++ b/tools/template_validation.py
@@ -108,9 +108,9 @@ def main(ai_path: str, template_path: str, run_validator: bool) -> None:
 
     templates_to_validate = {}
     for test in template.template_test:
-        diffs.extend(TemplateValidatorIntegration.validate_template(template, test))
+        diffs.extend(TemplateValidatorIntegration.validate_template(template, test, None))
 
-        renderer = TemplateValidatorIntegration._create_renderer(template, test)
+        renderer = TemplateValidatorIntegration._create_renderer(template, test, None)
         if renderer.render_condition():
             output = renderer.render_output()
             path = renderer.render_target_path()

--- a/tools/template_validation.py
+++ b/tools/template_validation.py
@@ -1,0 +1,137 @@
+import json
+import os.path
+from pprint import pprint
+
+import click
+from ruamel import yaml
+from validator.bundle import load_bundle
+from validator.validator import validate_bundle
+from yamllint import linter
+from yamllint.config import YamlLintConfig
+
+from reconcile.gql_definitions.templating.templates import TemplateV1
+from reconcile.templating.validator import TemplateDiff, TemplateValidatorIntegration
+from reconcile.utils.models import data_default_none
+from reconcile.utils.ruamel import create_ruamel_instance
+
+
+def validate_template(bundle_file: str, templates: dict[str, str]) -> list[dict]:
+    with open(bundle_file, "r", encoding="utf-8") as b:
+        bundle = load_bundle(b)
+
+    for target_path, template_data in list(templates.items()):
+        bundle.data[target_path] = yaml.safe_load(template_data)
+
+    results = validate_bundle(bundle)
+    return [
+        result["result"] for result in results if result["result"]["status"] == "ERROR"
+    ]
+
+
+def load_clean_yaml(ai_path: str, path: str) -> dict:
+    if not path.startswith("/data/"):
+        to_load = os.path.join(ai_path, "data", path.lstrip("/"))
+    else:
+        to_load = os.path.join(ai_path, path.lstrip("/"))
+
+    y = load_yaml(to_load)
+
+    if "$schema" in y:
+        del y["$schema"]
+    return y
+
+
+def load_yaml(to_load: str) -> dict:
+    ruamel_instance = create_ruamel_instance()
+    with open(to_load, "r", encoding="utf-8") as file:
+        return ruamel_instance.load(file)
+
+
+def print_validation_errors(errors: list[dict]) -> None:
+    print("--------- VALIDATION ERRORS ---------")
+    print(f"Found {len(errors)} errors during validation:")
+    for error in errors:
+        pprint(error)
+    print("--------- END VALIDATION ERRORS ---------")
+
+
+def print_lint_problems(lint_problems: list[linter.LintProblem]) -> None:
+    print("--------- LINTING ISSUES ---------")
+    print(f"Found {len(lint_problems)} lint problems:")
+    for problem in lint_problems:
+        print(f"Lint error in line: {problem.line}, {problem.desc}")
+    print("--------- END LINTING ISSUES ---------")
+
+
+def print_test_diffs(diffs: list[TemplateDiff]) -> None:
+    print("--------- TEMPLATE TEST DIFF ---------")
+    print("Template validation failed")
+    for d in diffs:
+        for line in d.diff.splitlines():
+            if line:
+                print(f"{line}")
+    print("--------- END TEMPLATE TEST DIFF ---------")
+
+
+@click.command()
+@click.option(
+    "--ai-path",
+    help="Path to the bundle file",
+    default=None,
+    required=True,
+)
+@click.option(
+    "--template-path",
+    help="Path to the template file",
+    default=None,
+    required=True,
+)
+@click.option(
+    "--run-validator",
+    help="Should template validation invoke qontract-validator",
+    default=False,
+    is_flag=True,
+)
+def main(ai_path: str, template_path: str, run_validator: bool) -> None:
+    templateRaw = load_clean_yaml(ai_path, template_path)
+
+    tests = []
+    for testRaw in templateRaw["templateTest"]:
+        test_yaml = load_clean_yaml(ai_path, testRaw["$ref"])
+        variables = json.dumps(test_yaml["variables"])
+        test_yaml["variables"] = variables
+        tests.append(test_yaml)
+
+    templateRaw["templateTest"] = tests
+    template: TemplateV1 = TemplateV1(**data_default_none(TemplateV1, templateRaw))
+    diffs: list[TemplateDiff] = []
+
+    templates_to_validate = {}
+    for test in template.template_test:
+        diffs.extend(TemplateValidatorIntegration.validate_template(template, test))
+
+        renderer = TemplateValidatorIntegration._create_renderer(template, test)
+        if renderer.render_condition():
+            output = renderer.render_output()
+            path = renderer.render_target_path()
+            lint_problems = list(
+                linter.run(output, YamlLintConfig(file=f"{ai_path}/.yamllint"), "")
+            )
+            if lint_problems:
+                print_lint_problems(lint_problems)
+            if run_validator:
+                templates_to_validate[path] = output
+
+    if run_validator:
+        validation_errors = validate_template(
+            f"{ai_path}/data.json", templates_to_validate
+        )
+        if validation_errors:
+            print_validation_errors(validation_errors)
+
+    if diffs:
+        print_test_diffs(diffs)
+
+
+if __name__ == "__main__":
+    main()  # pylint: disable=no-value-for-parameter

--- a/tools/template_validation.py
+++ b/tools/template_validation.py
@@ -1,7 +1,6 @@
 import json
 import os.path
 import sys
-from pprint import pprint
 
 import click
 from yamllint import linter  # type: ignore
@@ -30,14 +29,6 @@ def load_yaml(to_load: str) -> dict:
     ruamel_instance = create_ruamel_instance()
     with open(to_load, "r", encoding="utf-8") as file:
         return ruamel_instance.load(file)
-
-
-def print_validation_errors(errors: list[dict]) -> None:
-    print("--------- VALIDATION ERRORS ---------")
-    print(f"Found {len(errors)} errors during validation:")
-    for error in errors:
-        pprint(error)
-    print("--------- END VALIDATION ERRORS ---------")
 
 
 def print_lint_problems(lint_problems: list[linter.LintProblem]) -> None:


### PR DESCRIPTION
This adds a CLI which helps develop templates locally. It can be invoked as such:
```bash
template_validation.py --template-path /templating/templates/cert-manager/cert-manager.yml --ai-path $HOME/app-interface
```

The cli will do:

- Evaluate the provided template by parsing it and checking it against configured tests
- Ensuring the YAML is valid by running `yamllint`

It is a more convenient way to develop new templates, focused on creating tests first,