### PR TITLE
APPSRE-10229 OCM get service clusters

### DIFF
--- a/reconcile/test/ocm/test_utils_ocm_clusters.py
+++ b/reconcile/test/ocm/test_utils_ocm_clusters.py
@@ -22,7 +22,10 @@ from reconcile.utils.ocm import (
 from reconcile.utils.ocm.base import (
     ACTIVE_SUBSCRIPTION_STATES,
     ClusterDetails,
+    ClusterManagementReference,
+    FleetManagerServiceCluster,
     OCMCluster,
+    OCMModelLink,
     OCMOrganizationLabel,
     OCMSubscriptionLabel,
     build_label_container,
@@ -33,6 +36,7 @@ from reconcile.utils.ocm.clusters import (
     discover_clusters_for_subscriptions,
     get_cluster_details_for_subscriptions,
     get_node_pools,
+    get_service_clusters,
     get_version,
 )
 from reconcile.utils.ocm.labels import label_filter
@@ -332,3 +336,43 @@ def test_get_version(mocker: MockFixture) -> None:
     assert version["id"] == version_return["id"]
     assert version["raw_id"] == version_return["raw_id"]
     assert "foo" not in version
+
+
+def test_get_service_clusters_empty(mocker: MockFixture) -> None:
+    ocm = mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient", autospec=True)
+    ocm.get_paginated.return_value = []
+
+    service_clusters = [cluster for cluster in get_service_clusters(ocm_api=ocm)]
+
+    assert service_clusters == []
+
+
+def test_get_service_clusters_no_provision_shard(mocker: MockFixture) -> None:
+    ocm = mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient", autospec=True)
+    cluster_a = FleetManagerServiceCluster(
+        cluster_management_reference=ClusterManagementReference(
+            cluster_id="test1",
+            href="href1",
+        ),
+        provision_shard_reference=OCMModelLink(
+            id="shard1",
+        ),
+    )
+    data_a = cluster_a.dict(by_alias=True)
+    cluster_b = FleetManagerServiceCluster(
+        cluster_management_reference=ClusterManagementReference(
+            cluster_id="test2",
+            href="href2",
+        ),
+        provision_shard_reference=OCMModelLink(
+            id="shard2",
+        ),
+    )
+    data_b = cluster_b.dict(by_alias=True)
+    data_b["provision_shard_reference"] = {}
+
+    ocm.get_paginated.return_value = [data_a, data_b]
+
+    service_clusters = [cluster for cluster in get_service_clusters(ocm_api=ocm)]
+
+    assert service_clusters == [cluster_a]

--- a/reconcile/utils/ocm/base.py
+++ b/reconcile/utils/ocm/base.py
@@ -210,6 +210,27 @@ PRODUCT_ID_OSD = "osd"
 PRODUCT_ID_ROSA = "rosa"
 
 
+class ProvisionShard(BaseModel):
+    kind: str = "ProvisionShard"
+    id: str
+
+
+class ClusterManagementReference(BaseModel):
+    cluster_id: str
+    href: str
+
+
+class FleetManagerServiceCluster(BaseModel):
+    kind: str = "ServiceCluster"
+
+    """
+    Using OSDFleetManager API, which has different object ids.
+    https://api.openshift.com/?urls.primaryName=OSD%20Fleet%20Manager%20service
+    """
+    cluster_management_reference: ClusterManagementReference
+    provision_shard_reference: OCMModelLink
+
+
 class OCMCluster(BaseModel):
     kind: str = "Cluster"
     id: str

--- a/reconcile/utils/ocm/clusters.py
+++ b/reconcile/utils/ocm/clusters.py
@@ -11,10 +11,12 @@ from reconcile.utils.ocm.base import (
     PRODUCT_ID_OSD,
     PRODUCT_ID_ROSA,
     ClusterDetails,
+    FleetManagerServiceCluster,
     OCMCluster,
     OCMClusterState,
     OCMOrganizationLabel,
     OCMSubscriptionLabel,
+    ProvisionShard,
     build_label_container,
 )
 from reconcile.utils.ocm.labels import (
@@ -144,6 +146,26 @@ def get_ocm_clusters(
         max_page_size=100,
     ):
         yield OCMCluster(**cluster_dict)
+
+
+def get_provision_shard_for_cluster_id(
+    ocm_api: OCMBaseClient,
+    id: str,
+) -> ProvisionShard:
+    data = ocm_api.get(api_path=f"/api/clusters_mgmt/v1/clusters/{id}/provision_shard")
+    return ProvisionShard(**data)
+
+
+def get_service_clusters(
+    ocm_api: OCMBaseClient,
+) -> Generator[FleetManagerServiceCluster, None, None]:
+    for cluster_dict in ocm_api.get_paginated(
+        api_path="/api/osd_fleet_mgmt/v1/service_clusters",
+        max_page_size=100,
+    ):
+        if not cluster_dict.get("provision_shard_reference"):
+            continue
+        yield FleetManagerServiceCluster(**cluster_dict)
 
 
 def get_cluster_details_for_subscriptions(


### PR DESCRIPTION
Extending OCM lib to query service clusters and provision shards.

Note, that for querying service clusters we use the OSDFleetManager API, which uses different internal cluster ids than our cluster management API.

The idea is to query the `/provision_shard` of an HCP cluster and compare that to a list of service clusters we got from OSDFleetManager API.