### PR TITLE
openshift resources prometheus rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Additional tools that use the libraries created by the reconciliations are also 
   openshift-namespace-labels      Manages labels on OpenShift namespaces.
   openshift-namespaces            Manages OpenShift Namespaces.
   openshift-network-policies      Manages OpenShift NetworkPolicies.
+  openshift-prometheus-rules      Manages OpenShift Prometheus Rules.
   openshift-resourcequotas        Manages OpenShift ResourceQuota objects.
   openshift-resources             Manages OpenShift Resources.
   openshift-rolebindings          Configures Rolebindings in OpenShift
@@ -212,6 +213,8 @@ Additional tools that use the libraries created by the reconciliations are also 
                                   to Status Board.
   status-page-components          Manages components on statuspage.io hosted
                                   status pages.
+  status-page-maintenances        Manages maintenances on statuspage.io hosted
+                                  status pages.
   template-renderer               Render datafile templates in app-interface.
   template-validator              Test app-interface templates.
   terraform-aws-route53           Manage AWS Route53 resources using
@@ -227,7 +230,8 @@ Additional tools that use the libraries created by the reconciliations are also 
   terraform-users                 Manage AWS users using Terraform.
   terraform-vpc-peerings          Manage VPC peerings between OSD clusters and
                                   AWS accounts or other OSD clusters.
-  terraform-vpc-resources         Manage VPC creation through a VPC request.
+  terraform-vpc-resources         Manage VPC creation
+  unleash-feature-toggles         Manage Unleash feature toggles.
   vault-replication               Allow vault to replicate secrets to other
                                   instances.
   version-gate-approver           Approves OCM cluster upgrade version gates.

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1776,6 +1776,31 @@ def openshift_routes(
     )
 
 
+@integration.command(short_help="Manages OpenShift Prometheus Rules.")
+@threaded()
+@binary(["oc", "ssh"])
+@binary_version("oc", ["version", "--client"], OC_VERSION_REGEX, OC_VERSIONS)
+@internal()
+@use_jump_host()
+@cluster_name
+@namespace_name
+@click.pass_context
+def openshift_prometheus_rules(
+    ctx, thread_pool_size, internal, use_jump_host, cluster_name, namespace_name
+):
+    import reconcile.openshift_prometheus_rules
+
+    run_integration(
+        reconcile.openshift_prometheus_rules,
+        ctx.obj,
+        thread_pool_size,
+        internal,
+        use_jump_host,
+        cluster_name=cluster_name,
+        namespace_name=namespace_name,
+    )
+
+
 @integration.command(short_help="Configures the teams and members in Quay.")
 @click.pass_context
 def quay_membership(ctx):

--- a/reconcile/openshift_prometheus_rules.py
+++ b/reconcile/openshift_prometheus_rules.py
@@ -1,14 +1,13 @@
 from collections.abc import Iterable
 from typing import Any
 
-import reconcile.openshift_base as ob
 import reconcile.openshift_resources_base as orb
 from reconcile.utils.runtime.integration import DesiredStateShardConfig
 from reconcile.utils.semver_helper import make_semver
 
-QONTRACT_INTEGRATION = "openshift_resources"
-QONTRACT_INTEGRATION_VERSION = make_semver(1, 9, 3)
-PROVIDERS = ["resource", "resource-template"]
+QONTRACT_INTEGRATION = "openshift-prometheus-rules"
+QONTRACT_INTEGRATION_VERSION = make_semver(1, 0, 0)
+PROVIDERS = ["prometheus-rule"]
 
 
 def run(
@@ -23,7 +22,7 @@ def run(
     orb.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION
     orb.QONTRACT_INTEGRATION_VERSION = QONTRACT_INTEGRATION_VERSION
 
-    ri = orb.run(
+    orb.run(
         dry_run=dry_run,
         thread_pool_size=thread_pool_size,
         internal=internal,
@@ -34,11 +33,6 @@ def run(
         namespace_name=namespace_name,
         init_api_resources=True,
     )
-
-    # check for unused resources types
-    # listed under `managedResourceTypes`
-    if ri:
-        ob.check_unused_resource_types(ri)
 
 
 def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -835,6 +835,8 @@ def canonicalize_namespaces(
                 override = ["Secret"]
             elif providers[0] == "route":
                 override = ["Route"]
+            elif providers[0] == "prometheus-rule":
+                override = ["PrometheusRule"]
 
             namespace_info["openshiftResources"] = ors
             canonicalized_namespaces.append(namespace_info)


### PR DESCRIPTION
Introduce `openshift-prometheus-rules` as a separate integration that handles prometheus rule for namespace `openshiftResources`. Similar to `openshift-routes` or `openshift-vault-secrets`. This will speed up app-interface PR checks.

Ticket: [APPSRE-10344](https://issues.redhat.com/browse/APPSRE-10344)

