### PR TITLE
:bug: Add enableDeletions and deletionApprovals to vpc_requests query

### DIFF
--- a/reconcile/gql_definitions/common/aws_vpc_requests.py
+++ b/reconcile/gql_definitions/common/aws_vpc_requests.py
@@ -47,6 +47,12 @@ fragment VPCRequest on VPCRequest_v1 {
     terraformState {
       ...TerraformState
     }
+    enableDeletion
+    deletionApprovals {
+      type
+      name
+      expiration
+    }
   }
   region
   cidr_block {

--- a/reconcile/gql_definitions/fragments/aws_vpc_request.gql
+++ b/reconcile/gql_definitions/fragments/aws_vpc_request.gql
@@ -16,6 +16,12 @@ fragment VPCRequest on VPCRequest_v1 {
     terraformState {
       ...TerraformState
     }
+    enableDeletion
+    deletionApprovals {
+      type
+      name
+      expiration
+    }
   }
   region
   cidr_block {

--- a/reconcile/gql_definitions/fragments/aws_vpc_request.py
+++ b/reconcile/gql_definitions/fragments/aws_vpc_request.py
@@ -27,6 +27,12 @@ class ConfiguredBaseModel(BaseModel):
         extra=Extra.forbid
 
 
+class DeletionApprovalV1(ConfiguredBaseModel):
+    q_type: str = Field(..., alias="type")
+    name: str = Field(..., alias="name")
+    expiration: str = Field(..., alias="expiration")
+
+
 class AWSAccountV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     uid: str = Field(..., alias="uid")
@@ -36,6 +42,8 @@ class AWSAccountV1(ConfiguredBaseModel):
     resources_default_region: str = Field(..., alias="resourcesDefaultRegion")
     provider_version: str = Field(..., alias="providerVersion")
     terraform_state: Optional[TerraformState] = Field(..., alias="terraformState")
+    enable_deletion: Optional[bool] = Field(..., alias="enableDeletion")
+    deletion_approvals: Optional[list[DeletionApprovalV1]] = Field(..., alias="deletionApprovals")
 
 
 class NetworkV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -5343,6 +5343,11 @@
                         },
                         {
                             "kind": "OBJECT",
+                            "name": "GitlabInstance_v1",
+                            "ofType": null
+                        },
+                        {
+                            "kind": "OBJECT",
                             "name": "Integration_v1",
                             "ofType": null
                         },
@@ -28136,7 +28141,13 @@
                         }
                     ],
                     "inputFields": null,
-                    "interfaces": [],
+                    "interfaces": [
+                        {
+                            "kind": "INTERFACE",
+                            "name": "DatafileObject_v1",
+                            "ofType": null
+                        }
+                    ],
                     "enumValues": null,
                     "possibleTypes": null
                 },


### PR DESCRIPTION
This will enable us to delete the resources created by the integration by using the `deletionApprovals` object in app-interface.

Related to: [APPSRE-8743](https://issues.redhat.com/browse/APPSRE-8743)