### PR TITLE
Add extended early exit

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1200,8 +1200,18 @@ def openshift_upgrade_watcher(ctx, thread_pool_size, internal, use_jump_host):
 @integration.command(short_help="Manage Slack User Groups (channels and users).")
 @workspace_name
 @usergroup_name
+@enable_extended_early_exit
+@extended_early_exit_cache_ttl_seconds
+@log_cached_log_output
 @click.pass_context
-def slack_usergroups(ctx, workspace_name, usergroup_name):
+def slack_usergroups(
+    ctx,
+    workspace_name,
+    usergroup_name,
+    enable_extended_early_exit,
+    extended_early_exit_cache_ttl_seconds,
+    log_cached_log_output,
+):
     import reconcile.slack_usergroups
 
     run_integration(
@@ -1209,6 +1219,9 @@ def slack_usergroups(ctx, workspace_name, usergroup_name):
         ctx.obj,
         workspace_name,
         usergroup_name,
+        enable_extended_early_exit,
+        extended_early_exit_cache_ttl_seconds,
+        log_cached_log_output,
     )
 
 

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -14,10 +14,6 @@ from typing import (
 )
 from urllib.parse import urlparse
 
-from build.lib.reconcile.utils.extended_early_exit import (
-    ExtendedEarlyExitRunnerResult,
-    extended_early_exit_run,
-)
 from github.GithubException import UnknownObjectException
 from pydantic import BaseModel
 from pydantic.utils import deep_update
@@ -51,6 +47,10 @@ from reconcile.utils.disabled_integrations import integration_is_enabled
 from reconcile.utils.exceptions import (
     AppInterfaceSettingsError,
     UnknownError,
+)
+from reconcile.utils.extended_early_exit import (
+    ExtendedEarlyExitRunnerResult,
+    extended_early_exit_run,
 )
 from reconcile.utils.github_api import GithubRepositoryApi
 from reconcile.utils.gitlab_api import GitLabApi


### PR DESCRIPTION
This implements extended early exit for slack usergroups integration. 

- Payload is not set in Result, since the state data structure is not JSON hashable (using sets)
- This does not reduce the runtime by much (around. 1/5th). It drastically reduces API requests towards slack, which caused API rate liming errors in the past. More caching for computing desired state would be required to further reduce runtime. 