### PR TITLE
APPSRE-10351 promotion data cache

### DIFF
--- a/reconcile/test/conftest.py
+++ b/reconcile/test/conftest.py
@@ -10,7 +10,7 @@ from typing import (
     Any,
     Optional,
 )
-from unittest.mock import create_autospec
+from unittest.mock import MagicMock, create_autospec
 
 import pytest
 from pydantic import BaseModel
@@ -74,7 +74,8 @@ def s3_state_builder() -> Callable[[Mapping], State]:
             return get(key)
 
         state = create_autospec(spec=State)
-        state.get = get
+        mock_get = MagicMock(side_effect=get)
+        state.get = mock_get
         state.__getitem__ = __getitem__
         state.ls.side_effect = [data.get("ls", [])]
         return state

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -11,7 +11,7 @@ from reconcile.utils.promotion_state import (
 from reconcile.utils.state import State
 
 
-def test_key_exists_v1(s3_state_builder: Callable[[Mapping], State]):
+def test_key_exists_v1(s3_state_builder: Callable[[Mapping], State]) -> None:
     state = s3_state_builder({
         "ls": ["/promotions_v2/channel/uid/sha"],
         "get": {
@@ -34,9 +34,11 @@ def test_key_exists_v1(s3_state_builder: Callable[[Mapping], State]):
         saas_file="saas_file",
         check_in="2024-04-30 13:47:31.722437+00:00",
     )
+    state.ls.assert_called_once_with()  # type: ignore[attr-defined]
+    state.get.assert_called_once_with("promotions_v2/channel/uid/sha")  # type: ignore[attr-defined]
 
 
-def test_key_exists_v2(s3_state_builder: Callable[[Mapping], State]):
+def test_key_exists_v2(s3_state_builder: Callable[[Mapping], State]) -> None:
     state = s3_state_builder({
         "ls": ["/promotions_v2/channel/uid/sha"],
         "get": {
@@ -57,9 +59,11 @@ def test_key_exists_v2(s3_state_builder: Callable[[Mapping], State]):
         target_config_hash="hash",
         saas_file="saas_file",
     )
+    state.ls.assert_called_once_with()  # type: ignore[attr-defined]
+    state.get.assert_called_once_with("promotions_v2/channel/uid/sha")  # type: ignore[attr-defined]
 
 
-def test_key_does_not_exist(s3_state_builder: Callable[[Mapping], State]):
+def test_key_does_not_exist(s3_state_builder: Callable[[Mapping], State]) -> None:
     state = s3_state_builder({
         "ls": [],
         "get": {},
@@ -70,9 +74,13 @@ def test_key_does_not_exist(s3_state_builder: Callable[[Mapping], State]):
         channel="channel", sha="sha", target_uid="uid"
     )
     assert deployment_info is None
+    state.ls.assert_called_once_with()  # type: ignore[attr-defined]
+    state.get.assert_not_called()  # type: ignore[attr-defined]
 
 
-def test_key_does_not_exist_locally(s3_state_builder: Callable[[Mapping], State]):
+def test_key_does_not_exist_locally(
+    s3_state_builder: Callable[[Mapping], State],
+) -> None:
     state = s3_state_builder({
         "ls": [],
         "get": {
@@ -85,14 +93,16 @@ def test_key_does_not_exist_locally(s3_state_builder: Callable[[Mapping], State]
     })
     deployment_state = PromotionState(state=state)
     deployment_info = deployment_state.get_promotion_data(
-        channel="channel", sha="sha", target_uid="uid", local_lookup=False
+        channel="channel", sha="sha", target_uid="uid", pre_check_sha_exists=False
     )
     assert deployment_info == PromotionData(
         success=True, target_config_hash="hash", saas_file="saas_file"
     )
+    state.ls.assert_not_called()  # type: ignore[attr-defined]
+    state.get.assert_called_once_with("promotions_v2/channel/uid/sha")  # type: ignore[attr-defined]
 
 
-def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
+def test_publish_info(s3_state_builder: Callable[[Mapping], State]) -> None:
     state = s3_state_builder({
         "ls": [],
         "get": {},
@@ -115,7 +125,7 @@ def test_publish_info(s3_state_builder: Callable[[Mapping], State]):
     )
 
 
-def test_promotion_data_json_serializable():
+def test_promotion_data_json_serializable() -> None:
     """
     We store promotion data as json in s3
     """
@@ -126,3 +136,98 @@ def test_promotion_data_json_serializable():
         check_in="2024-04-30 13:47:31.722437+00:00",
     )
     json.dumps(promotion_data.dict())
+
+
+def test_promotion_data_cache(s3_state_builder: Callable[[Mapping], State]) -> None:
+    check_in = "2024-04-17 13:47:31.722437+00:00"
+    state = s3_state_builder({
+        "ls": [],
+        "get": {
+            "promotions_v2/channel/uid/sha": {
+                "success": True,
+                "target_config_hash": "hash",
+                "saas_file": "saas_file",
+                "check_in": check_in,
+            }
+        },
+    })
+    deployment_state = PromotionState(state=state)
+
+    # Fetch first time -> not in cache yet
+    deployment_info_first = deployment_state.get_promotion_data(
+        channel="channel",
+        sha="sha",
+        target_uid="uid",
+        pre_check_sha_exists=False,
+        use_cache=True,
+    )
+
+    # Fetch second time -> should be in cache
+    deployment_info_second = deployment_state.get_promotion_data(
+        channel="channel",
+        sha="sha",
+        target_uid="uid",
+        pre_check_sha_exists=False,
+        use_cache=True,
+    )
+
+    assert deployment_info_first == deployment_info_second
+    assert deployment_info_first == PromotionData(
+        success=True,
+        target_config_hash="hash",
+        saas_file="saas_file",
+        check_in=check_in,
+    )
+
+    state.get.assert_called_once_with("promotions_v2/channel/uid/sha")  # type: ignore[attr-defined]
+    state.ls.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_promotion_data_disabled_cache(
+    s3_state_builder: Callable[[Mapping], State],
+) -> None:
+    check_in = "2024-04-17 13:47:31.722437+00:00"
+    state = s3_state_builder({
+        "ls": [],
+        "get": {
+            "promotions_v2/channel/uid/sha": {
+                "success": True,
+                "target_config_hash": "hash",
+                "saas_file": "saas_file",
+                "check_in": check_in,
+            }
+        },
+    })
+    deployment_state = PromotionState(state=state)
+
+    # Fetch first time -> not in cache yet
+    deployment_info_first = deployment_state.get_promotion_data(
+        channel="channel",
+        sha="sha",
+        target_uid="uid",
+        pre_check_sha_exists=False,
+        use_cache=False,
+    )
+
+    # Fetch second time -> disabled cache
+    deployment_info_second = deployment_state.get_promotion_data(
+        channel="channel",
+        sha="sha",
+        target_uid="uid",
+        pre_check_sha_exists=False,
+        use_cache=False,
+    )
+
+    expected_promotion = PromotionData(
+        success=True,
+        target_config_hash="hash",
+        saas_file="saas_file",
+        check_in=check_in,
+    )
+
+    assert deployment_info_first == expected_promotion
+    assert deployment_info_second == expected_promotion
+
+    assert state.get.call_count == 2  # type: ignore[attr-defined]
+    state.get.assert_called_with("promotions_v2/channel/uid/sha")  # type: ignore[attr-defined]
+    state.ls.assert_not_called()  # type: ignore[attr-defined]

--- a/reconcile/test/utils/test_promotion_state.py
+++ b/reconcile/test/utils/test_promotion_state.py
@@ -183,7 +183,7 @@ def test_promotion_data_cache(s3_state_builder: Callable[[Mapping], State]) -> N
     state.ls.assert_not_called()  # type: ignore[attr-defined]
 
 
-def test_promotion_data_disabled_cache(
+def test_promotion_data_disabled_cache_by_default(
     s3_state_builder: Callable[[Mapping], State],
 ) -> None:
     check_in = "2024-04-17 13:47:31.722437+00:00"
@@ -206,7 +206,6 @@ def test_promotion_data_disabled_cache(
         sha="sha",
         target_uid="uid",
         pre_check_sha_exists=False,
-        use_cache=False,
     )
 
     # Fetch second time -> disabled cache

--- a/reconcile/utils/promotion_state.py
+++ b/reconcile/utils/promotion_state.py
@@ -34,6 +34,11 @@ class PromotionState:
     A wrapper around a reconcile.utils.state.State object.
     This is dedicated to storing and retrieving information
     about promotions on S3.
+
+    Note, that PromotionsState holds 2 caches.
+    One cache for the promotion data that has already been fetched.
+    Another cache for commit sha lookup, i.e., checking if a commit sha
+    exists in S3 before making any API calls to it.
     """
 
     def __init__(self, state: State):
@@ -67,6 +72,16 @@ class PromotionState:
         pre_check_sha_exists: bool = True,
         use_cache: bool = False,
     ) -> Optional[PromotionData]:
+        """
+        Fetch promotion data from S3.
+
+        @param use_cache: Each fetched promotion data is cached locally. Setting this
+        flag to True will use the cache if the data is already fetched.
+
+        @param pre_check_sha_exists: If set to True, we will check if the commit sha exists
+        in local cache and if not will exit before making any API calls. Note, that this requires
+        a prior call to cache_commit_shas_from_s3 to populate the local commit cache.
+        """
         cache_key_v2 = self._target_key(channel=channel, target_uid=target_uid)
         if pre_check_sha_exists and sha not in self._commits_by_channel[cache_key_v2]:
             # Lets reduce unecessary calls to S3
@@ -75,14 +90,11 @@ class PromotionState:
         path_v2 = f"promotions_v2/{channel}/{target_uid}/{sha}"
         if use_cache and path_v2 in self._promotion_data_cache:
             return self._promotion_data_cache[path_v2]
-        try:
-            data = self._state.get(path_v2)
-            promotion_data = PromotionData(**data)
-            self._promotion_data_cache[path_v2] = promotion_data
-            return promotion_data
-        except KeyError:
-            self._promotion_data_cache[path_v2] = None
-            return None
+
+        data = self._state.get(path_v2)
+        promotion_data = PromotionData(**data)
+        self._promotion_data_cache[path_v2] = promotion_data
+        return promotion_data
 
     def publish_promotion_data(
         self, sha: str, channel: str, target_uid: str, data: PromotionData

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1899,7 +1899,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     sha=promotion.commit_sha,
                     channel=channel.name,
                     target_uid=target_uid,
-                    local_lookup=False,
+                    pre_check_sha_exists=False,
                 )
                 if not (deployment and deployment.success):
                     logging.error(
@@ -2007,6 +2007,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                             saas_file=promotion.saas_file,
                             success=success,
                             target_config_hash=promotion.target_config_hash,
+                            # TODO: do not override - check if timestamp already exists
                             check_in=str(now),
                         ),
                     )


### PR DESCRIPTION
Saas promotion data will now be cached. The cache is disabled by default, to be fully backwards-compatible.

In a follow-up PR, saasherder will need to run more queries on promotion data - most of it will be redundant, but for saasherder logic it will be easier to not concern itself with the caching aspect.