### PR TITLE
fix test warnings

### DIFF
--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -850,8 +850,8 @@ def is_gate_applicable_to_cluster(gate: OCMVersionGate, cluster: OCMCluster) -> 
     # consider only gates after the clusters current minor version
     # OCM onls supports creating gate agreements for later minor versions than the
     # current cluster version
-    if not semver.match(
-        f"{cluster.minor_version()}.0", f"<{gate.version_raw_id_prefix}.0"
+    if not parse_semver(f"{cluster.minor_version()}.0").match(
+        f"<{gate.version_raw_id_prefix}.0"
     ):
         return False
 

--- a/reconcile/sql_query.py
+++ b/reconcile/sql_query.py
@@ -15,7 +15,6 @@ from typing import (
 )
 
 import jinja2
-from ruamel import yaml
 
 from reconcile import (
     openshift_base,
@@ -34,6 +33,7 @@ from reconcile.utils.openshift_resource import (
     OpenshiftResource,
     ResourceInventory,
 )
+from reconcile.utils.ruamel import create_ruamel_instance
 from reconcile.utils.secret_reader import SecretReader
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.smtp_client import (
@@ -591,6 +591,7 @@ def _build_openshift_resources(
     query_name = query["name"]
     common_resource_labels = _build_common_resource_labels(query)
     openshift_resources: list[OpenshiftResource] = []
+    yml = create_ruamel_instance()
     if pull_secret:
         labels = pull_secret["labels"] or {}
         labels.update(common_resource_labels)
@@ -651,7 +652,7 @@ def _build_openshift_resources(
     )
     openshift_resources.append(
         OpenshiftResource(
-            body=yaml.safe_load(job_yaml),
+            body=yml.load(job_yaml),
             integration=QONTRACT_INTEGRATION,
             integration_version=QONTRACT_INTEGRATION_VERSION,
         )

--- a/reconcile/test/test_ocm_machine_pools.py
+++ b/reconcile/test/test_ocm_machine_pools.py
@@ -32,7 +32,7 @@ from reconcile.ocm_machine_pools import (
 from reconcile.utils.ocm import OCM
 
 
-class TestPool(AbstractPool):
+class TstPool(AbstractPool):
     created = False
     deleted = False
     updated = False
@@ -57,8 +57,8 @@ class TestPool(AbstractPool):
 
 
 @pytest.fixture
-def test_pool() -> TestPool:
-    return TestPool(
+def test_pool() -> TstPool:
+    return TstPool(
         id="pool1",
         replicas=2,
         labels=None,
@@ -133,7 +133,7 @@ def ocm_mock():
 
 
 def test_diff__has_diff_autoscale(cluster_machine_pool: ClusterMachinePoolV1):
-    pool = TestPool(id="pool1", cluster="cluster1", cluster_type=ClusterType.OSD)
+    pool = TstPool(id="pool1", cluster="cluster1", cluster_type=ClusterType.OSD)
 
     assert cluster_machine_pool.autoscale is None
     assert not pool._has_diff_autoscale(cluster_machine_pool)

--- a/reconcile/test/test_ocm_machine_pools.py
+++ b/reconcile/test/test_ocm_machine_pools.py
@@ -32,7 +32,7 @@ from reconcile.ocm_machine_pools import (
 from reconcile.utils.ocm import OCM
 
 
-class TstPool(AbstractPool):
+class PoolStub(AbstractPool):
     created = False
     deleted = False
     updated = False
@@ -57,8 +57,8 @@ class TstPool(AbstractPool):
 
 
 @pytest.fixture
-def test_pool() -> TstPool:
-    return TstPool(
+def test_pool() -> PoolStub:
+    return PoolStub(
         id="pool1",
         replicas=2,
         labels=None,
@@ -133,7 +133,7 @@ def ocm_mock():
 
 
 def test_diff__has_diff_autoscale(cluster_machine_pool: ClusterMachinePoolV1):
-    pool = TstPool(id="pool1", cluster="cluster1", cluster_type=ClusterType.OSD)
+    pool = PoolStub(id="pool1", cluster="cluster1", cluster_type=ClusterType.OSD)
 
     assert cluster_machine_pool.autoscale is None
     assert not pool._has_diff_autoscale(cluster_machine_pool)

--- a/reconcile/test/test_status_board.py
+++ b/reconcile/test/test_status_board.py
@@ -18,7 +18,7 @@ from reconcile.status_board import (
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
-class TstStatusBoard(AbstractStatusBoard):
+class StatusBoardStub(AbstractStatusBoard):
     created: Optional[bool] = False
     deleted: Optional[bool] = False
     summarized: Optional[bool] = False
@@ -99,21 +99,21 @@ def test_status_board_handler(mocker: MockerFixture) -> None:
     ocm = mocker.patch("reconcile.status_board.OCMBaseClient")
     h = StatusBoardHandler(
         action="create",
-        status_board_object=TstStatusBoard(name="foo", fullname="foo"),
+        status_board_object=StatusBoardStub(name="foo", fullname="foo"),
     )
 
     h.act(dry_run=False, ocm=ocm)
-    assert isinstance(h.status_board_object, TstStatusBoard)
+    assert isinstance(h.status_board_object, StatusBoardStub)
     assert h.status_board_object.created
     assert h.status_board_object.summarized
 
     h = StatusBoardHandler(
         action="delete",
-        status_board_object=TstStatusBoard(name="foo", fullname="foo"),
+        status_board_object=StatusBoardStub(name="foo", fullname="foo"),
     )
 
     h.act(dry_run=False, ocm=ocm)
-    assert isinstance(h.status_board_object, TstStatusBoard)
+    assert isinstance(h.status_board_object, StatusBoardStub)
     assert h.status_board_object.deleted
     assert h.status_board_object.summarized
 

--- a/reconcile/test/test_status_board.py
+++ b/reconcile/test/test_status_board.py
@@ -18,7 +18,7 @@ from reconcile.status_board import (
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
-class TestStatusBoard(AbstractStatusBoard):
+class TstStatusBoard(AbstractStatusBoard):
     created: Optional[bool] = False
     deleted: Optional[bool] = False
     summarized: Optional[bool] = False
@@ -99,21 +99,21 @@ def test_status_board_handler(mocker: MockerFixture) -> None:
     ocm = mocker.patch("reconcile.status_board.OCMBaseClient")
     h = StatusBoardHandler(
         action="create",
-        status_board_object=TestStatusBoard(name="foo", fullname="foo"),
+        status_board_object=TstStatusBoard(name="foo", fullname="foo"),
     )
 
     h.act(dry_run=False, ocm=ocm)
-    assert isinstance(h.status_board_object, TestStatusBoard)
+    assert isinstance(h.status_board_object, TstStatusBoard)
     assert h.status_board_object.created
     assert h.status_board_object.summarized
 
     h = StatusBoardHandler(
         action="delete",
-        status_board_object=TestStatusBoard(name="foo", fullname="foo"),
+        status_board_object=TstStatusBoard(name="foo", fullname="foo"),
     )
 
     h.act(dry_run=False, ocm=ocm)
-    assert isinstance(h.status_board_object, TestStatusBoard)
+    assert isinstance(h.status_board_object, TstStatusBoard)
     assert h.status_board_object.deleted
     assert h.status_board_object.summarized
 

--- a/reconcile/test/utils/merge_request_manager/conftest.py
+++ b/reconcile/test/utils/merge_request_manager/conftest.py
@@ -41,7 +41,7 @@ def compiled_regexes(version_ref: str, data_ref1: str) -> dict[str, re.Pattern]:
     }
 
 
-class TestModel(BaseModel):
+class TstModel(BaseModel):
     data_ref1: str
 
 
@@ -50,8 +50,8 @@ def parser(
     compiled_regexes: dict[str, re.Pattern],
     version_ref: str,
 ) -> Parser:
-    return Parser[TestModel](
-        klass=TestModel,
+    return Parser[TstModel](
+        klass=TstModel,
         compiled_regexes=compiled_regexes,
         version_ref=version_ref,
         expected_version="1.0.0",

--- a/reconcile/test/utils/merge_request_manager/conftest.py
+++ b/reconcile/test/utils/merge_request_manager/conftest.py
@@ -41,7 +41,7 @@ def compiled_regexes(version_ref: str, data_ref1: str) -> dict[str, re.Pattern]:
     }
 
 
-class TstModel(BaseModel):
+class ModelStub(BaseModel):
     data_ref1: str
 
 
@@ -50,8 +50,8 @@ def parser(
     compiled_regexes: dict[str, re.Pattern],
     version_ref: str,
 ) -> Parser:
-    return Parser[TstModel](
-        klass=TstModel,
+    return Parser[ModelStub](
+        klass=ModelStub,
         compiled_regexes=compiled_regexes,
         version_ref=version_ref,
         expected_version="1.0.0",

--- a/reconcile/test/utils/merge_request_manager/test_merge_request_manager_.py
+++ b/reconcile/test/utils/merge_request_manager/test_merge_request_manager_.py
@@ -19,11 +19,11 @@ def gitlab_cli(mocker: MockerFixture) -> GitLabApi:
     return mocker.MagicMock(GitLabApi)
 
 
-class TstData(BaseModel):
+class DataStub(BaseModel):
     data_ref1: str
 
 
-class TstMRManager(MergeRequestManagerBase[TstData]):
+class MRManagerStub(MergeRequestManagerBase[DataStub]):
     def __init__(self, vcs: VCS, parser: Parser, label: str):
         super().__init__(vcs, parser, label)
 
@@ -34,10 +34,10 @@ class TstMRManager(MergeRequestManagerBase[TstData]):
 @pytest.fixture
 def mergereqeustmanager(
     parser: Parser, mocker: MockerFixture
-) -> tuple[TstMRManager, Mock]:
+) -> tuple[MRManagerStub, Mock]:
     vcs = mocker.MagicMock(VCS)
 
-    return TstMRManager(vcs, parser, "foo"), vcs
+    return MRManagerStub(vcs, parser, "foo"), vcs
 
 
 @pytest.mark.parametrize(
@@ -80,7 +80,7 @@ def mergereqeustmanager(
 def test_housekeeping(
     attributes: dict,
     closed_reason: str,
-    mergereqeustmanager: tuple[TstMRManager, Mock],
+    mergereqeustmanager: tuple[MRManagerStub, Mock],
     mocker: MockerFixture,
 ) -> None:
     mrm, vcs = mergereqeustmanager
@@ -100,7 +100,7 @@ def test_housekeeping(
 
 
 def test_merge_request_manager_fetch_avs_managed_open_merge_requests(
-    mergereqeustmanager: tuple[TstMRManager, Mock],
+    mergereqeustmanager: tuple[MRManagerStub, Mock],
     mocker: MockerFixture,
 ) -> None:
     mrm, vcs = mergereqeustmanager

--- a/reconcile/test/utils/merge_request_manager/test_merge_request_manager_.py
+++ b/reconcile/test/utils/merge_request_manager/test_merge_request_manager_.py
@@ -19,11 +19,11 @@ def gitlab_cli(mocker: MockerFixture) -> GitLabApi:
     return mocker.MagicMock(GitLabApi)
 
 
-class TestData(BaseModel):
+class TstData(BaseModel):
     data_ref1: str
 
 
-class TestMRManager(MergeRequestManagerBase[TestData]):
+class TstMRManager(MergeRequestManagerBase[TstData]):
     def __init__(self, vcs: VCS, parser: Parser, label: str):
         super().__init__(vcs, parser, label)
 
@@ -34,10 +34,10 @@ class TestMRManager(MergeRequestManagerBase[TestData]):
 @pytest.fixture
 def mergereqeustmanager(
     parser: Parser, mocker: MockerFixture
-) -> tuple[TestMRManager, Mock]:
+) -> tuple[TstMRManager, Mock]:
     vcs = mocker.MagicMock(VCS)
 
-    return TestMRManager(vcs, parser, "foo"), vcs
+    return TstMRManager(vcs, parser, "foo"), vcs
 
 
 @pytest.mark.parametrize(
@@ -80,7 +80,7 @@ def mergereqeustmanager(
 def test_housekeeping(
     attributes: dict,
     closed_reason: str,
-    mergereqeustmanager: tuple[TestMRManager, Mock],
+    mergereqeustmanager: tuple[TstMRManager, Mock],
     mocker: MockerFixture,
 ) -> None:
     mrm, vcs = mergereqeustmanager
@@ -100,7 +100,7 @@ def test_housekeeping(
 
 
 def test_merge_request_manager_fetch_avs_managed_open_merge_requests(
-    mergereqeustmanager: tuple[TestMRManager, Mock],
+    mergereqeustmanager: tuple[TstMRManager, Mock],
     mocker: MockerFixture,
 ) -> None:
     mrm, vcs = mergereqeustmanager

--- a/reconcile/test/utils/merge_request_manager/test_parser.py
+++ b/reconcile/test/utils/merge_request_manager/test_parser.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from reconcile.test.utils.merge_request_manager.conftest import TestModel
+from reconcile.test.utils.merge_request_manager.conftest import TstModel
 from reconcile.utils.merge_request_manager.parser import (
     Parser,
     ParserError,
@@ -13,7 +13,7 @@ from reconcile.utils.merge_request_manager.parser import (
 def test_paser_pass(parser: Parser, description: str) -> None:
     result = parser.parse(description)
 
-    assert result == TestModel(data_ref1="data1")
+    assert result == TstModel(data_ref1="data1")
 
 
 def test_parser_fail_missing_version(parser: Parser) -> None:

--- a/reconcile/test/utils/merge_request_manager/test_parser.py
+++ b/reconcile/test/utils/merge_request_manager/test_parser.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from reconcile.test.utils.merge_request_manager.conftest import TstModel
+from reconcile.test.utils.merge_request_manager.conftest import ModelStub
 from reconcile.utils.merge_request_manager.parser import (
     Parser,
     ParserError,
@@ -13,7 +13,7 @@ from reconcile.utils.merge_request_manager.parser import (
 def test_paser_pass(parser: Parser, description: str) -> None:
     result = parser.parse(description)
 
-    assert result == TstModel(data_ref1="data1")
+    assert result == ModelStub(data_ref1="data1")
 
 
 def test_parser_fail_missing_version(parser: Parser) -> None:

--- a/reconcile/utils/ocm/base.py
+++ b/reconcile/utils/ocm/base.py
@@ -8,13 +8,13 @@ from typing import (
     TypeVar,
 )
 
-import semver
 from pydantic import (
     BaseModel,
     Field,
 )
 
 from reconcile.utils.aws_helper import get_account_uid_from_arn, get_role_name_from_arn
+from reconcile.utils.semver_helper import parse_semver
 
 LabelSetTypeVar = TypeVar("LabelSetTypeVar", bound=BaseModel)
 ACTIVE_SUBSCRIPTION_STATES = {"Active", "Reserved"}
@@ -246,8 +246,8 @@ class OCMCluster(BaseModel):
     external_configuration: Optional[OCMExternalConfiguration]
 
     def minor_version(self) -> str:
-        version_info = semver.parse(self.version.raw_id)
-        return f"{version_info['major']}.{version_info['minor']}"
+        version_info = parse_semver(self.version.raw_id)
+        return f"{version_info.major}.{version_info.minor}"
 
     def available_upgrades(self) -> list[str]:
         return self.version.available_upgrades


### PR DESCRIPTION
**:white_check_mark: rename wrongly named test classes**

`pytest` uses `Test` as a pattern to discover tests. <- @janboll, @geoberle 

**:coffin: sql-query: fix deprecation warning**
