### PR TITLE
[qontract-cli] get component-versions

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2567,6 +2567,37 @@ def cost_report(ctx):
     print(command.execute())
 
 
+@get.command()
+@click.pass_context
+def component_versions(ctx):
+    data = []
+    saas_files = get_saas_files()
+    for sf in saas_files:
+        for rt in sf.resource_templates:
+            for t in rt.targets:
+                item = {
+                    "environment": t.namespace.environment.name,
+                    "namespace": t.namespace.name,
+                    "cluster": t.namespace.cluster.name,
+                    "app": sf.app.name,
+                    "saas_file": sf.name,
+                    "resource_template": rt.name,
+                    "ref": f"[{t.ref}]({rt.url}/blob/{t.ref}{rt.path})",
+                }
+                data.append(item)
+
+    columns = [
+        "environment",
+        "namespace",
+        "cluster",
+        "app",
+        "saas_file",
+        "resource_template",
+        "ref",
+    ]
+    print_output(ctx.obj["options"], data, columns)
+
+
 @root.group(name="set")
 @output
 @click.pass_context

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2571,7 +2571,7 @@ def cost_report(ctx):
 @click.pass_context
 def osd_component_versions(ctx):
     osd_environments = [
-        e["name"] for e in queries.get_environments() if e["product"]["name"] == "osdv4"
+        e["name"] for e in queries.get_environments() if e["product"]["name"] == "OSDv4"
     ]
     data = []
     saas_files = get_saas_files()

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2569,12 +2569,17 @@ def cost_report(ctx):
 
 @get.command()
 @click.pass_context
-def component_versions(ctx):
+def osd_component_versions(ctx):
+    osd_environments = [
+        e["name"] for e in queries.get_environments() if e["product"]["name"] == "osdv4"
+    ]
     data = []
     saas_files = get_saas_files()
     for sf in saas_files:
         for rt in sf.resource_templates:
             for t in rt.targets:
+                if t.namespace.environment.name not in osd_environments:
+                    continue
                 item = {
                     "environment": t.namespace.environment.name,
                     "namespace": t.namespace.name,


### PR DESCRIPTION
when saas files were first created, one of the underlying structures was: [environments](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-interface/api/entities-and-relations.md?ref_type=heads#products-environments-namespaces-and-apps).

the command in this PR outputs a list of components and their versions per environment.