### PR TITLE
Fix terraform vpc resources exit conditions

### DIFF
--- a/reconcile/gql_definitions/common/aws_vpc_requests.py
+++ b/reconcile/gql_definitions/common/aws_vpc_requests.py
@@ -33,6 +33,7 @@ fragment TerraformState on TerraformStateAWS_v1 {
 
 fragment VPCRequest on VPCRequest_v1 {
   identifier
+  delete
   account {
     name
     uid

--- a/reconcile/gql_definitions/fragments/aws_vpc_request.gql
+++ b/reconcile/gql_definitions/fragments/aws_vpc_request.gql
@@ -2,6 +2,7 @@
 
 fragment VPCRequest on VPCRequest_v1 {
   identifier
+  delete
   account {
     name
     uid

--- a/reconcile/gql_definitions/fragments/aws_vpc_request.py
+++ b/reconcile/gql_definitions/fragments/aws_vpc_request.py
@@ -50,6 +50,7 @@ class VPCRequestSubnetsListsV1(ConfiguredBaseModel):
 
 class VPCRequest(ConfiguredBaseModel):
     identifier: str = Field(..., alias="identifier")
+    delete: Optional[bool] = Field(..., alias="delete")
     account: AWSAccountV1 = Field(..., alias="account")
     region: str = Field(..., alias="region")
     cidr_block: NetworkV1 = Field(..., alias="cidr_block")

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -26238,6 +26238,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "delete",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "region",
                             "description": null,
                             "args": [],

--- a/reconcile/terraform_vpc_resources/integration.py
+++ b/reconcile/terraform_vpc_resources/integration.py
@@ -47,10 +47,6 @@ class TerraformVpcResourcesParams(PydanticRunParams):
     enable_deletion: bool = False
 
 
-class NoManagedVPCForAccount(Exception):
-    pass
-
-
 class TerraformVpcResources(QontractReconcileIntegration[TerraformVpcResourcesParams]):
     @property
     def name(self) -> str:
@@ -129,11 +125,11 @@ class TerraformVpcResources(QontractReconcileIntegration[TerraformVpcResourcesPa
         if data:
             accounts = self._filter_accounts(data, account_name)
             if account_name and not accounts:
-                error_msg = f"The account {account_name} doesn't have any managed vpc. Verify your input"
-                logging.error(error_msg)
-                raise NoManagedVPCForAccount(error_msg)
+                msg = f"The account {account_name} doesn't have any managed vpc. Verify your input"
+                logging.debug(msg)
+                sys.exit(ExitCodes.SUCCESS)
         else:
-            logging.warning("No VPC requests found, nothing to do.")
+            logging.debug("No VPC requests found, nothing to do.")
             sys.exit(ExitCodes.SUCCESS)
 
         accounts_untyped: list[dict] = [acc.dict(by_alias=True) for acc in accounts]

--- a/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
+++ b/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
@@ -15,7 +15,6 @@ from reconcile.gql_definitions.fragments.aws_vpc_request import (
 )
 from reconcile.status import ExitCodes
 from reconcile.terraform_vpc_resources.integration import (
-    NoManagedVPCForAccount,
     TerraformVpcResources,
     TerraformVpcResourcesParams,
 )
@@ -116,32 +115,6 @@ def secret_reader_side_effect(*args: Any) -> dict[str, Any] | None:
     raise Exception("Argument error")
 
 
-def test_log_message_for_no_vpc_requests(
-    mocker: MockerFixture,
-    caplog: pytest.LogCaptureFixture,
-    gql_class_factory: Callable,
-    mock_gql: MockerFixture,
-    mock_app_interface_vault_settings: MockerFixture,
-    mock_create_secret_reader: MockerFixture,
-) -> None:
-    # Mock a query response without any accounts
-    mocked_query = mocker.patch(
-        "reconcile.terraform_vpc_resources.integration.get_aws_vpc_requests",
-        autospec=True,
-    )
-    mocked_query.return_value = []
-
-    params = TerraformVpcResourcesParams(
-        account_name=None, print_to_file=None, thread_pool_size=1
-    )
-    with caplog.at_level(logging.INFO), pytest.raises(SystemExit) as sample:
-        TerraformVpcResources(params).run(dry_run=True)
-    assert sample.value.code == ExitCodes.SUCCESS
-    assert ["No VPC requests found, nothing to do."] == [
-        rec.message for rec in caplog.records
-    ]
-
-
 def test_log_message_for_accounts_having_vpc_requests(
     mocker: MockerFixture,
     caplog: pytest.LogCaptureFixture,
@@ -162,15 +135,15 @@ def test_log_message_for_accounts_having_vpc_requests(
         account_name=account_name, print_to_file=None, thread_pool_size=1
     )
     with (
-        caplog.at_level(logging.INFO),
-        pytest.raises(NoManagedVPCForAccount) as execption,
+        caplog.at_level(logging.DEBUG),
+        pytest.raises(SystemExit) as sample,
     ):
         TerraformVpcResources(params).run(dry_run=True)
 
     error_msg = (
         f"The account {account_name} doesn't have any managed vpc. Verify your input"
     )
-    assert execption.match(error_msg)
+    assert sample.value.code == ExitCodes.SUCCESS
     assert [error_msg] == [rec.message for rec in caplog.records]
 
 

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1189,6 +1189,9 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         self, vpc_requests: Iterable[VPCRequest], aws_provider_version: str
     ) -> None:
         for request in vpc_requests:
+            # skiping deleted requests
+            if request.delete:
+                continue
             # The default values here come from infra repo's module configuration
             values = {
                 "source": "terraform-aws-modules/vpc/aws",


### PR DESCRIPTION
Related to: [APPSRE-8743](https://issues.redhat.com/browse/APPSRE-8743)

After the deployment I've found some issues in the integration code:

Due to the way sharding is done in production the integration floods the reconcile channel in Slack. That is because most of the accounts don't have vpc-requests and if you pass one account (what is done in the shards) the integration raises an error. That was done to warn the user that they are not creating anything and do an early exit.

Also, if the integration is run without shards but there is no vpc-request defined, i.e. all the previously defined vpc-requests are deleted in app-interface, the integration skips the terraform apply step. That was also done to early exit.