### PR TITLE
APPSRE-10053 extend vcs to get diff

### DIFF
--- a/reconcile/test/utils/vcs/conftest.py
+++ b/reconcile/test/utils/vcs/conftest.py
@@ -2,10 +2,13 @@ from collections.abc import (
     Callable,
     Mapping,
 )
+from datetime import datetime
 from unittest.mock import create_autospec
 
 import pytest
+from github import Commit
 
+from reconcile.utils.github_api import GithubRepositoryApi
 from reconcile.utils.gitlab_api import GitLabApi
 from reconcile.utils.secret_reader import SecretReaderBase
 from reconcile.utils.vcs import VCS
@@ -18,17 +21,45 @@ def gitlab_api_builder() -> Callable[[Mapping], GitLabApi]:
         gitlab_api.get_merge_request_pipelines.side_effect = [
             data.get("MR_PIPELINES", [])
         ]
+
+        commits = [
+            {"id": sha, "committed_date": "2021-01-01T00:00:00Z"}
+            for sha in data.get("COMMITS", [])
+        ]
+        gitlab_api.repository_compare.side_effect = [commits]
         return gitlab_api
 
     return builder
 
 
 @pytest.fixture
+def github_api_builder() -> Callable[[Mapping], GithubRepositoryApi]:
+    def builder(data: Mapping) -> GithubRepositoryApi:
+        github_api = create_autospec(spec=GithubRepositoryApi)
+
+        commits = []
+
+        for d in data.get("COMMITS", []):
+            c = create_autospec(spec=Commit.Commit)
+            c.sha = d
+            c.commit.committer.date = datetime.fromisoformat("2021-01-01T00:00:00Z")
+            commits.append(c)
+
+        github_api.compare.side_effect = [commits]
+        return github_api
+
+    return builder
+
+
+@pytest.fixture
 def vcs_builder(
-    gitlab_api_builder: Callable[[Mapping], GitLabApi], secret_reader: SecretReaderBase
+    gitlab_api_builder: Callable[[Mapping], GitLabApi],
+    secret_reader: SecretReaderBase,
+    github_api_builder: Callable[[Mapping], GithubRepositoryApi],
 ) -> Callable[[Mapping], VCS]:
     def builder(data: Mapping) -> VCS:
         gitlab_api = gitlab_api_builder(data)
+        github_api = github_api_builder(data)
         vcs = VCS(
             allow_deleting_mrs=False,
             allow_opening_mrs=False,
@@ -40,6 +71,7 @@ def vcs_builder(
             secret_reader=secret_reader,
             dry_run=True,
             gitlab_instances=[],
+            github_api_per_repo_url={data.get("REPO", ""): github_api},
         )
         return vcs
 

--- a/reconcile/test/utils/vcs/test_vcs.py
+++ b/reconcile/test/utils/vcs/test_vcs.py
@@ -44,7 +44,7 @@ def test_commits_between_gitlab(vcs_builder: Callable[[Mapping], VCS]) -> None:
         auth_code=None,
     )
 
-    assert commits == [
+    assert sorted(commits) == sorted([
         Commit(
             repo="https://gitlab.com/some/repo",
             sha="sha1",
@@ -55,7 +55,7 @@ def test_commits_between_gitlab(vcs_builder: Callable[[Mapping], VCS]) -> None:
             sha="sha2",
             date=datetime.fromisoformat("2021-01-01T00:00:00Z"),
         ),
-    ]
+    ])
 
     vcs._gitlab_instance.repository_compare.assert_called_once_with(  # type: ignore[attr-defined]
         ref_from="from", ref_to="to", repo_url="https://gitlab.com/some/repo"
@@ -77,7 +77,7 @@ def test_commits_between_github(vcs_builder: Callable[[Mapping], VCS]) -> None:
     vcs._gh_per_repo_url[
         "https://github.com/some/repo"
     ].compare.assert_called_once_with(commit_from="from", commit_to="to")
-    assert commits == [
+    assert sorted(commits) == sorted([
         Commit(
             repo="https://github.com/some/repo",
             sha="sha1",
@@ -88,5 +88,5 @@ def test_commits_between_github(vcs_builder: Callable[[Mapping], VCS]) -> None:
             sha="sha2",
             date=datetime.fromisoformat("2021-01-01T00:00:00Z"),
         ),
-    ]
+    ])
     vcs._gitlab_instance.repository_compare.assert_not_called()  # type: ignore[attr-defined]

--- a/reconcile/test/utils/vcs/test_vcs.py
+++ b/reconcile/test/utils/vcs/test_vcs.py
@@ -1,10 +1,11 @@
 from collections.abc import Callable, Mapping
+from datetime import datetime
 from unittest.mock import create_autospec
 
 import pytest
 from gitlab.v4.objects import ProjectMergeRequest
 
-from reconcile.utils.vcs import VCS, MRCheckStatus
+from reconcile.utils.vcs import VCS, Commit, MRCheckStatus
 
 
 # https://docs.gitlab.com/ee/api/pipelines.html
@@ -28,3 +29,64 @@ def test_gitlab_mr_check_status(
 
     mr = create_autospec(spec=ProjectMergeRequest)
     assert vcs.get_gitlab_mr_check_status(mr=mr) == expected_status
+
+
+def test_commits_between_gitlab(vcs_builder: Callable[[Mapping], VCS]) -> None:
+    vcs = vcs_builder({
+        "REPO": "https://gitlab.com/some/repo",
+        "COMMITS": ["sha1", "sha2"],
+    })
+
+    commits = vcs.get_commits_between(
+        repo_url="https://gitlab.com/some/repo",
+        commit_from="from",
+        commit_to="to",
+        auth_code=None,
+    )
+
+    assert commits == [
+        Commit(
+            repo="https://gitlab.com/some/repo",
+            sha="sha1",
+            date=datetime.fromisoformat("2021-01-01T00:00:00Z"),
+        ),
+        Commit(
+            repo="https://gitlab.com/some/repo",
+            sha="sha2",
+            date=datetime.fromisoformat("2021-01-01T00:00:00Z"),
+        ),
+    ]
+
+    vcs._gitlab_instance.repository_compare.assert_called_once_with(  # type: ignore[attr-defined]
+        ref_from="from", ref_to="to", repo_url="https://gitlab.com/some/repo"
+    )
+    vcs._gh_per_repo_url["https://gitlab.com/some/repo"].compare.assert_not_called()
+
+
+def test_commits_between_github(vcs_builder: Callable[[Mapping], VCS]) -> None:
+    vcs = vcs_builder({
+        "REPO": "https://github.com/some/repo",
+        "COMMITS": ["sha1", "sha2"],
+    })
+    commits = vcs.get_commits_between(
+        repo_url="https://github.com/some/repo",
+        commit_from="from",
+        commit_to="to",
+        auth_code=None,
+    )
+    vcs._gh_per_repo_url[
+        "https://github.com/some/repo"
+    ].compare.assert_called_once_with(commit_from="from", commit_to="to")
+    assert commits == [
+        Commit(
+            repo="https://github.com/some/repo",
+            sha="sha1",
+            date=datetime.fromisoformat("2021-01-01T00:00:00Z"),
+        ),
+        Commit(
+            repo="https://github.com/some/repo",
+            sha="sha2",
+            date=datetime.fromisoformat("2021-01-01T00:00:00Z"),
+        ),
+    ]
+    vcs._gitlab_instance.repository_compare.assert_not_called()  # type: ignore[attr-defined]

--- a/reconcile/utils/vcs.py
+++ b/reconcile/utils/vcs.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 import re
 from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 from typing import Optional
 
@@ -29,6 +31,13 @@ class MRCheckStatus(Enum):
     RUNNING = 3
 
 
+@dataclass
+class Commit:
+    repo: str
+    sha: str
+    date: datetime
+
+
 class VCS:
     """
     Abstraction layer for aggregating different Version Control Systems.
@@ -46,17 +55,20 @@ class VCS:
         gitlab_instances: Iterable[GitlabInstanceV1],
         app_interface_repo_url: str,
         dry_run: bool,
-        allow_deleting_mrs: bool,
-        allow_opening_mrs: bool,
+        allow_deleting_mrs: bool = False,
+        allow_opening_mrs: bool = False,
         gitlab_instance: Optional[GitLabApi] = None,
         default_gh_token: Optional[str] = None,
         app_interface_api: Optional[GitLabApi] = None,
+        github_api_per_repo_url: Optional[dict[str, GithubRepositoryApi]] = None,
     ):
         self._dry_run = dry_run
         self._allow_deleting_mrs = allow_deleting_mrs
         self._allow_opening_mrs = allow_opening_mrs
         self._secret_reader = secret_reader
-        self._gh_per_repo_url: dict[str, GithubRepositoryApi] = {}
+        self._gh_per_repo_url: dict[str, GithubRepositoryApi] = (
+            {} if not github_api_per_repo_url else github_api_per_repo_url
+        )
         self._default_gh_token = (
             default_gh_token
             if default_gh_token
@@ -156,6 +168,44 @@ class VCS:
             return github.get_commit_sha(ref=ref)
         # assume gitlab by default
         return self._gitlab_instance.get_commit_sha(ref=ref, repo_url=repo_url)
+
+    def get_commits_between(
+        self,
+        repo_url: str,
+        commit_from: str,
+        commit_to: str,
+        auth_code: Optional[HasSecret],
+    ) -> list[Commit]:
+        """
+        Return a list of commits between two commits.
+        Note, that the commit_to is included in the result list, whereas commit_from is not included.
+        """
+        commits: list[Commit] = []
+        if "github.com" in repo_url:
+            github = self._init_github(repo_url=repo_url, auth_code=auth_code)
+            data = github.compare(commit_from=commit_from, commit_to=commit_to)
+            for gh_commit in data:
+                commits.append(
+                    Commit(
+                        repo=repo_url,
+                        sha=gh_commit.sha,
+                        date=gh_commit.commit.committer.date,
+                    )
+                )
+        # assume gitlab by default
+        else:
+            data = self._gitlab_instance.repository_compare(
+                repo_url=repo_url, ref_from=commit_from, ref_to=commit_to
+            )
+            for gl_commit in data:
+                commits.append(
+                    Commit(
+                        repo=repo_url,
+                        sha=gl_commit["id"],
+                        date=datetime.fromisoformat(gl_commit["committed_date"]),
+                    )
+                )
+        return commits
 
     def close_app_interface_mr(self, mr: ProjectMergeRequest, comment: str) -> None:
         if not self._allow_deleting_mrs:


### PR DESCRIPTION
We need a way to calculate the number of commits between 2 given commits. We extend the VCS util to calculate that diff. This is vcs agnostic, i.e., the consumer doesn't concern itself on whether the underlying repo url is gitlab or github.