### PR TITLE
requirements-test: botocore match version from setup.py

### DIFF
--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -11,5 +11,5 @@ moto~=2.2
 MarkupSafe==2.1.1
 smtpdfix==0.3.3
 pyfakefs~=5.1
-botocore==1.34.15
+botocore==1.34.94
 ruff==0.4.1


### PR DESCRIPTION
This also addresses the same issue which was fixed some time ago in #4095 