### PR TITLE
APPSRE-8713: fix vault writes with deadmanssnitch integration

### DIFF
--- a/reconcile/deadmanssnitch.py
+++ b/reconcile/deadmanssnitch.py
@@ -1,6 +1,5 @@
 import logging
 from typing import (
-    Optional,
     cast,
 )
 
@@ -62,17 +61,18 @@ class DeadMansSnitchIntegration(QontractReconcileIntegration[NoParams]):
     def get_snitch_name(cluster: ClusterV1) -> str:
         return cluster.prometheus_url.replace("https://", "")
 
-    def write_snitch_to_vault(
-        self, cluster_name: str, snitch_url: Optional[str]
-    ) -> None:
-        if snitch_url:
-            self.vault_client.write(
-                {
-                    "path": self.settings.snitches_path,
-                    "data": {f"deadmanssnitch-{cluster_name}-url": snitch_url},
-                },
-                decode_base64=False,
-            )
+    def write_snitch_to_vault(self, cluster_name: str, snitch_url: str) -> None:
+        vault_snitch_data = self.vault_client.read_all({
+            "path": self.settings.snitches_path
+        })
+        vault_snitch_data[f"deadmanssnitch-{cluster_name}-url"] = snitch_url
+        self.vault_client.write(
+            {
+                "path": self.settings.snitches_path,
+                "data": vault_snitch_data,
+            },
+            decode_base64=False,
+        )
 
     def add_vault_data(
         self, cluster_name: str, snitch: Snitch, snitch_secret_path: str

--- a/reconcile/test/test_deadmanssnitch.py
+++ b/reconcile/test/test_deadmanssnitch.py
@@ -201,6 +201,7 @@ def test_integration_for_update_vault(
     dms_integration = DeadMansSnitchIntegration()
     dms_integration._secret_reader = secret_reader
     dms_integration.settings = deadmanssnitch_settings
+    vault_mock.read_all.return_value = {"deadmanssnitch-test_cluster-url": "test"}
     dms_integration.vault_client = vault_mock
     mocker.patch("reconcile.deadmanssnitch.get_clusters_with_dms").return_value = [
         ClusterV1(
@@ -230,10 +231,11 @@ def test_integration_for_update_vault(
         )
     ]
     dms_integration.run(dry_run=False)
+    data = {"deadmanssnitch-test_cluster-url": "test_url"}
     vault_mock.write.assert_called_once_with(
         {
             "path": deadmanssnitch_settings.snitches_path,
-            "data": {"deadmanssnitch-test_cluster-url": "test_url"},
+            "data": data,
         },
         decode_base64=False,
     )

--- a/reconcile/test/test_deadmanssnitch.py
+++ b/reconcile/test/test_deadmanssnitch.py
@@ -102,6 +102,7 @@ def test_get_current_state(
     current_state = dms_integration.get_current_state(
         deadmanssnitch_api=deadmanssnitch_api,
         clusters=clusters,
+        vault_snitch_map={"deadmanssnitch-test_cluster_1-url": "secret"},
     )
     assert current_state["test_cluster_1"].vault_data == "secret"
 
@@ -116,6 +117,7 @@ def test_integration_for_create(
         "reconcile.deadmanssnitch.DeadMansSnitchIntegration.__init__"
     ).return_value = None
     dms_integration = DeadMansSnitchIntegration()
+    secret_reader.read_all.return_value = {}
     dms_integration._secret_reader = secret_reader
     dms_integration.settings = deadmanssnitch_settings
     dms_integration.vault_client = vault_mock
@@ -136,7 +138,18 @@ def test_integration_for_create(
     mock_create_snitch = mocker.patch(
         "reconcile.deadmanssnitch.DeadMansSnitchIntegration.create_snitch"
     )
-    mock_create_snitch.return_value = None
+    mock_create_snitch.return_value = Snitch(
+        name="prometheus.create_cluster.devshift.net",
+        token="test",
+        href="testc",
+        status="healthy",
+        alert_type="basic",
+        alert_email=["test_mail"],
+        interval="15_minute",
+        check_in_url="test_url",
+        tags=["app-sre"],
+        notes="test_notes",
+    )
     dms_integration.run(dry_run=False)
     mock_create_snitch.assert_called_once()
 
@@ -151,6 +164,7 @@ def test_integration_for_delete(
         "reconcile.deadmanssnitch.DeadMansSnitchIntegration.__init__"
     ).return_value = None
     dms_integration = DeadMansSnitchIntegration()
+    secret_reader.read_all.return_value = {"deadmanssnitch-create_cluster-url": "test"}
     dms_integration._secret_reader = secret_reader
     dms_integration.settings = deadmanssnitch_settings
     dms_integration.vault_client = vault_mock
@@ -199,9 +213,9 @@ def test_integration_for_update_vault(
         "reconcile.deadmanssnitch.DeadMansSnitchIntegration.__init__"
     ).return_value = None
     dms_integration = DeadMansSnitchIntegration()
+    secret_reader.read_all.return_value = {"deadmanssnitch-test_cluster-url": "test"}
     dms_integration._secret_reader = secret_reader
     dms_integration.settings = deadmanssnitch_settings
-    vault_mock.read_all.return_value = {"deadmanssnitch-test_cluster-url": "test"}
     dms_integration.vault_client = vault_mock
     mocker.patch("reconcile.deadmanssnitch.get_clusters_with_dms").return_value = [
         ClusterV1(


### PR DESCRIPTION
While testing it was found out that while writing data to vault...the integration is not upserting the data rather writing. This is not desired for the integration and lead to data loss.

Added changes to integration for reading/writing to vault only once if there is change in vault secret object