### PR TITLE
[slack-usergroups] speedup PR checks

### DIFF
--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -799,11 +799,18 @@ def run(
 
 def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:
     gqlapi = gql.get_api()
+    # exclude user.roles (cluster access roles) with tag_on_cluster_updates: false
+    # to speedup PR checks
+    users = get_users(gqlapi.query)
+    for user in users:
+        user.roles = [
+            role for role in user.roles or [] if role.tag_on_cluster_updates is False
+        ]
     return {
         "permissions": [p.dict() for p in get_permissions(gqlapi.query)],
         "pagerduty_instances": [
             p.dict() for p in get_pagerduty_instances(gqlapi.query)
         ],
-        "users": [u.dict() for u in get_users(gqlapi.query)],
+        "users": [u.dict() for u in users],
         "clusters": [c.dict() for c in get_clusters(gqlapi.query)],
     }

--- a/reconcile/utils/pagerduty_api.py
+++ b/reconcile/utils/pagerduty_api.py
@@ -76,7 +76,7 @@ class PagerDutyApi:
             self.users: list[pypd.User] = []
 
     def init_users(self) -> None:
-        self.users = pypd.User.find()
+        self.users = pypd.User.find(limit=100)
 
     def get_pagerduty_users(
         self, resource_type: str, resource_id: str


### PR DESCRIPTION
Ignore cluster access roles with `tag_on_cluster_updates: false` to improve PR runtime and reduce pagerduty API calls.

Context: https://redhat-internal.slack.com/archives/GGC2A0MS8/p1709551646681289