### PR TITLE
[ocm-aws-infrastructure-access] early exit

### DIFF
--- a/reconcile/ocm_aws_infrastructure_access.py
+++ b/reconcile/ocm_aws_infrastructure_access.py
@@ -200,3 +200,7 @@ def run(dry_run):
     act(
         dry_run, ocm_map, current_state, current_failed, desired_state, current_deleting
     )
+
+
+def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    return {"state": fetch_desired_state()}


### PR DESCRIPTION
related to https://issues.redhat.com/browse/OSD-21345

split from #4142, related to #4146

this is work to prevent OCM integrations from running on changes such as https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/98491.

how?
from inspecting the queries, all OCM integrations are running for this change (a role addition that is not related to OCM access) due to querying for users who have access to roles with aws access to groups that have aws infrasturcture access.

in this PR, we prevent ocm-aws-infrastructure-access from running in a MR that does not change the desired state.