### PR TITLE
add integration spec reference to qontract-schemas

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -23,6 +23,8 @@ https://github.com/helm/helm/releases
 
 ### Integration spec configuration
 
+These parameters match the [/app-sre/integration-spec-1.yml](https://github.com/app-sre/qontract-schemas/blob/main/schemas/app-sre/integration-spec-1.yml) schema.
+
 | Parameter                 | Description                                                              | Default                                                                 |
 |---------------------------|--------------------------------------------------------------------------|-------------------------------------------------------------------------|
 | cache                     | integration requires cache                                               | false                                                                   |


### PR DESCRIPTION
documentation enhancement to show the connection between integrations-manager and the helm chart.