### PR TITLE
fix annotations comparison in 3way diff strategy

### DIFF
--- a/reconcile/test/test_three_way_diff_strategy.py
+++ b/reconcile/test/test_three_way_diff_strategy.py
@@ -109,3 +109,13 @@ def test_3wpd_change_empty_env_value_should_not_apply(deployment):
     ]
 
     assert three_way_diff_using_hash(c_item, d_item) is True
+
+
+def test_3wpd_diff_detects_missing_annotation(deployment):
+    d_item = OR(deployment, "", "")
+    d_item.body["metadata"]["annotations"]["new-annotation"] = "test-value"
+    c_item = d_item.annotate(canonicalize=False)
+
+    del c_item.body["metadata"]["annotations"]["new-annotation"]
+
+    assert three_way_diff_using_hash(c_item, d_item) is False

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -17,7 +17,6 @@ from pydantic import BaseModel
 from reconcile.utils.metrics import GaugeMetric
 
 SECRET_MAX_KEY_LENGTH = 253
-LAC_ANNOTATION = "kubectl.kubernetes.io/last-applied-configuration"
 
 
 class ResourceKeyExistsError(Exception):

--- a/reconcile/utils/three_way_diff_strategy.py
+++ b/reconcile/utils/three_way_diff_strategy.py
@@ -20,6 +20,8 @@ NORMALIZE_COMPARE_EXCLUDED_ATTRS = {
     "managedFields",
     "namespace",
 }
+K8S_ANNOTATION_LAC = "kubectl.kubernetes.io/last-applied-configuration"
+NORMALIZE_IGNORE_ANNOTATIONS = QONTRACT_ANNOTATIONS | {K8S_ANNOTATION_LAC}
 
 
 def _normalize_secret(secret: OR) -> None:
@@ -59,9 +61,9 @@ def normalize_object(item: OR) -> OR:
         validate_k8s_object=False,
     )
 
-    annotations = n.body.get("annotations", {})
+    annotations = n.body.get("metadata", {}).get("annotations", {})
     metadata["annotations"] = {
-        k: v for k, v in annotations.items() if k not in QONTRACT_ANNOTATIONS
+        k: v for k, v in annotations.items() if k not in NORMALIZE_IGNORE_ANNOTATIONS
     }
 
     # Run normalizers on Kinds with special needs


### PR DESCRIPTION
The diff strategy was not detecting missing annotations in the current objects if they were removed outside of QR. 