### PR TITLE
dashdotdb-dora catch none saas files

### DIFF
--- a/reconcile/dashdotdb_dora.py
+++ b/reconcile/dashdotdb_dora.py
@@ -398,10 +398,14 @@ class DashdotdbDORA(DashdotdbBase):
     def get_repo_ref_for_sha(
         self, saastarget: SaasTarget, sha: str
     ) -> tuple[Optional[str], Optional[str]]:
-        saas_file_yaml = self.gl_app_interface_get_file(
-            saastarget.path, ref=sha
-        ).decode()
-        saas_file = yaml.safe_load(saas_file_yaml)
+        try:
+            saas_file_yaml = self.gl_app_interface_get_file(
+                saastarget.path, ref=sha
+            ).decode()
+            saas_file = yaml.safe_load(saas_file_yaml)
+        except Exception as e:
+            LOG.info(f"failed to decode saas file {saastarget.path} with error: {e}")
+            return (None, None)
 
         for rt in saas_file["resourceTemplates"]:
             if saastarget.resource_template != rt["name"]:


### PR DESCRIPTION
catch new error:

```
dashdotdb_dora.run()

File "/usr/local/lib/python3.11/site-packages/reconcile/dashdotdb_dora.py", line 305, in run

] = threaded.run(

^^^^^^^^^^^^^

File "/usr/local/lib/python3.11/site-packages/sretoolbox/utils/threaded.py", line 72, in run

return pmap(func,

^^^^^^^^^^

File "/usr/local/lib/python3.11/site-packages/sretoolbox/utils/concurrent.py", line 87, in pmap

return list(pool.map(func_partial, iterable))

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 619, in result_iterator

yield _result_or_cancel(fs.pop())

^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 317, in _result_or_cancel

return fut.result(timeout)

^^^^^^^^^^^^^^^^^^^

File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 449, in result

return self.__get_result()

^^^^^^^^^^^^^^^^^^^

File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 401, in __get_result

raise self._exception

File "/usr/lib64/python3.11/concurrent/futures/thread.py", line 58, in run

result = self.fn(*self.args, **self.kwargs)

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/usr/local/lib/python3.11/site-packages/sretoolbox/utils/concurrent.py", line 113, in _full_traceback

return func(*args, **kwargs)

^^^^^^^^^^^^^^^^^^^^^

File "/usr/local/lib/python3.11/site-packages/reconcile/dashdotdb_dora.py", line 393, in get_repo_changes

repo_url, ref_from = self.get_repo_ref_for_sha(saastarget, promotion_sha + "^")

^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

File "/usr/local/lib/python3.11/site-packages/reconcile/dashdotdb_dora.py", line 403, in get_repo_ref_for_sha

).decode()

^^^^^^

AttributeError: 'NoneType' object has no attribute 'decode'
```