### PR TITLE
[AUS] report version data without org inheritance

### DIFF
--- a/reconcile/aus/ocm_upgrade_scheduler.py
+++ b/reconcile/aus/ocm_upgrade_scheduler.py
@@ -39,20 +39,27 @@ class OCMClusterUpgradeSchedulerIntegration(
             ocm_api=ocm_api,
             org_upgrade_spec=org_upgrade_spec,
         )
-        version_data_map = aus.get_version_data_map(
-            dry_run=dry_run,
-            org_upgrade_spec=org_upgrade_spec,
-            integration=self.name,
-        )
-        version_data = version_data_map.get(
-            org_upgrade_spec.org.environment.name, org_upgrade_spec.org.org_id
-        )
 
+        # expose version data metrics for the current organization
+        # this does not include inherited version data from other
+        # organizations, so that aggregations in prometheus can be more
+        # flexible
         self.expose_version_data_metrics(
             ocm_env=org_upgrade_spec.org.environment.name,
             org_id=org_upgrade_spec.org.org_id,
-            version_data=version_data,
+            version_data=aus.get_version_data_map(
+                dry_run=True,
+                org_upgrade_spec=org_upgrade_spec,
+                integration=self.name,
+                inherit_version_data=False,
+            ).get(org_upgrade_spec.org.environment.name, org_upgrade_spec.org.org_id),
         )
+
+        version_data = aus.get_version_data_map(
+            dry_run=dry_run,
+            org_upgrade_spec=org_upgrade_spec,
+            integration=self.name,
+        ).get(org_upgrade_spec.org.environment.name, org_upgrade_spec.org.org_id)
         self.expose_remaining_soak_day_metrics(
             org_upgrade_spec=org_upgrade_spec,
             version_data=version_data,


### PR DESCRIPTION
the version data metrics should not incorporate inherited version data from other organizations. version data metrics need to be as plain as possible so we can aggregate them in prometheus to slice and dice in grafana. pre-agregation during metric exposure prevents that.

https://issues.redhat.com/browse/APPSRE-9865