### PR TITLE
Make tmp an emptydir

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -416,6 +416,8 @@ objects:
             {{- end }}
           {{- end }}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           {{- if $integration.cache }}
@@ -485,8 +487,6 @@ objects:
               memory: 120Mi
           {{- end }}
           volumeMounts:
-          - name: tmp-dir
-            mountPath: /tmp
           - name: logs
             mountPath: /fluentd/log/
           - name: fluentd-config

--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -485,6 +485,8 @@ objects:
               memory: 120Mi
           {{- end }}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: logs
             mountPath: /fluentd/log/
           - name: fluentd-config
@@ -521,6 +523,8 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
+        - name: tmp-dir
+          emptyDir: { }
         {{- if $logs.googleChat }}
         - name: buffer
           emptyDir: {}

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -205,6 +205,8 @@ objects:
               cpu: ${INTEGRATIONS_MANAGER_CPU_REQUEST}
               memory: ${INTEGRATIONS_MANAGER_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -257,6 +259,8 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
+        - name: tmp-dir
+          emptyDir: { }
         - name: buffer
           emptyDir: {}
 parameters:

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -194,6 +194,8 @@ objects:
               cpu: ${INTEGRATIONS_MANAGER_CPU_REQUEST}
               memory: ${INTEGRATIONS_MANAGER_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -244,6 +246,8 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
+        - name: tmp-dir
+          emptyDir: { }
 parameters:
 - name: IMAGE
   value: quay.io/app-sre/qontract-reconcile

--- a/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
@@ -148,6 +148,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -197,6 +199,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: apps/v1
   kind: Deployment
@@ -341,6 +345,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -391,6 +397,8 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
+        - name: tmp-dir
+          emptyDir: { }
 - apiVersion: v1
   kind: Service
   metadata:

--- a/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
@@ -148,6 +148,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -198,6 +200,8 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
+        - name: tmp-dir
+          emptyDir: { }
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -341,6 +345,8 @@ objects:
               cpu: 200m
               memory: 200Mi
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -390,6 +396,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/aws_account_shards.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shards.yml
@@ -148,6 +148,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -197,6 +199,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: apps/v1
   kind: Deployment
@@ -341,6 +345,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -390,6 +396,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/basic.yml
+++ b/reconcile/test/fixtures/helm/basic.yml
@@ -146,6 +146,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -195,6 +197,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/cache.yml
+++ b/reconcile/test/fixtures/helm/cache.yml
@@ -155,6 +155,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: cache
@@ -206,6 +208,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/cache_storage_vars.yml
+++ b/reconcile/test/fixtures/helm/cache_storage_vars.yml
@@ -155,6 +155,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: cache
@@ -206,6 +208,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/command.yml
+++ b/reconcile/test/fixtures/helm/command.yml
@@ -148,6 +148,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -197,6 +199,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/disable_unleash.yml
+++ b/reconcile/test/fixtures/helm/disable_unleash.yml
@@ -134,6 +134,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -183,6 +185,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -185,6 +185,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -236,6 +238,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
         - name: buffer
           emptyDir: {}

--- a/reconcile/test/fixtures/helm/environment_aware.yml
+++ b/reconcile/test/fixtures/helm/environment_aware.yml
@@ -172,6 +172,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -221,6 +223,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/exclude_service.yml
+++ b/reconcile/test/fixtures/helm/exclude_service.yml
@@ -146,6 +146,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -195,6 +197,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 parameters:
 - name: IMAGE

--- a/reconcile/test/fixtures/helm/extra_args.yml
+++ b/reconcile/test/fixtures/helm/extra_args.yml
@@ -148,6 +148,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -197,6 +199,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/extra_env.yml
+++ b/reconcile/test/fixtures/helm/extra_env.yml
@@ -153,6 +153,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -202,6 +204,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/integrations_manager.yml
+++ b/reconcile/test/fixtures/helm/integrations_manager.yml
@@ -154,6 +154,8 @@ objects:
               cpu: ${INTEGRATIONS_MANAGER_CPU_REQUEST}
               memory: ${INTEGRATIONS_MANAGER_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -203,6 +205,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/internal_certificates.yml
+++ b/reconcile/test/fixtures/helm/internal_certificates.yml
@@ -162,6 +162,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: internal-certificates
@@ -214,6 +216,8 @@ objects:
           emptyDir: {}
         - name: fluentd-config
           emptyDir: {}
+        - name: tmp-dir
+          emptyDir: { }
         - name: internal-certificates
           emptyDir: {}
 - apiVersion: v1

--- a/reconcile/test/fixtures/helm/logs_slack.yml
+++ b/reconcile/test/fixtures/helm/logs_slack.yml
@@ -164,6 +164,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -213,6 +215,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/shards.yml
+++ b/reconcile/test/fixtures/helm/shards.yml
@@ -146,6 +146,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -195,6 +197,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: apps/v1
   kind: Deployment
@@ -337,6 +341,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -386,6 +392,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/sleep_duration.yml
+++ b/reconcile/test/fixtures/helm/sleep_duration.yml
@@ -146,6 +146,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -195,6 +197,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/state.yml
+++ b/reconcile/test/fixtures/helm/state.yml
@@ -167,6 +167,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -233,6 +235,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/storage.yml
+++ b/reconcile/test/fixtures/helm/storage.yml
@@ -146,6 +146,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -195,6 +197,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service

--- a/reconcile/test/fixtures/helm/trigger.yml
+++ b/reconcile/test/fixtures/helm/trigger.yml
@@ -146,6 +146,8 @@ objects:
               cpu: ${INTEG_CPU_REQUEST}
               memory: ${INTEG_MEMORY_REQUEST}
           volumeMounts:
+          - name: tmp-dir
+            mountPath: /tmp
           - name: qontract-reconcile-toml
             mountPath: /config
           - name: logs
@@ -195,6 +197,8 @@ objects:
         - name: logs
           emptyDir: {}
         - name: fluentd-config
+          emptyDir: {}
+        - name: tmp-dir
           emptyDir: {}
 - apiVersion: v1
   kind: Service


### PR DESCRIPTION

`/tmp` is part of overlay fs right now. However it is used by i.e. terraform-resources and will be used by template-renderer soon for writig temporary data. Using an OverlayFS for writes can cause significant performance issues. Thus, create a separate mount for it using emptyDir
