### PR TITLE
Update ruff to 3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 line-length = 88
 target-version = 'py311'
-required-version = "0.2.1"
+required-version = "0.3.2"
 
 src = ["reconcile", "tools", "release", "dockerfiles/hack", "setup.py"]
 extend-exclude = ["reconcile/gql_definitions"]

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -126,7 +126,7 @@ class ReconcileErrorSummary(Exception):
 
     def __str__(self) -> str:
         formatted_exceptions = "\n".join([f"- {e}" for e in self.exceptions])
-        return f"Reconcile exceptions:\n{ formatted_exceptions }"
+        return f"Reconcile exceptions:\n{formatted_exceptions}"
 
 
 class AdvancedUpgradeSchedulerBaseIntegration(

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -140,7 +140,7 @@ def write_coverage_report_to_mr(
     approver_reachability = set()
     for d in change_decisions:
         approvers = [
-            f"{cr.context} - { ' '.join([f'@{a.org_username}' if a.tag_on_merge_requests else a.org_username for a in cr.approvers]) }"
+            f"{cr.context} - {' '.join([f'@{a.org_username}' if a.tag_on_merge_requests else a.org_username for a in cr.approvers])}"
             for cr in d.change_responsibles
         ]
         for cr in d.change_responsibles:

--- a/reconcile/change_owners/diff.py
+++ b/reconcile/change_owners/diff.py
@@ -45,7 +45,7 @@ class Diff:
             absolute_sub_path = sub_path
         elif sub_path_str.startswith(self.path_str()):
             absolute_sub_path = parse_jsonpath(
-                f"${sub_path_str[len(self.path_str()):]}"
+                f"${sub_path_str[len(self.path_str()) :]}"
             )
         else:
             raise Exception(

--- a/reconcile/dynatrace_token_provider.py
+++ b/reconcile/dynatrace_token_provider.py
@@ -75,7 +75,7 @@ class ReconcileErrorSummary(Exception):
 
     def __str__(self) -> str:
         formatted_exceptions = "\n".join([f"- {e}" for e in self.exceptions])
-        return f"Reconcile exceptions:\n{ formatted_exceptions }"
+        return f"Reconcile exceptions:\n{formatted_exceptions}"
 
 
 class DTPBaseMetric(BaseModel):

--- a/reconcile/test/utils/test_external_resource_spec.py
+++ b/reconcile/test/utils/test_external_resource_spec.py
@@ -375,7 +375,7 @@ def test_terraform_generic_secret_output_key_too_long(
     long_key = "a" * (SECRET_MAX_KEY_LENGTH + 1)
     spec.resource["output_format"] = {
         "provider": "generic-secret",
-        "data": f"{ long_key }: value",
+        "data": f"{long_key}: value",
     }
     spec.secret = resource_secret
 

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -13,4 +13,4 @@ MarkupSafe==2.1.1
 smtpdfix==0.3.3
 pyfakefs~=5.1
 botocore==1.34.15
-ruff==0.2.1
+ruff==0.3.2

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2115,7 +2115,7 @@ def change_types(ctx) -> None:
         data.append({
             "name": ct.name,
             "description": ct.description,
-            "applicable to": f"{ct.context_type.value} {ct.context_schema or '' }",
+            "applicable to": f"{ct.context_type.value} {ct.context_schema or ''}",
             "# usages": usage_statistics[ct.name],
         })
     columns = ["name", "description", "applicable to", "# usages"]


### PR DESCRIPTION
Keeping ruff up to date because my ruff-lsp keeps updating and using a global ruff instead of the local venv.