### PR TITLE
terraform required version

### DIFF
--- a/reconcile/test/utils/test_terrascript_cloudflare_client.py
+++ b/reconcile/test/utils/test_terrascript_cloudflare_client.py
@@ -11,8 +11,8 @@ from unittest.mock import (
 
 import pytest
 from terrascript import Terrascript
-from reconcile.cli import TERRAFORM_VERSION
 
+from reconcile.cli import TERRAFORM_VERSION
 from reconcile.utils.external_resource_spec import ExternalResourceSpec
 from reconcile.utils.secret_reader import SecretReaderBase
 from reconcile.utils.terraform.config import TerraformS3BackendConfig

--- a/reconcile/test/utils/test_terrascript_cloudflare_client.py
+++ b/reconcile/test/utils/test_terrascript_cloudflare_client.py
@@ -11,6 +11,7 @@ from unittest.mock import (
 
 import pytest
 from terrascript import Terrascript
+from reconcile.cli import TERRAFORM_VERSION
 
 from reconcile.utils.external_resource_spec import ExternalResourceSpec
 from reconcile.utils.secret_reader import SecretReaderBase
@@ -276,6 +277,7 @@ def test_create_cloudflare_resources_terraform_json(
                     "version": "3.18",
                 }
             },
+            "required_version": TERRAFORM_VERSION[0],
             "backend": {
                 "s3": {
                     "access_key": "access-key",

--- a/reconcile/utils/terrascript/cloudflare_client.py
+++ b/reconcile/utils/terrascript/cloudflare_client.py
@@ -107,7 +107,7 @@ def create_cloudflare_terrascript(
     terrascript += Terraform(
         backend=backend,
         required_providers=required_providers,
-        required_version=TERRAFORM_VERSION,
+        required_version=TERRAFORM_VERSION[0],
     )
 
     cloudflare_provider_values = {

--- a/reconcile/utils/terrascript/cloudflare_client.py
+++ b/reconcile/utils/terrascript/cloudflare_client.py
@@ -21,6 +21,7 @@ from terrascript import (
     provider,
 )
 
+from reconcile.cli import TERRAFORM_VERSION
 from reconcile.utils.exceptions import SecretIncompleteError
 from reconcile.utils.external_resource_spec import (
     ExternalResourceSpec,
@@ -103,7 +104,11 @@ def create_cloudflare_terrascript(
         }
     }
 
-    terrascript += Terraform(backend=backend, required_providers=required_providers)
+    terrascript += Terraform(
+        backend=backend,
+        required_providers=required_providers,
+        required_version=TERRAFORM_VERSION,
+    )
 
     cloudflare_provider_values = {
         "api_token": account_config.api_token,

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -450,7 +450,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                         "version": "2.2.0",
                     },
                 },
-                required_version=TERRAFORM_VERSION,
+                required_version=TERRAFORM_VERSION[0],
             )
             tss[name] = ts
             locks[name] = Lock()

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -142,6 +142,7 @@ from terrascript.resource import (
 
 import reconcile.utils.aws_helper as awsh
 from reconcile import queries
+from reconcile.cli import TERRAFORM_VERSION
 from reconcile.github_org import get_default_config
 from reconcile.gql_definitions.terraform_resources.terraform_resources_namespaces import (
     NamespaceTerraformResourceLifecycleV1,
@@ -449,6 +450,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                         "version": "2.2.0",
                     },
                 },
+                required_version=TERRAFORM_VERSION,
             )
             tss[name] = ts
             locks[name] = Lock()


### PR DESCRIPTION
terraform integrations validate the binary version.

there are cases that require manual intervention, such as importing resources. in such cases, we use the `--print-to-file` option and execute `terraform` locally.

this PR adds usage of `required_version` to avoid mistakes of binary version: https://developer.hashicorp.com/terraform/language/settings#specifying-a-required-terraform-version