### PR TITLE
Change oc binary in QR to 4.12

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -2,4 +2,4 @@
 # but it also serves as a reference for non-asdf users
 python 3.11.4
 terraform 0.13.7
-oc 4.14.12
+oc 4.12.46

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/qontract-reconcile-builder:0.5.2 as build-image
+FROM quay.io/app-sre/qontract-reconcile-builder:0.5.3 as build-image
 
 WORKDIR /work
 
@@ -14,7 +14,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
     python3 -m pip wheel . --wheel-dir /work/wheels
 
 
-FROM quay.io/app-sre/qontract-reconcile-base:0.11.0 as dev-image
+FROM quay.io/app-sre/qontract-reconcile-base:0.11.1 as dev-image
 
 ARG CONTAINER_UID=1000
 RUN useradd --uid ${CONTAINER_UID} reconcile
@@ -44,7 +44,7 @@ VOLUME ["/work"]
 ENTRYPOINT ["/work/dev/run.sh"]
 
 
-FROM quay.io/app-sre/qontract-reconcile-base:0.11.0 as prod-image
+FROM quay.io/app-sre/qontract-reconcile-base:0.11.1 as prod-image
 
 ARG quay_expiration=never
 LABEL quay.expires-after=${quay_expiration}

--- a/dockerfiles/Dockerfile.publish-release
+++ b/dockerfiles/Dockerfile.publish-release
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/qontract-reconcile-builder:0.5.2 as build-image
+FROM quay.io/app-sre/qontract-reconcile-builder:0.5.3 as build-image
 
 WORKDIR /work
 

--- a/dockerfiles/Dockerfile.test
+++ b/dockerfiles/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM quay.io/app-sre/qontract-reconcile-builder:0.5.2
+FROM quay.io/app-sre/qontract-reconcile-builder:0.5.3
 
 ENV TOX_PARALLEL_NO_SPINNER=1
 

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -46,7 +46,7 @@ from reconcile.utils.unleash import get_feature_toggle_state
 TERRAFORM_VERSION = "0.13.7"
 TERRAFORM_VERSION_REGEX = r"^Terraform\sv([\d]+\.[\d]+\.[\d]+)$"
 
-OC_VERSION = "4.14.12"
+OC_VERSION = "4.12.46"
 OC_VERSION_REGEX = r"^Client\sVersion:\s([\d]+\.[\d]+\.[\d]+)$"
 
 


### PR DESCRIPTION
[APPSRE-9849](https://issues.redhat.com/browse/APPSRE-9849)

Unfortunately the newer version of oc updated in https://github.com/app-sre/qontract-reconcile/pull/4082 caused issues in the FedRamp environment. Switching the oc binary to a 4.12 version to match up with what our FedRamp clusters are running.

Specifically: https://access.redhat.com/solutions/7046917