### PR TITLE
[qontract-cli] get rosa-create-cluster-command billing-account

### DIFF
--- a/reconcile/gql_definitions/common/clusters.gql
+++ b/reconcile/gql_definitions/common/clusters.gql
@@ -87,7 +87,13 @@ query Clusters($name: String) {
         availability_zones
         oidc_endpoint_url
         account {
+          name
           uid
+          terraformUsername
+          automationToken {
+            ... VaultSecret
+          }
+          resourcesDefaultRegion
           rosa {
             ocm_environments {
               ocm {

--- a/reconcile/gql_definitions/common/clusters.py
+++ b/reconcile/gql_definitions/common/clusters.py
@@ -186,7 +186,13 @@ query Clusters($name: String) {
         availability_zones
         oidc_endpoint_url
         account {
+          name
           uid
+          terraformUsername
+          automationToken {
+            ... VaultSecret
+          }
+          resourcesDefaultRegion
           rosa {
             ocm_environments {
               ocm {
@@ -473,7 +479,11 @@ class RosaOcmSpecV1(ConfiguredBaseModel):
 
 
 class ClusterSpecROSAV1_AWSAccountV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
     uid: str = Field(..., alias="uid")
+    terraform_username: Optional[str] = Field(..., alias="terraformUsername")
+    automation_token: VaultSecret = Field(..., alias="automationToken")
+    resources_default_region: str = Field(..., alias="resourcesDefaultRegion")
     rosa: Optional[RosaOcmSpecV1] = Field(..., alias="rosa")
 
 

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
     )
     from mypy_boto3_iam import IAMClient
     from mypy_boto3_iam.type_defs import AccessKeyMetadataTypeDef
+    from mypy_boto3_organizations import OrganizationsClient
     from mypy_boto3_rds import RDSClient
     from mypy_boto3_rds.type_defs import (
         DBInstanceMessageTypeDef,
@@ -70,7 +71,9 @@ else:
         FilterTypeDef
     ) = Route53Client = ResourceRecordSetTypeDef = ResourceRecordTypeDef = (
         HostedZoneTypeDef
-    ) = RDSClient = DBInstanceMessageTypeDef = UpgradeTargetTypeDef = object
+    ) = RDSClient = DBInstanceMessageTypeDef = UpgradeTargetTypeDef = (
+        OrganizationsClient
+    ) = object
 
 
 class InvalidResourceTypeError(Exception):
@@ -349,6 +352,12 @@ class AWSApi:  # pylint: disable=too-many-public-methods
     ):
         session = self.get_session(account_name)
         return self.get_session_client(session, "logs", region_name)
+
+    def _account_organizations_client(
+        self, account_name: str, region_name: Optional[str] = None
+    ) -> OrganizationsClient:
+        session = self.get_session(account_name)
+        return self.get_session_client(session, "organizations", region_name)
 
     def init_users(self):
         self.users = {}
@@ -1728,6 +1737,10 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         if versions := response["DBEngineVersions"]:
             return versions[0]["ValidUpgradeTarget"]
         return []
+
+    def get_organization_billing_account(self, account_name: str) -> str:
+        org = self._account_organizations_client(account_name)
+        return org.describe_organization()["Organization"]["MasterAccountId"]
 
 
 def aws_config_file_path() -> Optional[str]:

--- a/requirements/requirements-type.txt
+++ b/requirements/requirements-type.txt
@@ -14,7 +14,7 @@ types-tabulate
 types-toml
 types-dateparser
 types-oauthlib
-boto3-stubs[ec2,s3,rds,iam,route53]==1.34.15
+boto3-stubs[ec2,s3,rds,iam,route53,organizations]==1.34.15
 kubernetes-stubs==22.6.0
 qenerate==0.6.3
 types-psycopg2

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1309,9 +1309,17 @@ def rosa_create_cluster_command(ctx, cluster_name):
         print("must be a rosa cluster.")
         sys.exit(1)
 
+    settings = queries.get_app_interface_settings()
+    account = cluster.spec.account
+    with AWSApi(
+        1, [account.dict(by_alias=True)], settings=settings, init_users=False
+    ) as aws_api:
+        billing_account = aws_api.get_organization_billing_account(account.name)
+
     print(
         " ".join([
             "rosa create cluster",
+            f"--billing-account {billing_account}",
             f"--cluster-name {cluster.name}",
             "--sts",
             ("--private" if cluster.spec.private else ""),


### PR DESCRIPTION
this PR adds the `--billing-account` option to the rosa create-cluster-command subcommand.

related to https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/97504