### PR TITLE
[terraform-resources] aws provider 5.x enhancements

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4050,9 +4050,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             if val is not None:
                 values[key] = val
 
-        if self.versions and not self.versions.get(spec.provisioner_name).startswith(
-            "3"
-        ):
+        if self.versions and not self.versions.get(
+            spec.provisioner_name, ""
+        ).startswith("3"):
             if spec.provider == "rds":
                 if db_name := values.pop("name", None):
                     values["db_name"] = db_name

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4050,7 +4050,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             if val is not None:
                 values[key] = val
 
-        if not self.versions.get(spec.provisioner_name).startswith("3"):
+        if self.versions and not self.versions.get(spec.provisioner_name).startswith(
+            "3"
+        ):
             if spec.provider == "rds":
                 if db_name := values.pop("name", None):
                     values["db_name"] = db_name

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -385,7 +385,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             self.secret_reader = SecretReader(settings=settings)
         self.configs: dict[str, dict] = {}
         self.populate_configs(filtered_accounts)
-        self.versions = {a["name"]: a["providerVersion"] for a in filtered_accounts}
+        self.versions: dict[str, str] = {
+            a["name"]: a["providerVersion"] for a in filtered_accounts
+        }
         tss = {}
         locks = {}
         self.supported_regions = {}
@@ -1507,12 +1509,13 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         # we want to allow an empty name, so we
         # only validate names which are not empty
-        if values.get("name") and not self.validate_db_name(values["name"]):
+        db_name = values.get("name") or values.get("db_name")
+        if db_name and not self.validate_db_name(db_name):
             raise FetchResourceError(
                 f"[{account}] RDS name must contain 1 to 63 letters, "
                 + "numbers, or underscores. RDS name must begin with a "
                 + "letter. Subsequent characters can be letters, "
-                + f"underscores, or digits (0-9): {values['name']}"
+                + f"underscores, or digits (0-9): {db_name}"
             )
 
         if not values.get("apply_immediately"):
@@ -4046,6 +4049,22 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             # to allow passing empty strings, False, etc
             if val is not None:
                 values[key] = val
+
+        if not self.versions.get(spec.provisioner_name).startswith("3"):
+            if spec.provider == "rds":
+                if db_name := values.pop("name", None):
+                    values["db_name"] = db_name
+                if values.get("replica_source"):
+                    values.pop("db_name", None)
+            if spec.provider == "elasticache":
+                if description := values.pop("replication_group_description", None):
+                    values["description"] = description
+                if num_cache_clusters := values.pop("number_cache_clusters", None):
+                    values["num_cache_clusters"] = num_cache_clusters
+                if cluster_mode := values.pop("cluster_mode", {}):
+                    for k, v in cluster_mode.items():
+                        values[k] = v
+                values.pop("availability_zones", None)
 
         return values
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1509,7 +1509,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         # we want to allow an empty name, so we
         # only validate names which are not empty
-        db_name = values.get("name") or values.get("db_name")
+        db_name = values.get("name") or values.get("db_name") or ""
         if db_name and not self.validate_db_name(db_name):
             raise FetchResourceError(
                 f"[{account}] RDS name must contain 1 to 63 letters, "
@@ -1808,7 +1808,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         tf_resources.append(Output(output_name, value=output_value))
         # db.name
         output_name = output_prefix + "__db_name"
-        output_value = output_resource_db_name or values.get("name", "")
+        output_value = output_resource_db_name or db_name
         tf_resources.append(Output(output_name, value=output_value))
         # only set db user/password if not a replica or creation from snapshot
         if self._db_needs_auth(values):

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -4058,7 +4058,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     values["db_name"] = db_name
                 if values.get("replica_source"):
                     values.pop("db_name", None)
-            if spec.provider == "elasticache":
+            elif spec.provider == "elasticache":
                 if description := values.pop("replication_group_description", None):
                     values["description"] = description
                 if num_cache_clusters := values.pop("number_cache_clusters", None):


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-8577

these changes are required to be backwards compatible with data in app-interface(s), and also with terraform aws provider version 5.x.

we do this by updating `values` to match changes in the terraform provider.

testing release candidate here: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/99480