### PR TITLE
Revert "APPSRE-9802: bump oc version from 4.10.15 to 4.14.12"

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,4 +2,4 @@
 # but it also serves as a reference for non-asdf users
 python 3.11.4
 terraform 0.13.7
-oc 4.14.12
+oc 4.10.15

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -14,7 +14,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
     python3 -m pip wheel . --wheel-dir /work/wheels
 
 
-FROM quay.io/app-sre/qontract-reconcile-base:0.11.0 as dev-image
+FROM quay.io/app-sre/qontract-reconcile-base:0.10.2 as dev-image
 
 ARG CONTAINER_UID=1000
 RUN useradd --uid ${CONTAINER_UID} reconcile
@@ -44,7 +44,7 @@ VOLUME ["/work"]
 ENTRYPOINT ["/work/dev/run.sh"]
 
 
-FROM quay.io/app-sre/qontract-reconcile-base:0.11.0 as prod-image
+FROM quay.io/app-sre/qontract-reconcile-base:0.10.3 as prod-image
 
 ARG quay_expiration=never
 LABEL quay.expires-after=${quay_expiration}

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -46,7 +46,7 @@ from reconcile.utils.unleash import get_feature_toggle_state
 TERRAFORM_VERSION = "0.13.7"
 TERRAFORM_VERSION_REGEX = r"^Terraform\sv([\d]+\.[\d]+\.[\d]+)$"
 
-OC_VERSION = "4.14.12"
+OC_VERSION = "4.10.15"
 OC_VERSION_REGEX = r"^Client\sVersion:\s([\d]+\.[\d]+\.[\d]+)$"
 
 


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#4082

Unfortunately the newer version of `oc` caused issues in the FedRamp environment.

Specifically: https://access.redhat.com/solutions/7046917