### PR TITLE
 template-validator: log diffs in PR checks

### DIFF
--- a/reconcile/templating/validator.py
+++ b/reconcile/templating/validator.py
@@ -127,7 +127,7 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
         if diffs:
             for diff in diffs:
                 logging.error(f"template: {diff.template}, test: {diff.test}")
-                logging.debug(diff.diff)
+                logging.error(diff.diff)
             raise ValueError("Template validation failed")
 
     @property


### PR DESCRIPTION
Show the diffs in MR/PR checks. This is much more handy and convenient for regular users.