### PR TITLE
Use initial_version instead of version when creating cluster.

### DIFF
--- a/reconcile/templates/rosa-classic-cluster-creation.sh.j2
+++ b/reconcile/templates/rosa-classic-cluster-creation.sh.j2
@@ -50,7 +50,7 @@ rosa create cluster -y --cluster-name={{ cluster_name }} \
     --operator-roles-prefix {{ cluster_name }} \
     --subnet-ids {{ cluster.spec.subnet_ids | join(",") }} \
     --region {{ cluster.spec.region }} \
-    --version {{ cluster.spec.version }} \
+    --version {{ cluster.spec.initial_version }} \
     --machine-cidr {{ cluster.network.vpc }} \
     --service-cidr {{ cluster.network.service }} \
     --pod-cidr {{ cluster.network.pod }} \

--- a/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
+++ b/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
@@ -44,7 +44,7 @@ rosa create cluster --cluster-name={{ cluster_name }} \
     --operator-roles-prefix {{ cluster_name }} \
     --subnet-ids {{ cluster.spec.subnet_ids | join(",") }} \
     --region {{ cluster.spec.region }} \
-    --version {{ cluster.spec.version }} \
+    --version {{ cluster.spec.initial_version }} \
     --machine-cidr {{ cluster.network.vpc }} \
     --service-cidr {{ cluster.network.service }} \
     --pod-cidr {{ cluster.network.pod }} \

--- a/reconcile/test/fixtures/rosa/rosa_classic_script_result.sh
+++ b/reconcile/test/fixtures/rosa/rosa_classic_script_result.sh
@@ -38,7 +38,7 @@ rosa create cluster -y --cluster-name=cluster-2 \
     --operator-roles-prefix cluster-2 \
     --subnet-ids subnet-a,subnet-b,subnet-c \
     --region us-east-1 \
-    --version 4.10.16 \
+    --version 4.8.10 \
     --machine-cidr 10.0.0.0/16 \
     --service-cidr 172.30.0.0/16 \
     --pod-cidr 10.128.0.0/14 \

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result.sh
@@ -37,7 +37,7 @@ rosa create cluster --cluster-name=cluster-1 \
     --operator-roles-prefix cluster-1 \
     --subnet-ids subnet-a,subnet-b,subnet-c \
     --region us-east-1 \
-    --version 4.10.16 \
+    --version 4.8.10 \
     --machine-cidr 10.0.0.0/16 \
     --service-cidr 172.30.0.0/16 \
     --pod-cidr 10.128.0.0/14 \

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_dry_run.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_dry_run.sh
@@ -38,7 +38,7 @@ rosa create cluster --cluster-name=cluster-1 \
     --operator-roles-prefix cluster-1 \
     --subnet-ids subnet-a,subnet-b,subnet-c \
     --region us-east-1 \
-    --version 4.10.16 \
+    --version 4.8.10 \
     --machine-cidr 10.0.0.0/16 \
     --service-cidr 172.30.0.0/16 \
     --pod-cidr 10.128.0.0/14 \

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_no_provision_shard.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_no_provision_shard.sh
@@ -37,7 +37,7 @@ rosa create cluster --cluster-name=cluster-1 \
     --operator-roles-prefix cluster-1 \
     --subnet-ids subnet-a,subnet-b,subnet-c \
     --region us-east-1 \
-    --version 4.10.16 \
+    --version 4.8.10 \
     --machine-cidr 10.0.0.0/16 \
     --service-cidr 172.30.0.0/16 \
     --pod-cidr 10.128.0.0/14 \

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_private.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_private.sh
@@ -37,7 +37,7 @@ rosa create cluster --cluster-name=cluster-1 \
     --operator-roles-prefix cluster-1 \
     --subnet-ids subnet-a,subnet-b,subnet-c \
     --region us-east-1 \
-    --version 4.10.16 \
+    --version 4.8.10 \
     --machine-cidr 10.0.0.0/16 \
     --service-cidr 172.30.0.0/16 \
     --pod-cidr 10.128.0.0/14 \

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_reuse_oidc_config.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_reuse_oidc_config.sh
@@ -31,7 +31,7 @@ rosa create cluster --cluster-name=cluster-1 \
     --operator-roles-prefix cluster-1 \
     --subnet-ids subnet-a,subnet-b,subnet-c \
     --region us-east-1 \
-    --version 4.10.16 \
+    --version 4.8.10 \
     --machine-cidr 10.0.0.0/16 \
     --service-cidr 172.30.0.0/16 \
     --pod-cidr 10.128.0.0/14 \

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_uwm_enabled.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_uwm_enabled.sh
@@ -37,7 +37,7 @@ rosa create cluster --cluster-name=cluster-1 \
     --operator-roles-prefix cluster-1 \
     --subnet-ids subnet-a,subnet-b,subnet-c \
     --region us-east-1 \
-    --version 4.10.16 \
+    --version 4.8.10 \
     --machine-cidr 10.0.0.0/16 \
     --service-cidr 172.30.0.0/16 \
     --pod-cidr 10.128.0.0/14 \


### PR DESCRIPTION
`initial_version` spec is meant to be used at first while `version` is usually backfilled by AppSRE bot.