### PR TITLE
[AUS] consider node pool versions when exposing current version metrics

### DIFF
--- a/reconcile/aus/advanced_upgrade_service.py
+++ b/reconcile/aus/advanced_upgrade_service.py
@@ -21,7 +21,9 @@ from reconcile.aus.models import (
     NodePoolSpec,
     OrganizationUpgradeSpec,
 )
-from reconcile.aus.node_pool_spec import get_node_pool_specs
+from reconcile.aus.node_pool_spec import (
+    get_node_pool_specs_by_org_cluster,
+)
 from reconcile.aus.ocm_upgrade_scheduler_org import (
     OCMClusterUpgradeSchedulerOrgIntegration,
 )
@@ -150,7 +152,9 @@ class AdvancedUpgradeServiceIntegration(OCMClusterUpgradeSchedulerOrgIntegration
             labels_by_org = _get_org_labels(
                 ocm_api=ocm_api, org_ids=set(organizations.keys())
             )
-            node_pool_specs_by_org_cluster = _get_node_pools(ocm_api, clusters_by_org)
+            node_pool_specs_by_org_cluster = get_node_pool_specs_by_org_cluster(
+                ocm_api, clusters_by_org
+            )
 
         cluster_health_providers = self._health_check_providers_for_env(ocm_env.name)
 
@@ -241,24 +245,6 @@ def _get_org_labels(
     )
 
 
-def _get_node_pools(
-    ocm_api: OCMBaseClient,
-    clusters_by_org: dict[str, list[ClusterDetails]],
-) -> dict[str, dict[str, list[NodePoolSpec]]]:
-    """
-    Fetch node pool specs for all rosa hypershift clusters
-    Returns a dict with org IDs as keys, the values are dicts with cluster id as key
-    """
-    return {
-        org_id: {
-            c.ocm_cluster.id: get_node_pool_specs(ocm_api, c.ocm_cluster.id)
-            for c in clusters
-            if c.ocm_cluster.is_rosa_hypershift()
-        }
-        for org_id, clusters in clusters_by_org.items()
-    }
-
-
 def _build_org_upgrade_specs_for_ocm_env(
     orgs: dict[str, AUSOCMOrganization],
     clusters_by_org: dict[str, list[ClusterDetails]],
@@ -281,7 +267,8 @@ def _build_org_upgrade_specs_for_ocm_env(
                 org=orgs[org_id],
                 providers=cluster_health_providers,
             ),
-            node_pool_specs_by_cluster=node_pool_specs_by_org_cluster.get(org_id) or {},
+            node_pool_specs_by_cluster_id=node_pool_specs_by_org_cluster.get(org_id)
+            or {},
         )
         for org_id, clusters in clusters_by_org.items()
     }
@@ -339,7 +326,7 @@ def _build_org_upgrade_spec(
     org_labels: LabelContainer,
     version_data_inheritance: Optional["VersionDataInheritance"],
     cluster_health_provider: AUSClusterHealthCheckProvider,
-    node_pool_specs_by_cluster: dict[str, list[NodePoolSpec]],
+    node_pool_specs_by_cluster_id: dict[str, list[NodePoolSpec]],
 ) -> OrganizationUpgradeSpec:
     """
     Build a upgrade policy spec for each cluster in the organization that
@@ -384,7 +371,7 @@ def _build_org_upgrade_spec(
                     upgradePolicy=upgrade_policy,
                     cluster=c.ocm_cluster,
                     health=cluster_health,
-                    nodePools=node_pool_specs_by_cluster.get(c.ocm_cluster.id) or [],
+                    nodePools=node_pool_specs_by_cluster_id.get(c.ocm_cluster.id) or [],
                 )
             )
         except ValidationError as validation_error:

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -74,8 +74,6 @@ from reconcile.utils.filtering import remove_none_values_from_dict
 from reconcile.utils.ocm.addons import AddonService, AddonServiceV1, AddonServiceV2
 from reconcile.utils.ocm.clusters import (
     OCMCluster,
-    get_node_pools,
-    get_version,
 )
 from reconcile.utils.ocm.upgrades import (
     OCMVersionGate,
@@ -607,13 +605,13 @@ def fetch_current_state(
             for upgrade_policy in upgrade_policies:
                 upgrade_policy["cluster"] = spec.cluster
                 current_state.append(ControlPlaneUpgradePolicy(**upgrade_policy))
-            for node_pool in get_node_pools(ocm_api, spec.cluster.id):
+            for node_pool in spec.node_pools:
                 node_upgrade_policies = get_node_pool_upgrade_policies(
-                    ocm_api, spec.cluster.id, node_pool["id"]
+                    ocm_api, spec.cluster.id, node_pool.id
                 )
                 for upgrade_policy in node_upgrade_policies:
                     upgrade_policy["cluster"] = spec.cluster
-                    upgrade_policy["node_pool"] = node_pool["id"]
+                    upgrade_policy["node_pool"] = node_pool.id
                     current_state.append(NodePoolUpgradePolicy(**upgrade_policy))
         else:
             upgrade_policies = get_upgrade_policies(ocm_api, spec.cluster.id)
@@ -1002,27 +1000,23 @@ def _create_upgrade_policy(
 
 
 def _calculate_node_pool_diffs(
-    ocm_api: OCMBaseClient, spec: ClusterUpgradeSpec, now: datetime
+    spec: ClusterUpgradeSpec, now: datetime
 ) -> UpgradePolicyHandler | None:
-    node_pools = get_node_pools(ocm_api, spec.cluster.id)
-    if node_pools:
-        for pool in node_pools:
-            pool_version_id = pool.get("version", {}).get("id")
-            pool_version = get_version(ocm_api, pool_version_id)["raw_id"]
-            if parse_semver(pool_version).match(f"<{spec.current_version}"):
-                next_schedule = (now + timedelta(minutes=MIN_DELTA_MINUTES)).strftime(
-                    "%Y-%m-%dT%H:%M:%SZ"
-                )
-                return UpgradePolicyHandler(
-                    action="create",
-                    policy=NodePoolUpgradePolicy(
-                        cluster=spec.cluster,
-                        version=spec.current_version,
-                        schedule_type="manual",
-                        next_run=next_schedule,
-                        node_pool=pool["id"],
-                    ),
-                )
+    for pool in spec.node_pools:
+        if parse_semver(pool.version).match(f"<{spec.current_version}"):
+            next_schedule = (now + timedelta(minutes=MIN_DELTA_MINUTES)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
+            return UpgradePolicyHandler(
+                action="create",
+                policy=NodePoolUpgradePolicy(
+                    cluster=spec.cluster,
+                    version=spec.current_version,
+                    schedule_type="manual",
+                    next_run=next_schedule,
+                    node_pool=pool.id,
+                ),
+            )
     return None
 
 
@@ -1072,7 +1066,7 @@ def calculate_diff(
             if verify_lock_should_skip(spec, locked):
                 continue
 
-            node_pool_update = _calculate_node_pool_diffs(ocm_api, spec, now)
+            node_pool_update = _calculate_node_pool_diffs(spec, now)
             if node_pool_update:  # node pool update policy not yet created
                 diffs.append(node_pool_update)
                 set_mutex(locked, spec.cluster.id, spec.effective_mutexes)

--- a/reconcile/aus/base.py
+++ b/reconcile/aus/base.py
@@ -294,7 +294,7 @@ class AdvancedUpgradeSchedulerBaseIntegration(
                     org_id=cluster_upgrade_spec.org.org_id,
                     org_name=org_upgrade_spec.org.name,
                     channel=cluster_upgrade_spec.cluster.version.channel_group,
-                    current_version=cluster_upgrade_spec.current_version,
+                    current_version=cluster_upgrade_spec.oldest_current_version,
                     cluster_name=cluster_upgrade_spec.name,
                     schedule=cluster_upgrade_spec.upgrade_policy.schedule,
                     sector=cluster_upgrade_spec.upgrade_policy.conditions.sector or "",

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -22,6 +22,11 @@ from reconcile.utils.ocm.clusters import OCMCluster
 from reconcile.utils.semver_helper import parse_semver
 
 
+class NodePoolSpec(BaseModel):
+    id: str
+    version: str
+
+
 class ClusterUpgradeSpec(BaseModel):
     """
     An upgrade spec for a cluster.
@@ -31,6 +36,7 @@ class ClusterUpgradeSpec(BaseModel):
     cluster: OCMCluster
     upgrade_policy: ClusterUpgradePolicyV1 = Field(..., alias="upgradePolicy")
     health: AUSClusterHealth
+    node_pools: list[NodePoolSpec] = Field(default_factory=list, alias="nodePools")
 
     @property
     def name(self) -> str:

--- a/reconcile/aus/models.py
+++ b/reconcile/aus/models.py
@@ -51,6 +51,14 @@ class ClusterUpgradeSpec(BaseModel):
         return self.cluster.version.raw_id
 
     @property
+    def oldest_current_version(self) -> str:
+        """
+        Consider versions in node pools and the cluster itself, find the oldest one.
+        """
+        versions = [np.version for np in self.node_pools] + [self.current_version]
+        return min(versions, key=parse_semver)
+
+    @property
     def blocked_versions(self) -> set[str]:
         return set(self.org.blocked_versions or []) | set(
             self.upgrade_policy.conditions.blocked_versions or []

--- a/reconcile/aus/node_pool_spec.py
+++ b/reconcile/aus/node_pool_spec.py
@@ -1,5 +1,8 @@
+from collections.abc import Iterable, Mapping
+
 from reconcile.aus.models import NodePoolSpec
 from reconcile.utils.ocm import get_node_pools
+from reconcile.utils.ocm.base import ClusterDetails
 from reconcile.utils.ocm.clusters import get_version
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
@@ -14,3 +17,21 @@ def get_node_pool_specs(ocm_api: OCMBaseClient, cluster_id: str) -> list[NodePoo
         for p in node_pools
         if (version_id := p.get("version", {}).get("id"))
     ]
+
+
+def get_node_pool_specs_by_org_cluster(
+    ocm_api: OCMBaseClient,
+    clusters_by_org: Mapping[str, Iterable[ClusterDetails]],
+) -> dict[str, dict[str, list[NodePoolSpec]]]:
+    """
+    Fetch node pool specs for all rosa hypershift clusters
+    Returns a dict with org IDs as keys, the values are dicts with cluster id as key
+    """
+    return {
+        org_id: {
+            c.ocm_cluster.id: get_node_pool_specs(ocm_api, c.ocm_cluster.id)
+            for c in clusters
+            if c.ocm_cluster.is_rosa_hypershift()
+        }
+        for org_id, clusters in clusters_by_org.items()
+    }

--- a/reconcile/aus/node_pool_spec.py
+++ b/reconcile/aus/node_pool_spec.py
@@ -3,7 +3,6 @@ from collections.abc import Iterable, Mapping
 from reconcile.aus.models import NodePoolSpec
 from reconcile.utils.ocm import get_node_pools
 from reconcile.utils.ocm.base import ClusterDetails
-from reconcile.utils.ocm.clusters import get_version
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
@@ -12,10 +11,9 @@ def get_node_pool_specs(ocm_api: OCMBaseClient, cluster_id: str) -> list[NodePoo
     return [
         NodePoolSpec(
             id=p["id"],
-            version=get_version(ocm_api, version_id)["raw_id"],
+            version=p["version"]["raw_id"],
         )
         for p in node_pools
-        if (version_id := p.get("version", {}).get("id"))
     ]
 
 

--- a/reconcile/aus/node_pool_spec.py
+++ b/reconcile/aus/node_pool_spec.py
@@ -1,0 +1,16 @@
+from reconcile.aus.models import NodePoolSpec
+from reconcile.utils.ocm import get_node_pools
+from reconcile.utils.ocm.clusters import get_version
+from reconcile.utils.ocm_base_client import OCMBaseClient
+
+
+def get_node_pool_specs(ocm_api: OCMBaseClient, cluster_id: str) -> list[NodePoolSpec]:
+    node_pools = get_node_pools(ocm_api, cluster_id)
+    return [
+        NodePoolSpec(
+            id=p["id"],
+            version=get_version(ocm_api, version_id)["raw_id"],
+        )
+        for p in node_pools
+        if (version_id := p.get("version", {}).get("id"))
+    ]

--- a/reconcile/aus/ocm_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_upgrade_scheduler_org.py
@@ -1,11 +1,15 @@
+from collections import defaultdict
+
 from reconcile.aus.healthchecks import (
     AUSClusterHealthCheckProvider,
     build_cluster_health_providers_for_organization,
 )
 from reconcile.aus.models import (
     ClusterUpgradeSpec,
+    NodePoolSpec,
     OrganizationUpgradeSpec,
 )
+from reconcile.aus.node_pool_spec import get_node_pool_specs_by_org_cluster
 from reconcile.aus.ocm_upgrade_scheduler import OCMClusterUpgradeSchedulerIntegration
 from reconcile.gql_definitions.fragments.aus_organization import AUSOCMOrganization
 from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
@@ -41,6 +45,15 @@ class OCMClusterUpgradeSchedulerOrgIntegration(OCMClusterUpgradeSchedulerIntegra
                 ocm_env.name
             )
 
+            clusters_by_org = defaultdict(list)
+            for cluster in clusters:
+                clusters_by_org[cluster.organization_id].append(cluster)
+
+            node_pool_specs_by_org_cluster = get_node_pool_specs_by_org_cluster(
+                ocm_api,
+                clusters_by_org,
+            )
+
             return {
                 org.name: OrganizationUpgradeSpec(
                     org=org,
@@ -48,13 +61,15 @@ class OCMClusterUpgradeSchedulerOrgIntegration(OCMClusterUpgradeSchedulerIntegra
                         org=org,
                         clusters_by_name={
                             c.ocm_cluster.name: c.ocm_cluster
-                            for c in clusters
-                            if c.organization_id == org.org_id
+                            for c in clusters_by_org[org.org_id]
                         },
                         cluster_health_provider=build_cluster_health_providers_for_organization(
                             org=org,
                             providers=cluster_health_providers,
                         ),
+                        node_pool_specs_by_cluster_id=node_pool_specs_by_org_cluster[
+                            org.org_id
+                        ],
                     ),
                 )
                 for org in organizations
@@ -65,6 +80,7 @@ class OCMClusterUpgradeSchedulerOrgIntegration(OCMClusterUpgradeSchedulerIntegra
         org: AUSOCMOrganization,
         clusters_by_name: dict[str, OCMCluster],
         cluster_health_provider: AUSClusterHealthCheckProvider,
+        node_pool_specs_by_cluster_id: dict[str, list[NodePoolSpec]],
     ) -> list[ClusterUpgradeSpec]:
         return [
             ClusterUpgradeSpec(
@@ -75,9 +91,10 @@ class OCMClusterUpgradeSchedulerOrgIntegration(OCMClusterUpgradeSchedulerIntegra
                     cluster_external_id=clusters_by_name[cluster.name].external_id,
                     org_id=org.org_id,
                 ),
+                nodePools=node_pool_specs_by_cluster_id.get(ocm_cluster.id) or [],
             )
             for cluster in org.upgrade_policy_clusters or []
             # clusters that are not in the UUID dict will be ignored because
             # they don't exist in the OCM organization (or have been deprovisioned)
-            if cluster.name in clusters_by_name
+            if (ocm_cluster := clusters_by_name.get(cluster.name))
         ]

--- a/reconcile/test/ocm/aus/fixtures.py
+++ b/reconcile/test/ocm/aus/fixtures.py
@@ -13,6 +13,8 @@ from reconcile.gql_definitions.fragments.aus_organization import (
     AUSOCMOrganization,
     OpenShiftClusterManagerSectorDependenciesV1,
     OpenShiftClusterManagerSectorV1,
+    OpenShiftClusterManagerUpgradePolicyClusterSpecV1,
+    OpenShiftClusterManagerUpgradePolicyClusterV1,
     OpenShiftClusterManagerV1_OpenShiftClusterManagerV1,
     OpenShiftClusterManagerV1_OpenShiftClusterManagerV1_OpenShiftClusterManagerEnvironmentV1,
 )
@@ -55,6 +57,20 @@ def build_upgrade_policy(
             mutexes=mutexes,
             blockedVersions=blocked_versions,
         ),
+    )
+
+
+def build_upgrade_policy_cluster(
+    name: str = "name",
+    server_url: str = "https://server-url",
+    spec_id: str = "spec-id",
+    upgrade_policy: ClusterUpgradePolicyV1 | None = None,
+) -> OpenShiftClusterManagerUpgradePolicyClusterV1:
+    return OpenShiftClusterManagerUpgradePolicyClusterV1(
+        name=name,
+        serverUrl=server_url,
+        spec=OpenShiftClusterManagerUpgradePolicyClusterSpecV1(id=spec_id),
+        upgradePolicy=upgrade_policy or build_upgrade_policy(),
     )
 
 

--- a/reconcile/test/ocm/aus/fixtures.py
+++ b/reconcile/test/ocm/aus/fixtures.py
@@ -5,6 +5,7 @@ from reconcile.aus.healthchecks import AUSClusterHealth, AUSHealthError
 from reconcile.aus.models import (
     ClusterAddonUpgradeSpec,
     ClusterUpgradeSpec,
+    NodePoolSpec,
     OrganizationUpgradeSpec,
 )
 from reconcile.aus.version_gates.handler import GateHandler
@@ -169,7 +170,9 @@ def build_organization(
 
 
 def build_organization_upgrade_spec(
-    specs: list[tuple[OCMCluster, ClusterUpgradePolicyV1, AUSClusterHealth]],
+    specs: list[
+        tuple[OCMCluster, ClusterUpgradePolicyV1, AUSClusterHealth, list[NodePoolSpec]]
+    ],
     org: AUSOCMOrganization | None = None,
 ) -> OrganizationUpgradeSpec:
     org = org or build_organization()
@@ -181,8 +184,9 @@ def build_organization_upgrade_spec(
                 cluster=cluster,
                 upgradePolicy=upgrade_policy,
                 health=cluster_health,
+                nodePools=node_pools,
             )
-            for cluster, upgrade_policy, cluster_health in specs
+            for cluster, upgrade_policy, cluster_health, node_pools in specs
         ],
     )
 
@@ -197,6 +201,7 @@ def build_cluster_upgrade_spec(
     mutexes: list[str] | None = None,
     blocked_versions: list[str] | None = None,
     cluster_health: bool = True,
+    node_pools: list[NodePoolSpec] | None = None,
 ) -> ClusterUpgradeSpec:
     return ClusterUpgradeSpec(
         org=org or build_organization(),
@@ -212,6 +217,7 @@ def build_cluster_upgrade_spec(
         health=build_healthy_cluster_health()
         if cluster_health
         else build_unhealthy_cluster_health(),
+        nodePools=node_pools or [],
     )
 
 

--- a/reconcile/test/ocm/aus/test_base.py
+++ b/reconcile/test/ocm/aus/test_base.py
@@ -110,6 +110,7 @@ def test_calculate_diff_no_lock(
                     workloads=["workload1"], soak_days=0, mutexes=["mutex1"]
                 ),
                 build_cluster_health(),
+                [],
             ),
         ],
     )
@@ -150,8 +151,8 @@ def test_calculate_diff_locked_out(
     )
     org_upgrade_spec = build_organization_upgrade_spec(
         specs=[
-            (cluster_1, upgrade_policy_spec, build_cluster_health()),
-            (cluster_2, upgrade_policy_spec, build_cluster_health()),
+            (cluster_1, upgrade_policy_spec, build_cluster_health(), []),
+            (cluster_2, upgrade_policy_spec, build_cluster_health(), []),
         ],
     )
     diffs = base.calculate_diff(current_state, org_upgrade_spec, ocm_api, VersionData())
@@ -180,8 +181,8 @@ def test_calculate_diff_inter_lock(
     )
     org_upgrade_spec = build_organization_upgrade_spec(
         specs=[
-            (cluster_1, upgrade_policy_spec, build_cluster_health()),
-            (cluster_2, upgrade_policy_spec, build_cluster_health()),
+            (cluster_1, upgrade_policy_spec, build_cluster_health(), []),
+            (cluster_2, upgrade_policy_spec, build_cluster_health(), []),
         ],
     )
     diffs = base.calculate_diff([], org_upgrade_spec, ocm_api, VersionData())

--- a/reconcile/test/ocm/aus/test_node_pool_specs.py
+++ b/reconcile/test/ocm/aus/test_node_pool_specs.py
@@ -16,13 +16,10 @@ def test_get_node_pool_specs() -> None:
         "id": "np1",
         "version": {
             "id": "openshift-v4.15.17-candidate",
+            "raw_id": "4.15.17",
         },
     }
     ocm_api.get_paginated.return_value = [node_pool]
-    ocm_api.get.return_value = {
-        "id": "openshift-v4.15.17-candidate",
-        "raw_id": "4.15.17",
-    }
     specs = get_node_pool_specs(ocm_api=ocm_api, cluster_id="cluster-1")
 
     assert specs == [
@@ -34,9 +31,6 @@ def test_get_node_pool_specs() -> None:
     ocm_api.get_paginated.assert_called_once_with(
         "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"
     )
-    ocm_api.get.assert_called_once_with(
-        "/api/clusters_mgmt/v1/versions/openshift-v4.15.17-candidate"
-    )
 
 
 def test_get_node_pool_specs_by_org_cluster_for_hypershift_cluster() -> None:
@@ -46,13 +40,10 @@ def test_get_node_pool_specs_by_org_cluster_for_hypershift_cluster() -> None:
         "id": "np1",
         "version": {
             "id": "openshift-v4.15.17-candidate",
+            "raw_id": "4.15.17",
         },
     }
     ocm_api.get_paginated.return_value = [node_pool]
-    ocm_api.get.return_value = {
-        "id": "openshift-v4.15.17-candidate",
-        "raw_id": "4.15.17",
-    }
     cluster_details = build_cluster_details("cluster-1", hypershift=True)
     specs = get_node_pool_specs_by_org_cluster(
         ocm_api=ocm_api,
@@ -73,9 +64,6 @@ def test_get_node_pool_specs_by_org_cluster_for_hypershift_cluster() -> None:
     }
     ocm_api.get_paginated.assert_called_once_with(
         f"/api/clusters_mgmt/v1/clusters/{cluster_details.ocm_cluster.id}/node_pools"
-    )
-    ocm_api.get.assert_called_once_with(
-        "/api/clusters_mgmt/v1/versions/openshift-v4.15.17-candidate"
     )
 
 

--- a/reconcile/test/ocm/aus/test_node_pool_specs.py
+++ b/reconcile/test/ocm/aus/test_node_pool_specs.py
@@ -1,0 +1,35 @@
+from unittest.mock import create_autospec
+
+from reconcile.aus.models import NodePoolSpec
+from reconcile.aus.node_pool_spec import get_node_pool_specs
+from reconcile.utils.ocm_base_client import OCMBaseClient
+
+
+def test_get_node_pool_specs() -> None:
+    ocm_api = create_autospec(OCMBaseClient)
+    ocm_api.get_paginated.return_value = {}
+    node_pool = {
+        "id": "np1",
+        "version": {
+            "id": "openshift-v4.15.17-candidate",
+        },
+    }
+    ocm_api.get_paginated.return_value = [node_pool]
+    ocm_api.get.return_value = {
+        "id": "openshift-v4.15.17-candidate",
+        "raw_id": "4.15.17",
+    }
+    specs = get_node_pool_specs(ocm_api=ocm_api, cluster_id="cluster-1")
+
+    assert specs == [
+        NodePoolSpec(
+            id="np1",
+            version="4.15.17",
+        )
+    ]
+    ocm_api.get_paginated.assert_called_once_with(
+        "/api/clusters_mgmt/v1/clusters/cluster-1/node_pools"
+    )
+    ocm_api.get.assert_called_once_with(
+        "/api/clusters_mgmt/v1/versions/openshift-v4.15.17-candidate"
+    )

--- a/reconcile/test/ocm/aus/test_node_pool_specs.py
+++ b/reconcile/test/ocm/aus/test_node_pool_specs.py
@@ -1,7 +1,11 @@
 from unittest.mock import create_autospec
 
 from reconcile.aus.models import NodePoolSpec
-from reconcile.aus.node_pool_spec import get_node_pool_specs
+from reconcile.aus.node_pool_spec import (
+    get_node_pool_specs,
+    get_node_pool_specs_by_org_cluster,
+)
+from reconcile.test.ocm.fixtures import build_cluster_details
 from reconcile.utils.ocm_base_client import OCMBaseClient
 
 
@@ -33,3 +37,58 @@ def test_get_node_pool_specs() -> None:
     ocm_api.get.assert_called_once_with(
         "/api/clusters_mgmt/v1/versions/openshift-v4.15.17-candidate"
     )
+
+
+def test_get_node_pool_specs_by_org_cluster_for_hypershift_cluster() -> None:
+    ocm_api = create_autospec(OCMBaseClient)
+    ocm_api.get_paginated.return_value = {}
+    node_pool = {
+        "id": "np1",
+        "version": {
+            "id": "openshift-v4.15.17-candidate",
+        },
+    }
+    ocm_api.get_paginated.return_value = [node_pool]
+    ocm_api.get.return_value = {
+        "id": "openshift-v4.15.17-candidate",
+        "raw_id": "4.15.17",
+    }
+    cluster_details = build_cluster_details("cluster-1", hypershift=True)
+    specs = get_node_pool_specs_by_org_cluster(
+        ocm_api=ocm_api,
+        clusters_by_org={
+            "org1": [cluster_details],
+        },
+    )
+
+    assert specs == {
+        "org1": {
+            cluster_details.ocm_cluster.id: [
+                NodePoolSpec(
+                    id="np1",
+                    version="4.15.17",
+                )
+            ],
+        }
+    }
+    ocm_api.get_paginated.assert_called_once_with(
+        f"/api/clusters_mgmt/v1/clusters/{cluster_details.ocm_cluster.id}/node_pools"
+    )
+    ocm_api.get.assert_called_once_with(
+        "/api/clusters_mgmt/v1/versions/openshift-v4.15.17-candidate"
+    )
+
+
+def test_get_node_pool_specs_by_org_cluster_for_non_hypershift_cluster() -> None:
+    ocm_api = create_autospec(OCMBaseClient)
+    cluster_details = build_cluster_details("cluster-1", hypershift=False)
+    specs = get_node_pool_specs_by_org_cluster(
+        ocm_api=ocm_api,
+        clusters_by_org={
+            "org1": [cluster_details],
+        },
+    )
+
+    assert specs == {"org1": {}}
+    ocm_api.get_paginated.assert_not_called()
+    ocm_api.get.assert_not_called()

--- a/reconcile/test/ocm/aus/test_ocm_upgrade_scheduler_org.py
+++ b/reconcile/test/ocm/aus/test_ocm_upgrade_scheduler_org.py
@@ -1,0 +1,105 @@
+from typing import Any
+
+from pytest_mock import MockerFixture
+
+from reconcile.aus.base import AdvancedUpgradeSchedulerBaseIntegrationParams
+from reconcile.aus.healthchecks import AUSClusterHealth
+from reconcile.aus.models import ClusterUpgradeSpec, OrganizationUpgradeSpec
+from reconcile.aus.ocm_upgrade_scheduler_org import (
+    OCMClusterUpgradeSchedulerOrgIntegration,
+)
+from reconcile.gql_definitions.common.ocm_env_telemeter import OCMEnvTelemeterQueryData
+from reconcile.gql_definitions.fragments.aus_organization import (
+    AUSOCMOrganization,
+)
+from reconcile.gql_definitions.fragments.ocm_environment import OCMEnvironment
+from reconcile.test.ocm.aus.fixtures import (
+    build_organization,
+    build_upgrade_policy_cluster,
+)
+from reconcile.test.ocm.fixtures import build_cluster_details
+from reconcile.utils.ocm.base import ClusterDetails
+
+ORG_ID = "org-id"
+
+
+def setup_mocks(
+    mocker: MockerFixture,
+    orgs: list[AUSOCMOrganization],
+    clusters: list[ClusterDetails],
+) -> dict[str, Any]:
+    return {
+        "gql": mocker.patch("reconcile.aus.base.gql"),
+        "get_orgs_for_environment": mocker.patch(
+            "reconcile.aus.base.get_orgs_for_environment",
+            return_value=orgs,
+        ),
+        "init_ocm_base_client": mocker.patch(
+            "reconcile.aus.ocm_upgrade_scheduler_org.init_ocm_base_client",
+        ),
+        "discover_clusters_for_organizations": mocker.patch(
+            "reconcile.aus.ocm_upgrade_scheduler_org.discover_clusters_for_organizations",
+            return_value=clusters,
+        ),
+        "get_app_interface_vault_settings": mocker.patch(
+            "reconcile.utils.runtime.integration.get_app_interface_vault_settings",
+        ),
+        "create_secret_reader": mocker.patch(
+            "reconcile.utils.runtime.integration.create_secret_reader"
+        ),
+        "ocm_env_telemeter_query": mocker.patch(
+            "reconcile.aus.base.ocm_env_telemeter_query",
+            return_value=OCMEnvTelemeterQueryData(ocm_envs=[]),
+        ),
+    }
+
+
+def test_get_ocm_env_upgrade_specs_when_no_orgs(
+    mocker: MockerFixture,
+    ocm_env: OCMEnvironment,
+) -> None:
+    setup_mocks(mocker, orgs=[], clusters=[])
+    integration = OCMClusterUpgradeSchedulerOrgIntegration(
+        params=AdvancedUpgradeSchedulerBaseIntegrationParams(
+            ocm_organization_ids={ORG_ID},
+            excluded_ocm_organization_ids=set(),
+        ),
+    )
+
+    upgrade_specs = integration.get_ocm_env_upgrade_specs(ocm_env)
+
+    assert upgrade_specs == {}
+
+
+def test_get_ocm_env_upgrade_specs(
+    mocker: MockerFixture,
+    ocm_env: OCMEnvironment,
+) -> None:
+    org = build_organization(org_id=ORG_ID)
+    upgrade_policy_cluster = build_upgrade_policy_cluster(name="cluster-1")
+    org.upgrade_policy_clusters = [upgrade_policy_cluster]
+    cluster = build_cluster_details("cluster-1", org_id=ORG_ID)
+    setup_mocks(mocker, orgs=[org], clusters=[cluster])
+    expected_cluster_upgrade_spec = ClusterUpgradeSpec(
+        org=org,
+        upgradePolicy=upgrade_policy_cluster.upgrade_policy,
+        cluster=cluster.ocm_cluster,
+        health=AUSClusterHealth(state={}),
+    )
+    expected_upgrade_specs = {
+        org.name: OrganizationUpgradeSpec(
+            org=org,
+            specs=[expected_cluster_upgrade_spec],
+        )
+    }
+    integration = OCMClusterUpgradeSchedulerOrgIntegration(
+        params=AdvancedUpgradeSchedulerBaseIntegrationParams(
+            ocm_organization_ids={ORG_ID},
+            excluded_ocm_organization_ids=set(),
+        ),
+    )
+
+    upgrade_specs = integration.get_ocm_env_upgrade_specs(ocm_env)
+
+    assert upgrade_specs == expected_upgrade_specs
+    assert upgrade_specs[org.name].specs[0] == expected_cluster_upgrade_spec

--- a/reconcile/test/ocm/aus/test_version_data.py
+++ b/reconcile/test/ocm/aus/test_version_data.py
@@ -54,6 +54,7 @@ def test_get_version_data_map(
                         soak_days=1,
                     ),
                     build_cluster_health(),
+                    [],
                 )
             ],
         ),
@@ -121,6 +122,7 @@ def test_get_version_data_map_with_inheritance(
                         soak_days=1,
                     ),
                     build_cluster_health(),
+                    [],
                 )
             ],
         ),
@@ -216,6 +218,7 @@ def test_update_history(
                 ),
                 build_upgrade_policy(workloads=["workload1"], soak_days=0),
                 cluster_health[0],
+                [],
             ),
             (
                 build_ocm_cluster(
@@ -225,6 +228,7 @@ def test_update_history(
                 ),
                 build_upgrade_policy(workloads=["workload1"], soak_days=0),
                 cluster_health[1],
+                [],
             ),
             (
                 build_ocm_cluster(
@@ -234,6 +238,7 @@ def test_update_history(
                 ),
                 build_upgrade_policy(workloads=["workload2"], soak_days=0),
                 cluster_health[2],
+                [],
             ),
         ],
     )

--- a/reconcile/test/ocm/test_utils_ocm_clusters.py
+++ b/reconcile/test/ocm/test_utils_ocm_clusters.py
@@ -37,7 +37,6 @@ from reconcile.utils.ocm.clusters import (
     get_cluster_details_for_subscriptions,
     get_node_pools,
     get_service_clusters,
-    get_version,
 )
 from reconcile.utils.ocm.labels import label_filter
 from reconcile.utils.ocm.search_filters import Filter
@@ -320,22 +319,6 @@ def test_get_node_pools(mocker: MockFixture) -> None:
     assert node_pools[0]["instance_type"] == node_pool["instance_type"]
     assert node_pools[0]["replicas"] == node_pool["replicas"]
     assert "foo" not in node_pools[0]
-
-
-def test_get_version(mocker: MockFixture) -> None:
-    ocm = mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient", autospec=True)
-    ocm.get.return_value = {}
-
-    version = get_version(ocm, "test")
-    assert len(version) == 0
-
-    version_return = {"id": "openshift-v4.12.16", "raw_id": "4.12.16", "foo": "bar"}
-    ocm.get.return_value = version_return
-
-    version = get_version(ocm, "fooo")
-    assert version["id"] == version_return["id"]
-    assert version["raw_id"] == version_return["raw_id"]
-    assert "foo" not in version
 
 
 def test_get_service_clusters_empty(mocker: MockFixture) -> None:

--- a/reconcile/utils/ocm/clusters.py
+++ b/reconcile/utils/ocm/clusters.py
@@ -3,7 +3,6 @@ from collections.abc import (
     Generator,
     Iterable,
 )
-from functools import lru_cache
 from typing import Any
 
 from reconcile.utils.ocm.base import (
@@ -40,11 +39,6 @@ NODE_POOL_DESIRED_KEYS = {
     "aws_node_pool",
     "subnet",
     "version",
-}
-
-VERSION_DESIRED_KEYS = {
-    "id",
-    "raw_id",
 }
 
 
@@ -244,14 +238,6 @@ def get_node_pools(ocm_api: OCMBaseClient, cluster_id: str) -> list[dict[str, An
         results.append(result)
 
     return results
-
-
-@lru_cache
-def get_version(ocm_api: OCMBaseClient, version: str) -> dict[str, Any]:
-    api = f"/api/clusters_mgmt/v1/versions/{version}"
-
-    item = ocm_api.get(api)
-    return {k: v for k, v in item.items() if k in VERSION_DESIRED_KEYS}
 
 
 def get_provisioning_shard_id(ocm_api: OCMBaseClient, cluster_id: str) -> str:


### PR DESCRIPTION
Current metric `aus_cluster_upgrade_policy_info` will use cluster's version as `current_version`, when hypershift (HCP) cluster upgrade, control plane version will upgrade first, node pools will be upgraded after control plane upgrade, we want `current_version` in metrics stay as old version until all node pools upgrade done.

This change fetches node pools info early, avoid refetch in later stages, and combine node pool versions and cluster versions to expose metrics.

After new `raw_id` field exposed in node pools response at [OCM-9026](https://issues.redhat.com/browse/OCM-9026), we no longer need to send another request for version info, `get_version` call removed.

To test integration

```shell
$ qontract-reconcile --config config.toml --log-level DEBUG --dry-run advanced-upgrade-scheduler
```

[APPSRE-10332](https://issues.redhat.com/browse/APPSRE-10332)