### PR TITLE
[aws_api_typed] New AWS API

### DIFF
--- a/reconcile/test/utils/aws_api_typed/test_aws_api_typed_api.py
+++ b/reconcile/test/utils/aws_api_typed/test_aws_api_typed_api.py
@@ -56,13 +56,13 @@ def test_aws_api_typed_api_close(aws_api: AWSApi, mocker: MockerFixture) -> None
         ),
     ],
 )
-def test_aws_api_typed_api_init_or_get_sub_api(
+def test_aws_api_typed_api_init_sub_api(
     aws_api: AWSApi, mocker: MockerFixture, api_cls: type[SubApi], client_name: str
 ) -> None:
     session_mock = mocker.MagicMock()
     session_mock.client.return_value = client = mocker.MagicMock()
     aws_api.session = session_mock
-    sub_api = aws_api._init_or_get_sub_api(api_cls)
+    sub_api = aws_api._init_sub_api(api_cls)
 
     assert isinstance(sub_api, api_cls)
     session_mock.client.assert_called_once_with(client_name)

--- a/reconcile/test/utils/aws_api_typed/test_aws_api_typed_api.py
+++ b/reconcile/test/utils/aws_api_typed/test_aws_api_typed_api.py
@@ -98,3 +98,20 @@ def test_aws_api_typed_api_assume_role(aws_api: AWSApi, mocker: MockerFixture) -
     aws_api.sts.assume_role.assert_called_once_with(  # type: ignore
         account_id="account_id", role="role"
     )
+
+
+def test_aws_api_typed_api_get_temporary_credentials(
+    aws_api: AWSApi, mocker: MockerFixture
+) -> None:
+    mocker.patch.object(AWSApi, "sts")
+    aws_api.sts.get_session_token.return_value = AWSCredentials(  # type: ignore
+        AccessKeyId="access_key",
+        SecretAccessKey="secret_key",
+        SessionToken="session_token",
+        Expiration="1",
+    )
+    new_aws_api = aws_api.temporary_session(duration_seconds=1)
+    assert isinstance(new_aws_api, AWSApi)
+    aws_api.sts.get_session_token.assert_called_once_with(  # type: ignore
+        duration_seconds=1
+    )

--- a/reconcile/test/utils/aws_api_typed/test_aws_api_typed_api.py
+++ b/reconcile/test/utils/aws_api_typed/test_aws_api_typed_api.py
@@ -1,0 +1,100 @@
+import pytest
+from boto3 import Session
+from pytest_mock import MockerFixture
+
+from reconcile.utils.aws_api_typed.api import AWSApi, AWSStaticCredentials, SubApi
+from reconcile.utils.aws_api_typed.iam import AWSApiIam
+from reconcile.utils.aws_api_typed.organization import AWSApiOrganizations
+from reconcile.utils.aws_api_typed.sts import AWSApiSts, AWSCredentials
+
+
+@pytest.fixture
+def aws_api() -> AWSApi:
+    return AWSApi(
+        AWSStaticCredentials(
+            access_key_id="access_key_id",
+            secret_access_key="secret_access_key",
+            region="region",
+        )
+    )
+
+
+def test_aws_api_typed_api_init(aws_api: AWSApi) -> None:
+    assert isinstance(aws_api.session, Session)
+    assert aws_api.session.region_name == "region"
+
+
+def test_aws_api_typed_api_context_manager(
+    aws_api: AWSApi, mocker: MockerFixture
+) -> None:
+    client_mock = mocker.MagicMock()
+    aws_api._session_clients = [client_mock]
+    with aws_api as api:
+        assert api == aws_api
+    client_mock.close.assert_called_once()
+    assert not aws_api._session_clients
+
+
+def test_aws_api_typed_api_close(aws_api: AWSApi, mocker: MockerFixture) -> None:
+    client_mock = mocker.MagicMock()
+    aws_api._session_clients = [client_mock]
+    aws_api.close()
+    client_mock.close.assert_called_once()
+    assert not aws_api._session_clients
+
+
+@pytest.mark.parametrize(
+    "api_cls, client_name",
+    [
+        (AWSApiIam, "iam"),
+        (AWSApiOrganizations, "organizations"),
+        (AWSApiSts, "sts"),
+        pytest.param(
+            object,
+            "unknown",
+            marks=pytest.mark.xfail(strict=True, raises=ValueError),
+        ),
+    ],
+)
+def test_aws_api_typed_api_init_or_get_sub_api(
+    aws_api: AWSApi, mocker: MockerFixture, api_cls: type[SubApi], client_name: str
+) -> None:
+    session_mock = mocker.MagicMock()
+    session_mock.client.return_value = client = mocker.MagicMock()
+    aws_api.session = session_mock
+    sub_api = aws_api._init_or_get_sub_api(api_cls)
+
+    assert isinstance(sub_api, api_cls)
+    session_mock.client.assert_called_once_with(client_name)
+    assert aws_api._api_cache[str(api_cls)] == sub_api
+    assert aws_api._session_clients == [client]
+
+
+def test_aws_api_typed_api_sts(aws_api: AWSApi) -> None:
+    sub_api = aws_api.sts
+    assert isinstance(sub_api, AWSApiSts)
+
+
+def test_aws_api_typed_api_organizations(aws_api: AWSApi) -> None:
+    sub_api = aws_api.organizations
+    assert isinstance(sub_api, AWSApiOrganizations)
+
+
+def test_aws_api_typed_api_iam(aws_api: AWSApi) -> None:
+    sub_api = aws_api.iam
+    assert isinstance(sub_api, AWSApiIam)
+
+
+def test_aws_api_typed_api_assume_role(aws_api: AWSApi, mocker: MockerFixture) -> None:
+    mocker.patch.object(AWSApi, "sts")
+    aws_api.sts.assume_role.return_value = AWSCredentials(  # type: ignore
+        AccessKeyId="access_key",
+        SecretAccessKey="secret_key",
+        SessionToken="session_token",
+        Expiration="1",
+    )
+    new_aws_api = aws_api.assume_role("account_id", "role")
+    assert isinstance(new_aws_api, AWSApi)
+    aws_api.sts.assume_role.assert_called_once_with(  # type: ignore
+        account_id="account_id", role="role"
+    )

--- a/reconcile/test/utils/aws_api_typed/test_aws_api_typed_api.py
+++ b/reconcile/test/utils/aws_api_typed/test_aws_api_typed_api.py
@@ -66,7 +66,6 @@ def test_aws_api_typed_api_init_or_get_sub_api(
 
     assert isinstance(sub_api, api_cls)
     session_mock.client.assert_called_once_with(client_name)
-    assert aws_api._api_cache[str(api_cls)] == sub_api
     assert aws_api._session_clients == [client]
 
 

--- a/reconcile/test/utils/aws_api_typed/test_aws_api_typed_api_credentials.py
+++ b/reconcile/test/utils/aws_api_typed/test_aws_api_typed_api_credentials.py
@@ -1,0 +1,78 @@
+import pytest
+
+from reconcile.utils.aws_api_typed.api import (
+    AWSStaticCredentials,
+    AWSTemporaryCredentials,
+)
+
+
+@pytest.fixture
+def aws_static_credentials() -> AWSStaticCredentials:
+    return AWSStaticCredentials(
+        access_key_id="access-key-id",
+        secret_access_key="secret-access-key",
+        region="us-east-1",
+    )
+
+
+def test_static_credentials_as_env_vars(
+    aws_static_credentials: AWSStaticCredentials,
+) -> None:
+    assert aws_static_credentials.as_env_vars() == {
+        "AWS_ACCESS_KEY_ID": aws_static_credentials.access_key_id,
+        "AWS_SECRET_ACCESS_KEY": aws_static_credentials.secret_access_key,
+        "AWS_REGION": aws_static_credentials.region,
+    }
+
+
+@pytest.mark.parametrize(
+    "profile_name",
+    [
+        "default",
+        "some-profile",
+    ],
+)
+def test_static_credentials_as_file(
+    profile_name: str, aws_static_credentials: AWSStaticCredentials
+) -> None:
+    expected_file = f"""[{profile_name}]\naws_access_key_id = {aws_static_credentials.access_key_id}\naws_secret_access_key = {aws_static_credentials.secret_access_key}\nregion = {aws_static_credentials.region}\n"""
+    creds_file = aws_static_credentials.as_credentials_file(profile_name=profile_name)
+    assert creds_file == expected_file
+
+
+@pytest.fixture
+def aws_temporary_credentials() -> AWSTemporaryCredentials:
+    return AWSTemporaryCredentials(
+        access_key_id="access-key-id",
+        secret_access_key="secret-access-key",
+        session_token="session-token",
+        region="us-east-1",
+    )
+
+
+def test_temporary_credentials_as_env_vars(
+    aws_temporary_credentials: AWSTemporaryCredentials,
+) -> None:
+    assert aws_temporary_credentials.as_env_vars() == {
+        "AWS_ACCESS_KEY_ID": aws_temporary_credentials.access_key_id,
+        "AWS_SECRET_ACCESS_KEY": aws_temporary_credentials.secret_access_key,
+        "AWS_SESSION_TOKEN": aws_temporary_credentials.session_token,
+        "AWS_REGION": aws_temporary_credentials.region,
+    }
+
+
+@pytest.mark.parametrize(
+    "profile_name",
+    [
+        "default",
+        "some-profile",
+    ],
+)
+def test_temporary_credentials_as_file(
+    profile_name: str, aws_temporary_credentials: AWSTemporaryCredentials
+) -> None:
+    expected_file = f"""[{profile_name}]\naws_access_key_id = {aws_temporary_credentials.access_key_id}\naws_secret_access_key = {aws_temporary_credentials.secret_access_key}\naws_session_token = {aws_temporary_credentials.session_token}\nregion = {aws_temporary_credentials.region}\n"""
+    creds_file = aws_temporary_credentials.as_credentials_file(
+        profile_name=profile_name
+    )
+    assert creds_file == expected_file

--- a/reconcile/test/utils/aws_api_typed/test_aws_api_typed_iam.py
+++ b/reconcile/test/utils/aws_api_typed/test_aws_api_typed_iam.py
@@ -1,0 +1,73 @@
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.utils.aws_api_typed.iam import AWSApiIam
+
+if TYPE_CHECKING:
+    from mypy_boto3_iam import IAMClient
+else:
+    IAMClient = object
+
+
+@pytest.fixture
+def iam_client(mocker: MockerFixture) -> IAMClient:
+    return mocker.Mock()
+
+
+@pytest.fixture
+def aws_api_iam(iam_client: IAMClient) -> AWSApiIam:
+    return AWSApiIam(client=iam_client)
+
+
+def test_aws_api_typed_iam_create_access_key(
+    aws_api_iam: AWSApiIam, iam_client: MagicMock
+) -> None:
+    iam_client.create_access_key.return_value = {
+        "AccessKey": {
+            "AccessKeyId": "access_key_id",
+            "SecretAccessKey": "secret_access_key",
+        }
+    }
+    access_key = aws_api_iam.create_access_key("user")
+    assert access_key.access_key_id == "access_key_id"
+    assert access_key.secret_access_key == "secret_access_key"
+
+
+def test_aws_api_typed_iam_create_user(
+    aws_api_iam: AWSApiIam, iam_client: MagicMock
+) -> None:
+    iam_client.create_user.return_value = {
+        "User": {
+            "UserName": "user_name",
+            "UserId": "user_id",
+            "Arn": "arn",
+            "Path": "path",
+        }
+    }
+    user = aws_api_iam.create_user("user_name")
+    assert user.user_name == "user_name"
+    assert user.user_id == "user_id"
+    assert user.arn == "arn"
+    assert user.path == "path"
+
+
+def test_aws_api_typed_iam_attach_user_policy(
+    aws_api_iam: AWSApiIam, iam_client: MagicMock
+) -> None:
+    aws_api_iam.attach_user_policy("user_name", "policy_arn")
+    iam_client.attach_user_policy.assert_called_once_with(
+        UserName="user_name",
+        PolicyArn="policy_arn",
+    )
+
+
+def test_aws_api_typed_iam_create_account_alias(
+    aws_api_iam: AWSApiIam, iam_client: MagicMock
+) -> None:
+    aws_api_iam.create_account_alias("account_alias")
+    iam_client.create_account_alias.assert_called_once_with(
+        AccountAlias="account_alias",
+    )

--- a/reconcile/test/utils/aws_api_typed/test_aws_api_typed_organization.py
+++ b/reconcile/test/utils/aws_api_typed/test_aws_api_typed_organization.py
@@ -1,0 +1,118 @@
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.utils.aws_api_typed.organization import (
+    AWSAccountCreationException,
+    AWSApiOrganizations,
+)
+
+if TYPE_CHECKING:
+    from mypy_boto3_organizations import OrganizationsClient
+else:
+    OrganizationsClient = object
+
+
+@pytest.fixture
+def organization_client(mocker: MockerFixture) -> OrganizationsClient:
+    return mocker.Mock()
+
+
+@pytest.fixture
+def aws_api_organizations(
+    organization_client: OrganizationsClient,
+) -> AWSApiOrganizations:
+    return AWSApiOrganizations(client=organization_client)
+
+
+def test_aws_api_typed_organizations_move_account(
+    aws_api_organizations: AWSApiOrganizations, organization_client: MagicMock
+) -> None:
+    aws_api_organizations.move_account(
+        "account_id", "source_parent_id", "destination_parent_id"
+    )
+    organization_client.move_account.assert_called_once_with(
+        AccountId="account_id",
+        SourceParentId="source_parent_id",
+        DestinationParentId="destination_parent_id",
+    )
+
+
+def test_aws_api_typed_organizations_describe_create_account_status(
+    aws_api_organizations: AWSApiOrganizations, organization_client: MagicMock
+) -> None:
+    organization_client.describe_create_account_status.return_value = {
+        "CreateAccountStatus": {
+            "Id": "id",
+            "AccountName": "account_name",
+            "State": "state",
+            "RequestedTimestamp": "1708592227",
+            "CompletedTimestamp": "1708592235",
+            "AccountId": "account_id",
+        }
+    }
+    status = aws_api_organizations.describe_create_account_status(
+        "create_account_request_id"
+    )
+    assert status.id == "id"
+    assert status.account_name == "account_name"
+    assert status.account_id == "account_id"
+    assert status.state == "state"
+    assert not status.failure_reason
+
+
+def test_aws_api_typed_organizations_create_account(
+    aws_api_organizations: AWSApiOrganizations, organization_client: MagicMock
+) -> None:
+    organization_client.create_account.return_value = {
+        "CreateAccountStatus": {
+            "Id": "id",
+            "AccountName": "account_name",
+            "State": "state",
+            "RequestedTimestamp": "1708592227",
+            "CompletedTimestamp": "1708592235",
+            "AccountId": "account_id",
+        }
+    }
+    status = aws_api_organizations.create_account(
+        "email", "account_name", {"key": "value"}, True
+    )
+    assert status.id == "id"
+    assert status.account_name == "account_name"
+    assert status.account_id == "account_id"
+    assert status.state == "state"
+    assert not status.failure_reason
+    organization_client.create_account.assert_called_once_with(
+        Email="email",
+        AccountName="account_name",
+        IamUserAccessToBilling="ALLOW",
+        Tags=[{"Key": "key", "Value": "value"}],
+    )
+
+
+def test_aws_api_typed_organizations_create_account_error(
+    aws_api_organizations: AWSApiOrganizations, organization_client: MagicMock
+) -> None:
+    organization_client.create_account.return_value = {
+        "CreateAccountStatus": {
+            "Id": "id",
+            "AccountName": "account_name",
+            "State": "FAILED",
+            "RequestedTimestamp": "1708592227",
+            "CompletedTimestamp": "1708592235",
+            "AccountId": "account_id",
+            "FailureReason": "ACCOUNT_LIMIT_EXCEEDED",
+        }
+    }
+    with pytest.raises(AWSAccountCreationException):
+        aws_api_organizations.create_account(
+            "email", "account_name", {"key": "value"}, True
+        )
+    organization_client.create_account.assert_called_once_with(
+        Email="email",
+        AccountName="account_name",
+        IamUserAccessToBilling="ALLOW",
+        Tags=[{"Key": "key", "Value": "value"}],
+    )

--- a/reconcile/test/utils/aws_api_typed/test_aws_api_typed_sts.py
+++ b/reconcile/test/utils/aws_api_typed/test_aws_api_typed_sts.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from reconcile.utils.aws_api_typed.sts import AWSApiSts
+
+if TYPE_CHECKING:
+    from mypy_boto3_sts import STSClient
+else:
+    STSClient = object
+
+
+@pytest.fixture
+def sts_client(mocker: MockerFixture) -> STSClient:
+    return mocker.Mock()
+
+
+@pytest.fixture
+def aws_api_sts(sts_client: STSClient) -> AWSApiSts:
+    return AWSApiSts(client=sts_client)
+
+
+def test_aws_api_typed_sts_assume_role(
+    aws_api_sts: AWSApiSts, sts_client: MagicMock
+) -> None:
+    now = datetime.now()
+    sts_client.assume_role.return_value = {
+        "Credentials": {
+            "AccessKeyId": "access_key_id",
+            "SecretAccessKey": "secret_access_key",
+            "SessionToken": "session_token",
+            "Expiration": now,
+        }
+    }
+    credentials = aws_api_sts.assume_role("account_id", "role")
+    assert credentials.access_key_id == "access_key_id"
+    assert credentials.secret_access_key == "secret_access_key"
+    assert credentials.session_token == "session_token"
+    assert credentials.expiration == now
+
+
+def test_aws_api_typed_sts_get_session_token(
+    aws_api_sts: AWSApiSts, sts_client: MagicMock
+) -> None:
+    now = datetime.now()
+    sts_client.get_session_token.return_value = {
+        "Credentials": {
+            "AccessKeyId": "access_key_id",
+            "SecretAccessKey": "secret_access_key",
+            "SessionToken": "session_token",
+            "Expiration": now,
+        }
+    }
+    credentials = aws_api_sts.get_session_token()
+    assert credentials.access_key_id == "access_key_id"
+    assert credentials.secret_access_key == "secret_access_key"
+    assert credentials.session_token == "session_token"
+    assert credentials.expiration == now

--- a/reconcile/test/utils/test_aws_api.py
+++ b/reconcile/test/utils/test_aws_api.py
@@ -10,8 +10,6 @@ from pytest_mock import MockerFixture
 from reconcile.utils.aws_api import (
     AmiTag,
     AWSApi,
-    AWSStaticCredentials,
-    AWSTemporaryCredentials,
 )
 
 
@@ -379,80 +377,3 @@ def test_get_cluster_vpc_details_aws_error(
             "name": "some-account",
             "assume_region": "us-east-1",
         })
-
-
-#
-# AWS credential dataclasses
-#
-
-
-@pytest.fixture
-def aws_static_credentials():
-    return AWSStaticCredentials(
-        access_key_id="access-key-id",
-        secret_access_key="secret-access-key",
-        region="us-east-1",
-    )
-
-
-def test_static_credentials_as_env_vars(
-    aws_static_credentials: AWSStaticCredentials,
-) -> None:
-    assert aws_static_credentials.as_env_vars() == {
-        "AWS_ACCESS_KEY_ID": aws_static_credentials.access_key_id,
-        "AWS_SECRET_ACCESS_KEY": aws_static_credentials.secret_access_key,
-        "AWS_REGION": aws_static_credentials.region,
-    }
-
-
-@pytest.mark.parametrize(
-    "profile_name",
-    [
-        "default",
-        "some-profile",
-    ],
-)
-def test_static_credentials_as_file(
-    profile_name, aws_static_credentials: AWSStaticCredentials
-) -> None:
-    expected_file = f"""[{profile_name}]\naws_access_key_id = {aws_static_credentials.access_key_id}\naws_secret_access_key = {aws_static_credentials.secret_access_key}\nregion = {aws_static_credentials.region}\n"""
-    creds_file = aws_static_credentials.as_credentials_file(profile_name=profile_name)
-    assert creds_file == expected_file
-
-
-@pytest.fixture
-def aws_temporary_credentials():
-    return AWSTemporaryCredentials(
-        access_key_id="access-key-id",
-        secret_access_key="secret-access-key",
-        session_token="session-token",
-        region="us-east-1",
-    )
-
-
-def test_temporary_credentials_as_env_vars(
-    aws_temporary_credentials: AWSTemporaryCredentials,
-) -> None:
-    assert aws_temporary_credentials.as_env_vars() == {
-        "AWS_ACCESS_KEY_ID": aws_temporary_credentials.access_key_id,
-        "AWS_SECRET_ACCESS_KEY": aws_temporary_credentials.secret_access_key,
-        "AWS_SESSION_TOKEN": aws_temporary_credentials.session_token,
-        "AWS_REGION": aws_temporary_credentials.region,
-    }
-
-
-@pytest.mark.parametrize(
-    "profile_name",
-    [
-        "default",
-        "some-profile",
-    ],
-)
-def test_temporary_credentials_as_file(
-    profile_name, aws_temporary_credentials: AWSTemporaryCredentials
-) -> None:
-    expected_file = f"""[{profile_name}]\naws_access_key_id = {aws_temporary_credentials.access_key_id}\naws_secret_access_key = {aws_temporary_credentials.secret_access_key}\naws_session_token = {aws_temporary_credentials.session_token}\nregion = {aws_temporary_credentials.region}\n"""
-    creds_file = aws_temporary_credentials.as_credentials_file(
-        profile_name=profile_name
-    )
-    assert creds_file == expected_file

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1,9 +1,7 @@
 import logging
 import os
 import re
-import textwrap
 import time
-from abc import ABC, abstractmethod
 from collections.abc import (
     Iterable,
     Iterator,
@@ -87,118 +85,6 @@ class MissingARNError(Exception):
 KeyStatus = Union[Literal["Active"], Literal["Inactive"]]
 
 GOVCLOUD_PARTITION = "aws-us-gov"
-
-
-class AWSCredentials(ABC):
-    @abstractmethod
-    def as_env_vars(self) -> dict[str, str]:
-        """
-        Returns a dictionary of environment variables that can be used to authenticate with AWS.
-        """
-        ...
-
-    @abstractmethod
-    def as_credentials_file(self, profile_name: str = "default") -> str:
-        """
-        Returns a string that can be used to write an AWS credentials file.
-        """
-        ...
-
-    @abstractmethod
-    def build_session(self) -> Session:
-        """
-        Builds an AWS session using these credentials.
-        """
-        ...
-
-    def get_temporary_credentials(
-        self, duration_seconds: int = 900
-    ) -> "AWSTemporaryCredentials":
-        """
-        Builds temporary AWS credentials from a session. This is similar to assuming a role,
-        in the sense that the credentials will expire after a certain amount of time.
-
-        These temporary credentials have the same permissions as the session they were built from, except:
-        - they can't be used for anything IAM related
-        - for the STS API only the AssumeRole and GetSessionToken actions are allowed
-        """
-        session = self.build_session()
-        response = session.client("sts").get_session_token(
-            DurationSeconds=duration_seconds
-        )
-        tmp_creds = response["Credentials"]
-        return AWSTemporaryCredentials(
-            access_key_id=tmp_creds["AccessKeyId"],
-            secret_access_key=tmp_creds["SecretAccessKey"],
-            session_token=tmp_creds["SessionToken"],
-            region=session.region_name,
-        )
-
-
-class AWSStaticCredentials(BaseModel, AWSCredentials):
-    """
-    A model representing AWS credentials.
-    """
-
-    access_key_id: str
-    secret_access_key: str
-    region: str
-
-    def as_env_vars(self) -> dict[str, str]:
-        return {
-            "AWS_ACCESS_KEY_ID": self.access_key_id,
-            "AWS_SECRET_ACCESS_KEY": self.secret_access_key,
-            "AWS_REGION": self.region,
-        }
-
-    def as_credentials_file(self, profile_name: str = "default") -> str:
-        return textwrap.dedent(
-            f"""\
-            [{profile_name}]
-            aws_access_key_id = {self.access_key_id}
-            aws_secret_access_key = {self.secret_access_key}
-            region = {self.region}
-            """
-        )
-
-    def build_session(self) -> Session:
-        return Session(
-            aws_access_key_id=self.access_key_id,
-            aws_secret_access_key=self.secret_access_key,
-            region_name=self.region,
-        )
-
-
-class AWSTemporaryCredentials(AWSStaticCredentials):
-    """
-    A model representing temporary AWS credentials.
-    """
-
-    session_token: str
-
-    def as_env_vars(self) -> dict[str, str]:
-        env_vars = super().as_env_vars()
-        env_vars["AWS_SESSION_TOKEN"] = self.session_token
-        return env_vars
-
-    def as_credentials_file(self, profile_name: str = "default") -> str:
-        return textwrap.dedent(
-            f"""\
-            [{profile_name}]
-            aws_access_key_id = {self.access_key_id}
-            aws_secret_access_key = {self.secret_access_key}
-            aws_session_token = {self.session_token}
-            region = {self.region}
-            """
-        )
-
-    def build_session(self) -> Session:
-        return Session(
-            aws_access_key_id=self.access_key_id,
-            aws_secret_access_key=self.secret_access_key,
-            aws_session_token=self.session_token,
-            region_name=self.region,
-        )
 
 
 class AmiTag(BaseModel):

--- a/reconcile/utils/aws_api_typed/api.py
+++ b/reconcile/utils/aws_api_typed/api.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import textwrap
+from abc import ABC, abstractmethod
+from typing import Any, TypeVar
+
+from boto3 import Session
+from botocore.client import BaseClient
+from pydantic import BaseModel
+
+import reconcile.utils.aws_api_typed.iam
+import reconcile.utils.aws_api_typed.organization
+import reconcile.utils.aws_api_typed.sts
+from reconcile.utils.aws_api_typed.iam import AWSApiIam
+from reconcile.utils.aws_api_typed.organization import AWSApiOrganizations
+from reconcile.utils.aws_api_typed.sts import AWSApiSts
+
+SubApi = TypeVar("SubApi")
+
+
+class AWSCredentials(ABC):
+    @abstractmethod
+    def as_env_vars(self) -> dict[str, str]:
+        """
+        Returns a dictionary of environment variables that can be used to authenticate with AWS.
+        """
+        ...
+
+    @abstractmethod
+    def as_credentials_file(self, profile_name: str = "default") -> str:
+        """
+        Returns a string that can be used to write an AWS credentials file.
+        """
+        ...
+
+    @abstractmethod
+    def build_session(self) -> Session:
+        """
+        Builds an AWS session using these credentials.
+        """
+        ...
+
+    def get_temporary_credentials(
+        self, aws_api: AWSApi, duration_seconds: int = 900
+    ) -> AWSTemporaryCredentials:
+        """
+        Builds temporary AWS credentials from a session. This is similar to assuming a role,
+        in the sense that the credentials will expire after a certain amount of time.
+
+        These temporary credentials have the same permissions as the session they were built from, except:
+        - they can't be used for anything IAM related
+        - for the STS API only the AssumeRole and GetSessionToken actions are allowed
+        """
+        tmp_creds = aws_api.sts.get_session_token(duration_seconds=duration_seconds)
+        return AWSTemporaryCredentials(
+            access_key_id=tmp_creds.access_key_id,
+            secret_access_key=tmp_creds.secret_access_key,
+            session_token=tmp_creds.session_token,
+            region=aws_api.session.region_name,
+        )
+
+
+class AWSStaticCredentials(BaseModel, AWSCredentials):
+    """
+    A model representing AWS credentials.
+    """
+
+    access_key_id: str
+    secret_access_key: str
+    region: str
+
+    def as_env_vars(self) -> dict[str, str]:
+        return {
+            "AWS_ACCESS_KEY_ID": self.access_key_id,
+            "AWS_SECRET_ACCESS_KEY": self.secret_access_key,
+            "AWS_REGION": self.region,
+        }
+
+    def as_credentials_file(self, profile_name: str = "default") -> str:
+        return textwrap.dedent(
+            f"""\
+            [{profile_name}]
+            aws_access_key_id = {self.access_key_id}
+            aws_secret_access_key = {self.secret_access_key}
+            region = {self.region}
+            """
+        )
+
+    def build_session(self) -> Session:
+        return Session(
+            aws_access_key_id=self.access_key_id,
+            aws_secret_access_key=self.secret_access_key,
+            region_name=self.region,
+        )
+
+
+class AWSTemporaryCredentials(AWSStaticCredentials):
+    """
+    A model representing temporary AWS credentials.
+    """
+
+    session_token: str
+
+    def as_env_vars(self) -> dict[str, str]:
+        env_vars = super().as_env_vars()
+        env_vars["AWS_SESSION_TOKEN"] = self.session_token
+        return env_vars
+
+    def as_credentials_file(self, profile_name: str = "default") -> str:
+        return textwrap.dedent(
+            f"""\
+            [{profile_name}]
+            aws_access_key_id = {self.access_key_id}
+            aws_secret_access_key = {self.secret_access_key}
+            aws_session_token = {self.session_token}
+            region = {self.region}
+            """
+        )
+
+    def build_session(self) -> Session:
+        return Session(
+            aws_access_key_id=self.access_key_id,
+            aws_secret_access_key=self.secret_access_key,
+            aws_session_token=self.session_token,
+            region_name=self.region,
+        )
+
+
+class AWSApi:
+    def __init__(self, aws_credentials: AWSCredentials) -> None:
+        self.session = aws_credentials.build_session()
+        self._session_clients: list[BaseClient] = []
+        self._api_cache: dict = {}
+
+    def __enter__(self) -> AWSApi:
+        return self
+
+    def __exit__(self, *exec: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close all clients created by this API instance."""
+        for client in self._session_clients:
+            client.close()
+        self._session_clients = []
+
+    def _init_or_get_sub_api(self, api_cls: type[SubApi]) -> SubApi:
+        """Return a new or cached sub api client."""
+        if str(api_cls) in self._api_cache:
+            return self._api_cache[str(api_cls)]
+
+        match api_cls:
+            case reconcile.utils.aws_api_typed.iam.AWSApiIam:
+                client = self.session.client("iam")
+                api = api_cls(client)  # type: ignore # mypy bug, it doesn't recognize that api_cls is callable
+            case reconcile.utils.aws_api_typed.organization.AWSApiOrganizations:
+                client = self.session.client("organizations")
+                api = api_cls(client)
+            case reconcile.utils.aws_api_typed.sts.AWSApiSts:
+                client = self.session.client("sts")
+                api = api_cls(client)
+            case _:
+                raise ValueError(f"Unknown API class: {api_cls}")
+
+        self._api_cache[str(api_cls)] = api
+        self._session_clients.append(client)
+        return api
+
+    @property
+    def sts(self) -> AWSApiSts:
+        """Return an AWS STS Api client."""
+        return self._init_or_get_sub_api(AWSApiSts)
+
+    @property
+    def organizations(self) -> AWSApiOrganizations:
+        """Return an AWS Organizations Api client."""
+        return self._init_or_get_sub_api(AWSApiOrganizations)
+
+    @property
+    def iam(self) -> AWSApiIam:
+        """Return an AWS IAM Api client."""
+        return self._init_or_get_sub_api(AWSApiIam)
+
+    def assume_role(self, account_id: str, role: str) -> AWSApi:
+        """Return a new AWSApi with the assumed role."""
+        credentials = self.sts.assume_role(account_id=account_id, role=role)
+        return AWSApi(
+            AWSTemporaryCredentials(
+                access_key_id=credentials.access_key_id,
+                secret_access_key=credentials.secret_access_key,
+                session_token=credentials.session_token,
+                region=self.session.region_name,
+            )
+        )

--- a/reconcile/utils/aws_api_typed/api.py
+++ b/reconcile/utils/aws_api_typed/api.py
@@ -125,7 +125,7 @@ class AWSApi:
             client.close()
         self._session_clients = []
 
-    def _init_or_get_sub_api(self, api_cls: type[SubApi]) -> SubApi:
+    def _init_sub_api(self, api_cls: type[SubApi]) -> SubApi:
         """Return a new or cached sub api client."""
         match api_cls:
             case reconcile.utils.aws_api_typed.iam.AWSApiIam:
@@ -146,17 +146,17 @@ class AWSApi:
     @cached_property
     def sts(self) -> AWSApiSts:
         """Return an AWS STS Api client."""
-        return self._init_or_get_sub_api(AWSApiSts)
+        return self._init_sub_api(AWSApiSts)
 
     @cached_property
     def organizations(self) -> AWSApiOrganizations:
         """Return an AWS Organizations Api client."""
-        return self._init_or_get_sub_api(AWSApiOrganizations)
+        return self._init_sub_api(AWSApiOrganizations)
 
     @cached_property
     def iam(self) -> AWSApiIam:
         """Return an AWS IAM Api client."""
-        return self._init_or_get_sub_api(AWSApiIam)
+        return self._init_sub_api(AWSApiIam)
 
     def assume_role(self, account_id: str, role: str) -> AWSApi:
         """Return a new AWSApi with the assumed role."""

--- a/reconcile/utils/aws_api_typed/iam.py
+++ b/reconcile/utils/aws_api_typed/iam.py
@@ -1,0 +1,50 @@
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from mypy_boto3_iam import IAMClient
+else:
+    IAMClient = object
+
+
+class AWSAccessKey(BaseModel):
+    access_key_id: str = Field(..., alias="AccessKeyId")
+    secret_access_key: str = Field(..., alias="SecretAccessKey")
+
+
+class AWSUser(BaseModel):
+    user_name: str = Field(..., alias="UserName")
+    user_id: str = Field(..., alias="UserId")
+    arn: str = Field(..., alias="Arn")
+    path: str = Field(..., alias="Path")
+
+
+class AWSApiIam:
+    def __init__(self, client: IAMClient) -> None:
+        self.client = client
+
+    def create_access_key(self, user_name: str) -> AWSAccessKey:
+        """Create an access key for a given user."""
+        credentials = self.client.create_access_key(
+            UserName=user_name,
+        )
+        return AWSAccessKey(**credentials["AccessKey"])
+
+    def create_user(self, user_name: str) -> AWSUser:
+        """Create a new IAM user."""
+        user = self.client.create_user(
+            UserName=user_name,
+        )
+        return AWSUser(**user["User"])
+
+    def attach_user_policy(self, user_name: str, policy_arn: str) -> None:
+        """Attach a policy to a user."""
+        self.client.attach_user_policy(
+            UserName=user_name,
+            PolicyArn=policy_arn,
+        )
+
+    def create_account_alias(self, account_alias: str) -> None:
+        """Create an account alias."""
+        self.client.create_account_alias(AccountAlias=account_alias)

--- a/reconcile/utils/aws_api_typed/organization.py
+++ b/reconcile/utils/aws_api_typed/organization.py
@@ -1,0 +1,104 @@
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from mypy_boto3_organizations import OrganizationsClient
+    from mypy_boto3_organizations.literals import CreateAccountFailureReasonType
+else:
+    OrganizationsClient = object
+    CreateAccountFailureReasonType = object
+
+
+class AwsOrganizationOU(BaseModel):
+    id: str = Field(..., alias="Id")
+    arn: str = Field(..., alias="Arn")
+    name: str = Field(..., alias="Name")
+    children: list["AwsOrganizationOU"] = []
+
+    def find(self, path: str) -> "AwsOrganizationOU":
+        """Return an organizational unit by its path."""
+        name, *rest = path.strip("/").split("/")
+        subs = "/".join(rest)
+        if self.name == name:
+            if not rest:
+                return self
+            for child in self.children:
+                try:
+                    return child.find(subs)
+                except KeyError:
+                    pass
+        raise KeyError(f"OU not found: {path}")
+
+
+class AWSAccountStatus(BaseModel):
+    id: str = Field(..., alias="Id")
+    account_name: str = Field(..., alias="AccountName")
+    account_id: str = Field(..., alias="AccountId")
+    state: str = Field(..., alias="State")
+    failure_reason: CreateAccountFailureReasonType | None = Field(alias="FailureReason")
+
+
+class AWSAccountCreationException(Exception):
+    pass
+
+
+class AWSApiOrganizations:
+    def __init__(self, client: OrganizationsClient) -> None:
+        self.client = client
+
+    def get_organizational_units_tree(
+        self, root: AwsOrganizationOU | None = None
+    ) -> AwsOrganizationOU:
+        """List all organizational units for a given root recursively."""
+        if not root:
+            root = AwsOrganizationOU(**self.client.list_roots()["Roots"][0])
+
+        paginator = self.client.get_paginator("list_organizational_units_for_parent")
+        for page in paginator.paginate(ParentId=root.id):
+            for ou_raw in page["OrganizationalUnits"]:
+                ou = AwsOrganizationOU(**ou_raw)
+                root.children.append(ou)
+                self.get_organizational_units_tree(root=ou)
+        return root
+
+    def create_account(
+        self,
+        email: str,
+        account_name: str,
+        tags: Mapping[str, str],
+        access_to_billing: bool = True,
+    ) -> AWSAccountStatus:
+        """Create a new account in the organization."""
+        resp = self.client.create_account(
+            Email=email,
+            AccountName=account_name,
+            IamUserAccessToBilling="ALLOW" if access_to_billing else "DENY",
+            Tags=[{"Key": k, "Value": v} for k, v in tags.items()],
+        )
+        status = AWSAccountStatus(**resp["CreateAccountStatus"])
+        if status.state == "FAILED":
+            raise AWSAccountCreationException(
+                f"Account creation failed: {status.failure_reason}"
+            )
+        return status
+
+    def describe_create_account_status(
+        self, create_account_request_id: str
+    ) -> AWSAccountStatus:
+        """Return the status of a create account request."""
+        resp = self.client.describe_create_account_status(
+            CreateAccountRequestId=create_account_request_id
+        )
+        return AWSAccountStatus(**resp["CreateAccountStatus"])
+
+    def move_account(
+        self, account_id: str, source_parent_id: str, destination_parent_id: str
+    ) -> None:
+        """Move an account to a different organizational unit."""
+        self.client.move_account(
+            AccountId=account_id,
+            SourceParentId=source_parent_id,
+            DestinationParentId=destination_parent_id,
+        )

--- a/reconcile/utils/aws_api_typed/sts.py
+++ b/reconcile/utils/aws_api_typed/sts.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, Field
+
+if TYPE_CHECKING:
+    from mypy_boto3_sts import STSClient
+else:
+    STSClient = object
+
+
+class AWSCredentials(BaseModel):
+    access_key_id: str = Field(..., alias="AccessKeyId")
+    secret_access_key: str = Field(..., alias="SecretAccessKey")
+    session_token: str = Field(..., alias="SessionToken")
+    expiration: datetime = Field(..., alias="Expiration")
+
+
+class AWSApiSts:
+    def __init__(self, client: STSClient) -> None:
+        self.client = client
+
+    def assume_role(self, account_id: str, role: str) -> AWSCredentials:
+        """Assume a role and return temporary credentials."""
+        assumed_role_object = self.client.assume_role(
+            RoleArn=f"arn:aws:iam::{account_id}:role/{role}",
+            RoleSessionName=role,
+        )
+        return AWSCredentials(**assumed_role_object["Credentials"])
+
+    def get_session_token(self, duration_seconds: int = 900) -> AWSCredentials:
+        """Return temporary credentials."""
+        assumed_role_object = self.client.get_session_token(
+            DurationSeconds=duration_seconds
+        )
+        return AWSCredentials(**assumed_role_object["Credentials"])

--- a/requirements/requirements-type.txt
+++ b/requirements/requirements-type.txt
@@ -14,7 +14,7 @@ types-tabulate
 types-toml
 types-dateparser
 types-oauthlib
-boto3-stubs[ec2,s3,rds,iam,route53,organizations]==1.34.15
+boto3-stubs[ec2,s3,rds,iam,route53,organizations,sts]==1.34.15
 kubernetes-stubs==22.6.0
 qenerate==0.6.3
 types-psycopg2


### PR DESCRIPTION
Introduce a new typed and fully tested boto3 AWS API abstraction. This preperation work for [SDE-3698 - AWS account management](https://issues.redhat.com/browse/SDE-3698)

Usage example:

```python
with AWSApi(
    AWSStaticCredentials(
        region="us-east-1",
        access_key_id="XXX",
        secret_access_key="XXX",
    )
) as aws_api:
    with aws_api.assume_role(
        account_id="1234567890", role="AwsAccountManager"
    ) as acct_manager_role_api:
        # create a new account within the payer account
        status = acct_manager_role_api.organizations.create_account(
            email="mail@mail.org",
            account_name="JeanLuc",
            tags={"managed-by": "app-interface"},
        )
        print(status)
```