### PR TITLE
do not raise on no pagerduty instances

### DIFF
--- a/reconcile/typed_queries/pagerduty_instances.py
+++ b/reconcile/typed_queries/pagerduty_instances.py
@@ -6,7 +6,6 @@ from reconcile.gql_definitions.common.pagerduty_instances import (
     query,
 )
 from reconcile.utils import gql
-from reconcile.utils.exceptions import AppInterfaceSettingsError
 
 
 def get_pagerduty_instances(
@@ -16,7 +15,4 @@ def get_pagerduty_instances(
     if not query_func:
         gqlapi = gql.get_api()
         query_func = gqlapi.query
-    pagerduty_instances = query(query_func=query_func).pagerduty_instances
-    if not pagerduty_instances:
-        raise AppInterfaceSettingsError("no pagerduty instance(s) configured")
-    return pagerduty_instances
+    return query(query_func=query_func).pagerduty_instances or []


### PR DESCRIPTION
part of https://issues.redhat.com/browse/SDE-3947

in an attempt to run `qc get systems-and-tools` on sre-capabilities, there is no pagerduty in that repository.
generally, the code should accept multiple situations. slack-usergroups should be able to run for repos without pagerduty.

this PR makes the behavior more forgiving.