### PR TITLE
terraform cloudflare client provider version behavior

### DIFF
--- a/reconcile/utils/terrascript/cloudflare_client.py
+++ b/reconcile/utils/terrascript/cloudflare_client.py
@@ -105,11 +105,16 @@ def create_cloudflare_terrascript(
 
     terrascript += Terraform(backend=backend, required_providers=required_providers)
 
-    terrascript += provider.cloudflare(
-        api_token=account_config.api_token,
-        account_id=account_config.account_id,  # needed for some resources, see note below
-        rps=provider_rps,
-    )
+    cloudflare_provider_values = {
+        "api_token": account_config.api_token,
+        "rps": provider_rps,
+    }
+    if provider_version.startswith("3"):
+        cloudflare_provider_values["account_id"] = (
+            account_config.account_id
+        )  # needed for some resources, see note below
+
+    terrascript += provider.cloudflare(**cloudflare_provider_values)
 
     cloudflare_account_values = {
         "name": account_config.name,


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-8451

this PR introduces a conditional behavior to avoid adding `account_id` to provider section.

related to https://github.com/cloudflare/terraform-provider-cloudflare/issues/1646