### PR TITLE
[statuspage-components] list components using rest api

### DIFF
--- a/reconcile/statuspage/atlassian.py
+++ b/reconcile/statuspage/atlassian.py
@@ -67,9 +67,20 @@ class LegacyLibAtlassianAPI:
     def list_components(self) -> list[AtlassianRawComponent]:
         url = f"{self.api_url}/v1/pages/{self.page_id}/components"
         headers = {"Authorization": f"OAuth {self.token}"}
-        response = requests.get(url, headers=headers)
-        response.raise_for_status()
-        return [AtlassianRawComponent(**c) for c in response.json()]
+        all_components: list[AtlassianRawComponent] = []
+        page = 1
+        per_page = 100
+        while True:
+            params = {"page": page, "per_page": per_page}
+            response = requests.get(url, params=params, headers=headers)
+            response.raise_for_status()
+            components = [AtlassianRawComponent(**c) for c in response.json()]
+            all_components += components
+            if len(components) < per_page:
+                break
+            page += 1
+
+        return all_components
 
     def update_component(self, id: str, data: dict[str, Any]) -> None:
         self._client.components.update(id, **data)

--- a/reconcile/statuspage/atlassian.py
+++ b/reconcile/statuspage/atlassian.py
@@ -5,6 +5,7 @@ from typing import (
     Protocol,
 )
 
+import requests
 import statuspageio  # type: ignore
 from pydantic import BaseModel
 
@@ -64,12 +65,11 @@ class LegacyLibAtlassianAPI:
         )
 
     def list_components(self) -> list[AtlassianRawComponent]:
-        return [
-            AtlassianRawComponent(
-                **c.toDict(),
-            )
-            for c in self._client.components.list()
-        ]
+        url = f"{self.api_url}/v1/pages/{self.page_id}/components"
+        headers = {"Authorization": f"OAuth {self.token}"}
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        return [AtlassianRawComponent(**c) for c in response.json()]
 
     def update_component(self, id: str, data: dict[str, Any]) -> None:
         self._client.components.update(id, **data)


### PR DESCRIPTION
the integration is trying to create existing components due to not getting them due to lack of paging.

https://github.com/app-sre/qontract-reconcile/blob/8035934dfcd7a2fa1686383c41fb2d3711e89b25/reconcile/statuspage/atlassian.py#L54

this PR updates the `list_components` method only, but we might as well get rid of the usage of the legacy lib altogether.

API ref: https://developer.statuspage.io/#operation/getPagesPageIdComponents