### PR TITLE
Update cache source of terraform_resources to include resource specs

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -67,7 +67,7 @@ from reconcile.utils.vault import (
 )
 
 QONTRACT_INTEGRATION = "terraform_resources"
-QONTRACT_INTEGRATION_VERSION = make_semver(0, 5, 2)
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 5, 3)
 QONTRACT_TF_PREFIX = "qrtf"
 
 
@@ -350,6 +350,11 @@ class MultipleAccountNamesInDryRunException(Exception):
     pass
 
 
+class CacheSource(TypedDict):
+    terraform_configurations: dict[str, str]
+    resource_spec_inventory: ExternalResourceSpecInventory
+
+
 @defer
 def run(
     dry_run: bool,
@@ -414,11 +419,15 @@ def run(
         "terraform-resources-extended-early-exit",
         default=False,
     ):
+        cache_source = CacheSource(
+            terraform_configurations=ts.terraform_configurations(),
+            resource_spec_inventory=ts.resource_spec_inventory,
+        )
         extended_early_exit_run(
             integration=QONTRACT_INTEGRATION,
             integration_version=QONTRACT_INTEGRATION_VERSION,
             dry_run=dry_run,
-            cache_source=ts.terraform_configurations(),
+            cache_source=cache_source,
             shard="_".join(account_name) if account_name else "",
             ttl_seconds=extended_early_exit_cache_ttl_seconds,
             logger=logging.getLogger(),

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -370,12 +370,16 @@ def test_run_with_extended_early_exit_run_enabled(
         log_cached_log_output=True,
         defer=defer,
     )
+    expected_cache_source = {
+        "terraform_configurations": mocks["ts"].terraform_configurations.return_value,
+        "resource_spec_inventory": mocks["ts"].resource_spec_inventory,
+    }
 
     mocks["extended_early_exit_run"].assert_called_once_with(
         integration=integ.QONTRACT_INTEGRATION,
         integration_version=integ.QONTRACT_INTEGRATION_VERSION,
         dry_run=True,
-        cache_source=mocks["ts"].terraform_configurations.return_value,
+        cache_source=expected_cache_source,
         shard="a",
         ttl_seconds=60,
         logger=mocks["logging"].getLogger.return_value,


### PR DESCRIPTION
Some resource spec such as `output_format` is not used in terraform config, only used for openshfit secrets. Terraform config is not enough to cover all desired changes, changes for `output_format` won't cause cache miss, need to wait for cache expire to apply.

Add `resource_spec_inventory` to cache source to cover all config from desired state.