### PR TITLE
use datetime instead of str

### DIFF
--- a/reconcile/statuspage/atlassian.py
+++ b/reconcile/statuspage/atlassian.py
@@ -1,5 +1,6 @@
 import logging
 import time
+from datetime import datetime
 from typing import (
     Any,
     Self,
@@ -414,8 +415,8 @@ class AtlassianStatusPageProvider:
         return StatusMaintenance(
             name=name_override or raw_maintenance.name,
             message=raw_maintenance.incident_updates[0].body,
-            schedule_start=raw_maintenance.scheduled_for,
-            schedule_end=raw_maintenance.scheduled_until,
+            schedule_start=datetime.fromisoformat(raw_maintenance.scheduled_for),
+            schedule_end=datetime.fromisoformat(raw_maintenance.scheduled_until),
             components=[
                 self._raw_component_to_status_component(c)
                 for c in raw_maintenance.components
@@ -470,8 +471,8 @@ class AtlassianStatusPageProvider:
         data = {
             "name": maintenance.name,
             "status": "scheduled",
-            "scheduled_for": maintenance.schedule_start,
-            "scheduled_until": maintenance.schedule_end,
+            "scheduled_for": maintenance.schedule_start.isoformat(),
+            "scheduled_until": maintenance.schedule_end.isoformat(),
             "body": maintenance.message,
             "scheduled_remind_prior": maintenance.announcements.remind_subscribers,
             "scheduled_auto_transition": True,

--- a/reconcile/statuspage/integrations/maintenances.py
+++ b/reconcile/statuspage/integrations/maintenances.py
@@ -55,7 +55,7 @@ class StatusPageMaintenancesIntegration(QontractReconcileIntegration[NoParams]):
         now = datetime.now(UTC)
         slack = slackapi_from_queries(QONTRACT_INTEGRATION, init_usergroups=False)
         for m in desired_state:
-            scheduled_start = datetime.fromisoformat(m.schedule_start)
+            scheduled_start = m.schedule_start
             if now <= scheduled_start <= now + timedelta(hours=1):
                 state_key = f"notifications/{m.name}"
                 if binding_state.state.exists(state_key):

--- a/reconcile/statuspage/page.py
+++ b/reconcile/statuspage/page.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Self, cast
 
 from pydantic import BaseModel
@@ -128,8 +129,8 @@ class StatusMaintenance(BaseModel):
 
     name: str
     message: str
-    schedule_start: str
-    schedule_end: str
+    schedule_start: datetime
+    schedule_end: datetime
     components: list[StatusComponent]
     announcements: StatusMaintenanceAnnouncement
 


### PR DESCRIPTION
The API might return a different precision than what we put in app-interface. Lets compare diffs based on datetime.