### PR TITLE
update prometheus datasource for sre-capabilities related dashboards

### DIFF
--- a/grafana-dashboards/sre-capability-idp.configmap.yaml
+++ b/grafana-dashboards/sre-capability-idp.configmap.yaml
@@ -61,6 +61,7 @@ data:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "Clusters",
@@ -74,6 +75,7 @@ data:
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -169,6 +171,7 @@ data:
                 "mode": "palette-classic"
               },
               "custom": {
+                "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
                 "axisLabel": "SSO Clients",
@@ -182,6 +185,7 @@ data:
                   "tooltip": false,
                   "viz": false
                 },
+                "insertNulls": false,
                 "lineInterpolation": "linear",
                 "lineWidth": 1,
                 "pointSize": 5,
@@ -299,9 +303,11 @@ data:
               "limit": 1,
               "values": true
             },
-            "textMode": "auto"
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "10.4.1",
           "targets": [
             {
               "datasource": {
@@ -364,9 +370,11 @@ data:
               "limit": 1,
               "values": true
             },
-            "textMode": "auto"
+            "showPercentChange": false,
+            "textMode": "auto",
+            "wideLayout": true
           },
-          "pluginVersion": "9.3.8",
+          "pluginVersion": "10.4.1",
           "targets": [
             {
               "datasource": {
@@ -385,8 +393,7 @@ data:
           "type": "stat"
         }
       ],
-      "schemaVersion": 37,
-      "style": "dark",
+      "schemaVersion": 39,
       "tags": [],
       "templating": {
         "list": []
@@ -399,6 +406,6 @@ data:
       "timezone": "",
       "title": "RedHat SSO IDP Overview",
       "uid": "0lZiDarVz",
-      "version": 4,
+      "version": 5,
       "weekStart": ""
     }


### PR DESCRIPTION
Update the prometheus data source off the RHIDP dashboard because `sre-capabilities` has been migrated to appsrep09ue1.