### PR TITLE
ROSA HCP provisioning support explicit aws billing account

### DIFF
--- a/reconcile/gql_definitions/common/clusters.gql
+++ b/reconcile/gql_definitions/common/clusters.gql
@@ -89,6 +89,9 @@ query Clusters($name: String) {
               worker_role_arn
             }
           }
+          billingAccount {
+            uid
+          }
         }
       }
       id

--- a/reconcile/gql_definitions/common/clusters.py
+++ b/reconcile/gql_definitions/common/clusters.py
@@ -190,6 +190,9 @@ query Clusters($name: String) {
               worker_role_arn
             }
           }
+          billingAccount {
+            uid
+          }
         }
       }
       id
@@ -438,6 +441,10 @@ class RosaOcmSpecV1(ConfiguredBaseModel):
     ocm_environments: Optional[list[RosaOcmAwsSpecV1]] = Field(..., alias="ocm_environments")
 
 
+class AWSAccountV1_AWSAccountV1(ConfiguredBaseModel):
+    uid: str = Field(..., alias="uid")
+
+
 class AWSAccountV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
     uid: str = Field(..., alias="uid")
@@ -445,6 +452,7 @@ class AWSAccountV1(ConfiguredBaseModel):
     automation_token: VaultSecret = Field(..., alias="automationToken")
     resources_default_region: str = Field(..., alias="resourcesDefaultRegion")
     rosa: Optional[RosaOcmSpecV1] = Field(..., alias="rosa")
+    billing_account: Optional[AWSAccountV1_AWSAccountV1] = Field(..., alias="billingAccount")
 
 
 class ClusterSpecROSAV1(ClusterSpecV1):

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -10087,6 +10087,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "billingAccount",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "OBJECT",
+                                "name": "AWSAccount_v1",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "sso",
                             "description": null,
                             "args": [],

--- a/reconcile/ocm/types.py
+++ b/reconcile/ocm/types.py
@@ -70,6 +70,7 @@ class ROSAOcmAwsAttrs(BaseModel):
 class ROSAClusterAWSAccount(BaseModel):
     uid: str
     rosa: ROSAOcmAwsAttrs | None
+    billing_account_id: str | None
 
     class Config:
         extra = Extra.forbid

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -80,7 +80,7 @@ def _set_rosa_ocm_attrs(cluster: Mapping[str, Any]):
         uid=uid,
         rosa=rosa,
     )
-    if billing_account := account["billingAccount"]:
+    if billing_account := account.get("billingAccount"):
         rosa_cluster_aws_account.billing_account_id = billing_account["uid"]
     cluster["spec"]["account"] = rosa_cluster_aws_account
 

--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -45,8 +45,9 @@ def _set_rosa_ocm_attrs(cluster: Mapping[str, Any]):
     but the cluster only needs the target OCM environment where it belongs.
     This method changes the cluster dictionary to include just those.
     """
-    uid = cluster["spec"]["account"]["uid"]
-    rosa_ocm_configs = cluster["spec"]["account"]["rosa"]
+    account = cluster["spec"]["account"]
+    uid = account["uid"]
+    rosa_ocm_configs = account["rosa"]
     rosa: ROSAOcmAwsAttrs | None = None
     if rosa_ocm_configs:
         ocm_env = [
@@ -75,10 +76,13 @@ def _set_rosa_ocm_attrs(cluster: Mapping[str, Any]):
         rosa = None
 
     # doing this allows to exclude account fields which can be queried in graphql
-    cluster["spec"]["account"] = ROSAClusterAWSAccount(
+    rosa_cluster_aws_account = ROSAClusterAWSAccount(
         uid=uid,
         rosa=rosa,
     )
+    if billing_account := account["billingAccount"]:
+        rosa_cluster_aws_account.billing_account_id = billing_account["uid"]
+    cluster["spec"]["account"] = rosa_cluster_aws_account
 
 
 def fetch_desired_state(clusters: Iterable[Mapping[str, Any]]) -> dict[str, OCMSpec]:

--- a/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
+++ b/reconcile/templates/rosa-hcp-cluster-creation.sh.j2
@@ -26,7 +26,11 @@ INSTALLER_ROLE_ARN=$(rosa list account-roles --region us-east-1 -o json | jq '.[
 rosa create operator-roles --prefix {{ cluster_name }} --oidc-config-id ${OIDC_CONFIG_ID} --hosted-cp --installer-role-arn ${INSTALLER_ROLE_ARN} -m auto -y
 
 # cluster creation
+{% if cluster.spec.account.billing_account_id %}
+BILLING_ACCOUNT_ID="{{ cluster.spec.account.billing_account_id }}"
+{% else %}
 BILLING_ACCOUNT_ID=$(aws organizations describe-organization | jq .Organization.MasterAccountId -r)
+{% endif %}
 rosa create cluster --cluster-name={{ cluster_name }} \
     --billing-account ${BILLING_ACCOUNT_ID} \
     {% if dry_run -%}

--- a/reconcile/test/fixtures/rosa/rosa_hcp_script_result_billing_account.sh
+++ b/reconcile/test/fixtures/rosa/rosa_hcp_script_result_billing_account.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+rosa init
+rosa create ocm-role --admin -y -m auto
+rosa create account-roles --hosted-cp -y -m auto
+rosa create user-role -y -m auto
+
+# OIDC config
+OIDC_CONFIG_ID=$(rosa list oidc-provider -o json | jq '.[0].arn // "/" | split("/") | .[-1]' -r)
+if [[ -z "${OIDC_CONFIG_ID}" ]]; then
+    rosa create oidc-config -m auto -y
+    OIDC_CONFIG_ID=$(rosa list oidc-provider -o json | jq '.[0].arn // "/" | split("/") | .[-1]' -r)
+else
+    echo "reuse existing OIDC config ${OIDC_CONFIG_ID}"
+fi
+
+# operator roles
+INSTALLER_ROLE_ARN=$(rosa list account-roles --region us-east-1 -o json | jq '.[] | select(.RoleType == "Installer") | .RoleARN' -r)
+rosa create operator-roles --prefix cluster-1 --oidc-config-id ${OIDC_CONFIG_ID} --hosted-cp --installer-role-arn ${INSTALLER_ROLE_ARN} -m auto -y
+
+# cluster creation
+BILLING_ACCOUNT_ID="123456789"
+rosa create cluster --cluster-name=cluster-1 \
+    --billing-account ${BILLING_ACCOUNT_ID} \
+    --dry-run \
+    --sts \
+    --hosted-cp \
+    --oidc-config-id ${OIDC_CONFIG_ID} \
+    --operator-roles-prefix cluster-1 \
+    --subnet-ids subnet-a,subnet-b,subnet-c \
+    --region us-east-1 \
+    --version 4.8.10 \
+    --machine-cidr 10.0.0.0/16 \
+    --service-cidr 172.30.0.0/16 \
+    --pod-cidr 10.128.0.0/14 \
+    --host-prefix 23 \
+    --replicas 1 \
+    --compute-machine-type m5.xlarge \
+    --disable-workload-monitoring \
+    --properties provision_shard_id:provision_shard_id \
+    --channel-group stable

--- a/reconcile/test/utils/rosa/test_rosa_hcp_script_template.py
+++ b/reconcile/test/utils/rosa/test_rosa_hcp_script_template.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from reconcile.ocm.types import OCMSpec
+from reconcile.ocm.types import OCMSpec, ROSAClusterSpec
 from reconcile.test.fixtures import Fixtures
 from reconcile.utils.models import data_default_none
 from reconcile.utils.rosa.session import generate_rosa_creation_script
@@ -85,6 +85,18 @@ def test_generate_rosa_creation_script_dry_run(
     rosa_cluster_spec: OCMSpec, script_result_fixtures: Fixtures
 ) -> None:
     expected = script_result_fixtures.get("rosa_hcp_script_result_dry_run.sh")
+    script = generate_rosa_creation_script(
+        cluster_name="cluster-1", cluster=rosa_cluster_spec, dry_run=True
+    )
+    assert normalize_script(expected) == normalize_script(script)
+
+
+def test_generate_rosa_creation_script_billing_account(
+    rosa_cluster_spec: OCMSpec, script_result_fixtures: Fixtures
+) -> None:
+    expected = script_result_fixtures.get("rosa_hcp_script_result_billing_account.sh")
+    if isinstance(rosa_cluster_spec.spec, ROSAClusterSpec):
+        rosa_cluster_spec.spec.account.billing_account_id = "123456789"
     script = generate_rosa_creation_script(
         cluster_name="cluster-1", cluster=rosa_cluster_spec, dry_run=True
     )

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1359,10 +1359,14 @@ def rosa_create_cluster_command(ctx, cluster_name):
 
     settings = queries.get_app_interface_settings()
     account = cluster.spec.account
-    with AWSApi(
-        1, [account.dict(by_alias=True)], settings=settings, init_users=False
-    ) as aws_api:
-        billing_account = aws_api.get_organization_billing_account(account.name)
+
+    if account.billing_account:
+        billing_account = account.billing_account.uid
+    else:
+        with AWSApi(
+            1, [account.dict(by_alias=True)], settings=settings, init_users=False
+        ) as aws_api:
+            billing_account = aws_api.get_organization_billing_account(account.name)
 
     print(
         " ".join([


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10457

depends on https://github.com/app-sre/qontract-schemas/pull/681

with this change we can explicitly define an aws account to act as the billing account. even... self.