### PR TITLE
fix: all jobs are currently always skipped

### DIFF
--- a/reconcile/utils/jjb_client.py
+++ b/reconcile/utils/jjb_client.py
@@ -288,7 +288,7 @@ class JJB:  # pylint: disable=too-many-public-methods
                     project_url_raw = job["properties"][0]["github"]["url"]
                     if "https://github.com" in project_url_raw:
                         continue
-                    if job.get("disabled"):
+                    if str(job.get("disabled")).lower() == "true":
                         continue
                     job_url = "{}/project/{}".format(
                         self.instance_urls[name], job["name"]


### PR DESCRIPTION
All jobs are currently always skipped as `disable` is a string containing `"true"` or `"false"` and thus always evaluating to `True`. This fix should allow both booleans and strings to be accepted.

Fixing https://github.com/app-sre/qontract-reconcile/pull/4451

cc @maorfr 