### PR TITLE
terraform cloudflare_worker_script add account id

### DIFF
--- a/reconcile/utils/terrascript/cloudflare_resources.py
+++ b/reconcile/utils/terrascript/cloudflare_resources.py
@@ -151,6 +151,7 @@ class CloudflareWorkerScriptTerrascriptResource(TerrascriptResource):
             "name": name,
             "content": f"${{var.{identifier}_content}}",
             "plain_text_binding": values.pop("vars"),
+            "account_id": "${var.account_id}",
         }
         return [
             cloudflare_worker_script(identifier, **worker_script_values),


### PR DESCRIPTION
```
The argument "account_id" is required, but no definition was found.
```