### PR TITLE
[qontract-cli] get systems-and-toold include app-interface instances

### DIFF
--- a/reconcile/gql_definitions/common/app_code_component_repos.gql
+++ b/reconcile/gql_definitions/common/app_code_component_repos.gql
@@ -3,6 +3,8 @@
 query AppCodeComponentRepos {
   apps: apps_v1 {
     codeComponents {
+      name
+      resource
       url
     }
   }

--- a/reconcile/gql_definitions/common/app_code_component_repos.py
+++ b/reconcile/gql_definitions/common/app_code_component_repos.py
@@ -22,6 +22,8 @@ DEFINITION = """
 query AppCodeComponentRepos {
   apps: apps_v1 {
     codeComponents {
+      name
+      resource
       url
     }
   }
@@ -36,6 +38,8 @@ class ConfiguredBaseModel(BaseModel):
 
 
 class AppCodeComponentsV1(ConfiguredBaseModel):
+    name: str = Field(..., alias="name")
+    resource: str = Field(..., alias="resource")
     url: str = Field(..., alias="url")
 
 

--- a/reconcile/typed_queries/repos.py
+++ b/reconcile/typed_queries/repos.py
@@ -1,17 +1,30 @@
 from collections.abc import Callable
 from typing import Optional
 
-from reconcile.gql_definitions.common.app_code_component_repos import query
+from reconcile.gql_definitions.common.app_code_component_repos import (
+    AppCodeComponentsV1,
+    query,
+)
 from reconcile.utils import gql
+
+
+def get_code_components(
+    server: str = "",
+    query_func: Optional[Callable] = None,
+) -> list[AppCodeComponentsV1]:
+    if not query_func:
+        query_func = gql.get_api().query
+    code_components: list[AppCodeComponentsV1] = []
+    for app in query(query_func).apps or []:
+        code_components += [
+            c for c in app.code_components or [] if c.url.startswith(server)
+        ]
+    return code_components
 
 
 def get_repos(
     server: str = "",
     query_func: Optional[Callable] = None,
 ) -> list[str]:
-    if not query_func:
-        query_func = gql.get_api().query
-    repos: list[str] = []
-    for app in query(query_func).apps or []:
-        repos += [c.url for c in app.code_components or [] if c.url.startswith(server)]
-    return repos
+    code_components = get_code_components(server=server, query_func=query_func)
+    return [c.url for c in code_components]

--- a/tools/cli_commands/systems_and_tools.py
+++ b/tools/cli_commands/systems_and_tools.py
@@ -8,7 +8,9 @@ from typing import (
 
 from pydantic import BaseModel
 
-from reconcile.gql_definitions.common.app_code_component_repos import AppCodeComponentsV1
+from reconcile.gql_definitions.common.app_code_component_repos import (
+    AppCodeComponentsV1,
+)
 from reconcile.gql_definitions.common.clusters import ClusterV1
 from reconcile.gql_definitions.common.pagerduty_instances import (
     PagerDutyInstanceV1,
@@ -319,7 +321,9 @@ def get_systems_and_tools_inventory() -> SystemToolInventory:
     inventory.update(get_unleash_instances())
     inventory.update(get_vault_instances())
     inventory.update(get_cloudflare_accounts())
-    inventory.update([c for c in get_code_components() if c.resource == "app-interface"])
+    inventory.update([
+        c for c in get_code_components() if c.resource == "app-interface"
+    ])
 
     inventory.systems_and_tools.append(
         SystemTool(

--- a/tools/cli_commands/systems_and_tools.py
+++ b/tools/cli_commands/systems_and_tools.py
@@ -8,6 +8,7 @@ from typing import (
 
 from pydantic import BaseModel
 
+from reconcile.gql_definitions.common.app_code_component_repos import AppCodeComponentsV1
 from reconcile.gql_definitions.common.clusters import ClusterV1
 from reconcile.gql_definitions.common.pagerduty_instances import (
     PagerDutyInstanceV1,
@@ -46,6 +47,7 @@ from reconcile.typed_queries.jira import get_jira_servers
 from reconcile.typed_queries.ocm import get_ocm_environments
 from reconcile.typed_queries.pagerduty_instances import get_pagerduty_instances
 from reconcile.typed_queries.quay import get_quay_instances
+from reconcile.typed_queries.repos import get_code_components
 from reconcile.typed_queries.slack import get_slack_workspaces
 from reconcile.typed_queries.terraform_tgw_attachments.aws_accounts import (
     get_aws_accounts,
@@ -97,6 +99,8 @@ class SystemTool(BaseModel):
                 return cls.init_from_vault_instance(model)
             case CloudflareAccountV1():
                 return cls.init_from_cloudflare_account(model)
+            case AppCodeComponentsV1():
+                return cls.init_from_code_component(model)
             case _:
                 raise NotImplementedError(f"unsupported: {model}")
 
@@ -250,6 +254,16 @@ class SystemTool(BaseModel):
             description=a.description,
         )
 
+    @classmethod
+    def init_from_code_component(cls, c: AppCodeComponentsV1) -> Self:
+        return cls(
+            system_type=c.resource,
+            system_id=c.name,
+            name=c.name,
+            url=c.url,
+            description=c.name,
+        )
+
 
 class SystemToolInventory:
     def __init__(self) -> None:
@@ -305,6 +319,7 @@ def get_systems_and_tools_inventory() -> SystemToolInventory:
     inventory.update(get_unleash_instances())
     inventory.update(get_vault_instances())
     inventory.update(get_cloudflare_accounts())
+    inventory.update([c for c in get_code_components() if c.resource == "app-interface"])
 
     inventory.systems_and_tools.append(
         SystemTool(


### PR DESCRIPTION
part of https://issues.redhat.com/browse/SDE-3947

depends on https://github.com/app-sre/qontract-schemas/pull/494

follows up on #4384

adds output to the report for every repository mentioned in app codeComponents if the resource equals app-interface.

example: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/106876