### PR TITLE
template-renderer: foreach loop

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -1304,6 +1304,16 @@
                             "description": null,
                             "args": [
                                 {
+                                    "name": "name",
+                                    "description": null,
+                                    "type": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    },
+                                    "defaultValue": null
+                                },
+                                {
                                     "name": "path",
                                     "description": null,
                                     "type": {
@@ -1392,7 +1402,7 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "escalation_policies_1",
+                            "name": "escalation_policies_v1",
                             "description": null,
                             "args": [
                                 {
@@ -32194,6 +32204,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "forEach",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "TemplateCollectionForEach_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "description",
                             "description": null,
                             "args": [],
@@ -32254,6 +32276,37 @@
                             "ofType": null
                         }
                     ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "TemplateCollectionForEach_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "items",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "JSON",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
                 },

--- a/reconcile/gql_definitions/templating/template_collection.gql
+++ b/reconcile/gql_definitions/templating/template_collection.gql
@@ -6,6 +6,9 @@ query TemplateCollection_v1 {
     additionalMrLabels
     description
     enableAutoApproval
+    forEach {
+      items
+    }
     variables {
       static
       dynamic {

--- a/reconcile/gql_definitions/templating/template_collection.py
+++ b/reconcile/gql_definitions/templating/template_collection.py
@@ -25,6 +25,9 @@ query TemplateCollection_v1 {
     additionalMrLabels
     description
     enableAutoApproval
+    forEach {
+      items
+    }
     variables {
       static
       dynamic {
@@ -52,6 +55,10 @@ class ConfiguredBaseModel(BaseModel):
     class Config:
         smart_union=True
         extra=Extra.forbid
+
+
+class TemplateCollectionForEachV1(ConfiguredBaseModel):
+    items: Optional[list[Json]] = Field(..., alias="items")
 
 
 class TemplateCollectionVariablesQueriesV1(ConfiguredBaseModel):
@@ -83,6 +90,7 @@ class TemplateCollectionV1(ConfiguredBaseModel):
     additional_mr_labels: Optional[list[str]] = Field(..., alias="additionalMrLabels")
     description: str = Field(..., alias="description")
     enable_auto_approval: Optional[bool] = Field(..., alias="enableAutoApproval")
+    for_each: Optional[TemplateCollectionForEachV1] = Field(..., alias="forEach")
     variables: Optional[TemplateCollectionVariablesV1] = Field(..., alias="variables")
     templates: list[TemplateV1] = Field(..., alias="templates")
 

--- a/reconcile/test/templating/test_renderer.py
+++ b/reconcile/test/templating/test_renderer.py
@@ -43,7 +43,7 @@ def collection_variables(gql_class_factory: Callable) -> TemplateCollectionVaria
 
 
 @pytest.fixture
-def foreach_item() -> dict[str, Any]:
+def each() -> dict[str, Any]:
     return {"name": "item-0"}
 
 
@@ -54,8 +54,8 @@ def collection_variables_foreach(
     return gql_class_factory(
         TemplateCollectionVariablesV1,
         {
-            "static": '{"foo": "{{ foreach_item.name }}"}',
-            "dynamic": [{"name": "foo", "query": "query {{ foreach_item.name }}"}],
+            "static": '{"foo": "{{ each.name }}"}',
+            "dynamic": [{"name": "foo", "query": "query {{ each.name }}"}],
         },
     )
 
@@ -158,11 +158,9 @@ def test_unpack_static_variables(
 
 def test_unpack_static_variables_foreach(
     collection_variables_foreach: TemplateCollectionVariablesV1,
-    foreach_item: dict[str, Any],
+    each: dict[str, Any],
 ) -> None:
-    # "static": '{"foo": "{{ foreach_item.name }}"}',
-    #         "dynamic": [{"name": "foo", "query": "query {{ foreach_item.name }}"}],
-    assert unpack_static_variables(collection_variables_foreach, foreach_item) == {
+    assert unpack_static_variables(collection_variables_foreach, each) == {
         "foo": "item-0"
     }
 
@@ -234,10 +232,10 @@ def test_unpack_dynamic_variables_templated_query_jinja_error(
 def test_unpack_dynamic_variables_foreach(
     mocker: MockerFixture,
     collection_variables_foreach: TemplateCollectionVariablesV1,
-    foreach_item: dict[str, Any],
+    each: dict[str, Any],
 ) -> None:
     gql = mocker.patch("reconcile.templating.renderer.gql.GqlApi", autospec=True)
-    unpack_dynamic_variables(collection_variables_foreach, foreach_item, gql)
+    unpack_dynamic_variables(collection_variables_foreach, each, gql)
     gql.query.assert_called_once_with("query item-0")
 
 
@@ -565,7 +563,7 @@ def test_reconcile_variables(
     pt.assert_called_once()
     assert pt.call_args[0] == (
         ANY,
-        {"dynamic": {"foo": "bar"}, "static": {"baz": "qux"}, "foreach_item": {}},
+        {"dynamic": {"foo": "bar"}, "static": {"baz": "qux"}},
         ANY,
         r,
         ANY,


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-10379

depends on https://github.com/app-sre/qontract-schemas/pull/667

Example in a template-collection:

```yaml
forEach:
  items:
  - cluster_name: app-sre-prod-01
    value: value1
  - cluster_name: app-sre-prod-04
    value: value2

variables:
  static:
    foo: FOO
    bar: "This is for value {{ foreach_item.value }}"
  dynamic:
  - name: cluster
    query: |
      {
      clusters: clusters_v1(filter: {
          name: "{{ foreach_item.cluster_name }}"
        })
        {
          name
          consoleUrl
        }
      }
```
