### PR TITLE
[tf-repo] change behavior when state has to be recreated

### DIFF
--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -112,7 +112,6 @@ class TerraformRepoIntegration(
             # when updating TerraformRepoV1 GQL schema, Pydantic does not gracefully handle these changes and fails to parse
             # the existing state stored in S3. This is due to a behavior in Pydantic V1 that has since been addressed in V2
             # https://docs.pydantic.dev/latest/blog/pydantic-v2/#required-vs-nullable-cleanup
-            # so in this case, tf-repo will just recreate all of those state files in S3 and not actually do a plan or apply
             logging.error(err)
             logging.info(
                 "Unable to parse existing Terraform-Repo state from S3. Note that this is separate from the actual .tfstate files. Terraform Repo will re-create its own state upon merge and will not update any infrastructure. This typically occurs with changes to the Terraform Repo schema files and is normally resolved once state is re-created."

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -125,6 +125,9 @@ class TerraformRepoIntegration(
                 recreate_state=True,
             )
 
+            if repo_diff_result:
+                self.print_output(repo_diff_result, dry_run)
+
     def print_output(self, diff: list[TerraformRepoV1], dry_run: bool) -> OutputFile:
         """Parses and prints the output of a Terraform Repo diff for the executor
 


### PR DESCRIPTION
Schema changes to the [`/aws/terraform-repo-1.yml` schemas](https://github.com/app-sre/qontract-schemas/blob/main/schemas/aws/terraform-repo-1.yml) require Terraform Repo's internal concept of state to be recreated. 

My initial approach was to simply have tf-repo go in and recreate its own statefiles with no terraform plan/apply, however that doesn't provide much confidence that future plans and applies will be executed without issue. Therefore, I've updated the function to run plans and applies when tf-repo's own state is recreated.