### PR TITLE
[openshift-resources] support templating from s3 object

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -42,6 +42,7 @@ from reconcile.utils.exceptions import FetchResourceError
 from reconcile.utils.jinja2.utils import (
     FetchSecretError,
     lookup_github_file_content,
+    lookup_s3_object,
     lookup_secret,
     process_extracurlyjinja2_template,
     process_jinja2_template,
@@ -1184,6 +1185,7 @@ def early_exit_monkey_patch():
     orig_lookup_github_file_content = lookup_github_file_content
     orig_url_makes_sense = url_makes_sense
     orig_check_alertmanager_config = check_alertmanager_config
+    orig_lookup_s3_object = lookup_s3_object
 
     try:
         yield _early_exit_monkey_patch_assign(
@@ -1209,6 +1211,7 @@ def early_exit_monkey_patch():
             orig_lookup_github_file_content,
             orig_url_makes_sense,
             orig_check_alertmanager_config,
+            orig_lookup_s3_object,
         )
 
 
@@ -1217,11 +1220,13 @@ def _early_exit_monkey_patch_assign(
     lookup_github_file_content,
     url_makes_sense,
     check_alertmanager_config,
+    lookup_s3_object,
 ):
     sys.modules[__name__].lookup_secret = lookup_secret
     sys.modules[__name__].lookup_github_file_content = lookup_github_file_content
     sys.modules[__name__].url_makes_sense = url_makes_sense
     sys.modules[__name__].check_alertmanager_config = check_alertmanager_config
+    sys.modules[__name__].lookup_s3_object = lookup_s3_object
 
 
 def desired_state_shard_config() -> DesiredStateShardConfig:

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
         ResourceRecordSetTypeDef,
         ResourceRecordTypeDef,
     )
+    from mypy_boto3_s3 import S3Client
 else:
     EC2Client = EC2ServiceResource = RouteTableTypeDef = SubnetTypeDef = (
         TransitGatewayTypeDef
@@ -71,7 +72,7 @@ else:
         HostedZoneTypeDef
     ) = RDSClient = DBInstanceMessageTypeDef = UpgradeTargetTypeDef = (
         OrganizationsClient
-    ) = object
+    ) = S3Client = object
 
 
 class InvalidResourceTypeError(Exception):
@@ -244,6 +245,12 @@ class AWSApi:  # pylint: disable=too-many-public-methods
     ) -> OrganizationsClient:
         session = self.get_session(account_name)
         return self.get_session_client(session, "organizations", region_name)
+
+    def _account_s3_client(
+        self, account_name: str, region_name: Optional[str] = None
+    ) -> S3Client:
+        session = self.get_session(account_name)
+        return self.get_session_client(session, "s3", region_name)
 
     def init_users(self):
         self.users = {}
@@ -1627,6 +1634,18 @@ class AWSApi:  # pylint: disable=too-many-public-methods
     def get_organization_billing_account(self, account_name: str) -> str:
         org = self._account_organizations_client(account_name)
         return org.describe_organization()["Organization"]["MasterAccountId"]
+
+    def get_s3_object_content(
+        self,
+        account_name: str,
+        bucket_name: str,
+        path: str,
+        region_name: Optional[str] = None,
+    ) -> str:
+        s3 = self._account_s3_client(account_name, region_name=region_name)
+        return (
+            s3.get_object(Bucket=bucket_name, Key=path)["Body"].read().decode("utf-8")
+        )
 
 
 def aws_config_file_path() -> Optional[str]:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-9898

following up on #4158, we want to be able to dump these results from s3 to a ConfigMap.

this PR introduces templating from an s3 object, which will allow us to:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: publisher-data
data:
  publisher-data.json:
    {{ s3('account-name', 'bucket-name', 'path/to/object') | tojson }}
```
example: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/99057