### PR TITLE
:sparkles: glitchtip-project-alerts: support Jira components and issue type

### DIFF
--- a/reconcile/glitchtip_project_alerts/integration.py
+++ b/reconcile/glitchtip_project_alerts/integration.py
@@ -129,8 +129,7 @@ class GlitchtipProjectAlertsIntegration(
                 alert_labels = glitchtip_project.jira.labels or []
 
                 if glitchtip_project.jira.project:
-                    if glitchtip_project.jira.components:
-                        params["components"] = glitchtip_project.jira.components
+                    params["components"] = glitchtip_project.jira.components or []
                     params["labels"] = alert_labels
                     url = f"{gjb_alert_url}/{glitchtip_project.jira.project}?{urlencode(params, True)}"
                     alerts.append(
@@ -161,10 +160,10 @@ class GlitchtipProjectAlertsIntegration(
                         ):
                             continue
                         params["labels"] = alert_labels + (channels.jira_labels or [])
-                        if channels.jira_component:
-                            params["components"] = [channels.jira_component]
-                        if board.issue_type:
-                            params["issue_type"] = board.issue_type
+                        params["components"] = (
+                            [channels.jira_component] if channels.jira_component else []
+                        )
+                        params["issue_type"] = board.issue_type or "Bug"
                         url = f"{gjb_alert_url}/{board.name}?{urlencode(params, True)}"
                         alerts.append(
                             ProjectAlert(

--- a/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.gql
+++ b/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.gql
@@ -30,10 +30,18 @@ query GlitchtipProjectsWithAlerts {
     }
     jira {
       project
-      board {
-        name
-        disable {
-          integrations
+      components
+      escalationPolicy {
+        channels {
+          jiraBoard {
+            name
+            issueType
+            disable {
+              integrations
+            }
+          }
+          jiraComponent
+          jiraLabels
         }
       }
       labels

--- a/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.py
+++ b/reconcile/gql_definitions/glitchtip_project_alerts/glitchtip_project.py
@@ -58,10 +58,18 @@ query GlitchtipProjectsWithAlerts {
     }
     jira {
       project
-      board {
-        name
-        disable {
-          integrations
+      components
+      escalationPolicy {
+        channels {
+          jiraBoard {
+            name
+            issueType
+            disable {
+              integrations
+            }
+          }
+          jiraComponent
+          jiraLabels
         }
       }
       labels
@@ -113,12 +121,24 @@ class DisableJiraBoardAutomationsV1(ConfiguredBaseModel):
 
 class JiraBoardV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+    issue_type: Optional[str] = Field(..., alias="issueType")
     disable: Optional[DisableJiraBoardAutomationsV1] = Field(..., alias="disable")
+
+
+class AppEscalationPolicyChannelsV1(ConfiguredBaseModel):
+    jira_board: list[JiraBoardV1] = Field(..., alias="jiraBoard")
+    jira_component: Optional[str] = Field(..., alias="jiraComponent")
+    jira_labels: Optional[list[str]] = Field(..., alias="jiraLabels")
+
+
+class AppEscalationPolicyV1(ConfiguredBaseModel):
+    channels: AppEscalationPolicyChannelsV1 = Field(..., alias="channels")
 
 
 class GlitchtipProjectJiraV1(ConfiguredBaseModel):
     project: Optional[str] = Field(..., alias="project")
-    board: Optional[JiraBoardV1] = Field(..., alias="board")
+    components: Optional[list[str]] = Field(..., alias="components")
+    escalation_policy: Optional[AppEscalationPolicyV1] = Field(..., alias="escalationPolicy")
     labels: Optional[list[str]] = Field(..., alias="labels")
 
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -23630,6 +23630,18 @@
                     "description": null,
                     "fields": [
                         {
+                            "name": "escalationPolicy",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "AppEscalationPolicy_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "project",
                             "description": null,
                             "args": [],
@@ -23642,13 +23654,21 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "board",
+                            "name": "components",
                             "description": null,
                             "args": [],
                             "type": {
-                                "kind": "OBJECT",
-                                "name": "JiraBoard_v1",
-                                "ofType": null
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
                             },
                             "isDeprecated": false,
                             "deprecationReason": null

--- a/reconcile/test/fixtures/glitchtip/project_alerts.yml
+++ b/reconcile/test/fixtures/glitchtip/project_alerts.yml
@@ -47,9 +47,17 @@ glitchtip_projects:
       name: glitchtip-dev
   jira:
     project: null
-    board:
-      name: JIRA-VIA-BOARD
-      disable: null
+    components: null
+    escalationPolicy:
+      channels:
+        jiraBoard:
+        - name: JIRA-VIA-BOARD
+          disable: null
+          issueType: CustomIssueType
+        jiraComponent: jira-component
+        jiraLabels:
+        - escalation-label-1
+        - escalation-label-2
     labels:
     - example-label-1
     - example-label-2
@@ -68,9 +76,14 @@ glitchtip_projects:
     instance:
       name: glitchtip-dev
   jira:
-    board: null
+    escalationPolicy: null
     project: JIRA-VIA-PROJECT
-    labels: null
+    components:
+    - jira-component-1
+    - jira-component-2
+    labels:
+    - example-label-1
+    - example-label-2
   alerts: null
 
 - name: integration-disabled
@@ -81,11 +94,17 @@ glitchtip_projects:
       name: glitchtip-dev
   jira:
     project: null
-    board:
-      name: JIRA-VIA-BOARD
-      disable:
-        integrations:
-        - glitchtip-project-alerts
+    components: null
+    escalationPolicy:
+      channels:
+        jiraBoard:
+        - name: JIRA-VIA-BOARD
+          disable:
+            integrations:
+            - glitchtip-project-alerts
+          issueType: null
+        jiraComponent: null
+        jiraLabels: null
     labels: null
   alerts: null
 
@@ -97,10 +116,16 @@ glitchtip_projects:
       name: glitchtip-dev
   jira:
     project: null
-    board:
-      name: JIRA-VIA-BOARD
-      disable:
-        integrations:
-        - jira-permissions-validator
+    components: null
+    escalationPolicy:
+      channels:
+        jiraBoard:
+        - name: JIRA-VIA-BOARD
+          disable:
+            integrations:
+            - jira-permissions-validator
+          issueType: null
+        jiraComponent: null
+        jiraLabels: null
     labels: null
   alerts: null

--- a/reconcile/test/glitchtip/test_glitchtip_project_alerts.py
+++ b/reconcile/test/glitchtip/test_glitchtip_project_alerts.py
@@ -13,6 +13,8 @@ from reconcile.glitchtip_project_alerts.integration import (
 )
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.gql_definitions.glitchtip_project_alerts.glitchtip_project import (
+    AppEscalationPolicyChannelsV1,
+    AppEscalationPolicyV1,
     DisableJiraBoardAutomationsV1,
     GlitchtipInstanceV1,
     GlitchtipOrganizationV1,
@@ -193,7 +195,20 @@ def test_glitchtip_project_alerts_get_projects(
             ],
             jira=GlitchtipProjectJiraV1(
                 project=None,
-                board=JiraBoardV1(name="JIRA-VIA-BOARD", disable=None),
+                components=None,
+                escalationPolicy=AppEscalationPolicyV1(
+                    channels=AppEscalationPolicyChannelsV1(
+                        jiraBoard=[
+                            JiraBoardV1(
+                                name="JIRA-VIA-BOARD",
+                                issueType="CustomIssueType",
+                                disable=None,
+                            )
+                        ],
+                        jiraComponent="jira-component",
+                        jiraLabels=["escalation-label-1", "escalation-label-2"],
+                    )
+                ),
                 labels=["example-label-1", "example-label-2"],
             ),
         ),
@@ -205,7 +220,10 @@ def test_glitchtip_project_alerts_get_projects(
             ),
             alerts=None,
             jira=GlitchtipProjectJiraV1(
-                project="JIRA-VIA-PROJECT", board=None, labels=None
+                project="JIRA-VIA-PROJECT",
+                components=["jira-component-1", "jira-component-2"],
+                escalationPolicy=None,
+                labels=["example-label-1", "example-label-2"],
             ),
         ),
         GlitchtipProjectV1(
@@ -217,11 +235,21 @@ def test_glitchtip_project_alerts_get_projects(
             alerts=None,
             jira=GlitchtipProjectJiraV1(
                 project=None,
-                board=JiraBoardV1(
-                    name="JIRA-VIA-BOARD",
-                    disable=DisableJiraBoardAutomationsV1(
-                        integrations=["glitchtip-project-alerts"]
-                    ),
+                components=None,
+                escalationPolicy=AppEscalationPolicyV1(
+                    channels=AppEscalationPolicyChannelsV1(
+                        jiraBoard=[
+                            JiraBoardV1(
+                                name="JIRA-VIA-BOARD",
+                                issueType=None,
+                                disable=DisableJiraBoardAutomationsV1(
+                                    integrations=["glitchtip-project-alerts"]
+                                ),
+                            )
+                        ],
+                        jiraComponent=None,
+                        jiraLabels=None,
+                    )
                 ),
                 labels=None,
             ),
@@ -235,11 +263,21 @@ def test_glitchtip_project_alerts_get_projects(
             alerts=None,
             jira=GlitchtipProjectJiraV1(
                 project=None,
-                board=JiraBoardV1(
-                    name="JIRA-VIA-BOARD",
-                    disable=DisableJiraBoardAutomationsV1(
-                        integrations=["jira-permissions-validator"]
-                    ),
+                components=None,
+                escalationPolicy=AppEscalationPolicyV1(
+                    channels=AppEscalationPolicyChannelsV1(
+                        jiraBoard=[
+                            JiraBoardV1(
+                                name="JIRA-VIA-BOARD",
+                                issueType=None,
+                                disable=DisableJiraBoardAutomationsV1(
+                                    integrations=["jira-permissions-validator"]
+                                ),
+                            )
+                        ],
+                        jiraComponent=None,
+                        jiraLabels=None,
+                    )
                 ),
                 labels=None,
             ),
@@ -312,7 +350,7 @@ def test_glitchtip_project_alerts_fetch_desire_state(
                 ProjectAlertRecipient(
                     pk=None,
                     recipient_type=RecipientType.WEBHOOK,
-                    url="http://gjb.com/JIRA-VIA-BOARD?token=secret&labels=example-label-1&labels=example-label-2",
+                    url="http://gjb.com/JIRA-VIA-BOARD?token=secret&labels=example-label-1&labels=example-label-2&labels=escalation-label-1&labels=escalation-label-2&components=jira-component&issue_type=CustomIssueType",
                 )
             ],
         ),
@@ -328,7 +366,7 @@ def test_glitchtip_project_alerts_fetch_desire_state(
                 ProjectAlertRecipient(
                     pk=None,
                     recipient_type=RecipientType.WEBHOOK,
-                    url="http://gjb.com/JIRA-VIA-PROJECT?token=secret",
+                    url="http://gjb.com/JIRA-VIA-PROJECT?token=secret&components=jira-component-1&components=jira-component-2&labels=example-label-1&labels=example-label-2",
                 )
             ],
         )

--- a/reconcile/test/glitchtip/test_glitchtip_project_alerts.py
+++ b/reconcile/test/glitchtip/test_glitchtip_project_alerts.py
@@ -350,7 +350,7 @@ def test_glitchtip_project_alerts_fetch_desire_state(
                 ProjectAlertRecipient(
                     pk=None,
                     recipient_type=RecipientType.WEBHOOK,
-                    url="http://gjb.com/JIRA-VIA-BOARD?token=secret&labels=example-label-1&labels=example-label-2&labels=escalation-label-1&labels=escalation-label-2&components=jira-component&issue_type=CustomIssueType",
+                    url="http://gjb.com/JIRA-VIA-BOARD?labels=example-label-1&labels=example-label-2&labels=escalation-label-1&labels=escalation-label-2&components=jira-component&token=secret&issue_type=CustomIssueType",
                 )
             ],
         ),
@@ -366,7 +366,7 @@ def test_glitchtip_project_alerts_fetch_desire_state(
                 ProjectAlertRecipient(
                     pk=None,
                     recipient_type=RecipientType.WEBHOOK,
-                    url="http://gjb.com/JIRA-VIA-PROJECT?token=secret&components=jira-component-1&components=jira-component-2&labels=example-label-1&labels=example-label-2",
+                    url="http://gjb.com/JIRA-VIA-PROJECT?labels=example-label-1&labels=example-label-2&components=jira-component-1&components=jira-component-2&token=secret",
                 )
             ],
         )


### PR DESCRIPTION
Add support for Jira components and custom issue type.

Ticket: [APPSRE-10356](https://issues.redhat.com/browse/APPSRE-10356)

Depends on:
* https://github.com/app-sre/qontract-schemas/pull/671
* https://github.com/app-sre/glitchtip-jira-bridge/pull/16