### PR TITLE
[AUS] enable ingress gate to be auto approvable

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -1093,7 +1093,7 @@ def calculate_diff(
                 )
                 if gates:
                     gate_ids = [gate.id for gate in gates]
-                    logging.debug(
+                    logging.info(
                         f"[{spec.org.org_id}/{spec.org.name}/{spec.cluster.name}] found gates for {target_version_prefix} - {gate_ids} "
                         "Skip creation of an upgrade policy until all of them have been acked by the version-gate-approver integration or a user."
                     )

--- a/reconcile/aus/version_gates/__init__.py
+++ b/reconcile/aus/version_gates/__init__.py
@@ -1,6 +1,10 @@
 from typing import Type
 
-from reconcile.aus.version_gates import ocp_gate_handler, sts_version_gate_handler, ingress_gate_handler
+from reconcile.aus.version_gates import (
+    ingress_gate_handler,
+    ocp_gate_handler,
+    sts_version_gate_handler,
+)
 from reconcile.aus.version_gates.handler import GateHandler
 
 HANDLERS: dict[str, Type[GateHandler]] = {

--- a/reconcile/aus/version_gates/__init__.py
+++ b/reconcile/aus/version_gates/__init__.py
@@ -1,9 +1,10 @@
 from typing import Type
 
-from reconcile.aus.version_gates import ocp_gate_handler, sts_version_gate_handler
+from reconcile.aus.version_gates import ocp_gate_handler, sts_version_gate_handler, ingress_gate_handler
 from reconcile.aus.version_gates.handler import GateHandler
 
 HANDLERS: dict[str, Type[GateHandler]] = {
     ocp_gate_handler.GATE_LABEL: ocp_gate_handler.OCPGateHandler,
     sts_version_gate_handler.GATE_LABEL: sts_version_gate_handler.STSGateHandler,
+    ingress_gate_handler.GATE_LABEL: ingress_gate_handler.IngressGateHandler,
 }

--- a/reconcile/aus/version_gates/ingress_gate_handler.py
+++ b/reconcile/aus/version_gates/ingress_gate_handler.py
@@ -1,0 +1,30 @@
+from reconcile.aus.version_gates.handler import GateHandler
+from reconcile.utils.ocm.base import OCMCluster, OCMVersionGate
+from reconcile.utils.ocm_base_client import OCMBaseClient
+
+GATE_LABEL = "api.openshift.com/gate-ingress"
+
+
+class IngressGateHandler(GateHandler):
+    """
+    https://access.redhat.com/node/7028653
+    """
+
+    @staticmethod
+    def gate_applicable_to_cluster(_: OCMCluster) -> bool:
+        # applicable to all cluster types
+        return True
+
+    def handle(
+        self,
+        ocm_api: OCMBaseClient,
+        ocm_org_id: str,
+        cluster: OCMCluster,
+        gate: OCMVersionGate,
+        dry_run: bool,
+    ) -> bool:
+        # there is no automatic remediation for this gate
+        # users need to manually do the required changes to their clusters
+        # or their clusters are not affected and they can accept the gate
+        # in the upgradePolicy.versionGateApprovals field
+        return True

--- a/reconcile/aus/version_gates/ingress_gate_handler.py
+++ b/reconcile/aus/version_gates/ingress_gate_handler.py
@@ -25,6 +25,8 @@ class IngressGateHandler(GateHandler):
     ) -> bool:
         # there is no automatic remediation for this gate
         # users need to manually do the required changes to their clusters
-        # or their clusters are not affected and they can accept the gate
-        # in the upgradePolicy.versionGateApprovals field
+        # and then need to ack the gate on their own or let version-gate-approver
+        # do it for them when they list this gate under upgradePolicy.versionGateApprovals
+        # in their cluster file or the sre-capabilities.aus.version-gate-approvals
+        # OCM subscription label
         return True


### PR DESCRIPTION
add the `gate-ingress` version gate to the list of valid gates to be auto acknowledable by the AUS version-gate-approver

the implementation is mostly about letting the version-gate-approver integration know that such a gate exists and how to handle it if users decide that they want to auto ack it.

depends on https://github.com/app-sre/qontract-schemas/pull/609

part of https://issues.redhat.com/browse/APPSRE-7949