### PR TITLE
[AUS] skip cluster upgrade scheduling on unacked gates

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -1097,6 +1097,7 @@ def calculate_diff(
                         f"[{spec.org.org_id}/{spec.org.name}/{spec.cluster.name}] found gates for {target_version_prefix} - {gate_ids} "
                         "Skip creation of an upgrade policy until all of them have been acked by the version-gate-approver integration or a user."
                     )
+                    continue
                 diffs.append(
                     UpgradePolicyHandler(
                         action="create",


### PR DESCRIPTION
if a cluster has unacked version gates, the OCM API to create an upgrade policy will fail. this PR prevents that failure by not scheduling an upgrade in such situations.

follow up to https://github.com/app-sre/qontract-reconcile/pull/4103 which was incomplete

part of APPSRE-7949