### PR TITLE
[dashdotdb-dora] skip not found gitlab files

### DIFF
--- a/reconcile/dashdotdb_dora.py
+++ b/reconcile/dashdotdb_dora.py
@@ -397,9 +397,13 @@ class DashdotdbDORA(DashdotdbBase):
     def get_repo_ref_for_sha(
         self, saastarget: SaasTarget, sha: str
     ) -> tuple[Optional[str], Optional[str]]:
-        saas_file_yaml = self.gl_app_interface_get_file(
-            saastarget.path, ref=sha
-        ).decode()
+        try:
+            saas_file_yaml = self.gl_app_interface_get_file(
+                saastarget.path, ref=sha
+            ).decode()
+        except Exception:
+            LOG.error(f"can't get file from {saastarget.path} ref {sha}")
+            return (None, None)
         saas_file = yaml.safe_load(saas_file_yaml)
 
         for rt in saas_file["resourceTemplates"]:

--- a/reconcile/utils/github_api.py
+++ b/reconcile/utils/github_api.py
@@ -10,6 +10,7 @@ from urllib.parse import urlparse
 from github import (
     Commit,
     Github,
+    GithubException,
     UnknownObjectException,
 )
 from sretoolbox.utils import retry
@@ -83,6 +84,10 @@ class GithubRepositoryApi:
     def get_commit_sha(self, ref: str) -> str:
         return self._repo.get_commit(sha=ref).sha
 
-    @retry()
     def compare(self, commit_from: str, commit_to: str) -> list[Commit.Commit]:
-        return self._repo.compare(commit_from, commit_to).commits
+        try:
+            return self._repo.compare(commit_from, commit_to).commits
+        except GithubException as e:
+            if "No common ancestor" in str(e):
+                return []
+            raise


### PR DESCRIPTION
some requests do not come back from gitlab. here is an example: https://gitlab.cee.redhat.com/service/app-interface/-/blob/1e77e30b39913855c36c89e26ed8741ff7a00d35/data/services/ocm/osd-fleet-manager/cicd/deploy.yaml?ref_type=heads

others fail for no ancestry between commits.

with this PR, we do our best to collect the rest of the data