### PR TITLE
[change-owners] approval detection for split changes

### DIFF
--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -144,7 +144,9 @@ def write_coverage_report_to_mr(
             for cr in d.change_responsibles
         ]
         if d.coverable_by_fragment_decisions:
-            approvers.append("automatically approved if all sub-properties are approved")
+            approvers.append(
+                "automatically approved if all sub-properties are approved"
+            )
         for cr in d.change_responsibles:
             approver_reachability.update({
                 ar.render_for_mr_report() for ar in cr.approver_reachability or []

--- a/reconcile/change_owners/change_owners.py
+++ b/reconcile/change_owners/change_owners.py
@@ -143,6 +143,8 @@ def write_coverage_report_to_mr(
             f"{cr.context} - {' '.join([f'@{a.org_username}' if a.tag_on_merge_requests else a.org_username for a in cr.approvers])}"
             for cr in d.change_responsibles
         ]
+        if d.coverable_by_fragment_decisions:
+            approvers.append("automatically approved if all sub-properties are approved")
         for cr in d.change_responsibles:
             approver_reachability.update({
                 ar.render_for_mr_report() for ar in cr.approver_reachability or []
@@ -199,6 +201,17 @@ def write_coverage_report_to_mr(
 def write_coverage_report_to_stdout(change_decisions: list[ChangeDecision]) -> None:
     results = []
     for d in change_decisions:
+        if d.coverable_by_fragment_decisions:
+            results.append({
+                "file": d.file.path,
+                "schema": d.file.schema,
+                "changed path": d.diff.path,
+                "change type": "...",
+                "origin": "...",
+                "context": "coverable by fragments",
+                "approver_reachability": "",
+                "disabled": False,
+            })
         if d.coverage:
             for ctx in d.coverage:
                 results.append({

--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -80,6 +80,10 @@ class DiffCoverage:
     parent: Optional["DiffCoverage"] = None
 
     @property
+    def diff_fragments(self) -> Sequence["DiffCoverage"]:
+        return self._split_into
+
+    @property
     def change_owner_labels(self) -> set[str]:
         """
         Returns a list of change-owner labels of all involved change-type contexts.


### PR DESCRIPTION
consider a path in a datafile approved if all individual parts of the datafile are covered by change-types and have been approved.

e.g. consider the introduction of an RDS overrides section in a namespace

```yaml
externalResources:
- provider: aws
  provisioner:
    $ref: /aws/account.yml
  resources:
  - provider: rds
    ...
+   overrides:
+     timeouts:
+       create: 2h
+      apply_immediately: true

```

the entire `overrides` section is covered by a high priviledge change-type and the `timeouts` and `apply_immediately` properties are covered by two other specialized change-types.

this PR will allow the change to be self-serviceable by:
* the high priviledge change-type...
* ... or the two specialized change-types, without the need of the high priviledge change-type