### PR TITLE
[terraform-tgw-attachments] Pass account_name as kwargs for shard dry run

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2201,7 +2201,7 @@ def terraform_tgw_attachments(
         print_to_file,
         enable_deletion,
         thread_pool_size,
-        account_name,
+        account_name=account_name,
     )
 
 


### PR DESCRIPTION
Only `kwargs` can be override in [copy_and_update](https://github.com/app-sre/qontract-reconcile/blob/dcf849f9f2441fbd906b52ccb1e3abfa5d783d86/reconcile/utils/runtime/integration.py#L262) for [_integration_dry_run](https://github.com/app-sre/qontract-reconcile/blob/b8281476eb8876e264f80b1f6eaeed93e46a2118/reconcile/utils/runtime/runner.py#L173).

Otherwise it will fail due to `run() got multiple values for argument 'account_name'`.