### PR TITLE
APPSRE-10351 fetch saas state via cli

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -3668,7 +3668,13 @@ def get_promotion_state(channel: str, sha: str):
     )
 
     promotion_state = SaasPromotionState.create(promotion_state=None, saas_files=None)
-    promotion_state.get(channel=channel, sha=sha)
+    for publisher_id, state in promotion_state.get(channel=channel, sha=sha).items():
+        print()
+        if not state:
+            print(f"No state found for {publisher_id=}")
+        else:
+            print(f"State for {publisher_id=}:")
+            print(state)
 
 
 @root.command()

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -3659,6 +3659,19 @@ def gpg_encrypt(
 
 
 @root.command()
+@click.option("--channel", help="the channel that state is part of")
+@click.option("--sha", help="the commit sha we want state for")
+@environ(["APP_INTERFACE_STATE_BUCKET"])
+def get_promotion_state(channel: str, sha: str):
+    from tools.saas_promotion_state.saas_promotion_state import (
+        SaasPromotionState,
+    )
+
+    promotion_state = SaasPromotionState.create(promotion_state=None, saas_files=None)
+    promotion_state.get(channel=channel, sha=sha)
+
+
+@root.command()
 @click.option("--change-type-name")
 @click.option("--role-name")
 @click.option(

--- a/tools/saas_promotion_state/saas_promotion_state.py
+++ b/tools/saas_promotion_state/saas_promotion_state.py
@@ -9,7 +9,7 @@ from reconcile.typed_queries.app_interface_vault_settings import (
     get_app_interface_vault_settings,
 )
 from reconcile.typed_queries.saas_files import SaasFile, get_saas_files
-from reconcile.utils.promotion_state import PromotionState
+from reconcile.utils.promotion_state import PromotionData, PromotionState
 from reconcile.utils.secret_reader import create_secret_reader
 from reconcile.utils.state import init_state
 
@@ -40,28 +40,19 @@ class SaasPromotionState:
                             )
         return publisher_uids
 
-    def get(self, channel: str, sha: str) -> None:
-        publisher_ids = self._publisher_ids_for_channel(
-            channel=channel, saas_files=self._saas_files
-        )
-        if not publisher_ids:
-            print(f"No publishers found for channel {channel}")
-            return
-        for publisher_id in publisher_ids:
-            print()
-            print(f"Last state for publisher with ID {publisher_id}:")
-            data = self._promotion_state.get_promotion_data(
+    def get(self, channel: str, sha: str) -> dict[str, PromotionData | None]:
+        return {
+            publisher_id: self._promotion_state.get_promotion_data(
                 sha=sha,
                 channel=channel,
                 use_cache=False,
                 target_uid=publisher_id,
                 pre_check_sha_exists=False,
             )
-            if not data:
-                print(f"No data found for publisher {publisher_id}")
-                continue
-            else:
-                print(data)
+            for publisher_id in self._publisher_ids_for_channel(
+                channel=channel, saas_files=self._saas_files
+            )
+        }
 
     @staticmethod
     def create(

--- a/tools/saas_promotion_state/saas_promotion_state.py
+++ b/tools/saas_promotion_state/saas_promotion_state.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from reconcile.openshift_saas_deploy import (
+    QONTRACT_INTEGRATION as OPENSHIFT_SAAS_DEPLOY,
+)
+from reconcile.typed_queries.app_interface_vault_settings import (
+    get_app_interface_vault_settings,
+)
+from reconcile.typed_queries.saas_files import SaasFile, get_saas_files
+from reconcile.utils.promotion_state import PromotionState
+from reconcile.utils.secret_reader import create_secret_reader
+from reconcile.utils.state import init_state
+
+
+class SaasPromotionState:
+    def __init__(
+        self, promotion_state: PromotionState, saas_files: Iterable[SaasFile]
+    ) -> None:
+        self._promotion_state = promotion_state
+        self._saas_files = saas_files
+
+    def _publisher_ids_for_channel(
+        self, channel: str, saas_files: Iterable[SaasFile]
+    ) -> list[str]:
+        publisher_uids: list[str] = []
+        for saas_file in saas_files:
+            for resource_template in saas_file.resource_templates:
+                for target in resource_template.targets:
+                    if not target.promotion:
+                        continue
+                    for publish_channel in target.promotion.publish or []:
+                        if publish_channel == channel:
+                            publisher_uids.append(
+                                target.uid(
+                                    parent_saas_file_name=saas_file.name,
+                                    parent_resource_template_name=resource_template.name,
+                                )
+                            )
+        return publisher_uids
+
+    def get(self, channel: str, sha: str) -> None:
+        publisher_ids = self._publisher_ids_for_channel(
+            channel=channel, saas_files=self._saas_files
+        )
+        if not publisher_ids:
+            print(f"No publishers found for channel {channel}")
+            return
+        for publisher_id in publisher_ids:
+            print()
+            print(f"Last state for publisher with ID {publisher_id}:")
+            data = self._promotion_state.get_promotion_data(
+                sha=sha,
+                channel=channel,
+                use_cache=False,
+                target_uid=publisher_id,
+                pre_check_sha_exists=False,
+            )
+            if not data:
+                print(f"No data found for publisher {publisher_id}")
+                continue
+            else:
+                print(data)
+
+    @staticmethod
+    def create(
+        promotion_state: PromotionState | None, saas_files: Iterable[SaasFile] | None
+    ) -> SaasPromotionState:
+        if not promotion_state:
+            vault_settings = get_app_interface_vault_settings()
+            secret_reader = create_secret_reader(use_vault=vault_settings.vault)
+            saas_deploy_state = init_state(
+                integration=OPENSHIFT_SAAS_DEPLOY, secret_reader=secret_reader
+            )
+            promotion_state = PromotionState(state=saas_deploy_state)
+        if not saas_files:
+            saas_files = get_saas_files()
+        return SaasPromotionState(
+            promotion_state=promotion_state, saas_files=saas_files
+        )

--- a/tools/test/conftest.py
+++ b/tools/test/conftest.py
@@ -1,18 +1,60 @@
 from collections.abc import (
     Callable,
+    Iterable,
+    Mapping,
     MutableMapping,
 )
+from pathlib import Path
 from typing import Any
 
 import pytest
 from pydantic import BaseModel
 from pydantic.error_wrappers import ValidationError
 
+from reconcile.typed_queries.saas_files import SaasFile
 from reconcile.utils.models import data_default_none
 
 
 class GQLClassFactoryError(Exception):
     pass
+
+
+@pytest.fixture
+def saas_files_builder(
+    gql_class_factory: Callable[[type[SaasFile], Mapping], SaasFile],
+) -> Callable[[Iterable[MutableMapping]], list[SaasFile]]:
+    def builder(data: Iterable[MutableMapping]) -> list[SaasFile]:
+        for d in data:
+            if "app" not in d:
+                d["app"] = {}
+            if "pipelinesProvider" not in d:
+                d["pipelinesProvider"] = {}
+            if "managedResourceTypes" not in d:
+                d["managedResourceTypes"] = []
+            if "imagePatterns" not in d:
+                d["imagePatterns"] = []
+            for rt in d.get("resourceTemplates", []):
+                for t in rt.get("targets", []):
+                    ns = t["namespace"]
+                    if "name" not in ns:
+                        ns["name"] = "some_name"
+                    if "environment" not in ns:
+                        ns["environment"] = {}
+                    if "app" not in ns:
+                        ns["app"] = {}
+                    if "cluster" not in ns:
+                        ns["cluster"] = {}
+        return [gql_class_factory(SaasFile, d) for d in data]
+
+    return builder
+
+
+@pytest.fixture
+def fx() -> Callable:
+    def _fx(name: str) -> str:
+        return (Path(__file__).parent / "fixtures" / name).read_text()
+
+    return _fx
 
 
 @pytest.fixture

--- a/tools/test/test_saas_promotion_state.py
+++ b/tools/test/test_saas_promotion_state.py
@@ -1,0 +1,78 @@
+from collections.abc import (
+    Callable,
+    Iterable,
+    Mapping,
+)
+from unittest.mock import (
+    create_autospec,
+)
+
+from reconcile.typed_queries.saas_files import SaasFile
+from reconcile.utils.promotion_state import PromotionState
+from tools.saas_promotion_state.saas_promotion_state import (
+    SaasPromotionState,
+)
+
+
+def test_saas_promotion_state(
+    saas_files_builder: Callable[[Iterable[Mapping]], list[SaasFile]],
+) -> None:
+    saas_files = saas_files_builder([
+        {
+            "path": "/saas1.yml",
+            "name": "saas_1",
+            "resourceTemplates": [
+                {
+                    "name": "template_1",
+                    "url": "repo1/url",
+                    "targets": [
+                        {
+                            "ref": "main",
+                            "namespace": {"path": "/namespace1.yml"},
+                            "promotion": {
+                                "publish": ["channel-a"],
+                            },
+                        }
+                    ],
+                }
+            ],
+        },
+        {
+            "path": "/saas2.yml",
+            "name": "saas_2",
+            "resourceTemplates": [
+                {
+                    "name": "template_2",
+                    "url": "repo2/url",
+                    "targets": [
+                        {
+                            "ref": "main",
+                            "namespace": {"path": "/namespace2.yml"},
+                            "promotion": {
+                                "publish": ["channel-b"],
+                                "subscribe": ["channel-a"],
+                            },
+                        },
+                        {
+                            "ref": "main",
+                            "namespace": {"path": "/namespace3.yml"},
+                        },
+                    ],
+                }
+            ],
+        },
+    ])
+
+    promotion_state = create_autospec(spec=PromotionState)
+    promotion_state.get_promotion_data.return_value = ["data"]
+    saas_promotion_state = SaasPromotionState.create(
+        promotion_state=promotion_state, saas_files=saas_files
+    )
+    saas_promotion_state.get(channel="channel-a", sha="main")
+    promotion_state.get_promotion_data.assert_called_once_with(
+        sha="main",
+        channel="channel-a",
+        use_cache=False,
+        target_uid="616af45d7fad7f4eea8d52b8b5e8a058cef82ab0",
+        pre_check_sha_exists=False,
+    )

--- a/tools/test/test_saas_promotion_state.py
+++ b/tools/test/test_saas_promotion_state.py
@@ -8,7 +8,7 @@ from unittest.mock import (
 )
 
 from reconcile.typed_queries.saas_files import SaasFile
-from reconcile.utils.promotion_state import PromotionState
+from reconcile.utils.promotion_state import PromotionData, PromotionState
 from tools.saas_promotion_state.saas_promotion_state import (
     SaasPromotionState,
 )
@@ -63,12 +63,20 @@ def test_saas_promotion_state(
         },
     ])
 
+    expected = PromotionData(
+        check_in="test1",
+        saas_file="test2",
+        success=True,
+        target_config_hash="test3",
+    )
     promotion_state = create_autospec(spec=PromotionState)
-    promotion_state.get_promotion_data.return_value = ["data"]
+    promotion_state.get_promotion_data.return_value = expected
     saas_promotion_state = SaasPromotionState.create(
         promotion_state=promotion_state, saas_files=saas_files
     )
-    saas_promotion_state.get(channel="channel-a", sha="main")
+    result = saas_promotion_state.get(channel="channel-a", sha="main")
+
+    assert result == {"616af45d7fad7f4eea8d52b8b5e8a058cef82ab0": expected}
     promotion_state.get_promotion_data.assert_called_once_with(
         sha="main",
         channel="channel-a",


### PR DESCRIPTION
qontract-cli command to help debugging saas deploy state. The command lists all publisher states from S3 for a given channel/sha

```
qontract-cli --config config.cli.toml get-promotion-state --channel my-channel --sha my-sha

Last state for publisher with ID 398f48dcaa4bbcac0a95f7ad0d94211d7c212bd0:
success=True target_config_hash='ada2226de1208856' saas_file='saas-file-name' check_in='2024-06-10 08:34:58.595463+00:00'
```
