### PR TITLE
add tini to qr image to help reap orphaned processes

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -68,6 +68,12 @@ CMD [ "/run-integration.py" ]
 FROM prod-image as fips-prod-image
 ENV OC_VERSION=4.10.15
 
+# Tini
+ENV TINI_VERSION v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+ENTRYPOINT ["/tini", "--"]
+
 # oc versions sometimes have issues with FIPS enabled systems requiring us to use specific
 # versions in these environments so in this case we extract an older version of oc and kubectl
 COPY --chown=0:0 --from=quay.io/app-sre/qontract-reconcile-oc:0.1.0 \


### PR DESCRIPTION
[APPSRE-9812](https://issues.redhat.com/browse/APPSRE-9812)

The qontract-reconcile integration cannot clean up zombie processes, leading to issues with memory and thread startup.

This update incorporates [tini](https://github.com/krallin/tini) as the init system to improve process cleanup.

The change was locally tested to observe process cleanup efficiency. Additionally, this will apply to the fips build stage for testing purposes. 

