### PR TITLE
:heavy_minus_sign: do not install old botocore

### DIFF
--- a/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
+++ b/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
@@ -1,11 +1,15 @@
 from collections.abc import Callable, Generator
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import boto3
 import pytest
 from moto import mock_s3
-from mypy_boto3_s3 import S3Client
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+else:
+    S3Client = object
 from pytest_mock import MockerFixture
 
 from reconcile.aws_account_manager.reconciler import (

--- a/reconcile/test/utils/test_state.py
+++ b/reconcile/test/utils/test_state.py
@@ -1,10 +1,14 @@
 from collections.abc import Generator
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 import boto3
 import pytest
 from moto import mock_s3
-from mypy_boto3_s3 import S3Client
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+else:
+    S3Client = object
 from pytest import MonkeyPatch
 from pytest_mock import MockerFixture
 

--- a/reconcile/utils/state.py
+++ b/reconcile/utils/state.py
@@ -6,6 +6,7 @@ from abc import abstractmethod
 from collections.abc import Callable, Generator, Mapping
 from dataclasses import dataclass, field
 from typing import (
+    TYPE_CHECKING,
     Any,
     Optional,
     Self,
@@ -13,7 +14,12 @@ from typing import (
 
 import boto3
 from botocore.errorfactory import ClientError
-from mypy_boto3_s3 import S3Client
+
+if TYPE_CHECKING:
+    from mypy_boto3_s3 import S3Client
+else:
+    S3Client = object
+
 from pydantic import BaseModel
 
 from reconcile.gql_definitions.common.app_interface_state_settings import (

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -11,5 +11,4 @@ moto~=2.2
 MarkupSafe==2.1.1
 smtpdfix==0.3.3
 pyfakefs~=5.1
-botocore==1.34.15
 ruff==0.4.5

--- a/requirements/requirements-type.txt
+++ b/requirements/requirements-type.txt
@@ -14,7 +14,8 @@ types-tabulate
 types-toml
 types-dateparser
 types-oauthlib
-boto3-stubs[ec2,s3,rds,iam,route53,organizations,service-quotas,sts,support,dynamodb]==1.34.15
+# keep in sync with boto3 in setup.py
+boto3-stubs[ec2,s3,rds,iam,route53,organizations,service-quotas,sts,support,dynamodb]==1.34.94
 kubernetes-stubs==22.6.0
 qenerate==0.6.3
 types-psycopg2

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
+from release import version
 from setuptools import (
     find_packages,
     setup,
 )
-
-from release import version
 
 setup(
     name="qontract-reconcile",
@@ -32,7 +31,6 @@ setup(
         # keep in sync with boto3-stubs in requirements-type.txt
         "boto3==1.34.94",
         "botocore==1.34.94",
-        "mypy-boto3-s3==1.34.14",
         "urllib3~=2.2",
         "slack_sdk>=3.10,<4.0",
         "pypd>=1.1.0,<1.2.0",

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
-from release import version
 from setuptools import (
     find_packages,
     setup,
 )
+
+from release import version
 
 setup(
     name="qontract-reconcile",
@@ -28,6 +29,7 @@ setup(
         "anymarkup>=0.7.0,<0.9.0",
         "python-gitlab>=1.11.0,<1.12.0",
         "semver~=3.0",
+        # keep in sync with boto3-stubs in requirements-type.txt
         "boto3==1.34.94",
         "botocore==1.34.94",
         "mypy-boto3-s3==1.34.14",


### PR DESCRIPTION
Fix

```
qontract-reconcile 0.10.1rc831 requires boto3==1.34.94, but you have boto3 1.34.15 which is incompatible.
qontract-reconcile 0.10.1rc831 requires botocore==1.34.94, but you have botocore 1.34.15 which is incompatible.
qontract-reconcile 0.10.1rc831 requires urllib3~=2.2, but you have urllib3 2.0.7 which is incompatible.
```