### PR TITLE
added SecretFieldNotFound to exception list

### DIFF
--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -22,6 +22,7 @@ from reconcile.utils.jinja2.filters import (
     urlunescape,
 )
 from reconcile.utils.secret_reader import SecretNotFound, SecretReader, SecretReaderBase
+from reconcile.utils.vault import SecretFieldNotFound
 
 
 class Jinja2TemplateError(Exception):
@@ -138,7 +139,7 @@ def lookup_secret(
         if not secret_reader:
             secret_reader = SecretReader(settings)
         return secret_reader.read(secret)
-    except SecretNotFound as e:
+    except (SecretNotFound, SecretFieldNotFound) as e:
         if allow_not_found:
             return None
         raise FetchSecretError(e)


### PR DESCRIPTION
Added additional SecretFieldNotFound exception to supress unwanted exception caused during rendering templates.

While testing template rendering it was observed that SecretFieldNotFound is another exception that can occur in case the secret does not exists in vault which lead to MR fails. 
