### PR TITLE
[terraform-tgw-attachments] ignore deletion approvals in early exit

### DIFF
--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -489,7 +489,10 @@ def run(
 
 
 def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:
-    return _fetch_desired_state_data_source().dict(by_alias=True)
+    desired_state = _fetch_desired_state_data_source()
+    for a in desired_state.accounts:
+        a.deletion_approvals = []
+    return desired_state.dict(by_alias=True)
 
 
 def desired_state_shard_config() -> DesiredStateShardConfig:


### PR DESCRIPTION
to avoid running this integration in pr-check or changes to, for example, deletion of external resources.

if nothing changes except for deletion approvals, the integration has nothing to do.