### PR TITLE
Fix it to be consistent with the API response.

### DIFF
--- a/reconcile/utils/glitchtip/models.py
+++ b/reconcile/utils/glitchtip/models.py
@@ -117,7 +117,7 @@ class ProjectAlertRecipient(BaseModel):
 class ProjectAlert(BaseModel):
     pk: int | None
     name: str
-    timespan_minutes: int
+    timespan_minutes: int = Field(alias="timespanMinutes")
     quantity: int
     recipients: list[ProjectAlertRecipient] = Field([], alias="alertRecipients")
 


### PR DESCRIPTION
We were getting validation error about ProjectAlert:

```
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/glitchtip/client.py", line 116, in <listcomp>
    ProjectAlert(**r)
  File "pydantic/main.py", line 341, in pydantic.main.BaseModel.__init__
pydantic.error_wrappers.ValidationError: 1 validation error for ProjectAlert
timespan_minutes
  field required (type=value_error.missing)
```
Slack [thread](https://redhat-internal.slack.com/archives/GGC2A0MS8/p1720556494504479?thread_ts=1720555589.622789&cid=GGC2A0MS8)

**Testing:** 
Run locally without error:
```
$qontract-reconcile --dry-run --config config.debug.toml glitchtip-project-alerts 
[2024-07-09 17:46:32] [INFO] [DRY-RUN] [integration.py:reconcile:245] - ['create_project_alert', 'insights/hcc-content-sources-stage/alert-4']
[2024-07-09 17:46:32] [INFO] [DRY-RUN] [integration.py:reconcile:245] - ['create_project_alert', 'insights/hcc-content-sources/alert-3']
```
