### PR TITLE
oc apply handle request entity too large

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -40,6 +40,7 @@ from reconcile.utils.oc import (
     OCClient,
     OCLogMsg,
     PrimaryClusterIPCanNotBeUnsetError,
+    RequestEntityTooLargeError,
     StatefulSetUpdateForbidden,
     StatusCodeError,
     UnsupportedMediaTypeError,
@@ -402,7 +403,7 @@ def apply(
 
         try:
             oc.apply(namespace, annotated)
-        except InvalidValueApplyError:
+        except (InvalidValueApplyError, RequestEntityTooLargeError):
             oc.remove_last_applied_configuration(
                 namespace, resource_type, resource.name
             )

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -127,6 +127,10 @@ class JobNotRunningError(Exception):
     pass
 
 
+class RequestEntityTooLargeError(Exception):
+    pass
+
+
 class OCDecorators:
     @classmethod
     def process_reconcile_time(cls, function):
@@ -1118,6 +1122,8 @@ class OCCli:  # pylint: disable=too-many-public-methods
                     raise StatefulSetUpdateForbidden(f"[{self.server}]: {err}")
                 if "the object has been modified" in err:
                     raise ObjectHasBeenModifiedError(f"[{self.server}]: {err}")
+                if "Request entity too large" in err:
+                    raise RequestEntityTooLargeError(f"[{self.server}]: {err}")
             if not (allow_not_found and "NotFound" in err):
                 raise StatusCodeError(f"[{self.server}]: {err}")
 


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10378

Because of several escaping and the last-applied-configuration holds an older version of the enormous grafana JSON.

There is a potential solution that could work-removing the existing last-applied-configuration annotation before oc apply.