### PR TITLE
[status-page-components] deprecate usage of transity-statuspageio

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         "websocket-client<0.55.0,>=0.35",
         "sshtunnel>=0.4.0",
         "croniter>=1.0.15,<1.1.0",
-        "transity-statuspageio>=0.0.3,<0.1",
         "pydantic~=1.10.6",
         "MarkupSafe==2.1.1",
         "filetype~=1.2.0",


### PR DESCRIPTION
* the underlying library is not maintained anymore
* the library has no type annotated
* the library does not support pagination which becomes important for this API