### PR TITLE
ignore missing integration file when not validating schemas

### DIFF
--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -122,7 +122,7 @@ class GqlApi:
                     self._valid_schemas = integration["schemas"]
                     break
 
-            if not self._valid_schemas:
+            if validate_schemas and not self._valid_schemas:
                 raise GqlApiIntegrationNotFound(int_name)
 
     def _init_gql_client(self) -> Client:


### PR DESCRIPTION
for usage with `qontract-reconcile --no-validate-schemas`