### PR TITLE
handle RequestEntityTooLargeError by using `oc create` or `oc replace`

### DIFF
--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -401,12 +401,16 @@ def apply(
 
         try:
             oc.apply(namespace, annotated)
-        except (InvalidValueApplyError, RequestEntityTooLargeError):
+        except InvalidValueApplyError:
             oc.remove_last_applied_configuration(
                 namespace, resource_type, resource.name
             )
             oc.apply(namespace, annotated)
-        except (MetaDataAnnotationsTooLongApplyError, UnsupportedMediaTypeError):
+        except (
+            MetaDataAnnotationsTooLongApplyError,
+            UnsupportedMediaTypeError,
+            RequestEntityTooLargeError,
+        ):
             if not oc.get(
                 namespace, resource_type, resource.name, allow_not_found=True
             ):


### PR DESCRIPTION
to avoid the last-applied annotation. This may still fail if the resource is still too big, but then we cannot do more!

error:
```
for: "STDIN": error when patching "STDIN": Request entity too large: limit is 3145728
```

https://issues.redhat.com/browse/APPSRE-10378

The previous fix from https://github.com/app-sre/qontract-reconcile/pull/4437/files was trying to remove the annotation from the existing resource and then still used `apply`, which contains the annotation and fails.