### PR TITLE
explicitly return diff when a resource switches integrations

### DIFF
--- a/reconcile/test/test_three_way_diff_strategy.py
+++ b/reconcile/test/test_three_way_diff_strategy.py
@@ -119,3 +119,13 @@ def test_3wpd_diff_detects_missing_annotation(deployment):
     del c_item.body["metadata"]["annotations"]["new-annotation"]
 
     assert three_way_diff_using_hash(c_item, d_item) is False
+
+
+def test_3wpd_diff_detects_switch_integration(deployment):
+    d_item = OR(deployment, "same-integration", "")
+    deployment["metadata"]["annotations"]["qontract.integration"] = (
+        "different-integration"
+    )
+    c_item = OR(deployment, "same-integration", "").annotate(canonicalize=False)
+
+    assert three_way_diff_using_hash(c_item, d_item) is False

--- a/reconcile/utils/three_way_diff_strategy.py
+++ b/reconcile/utils/three_way_diff_strategy.py
@@ -131,7 +131,9 @@ def three_way_diff_using_hash(c_item: OR, d_item: OR) -> bool:
         logging.debug("Current object QR hash is missing -> Apply")
         return False
 
-    if (c_item_integration := annotations["qontract.integration"]) != d_item.integration:
+    if (
+        c_item_integration := annotations["qontract.integration"]
+    ) != d_item.integration:
         logging.info(
             f"resource switching integration from {c_item_integration} to {d_item.integration}"
         )

--- a/reconcile/utils/three_way_diff_strategy.py
+++ b/reconcile/utils/three_way_diff_strategy.py
@@ -131,6 +131,12 @@ def three_way_diff_using_hash(c_item: OR, d_item: OR) -> bool:
         logging.debug("Current object QR hash is missing -> Apply")
         return False
 
+    if (c_item_integration := annotations["qontract.integration"]) != d_item.integration:
+        logging.info(
+            f"resource switching integration from {c_item_integration} to {d_item.integration}"
+        )
+        return False
+
     # Original object does not match Desired -> Apply
     # Current object hash is not recalculated!
     if c_item_sha256 != d_item.sha256sum():


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10344

a fix on top of #4411

we currently ignore the integration annotation. in the above mentioned PR, existing resources are going to be managed by a new integration and we must update them in-place.