### PR TITLE
:sparkles: ocm-labels: add --ignored-label-prefixes command line option

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -3489,8 +3489,15 @@ def skupper_network(ctx, thread_pool_size, internal, use_jump_host):
     envvar="OL_MANAGED_LABEL_PREFIXES",
     default="sre-capabilities",
 )
+@click.option(
+    "--ignored-label-prefixes",
+    help="A comma list of label prefixes that must be ignored.",
+    required=True,
+    envvar="OL_IGNORED_LABEL_PREFIXES",
+    default="sre-capabilities.rhidp",
+)
 @click.pass_context
-def ocm_labels(ctx, managed_label_prefixes):
+def ocm_labels(ctx, managed_label_prefixes, ignored_label_prefixes):
     from reconcile.ocm_labels.integration import (
         OcmLabelsIntegration,
         OcmLabelsIntegrationParams,
@@ -3500,6 +3507,7 @@ def ocm_labels(ctx, managed_label_prefixes):
         integration=OcmLabelsIntegration(
             OcmLabelsIntegrationParams(
                 managed_label_prefixes=list(set(managed_label_prefixes.split(","))),
+                ignored_label_prefixes=list(set(ignored_label_prefixes.split(","))),
             )
         ),
         ctx=ctx.obj,

--- a/reconcile/test/ocm_labels/conftest.py
+++ b/reconcile/test/ocm_labels/conftest.py
@@ -147,6 +147,7 @@ def ocm_clusters(build_cluster_details: Callable) -> list[ClusterDetails]:
             subs_labels=[
                 ("my-label-prefix.to-be-removed", "enabled"),
                 ("my-label-prefix.to-be-changed", "disabled"),
+                ("my-label-prefix.must-be-ignored.foobar", "enabled"),
                 ("do-not-touch", "enabled"),
             ],
         ),

--- a/reconcile/test/ocm_labels/test_ocm_labels_integration.py
+++ b/reconcile/test/ocm_labels/test_ocm_labels_integration.py
@@ -132,7 +132,9 @@ def test_ocm_labels_fetch_current_state(
 
     assert (
         ocm_labels.fetch_subscription_label_current_state(
-            clusters, managed_label_prefixes=["my-label-prefix"]
+            clusters,
+            managed_label_prefixes=["my-label-prefix"],
+            ignored_label_prefixes=["my-label-prefix.must-be-ignored"],
         )
         == subscription_label_current_state
     )


### PR DESCRIPTION
`ocm-labels` must ignore `sre-capabilities.rhidp` because it's managed by `cluster-auth-rhidp`. Having a `--ignored-label-prefixes` command line option makes the integration setting easier to maintain.

Ticket: [APPSRE-8307](https://issues.redhat.com/browse/APPSRE-8307)