### PR TITLE
fix ClonedRepoGitlabPersistence

### DIFF
--- a/reconcile/templating/renderer.py
+++ b/reconcile/templating/renderer.py
@@ -168,7 +168,7 @@ class ClonedRepoGitlabPersistence(FilePersistence):
             raise ValueError("ClonedRepoGitlabPersistence.result not set!")
         self.result.outputs = self.outputs
 
-        if self.dry_run:
+        if self.dry_run or not self.outputs:
             return
 
         self.mr_manager.housekeeping()
@@ -347,6 +347,7 @@ class TemplateRendererIntegration(QontractReconcileIntegration):
             )
             with persistence as p:
                 p.result = result
+                p.outputs = []
                 for item in for_each_items:
                     self.reconcile_template_collection(
                         collection=collection,


### PR DESCRIPTION
fix https://github.com/app-sre/qontract-reconcile/pull/4499/commits/65a97e0fc556b277a6462b4a11f93a64a835f92c

outputs should be emptied for each template collection, and we should do nothing if ClonedRepoGitlabPersistence gets no output.