### PR TITLE
APPSRE-10351 mark saas deploy state successful

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -3691,6 +3691,27 @@ def get_promotion_state(channel: str, sha: str):
 
 
 @root.command()
+@click.option("--channel", help="the channel that state is part of")
+@click.option("--sha", help="the commit sha we want state for")
+@click.option("--publisher-id", help="the publisher id we want state for")
+@environ(["APP_INTERFACE_STATE_BUCKET"])
+def mark_promotion_state_successful(channel: str, sha: str, publisher_id: str):
+    from tools.saas_promotion_state.saas_promotion_state import (
+        SaasPromotionState,
+    )
+
+    promotion_state = SaasPromotionState.create(promotion_state=None, saas_files=None)
+    print(f"Current states for {publisher_id=}")
+    print(promotion_state.get(channel=channel, sha=sha).get(publisher_id, None))
+    print()
+    print("Pushing new state ...")
+    promotion_state.set_successful(channel=channel, sha=sha, publisher_uid=publisher_id)
+    print()
+    print(f"New state for {publisher_id=}")
+    print(promotion_state.get(channel=channel, sha=sha).get(publisher_id, None))
+
+
+@root.command()
 @click.option("--change-type-name")
 @click.option("--role-name")
 @click.option(

--- a/tools/test/test_saas_promotion_state.py
+++ b/tools/test/test_saas_promotion_state.py
@@ -7,14 +7,18 @@ from unittest.mock import (
     create_autospec,
 )
 
+from pytest import raises
+
 from reconcile.typed_queries.saas_files import SaasFile
 from reconcile.utils.promotion_state import PromotionData, PromotionState
 from tools.saas_promotion_state.saas_promotion_state import (
     SaasPromotionState,
+    SaasPromotionStateException,
+    SaasPromotionStateMissingException,
 )
 
 
-def test_saas_promotion_state(
+def test_get_saas_promotion_state(
     saas_files_builder: Callable[[Iterable[Mapping]], list[SaasFile]],
 ) -> None:
     saas_files = saas_files_builder([
@@ -84,3 +88,100 @@ def test_saas_promotion_state(
         target_uid="616af45d7fad7f4eea8d52b8b5e8a058cef82ab0",
         pre_check_sha_exists=False,
     )
+
+
+def test_set_saas_promotion_state_success(
+    saas_files_builder: Callable[[Iterable[Mapping]], list[SaasFile]],
+) -> None:
+    saas_files = saas_files_builder([{"resourceTemplates": []}])
+
+    current_data = PromotionData(
+        check_in="test1",
+        saas_file="test2",
+        success=False,
+        target_config_hash="test3",
+    )
+    promotion_state = create_autospec(spec=PromotionState)
+    promotion_state.get_promotion_data.return_value = current_data
+    saas_promotion_state = SaasPromotionState.create(
+        promotion_state=promotion_state, saas_files=saas_files
+    )
+    saas_promotion_state.set_successful(
+        channel="test-channel", sha="test-sha", publisher_uid="test-uid"
+    )
+
+    promotion_state.get_promotion_data.assert_called_once_with(
+        sha="test-sha",
+        channel="test-channel",
+        use_cache=False,
+        target_uid="test-uid",
+        pre_check_sha_exists=False,
+    )
+    promotion_state.publish_promotion_data.assert_called_once_with(
+        data=PromotionData(
+            check_in="test1",
+            saas_file="test2",
+            success=True,
+            target_config_hash="test3",
+        ),
+        channel="test-channel",
+        sha="test-sha",
+        target_uid="test-uid",
+    )
+
+
+def test_set_saas_promotion_state_missing(
+    saas_files_builder: Callable[[Iterable[Mapping]], list[SaasFile]],
+) -> None:
+    saas_files = saas_files_builder([{"resourceTemplates": []}])
+    promotion_state = create_autospec(spec=PromotionState)
+    promotion_state.get_promotion_data.return_value = None
+    saas_promotion_state = SaasPromotionState.create(
+        promotion_state=promotion_state, saas_files=saas_files
+    )
+
+    with raises(SaasPromotionStateMissingException):
+        saas_promotion_state.set_successful(
+            channel="test-channel", sha="test-sha", publisher_uid="test-uid"
+        )
+
+    promotion_state.get_promotion_data.assert_called_once_with(
+        sha="test-sha",
+        channel="test-channel",
+        use_cache=False,
+        target_uid="test-uid",
+        pre_check_sha_exists=False,
+    )
+    promotion_state.publish_promotion_data.assert_not_called()
+
+
+def test_set_saas_promotion_state_already_successful(
+    saas_files_builder: Callable[[Iterable[Mapping]], list[SaasFile]],
+) -> None:
+    saas_files = saas_files_builder([{"resourceTemplates": []}])
+
+    current_data = PromotionData(
+        check_in="test1",
+        saas_file="test2",
+        success=True,
+        target_config_hash="test3",
+    )
+    promotion_state = create_autospec(spec=PromotionState)
+    promotion_state.get_promotion_data.return_value = current_data
+    saas_promotion_state = SaasPromotionState.create(
+        promotion_state=promotion_state, saas_files=saas_files
+    )
+
+    with raises(SaasPromotionStateException):
+        saas_promotion_state.set_successful(
+            channel="test-channel", sha="test-sha", publisher_uid="test-uid"
+        )
+
+    promotion_state.get_promotion_data.assert_called_once_with(
+        sha="test-sha",
+        channel="test-channel",
+        use_cache=False,
+        target_uid="test-uid",
+        pre_check_sha_exists=False,
+    )
+    promotion_state.publish_promotion_data.assert_not_called()


### PR DESCRIPTION
qontract-cli tool to override last saas deploy state as successful. This can be necessary to unblock auto-promotions.