### PR TITLE
Suppress warnings when list items using gitlab api

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -277,7 +277,11 @@ def is_good_to_merge(labels):
 
 def is_rebased(mr, gl: GitLabApi) -> bool:
     target_branch = mr.target_branch
-    head = gl.project.commits.list(ref_name=target_branch, per_page=1)[0].id
+    head = gl.project.commits.list(
+        ref_name=target_branch,
+        per_page=1,
+        page=1,
+    )[0].id
     result = gl.project.repository_compare(mr.sha, head)
     return len(result["commits"]) == 0
 

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -126,6 +126,7 @@ def test_is_rebase():
     mocked_gitlab_api.project.commits.list.assert_called_once_with(
         ref_name=expected_ref,
         per_page=1,
+        page=1,
     )
     mocked_gitlab_api.project.repository_compare.assert_called_once_with(
         expected_sha,

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -694,7 +694,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
 
     def get_user(self, username):
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        user = self.gl.users.list(search=username)
+        user = self.gl.users.list(search=username, page=1, per_page=1)
         if len(user) == 0:
             logging.error(username + " user not found")
             return
@@ -774,7 +774,8 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
                 break
         # labels
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        label_events = mr.resourcelabelevents.list()
+        # TODO: this may send multiple requests, update metrics accordingly
+        label_events = mr.resourcelabelevents.list(get_all=True)
         for label in reversed(label_events):
             if label.action == "add" and label.label["name"] in hold_labels:
                 username = label.user["username"]

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -854,7 +854,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
     def get_commit_sha(self, ref: str, repo_url: str) -> str:
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
         project = self.get_project(repo_url)
-        commits = project.commits.list(ref_name=ref, per_page=1)
+        commits = project.commits.list(ref_name=ref, per_page=1, page=1)
         return commits[0].id
 
     def repository_compare(

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -707,7 +707,8 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
         if p is None:
             return []
         gitlab_request.labels(integration=INTEGRATION_NAME).inc()
-        return p.hooks.list(per_page=100)
+        # TODO: get_all may send multiple requests, update metrics accordingly
+        return p.hooks.list(per_page=100, get_all=True)
 
     def create_project_hook(self, repo_url, data):
         p = self.get_project(repo_url)

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -812,7 +812,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             if not self.gitlab:
                 raise Exception("gitlab is not initialized")
             project = self.gitlab.get_project(url)
-            commits = project.commits.list(ref_name=ref, per_page=1)
+            commits = project.commits.list(ref_name=ref, per_page=1, page=1)
             commit_sha = commits[0].id
 
         return commit_sha

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -5391,7 +5391,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         if "gitlab" in url:
             gitlab = self.init_gitlab()
             project = gitlab.get_project(url)
-            commits = project.commits.list(ref_name=ref, per_page=1)
+            commits = project.commits.list(ref_name=ref, per_page=1, page=1)
             return commits[0].id
 
         return ""

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2187,7 +2187,11 @@ def app_interface_merge_history(ctx):
     settings = queries.get_app_interface_settings()
     instance = queries.get_gitlab_instance()
     gl = GitLabApi(instance, project_url=settings["repoUrl"], settings=settings)
-    merge_requests = gl.project.mergerequests.list(state=MRState.MERGED, per_page=100)
+    merge_requests = gl.project.mergerequests.list(
+        state=MRState.MERGED,
+        per_page=100,
+        get_all=True,
+    )
 
     columns = [
         "id",


### PR DESCRIPTION
We use `per_page=1` in `list` to get first item back, new `python-gitlab` requires explicit set `get_all` or `page`, so it will be `.list(per_page=1, page=1)`.


> UserWarning: Calling a `list()` method without specifying `get_all=True` or `iterator=True` will return a maximum of 1 items. Your query returned 1 of many items. See https://python-gitlab.readthedocs.io/en/v4.6.0/api-usage.html#pagination for more details. If this was done intentionally, then this warning can be supressed by adding the argument `get_all=False` to the `list()` call.

Also fixed a few other places when calling `list()` without specifying `get_all` or `iterator`.