### PR TITLE
[ocm-machine-pools] nodepool subnet specdrift

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2394,11 +2394,14 @@ def ocm_addons_upgrade_tests_trigger(ctx):
 
 
 @integration.command(short_help="Manage Machine Pools in OCM.")
+@gitlab_project_id
 @click.pass_context
-def ocm_machine_pools(ctx):
+def ocm_machine_pools(ctx, gitlab_project_id):
     import reconcile.ocm_machine_pools
 
-    run_integration(reconcile.ocm_machine_pools, ctx.obj)
+    run_integration(
+        reconcile.ocm_machine_pools, ctx.obj, gitlab_project_id=gitlab_project_id
+    )
 
 
 @integration.command(short_help="Manage Upgrade Policy schedules in OCM organizations.")

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -247,7 +247,7 @@ class NodePool(AbstractPool):
     subnet: Optional[str]
 
     def delete(self, ocm: OCM) -> None:
-        ocm.delete_node_pool(self.cluster, self.dict(by_alias=True))
+        ocm.delete_node_pool(self.cluster, self.id)
 
     def create(self, ocm: OCM) -> None:
         spec = self.dict(by_alias=True)

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -262,7 +262,9 @@ class NodePool(AbstractPool):
             or self.taints != pool.taints
             or self.labels != pool.labels
             or self.aws_node_pool.instance_type != pool.instance_type
-            or self.subnet != pool.subnet
+            # if the nodepool in app-interface does not define a subnet explicitely
+            # we don't consider it a diff. we don't manage it
+            or (pool.subnet is not None and self.subnet != pool.subnet)
             or self._has_diff_autoscale(pool)
         )
 
@@ -373,7 +375,7 @@ def _classify_cluster_type(cluster: ClusterV1) -> ClusterType:
             raise ValueError(f"unknown cluster type for cluster {cluster.name}")
 
 
-def fetch_current_state_for_cluster(cluster, ocm):
+def fetch_current_state_for_cluster(cluster: ClusterV1, ocm: OCM) -> list[AbstractPool]:
     cluster_type = _classify_cluster_type(cluster)
     if cluster_type == ClusterType.ROSA_HCP:
         return [

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -278,7 +278,9 @@ class NodePool(AbstractPool):
             or self.labels != pool.labels
             or self.aws_node_pool.instance_type != pool.instance_type
             # if the nodepool in app-interface does not define a subnet explicitely
-            # we don't consider it a diff. we don't manage it
+            # we don't consider it a diff. we don't manage it, but `get_pool_spec_to_update`
+            # will highlight it as a spec drift that is going to be fixed with an MR
+            # towards app-interface
             or (pool.subnet is not None and self.subnet != pool.subnet)
             or self._has_diff_autoscale(pool)
         )

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -299,16 +299,17 @@ class NodePool(AbstractPool):
         if app-interface does not define a subnet explicitely or if the
         subnet is different from OCM, we consider the spec in app-interface oudated.
 
-        in such a case this method returns a clone of the current pool definition
+        In such a case this method returns a clone of the current pool definition
         in app-interface with the subnet updated to the one in OCM. if no update
         is required, None is returned
 
-        how can this happen?
-        * cluster gets created without specified subnets and ROSA CLI picks the subnet
+        How can this happen?
+        * a cluster was created without specified subnets and ROSA CLI picks the subnet
           assignment for the nodepools
         * nodepools have been recreated on OCM side without app-interface involvement
+          and the subnet changed
         """
-        if pool.subnet is None and self.subnet != pool.subnet:
+        if pool.subnet is None or self.subnet != pool.subnet:
             return pool.copy(update={"subnet": self.subnet})
         return None
 

--- a/reconcile/ocm_machine_pools.py
+++ b/reconcile/ocm_machine_pools.py
@@ -306,7 +306,7 @@ class NodePool(AbstractPool):
           assignment for the nodepools
         * nodepools have been recreated on OCM side without app-interface involvement
         """
-        if pool.subnet is None or self.subnet != pool.subnet:
+        if pool.subnet is None and self.subnet != pool.subnet:
             return pool.copy(update={"subnet": self.subnet})
         return None
 
@@ -567,9 +567,7 @@ def calculate_spec_drift(
         desired_pool = desired_machine_pools.get(pool_key)
         if not desired_pool:
             continue
-        update = current_pool.get_pool_spec_to_update(
-            desired_machine_pools.get(pool_key)
-        )
+        update = current_pool.get_pool_spec_to_update(desired_pool)
         if update:
             cluster_path = desired_state[pool_key[0]].cluster_path
             spec_drift_updates.append((cluster_path, update))
@@ -607,7 +605,8 @@ def _cluster_is_compatible(cluster: ClusterV1) -> bool:
     return (
         cluster.ocm is not None
         and cluster.machine_pools is not None
-        and cluster.spec and cluster.spec.q_id is not None
+        and cluster.spec is not None
+        and cluster.spec.q_id is not None
     )
 
 

--- a/reconcile/test/test_ocm_machine_pools.py
+++ b/reconcile/test/test_ocm_machine_pools.py
@@ -923,6 +923,7 @@ def default_hypershift_worker_machine_pool() -> dict:
         "id": "workers",
         "instance_type": "m5.xlarge",
         "replicas": 2,
+        "subnet": "subnet-1",
     }
 
 
@@ -943,7 +944,7 @@ def expected_node_pool_create_payload() -> dict:
         "id": "workers",
         "labels": None,
         "replicas": 2,
-        "subnet": None,
+        "subnet": "subnet-1",
         "taints": [],
     }
 
@@ -970,6 +971,7 @@ def existing_updated_hypershift_node_pools() -> list[dict]:
             "id": "workers",
             "aws_node_pool": {"instance_type": "m5.xlarge"},
             "replicas": 3,
+            "subnet": "subnet-1",
         }
     ]
 
@@ -1020,34 +1022,21 @@ def existing_multiple_hypershift_node_pools() -> list[dict]:
             "id": "workers",
             "aws_node_pool": {"instance_type": "m5.xlarge"},
             "replicas": 3,
+            "subnet": "subnet-1",
         },
         {
             "id": "new-workers",
             "aws_node_pool": {"instance_type": "m5.xlarge"},
             "replicas": 3,
+            "subnet": "subnet-2",
         },
     ]
-
-
-@pytest.fixture
-def expected_hypershift_node_pool_delete_payload() -> dict:
-    return {
-        "autoscaling": None,
-        "cluster": "hypershift-cluster",
-        "id": "new-workers",
-        "aws_node_pool": {"instance_type": "m5.xlarge"},
-        "labels": None,
-        "replicas": 3,
-        "subnet": None,
-        "taints": None,
-    }
 
 
 def test_run_delete_node_pool(
     mocker: MockerFixture,
     hypershift_cluster: ClusterV1,
     existing_multiple_hypershift_node_pools: list[dict],
-    expected_hypershift_node_pool_delete_payload: dict,
 ) -> None:
     mocks = setup_mocks(
         mocker,
@@ -1059,7 +1048,7 @@ def test_run_delete_node_pool(
 
     mocks["OCM"].delete_node_pool.assert_called_once_with(
         hypershift_cluster.name,
-        expected_hypershift_node_pool_delete_payload,
+        "new-workers",
     )
 
 
@@ -1069,6 +1058,7 @@ def non_default_hypershift_worker_machine_pool() -> dict:
         "id": "new-workers",
         "instance_type": "m5.xlarge",
         "replicas": 3,
+        "subnet": "subnet-3",
     }
 
 
@@ -1087,16 +1077,19 @@ def existing_multiple_hypershift_node_pools_with_defaults() -> list[dict]:
             "id": "workers",
             "aws_node_pool": {"instance_type": "m5.xlarge"},
             "replicas": 3,
+            "subnet": "subnet-1",
         },
         {
             "id": "workers-1",
             "aws_node_pool": {"instance_type": "m5.xlarge"},
             "replicas": 3,
+            "subnet": "subnet-2",
         },
         {
             "id": "new-workers",
             "aws_node_pool": {"instance_type": "m5.xlarge"},
             "replicas": 3,
+            "subnet": "subnet-3",
         },
     ]
 
@@ -1121,6 +1114,7 @@ def test_update_app_interface_with_subnet(
     mocker: MockerFixture,
     hypershift_cluster: ClusterV1,
 ) -> None:
+    hypershift_cluster.machine_pools[0].subnet = None
     setup_mocks(
         mocker,
         clusters=[hypershift_cluster],

--- a/reconcile/test/test_ocm_machine_pools.py
+++ b/reconcile/test/test_ocm_machine_pools.py
@@ -1143,9 +1143,8 @@ def test_update_app_interface_with_subnet(
     update_app_interface_mock.assert_called_once_with(
         False,
         None,
-        [
-            (
-                hypershift_cluster.path,
+        {
+            hypershift_cluster.path: [
                 ClusterMachinePoolV1(
                     id="workers",
                     instance_type="m5.xlarge",
@@ -1155,6 +1154,6 @@ def test_update_app_interface_with_subnet(
                     taints=None,
                     subnet="subnet-1",
                 ),
-            )
-        ],
+            ]
+        },
     )

--- a/reconcile/test/test_ocm_machine_pools.py
+++ b/reconcile/test/test_ocm_machine_pools.py
@@ -345,6 +345,13 @@ def test_pool_node_pool_invalid_diff_subnet(node_pool, cluster_machine_pool):
     assert node_pool.invalid_diff(cluster_machine_pool)
 
 
+def test_pool_node_pool_valid_diff_subnet(node_pool, cluster_machine_pool):
+    cluster_machine_pool.subnet = None
+    node_pool.subnet = "foo"
+    cluster_machine_pool.replicas = 2
+    assert not node_pool.has_diff(cluster_machine_pool)
+
+
 def test_pool_node_pool_invalid_diff_instance_type(node_pool, cluster_machine_pool):
     cluster_machine_pool.instance_type = "foo"
     assert node_pool.invalid_diff(cluster_machine_pool)
@@ -1114,7 +1121,7 @@ def test_update_app_interface_with_subnet(
     mocker: MockerFixture,
     hypershift_cluster: ClusterV1,
 ) -> None:
-    hypershift_cluster.machine_pools[0].subnet = None
+    hypershift_cluster.machine_pools[0].subnet = None  # type: ignore
     setup_mocks(
         mocker,
         clusters=[hypershift_cluster],

--- a/reconcile/test/utils/test_mr_machine_pool_updates.py
+++ b/reconcile/test/utils/test_mr_machine_pool_updates.py
@@ -1,0 +1,114 @@
+from io import StringIO
+from typing import Any
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from ruamel.yaml import YAML
+
+from reconcile.test.fixtures import Fixtures
+from reconcile.utils.mr.cluster_machine_pool_updates import ClustersMachinePoolUpdates
+from reconcile.utils.ruamel import create_ruamel_instance
+
+
+@pytest.fixture
+def fxt() -> Fixtures:
+    return Fixtures("clusters")
+
+
+@pytest.fixture
+def cluster_spec(fxt: Fixtures) -> dict[str, Any]:
+    return fxt.get_anymarkup("rosa_hcp_spec_ai.yml")
+
+
+@pytest.fixture
+def cluster_spec_raw(fxt: Fixtures) -> str:
+    return fxt.get("rosa_hcp_spec_ai.yml")
+
+
+@pytest.fixture
+def yaml() -> YAML:
+    return create_ruamel_instance(explicit_start=True, width=4096)
+
+
+@pytest.fixture
+def gitlab_cli(cluster_spec_raw: str) -> MagicMock:
+    cli = MagicMock()
+    cli.project.files.get.return_value = cluster_spec_raw.encode()
+    return cli
+
+
+def test_normalized_machine_pool_updates() -> None:
+    mr = ClustersMachinePoolUpdates({
+        "/path": [
+            {
+                "id": "worker",
+                "instance_type": "m5.xlarge",
+                "autoscaling": None,
+                "subnet": "subnet-1",
+            }
+        ]
+    })
+    assert mr.normalized_machine_pool_updates() == {
+        "/path": [
+            {
+                "id": "worker",
+                "instance_type": "m5.xlarge",
+                "subnet": "subnet-1",
+            }
+        ]
+    }
+
+
+@patch.object(ClustersMachinePoolUpdates, "cancel", autospec=True, return_value=None)
+def test_mr_machine_pool_update_changes_to_spec(
+    cancel_mock: Mock, cluster_spec_raw: str, gitlab_cli: MagicMock, yaml: YAML
+) -> None:
+    mr = ClustersMachinePoolUpdates({
+        "/path": [
+            {
+                "id": "worker",
+                "instance_type": "m5.xlarge",
+                "autoscaling": None,
+                "subnet": "subnet-1",
+            }
+        ]
+    })
+    mr.branch = "abranch"
+    mr.process(gitlab_cli)
+
+    with StringIO() as stream:
+        cluster_spec = yaml.load(cluster_spec_raw)
+        cluster_spec["machinePools"][0]["subnet"] = "subnet-1"
+        yaml.dump(cluster_spec, stream)
+        new_content = stream.getvalue()
+
+    gitlab_cli.update_file.assert_called_once_with(
+        branch_name="abranch",
+        file_path="data/path",
+        commit_message="update cluster data/path machine-pool fields",
+        content=new_content,
+    )
+    cancel_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "no_op_changes",
+    [
+        {"/path": []},
+        {},
+    ],
+)
+@patch.object(ClustersMachinePoolUpdates, "cancel", autospec=True, return_value=None)
+def test_mr_machine_pool_update_no_changes(
+    cancel_mock: Mock,
+    cluster_spec_raw: str,
+    gitlab_cli: MagicMock,
+    yaml: YAML,
+    no_op_changes: dict,
+) -> None:
+    mr = ClustersMachinePoolUpdates(no_op_changes)
+    mr.branch = "abranch"
+    mr.process(gitlab_cli)
+
+    gitlab_cli.update_file.assert_not_called()
+    cancel_mock.assert_called()

--- a/reconcile/utils/mr/cluster_machine_pool_updates.py
+++ b/reconcile/utils/mr/cluster_machine_pool_updates.py
@@ -10,19 +10,14 @@ from reconcile.utils.ruamel import create_ruamel_instance
 class ClustersMachinePoolUpdates(MergeRequestBase):
     name = "create_cluster_machine_pool_updates_mr"
 
-    def __init__(self) -> None:
-        self.machine_pool_updates: dict[str, list[dict[str, Any]]] = {}
+    def __init__(self, machine_pool_updates: dict[str, list[dict[str, Any]]]) -> None:
+        self.machine_pool_updates: dict[str, list[dict[str, Any]]] = (
+            machine_pool_updates
+        )
 
         super().__init__()
 
         self.labels = []
-
-    def add_machine_pool_update(
-        self, cluster_name: str, machine_pool: dict[str, Any]
-    ) -> None:
-        if cluster_name not in self.machine_pool_updates:
-            self.machine_pool_updates[cluster_name] = []
-        self.machine_pool_updates[cluster_name].append(machine_pool)
 
     @property
     def title(self) -> str:
@@ -32,10 +27,21 @@ class ClustersMachinePoolUpdates(MergeRequestBase):
     def description(self) -> str:
         return DecisionCommand.APPROVED.value
 
+    def normalized_machine_pool_updates(self) -> dict[str, list[dict[str, Any]]]:
+        return {
+            cluster_path: [
+                clean_none_values_from_dict(update) for update in pool_updates
+            ]
+            for cluster_path, pool_updates in self.machine_pool_updates.items()
+        }
+
     def process(self, gitlab_cli: GitLabApi) -> None:
         yaml = create_ruamel_instance(explicit_start=True, width=4096)
         changes = False
-        for cluster_path, machine_pool_updates in self.machine_pool_updates.items():
+        for (
+            cluster_path,
+            machine_pool_updates,
+        ) in self.normalized_machine_pool_updates().items():
             cluster_fs_path = f"data{cluster_path}"
             if not machine_pool_updates:
                 continue
@@ -45,7 +51,7 @@ class ClustersMachinePoolUpdates(MergeRequestBase):
             )
             content = yaml.load(raw_file.decode())
             if "machinePools" not in content:
-                self.cancel("machinePools missing. Nothing to do.")
+                self.cancel(f"{cluster_fs_path} misses machinePools. Nothing to do.")
 
             for machine_pool in machine_pool_updates:
                 for mp in content["machinePools"]:
@@ -57,7 +63,7 @@ class ClustersMachinePoolUpdates(MergeRequestBase):
                 yaml.dump(content, stream)
                 new_content = stream.getvalue()
 
-            msg = f"update cluster {content['name']} spec fields"
+            msg = f"update cluster {cluster_fs_path} machine-pool fields"
             gitlab_cli.update_file(
                 branch_name=self.branch,
                 file_path=cluster_fs_path,
@@ -67,3 +73,7 @@ class ClustersMachinePoolUpdates(MergeRequestBase):
 
         if not changes:
             self.cancel("Clusters are up to date. Nothing to do.")
+
+
+def clean_none_values_from_dict(d: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in d.items() if v is not None}

--- a/reconcile/utils/mr/cluster_machine_pool_updates.py
+++ b/reconcile/utils/mr/cluster_machine_pool_updates.py
@@ -1,16 +1,10 @@
 from io import StringIO
 from typing import Any
 
-from ruamel.yaml import YAML
-
 from reconcile.change_owners.decision import DecisionCommand
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.mr.base import MergeRequestBase
-
-yaml = YAML()
-yaml.explicit_start = True
-# Lets prevent line wraps
-yaml.width = 4096
+from reconcile.utils.ruamel import create_ruamel_instance
 
 
 class ClustersMachinePoolUpdates(MergeRequestBase):
@@ -39,6 +33,7 @@ class ClustersMachinePoolUpdates(MergeRequestBase):
         return DecisionCommand.APPROVED.value
 
     def process(self, gitlab_cli: GitLabApi) -> None:
+        yaml = create_ruamel_instance(explicit_start=True, width=4096)
         changes = False
         for cluster_path, machine_pool_updates in self.machine_pool_updates.items():
             cluster_fs_path = f"data{cluster_path}"

--- a/reconcile/utils/mr/cluster_machine_pool_updates.py
+++ b/reconcile/utils/mr/cluster_machine_pool_updates.py
@@ -1,0 +1,74 @@
+from io import StringIO
+from typing import Any
+
+from ruamel.yaml import YAML
+
+from reconcile.change_owners.decision import DecisionCommand
+from reconcile.utils.gitlab_api import GitLabApi
+from reconcile.utils.mr.base import MergeRequestBase
+
+yaml = YAML()
+yaml.explicit_start = True
+# Lets prevent line wraps
+yaml.width = 4096
+
+
+class ClustersMachinePoolUpdates(MergeRequestBase):
+    name = "create_cluster_machine_pool_updates_mr"
+
+    def __init__(self) -> None:
+        self.machine_pool_updates: dict[str, list[dict[str, Any]]] = {}
+
+        super().__init__()
+
+        self.labels = []
+
+    def add_machine_pool_update(
+        self, cluster_name: str, machine_pool: dict[str, Any]
+    ) -> None:
+        if cluster_name not in self.machine_pool_updates:
+            self.machine_pool_updates[cluster_name] = []
+        self.machine_pool_updates[cluster_name].append(machine_pool)
+
+    @property
+    def title(self) -> str:
+        return f"[{self.name}] machine pool updates"
+
+    @property
+    def description(self) -> str:
+        return DecisionCommand.APPROVED.value
+
+    def process(self, gitlab_cli: GitLabApi) -> None:
+        changes = False
+        for cluster_path, machine_pool_updates in self.machine_pool_updates.items():
+            cluster_fs_path = f"data{cluster_path}"
+            if not machine_pool_updates:
+                continue
+
+            raw_file = gitlab_cli.project.files.get(
+                file_path=cluster_fs_path, ref=gitlab_cli.main_branch
+            )
+            content = yaml.load(raw_file.decode())
+            if "machinePools" not in content:
+                self.cancel("machinePools missing. Nothing to do.")
+
+            for machine_pool in machine_pool_updates:
+                for mp in content["machinePools"]:
+                    if mp["id"] == machine_pool["id"]:
+                        mp.update(machine_pool)
+                        changes = True
+
+            with StringIO() as stream:
+                yaml.dump(content, stream)
+                new_content = stream.getvalue()
+
+            msg = f"update cluster {content['name']} spec fields"
+            gitlab_cli.update_file(
+                branch_name=self.branch,
+                file_path=cluster_fs_path,
+                commit_message=msg,
+                content=new_content,
+            )
+
+        if not changes:
+            self.cancel("Clusters are up to date. Nothing to do.")

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -575,7 +575,7 @@ class OCM:  # pylint: disable=too-many-public-methods
 
         return get_node_pools(self._ocm_client, cluster_id)
 
-    def delete_node_pool(self, cluster, spec):
+    def delete_node_pool(self, cluster, node_pool_id):
         """Deletes an existing Node Pool
 
         :param cluster: cluster name
@@ -585,7 +585,6 @@ class OCM:  # pylint: disable=too-many-public-methods
         :type spec: dictionary
         """
         cluster_id = self.cluster_ids[cluster]
-        node_pool_id = spec["id"]
         api = f"{CS_API_BASE}/v1/clusters/{cluster_id}/node_pools/" + f"{node_pool_id}"
         self._delete(api)
 


### PR DESCRIPTION
specifying the subnet IDs of HCP nodepools in the clusters file upfront the cluster installation does not work well with how the rosa cli creates nodepools during cluster creation. there is no way to influence nodepool subnet placement at this stage. so it makes sense to not specify the subnets of HCP nodepools in app-interface during cluster creation

BUT

we can patch them in the cluster file once they are known!

this PR opens an MR to add the subnet IDs to the cluster file if it is not defined yet.

bonus: this PR will also ignore clusters that are not ready yet for machine pool management (`spec.id` not set yet). this avoids`ocm-machine-pool` reconcile errors during cluster provisioning.

reminder:
* when a nodepool does not exist yet in OCM, app-interface is the source of truth for the subnet
* once a nodepool exists in OCM, the subnet ID can't be changed anymore and OCM acts as the source of truth (the existing code reflects that by not allowing a subnet ID change on existing nodepools)

demo MR: https://gitlab.cee.redhat.com/goberlec/app-interface/-/merge_requests/12/diffs

part of https://issues.redhat.com/browse/APPSRE-9883