### PR TITLE
bump terraform to v1

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 # this file is used by asdf to automatically select the correct tool versions
 # but it also serves as a reference for non-asdf users
 python 3.11.4
-terraform 0.13.7
+terraform 1.5.7
 oc 4.12.46

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -14,7 +14,7 @@ RUN python3 -m pip install --no-cache-dir --upgrade pip setuptools wheel && \
     python3 -m pip wheel . --wheel-dir /work/wheels
 
 
-FROM quay.io/app-sre/qontract-reconcile-base:0.11.1 as dev-image
+FROM quay.io/app-sre/qontract-reconcile-base:0.12.1 as dev-image
 
 ARG CONTAINER_UID=1000
 RUN useradd --uid ${CONTAINER_UID} reconcile
@@ -44,7 +44,7 @@ VOLUME ["/work"]
 ENTRYPOINT ["/work/dev/run.sh"]
 
 
-FROM quay.io/app-sre/qontract-reconcile-base:0.11.1 as prod-image
+FROM quay.io/app-sre/qontract-reconcile-base:0.12.1 as prod-image
 
 ARG quay_expiration=never
 LABEL quay.expires-after=${quay_expiration}

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -43,7 +43,7 @@ from reconcile.utils.runtime.runner import (
 )
 from reconcile.utils.unleash import get_feature_toggle_state
 
-TERRAFORM_VERSION = ["0.13.7"]
+TERRAFORM_VERSION = ["1.5.7"]
 TERRAFORM_VERSION_REGEX = r"^Terraform\sv([\d]+\.[\d]+\.[\d]+)$"
 
 OC_VERSIONS = ["4.12.46", "4.10.15"]


### PR DESCRIPTION
related to https://issues.redhat.com/browse/APPSRE-9906

this PR promoted qontract-reconcile-base image with changes to terraform binary to v1 (#103) and cloudflare provider 4.x (#104, not reflected in this PR).