### PR TITLE
:sparkles: ldap-groups: manage notes and owners

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -10900,8 +10900,8 @@
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "SCALAR",
-                                "name": "String",
+                                "kind": "OBJECT",
+                                "name": "LdapGroup_v1",
                                 "ofType": null
                             },
                             "isDeprecated": false,
@@ -12816,6 +12816,57 @@
                             "ofType": null
                         }
                     ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "LdapGroup_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "name",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "notes",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "membersAreOwners",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
                 },

--- a/reconcile/gql_definitions/ldap_groups/roles.gql
+++ b/reconcile/gql_definitions/ldap_groups/roles.gql
@@ -3,7 +3,11 @@
 query LdapGroupsRolesQuery {
   roles: roles_v1 {
     name
-    ldapGroup
+    ldapGroup {
+      name
+      notes
+      membersAreOwners
+    }
     users {
       org_username
     }

--- a/reconcile/gql_definitions/ldap_groups/roles.py
+++ b/reconcile/gql_definitions/ldap_groups/roles.py
@@ -33,7 +33,11 @@ fragment AWSAccountSSO on AWSAccount_v1 {
 query LdapGroupsRolesQuery {
   roles: roles_v1 {
     name
-    ldapGroup
+    ldapGroup {
+      name
+      notes
+      membersAreOwners
+    }
     users {
       org_username
     }
@@ -58,6 +62,12 @@ class ConfiguredBaseModel(BaseModel):
         extra=Extra.forbid
 
 
+class LdapGroupV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+    notes: Optional[str] = Field(..., alias="notes")
+    members_are_owners: Optional[bool] = Field(..., alias="membersAreOwners")
+
+
 class UserV1(ConfiguredBaseModel):
     org_username: str = Field(..., alias="org_username")
 
@@ -72,7 +82,7 @@ class AWSGroupV1(ConfiguredBaseModel):
 
 class RoleV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
-    ldap_group: Optional[str] = Field(..., alias="ldapGroup")
+    ldap_group: Optional[LdapGroupV1] = Field(..., alias="ldapGroup")
     users: list[UserV1] = Field(..., alias="users")
     user_policies: Optional[list[AWSUserPolicyV1]] = Field(..., alias="user_policies")
     aws_groups: Optional[list[AWSGroupV1]] = Field(..., alias="aws_groups")

--- a/reconcile/test/fixtures/ldap_groups/roles.yml
+++ b/reconcile/test/fixtures/ldap_groups/roles.yml
@@ -7,14 +7,26 @@ roles:
   - org_username: riker
 
 - name: test-group
-  ldapGroup: ai-dev-test-group
+  ldapGroup:
+    name: ai-dev-test-group
+  users:
+  - org_username: pike
+  - org_username: uhura
+
+# notes and membersAreOwners
+- name: test-group2
+  ldapGroup:
+    name: ai-dev-test-group-with-notes
+    notes: Just a note
+    membersAreOwners: true
   users:
   - org_username: pike
   - org_username: uhura
 
 # role for roles and aws roles
 - name: ldap-and-aws-role
-  ldapGroup: ai-dev-test-group-2
+  ldapGroup:
+    name: ai-dev-test-group-2
   users:
   - org_username: pike
   - org_username: uhura

--- a/reconcile/test/ldap_groups/conftest.py
+++ b/reconcile/test/ldap_groups/conftest.py
@@ -41,11 +41,6 @@ def raw_fixture_data(fx: Fixtures) -> dict[str, Any]:
 
 
 @pytest.fixture
-def raw_fixture_data_aws_groups(fx: Fixtures) -> dict[str, Any]:
-    return fx.get_anymarkup("aws_groups.yml")
-
-
-@pytest.fixture
 def roles(
     fx: Fixtures,
     data_factory: Callable[[type[RoleV1], Mapping[str, Any]], Mapping[str, Any]],
@@ -84,7 +79,34 @@ def group(owners: Iterable[Entity]) -> Group:
 
 
 @pytest.fixture
-def group2(owners: Iterable[Entity]) -> Group:
+def group2(owners: list[Entity]) -> Group:
+    # keep in sync with fx/roles.yml
+    return Group(
+        name="ai-dev-test-group-with-notes",
+        description="Persisted App-Interface role. Managed by qontract-reconcile",
+        member_approval_type="self-service",
+        contact_list="email@example.org",
+        owners=owners
+        + [
+            Entity(type=EntityType.USER, id="pike"),
+            Entity(type=EntityType.USER, id="uhura"),
+        ],
+        display_name="ai-dev-test-group-with-notes (App-Interface))",
+        notes="Just a note",
+        rover_group_member_query=None,
+        rover_group_inclusions=None,
+        rover_group_exclusions=None,
+        members=[
+            Entity(type=EntityType.USER, id="pike"),
+            Entity(type=EntityType.USER, id="uhura"),
+        ],
+        member_of=None,
+        namespace=None,
+    )
+
+
+@pytest.fixture
+def group3(owners: Iterable[Entity]) -> Group:
     # keep in sync with fx/roles.yml
     return Group(
         name="ai-dev-test-group-2",
@@ -104,6 +126,11 @@ def group2(owners: Iterable[Entity]) -> Group:
         member_of=None,
         namespace=None,
     )
+
+
+@pytest.fixture
+def groups(group: Group, group2: Group, group3: Group) -> list[Group]:
+    return [group, group2, group3]
 
 
 @pytest.fixture

--- a/reconcile/test/ldap_groups/test_ldap_groups_integration.py
+++ b/reconcile/test/ldap_groups/test_ldap_groups_integration.py
@@ -72,7 +72,19 @@ def test_ldap_groups_integration_get_roles(
             RoleV1,
             {
                 "name": "test-group",
-                "ldapGroup": "ai-dev-test-group",
+                "ldapGroup": {"name": "ai-dev-test-group"},
+                "users": [{"org_username": "pike"}, {"org_username": "uhura"}],
+            },
+        ),
+        gql_class_factory(
+            RoleV1,
+            {
+                "name": "test-group2",
+                "ldapGroup": {
+                    "name": "ai-dev-test-group-with-notes",
+                    "notes": "Just a note",
+                    "membersAreOwners": True,
+                },
                 "users": [{"org_username": "pike"}, {"org_username": "uhura"}],
             },
         ),
@@ -80,7 +92,7 @@ def test_ldap_groups_integration_get_roles(
             RoleV1,
             {
                 "name": "ldap-and-aws-role",
-                "ldapGroup": "ai-dev-test-group-2",
+                "ldapGroup": {"name": "ai-dev-test-group-2"},
                 "users": [{"org_username": "pike"}, {"org_username": "uhura"}],
                 "user_policies": None,
                 "aws_groups": [
@@ -209,15 +221,15 @@ def test_ldap_groups_integration_get_roles_duplicates(
 def test_ldap_groups_integration_get_desired_groups_for_roles(
     intg: LdapGroupsIntegration,
     roles: Iterable[RoleV1],
-    owners: Iterable[Entity],
-    group: Group,
-    group2: Group,
+    owners: list[Entity],
+    groups: list[Group],
 ) -> None:
-    assert intg.get_desired_groups_for_roles(
+    resp = intg.get_desired_groups_for_roles(
         roles=roles,
-        owners=owners,
+        default_owners=owners,
         contact_list="email@example.org",
-    ) == [group, group2]
+    )
+    assert resp == groups
 
 
 def test_ldap_groups_integration_get_desired_groups_for_aws_roles(
@@ -226,7 +238,7 @@ def test_ldap_groups_integration_get_desired_groups_for_aws_roles(
     owners: list[Entity],
 ) -> None:
     assert intg.get_desired_groups_for_aws_roles(
-        roles=roles, owners=owners, contact_list="email@example.org"
+        roles=roles, default_owners=owners, contact_list="email@example.org"
     ) == [
         Group(
             name="rover-prefix-123456789-ldap-and-aws-role",

--- a/reconcile/utils/internal_groups/models.py
+++ b/reconcile/utils/internal_groups/models.py
@@ -54,7 +54,7 @@ class Group(BaseModel):
             self.description == other.description
             and self.member_approval_type == other.member_approval_type
             and self.contact_list == other.contact_list
-            and self.owners == other.owners
+            and set(self.owners) == set(other.owners)
             and self.display_name == other.display_name
             and self.notes == other.notes
             and set(self.members) == set(other.members)


### PR DESCRIPTION
`ldap-groups` manage Rover notes and owners.

The goal is to enable our LDAP groups to be authZ groups for Bitwarden collections. Rover group requirements are:

* Rover group notes must contain the string `@BW@` somewhere
* At least 2 owners are set

Depends on: https://github.com/app-sre/qontract-schemas/pull/639

Tickets
* [APPSRE-10201](https://issues.redhat.com/browse/APPSRE-10201)
* [APPSRE-8399](https://issues.redhat.com/browse/APPSRE-8399)