### PR TITLE
[AUS] prevent multiple concurrent upgrades per cluster

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -844,7 +844,7 @@ def verify_schedule_should_skip(
 def verify_lock_should_skip(
     desired: ClusterUpgradeSpec, locked: dict[str, str]
 ) -> bool:
-    mutexes = desired.upgrade_policy.conditions.mutexes or []
+    mutexes = desired.effective_mutexes
     if any(lock in locked for lock in mutexes):
         locking = {lock: locked[lock] for lock in mutexes if lock in locked}
         logging.debug(
@@ -930,7 +930,7 @@ def calculate_diff(
     locked: dict[str, str] = {}
     for spec in desired_state.specs:
         if spec.cluster.id in [s.cluster.id for s in current_state]:
-            for mutex in spec.upgrade_policy.conditions.mutexes or []:
+            for mutex in spec.effective_mutexes:
                 locked[mutex] = spec.cluster.id
 
     now = datetime.utcnow()
@@ -946,7 +946,7 @@ def calculate_diff(
             if node_pool_update:  # node pool update policy not yet created
                 diffs.append(node_pool_update)
                 set_mutex(
-                    locked, spec.cluster.id, spec.upgrade_policy.conditions.mutexes
+                    locked, spec.cluster.id, spec.effective_mutexes
                 )
                 continue
 
@@ -1024,7 +1024,7 @@ def calculate_diff(
                         policy=_create_upgrade_policy(next_schedule, spec, version),
                     )
                 )
-            set_mutex(locked, spec.cluster.id, spec.upgrade_policy.conditions.mutexes)
+            set_mutex(locked, spec.cluster.id, spec.effective_mutexes)
 
     return diffs
 

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -919,9 +919,9 @@ def calculate_diff(
     """
 
     def set_mutex(
-        locked: dict[str, str], cluster_id: str, mutexes: Optional[list[str]] = None
+        locked: dict[str, str], cluster_id: str, mutexes: Optional[set[str]] = None
     ) -> None:
-        for mutex in mutexes or []:
+        for mutex in mutexes or set():
             locked[mutex] = cluster_id
 
     diffs: list[UpgradePolicyHandler] = []
@@ -945,9 +945,7 @@ def calculate_diff(
             node_pool_update = _calculate_node_pool_diffs(ocm_api, spec, now)
             if node_pool_update:  # node pool update policy not yet created
                 diffs.append(node_pool_update)
-                set_mutex(
-                    locked, spec.cluster.id, spec.effective_mutexes
-                )
+                set_mutex(locked, spec.cluster.id, spec.effective_mutexes)
                 continue
 
         # ignore clusters with an existing upgrade policy

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -56,10 +56,11 @@ class ClusterUpgradeSpec(BaseModel):
         return self.cluster.available_upgrades()
 
     @property
-    def effective_mutexes(self) -> list[str]:
-        mutexes = self.upgrade_policy.conditions.mutexes or []
-        mutexes.append(self.cluster.id)
+    def effective_mutexes(self) -> set[str]:
+        mutexes = set(self.upgrade_policy.conditions.mutexes or [])
+        mutexes.add(self.cluster.id)
         return mutexes
+
 
 class ClusterAddonUpgradeSpec(ClusterUpgradeSpec):
     addon: OCMAddonInstallation

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -55,6 +55,11 @@ class ClusterUpgradeSpec(BaseModel):
     def get_available_upgrades(self) -> list[str]:
         return self.cluster.available_upgrades()
 
+    @property
+    def effective_mutexes(self) -> list[str]:
+        mutexes = self.upgrade_policy.conditions.mutexes or []
+        mutexes.append(self.cluster.id)
+        return mutexes
 
 class ClusterAddonUpgradeSpec(ClusterUpgradeSpec):
     addon: OCMAddonInstallation

--- a/reconcile/test/ocm/aus/conftest.py
+++ b/reconcile/test/ocm/aus/conftest.py
@@ -5,8 +5,10 @@ import pytest
 from pytest_mock import MockerFixture
 
 from reconcile.aus.cluster_version_data import VersionData
+from reconcile.aus.version_gates import ocp_gate_handler, sts_version_gate_handler
 from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
+from reconcile.utils.ocm.base import OCMVersionGate
 
 
 @pytest.fixture
@@ -109,3 +111,51 @@ def ocm2_state(low_version: str, high_version: str) -> dict[str, Any]:
 @pytest.fixture
 def ocm2_version_data(ocm2_state: dict[str, Any]) -> VersionData:
     return VersionData(**ocm2_state)
+
+
+VERSION_GATE_4_12_OCP_ID = "e3ed7585-7033-11ed-ac97-0a580a830014"
+VERSION_GATE_4_13_OCP_ID = "f0bbef99-d1ea-11ed-aefd-0a580a800209"
+VERSION_GATE_4_13_STS_ID = "ec6fa2a0-d1ea-11ed-aefd-0a580a800209"
+
+
+@pytest.fixture
+def version_gate_4_12_ocp() -> OCMVersionGate:
+    return OCMVersionGate(**{
+        "kind": "VersionGate",
+        "id": VERSION_GATE_4_12_OCP_ID,
+        "version_raw_id_prefix": "4.12",
+        "label": ocp_gate_handler.GATE_LABEL,
+        "value": "4.12",
+        "sts_only": False,
+    })
+
+
+@pytest.fixture
+def version_gate_4_13_ocp() -> OCMVersionGate:
+    return OCMVersionGate(**{
+        "kind": "VersionGate",
+        "id": VERSION_GATE_4_13_OCP_ID,
+        "version_raw_id_prefix": "4.13",
+        "label": ocp_gate_handler.GATE_LABEL,
+        "value": "4.13",
+        "sts_only": False,
+    })
+
+
+@pytest.fixture
+def version_gate_4_13_sts() -> OCMVersionGate:
+    return OCMVersionGate(**{
+        "kind": "VersionGate",
+        "id": VERSION_GATE_4_13_STS_ID,
+        "version_raw_id_prefix": "4.13",
+        "label": sts_version_gate_handler.GATE_LABEL,
+        "value": "4.13",
+        "sts_only": True,
+    })
+
+
+@pytest.fixture
+def version_gates(
+    version_gate_4_13_ocp: OCMVersionGate, version_gate_4_13_sts: OCMVersionGate
+) -> list[OCMVersionGate]:
+    return [version_gate_4_13_ocp, version_gate_4_13_sts]

--- a/reconcile/test/ocm/aus/test_version_gate_approver.py
+++ b/reconcile/test/ocm/aus/test_version_gate_approver.py
@@ -11,9 +11,13 @@ from reconcile.aus.version_gate_approver import (
     VersionGateApproverParams,
     get_enabled_gate_handlers,
 )
-from reconcile.aus.version_gates import ocp_gate_handler
+from reconcile.aus.version_gates import ocp_gate_handler, sts_version_gate_handler
 from reconcile.aus.version_gates.handler import GateHandler
 from reconcile.aus.version_gates.sts_version_gate_handler import STSGateHandler
+from reconcile.test.ocm.aus.conftest import (
+    VERSION_GATE_4_13_OCP_ID,
+    VERSION_GATE_4_13_STS_ID,
+)
 from reconcile.test.ocm.aus.fixtures import NoopGateHandler
 from reconcile.test.ocm.fixtures import build_ocm_cluster
 from reconcile.test.ocm.test_utils_ocm_labels import build_subscription_label
@@ -28,43 +32,6 @@ from reconcile.utils.ocm.base import (
     build_label_container,
 )
 from reconcile.utils.ocm_base_client import OCMBaseClient
-
-VERSION_GATE_4_13_OCP_ID = "f0bbef99-d1ea-11ed-aefd-0a580a800209"
-VERSION_GATE_4_13_STS_ID = "ec6fa2a0-d1ea-11ed-aefd-0a580a800209"
-
-GATE_LABEL_STS = "api.openshift.com/gate-sts"
-GATE_LABEL_OCP = "api.openshift.com/gate-ocp"
-
-
-@pytest.fixture
-def version_gate_4_13_ocp() -> OCMVersionGate:
-    return OCMVersionGate(**{
-        "kind": "VersionGate",
-        "id": VERSION_GATE_4_13_OCP_ID,
-        "version_raw_id_prefix": "4.13",
-        "label": GATE_LABEL_OCP,
-        "value": "4.13",
-        "sts_only": False,
-    })
-
-
-@pytest.fixture
-def version_gate_4_13_sts() -> OCMVersionGate:
-    return OCMVersionGate(**{
-        "kind": "VersionGate",
-        "id": VERSION_GATE_4_13_STS_ID,
-        "version_raw_id_prefix": "4.13",
-        "label": GATE_LABEL_STS,
-        "value": "4.13",
-        "sts_only": True,
-    })
-
-
-@pytest.fixture
-def version_gates(
-    version_gate_4_13_ocp: OCMVersionGate, version_gate_4_13_sts: OCMVersionGate
-) -> list[OCMVersionGate]:
-    return [version_gate_4_13_ocp, version_gate_4_13_sts]
 
 
 @pytest.fixture
@@ -89,11 +56,11 @@ def integration(job_controller: K8sJobController) -> VersionGateApprover:
         )
     )
     approver.handlers = {
-        GATE_LABEL_STS: STSGateHandler(
+        sts_version_gate_handler.GATE_LABEL: STSGateHandler(
             job_controller=job_controller,
             aws_iam_role="role",
         ),
-        GATE_LABEL_OCP: NoopGateHandler(),
+        ocp_gate_handler.GATE_LABEL: NoopGateHandler(),
     }
     return approver
 


### PR DESCRIPTION
prevent multiple node pool upgrades from being scheduled. OCM prevents it anyways. so this is mostly about not failing the integration in such situations, keeping a tidy log and less reconcile alerts.

how: add the ID of the cluster as a mutex