### PR TITLE
[ocm-clusters] enforce one HCP cluster per AWS account

### DIFF
--- a/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
+++ b/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
+if (( CURRENT_CLUSTER_COUNT > 0 )); then
+  echo "Error: This account already has a cluster. Only one cluster per account is supported."
+  exit 1
+fi
+
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto

--- a/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
+++ b/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
 if (( CURRENT_CLUSTER_COUNT > 0 )); then
   echo "Error: This account already has a cluster. Only one cluster per account is supported."

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
+if (( CURRENT_CLUSTER_COUNT > 0 )); then
+  echo "Error: This account already has a cluster. Only one cluster per account is supported."
+  exit 1
+fi
+
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
 if (( CURRENT_CLUSTER_COUNT > 0 )); then
   echo "Error: This account already has a cluster. Only one cluster per account is supported."

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_dry_run.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_dry_run.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
+if (( CURRENT_CLUSTER_COUNT > 0 )); then
+  echo "Error: This account already has a cluster. Only one cluster per account is supported."
+  exit 1
+fi
+
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_dry_run.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_dry_run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
 if (( CURRENT_CLUSTER_COUNT > 0 )); then
   echo "Error: This account already has a cluster. Only one cluster per account is supported."

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_no_provision_shard.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_no_provision_shard.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
+if (( CURRENT_CLUSTER_COUNT > 0 )); then
+  echo "Error: This account already has a cluster. Only one cluster per account is supported."
+  exit 1
+fi
+
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_no_provision_shard.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_no_provision_shard.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
 if (( CURRENT_CLUSTER_COUNT > 0 )); then
   echo "Error: This account already has a cluster. Only one cluster per account is supported."

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_private.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_private.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
+if (( CURRENT_CLUSTER_COUNT > 0 )); then
+  echo "Error: This account already has a cluster. Only one cluster per account is supported."
+  exit 1
+fi
+
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_private.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_private.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
 if (( CURRENT_CLUSTER_COUNT > 0 )); then
   echo "Error: This account already has a cluster. Only one cluster per account is supported."

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_reuse_oidc_config.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_reuse_oidc_config.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
+if (( CURRENT_CLUSTER_COUNT > 0 )); then
+  echo "Error: This account already has a cluster. Only one cluster per account is supported."
+  exit 1
+fi
+
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_reuse_oidc_config.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_reuse_oidc_config.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
 if (( CURRENT_CLUSTER_COUNT > 0 )); then
   echo "Error: This account already has a cluster. Only one cluster per account is supported."

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_uwm_enabled.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_uwm_enabled.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
+if (( CURRENT_CLUSTER_COUNT > 0 )); then
+  echo "Error: This account already has a cluster. Only one cluster per account is supported."
+  exit 1
+fi
+
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_uwm_enabled.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_uwm_enabled.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -o pipefail
+
 CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
 if (( CURRENT_CLUSTER_COUNT > 0 )); then
   echo "Error: This account already has a cluster. Only one cluster per account is supported."

--- a/reconcile/utils/jobcontroller/controller.py
+++ b/reconcile/utils/jobcontroller/controller.py
@@ -371,12 +371,12 @@ class K8sJobController:
         if sleep_interval_seconds > 0:
             self.time_module.sleep(sleep_interval_seconds)
 
-    def store_job_logs(self, job_name: str, output_dir_path: str) -> None:
+    def store_job_logs(self, job_name: str, output_dir_path: str) -> str:
         """
         Stores the logs of a job in the given output directory.
         The filename will be the name of the job.
         """
-        self.oc.job_logs_latest_pod(
+        return self.oc.job_logs_latest_pod(
             namespace=self.namespace,
             name=job_name,
             output=output_dir_path,

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -735,7 +735,7 @@ class OCCli:  # pylint: disable=too-many-public-methods
         # collect logs to file async
         Popen(self.oc_base_cmd + cmd, stdout=output_file)
 
-    def job_logs_latest_pod(self, namespace, name, output) -> str:
+    def job_logs_latest_pod(self, namespace: str, name: str, output: str) -> str:
         pods = self.get_items("Pod", namespace=namespace, labels={"job-name": name})
 
         finished_pods = [

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -735,7 +735,7 @@ class OCCli:  # pylint: disable=too-many-public-methods
         # collect logs to file async
         Popen(self.oc_base_cmd + cmd, stdout=output_file)
 
-    def job_logs_latest_pod(self, namespace, name, output):
+    def job_logs_latest_pod(self, namespace, name, output) -> str:
         pods = self.get_items("Pod", namespace=namespace, labels={"job-name": name})
 
         finished_pods = [
@@ -754,9 +754,13 @@ class OCCli:  # pylint: disable=too-many-public-methods
             namespace,
             f"pod/{latest_pod['metadata']['name']}",
         ]
-        output_file = open(os.path.join(output, name), "w", encoding="locale")
-        # collect logs to file async
-        Popen(self.oc_base_cmd + cmd, stdout=output_file)
+        output_file_name = os.path.join(output, name)
+        with open(output_file_name, "w", encoding="locale") as f:
+            # collect logs to file async
+            p = Popen(self.oc_base_cmd + cmd, stdout=f)
+            # wait here for the log collection to finish
+            p.wait()
+        return output_file_name
 
     @staticmethod
     def get_service_account_username(user):

--- a/reconcile/utils/rosa/session.py
+++ b/reconcile/utils/rosa/session.py
@@ -83,9 +83,6 @@ class RosaSession:
             service_account=self.service_account,
         )
 
-    def wrap_cli_command(self, cmd: str) -> str:
-        return f"rosa login > /dev/null && {cmd}"
-
     def cli_execute(
         self,
         cmd: str,
@@ -106,11 +103,10 @@ class RosaSession:
             concurrency_policy=JobConcurrencyPolicy.REPLACE_FAILED,
         )
         log_dir = tempfile.mkdtemp()
-        self.job_controller.store_job_logs(job.name(), log_dir)
-        log_file = f"{log_dir}/{job.name()}"
+        log_file_name = self.job_controller.store_job_logs(job.name(), log_dir)
         if status != JobStatus.SUCCESS:
-            raise RosaCliException(status, cmd, LogHandle(log_file))
-        return RosaCliResult(status, cmd, LogHandle(log_file))
+            raise RosaCliException(status, cmd, LogHandle(log_file_name))
+        return RosaCliResult(status, cmd, LogHandle(log_file_name))
 
     def create_hcp_cluster(
         self, cluster_name: str, spec: OCMSpec, dry_run: bool


### PR DESCRIPTION
for the HCP cluster creation automation, we assume one cluster per account right now. instead of just assuming, lets enforce it.

if a cluster exists already in an account, the rosa cli script will fail (also during PR checks).

bonus: fix some logging issue where job logs were not always shown