### PR TITLE
[ocm-groups] early exit

### DIFF
--- a/reconcile/ocm_groups.py
+++ b/reconcile/ocm_groups.py
@@ -91,3 +91,18 @@ def run(dry_run, thread_pool_size=10):
 
         if not dry_run:
             act(diff, ocm_map)
+
+
+def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
+    clusters = [
+        c["name"]
+        for c in queries.get_clusters()
+        if integration_is_enabled(QONTRACT_INTEGRATION, c) and _cluster_is_compatible(c)
+    ]
+    desired_state = openshift_groups.fetch_desired_state(clusters=clusters)
+    # we only manage dedicated-admins via OCM
+    desired_state = [s for s in desired_state if s["group"] == "dedicated-admins"]
+
+    return {
+        "state": desired_state,
+    }

--- a/reconcile/ocm_groups.py
+++ b/reconcile/ocm_groups.py
@@ -74,7 +74,7 @@ def run(dry_run, thread_pool_size=10):
         sys.exit(ExitCodes.SUCCESS)
 
     ocm_map, current_state = fetch_current_state(clusters, thread_pool_size)
-    desired_state = openshift_groups.fetch_desired_state(oc_map=ocm_map)
+    desired_state = openshift_groups.fetch_desired_state(clusters=ocm_map.clusters())
 
     # we only manage dedicated-admins via OCM
     current_state = [s for s in current_state if s["group"] == "dedicated-admins"]

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -110,7 +110,7 @@ def fetch_current_state(
 
 
 def fetch_desired_state(
-    oc_map: Optional[ClusterMap], enforced_user_keys: Optional[list[str]] = None
+    clusters: list[str], enforced_user_keys: Optional[list[str]] = None
 ) -> list[dict[str, str]]:
     gqlapi = gql.get_api()
     roles = expiration.filter(query_managed_roles(query_func=gqlapi.query).roles or [])
@@ -120,7 +120,7 @@ def fetch_desired_state(
         for a in r.access or []:
             if not a.cluster or not a.group:
                 continue
-            if oc_map and a.cluster.name not in oc_map.clusters():
+            if a.cluster.name not in clusters:
                 continue
 
             user_keys = ob.determine_user_keys_for_access(
@@ -273,7 +273,7 @@ def run(
     )
     if defer:
         defer(oc_map.cleanup)
-    desired_state = fetch_desired_state(oc_map)
+    desired_state = fetch_desired_state(oc_map.clusters())
 
     # we only manage dedicated-admins via OCM
     current_state = [

--- a/reconcile/openshift_groups.py
+++ b/reconcile/openshift_groups.py
@@ -120,7 +120,7 @@ def fetch_desired_state(
         for a in r.access or []:
             if not a.cluster or not a.group:
                 continue
-            if a.cluster.name not in clusters:
+            if clusters and a.cluster.name not in clusters:
                 continue
 
             user_keys = ob.determine_user_keys_for_access(

--- a/reconcile/openshift_users.py
+++ b/reconcile/openshift_users.py
@@ -108,7 +108,7 @@ def fetch_desired_state(
     desired_state.extend(flat_rolebindings_desired_state)
 
     groups_desired_state = openshift_groups.fetch_desired_state(
-        oc_map, enforced_user_keys=enforced_user_keys
+        oc_map.clusters(), enforced_user_keys=enforced_user_keys
     )
     flat_groups_desired_state = [
         {"cluster": s["cluster"], "user": s["user"]} for s in groups_desired_state

--- a/reconcile/openshift_users.py
+++ b/reconcile/openshift_users.py
@@ -108,7 +108,8 @@ def fetch_desired_state(
     desired_state.extend(flat_rolebindings_desired_state)
 
     groups_desired_state = openshift_groups.fetch_desired_state(
-        oc_map.clusters(), enforced_user_keys=enforced_user_keys
+        clusters=oc_map.clusters() if oc_map else [],
+        enforced_user_keys=enforced_user_keys,
     )
     flat_groups_desired_state = [
         {"cluster": s["cluster"], "user": s["user"]} for s in groups_desired_state


### PR DESCRIPTION
related to https://issues.redhat.com/browse/OSD-21345

split from #4142, related to #4145

this is work to prevent OCM integrations from running on changes such as https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/98491.

how?
from inspecting the queries, all OCM integrations are running for this change (a role addition that is not related to OCM access) due to querying for users who have access to roles with aws access to groups that have aws infrasturcture access.

in this PR, we prevent ocm-groups from running in a MR that does not change the desired state.