### PR TITLE
:sparkles: aws-account-manager: support takeover of existing accounts

### DIFF
--- a/reconcile/aws_account_manager/integration.py
+++ b/reconcile/aws_account_manager/integration.py
@@ -159,7 +159,8 @@ class AwsAccountMgmtIntegration(
     ) -> None:
         """Create new AWS accounts."""
         for account_request in account_requests:
-            if not (
+            uid = account_request.uid
+            if not uid and not (
                 uid := reconciler.create_organization_account(
                     aws_api=aws_api,
                     name=account_request.name,

--- a/reconcile/aws_account_manager/integration.py
+++ b/reconcile/aws_account_manager/integration.py
@@ -159,14 +159,12 @@ class AwsAccountMgmtIntegration(
     ) -> None:
         """Create new AWS accounts."""
         for account_request in account_requests:
-            uid = account_request.uid
-            if not uid and not (
-                uid := reconciler.create_organization_account(
-                    aws_api=aws_api,
-                    name=account_request.name,
-                    email=account_request.account_owner.email,
-                )
-            ):
+            uid = account_request.uid or reconciler.create_organization_account(
+                aws_api=aws_api,
+                name=account_request.name,
+                email=account_request.account_owner.email,
+            )
+            if not uid:
                 continue
 
             with aws_api.assume_role(

--- a/reconcile/gql_definitions/aws_account_manager/aws_accounts.gql
+++ b/reconcile/gql_definitions/aws_account_manager/aws_accounts.gql
@@ -34,6 +34,7 @@ query AWSAccountManagerAccounts {
       }
       resourcesDefaultRegion
       supportedDeploymentRegions
+      uid
     }
     organization_accounts {
       ... AWSAccountManaged

--- a/reconcile/gql_definitions/aws_account_manager/aws_accounts.py
+++ b/reconcile/gql_definitions/aws_account_manager/aws_accounts.py
@@ -88,6 +88,7 @@ query AWSAccountManagerAccounts {
       }
       resourcesDefaultRegion
       supportedDeploymentRegions
+      uid
     }
     organization_accounts {
       ... AWSAccountManaged
@@ -139,6 +140,7 @@ class AWSAccountRequestV1(ConfiguredBaseModel):
     quota_limits: Optional[list[AWSQuotaLimitsV1]] = Field(..., alias="quotaLimits")
     resources_default_region: str = Field(..., alias="resourcesDefaultRegion")
     supported_deployment_regions: Optional[list[str]] = Field(..., alias="supportedDeploymentRegions")
+    uid: Optional[str] = Field(..., alias="uid")
 
 
 class AWSAccountV1(AWSAccountManaged):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -14883,6 +14883,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "uid",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,

--- a/reconcile/test/aws_account_manager/test_aws_account_manager_integration.py
+++ b/reconcile/test/aws_account_manager/test_aws_account_manager_integration.py
@@ -174,6 +174,28 @@ def test_aws_account_manager_utils_integration_create_accounts_create_account_fi
     )
 
 
+def test_aws_account_manager_utils_integration_create_accounts_takeover(
+    aws_api: MagicMock,
+    reconciler: MagicMock,
+    merge_request_manager: MagicMock,
+    account_request: AWSAccountRequestV1,
+    intg: AwsAccountMgmtIntegration,
+) -> None:
+    reconciler.create_iam_user.return_value = None
+    # if account_request.uid is set, we assume it's a takeover
+    account_request.uid = "1111111111"
+    intg.create_accounts(
+        aws_api,
+        reconciler,
+        merge_request_manager,
+        "account-template - {{ uid }}",
+        [account_request],
+    )
+    reconciler.create_organization_account.assert_not_called()
+    reconciler.create_iam_user.assert_called_once()
+    merge_request_manager.create_account_file.assert_called_once()
+
+
 def test_aws_account_manager_utils_integration_reconcile_organization_accounts(
     aws_api: MagicMock,
     reconciler: MagicMock,


### PR DESCRIPTION
If `account-request.uid` is specified, `aws-account-manager` will take over an existing account instead of creating a new one.

Ticket: [APPSRE-10430](https://issues.redhat.com/browse/APPSRE-10430)
Depends on: https://github.com/app-sre/qontract-schemas/pull/672