### PR TITLE
increase timeout for rosa cluster creation job

### DIFF
--- a/reconcile/utils/rosa/session.py
+++ b/reconcile/utils/rosa/session.py
@@ -88,7 +88,7 @@ class RosaSession:
         cmd: str,
         annotations: Optional[dict[str, str]] = None,
         image: Optional[str] = None,
-        check_interval_seconds: Optional[int] = 5,
+        check_interval_seconds: int = 5,
         timeout_seconds: int = 60,
     ) -> RosaCliResult:
         """
@@ -115,7 +115,7 @@ class RosaSession:
         cluster_name: str,
         spec: OCMSpec,
         dry_run: bool,
-        check_interval_seconds: Optional[int] = 10,
+        check_interval_seconds: int = 10,
         timeout_seconds: int = 300,
     ) -> RosaCliResult:
         """


### PR DESCRIPTION
increase the timeout for the ROSA HCP cluster creation job to 5 minutes up from 60 seconds. this is defined statically for now to solve an issue. an upcoming PR will make this configurable