### PR TITLE
:bug: ignore AWS accounts without a terraformState

### DIFF
--- a/reconcile/aws_saml_idp/integration.py
+++ b/reconcile/aws_saml_idp/integration.py
@@ -76,6 +76,8 @@ class AwsSamlIdpIntegration(QontractReconcileIntegration[AwsSamlIdpIntegrationPa
             for account in data.accounts or []
             if integration_is_enabled(self.name, account)
             and (not account_name or account.name == account_name)
+            # a new account does not have a terraform state yet, ignore it until terraform-init does its job
+            and account.terraform_state
         ]
 
     def build_saml_idp_config(

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -583,7 +583,13 @@ def get_aws_accounts(
         ecrs=ecrs,
         cleanup=cleanup,
     )
-    return gqlapi.query(query)["accounts"]
+    accounts = gqlapi.query(query)["accounts"]
+    if terraform_state:
+        # a new account does not have a terraform state yet, ignore it until terraform-init does its job
+        return [
+            account for account in accounts if account.get("terraformState") is not None
+        ]
+    return accounts
 
 
 def get_state_aws_accounts(reset_passwords=False):

--- a/reconcile/test/aws_saml_idp/test_aws_saml_idp_integration.py
+++ b/reconcile/test/aws_saml_idp/test_aws_saml_idp_integration.py
@@ -32,6 +32,7 @@ def test_aws_saml_idp_get_aws_accounts(
                 "automationToken": {"path": "/path/to/token", "field": "all"},
                 "enableDeletion": True,
                 "premiumSupport": True,
+                "terraformState": {"integrations": []},
             },
         ),
         gql_class_factory(
@@ -47,6 +48,7 @@ def test_aws_saml_idp_get_aws_accounts(
                 "automationToken": {"path": "/path/to/token", "field": "all"},
                 "enableDeletion": True,
                 "premiumSupport": True,
+                "terraformState": {"integrations": []},
             },
         ),
     ]
@@ -64,6 +66,7 @@ def test_aws_saml_idp_get_aws_accounts(
                 "automationToken": {"path": "/path/to/token", "field": "all"},
                 "enableDeletion": True,
                 "premiumSupport": True,
+                "terraformState": {"integrations": []},
             },
         )
     ]

--- a/reconcile/test/fixtures/aws_saml_idp/aws_accounts.yml
+++ b/reconcile/test/fixtures/aws_saml_idp/aws_accounts.yml
@@ -15,6 +15,8 @@ accounts:
     field: all
   enableDeletion: true
   premiumSupport: true
+  terraformState:
+    integrations: []
 
 - sso: false
   name: account-2
@@ -32,6 +34,8 @@ accounts:
     field: all
   enableDeletion: true
   premiumSupport: true
+  terraformState:
+    integrations: []
 
 # integration disabled
 - sso: false
@@ -53,3 +57,24 @@ accounts:
   disable:
     integrations:
     - aws-saml-idp
+  terraformState:
+    integrations: []
+
+# no terraformState
+- sso: false
+  name: account-2
+  uid: '1'
+  resourcesDefaultRegion: us-east-1
+  supportedDeploymentRegions:
+  - us-east-1
+  - us-east-2
+  providerVersion: 3.76.0
+  accountOwners:
+  - name: 'owner'
+    email: email@example.com
+  automationToken:
+    path: /path/to/token
+    field: all
+  enableDeletion: true
+  premiumSupport: true
+


### PR DESCRIPTION
A newly created AWS account (`/aws/account-1.yml` via `aws-account-manager`) doesn't have a `terraformState` set; this will be done via another additional integration `terraform-init` later based on the account file (`/aws/account-1.yml`). All terraform related integrations should ignore such an account until a `terraformState` attribute is present.

Context: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/101355