### PR TITLE
APPSRE-10117 SAPM introduce MR kind

### DIFF
--- a/reconcile/saas_auto_promotions_manager/integration.py
+++ b/reconcile/saas_auto_promotions_manager/integration.py
@@ -6,14 +6,14 @@ from sretoolbox.utils import threaded
 from reconcile.openshift_saas_deploy import (
     QONTRACT_INTEGRATION as OPENSHIFT_SAAS_DEPLOY,
 )
+from reconcile.saas_auto_promotions_manager.merge_request_manager.batcher import (
+    Batcher,
+)
 from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request_manager_v2 import (
     MergeRequestManagerV2,
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.mr_parser import (
     MRParser,
-)
-from reconcile.saas_auto_promotions_manager.merge_request_manager.reconciler import (
-    Reconciler,
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
     Renderer,
@@ -135,7 +135,7 @@ def init_external_dependencies(
     mr_parser = MRParser(vcs=vcs)
     merge_request_manager_v2 = MergeRequestManagerV2(
         vcs=vcs,
-        reconciler=Reconciler(),
+        reconciler=Batcher(),
         mr_parser=mr_parser,
         renderer=Renderer(),
     )

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/batcher.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/batcher.py
@@ -39,11 +39,11 @@ class Diff:
     additions: list[Addition]
 
 
-class Reconciler:
+class Batcher:
     """
-    The reconciler calculates a Diff. I.e., which MRs need to be opened (Addition)
-    and which MRs need to be closed (Deletion). The reconciler has no external
-    dependencies and does not interact with VCS. The reconciler expects to be
+    The batcher calculates a Diff. I.e., which MRs need to be opened (Addition)
+    and which MRs need to be closed (Deletion). The batcher has no external
+    dependencies and does not interact with VCS. The batcher expects to be
     given the desired state (which promotions do we want) and the current state
     (the currently open MRs) in order to calculate the Diff.
     """

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/desired_state.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/desired_state.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from collections.abc import Iterable
 
-from reconcile.saas_auto_promotions_manager.merge_request_manager.reconciler import (
+from reconcile.saas_auto_promotions_manager.merge_request_manager.batcher import (
     Promotion,
 )
 from reconcile.saas_auto_promotions_manager.subscriber import Subscriber

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager_v2.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager_v2.py
@@ -3,6 +3,10 @@ from collections.abc import Iterable
 
 from gitlab.exceptions import GitlabGetError
 
+from reconcile.saas_auto_promotions_manager.merge_request_manager.batcher import (
+    Addition,
+    Batcher,
+)
 from reconcile.saas_auto_promotions_manager.merge_request_manager.desired_state import (
     DesiredState,
 )
@@ -20,10 +24,6 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.metrics import
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.mr_parser import (
     MRParser,
-)
-from reconcile.saas_auto_promotions_manager.merge_request_manager.reconciler import (
-    Addition,
-    Reconciler,
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
     Renderer,
@@ -61,7 +61,7 @@ class MergeRequestManagerV2:
     """
 
     def __init__(
-        self, vcs: VCS, mr_parser: MRParser, reconciler: Reconciler, renderer: Renderer
+        self, vcs: VCS, mr_parser: MRParser, reconciler: Batcher, renderer: Renderer
     ):
         self._vcs = vcs
         self._mr_parser = mr_parser

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager_v2.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager_v2.py
@@ -130,7 +130,8 @@ class MergeRequestManagerV2:
         )
 
     def reconcile(self, subscribers: Iterable[Subscriber]) -> None:
-        current_state = self._mr_parser.retrieve_open_mrs(label=SAPM_LABEL)
+        self._mr_parser.fetch_mrs(label=SAPM_LABEL)
+        current_state = self._mr_parser.get_open_batcher_mrs()
         desired_state = DesiredState(subscribers=subscribers)
         self._desired_state = desired_state
 

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/open_merge_requests.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/open_merge_requests.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from enum import Enum
+
+from gitlab.v4.objects import ProjectMergeRequest
+
+
+class MRKind(Enum):
+    BATCHER = "batcher"
+    SCHEDULER = "scheduler"
+
+
+@dataclass
+class OpenBatcherMergeRequest:
+    raw: ProjectMergeRequest
+    content_hashes: set[str]
+    channels: set[str]
+    failed_mr_check: bool
+    is_batchable: bool
+
+
+@dataclass
+class OpenSchedulerMergeRequest:
+    pass

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/reconciler.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/reconciler.py
@@ -3,8 +3,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
 
-from reconcile.saas_auto_promotions_manager.merge_request_manager.mr_parser import (
-    OpenMergeRequest,
+from reconcile.saas_auto_promotions_manager.merge_request_manager.open_merge_requests import (
+    OpenBatcherMergeRequest,
 )
 
 
@@ -22,7 +22,7 @@ class Promotion:
 
 @dataclass
 class Deletion:
-    mr: OpenMergeRequest
+    mr: OpenBatcherMergeRequest
     reason: Reason
 
 
@@ -50,7 +50,7 @@ class Reconciler:
 
     def __init__(self) -> None:
         self._desired_promotions: Iterable[Promotion] = []
-        self._open_mrs: Iterable[OpenMergeRequest] = []
+        self._open_mrs: Iterable[OpenBatcherMergeRequest] = []
 
     def _unbatch(self, diff: Diff) -> None:
         """
@@ -61,7 +61,7 @@ class Reconciler:
         and close the old batched MR. By doing so, we ensure that unrelated MRs are not blocking each other.
         Unbatched MRs are marked and will never be batched again.
         """
-        open_mrs_after_unbatching: list[OpenMergeRequest] = []
+        open_mrs_after_unbatching: list[OpenBatcherMergeRequest] = []
         unbatchable_hashes: set[str] = set()
         falsely_marked_batchable_hashes: set[str] = set()
         for mr in self._open_mrs:
@@ -107,7 +107,7 @@ class Reconciler:
         for promotion in self._desired_promotions:
             all_desired_content_hashes.update(promotion.content_hashes)
 
-        open_mrs_after_deletion: list[OpenMergeRequest] = []
+        open_mrs_after_deletion: list[OpenBatcherMergeRequest] = []
         for mr in self._open_mrs:
             if mr.content_hashes.issubset(all_desired_content_hashes):
                 open_mrs_after_deletion.append(mr)
@@ -145,7 +145,7 @@ class Reconciler:
         if not unsubmitted_promotions:
             return
 
-        batch_with_capacity: Optional[OpenMergeRequest] = None
+        batch_with_capacity: Optional[OpenBatcherMergeRequest] = None
         for mr in self._open_mrs:
             if mr.is_batchable and len(mr.content_hashes) < batch_limit:
                 batch_with_capacity = mr
@@ -194,7 +194,7 @@ class Reconciler:
     def reconcile(
         self,
         desired_promotions: Iterable[Promotion],
-        open_mrs: Iterable[OpenMergeRequest],
+        open_mrs: Iterable[OpenBatcherMergeRequest],
         batch_limit: int,
     ) -> Diff:
         self._open_mrs = open_mrs

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
@@ -25,6 +25,7 @@ CONTENT_HASHES = "content_hashes"
 CHANNELS_REF = "channels"
 IS_BATCHABLE = "is_batchable"
 VERSION_REF = "sapm_version"
+MR_KIND_REF = "kind"
 
 
 class Renderer:

--- a/reconcile/saas_auto_promotions_manager/meta.py
+++ b/reconcile/saas_auto_promotions_manager/meta.py
@@ -1,4 +1,4 @@
 from reconcile.utils.semver_helper import make_semver
 
 QONTRACT_INTEGRATION = "saas-auto-promotions-manager"
-QONTRACT_INTEGRATION_VERSION = make_semver(2, 2, 0)
+QONTRACT_INTEGRATION_VERSION = make_semver(2, 3, 0)

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/conftest.py
@@ -8,16 +8,16 @@ from unittest.mock import create_autospec
 import pytest
 from gitlab.v4.objects import ProjectMergeRequest
 
+from reconcile.saas_auto_promotions_manager.merge_request_manager.batcher import (
+    Batcher,
+    Diff,
+)
 from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request_manager_v2 import (
     SAPM_LABEL,
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.mr_parser import (
     MRParser,
     OpenBatcherMergeRequest,
-)
-from reconcile.saas_auto_promotions_manager.merge_request_manager.reconciler import (
-    Diff,
-    Reconciler,
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
     CHANNELS_REF,
@@ -101,9 +101,9 @@ def mr_parser_builder() -> Callable[[Iterable[OpenBatcherMergeRequest]], MRParse
 
 
 @pytest.fixture
-def reconciler_builder() -> Callable[[Diff], Reconciler]:
-    def builder(data: Diff) -> Reconciler:
-        reconciler = create_autospec(spec=Reconciler)
+def reconciler_builder() -> Callable[[Diff], Batcher]:
+    def builder(data: Diff) -> Batcher:
+        reconciler = create_autospec(spec=Batcher)
         reconciler.reconcile.side_effect = [data]
         return reconciler
 

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/conftest.py
@@ -13,7 +13,7 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request_
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.mr_parser import (
     MRParser,
-    OpenMergeRequest,
+    OpenBatcherMergeRequest,
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.reconciler import (
     Diff,
@@ -91,8 +91,8 @@ def vcs_builder(
 
 
 @pytest.fixture
-def mr_parser_builder() -> Callable[[Iterable[OpenMergeRequest]], MRParser]:
-    def builder(data: Iterable[OpenMergeRequest]) -> MRParser:
+def mr_parser_builder() -> Callable[[Iterable[OpenBatcherMergeRequest]], MRParser]:
+    def builder(data: Iterable[OpenBatcherMergeRequest]) -> MRParser:
         mr_parser = create_autospec(spec=MRParser)
         mr_parser.retrieve_open_mrs.side_effect = [data]
         return mr_parser

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_merge_request_manager.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_merge_request_manager.py
@@ -8,7 +8,9 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request_
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.mr_parser import (
     MRParser,
-    OpenMergeRequest,
+)
+from reconcile.saas_auto_promotions_manager.merge_request_manager.open_merge_requests import (
+    OpenBatcherMergeRequest,
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.reconciler import (
     Addition,
@@ -42,7 +44,7 @@ def test_reconcile(
         })
     ]
     deletion = Deletion(
-        mr=OpenMergeRequest(
+        mr=OpenBatcherMergeRequest(
             raw=create_autospec(spec=ProjectMergeRequest),
             channels=set(),
             content_hashes=set(),

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_merge_request_manager.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_merge_request_manager.py
@@ -3,6 +3,13 @@ from unittest.mock import call, create_autospec
 
 from gitlab.v4.objects import ProjectMergeRequest
 
+from reconcile.saas_auto_promotions_manager.merge_request_manager.batcher import (
+    Addition,
+    Batcher,
+    Deletion,
+    Diff,
+    Reason,
+)
 from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request_manager_v2 import (
     MergeRequestManagerV2,
 )
@@ -11,13 +18,6 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.mr_parser impo
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.open_merge_requests import (
     OpenBatcherMergeRequest,
-)
-from reconcile.saas_auto_promotions_manager.merge_request_manager.reconciler import (
-    Addition,
-    Deletion,
-    Diff,
-    Reason,
-    Reconciler,
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
     Renderer,
@@ -31,7 +31,7 @@ from reconcile.utils.vcs import VCS
 
 
 def test_reconcile(
-    reconciler_builder: Callable[[Diff], Reconciler],
+    reconciler_builder: Callable[[Diff], Batcher],
     subscriber_builder: Callable[..., Subscriber],
 ) -> None:
     vcs = create_autospec(spec=VCS)

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_reconciler.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_reconciler.py
@@ -4,16 +4,16 @@ from unittest.mock import create_autospec
 import pytest
 from gitlab.v4.objects import ProjectMergeRequest
 
-from reconcile.saas_auto_promotions_manager.merge_request_manager.open_merge_requests import (
-    OpenBatcherMergeRequest,
-)
-from reconcile.saas_auto_promotions_manager.merge_request_manager.reconciler import (
+from reconcile.saas_auto_promotions_manager.merge_request_manager.batcher import (
     Addition,
+    Batcher,
     Deletion,
     Diff,
     Promotion,
     Reason,
-    Reconciler,
+)
+from reconcile.saas_auto_promotions_manager.merge_request_manager.open_merge_requests import (
+    OpenBatcherMergeRequest,
 )
 
 
@@ -460,7 +460,7 @@ def test_reconcile(
     open_mrs: list[OpenBatcherMergeRequest],
     expected_diff: Diff,
 ) -> None:
-    reconciler = Reconciler()
+    reconciler = Batcher()
     diff = reconciler.reconcile(
         desired_promotions=desired_promotions, open_mrs=open_mrs, batch_limit=5
     )

--- a/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_reconciler.py
+++ b/reconcile/test/saas_auto_promotions_manager/merge_request_manager/merge_request_manager/test_reconciler.py
@@ -4,8 +4,8 @@ from unittest.mock import create_autospec
 import pytest
 from gitlab.v4.objects import ProjectMergeRequest
 
-from reconcile.saas_auto_promotions_manager.merge_request_manager.mr_parser import (
-    OpenMergeRequest,
+from reconcile.saas_auto_promotions_manager.merge_request_manager.open_merge_requests import (
+    OpenBatcherMergeRequest,
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.reconciler import (
     Addition,
@@ -69,28 +69,28 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
         (
             [],
             [
-                OpenMergeRequest(
+                OpenBatcherMergeRequest(
                     raw=create_autospec(spec=ProjectMergeRequest),
                     channels={"chan1", "chan2"},
                     content_hashes={"hash1", "hash2"},
                     failed_mr_check=True,
                     is_batchable=True,
                 ),
-                OpenMergeRequest(
+                OpenBatcherMergeRequest(
                     raw=create_autospec(spec=ProjectMergeRequest),
                     channels={"chan3"},
                     content_hashes={"hash3"},
                     failed_mr_check=False,
                     is_batchable=True,
                 ),
-                OpenMergeRequest(
+                OpenBatcherMergeRequest(
                     raw=create_autospec(spec=ProjectMergeRequest),
                     channels={"chan4"},
                     content_hashes={"hash4"},
                     failed_mr_check=False,
                     is_batchable=False,
                 ),
-                OpenMergeRequest(
+                OpenBatcherMergeRequest(
                     raw=create_autospec(spec=ProjectMergeRequest),
                     channels={"chan5"},
                     content_hashes={"hash5"},
@@ -101,7 +101,7 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
             Diff(
                 deletions=[
                     Deletion(
-                        mr=OpenMergeRequest(
+                        mr=OpenBatcherMergeRequest(
                             raw=create_autospec(spec=ProjectMergeRequest),
                             channels={"chan1", "chan2"},
                             content_hashes={"hash1", "hash2"},
@@ -111,7 +111,7 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
                         reason=Reason.MISSING_UNBATCHING,
                     ),
                     Deletion(
-                        mr=OpenMergeRequest(
+                        mr=OpenBatcherMergeRequest(
                             raw=create_autospec(spec=ProjectMergeRequest),
                             channels={"chan3"},
                             content_hashes={"hash3"},
@@ -121,7 +121,7 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
                         reason=Reason.OUTDATED_CONTENT,
                     ),
                     Deletion(
-                        mr=OpenMergeRequest(
+                        mr=OpenBatcherMergeRequest(
                             raw=create_autospec(spec=ProjectMergeRequest),
                             channels={"chan4"},
                             content_hashes={"hash4"},
@@ -131,7 +131,7 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
                         reason=Reason.OUTDATED_CONTENT,
                     ),
                     Deletion(
-                        mr=OpenMergeRequest(
+                        mr=OpenBatcherMergeRequest(
                             raw=create_autospec(spec=ProjectMergeRequest),
                             channels={"chan5"},
                             content_hashes={"hash5"},
@@ -161,7 +161,7 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
                 ),
             ],
             [
-                OpenMergeRequest(
+                OpenBatcherMergeRequest(
                     raw=create_autospec(spec=ProjectMergeRequest),
                     channels={"chan1", "chan2"},
                     content_hashes={"hash1", "hash2"},
@@ -172,7 +172,7 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
             Diff(
                 deletions=[
                     Deletion(
-                        mr=OpenMergeRequest(
+                        mr=OpenBatcherMergeRequest(
                             raw=create_autospec(spec=ProjectMergeRequest),
                             channels={"chan1", "chan2"},
                             content_hashes={"hash1", "hash2"},
@@ -210,7 +210,7 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
                 ),
             ],
             [
-                OpenMergeRequest(
+                OpenBatcherMergeRequest(
                     raw=create_autospec(spec=ProjectMergeRequest),
                     channels={"chan1", "chan2"},
                     content_hashes={"hash1", "hash2"},
@@ -243,7 +243,7 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
                 ),
             ],
             [
-                OpenMergeRequest(
+                OpenBatcherMergeRequest(
                     raw=create_autospec(spec=ProjectMergeRequest),
                     channels={"chan1", "chan2"},
                     content_hashes={"hash1", "hash2"},
@@ -254,7 +254,7 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
             Diff(
                 deletions=[
                     Deletion(
-                        mr=OpenMergeRequest(
+                        mr=OpenBatcherMergeRequest(
                             raw=create_autospec(spec=ProjectMergeRequest),
                             channels={"chan1", "chan2"},
                             content_hashes={"hash1", "hash2"},
@@ -301,7 +301,7 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
                 ),
             ],
             [
-                OpenMergeRequest(
+                OpenBatcherMergeRequest(
                     raw=create_autospec(spec=ProjectMergeRequest),
                     channels={"chan1", "chan2"},
                     content_hashes={"hash1", "hash2"},
@@ -312,7 +312,7 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
             Diff(
                 deletions=[
                     Deletion(
-                        mr=OpenMergeRequest(
+                        mr=OpenBatcherMergeRequest(
                             raw=create_autospec(spec=ProjectMergeRequest),
                             channels={"chan1", "chan2"},
                             content_hashes={"hash1", "hash2"},
@@ -380,7 +380,7 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
                 ),
             ],
             [
-                OpenMergeRequest(
+                OpenBatcherMergeRequest(
                     raw=create_autospec(spec=ProjectMergeRequest),
                     channels={"chan1"},
                     content_hashes={"hash1"},
@@ -424,14 +424,14 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
                 ),
             ],
             [
-                OpenMergeRequest(
+                OpenBatcherMergeRequest(
                     raw=create_autospec(spec=ProjectMergeRequest),
                     channels={"chan1"},
                     content_hashes={"hash1"},
                     failed_mr_check=False,
                     is_batchable=False,
                 ),
-                OpenMergeRequest(
+                OpenBatcherMergeRequest(
                     raw=create_autospec(spec=ProjectMergeRequest),
                     channels={"chan2"},
                     content_hashes={"hash2"},
@@ -457,7 +457,7 @@ def _aggregate_channels(items: Sequence[Addition | Deletion]) -> set[str]:
 )
 def test_reconcile(
     desired_promotions: list[Promotion],
-    open_mrs: list[OpenMergeRequest],
+    open_mrs: list[OpenBatcherMergeRequest],
     expected_diff: Diff,
 ) -> None:
     reconciler = Reconciler()

--- a/reconcile/test/saas_auto_promotions_manager/test_integration_test.py
+++ b/reconcile/test/saas_auto_promotions_manager/test_integration_test.py
@@ -1,14 +1,14 @@
 from unittest.mock import create_autospec
 
 from reconcile.saas_auto_promotions_manager.integration import SaasAutoPromotionsManager
+from reconcile.saas_auto_promotions_manager.merge_request_manager.batcher import (
+    Batcher,
+)
 from reconcile.saas_auto_promotions_manager.merge_request_manager.merge_request_manager_v2 import (
     MergeRequestManagerV2,
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.mr_parser import (
     MRParser,
-)
-from reconcile.saas_auto_promotions_manager.merge_request_manager.reconciler import (
-    Reconciler,
 )
 from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer import (
     Renderer,
@@ -33,7 +33,7 @@ def test_integration_test():
     vcs = create_autospec(spec=VCS)
     merge_request_manager_v2 = MergeRequestManagerV2(
         vcs=vcs,
-        reconciler=create_autospec(spec=Reconciler),
+        reconciler=create_autospec(spec=Batcher),
         mr_parser=create_autospec(spec=MRParser),
         renderer=create_autospec(spec=Renderer),
     )


### PR DESCRIPTION
SAPM MRs now hold a `kind` attribute. a MR can be of kin `scheduler` or `batcher`. The `batcher` is what we already actively use today. In follow-up PRs, we will create a `Scheduler` component that will handle SAPM MRs of kind `scheduler`, separate from the batcher.