### PR TITLE
[status-page-maintenances] only manage scheduled maintenances

### DIFF
--- a/reconcile/statuspage/atlassian.py
+++ b/reconcile/statuspage/atlassian.py
@@ -398,7 +398,7 @@ class AtlassianStatusPageProvider:
         )
 
     @property
-    def maintenances(self) -> list[StatusMaintenance]:
+    def scheduled_maintenances(self) -> list[StatusMaintenance]:
         return [
             StatusMaintenance(
                 name=m.name,

--- a/reconcile/statuspage/integrations/maintenances.py
+++ b/reconcile/statuspage/integrations/maintenances.py
@@ -65,7 +65,7 @@ class StatusPageMaintenancesIntegration(QontractReconcileIntegration[NoParams]):
                 self.reconcile(
                     dry_run=dry_run,
                     desired_state=desired_state,
-                    current_state=page_provider.maintenances,
+                    current_state=page_provider.scheduled_maintenances,
                     provider=page_provider,
                 )
             except Exception:

--- a/reconcile/statuspage/integrations/maintenances.py
+++ b/reconcile/statuspage/integrations/maintenances.py
@@ -1,5 +1,6 @@
 import logging
 import sys
+from datetime import datetime, timezone
 
 from reconcile.statuspage.atlassian import AtlassianStatusPageProvider
 from reconcile.statuspage.integration import get_binding_state, get_status_pages
@@ -46,6 +47,7 @@ class StatusPageMaintenancesIntegration(QontractReconcileIntegration[NoParams]):
     def run(self, dry_run: bool = False) -> None:
         binding_state = get_binding_state(self.name, self.secret_reader)
         pages = get_status_pages()
+        now = datetime.now(timezone.utc)
 
         error = False
         for p in pages:
@@ -53,6 +55,7 @@ class StatusPageMaintenancesIntegration(QontractReconcileIntegration[NoParams]):
                 desired_state = [
                     StatusMaintenance.init_from_maintenance(m)
                     for m in p.maintenances or []
+                    if datetime.fromisoformat(m.scheduled_start) > now
                 ]
                 page_provider = AtlassianStatusPageProvider.init_from_page(
                     page=p,

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2589,7 +2589,7 @@ def maintenances(ctx):
             "services": ", ".join(a.name for a in m.affected_services),
         }
         for m in maintenances
-        if datetime.fromisoformat(m.scheduled_end) > now
+        if datetime.fromisoformat(m.scheduled_start) > now
     ]
     columns = [
         "name",


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10225

design document: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/maintenances.md

follows up on https://github.com/app-sre/qontract-reconcile/pull/4344 and #4348

in this PR we add a condition to only manage scheduled maintenances.