### PR TITLE
Rds upgrade validation

### DIFF
--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -66,7 +66,7 @@ from reconcile.utils.vault import (
 )
 
 QONTRACT_INTEGRATION = "terraform_resources"
-QONTRACT_INTEGRATION_VERSION = make_semver(0, 5, 4)
+QONTRACT_INTEGRATION_VERSION = make_semver(0, 5, 5)
 QONTRACT_TF_PREFIX = "qrtf"
 
 

--- a/reconcile/test/utils/test_aws_api.py
+++ b/reconcile/test/utils/test_aws_api.py
@@ -274,6 +274,7 @@ def test_get_db_valid_upgrade_target(
     mocked_rds_client.describe_db_engine_versions.assert_called_once_with(
         Engine=engine,
         EngineVersion=engine_version,
+        IncludeAll=True,
     )
 
 

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -1621,7 +1621,9 @@ class AWSApi:  # pylint: disable=too-many-public-methods
 
         rds = self._account_rds_client(account_name, **optional_kwargs)
         response = rds.describe_db_engine_versions(
-            Engine=engine, EngineVersion=engine_version
+            Engine=engine,
+            EngineVersion=engine_version,
+            IncludeAll=True,
         )
 
         if versions := response["DBEngineVersions"]:

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -762,13 +762,6 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
             valid_upgrade_target = self._aws_api.get_db_valid_upgrade_target(
                 account_name, engine, before_version, region_name=region_name
             )
-            if not valid_upgrade_target:
-                # valid_upgrade_target can be empty when current version is no longer supported by AWS.
-                # In this case, we can't validate it, so skip.
-                logging.warning(
-                    f"No valid upgrade target available, skip validation for {resource_name}."
-                )
-                return
             target = next(
                 (
                     t


### PR DESCRIPTION
Follow up on #4464

Use `IncludeAll` in [DescribeDBEngineVersions](https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBEngineVersions.html), this will return all versions including deprecated ones.

So we can assume all current RDS versions can always fetch related info back, test case for empty valid upgrade target fallback to normal target not found case.

[APPSRE-7777](https://issues.redhat.com/browse/APPSRE-7777)