### PR TITLE
[terraform-resources] skip validation when no target upgrade info available for RDS

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -66,7 +66,7 @@ from reconcile.utils.vault import (
 )
 
 QONTRACT_INTEGRATION = "terraform_resources"
-QONTRACT_INTEGRATION_VERSION = make_semver(0, 5, 3)
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 5, 4)
 QONTRACT_TF_PREFIX = "qrtf"
 
 

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -757,7 +757,6 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         if after_version == before_version:
             return
 
-        allow_major_version_upgrade = after.get("allow_major_version_upgrade", False)
         region_name = get_region_from_availability_zone(before["availability_zone"])
         if self._aws_api is not None:
             valid_upgrade_target = self._aws_api.get_db_valid_upgrade_target(
@@ -765,13 +764,10 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
             )
             if not valid_upgrade_target:
                 # valid_upgrade_target can be empty when current version is no longer supported by AWS.
-                # In this case, we can't validate it, so treat it as major version upgrade for safety.
-                # Skip validation if allow_major_version_upgrade is enabled.
-                if not allow_major_version_upgrade:
-                    raise ValueError(
-                        "allow_major_version_upgrade is not enabled for upgrading RDS instance: "
-                        f"{resource_name} to a new version when there is no valid upgrade target available."
-                    )
+                # In this case, we can't validate it, so skip.
+                logging.warning(
+                    f"No valid upgrade target available, skip validation for {resource_name}."
+                )
                 return
             target = next(
                 (
@@ -786,6 +782,10 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                     f"Cannot upgrade RDS instance: {resource_name} "
                     f"from {before_version} to {after_version}"
                 )
+            allow_major_version_upgrade = after.get(
+                "allow_major_version_upgrade",
+                False,
+            )
             if target["IsMajorVersionUpgrade"] and not allow_major_version_upgrade:
                 raise ValueError(
                     "allow_major_version_upgrade is not enabled for upgrading RDS instance: "


### PR DESCRIPTION
Follow up on https://github.com/app-sre/qontract-reconcile/pull/3576

Skip validation when no target upgrade info available.

[APPSRE-7777](https://issues.redhat.com/browse/APPSRE-7777)