### PR TITLE
[terraform-users] do not create IAM users in AWS accounts with SSO enabled

### DIFF
--- a/reconcile/terraform_users.py
+++ b/reconcile/terraform_users.py
@@ -39,6 +39,7 @@ mandatory
 policy
 account {
   name
+  sso
   uid
 }
 """
@@ -57,6 +58,7 @@ TF_QUERY = """
       policies
       account {
         name
+        sso
         consoleUrl
         uid
         policies {

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -689,6 +689,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 group_name = aws_group["name"]
                 group_policies = aws_group["policies"]
                 account = aws_group["account"]
+                if account["sso"] is True:
+                    # AWS accounts with SSO enabled do not need IAM groups
+                    continue
                 account_name = account["name"]
                 if account_name not in groups:
                     groups[account_name] = {}
@@ -759,6 +762,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             for aws_group in aws_groups:
                 group_name = aws_group["name"]
                 account = aws_group["account"]
+                if account["sso"] is True:
+                    # AWS accounts with SSO enabled do not need IAM users
+                    continue
                 account_name = account["name"]
                 account_console_url = account["consoleUrl"]
 
@@ -841,6 +847,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     self.add_resource(account_name, tf_output)
 
             for user_policy in user_policies:
+                if user_policy["account"]["sso"] is True:
+                    # AWS accounts with SSO enabled do not need user policies
+                    continue
                 policy_name = user_policy["name"]
                 account_name = user_policy["account"]["name"]
                 for user in users:


### PR DESCRIPTION
We don't need IAM users, groups, and user policies in accounts with SSO enabled.

Ticket: [APPSRE-9811](https://issues.redhat.com/browse/APPSRE-9811)