### PR TITLE
[rosa-cli] support for running longer scripts

### DIFF
--- a/reconcile/test/utils/jobcontroller/fixtures.py
+++ b/reconcile/test/utils/jobcontroller/fixtures.py
@@ -14,6 +14,7 @@ class SomeJob(K8sJob, BaseModel):
     identifying_attribute: str
     backoff_limit: int = 0
     credentials: Optional[dict[str, str]] = None
+    script: Optional[str] = None
 
     def name_prefix(self) -> str:
         return "some-job"
@@ -30,6 +31,15 @@ class SomeJob(K8sJob, BaseModel):
 
     def secret_data(self) -> dict[str, str]:
         return self.credentials or {}
+
+    def scripts(self) -> dict[str, str]:
+        return (
+            {
+                "script.sh": self.script,
+            }
+            if self.script
+            else {}
+        )
 
 
 class SomeJobV2(K8sJob, BaseModel):

--- a/reconcile/test/utils/rosa/test_log_handler.py
+++ b/reconcile/test/utils/rosa/test_log_handler.py
@@ -21,7 +21,7 @@ def test_log_handle_get_log_lines(
     max_lines: int, expected_lines: int, log_handle: LogHandle
 ) -> None:
     lines = log_handle.get_log_lines(max_lines=max_lines)
-    assert len(lines) == expected_lines
+    assert len(list(lines)) == expected_lines
     for line in lines:
         assert not line.endswith("\n")
 

--- a/reconcile/test/utils/rosa/test_rosa_cli.py
+++ b/reconcile/test/utils/rosa/test_rosa_cli.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import pytest
 
-from reconcile.utils.rosa.rosa_cli import RosaJob
+from reconcile.utils.rosa.rosa_cli import RosaJob, EXEC_SCRIPT
 
 
 @pytest.mark.parametrize(
@@ -38,7 +38,6 @@ def test_rosa_job_spec(rosa_job: RosaJob) -> None:
     job_spec = rosa_job.job_spec()
     container = job_spec.template.spec.containers[0]  # type: ignore
     assert container.image == rosa_job.image
-    assert container.args == [rosa_job.cmd]
     assert {e.name for e in container.env or []} == {
         "AWS_SHARED_CREDENTIALS_FILE",
         "AWS_REGION",

--- a/reconcile/test/utils/rosa/test_rosa_cli.py
+++ b/reconcile/test/utils/rosa/test_rosa_cli.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import pytest
 
-from reconcile.utils.rosa.rosa_cli import RosaJob, EXEC_SCRIPT
+from reconcile.utils.rosa.rosa_cli import RosaJob
 
 
 @pytest.mark.parametrize(

--- a/reconcile/test/utils/rosa/test_rosa_cli.py
+++ b/reconcile/test/utils/rosa/test_rosa_cli.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import pytest
 
-from reconcile.utils.rosa.rosa_cli import RosaJob
+from reconcile.utils.rosa.rosa_cli import EXEC_SCRIPT, RosaJob
 
 
 @pytest.mark.parametrize(
@@ -31,6 +31,13 @@ def test_rosa_job_secret_data(rosa_job: RosaJob) -> None:
     secret_data = rosa_job.secret_data()
     assert set(secret_data.keys()) == {
         "OCM_TOKEN",
+    }
+
+
+def test_rosa_job_scripts(rosa_job: RosaJob) -> None:
+    scripts = rosa_job.scripts()
+    assert set(scripts.keys()) == {
+        EXEC_SCRIPT,
     }
 
 

--- a/reconcile/utils/jobcontroller/controller.py
+++ b/reconcile/utils/jobcontroller/controller.py
@@ -258,8 +258,16 @@ class K8sJobController:
 
     def build_secret(self, job: K8sJob) -> Optional[V1Secret]:
         secret_data = job.secret_data()
-        if not secret_data:
+        script_data = job.scripts()
+        # fail if both dicts have overlapping keys
+        if not set(secret_data).isdisjoint(script_data):
+            raise Exception(
+                f"Secret data and script data have overlapping keys for {job.name()}"
+            )
+        data = {**secret_data, **script_data}
+        if not data:
             return None
+
         job_name = job.name()
         job_uid = self._lookup_job_uid(job_name)
         if not job_uid:
@@ -280,7 +288,7 @@ class K8sJobController:
                     )
                 ],
             ),
-            string_data=secret_data,
+            string_data=data,
         )
 
     def create_job(self, job: K8sJob) -> None:

--- a/reconcile/utils/jobcontroller/controller.py
+++ b/reconcile/utils/jobcontroller/controller.py
@@ -261,7 +261,7 @@ class K8sJobController:
         script_data = job.scripts()
         # fail if both dicts have overlapping keys
         if not set(secret_data).isdisjoint(script_data):
-            raise Exception(
+            raise JobValidationError(
                 f"Secret data and script data have overlapping keys for {job.name()}"
             )
         data = {**secret_data, **script_data}

--- a/reconcile/utils/jobcontroller/models.py
+++ b/reconcile/utils/jobcontroller/models.py
@@ -145,6 +145,10 @@ class K8sJob(ABC):
         return {}
 
     def secret_data_to_env_vars_secret_refs(self) -> list[V1EnvVar]:
+        """
+        Helper function to generate env var references from the `secret_data`,
+        to be used in container specs
+        """
         secret_name = self.name()
         return [
             V1EnvVar(
@@ -160,6 +164,10 @@ class K8sJob(ABC):
         ]
 
     def scripts_volume_mount(self, directory: str) -> V1VolumeMount:
+        """
+        Helper function to generate a volume mount for the `scripts` to be used
+        in container specs
+        """
         secret_name = self.name()
         return V1VolumeMount(
             name=secret_name,
@@ -167,6 +175,10 @@ class K8sJob(ABC):
         )
 
     def scripts_volume(self) -> V1Volume:
+        """
+        Helper function to generate a volume for the `scripts` to be used in
+        pod specs
+        """
         secret_name = self.name()
         return V1Volume(
             name=secret_name,

--- a/reconcile/utils/rosa/rosa_cli.py
+++ b/reconcile/utils/rosa/rosa_cli.py
@@ -27,6 +27,7 @@ from reconcile.utils.jobcontroller.models import JobStatus, K8sJob
 SCRIPTS_MOUNT_PATH = "/scripts"
 EXEC_SCRIPT = "execute.sh"
 
+
 class LogHandle:
     """
     Represents a handle to a log file and offers convenience methods to consume


### PR DESCRIPTION
not all rosa cli automations are single commands. if longer scripts are required, passing commands as ENV variables becomes cumbersome and brittle. mounting the script as a file into the job container is much more stable.

this PR introduces such scripting functionality.

bonus: get the last x logfiles from a pod

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>
