### PR TITLE
jira-permissions-validator: disable JIRA logs

### DIFF
--- a/reconcile/test/utils/test_jira_client.py
+++ b/reconcile/test/utils/test_jira_client.py
@@ -48,6 +48,7 @@ def test_create_with_jira_watcher_settings(
         expected_server_url,
         token_auth=expected_token,
         timeout=(expected_read_timeout, expected_connect_timeout),
+        logging=False,
     )
 
 
@@ -75,4 +76,5 @@ def test_create_with_defaults(
         expected_server_url,
         token_auth=expected_token,
         timeout=(expected_read_timeout, expected_connect_timeout),
+        logging=False,
     )

--- a/reconcile/utils/jira_client.py
+++ b/reconcile/utils/jira_client.py
@@ -105,7 +105,10 @@ class JiraClient:
             raise RuntimeError("JiraClient.server is not set.")
 
         self.jira = JIRA(
-            self.server, token_auth=token_auth, timeout=(read_timeout, connect_timeout)
+            self.server,
+            token_auth=token_auth,
+            timeout=(read_timeout, connect_timeout),
+            logging=False,
         )
 
     @staticmethod
@@ -121,7 +124,10 @@ class JiraClient:
             read_timeout = jira_watcher_settings.read_timeout
             connect_timeout = jira_watcher_settings.connect_timeout
         jira_api = JIRA(
-            server=server_url, token_auth=token, timeout=(read_timeout, connect_timeout)
+            server=server_url,
+            token_auth=token,
+            timeout=(read_timeout, connect_timeout),
+            logging=False,
         )
         return JiraClient(
             jira_api=jira_api,
@@ -228,6 +234,7 @@ class JiraClient:
                 JiraClient.DEFAULT_READ_TIMEOUT,
                 JiraClient.DEFAULT_CONNECT_TIMEOUT,
             ),
+            logging=False,
         )
         return [project.key for project in jira_api_anon.projects()]
 


### PR DESCRIPTION
Disable JIRA library logs like

```
[jira-permissions-validator] Request rate limited by Jira. Request should be retried after 0 seconds.
[jira-permissions-validator] 5 tokens are issued every 1 seconds.
[jira-permissions-validator] You can accumulate up to 5 tokens.
[jira-permissions-validator] Consider adding an exemption for the user as explained in: https://confluence.atlassian.com/adminjiraserver/improving-instance-stability-with-rate-limiting-983794911.html
[jira-permissions-validator] Got recoverable error from GET https://issues.redhat.com/rest/api/2/mypermissions, will retry [1/3] in 1.413039281676533s. Err: 429 Too Many Requests
```