### PR TITLE
lookup_s3_object add to yield _early_exit_monkey_patch_assign

### DIFF
--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -1204,6 +1204,10 @@ def early_exit_monkey_patch():
             secret_reader=None: f"github({repo}, {path}, {ref})",
             lambda url: False,
             lambda data, path, alertmanager_config_key, decode_base64=False: True,
+            lambda account_name,
+            bucket_name,
+            path,
+            region_name=None: f"lookup_s3_object({account_name}, {bucket_name}, {path}, {region_name})",
         )
     finally:
         _early_exit_monkey_patch_assign(


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-9898

fixes #4169

```
Arguments: (TypeError("_early_exit_monkey_patch_assign() missing 1 required positional argument: 'lookup_s3_object'"),)
```