### PR TITLE
[dtp] Create new token for Route Monitoring Operator

### DIFF
--- a/reconcile/dynatrace_token_provider.py
+++ b/reconcile/dynatrace_token_provider.py
@@ -151,8 +151,6 @@ class DynatraceTokenProviderIntegration(
                 existing_dtp_tokens = {}
 
                 for cluster in clusters:
-                    if cluster.ocm_cluster.display_name != "appint-ex-01":
-                        continue
                     try:
                         with DTPOrganizationErrorRate(
                             integration=self.name,


### PR DESCRIPTION
Create new token for Route Monitoring Operator as a new Secret in SyncSet for a different namespace.

This was tested e2e in integration environment.