### PR TITLE
[APPSRE-10198] Use generateName instead of timestamp to create a unique PipelineRun name

### DIFF
--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 from collections.abc import Callable
 from threading import Lock
@@ -356,11 +355,7 @@ def _construct_tekton_trigger_resource(
     tkn_name, tkn_long_name = SaasHerder.build_saas_file_env_combo(
         saas_file_name, env_name
     )
-    # using a timestamp to make the resource name unique.
-    # we may want to revisit traceability, but this is compatible
-    # with what we currently have in Jenkins.
-    ts = datetime.datetime.utcnow().strftime("%Y%m%d%H%M")  # len 12
-    name = f"{tkn_name.lower()}-{ts}"
+    name = tkn_name.lower()
 
     parameters = [
         {"name": "saas_file_name", "value": saas_file_name},
@@ -381,7 +376,7 @@ def _construct_tekton_trigger_resource(
     body: dict[str, Any] = {
         "apiVersion": "tekton.dev/v1",
         "kind": "PipelineRun",
-        "metadata": {"name": name},
+        "metadata": {"generateName": f"{name}-"},
         "spec": {
             "pipelineRef": {"name": tkn_pipeline_name},
             "params": parameters,

--- a/reconcile/test/test_openshift_saas_deploy.py
+++ b/reconcile/test/test_openshift_saas_deploy.py
@@ -15,6 +15,7 @@ from reconcile.utils import (
     openshift_resource,
     slack_api,
 )
+from reconcile.utils.saasherder.saasherder import UNIQUE_SAAS_FILE_ENV_COMBO_LEN
 
 
 @pytest.fixture
@@ -72,7 +73,7 @@ def test_compose_console_url_with_medium_saas_name(
 
     url = compose_console_url(saas_file, env_name)
 
-    expected_run_name = f"{saas_name}-{env_name}"[:50]
+    expected_run_name = f"{saas_name}-{env_name}"[:UNIQUE_SAAS_FILE_ENV_COMBO_LEN]
     assert (
         url == "https://console.url/k8s/ns/namespace_name/tekton.dev~v1beta1~Pipeline/"
         "o-saas-deploy-saas-openshift-cert-manager-routes/"

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -51,6 +51,7 @@ from reconcile.utils.jump_host import (
 )
 from reconcile.utils.metrics import reconcile_time
 from reconcile.utils.oc_connection_parameters import OCConnectionParameters
+from reconcile.utils.openshift_resource import OpenshiftResource as OR
 from reconcile.utils.secret_reader import (
     SecretNotFound,
     SecretReader,
@@ -162,17 +163,10 @@ class OCDecorators:
             time_spent = time.time() - commit_time
 
             try:
-                resource_kind = msg.resource["kind"]
-                # PipelineRun name can be empty when creating
-                if (
-                    resource_kind == "PipelineRun"
-                    and "name" not in msg.resource["metadata"]
-                ):
-                    resource_name = msg.resource["metadata"]["generateName"][:-1]
-                else:
-                    resource_name = msg.resource["metadata"]["name"]
-                annotations = msg.resource["metadata"].get("annotations", {})
-            except KeyError as e:
+                resource_kind = msg.resource.kind
+                resource_name = msg.resource.name
+                annotations = msg.resource.annotations
+            except Exception as e:
                 logging.warning(f"Error processing metric: {e}")
                 return result
 
@@ -211,11 +205,11 @@ class OCDecorators:
 class OCProcessReconcileTimeDecoratorMsg:
     def __init__(
         self,
-        namespace,
-        resource,
-        server,
-        slow_oc_reconcile_threshold,
-        is_log_slow_oc_reconcile,
+        namespace: str,
+        resource: OR,
+        server: Optional[str],
+        slow_oc_reconcile_threshold: float,
+        is_log_slow_oc_reconcile: bool,
     ):
         self.namespace = namespace
         self.resource = resource
@@ -530,7 +524,7 @@ class OCCli:  # pylint: disable=too-many-public-methods
         ]
         self._run(cmd)
 
-    def _msg_to_process_reconcile_time(self, namespace, resource):
+    def _msg_to_process_reconcile_time(self, namespace: str, resource: OR):
         return OCProcessReconcileTimeDecoratorMsg(
             namespace=namespace,
             resource=resource,
@@ -557,25 +551,25 @@ class OCCli:  # pylint: disable=too-many-public-methods
     def apply(self, namespace, resource):
         cmd = ["apply", "-n", namespace, "-f", "-"]
         self._run(cmd, stdin=resource.toJSON(), apply=True)
-        return self._msg_to_process_reconcile_time(namespace, resource.body)
+        return self._msg_to_process_reconcile_time(namespace, resource)
 
     @OCDecorators.process_reconcile_time
     def create(self, namespace, resource):
         cmd = ["create", "-n", namespace, "-f", "-"]
         self._run(cmd, stdin=resource.toJSON(), apply=True)
-        return self._msg_to_process_reconcile_time(namespace, resource.body)
+        return self._msg_to_process_reconcile_time(namespace, resource)
 
     @OCDecorators.process_reconcile_time
     def replace(self, namespace, resource):
         cmd = ["replace", "-n", namespace, "-f", "-"]
         self._run(cmd, stdin=resource.toJSON(), apply=True)
-        return self._msg_to_process_reconcile_time(namespace, resource.body)
+        return self._msg_to_process_reconcile_time(namespace, resource)
 
     @OCDecorators.process_reconcile_time
     def patch(self, namespace, kind, name, patch):
         cmd = ["patch", "-n", namespace, kind, name, "-p", json.dumps(patch)]
         self._run(cmd)
-        resource = {"kind": kind, "metadata": {"name": name}}
+        resource = OR({"kind": kind, "metadata": {"name": name}}, "", "")
         return self._msg_to_process_reconcile_time(namespace, resource)
 
     @OCDecorators.process_reconcile_time

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -163,7 +163,14 @@ class OCDecorators:
 
             try:
                 resource_kind = msg.resource["kind"]
-                resource_name = msg.resource["metadata"]["name"]
+                # PipelineRun name can be empty when creating
+                if (
+                    resource_kind == "PipelineRun"
+                    and "name" not in msg.resource["metadata"]
+                ):
+                    resource_name = msg.resource["metadata"]["generateName"][:-1]
+                else:
+                    resource_name = msg.resource["metadata"]["name"]
                 annotations = msg.resource["metadata"].get("annotations", {})
             except KeyError as e:
                 logging.warning(f"Error processing metric: {e}")

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -214,7 +214,11 @@ class OpenshiftResource:
 
     @property
     def name(self):
-        return self.body["metadata"]["name"]
+        # PipelineRun name can be empty when creating
+        if self.kind == "PipelineRun" and "name" not in self.body["metadata"]:
+            return self.body["metadata"]["generateName"][:-1]
+        else:
+            return self.body["metadata"]["name"]
 
     @property
     def kind(self):

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -225,6 +225,10 @@ class OpenshiftResource:
         return self.body["kind"]
 
     @property
+    def annotations(self):
+        return self.body["metadata"].get("annotations", {})
+
+    @property
     def kind_and_group(self):
         return fully_qualified_kind(self.kind, self.body["apiVersion"])
 

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -93,7 +93,7 @@ from reconcile.utils.state import State
 TARGET_CONFIG_HASH = "target_config_hash"
 
 
-UNIQUE_SAAS_FILE_ENV_COMBO_LEN = 50
+UNIQUE_SAAS_FILE_ENV_COMBO_LEN = 56
 
 
 def is_commit_sha(ref: str) -> bool:
@@ -491,7 +491,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         """
         Build a tuple of short and long names for a saas file and environment combo,
         max tekton pipelinerun name length can be 63,
-        leaving 12 for the timestamp leaves us with 51 to create a unique pipelinerun name.
+        leaving 7 for the rerun leaves us with 56 to create a unique pipelinerun name.
 
         :param saas_file_name: name of the saas file
         :param env_name: name of the environment


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-10198

Use generateName instead of timestamp to create a unique PipelineRun name. https://ibm.github.io/tekton-tutorial-openshift/lab1/6_create-pipeline-run/. And fix PipelineRun name too long to retrigger issue.

`
admission webhook "validation.webhook.pipeline.tekton.dev" denied the request: validation failed: Invalid resource name: length must be no more than 63 characters: metadata.name
`

