### PR TITLE
:bug: aws-version-sync: fix showing MRs in the review queue if auto-merge is disabled

### DIFF
--- a/reconcile/aws_version_sync/merge_request_manager/merge_request_manager.py
+++ b/reconcile/aws_version_sync/merge_request_manager/merge_request_manager.py
@@ -15,10 +15,7 @@ from reconcile.aws_version_sync.merge_request_manager.merge_request import (
 )
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.mr.base import MergeRequestBase
-from reconcile.utils.mr.labels import (
-    AUTO_MERGE,
-    SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE,
-)
+from reconcile.utils.mr.labels import AUTO_MERGE
 from reconcile.utils.vcs import VCS
 
 
@@ -226,8 +223,6 @@ class MergeRequestManager:
         mr_labels = [AVS_LABEL]
         if self._auto_merge_enabled:
             mr_labels.append(AUTO_MERGE)
-        else:
-            mr_labels.append(SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE)
         self._vcs.open_app_interface_merge_request(
             mr=AVSMR(
                 path=namespace_file,

--- a/reconcile/test/aws_version_sync/merge_request_manager/test_merge_request_manager.py
+++ b/reconcile/test/aws_version_sync/merge_request_manager/test_merge_request_manager.py
@@ -26,10 +26,7 @@ from reconcile.aws_version_sync.merge_request_manager.merge_request_manager impo
     OpenMergeRequest,
 )
 from reconcile.utils.gitlab_api import GitLabApi
-from reconcile.utils.mr.labels import (
-    AUTO_MERGE,
-    SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE,
-)
+from reconcile.utils.mr.labels import AUTO_MERGE
 from reconcile.utils.vcs import VCS
 
 
@@ -341,6 +338,5 @@ def test_merge_request_manager_create_avs_merge_request_auto_merge_off(
 
     vcs_mock.close_app_interface_mr.assert_not_called()
     assert vcs_mock.open_app_interface_merge_request.call_args.kwargs["mr"].labels == [
-        AVS_LABEL,
-        SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE,
+        AVS_LABEL
     ]

--- a/reconcile/utils/mr/labels.py
+++ b/reconcile/utils/mr/labels.py
@@ -26,3 +26,5 @@ def change_owner_label(label: str) -> str:
 SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE = change_owner_label(
     "show-self-serviceable-in-review-queue"
 )
+# aws-version-sync
+AVS = "AVS"

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -108,6 +108,7 @@ from reconcile.utils.keycloak import (
     SSOClient,
 )
 from reconcile.utils.mr.labels import (
+    AVS,
     SAAS_FILE_UPDATE,
     SELF_SERVICEABLE,
     SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE,
@@ -1975,6 +1976,7 @@ def app_interface_review_queue(ctx) -> None:
             if (
                 SELF_SERVICEABLE in labels
                 and SHOW_SELF_SERVICEABLE_IN_REVIEW_QUEUE not in labels
+                and AVS not in labels
             ):
                 continue
 


### PR DESCRIPTION
The change-owners integration manages the `show-self-serviceable-in-review-queue` label and can't be used to show arbitrary MRs in the review queue. As long as we don't enable the auto-merge of AVS MRs, we need to show them in the review queue filtered by the `AVS` label.