### PR TITLE
Introduce persistence context

### DIFF
--- a/reconcile/templating/renderer.py
+++ b/reconcile/templating/renderer.py
@@ -5,7 +5,7 @@ import os
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any, Optional, Self
 
 import gitlab
 from ruamel import yaml
@@ -40,8 +40,7 @@ from reconcile.utils.vcs import VCS
 
 QONTRACT_INTEGRATION = "template-renderer"
 
-# Renders templates again to detect drift after one day
-CACHE_TTL_MINUTES = 24 * 60
+CACHE_TTL_MINUTES = 12
 
 APP_INTERFACE_PATH_SEPERATOR = "/"
 
@@ -111,7 +110,7 @@ class PersistenceContext(FilePersistence):
     def __init__(self, persistence: FilePersistence, dry_run: bool) -> None:
         self.persistence = persistence
         self.dry_run = dry_run
-        self.content_cache: dict[str, str] = {}
+        self.content_cache: dict[str, Optional[str]] = {}
         self.output_cache: dict[str, TemplateOutput] = {}
 
     def write(self, outputs: list[TemplateOutput]) -> None:
@@ -124,10 +123,10 @@ class PersistenceContext(FilePersistence):
             self.content_cache[path] = self.persistence.read(path)
         return self.content_cache[path]
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, exc_type, exc_value, traceback):
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         if not self.dry_run:
             self.persistence.write(list(self.output_cache.values()))
 

--- a/reconcile/templating/renderer.py
+++ b/reconcile/templating/renderer.py
@@ -248,7 +248,7 @@ class TemplateRendererIntegration(QontractReconcileIntegration):
                         outputs.append(output)
 
                     p.write(outputs)
-                    if state:
+                    if state and not dry_run:
                         state.add(
                             c.name,
                             {

--- a/reconcile/test/templating/test_renderer.py
+++ b/reconcile/test/templating/test_renderer.py
@@ -269,7 +269,7 @@ def test_reconcile_state_match(
     p.write.assert_not_called()
 
 
-def test_persistence_context_dry_run(mocker: MockerFixture):
+def test_persistence_context_dry_run(mocker: MockerFixture) -> None:
     persistence_mock = mocker.MagicMock(LocalFilePersistence)
 
     with PersistenceContext(persistence_mock, True):
@@ -281,7 +281,7 @@ def test_persistence_context_dry_run(mocker: MockerFixture):
     persistence_mock.write.assert_called_once()
 
 
-def test_persistence_read(mocker: MockerFixture):
+def test_persistence_read(mocker: MockerFixture) -> None:
     persistence_mock = mocker.MagicMock(LocalFilePersistence)
     persistence_mock.read.return_value = "foo"
     p = PersistenceContext(persistence_mock, False)
@@ -292,7 +292,7 @@ def test_persistence_read(mocker: MockerFixture):
     assert p.content_cache == {"foo": "foo"}
 
 
-def test_persistence_write(mocker: MockerFixture):
+def test_persistence_write(mocker: MockerFixture) -> None:
     test_path = "foo"
     persistence_mock = mocker.MagicMock(LocalFilePersistence)
     persistence_mock.read.return_value = "initial_value"


### PR DESCRIPTION
Context holds the value of a file managed by a template collection.

This fixes a bug, where a collection updating a file multiple times using more then one template, could lead to missing updates. Reason was, that previously everytime the file was read from persistence, i.e. gitlab. Now the content is held in the cache of a context manager.

Fixes: [APPSRE-10033](https://issues.redhat.com/browse/APPSRE-10033)