### PR TITLE
[status-page-maintenaces] only return maintenances with bindings

### DIFF
--- a/reconcile/statuspage/integrations/maintenances.py
+++ b/reconcile/statuspage/integrations/maintenances.py
@@ -64,10 +64,15 @@ class StatusPageMaintenancesIntegration(QontractReconcileIntegration[NoParams]):
                     token=self.secret_reader.read_secret(p.credentials),
                     component_binding_state=binding_state,
                 )
+                current_state = [
+                    m
+                    for m in page_provider.scheduled_maintenances
+                    if page_provider.has_component_binding_for(m.name)
+                ]
                 self.reconcile(
                     dry_run=dry_run,
                     desired_state=desired_state,
-                    current_state=page_provider.scheduled_maintenances,
+                    current_state=current_state,
                     provider=page_provider,
                 )
             except Exception:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10225

design document: https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/design-docs/maintenances.md

follows up on https://github.com/app-sre/qontract-reconcile/pull/4344

in this PR we limit the scope of maintenances to return only to ones that were created by the integration:
https://github.com/app-sre/qontract-reconcile/blob/e1238a0e29bded55c993a362da20ae1f3636ab1c/reconcile/statuspage/atlassian.py#L421-L425

this is because we want to allow maintenances to be managed from both the integrations and by humans. the integration can not be authoritative, and the binding is used to determine if a maintenance is owned by the integration or not.