### PR TITLE
[slack-usergroups] ignore deleted users

### DIFF
--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -561,13 +561,14 @@ def _update_usergroup_users_from_state(
             desired_ug_state.user_names
         ).items()
     ]
+    active_user_names = set(s.name for s in slack_user_objects)
 
-    if len(slack_user_objects) != len(desired_ug_state.user_names):
+    if len(active_user_names) != len(desired_ug_state.user_names):
         logging.info(
-            f"Following usernames are incorrect for usergroup {desired_ug_state.usergroup} and could not be matched with slack users {desired_ug_state.user_names - set(s.name for s in slack_user_objects)}"
+            f"Following usernames are incorrect for usergroup {desired_ug_state.usergroup} and could not be matched with slack users {desired_ug_state.user_names - active_user_names}"
         )
 
-    for user in desired_ug_state.user_names - current_ug_state.user_names:
+    for user in active_user_names - current_ug_state.user_names:
         logging.info([
             "add_user_to_usergroup",
             desired_ug_state.workspace,
@@ -575,7 +576,7 @@ def _update_usergroup_users_from_state(
             user,
         ])
 
-    for user in current_ug_state.user_names - desired_ug_state.user_names:
+    for user in current_ug_state.user_names - active_user_names:
         logging.info([
             "del_user_from_usergroup",
             desired_ug_state.workspace,

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -557,7 +557,7 @@ def _update_usergroup_users_from_state(
 
     slack_user_objects = [
         SlackObject(pk=pk, name=name)
-        for pk, name in slack_client.get_users_by_names(
+        for pk, name in slack_client.get_active_users_by_names(
             desired_ug_state.user_names
         ).items()
     ]

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -566,8 +566,6 @@ def _update_usergroup_users_from_state(
         logging.info(
             f"Following usernames are incorrect for usergroup {desired_ug_state.usergroup} and could not be matched with slack users {desired_ug_state.user_names - set(s.name for s in slack_user_objects)}"
         )
-        error_occurred = True
-        return 0
 
     for user in desired_ug_state.user_names - current_ug_state.user_names:
         logging.info([

--- a/reconcile/test/test_slack_usergroups.py
+++ b/reconcile/test/test_slack_usergroups.py
@@ -579,7 +579,7 @@ def test_act_empty_current_state(
 
     slack_client_mock.create_usergroup.return_value = "USERGA"
     slack_client_mock.get_usergroup_id.return_value = "USERGA"
-    slack_client_mock.get_users_by_names.return_value = {"USERA": "username"}
+    slack_client_mock.get_active_users_by_names.return_value = {"USERA": "username"}
     slack_client_mock.get_channels_by_names.return_value = {"CHANA": "someotherchannel"}
 
     act(current_state, desired_state, slack_map, dry_run=False)
@@ -605,7 +605,7 @@ def test_act_update_usergroup_users(
     }
 
     slack_client_mock.get_usergroup_id.return_value = "USERGA"
-    slack_client_mock.get_users_by_names.return_value = {
+    slack_client_mock.get_active_users_by_names.return_value = {
         "USERB": "someotherusername",
         "USERC": "anotheruser",
     }
@@ -629,7 +629,7 @@ def test_act_update_usergroup_channels(
     desired_state["slack-workspace"]["usergroup-1"].channel_names = {"CHANB"}
 
     slack_client_mock.get_usergroup_id.return_value = "USERGA"
-    slack_client_mock.get_users_by_names.return_value = {"USERA": "username"}
+    slack_client_mock.get_active_users_by_names.return_value = {"USERA": "username"}
     slack_client_mock.get_channels_by_names.return_value = {"CHANB": "channel"}
 
     act(current_state, desired_state, slack_map, dry_run=False)
@@ -651,7 +651,7 @@ def test_act_update_usergroup_description(
     ].description = "A different description"
 
     slack_client_mock.get_usergroup_id.return_value = "USERGA"
-    slack_client_mock.get_users_by_names.return_value = {"USERA": "username"}
+    slack_client_mock.get_active_users_by_names.return_value = {"USERA": "username"}
     slack_client_mock.get_channels_by_names.return_value = {"CHANA": "channel"}
 
     act(current_state, desired_state, slack_map, dry_run=False)
@@ -675,7 +675,7 @@ def test_act_update_usergroup_desc_and_channels(
     ].description = "A different description"
 
     slack_client_mock.get_usergroup_id.return_value = "USERGA"
-    slack_client_mock.get_users_by_names.return_value = {"USERA": "username"}
+    slack_client_mock.get_active_users_by_names.return_value = {"USERA": "username"}
     slack_client_mock.get_channels_by_names.return_value = {"CHANB": "someotherchannel"}
 
     act(current_state, desired_state, slack_map, dry_run=False)
@@ -716,7 +716,7 @@ def test_act_add_new_usergroups(
     desired_state = copy.deepcopy(base_state)
 
     slack_client_mock.get_usergroup_id.side_effect = get_ugid
-    slack_client_mock.get_users_by_names.side_effect = get_users
+    slack_client_mock.get_active_users_by_names.side_effect = get_users
     slack_client_mock.get_channels_by_names.side_effect = get_channels
 
     desired_state["slack-workspace"]["usergroup-2"] = State(

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -417,11 +417,11 @@ class SlackApi:
             k: v["name"] for k, v in self._get("channels").items() if k in channels_ids
         }
 
-    def get_users_by_names(self, user_names: Iterable[str]) -> dict[str, str]:
+    def get_active_users_by_names(self, user_names: Iterable[str]) -> dict[str, str]:
         return {
             k: v["name"]
             for k, v in self._get("users").items()
-            if v["name"] in user_names
+            if v["name"] in user_names and not v["deleted"]
         }
 
     def get_users_by_ids(self, users_ids: Iterable[str]) -> dict[str, str]:


### PR DESCRIPTION
api ref: https://api.slack.com/methods/users.list

deleted users still appear in the system, with a `deleted` attribute. let's avoid acting on deleted users, unless we are very intentional (like when emptying a usergroup).