### PR TITLE
APPSRE-10229 return token id too

### DIFF
--- a/reconcile/test/utils/dynatrace/conftest.py
+++ b/reconcile/test/utils/dynatrace/conftest.py
@@ -15,9 +15,10 @@ def dynatrace_api_builder() -> Callable[[Mapping], Dynatrace]:
         dynatrace_mock.tokens = token_service
 
         token_created_result = data.get("CREATE_TOKEN_RESULT")
-        if isinstance(token_created_result, str):
+        if isinstance(token_created_result, tuple):
             token = create_autospec(spec=ApiTokenCreated)
-            token.token = token_created_result
+            token.id = token_created_result[0]
+            token.token = token_created_result[1]
             token_service.create.return_value = token
         else:
             # For raising exceptions

--- a/reconcile/test/utils/dynatrace/test_dynatrace_client.py
+++ b/reconcile/test/utils/dynatrace/test_dynatrace_client.py
@@ -4,6 +4,7 @@ from dynatrace import Dynatrace
 from pytest import raises
 
 from reconcile.utils.dynatrace.client import (
+    DynatraceAPITokenCreated,
     DynatraceClient,
     DynatraceTokenCreationError,
     DynatraceTokenRetrievalError,
@@ -13,12 +14,12 @@ from reconcile.utils.dynatrace.client import (
 def test_dynatrace_create_token_success(
     dynatrace_api_builder: Callable[[Mapping], Dynatrace],
 ) -> None:
-    api = dynatrace_api_builder({"CREATE_TOKEN_RESULT": "test-token"})
+    api = dynatrace_api_builder({"CREATE_TOKEN_RESULT": ("id1", "test-token")})
 
     client = DynatraceClient.create(environment_url="test-env", token=None, api=api)
     token = client.create_api_token(name="test-token-name", scopes=["test-scope"])
 
-    assert token == "test-token"
+    assert token == DynatraceAPITokenCreated(token="test-token", id="id1")
     api.tokens.create.assert_called_once_with(
         name="test-token-name", scopes=["test-scope"]
     )

--- a/reconcile/utils/dynatrace/client.py
+++ b/reconcile/utils/dynatrace/client.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 from dynatrace import Dynatrace
+from pydantic import BaseModel
 
 
 class DynatraceTokenCreationError(Exception):
@@ -13,19 +14,30 @@ class DynatraceTokenRetrievalError(Exception):
     pass
 
 
+class DynatraceAPITokenCreated(BaseModel):
+    """
+    Wrap dynatrace.ApiTokenCreated for decoupling
+    """
+
+    token: str
+    id: str
+
+
 class DynatraceClient:
     def __init__(self, environment_url: str, api: Dynatrace) -> None:
         self._environment_url = environment_url
         self._api = api
 
-    def create_api_token(self, name: str, scopes: Iterable[str]) -> str:
+    def create_api_token(
+        self, name: str, scopes: Iterable[str]
+    ) -> DynatraceAPITokenCreated:
         try:
             token = self._api.tokens.create(name=name, scopes=scopes)
         except Exception as e:
             raise DynatraceTokenCreationError(
                 f"{self._environment_url=} Failed to create token for {name=}", e
             ) from e
-        return token.token
+        return DynatraceAPITokenCreated(token=token.token, id=token.id)
 
     def get_token_ids_for_name_prefix(self, prefix: str) -> list[str]:
         try:


### PR DESCRIPTION
When a token is created, it has the secret and an id. We should return both to the caller.