### PR TITLE
:bug: jiraclient: add timeout to public_project

### DIFF
--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -96,14 +96,11 @@ class JiraClient:
         if settings and settings["jiraWatcher"]:
             read_timeout = settings["jiraWatcher"]["readTimeout"]
             connect_timeout = settings["jiraWatcher"]["connectTimeout"]
+        self.timeout = (read_timeout, connect_timeout)
         if not self.server:
             raise RuntimeError("JiraClient.server is not set.")
 
-        self.jira = JIRA(
-            self.server,
-            token_auth=token_auth,
-            timeout=(read_timeout, connect_timeout),
-        )
+        self.jira = JIRA(self.server, token_auth=token_auth, timeout=self.timeout)
 
     @staticmethod
     def create(
@@ -218,7 +215,7 @@ class JiraClient:
             raise RuntimeError("JiraClient.server is not set.")
 
         # use anonymous access to get public projects
-        jira_api_anon = JIRA(server=self.server)
+        jira_api_anon = JIRA(server=self.server, timeout=self.timeout)
         return [project.key for project in jira_api_anon.projects()]
 
     def components(self) -> list[str]:


### PR DESCRIPTION
`jiraclient.public_project` may hang because of missing HTTP timeout.