### PR TITLE
APPSRE-10351 remember if promotion was successful

### DIFF
--- a/reconcile/utils/promotion_state.py
+++ b/reconcile/utils/promotion_state.py
@@ -18,10 +18,15 @@ class PromotionData(BaseModel):
     requirements.
     """
 
+    # The success is primarily used for SAPM auto-promotions
     success: bool
     target_config_hash: str | None
     saas_file: str | None
     check_in: str | None
+    # Whether this promotion has ever succeeded
+    # Note, this shouldnt be overridden on subsequent promotions of same ref
+    # This attribute is primarily used by saasherder validations
+    has_succeeded_once: bool | None
 
     class Config:
         smart_union = True

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1936,22 +1936,6 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         if not (self.state and self._promotion_state):
             raise Exception("state is not initialized")
 
-        # If we have more than 1 publisher channel, then we can lookup S3 keys
-        # upfront which can reduce unecessary S3 calls for missing states.
-        # However, if we only have a single channel, then the extra API call
-        # to cache the keys doesnt make sense.
-        num_publish_channels = sum(
-            [
-                len(promotion.publish)
-                for promotion in self.promotions
-                if promotion and promotion.publish
-            ],
-            0,
-        )
-        use_prefix_cache = num_publish_channels > 1
-        if use_prefix_cache:
-            self._promotion_state.cache_commit_shas_from_s3()
-
         now = datetime.now(UTC)
         for promotion in self.promotions:
             if promotion is None:
@@ -1968,7 +1952,6 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         channel=channel,
                         target_uid=promotion.saas_target_uid,
                         use_cache=True,
-                        use_prefix_cache=use_prefix_cache,
                     )
                     if current_state and current_state.has_succeeded_once:
                         has_succeeded_once = True

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1936,6 +1936,22 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         if not (self.state and self._promotion_state):
             raise Exception("state is not initialized")
 
+        # If we have more than 1 publisher channel, then we can lookup S3 keys
+        # upfront which can reduce unecessary S3 calls for missing states.
+        # However, if we only have a single channel, then the extra API call
+        # to cache the keys doesnt make sense.
+        num_publish_channels = sum(
+            [
+                len(promotion.publish)
+                for promotion in self.promotions
+                if promotion and promotion.publish
+            ],
+            0,
+        )
+        use_prefix_cache = num_publish_channels > 1
+        if use_prefix_cache:
+            self._promotion_state.cache_commit_shas_from_s3()
+
         now = datetime.now(UTC)
         for promotion in self.promotions:
             if promotion is None:
@@ -1952,6 +1968,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         channel=channel,
                         target_uid=promotion.saas_target_uid,
                         use_cache=True,
+                        use_prefix_cache=use_prefix_cache,
                     )
                     if current_state and current_state.has_succeeded_once:
                         has_succeeded_once = True


### PR DESCRIPTION
Adding a `has_succeeded_once` attribute to our openshift-saas-deploy state data.

Currently, saasherder validation can fail for unrelated targets in a saas file if any targets re-deployment failed (e.g., due to parameter changes).

The idea of this flag is to remember if a promotion for a ref has ever been successful. If we deploy a publisher ref multiple times (e.g., due to parameter change), we each time override the state with the latest result. This might lead to saas files failing validation in unexpected situations (they worked once for a ref, but then stop at some point for that same ref in a completely unrelated target).

By remembering if a deployment ever succeeded, we neglect potential issues stemming from re-deployments.
Note, that SAPM will still fully rely on latest state only. The validation change will only affect the saasherder.

The negative side effect of this change is that we make one additional S3 call for each target, in order to fetch the current state. However, that is sth we might need in the future anyways, e.g., if we want to avoid overriding soakDays counters on re-deployments.