### PR TITLE
 aws-saml-roles: add extended early exit

### DIFF
--- a/reconcile/aws_saml_roles/integration.py
+++ b/reconcile/aws_saml_roles/integration.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import sys
 from collections.abc import (
     Callable,
@@ -6,6 +7,7 @@ from collections.abc import (
 )
 from typing import (
     Any,
+    TypedDict,
 )
 
 from pydantic import BaseModel, root_validator, validator
@@ -25,6 +27,10 @@ from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.aws_helper import unique_sso_aws_accounts
 from reconcile.utils.defer import defer
 from reconcile.utils.disabled_integrations import integration_is_enabled
+from reconcile.utils.extended_early_exit import (
+    ExtendedEarlyExitRunnerResult,
+    extended_early_exit_run,
+)
 from reconcile.utils.runtime.integration import (
     PydanticRunParams,
     QontractReconcileIntegration,
@@ -32,6 +38,7 @@ from reconcile.utils.runtime.integration import (
 from reconcile.utils.semver_helper import make_semver
 from reconcile.utils.terraform_client import TerraformClient
 from reconcile.utils.terrascript_aws_client import TerrascriptClient
+from reconcile.utils.unleash.client import get_feature_toggle_state
 
 QONTRACT_INTEGRATION = "aws-saml-roles"
 QONTRACT_INTEGRATION_VERSION = make_semver(1, 0, 0)
@@ -45,6 +52,10 @@ class AwsSamlRolesIntegrationParams(PydanticRunParams):
     saml_idp_name: str
     max_session_duration_hours: int = 1
     account_name: str | None = None
+    # extended early exit parameters
+    enable_extended_early_exit: bool = False
+    extended_early_exit_cache_ttl_seconds: int = 3600
+    log_cached_log_output: bool = False
 
     @validator("max_session_duration_hours")
     def max_session_duration_range(cls, v: str | int) -> int:
@@ -127,6 +138,12 @@ class AwsRole(BaseModel):
                 f"The role '{values['name']}' has duplicate managed policies."
             )
         return values
+
+
+class RunnerParams(TypedDict):
+    tf: TerraformClient
+    dry_run: bool
+    enable_deletion: bool
 
 
 class AwsSamlRolesIntegration(
@@ -264,13 +281,42 @@ class AwsSamlRolesIntegration(
         if defer:
             defer(tf.cleanup)
 
-        _, err = tf.plan(self.params.enable_deletion)
-        if err:
-            sys.exit(ExitCodes.ERROR)
+        runner_params: RunnerParams = dict(
+            tf=tf,
+            dry_run=dry_run,
+            enable_deletion=self.params.enable_deletion,
+        )
 
-        if dry_run:
-            return
+        if self.params.enable_extended_early_exit and get_feature_toggle_state(
+            f"{QONTRACT_INTEGRATION}-extended-early-exit", default=True
+        ):
+            extended_early_exit_run(
+                integration=QONTRACT_INTEGRATION,
+                integration_version=QONTRACT_INTEGRATION_VERSION,
+                dry_run=dry_run,
+                cache_source=ts.terraform_configurations(),
+                shard=self.params.account_name if self.params.account_name else "",
+                ttl_seconds=self.params.extended_early_exit_cache_ttl_seconds,
+                logger=logging.getLogger(),
+                runner=runner,
+                runner_params=runner_params,
+                log_cached_log_output=self.params.log_cached_log_output,
+            )
+        else:
+            runner(**runner_params)
 
-        err = tf.apply()
-        if err:
-            sys.exit(ExitCodes.ERROR)
+
+def runner(
+    dry_run: bool, tf: TerraformClient, enable_deletion: bool
+) -> ExtendedEarlyExitRunnerResult:
+    _, err = tf.plan(enable_deletion)
+    if err:
+        raise RuntimeError("Terraform plan has errors")
+
+    if dry_run:
+        return ExtendedEarlyExitRunnerResult(payload={}, applied_count=0)
+
+    if err := tf.apply():
+        raise RuntimeError("Terraform apply has errors")
+
+    return ExtendedEarlyExitRunnerResult(payload={}, applied_count=tf.apply_count)

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -933,6 +933,9 @@ def openshift_serviceaccount_tokens(
     required=True,
     default=6,
 )
+@enable_extended_early_exit
+@extended_early_exit_cache_ttl_seconds
+@log_cached_log_output
 @click.pass_context
 def aws_saml_roles(
     ctx,
@@ -942,6 +945,9 @@ def aws_saml_roles(
     account_name,
     saml_idp_name,
     max_session_duration_hours,
+    enable_extended_early_exit,
+    extended_early_exit_cache_ttl_seconds,
+    log_cached_log_output,
 ):
     from reconcile.aws_saml_roles.integration import (
         AwsSamlRolesIntegration,
@@ -957,6 +963,9 @@ def aws_saml_roles(
                 saml_idp_name=saml_idp_name,
                 max_session_duration_hours=max_session_duration_hours,
                 account_name=account_name,
+                enable_extended_early_exit=enable_extended_early_exit,
+                extended_early_exit_cache_ttl_seconds=extended_early_exit_cache_ttl_seconds,
+                log_cached_log_output=log_cached_log_output,
             )
         ),
         ctx=ctx.obj,


### PR DESCRIPTION
Add extended early exit to `aws-saml-roles` to speed up PR checks.

Ticket: [APPSRE-10277](https://issues.redhat.com/browse/APPSRE-10277)