### PR TITLE
Enhance template rendering

### DIFF
--- a/reconcile/templating/renderer.py
+++ b/reconcile/templating/renderer.py
@@ -108,8 +108,8 @@ class TemplateRendererIntegration(QontractReconcileIntegration):
     def __init__(self, params: TemplateRendererIntegrationParams) -> None:
         super().__init__(params)
 
-    @staticmethod
     def process_template(
+        self,
         template: TemplateV1,
         variables: dict,
         persistence: FilePersistence,
@@ -120,6 +120,7 @@ class TemplateRendererIntegration(QontractReconcileIntegration):
             TemplateData(
                 variables=variables,
             ),
+            secret_reader=self.secret_reader,
         )
         target_path = r.render_target_path()
 

--- a/reconcile/templating/rendering.py
+++ b/reconcile/templating/rendering.py
@@ -5,6 +5,7 @@ from jinja2.sandbox import SandboxedEnvironment
 from pydantic import BaseModel
 from ruamel import yaml
 
+from reconcile.utils.jinja2.utils import process_jinja2_template
 from reconcile.utils.jsonpath import parse_jsonpath
 
 
@@ -37,15 +38,12 @@ class Renderer(ABC):
     def __init__(self, template: Template, data: TemplateData):
         self.template = template
         self.data = data
-        self.jinja_env = SandboxedEnvironment()
 
     def _jinja2_render_kwargs(self) -> dict[str, Any]:
         return {**self.data.variables, "current": self.data.current}
 
     def _render_template(self, template: str) -> str:
-        return self.jinja_env.from_string(template).render(
-            **self._jinja2_render_kwargs()
-        )
+        return process_jinja2_template(body=template, vars=self._jinja2_render_kwargs())
 
     @abstractmethod
     def render_output(self) -> str:

--- a/reconcile/templating/rendering.py
+++ b/reconcile/templating/rendering.py
@@ -1,12 +1,12 @@
 from abc import ABC, abstractmethod
 from typing import Any, Optional, Protocol
 
-from jinja2.sandbox import SandboxedEnvironment
 from pydantic import BaseModel
 from ruamel import yaml
 
 from reconcile.utils.jinja2.utils import process_jinja2_template
 from reconcile.utils.jsonpath import parse_jsonpath
+from reconcile.utils.secret_reader import SecretReaderBase
 
 
 class TemplateData(BaseModel):
@@ -35,15 +35,25 @@ class Template(Protocol):
 
 
 class Renderer(ABC):
-    def __init__(self, template: Template, data: TemplateData):
+    def __init__(
+        self,
+        template: Template,
+        data: TemplateData,
+        secret_reader: SecretReaderBase,
+    ):
         self.template = template
         self.data = data
+        self.secret_reader = secret_reader
 
     def _jinja2_render_kwargs(self) -> dict[str, Any]:
         return {**self.data.variables, "current": self.data.current}
 
     def _render_template(self, template: str) -> str:
-        return process_jinja2_template(body=template, vars=self._jinja2_render_kwargs())
+        return process_jinja2_template(
+            body=template,
+            vars=self._jinja2_render_kwargs(),
+            secret_reader=self.secret_reader,
+        )
 
     @abstractmethod
     def render_output(self) -> str:
@@ -124,7 +134,15 @@ class PatchRenderer(Renderer):
         return yaml.dump(self.data.current, width=4096, Dumper=yaml.RoundTripDumper)
 
 
-def create_renderer(template: Template, data: TemplateData) -> Renderer:
+def create_renderer(
+    template: Template,
+    data: TemplateData,
+    secret_reader: SecretReaderBase,
+) -> Renderer:
     if template.patch:
-        return PatchRenderer(template=template, data=data)
-    return FullRenderer(template=template, data=data)
+        return PatchRenderer(template=template, data=data, secret_reader=secret_reader)
+    return FullRenderer(
+        template=template,
+        data=data,
+        secret_reader=secret_reader,
+    )

--- a/reconcile/templating/validator.py
+++ b/reconcile/templating/validator.py
@@ -52,7 +52,6 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
         for template in get_templates():
             for test in template.template_test:
                 logging.info(f"Running test {test.name} for template {template.name}")
-
                 r = create_renderer(
                     template,
                     TemplateData(
@@ -61,6 +60,7 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
                             test.current or "", Loader=yaml.RoundTripLoader
                         ),
                     ),
+                    secret_reader=self.secret_reader,
                 )
                 if test.expected_target_path:
                     self.diff_result(

--- a/reconcile/test/templating/conftest.py
+++ b/reconcile/test/templating/conftest.py
@@ -1,9 +1,11 @@
 from typing import Any, Callable
 
 import pytest
+from pytest_mock import MockerFixture
 
 from reconcile.gql_definitions.templating.templates import TemplateV1
 from reconcile.test.fixtures import Fixtures
+from reconcile.utils.secret_reader import SecretReader
 
 
 @pytest.fixture
@@ -22,3 +24,8 @@ def get_fixture(fxt: Fixtures, gql_class_factory: Callable) -> Callable:
         }
 
     return _f
+
+
+@pytest.fixture
+def secret_reader(mocker: MockerFixture) -> SecretReader:
+    return mocker.patch("reconcile.utils.secret_reader.SecretReader", autospec=True)

--- a/reconcile/test/templating/test_full_rendering.py
+++ b/reconcile/test/templating/test_full_rendering.py
@@ -1,19 +1,28 @@
 from collections.abc import Callable
 
 from reconcile.templating.rendering import FullRenderer, TemplateData
+from reconcile.utils.secret_reader import SecretReader
 
 
-def test_full_rendering(get_fixture: Callable) -> None:
+def test_full_rendering(get_fixture: Callable, secret_reader: SecretReader) -> None:
     template, _, expected = get_fixture("full.yaml").values()
 
-    r = FullRenderer(template, TemplateData(variables={"bar": "bar"}, current=None))
+    r = FullRenderer(
+        template,
+        TemplateData(variables={"bar": "bar"}, current=None),
+        secret_reader=secret_reader,
+    )
 
     assert r.render_output() == expected
     assert r.render_target_path() == "/bar/foo.yml"
 
 
-def test_full_not_rendering(get_fixture: Callable) -> None:
+def test_full_not_rendering(get_fixture: Callable, secret_reader: SecretReader) -> None:
     template, _, _ = get_fixture("not_rendering.yaml").values()
 
-    r = FullRenderer(template, TemplateData(variables={"bar": "bar"}, current=None))
+    r = FullRenderer(
+        template,
+        TemplateData(variables={"bar": "bar"}, current=None),
+        secret_reader=secret_reader,
+    )
     assert not r.render_condition()

--- a/reconcile/test/templating/test_patch_rendering.py
+++ b/reconcile/test/templating/test_patch_rendering.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 import pytest
 
 from reconcile.templating.rendering import PatchRenderer, TemplateData
+from reconcile.utils.secret_reader import SecretReader
 
 
 @pytest.mark.parametrize(
@@ -17,11 +18,14 @@ from reconcile.templating.rendering import PatchRenderer, TemplateData
 def test_patch_ref_update(
     get_fixture: Callable,
     fixture_file: str,
+    secret_reader: SecretReader,
 ) -> None:
     template, current, expected = get_fixture(fixture_file).values()
 
     r = PatchRenderer(
-        template, TemplateData(variables={"bar": "bar", "foo": "foo"}, current=current)
+        template,
+        TemplateData(variables={"bar": "bar", "foo": "foo"}, current=current),
+        secret_reader=secret_reader,
     )
 
     assert r.render_output().strip() == expected.strip()
@@ -37,11 +41,14 @@ def test_patch_ref_update(
 def test_patch_raises(
     get_fixture: Callable,
     fixture_file: str,
+    secret_reader: SecretReader,
 ) -> None:
     template, _, _ = get_fixture(fixture_file).values()
 
     with pytest.raises(ValueError):
         r = PatchRenderer(
-            template, TemplateData(variables={"bar": "bar", "foo": "foo"})
+            template,
+            TemplateData(variables={"bar": "bar", "foo": "foo"}),
+            secret_reader=secret_reader,
         )
         r.render_output()

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -7,7 +7,6 @@ from sretoolbox.utils import retry
 
 from reconcile.checkpoint import url_makes_sense
 from reconcile.github_users import init_github
-from reconcile.typed_queries.clusters_minimal import get_clusters_minimal
 from reconcile.utils import gql
 from reconcile.utils.jinja2.extensions import B64EncodeExtension, RaiseErrorExtension
 from reconcile.utils.jinja2.filters import (
@@ -20,8 +19,6 @@ from reconcile.utils.jinja2.filters import (
     urlescape,
     urlunescape,
 )
-from reconcile.utils.oc import OCCli
-from reconcile.utils.oc_map import init_oc_map_from_clusters
 from reconcile.utils.secret_reader import SecretNotFound, SecretReader, SecretReaderBase
 
 
@@ -83,24 +80,6 @@ def lookup_github_file_content(
     gh = init_github()
     c = gh.get_repo(repo).get_contents(path, ref).decoded_content
     return c.decode("utf-8")
-
-
-def openshift_namespace_exists(
-    cluster_name: str,
-    namespace: str,
-    secret_reader: Optional[SecretReaderBase],
-) -> bool:
-    if not secret_reader:
-        return False
-    clusters = get_clusters_minimal(name=cluster_name)
-    oc_map = init_oc_map_from_clusters(clusters, secret_reader)
-    oc = oc_map.get(cluster_name)
-    if isinstance(oc, OCCli):
-        namespace_object = oc.get(
-            "default", "Namespace", name=namespace, allow_not_found=True
-        )
-        return namespace_object.get("status", {}).get("phase", "") == "Active"
-    return False
 
 
 def lookup_graphql_query_results(query: str, **kwargs: dict[str, Any]) -> list[Any]:
@@ -177,9 +156,6 @@ def process_jinja2_template(
         "hash_list": hash_list,
         "query": lookup_graphql_query_results,
         "url": url_makes_sense,
-        "openshift_namespace_exists": lambda c, n: openshift_namespace_exists(
-            cluster_name=c, namespace=n, secret_reader=secret_reader
-        ),
     })
     if "_template_mocks" in vars:
         for k, v in vars["_template_mocks"].items():


### PR DESCRIPTION
Add the openshift_namespace_exists method, which can be used by templates to check if a namespace exists on a cluster.

Make it possible to mock these lambdas by passing in `_template_mock` variables.
