### PR TITLE
cloudflare_worker_script add account_id

### DIFF
--- a/reconcile/utils/terrascript/cloudflare_resources.py
+++ b/reconcile/utils/terrascript/cloudflare_resources.py
@@ -151,6 +151,7 @@ class CloudflareWorkerScriptTerrascriptResource(TerrascriptResource):
             "name": name,
             "content": f"${{var.{identifier}_content}}",
             "plain_text_binding": values.pop("vars"),
+            "account_id": "${var.account_id}",
         }
         return [
             cloudflare_worker_script(identifier, **worker_script_values),


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-9906

in an attempt to upgrade to terraform v1, the following error shows up (#4173):
```
The argument "account_id" is required, but no definition was found.
```

this PR would add the missing attribute while we are on a 3.x provider, so we are ready for a terraform v1 migration.