### PR TITLE
fix create_ocm_upgrade_scheduler_org_updates_mr

### DIFF
--- a/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
+++ b/reconcile/utils/mr/ocm_upgrade_scheduler_org_updates.py
@@ -37,8 +37,6 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
         for update in self.updates_info["updates"]:
             action = update["action"]
             cluster_name = update["cluster"]
-            cluster_id = update["id"]
-            cluster_server_url = update["url"]
             upgrade_policy = update.get("policy")
 
             if action == "add":
@@ -49,8 +47,8 @@ class CreateOCMUpgradeSchedulerOrgUpdates(MergeRequestBase):
                     continue
                 item = {
                     "name": cluster_name,
-                    "serverUrl": cluster_server_url,
-                    "spec": {"id": cluster_id},
+                    "serverUrl": update["url"],
+                    "spec": {"id": update["id"]},
                     "upgradePolicy": upgrade_policy,
                 }
                 upgrade_policy_clusters.append(item)


### PR DESCRIPTION
fixes #4406

not all messages have the `id` and `url` fields, like `delete` actions.

only use these keys when it's an `add` action to avoid `KeyError`.