### PR TITLE
[ocm-aws-infrastructure-access] improvements

### DIFF
--- a/reconcile/gql_definitions/common/clusters.gql
+++ b/reconcile/gql_definitions/common/clusters.gql
@@ -54,24 +54,6 @@ query Clusters($name: String) {
         }
       }
     }
-    awsInfrastructureAccess {
-      awsGroup {
-        account {
-          name
-          uid
-          terraformUsername
-          automationToken {
-            ... VaultSecret
-          }
-        }
-        roles {
-          users {
-            org_username
-          }
-        }
-      }
-      accessLevel
-    }
     awsInfrastructureManagementAccounts {
       ... AWSInfrastructureManagementAccount
     }

--- a/reconcile/gql_definitions/common/clusters.py
+++ b/reconcile/gql_definitions/common/clusters.py
@@ -154,24 +154,6 @@ query Clusters($name: String) {
         }
       }
     }
-    awsInfrastructureAccess {
-      awsGroup {
-        account {
-          name
-          uid
-          terraformUsername
-          automationToken {
-            ... VaultSecret
-          }
-        }
-        roles {
-          users {
-            org_username
-          }
-        }
-      }
-      accessLevel
-    }
     awsInfrastructureManagementAccounts {
       ... AWSInfrastructureManagementAccount
     }
@@ -416,31 +398,6 @@ class OpenShiftClusterManagerV1(ConfiguredBaseModel):
     sectors: Optional[list[OpenShiftClusterManagerSectorV1]] = Field(..., alias="sectors")
 
 
-class AWSAccountV1(ConfiguredBaseModel):
-    name: str = Field(..., alias="name")
-    uid: str = Field(..., alias="uid")
-    terraform_username: Optional[str] = Field(..., alias="terraformUsername")
-    automation_token: VaultSecret = Field(..., alias="automationToken")
-
-
-class UserV1(ConfiguredBaseModel):
-    org_username: str = Field(..., alias="org_username")
-
-
-class RoleV1(ConfiguredBaseModel):
-    users: list[UserV1] = Field(..., alias="users")
-
-
-class AWSGroupV1(ConfiguredBaseModel):
-    account: AWSAccountV1 = Field(..., alias="account")
-    roles: Optional[list[RoleV1]] = Field(..., alias="roles")
-
-
-class AWSInfrastructureAccessV1(ConfiguredBaseModel):
-    aws_group: AWSGroupV1 = Field(..., alias="awsGroup")
-    access_level: str = Field(..., alias="accessLevel")
-
-
 class ClusterSpecV1(ConfiguredBaseModel):
     product: str = Field(..., alias="product")
     hypershift: Optional[bool] = Field(..., alias="hypershift")
@@ -479,7 +436,7 @@ class RosaOcmSpecV1(ConfiguredBaseModel):
     ocm_environments: Optional[list[RosaOcmAwsSpecV1]] = Field(..., alias="ocm_environments")
 
 
-class ClusterSpecROSAV1_AWSAccountV1(ConfiguredBaseModel):
+class AWSAccountV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     uid: str = Field(..., alias="uid")
     terraform_username: Optional[str] = Field(..., alias="terraformUsername")
@@ -492,7 +449,7 @@ class ClusterSpecROSAV1(ClusterSpecV1):
     subnet_ids: Optional[list[str]] = Field(..., alias="subnet_ids")
     availability_zones: Optional[list[str]] = Field(..., alias="availability_zones")
     oidc_endpoint_url: Optional[str] = Field(..., alias="oidc_endpoint_url")
-    account: Optional[ClusterSpecROSAV1_AWSAccountV1] = Field(..., alias="account")
+    account: Optional[AWSAccountV1] = Field(..., alias="account")
 
 
 class ClusterExternalConfigurationV1(ConfiguredBaseModel):
@@ -579,19 +536,19 @@ class ClusterPeeringConnectionClusterRequesterV1_ClusterV1_ClusterSpecV1(Configu
     region: str = Field(..., alias="region")
 
 
-class ClusterPeeringConnectionClusterRequesterV1_ClusterV1_AWSInfrastructureAccessV1_AWSGroupV1_AWSAccountV1(ConfiguredBaseModel):
+class AWSGroupV1_AWSAccountV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     uid: str = Field(..., alias="uid")
     terraform_username: Optional[str] = Field(..., alias="terraformUsername")
     automation_token: VaultSecret = Field(..., alias="automationToken")
 
 
-class ClusterPeeringConnectionClusterRequesterV1_ClusterV1_AWSInfrastructureAccessV1_AWSGroupV1(ConfiguredBaseModel):
-    account: ClusterPeeringConnectionClusterRequesterV1_ClusterV1_AWSInfrastructureAccessV1_AWSGroupV1_AWSAccountV1 = Field(..., alias="account")
+class AWSGroupV1(ConfiguredBaseModel):
+    account: AWSGroupV1_AWSAccountV1 = Field(..., alias="account")
 
 
-class ClusterPeeringConnectionClusterRequesterV1_ClusterV1_AWSInfrastructureAccessV1(ConfiguredBaseModel):
-    aws_group: ClusterPeeringConnectionClusterRequesterV1_ClusterV1_AWSInfrastructureAccessV1_AWSGroupV1 = Field(..., alias="awsGroup")
+class AWSInfrastructureAccessV1(ConfiguredBaseModel):
+    aws_group: AWSGroupV1 = Field(..., alias="awsGroup")
     access_level: str = Field(..., alias="accessLevel")
 
 
@@ -626,7 +583,7 @@ class ClusterPeeringConnectionClusterRequesterV1_ClusterV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     network: Optional[ClusterPeeringConnectionClusterRequesterV1_ClusterV1_ClusterNetworkV1] = Field(..., alias="network")
     spec: Optional[ClusterPeeringConnectionClusterRequesterV1_ClusterV1_ClusterSpecV1] = Field(..., alias="spec")
-    aws_infrastructure_access: Optional[list[ClusterPeeringConnectionClusterRequesterV1_ClusterV1_AWSInfrastructureAccessV1]] = Field(..., alias="awsInfrastructureAccess")
+    aws_infrastructure_access: Optional[list[AWSInfrastructureAccessV1]] = Field(..., alias="awsInfrastructureAccess")
     aws_infrastructure_management_accounts: Optional[list[AWSInfrastructureManagementAccount]] = Field(..., alias="awsInfrastructureManagementAccounts")
     peering: Optional[ClusterPeeringConnectionClusterRequesterV1_ClusterV1_ClusterPeeringV1] = Field(..., alias="peering")
 
@@ -666,7 +623,6 @@ class ClusterV1(ConfiguredBaseModel):
     jump_host: Optional[CommonJumphostFields] = Field(..., alias="jumpHost")
     auth: list[Union[ClusterAuthGithubOrgTeamV1, ClusterAuthGithubOrgV1, ClusterAuthV1]] = Field(..., alias="auth")
     ocm: Optional[OpenShiftClusterManagerV1] = Field(..., alias="ocm")
-    aws_infrastructure_access: Optional[list[AWSInfrastructureAccessV1]] = Field(..., alias="awsInfrastructureAccess")
     aws_infrastructure_management_accounts: Optional[list[AWSInfrastructureManagementAccount]] = Field(..., alias="awsInfrastructureManagementAccounts")
     spec: Optional[Union[ClusterSpecROSAV1, ClusterSpecOSDV1, ClusterSpecV1]] = Field(..., alias="spec")
     external_configuration: Optional[ClusterExternalConfigurationV1] = Field(..., alias="externalConfiguration")

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -203,3 +203,6 @@ def run(dry_run):
     act(
         dry_run, ocm_map, current_state, current_failed, desired_state, current_deleting
     )
+
+def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    return {"state": fetch_desired_state(get_clusters())}

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -52,17 +52,14 @@ def fetch_current_state(clusters):
     return ocm_map, current_state, current_failed, current_deleting
 
 
-def fetch_desired_state():
+def fetch_desired_state(
+    clusters: Iterable[Mapping[str, Any]],
+) -> Iterable[Mapping[str, str]]:
     desired_state = []
 
     # get desired state defined in awsInfrastructureAccess
     # or awsInfrastructureManagementAccounts
     # sections of cluster files
-    clusters = [
-        c
-        for c in queries.get_clusters(aws_infrastructure_access=True)
-        if c.get("ocm") is not None and c["spec"]["product"] in SUPPORTED_OCM_PRODUCTS
-    ]
     for cluster_info in clusters:
         cluster = cluster_info["name"]
         aws_infra_access_items = cluster_info.get("awsInfrastructureAccess") or []
@@ -196,7 +193,7 @@ def run(dry_run):
     ocm_map, current_state, current_failed, current_deleting = fetch_current_state(
         clusters
     )
-    desired_state = fetch_desired_state()
+    desired_state = fetch_desired_state(clusters)
     act(
         dry_run, ocm_map, current_state, current_failed, desired_state, current_deleting
     )

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -60,7 +60,7 @@ def fetch_desired_state():
     # sections of cluster files
     clusters = [
         c
-        for c in queries.get_clusters()
+        for c in queries.get_clusters(aws_infrastructure_access=True)
         if c.get("ocm") is not None and c["spec"]["product"] in SUPPORTED_OCM_PRODUCTS
     ]
     for cluster_info in clusters:
@@ -184,7 +184,7 @@ def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
 def run(dry_run):
     clusters = [
         c
-        for c in queries.get_clusters()
+        for c in queries.get_clusters(aws_infrastructure_access=True)
         if integration_is_enabled(QONTRACT_INTEGRATION, c) and _cluster_is_compatible(c)
     ]
     if not clusters:

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -204,5 +204,6 @@ def run(dry_run):
         dry_run, ocm_map, current_state, current_failed, desired_state, current_deleting
     )
 
+
 def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:
     return {"state": fetch_desired_state(get_clusters())}

--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -22,14 +22,6 @@ QONTRACT_INTEGRATION = "ocm-aws-infrastructure-access"
 SUPPORTED_OCM_PRODUCTS = [OCM_PRODUCT_OSD]
 
 
-def get_clusters() -> Iterable[Mapping[str, Any]]:
-    return [
-        c
-        for c in queries.get_clusters(aws_infrastructure_access=True)
-        if integration_is_enabled(QONTRACT_INTEGRATION, c) and _cluster_is_compatible(c)
-    ]
-
-
 def fetch_current_state(
     clusters: Iterable[Mapping[str, Any]],
 ) -> Tuple[OCMMap, list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]]]:
@@ -186,6 +178,14 @@ def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
         cluster.get("ocm") is not None
         and cluster["spec"]["product"] in SUPPORTED_OCM_PRODUCTS
     )
+
+
+def get_clusters() -> Iterable[Mapping[str, Any]]:
+    return [
+        c
+        for c in queries.get_clusters(aws_infrastructure_access=True)
+        if integration_is_enabled(QONTRACT_INTEGRATION, c) and _cluster_is_compatible(c)
+    ]
 
 
 def run(dry_run):

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -642,6 +642,32 @@ CLUSTER_FILTER_QUERY = """
 {% endif %}
 """
 
+AWS_INFRASTRUCTURE_ACCESS_QUERY = """
+{% if aws_infrastructure_access %}
+awsInfrastructureAccess {
+  awsGroup {
+    account {
+      name
+      uid
+      terraformUsername
+      automationToken {
+        path
+        field
+        version
+        format
+      }
+    }
+    roles {
+      users {
+        org_username
+      }
+    }
+  }
+  accessLevel
+}
+{% endif %}
+"""
+
 CLUSTERS_QUERY = """
 {
   clusters: clusters_v1
@@ -714,29 +740,7 @@ CLUSTERS_QUERY = """
         }
       }
     }
-    {% if aws_infrastructure_access %}
-    awsInfrastructureAccess {
-      awsGroup {
-        account {
-          name
-          uid
-          terraformUsername
-          automationToken {
-            path
-            field
-            version
-            format
-          }
-        }
-        roles {
-          users {
-            org_username
-          }
-        }
-      }
-      accessLevel
-    }
-    {% endif %}
+    %s
     %s
     spec {
       product
@@ -956,6 +960,7 @@ CLUSTERS_QUERY = """
 """ % (
     indent(CLUSTER_FILTER_QUERY, 2 * " "),
     indent(JUMPHOST_FIELDS, 6 * " "),
+    indent(AWS_INFRASTRUCTURE_ACCESS_QUERY, 4 * " "),
     indent(AWS_INFRA_MANAGEMENT_ACCOUNT, 4 * " "),
     indent(AWS_INFRA_MANAGEMENT_ACCOUNT, 12 * " "),
 )

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -714,6 +714,7 @@ CLUSTERS_QUERY = """
         }
       }
     }
+    {% if aws_infrastructure_access %}
     awsInfrastructureAccess {
       awsGroup {
         account {
@@ -735,6 +736,7 @@ CLUSTERS_QUERY = """
       }
       accessLevel
     }
+    {% endif %}
     %s
     spec {
       product
@@ -1010,12 +1012,13 @@ CLUSTERS_MINIMAL_QUERY = """
 )
 
 
-def get_clusters(minimal=False):
+def get_clusters(minimal: bool = False, aws_infrastructure_access: bool = False):
     """Returns all Clusters"""
     gqlapi = gql.get_api()
     tmpl = CLUSTERS_MINIMAL_QUERY if minimal else CLUSTERS_QUERY
     query = Template(tmpl).render(
         filter=None,
+        aws_infrastructure_access=aws_infrastructure_access,
     )
     return gqlapi.query(query)["clusters"]
 

--- a/reconcile/test/fixtures/oc_connection_parameters/cluster_custom_token.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/cluster_custom_token.yml
@@ -9,7 +9,6 @@ automationToken:
   format: null
   path: path/to/automation_token
   version: null
-awsInfrastructureAccess: []
 awsInfrastructureManagementAccounts: []
 clusterAdmin: false
 clusterAdminAutomationToken:

--- a/reconcile/test/fixtures/oc_connection_parameters/cluster_no_jumphost.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/cluster_no_jumphost.yml
@@ -9,7 +9,6 @@ automationToken:
   format: null
   path: path/to/automation_token
   version: null
-awsInfrastructureAccess: []
 awsInfrastructureManagementAccounts: []
 clusterAdmin: false
 clusterAdminAutomationToken:

--- a/reconcile/test/fixtures/oc_connection_parameters/cluster_with_jumphost.yml
+++ b/reconcile/test/fixtures/oc_connection_parameters/cluster_with_jumphost.yml
@@ -9,7 +9,6 @@ automationToken:
   format: null
   path: path/to/automation_token
   version: null
-awsInfrastructureAccess: []
 awsInfrastructureManagementAccounts: []
 clusterAdmin: true
 clusterAdminAutomationToken:

--- a/reconcile/test/fixtures/openshift_upgrade_watcher/cluster1.yml
+++ b/reconcile/test/fixtures/openshift_upgrade_watcher/cluster1.yml
@@ -9,7 +9,6 @@ automationToken:
   format: null
   path: path/to/automation_token
   version: null
-awsInfrastructureAccess: []
 awsInfrastructureManagementAccounts: []
 clusterAdmin: false
 clusterAdminAutomationToken:

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1020,7 +1020,7 @@ def cidr_blocks(ctx) -> None:
 
 def ocm_aws_infrastructure_access_switch_role_links_data() -> list[dict]:
     settings = queries.get_app_interface_settings()
-    clusters = queries.get_clusters()
+    clusters = queries.get_clusters(aws_infrastructure_access=True)
     clusters = [c for c in clusters if c.get("ocm") is not None]
     accounts = {a["uid"]: a["name"] for a in queries.get_aws_accounts()}
     ocm_map = OCMMap(clusters=clusters, settings=settings)


### PR DESCRIPTION
related to https://issues.redhat.com/browse/OSD-21345

this is really work to prevent OCM integrations from running on changes such as https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/98491.

how?
from inspecting the queries, all OCM integrations are running for this change (a role addition that is not related to OCM access) due to querying for users who have access to roles with aws access to groups that have aws infrasturcture access.

first, we prevent other ocm integrations from querying for this information.
second, we will implement early exit for ocm-aws-infrastucture-access.