### PR TITLE
[saasherder] set image.tag by default in helm provider

### DIFF
--- a/reconcile/utils/saasherder/models.py
+++ b/reconcile/utils/saasherder/models.py
@@ -272,7 +272,7 @@ class TargetSpec:
     def delete(self) -> bool:
         return bool(self.target.delete)
 
-    def parameters(self, adjust: bool = True) -> dict[str, str]:
+    def parameters(self, adjust: bool = True) -> dict[str, Any]:
         environment_parameters = self._collect_parameters(
             self.target.namespace.environment, adjust=adjust
         )

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -983,12 +983,15 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 if self.gitlab and url.startswith(self.gitlab.server)
                 else True
             )
-            html_url = f"{url}/tree/{target.ref}{path}"
+            consolidated_parameters = spec.parameters(adjust=False)
+            if not consolidated_parameters.get("image", {}).get("tag"):
+                image_tag = commit_sha[:hash_length]
+                consolidated_parameters.setdefault("image", {})["tag"] = image_tag
             resources = helm.template_all(
                 url=url,
                 path=path,
                 name=resource_template_name,
-                values=spec.parameters(adjust=False),
+                values=consolidated_parameters,
                 ssl_verify=ssl_verify,
             )
 

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -985,6 +985,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             )
             consolidated_parameters = spec.parameters(adjust=False)
             if not consolidated_parameters.get("image", {}).get("tag"):
+                commit_sha = self._get_commit_sha(url, target.ref, github)
                 image_tag = commit_sha[:hash_length]
                 consolidated_parameters.setdefault("image", {})["tag"] = image_tag
             resources = helm.template_all(

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -983,6 +983,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 if self.gitlab and url.startswith(self.gitlab.server)
                 else True
             )
+            html_url = f"{url}/tree/{target.ref}{path}"
             consolidated_parameters = spec.parameters(adjust=False)
             if not consolidated_parameters.get("image", {}).get("tag"):
                 commit_sha = self._get_commit_sha(url, target.ref, github)


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2250

set `image.tag` parameter (values) by default to match provider `openshift-template` behavior: https://github.com/app-sre/qontract-reconcile/blob/57bf641261bc966627f6e0120b1b9c923249461b/reconcile/utils/saasherder/saasherder.py#L916