### PR TITLE
bug fix for normalizing openshift resources with Null annotations

### DIFF
--- a/reconcile/utils/three_way_diff_strategy.py
+++ b/reconcile/utils/three_way_diff_strategy.py
@@ -61,7 +61,7 @@ def normalize_object(item: OR) -> OR:
         validate_k8s_object=False,
     )
 
-    annotations = n.body.get("metadata", {}).get("annotations", {})
+    annotations = n.body.get("metadata").get("annotations") or {}
     metadata["annotations"] = {
         k: v for k, v in annotations.items() if k not in NORMALIZE_IGNORE_ANNOTATIONS
     }


### PR DESCRIPTION
Followup to #4368, see [slack discussion here](https://redhat-internal.slack.com/archives/GGC2A0MS8/p1716990846684109)

The following is considered valid YAML for an OpenShift Route:

```yaml
apiVersion: route.openshift.io/v1
kind: Route
metadata:
  annotations:
  name: cool-route
  namespace: app-interface
```

`annotations` can be left blank which will result in this function failing when trying to read `annotations.items()` as it is trying to call `.items()` on a `NoneType` object. This fix ensures that if `annotations = None`, then an empty dictionary will be returned.