### PR TITLE
Run terraform init in sequence

### DIFF
--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -142,7 +142,8 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
             TerraformSpec(name=name, working_dir=wd)
             for name, wd in self.working_dirs.items()
         ]
-        threaded.run(self.terraform_init, self.specs, self.thread_pool_size)
+        for spec in self.specs:
+            self.terraform_init(spec)
 
     @contextmanager
     def _terraform_log_file(


### PR DESCRIPTION
Avoid issues when multiple terraform init try to populate plugin cache at the same time.

https://developer.hashicorp.com/terraform/cli/config/config-file#provider-plugin-cache

> Note: The plugin cache directory is not guaranteed to be concurrency safe. The provider installer's behavior in environments with multiple terraform init calls is undefined.