### PR TITLE
[fedramp] helm updates for FIPS image

### DIFF
--- a/helm/qontract-reconcile/values-manager-fedramp.yaml
+++ b/helm/qontract-reconcile/values-manager-fedramp.yaml
@@ -21,3 +21,4 @@ integrations:
   shard_specs:
   - shard_id: 0
     shards: 1
+    extra_args: -i quay.io/app-sre/qontract-reconcile-fips

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -148,6 +148,8 @@ objects:
             value: "${INTEGRATIONS_MANAGER_IMAGE_TAG_FROM_REF}"
           - name: INTEGRATION_NAME
             value: integrations-manager
+          - name: INTEGRATION_EXTRA_ARGS
+            value: "-i quay.io/app-sre/qontract-reconcile-fips"
           - name: SLEEP_DURATION_SECS
             value: ${SLEEP_DURATION_SECS}
           - name: GITHUB_API


### PR DESCRIPTION
[APPSRE-9849](https://issues.redhat.com/browse/APPSRE-9849)

Now that we have a new FIPS compatible qontract-reconcile image being built, we need to ensure that all integration pods spawned in FedRamp are using that image not the standard QR image. integrations_manager is responsible for creating those pods and supports an `--image/-i` option to specify which image to use in the newly created pods so I've updated the FR OpenShift template so that new pods use the correct image.

I did not update the `IMAGE` tag [here](https://github.com/cubismod/qontract-reconcile/blob/bac0399c1f3e77b5d4464ac54146dadbe89cee1a/openshift/qontract-manager-fedramp.yaml#L264) as that can just be adjusted within the saas file deploying QR.