### PR TITLE
[gitlab-permissions] exclude repositories with manage permissions false

### DIFF
--- a/reconcile/gitlab_permissions.py
+++ b/reconcile/gitlab_permissions.py
@@ -49,7 +49,7 @@ def run(dry_run, thread_pool_size=10, defer=None):
     gl = GitLabApi(instance, settings=settings)
     if defer:
         defer(gl.cleanup)
-    repos = queries.get_repos(server=gl.server)
+    repos = queries.get_repos(server=gl.server, exclude_manage_permissions=True)
     app_sre = gl.get_app_sre_group_users()
     results = threaded.run(
         get_members_to_add, repos, thread_pool_size, gl=gl, app_sre=app_sre

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -1724,6 +1724,7 @@ CODE_COMPONENT_REPO_QUERY = """
   apps: apps_v1 {
     codeComponents {
       url
+      managePermissions
     }
   }
 }
@@ -1756,7 +1757,7 @@ def get_review_repos():
     ]
 
 
-def get_repos(server="") -> list[str]:
+def get_repos(server: str = "", exclude_manage_permissions: bool = False) -> list[str]:
     """Returns all repos defined under codeComponents
     Optional arguments:
     server: url of the server to return. for example: https://github.com
@@ -1766,6 +1767,8 @@ def get_repos(server="") -> list[str]:
     for a in apps:
         if a["codeComponents"] is not None:
             for c in a["codeComponents"]:
+                if exclude_manage_permissions and c.get("managePermissions") is False:
+                    continue
                 if c["url"].startswith(server):
                     repos.append(c["url"])
     return repos


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10271

depends on https://github.com/app-sre/qontract-schemas/pull/656

by adding `managePermissions: false`, a code component owner can define to avoid having AppSRE team members added to the repository as Maintainers.