### PR TITLE
[terraform-resources] prevent same account from being included and excluded

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -203,8 +203,8 @@ def get_aws_accounts(
         logging.error(message)
         raise ExcludeAccountsAndDryRunException(message)
 
-    if exclude_accounts and include_accounts:
-        message = "Using --exclude-accounts and --account-name at the same time is not allowed"
+    if any(a in exclude_accounts for a in include_accounts):
+        message = "Using --exclude-accounts and --account-name with the same account is not allowed"
         logging.error(message)
         raise ExcludeAccountsAndAccountNameException(message)
 

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -203,7 +203,9 @@ def get_aws_accounts(
         logging.error(message)
         raise ExcludeAccountsAndDryRunException(message)
 
-    if any(a in exclude_accounts for a in include_accounts):
+    if (exclude_accounts and include_accounts) and any(
+        a in exclude_accounts for a in include_accounts
+    ):
         message = "Using --exclude-accounts and --account-name with the same account is not allowed"
         logging.error(message)
         raise ExcludeAccountsAndAccountNameException(message)

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -23,12 +23,12 @@ def test_cannot_use_exclude_accounts_if_not_dry_run():
     assert "--exclude-accounts is only supported in dry-run mode" in str(excinfo.value)
 
 
-def test_cannot_use_exclude_account_with_account_name():
+def test_cannot_use_exclude_account_with_same_account_name():
     with pytest.raises(integ.ExcludeAccountsAndAccountNameException) as excinfo:
-        integ.run(True, exclude_accounts=("a", "b"), account_name=("c", "d"))
+        integ.run(True, exclude_accounts=("a", "b"), account_name=("b", "c", "d"))
 
     assert (
-        "Using --exclude-accounts and --account-name at the same time is not allowed"
+        "Using --exclude-accounts and --account-name with the same account is not allowed"
         in str(excinfo.value)
     )
 


### PR DESCRIPTION
we currently fail if `--account-name` is used with `--exclude-accounts`.

this failure is introduced by the `select-integrations.py` enhancement to only check affected shards (the implementation is the usage of `--account-name`), while also supporting `shardSpecOverrides`.

with this adjustment, we only fail if the same account is both included and excluded.