### PR TITLE
Fix bug in prometheus rules tester

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -3013,7 +3013,7 @@ def prometheus_rules_tester(ctx, thread_pool_size, cluster_name):
         reconcile.prometheus_rules_tester.integration,
         ctx.obj,
         thread_pool_size,
-        cluster_name=cluster_name,
+        cluster_names=cluster_name,
     )
 
 

--- a/reconcile/prometheus_rules_tester/integration.py
+++ b/reconcile/prometheus_rules_tester/integration.py
@@ -122,12 +122,12 @@ def fetch_rule_and_tests(
 def get_rules_and_tests(
     vault_settings: AppInterfaceSettingsV1,
     thread_pool_size: int,
-    cluster_name: Optional[tuple[str]] = None,
+    cluster_names: Optional[tuple[str]] = None,
 ) -> list[Test]:
     """Iterates through all namespaces and returns a list of tests to run"""
     namespace_with_prom_rules, _ = orb.get_namespaces(
         PROVIDERS,
-        cluster_names=cluster_name if cluster_name else [],
+        cluster_names=cluster_names if cluster_names else [],
         namespace_name=NAMESPACE_NAME,
     )
 
@@ -225,14 +225,14 @@ def check_rules_and_tests(
     vault_settings: AppInterfaceSettingsV1,
     alerting_services: Iterable[str],
     thread_pool_size: int,
-    cluster_name: Optional[tuple[str]] = None,
+    cluster_names: Optional[tuple[str]] = None,
 ) -> list[Test]:
     """Fetch rules and associated tests, run checks on rules and tests if they exist
     and return a list of failed checks/tests"""
     tests = get_rules_and_tests(
         vault_settings=vault_settings,
         thread_pool_size=thread_pool_size,
-        cluster_name=cluster_name,
+        cluster_names=cluster_names,
     )
     threaded.run(
         func=run_test,
@@ -254,7 +254,7 @@ def run(
     orb.QONTRACT_INTEGRATION_VERSION = QONTRACT_INTEGRATION_VERSION
 
     failed_tests = check_rules_and_tests(
-        cluster_name=cluster_names,
+        cluster_names=cluster_names,
         vault_settings=get_app_interface_vault_settings(),
         alerting_services=get_alerting_services(),
         thread_pool_size=thread_pool_size,

--- a/reconcile/prometheus_rules_tester/integration.py
+++ b/reconcile/prometheus_rules_tester/integration.py
@@ -122,12 +122,12 @@ def fetch_rule_and_tests(
 def get_rules_and_tests(
     vault_settings: AppInterfaceSettingsV1,
     thread_pool_size: int,
-    cluster_name: Optional[str] = None,
+    cluster_name: Optional[tuple[str]] = None,
 ) -> list[Test]:
     """Iterates through all namespaces and returns a list of tests to run"""
     namespace_with_prom_rules, _ = orb.get_namespaces(
         PROVIDERS,
-        cluster_names=[cluster_name] if cluster_name else [],
+        cluster_names=cluster_name if cluster_name else [],
         namespace_name=NAMESPACE_NAME,
     )
 
@@ -225,7 +225,7 @@ def check_rules_and_tests(
     vault_settings: AppInterfaceSettingsV1,
     alerting_services: Iterable[str],
     thread_pool_size: int,
-    cluster_name: Optional[str] = None,
+    cluster_name: Optional[tuple[str]] = None,
 ) -> list[Test]:
     """Fetch rules and associated tests, run checks on rules and tests if they exist
     and return a list of failed checks/tests"""
@@ -247,7 +247,7 @@ def check_rules_and_tests(
 
 
 def run(
-    dry_run: bool, thread_pool_size: int, cluster_name: Optional[str] = None
+    dry_run: bool, thread_pool_size: int, cluster_name: Optional[tuple[str]] = None
 ) -> None:
     """Check prometheus rules syntax and run the tests associated to them"""
     orb.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION

--- a/reconcile/prometheus_rules_tester/integration.py
+++ b/reconcile/prometheus_rules_tester/integration.py
@@ -247,14 +247,14 @@ def check_rules_and_tests(
 
 
 def run(
-    dry_run: bool, thread_pool_size: int, cluster_name: Optional[tuple[str]] = None
+    dry_run: bool, thread_pool_size: int, cluster_names: Optional[tuple[str]] = None
 ) -> None:
     """Check prometheus rules syntax and run the tests associated to them"""
     orb.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION
     orb.QONTRACT_INTEGRATION_VERSION = QONTRACT_INTEGRATION_VERSION
 
     failed_tests = check_rules_and_tests(
-        cluster_name=cluster_name,
+        cluster_name=cluster_names,
         vault_settings=get_app_interface_vault_settings(),
         alerting_services=get_alerting_services(),
         thread_pool_size=thread_pool_size,

--- a/reconcile/prometheus_rules_tester/integration.py
+++ b/reconcile/prometheus_rules_tester/integration.py
@@ -122,7 +122,7 @@ def fetch_rule_and_tests(
 def get_rules_and_tests(
     vault_settings: AppInterfaceSettingsV1,
     thread_pool_size: int,
-    cluster_names: Optional[tuple[str]] = None,
+    cluster_names: Optional[Iterable[str]] = None,
 ) -> list[Test]:
     """Iterates through all namespaces and returns a list of tests to run"""
     namespace_with_prom_rules, _ = orb.get_namespaces(
@@ -225,7 +225,7 @@ def check_rules_and_tests(
     vault_settings: AppInterfaceSettingsV1,
     alerting_services: Iterable[str],
     thread_pool_size: int,
-    cluster_names: Optional[tuple[str]] = None,
+    cluster_names: Optional[Iterable[str]] = None,
 ) -> list[Test]:
     """Fetch rules and associated tests, run checks on rules and tests if they exist
     and return a list of failed checks/tests"""
@@ -247,7 +247,7 @@ def check_rules_and_tests(
 
 
 def run(
-    dry_run: bool, thread_pool_size: int, cluster_names: Optional[tuple[str]] = None
+    dry_run: bool, thread_pool_size: int, cluster_names: Optional[Iterable[str]] = None
 ) -> None:
     """Check prometheus rules syntax and run the tests associated to them"""
     orb.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION

--- a/reconcile/test/test_prometheus_rules_tester.py
+++ b/reconcile/test/test_prometheus_rules_tester.py
@@ -146,6 +146,6 @@ class TestPrometheusRulesTester:
         error_msg = (
             "Error checking rule bad-test.prometheusrules.yaml "
             "from namespace openshift-customer-monitoring in "
-            f"cluster {cluster_name}: Error running promtool command"
+            f"cluster {cluster_name[0]}: Error running promtool command"
         )
         assert error_msg in caplog.text

--- a/reconcile/test/test_prometheus_rules_tester.py
+++ b/reconcile/test/test_prometheus_rules_tester.py
@@ -136,7 +136,7 @@ class TestPrometheusRulesTester:
         self.ns_data = self.fxt.get_anymarkup("ns-bad-test.yaml")
         mocker_alerting_services.return_value = {"yak-shaver"}
         mocker_vault_settings.return_value = AppInterfaceSettingsV1(vault=False)
-        cluster_name = "appint-ex-01"
+        cluster_name = ("appint-ex-01",)
 
         with pytest.raises(SystemExit) as exc:
             run(False, THREAD_POOL_SIZE, cluster_name=cluster_name)

--- a/reconcile/test/test_prometheus_rules_tester.py
+++ b/reconcile/test/test_prometheus_rules_tester.py
@@ -69,7 +69,7 @@ class TestPrometheusRulesTester:
             vault_settings=self.vault_settings,
             alerting_services=self.alerting_services,
             thread_pool_size=THREAD_POOL_SIZE,
-            cluster_name=cluster_name,
+            cluster_names=cluster_name,
         )
 
     def test_ok_non_templated(self) -> None:

--- a/reconcile/test/test_prometheus_rules_tester.py
+++ b/reconcile/test/test_prometheus_rules_tester.py
@@ -139,7 +139,7 @@ class TestPrometheusRulesTester:
         cluster_name = ("appint-ex-01",)
 
         with pytest.raises(SystemExit) as exc:
-            run(False, THREAD_POOL_SIZE, cluster_name=cluster_name)
+            run(False, THREAD_POOL_SIZE, cluster_names=cluster_name)
 
         assert exc.value.code == ExitCodes.ERROR
 


### PR DESCRIPTION
Passed in cluster_name is already an iterable, do not convert it to list anymore, so the namespace filter can use it correctly

[APPSRE-10066](https://issues.redhat.com/browse/APPSRE-10066)