### PR TITLE
Cost Report improvements

### DIFF
--- a/reconcile/test/utils/test_oauth2_backend_application_session.py
+++ b/reconcile/test/utils/test_oauth2_backend_application_session.py
@@ -5,6 +5,7 @@ import pytest
 from oauthlib.oauth2 import TokenExpiredError
 from pytest_mock import MockerFixture
 from requests import Response
+from requests.adapters import HTTPAdapter
 
 from reconcile.utils.oauth2_backend_application_session import (
     OAuth2BackendApplicationSession,
@@ -58,7 +59,7 @@ def test_oauth2_auto_session_init(
     mock_oauth2_session.return_value.close.assert_called_once_with()
 
 
-def build_oauth2_auto_session() -> OAuth2BackendApplicationSession:
+def build_oauth2_backend_application_session() -> OAuth2BackendApplicationSession:
     return OAuth2BackendApplicationSession(
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
@@ -72,7 +73,7 @@ def test_first_request_auto_fetch_token(
 ) -> None:
     mocked_oauth2_session = mock_oauth2_session.return_value
     mocked_oauth2_session.authorized = False
-    session = build_oauth2_auto_session()
+    session = build_oauth2_backend_application_session()
 
     response = session.request(method="GET", url="http://some-url")
 
@@ -100,7 +101,7 @@ def test_request_when_token_is_fetched(
 ) -> None:
     mocked_oauth2_session = mock_oauth2_session.return_value
     mocked_oauth2_session.authorized = True
-    session = build_oauth2_auto_session()
+    session = build_oauth2_backend_application_session()
 
     response = session.request(method="GET", url="http://some-url")
 
@@ -127,7 +128,7 @@ def test_request_when_token_is_expired(
         TokenExpiredError(),
         expected_response,
     ]
-    session = build_oauth2_auto_session()
+    session = build_oauth2_backend_application_session()
 
     response = session.request(method="GET", url="http://some-url")
 
@@ -166,7 +167,7 @@ def test_fetch_token(
 ) -> None:
     expected_token = {"access_token": "abc"}
     mock_oauth2_session.return_value.fetch_token.return_value = expected_token
-    session = build_oauth2_auto_session()
+    session = build_oauth2_backend_application_session()
 
     token = session.fetch_token()
 
@@ -178,3 +179,15 @@ def test_fetch_token(
         scope=SCOPE,
         headers=EXPECTED_FETCH_TOKEN_HEADERS,
     )
+
+
+def test_mount(
+    mock_oauth2_session: Any,
+) -> None:
+    session = build_oauth2_backend_application_session()
+
+    adapter = HTTPAdapter()
+
+    session.mount("http://", adapter)
+
+    mock_oauth2_session.return_value.mount.assert_called_once_with("http://", adapter)

--- a/reconcile/test/utils/test_oauth2_backend_application_session.py
+++ b/reconcile/test/utils/test_oauth2_backend_application_session.py
@@ -185,9 +185,87 @@ def test_mount(
     mock_oauth2_session: Any,
 ) -> None:
     session = build_oauth2_backend_application_session()
-
     adapter = HTTPAdapter()
 
     session.mount("http://", adapter)
 
     mock_oauth2_session.return_value.mount.assert_called_once_with("http://", adapter)
+
+
+def test_headers(
+    mock_oauth2_session: Any,
+) -> None:
+    mock_oauth2_session.return_value.headers = {}
+    session = build_oauth2_backend_application_session()
+
+    session.headers.update({"Content-Type": "application/json"})
+
+    assert mock_oauth2_session.return_value.headers == {
+        "Content-Type": "application/json"
+    }
+
+
+def test_get_auth(
+    mock_oauth2_session: Any,
+) -> None:
+    mock_oauth2_session.return_value.auth = "auth"
+    session = build_oauth2_backend_application_session()
+
+    auth = session.auth
+
+    assert auth == mock_oauth2_session.return_value.auth
+
+
+def test_set_auth(
+    mock_oauth2_session: Any,
+) -> None:
+    mock_oauth2_session.return_value.auth = "auth"
+    session = build_oauth2_backend_application_session()
+
+    session.auth = None
+
+    assert mock_oauth2_session.return_value.auth is None
+
+
+def test_get(
+    mock_oauth2_session: Any,
+) -> None:
+    session = build_oauth2_backend_application_session()
+
+    response = session.get("http://some-url")
+
+    assert response == mock_oauth2_session.return_value.get.return_value
+    mock_oauth2_session.return_value.get.assert_called_once_with("http://some-url")
+
+
+def test_post(
+    mock_oauth2_session: Any,
+) -> None:
+    session = build_oauth2_backend_application_session()
+
+    response = session.post("http://some-url")
+
+    assert response == mock_oauth2_session.return_value.post.return_value
+    mock_oauth2_session.return_value.post.assert_called_once_with("http://some-url")
+
+
+def test_put(
+    mock_oauth2_session: Any,
+) -> None:
+    session = build_oauth2_backend_application_session()
+
+    response = session.put("http://some-url")
+
+    assert response == mock_oauth2_session.return_value.put.return_value
+    mock_oauth2_session.return_value.put.assert_called_once_with("http://some-url")
+
+
+def test_delete(
+    mock_oauth2_session: Any,
+) -> None:
+    session = build_oauth2_backend_application_session()
+
+    response = session.delete("http://some-url")
+
+    assert response == mock_oauth2_session.return_value.delete.return_value
+    mock_oauth2_session.return_value.delete.assert_called_once_with("http://some-url")

--- a/reconcile/utils/oauth2_backend_application_session.py
+++ b/reconcile/utils/oauth2_backend_application_session.py
@@ -4,6 +4,7 @@ from typing import Any, Self
 
 from oauthlib.oauth2 import BackendApplicationClient, TokenExpiredError
 from requests import Response
+from requests.adapters import BaseAdapter
 from requests_oauthlib import OAuth2Session
 
 FETCH_TOKEN_HEADERS = {
@@ -59,6 +60,9 @@ class OAuth2BackendApplicationSession:
                 scope=self.scope,
                 headers=FETCH_TOKEN_HEADERS,
             )
+
+    def mount(self, prefix: str, adapter: BaseAdapter):
+        self.session.mount(prefix, adapter)
 
     def request(
         self,

--- a/reconcile/utils/oauth2_backend_application_session.py
+++ b/reconcile/utils/oauth2_backend_application_session.py
@@ -1,5 +1,5 @@
 import threading
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from typing import Any, Self
 
 from oauthlib.oauth2 import BackendApplicationClient, TokenExpiredError
@@ -40,9 +40,6 @@ class OAuth2BackendApplicationSession:
     def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
         self.close()
 
-    def close(self) -> None:
-        self.session.close()
-
     def fetch_token(self) -> dict:
         """
         Fetch token from token_url and store it in the session.
@@ -60,9 +57,6 @@ class OAuth2BackendApplicationSession:
                 scope=self.scope,
                 headers=FETCH_TOKEN_HEADERS,
             )
-
-    def mount(self, prefix: str, adapter: BaseAdapter):
-        self.session.mount(prefix, adapter)
 
     def request(
         self,
@@ -104,3 +98,35 @@ class OAuth2BackendApplicationSession:
                 client_secret=client_secret,
                 **kwargs,
             )
+
+    # Delegates for ApiBase
+
+    def close(self) -> None:
+        self.session.close()
+
+    def mount(self, prefix: str, adapter: BaseAdapter) -> None:
+        self.session.mount(prefix, adapter)
+
+    @property
+    def headers(self) -> MutableMapping:
+        return self.session.headers
+
+    @property
+    def auth(self) -> Any:
+        return self.session.auth
+
+    @auth.setter
+    def auth(self, value: Any) -> None:
+        self.session.auth = value
+
+    def get(self, url: str, **kwargs: Any) -> Response:
+        return self.session.get(url, **kwargs)
+
+    def post(self, url: str, **kwargs: Any) -> Response:
+        return self.session.post(url, **kwargs)
+
+    def put(self, url: str, **kwargs: Any) -> Response:
+        return self.session.put(url, **kwargs)
+
+    def delete(self, url: str, **kwargs: Any) -> Response:
+        return self.session.delete(url, **kwargs)

--- a/reconcile/utils/rest_api_base.py
+++ b/reconcile/utils/rest_api_base.py
@@ -2,6 +2,7 @@ from typing import Any, Self
 from urllib.parse import urljoin
 
 import requests
+from urllib3 import Retry
 
 from reconcile.utils.oauth2_backend_application_session import (
     OAuth2BackendApplicationSession,
@@ -44,7 +45,7 @@ class ApiBase:
         self,
         host: str,
         auth: requests.auth.AuthBase | None = None,
-        max_retries: int | None = None,
+        max_retries: int | Retry | None = None,
         read_timeout: float | None = None,
         session: requests.Session | OAuth2BackendApplicationSession | None = None,
     ) -> None:
@@ -52,18 +53,16 @@ class ApiBase:
         self.max_retries = max_retries if max_retries is not None else 3
         self.read_timeout = read_timeout if read_timeout is not None else 30
         self.session = session or requests.Session()
-        if not session:
-            if auth:
-                self.session.auth = auth
+        if auth:
+            self.session.auth = auth
+        for prefix in ["http://", "https://"]:
             self.session.mount(
-                "https://", requests.adapters.HTTPAdapter(max_retries=self.max_retries)
+                prefix,
+                requests.adapters.HTTPAdapter(max_retries=self.max_retries),
             )
-            self.session.mount(
-                "http://", requests.adapters.HTTPAdapter(max_retries=self.max_retries)
-            )
-            self.session.headers.update({
-                "Content-Type": "application/json",
-            })
+        self.session.headers.update({
+            "Content-Type": "application/json",
+        })
 
     def __enter__(self) -> Self:
         return self

--- a/reconcile/utils/rest_api_base.py
+++ b/reconcile/utils/rest_api_base.py
@@ -3,6 +3,10 @@ from urllib.parse import urljoin
 
 import requests
 
+from reconcile.utils.oauth2_backend_application_session import (
+    OAuth2BackendApplicationSession,
+)
+
 
 def get_next_url(links: dict[str, dict[str, str]]) -> str | None:
     """Parse response header 'Link' attribute and return the next page url if exists.
@@ -42,7 +46,7 @@ class ApiBase:
         auth: requests.auth.AuthBase | None = None,
         max_retries: int | None = None,
         read_timeout: float | None = None,
-        session: requests.Session | None = None,
+        session: requests.Session | OAuth2BackendApplicationSession | None = None,
     ) -> None:
         self.host = host
         self.max_retries = max_retries if max_retries is not None else 3

--- a/tools/cli_commands/cost_report/cost_management_api.py
+++ b/tools/cli_commands/cost_report/cost_management_api.py
@@ -1,5 +1,8 @@
 from typing import Any, List, Self
 
+from requests.adapters import HTTPAdapter
+from urllib3.util import Retry
+
 from reconcile.utils.oauth2_backend_application_session import (
     OAuth2BackendApplicationSession,
 )
@@ -26,6 +29,13 @@ class CostManagementApi:
             token_url=token_url,
             scope=scope,
         )
+        for prefix in ["http://", "https://"]:
+            retries = Retry(
+                total=3,
+                backoff_factor=15,  # large backoff required for server-side processing
+                status_forcelist=[500, 502, 503, 504],
+            )
+            self.session.mount(prefix, HTTPAdapter(max_retries=retries))
 
     def __enter__(self) -> Self:
         return self

--- a/tools/cli_commands/cost_report/view.py
+++ b/tools/cli_commands/cost_report/view.py
@@ -16,7 +16,7 @@ LAYOUT = """\
 """
 
 HEADER = """\
-# Cost Report
+# AWS Cost Report
 """
 
 SUMMARY = """\

--- a/tools/cli_commands/test/fixtures/aws_cost_report.md
+++ b/tools/cli_commands/test/fixtures/aws_cost_report.md
@@ -1,6 +1,6 @@
 [TOC]
 
-# Cost Report
+# AWS Cost Report
 
 ## Summary
 

--- a/tools/cli_commands/test/fixtures/empty_aws_cost_report.md
+++ b/tools/cli_commands/test/fixtures/empty_aws_cost_report.md
@@ -1,6 +1,6 @@
 [TOC]
 
-# Cost Report
+# AWS Cost Report
 
 ## Summary
 

--- a/tools/cli_commands/test/test_cost_management_api.py
+++ b/tools/cli_commands/test/test_cost_management_api.py
@@ -59,6 +59,7 @@ def test_cost_management_api_init(
         token_url=TOKEN_URL,
         scope=SCOPE,
     )
+    assert mock_session.return_value.mount.call_count == 2
     mock_session.return_value.close.assert_called_once_with()
 
 

--- a/tools/cli_commands/test/test_cost_management_api.py
+++ b/tools/cli_commands/test/test_cost_management_api.py
@@ -50,7 +50,7 @@ def test_cost_management_api_init(
     ) as api:
         pass
 
-    assert api.base_url == BASE_URL
+    assert api.host == BASE_URL
     assert api.session == mock_session.return_value
 
     mock_session.assert_called_once_with(

--- a/tools/cli_commands/test/test_cost_report.py
+++ b/tools/cli_commands/test/test_cost_report.py
@@ -137,7 +137,7 @@ def test_cost_report_execute(
     mock_get_app_names: Any,
     fx: Callable,
 ) -> None:
-    expected_output = fx("empty_cost_report.md")
+    expected_output = fx("empty_aws_cost_report.md")
     mock_get_app_names.return_value = []
 
     output = cost_report_command.execute()
@@ -290,7 +290,7 @@ def test_cost_report_render(
     cost_report_command: CostReportCommand,
     fx: Callable,
 ) -> None:
-    expected_output = fx("cost_report.md")
+    expected_output = fx("aws_cost_report.md")
     reports = {
         "parent": PARENT_APP_REPORT,
         "child": CHILD_APP_REPORT,

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2600,7 +2600,7 @@ def alerts(ctx, file_path):
 
 @get.command()
 @click.pass_context
-def cost_report(ctx):
+def aws_cost_report(ctx):
     command = CostReportCommand.create()
     print(command.execute())
 

--- a/tools/test/test_qontract_cli.py
+++ b/tools/test/test_qontract_cli.py
@@ -132,12 +132,12 @@ def mock_cost_report_command(mocker):
     return mocker.patch("tools.qontract_cli.CostReportCommand", autospec=True)
 
 
-def test_get_cost_report(env_vars, mock_queries, mock_cost_report_command):
+def test_get_aws_cost_report(env_vars, mock_queries, mock_cost_report_command):
     mock_cost_report_command.create.return_value.execute.return_value = "some report"
     runner = CliRunner()
     result = runner.invoke(
         qontract_cli.get,
-        "cost-report",
+        "aws-cost-report",
         obj={},
     )
 


### PR DESCRIPTION
* rename `cost-report` to `aws-cost-report` to make it explicit as later we will have `openshift-cost-report`
* add retries to `CostManagementApi` due to sometimes got 504 gateway timeout from server
* Refactor `CostManagementApi` using new `ApiBase` from https://github.com/app-sre/qontract-reconcile/pull/4265

Note other code renames will be done in openshift cost report change.

[SDE-3693](https://issues.redhat.com/browse/SDE-3693)