### PR TITLE
:bug: template-validator: expectedToRender must be default True

### DIFF
--- a/reconcile/templating/validator.py
+++ b/reconcile/templating/validator.py
@@ -79,15 +79,17 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
 
         # Check condition
         should_render = r.render_condition()
-        if (
-            template_test.expected_to_render is not None
-            and template_test.expected_to_render != should_render
-        ):
+        expected_to_render = (
+            template_test.expected_to_render
+            if template_test.expected_to_render is not None
+            else True
+        )
+        if expected_to_render != should_render:
             diffs.append(
                 TemplateDiff(
                     template=template.name,
                     test=template_test.name,
-                    diff=f"Condition mismatch, got: {should_render}, expected: {template_test.expected_to_render}",
+                    diff=f"Condition mismatch for expectedToRender, got: {should_render}, expected: {expected_to_render}",
                 )
             )
 

--- a/reconcile/test/templating/test_validator.py
+++ b/reconcile/test/templating/test_validator.py
@@ -101,7 +101,29 @@ def test_validate_output_condition_diff(
         ruaml_instance,
     )
     assert diff
-    assert diff[0].diff == "Condition mismatch, got: False, expected: True"
+    assert (
+        diff[0].diff
+        == "Condition mismatch for expectedToRender, got: False, expected: True"
+    )
+
+
+def test_validate_output_condition_diff_expected_to_render_default_true(
+    simple_template: TemplateV1,
+    simple_template_test: TemplateTestV1,
+    ruaml_instance: yaml.YAML,
+) -> None:
+    simple_template_test.expected_to_render = None
+    simple_template.condition = "{{1 == 2}}"
+    diff = TemplateValidatorIntegration.validate_template(
+        simple_template,
+        simple_template_test,
+        ruaml_instance,
+    )
+    assert diff
+    assert (
+        diff[0].diff
+        == "Condition mismatch for expectedToRender, got: False, expected: True"
+    )
 
 
 def test_validate_target_path_diff(


### PR DESCRIPTION
Handle unset `/app-interface/template-test-1,expectedToRender` like `/app-interface/template-test-1.expectedToRender: true`. Otherwise, if `expectedToRender` is not set, tests may not work correctly.

