### PR TITLE
[jenkins-webhooks] skip disabled jobs

### DIFF
--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -288,6 +288,8 @@ class JJB:  # pylint: disable=too-many-public-methods
                     project_url_raw = job["properties"][0]["github"]["url"]
                     if "https://github.com" in project_url_raw:
                         continue
+                    if job.get("disabled"):
+                        continue
                     job_url = "{}/project/{}".format(
                         self.instance_urls[name], job["name"]
                     )


### PR DESCRIPTION
a disabled job does not require a webhook