### PR TITLE
template renderer improvements

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2084,7 +2084,8 @@ def template_validator(ctx):
 )
 @click.option(
     "--clone-repo",
-    help="Path to a folder app-interface repo should be cloned to. Use this for regular integration run.",
+    is_flag=True,
+    help="Flag to enable cloning of the app-interface repo. Use this for regular integration run.",
     default=False,
 )
 @click.option(

--- a/reconcile/templating/lib/rendering.py
+++ b/reconcile/templating/lib/rendering.py
@@ -78,7 +78,7 @@ class Renderer(ABC):
         pass
 
     def render_target_path(self) -> str:
-        return self._render_template(self.template.target_path)
+        return self._render_template(self.template.target_path).strip()
 
     def render_condition(self) -> bool:
         return self._render_template(self.template.condition or "True") == "True"

--- a/reconcile/templating/lib/rendering.py
+++ b/reconcile/templating/lib/rendering.py
@@ -108,7 +108,7 @@ class PatchRenderer(Renderer):
         if self.template.patch is None:  # here to satisfy mypy
             raise ValueError("PatchRenderer requires a patch")
 
-        p = parse_jsonpath(self.template.patch.path)
+        p = parse_jsonpath(self._render_template(self.template.patch.path))
 
         matched_values = [match.value for match in p.find(self.data.current)]
 

--- a/reconcile/test/fixtures/templating/full.yaml
+++ b/reconcile/test/fixtures/templating/full.yaml
@@ -1,7 +1,11 @@
 template:
   name: full
 
-  targetPath: /{{bar}}/foo.yml
+  # test targetPath with templating, multiline and whitespaces
+  targetPath: |
+    {% if true %}
+        /{{bar}}/foo.yml     {# with whitespaces and newlines #}
+    {% endif %}
 
   template: |
     foo: {{ bar }}

--- a/reconcile/test/fixtures/templating/patch_path_template.yaml
+++ b/reconcile/test/fixtures/templating/patch_path_template.yaml
@@ -1,0 +1,33 @@
+---
+template:
+  name: update file
+
+  targetPath: /some/saas/deploy.yml
+
+  patch:
+    path: "$.externalResources[?provisioner.'$ref'=='/{{ bar }}/account.yml'].resources"
+    identifier: identifier
+
+  template: |
+    identifier: {{ bar }}
+    output_resource_name: {{ bar }}
+
+  templateTest: []
+current:
+  externalResources:
+  - provisioner:
+      $ref: /bar/account.yml
+    resources:
+    - identifier: just-another-identifier
+      output_resource_name: just-another-identifier
+
+expected: |
+  ---
+  externalResources:
+  - provisioner:
+      $ref: /bar/account.yml
+    resources:
+    - identifier: just-another-identifier
+      output_resource_name: just-another-identifier
+    - identifier: bar
+      output_resource_name: bar

--- a/reconcile/test/templating/lib/test_patch_rendering.py
+++ b/reconcile/test/templating/lib/test_patch_rendering.py
@@ -19,6 +19,7 @@ from reconcile.utils.secret_reader import SecretReader
         "patch_jsonpath_identifier.yaml",
         "patch_jsonpath_identifier_update.yaml",
         "patch_list.yaml",
+        "patch_path_template.yaml",
     ],
 )
 def test_patch_ref_update(

--- a/reconcile/test/templating/test_renderer.py
+++ b/reconcile/test/templating/test_renderer.py
@@ -2,7 +2,7 @@ import os
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
-from unittest.mock import ANY
+from unittest.mock import ANY, MagicMock
 
 import pytest
 from gitlab import GitlabGetError
@@ -103,7 +103,7 @@ def template_collection(
 @pytest.fixture
 def local_file_persistence(tmp_path: Path) -> LocalFilePersistence:
     os.mkdir(tmp_path / "data")
-    return LocalFilePersistence(str(tmp_path / "data"))
+    return LocalFilePersistence(False, str(tmp_path / "data"))
 
 
 @pytest.fixture
@@ -144,9 +144,20 @@ def reconcile_mocks(mocker: MockerFixture) -> tuple:
     pt = mocker.patch.object(t, "process_template")
     mocker.patch("reconcile.templating.renderer.init_from_config")
     p = mocker.MagicMock(LocalFilePersistence)
+    p.dry_run = False
     r = create_ruamel_instance()
 
     return t, p, r, pt
+
+
+@pytest.fixture
+def vcs(mocker: MockerFixture) -> MagicMock:
+    return mocker.MagicMock(VCS)
+
+
+@pytest.fixture
+def mr_manager(mocker: MockerFixture) -> MagicMock:
+    return mocker.MagicMock(MergeRequestManager)
 
 
 def test_unpack_static_variables(
@@ -252,14 +263,22 @@ def test_join_path() -> None:
     assert join_path("foo", "/bar") == "foo/bar"
 
 
-def test_local_file_persistence_write(
-    tmp_path: Path, template_result: TemplateResult
-) -> None:
+def test_local_file_persistence_write(tmp_path: Path) -> None:
     os.makedirs(tmp_path / "data")
-    lfp = LocalFilePersistence(str(tmp_path / "data"))
-    template_result.outputs = [TemplateOutput(path="/foo", content="bar")]
-    lfp.write(template_result)
+    with LocalFilePersistence(
+        dry_run=False, app_interface_data_path=str(tmp_path / "data")
+    ) as lfp:
+        lfp.write(TemplateOutput(path="/foo", content="bar"))
     assert (tmp_path / "data" / "foo").read_text() == "bar"
+
+
+def test_local_file_persistence_write_dry_run(tmp_path: Path) -> None:
+    os.makedirs(tmp_path / "data")
+    with LocalFilePersistence(
+        dry_run=True, app_interface_data_path=str(tmp_path / "data")
+    ) as lfp:
+        lfp.write(TemplateOutput(path="/foo", content="bar"))
+    assert not (tmp_path / "data" / "foo").exists()
 
 
 def test_local_file_persistence_read(tmp_path: Path) -> None:
@@ -267,18 +286,21 @@ def test_local_file_persistence_read(tmp_path: Path) -> None:
     os.makedirs(data_dir)
     test_file = data_dir / "foo"
     test_file.write_text("hello")
-    lfp = LocalFilePersistence(str(data_dir))
+    lfp = LocalFilePersistence(dry_run=False, app_interface_data_path=str(data_dir))
     assert lfp.read("foo") == "hello"
 
 
 def test_crg_file_persistence_write(
-    mocker: MockerFixture, tmp_path: Path, template_result: TemplateResult
+    vcs: MagicMock,
+    mr_manager: MagicMock,
+    tmp_path: Path,
+    template_result: TemplateResult,
 ) -> None:
-    vcs = mocker.MagicMock(VCS)
-    mr_manager = mocker.MagicMock(MergeRequestManager)
-    template_result.outputs = [TemplateOutput(path="/foo", content="bar")]
-    crg = ClonedRepoGitlabPersistence(str(tmp_path), vcs, mr_manager)
-    crg.write(template_result)
+    with ClonedRepoGitlabPersistence(
+        dry_run=False, local_path=str(tmp_path), vcs=vcs, mr_manager=mr_manager
+    ) as crg:
+        crg.result = template_result
+        crg.write(TemplateOutput(path="/foo", content="bar"))
 
     mr_manager.housekeeping.assert_called_once()
     mr_manager.create_merge_request.assert_called_once_with(
@@ -286,25 +308,58 @@ def test_crg_file_persistence_write(
     )
 
 
-def test_crg_file_persistence_write_auto_approval(
-    mocker: MockerFixture, tmp_path: Path, template_result: TemplateResult
+def test_crg_file_persistence_write_dry_run(
+    vcs: MagicMock,
+    mr_manager: MagicMock,
+    tmp_path: Path,
+    template_result: TemplateResult,
 ) -> None:
-    vcs = mocker.MagicMock(VCS)
-    mr_manager = mocker.MagicMock(MergeRequestManager)
-    crg = ClonedRepoGitlabPersistence(str(tmp_path), vcs, mr_manager)
+    with ClonedRepoGitlabPersistence(
+        dry_run=True, local_path=str(tmp_path), vcs=vcs, mr_manager=mr_manager
+    ) as crg:
+        crg.result = template_result
+        crg.write(TemplateOutput(path="/foo", content="bar"))
 
-    tauto = TemplateOutput(path="/foo", content="bar", auto_approved=True)
-    tnoauto = TemplateOutput(path="/foo2", content="bar2", auto_approved=False)
-    template_result.outputs = [tauto, tnoauto]
-    crg.write(template_result)
+    mr_manager.housekeeping.assert_not_called()
+    mr_manager.create_merge_request.assert_not_called()
 
-    assert template_result.outputs == [tauto, tnoauto]
+
+def test_crg_file_persistence_write_no_auto_approval(
+    vcs: MagicMock,
+    mr_manager: MagicMock,
+    tmp_path: Path,
+    template_result: TemplateResult,
+) -> None:
+    with ClonedRepoGitlabPersistence(
+        dry_run=False, local_path=str(tmp_path), vcs=vcs, mr_manager=mr_manager
+    ) as crg:
+        crg.result = template_result
+        tauto = TemplateOutput(path="/foo", content="bar", auto_approved=True)
+        crg.write(tauto)
+        tnoauto = TemplateOutput(path="/foo2", content="bar2", auto_approved=False)
+        crg.write(tnoauto)
+
+    assert crg.result.outputs == [tauto, tnoauto]
     mr_manager.create_merge_request.assert_called_with(
         MrData(result=template_result, auto_approved=False)
     )
 
+
+def test_crg_file_persistence_write_auto_approval(
+    tmp_path: Path,
+    template_result: TemplateResult,
+    vcs: MagicMock,
+    mr_manager: MagicMock,
+) -> None:
     template_result.enable_auto_approval = True
-    crg.write(template_result)
+    with ClonedRepoGitlabPersistence(
+        dry_run=False, local_path=str(tmp_path), vcs=vcs, mr_manager=mr_manager
+    ) as crg:
+        crg.result = template_result
+        tauto = TemplateOutput(path="/foo", content="bar", auto_approved=True)
+        crg.write(tauto)
+        tnoauto = TemplateOutput(path="/foo2", content="bar2", auto_approved=False)
+        crg.write(tnoauto)
 
     assert template_result.outputs == [tauto]
     mr_manager.create_merge_request.assert_called_with(
@@ -312,52 +367,48 @@ def test_crg_file_persistence_write_auto_approval(
     )
 
 
-def test_crg_file_persistence_read_found(mocker: MockerFixture, tmp_path: Path) -> None:
-    vcs = mocker.MagicMock(VCS)
+def test_crg_file_persistence_read_found(
+    vcs: MagicMock, mr_manager: MagicMock, tmp_path: Path
+) -> None:
     os.makedirs(tmp_path / "data")
     test_file = tmp_path / "data" / "foo"
     test_file.write_text("hello")
-    mr_manager = mocker.MagicMock(MergeRequestManager)
-    crg = ClonedRepoGitlabPersistence(str(tmp_path), vcs, mr_manager)
-
+    crg = ClonedRepoGitlabPersistence(False, str(tmp_path), vcs, mr_manager)
     assert crg.read("foo") == "hello"
 
 
-def test_crg_file_persistence_read_miss(mocker: MockerFixture, tmp_path: Path) -> None:
-    vcs = mocker.MagicMock(VCS)
+def test_crg_file_persistence_read_miss(
+    vcs: MagicMock, mr_manager: MagicMock, tmp_path: Path
+) -> None:
     vcs.get_file_content_from_app_interface_master.side_effect = GitlabGetError()
-    mr_manager = mocker.MagicMock(MergeRequestManager)
-    crg = ClonedRepoGitlabPersistence(str(tmp_path), vcs, mr_manager)
-
+    crg = ClonedRepoGitlabPersistence(False, str(tmp_path), vcs, mr_manager)
     assert crg.read("foo") is None
 
 
-def test_persistence_transaction_dry_run(
-    mocker: MockerFixture, template_result: TemplateResult
-) -> None:
-    test_path = "foo"
+def test_persistence_transaction_dry_run(mocker: MockerFixture) -> None:
     persistence_mock = mocker.MagicMock(LocalFilePersistence)
+    output = TemplateOutput(path="foo", content="updated_value")
+    output2 = TemplateOutput(path="foo2", content="updated_value")
 
-    output = TemplateOutput(path=test_path, content="updated_value")
-
-    with PersistenceTransaction(persistence_mock, True) as p:
-        p.write(template_result)
-        template_result.outputs = [output]
-        p.write(template_result)
+    persistence_mock.dry_run = True
+    with PersistenceTransaction(persistence_mock) as p:
+        p.write(output)
     persistence_mock.write.assert_not_called()
 
-    template_result.outputs = []
-    with PersistenceTransaction(persistence_mock, False) as p:
-        p.write(template_result)
-        template_result.outputs = [output]
-        p.write(template_result)
-    persistence_mock.write.assert_called_once()
+    persistence_mock.dry_run = False
+    print(persistence_mock.dry_run)
+    with PersistenceTransaction(persistence_mock) as p:
+        p.write(output)
+        p.write(output2)
+    assert persistence_mock.write.call_count == 2
+    persistence_mock.write.assert_has_calls([mocker.call(output), mocker.call(output2)])
 
 
 def test_persistence_transaction_read(mocker: MockerFixture) -> None:
     persistence_mock = mocker.MagicMock(LocalFilePersistence)
     persistence_mock.read.return_value = "foo"
-    p = PersistenceTransaction(persistence_mock, False)
+    persistence_mock.dry_run = False
+    p = PersistenceTransaction(persistence_mock)
     p.read("foo")
     p.read("foo")
 
@@ -366,19 +417,18 @@ def test_persistence_transaction_read(mocker: MockerFixture) -> None:
 
 
 def test_persistence_transaction_write(
-    mocker: MockerFixture, template_result: TemplateResult
+    mocker: MockerFixture,
 ) -> None:
     test_path = "foo"
     persistence_mock = mocker.MagicMock(LocalFilePersistence)
     persistence_mock.read.return_value = "initial_value"
-    p = PersistenceTransaction(persistence_mock, False)
+    persistence_mock.dry_run = False
+    p = PersistenceTransaction(persistence_mock)
     p.read(test_path)
     assert p.content_cache == {test_path: "initial_value"}
 
     output = TemplateOutput(path=test_path, content="updated_value")
-    p.write(template_result)
-    template_result.outputs = [output]
-    p.write(template_result)
+    p.write(output)
 
     assert p.output_cache == {output.path: output}
     assert p.content_cache == {test_path: "updated_value"}
@@ -407,10 +457,8 @@ def test_process_template_overwrite(
     local_file_persistence: LocalFilePersistence,
     ruaml_instance: yaml.YAML,
     secret_reader: SecretReader,
-    template_result: TemplateResult,
 ) -> None:
-    template_result.outputs = [TemplateOutput(path="/target_path", content="bar")]
-    local_file_persistence.write(template_result)
+    local_file_persistence.write(TemplateOutput(path="/target_path", content="bar"))
     t = TemplateRendererIntegration(TemplateRendererIntegrationParams())
     t._secret_reader = secret_reader
     output = t.process_template(
@@ -465,11 +513,7 @@ def test_reconcile_simple(
     gtc.return_value = [template_collection]
 
     t, p, r, pt = reconcile_mocks
-    t.reconcile(
-        False,
-        p,
-        r,
-    )
+    t.reconcile(p, r)
 
     pt.assert_called_once()
     assert pt.call_args[0] == (
@@ -486,7 +530,6 @@ def test_reconcile_simple(
         ANY,
         r,
     )
-    p.write.assert_called_once()
 
 
 def test_reconcile_twice(
@@ -498,32 +541,9 @@ def test_reconcile_twice(
 
     gtc = mocker.patch("reconcile.templating.renderer.get_template_collections")
     gtc.return_value = [template_collection, template_collection]
-    t.reconcile(
-        False,
-        p,
-        r,
-    )
+    t.reconcile(p, r)
 
     assert pt.call_count == 2
-    assert p.write.call_count == 2
-
-
-def test_reconcile_dry_run(
-    mocker: MockerFixture,
-    reconcile_mocks: tuple,
-    template_collection: TemplateCollectionV1,
-) -> None:
-    t, p, r, pt = reconcile_mocks
-    gtc = mocker.patch("reconcile.templating.renderer.get_template_collections")
-    gtc.return_value = [template_collection, template_collection]
-    t.reconcile(
-        True,
-        p,
-        r,
-    )
-
-    assert pt.call_count == 2
-    assert p.write.call_count == 0
 
 
 def test_reconcile_variables(
@@ -544,11 +564,7 @@ def test_reconcile_variables(
     usv = mocker.patch("reconcile.templating.renderer.unpack_static_variables")
     usv.return_value = {"baz": "qux"}
 
-    t.reconcile(
-        True,
-        p,
-        r,
-    )
+    t.reconcile(p, r)
 
     pt.assert_called_once()
     assert pt.call_args[0] == (

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -130,7 +130,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
     @cached_property
     def project_main_branch(self) -> str:
         return next(
-            (b.name for b in self.project.branches.list() if b.default),
+            (b.name for b in self.project.branches.list(iterator=True) if b.default),
             DEFAULT_MAIN_BRANCH,
         )
 


### PR DESCRIPTION
This PR has several `template-renderer` improvements and bugfixes:

###  **:sparkles: render template.patch.path**

`template.patch.path` can be a template, too.


### **:bug: template-renderer: fix --clone-repo option**

`-clone-repo` command line option is a flag

### **:bug: template-renderer: strip targetPath**

Strip whitespaces and new lines from `targetPath`. Especially useful if `targetPath` is multiline and a template. 

### **:bug: template-renderer: update file cache for after each template**

In case two templates are dependent, e.g., the 1st one introduces an `openshiftResource` for an AWS account, and the 2nd adds an additional resource, then the internal file cache must have the result from the 1st one. See [this as an example](https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/109948/diffs#e159c5d0c1477875efa58ad0e33e050a7fa84e98_444_416). `aws-resource-exporter` introduces `provisioner: $ref: /aws/jeanluc/account.yml` and `cloudwatch-exporter` adds another `resource.provider: aws-iam-service-account`

### **:bug: gitlab: fix Calling a `list()` method without specifying `get_all=True` or `iterator=True` will return a maximum of 20 items warning**

python-gitlab 4.6 upgrade bug