### PR TITLE
[terraform-users] do not replace special AWS variables

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -843,13 +843,8 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             for user_policy in user_policies:
                 policy_name = user_policy["name"]
                 account_name = user_policy["account"]["name"]
-                account_uid = user_policy["account"]["uid"]
                 for user in users:
-                    # replace known keys with values
                     user_name = self._get_aws_username(user)
-                    policy = user_policy["policy"]
-                    policy = policy.replace("${aws:username}", user_name)
-                    policy = policy.replace("${aws:accountid}", account_uid)
 
                     # Ref: terraform aws_iam_policy
                     tf_iam_user = self.get_tf_iam_user(user_name)
@@ -857,7 +852,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     tf_aws_iam_policy = aws_iam_policy(
                         identifier,
                         name=identifier,
-                        policy=policy,
+                        policy=user_policy["policy"],
                     )
                     self.add_resource(account_name, tf_aws_iam_policy)
                     # Ref: terraform aws_iam_user_policy_attachment


### PR DESCRIPTION
Remove the `${aws.username}` and `${aws.accountid}` string replacement in favor of properly escaped variables in the policy. E.g. `$${aws.username}` instead of `${aws.username}`. 

Part of: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/98869

See [IAM policy elements: Variables and tags](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html) for more details about all available AWS variables.

Why this change, you may ask?

During the development of https://github.com/app-sre/qontract-reconcile/pull/4184, I found some problems with this replacement:

* `${aws.username}` in an app-interface policy yaml can't be [parsed by terraform](https://github.com/hashicorp/terraform-provider-aws/issues/5984)
* To use the official AWS variable, you must escape it via `$${aws.username}` and terraform will be happy
* Nevertheless, `${aws.username}` in app-interface was introduced without the knowledge about the AWS variable `${aws.username}` and we replacing it just with the usernames.
* Now I want to change this behavior, otherwise each time someone wants to use [aws_iam_policy](https://github.com/app-sre/qontract-reconcile/pull/4184/files#diff-4db367e141fd1992ae5a98872e6101dde4bf61a460c1bd0097176c6fbc849ac2R2577) must do the `${aws.username}` replacement as well