### PR TITLE
SAPM allow running on reduced set of saas files

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2067,10 +2067,14 @@ def cna_resources(
 
 @integration.command(short_help="Manage auto-promotions defined in SaaS files")
 @threaded()
+@click.option("--env-name", default=None, help="environment to filter saas files by")
+@click.option("--app-name", default=None, help="app to filter saas files by.")
 @click.pass_context
 def saas_auto_promotions_manager(
     ctx,
     thread_pool_size,
+    env_name,
+    app_name,
 ):
     import reconcile.saas_auto_promotions_manager.integration
 
@@ -2078,6 +2082,8 @@ def saas_auto_promotions_manager(
         reconcile.saas_auto_promotions_manager.integration,
         ctx.obj,
         thread_pool_size,
+        env_name=env_name,
+        app_name=app_name,
     )
 
 

--- a/reconcile/saas_auto_promotions_manager/integration.py
+++ b/reconcile/saas_auto_promotions_manager/integration.py
@@ -92,6 +92,8 @@ class SaasAutoPromotionsManager:
 
 def init_external_dependencies(
     dry_run: bool,
+    env_name: Optional[str] = None,
+    app_name: Optional[str] = None,
 ) -> tuple[PromotionState, VCS, SaasFilesInventory, MergeRequestManagerV2]:
     """
     Lets initialize everything that involves calls to external dependencies:
@@ -126,7 +128,7 @@ def init_external_dependencies(
         mr_parser=mr_parser,
         renderer=Renderer(),
     )
-    saas_files = get_saas_files()
+    saas_files = get_saas_files(env_name=env_name, app_name=app_name)
     saas_inventory = SaasFilesInventory(saas_files=saas_files)
     deployment_state = PromotionState(
         state=init_state(integration=OPENSHIFT_SAAS_DEPLOY, secret_reader=secret_reader)
@@ -143,6 +145,8 @@ def init_external_dependencies(
 def run(
     dry_run: bool,
     thread_pool_size: int,
+    env_name: Optional[str] = None,
+    app_name: Optional[str] = None,
     defer: Optional[Callable] = None,
 ) -> None:
     (
@@ -150,7 +154,9 @@ def run(
         vcs,
         saas_inventory,
         merge_request_manager_v2,
-    ) = init_external_dependencies(dry_run=dry_run)
+    ) = init_external_dependencies(
+        dry_run=dry_run, env_name=env_name, app_name=app_name
+    )
     if defer:
         defer(vcs.cleanup)
 


### PR DESCRIPTION
If we run SAPM locally, we would like to be able to reduce the amount of queries to github/gitlab.