### PR TITLE
[ocm-clusters] do not enforce one HCP cluster per AWS account

### DIFF
--- a/reconcile/templates/rosa-classic-cluster-creation.sh.j2
+++ b/reconcile/templates/rosa-classic-cluster-creation.sh.j2
@@ -3,12 +3,6 @@
 set -e
 set -o pipefail
 
-CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
-if (( CURRENT_CLUSTER_COUNT > 0 )); then
-  echo "Error: This account already has a cluster. Only one cluster per account is supported."
-  exit 1
-fi
-
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --classic -y -m auto

--- a/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
+++ b/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
@@ -3,12 +3,6 @@
 set -e
 set -o pipefail
 
-CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
-if (( CURRENT_CLUSTER_COUNT > 0 )); then
-  echo "Error: This account already has a cluster. Only one cluster per account is supported."
-  exit 1
-fi
-
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto

--- a/reconcile/test/fixtures/rosa/rosa_classic_script_result.sh
+++ b/reconcile/test/fixtures/rosa/rosa_classic_script_result.sh
@@ -3,12 +3,6 @@
 set -e
 set -o pipefail
 
-CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
-if (( CURRENT_CLUSTER_COUNT > 0 )); then
-  echo "Error: This account already has a cluster. Only one cluster per account is supported."
-  exit 1
-fi
-
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --classic -y -m auto

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result.sh
@@ -3,12 +3,6 @@
 set -e
 set -o pipefail
 
-CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
-if (( CURRENT_CLUSTER_COUNT > 0 )); then
-  echo "Error: This account already has a cluster. Only one cluster per account is supported."
-  exit 1
-fi
-
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_dry_run.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_dry_run.sh
@@ -3,12 +3,6 @@
 set -e
 set -o pipefail
 
-CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
-if (( CURRENT_CLUSTER_COUNT > 0 )); then
-  echo "Error: This account already has a cluster. Only one cluster per account is supported."
-  exit 1
-fi
-
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_no_provision_shard.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_no_provision_shard.sh
@@ -3,12 +3,6 @@
 set -e
 set -o pipefail
 
-CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
-if (( CURRENT_CLUSTER_COUNT > 0 )); then
-  echo "Error: This account already has a cluster. Only one cluster per account is supported."
-  exit 1
-fi
-
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_private.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_private.sh
@@ -3,12 +3,6 @@
 set -e
 set -o pipefail
 
-CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
-if (( CURRENT_CLUSTER_COUNT > 0 )); then
-  echo "Error: This account already has a cluster. Only one cluster per account is supported."
-  exit 1
-fi
-
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_reuse_oidc_config.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_reuse_oidc_config.sh
@@ -3,12 +3,6 @@
 set -e
 set -o pipefail
 
-CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
-if (( CURRENT_CLUSTER_COUNT > 0 )); then
-  echo "Error: This account already has a cluster. Only one cluster per account is supported."
-  exit 1
-fi
-
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_uwm_enabled.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_uwm_enabled.sh
@@ -3,12 +3,6 @@
 set -e
 set -o pipefail
 
-CURRENT_CLUSTER_COUNT=$(rosa list clusters -o json | jq 'length')
-if (( CURRENT_CLUSTER_COUNT > 0 )); then
-  echo "Error: This account already has a cluster. Only one cluster per account is supported."
-  exit 1
-fi
-
 rosa init
 rosa create ocm-role --admin -y -m auto
 rosa create account-roles --hosted-cp -y -m auto


### PR DESCRIPTION
partially revert #4136 

supporting a single cluster per aws account is an AppSRE decision for managing our own clusters.
app-interface, as a tool, should be able to support multiple clusters in an aws account. open source ftw :tada: 

we can add a safety net in app-interface to enforce that every cluster in the AppSRE OCM org is in a unique aws account. this should not be a code limitation.