### PR TITLE
[terraform-tgw-attachments] allow traffic from the TGW on an HCPs VPC endpoint

### DIFF
--- a/reconcile/gql_definitions/common/clusters_with_peering.gql
+++ b/reconcile/gql_definitions/common/clusters_with_peering.gql
@@ -24,6 +24,8 @@ query ClustersWithPeering {
 
     spec {
       region
+      hypershift
+      private
       ... on ClusterSpecROSA_v1 {
         account {
           name
@@ -71,6 +73,7 @@ query ClustersWithPeering {
           cidrBlock
           manageSecurityGroups
           manageRoute53Associations
+          allowPrivateHcpApiAccess
           assumeRole
         }
         ... on ClusterPeeringConnectionClusterRequester_v1 {

--- a/reconcile/gql_definitions/common/clusters_with_peering.py
+++ b/reconcile/gql_definitions/common/clusters_with_peering.py
@@ -99,6 +99,8 @@ query ClustersWithPeering {
 
     spec {
       region
+      hypershift
+      private
       ... on ClusterSpecROSA_v1 {
         account {
           name
@@ -146,6 +148,7 @@ query ClustersWithPeering {
           cidrBlock
           manageSecurityGroups
           manageRoute53Associations
+          allowPrivateHcpApiAccess
           assumeRole
         }
         ... on ClusterPeeringConnectionClusterRequester_v1 {
@@ -211,6 +214,8 @@ class OpenShiftClusterManagerV1(ConfiguredBaseModel):
 
 class ClusterSpecV1(ConfiguredBaseModel):
     region: str = Field(..., alias="region")
+    hypershift: Optional[bool] = Field(..., alias="hypershift")
+    private: bool = Field(..., alias="private")
 
 
 class AWSAccountV1(ConfiguredBaseModel):
@@ -264,6 +269,7 @@ class ClusterPeeringConnectionAccountTGWV1(ClusterPeeringConnectionV1):
     cidr_block: Optional[str] = Field(..., alias="cidrBlock")
     manage_security_groups: Optional[bool] = Field(..., alias="manageSecurityGroups")
     manage_route53_associations: Optional[bool] = Field(..., alias="manageRoute53Associations")
+    allow_private_hcp_api_access: Optional[bool] = Field(..., alias="allowPrivateHcpApiAccess")
     assume_role: Optional[str] = Field(..., alias="assumeRole")
 
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -33702,6 +33702,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "allowPrivateHcpApiAccess",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "cidrBlock",
                             "description": null,
                             "args": [],

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1307,6 +1307,20 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     )
                     self.add_resource(infra_account_name, tf_resource)
 
+            if accepter.api_security_group_id:
+                hcp_api_ingress_rule = aws_security_group_rule(
+                    f"api-access-from-{requester.tgw_id}",
+                    provider="aws." + acc_alias,
+                    type="ingress",
+                    security_group_id=accepter.api_security_group_id,
+                    cidr_blocks=requester.cidr_block,
+                    from_port=443,
+                    to_port=443,
+                    protocol="tcp",
+                    description=f"HCP API access from TGW attachment {requester.tgw_id}",
+                )
+                self.add_resource(infra_account_name, hcp_api_ingress_rule)
+
             # add rules to security groups of VPCs which are attached
             # to the transit gateway to allow traffic through the routes
             requester_rules = requester.rules


### PR DESCRIPTION
similar to regular peerings, we want traffic via TGW attachments to reach the API of a private HCP via its VPC endpoint

follows up on https://github.com/app-sre/qontract-reconcile/pull/3969

part of https://issues.redhat.com/browse/APPSRE-9883

depends on https://github.com/app-sre/qontract-schemas/pull/598