### PR TITLE
[cst] add a missing error return

### DIFF
--- a/run-test-container-image.sh
+++ b/run-test-container-image.sh
@@ -90,6 +90,7 @@ run_cst_using_container() {
             -i "$IMAGE_NAME:$IMAGE_TAG"
     else
         echo "Unsupported $CONTAINER_ENGINE to run container structure tests"
+        return 1
     fi
 }
 


### PR DESCRIPTION
When working on https://github.com/app-sre/terraform-repo-executor/pull/22, I noticed that one error case didn't return an error on failure so fixing that here.