### PR TITLE
:sparkles: template-renderer: make the jinja2 whitespace control behavior configurable

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -32715,6 +32715,18 @@
                             },
                             "isDeprecated": false,
                             "deprecationReason": null
+                        },
+                        {
+                            "name": "templateRenderOptions",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "TemplateRenderOptions_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
                         }
                     ],
                     "inputFields": null,
@@ -32893,6 +32905,53 @@
                             "ofType": null
                         }
                     ],
+                    "enumValues": null,
+                    "possibleTypes": null
+                },
+                {
+                    "kind": "OBJECT",
+                    "name": "TemplateRenderOptions_v1",
+                    "description": null,
+                    "fields": [
+                        {
+                            "name": "trimBlocks",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "lstripBlocks",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
+                            "name": "keepTrailingNewline",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        }
+                    ],
+                    "inputFields": null,
+                    "interfaces": [],
                     "enumValues": null,
                     "possibleTypes": null
                 },

--- a/reconcile/gql_definitions/templating/template_collection.gql
+++ b/reconcile/gql_definitions/templating/template_collection.gql
@@ -26,6 +26,11 @@ query TemplateCollection_v1 {
         identifier
       }
       template
+      templateRenderOptions {
+        trimBlocks
+        lstripBlocks
+        keepTrailingNewline
+      }
     }
   }
 }

--- a/reconcile/gql_definitions/templating/template_collection.py
+++ b/reconcile/gql_definitions/templating/template_collection.py
@@ -45,6 +45,11 @@ query TemplateCollection_v1 {
         identifier
       }
       template
+      templateRenderOptions {
+        trimBlocks
+        lstripBlocks
+        keepTrailingNewline
+      }
     }
   }
 }
@@ -76,6 +81,12 @@ class TemplatePatchV1(ConfiguredBaseModel):
     identifier: Optional[str] = Field(..., alias="identifier")
 
 
+class TemplateRenderOptionsV1(ConfiguredBaseModel):
+    trim_blocks: Optional[bool] = Field(..., alias="trimBlocks")
+    lstrip_blocks: Optional[bool] = Field(..., alias="lstripBlocks")
+    keep_trailing_newline: Optional[bool] = Field(..., alias="keepTrailingNewline")
+
+
 class TemplateV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     auto_approved: Optional[bool] = Field(..., alias="autoApproved")
@@ -83,6 +94,7 @@ class TemplateV1(ConfiguredBaseModel):
     target_path: str = Field(..., alias="targetPath")
     patch: Optional[TemplatePatchV1] = Field(..., alias="patch")
     template: str = Field(..., alias="template")
+    template_render_options: Optional[TemplateRenderOptionsV1] = Field(..., alias="templateRenderOptions")
 
 
 class TemplateCollectionV1(ConfiguredBaseModel):

--- a/reconcile/gql_definitions/templating/templates.gql
+++ b/reconcile/gql_definitions/templating/templates.gql
@@ -19,5 +19,10 @@ query Templatev1 {
       expectedTargetPath
       expectedToRender
     }
+    templateRenderOptions {
+      trimBlocks
+      lstripBlocks
+      keepTrailingNewline
+    }
   }
 }

--- a/reconcile/gql_definitions/templating/templates.py
+++ b/reconcile/gql_definitions/templating/templates.py
@@ -38,6 +38,11 @@ query Templatev1 {
       expectedTargetPath
       expectedToRender
     }
+    templateRenderOptions {
+      trimBlocks
+      lstripBlocks
+      keepTrailingNewline
+    }
   }
 }
 """
@@ -63,6 +68,12 @@ class TemplateTestV1(ConfiguredBaseModel):
     expected_to_render: Optional[bool] = Field(..., alias="expectedToRender")
 
 
+class TemplateRenderOptionsV1(ConfiguredBaseModel):
+    trim_blocks: Optional[bool] = Field(..., alias="trimBlocks")
+    lstrip_blocks: Optional[bool] = Field(..., alias="lstripBlocks")
+    keep_trailing_newline: Optional[bool] = Field(..., alias="keepTrailingNewline")
+
+
 class TemplateV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     auto_approved: Optional[bool] = Field(..., alias="autoApproved")
@@ -71,6 +82,7 @@ class TemplateV1(ConfiguredBaseModel):
     target_path: str = Field(..., alias="targetPath")
     template: str = Field(..., alias="template")
     template_test: list[TemplateTestV1] = Field(..., alias="templateTest")
+    template_render_options: Optional[TemplateRenderOptionsV1] = Field(..., alias="templateRenderOptions")
 
 
 class Templatev1QueryData(ConfiguredBaseModel):

--- a/reconcile/templating/lib/rendering.py
+++ b/reconcile/templating/lib/rendering.py
@@ -43,11 +43,17 @@ class Renderer(ABC):
         template: Template,
         data: TemplateData,
         secret_reader: SecretReaderBase | None = None,
+        trim_blocks: bool = False,
+        lstrip_blocks: bool = False,
+        keep_trailing_newline: bool = False,
     ):
         self.template = template
         self.data = data
         self.secret_reader = secret_reader
         self.ruamel_instance = create_ruamel_instance(explicit_start=True)
+        self.trim_blocks = trim_blocks
+        self.lstrip_blocks = lstrip_blocks
+        self.keep_trailing_newline = keep_trailing_newline
 
     def _jinja2_render_kwargs(self) -> dict[str, Any]:
         return {**self.data.variables, "current": self.data.current}
@@ -58,6 +64,9 @@ class Renderer(ABC):
                 body=template,
                 vars=self._jinja2_render_kwargs(),
                 secret_reader=self.secret_reader,
+                trim_blocks=self.trim_blocks,
+                lstrip_blocks=self.lstrip_blocks,
+                keep_trailing_newline=self.keep_trailing_newline,
             )
         except Jinja2TemplateError as e:
             logging.error(f"Error rendering template {self.template.name}: {e}")
@@ -150,11 +159,24 @@ def create_renderer(
     template: Template,
     data: TemplateData,
     secret_reader: SecretReaderBase | None = None,
+    trim_blocks: bool = False,
+    lstrip_blocks: bool = False,
+    keep_trailing_newline: bool = False,
 ) -> Renderer:
     if template.patch:
-        return PatchRenderer(template=template, data=data, secret_reader=secret_reader)
+        return PatchRenderer(
+            template=template,
+            data=data,
+            secret_reader=secret_reader,
+            trim_blocks=trim_blocks,
+            lstrip_blocks=lstrip_blocks,
+            keep_trailing_newline=keep_trailing_newline,
+        )
     return FullRenderer(
         template=template,
         data=data,
         secret_reader=secret_reader,
+        trim_blocks=trim_blocks,
+        lstrip_blocks=lstrip_blocks,
+        keep_trailing_newline=keep_trailing_newline,
     )

--- a/reconcile/templating/renderer.py
+++ b/reconcile/templating/renderer.py
@@ -215,28 +215,23 @@ class TemplateRendererIntegration(QontractReconcileIntegration):
         variables: dict,
         secret_reader: SecretReaderBase | None = None,
     ) -> Renderer:
-        template_render_options = TemplateRenderOptions()
-        if template.template_render_options:
-            if template.template_render_options.trim_blocks is not None:
-                template_render_options.trim_blocks = (
-                    template.template_render_options.trim_blocks
-                )
-            if template.template_render_options.lstrip_blocks is not None:
-                template_render_options.lstrip_blocks = (
-                    template.template_render_options.lstrip_blocks
-                )
-            if template.template_render_options.keep_trailing_newline is not None:
-                template_render_options.keep_trailing_newline = (
-                    template.template_render_options.keep_trailing_newline
-                )
-
         return create_renderer(
             template,
             TemplateData(
                 variables=variables,
             ),
             secret_reader=secret_reader,
-            template_render_options=template_render_options,
+            template_render_options=TemplateRenderOptions.create(
+                trim_blocks=template.template_render_options.trim_blocks
+                if template.template_render_options
+                else None,
+                lstrip_blocks=template.template_render_options.lstrip_blocks
+                if template.template_render_options
+                else None,
+                keep_trailing_newline=template.template_render_options.keep_trailing_newline
+                if template.template_render_options
+                else None,
+            ),
         )
 
     def process_template(

--- a/reconcile/templating/renderer.py
+++ b/reconcile/templating/renderer.py
@@ -23,6 +23,7 @@ from reconcile.templating.lib.merge_request_manager import (
 )
 from reconcile.templating.lib.model import TemplateInput, TemplateOutput
 from reconcile.templating.lib.rendering import (
+    Renderer,
     TemplateData,
     create_renderer,
 )
@@ -32,12 +33,13 @@ from reconcile.typed_queries.gitlab_instances import get_gitlab_instances
 from reconcile.utils import gql
 from reconcile.utils.git import clone
 from reconcile.utils.gql import GqlApi, init_from_config
-from reconcile.utils.jinja2.utils import process_jinja2_template
+from reconcile.utils.jinja2.utils import TemplateRenderOptions, process_jinja2_template
 from reconcile.utils.ruamel import create_ruamel_instance
 from reconcile.utils.runtime.integration import (
     PydanticRunParams,
     QontractReconcileIntegration,
 )
+from reconcile.utils.secret_reader import SecretReaderBase
 from reconcile.utils.vcs import VCS
 
 QONTRACT_INTEGRATION = "template-renderer"
@@ -207,6 +209,36 @@ class TemplateRendererIntegration(QontractReconcileIntegration):
     def __init__(self, params: TemplateRendererIntegrationParams) -> None:
         super().__init__(params)
 
+    @staticmethod
+    def _create_renderer(
+        template: TemplateV1,
+        variables: dict,
+        secret_reader: SecretReaderBase | None = None,
+    ) -> Renderer:
+        template_render_options = TemplateRenderOptions()
+        if template.template_render_options:
+            if template.template_render_options.trim_blocks is not None:
+                template_render_options.trim_blocks = (
+                    template.template_render_options.trim_blocks
+                )
+            if template.template_render_options.lstrip_blocks is not None:
+                template_render_options.lstrip_blocks = (
+                    template.template_render_options.lstrip_blocks
+                )
+            if template.template_render_options.keep_trailing_newline is not None:
+                template_render_options.keep_trailing_newline = (
+                    template.template_render_options.keep_trailing_newline
+                )
+
+        return create_renderer(
+            template,
+            TemplateData(
+                variables=variables,
+            ),
+            secret_reader=secret_reader,
+            template_render_options=template_render_options,
+        )
+
     def process_template(
         self,
         template: TemplateV1,
@@ -215,12 +247,8 @@ class TemplateRendererIntegration(QontractReconcileIntegration):
         ruaml_instance: yaml.YAML,
         template_input: TemplateInput,
     ) -> TemplateOutput | None:
-        r = create_renderer(
-            template,
-            TemplateData(
-                variables=variables,
-            ),
-            secret_reader=self.secret_reader,
+        r = TemplateRendererIntegration._create_renderer(
+            template, variables, secret_reader=self.secret_reader
         )
         target_path = r.render_target_path()
 

--- a/reconcile/templating/validator.py
+++ b/reconcile/templating/validator.py
@@ -44,20 +44,6 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
         ruaml_instance: yaml.YAML,
         secret_reader: SecretReaderBase | None = None,
     ) -> Renderer:
-        template_render_options = TemplateRenderOptions()
-        if template.template_render_options:
-            if template.template_render_options.trim_blocks is not None:
-                template_render_options.trim_blocks = (
-                    template.template_render_options.trim_blocks
-                )
-            if template.template_render_options.lstrip_blocks is not None:
-                template_render_options.lstrip_blocks = (
-                    template.template_render_options.lstrip_blocks
-                )
-            if template.template_render_options.keep_trailing_newline is not None:
-                template_render_options.keep_trailing_newline = (
-                    template.template_render_options.keep_trailing_newline
-                )
         return create_renderer(
             template,
             TemplateData(
@@ -65,7 +51,17 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
                 current=ruaml_instance.load(template_test.current or ""),
             ),
             secret_reader=secret_reader,
-            template_render_options=template_render_options,
+            template_render_options=TemplateRenderOptions.create(
+                trim_blocks=template.template_render_options.trim_blocks
+                if template.template_render_options
+                else None,
+                lstrip_blocks=template.template_render_options.lstrip_blocks
+                if template.template_render_options
+                else None,
+                keep_trailing_newline=template.template_render_options.keep_trailing_newline
+                if template.template_render_options
+                else None,
+            ),
         )
 
     @staticmethod

--- a/reconcile/templating/validator.py
+++ b/reconcile/templating/validator.py
@@ -42,6 +42,9 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
         template_test: TemplateTestV1,
         ruaml_instance: yaml.YAML,
         secret_reader: SecretReaderBase | None = None,
+        trim_blocks: bool = False,
+        lstrip_blocks: bool = False,
+        keep_trailing_newline: bool = False,
     ) -> Renderer:
         return create_renderer(
             template,
@@ -50,6 +53,9 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
                 current=ruaml_instance.load(template_test.current or ""),
             ),
             secret_reader=secret_reader,
+            trim_blocks=trim_blocks,
+            lstrip_blocks=lstrip_blocks,
+            keep_trailing_newline=keep_trailing_newline,
         )
 
     @staticmethod
@@ -62,7 +68,22 @@ class TemplateValidatorIntegration(QontractReconcileIntegration):
         diffs: list[TemplateDiff] = []
 
         r = TemplateValidatorIntegration._create_renderer(
-            template, template_test, ruaml_instance, secret_reader=secret_reader
+            template,
+            template_test,
+            ruaml_instance,
+            secret_reader=secret_reader,
+            trim_blocks=template.template_render_options.trim_blocks
+            if template.template_render_options
+            and template.template_render_options.trim_blocks is not None
+            else False,
+            lstrip_blocks=template.template_render_options.lstrip_blocks
+            if template.template_render_options
+            and template.template_render_options.lstrip_blocks is not None
+            else False,
+            keep_trailing_newline=template.template_render_options.keep_trailing_newline
+            if template.template_render_options
+            and template.template_render_options.keep_trailing_newline is not None
+            else False,
         )
 
         # Check target path

--- a/reconcile/test/templating/test_renderer.py
+++ b/reconcile/test/templating/test_renderer.py
@@ -491,6 +491,7 @@ def test_reconcile_simple(
             patch=None,
             template="template",
             autoApproved=None,
+            templateRenderOptions=None,
         ),
         {},
         ANY,

--- a/reconcile/test/templating/test_renderer.py
+++ b/reconcile/test/templating/test_renderer.py
@@ -575,9 +575,9 @@ def test_reconcile_variables(
 def test__calc_template_hash(template_collection: TemplateCollectionV1) -> None:
     assert (
         calc_template_hash(template_collection, {"foo": "bar"})
-        == "53f3aae861cd9cf2cae255276670f8a69923c1c3f7eec05deb30264414613dcf"
+        == "1b57a0dfecb088946a296b43c7c6ca1845614c544d60a7ef4180d69c8d80517f"
     )
     assert (
         calc_template_hash(template_collection, {"foo": "baz"})
-        == "21c114ed34b09ad63973de146ef0f9387f919157e7acb53ddc333a92a9d0f531"
+        == "ea1fbc437defbad64a9feda91d9a34573ab0a464adeb205f03b490c08190a4df"
     )

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -49,11 +49,7 @@ def compile_jinja2_template(
 ) -> Any:
     if not template_render_options:
         template_render_options = TemplateRenderOptions()
-    env: dict[str, Any] = {
-        "trim_blocks": template_render_options.trim_blocks,
-        "lstrip_blocks": template_render_options.lstrip_blocks,
-        "keep_trailing_newline": template_render_options.keep_trailing_newline,
-    }
+    env: dict[str, Any] = template_render_options.dict()
     if extra_curly:
         env.update({
             "block_start_string": "{{%",

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -1,5 +1,5 @@
 from functools import cache
-from typing import Any
+from typing import Any, Self
 
 import jinja2
 from jinja2.sandbox import SandboxedEnvironment
@@ -33,12 +33,25 @@ class Jinja2TemplateError(Exception):
 
 
 class TemplateRenderOptions(BaseModel):
-    trim_blocks: bool = False
-    lstrip_blocks: bool = False
-    keep_trailing_newline: bool = False
+    trim_blocks: bool
+    lstrip_blocks: bool
+    keep_trailing_newline: bool
 
     class Config:
         frozen = True
+
+    @classmethod
+    def create(
+        cls,
+        trim_blocks: bool | None = None,
+        lstrip_blocks: bool | None = None,
+        keep_trailing_newline: bool | None = None,
+    ) -> Self:
+        return cls(
+            trim_blocks=trim_blocks or False,
+            lstrip_blocks=lstrip_blocks or False,
+            keep_trailing_newline=keep_trailing_newline or False,
+        )
 
 
 @cache
@@ -48,7 +61,7 @@ def compile_jinja2_template(
     template_render_options: TemplateRenderOptions | None = None,
 ) -> Any:
     if not template_render_options:
-        template_render_options = TemplateRenderOptions()
+        template_render_options = TemplateRenderOptions.create()
     env: dict[str, Any] = template_render_options.dict()
     if extra_curly:
         env.update({

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -32,8 +32,18 @@ class Jinja2TemplateError(Exception):
 
 
 @cache
-def compile_jinja2_template(body: str, extra_curly: bool = False) -> Any:
-    env: dict = {}
+def compile_jinja2_template(
+    body: str,
+    extra_curly: bool = False,
+    trim_blocks: bool = False,
+    lstrip_blocks: bool = False,
+    keep_trailing_newline: bool = False,
+) -> Any:
+    env: dict[str, Any] = {
+        "trim_blocks": trim_blocks,
+        "lstrip_blocks": lstrip_blocks,
+        "keep_trailing_newline": keep_trailing_newline,
+    }
     if extra_curly:
         env = {
             "block_start_string": "{{%",
@@ -154,6 +164,9 @@ def process_jinja2_template(
     extra_curly: bool = False,
     settings: dict[str, Any] | None = None,
     secret_reader: SecretReaderBase | None = None,
+    trim_blocks: bool = False,
+    lstrip_blocks: bool = False,
+    keep_trailing_newline: bool = False,
 ) -> Any:
     if vars is None:
         vars = {}
@@ -187,7 +200,13 @@ def process_jinja2_template(
         for k, v in vars["_template_mocks"].items():
             vars[k] = lambda *args, **kwargs: v
     try:
-        template = compile_jinja2_template(body, extra_curly)
+        template = compile_jinja2_template(
+            body,
+            extra_curly,
+            trim_blocks=trim_blocks,
+            lstrip_blocks=lstrip_blocks,
+            keep_trailing_newline=keep_trailing_newline,
+        )
         r = template.render(vars)
     except Exception as e:
         raise Jinja2TemplateError(e)
@@ -200,6 +219,9 @@ def process_extracurlyjinja2_template(
     extra_curly: bool = True,
     settings: dict[str, Any] | None = None,
     secret_reader: SecretReaderBase | None = None,
+    trim_blocks: bool = False,
+    lstrip_blocks: bool = False,
+    keep_trailing_newline: bool = False,
 ) -> Any:
     if vars is None:
         vars = {}
@@ -209,6 +231,9 @@ def process_extracurlyjinja2_template(
         extra_curly=True,
         settings=settings,
         secret_reader=secret_reader,
+        trim_blocks=trim_blocks,
+        lstrip_blocks=lstrip_blocks,
+        keep_trailing_newline=keep_trailing_newline,
     )
 
 

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -45,14 +45,14 @@ def compile_jinja2_template(
         "keep_trailing_newline": keep_trailing_newline,
     }
     if extra_curly:
-        env = {
+        env.update({
             "block_start_string": "{{%",
             "block_end_string": "%}}",
             "variable_start_string": "{{{",
             "variable_end_string": "}}}",
             "comment_start_string": "{{#",
             "comment_end_string": "#}}",
-        }
+        })
 
     jinja_env = SandboxedEnvironment(
         extensions=[B64EncodeExtension, RaiseErrorExtension],


### PR DESCRIPTION
Make the jinja [whitespace control](https://jinja.palletsprojects.com/en/3.1.x/templates/#whitespace-control) behavior configurable for a template by introducing `trim_blocks`, `lstrip_blocks`, and `keep_trailing_newline` as `templateRenderOptions`. The default will still be `False` for all three options.


Depends on: https://github.com/app-sre/qontract-schemas/pull/675