### PR TITLE
[terraform-resources] 5.x provider asg updates

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5469,7 +5469,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 override
             )
 
-        asg_value["tags"] = [
+        asg_value["tag"] = [
             {"key": k, "value": v, "propagate_at_launch": True} for k, v in tags.items()
         ]
         asg_resource = aws_autoscaling_group(identifier, **asg_value)


### PR DESCRIPTION
use `tag` instead of `tags` for autoscaling groups.

https://registry.terraform.io/providers/hashicorp/aws/3.76.1/docs/resources/autoscaling_group#tag-and-tags
vs
https://registry.terraform.io/providers/hashicorp/aws/5.39.1/docs/resources/autoscaling_group#tag