### PR TITLE
[AUS] declare version gates to approve and handle

### DIFF
--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -364,6 +364,9 @@ class ClusterUpgradePolicyLabelSet(BaseModel):
     mutexes: Optional[CSV] = Field(alias=aus_label_key("mutexes"))
     sector: Optional[str] = Field(alias=aus_label_key("sector"))
     blocked_versions: Optional[CSV] = Field(alias=aus_label_key("blocked-versions"))
+    version_gate_approvals: Optional[CSV] = Field(
+        alias=aus_label_key("version-gate-approvals")
+    )
     _schedule_validator = validator("schedule", allow_reuse=True)(cron_validator)
 
     def build_labels_dict(self) -> dict[str, str]:
@@ -388,6 +391,7 @@ def build_cluster_upgrade_policy_label_set(
     mutexes: Optional[list[str]] = None,
     sector: Optional[str] = None,
     blocked_versions: Optional[list[str]] = None,
+    version_gate_approvals: Optional[list[str]] = None,
 ) -> ClusterUpgradePolicyLabelSet:
     return ClusterUpgradePolicyLabelSet(**{
         aus_label_key("workloads"): ",".join(workloads),
@@ -397,6 +401,9 @@ def build_cluster_upgrade_policy_label_set(
         aus_label_key("sector"): sector,
         aus_label_key("blocked-versions"): ",".join(blocked_versions)
         if blocked_versions
+        else None,
+        aus_label_key("version-gate-approvals"): ",".join(version_gate_approvals)
+        if version_gate_approvals
         else None,
     })
 
@@ -410,6 +417,7 @@ def _build_policy_from_labels(labels: LabelContainer) -> ClusterUpgradePolicyV1:
     policy_labelset = build_labelset(labels, ClusterUpgradePolicyLabelSet)
     return ClusterUpgradePolicyV1(
         workloads=policy_labelset.workloads,
+        versionGateApprovals=policy_labelset.version_gate_approvals,
         schedule=policy_labelset.schedule,
         conditions=ClusterUpgradePolicyConditionsV1(
             soakDays=policy_labelset.soak_days,

--- a/reconcile/aus/aus_label_source.py
+++ b/reconcile/aus/aus_label_source.py
@@ -52,6 +52,7 @@ class AUSClusterUpgradePolicyLabelSource(LabelSource):
             mutexes=policy.conditions.mutexes,
             sector=policy.conditions.sector,
             blocked_versions=policy.conditions.blocked_versions,
+            version_gate_approvals=policy.version_gate_approvals,
         ).build_labels_dict()
 
 

--- a/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.py
+++ b/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.py
@@ -84,6 +84,7 @@ fragment AUSOCMOrganization on OpenShiftClusterManager_v1 {
 fragment ClusterUpgradePolicyV1 on ClusterUpgradePolicy_v1 {
   workloads
   schedule
+  versionGateApprovals
   conditions {
     mutexes
     soakDays

--- a/reconcile/gql_definitions/advanced_upgrade_service/aus_organization.py
+++ b/reconcile/gql_definitions/advanced_upgrade_service/aus_organization.py
@@ -83,6 +83,7 @@ fragment AUSOCMOrganization on OpenShiftClusterManager_v1 {
 fragment ClusterUpgradePolicyV1 on ClusterUpgradePolicy_v1 {
   workloads
   schedule
+  versionGateApprovals
   conditions {
     mutexes
     soakDays

--- a/reconcile/gql_definitions/common/clusters.py
+++ b/reconcile/gql_definitions/common/clusters.py
@@ -62,6 +62,7 @@ fragment AWSVPC on AWSVPC_v1 {
 fragment ClusterUpgradePolicyV1 on ClusterUpgradePolicy_v1 {
   workloads
   schedule
+  versionGateApprovals
   conditions {
     mutexes
     soakDays

--- a/reconcile/gql_definitions/fragments/upgrade_policy.gql
+++ b/reconcile/gql_definitions/fragments/upgrade_policy.gql
@@ -3,6 +3,7 @@
 fragment ClusterUpgradePolicyV1 on ClusterUpgradePolicy_v1 {
   workloads
   schedule
+  versionGateApprovals
   conditions {
     mutexes
     soakDays

--- a/reconcile/gql_definitions/fragments/upgrade_policy.py
+++ b/reconcile/gql_definitions/fragments/upgrade_policy.py
@@ -34,4 +34,5 @@ class ClusterUpgradePolicyConditionsV1(ConfiguredBaseModel):
 class ClusterUpgradePolicyV1(ConfiguredBaseModel):
     workloads: list[str] = Field(..., alias="workloads")
     schedule: str = Field(..., alias="schedule")
+    version_gate_approvals: Optional[list[str]] = Field(..., alias="versionGateApprovals")
     conditions: ClusterUpgradePolicyConditionsV1 = Field(..., alias="conditions")

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -7355,6 +7355,26 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "versionGateApprovals",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "conditions",
                             "description": null,
                             "args": [],

--- a/reconcile/test/oc/fixtures.py
+++ b/reconcile/test/oc/fixtures.py
@@ -1,15 +1,16 @@
 from reconcile.gql_definitions.common.clusters import ClusterV1
 from reconcile.gql_definitions.common.namespaces import NamespaceV1
 from reconcile.test.fixtures import Fixtures
+from reconcile.utils.models import data_default_none
 
 fxt = Fixtures("oc_connection_parameters")
 
 
 def load_cluster_for_connection_parameters(path: str) -> ClusterV1:
     content = fxt.get_anymarkup(path)
-    return ClusterV1(**content)
+    return ClusterV1(**data_default_none(ClusterV1, content))
 
 
 def load_namespace_for_connection_parameters(path: str) -> NamespaceV1:
     content = fxt.get_anymarkup(path)
-    return NamespaceV1(**content)
+    return NamespaceV1(**data_default_none(NamespaceV1, content))

--- a/reconcile/test/ocm/aus/fixtures.py
+++ b/reconcile/test/ocm/aus/fixtures.py
@@ -44,6 +44,7 @@ def build_upgrade_policy(
     return ClusterUpgradePolicyV1(
         schedule=schedule or "* * * * *",
         workloads=workloads or ["workload1"],
+        versionGateApprovals=None,
         conditions=ClusterUpgradePolicyConditionsV1(
             soakDays=soak_days,
             sector=sector,

--- a/reconcile/test/test_openshift_upgrade_watcher.py
+++ b/reconcile/test/test_openshift_upgrade_watcher.py
@@ -8,13 +8,14 @@ import pytest
 from reconcile import openshift_upgrade_watcher as ouw
 from reconcile.gql_definitions.common.clusters import ClusterV1
 from reconcile.test.fixtures import Fixtures
+from reconcile.utils.models import data_default_none
 
 fxt = Fixtures("openshift_upgrade_watcher")
 
 
 def load_cluster(path: str) -> ClusterV1:
     content = fxt.get_anymarkup(path)
-    return ClusterV1(**content)
+    return ClusterV1(**data_default_none(ClusterV1, content))
 
 
 @pytest.fixture


### PR DESCRIPTION
upgrade policies can now hold a list of version gate labels AUS should handle and approve automatically in the `versionGateApproval` field.

this PR only transfers such declaration to OCM subscription labels. the AUS change to act on them is handled in this PR: https://github.com/app-sre/qontract-reconcile/pull/4103

depends on https://github.com/app-sre/qontract-schemas/pull/594