### PR TITLE
Template Renderer use git clone

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1973,13 +1973,12 @@ def template_validator(ctx):
     envvar="APP_INTERFACE_DATA_PATH",
 )
 @click.option(
-    "--git-clone-path",
+    "--clone-repo",
     help="Path to a folder app-interface repo should be cloned to. Use this for regular integration run.",
-    required=False,
-    envvar="GIT_CLONE_PATH",
+    default=False,
 )
 @click.pass_context
-def template_renderer(ctx, app_interface_data_path, git_clone_path):
+def template_renderer(ctx, app_interface_data_path, clone_repo):
     from reconcile.templating.renderer import (
         TemplateRendererIntegration,
         TemplateRendererIntegrationParams,
@@ -1989,7 +1988,7 @@ def template_renderer(ctx, app_interface_data_path, git_clone_path):
         integration=TemplateRendererIntegration(
             TemplateRendererIntegrationParams(
                 app_interface_data_path=app_interface_data_path,
-                git_clone_path=git_clone_path,
+                clone_repo=clone_repo,
             )
         ),
         ctx=ctx.obj,

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1968,12 +1968,18 @@ def template_validator(ctx):
 @integration.command(short_help="Render datafile templates in app-interface.")
 @click.option(
     "--app-interface-data-path",
-    help="Path to app-interface dictory, used to write output and calculate diff in dry-run.",
+    help="Path to data dir in app-interface repo. Use this for local rendering or in MR checks.",
     required=False,
     envvar="APP_INTERFACE_DATA_PATH",
 )
+@click.option(
+    "--git-clone-path",
+    help="Path to a folder app-interface repo should be cloned to. Use this for regular integration run.",
+    required=False,
+    envvar="GIT_CLONE_PATH",
+)
 @click.pass_context
-def template_renderer(ctx, app_interface_data_path):
+def template_renderer(ctx, app_interface_data_path, git_clone_path):
     from reconcile.templating.renderer import (
         TemplateRendererIntegration,
         TemplateRendererIntegrationParams,
@@ -1982,7 +1988,8 @@ def template_renderer(ctx, app_interface_data_path):
     run_class_integration(
         integration=TemplateRendererIntegration(
             TemplateRendererIntegrationParams(
-                app_interface_data_path=app_interface_data_path
+                app_interface_data_path=app_interface_data_path,
+                git_clone_path=git_clone_path,
             )
         ),
         ctx=ctx.obj,

--- a/reconcile/templating/renderer.py
+++ b/reconcile/templating/renderer.py
@@ -290,8 +290,7 @@ class TemplateRendererIntegration(QontractReconcileIntegration):
             )
             url = get_app_interface_repo_url()
 
-            ssl_verify = [g.ssl_verify for g in gitlab_instances if g.url in url]
-            assert len(ssl_verify) == 1, "Expected gitlab instance to be configured"
+            ssl_verify = next(g.ssl_verify for g in gitlab_instances if g.url in url)
 
             with tempfile.TemporaryDirectory(
                 prefix=f"{QONTRACT_INTEGRATION}-",

--- a/reconcile/templating/renderer.py
+++ b/reconcile/templating/renderer.py
@@ -297,7 +297,7 @@ class TemplateRendererIntegration(QontractReconcileIntegration):
             ) as temp_dir:
                 logging.debug(f"Cloning {url} to {temp_dir}")
 
-                clone(url, temp_dir, depth=1, verify=ssl_verify[0])
+                clone(url, temp_dir, depth=1, verify=ssl_verify)
 
                 persistence = ClonedRepoGitlabPersistence(
                     temp_dir, vcs, merge_request_manager

--- a/reconcile/templating/renderer.py
+++ b/reconcile/templating/renderer.py
@@ -290,7 +290,9 @@ class TemplateRendererIntegration(QontractReconcileIntegration):
             )
             url = get_app_interface_repo_url()
 
-            ssl_verify = next(g.ssl_verify for g in gitlab_instances if g.url in url)
+            ssl_verify = next(
+                g.ssl_verify for g in gitlab_instances if url.startswith(g.url)
+            )
 
             with tempfile.TemporaryDirectory(
                 prefix=f"{QONTRACT_INTEGRATION}-",

--- a/reconcile/test/templating/test_renderer.py
+++ b/reconcile/test/templating/test_renderer.py
@@ -1,6 +1,7 @@
-from datetime import datetime
+import os
 from pathlib import Path
 from typing import Callable
+from unittest.mock import ANY
 
 import pytest
 from gitlab import GitlabGetError
@@ -14,7 +15,7 @@ from reconcile.gql_definitions.templating.template_collection import (
 )
 from reconcile.templating.lib.merge_request_manager import MergeRequestManager
 from reconcile.templating.renderer import (
-    GitlabFilePersistence,
+    ClonedRepoGitlabPersistence,
     LocalFilePersistence,
     TemplateOutput,
     TemplateRendererIntegration,
@@ -25,7 +26,6 @@ from reconcile.templating.renderer import (
 )
 from reconcile.utils.ruamel import create_ruamel_instance
 from reconcile.utils.secret_reader import SecretReader
-from reconcile.utils.state import State
 from reconcile.utils.vcs import VCS
 
 
@@ -66,7 +66,8 @@ def template_collection(
 
 @pytest.fixture
 def local_file_persistence(tmp_path: Path) -> LocalFilePersistence:
-    return LocalFilePersistence(str(tmp_path))
+    os.mkdir(tmp_path / "data")
+    return LocalFilePersistence(str(tmp_path / "data"))
 
 
 @pytest.fixture
@@ -124,47 +125,50 @@ def test_join_path() -> None:
 
 
 def test_local_file_persistence_write(tmp_path: Path) -> None:
-    lfp = LocalFilePersistence(str(tmp_path))
+    os.makedirs(tmp_path / "data")
+    lfp = LocalFilePersistence(str(tmp_path / "data"))
     lfp.write([TemplateOutput(path="/foo", content="bar")])
-    assert (tmp_path / "foo").read_text() == "bar"
+    assert (tmp_path / "data" / "foo").read_text() == "bar"
 
 
 def test_local_file_persistence_read(tmp_path: Path) -> None:
-    test_file = tmp_path / "foo"
+    data_dir = tmp_path / "data"
+    os.makedirs(data_dir)
+    test_file = data_dir / "foo"
     test_file.write_text("hello")
-    lfp = LocalFilePersistence(str(tmp_path))
+    lfp = LocalFilePersistence(str(data_dir))
     assert lfp.read("foo") == "hello"
 
 
-def test_gitlab_file_persistence_write(mocker: MockerFixture) -> None:
+def test_crg_file_persistence_write(mocker: MockerFixture, tmp_path: Path) -> None:
     vcs = mocker.MagicMock(VCS)
     mr_manager = mocker.MagicMock(MergeRequestManager)
     output = [TemplateOutput(path="/foo", content="bar")]
-    gfp = GitlabFilePersistence(vcs, mr_manager)
-    gfp.write(output)
+    crg = ClonedRepoGitlabPersistence(str(tmp_path), vcs, mr_manager)
+    crg.write(output)
 
     mr_manager.housekeeping.assert_called_once()
     mr_manager.create_merge_request.assert_called_once_with(output)
 
 
-def test_gitlable_file_persistence_read_found(mocker: MockerFixture) -> None:
+def test_crg_file_persistence_read_found(mocker: MockerFixture, tmp_path: Path) -> None:
     vcs = mocker.MagicMock(VCS)
-    vcs.get_file_content_from_app_interface_master.return_value = "hello"
+    os.makedirs(tmp_path / "data")
+    test_file = tmp_path / "data" / "foo"
+    test_file.write_text("hello")
     mr_manager = mocker.MagicMock(MergeRequestManager)
-    gfp = GitlabFilePersistence(vcs, mr_manager)
+    crg = ClonedRepoGitlabPersistence(str(tmp_path), vcs, mr_manager)
 
-    assert gfp.read("foo") == "hello"
-    vcs.get_file_content_from_app_interface_master.assert_called_once_with("foo")
+    assert crg.read("foo") == "hello"
 
 
-def test_gitlable_file_persistence_read_miss(mocker: MockerFixture) -> None:
+def test_crg_file_persistence_read_miss(mocker: MockerFixture, tmp_path: Path) -> None:
     vcs = mocker.MagicMock(VCS)
     vcs.get_file_content_from_app_interface_master.side_effect = GitlabGetError()
     mr_manager = mocker.MagicMock(MergeRequestManager)
-    gfp = GitlabFilePersistence(vcs, mr_manager)
+    crg = ClonedRepoGitlabPersistence(str(tmp_path), vcs, mr_manager)
 
-    assert gfp.read("foo") is None
-    vcs.get_file_content_from_app_interface_master.assert_called_once_with("foo")
+    assert crg.read("foo") is None
 
 
 def test_process_template_simple(
@@ -217,52 +221,33 @@ def test_process_template_match(
     assert output is None
 
 
-def test_reconcile_state_mismatch(
+def test_reconcile(
     mocker: MockerFixture, template_collection: TemplateCollectionV1
 ) -> None:
     t = TemplateRendererIntegration(TemplateRendererIntegrationParams())
-    state = mocker.MagicMock(State)
-    state.exists.return_value = True
     pt = mocker.patch.object(t, "process_template")
     mocker.patch("reconcile.templating.renderer.init_from_config")
     gtc = mocker.patch("reconcile.templating.renderer.get_template_collections")
     gtc.return_value = [template_collection]
     p = mocker.MagicMock(LocalFilePersistence)
+    r = (create_ruamel_instance(),)
     t.reconcile(
         False,
         p,
-        create_ruamel_instance(),
-        state,
+        r,
     )
 
     pt.assert_called_once()
-    state.add.assert_called_once()
-    p.write.assert_called_once()
-
-
-def test_reconcile_state_match(
-    mocker: MockerFixture, template_collection: TemplateCollectionV1
-) -> None:
-    t = TemplateRendererIntegration(TemplateRendererIntegrationParams())
-    state = mocker.MagicMock(State)
-    state.exists.return_value = True
-    # Hash optained using debugger
-    state.get.return_value = {
-        "hash": "f8e46492df18572b06967588c8074ef5a4a7ba2810d5f901ea94098f80856568",
-        "timestamp": datetime.now().isoformat(),
-    }
-    pt = mocker.patch.object(t, "process_template")
-    mocker.patch("reconcile.templating.renderer.init_from_config")
-    gtc = mocker.patch("reconcile.templating.renderer.get_template_collections")
-    gtc.return_value = [template_collection]
-    p = mocker.MagicMock(LocalFilePersistence)
-
-    t.reconcile(
-        False,
-        p,
-        create_ruamel_instance(),
-        state,
+    assert pt.call_args[0] == (
+        TemplateV1(
+            name="test",
+            condition="{{1 == 1}}",
+            targetPath="/target_path",
+            patch=None,
+            template="template",
+        ),
+        {},
+        ANY,
+        r,
     )
-
-    pt.assert_not_called()
-    p.write.assert_not_called()
+    p.write.assert_called_once()

--- a/reconcile/test/templating/test_renderer.py
+++ b/reconcile/test/templating/test_renderer.py
@@ -230,7 +230,7 @@ def test_reconcile(
     gtc = mocker.patch("reconcile.templating.renderer.get_template_collections")
     gtc.return_value = [template_collection]
     p = mocker.MagicMock(LocalFilePersistence)
-    r = (create_ruamel_instance(),)
+    r = create_ruamel_instance()
     t.reconcile(
         False,
         p,

--- a/reconcile/utils/git.py
+++ b/reconcile/utils/git.py
@@ -6,8 +6,11 @@ class GitError(Exception):
     pass
 
 
-def clone(repo_url, wd, depth=None):
-    cmd = ["git", "clone"]
+def clone(repo_url, wd, depth=None, verify=True):
+    cmd = ["git"]
+    if not verify:
+        cmd += ["-c", "http.sslVerify=false"]
+    cmd += ["clone"]
     if depth:
         cmd += ["--depth", str(depth)]
     cmd += [repo_url, wd]

--- a/reconcile/utils/git.py
+++ b/reconcile/utils/git.py
@@ -6,9 +6,13 @@ class GitError(Exception):
     pass
 
 
-def clone(repo_url, wd):
+def clone(repo_url, wd, depth=None):
+    base_cmd = ["git", "clone"]
+    if depth:
+        base_cmd.extend(["--depth", str(depth)])
+    base_cmd.append(repo_url)
+    cmd = base_cmd + [wd]
     # pylint: disable=subprocess-run-check
-    cmd = ["git", "clone", repo_url, wd]
     result = subprocess.run(
         cmd, cwd=wd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
     )

--- a/reconcile/utils/git.py
+++ b/reconcile/utils/git.py
@@ -7,12 +7,10 @@ class GitError(Exception):
 
 
 def clone(repo_url, wd, depth=None):
-    base_cmd = ["git", "clone"]
+    cmd = ["git", "clone"]
     if depth:
-        base_cmd.extend(["--depth", str(depth)])
-    base_cmd.append(repo_url)
-    cmd = base_cmd + [wd]
-    # pylint: disable=subprocess-run-check
+        cmd += ["--depth", str(depth)]
+    cmd += [repo_url, wd]
     result = subprocess.run(
         cmd, cwd=wd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
     )
@@ -21,7 +19,6 @@ def clone(repo_url, wd, depth=None):
 
 
 def checkout(commit, wd):
-    # pylint: disable=subprocess-run-check
     cmd = ["git", "checkout", commit]
     result = subprocess.run(
         cmd, cwd=wd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
@@ -33,7 +30,6 @@ def checkout(commit, wd):
 def is_file_in_git_repo(file_path):
     real_path = os.path.realpath(file_path)
     dir_path = os.path.dirname(real_path)
-    # pylint: disable=subprocess-run-check
     cmd = ["git", "rev-parse", "--is-inside-work-tree"]
     result = subprocess.run(
         cmd, cwd=dir_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False


### PR DESCRIPTION
This introduces ClonedRepoGitlabPersistence, which uses local directory for read and gitlab api for writes. 

This drastically reduces API calls and speeds up the process overall. It also fixes a bug by introducing the persistence context.