### PR TITLE
extract qontract-reconcile-toml secret name to parameter

### DIFF
--- a/helm/qontract-reconcile/templates/template.yaml
+++ b/helm/qontract-reconcile/templates/template.yaml
@@ -528,7 +528,7 @@ objects:
         {{- end }}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -674,7 +674,7 @@ objects:
             volumes:
             - name: qontract-reconcile-toml
               secret:
-                secretName: qontract-reconcile-toml
+                secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
             - name: qontract-reconcile-sa-token
               projected:
                 sources:
@@ -723,6 +723,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/openshift/qontract-manager-fedramp.yaml
+++ b/openshift/qontract-manager-fedramp.yaml
@@ -261,7 +261,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -295,6 +295,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/openshift/qontract-manager.yaml
+++ b/openshift/qontract-manager.yaml
@@ -241,7 +241,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -273,6 +273,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_disabled.yml
@@ -195,7 +195,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -392,7 +392,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -438,6 +438,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shard_spec_override.yml
@@ -195,7 +195,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -392,7 +392,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -438,6 +438,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/aws_account_shards.yml
+++ b/reconcile/test/fixtures/helm/aws_account_shards.yml
@@ -195,7 +195,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -392,7 +392,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -438,6 +438,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/basic.yml
+++ b/reconcile/test/fixtures/helm/basic.yml
@@ -193,7 +193,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -239,6 +239,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/cache.yml
+++ b/reconcile/test/fixtures/helm/cache.yml
@@ -204,7 +204,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -250,6 +250,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/cache_storage_vars.yml
+++ b/reconcile/test/fixtures/helm/cache_storage_vars.yml
@@ -204,7 +204,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -250,6 +250,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/command.yml
+++ b/reconcile/test/fixtures/helm/command.yml
@@ -195,7 +195,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -241,6 +241,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/concurrency_policy.yml
+++ b/reconcile/test/fixtures/helm/concurrency_policy.yml
@@ -67,7 +67,7 @@ objects:
             volumes:
             - name: qontract-reconcile-toml
               secret:
-                secretName: qontract-reconcile-toml
+                secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
             - name: qontract-reconcile-sa-token
               projected: 
                 sources:
@@ -113,6 +113,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/cron.yml
+++ b/reconcile/test/fixtures/helm/cron.yml
@@ -67,7 +67,7 @@ objects:
             volumes:
             - name: qontract-reconcile-toml
               secret:
-                secretName: qontract-reconcile-toml
+                secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
             - name: qontract-reconcile-sa-token
               projected: 
                 sources:
@@ -113,6 +113,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/dashdotdb.yml
+++ b/reconcile/test/fixtures/helm/dashdotdb.yml
@@ -72,7 +72,7 @@ objects:
             volumes:
             - name: qontract-reconcile-toml
               secret:
-                secretName: qontract-reconcile-toml
+                secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
             - name: qontract-reconcile-sa-token
               projected: 
                 sources:
@@ -118,6 +118,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/disable_unleash.yml
+++ b/reconcile/test/fixtures/helm/disable_unleash.yml
@@ -181,7 +181,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -227,6 +227,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/enable_google_chat.yml
+++ b/reconcile/test/fixtures/helm/enable_google_chat.yml
@@ -234,7 +234,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -282,6 +282,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/enable_pushgateway.yml
+++ b/reconcile/test/fixtures/helm/enable_pushgateway.yml
@@ -84,7 +84,7 @@ objects:
             volumes:
             - name: qontract-reconcile-toml
               secret:
-                secretName: qontract-reconcile-toml
+                secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
             - name: qontract-reconcile-sa-token
               projected: 
                 sources:
@@ -130,6 +130,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/environment_aware.yml
+++ b/reconcile/test/fixtures/helm/environment_aware.yml
@@ -219,7 +219,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -265,6 +265,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/exclude_service.yml
+++ b/reconcile/test/fixtures/helm/exclude_service.yml
@@ -193,7 +193,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -225,6 +225,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/extra_args.yml
+++ b/reconcile/test/fixtures/helm/extra_args.yml
@@ -195,7 +195,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -241,6 +241,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/extra_env.yml
+++ b/reconcile/test/fixtures/helm/extra_env.yml
@@ -200,7 +200,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -246,6 +246,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/failure_history.yml
+++ b/reconcile/test/fixtures/helm/failure_history.yml
@@ -67,7 +67,7 @@ objects:
             volumes:
             - name: qontract-reconcile-toml
               secret:
-                secretName: qontract-reconcile-toml
+                secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
             - name: qontract-reconcile-sa-token
               projected: 
                 sources:
@@ -113,6 +113,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/integrations_manager.yml
+++ b/reconcile/test/fixtures/helm/integrations_manager.yml
@@ -201,7 +201,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -247,6 +247,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/internal_certificates.yml
+++ b/reconcile/test/fixtures/helm/internal_certificates.yml
@@ -211,7 +211,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -259,6 +259,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/logs_slack.yml
+++ b/reconcile/test/fixtures/helm/logs_slack.yml
@@ -211,7 +211,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -257,6 +257,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/restart_policy.yml
+++ b/reconcile/test/fixtures/helm/restart_policy.yml
@@ -67,7 +67,7 @@ objects:
             volumes:
             - name: qontract-reconcile-toml
               secret:
-                secretName: qontract-reconcile-toml
+                secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
             - name: qontract-reconcile-sa-token
               projected: 
                 sources:
@@ -113,6 +113,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/shards.yml
+++ b/reconcile/test/fixtures/helm/shards.yml
@@ -193,7 +193,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -388,7 +388,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -434,6 +434,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/sleep_duration.yml
+++ b/reconcile/test/fixtures/helm/sleep_duration.yml
@@ -193,7 +193,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -239,6 +239,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/state.yml
+++ b/reconcile/test/fixtures/helm/state.yml
@@ -231,7 +231,7 @@ objects:
             optional: true
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -277,6 +277,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/storage.yml
+++ b/reconcile/test/fixtures/helm/storage.yml
@@ -193,7 +193,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -239,6 +239,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/success_history.yml
+++ b/reconcile/test/fixtures/helm/success_history.yml
@@ -67,7 +67,7 @@ objects:
             volumes:
             - name: qontract-reconcile-toml
               secret:
-                secretName: qontract-reconcile-toml
+                secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
             - name: qontract-reconcile-sa-token
               projected: 
                 sources:
@@ -113,6 +113,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT

--- a/reconcile/test/fixtures/helm/trigger.yml
+++ b/reconcile/test/fixtures/helm/trigger.yml
@@ -193,7 +193,7 @@ objects:
                 path: ${KUBE_SA_TOKEN_FILENAME}
         - name: qontract-reconcile-toml
           secret:
-            secretName: qontract-reconcile-toml
+            secretName: ${QONTRACT_RECONCILE_TOML_SECRET_NAME}
         - name: logs
           emptyDir: {}
         - name: fluentd-config
@@ -239,6 +239,8 @@ parameters:
   value: --dry-run
 - name: SLEEP_DURATION_SECS
   value: "300"
+- name: QONTRACT_RECONCILE_TOML_SECRET_NAME
+  value: qontract-reconcile-toml
 - name: APP_INTERFACE_SQS_SECRET_NAME
   value: app-interface-sqs
 - name: APP_INTERFACE_STATE_BUCKET_ACCOUNT


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10491

this change makes it optional to define a different Secret to use, instead of updating the secret in place in the namespace.