### PR TITLE
[terraform-resources] aws provider 5.x fixes

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1509,7 +1509,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
 
         # we want to allow an empty name, so we
         # only validate names which are not empty
-        db_name = values.get("name") or values.get("db_name") or ""
+        db_name = self._get_db_name_from_values(values)
         if db_name and not self.validate_db_name(db_name):
             raise FetchResourceError(
                 f"[{account}] RDS name must contain 1 to 63 letters, "
@@ -1852,6 +1852,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             if spec.identifier == source and spec.provider == provider:
                 return spec
         return None
+
+    def _get_db_name_from_values(self, values: dict) -> str:
+        return values.get("name") or values.get("db_name") or ""
 
     @staticmethod
     def _region_from_availability_zone(az):

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1682,6 +1682,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                     replica_region = self.default_regions.get(account)
 
                 source_values = self.init_values(source_info)
+                db_name = self._get_db_name_from_values(source_values)
                 if replica_region == region:
                     # replica is in the same region as source
                     values["replicate_source_db"] = replica_source


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-8577

follow up on #4188

since `replica_source` can no longer co-exist with `name` or `db_name`, we popped them in #4188. the implication is that read replica output for db_name is now empty, which results in missing fields in output secrets (namespace/vault).

this PR sets `db_name` for read replicas based on the source replica info.