### PR TITLE
[aws-saml-roles] apply user policies

### DIFF
--- a/reconcile/gql_definitions/aws_saml_roles/aws_groups.gql
+++ b/reconcile/gql_definitions/aws_saml_roles/aws_groups.gql
@@ -12,8 +12,16 @@ query AwsSamlRolesAwsGroupQuery {
       }
     }
     roles {
+      name
       users {
         org_username
+      }
+      user_policies {
+        name
+        policy
+        account {
+          uid
+        }
       }
     }
     policies

--- a/reconcile/gql_definitions/aws_saml_roles/aws_groups.py
+++ b/reconcile/gql_definitions/aws_saml_roles/aws_groups.py
@@ -31,8 +31,16 @@ query AwsSamlRolesAwsGroupQuery {
       }
     }
     roles {
+      name
       users {
         org_username
+      }
+      user_policies {
+        name
+        policy
+        account {
+          uid
+        }
       }
     }
     policies
@@ -62,8 +70,20 @@ class UserV1(ConfiguredBaseModel):
     org_username: str = Field(..., alias="org_username")
 
 
+class AWSUserPolicyV1_AWSAccountV1(ConfiguredBaseModel):
+    uid: str = Field(..., alias="uid")
+
+
+class AWSUserPolicyV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+    policy: Json = Field(..., alias="policy")
+    account: AWSUserPolicyV1_AWSAccountV1 = Field(..., alias="account")
+
+
 class RoleV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
     users: list[UserV1] = Field(..., alias="users")
+    user_policies: Optional[list[AWSUserPolicyV1]] = Field(..., alias="user_policies")
 
 
 class AWSGroupV1(ConfiguredBaseModel):

--- a/reconcile/test/aws_saml_roles/test_aws_saml_roles_integration.py
+++ b/reconcile/test/aws_saml_roles/test_aws_saml_roles_integration.py
@@ -88,7 +88,14 @@ def test_aws_saml_roles_get_aws_groups(
                 "name": "group-1",
                 "account": {"name": "account-1", "uid": "1", "sso": True},
                 "roles": [
-                    {"users": [{"org_username": "user-1"}, {"org_username": "user-2"}]}
+                    {
+                        "name": "role-name",
+                        "users": [
+                            {"org_username": "user-1"},
+                            {"org_username": "user-2"},
+                        ],
+                        "user_policies": [],
+                    }
                 ],
                 "policies": ["AdministratorAccess"],
             },
@@ -100,10 +107,27 @@ def test_aws_saml_roles_get_aws_groups(
                 "account": {"name": "account-2", "uid": "2", "sso": True},
                 "roles": [
                     {
+                        "name": "role-name",
                         "users": [
                             {"org_username": "other-user-1"},
                             {"org_username": "other-user-2"},
-                        ]
+                        ],
+                        "user_policies": [
+                            {
+                                "name": "performance-insights",
+                                "policy": """{
+                                    "Version": "2012-10-17",
+                                    "Statement": [
+                                        {
+                                            "Effect": "Allow",
+                                            "Action": "pi:*",
+                                            "Resource": "*"
+                                        }
+                                    ]
+                                }""",
+                                "account": {"uid": "2"},
+                            }
+                        ],
                     }
                 ],
                 "policies": ["AdministratorAccess"],
@@ -117,7 +141,14 @@ def test_aws_saml_roles_get_aws_groups(
                 "name": "group-1",
                 "account": {"name": "account-1", "uid": "1", "sso": True},
                 "roles": [
-                    {"users": [{"org_username": "user-1"}, {"org_username": "user-2"}]}
+                    {
+                        "name": "role-name",
+                        "users": [
+                            {"org_username": "user-1"},
+                            {"org_username": "user-2"},
+                        ],
+                        "user_policies": [],
+                    }
                 ],
                 "policies": ["AdministratorAccess"],
             },
@@ -135,14 +166,16 @@ def test_aws_saml_roles_populate_saml_iam_roles(
             account="account-1",
             name="group-1",
             saml_provider_name="saml-idp",
-            policies=["AdministratorAccess"],
+            aws_managed_policies=["AdministratorAccess"],
+            customer_managed_policies=[],
             max_session_duration_hours=1,
         ),
         mocker.call(
             account="account-2",
             name="group-2",
             saml_provider_name="saml-idp",
-            policies=["AdministratorAccess"],
+            aws_managed_policies=["AdministratorAccess"],
+            customer_managed_policies=["saml-group-2-role-name-performance-insights"],
             max_session_duration_hours=1,
         ),
     ])

--- a/reconcile/test/fixtures/aws_saml_roles/aws_groups.yml
+++ b/reconcile/test/fixtures/aws_saml_roles/aws_groups.yml
@@ -5,7 +5,8 @@ aws_groups:
     uid: '1'
     sso: true
   roles:
-  - users:
+  - name: role-name
+    users:
     - org_username: user-1
     - org_username: user-2
   policies:
@@ -17,9 +18,39 @@ aws_groups:
     uid: '2'
     sso: true
   roles:
-  - users:
+  - name: role-name
+    users:
     - org_username: other-user-1
     - org_username: other-user-2
+    user_policies:
+    - name: performance-insights
+      policy: |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "pi:*",
+              "Resource": "*"
+            }
+          ]
+        }
+      account:
+        uid: '2'
+    - name: another-account-must-be-ignored
+      policy: |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Action": "pi:*",
+              "Resource": "*"
+            }
+          ]
+        }
+      account:
+        uid: '999'
   policies:
   - AdministratorAccess
 
@@ -42,7 +73,8 @@ aws_groups:
     uid: '1'
     sso: false
   roles:
-  - users:
+  - name: role-name
+    users:
     - org_username: user-1
     - org_username: user-2
   policies:
@@ -54,7 +86,8 @@ aws_groups:
     uid: '1'
     sso: true
   roles:
-  - users: []
+  - name: role-name
+    users: []
   policies:
   - AdministratorAccess
 
@@ -73,7 +106,8 @@ aws_groups:
     uid: '1'
     sso: true
   roles:
-  - users:
+  - name: role-name
+    users:
     - org_username: user-1
     - org_username: user-2
   policies: []

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -829,13 +829,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             for user_policy in user_policies:
                 policy_name = user_policy["name"]
                 account_name = user_policy["account"]["name"]
-                account_uid = user_policy["account"]["uid"]
                 for user in users:
-                    # replace known keys with values
                     user_name = self._get_aws_username(user)
-                    policy = user_policy["policy"]
-                    policy = policy.replace("${aws:username}", user_name)
-                    policy = policy.replace("${aws:accountid}", account_uid)
 
                     # Ref: terraform aws_iam_policy
                     tf_iam_user = self.get_tf_iam_user(user_name)
@@ -843,7 +838,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     tf_aws_iam_policy = aws_iam_policy(
                         identifier,
                         name=identifier,
-                        policy=policy,
+                        policy=user_policy["policy"],
                     )
                     self.add_resource(account_name, tf_aws_iam_policy)
                     # Ref: terraform aws_iam_user_policy_attachment


### PR DESCRIPTION
`aws-saml-roles` must also consider user-specific AWS policies (`/aws/role-1.user_policies`). The integration creates an AWS policy for each user policy (saml-$GROUP_NAME-$ROLE_NAME-$POLICY_NAME) with an extra `Condition` section to allow it only to the role.users. 

Additionally, it removes the `${aws.username}` and `${aws.accountid}` string replacement in favor of properly escaped variables in the policy. e.g. `$${aws.username}` instead of `${aws.username}`

Ticket: [APPSRE-9900](https://issues.redhat.com/browse/APPSRE-9900)
