### PR TITLE
[slack-usergroups] do not add users with tag_on_merge_requests false to groups from OWNERS files

### DIFF
--- a/reconcile/gql_definitions/common/users.py
+++ b/reconcile/gql_definitions/common/users.py
@@ -27,6 +27,7 @@ fragment User on User_v1 {
   github_username
   slack_username
   pagerduty_username
+  tag_on_merge_requests
 }
 
 query Users {

--- a/reconcile/gql_definitions/fragments/user.gql
+++ b/reconcile/gql_definitions/fragments/user.gql
@@ -5,4 +5,5 @@ fragment User on User_v1 {
   github_username
   slack_username
   pagerduty_username
+  tag_on_merge_requests
 }

--- a/reconcile/gql_definitions/fragments/user.py
+++ b/reconcile/gql_definitions/fragments/user.py
@@ -30,3 +30,4 @@ class User(ConfiguredBaseModel):
     github_username: str = Field(..., alias="github_username")
     slack_username: Optional[str] = Field(..., alias="slack_username")
     pagerduty_username: Optional[str] = Field(..., alias="pagerduty_username")
+    tag_on_merge_requests: Optional[bool] = Field(..., alias="tag_on_merge_requests")

--- a/reconcile/gql_definitions/openshift_groups/managed_roles.py
+++ b/reconcile/gql_definitions/openshift_groups/managed_roles.py
@@ -27,6 +27,7 @@ fragment User on User_v1 {
   github_username
   slack_username
   pagerduty_username
+  tag_on_merge_requests
 }
 
 query OpenshiftGroupsManagedRoles {

--- a/reconcile/gql_definitions/slack_usergroups/permissions.py
+++ b/reconcile/gql_definitions/slack_usergroups/permissions.py
@@ -28,6 +28,7 @@ fragment User on User_v1 {
   github_username
   slack_username
   pagerduty_username
+  tag_on_merge_requests
 }
 
 fragment VaultSecret on VaultSecret_v1 {

--- a/reconcile/gql_definitions/slack_usergroups/users.py
+++ b/reconcile/gql_definitions/slack_usergroups/users.py
@@ -27,6 +27,7 @@ fragment User on User_v1 {
   github_username
   slack_username
   pagerduty_username
+  tag_on_merge_requests
 }
 
 query SlackUsergroupClusterUser {

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -333,6 +333,7 @@ def get_slack_usernames_from_owners(
                 get_slack_username(u)
                 for u in users
                 if getattr(u, user_key).lower() in [o.lower() for o in all_owners]
+                and u.tag_on_merge_requests is not False
             ]
             not_found_users = [
                 owner

--- a/reconcile/test/fixtures/slack_usergroups/permissions.yml
+++ b/reconcile/test/fixtures/slack_usergroups/permissions.yml
@@ -52,6 +52,7 @@ permissions:
           slack_username: slack_username
           pagerduty_username: pagerduty_username
           github_username: github_username
+          tag_on_merge_requests: null
     schedule:
       schedule:
         - start: '2022-12-23 09:00'
@@ -62,6 +63,7 @@ permissions:
               slack_username: slack_username
               pagerduty_username: pagerduty_username
               github_username: github_username
+              tag_on_merge_requests: null
     skip: null
     workspace:
       name: coreos

--- a/reconcile/test/fixtures/slack_usergroups/users.yml
+++ b/reconcile/test/fixtures/slack_usergroups/users.yml
@@ -6,6 +6,7 @@ users:
     slack_username: user1-slack-username
     pagerduty_username: user1-pagerduty-username
     tag_on_cluster_updates: null
+    tag_on_merge_requests: null
     roles:
       - tag_on_cluster_updates: null
         access:
@@ -18,6 +19,7 @@ users:
     slack_username: user2-slack-username
     pagerduty_username: user2-pagerduty-username
     tag_on_cluster_updates: null
+    tag_on_merge_requests: null
     roles:
       - tag_on_cluster_updates: null
         access:

--- a/reconcile/test/test_gitlab_members.py
+++ b/reconcile/test/test_gitlab_members.py
@@ -67,6 +67,7 @@ def user() -> User:
         github_username="github_username",
         name="name",
         pagerduty_username="pagerduty_username",
+        tag_on_merge_requests=None,
     )
 
 

--- a/reconcile/test/test_slack_usergroups.py
+++ b/reconcile/test/test_slack_usergroups.py
@@ -79,6 +79,7 @@ def user() -> UserV1:
         name="name",
         pagerduty_username="pagerduty",
         tag_on_cluster_updates=None,
+        tag_on_merge_requests=None,
         roles=None,
     )
 


### PR DESCRIPTION
in our use case, such groups are used for PR review requests on slack.

if a user sets `tag_on_merge_requests: false`, they shouldn't be pinged for reviews, not in gitlab (current implementation) and not in slack as well.