### PR TITLE
[tf-repo qr] Versioning and Improved Vault Secret Support

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -30829,6 +30829,22 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "tfVersion",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -30845,6 +30845,61 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "variables",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "TerraformRepoVariables_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "TerraformRepoVariables_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "inputs",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "VaultSecret_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "outputs",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "OBJECT",
+                                    "name": "VaultSecret_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
@@ -25,5 +25,13 @@ query TerraformRepo {
     delete
     requireFips
     tfVersion
+    variables {
+      inputs {
+        ...VaultSecret
+      }
+      outputs {
+        ...VaultSecret
+      }
+    }
   }
 }

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
@@ -24,5 +24,6 @@ query TerraformRepo {
     projectPath
     delete
     requireFips
+    tfVersion
   }
 }

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.py
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.py
@@ -53,6 +53,14 @@ query TerraformRepo {
     delete
     requireFips
     tfVersion
+    variables {
+      inputs {
+        ...VaultSecret
+      }
+      outputs {
+        ...VaultSecret
+      }
+    }
   }
 }
 """
@@ -83,6 +91,11 @@ class AWSAccountV1(ConfiguredBaseModel):
     terraform_state: Optional[TerraformStateAWSV1] = Field(..., alias="terraformState")
 
 
+class TerraformRepoVariablesV1(ConfiguredBaseModel):
+    inputs: VaultSecret = Field(..., alias="inputs")
+    outputs: VaultSecret = Field(..., alias="outputs")
+
+
 class TerraformRepoV1(ConfiguredBaseModel):
     account: AWSAccountV1 = Field(..., alias="account")
     name: str = Field(..., alias="name")
@@ -92,6 +105,7 @@ class TerraformRepoV1(ConfiguredBaseModel):
     delete: Optional[bool] = Field(..., alias="delete")
     require_fips: Optional[bool] = Field(..., alias="requireFips")
     tf_version: str = Field(..., alias="tfVersion")
+    variables: Optional[TerraformRepoVariablesV1] = Field(..., alias="variables")
 
 
 class TerraformRepoQueryData(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.py
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.py
@@ -52,6 +52,7 @@ query TerraformRepo {
     projectPath
     delete
     requireFips
+    tfVersion
   }
 }
 """
@@ -90,6 +91,7 @@ class TerraformRepoV1(ConfiguredBaseModel):
     project_path: str = Field(..., alias="projectPath")
     delete: Optional[bool] = Field(..., alias="delete")
     require_fips: Optional[bool] = Field(..., alias="requireFips")
+    tf_version: str = Field(..., alias="tfVersion")
 
 
 class TerraformRepoQueryData(ConfiguredBaseModel):

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -12,8 +12,10 @@ from pydantic import (
 )
 
 from reconcile import queries
+from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.gql_definitions.terraform_repo.terraform_repo import (
     TerraformRepoV1,
+    TerraformRepoVariablesV1,
     query,
 )
 from reconcile.utils import gql
@@ -35,10 +37,6 @@ from reconcile.utils.state import (
 )
 
 
-class RepoSecret(BaseModel):
-    path: str
-    version: Optional[int]
-
 
 class RepoOutput(BaseModel):
     repository: str
@@ -46,7 +44,8 @@ class RepoOutput(BaseModel):
     ref: str
     project_path: str
     delete: bool
-    secret: RepoSecret
+    aws_creds: VaultSecret
+    variables: Optional[TerraformRepoVariablesV1]
     bucket: Optional[str]
     region: Optional[str]
     bucket_path: Optional[str]
@@ -146,10 +145,8 @@ class TerraformRepoIntegration(
                 delete=repo.delete or False,
                 require_fips=repo.require_fips or False,
                 tf_version=repo.tf_version,
-                secret=RepoSecret(
-                    path=repo.account.automation_token.path,
-                    version=repo.account.automation_token.version,
-                ),
+                aws_creds=repo.account.automation_token,
+                variables=repo.variables
             )
             # terraform-repo will store its statefiles in a specified directory if there is a
             # terraform-state yaml file associated with the AWS account and a configuration is

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -51,6 +51,7 @@ class RepoOutput(BaseModel):
     region: Optional[str]
     bucket_path: Optional[str]
     require_fips: bool
+    tf_version: str
 
 
 class OutputFile(BaseModel):
@@ -144,6 +145,7 @@ class TerraformRepoIntegration(
                 project_path=repo.project_path,
                 delete=repo.delete or False,
                 require_fips=repo.require_fips or False,
+                tf_version=repo.tf_version,
                 secret=RepoSecret(
                     path=repo.account.automation_token.path,
                     version=repo.account.automation_token.version,

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -37,7 +37,6 @@ from reconcile.utils.state import (
 )
 
 
-
 class RepoOutput(BaseModel):
     repository: str
     name: str
@@ -126,13 +125,16 @@ class TerraformRepoIntegration(
                 recreate_state=True,
             )
 
-    def print_output(self, diff: list[TerraformRepoV1], dry_run: bool) -> None:
+    def print_output(self, diff: list[TerraformRepoV1], dry_run: bool) -> OutputFile:
         """Parses and prints the output of a Terraform Repo diff for the executor
 
         :param diff: list of terraform repos to be acted on
         :type diff: list[TerraformRepoV1]
         :param dry_run: whether the executor should perform a tf apply
         :type dry_run: bool
+
+        :return: output of diff (used for testing)
+        :rtype: OutputFile
         """
         actions_list: list[RepoOutput] = []
 
@@ -146,7 +148,7 @@ class TerraformRepoIntegration(
                 require_fips=repo.require_fips or False,
                 tf_version=repo.tf_version,
                 aws_creds=repo.account.automation_token,
-                variables=repo.variables
+                variables=repo.variables,
             )
             # terraform-repo will store its statefiles in a specified directory if there is a
             # terraform-state yaml file associated with the AWS account and a configuration is
@@ -177,6 +179,8 @@ class TerraformRepoIntegration(
                 raise ParameterError(f"Unable to write to '{self.params.output_file}'")
         else:
             print(yaml.safe_dump(data=output.dict(), explicit_start=True))
+
+        return output
 
     def get_repos(self, query_func: Callable) -> list[TerraformRepoV1]:
         """Gets a list of terraform repos defined in App Interface

--- a/reconcile/test/test_terraform_repo.py
+++ b/reconcile/test/test_terraform_repo.py
@@ -21,8 +21,10 @@ from reconcile.utils.state import State
 
 A_REPO = "https://git-example/tf-repo-example"
 A_REPO_SHA = "a390f5cb20322c90861d6d80e9b70c6a579be1d0"
+A_REPO_VERSION = "1.4.5"
 B_REPO = "https://git-example/tf-repo-example2"
 B_REPO_SHA = "94edb90815e502b387c25358f5ec602e52d0bfbb"
+B_REPO_VERSION = "1.5.7"
 AWS_UID = "000000000000"
 AUTOMATION_TOKEN_PATH = "aws-secrets/terraform/foo"
 STATE_REGION = "us-east-1"
@@ -40,6 +42,7 @@ def existing_repo(aws_account) -> TerraformRepoV1:
         projectPath="tf",
         delete=False,
         requireFips=True,
+        tfVersion=A_REPO_VERSION,
     )
 
 
@@ -60,6 +63,7 @@ def existing_repo_output() -> str:
           region: {STATE_REGION}
           bucket_path: tf-repo
           require_fips: true
+          tf_version: {A_REPO_VERSION}
     """
 
 
@@ -73,6 +77,7 @@ def new_repo(aws_account_no_state) -> TerraformRepoV1:
         projectPath="tf",
         delete=False,
         requireFips=False,
+        tfVersion=B_REPO_VERSION,
     )
 
 
@@ -93,6 +98,7 @@ def new_repo_output() -> str:
           region: null
           bucket_path: null
           require_fips: false
+          tf_version: {B_REPO_VERSION}
     """
 
 
@@ -266,6 +272,7 @@ def test_get_repo_state(s3_state_builder, int_params, existing_repo):
                 "projectPath": "tf",
                 "delete": False,
                 "requireFips": True,
+                "tfVersion": A_REPO_VERSION,
                 "account": {
                     "name": "foo",
                     "uid": AWS_UID,


### PR DESCRIPTION
[APPSRE-8705](https://issues.redhat.com/browse/APPSRE-8705)

Implements new functionality for Terraform Repo based off of the [Milestone 1 design document](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/initiatives/terraform-repo-commercial.md?ref_type=heads#milestone-1-commercialize-terraform-repo).

Majority of this PR is updating GQL definitions to match my updates proposed in: https://github.com/app-sre/qontract-schemas/pull/579 and then produce a new output with those fields for the Terraform Repo Executor to use.

This adds two fields to a Terraform Repo representation in App Interface. The first of which allows a user to specify which version of the Terraform binary to use when planning/applying. The second allows them to load Vault secrets from a specified path as [Input Variables](https://developer.hashicorp.com/terraform/language/values/variables) and write any outputs from their Terraform apply to Vault using [outputs](https://developer.hashicorp.com/terraform/language/values/outputs).

Dependent on: https://github.com/app-sre/qontract-schemas/pull/579 & this PR is depended on by https://github.com/app-sre/terraform-repo-executor/pull/17