### PR TITLE
:bug: terraform-tgw-attachment: honor aws_account.disable.integrations during PR checks

### DIFF
--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -39,6 +39,7 @@ from reconcile.typed_queries.terraform_tgw_attachments.aws_accounts import (
 from reconcile.utils import gql
 from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.defer import defer
+from reconcile.utils.disabled_integrations import integration_is_enabled
 from reconcile.utils.ocm import (
     OCM,
     OCMMap,
@@ -381,7 +382,12 @@ def _filter_tgw_accounts(
                     ClusterPeeringConnectionAccountTGWV1, peer_connection
                 )
                 tgw_account_names.add(tgw_peer_connection.account.name)
-    return [a for a in accounts if a.name in tgw_account_names]
+    return [
+        a
+        for a in accounts
+        if a.name in tgw_account_names
+        and integration_is_enabled(QONTRACT_INTEGRATION.replace("_", "-"), a)
+    ]
 
 
 def _fetch_desired_state_data_source(


### PR DESCRIPTION
Do not run `terraform-tgw-attachments` for accounts were the integration is disabled. This will speedup the PR checks!