### PR TITLE
saasherder autogenerate parameter COMMIT_SHA

### DIFF
--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -959,6 +959,9 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 )
                 raise
 
+            # add COMMIT_SHA only if it is unspecified
+            consolidated_parameters.setdefault("COMMIT_SHA", commit_sha)
+
             # add IMAGE_TAG only if it is unspecified
             if not (image_tag := consolidated_parameters.get("IMAGE_TAG", "")):
                 sha_substring = commit_sha[:hash_length]


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10312

the commit sha is generally used to figure out IMAGE_TAG (first N chars, usually 7, of the commit sha).

in case a team needed the full 40, they could specify `hash_length: 40` and be done with it.

what if some teams needs both?

by adding `COMMIT_SHA`, we always provide the full 40. this allows to keep using IMAGE_TAG for images.

example requirement:
deploying a ConfigMap for HyperShift Operator that includes the following section:
```

        # openshift/hypershift.git branch main commit dcb53a0
        hypershift-operator: quay.io/acm-d/rhtap-hypershift-operator:dcb53a0aba273de04ded0285aa4a2c5a63a04ed2

```
`dcb53a0` / `dcb53a0aba273de04ded0285aa4a2c5a63a04ed2` are the image tag / commit sha.