### PR TITLE
saasheder fix helm image.tag handling to consider image not a map

### DIFF
--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -969,7 +969,8 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 else True
             )
             consolidated_parameters = spec.parameters(adjust=False)
-            if not consolidated_parameters.get("image", {}).get("tag"):
+            image = consolidated_parameters.get("image", {})
+            if isinstance(image, dict) and not image.get("tag"):
                 commit_sha = self._get_commit_sha(url, ref, github)
                 image_tag = commit_sha[:hash_length]
                 consolidated_parameters.setdefault("image", {})["tag"] = image_tag


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2250

`image` is sometimes just a string.