### PR TITLE
[AUS] bugfix addon upgrade policy field name mismatch

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -587,13 +587,22 @@ def fetch_current_state(
     for spec in org_upgrade_spec.specs:
         if addons and isinstance(spec, ClusterAddonUpgradeSpec):
             addon_spec = cast(ClusterAddonUpgradeSpec, spec)
-            upgrade_policies = addon_service.get_addon_upgrade_policies(
+            addon_upgrade_policies = addon_service.get_addon_upgrade_policies(
                 ocm_api, spec.cluster.id, addon_id=addon_spec.addon.addon.id
             )
-            for upgrade_policy in upgrade_policies:
-                upgrade_policy["cluster"] = spec.cluster
+            for addon_upgrade_policy in addon_upgrade_policies:
                 current_state.append(
-                    AddonUpgradePolicy(**upgrade_policy, addon_service=addon_service)
+                    AddonUpgradePolicy(
+                        id=addon_upgrade_policy.id,
+                        addon_id=addon_spec.addon.addon.id,
+                        cluster=spec.cluster,
+                        next_run=addon_upgrade_policy.next_run,
+                        schedule=addon_upgrade_policy.schedule,
+                        schedule_type=addon_upgrade_policy.schedule_type,
+                        version=addon_upgrade_policy.version,
+                        state=addon_upgrade_policy.state,
+                        addon_service=addon_service,
+                    )
                 )
         elif spec.cluster.is_rosa_hypershift():
             upgrade_policies = get_control_plane_upgrade_policies(

--- a/reconcile/utils/ocm/base.py
+++ b/reconcile/utils/ocm/base.py
@@ -575,6 +575,17 @@ class OCMOIdentityProviderOidc(OCMOIdentityProvider):
         return self.name == other.name and self.open_id == other.open_id
 
 
+class OCMAddonUpgradePolicy(BaseModel):
+    id: str
+    addon_id: str
+    cluster_id: str
+    next_run: Optional[str]
+    schedule: Optional[str]
+    schedule_type: str
+    version: str
+    state: Optional[str]
+
+
 def build_label_container(
     *label_iterables: Optional[Iterable[OCMLabel]],
 ) -> LabelContainer:


### PR DESCRIPTION
an addon upgrade policy field name (`schedule_type`) in the new addon service is named differently compared to the previous version of the addon service.

instead of passing addon upgrade policy current state around as dicts, a dataclass has been introduced and the field name mismatches in the addon service versions are now contained in the implementation of the respective addon service access code.

part of https://issues.redhat.com/browse/APPSRE-10137