### PR TITLE
:bug: jira-permission-validator: do not log sporadic 401 jira server errors

### DIFF
--- a/reconcile/jira_permissions_validator.py
+++ b/reconcile/jira_permissions_validator.py
@@ -166,12 +166,16 @@ def board_is_valid(
                 )
                 error |= ValidationError.INVALID_PRIORITY
     except JIRAError as e:
-        if e.status_code != 403:
+        if e.status_code == 401:
+            # sporadic 401 errors, retrying
+            pass
+        elif e.status_code == 403:
+            logging.error(
+                f"[{board.name}] AppSRE Jira Bot user does not have all necessary permissions. Try granting the user the administrator permissions. API URL: {e.url}"
+            )
+            error |= ValidationError.PERMISSION_ERROR
+        else:
             raise
-        logging.error(
-            f"[{board.name}] AppSRE Jira Bot user does not have all necessary permissions. Try granting the user the administrator permissions. API URL: {e.url}"
-        )
-        error |= ValidationError.PERMISSION_ERROR
 
     return error
 

--- a/reconcile/jira_permissions_validator.py
+++ b/reconcile/jira_permissions_validator.py
@@ -168,7 +168,7 @@ def board_is_valid(
     except JIRAError as e:
         if e.status_code == 401:
             # sporadic 401 errors, retrying
-            pass
+            logging.debug(f"[{board.name}] sporadic 401 error! Retry later.")
         elif e.status_code == 403:
             logging.error(
                 f"[{board.name}] AppSRE Jira Bot user does not have all necessary permissions. Try granting the user the administrator permissions. API URL: {e.url}"


### PR DESCRIPTION
Those 401 messages are just annoying in #sd-appsre-reconcile.