### PR TITLE
update entrypoint for tini

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -72,7 +72,7 @@ ENV OC_VERSION=4.10.15
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--", "/run-integration.py"]
+ENTRYPOINT ["/tini", "--"]
 
 # oc versions sometimes have issues with FIPS enabled systems requiring us to use specific
 # versions in these environments so in this case we extract an older version of oc and kubectl


### PR DESCRIPTION
Removing the `/run-integration.py` argument in the FIPS image entrypoint. The reason being that this will break Jenkins builds as they attempt to perform a docker/podman run.

`podman run --rm ... quay.io/app-sre/qontract-reconcile-fips:9a81949 qontract-reconcile --config /config/config.toml ...` will evaluate to actually running the following command in the container:

`/tini -- /run-integration.py qontract-reconcile --config /config/config.toml ...` when it should just run `/tini -- qontract-reconcile --config /config/config.toml ...`

