### PR TITLE
 aws-account-manager: region related fields

### DIFF
--- a/reconcile/gql_definitions/aws_account_manager/aws_accounts.gql
+++ b/reconcile/gql_definitions/aws_account_manager/aws_accounts.gql
@@ -32,6 +32,8 @@ query AWSAccountManagerAccounts {
       quotaLimits {
         path
       }
+      resourcesDefaultRegion
+      supportedDeploymentRegions
     }
     organization_accounts {
       ... AWSAccountManaged

--- a/reconcile/gql_definitions/aws_account_manager/aws_accounts.py
+++ b/reconcile/gql_definitions/aws_account_manager/aws_accounts.py
@@ -80,6 +80,8 @@ query AWSAccountManagerAccounts {
       quotaLimits {
         path
       }
+      resourcesDefaultRegion
+      supportedDeploymentRegions
     }
     organization_accounts {
       ... AWSAccountManaged
@@ -129,6 +131,8 @@ class AWSAccountRequestV1(ConfiguredBaseModel):
     account_owner: OwnerV1 = Field(..., alias="accountOwner")
     organization: AWSOrganizationV1 = Field(..., alias="organization")
     quota_limits: Optional[list[AWSQuotaLimitsV1]] = Field(..., alias="quotaLimits")
+    resources_default_region: str = Field(..., alias="resourcesDefaultRegion")
+    supported_deployment_regions: Optional[list[str]] = Field(..., alias="supportedDeploymentRegions")
 
 
 class AWSAccountV1(AWSAccountManaged):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -14569,6 +14569,42 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "resourcesDefaultRegion",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "supportedDeploymentRegions",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -25886,8 +25922,8 @@
                                     "kind": "NON_NULL",
                                     "name": null,
                                     "ofType": {
-                                        "kind": "OBJECT",
-                                        "name": "VPCRequestSubnets_v1",
+                                        "kind": "SCALAR",
+                                        "name": "String",
                                         "ofType": null
                                     }
                                 }
@@ -25906,53 +25942,30 @@
                                     "kind": "NON_NULL",
                                     "name": null,
                                     "ofType": {
-                                        "kind": "OBJECT",
-                                        "name": "VPCRequestSubnets_v1",
+                                        "kind": "SCALAR",
+                                        "name": "String",
                                         "ofType": null
                                     }
                                 }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "VPCRequestSubnets_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "availability_zone",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
                         },
                         {
-                            "name": "cidr_block",
+                            "name": "availability_zones",
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "NON_NULL",
+                                "kind": "LIST",
                                 "name": null,
                                 "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
                                 }
                             },
                             "isDeprecated": false,


### PR DESCRIPTION
Get `resourcesDefaultRegion` and `supportedDeploymentRegions` region related field.

Ticket: [APPSRE-9984](https://issues.redhat.com/browse/APPSRE-9984)
Depends on: https://github.com/app-sre/qontract-schemas/pull/638