### PR TITLE
[ocm-aws-infrastructure-access] reduce query

### DIFF
--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -60,7 +60,7 @@ def fetch_desired_state():
     # sections of cluster files
     clusters = [
         c
-        for c in queries.get_clusters()
+        for c in queries.get_clusters(aws_infrastructure_access=True)
         if c.get("ocm") is not None and c["spec"]["product"] in SUPPORTED_OCM_PRODUCTS
     ]
     for cluster_info in clusters:
@@ -184,7 +184,7 @@ def _cluster_is_compatible(cluster: Mapping[str, Any]) -> bool:
 def run(dry_run):
     clusters = [
         c
-        for c in queries.get_clusters()
+        for c in queries.get_clusters(aws_infrastructure_access=True)
         if integration_is_enabled(QONTRACT_INTEGRATION, c) and _cluster_is_compatible(c)
     ]
     if not clusters:

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -642,6 +642,32 @@ CLUSTER_FILTER_QUERY = """
 {% endif %}
 """
 
+AWS_INFRASTRUCTURE_ACCESS_QUERY = """
+{% if aws_infrastructure_access %}
+awsInfrastructureAccess {
+  awsGroup {
+    account {
+      name
+      uid
+      terraformUsername
+      automationToken {
+        path
+        field
+        version
+        format
+      }
+    }
+    roles {
+      users {
+        org_username
+      }
+    }
+  }
+  accessLevel
+}
+{% endif %}
+"""
+
 CLUSTERS_QUERY = """
 {
   clusters: clusters_v1
@@ -714,27 +740,7 @@ CLUSTERS_QUERY = """
         }
       }
     }
-    awsInfrastructureAccess {
-      awsGroup {
-        account {
-          name
-          uid
-          terraformUsername
-          automationToken {
-            path
-            field
-            version
-            format
-          }
-        }
-        roles {
-          users {
-            org_username
-          }
-        }
-      }
-      accessLevel
-    }
+    %s
     %s
     spec {
       product
@@ -954,6 +960,7 @@ CLUSTERS_QUERY = """
 """ % (
     indent(CLUSTER_FILTER_QUERY, 2 * " "),
     indent(JUMPHOST_FIELDS, 6 * " "),
+    indent(AWS_INFRASTRUCTURE_ACCESS_QUERY, 4 * " "),
     indent(AWS_INFRA_MANAGEMENT_ACCOUNT, 4 * " "),
     indent(AWS_INFRA_MANAGEMENT_ACCOUNT, 12 * " "),
 )
@@ -1010,12 +1017,13 @@ CLUSTERS_MINIMAL_QUERY = """
 )
 
 
-def get_clusters(minimal=False):
+def get_clusters(minimal: bool = False, aws_infrastructure_access: bool = False):
     """Returns all Clusters"""
     gqlapi = gql.get_api()
     tmpl = CLUSTERS_MINIMAL_QUERY if minimal else CLUSTERS_QUERY
     query = Template(tmpl).render(
         filter=None,
+        aws_infrastructure_access=aws_infrastructure_access,
     )
     return gqlapi.query(query)["clusters"]
 


### PR DESCRIPTION
related to https://issues.redhat.com/browse/OSD-21345

split from #4142, related to #4144

this is work to prevent OCM integrations from running on changes such as https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/98491.

how?
from inspecting the queries, all OCM integrations are running for this change (a role addition that is not related to OCM access) due to querying for users who have access to roles with aws access to groups that have aws infrasturcture access.

in this PR, we prevent other ocm integrations from querying for this information.