### PR TITLE
Introduce ERv2 Outputs sync integration

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -3712,6 +3712,24 @@ def external_resources(
     )
 
 
+@integration.command(
+    short_help="Syncs External Resources Secrets from Vault to Clusters"
+)
+@click.pass_context
+@threaded(default=5)
+def external_resources_secrets_sync(
+    ctx,
+    thread_pool_size: int,
+):
+    import reconcile.external_resources.integration_secrets_sync
+
+    run_integration(
+        reconcile.external_resources.integration_secrets_sync,
+        ctx.obj,
+        thread_pool_size,
+    )
+
+
 def get_integration_cli_meta() -> dict[str, IntegrationMeta]:
     """
     returns all integrations known to cli.py via click introspection

--- a/reconcile/external_resources/integration.py
+++ b/reconcile/external_resources/integration.py
@@ -124,7 +124,12 @@ def run(
                 dry_run_job_suffix=dry_run_job_suffix,
             ),
             secrets_reconciler=build_incluster_secrets_reconciler(
-                workers_cluster, workers_namespace, secret_reader, vault_path="app-sre"
+                workers_cluster,
+                workers_namespace,
+                secret_reader,
+                vault_path=er_settings.vault_secrets_path,
+                thread_pool_size=thread_pool_size,
+                dry_run=dry_run,
             ),
         )
 

--- a/reconcile/external_resources/integration_secrets_sync.py
+++ b/reconcile/external_resources/integration_secrets_sync.py
@@ -1,0 +1,32 @@
+from reconcile.external_resources.model import ExternalResourcesInventory
+from reconcile.external_resources.secrets_sync import VaultSecretsReconciler
+from reconcile.typed_queries.app_interface_vault_settings import (
+    get_app_interface_vault_settings,
+)
+from reconcile.typed_queries.external_resources import get_namespaces, get_settings
+from reconcile.utils.openshift_resource import ResourceInventory
+from reconcile.utils.secret_reader import create_secret_reader
+from reconcile.utils.semver_helper import make_semver
+
+QONTRACT_INTEGRATION = "external_resources_secrets_sync"
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
+
+
+def run(dry_run: bool, thread_pool_size: int) -> None:
+    """Integration that syncs External Resources Outputs Secrets from Vault into
+    the target clusters
+    """
+    vault_settings = get_app_interface_vault_settings()
+    secrets_reader = create_secret_reader(use_vault=vault_settings.vault)
+    er_settings = get_settings()[0]
+    namespaces = [ns for ns in get_namespaces() if ns.external_resources]
+    er_inventory = ExternalResourcesInventory(namespaces)
+
+    reconciler = VaultSecretsReconciler(
+        ri=ResourceInventory(),
+        secrets_reader=secrets_reader,
+        vault_path=er_settings.vault_secrets_path,
+        thread_pool_size=thread_pool_size,
+        dry_run=dry_run,
+    )
+    reconciler.sync_secrets(er_inventory.values())

--- a/reconcile/external_resources/integration_secrets_sync.py
+++ b/reconcile/external_resources/integration_secrets_sync.py
@@ -1,9 +1,16 @@
-from reconcile.external_resources.model import ExternalResourcesInventory
+from reconcile.external_resources.model import (
+    ExternalResourcesInventory,
+    load_module_inventory,
+)
 from reconcile.external_resources.secrets_sync import VaultSecretsReconciler
 from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,
 )
-from reconcile.typed_queries.external_resources import get_namespaces, get_settings
+from reconcile.typed_queries.external_resources import (
+    get_modules,
+    get_namespaces,
+    get_settings,
+)
 from reconcile.utils.openshift_resource import ResourceInventory
 from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.semver_helper import make_semver
@@ -17,16 +24,24 @@ def run(dry_run: bool, thread_pool_size: int) -> None:
     the target clusters
     """
     vault_settings = get_app_interface_vault_settings()
-    secrets_reader = create_secret_reader(use_vault=vault_settings.vault)
+    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
     er_settings = get_settings()[0]
+
     namespaces = [ns for ns in get_namespaces() if ns.external_resources]
     er_inventory = ExternalResourcesInventory(namespaces)
+    m_inventory = load_module_inventory(get_modules())
+
+    to_sync_specs = []
+    for key, spec in er_inventory.items():
+        module = m_inventory.get_from_external_resource_key(key)
+        if module.outputs_secret_sync:
+            to_sync_specs.append(spec)
 
     reconciler = VaultSecretsReconciler(
         ri=ResourceInventory(),
-        secrets_reader=secrets_reader,
+        secrets_reader=secret_reader,
         vault_path=er_settings.vault_secrets_path,
         thread_pool_size=thread_pool_size,
         dry_run=dry_run,
     )
-    reconciler.sync_secrets(er_inventory.values())
+    reconciler.sync_secrets(to_sync_specs)

--- a/reconcile/external_resources/integration_secrets_sync.py
+++ b/reconcile/external_resources/integration_secrets_sync.py
@@ -31,11 +31,11 @@ def run(dry_run: bool, thread_pool_size: int) -> None:
     er_inventory = ExternalResourcesInventory(namespaces)
     m_inventory = load_module_inventory(get_modules())
 
-    to_sync_specs = []
-    for key, spec in er_inventory.items():
-        module = m_inventory.get_from_external_resource_key(key)
-        if module.outputs_secret_sync:
-            to_sync_specs.append(spec)
+    to_sync_specs = [
+        spec
+        for key, spec in er_inventory.items()
+        if m_inventory.get_from_external_resource_key(key).outputs_secret_sync
+    ]
 
     reconciler = VaultSecretsReconciler(
         ri=ResourceInventory(),

--- a/reconcile/external_resources/manager.py
+++ b/reconcile/external_resources/manager.py
@@ -212,7 +212,7 @@ class ExternalResourcesManager:
             ResourceStatus.DELETE_IN_PROGRESS,
             ResourceStatus.IN_PROGRESS,
         ]):
-            return need_secret_sync
+            return False
 
         logging.info(
             "Reconciliation In progress. Action: %s, Key:%s",
@@ -275,9 +275,45 @@ class ExternalResourcesManager:
             r.action == Action.APPLY and state.resource_status == ResourceStatus.CREATED
         )
 
-    def _sync_secrets(self, keys: Iterable[ExternalResourceKey]) -> None:
-        specs = [spec for key in keys if (spec := self.er_inventory.get(key))]
-        self.secrets_reconciler.sync_secrets(specs=specs)
+    def _sync_secrets(
+        self,
+        to_sync_keys: Iterable[ExternalResourceKey],
+        pending_sync_keys: Iterable[ExternalResourceKey],
+    ) -> None:
+        specs = [
+            spec
+            for key in set(to_sync_keys) | set(pending_sync_keys)
+            if (spec := self.er_inventory.get(key))
+        ]
+
+        sync_error_spec_keys = {
+            ExternalResourceKey.from_spec(spec)
+            for spec in self.secrets_reconciler.sync_secrets(specs=specs)
+        }
+
+        for key in to_sync_keys:
+            if key in sync_error_spec_keys:
+                logging.info(
+                    "Marking Resource: %s as %s",
+                    key,
+                    ResourceStatus.PENDING_SECRET_SYNC,
+                )
+                self.state_mgr.update_resource_status(
+                    key, ResourceStatus.PENDING_SECRET_SYNC
+                )
+
+        for key in pending_sync_keys:
+            if key in sync_error_spec_keys:
+                logging.info(
+                    "Outputs secret for key can not be reconciled. Key: %s", key
+                )
+            else:
+                logging.info(
+                    "Outputs secret for key has been reconciled. Marking resource as %s. Key: %s",
+                    ResourceStatus.CREATED,
+                    key,
+                )
+                self.state_mgr.update_resource_status(key, ResourceStatus.CREATED)
 
     def _build_external_resource(
         self, spec: ExternalResourceSpec, er_inventory: ExternalResourcesInventory
@@ -295,12 +331,12 @@ class ExternalResourcesManager:
     def handle_resources(self) -> None:
         desired_r = self._get_desired_objects_reconciliations()
         deleted_r = self._get_deleted_objects_reconciliations()
-        to_sync: set[ExternalResourceKey] = set()
+        to_sync_keys: set[ExternalResourceKey] = set()
         for r in desired_r.union(deleted_r):
             state = self.state_mgr.get_external_resource_state(r.key)
             need_sync = self._update_in_progress_state(r, state)
             if need_sync:
-                to_sync.add(r.key)
+                to_sync_keys.add(r.key)
 
             metrics.set_gauge(
                 ExternalResourcesReconcileErrorsGauge(
@@ -316,8 +352,14 @@ class ExternalResourcesManager:
                 self.reconciler.reconcile_resource(reconciliation=r)
                 self._update_state(r, state)
 
-        if to_sync:
-            self._sync_secrets(keys=to_sync)
+        pending_sync_keys = self.state_mgr.get_keys_by_status(
+            ResourceStatus.PENDING_SECRET_SYNC
+        )
+
+        if to_sync_keys or pending_sync_keys:
+            self._sync_secrets(
+                to_sync_keys=to_sync_keys, pending_sync_keys=pending_sync_keys
+            )
 
     def handle_dry_run_resources(self) -> None:
         desired_r = self._get_desired_objects_reconciliations()

--- a/reconcile/external_resources/meta.py
+++ b/reconcile/external_resources/meta.py
@@ -2,3 +2,12 @@ from reconcile.utils.semver_helper import make_semver
 
 QONTRACT_INTEGRATION = "external_resources"
 QONTRACT_INTEGRATION_VERSION = make_semver(0, 1, 0)
+
+
+SECRET_ANN_PREFIX = "external-resources"
+SECRET_ANN_PROVISION_PROVIDER = SECRET_ANN_PREFIX + "/provision_provider"
+SECRET_ANN_PROVISIONER = SECRET_ANN_PREFIX + "/provisioner_name"
+SECRET_ANN_PROVIDER = SECRET_ANN_PREFIX + "/provider"
+SECRET_ANN_IDENTIFIER = SECRET_ANN_PREFIX + "/identifier"
+SECRET_UPDATED_AT = SECRET_ANN_PREFIX + "/updated_at"
+SECRET_UPDATED_AT_TIMEFORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/reconcile/external_resources/secrets_sync.py
+++ b/reconcile/external_resources/secrets_sync.py
@@ -1,12 +1,13 @@
 import base64
 import json
+import logging
 from abc import abstractmethod
 from collections.abc import Iterable, Mapping
 from hashlib import shake_128
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 from pydantic import BaseModel
-from sretoolbox.utils import retry
+from sretoolbox.utils import threaded
 
 from reconcile.external_resources.meta import (
     QONTRACT_INTEGRATION,
@@ -44,49 +45,51 @@ class SecretsReconciler:
         self,
         ri: ResourceInventory,
         secrets_reader: SecretReaderBase,
-        vault_path: str,
-        vault_client: VaultClient,
+        thread_pool_size: int,
+        dry_run: bool,
     ) -> None:
         self.secrets_reader = secrets_reader
         self.ri = ri
-        self.vault_path = vault_path
-        self.vault_client = cast(_VaultClient, vault_client)
+        self.thread_pool_size = thread_pool_size
+        self.dry_run = dry_run
 
     @abstractmethod
     def _populate_secret_data(self, specs: Iterable[ExternalResourceSpec]) -> None:
         raise NotImplementedError()
 
-    def _populate_annotations(self, spec: ExternalResourceSpec) -> None:
+    def _annotate(self, spec: ExternalResourceSpec) -> None:
         try:
             annotations = json.loads(spec.resource["annotations"])
         except Exception:
             annotations = {}
-
-        annotations["provision_provider"] = spec.provision_provider
-        annotations["provisioner"] = spec.provisioner_name
-        annotations["provider"] = spec.provider
-        annotations["identifier"] = spec.identifier
-
+        annotations["external-resources/provision_provider"] = spec.provision_provider
+        annotations["external-resources/provisioner_name"] = spec.provisioner_name
+        annotations["external-resources/provider"] = spec.provider
+        annotations["external-resources/identifier"] = spec.identifier
         spec.resource["annotations"] = json.dumps(annotations)
 
-    def _initialize_ri(
+    def _specs_with_secret(
         self,
-        ri: ResourceInventory,
         specs: Iterable[ExternalResourceSpec],
+    ) -> Iterable[ExternalResourceSpec]:
+        return [spec for spec in specs if spec.secret]
+
+    def _add_secret_to_ri(
+        self,
+        spec: ExternalResourceSpec,
     ) -> None:
-        for spec in specs:
-            ri.initialize_resource_type(
-                spec.cluster_name, spec.namespace_name, "Secret"
-            )
-            ri.add_desired(
-                spec.cluster_name,
-                spec.namespace_name,
-                "Secret",
-                name=spec.output_resource_name,
-                value=spec.build_oc_secret(
-                    QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION
-                ),
-            )
+        self.ri.initialize_resource_type(
+            spec.cluster_name, spec.namespace_name, "Secret"
+        )
+        self.ri.add_desired(
+            spec.cluster_name,
+            spec.namespace_name,
+            "Secret",
+            name=spec.output_resource_name,
+            value=spec.build_oc_secret(
+                QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION
+            ).annotate(),
+        )
 
     def _init_ocmap(self, specs: Iterable[ExternalResourceSpec]) -> OCMap:
         return init_oc_map_from_clusters(
@@ -99,32 +102,34 @@ class SecretsReconciler:
             integration=QONTRACT_INTEGRATION,
         )
 
-    @retry()
-    def _write_secrets_to_vault(self, spec: ExternalResourceSpec) -> None:
-        if spec.secret:
-            secret_path = f"{self.vault_path}/{QONTRACT_INTEGRATION}/{spec.cluster_name}/{spec.namespace_name}/{spec.output_resource_name}"
-            stringified_secret = {k: str(v) for k, v in spec.secret.items()}
-            desired_secret = {"path": secret_path, "data": stringified_secret}
-            self.vault_client.write(desired_secret, decode_base64=False)
-
     def sync_secrets(self, specs: Iterable[ExternalResourceSpec]) -> None:
         self._populate_secret_data(specs)
-        ri = ResourceInventory()
-        self._initialize_ri(ri, specs)
-        ocmap = self._init_ocmap(specs)
-        for item in ri:
-            self.reconcile_data(item, ri, ocmap)
+
+        to_sync_specs = self._specs_with_secret(specs)
+        for spec in to_sync_specs:
+            self._annotate(spec)
+            self._add_secret_to_ri(spec)
+
+        ocmap = self._init_ocmap(to_sync_specs)
+        threaded.run(
+            self.reconcile_data,
+            self.ri,
+            thread_pool_size=self.thread_pool_size,
+            ocmap=ocmap,
+        )
 
     def reconcile_data(
         self,
         ri_item: tuple[str, str, str, Mapping[str, Any]],
-        ri: ResourceInventory,
         ocmap: OCMap,
     ) -> None:
         cluster, namespace, kind, data = ri_item
         oc = ocmap.get_cluster(cluster)
         names = list(data["desired"].keys())
 
+        logging.debug(
+            "Getting Secrets from cluster/namespace %s/%s", cluster, namespace
+        )
         items = oc.get_items("Secret", namespace=namespace, resource_names=names)
         for item in items:
             obj = OpenshiftResource(
@@ -132,7 +137,7 @@ class SecretsReconciler:
                 integration=QONTRACT_INTEGRATION,
                 integration_version=QONTRACT_INTEGRATION_VERSION,
             )
-            ri.add_current(cluster, namespace, kind, name=obj.name, value=obj)
+            self.ri.add_current(cluster, namespace, kind, name=obj.name, value=obj)
 
         diff = diff_mappings(
             data["current"], data["desired"], equal=three_way_diff_using_hash
@@ -146,7 +151,14 @@ class SecretsReconciler:
         self, oc: OCCli, namespace: str, items: Iterable[OpenshiftResource]
     ) -> None:
         for i in items:
-            oc.apply(namespace, resource=i)
+            logging.debug(
+                "Updating Secret Cluster: %s, Namespace: %s, Secret: %s",
+                oc.cluster_name,
+                namespace,
+                i.name,
+            )
+            if not self.dry_run:
+                oc.apply(namespace, resource=i)
 
 
 class InClusterSecretsReconciler(SecretsReconciler):
@@ -159,56 +171,77 @@ class InClusterSecretsReconciler(SecretsReconciler):
         cluster: str,
         namespace: str,
         oc: OCCli,
+        thread_pool_size: int,
+        dry_run: bool,
     ):
-        super().__init__(ri, secrets_reader, vault_path, vault_client)
+        super().__init__(ri, secrets_reader, thread_pool_size, dry_run)
 
         self.cluster = cluster
         self.namespace = namespace
         self.oc = oc
         self.source_secrets: list[str] = []
+        self.vault_client = vault_client
+        self.vault_path = vault_path
 
     def _get_spec_hash(self, spec: ExternalResourceSpec) -> str:
         secret_key = f"{spec.provision_provider}-{spec.provisioner_name}-{spec.provider}-{spec.identifier}"
         return shake_128(secret_key.encode("utf-8")).hexdigest(16)
 
+    def _get_spec_outputs_secret_name(self, spec: ExternalResourceSpec) -> str:
+        return "external-resources-output-" + self._get_spec_hash(spec)
+
     def _populate_secret_data(self, specs: Iterable[ExternalResourceSpec]) -> None:
         if not specs:
             return
-        secrets_map = {
-            "external-resources-output-" + self._get_spec_hash(spec): spec
-            for spec in specs
-        }
+
+        secrets_map = {self._get_spec_outputs_secret_name(spec): spec for spec in specs}
+
         secrets = self.oc.get_items(
             "Secret", namespace=self.namespace, resource_names=list(secrets_map.keys())
         )
+
         for secret in secrets:
             secret_name = secret["metadata"]["name"]
             spec = secrets_map[secret_name]
             data = dict[str, str]()
             for k, v in secret["data"].items():
                 decoded = base64.b64decode(v).decode("utf-8")
+
                 if decoded.startswith("__vault__:"):
                     _secret_ref = json.loads(decoded.replace("__vault__:", ""))
                     secret_ref = VaultSecret(**_secret_ref)
                     data[k] = self.secrets_reader.read_secret(secret_ref)
                 else:
                     data[k] = decoded
+
             spec.secret = data
 
-        self.source_secrets = list(secrets_map.keys())
-
-    def _delete_source_secrets(self) -> None:
-        for secret_name in self.source_secrets:
-            print("Deleting secret " + secret_name)
+    def _delete_source_secrets(self, specs: Iterable[ExternalResourceSpec]) -> None:
+        for spec in self._specs_with_secret(specs):
+            secret_name = "external-resources-output-" + self._get_spec_hash(spec)
+            logging.debug("Deleting secret " + secret_name)
             self.oc.delete(namespace=self.namespace, kind="Secret", name=secret_name)
+
+    def _write_secrets_to_vault(self, specs: Iterable[ExternalResourceSpec]) -> None:
+        for spec in self._specs_with_secret(specs):
+            secret_path = f"{self.vault_path}/{spec.cluster_name}/{spec.namespace_name}/{spec.identifier}"
+            stringified_secret = {k: str(v) for k, v in spec.secret.items()}
+            desired_secret = {"path": secret_path, "data": stringified_secret}
+            self.vault_client.write(desired_secret, decode_base64=False)  # type: ignore[attr-defined]
 
     def sync_secrets(self, specs: Iterable[ExternalResourceSpec]) -> None:
         super().sync_secrets(specs)
-        self._delete_source_secrets()
+        self._write_secrets_to_vault(specs)
+        self._delete_source_secrets(specs)
 
 
 def build_incluster_secrets_reconciler(
-    cluster: str, namespace: str, secrets_reader: SecretReaderBase, vault_path: str
+    cluster: str,
+    namespace: str,
+    secrets_reader: SecretReaderBase,
+    vault_path: str,
+    thread_pool_size: int,
+    dry_run: bool,
 ) -> InClusterSecretsReconciler:
     ri = ResourceInventory()
     ocmap = init_oc_map_from_clusters(
@@ -217,13 +250,41 @@ def build_incluster_secrets_reconciler(
         integration=QONTRACT_INTEGRATION,
     )
     oc = ocmap.get_cluster(cluster)
-    vault_client = VaultClient()
     return InClusterSecretsReconciler(
         cluster=cluster,
         namespace=namespace,
         ri=ri,
         oc=oc,
         vault_path=vault_path,
-        vault_client=vault_client,
+        vault_client=VaultClient(),
         secrets_reader=secrets_reader,
+        thread_pool_size=thread_pool_size,
+        dry_run=dry_run,
     )
+
+
+class VaultSecretsReconciler(SecretsReconciler):
+    def __init__(
+        self,
+        ri: ResourceInventory,
+        secrets_reader: SecretReaderBase,
+        vault_path: str,
+        thread_pool_size: int,
+        dry_run: bool,
+    ):
+        super().__init__(ri, secrets_reader, thread_pool_size, dry_run)
+        self.secrets_reader = secrets_reader
+        self.vault_path = vault_path
+
+    def _populate_secret_data(self, specs: Iterable[ExternalResourceSpec]) -> None:
+        threaded.run(self._read_secret, specs, self.thread_pool_size)
+
+    def _read_secret(self, spec: ExternalResourceSpec) -> None:
+        secret_path = f"{self.vault_path}/{spec.cluster_name}/{spec.namespace_name}/{spec.identifier}"
+        try:
+            logging.debug("Reading Secret %s", secret_path)
+            data = self.secrets_reader.read_all({"path": secret_path})
+            spec.secret = data
+        except Exception:
+            msg = f"Error getting secret from vault, skipping. [{secret_path}]"
+            logging.debug(msg)

--- a/reconcile/external_resources/secrets_sync.py
+++ b/reconcile/external_resources/secrets_sync.py
@@ -26,7 +26,7 @@ from reconcile.utils.oc import (
 )
 from reconcile.utils.oc_map import OCMap, init_oc_map_from_clusters
 from reconcile.utils.openshift_resource import OpenshiftResource, ResourceInventory
-from reconcile.utils.secret_reader import SecretReaderBase
+from reconcile.utils.secret_reader import SecretNotFound, SecretReaderBase
 from reconcile.utils.three_way_diff_strategy import three_way_diff_using_hash
 from reconcile.utils.vault import (
     VaultClient,
@@ -356,6 +356,5 @@ class VaultSecretsReconciler(SecretsReconciler):
             logging.debug("Reading Secret %s", secret_path)
             data = self.secrets_reader.read_all({"path": secret_path})
             spec.secret = data
-        except Exception:
-            msg = f"Error getting secret from vault, skipping. [{secret_path}]"
-            logging.info(msg)
+        except SecretNotFound:
+            logging.info("Error getting secret from vault, skipping. [%s]", secret_path)

--- a/reconcile/external_resources/state.py
+++ b/reconcile/external_resources/state.py
@@ -35,6 +35,7 @@ class ResourceStatus(str, Enum):
     IN_PROGRESS: str = "IN_PROGRESS"
     DELETE_IN_PROGRESS: str = "DELETE_IN_PROGRESS"
     ERROR: str = "ERROR"
+    PENDING_SECRET_SYNC: str = "PENDING_SECRET_SYNC"
 
 
 class ExternalResourceState(BaseModel):
@@ -235,6 +236,15 @@ class ExternalResourcesStateDynamoDB:
 
     def get_all_resource_keys(self) -> set[ExternalResourceKey]:
         return {k for k in self.partial_resources.keys()}
+
+    def get_keys_by_status(
+        self, resource_status: ResourceStatus
+    ) -> set[ExternalResourceKey]:
+        return {
+            k
+            for k, v in self.partial_resources.items()
+            if v.resource_status == resource_status
+        }
 
     def update_resource_status(
         self, key: ExternalResourceKey, status: ResourceStatus

--- a/reconcile/gql_definitions/external_resources/external_resources_modules.gql
+++ b/reconcile/gql_definitions/external_resources/external_resources_modules.gql
@@ -9,5 +9,6 @@ query ExternalResourcesModules {
         default_version
         reconcile_drift_interval_minutes
         reconcile_timeout_minutes
+        outputs_secret_sync
     }
 }

--- a/reconcile/gql_definitions/external_resources/external_resources_modules.py
+++ b/reconcile/gql_definitions/external_resources/external_resources_modules.py
@@ -28,6 +28,7 @@ query ExternalResourcesModules {
         default_version
         reconcile_drift_interval_minutes
         reconcile_timeout_minutes
+        outputs_secret_sync
     }
 }
 """
@@ -47,6 +48,7 @@ class ExternalResourcesModuleV1(ConfiguredBaseModel):
     default_version: str = Field(..., alias="default_version")
     reconcile_drift_interval_minutes: str = Field(..., alias="reconcile_drift_interval_minutes")
     reconcile_timeout_minutes: str = Field(..., alias="reconcile_timeout_minutes")
+    outputs_secret_sync: bool = Field(..., alias="outputs_secret_sync")
 
 
 class ExternalResourcesModulesQueryData(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/external_resources/external_resources_settings.gql
+++ b/reconcile/gql_definitions/external_resources/external_resources_settings.gql
@@ -16,5 +16,6 @@ query ExternalResourcesSettings {
         tf_state_bucket
         tf_state_region
         tf_state_dynamodb_table
+        vault_secrets_path
     }
 }

--- a/reconcile/gql_definitions/external_resources/external_resources_settings.py
+++ b/reconcile/gql_definitions/external_resources/external_resources_settings.py
@@ -35,6 +35,7 @@ query ExternalResourcesSettings {
         tf_state_bucket
         tf_state_region
         tf_state_dynamodb_table
+        vault_secrets_path
     }
 }
 """
@@ -67,6 +68,7 @@ class ExternalResourcesSettingsV1(ConfiguredBaseModel):
     tf_state_bucket: Optional[str] = Field(..., alias="tf_state_bucket")
     tf_state_region: Optional[str] = Field(..., alias="tf_state_region")
     tf_state_dynamodb_table: Optional[str] = Field(..., alias="tf_state_dynamodb_table")
+    vault_secrets_path: str = Field(..., alias="vault_secrets_path")
 
 
 class ExternalResourcesSettingsQueryData(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -32986,6 +32986,22 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "outputs_secret_sync",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "Boolean",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -32775,6 +32775,22 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "vault_secrets_path",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "tf_state_bucket",
                             "description": null,
                             "args": [],

--- a/reconcile/test/external_resources/test_manager.py
+++ b/reconcile/test/external_resources/test_manager.py
@@ -60,6 +60,7 @@ def module() -> ExternalResourcesModuleV1:
         provider="aws-iam-role",
         reconcile_drift_interval_minutes=60,
         reconcile_timeout_minutes=60,
+        outputs_secret_sync=True,
     )
 
 

--- a/reconcile/test/external_resources/test_manager.py
+++ b/reconcile/test/external_resources/test_manager.py
@@ -163,7 +163,7 @@ def test_resource_needs_reconciliation_drift(
             ResourceStatus.IN_PROGRESS,
             Action.APPLY,
             ReconcileStatus.SUCCESS,
-            ResourceStatus.CREATED,
+            ResourceStatus.PENDING_SECRET_SYNC,
         ),
         (
             ResourceStatus.IN_PROGRESS,

--- a/reconcile/test/external_resources/test_manager.py
+++ b/reconcile/test/external_resources/test_manager.py
@@ -46,6 +46,7 @@ def settings() -> ExternalResourcesSettingsV1:
         state_dynamodb_region="us-east-1",
         workers_cluster=ClusterV1(name="appint-ex-01"),
         workers_namespace=NamespaceV1(name="external-resources-poc"),
+        vault_secrets_path="app-sre/integration-outputs/external-resources",
     )
 
 

--- a/reconcile/test/external_resources/test_secrets_sync.py
+++ b/reconcile/test/external_resources/test_secrets_sync.py
@@ -1,0 +1,96 @@
+import copy
+from datetime import datetime, timezone
+
+from pytest import fixture
+
+from reconcile.external_resources.meta import (
+    QONTRACT_INTEGRATION,
+    QONTRACT_INTEGRATION_VERSION,
+)
+from reconcile.external_resources.secrets_sync import (
+    SECRET_UPDATED_AT,
+    SECRET_UPDATED_AT_TIMEFORMAT,
+    SecretHelper,
+)
+from reconcile.utils.openshift_resource import OpenshiftResource
+
+
+@fixture
+def resource() -> OpenshiftResource:
+    return OpenshiftResource(
+        body={
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "type": "Opaque",
+            "data": {
+                "attribute": "cvalue",
+            },
+            "metadata": {
+                "annotations": {
+                    "external-resources/identifier": "rds-test-01",
+                    "external-resources/provider": "rds",
+                    "external-resources/provision_provider": "aws",
+                    "external-resources/provisioner_name": "app-int-example-01",
+                    "external-resources/updated_at": "2024-05-29T18:44:46",
+                    "qontract.caller_name": "app-int-example-01",
+                    "qontract.integration": "external_resources",
+                    "qontract.integration_version": "0.1.0",
+                    "qontract.recycle": "true",
+                    "qontract.sha256sum": "b8bb13e6548bc418d4ea9c01d0d040b6150558f9ba2bb59ea95fd401585adf76",
+                    "qontract.update": "2024-05-29T16:44:37",
+                },
+                "name": "creds",
+                "namespace": "external-resources-poc",
+            },
+        },
+        integration=QONTRACT_INTEGRATION,
+        integration_version=QONTRACT_INTEGRATION_VERSION,
+        validate_k8s_object=False,
+    )
+
+
+@fixture
+def current(resource: OpenshiftResource) -> OpenshiftResource:
+    return resource
+
+
+@fixture
+def desired(resource: OpenshiftResource) -> OpenshiftResource:
+    return copy.deepcopy(resource)
+
+
+def test_update_at_doesnot_triggers_update(
+    current: OpenshiftResource,
+    desired: OpenshiftResource,
+) -> None:
+    desired.annotations[SECRET_UPDATED_AT] = datetime.now(timezone.utc).strftime(
+        SECRET_UPDATED_AT_TIMEFORMAT
+    )
+    assert SecretHelper.compare(current, desired) is True
+
+
+def test_new_data_triggers_update(
+    current: OpenshiftResource,
+    desired: OpenshiftResource,
+) -> None:
+    desired.annotations[SECRET_UPDATED_AT] = datetime.now(timezone.utc).strftime(
+        SECRET_UPDATED_AT_TIMEFORMAT
+    )
+    desired.body["data"]["new_key"] = "new_value"
+    assert SecretHelper.compare(current, desired) is False
+
+
+def test_current_no_annotation_triggers_update(
+    current: OpenshiftResource,
+    desired: OpenshiftResource,
+) -> None:
+    current.annotations.pop(SECRET_UPDATED_AT, None)
+    assert SecretHelper.compare(current, desired) is False
+
+
+def test_current_new_data_dont_triggers_update(
+    current: OpenshiftResource,
+    desired: OpenshiftResource,
+) -> None:
+    current.body["data"]["new_key"] = "new_value"
+    assert SecretHelper.compare(current, desired) is True

--- a/reconcile/utils/external_resource_spec.py
+++ b/reconcile/utils/external_resource_spec.py
@@ -87,6 +87,11 @@ class ExternalResourceSpec:
     resource: MutableMapping[str, Any]
     namespace: Mapping[str, Any]
     secret: Mapping[str, str] = field(init=False, default_factory=lambda: {})
+    # Metadata is used for processing data that shuold not be included in the secret data
+    # e.g: ERV2 adds a updated_at attribute that acts as optimistic lock.
+    metadata: MutableMapping[str, str] = field(
+        init=False, compare=False, repr=False, hash=False, default_factory=lambda: {}
+    )
 
     @property
     def provider(self) -> str:

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -14,6 +14,7 @@ from typing import (
 import semver
 from pydantic import BaseModel
 
+from reconcile.external_resources.meta import SECRET_UPDATED_AT
 from reconcile.utils.metrics import GaugeMetric
 
 SECRET_MAX_KEY_LENGTH = 253
@@ -526,6 +527,9 @@ class OpenshiftResource:
         # remove qontract specific params
         for a in QONTRACT_ANNOTATIONS:
             annotations.pop(a, None)
+
+        # Remove external resources annotation used for optimistic locking
+        annotations.pop(SECRET_UPDATED_AT, None)
         return body
 
     @staticmethod


### PR DESCRIPTION
This PR introduces an integration to sync External resource outputs from Vault into the target clusters.

As discussed in the design, ERv2 will continuously sync the outputs from Vault instead of running Terraform for all the resources at each iteration.

The full Picture: 
ERv2 Resource ACTION (Create or Update) -> It will update Vault and Sync the Outputs into the target cluster. 
ERv2 Secrets Sync Integration -> Will loop over all Outputs and sync them into clusters to ensure the Outputs desired state.

Requires: 
* https://github.com/app-sre/qontract-schemas/pull/654/files