### PR TITLE
fix template foreach loop

### DIFF
--- a/reconcile/templating/lib/merge_request_manager.py
+++ b/reconcile/templating/lib/merge_request_manager.py
@@ -136,7 +136,7 @@ class MergeRequestManager(MergeRequestManagerBase[TemplateInfo]):
 
         output = data.data
         collections = {o.input.collection for o in output}
-        collection_hashes = {o.input.collection_hash for o in output}
+        collection_hashes = {o.input.calc_template_hash() for o in output}
         additional_labels = {label for o in output for label in o.input.labels}
         # From the way the code is written, we can assert that there is only one collection and one template hash
         assert len(collections) == 1

--- a/reconcile/templating/lib/model.py
+++ b/reconcile/templating/lib/model.py
@@ -1,11 +1,29 @@
+from typing import Any
+
+from deepdiff import DeepHash
 from pydantic import BaseModel
+
+from reconcile.gql_definitions.templating.template_collection import (
+    TemplateV1,
+)
 
 
 class TemplateInput(BaseModel):
     collection: str
-    collection_hash: str
+    templates: list[TemplateV1] = []
+    variables: list[dict[str, Any]] = []
+    collection_hash: str = ""
     enable_auto_approval: bool = False
     labels: list[str] = []
+
+    def calc_template_hash(self) -> str:
+        if not self.collection_hash:
+            hashable = {
+                "templates": sorted(self.templates, key=lambda x: x.name),
+                "variables": self.variables,
+            }
+            self.collection_hash = DeepHash(hashable)[hashable]
+        return self.collection_hash
 
 
 class TemplateOutput(BaseModel):

--- a/reconcile/templating/renderer.py
+++ b/reconcile/templating/renderer.py
@@ -7,7 +7,6 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Self
 
-from deepdiff import DeepHash
 from ruamel import yaml
 
 from reconcile.gql_definitions.templating.template_collection import (
@@ -187,14 +186,6 @@ def unpack_dynamic_variables(
     return dynamic
 
 
-def calc_template_hash(c: TemplateCollectionV1, variables: dict[str, Any]) -> str:
-    hashable = {
-        "templates": sorted(c.templates, key=lambda x: x.name),
-        "variables": variables,
-    }
-    return DeepHash(hashable)[hashable]
-
-
 class TemplateRendererIntegrationParams(PydanticRunParams):
     clone_repo: bool = False
     app_interface_data_path: str | None
@@ -276,11 +267,11 @@ class TemplateRendererIntegration(QontractReconcileIntegration):
         self,
         collection: TemplateCollectionV1,
         gql_api: GqlApi,
-        dry_run: bool,
         persistence: FilePersistence,
         ruamel_instance: yaml.YAML,
+        input: TemplateInput,
         each: dict[str, Any],
-    ) -> None:
+    ) -> list[TemplateOutput]:
         variables = {}
         if collection.variables:
             variables = {
@@ -289,20 +280,17 @@ class TemplateRendererIntegration(QontractReconcileIntegration):
                 ),
                 "static": unpack_static_variables(collection.variables, each),
             }
+            input.variables.append(variables)
 
-        with PersistenceTransaction(persistence, dry_run) as p:
-            input = TemplateInput(
-                collection=collection.name,
-                collection_hash=calc_template_hash(collection, variables),
-                enable_auto_approval=collection.enable_auto_approval or False,
-                labels=collection.additional_mr_labels or [],
+        outputs: list[TemplateOutput] = []
+        for template in collection.templates:
+            output = self.process_template(
+                template, variables, persistence, ruamel_instance, input
             )
-            for template in collection.templates:
-                output = self.process_template(
-                    template, variables, p, ruamel_instance, input
-                )
-                if not dry_run and output:
-                    p.write([output])
+            if output:
+                outputs.append(output)
+
+        return outputs
 
     def reconcile(
         self,
@@ -317,15 +305,27 @@ class TemplateRendererIntegration(QontractReconcileIntegration):
             for_each_items: list[dict[str, Any]] = [{}]
             if c.for_each and c.for_each.items:
                 for_each_items = c.for_each.items
-            for item in for_each_items:
-                self.reconcile_template_collection(
-                    c,
-                    gql_no_validation,
-                    dry_run,
-                    persistence,
-                    ruamel_instance,
-                    item,
-                )
+            input = TemplateInput(
+                collection=c.name,
+                templates=c.templates,
+                enable_auto_approval=c.enable_auto_approval or False,
+                labels=c.additional_mr_labels or [],
+            )
+            with PersistenceTransaction(persistence, dry_run) as p:
+                outputs: list[TemplateOutput] = []
+                for item in for_each_items:
+                    outputs.extend(
+                        self.reconcile_template_collection(
+                            c,
+                            gql_no_validation,
+                            p,
+                            ruamel_instance,
+                            input,
+                            item,
+                        )
+                    )
+                if not dry_run and outputs:
+                    p.write(outputs)
 
     @property
     def name(self) -> str:

--- a/reconcile/test/templating/test_renderer.py
+++ b/reconcile/test/templating/test_renderer.py
@@ -24,7 +24,6 @@ from reconcile.templating.renderer import (
     TemplateOutput,
     TemplateRendererIntegration,
     TemplateRendererIntegrationParams,
-    calc_template_hash,
     join_path,
     unpack_dynamic_variables,
     unpack_static_variables,
@@ -120,10 +119,10 @@ def template_renderer_integration(mocker: MockerFixture) -> TemplateRendererInte
 
 
 @pytest.fixture
-def template_input() -> TemplateInput:
+def template_input(template_simple: TemplateV1) -> TemplateInput:
     return TemplateInput(
         collection="test",
-        collection_hash="test",
+        templates=[template_simple.dict(by_alias=True)],
         enable_auto_approval=False,
     )
 
@@ -572,12 +571,15 @@ def test_reconcile_variables(
     )
 
 
-def test__calc_template_hash(template_collection: TemplateCollectionV1) -> None:
+def test__calc_template_hash(template_input: TemplateInput) -> None:
+    template_input.variables.append({"foo": "bar"})
     assert (
-        calc_template_hash(template_collection, {"foo": "bar"})
-        == "1b57a0dfecb088946a296b43c7c6ca1845614c544d60a7ef4180d69c8d80517f"
+        template_input.calc_template_hash()
+        == "8e4d8c1163e03d82941948fccab4dce6135cf50b722369565f066f7a5bfbca61"
     )
+    template_input.collection_hash = ""
+    template_input.variables.append({"baz": "qux"})
     assert (
-        calc_template_hash(template_collection, {"foo": "baz"})
-        == "ea1fbc437defbad64a9feda91d9a34573ab0a464adeb205f03b490c08190a4df"
+        template_input.calc_template_hash()
+        == "8a60dc820267f26fd7c480a65d5ea8b9ac7c169ed9eaf5dd8543074f9486e5a1"
     )


### PR DESCRIPTION
fix https://github.com/app-sre/qontract-reconcile/pull/4429

according to https://github.com/app-sre/qontract-reconcile/blob/e58b957b523d0dd46f0197eb41dd5fcd73569439/reconcile/templating/lib/merge_request_manager.py#L237-L250 for a single template collection, it can only open one MR at the same time. So all outputs generated by one collection should be written together to be included in one MR. (Failed example:   https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/108782)

Meanwhile, template_hash should include all unpack variables to detect collection changes.