### PR TITLE
[prometheus-rules-tester] reduce resources to prometheus-rule only

### DIFF
--- a/reconcile/prometheus_rules_tester/integration.py
+++ b/reconcile/prometheus_rules_tester/integration.py
@@ -133,7 +133,10 @@ def get_rules_and_tests(
 
     iterable = []
     for namespace in namespace_with_prom_rules:
-        for resource in namespace["openshiftResources"]:
+        prom_rules = [
+            r for r in namespace["openshiftResources"] if r["provider"] in PROVIDERS
+        ]
+        for resource in prom_rules:
             iterable.append(
                 RuleToFetch(
                     namespace=namespace,


### PR DESCRIPTION
slack thread: https://redhat-internal.slack.com/archives/CCRND57FW/p1709123601855539

with this change, we not only reduce the run time of the integration, but also eliminate runs with `early_exit` in case no prometheus tests have changed.