### PR TITLE
[status-page-maintenances] slack output

### DIFF
--- a/reconcile/statuspage/integrations/maintenances.py
+++ b/reconcile/statuspage/integrations/maintenances.py
@@ -1,10 +1,12 @@
 import logging
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
+from reconcile.slack_base import slackapi_from_queries
 from reconcile.statuspage.atlassian import AtlassianStatusPageProvider
 from reconcile.statuspage.integration import get_binding_state, get_status_pages
 from reconcile.statuspage.page import StatusMaintenance
+from reconcile.statuspage.state import ComponentBindingState, S3ComponentBindingState
 from reconcile.utils.differ import diff_iterables
 from reconcile.utils.runtime.integration import (
     NoParams,
@@ -44,6 +46,25 @@ class StatusPageMaintenancesIntegration(QontractReconcileIntegration[NoParams]):
                 f"Delete StatusPage Maintenance is not supported at this time: {d.name}"
             )
 
+    def notify(
+        self,
+        dry_run: bool,
+        desired_state: list[StatusMaintenance],
+        binding_state: S3ComponentBindingState,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        for m in desired_state:
+            scheduled_start = datetime.fromisoformat(m.schedule_start)
+            if now <= scheduled_start <= now + timedelta(hours=1):
+                state_key = f"notifications/{m.name}"
+                if binding_state.state.exists(state_key):
+                    continue
+                logging.info(f"Notify StatusPage Maintenance: {m.name}")
+                if not dry_run:
+                    slack = slackapi_from_queries(QONTRACT_INTEGRATION)
+                    slack.chat_post_message(m.message)
+                    binding_state.state.add(f"notifications/{m.name}")
+
     def run(self, dry_run: bool = False) -> None:
         binding_state = get_binding_state(self.name, self.secret_reader)
         pages = get_status_pages()
@@ -74,6 +95,11 @@ class StatusPageMaintenancesIntegration(QontractReconcileIntegration[NoParams]):
                     desired_state=desired_state,
                     current_state=current_state,
                     provider=page_provider,
+                )
+                self.notify(
+                    dry_run=dry_run,
+                    desired_state=desired_state,
+                    binding_state=binding_state,
                 )
             except Exception:
                 logging.exception(f"failed to reconcile statuspage {p.name}")

--- a/reconcile/statuspage/integrations/maintenances.py
+++ b/reconcile/statuspage/integrations/maintenances.py
@@ -6,7 +6,7 @@ from reconcile.slack_base import slackapi_from_queries
 from reconcile.statuspage.atlassian import AtlassianStatusPageProvider
 from reconcile.statuspage.integration import get_binding_state, get_status_pages
 from reconcile.statuspage.page import StatusMaintenance
-from reconcile.statuspage.state import ComponentBindingState, S3ComponentBindingState
+from reconcile.statuspage.state import S3ComponentBindingState
 from reconcile.utils.differ import diff_iterables
 from reconcile.utils.runtime.integration import (
     NoParams,

--- a/reconcile/statuspage/integrations/maintenances.py
+++ b/reconcile/statuspage/integrations/maintenances.py
@@ -53,6 +53,7 @@ class StatusPageMaintenancesIntegration(QontractReconcileIntegration[NoParams]):
         binding_state: S3ComponentBindingState,
     ) -> None:
         now = datetime.now(timezone.utc)
+        slack = slackapi_from_queries(QONTRACT_INTEGRATION, init_usergroups=False)
         for m in desired_state:
             scheduled_start = datetime.fromisoformat(m.schedule_start)
             if now <= scheduled_start <= now + timedelta(hours=1):
@@ -61,7 +62,6 @@ class StatusPageMaintenancesIntegration(QontractReconcileIntegration[NoParams]):
                     continue
                 logging.info(f"Notify StatusPage Maintenance: {m.name}")
                 if not dry_run:
-                    slack = slackapi_from_queries(QONTRACT_INTEGRATION)
                     slack.chat_post_message(m.message)
                     binding_state.state.add(f"notifications/{m.name}")
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10268

depends on https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/106453

this PR adds a slack output when a maintenance is less then an hour away. using state, we guarantee the notification is only sent once.