### PR TITLE
:stethoscope: aws-account-manager: expose some metrics

### DIFF
--- a/reconcile/aws_account_manager/integration.py
+++ b/reconcile/aws_account_manager/integration.py
@@ -314,13 +314,14 @@ class AwsAccountMgmtIntegration(
                 value=len(payer_accounts),
             )
 
-            metrics_container.set_gauge(
-                OrgAccountCounter(flavor=self.params.flavor),
-                value=sum([
-                    len(payer_account.organization_accounts or [])
-                    for payer_account in payer_accounts
-                ]),
-            )
+            for payer_account in payer_accounts:
+                metrics_container.set_gauge(
+                    OrgAccountCounter(
+                        flavor=self.params.flavor,
+                        payer_account=payer_account.name,
+                    ),
+                    value=sum([len(payer_account.organization_accounts or [])]),
+                )
             metrics_container.set_gauge(
                 NonOrgAccountCounter(flavor=self.params.flavor),
                 value=len(non_organization_accounts),

--- a/reconcile/aws_account_manager/metrics.py
+++ b/reconcile/aws_account_manager/metrics.py
@@ -1,0 +1,37 @@
+from pydantic import BaseModel
+
+from reconcile.utils.metrics import GaugeMetric
+
+
+class BaseMetric(BaseModel):
+    """Base class for all AWS account manager metrics."""
+
+    flavor: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "aws_account_manager"
+
+
+class PayerAccountCounter(BaseMetric, GaugeMetric):
+    """Number of managed payer accounts."""
+
+    @classmethod
+    def name(cls) -> str:
+        return super().name() + "_payer_account_count"
+
+
+class OrgAccountCounter(BaseMetric, GaugeMetric):
+    """Number of managed organization accounts."""
+
+    @classmethod
+    def name(cls) -> str:
+        return super().name() + "_org_account_count"
+
+
+class NonOrgAccountCounter(BaseMetric, GaugeMetric):
+    """Number of managed non-organization accounts."""
+
+    @classmethod
+    def name(cls) -> str:
+        return super().name() + "_non_org_account_count"

--- a/reconcile/aws_account_manager/metrics.py
+++ b/reconcile/aws_account_manager/metrics.py
@@ -22,7 +22,9 @@ class PayerAccountCounter(BaseMetric, GaugeMetric):
 
 
 class OrgAccountCounter(BaseMetric, GaugeMetric):
-    """Number of managed organization accounts."""
+    """Number of managed organization accounts per payer account."""
+
+    payer_account: str
 
     @classmethod
     def name(cls) -> str:


### PR DESCRIPTION
Expose these metrics:

```
# HELP aws_account_manager_payer_account_count Number of managed payer accounts.
# TYPE aws_account_manager_payer_account_count gauge
aws_account_manager_payer_account_count{flavor="app-interface-commercial"} X

# HELP aws_account_manager_org_account_count Number of managed organization accounts per payer account.
# TYPE aws_account_manager_org_account_count gauge
aws_account_manager_org_account_count{flavor="app-interface-commercial", payer_account="XXXX"} X

# HELP aws_account_manager_non_org_account_count Number of managed non-organization accounts.
# TYPE aws_account_manager_non_org_account_count gauge
aws_account_manager_non_org_account_count{flavor="app-interface-commercial"} X
```

Ticket: [APPSRE-9983](https://issues.redhat.com/browse/APPSRE-9983)