### PR TITLE
[openshift-namespaces] fail on openshift namespaces on dry-run

### DIFF
--- a/reconcile/openshift_namespaces.py
+++ b/reconcile/openshift_namespaces.py
@@ -114,6 +114,8 @@ def manage_namespaces(spec: Mapping[str, str], oc_map: OCMap, dry_run: bool) -> 
     exists = oc.project_exists(namespace)
     action = None
     if not exists and desired_state == NS_STATE_PRESENT:
+        if namespace.startswith("openshift-"):
+            raise ValueError('cannot request a project starting with "openshift-"')
         action = NS_ACTION_CREATE
     elif exists and desired_state == NS_STATE_ABSENT:
         action = NS_ACTION_DELETE


### PR DESCRIPTION
we currently do not fail in dry-run: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/97765
leading to reverts: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/98529

this is known - we can not create `openshift-` namespaces. let's fail in dry-run.

the logic to raise an exception is consistent and will be handled in https://github.com/app-sre/qontract-reconcile/pull/4148/files#diff-3faaaf915e42878fb84d5d26fff3791258ff2e290185c31da412e4ab0f5104beR129-R141