### PR TITLE
[AUS] support new addon service

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -365,6 +365,11 @@ class AdvancedUpgradeSchedulerBaseIntegration(
 
 
 def init_addon_service(ocm_env: OCMEnvironment) -> AddonService:
+    """
+    Initialize the right version of addon-service for an OCM environment.
+    Since this is just temporary until all OCM environments are on v2, we
+    use a label on the OCM environmentschema to determine which version to use.
+    """
     addon_service_version = (ocm_env.labels or {}).get(
         "feature_flag_addon_service_version"
     ) or "v2"
@@ -372,6 +377,12 @@ def init_addon_service(ocm_env: OCMEnvironment) -> AddonService:
 
 
 def init_addon_service_version(addon_service_version: str) -> AddonService:
+    """
+    Initialize the right version of addon-service based on the version string.
+    Supported versions are:
+    - v1: part of CS
+    - v2: standalone service using upgrade-plans instead of upgrade-policies
+    """
     match addon_service_version:
         case "v1":
             return AddonServiceV1()

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -8,6 +8,7 @@ from abc import (
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
 from typing import (
     Callable,
@@ -74,6 +75,7 @@ from reconcile.utils.clusterhealth.telemeter import (
 from reconcile.utils.defer import defer
 from reconcile.utils.disabled_integrations import integration_is_enabled
 from reconcile.utils.filtering import remove_none_values_from_dict
+from reconcile.utils.ocm.addons import AddonService, AddonServiceV1, AddonServiceV2
 from reconcile.utils.ocm.clusters import (
     OCMCluster,
     get_node_pools,
@@ -81,14 +83,11 @@ from reconcile.utils.ocm.clusters import (
 )
 from reconcile.utils.ocm.upgrades import (
     OCMVersionGate,
-    create_addon_upgrade_policy,
     create_control_plane_upgrade_policy,
     create_node_pool_upgrade_policy,
     create_upgrade_policy,
-    delete_addon_upgrade_policy,
     delete_control_plane_upgrade_policy,
     delete_upgrade_policy,
-    get_addon_upgrade_policies,
     get_control_plane_upgrade_policies,
     get_node_pool_upgrade_policies,
     get_upgrade_policies,
@@ -365,6 +364,23 @@ class AdvancedUpgradeSchedulerBaseIntegration(
         return None
 
 
+def init_addon_service(ocm_env: OCMEnvironment) -> AddonService:
+    addon_service_version = (ocm_env.labels or {}).get(
+        "feature_flag_addon_service_version"
+    ) or "v2"
+    return init_addon_service_version(addon_service_version)
+
+
+def init_addon_service_version(addon_service_version: str) -> AddonService:
+    match addon_service_version:
+        case "v1":
+            return AddonServiceV1()
+        case "v2":
+            return AddonServiceV2()
+        case _:
+            raise ValueError(f"Unknown addon service version: {addon_service_version}")
+
+
 class RemainingSoakDayMetricsBuilder(Protocol):
     def __call__(
         self, cluster_uuid: str, soaking_version: str
@@ -397,27 +413,39 @@ class AbstractUpgradePolicy(ABC, BaseModel):
         pass
 
 
+def addon_upgrade_policy_soonest_next_run() -> str:
+    now = datetime.now(tz=timezone.utc)
+    next_run = now + timedelta(minutes=MIN_DELTA_MINUTES)
+    return next_run.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 class AddonUpgradePolicy(AbstractUpgradePolicy):
     """Class to create and delete Addon upgrade policies in OCM"""
 
     addon_id: str
+    addon_service: AddonService
+
+    class Config:
+        arbitrary_types_allowed = True
 
     def create(self, ocm_api: OCMBaseClient) -> None:
-        item = {
-            "version": self.version,
-            "schedule_type": "manual",
-            "addon_id": self.addon_id,
-            "cluster_id": self.cluster.id,
-            "upgrade_type": "ADDON",
-        }
-        create_addon_upgrade_policy(ocm_api, self.cluster.id, item)
+        self.addon_service.create_addon_upgrade_policy(
+            ocm_api=ocm_api,
+            cluster_id=self.cluster.id,
+            addon_id=self.addon_id,
+            schedule_type="manual",
+            version=self.version,
+            next_run=self.next_run or addon_upgrade_policy_soonest_next_run(),
+        )
 
     def delete(self, ocm_api: OCMBaseClient) -> None:
         if not self.id:
             raise ValueError(
                 "Cannot delete addon upgrade policy without id (not created yet)"
             )
-        delete_addon_upgrade_policy(ocm_api, self.cluster.id, self.id)
+        self.addon_service.delete_addon_upgrade_policy(
+            ocm_api=ocm_api, cluster_id=self.cluster.id, policy_id=self.id
+        )
 
     def summarize(self) -> str:
         details = {
@@ -544,15 +572,18 @@ def fetch_current_state(
     addons: bool = False,
 ) -> list[AbstractUpgradePolicy]:
     current_state: list[AbstractUpgradePolicy] = []
+    addon_service = init_addon_service(org_upgrade_spec.org.environment)
     for spec in org_upgrade_spec.specs:
         if addons and isinstance(spec, ClusterAddonUpgradeSpec):
             addon_spec = cast(ClusterAddonUpgradeSpec, spec)
-            upgrade_policies = get_addon_upgrade_policies(
+            upgrade_policies = addon_service.get_addon_upgrade_policies(
                 ocm_api, spec.cluster.id, addon_id=addon_spec.addon.addon.id
             )
             for upgrade_policy in upgrade_policies:
                 upgrade_policy["cluster"] = spec.cluster
-                current_state.append(AddonUpgradePolicy(**upgrade_policy))
+                current_state.append(
+                    AddonUpgradePolicy(**upgrade_policy, addon_service=addon_service)
+                )
         elif spec.cluster.is_rosa_hypershift():
             upgrade_policies = get_control_plane_upgrade_policies(
                 ocm_api, spec.cluster.id
@@ -1015,6 +1046,7 @@ def calculate_diff(
             for mutex in spec.effective_mutexes:
                 locked[mutex] = spec.cluster.id
 
+    addon_service = init_addon_service(desired_state.org.environment)
     now = datetime.utcnow()
     gates = get_version_gates(ocm_api)
     for spec in desired_state.specs:
@@ -1063,6 +1095,7 @@ def calculate_diff(
                             schedule_type="manual",
                             addon_id=addon_id,
                             upgrade_type="ADDON",
+                            addon_service=addon_service,
                         ),
                     )
                 )

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2469,6 +2469,7 @@ def ocm_addons_upgrade_scheduler_org(
     run_class_integration(
         integration=OCMAddonsUpgradeSchedulerOrgIntegration(
             AdvancedUpgradeSchedulerBaseIntegrationParams(
+                ocm_environment="ocm-integration",
                 ocm_organization_ids=set(org_id),
                 excluded_ocm_organization_ids=set(exclude_org_id),
             )

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1280,6 +1280,7 @@ OCM_QUERY = """
     environment {
       name
       url
+      labels
       accessTokenClientId
       accessTokenUrl
       accessTokenClientSecret {

--- a/reconcile/utils/ocm/addons.py
+++ b/reconcile/utils/ocm/addons.py
@@ -6,46 +6,209 @@ from typing import (
 from reconcile.utils.ocm.base import OCMAddonInstallation
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
+ADDON_UPGRADE_POLICY_DESIRED_KEYS = {
+    "id",
+    "addon_id",
+    "schedule_type",
+    "schedule",
+    "next_run",
+    "version",
+}
 
-def get_addons_for_cluster(
-    ocm_api: OCMBaseClient,
-    cluster_id: str,
-    addon_latest_versions: dict[str, str],
-    required_state: Optional[str],
-) -> list[OCMAddonInstallation]:
-    """
-    Returns a list of Addons installed on a cluster
 
-    :param cluster_id: ID of the cluster
-    :param addon_latest_versions: dict of addon_id -> latest version. This allows us to
-        populate the addonsinstalation available upgrades in an efficient way.
-    :param required_state: only return addons with this state
-    """
+class AddonService:
+    def get_addon_latest_versions(self, ocm_api: OCMBaseClient) -> dict[str, str]:
+        """
+        Returns the latest version for each addon.
+        """
+        latest_versions: dict[str, str] = {}
+        for addon in ocm_api.get_paginated(f"{self.addon_base_api_path()}/addons"):
+            addon_id = addon["id"]
+            latest_versions[addon_id] = addon["version"]["id"]
+        return latest_versions
 
-    params: Optional[dict[str, Any]] = None
-    if required_state:
-        params = {"search": f"state='{required_state}'"}
+    def get_addons_for_cluster(
+        self,
+        ocm_api: OCMBaseClient,
+        cluster_id: str,
+        addon_latest_versions: dict[str, str],
+        required_state: Optional[str],
+    ) -> list[OCMAddonInstallation]:
+        """
+        Returns a list of Addons installed on a cluster
 
-    addons = []
-    for addon in ocm_api.get_paginated(
-        api_path=f"/api/clusters_mgmt/v1/clusters/{cluster_id}/addons",
-        params=params,
-    ):
-        current_version = addon["addon_version"]["id"]
-        latest_version = addon_latest_versions.get(addon["id"])
-        addon["addon_version"]["available_upgrades"] = (
-            [latest_version] if latest_version != current_version else []
+        :param cluster_id: ID of the cluster
+        :param addon_latest_versions: dict of addon_id -> latest version. This allows us to
+            populate the addonsinstalation available upgrades in an efficient way.
+        :param required_state: only return addons with this state
+        """
+
+        params: Optional[dict[str, Any]] = None
+        if required_state:
+            params = {"search": f"state='{required_state}'"}
+
+        addons = []
+        for addon in ocm_api.get_paginated(
+            api_path=f"{self.addon_base_api_path()}/clusters/{cluster_id}/addons",
+            params=params,
+        ):
+            current_version = addon["addon_version"]["id"]
+            latest_version = addon_latest_versions.get(addon["id"])
+            addon["addon_version"]["available_upgrades"] = (
+                [latest_version] if latest_version != current_version else []
+            )
+            addons.append(OCMAddonInstallation(**addon))
+        return addons
+
+    def addon_base_api_path(self) -> str:
+        raise NotImplementedError()
+
+    def get_addon_upgrade_policies(
+        self, ocm_api: OCMBaseClient, cluster_id: str, addon_id: Optional[str] = None
+    ) -> list[dict[str, Any]]:
+        raise NotImplementedError()
+
+    def create_addon_upgrade_policy(
+        self,
+        ocm_api: OCMBaseClient,
+        cluster_id: str,
+        addon_id: str,
+        schedule_type: str,
+        version: str,
+        next_run: str,
+    ) -> None:
+        raise NotImplementedError()
+
+    def delete_addon_upgrade_policy(
+        self, ocm_api: OCMBaseClient, cluster_id: str, policy_id: str
+    ) -> None:
+        raise NotImplementedError()
+
+
+class AddonServiceV1(AddonService):
+    def addon_base_api_path(self) -> str:
+        return "/api/clusters_mgmt/v1"
+
+    def get_addon_upgrade_policies(
+        self, ocm_api: OCMBaseClient, cluster_id: str, addon_id: Optional[str] = None
+    ) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+
+        for policy in ocm_api.get_paginated(
+            f"{self.addon_base_api_path()}/clusters/{cluster_id}/addon_upgrade_policies"
+        ):
+            if addon_id and policy["addon_id"] != addon_id:
+                continue
+            policy_data = {
+                k: v
+                for k, v in policy.items()
+                if k in ADDON_UPGRADE_POLICY_DESIRED_KEYS
+            }
+            policy_data["state"] = self._get_addon_upgrade_policy_state(
+                ocm_api, cluster_id, policy["id"]
+            )
+            results.append(policy_data)
+
+        return results
+
+    def _get_addon_upgrade_policy_state(
+        self, ocm_api: OCMBaseClient, cluster_id: str, addon_upgrade_policy_id: str
+    ) -> Optional[str]:
+        try:
+            state_data = ocm_api.get(
+                f"{self.addon_base_api_path()}/clusters/{cluster_id}/addon_upgrade_policies/{addon_upgrade_policy_id}/state"
+            )
+            return state_data.get("value")
+        except Exception:
+            return None
+
+    def create_addon_upgrade_policy(
+        self,
+        ocm_api: OCMBaseClient,
+        cluster_id: str,
+        addon_id: str,
+        schedule_type: str,
+        version: str,
+        next_run: str,
+    ) -> None:
+        """
+        Creates a new Addon Upgrade Policy
+        """
+        spec = {
+            "version": version,
+            "schedule_type": schedule_type,
+            "addon_id": addon_id,
+            "cluster_id": cluster_id,
+            "upgrade_type": "ADDON",
+        }
+        ocm_api.post(
+            f"{self.addon_base_api_path()}/clusters/{cluster_id}/addon_upgrade_policies",
+            spec,
         )
-        addons.append(OCMAddonInstallation(**addon))
-    return addons
+
+    def delete_addon_upgrade_policy(
+        self, ocm_api: OCMBaseClient, cluster_id: str, policy_id: str
+    ) -> None:
+        """
+        Deletes an existing Addon Upgrade Policy
+        """
+        ocm_api.delete(
+            f"{self.addon_base_api_path()}/clusters/{cluster_id}/addon_upgrade_policies/{policy_id}"
+        )
 
 
-def get_addon_latest_versions(ocm_api: OCMBaseClient) -> dict[str, str]:
-    """
-    Returns the latest version for each addon.
-    """
-    latest_versions: dict[str, str] = {}
-    for addon in ocm_api.get_paginated("/api/clusters_mgmt/v1/addons"):
-        addon_id = addon["id"]
-        latest_versions[addon_id] = addon["version"]["id"]
-    return latest_versions
+class AddonServiceV2(AddonService):
+    def addon_base_api_path(self) -> str:
+        return "/api/addons_mgmt/v1"
+
+    def get_addon_upgrade_policies(
+        self, ocm_api: OCMBaseClient, cluster_id: str, addon_id: Optional[str] = None
+    ) -> list[dict[str, Any]]:
+        results: list[dict[str, Any]] = []
+
+        for policy in ocm_api.get_paginated(
+            f"{self.addon_base_api_path()}/clusters/{cluster_id}/upgrade_plan"
+        ):
+            if addon_id and policy["addon_id"] != addon_id:
+                continue
+            policy_data = {
+                k: v
+                for k, v in policy.items()
+                if k in ADDON_UPGRADE_POLICY_DESIRED_KEYS
+            }
+            results.append(policy_data)
+
+        return results
+
+    def create_addon_upgrade_policy(
+        self,
+        ocm_api: OCMBaseClient,
+        cluster_id: str,
+        addon_id: str,
+        schedule_type: str,
+        version: str,
+        next_run: str,
+    ) -> None:
+        """
+        Creates a new Addon Upgrade Policy
+        """
+        spec = {
+            "version": version,
+            "type": schedule_type,
+            "addon_id": addon_id,
+            "cluster_id": cluster_id,
+            "next_run": next_run,
+        }
+        ocm_api.post(
+            f"{self.addon_base_api_path()}/clusters/{cluster_id}/upgrade_plan", spec
+        )
+
+    def delete_addon_upgrade_policy(
+        self, ocm_api: OCMBaseClient, cluster_id: str, policy_id: str
+    ) -> None:
+        """
+        Deletes an existing Addon Upgrade Policy
+        """
+        ocm_api.delete(
+            f"{self.addon_base_api_path()}/clusters/{cluster_id}/upgrade_plan/{policy_id}"
+        )

--- a/reconcile/utils/ocm/addons.py
+++ b/reconcile/utils/ocm/addons.py
@@ -86,6 +86,9 @@ class AddonService:
 
 
 class AddonServiceV1(AddonService):
+    """
+    The original addon-service API that is part of CS.
+    """
     def addon_base_api_path(self) -> str:
         return "/api/clusters_mgmt/v1"
 
@@ -158,6 +161,10 @@ class AddonServiceV1(AddonService):
 
 
 class AddonServiceV2(AddonService):
+    """
+    The dedicated addon-service API that is part of OCM.
+    """
+
     def addon_base_api_path(self) -> str:
         return "/api/addons_mgmt/v1"
 
@@ -190,7 +197,7 @@ class AddonServiceV2(AddonService):
         next_run: str,
     ) -> None:
         """
-        Creates a new Addon Upgrade Policy
+        Schedules an addon upgrade. Leverages addon-service upgrade plans behind the scene.
         """
         spec = {
             "version": version,
@@ -207,7 +214,7 @@ class AddonServiceV2(AddonService):
         self, ocm_api: OCMBaseClient, cluster_id: str, policy_id: str
     ) -> None:
         """
-        Deletes an existing Addon Upgrade Policy
+        Deletes an existing upgrade plan.
         """
         ocm_api.delete(
             f"{self.addon_base_api_path()}/clusters/{cluster_id}/upgrade_plan/{policy_id}"

--- a/reconcile/utils/ocm/addons.py
+++ b/reconcile/utils/ocm/addons.py
@@ -89,6 +89,7 @@ class AddonServiceV1(AddonService):
     """
     The original addon-service API that is part of CS.
     """
+
     def addon_base_api_path(self) -> str:
         return "/api/clusters_mgmt/v1"
 

--- a/reconcile/utils/ocm/upgrades.py
+++ b/reconcile/utils/ocm/upgrades.py
@@ -8,76 +8,10 @@ from reconcile.utils.ocm.base import OCMVersionGate
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 UPGRADE_POLICY_DESIRED_KEYS = {"id", "schedule_type", "schedule", "next_run", "version"}
-ADDON_UPGRADE_POLICY_DESIRED_KEYS = {
-    "id",
-    "addon_id",
-    "schedule_type",
-    "schedule",
-    "next_run",
-    "version",
-}
 
 
 def build_cluster_url(cluster_id: str) -> str:
     return f"/api/clusters_mgmt/v1/clusters/{cluster_id}"
-
-
-#
-# ADDON UPGRADE POLICIES
-#
-
-
-def get_addon_upgrade_policies(
-    ocm_api: OCMBaseClient, cluster_id: str, addon_id: Optional[str] = None
-) -> list[dict[str, Any]]:
-    results: list[dict[str, Any]] = []
-
-    for policy in ocm_api.get_paginated(
-        f"{build_cluster_url(cluster_id)}/addon_upgrade_policies"
-    ):
-        if addon_id and policy["addon_id"] != addon_id:
-            continue
-        policy_data = {
-            k: v for k, v in policy.items() if k in ADDON_UPGRADE_POLICY_DESIRED_KEYS
-        }
-        policy_data["state"] = get_addon_upgrade_policy_state(
-            ocm_api, cluster_id, policy["id"]
-        )
-        results.append(policy_data)
-
-    return results
-
-
-def get_addon_upgrade_policy_state(
-    ocm_api: OCMBaseClient, cluster_id: str, addon_upgrade_policy_id: str
-) -> Optional[str]:
-    try:
-        state_data = ocm_api.get(
-            f"{build_cluster_url(cluster_id)}/addon_upgrade_policies/{addon_upgrade_policy_id}/state"
-        )
-        return state_data.get("value")
-    except Exception:
-        return None
-
-
-def create_addon_upgrade_policy(
-    ocm_api: OCMBaseClient, cluster_id: str, spec: dict
-) -> None:
-    """
-    Creates a new Addon Upgrade Policy
-    """
-    ocm_api.post(f"{build_cluster_url(cluster_id)}/addon_upgrade_policies", spec)
-
-
-def delete_addon_upgrade_policy(
-    ocm_api: OCMBaseClient, cluster_id: str, policy_id: str
-) -> None:
-    """
-    Deletes an existing Addon Upgrade Policy
-    """
-    ocm_api.delete(
-        f"{build_cluster_url(cluster_id)}/addon_upgrade_policies/{policy_id}"
-    )
 
 
 #


### PR DESCRIPTION
certain addon related OCM API endpoints have been moved to their own service. this PR introduces support for the new endpoints while keeping support for the old ones during the time of migration.

the most involved change is the rename of `upgrade_policies` to `upgrade_plans` with some minor nuances in field names.

a label on the OCM environment schema file controls which version of the API is to be used for that specific OCM environment.

```yaml
---
$schema: /openshift/openshift-cluster-manager-environment-1.yml
labels:
  feature_flag_addon_service_version: "$version"
```

use `v1` for the old APIs under `cluster_mgmt` and `v2` for the new API under `addons_mgmt`.

new API: https://gitlab.cee.redhat.com/ocm/ocm-addons-service/-/blob/main/openapi/ocm-addons-service.yaml

part of: https://issues.redhat.com/browse/APPSRE-9931