### PR TITLE
[terraform-resources] rds event notifications use identifier instead of id

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1778,7 +1778,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 if sns_topic_name.startswith("arn:"):
                     raise ValueError("destination should not be an arn")
                 e_n["sns_topic"] = "${aws_sns_topic" + "." + sns_topic_name + ".arn}"
-                e_n["source_ids"] = ["${aws_db_instance" + "." + identifier + ".id}"]
+                e_n["source_ids"] = [identifier]
                 source_type = e_n.get("source_type", "all")
                 e_n_identifier = (
                     f"{sns_topic_name}_{source_type}_aws_db_event_subscription"


### PR DESCRIPTION
```
[terraform-resources] [<account> - apply] Error: creating RDS Event Subscription (terraform-20240317103136899600000001): operation error RDS: CreateEventSubscription, https response error StatusCode: 404, RequestID: ef365010-5ac2-4010-bdba-c4d331553266, SourceNotFound: Could not find source :db-X2DZTPZZBF4OCRVD35QD4PJQIU
```