### PR TITLE
Improvements to the SAPM S3 publisher

### DIFF
--- a/reconcile/saas_auto_promotions_manager/publisher.py
+++ b/reconcile/saas_auto_promotions_manager/publisher.py
@@ -32,11 +32,14 @@ class Publisher:
         uid: str,
         saas_name: str,
         saas_file_path: str,
+        app_name: str,
         namespace_name: str,
         resource_template_name: str,
         target_name: Optional[str],
         cluster_name: str,
         auth_code: Optional[HasSecret],
+        publish_job_logs: Optional[bool],
+        has_subscriber: bool = True,
     ):
         self._ref = ref
         self._repo_url = repo_url
@@ -47,10 +50,13 @@ class Publisher:
         self.uid = uid
         self.saas_name = saas_name
         self.saas_file_path = saas_file_path
+        self.app_name = app_name
         self.namespace_name = namespace_name
         self.resource_template_name = resource_template_name
-        self.target_name = target_name if target_name else "default"
+        self.target_name = target_name if target_name else "None"
         self.cluster_name = cluster_name
+        self.publish_job_logs = bool(publish_job_logs)
+        self.has_subscriber = has_subscriber
 
     def fetch_commit_shas_and_deployment_info(
         self, vcs: VCS, deployment_state: PromotionState

--- a/reconcile/saas_auto_promotions_manager/s3_exporter.py
+++ b/reconcile/saas_auto_promotions_manager/s3_exporter.py
@@ -62,7 +62,7 @@ class S3Exporter:
         data: dict[str, dict] = {}
         for publisher in publishers:
             publisher_data = PublisherData.from_publisher(publisher)
-            key = f"{publisher.saas_name}/{publisher.resource_template_name}/{publisher.target_name}/{publisher.cluster_name}/{publisher.namespace_name}"
+            key = f"{publisher.app_name}/{publisher.saas_name}/{publisher.resource_template_name}/{publisher.target_name}/{publisher.cluster_name}/{publisher.namespace_name}/{publisher.publish_job_logs}"
             data[key] = {
                 "commit_sha": publisher_data.commit_sha,
                 "deployment_state": publisher_data.deployment_state.value,

--- a/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
+++ b/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
@@ -34,6 +34,11 @@ class SaasFilesInventory:
         self._assemble_publishers()
         self._remove_unsupported()
 
+
+    @property
+    def publishers_with_subscribers(self) -> list[Publisher]:
+        return [p for p in self.publishers if p.has_subscriber]
+
     def _assemble_publishers(self) -> None:
         for saas_file in self._saas_files:
             for resource_template in saas_file.resource_templates:

--- a/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
+++ b/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
@@ -34,7 +34,6 @@ class SaasFilesInventory:
         self._assemble_publishers()
         self._remove_unsupported()
 
-
     @property
     def publishers_with_subscribers(self) -> list[Publisher]:
         return [p for p in self.publishers if p.has_subscriber]

--- a/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
+++ b/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
@@ -54,12 +54,15 @@ class SaasFilesInventory:
                         repo_url=resource_template.url,
                         saas_file_path=saas_file.path,
                         saas_name=saas_file.name,
+                        app_name=saas_file.app.name,
                         namespace_name=target.namespace.name,
                         cluster_name=target.namespace.cluster.name,
                         resource_template_name=resource_template.name,
                         target_name=target.name,
+                        publish_job_logs=saas_file.publish_job_logs,
                         auth_code=auth_code,
                     )
+
                     has_subscriber = False
                     for publish_channel in target.promotion.publish or []:
                         if publish_channel not in self._channels_by_name:
@@ -71,8 +74,9 @@ class SaasFilesInventory:
                         self._channels_by_name[publish_channel].publishers.append(
                             publisher
                         )
-                    if has_subscriber:
-                        self.publishers.append(publisher)
+
+                    publisher.has_subscriber = has_subscriber
+                    self.publishers.append(publisher)
 
     def _assemble_subscribers_with_auto_promotions(self) -> None:
         for saas_file in self._saas_files:

--- a/reconcile/test/saas_auto_promotions_manager/s3_exporter/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/s3_exporter/conftest.py
@@ -14,10 +14,13 @@ def publisher_builder() -> Callable[[Mapping], Publisher]:
             uid="",
             saas_name=data["saas_name"],
             saas_file_path="",
+            app_name="",
             namespace_name=data["namespace_name"],
             cluster_name=data["cluster_name"],
             target_name=data.get("target_name"),
             resource_template_name=data["resource_template_name"],
+            publish_job_logs=True,
+            has_subscriber=True,
             auth_code=None,
         )
         publisher.commit_sha = data["commit_sha"]

--- a/reconcile/test/saas_auto_promotions_manager/s3_exporter/test_s3_exporter.py
+++ b/reconcile/test/saas_auto_promotions_manager/s3_exporter/test_s3_exporter.py
@@ -23,7 +23,7 @@ def test_s3_exporter(publisher_builder: Callable[[Mapping], Publisher]) -> None:
     ]
 
     expected = {
-        "saas-1/template-1/target-1/cluster-1/namespace-1": {
+        "/saas-1/template-1/target-1/cluster-1/namespace-1/True": {
             "commit_sha": "123",
             "deployment_state": "success",
         }
@@ -53,7 +53,7 @@ def test_s3_exporter_failed_deployment(
     ]
 
     expected = {
-        "saas-1/template-1/default/cluster-1/namespace-1": {
+        "/saas-1/template-1/None/cluster-1/namespace-1/True": {
             "commit_sha": "123",
             "deployment_state": "failed",
         }
@@ -83,7 +83,7 @@ def test_s3_exporter_missing_deployment(
     ]
 
     expected = {
-        "saas-1/template-1/default/cluster-1/namespace-1": {
+        "/saas-1/template-1/None/cluster-1/namespace-1/True": {
             "commit_sha": "123",
             "deployment_state": "missing",
         }
@@ -121,11 +121,11 @@ def test_s3_export_multiple(
     ]
 
     expected = {
-        "saas-1/template-1/default/cluster-1/namespace-1": {
+        "/saas-1/template-1/None/cluster-1/namespace-1/True": {
             "commit_sha": "123",
             "deployment_state": "success",
         },
-        "saas-2/template-2/default/cluster-2/namespace-2": {
+        "/saas-2/template-2/None/cluster-2/namespace-2/True": {
             "commit_sha": "456",
             "deployment_state": "failed",
         },

--- a/reconcile/test/saas_auto_promotions_manager/subscriber/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/subscriber/conftest.py
@@ -52,8 +52,11 @@ def subscriber_builder(
                     namespace_name="",
                     saas_name="",
                     saas_file_path="",
+                    app_name="",
                     resource_template_name="",
                     target_name=None,
+                    publish_job_logs=True,
+                    has_subscriber=True,
                     auth_code=None,
                 )
                 publisher.commit_sha = publisher_data[REAL_WORLD_SHA]

--- a/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_multiple_publishers_for_single_channel.py
+++ b/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_multiple_publishers_for_single_channel.py
@@ -62,5 +62,7 @@ def test_multiple_publishers_for_single_channel(
         },
     ])
     inventory = SaasFilesInventory(saas_files=saas_files)
-    assert len(inventory.publishers) == 2
+
+    assert len(inventory.publishers) == 3
+    assert len(inventory.publishers_with_subscribers) == 2
     assert len(inventory.subscribers) == 1

--- a/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_use_target_config_hash.py
+++ b/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_use_target_config_hash.py
@@ -56,6 +56,7 @@ def test_use_target_config_hash(
         },
     ])
     inventory = SaasFilesInventory(saas_files=saas_files)
-    assert len(inventory.publishers) == 1
+    assert len(inventory.publishers) == 2
+    assert len(inventory.publishers_with_subscribers) == 1
     assert len(inventory.subscribers) == 1
     assert inventory.subscribers[0]._use_target_config_hash

--- a/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_with_auto_promote.py
+++ b/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_with_auto_promote.py
@@ -67,6 +67,7 @@ def test_single_channel(
         },
     ])
     inventory = SaasFilesInventory(saas_files=saas_files)
-    assert len(inventory.publishers) == 1
+    assert len(inventory.publishers) == 2
+    assert len(inventory.publishers_with_subscribers) == 1
     assert len(inventory.subscribers) == 1
     assert not inventory.subscribers[0]._use_target_config_hash

--- a/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_without_auto_promote.py
+++ b/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_without_auto_promote.py
@@ -59,5 +59,6 @@ def test_saas_files_without_auto_promote(
         },
     ])
     inventory = SaasFilesInventory(saas_files=saas_files)
-    assert len(inventory.publishers) == 0
+    assert len(inventory.publishers) == 2
+    assert len(inventory.publishers_with_subscribers) == 0
     assert len(inventory.subscribers) == 0


### PR DESCRIPTION
This PR brings improves several things in the SAPM S3 exporter:

- `app_name` is provided as part of the node. This is necessary because integrations using the publisher data will filter by `app_name`
- Information about whether or not a job is a test job is codified via `publish_job_logs`.
- If target is not defined, it defaults to `None` instead of default. This is more in line with other integrations we have.
- And more importantly, now all nodes that publish will be in the output, which is a changed compared with the current state, where only those that publish AND are being subscribed to by other nodes do appear.