### PR TITLE
[fips image] add CMD

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -72,9 +72,11 @@ ENV OC_VERSION=4.10.15
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
-ENTRYPOINT ["/tini", "--"]
 
 # oc versions sometimes have issues with FIPS enabled systems requiring us to use specific
 # versions in these environments so in this case we extract an older version of oc and kubectl
 COPY --chown=0:0 --from=quay.io/app-sre/qontract-reconcile-oc:0.1.0 \
     /work/${OC_VERSION}/ /usr/local/bin/
+
+ENTRYPOINT ["/tini", "--"]
+CMD [ "/run-integration.py" ]


### PR DESCRIPTION
Followup to #4315

According to [this issue](https://github.com/moby/moby/issues/5147) & [stackoverflow](https://stackoverflow.com/questions/49028644/is-cmd-in-parent-docker-overriden-by-cmd-entrypoint-in-child-docker-image) along with running a `docker inspect` on the FIPS image:

![image](https://github.com/app-sre/qontract-reconcile/assets/4098927/d7147b14-5cd6-4a7f-ac34-3c45839413ae)

when using a multistage build, if you define an entrypoint in the child image, the `CMD` is set to `null` which breaks functionality on OpenShift. I've updated the Dockerfile to match [Tini's recommend method](https://github.com/krallin/tini?tab=readme-ov-file#using-tini) in light of this.