### PR TITLE
APPSRE-10117 refactor for SAPM soakDays

### DIFF
--- a/reconcile/saas_auto_promotions_manager/integration.py
+++ b/reconcile/saas_auto_promotions_manager/integration.py
@@ -18,6 +18,7 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.reconciler imp
 from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
     Renderer,
 )
+from reconcile.saas_auto_promotions_manager.meta import QONTRACT_INTEGRATION
 from reconcile.saas_auto_promotions_manager.publisher import Publisher
 from reconcile.saas_auto_promotions_manager.s3_exporter import S3Exporter
 from reconcile.saas_auto_promotions_manager.subscriber import Subscriber
@@ -34,13 +35,9 @@ from reconcile.typed_queries.saas_files import get_saas_files
 from reconcile.utils.defer import defer
 from reconcile.utils.promotion_state import PromotionState
 from reconcile.utils.secret_reader import create_secret_reader
-from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.state import State, init_state
 from reconcile.utils.unleash import get_feature_toggle_state
 from reconcile.utils.vcs import VCS
-
-QONTRACT_INTEGRATION = "saas-auto-promotions-manager"
-QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
 
 
 class SaasAutoPromotionsManager:

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/desired_state.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/desired_state.py
@@ -1,0 +1,28 @@
+from collections import defaultdict
+from collections.abc import Iterable
+
+from reconcile.saas_auto_promotions_manager.merge_request_manager.reconciler import (
+    Promotion,
+)
+from reconcile.saas_auto_promotions_manager.subscriber import Subscriber
+
+
+class DesiredState:
+    def __init__(self, subscribers: Iterable[Subscriber]) -> None:
+        self.content_hash_to_subscriber: dict[str, list[Subscriber]] = {}
+        subscribers_per_channel_combo: dict[str, list[Subscriber]] = defaultdict(list)
+        for subscriber in subscribers:
+            channel_combo = ",".join([c.name for c in subscriber.channels])
+            subscribers_per_channel_combo[channel_combo].append(subscriber)
+
+        desired_promotions: list[Promotion] = []
+        for channel_combo, subs in subscribers_per_channel_combo.items():
+            combined_content_hash = Subscriber.combined_content_hash(subscribers=subs)
+            self.content_hash_to_subscriber[combined_content_hash] = subs
+            desired_promotions.append(
+                Promotion(
+                    content_hashes={combined_content_hash},
+                    channels={channel_combo},
+                )
+            )
+        self.promotions = desired_promotions

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/reconciler.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/reconciler.py
@@ -14,7 +14,7 @@ class Reason(Enum):
     NEW_BATCH = "Closing this MR in favor of a new batch MR."
 
 
-@dataclass
+@dataclass(order=True)
 class Promotion:
     content_hashes: set[str]
     channels: set[str]

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
@@ -13,13 +13,14 @@ from reconcile.gql_definitions.common.saas_files import (
 from reconcile.gql_definitions.fragments.saas_target_namespace import (
     SaasTargetNamespace,
 )
+from reconcile.saas_auto_promotions_manager.meta import QONTRACT_INTEGRATION_VERSION
 from reconcile.saas_auto_promotions_manager.subscriber import Subscriber
 from reconcile.utils.ruamel import create_ruamel_instance
 
 PROMOTION_DATA_SEPARATOR = (
     "**SAPM Data - DO NOT MANUALLY CHANGE ANYTHING BELOW THIS LINE**"
 )
-SAPM_VERSION = "2.1.3"
+SAPM_VERSION = QONTRACT_INTEGRATION_VERSION
 CONTENT_HASHES = "content_hashes"
 CHANNELS_REF = "channels"
 IS_BATCHABLE = "is_batchable"

--- a/reconcile/saas_auto_promotions_manager/meta.py
+++ b/reconcile/saas_auto_promotions_manager/meta.py
@@ -1,0 +1,4 @@
+from reconcile.utils.semver_helper import make_semver
+
+QONTRACT_INTEGRATION = "saas-auto-promotions-manager"
+QONTRACT_INTEGRATION_VERSION = make_semver(2, 2, 0)

--- a/reconcile/saas_auto_promotions_manager/meta.py
+++ b/reconcile/saas_auto_promotions_manager/meta.py
@@ -1,4 +1,4 @@
 from reconcile.utils.semver_helper import make_semver
 
 QONTRACT_INTEGRATION = "saas-auto-promotions-manager"
-QONTRACT_INTEGRATION_VERSION = make_semver(2, 2, 0)
+QONTRACT_INTEGRATION_VERSION = make_semver(2, 1, 4)

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_desired_state.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_desired_state.py
@@ -1,0 +1,60 @@
+from collections.abc import Callable
+
+from reconcile.saas_auto_promotions_manager.merge_request_manager.desired_state import (
+    DesiredState,
+)
+from reconcile.saas_auto_promotions_manager.subscriber import Subscriber
+
+from .data_keys import (
+    CHANNEL,
+)
+
+
+def test_desired_state_empty() -> None:
+    desired_state = DesiredState(subscribers=[])
+    assert desired_state.promotions == []
+
+
+def test_desired_state_single_subscriber(
+    subscriber_builder: Callable[..., Subscriber],
+) -> None:
+    subscriber = subscriber_builder({})
+    desired_state = DesiredState(subscribers=[subscriber])
+    assert len(desired_state.promotions) == 1
+    assert desired_state.promotions[0].content_hashes == {
+        Subscriber.combined_content_hash([subscriber])
+    }
+
+
+def test_desired_state_multiple_subscribers_same_channel_combo(
+    subscriber_builder: Callable[..., Subscriber],
+) -> None:
+    subscriber_a = subscriber_builder({CHANNEL: ["channel-a", "channel-b"]})
+    subscriber_a.desired_ref = "ref-a"
+    subscriber_b = subscriber_builder({CHANNEL: ["channel-a", "channel-b"]})
+    subscriber_b.desired_ref = "ref-b"
+    desired_state = DesiredState(subscribers=[subscriber_a, subscriber_b])
+    assert len(desired_state.promotions) == 1
+    assert desired_state.promotions[0].content_hashes == {
+        Subscriber.combined_content_hash([subscriber_a, subscriber_b]),
+    }
+
+
+def test_desired_state_multiple_subscribers_different_channel_combo(
+    subscriber_builder: Callable[..., Subscriber],
+) -> None:
+    subscriber_a = subscriber_builder({CHANNEL: ["channel-a", "channel-b"]})
+    subscriber_a.desired_ref = "ref-a"
+    subscriber_b = subscriber_builder({CHANNEL: ["channel-a", "channel-b"]})
+    subscriber_b.desired_ref = "ref-b"
+    subscriber_c = subscriber_builder({CHANNEL: ["channel-b", "channel-c"]})
+    subscriber_c.desired_ref = "ref-c"
+    desired_state = DesiredState(subscribers=[subscriber_a, subscriber_b, subscriber_c])
+    sorted_promotions = sorted(desired_state.promotions)
+    assert len(desired_state.promotions) == 2
+    assert sorted_promotions[0].content_hashes == {
+        Subscriber.combined_content_hash([subscriber_a, subscriber_b]),
+    }
+    assert sorted_promotions[1].content_hashes == {
+        Subscriber.combined_content_hash([subscriber_c]),
+    }


### PR DESCRIPTION
We extract the calculation of SAPM desired promotion state into a dedicated class with proper tests. 

In a follow-up PR we will add soakDays logic, which will bring some substantial change to the DesiredState logic.