### PR TITLE
Revert "✨ openshift-resources: bugfix"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,8 @@ module = [
     "reconcile.openshift_namespace_labels",
     "reconcile.openshift_network_policies",
     "reconcile.openshift_resourcequotas",
+    "reconcile.openshift_resources_base",
+    "reconcile.openshift_resources",
     "reconcile.openshift_rolebindings",
     "reconcile.openshift_routes",
     "reconcile.openshift_serviceaccount_tokens",

--- a/reconcile/openshift_resources.py
+++ b/reconcile/openshift_resources.py
@@ -1,4 +1,3 @@
-from collections.abc import Iterable
 from typing import Any
 
 import reconcile.openshift_base as ob
@@ -12,14 +11,15 @@ PROVIDERS = ["resource", "resource-template", "prometheus-rule"]
 
 
 def run(
-    dry_run: bool,
-    thread_pool_size: int = 10,
-    internal: bool | None = None,
-    use_jump_host: bool = True,
-    cluster_name: Iterable[str] | None = None,
-    exclude_cluster: Iterable[str] | None = None,
-    namespace_name: str | None = None,
-) -> None:
+    dry_run,
+    thread_pool_size=10,
+    internal=None,
+    use_jump_host=True,
+    cluster_name=None,
+    exclude_cluster=None,
+    namespace_name=None,
+    defer=None,
+):
     orb.QONTRACT_INTEGRATION = QONTRACT_INTEGRATION
     orb.QONTRACT_INTEGRATION_VERSION = QONTRACT_INTEGRATION_VERSION
 
@@ -41,7 +41,7 @@ def run(
         ob.check_unused_resource_types(ri)
 
 
-def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:
+def early_exit_desired_state(*args, **kwargs) -> dict[str, Any]:
     return orb.early_exit_desired_state(PROVIDERS)
 
 

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -7,11 +7,8 @@ import re
 import sys
 from collections import defaultdict
 from collections.abc import (
-    Callable,
-    Generator,
     Iterable,
     Mapping,
-    MutableMapping,
     Sequence,
 )
 from contextlib import contextmanager
@@ -24,7 +21,6 @@ from typing import (
     Protocol,
     Tuple,
 )
-from unittest.mock import DEFAULT, patch
 
 import anymarkup
 from deepdiff import DeepHash
@@ -33,9 +29,9 @@ from sretoolbox.utils import (
 )
 
 import reconcile.openshift_base as ob
-import reconcile.utils.jinja2.utils as jinja2_utils
 from reconcile import queries
 from reconcile.change_owners.diff import IDENTIFIER_FIELD_NAME
+from reconcile.checkpoint import url_makes_sense
 from reconcile.utils import (
     amtool,
     gql,
@@ -45,6 +41,9 @@ from reconcile.utils.defer import defer
 from reconcile.utils.exceptions import FetchResourceError
 from reconcile.utils.jinja2.utils import (
     FetchSecretError,
+    lookup_github_file_content,
+    lookup_s3_object,
+    lookup_secret,
     process_extracurlyjinja2_template,
     process_jinja2_template,
 )
@@ -238,23 +237,23 @@ KUBERNETES_SECRET_DATA_KEY_RE = "^[-._a-zA-Z0-9]+$"
 _log_lock = Lock()
 
 
-def _locked_info_log(msg: str) -> None:
+def _locked_info_log(msg: str):
     with _log_lock:
         logging.info(msg)
 
 
-def _locked_debug_log(msg: str) -> None:
+def _locked_debug_log(msg: str):
     with _log_lock:
         logging.debug(msg)
 
 
-def _locked_error_log(msg: str) -> None:
+def _locked_error_log(msg: str):
     with _log_lock:
         logging.error(msg)
 
 
 class FetchRouteError(Exception):
-    def __init__(self, msg: Any):
+    def __init__(self, msg):
         super().__init__("error fetching route: " + str(msg))
 
 
@@ -267,21 +266,16 @@ class SecretKeyFormatError(Exception):
 
 
 class UnknownProviderError(Exception):
-    def __init__(self, msg: Any):
+    def __init__(self, msg):
         super().__init__("unknown provider error: " + str(msg))
 
 
 class UnknownTemplateTypeError(Exception):
-    def __init__(self, msg: Any):
+    def __init__(self, msg):
         super().__init__("unknown template type error: " + str(msg))
 
 
-def check_alertmanager_config(
-    data: Mapping[str, Any],
-    path: str,
-    alertmanager_config_key: str,
-    decode_base64: bool = False,
-) -> None:
+def check_alertmanager_config(data, path, alertmanager_config_key, decode_base64=False):
     try:
         config = data[alertmanager_config_key]
     except KeyError:
@@ -301,15 +295,15 @@ def check_alertmanager_config(
 
 
 def fetch_provider_resource(
-    resource: Mapping,
-    tfunc: Callable | None = None,
-    tvars: Mapping[str, Any] | None = None,
-    validate_json: bool = False,
-    validate_alertmanager_config: bool = False,
-    alertmanager_config_key: str = "alertmanager.yaml",
-    add_path_to_prom_rules: bool = True,
-    skip_validation: bool = False,
-    settings: Mapping[str, Any] | None = None,
+    resource: dict,
+    tfunc=None,
+    tvars=None,
+    validate_json=False,
+    validate_alertmanager_config=False,
+    alertmanager_config_key="alertmanager.yaml",
+    add_path_to_prom_rules=True,
+    skip_validation=False,
+    settings=None,
 ) -> OR:
     path = resource["path"]
     content = resource["content"]
@@ -389,17 +383,17 @@ def fetch_provider_resource(
 
 
 def fetch_provider_vault_secret(
-    path: str,
-    version: str,
-    name: str,
-    labels: Mapping[str, str] | None,
-    annotations: Mapping[str, str],
-    type: str,
-    integration: str,
-    integration_version: str,
-    validate_alertmanager_config: bool = False,
-    alertmanager_config_key: str = "alertmanager.yaml",
-    settings: Mapping[str, Any] | None = None,
+    path,
+    version,
+    name,
+    labels,
+    annotations,
+    type,
+    integration,
+    integration_version,
+    validate_alertmanager_config=False,
+    alertmanager_config_key="alertmanager.yaml",
+    settings=None,
 ) -> OR:
     # get the fields from vault
     secret_reader = SecretReader(settings)
@@ -409,7 +403,7 @@ def fetch_provider_vault_secret(
         check_alertmanager_config(raw_data, path, alertmanager_config_key)
 
     # construct oc resource
-    body: dict[str, Any] = {
+    body = {
         "apiVersion": "v1",
         "kind": "Secret",
         "type": type,
@@ -439,7 +433,7 @@ def fetch_provider_vault_secret(
 # any white space issues. If any issues are uncovered, an exception will be
 # raised.
 # we're receiving the full key: value information, not simply a list of keys.
-def assert_valid_secret_keys(secrets_data: dict[str, str]) -> None:
+def assert_valid_secret_keys(secrets_data: dict[str, str]):
     for k in secrets_data:
         matches = re.search(KUBERNETES_SECRET_DATA_KEY_RE, k)
         if not matches:
@@ -448,12 +442,7 @@ def assert_valid_secret_keys(secrets_data: dict[str, str]) -> None:
             )
 
 
-def fetch_provider_route(
-    resource: Mapping,
-    tls_path: str | None,
-    tls_version: str | None,
-    settings: Mapping | None = None,
-) -> OR:
+def fetch_provider_route(resource: dict, tls_path, tls_version, settings=None) -> OR:
     path = resource["path"]
     openshift_resource = fetch_provider_resource(resource)
 
@@ -496,10 +485,7 @@ def fetch_provider_route(
 
 
 def fetch_openshift_resource(
-    resource: Mapping,
-    parent: Mapping[str, Any],
-    settings: Mapping | None = None,
-    skip_validation: bool = False,
+    resource, parent, settings=None, skip_validation=False
 ) -> OR:
     provider = resource["provider"]
     if provider == "resource":
@@ -646,8 +632,8 @@ def fetch_current_state(
     cluster: str,
     namespace: str,
     kind: str,
-    resource_names: Iterable[str] | None,
-) -> None:
+    resource_names=Iterable[str],
+):
     _locked_debug_log(f"Fetching {kind} from {cluster}/{namespace}")
     if not oc.is_kind_supported(kind):
         logging.warning(f"[{cluster}] cluster has no API resource {kind}.")
@@ -673,8 +659,8 @@ def fetch_desired_state(
     resource: Mapping[str, Any],
     parent: Mapping[str, Any],
     privileged: bool,
-    settings: Mapping[str, Any] | None = None,
-) -> None:
+    settings: Optional[Mapping[str, Any]] = None,
+):
     try:
         openshift_resource = fetch_openshift_resource(resource, parent, settings)
     except (
@@ -731,7 +717,7 @@ def fetch_desired_state(
 def fetch_states(
     spec: ob.StateSpec,
     ri: ResourceInventory,
-    settings: Mapping[str, Any] | None = None,
+    settings: Optional[Mapping[str, Any]] = None,
 ) -> None:
     try:
         if isinstance(spec, ob.CurrentStateSpec):
@@ -761,13 +747,13 @@ def fetch_states(
 
 
 def fetch_data(
-    namespaces: Iterable[Mapping[str, Any]],
-    thread_pool_size: int,
-    internal: bool | None,
-    use_jump_host: bool,
-    init_api_resources: bool = False,
-    overrides: Iterable[str] | None = None,
-) -> tuple[OC_Map, ResourceInventory]:
+    namespaces,
+    thread_pool_size,
+    internal,
+    use_jump_host,
+    init_api_resources=False,
+    overrides=None,
+):
     ri = ResourceInventory()
     settings = queries.get_app_interface_settings()
     logging.debug(f"Overriding keys {overrides}")
@@ -789,11 +775,11 @@ def fetch_data(
 
 
 def filter_namespaces_by_cluster_and_namespace(
-    namespaces: Sequence[dict[str, Any]],
-    cluster_names: Iterable[str] | None,
-    exclude_clusters: Iterable[str] | None,
-    namespace_name: str | None,
-) -> Sequence[dict[str, Any]]:
+    namespaces,
+    cluster_names: Optional[Iterable[str]],
+    exclude_clusters: Optional[Iterable[str]],
+    namespace_name: Optional[str],
+):
     if cluster_names:
         namespaces = [n for n in namespaces if n["cluster"]["name"] in cluster_names]
     elif exclude_clusters:
@@ -809,9 +795,9 @@ def filter_namespaces_by_cluster_and_namespace(
 
 def canonicalize_namespaces(
     namespaces: Iterable[dict[str, Any]],
-    providers: Sequence[str],
-    resource_schema_filter: str | None = None,
-) -> tuple[list[dict[str, Any]], list[str] | None]:
+    providers: list[str],
+    resource_schema_filter: Optional[str] = None,
+) -> tuple[list[dict[str, Any]], Optional[list[str]]]:
     canonicalized_namespaces = []
     override = None
     logging.debug(f"Received providers {providers}")
@@ -843,17 +829,17 @@ def canonicalize_namespaces(
 
 
 def get_namespaces(
-    providers: Sequence[str] | None = None,
-    cluster_names: Iterable[str] | None = None,
-    exclude_clusters: Iterable[str] | None = None,
-    namespace_name: str | None = None,
-    resource_schema_filter: str | None = None,
-    filter_by_shard: bool | None = True,
-) -> tuple[list[dict[str, Any]], list[str] | None]:
+    providers: Optional[list[str]] = None,
+    cluster_names: Optional[Iterable[str]] = None,
+    exclude_clusters: Optional[Iterable[str]] = None,
+    namespace_name: Optional[str] = None,
+    resource_schema_filter: Optional[str] = None,
+    filter_by_shard: Optional[bool] = True,
+) -> tuple[list[dict[str, Any]], Optional[list[str]]]:
     if providers is None:
         providers = []
     gqlapi = gql.get_api()
-    namespaces: list[dict[str, Any]] = [
+    namespaces = [
         namespace_info
         for namespace_info in gqlapi.query(NAMESPACES_QUERY)["namespaces"]
         if not ob.is_namespace_deleted(namespace_info)
@@ -864,33 +850,33 @@ def get_namespaces(
             )
         )
     ]
-    _namespaces = filter_namespaces_by_cluster_and_namespace(
+    namespaces = filter_namespaces_by_cluster_and_namespace(
         namespaces, cluster_names, exclude_clusters, namespace_name
     )
-    return canonicalize_namespaces(_namespaces, providers, resource_schema_filter)
+    return canonicalize_namespaces(namespaces, providers, resource_schema_filter)
 
 
 @defer
 def run(
-    dry_run: bool,
-    thread_pool_size: int = 10,
-    internal: bool | None = None,
-    use_jump_host: bool = True,
-    providers: Sequence[str] | None = None,
-    cluster_name: Sequence[str] | None = None,
-    exclude_cluster: Sequence[str] | None = None,
-    namespace_name: str | None = None,
-    init_api_resources: bool = False,
-    defer: Callable | None = None,
-) -> ResourceInventory | None:
+    dry_run,
+    thread_pool_size=10,
+    internal=None,
+    use_jump_host=True,
+    providers=None,
+    cluster_name: Optional[Sequence[str]] = None,
+    exclude_cluster: Optional[Sequence[str]] = None,
+    namespace_name=None,
+    init_api_resources=False,
+    defer=None,
+):
     # https://click.palletsprojects.com/en/8.1.x/options/#multiple-options
     cluster_names = cluster_name
     exclude_clusters = exclude_cluster
 
-    if exclude_clusters and not dry_run:
+    if exclude_cluster and not dry_run:
         raise RuntimeError("--exclude-cluster is only supported in dry-run mode")
 
-    if exclude_clusters and cluster_names:
+    if exclude_cluster and cluster_name:
         raise RuntimeError(
             "--cluster-name and --exclude-cluster can not be used together"
         )
@@ -908,7 +894,7 @@ def run(
     if not namespaces:
         logging.debug(
             "No namespaces found when filtering for "
-            f"cluster={cluster_names}, namespace={namespace_name}. "
+            f"cluster={cluster_name}, namespace={namespace_name}. "
             "Exiting."
         )
         return None
@@ -920,8 +906,7 @@ def run(
         init_api_resources=init_api_resources,
         overrides=overrides,
     )
-    if defer:
-        defer(oc_map.cleanup)
+    defer(oc_map.cleanup)
     if dry_run and QONTRACT_INTEGRATION == "openshift-resources":
         error = check_cluster_scoped_resources(oc_map, ri, namespaces, None)
         if error:
@@ -1145,7 +1130,7 @@ def early_exit_desired_state(
             settings=settings,
         )
 
-    def post_process_ns(ns: MutableMapping) -> MutableMapping:
+    def post_process_ns(ns):
         # the sharedResources have been aggreated into the openshiftResources
         # and are no longer needed - speeds up diffing process
         del ns["sharedResources"]
@@ -1166,7 +1151,7 @@ def early_exit_desired_state(
     }
 
 
-def _early_exit_fetch_resource(spec: Sequence, settings: Mapping) -> dict[str, str]:
+def _early_exit_fetch_resource(spec, settings):
     resource = spec[0]
     ns_info = spec[1]
     cluster_name = ns_info["cluster"]["name"]
@@ -1194,44 +1179,58 @@ def _early_exit_fetch_resource(spec: Sequence, settings: Mapping) -> dict[str, s
 
 
 @contextmanager
-def early_exit_monkey_patch() -> Generator:
+def early_exit_monkey_patch():
     """Avoid looking outside of app-interface on early-exit pr-check."""
-    with patch.multiple(
-        jinja2_utils,
-        lookup_secret=DEFAULT,
-        lookup_github_file_content=DEFAULT,
-        url_makes_sense=DEFAULT,
-        lookup_s3_object=DEFAULT,
-    ) as mocks:
-        mocks["lookup_secret"].side_effect = (
+    orig_lookup_secret = lookup_secret
+    orig_lookup_github_file_content = lookup_github_file_content
+    orig_url_makes_sense = url_makes_sense
+    orig_check_alertmanager_config = check_alertmanager_config
+    orig_lookup_s3_object = lookup_s3_object
+
+    try:
+        yield _early_exit_monkey_patch_assign(
             lambda path,
             key,
             version=None,
             tvars=None,
             allow_not_found=False,
             settings=None,
-            secret_reader=None: f"vault({path}, {key}, {version}"
-        )
-        mocks["lookup_github_file_content"].side_effect = (
+            secret_reader=None: f"vault({path}, {key}, {version}, {allow_not_found})",
             lambda repo,
             path,
             ref,
             tvars=None,
             settings=None,
-            secret_reader=None: f"github({repo}, {path}, {ref})"
-        )
-        mocks["url_makes_sense"].return_value = False
-        mocks["lookup_s3_object"].side_effect = (
+            secret_reader=None: f"github({repo}, {path}, {ref})",
+            lambda url: False,
+            lambda data, path, alertmanager_config_key, decode_base64=False: True,
             lambda account_name,
             bucket_name,
             path,
-            region_name=None: f"lookup_s3_object({account_name}, {bucket_name}, {path}, {region_name})"
+            region_name=None: f"lookup_s3_object({account_name}, {bucket_name}, {path}, {region_name})",
         )
-        with patch(
-            "reconcile.openshift_resources_base.check_alertmanager_config",
-            return_value=True,
-        ):
-            yield
+    finally:
+        _early_exit_monkey_patch_assign(
+            orig_lookup_secret,
+            orig_lookup_github_file_content,
+            orig_url_makes_sense,
+            orig_check_alertmanager_config,
+            orig_lookup_s3_object,
+        )
+
+
+def _early_exit_monkey_patch_assign(
+    lookup_secret,
+    lookup_github_file_content,
+    url_makes_sense,
+    check_alertmanager_config,
+    lookup_s3_object,
+):
+    sys.modules[__name__].lookup_secret = lookup_secret
+    sys.modules[__name__].lookup_github_file_content = lookup_github_file_content
+    sys.modules[__name__].url_makes_sense = url_makes_sense
+    sys.modules[__name__].check_alertmanager_config = check_alertmanager_config
+    sys.modules[__name__].lookup_s3_object = lookup_s3_object
 
 
 def desired_state_shard_config() -> DesiredStateShardConfig:


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#4386

`prometheus-rules-tester` is failing:

```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/jinja2/utils.py", line 191, in process_jinja2_template
    r = template.render(vars)
        ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/jinja2/environment.py", line 1304, in render
    self.environment.handle_exception()
  File "/usr/local/lib/python3.11/site-packages/jinja2/environment.py", line 939, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 18, in top-level template code
  File "/usr/local/lib/python3.11/site-packages/jinja2/sandbox.py", line 393, in call
    raise SecurityError(f"{__obj!r} is not safely callable")
jinja2.exceptions.SecurityError: <MagicMock name='url_makes_sense' id='140596539051728'> is not safely callable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/reconcile/openshift_resources_base.py", line 625, in fetch_openshift_resource
    openshift_resource = fetch_provider_resource(
                         ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/openshift_resources_base.py", line 317, in fetch_provider_resource
    content = tfunc(body=content, vars=tvars, settings=settings)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/jinja2/utils.py", line 206, in process_extracurlyjinja2_template
    return process_jinja2_template(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/jinja2/utils.py", line 193, in process_jinja2_template
    raise Jinja2TemplateError(e)
reconcile.utils.jinja2.utils.Jinja2TemplateError: error processing jinja2 template: <MagicMock name='url_makes_sense' id='140596539051728'> is not safely callable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 122, in get_desired_state_diff
    previous_desired_state = run_cfg.comparison_bundle_desired_state()
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 76, in comparison_bundle_desired_state
    self.integration.get_early_exit_desired_state()
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/integration.py", line 304, in get_early_exit_desired_state
    return self.params.module.early_exit_desired_state(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/prometheus_rules_tester/integration.py", line 276, in early_exit_desired_state
    tests = get_rules_and_tests(
            ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/prometheus_rules_tester/integration.py", line 147, in get_rules_and_tests
    return threaded.run(
           ^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sretoolbox/utils/threaded.py", line 72, in run
    return pmap(
           ^^^^^
  File "/usr/local/lib/python3.11/site-packages/sretoolbox/utils/concurrent.py", line 88, in pmap
    return list(pool.map(func_partial, iterable))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 619, in result_iterator
    yield _result_or_cancel(fs.pop())
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 317, in _result_or_cancel
    return fut.result(timeout)
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 449, in result
    return self.__get_result()
           ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/concurrent/futures/_base.py", line 401, in __get_result
    raise self._exception
  File "/usr/lib64/python3.11/concurrent/futures/thread.py", line 58, in run
    result = self.fn(*self.args, **self.kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sretoolbox/utils/concurrent.py", line 114, in _full_traceback
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/prometheus_rules_tester/integration.py", line 77, in fetch_rule_and_tests
    openshift_resource = orb.fetch_openshift_resource(
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/openshift_resources_base.py", line 635, in fetch_openshift_resource
    raise ResourceTemplateRenderError(msg)
reconcile.openshift_resources_base.ResourceTemplateRenderError: could not render template at path /app-sre/app-sre-contract/app-sre-contract.prometheusrules.yaml.j2
error processing jinja2 template: <MagicMock name='url_makes_sense' id='140596539051728'> is not safely callable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib64/python3.11/logging/__init__.py", line 1110, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/logging/__init__.py", line 953, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/logging/__init__.py", line 687, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/logging/__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  File "/usr/local/bin/qontract-reconcile", line 8, in <module>
    sys.exit(integration())
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/binary.py", line 21, in f_binary
    f(*args, **kwargs)
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/binary.py", line 71, in f_binary_version
    f(*args, **kwargs)
  File "/usr/local/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.11/site-packages/reconcile/cli.py", line 3170, in prometheus_rules_tester
    run_integration(
  File "/usr/local/lib/python3.11/site-packages/reconcile/cli.py", line 582, in run_integration
    run_class_integration(
  File "/usr/local/lib/python3.11/site-packages/reconcile/cli.py", line 609, in run_class_integration
    run_integration_cfg(
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 156, in run_integration_cfg
    desired_state_diff = get_desired_state_diff(run_cfg)
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 126, in get_desired_state_diff
    logging.exception(
Message: 'Failed to fetch desired state for comparison bundle 87199b1d271d7bd7973a6f3337757287549b4a59b4153b488a08bd5265a76071'
Arguments: (ResourceTemplateRenderError("could not render template at path /app-sre/app-sre-contract/app-sre-contract.prometheusrules.yaml.j2\nerror processing jinja2 template: <MagicMock name='url_makes_sense' id='140596539051728'> is not safely callable"),)
```