### PR TITLE
:pencil2: aws-account-manager: fix typo

### DIFF
--- a/reconcile/aws_account_manager/integration.py
+++ b/reconcile/aws_account_manager/integration.py
@@ -320,7 +320,7 @@ class AwsAccountMgmtIntegration(
                         flavor=self.params.flavor,
                         payer_account=payer_account.name,
                     ),
-                    value=sum([len(payer_account.organization_accounts or [])]),
+                    value=len(payer_account.organization_accounts or []),
                 )
             metrics_container.set_gauge(
                 NonOrgAccountCounter(flavor=self.params.flavor),


### PR DESCRIPTION
Fix just a stupid typo introduced in #4235