### PR TITLE
:white_check_mark: replace httpretty with pytest-httpserver

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -335,7 +335,6 @@ module = [
     "reconcile.test.utils.test_quay_api",
     "reconcile.test.utils.test_semver_helper",
     "reconcile.test.utils.test_sharding",
-    "reconcile.test.utils.test_slack_api",
     "reconcile.test.utils.test_smtp_client",
     "reconcile.test.utils.test_terraform_client",
     "reconcile.test.utils.test_terraform_config_client",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -377,6 +377,7 @@ module = [
     "prometheus_client.*",
     "pygments.*",
     "pypd.*",
+    "pytest_httpserver.*",
     "pytest_mock.*",
     "pytest.*",
     "python_terraform.*",
@@ -391,5 +392,6 @@ module = [
     "testslide.*",
     "UnleashClient.*",
     "urllib3.*",
+    "werkzeug.*",
 ]
 ignore_missing_imports = true

--- a/reconcile/test/aws_saml_idp/test_aws_saml_idp_integration.py
+++ b/reconcile/test/aws_saml_idp/test_aws_saml_idp_integration.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 
-import httpretty as _httpretty
+from pytest_httpserver import HTTPServer
 
 from reconcile.aws_saml_idp.integration import AwsSamlIdpIntegration, SamlIdpConfig
 from reconcile.gql_definitions.aws_saml_idp.aws_accounts import AWSAccountV1
@@ -78,8 +78,10 @@ def test_aws_saml_idp_build_saml_idp_config(
 
 
 def test_aws_saml_idp_get_saml_metadata(
-    intg: AwsSamlIdpIntegration, httpretty: _httpretty
+    intg: AwsSamlIdpIntegration, httpserver: HTTPServer
 ) -> None:
-    url = "https://saml-metadata-url.example.com/metadata.xml"
-    httpretty.register_uri("GET", url, body="metadata")
-    assert intg.get_saml_metadata(saml_metadata_url=url) == "metadata"
+    httpserver.expect_request("/metadata.xml").respond_with_data("metadata")
+    assert (
+        intg.get_saml_metadata(saml_metadata_url=httpserver.url_for("/metadata.xml"))
+        == "metadata"
+    )

--- a/reconcile/test/conftest.py
+++ b/reconcile/test/conftest.py
@@ -154,25 +154,6 @@ def gql_api_builder() -> Callable[[Optional[Mapping]], GqlApi]:
 
 
 @pytest.fixture
-def set_httpretty_responses_based_on_fixture(httpretty: _httpretty) -> Callable:
-    """Create httpretty responses based fixture files."""
-
-    def _(url: str, fx: Fixtures, paths: Iterable[str]) -> None:
-        for path in paths:
-            for method in ["get", "post", "put", "patch", "delete"]:
-                method_file = Path(fx.path(path)) / f"{method}.json"
-                if method_file.exists():
-                    httpretty.register_uri(
-                        getattr(httpretty, method.upper()),
-                        f"{url}/{path}",
-                        body=method_file.read_text(),
-                        content_type="text/json",
-                    )
-
-    return _
-
-
-@pytest.fixture
 def set_httpserver_responses_based_on_fixture(httpserver: HTTPServer) -> Callable:
     """Create httpserver responses based fixture files."""
 

--- a/reconcile/test/conftest.py
+++ b/reconcile/test/conftest.py
@@ -12,7 +12,6 @@ from typing import (
 )
 from unittest.mock import create_autospec
 
-import httpretty as _httpretty
 import pytest
 from pydantic import BaseModel
 from pydantic.error_wrappers import ValidationError
@@ -28,13 +27,6 @@ from reconcile.utils.state import State
 @pytest.fixture
 def patch_sleep(mocker):
     yield mocker.patch.object(time, "sleep")
-
-
-@pytest.fixture()
-def httpretty():
-    with _httpretty.enabled(allow_net_connect=False):
-        _httpretty.reset()
-        yield _httpretty
 
 
 @pytest.fixture

--- a/reconcile/test/fixtures/glitchtip/reconciler/projects/no_current_projects.yml
+++ b/reconcile/test/fixtures/glitchtip/reconciler/projects/no_current_projects.yml
@@ -43,14 +43,6 @@ desired_projects:
         users: []
 
 expected_return_value:
-  - name: rosetta-flight-control
-    id: 10
-    platform: python
-    slug: rosetta-flight-control
-    teams:
-      - id: 7
-        slug: esa-flight-control
-        users: []
   - name: rosetta-spacecraft
     id: 9
     platform: python
@@ -61,6 +53,14 @@ expected_return_value:
         users: []
       - id: 6
         slug: esa-pilots
+        users: []
+  - name: rosetta-flight-control
+    id: 10
+    platform: python
+    slug: rosetta-flight-control
+    teams:
+      - id: 7
+        slug: esa-flight-control
         users: []
 
 glitchtip_urls:

--- a/reconcile/test/fixtures/glitchtip/reconciler/teams/mixed.yml
+++ b/reconcile/test/fixtures/glitchtip/reconciler/teams/mixed.yml
@@ -78,7 +78,8 @@ glitchtip_urls:
       - id: 6
         slug: esa-pilots
   - name: "team users"
-    uri: /api/0/teams/esa/esa-pilots/members/?limit=100"
+    uri: /api/0/teams/esa/esa-pilots/members/
+    query: limit=100
     method: get
     responses:
       - - email: SamanthaCristoforetti@nasa.com
@@ -98,7 +99,8 @@ glitchtip_urls:
       - id: 7
         slug: esa-flight-control
   - name: "team users"
-    uri: /api/0/teams/esa/esa-flight-control/members/?limit=100"
+    uri: /api/0/teams/esa/esa-flight-control/members/
+    query: limit=100
     method: get
     responses:
       - - email: TimPeake@nasa.com

--- a/reconcile/test/fixtures/glitchtip/reconciler/teams/no_current_teams.yml
+++ b/reconcile/test/fixtures/glitchtip/reconciler/teams/no_current_teams.yml
@@ -35,19 +35,19 @@ desired_teams:
         role: member
 
 expected_return_value:
-  - id: 7
-    slug: esa-flight-control
-    users:
-      - email: TimPeake@nasa.com
-        pending: false
-        id: 26
-        role: member
   - id: 6
     slug: esa-pilots
     users:
       - email: SamanthaCristoforetti@nasa.com
         pending: false
         id: 24
+        role: member
+  - id: 7
+    slug: esa-flight-control
+    users:
+      - email: TimPeake@nasa.com
+        pending: false
+        id: 26
         role: member
 
 glitchtip_urls:
@@ -71,7 +71,8 @@ glitchtip_urls:
       - id: 6
         slug: esa-pilots
   - name: "team users"
-    uri: /api/0/teams/esa/esa-pilots/members/?limit=100"
+    uri: /api/0/teams/esa/esa-pilots/members/
+    query: limit=100
     method: get
     responses:
       - - email: SamanthaCristoforetti@nasa.com
@@ -86,7 +87,8 @@ glitchtip_urls:
       - id: 7
         slug: esa-flight-control
   - name: "team users"
-    uri: /api/0/teams/esa/esa-flight-control/members/?limit=100"
+    uri: /api/0/teams/esa/esa-flight-control/members/
+    query: limit=100
     method: get
     responses:
       - - email: TimPeake@nasa.com

--- a/reconcile/test/glitchtip/conftest.py
+++ b/reconcile/test/glitchtip/conftest.py
@@ -3,6 +3,7 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
+from pytest_httpserver import HTTPServer
 from pytest_mock import MockerFixture
 
 from reconcile.test.fixtures import Fixtures
@@ -14,8 +15,8 @@ from reconcile.utils.rest_api_base import BearerTokenAuth
 
 
 @pytest.fixture
-def glitchtip_url() -> str:
-    return "http://fake-glitchtip-server.com"
+def glitchtip_url(httpserver: HTTPServer) -> str:
+    return httpserver.url_for("")
 
 
 @pytest.fixture
@@ -45,45 +46,44 @@ def fx() -> Fixtures:
 
 @pytest.fixture
 def glitchtip_server_full_api_response(
-    set_httpretty_responses_based_on_fixture: Callable, glitchtip_url: str, fx: Fixtures
+    set_httpserver_responses_based_on_fixture: Callable, fx: Fixtures
 ) -> None:
     """Text fixture.
 
     See reconcile/glitchtip/README.md for more details.
     """
-    set_httpretty_responses_based_on_fixture(
-        url=glitchtip_url,
+    set_httpserver_responses_based_on_fixture(
         fx=fx,
         paths=[
-            "api/0/organizations/",
-            "api/0/organizations/esa/",
-            "api/0/organizations/esa/teams/",
-            "api/0/organizations/nasa/teams/",
-            "api/0/organizations/esa/projects/",
-            "api/0/organizations/nasa/projects/",
-            "api/0/organizations/esa/members/",
-            "api/0/organizations/nasa/members/",
-            "api/0/organizations/nasa/members/29/",
-            "api/0/organizations/nasa/members/29/teams/nasa-pilots/",
-            "api/0/projects/nasa/science-tools/teams/nasa-flight-control/",
-            "api/0/projects/nasa/science-tools/",
-            "api/0/teams/esa/esa-pilots/",
-            "api/0/teams/esa/esa-pilots/members/",
-            "api/0/teams/esa/esa-flight-control/members/",
-            "api/0/teams/nasa/nasa-pilots/members/",
-            "api/0/teams/nasa/nasa-pilots/projects/",
-            "api/0/teams/nasa/nasa-flight-control/members/",
+            "/api/0/organizations/",
+            "/api/0/organizations/esa/",
+            "/api/0/organizations/esa/teams/",
+            "/api/0/organizations/nasa/teams/",
+            "/api/0/organizations/esa/projects/",
+            "/api/0/organizations/nasa/projects/",
+            "/api/0/organizations/esa/members/",
+            "/api/0/organizations/nasa/members/",
+            "/api/0/organizations/nasa/members/29/",
+            "/api/0/organizations/nasa/members/29/teams/nasa-pilots/",
+            "/api/0/projects/nasa/science-tools/teams/nasa-flight-control/",
+            "/api/0/projects/nasa/science-tools/",
+            "/api/0/teams/esa/esa-pilots/",
+            "/api/0/teams/esa/esa-pilots/members/",
+            "/api/0/teams/esa/esa-flight-control/members/",
+            "/api/0/teams/nasa/nasa-pilots/members/",
+            "/api/0/teams/nasa/nasa-pilots/projects/",
+            "/api/0/teams/nasa/nasa-flight-control/members/",
             # glitchtip-project-dsn
-            "api/0/projects/nasa/apollo-11-flight-control/keys/",
-            "api/0/projects/empty-org/project-does-not-exist-yet/keys/",
-            "api/0/organizations/empty-org/projects/",
+            "/api/0/projects/nasa/apollo-11-flight-control/keys/",
+            "/api/0/projects/empty-org/project-does-not-exist-yet/keys/",
+            "/api/0/organizations/empty-org/projects/",
             # project-alerts
-            "api/0/projects/nasa/science-tools/alerts/",
-            "api/0/projects/nasa/science-tools/alerts/1/",
-            "api/0/projects/esa/rosetta-flight-control/alerts/",
-            "api/0/projects/esa/rosetta-spacecraft/alerts/",
-            "api/0/projects/nasa/apollo-11-flight-control/alerts/",
-            "api/0/projects/nasa/apollo-11-spacecraft/alerts/",
+            "/api/0/projects/nasa/science-tools/alerts/",
+            "/api/0/projects/nasa/science-tools/alerts/1/",
+            "/api/0/projects/esa/rosetta-flight-control/alerts/",
+            "/api/0/projects/esa/rosetta-spacecraft/alerts/",
+            "/api/0/projects/nasa/apollo-11-flight-control/alerts/",
+            "/api/0/projects/nasa/apollo-11-spacecraft/alerts/",
         ],
     )
 

--- a/reconcile/test/glitchtip/test_glitchtip.py
+++ b/reconcile/test/glitchtip/test_glitchtip.py
@@ -19,7 +19,6 @@ from reconcile.utils.internal_groups.models import (
 
 def test_fetch_current_state(
     glitchtip_client: GlitchtipClient,
-    glitchtip_server_full_api_response: None,
     fx: Fixtures,
 ) -> None:
     current_state = fetch_current_state(

--- a/reconcile/test/ocm/test_utils_ocm_base.py
+++ b/reconcile/test/ocm/test_utils_ocm_base.py
@@ -1,7 +1,7 @@
 from typing import Callable
 
 import pytest
-from httpretty.core import HTTPrettyRequest
+from werkzeug import Request
 
 from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.test.ocm.test_utils_ocm_get_json import build_paged_ocm_response
@@ -26,18 +26,21 @@ def test_get_json_pagination(
     nr_of_items: int,
     page_size: int,
     ocm_api: OCMBaseClient,
-    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_all_ocm_http_requests: Callable[[str, str], list[HTTPrettyRequest]],
+    register_ocm_url_responses: Callable[[list[OcmUrl], int], int],
+    find_all_ocm_http_requests: Callable[[str, str], list[Request]],
 ) -> None:
-    register_ocm_url_responses([
-        OcmUrl(
-            method="GET",
-            uri="/api",
-            responses=build_paged_ocm_response(
-                nr_of_items=nr_of_items, page_size=page_size
-            ),
-        )
-    ])
+    register_ocm_url_responses(
+        [
+            OcmUrl(
+                method="GET",
+                uri="/api",
+                responses=build_paged_ocm_response(
+                    nr_of_items=nr_of_items, page_size=page_size
+                ),
+            )
+        ],
+        page_size,
+    )
 
     resp = list(ocm_api.get_paginated("/api", max_page_size=page_size))
 
@@ -50,21 +53,24 @@ def test_get_json_pagination(
 
 def test_get_json_pagination_max_pages(
     ocm_api: OCMBaseClient,
-    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_all_ocm_http_requests: Callable[[str, str], list[HTTPrettyRequest]],
+    register_ocm_url_responses: Callable[[list[OcmUrl], int], int],
+    find_all_ocm_http_requests: Callable[[str, str], list[Request]],
 ) -> None:
     nr_of_items = 10
     page_size = 3
     max_pages = 2
-    register_ocm_url_responses([
-        OcmUrl(
-            method="GET",
-            uri="/api",
-            responses=build_paged_ocm_response(
-                nr_of_items=nr_of_items, page_size=page_size
-            ),
-        )
-    ])
+    register_ocm_url_responses(
+        [
+            OcmUrl(
+                method="GET",
+                uri="/api",
+                responses=build_paged_ocm_response(
+                    nr_of_items=nr_of_items, page_size=page_size
+                ),
+            )
+        ],
+        page_size,
+    )
     resp = list(
         ocm_api.get_paginated("/api", max_page_size=page_size, max_pages=max_pages)
     )

--- a/reconcile/test/ocm/test_utils_ocm_clusters.py
+++ b/reconcile/test/ocm/test_utils_ocm_clusters.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from typing import Optional
 
+from pytest_httpserver import HTTPServer
 from pytest_mock import (
     MockerFixture,
     MockFixture,
@@ -192,6 +193,7 @@ def test_get_clusters_for_subscriptions(
     mocker: MockerFixture,
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
+    httpserver: HTTPServer,
 ) -> None:
     """
     Tests the subscription and organization labels are properly queried
@@ -214,6 +216,8 @@ def test_get_clusters_for_subscriptions(
         build_organization_label("org_label", "value", "another_org_id"),
     ])
 
+    # clear default /api/clusters_mgmt/v1/clusters request handler
+    httpserver.clear_all_handlers()
     register_ocm_url_responses([
         OcmUrl(method="GET", uri="/api/clusters_mgmt/v1/clusters").add_list_response([
             build_ocm_cluster(

--- a/reconcile/test/ocm/test_utils_ocm_get_json.py
+++ b/reconcile/test/ocm/test_utils_ocm_get_json.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 import pytest
-from httpretty.core import HTTPrettyRequest
+from werkzeug import Request
 
 from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.utils.ocm import OCM
@@ -39,18 +39,21 @@ def test_get_json_pagination(
     nr_of_items: int,
     page_size: int,
     ocm: OCM,
-    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_all_ocm_http_requests: Callable[[str, str], list[HTTPrettyRequest]],
+    register_ocm_url_responses: Callable[[list[OcmUrl], int], int],
+    find_all_ocm_http_requests: Callable[[str, str], list[Request]],
 ) -> None:
-    register_ocm_url_responses([
-        OcmUrl(
-            method="GET",
-            uri="/api",
-            responses=build_paged_ocm_response(
-                nr_of_items=nr_of_items, page_size=page_size
-            ),
-        )
-    ])
+    register_ocm_url_responses(
+        [
+            OcmUrl(
+                method="GET",
+                uri="/api",
+                responses=build_paged_ocm_response(
+                    nr_of_items=nr_of_items, page_size=page_size
+                ),
+            )
+        ],
+        page_size,
+    )
 
     resp = ocm._get_json("/api", page_size=page_size)
 
@@ -66,15 +69,18 @@ def test_get_json_pagination(
 
 def test_get_json_empty_list(
     ocm: OCM,
-    register_ocm_url_responses: Callable[[list[OcmUrl]], int],
+    register_ocm_url_responses: Callable[[list[OcmUrl], int], int],
 ) -> None:
-    register_ocm_url_responses([
-        OcmUrl(
-            method="GET",
-            uri="/api",
-            responses=build_paged_ocm_response(nr_of_items=0, page_size=10),
-        )
-    ])
+    register_ocm_url_responses(
+        [
+            OcmUrl(
+                method="GET",
+                uri="/api",
+                responses=build_paged_ocm_response(nr_of_items=0, page_size=10),
+            )
+        ],
+        10,
+    )
 
     resp = ocm._get_json("/api", page_size=10)
 

--- a/reconcile/test/ocm/test_utils_ocm_identity_providers.py
+++ b/reconcile/test/ocm/test_utils_ocm_identity_providers.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 
-from httpretty.core import HTTPrettyRequest
+from werkzeug import Request
 
 from reconcile.test.ocm.fixtures import (
     OcmUrl,
@@ -60,7 +60,7 @@ def test_utils_get_subscription_labels(
 def test_add_identity_provider(
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_all_ocm_http_requests: Callable[[str], list[HTTPrettyRequest]],
+    find_all_ocm_http_requests: Callable[[str], list[Request]],
 ) -> None:
     ocm_cluster = build_ocm_cluster("cluster")
     ocm_cluster.identity_providers.href = "/api/foobar"
@@ -75,7 +75,7 @@ def test_add_identity_provider(
 def test_update_identity_provider(
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_all_ocm_http_requests: Callable[[str], list[HTTPrettyRequest]],
+    find_all_ocm_http_requests: Callable[[str], list[Request]],
 ) -> None:
     register_ocm_url_responses([OcmUrl(method="PATCH", uri=IDP_OIDC.href)])
     update_identity_provider(ocm_api, IDP_OIDC)
@@ -86,7 +86,7 @@ def test_update_identity_provider(
 def test_delete_identity_provider(
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_all_ocm_http_requests: Callable[[str], list[HTTPrettyRequest]],
+    find_all_ocm_http_requests: Callable[[str], list[Request]],
 ) -> None:
     register_ocm_url_responses([OcmUrl(method="DELETE", uri=IDP_OTHER.href)])
     delete_identity_provider(ocm_api, IDP_OTHER)

--- a/reconcile/test/ocm/test_utils_ocm_labels.py
+++ b/reconcile/test/ocm/test_utils_ocm_labels.py
@@ -2,8 +2,8 @@ from collections.abc import Callable
 from typing import Optional
 
 import pytest
-from httpretty.core import HTTPrettyRequest
 from pytest_mock import MockerFixture
+from werkzeug import Request
 
 from reconcile.test.ocm.fixtures import (
     OcmUrl,
@@ -324,7 +324,7 @@ def build_cluster_details(
 def test_add_subscription_labels(
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_all_ocm_http_requests: Callable[[str], list[HTTPrettyRequest]],
+    find_all_ocm_http_requests: Callable[[str], list[Request]],
 ) -> None:
     cluster = build_cluster_details()
     cluster.ocm_cluster.subscription.href = "/api/foobar/sub"
@@ -342,7 +342,7 @@ def test_add_subscription_labels(
 def test_update_ocm_labels(
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_all_ocm_http_requests: Callable[[str], list[HTTPrettyRequest]],
+    find_all_ocm_http_requests: Callable[[str], list[Request]],
 ) -> None:
     cluster = build_cluster_details(subs_labels=[("label", "value")])
 
@@ -359,7 +359,7 @@ def test_update_ocm_labels(
 def test_delete_ocm_labels(
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_all_ocm_http_requests: Callable[[str], list[HTTPrettyRequest]],
+    find_all_ocm_http_requests: Callable[[str], list[Request]],
 ) -> None:
     cluster = build_cluster_details(subs_labels=[("label", "value")])
 

--- a/reconcile/test/ocm/test_utils_ocm_service_log.py
+++ b/reconcile/test/ocm/test_utils_ocm_service_log.py
@@ -7,8 +7,8 @@ from datetime import (
 from typing import Optional
 
 import pytest
-from httpretty.core import HTTPrettyRequest
 from pytest_mock import MockerFixture
+from werkzeug import Request
 
 from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.utils.ocm import service_log
@@ -75,7 +75,7 @@ def example_service_log(
 def test_get_service_logs_for_cluster_uuid(
     ocm_api: OCMBaseClient,
     example_service_log: OCMClusterServiceLog,
-    find_ocm_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
+    find_ocm_http_request: Callable[[str, str], Optional[Request]],
 ) -> None:
     cluster_uuid = "cluster_uuid"
     fetched_logs = list(
@@ -87,13 +87,13 @@ def test_get_service_logs_for_cluster_uuid(
     assert [example_service_log] == fetched_logs
     get_request = find_ocm_http_request("GET", CLUSTER_SERVICE_LOGS_LIST_ENDPOINT)
     assert get_request
-    assert get_request.querystring["cluster_uuid"] == [cluster_uuid]
+    assert get_request.args["cluster_uuid"] == cluster_uuid
 
 
 def test_get_service_logs_for_cluster_uuid_with_filter(
     ocm_api: OCMBaseClient,
     example_service_log: OCMClusterServiceLog,
-    find_ocm_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
+    find_ocm_http_request: Callable[[str, str], Optional[Request]],
 ) -> None:
     cluster_uuid = "cluster_uuid"
     service_filter = Filter().eq("service_name", "some-service")
@@ -107,14 +107,14 @@ def test_get_service_logs_for_cluster_uuid_with_filter(
     assert [example_service_log] == fetched_logs
     get_request = find_ocm_http_request("GET", CLUSTER_SERVICE_LOGS_LIST_ENDPOINT)
     assert get_request
-    assert get_request.querystring["cluster_uuid"] == [cluster_uuid]
-    assert get_request.querystring["search"] == [service_filter.render()]
+    assert get_request.args["cluster_uuid"] == cluster_uuid
+    assert get_request.args["search"] == service_filter.render()
 
 
 def test_create_service_log(
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_ocm_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
+    find_ocm_http_request: Callable[[str, str], Optional[Request]],
 ) -> None:
     timestamp = datetime(2020, 1, 2, 0, 0, 0, 0, tzinfo=timezone.utc)
     register_ocm_url_responses([
@@ -192,7 +192,7 @@ def test_create_service_log_dedup_timedelta_filter(
 def test_create_service_log_dedup(
     ocm_api: OCMBaseClient,
     example_service_log: OCMClusterServiceLog,
-    find_ocm_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
+    find_ocm_http_request: Callable[[str, str], Optional[Request]],
 ) -> None:
     create_service_log(
         ocm_api=ocm_api,
@@ -212,7 +212,7 @@ def test_create_service_log_dedup(
 def test_create_service_log_dedup_no_dup(
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_ocm_http_request: Callable[[str, str], Optional[HTTPrettyRequest]],
+    find_ocm_http_request: Callable[[str, str], Optional[Request]],
 ) -> None:
     register_ocm_url_responses([
         OcmUrl(

--- a/reconcile/test/ocm/test_utils_ocm_syncset.py
+++ b/reconcile/test/ocm/test_utils_ocm_syncset.py
@@ -1,8 +1,8 @@
 from collections.abc import Callable
 from typing import Any
 
-from httpretty.core import HTTPrettyRequest
 from pytest_mock import MockerFixture
+from werkzeug import Request
 
 from reconcile.test.ocm.fixtures import OcmUrl
 from reconcile.utils.ocm import syncsets
@@ -54,7 +54,7 @@ def test_utils_get_syncsets(
 def test_create_syncset(
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_all_ocm_http_requests: Callable[[str], list[HTTPrettyRequest]],
+    find_all_ocm_http_requests: Callable[[str], list[Request]],
 ) -> None:
     cluster_id = "123abc"
     syncset_id = "xyz"
@@ -74,7 +74,7 @@ def test_create_syncset(
 def test_patch_syncset(
     ocm_api: OCMBaseClient,
     register_ocm_url_responses: Callable[[list[OcmUrl]], int],
-    find_all_ocm_http_requests: Callable[[str], list[HTTPrettyRequest]],
+    find_all_ocm_http_requests: Callable[[str], list[Request]],
 ) -> None:
     cluster_id = "123abc"
     syncset_id = "xyz"

--- a/reconcile/test/test_deadmanssnitch.py
+++ b/reconcile/test/test_deadmanssnitch.py
@@ -20,7 +20,7 @@ from reconcile.utils.deadmanssnitch_api import (
 
 
 @pytest.fixture
-def deadmanssnitch_api() -> MockerFixture:
+def deadmanssnitch_api() -> MagicMock:
     return create_autospec(DeadMansSnitchApi)
 
 
@@ -55,7 +55,7 @@ def secret_reader(mocker: MockerFixture) -> MockerFixture:
 
 def test_get_current_state(
     secret_reader: MagicMock,
-    deadmanssnitch_api: MockerFixture,
+    deadmanssnitch_api: MagicMock,
     mocker: MockerFixture,
     deadmanssnitch_settings: DeadMansSnitchSettingsV1,
 ) -> None:

--- a/reconcile/test/utils/internal_groups/test_internal_groups_client.py
+++ b/reconcile/test/utils/internal_groups/test_internal_groups_client.py
@@ -1,5 +1,5 @@
-import httpretty as httpretty_module
 import pytest
+from pytest_httpserver import HTTPServer
 
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.internal_groups.client import (
@@ -11,13 +11,13 @@ from reconcile.utils.internal_groups.models import Group
 
 
 def test_internal_groups_api_create_group(
-    httpretty: httpretty_module, internal_groups_api: InternalGroupsApi, fx: Fixtures
+    httpserver: HTTPServer, internal_groups_api: InternalGroupsApi, fx: Fixtures
 ) -> None:
     assert internal_groups_api.create_group(data={"fake": "fake"}) == fx.get_json(
         "v1/groups/post.json"
     )
 
-    assert httpretty.last_request().body == b'{"fake": "fake"}'
+    assert httpserver.log[0][0].json == {"fake": "fake"}
 
 
 def test_internal_groups_api_delete_group(
@@ -36,7 +36,7 @@ def test_internal_groups_api_delete_unknown_group(
 
 
 def test_internal_groups_api_update_group(
-    httpretty: httpretty_module,
+    httpserver: HTTPServer,
     internal_groups_api: InternalGroupsApi,
     fx: Fixtures,
     group_name: str,
@@ -45,11 +45,11 @@ def test_internal_groups_api_update_group(
         name=group_name, data={"fake": "fake"}
     ) == fx.get_json(f"v1/groups/{group_name}/patch.json")
 
-    assert httpretty.last_request().body == b'{"fake": "fake"}'
+    assert httpserver.log[0][0].json == {"fake": "fake"}
 
 
 def test_internal_groups_api_get_group(
-    httpretty: httpretty_module,
+    httpserver: HTTPServer,
     internal_groups_api: InternalGroupsApi,
     fx: Fixtures,
     group_name: str,
@@ -58,7 +58,7 @@ def test_internal_groups_api_get_group(
         f"v1/groups/{group_name}/get.json"
     )
 
-    assert httpretty.last_request().headers.get("content-type") == "application/json"
+    assert httpserver.log[0][0].headers.get("content-type") == "application/json"
 
 
 def test_internal_groups_api_get_group_not_found(

--- a/reconcile/test/utils/test_deadmanssnitch_api.py
+++ b/reconcile/test/utils/test_deadmanssnitch_api.py
@@ -1,7 +1,5 @@
-import json
-
-import httpretty
 import pytest
+from pytest_httpserver import HTTPServer
 from requests.exceptions import HTTPError
 
 from reconcile.utils.deadmanssnitch_api import (
@@ -9,74 +7,19 @@ from reconcile.utils.deadmanssnitch_api import (
 )
 
 TOKEN = "test_token"
-FAKE_URL = "https://fake.deadmanssnitch.com/v1/snitches"
+URL = "/v1/snitches"
 
 
 @pytest.fixture
-def deadmanssnitch_api() -> DeadMansSnitchApi:
-    return DeadMansSnitchApi(token=TOKEN, url=FAKE_URL)
+def deadmanssnitch_api(httpserver: HTTPServer) -> DeadMansSnitchApi:
+    return DeadMansSnitchApi(token=TOKEN, url=httpserver.url_for(URL))
 
 
-@httpretty.activate(allow_net_connect=False)
-def test_get_all_snitches(deadmanssnitch_api: DeadMansSnitchApi) -> None:
-    httpretty.register_uri(
-        httpretty.GET,
-        f"{deadmanssnitch_api.url}?tags=appsre",
-        body=json.dumps([
-            {
-                "token": "test",
-                "href": "testc",
-                "name": "test",
-                "tags": ["app-sre"],
-                "notes": "test_notes",
-                "status": "healthy",
-                "check_in_url": "test_url",
-                "type": {"interval": "15_minute"},
-                "interval": "15_minute",
-                "alert_type": "basic",
-                "alert_email": ["test_mail"],
-            }
-        ]),
-        content_type="text/json",
-        status=200,
-    )
-    snitches = deadmanssnitch_api.get_snitches(tags=["appsre"])
-    assert len(snitches) == 1 and snitches[0].name == "test"
-
-
-@httpretty.activate(allow_net_connect=False)
-def test_get_all_snitches_failed(deadmanssnitch_api: DeadMansSnitchApi) -> None:
-    httpretty.register_uri(
-        httpretty.GET,
-        f"{deadmanssnitch_api.url}?tags=appsre",
-        body=json.dumps([
-            {
-                "token": "test",
-                "href": "testc",
-                "name": "test",
-                "tags": ["app-sre"],
-                "notes": "test_notes",
-                "status": "healthy",
-                "check_in_url": "test_url",
-                "type": {"interval": "15_minute"},
-                "interval": "15_minute",
-                "alert_type": "basic",
-                "alert_email": ["test_mail"],
-            }
-        ]),
-        content_type="text/json",
-        status=401,
-    )
-    with pytest.raises(HTTPError):
-        deadmanssnitch_api.get_snitches(tags=["appsre"])
-
-
-@httpretty.activate(allow_net_connect=False)
-def test_create_snitch(deadmanssnitch_api: DeadMansSnitchApi) -> None:
-    httpretty.register_uri(
-        httpretty.POST,
-        deadmanssnitch_api.url,
-        body=json.dumps({
+def test_get_all_snitches(
+    httpserver: HTTPServer, deadmanssnitch_api: DeadMansSnitchApi
+) -> None:
+    httpserver.expect_request(URL, query_string="tags=appsre").respond_with_json([
+        {
             "token": "test",
             "href": "testc",
             "name": "test",
@@ -88,59 +31,66 @@ def test_create_snitch(deadmanssnitch_api: DeadMansSnitchApi) -> None:
             "interval": "15_minute",
             "alert_type": "basic",
             "alert_email": ["test_mail"],
-        }),
-        content_type="application/json",
-        status=200,
+        }
+    ])
+    snitches = deadmanssnitch_api.get_snitches(tags=["appsre"])
+    assert len(snitches) == 1 and snitches[0].name == "test"
+
+
+def test_get_all_snitches_failed(
+    httpserver: HTTPServer, deadmanssnitch_api: DeadMansSnitchApi
+) -> None:
+    httpserver.expect_request(URL, query_string="tags=appsre").respond_with_data(
+        status=401
     )
+    with pytest.raises(HTTPError):
+        deadmanssnitch_api.get_snitches(tags=["appsre"])
+
+
+def test_create_snitch(
+    httpserver: HTTPServer, deadmanssnitch_api: DeadMansSnitchApi
+) -> None:
+    httpserver.expect_request(URL, method="POST").respond_with_json({
+        "token": "test",
+        "href": "testc",
+        "name": "test",
+        "tags": ["app-sre"],
+        "notes": "test_notes",
+        "status": "healthy",
+        "check_in_url": "test_url",
+        "type": {"interval": "15_minute"},
+        "interval": "15_minute",
+        "alert_type": "basic",
+        "alert_email": ["test_mail"],
+    })
     snitch = deadmanssnitch_api.create_snitch(
         payload={"name": "test", "interval": "15_minute"}
     )
     assert snitch.name == "test"
 
 
-@httpretty.activate(allow_net_connect=False)
-def test_create_snitch_failed(deadmanssnitch_api: DeadMansSnitchApi) -> None:
-    httpretty.register_uri(
-        httpretty.POST,
-        deadmanssnitch_api.url,
-        body=json.dumps({
-            "token": "test",
-            "href": "testc",
-            "name": "test",
-            "tags": ["app-sre"],
-            "notes": "test_notes",
-            "status": "healthy",
-            "check_in_url": "test_url",
-            "type": {"interval": "15_minute"},
-            "interval": "15_minute",
-            "alert_type": "basic",
-            "alert_email": ["test_mail"],
-        }),
-        content_type="application/json",
-        status=403,
-    )
+def test_create_snitch_failed(
+    httpserver: HTTPServer, deadmanssnitch_api: DeadMansSnitchApi
+) -> None:
+    httpserver.expect_request(URL, method="POST").respond_with_data(status=403)
     with pytest.raises(HTTPError):
         deadmanssnitch_api.create_snitch(
             payload={"name": "test", "interval": "15_minute"}
         )
 
 
-@httpretty.activate(allow_net_connect=False)
-def test_delete_snitch(deadmanssnitch_api: DeadMansSnitchApi) -> None:
-    httpretty.register_uri(
-        httpretty.DELETE,
-        f"{deadmanssnitch_api.url}/{TOKEN}",
-        status=200,
-    )
+def test_delete_snitch(
+    httpserver: HTTPServer, deadmanssnitch_api: DeadMansSnitchApi
+) -> None:
+    httpserver.expect_request(f"{URL}/{TOKEN}", method="DELETE").respond_with_data()
     deadmanssnitch_api.delete_snitch(token=TOKEN)
 
 
-@httpretty.activate(allow_net_connect=False)
-def test_delete_snitch_failed(deadmanssnitch_api: DeadMansSnitchApi) -> None:
-    httpretty.register_uri(
-        httpretty.DELETE,
-        f"{deadmanssnitch_api.url}/{TOKEN}",
-        status=404,
+def test_delete_snitch_failed(
+    httpserver: HTTPServer, deadmanssnitch_api: DeadMansSnitchApi
+) -> None:
+    httpserver.expect_request(f"{URL}/{TOKEN}", method="DELETE").respond_with_data(
+        status=404
     )
     with pytest.raises(HTTPError):
         deadmanssnitch_api.delete_snitch(token=TOKEN)

--- a/reconcile/utils/deadmanssnitch_api.py
+++ b/reconcile/utils/deadmanssnitch_api.py
@@ -49,10 +49,12 @@ class DeadMansSnitchApi:
         self.session.close()
 
     def get_snitches(self, tags: list[str]) -> list[Snitch]:
-        full_url = f"{self.url}?tags={','.join(tags)}"
         logging.debug("Getting snitches for tags:%s", tags)
         response = self.session.get(
-            url=full_url, auth=(self.token, ""), timeout=self.timeout
+            url=self.url,
+            params={"tags": ",".join(tags)},
+            auth=(self.token, ""),
+            timeout=self.timeout,
         )
         response.raise_for_status()
         snitches = [Snitch(**item) for item in response.json()]

--- a/reconcile/utils/rest_api_base.py
+++ b/reconcile/utils/rest_api_base.py
@@ -75,6 +75,7 @@ class ApiBase:
 
     def _get(self, url: str) -> dict[str, Any]:
         response = self.session.get(urljoin(self.host, url), timeout=self.read_timeout)
+        response.raise_for_status()
         return response.json()
 
     def _list(

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -166,6 +166,7 @@ class SlackApi:
         api_config: Optional[SlackApiConfig] = None,
         init_usergroups: bool = True,
         channel: Optional[str] = None,
+        slack_url: Optional[str] = None,
         **chat_kwargs: Any,
     ) -> None:
         """
@@ -187,7 +188,11 @@ class SlackApi:
         else:
             self.config = SlackApiConfig()
 
-        self._sc = WebClient(token=token, timeout=self.config.timeout)
+        self._sc = WebClient(
+            token=token,
+            timeout=self.config.timeout,
+            base_url=slack_url or WebClient.BASE_URL,
+        )
         self._configure_client_retry()
 
         self._results: dict[str, Any] = {}

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -1,6 +1,4 @@
 anymarkup==0.8.1
-# Pin httpretty because of https://github.com/gabrielfalcao/HTTPretty/issues/425. version 1.1.5 should be fine when released
-git+https://github.com/gabrielfalcao/HTTPretty.git@c255165a86bef7f894c3a446b41d0b3379c5c2be
 kubernetes~=24.0
 pytest~=7.2
 pytest-cov~=4.0.0

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -4,6 +4,7 @@ git+https://github.com/gabrielfalcao/HTTPretty.git@c255165a86bef7f894c3a446b41d0
 kubernetes~=24.0
 pytest~=7.2
 pytest-cov~=4.0.0
+pytest-httpserver~=1.0
 pytest-mock~=3.6
 responses==0.23.1
 testslide~=2.7

--- a/tools/cli_commands/test/test_cost_management_api.py
+++ b/tools/cli_commands/test/test_cost_management_api.py
@@ -1,11 +1,10 @@
 from collections.abc import Callable
 from decimal import Decimal
-from typing import Any, Tuple
+from typing import Any
 
-import httpretty
 import pytest
 import requests
-from httpretty.core import HTTPrettyRequest
+from pytest_httpserver import HTTPServer
 from pytest_mock import MockerFixture
 from requests import HTTPError
 
@@ -31,18 +30,20 @@ def mock_session(mocker: MockerFixture) -> Any:
     )
 
 
-BASE_URL = "http://base_url"
+@pytest.fixture
+def base_url(httpserver: HTTPServer) -> str:
+    return httpserver.url_for("")
+
+
 TOKEN_URL = "token_url"
 CLIENT_ID = "client_id"
 CLIENT_SECRET = "client_secret"
 SCOPE = ["some-scope"]
 
 
-def test_cost_management_api_init(
-    mock_session: Any,
-) -> None:
+def test_cost_management_api_init(mock_session: Any, base_url: str) -> None:
     with CostManagementApi(
-        base_url=BASE_URL,
+        base_url=base_url,
         token_url=TOKEN_URL,
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
@@ -50,7 +51,7 @@ def test_cost_management_api_init(
     ) as api:
         pass
 
-    assert api.host == BASE_URL
+    assert api.host == base_url
     assert api.session == mock_session.return_value
 
     mock_session.assert_called_once_with(
@@ -64,13 +65,11 @@ def test_cost_management_api_init(
 
 
 @pytest.fixture
-def cost_management_api(
-    mock_session: Any,
-) -> CostManagementApi:
+def cost_management_api(mock_session: Any, base_url: str) -> CostManagementApi:
     # swap to requests.request to skip oauth2 logic
     mock_session.return_value.request.side_effect = requests.request
     return CostManagementApi(
-        base_url=BASE_URL,
+        base_url=base_url,
         token_url=TOKEN_URL,
         client_id=CLIENT_ID,
         client_secret=CLIENT_SECRET,
@@ -133,48 +132,32 @@ EXPECTED_REPORT_COST_RESPONSE = ReportCostResponse(
 )
 
 
-@httpretty.activate(allow_net_connect=False, verbose=True)
 def test_get_aws_costs_report(
-    cost_management_api: CostManagementApi,
-    fx: Callable,
+    cost_management_api: CostManagementApi, fx: Callable, httpserver: HTTPServer
 ) -> None:
     response_body = fx("aws_cost_report.json")
-    httpretty.register_uri(
-        httpretty.GET,
-        f"{BASE_URL}/reports/aws/costs/?"
-        "cost_type=calculated_amortized_cost&"
-        "delta=cost&"
-        "filter[resolution]=monthly&"
-        "filter[tag:app]=test&"
-        "filter[time_scope_units]=month&"
-        "filter[time_scope_value]=-2&"
-        "group_by[service]=*",
-        body=response_body,
-        match_querystring=True,
-    )
+    httpserver.expect_request(
+        "/reports/aws/costs/",
+        query_string={
+            "cost_type": "calculated_amortized_cost",
+            "delta": "cost",
+            "filter[resolution]": "monthly",
+            "filter[tag:app]": "test",
+            "filter[time_scope_units]": "month",
+            "filter[time_scope_value]": "-2",
+            "group_by[service]": "*",
+        },
+    ).respond_with_data(response_body)
 
     report_cost_response = cost_management_api.get_aws_costs_report(app="test")
 
     assert report_cost_response == EXPECTED_REPORT_COST_RESPONSE
 
 
-@httpretty.activate(allow_net_connect=False, verbose=True)
 def test_get_aws_costs_report_error(
-    cost_management_api: CostManagementApi,
-    fx: Callable,
+    cost_management_api: CostManagementApi, fx: Callable, httpserver: HTTPServer
 ) -> None:
-    def callback(
-        _request: HTTPrettyRequest,
-        _url: str,
-        headers: dict,
-    ) -> Tuple[int, dict, str]:
-        return 500, headers, ""
-
-    httpretty.register_uri(
-        httpretty.GET,
-        f"{BASE_URL}/reports/aws/costs/",
-        body=callback,
-    )
+    httpserver.expect_request("/reports/aws/costs/").respond_with_data(status=500)
 
     with pytest.raises(HTTPError) as error:
         cost_management_api.get_aws_costs_report(app="test")


### PR DESCRIPTION
Replace unmaintained `httpretty` with `pytest-httpserver`.

Ticket: [APPSRE-10168](https://issues.redhat.com/browse/APPSRE-10168)

Hints for the reviewer:
* Review commit by commit