### PR TITLE
Fix infinite get group projects

### DIFF
--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -303,7 +303,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
     ) -> tuple[int, dict[str, Any]]:
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         group = self.gl.groups.get(group_name)
-        shared_projects = self.get_items(group.projects.list, all=True)
+        shared_projects = self.get_items(group.projects.list)
         return group.id, {
             project.web_url: shared_group
             for project in shared_projects


### PR DESCRIPTION
After python-gitlab [upgraded](https://github.com/app-sre/qontract-reconcile/pull/4467), `all` is conflict with current `get_items`, either use `group.projects.list(get_all=True)` or `get_items(group.projects.list)`.