### PR TITLE
Fix terraform vpc resources inint outputs

### DIFF
--- a/reconcile/terraform_vpc_resources/integration.py
+++ b/reconcile/terraform_vpc_resources/integration.py
@@ -170,6 +170,8 @@ class TerraformVpcResources(QontractReconcileIntegration[TerraformVpcResourcesPa
 
         tf_client.apply()
 
+        tf_client.init_outputs()
+
         handled_output = self._handle_outputs(data, tf_client.outputs)
 
         # MR and template Management

--- a/reconcile/terraform_vpc_resources/integration.py
+++ b/reconcile/terraform_vpc_resources/integration.py
@@ -70,7 +70,14 @@ class TerraformVpcResources(QontractReconcileIntegration[TerraformVpcResourcesPa
         """Receives a terraform outputs dict and returns a map of outputs per VPC requests"""
         outputs_per_request: MutableMapping[str, Any] = {}
         for request in requests:
+            # Skiping requests that don't have outputs,
+            # this happens because we are not filtering the requests
+            # when running the integration for a single account with --account-name
+            if request.account.name not in outputs.keys():
+                continue
+
             outputs_per_request[request.identifier] = []
+
             outputs_per_account = outputs[request.account.name]
 
             # If the output exists for that request get its value


### PR DESCRIPTION
To avoid using empty outputs we are using the `init_outputs` method before `_handle_outputs`. 