### PR TITLE
[template-renderer] Keep newline when patch template

### DIFF
--- a/reconcile/templating/rendering.py
+++ b/reconcile/templating/rendering.py
@@ -46,7 +46,7 @@ class Renderer(ABC):
         self.template = template
         self.data = data
         self.secret_reader = secret_reader
-        self.ruaml_instace = create_ruamel_instance()
+        self.ruamel_instance = create_ruamel_instance()
 
     def _jinja2_render_kwargs(self) -> dict[str, Any]:
         return {**self.data.variables, "current": self.data.current}
@@ -110,7 +110,7 @@ class PatchRenderer(Renderer):
             )
         matched_value = matched_values[0]
 
-        data_to_add = self.ruaml_instace.load(
+        data_to_add = self.ruamel_instance.load(
             self._render_template(self.template.template)
         )
 
@@ -125,23 +125,23 @@ class PatchRenderer(Renderer):
                     f"Expected identifier {self.template.patch.identifier} in data to add"
                 )
 
-            data = next(
+            index = next(
                 (
-                    data
-                    for data in matched_value
+                    index
+                    for index, data in enumerate(matched_value)
                     if data.get(self.template.patch.identifier) == dta_identifier
                 ),
                 None,
             )
-            if data is None:
+            if index is None:
                 matched_value.append(data_to_add)
             else:
-                data.update(data_to_add)
+                matched_value[index] = data_to_add
         else:
             matched_value.update(data_to_add)
 
         with StringIO() as s:
-            self.ruaml_instace.dump(self.data.current, s)
+            self.ruamel_instance.dump(self.data.current, s)
             return s.getvalue()
 
 

--- a/reconcile/test/fixtures/templating/patch_add_newline_list.yaml
+++ b/reconcile/test/fixtures/templating/patch_add_newline_list.yaml
@@ -1,0 +1,43 @@
+template:
+  name: update file
+
+  targetPath: /some/saas/deploy.yml
+
+  patch:
+    path: '$.resourceTemplates[?name=="saas"].targets'
+    identifier: namespace
+
+  template: |
+
+
+    namespace:
+
+      $ref: additional.yaml
+
+    version:
+      foo: {{bar}}
+
+  templateTest: []
+current:
+  resourceTemplates:
+    - name: saas
+      targets:
+        - namespace:
+            $ref: existing.yaml
+          version:
+            foo: bar
+expected: |
+  resourceTemplates:
+  - name: saas
+    targets:
+    - namespace:
+        $ref: existing.yaml
+      version:
+        foo: bar
+
+    - namespace:
+
+        $ref: additional.yaml
+
+      version:
+        foo: bar

--- a/reconcile/test/fixtures/templating/patch_overwrite_newline_list.yaml
+++ b/reconcile/test/fixtures/templating/patch_overwrite_newline_list.yaml
@@ -1,0 +1,39 @@
+template:
+  name: update file
+
+  targetPath: /some/saas/deploy.yml
+
+  patch:
+    path: '$.resourceTemplates[?name=="saas"].targets'
+    identifier: namespace
+
+  template: |
+
+
+    namespace:
+
+      $ref: existing.yaml
+
+    version:
+      foo: {{bar}}
+
+  templateTest: []
+current:
+  resourceTemplates:
+    - name: saas
+      targets:
+        - namespace:
+            $ref: existing.yaml
+          version:
+            foo: bar
+expected: |
+  resourceTemplates:
+  - name: saas
+    targets:
+
+    - namespace:
+
+        $ref: existing.yaml
+
+      version:
+        foo: bar

--- a/reconcile/test/templating/test_patch_rendering.py
+++ b/reconcile/test/templating/test_patch_rendering.py
@@ -11,6 +11,8 @@ from reconcile.utils.secret_reader import SecretReader
     [
         "patch_simple.yaml",
         "patch_updated.yaml",
+        "patch_add_newline_list.yaml",
+        "patch_overwrite_newline_list.yaml",
         "patch_overwrite.yaml",
         "patch_overwrite_nested.yaml",
     ],


### PR DESCRIPTION
When parse template using ruamel, there needs to be 2 newlines at start for it to be recognized as a newline comment. See example in [patch_add_newline_list.yaml](https://github.com/hemslo/qontract-reconcile/blob/f6a45e21acbbc18595156fcec9cf16b72931293c/reconcile/test/fixtures/templating/patch_add_newline_list.yaml)

To support keeping newlines when overwrite item in list, the item in list has to be replaced by parsed yaml object instead of update in place.

There is one remaining issue about overwrite item in dict, so far the dict items are patched, for example in test case [patch_overwrite_nested.yaml](https://github.com/app-sre/qontract-reconcile/blob/cfb5b6fc1e3594afdcbda82551b37269864fa352/reconcile/test/fixtures/templating/patch_overwrite_nested.yaml), matched `$.version` is a dict, template only contains `foo` key, since we are using `update` on that dict directly, only `foo` will be updated, so it will skip newline (comment sections). We need to design what's the expected behaviour for non list overwrite, like dict and plain values.

[APPSRE-8796](https://issues.redhat.com/browse/APPSRE-8796)