### PR TITLE
[qontract-cli] get systems-and-tools collect clusters from ocm organizations

### DIFF
--- a/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.py
+++ b/reconcile/gql_definitions/advanced_upgrade_service/aus_clusters.py
@@ -24,6 +24,7 @@ from reconcile.gql_definitions.fragments.upgrade_policy import ClusterUpgradePol
 DEFINITION = """
 fragment AUSOCMOrganization on OpenShiftClusterManager_v1 {
   name
+  labels
   environment {
     ... OCMEnvironment
   }
@@ -75,6 +76,10 @@ fragment AUSOCMOrganization on OpenShiftClusterManager_v1 {
   upgradePolicyAllowedWorkloads
   upgradePolicyClusters {
     name
+    serverUrl
+    spec {
+      id
+    }
     upgradePolicy {
       ... ClusterUpgradePolicyV1
     }

--- a/reconcile/gql_definitions/advanced_upgrade_service/aus_organization.py
+++ b/reconcile/gql_definitions/advanced_upgrade_service/aus_organization.py
@@ -23,6 +23,7 @@ from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganizat
 DEFINITION = """
 fragment AUSOCMOrganization on OpenShiftClusterManager_v1 {
   name
+  labels
   environment {
     ... OCMEnvironment
   }
@@ -74,6 +75,10 @@ fragment AUSOCMOrganization on OpenShiftClusterManager_v1 {
   upgradePolicyAllowedWorkloads
   upgradePolicyClusters {
     name
+    serverUrl
+    spec {
+      id
+    }
     upgradePolicy {
       ... ClusterUpgradePolicyV1
     }

--- a/reconcile/gql_definitions/fragments/aus_organization.gql
+++ b/reconcile/gql_definitions/fragments/aus_organization.gql
@@ -2,6 +2,7 @@
 
 fragment AUSOCMOrganization on OpenShiftClusterManager_v1 {
   name
+  labels
   environment {
     ... OCMEnvironment
   }
@@ -53,6 +54,10 @@ fragment AUSOCMOrganization on OpenShiftClusterManager_v1 {
   upgradePolicyAllowedWorkloads
   upgradePolicyClusters {
     name
+    serverUrl
+    spec {
+      id
+    }
     upgradePolicy {
       ... ClusterUpgradePolicyV1
     }

--- a/reconcile/gql_definitions/fragments/aus_organization.py
+++ b/reconcile/gql_definitions/fragments/aus_organization.py
@@ -70,8 +70,14 @@ class OpenShiftClusterManagerSectorV1(ConfiguredBaseModel):
     dependencies: Optional[list[OpenShiftClusterManagerSectorDependenciesV1]] = Field(..., alias="dependencies")
 
 
+class OpenShiftClusterManagerUpgradePolicyClusterSpecV1(ConfiguredBaseModel):
+    q_id: str = Field(..., alias="id")
+
+
 class OpenShiftClusterManagerUpgradePolicyClusterV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+    server_url: Optional[str] = Field(..., alias="serverUrl")
+    spec: Optional[OpenShiftClusterManagerUpgradePolicyClusterSpecV1] = Field(..., alias="spec")
     upgrade_policy: ClusterUpgradePolicyV1 = Field(..., alias="upgradePolicy")
 
 
@@ -82,6 +88,7 @@ class AusClusterHealthCheckV1(ConfiguredBaseModel):
 
 class AUSOCMOrganization(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+    labels: Optional[Json] = Field(..., alias="labels")
     environment: OCMEnvironment = Field(..., alias="environment")
     org_id: str = Field(..., alias="orgId")
     access_token_client_id: Optional[str] = Field(..., alias="accessTokenClientId")

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -8341,6 +8341,30 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "serverUrl",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "spec",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "OpenShiftClusterManagerUpgradePolicyClusterSpec_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "upgradePolicy",
                             "description": null,
                             "args": [],
@@ -8350,6 +8374,33 @@
                                 "ofType": {
                                     "kind": "OBJECT",
                                     "name": "ClusterUpgradePolicy_v1",
+                                    "ofType": null
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "OpenShiftClusterManagerUpgradePolicyClusterSpec_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "id",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "NON_NULL",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "SCALAR",
+                                    "name": "String",
                                     "ofType": null
                                 }
                             },
@@ -37222,33 +37273,6 @@
                             "ofType": null
                         }
                     ],
-                    "enumValues": null,
-                    "possibleTypes": null
-                },
-                {
-                    "kind": "OBJECT",
-                    "name": "OpenShiftClusterManagerUpgradePolicyClusterSpec_v1",
-                    "description": null,
-                    "fields": [
-                        {
-                            "name": "id",
-                            "description": null,
-                            "args": [],
-                            "type": {
-                                "kind": "NON_NULL",
-                                "name": null,
-                                "ofType": {
-                                    "kind": "SCALAR",
-                                    "name": "String",
-                                    "ofType": null
-                                }
-                            },
-                            "isDeprecated": false,
-                            "deprecationReason": null
-                        }
-                    ],
-                    "inputFields": null,
-                    "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
                 },

--- a/reconcile/ocm_upgrade_scheduler_org_updater.py
+++ b/reconcile/ocm_upgrade_scheduler_org_updater.py
@@ -90,6 +90,8 @@ def run(dry_run, gitlab_project_id):
                         item = {
                             "action": "add",
                             "cluster": ocm_cluster_name,
+                            "url": ocm_cluster_spec.server_url,
+                            "id": ocm_cluster_spec.spec.id,
                             "policy": policy,
                         }
                         updates.append(item)

--- a/reconcile/test/ocm/aus/fixtures.py
+++ b/reconcile/test/ocm/aus/fixtures.py
@@ -94,6 +94,7 @@ def build_organization(
     )
     return AUSOCMOrganization(
         name=org_name or "org-name",
+        labels=None,
         environment=ocm_env or build_ocm_environment(env_name or "env-name"),
         orgId=org_id,
         blockedVersions=blocked_versions,

--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -37,6 +37,8 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
         for update in self.updates_info["updates"]:
             action = update["action"]
             cluster_name = update["cluster"]
+            cluster_id = update["id"]
+            cluster_server_url = update["url"]
             upgrade_policy = update.get("policy")
 
             if action == "add":
@@ -47,6 +49,8 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
                     continue
                 item = {
                     "name": cluster_name,
+                    "serverUrl": cluster_server_url,
+                    "spec": {"id": cluster_id},
                     "upgradePolicy": upgrade_policy,
                 }
                 upgrade_policy_clusters.append(item)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/SDE-3947

depends on https://github.com/app-sre/qontract-schemas/pull/660

with this addition we can run the report on sre-capabilities and expose OSD-FM managed clusters.

output: https://gitlab.cee.redhat.com/service/sre-capabilities-output/-/blob/main/systems-and-tools.md