### PR TITLE
[CLI]Add cli option to get a cidr block for a new cluster.

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1025,19 +1025,19 @@ def network_reservations(ctx) -> None:
     "--managed",
     help="Only consider managed network, i.e. network reserved with a network-1 yaml in App Interface",
     type=bool,
-    default=False
+    default=False,
 )
 @click.option(
     "--for-cluster",
     help="Get the latest available CIDR block for new cluster. A decimal number between 1~32.",
     type=bool,
-    default=False
+    default=False,
 )
 @click.option(
     "--mask",
     help="Mask for the latest available CIDR block for AWS resources. A decimal number between 1~32.",
     type=int,
-    default=24
+    default=24,
 )
 @click.pass_context
 def cidr_blocks(ctx, managed: bool, for_cluster: int, mask: int) -> None:
@@ -1091,19 +1091,20 @@ def cidr_blocks(ctx, managed: bool, for_cluster: int, mask: int) -> None:
     if managed:
         # TODO use networ-1 schema once the most recent VPCs for each type are migrated
         print("NOT IMPLEMENTED.")
-    else:
-        if for_cluster:
-            print(f"INFO: You are reserving {2**(32-mask)} network addresses")
-            latest_declared_addr = ipaddress.ip_address([item for item in cidrs if item["type"]=="cluster"][-1]["to"])
-            avail_addr = latest_declared_addr + 1
-            print(f"INFO: Latest available network address: {str(avail_addr)}")
-            try: 
-                result_cidr_block = str(ipaddress.ip_network((avail_addr, mask)))
-            except  ValueError as e:
-                print(f"Invalid CIDR Mask {mask} Provided.")
-                sys.exit(1)
-            print(f"\nYou can use: {str(result_cidr_block)}")
-    if not for_cluster: 
+    elif for_cluster:
+        print(f"INFO: You are reserving {2 ** (32 - mask)} network addresses")
+        latest_declared_addr = ipaddress.ip_address(
+            [item for item in cidrs if item["type"] == "cluster"][-1]["to"]
+        )
+        avail_addr = latest_declared_addr + 1
+        print(f"INFO: Latest available network address: {str(avail_addr)}")
+        try:
+            result_cidr_block = str(ipaddress.ip_network((avail_addr, mask)))
+        except ValueError:
+            print(f"Invalid CIDR Mask {mask} Provided.")
+            sys.exit(1)
+        print(f"\nYou can use: {str(result_cidr_block)}")
+    if not for_cluster:
         ctx.obj["options"]["sort"] = False
         print_output(ctx.obj["options"], cidrs, columns)
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1096,12 +1096,13 @@ def cidr_blocks(ctx, managed: bool, for_cluster: int, mask: int) -> None:
             [item for item in cidrs if item["type"] == "cluster"][-1]["to"]
         )
         avail_addr = latest_declared_addr + 1
+        print(f"INFO: Latest available network address: {str(avail_addr)}")
         try:
             result_cidr_block = str(ipaddress.ip_network((avail_addr, mask)))
         except ValueError:
-            print(f"Invalid CIDR Mask {mask} Provided.")
+            print(f"ERROR: Invalid CIDR Mask {mask} Provided.")
             sys.exit(1)
-        print(f"INFO: Latest available network address: {str(avail_addr)}")
+        print(f"INFO: You are reserving {str(2**(32-mask))} network addresses.")
         print(f"\nYou can use: {str(result_cidr_block)}")
     if not for_cluster:
         ctx.obj["options"]["sort"] = False

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1022,14 +1022,8 @@ def network_reservations(ctx) -> None:
 
 @get.command()
 @click.option(
-    "--managed",
-    help="Only consider managed network, i.e. network reserved with a network-1 yaml in App Interface",
-    type=bool,
-    default=False,
-)
-@click.option(
     "--for-cluster",
-    help="Get the latest available CIDR block for new cluster. A decimal number between 1~32.",
+    help="If it is for getting cidr block for a cluster.",
     type=bool,
     default=False,
 )
@@ -1040,7 +1034,7 @@ def network_reservations(ctx) -> None:
     default=24,
 )
 @click.pass_context
-def cidr_blocks(ctx, managed: bool, for_cluster: int, mask: int) -> None:
+def cidr_blocks(ctx, for_cluster: int, mask: int) -> None:
     import ipaddress
 
     from reconcile.typed_queries.aws_vpcs import get_aws_vpcs
@@ -1088,10 +1082,7 @@ def cidr_blocks(ctx, managed: bool, for_cluster: int, mask: int) -> None:
 
     cidrs.sort(key=lambda item: ipaddress.ip_network(item["cidr"]))
 
-    if managed:
-        # TODO use networ-1 schema once the most recent VPCs for each type are migrated
-        print("NOT IMPLEMENTED.")
-    elif for_cluster:
+    if for_cluster:
         latest_declared_addr = ipaddress.ip_address(
             [item for item in cidrs if item["type"] == "cluster"][-1]["to"]
         )
@@ -1104,7 +1095,7 @@ def cidr_blocks(ctx, managed: bool, for_cluster: int, mask: int) -> None:
             sys.exit(1)
         print(f"INFO: You are reserving {str(2 ** (32 - mask))} network addresses.")
         print(f"\nYou can use: {str(result_cidr_block)}")
-    if not for_cluster:
+    else:
         ctx.obj["options"]["sort"] = False
         print_output(ctx.obj["options"], cidrs, columns)
 

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1092,17 +1092,16 @@ def cidr_blocks(ctx, managed: bool, for_cluster: int, mask: int) -> None:
         # TODO use networ-1 schema once the most recent VPCs for each type are migrated
         print("NOT IMPLEMENTED.")
     elif for_cluster:
-        print(f"INFO: You are reserving {2 ** (32 - mask)} network addresses")
         latest_declared_addr = ipaddress.ip_address(
             [item for item in cidrs if item["type"] == "cluster"][-1]["to"]
         )
         avail_addr = latest_declared_addr + 1
-        print(f"INFO: Latest available network address: {str(avail_addr)}")
         try:
             result_cidr_block = str(ipaddress.ip_network((avail_addr, mask)))
         except ValueError:
             print(f"Invalid CIDR Mask {mask} Provided.")
             sys.exit(1)
+        print(f"INFO: Latest available network address: {str(avail_addr)}")
         print(f"\nYou can use: {str(result_cidr_block)}")
     if not for_cluster:
         ctx.obj["options"]["sort"] = False

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1083,10 +1083,17 @@ def cidr_blocks(ctx, for_cluster: int, mask: int) -> None:
     cidrs.sort(key=lambda item: ipaddress.ip_network(item["cidr"]))
 
     if for_cluster:
-        latest_declared_addr = ipaddress.ip_address(
-            [item for item in cidrs if item["type"] == "cluster"][-1]["to"]
+        latest_cluster_cidr = next(
+            (item for item in reversed(cidrs) if item["type"] == "cluster"),
+            None,
         )
-        avail_addr = latest_declared_addr + 1
+
+        if not latest_cluster_cidr:
+            print("ERROR: Unable to find any existing cluster CIDR block.")
+            sys.exit(1)
+
+        avail_addr = ipaddress.ip_address(latest_cluster_cidr["to"]) + 1
+
         print(f"INFO: Latest available network address: {str(avail_addr)}")
         try:
             result_cidr_block = str(ipaddress.ip_network((avail_addr, mask)))

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1102,7 +1102,7 @@ def cidr_blocks(ctx, managed: bool, for_cluster: int, mask: int) -> None:
         except ValueError:
             print(f"ERROR: Invalid CIDR Mask {mask} Provided.")
             sys.exit(1)
-        print(f"INFO: You are reserving {str(2**(32-mask))} network addresses.")
+        print(f"INFO: You are reserving {str(2 ** (32 - mask))} network addresses.")
         print(f"\nYou can use: {str(result_cidr_block)}")
     if not for_cluster:
         ctx.obj["options"]["sort"] = False


### PR DESCRIPTION
Building on top of `qontract-cli get cidr-blocks`, with this we can get the latest available CIDR block for a new cluster. This can server as a building block for later automation of one yaml cluster provisioning.  Example: `qontract-cli --config config.debug.toml get cidr-blocks --for-cluster True --mask 24` Output:
```
INFO: Latest available network address: 10.170.71.0
INFO: You are reserving 256 network addresses.

You can use: 10.170.71.0/24
```

Note that this is only for cluster but not AWS resource VPC for now.