### PR TITLE
ruff upgrade and enable some additional checks

### DIFF
--- a/dockerfiles/hack/run-integration.py
+++ b/dockerfiles/hack/run-integration.py
@@ -125,7 +125,7 @@ def build_entry_point_func(command_name: str) -> click.Command:
         ep.name: ep for ep in metadata.entry_points().select(group="console_scripts")
     }
     entry_point: metadata.EntryPoint | None = console_script_entry_points.get(
-        command_name, None
+        command_name
     )
     if entry_point:
         return entry_point.load()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ ignore = [
     "PLW2901", # `for` loop variable `v` overwritten by assignment target
     "UP031",   # Use format specifiers instead of percent format
     "SIM102",  # Use a single `if` statement instead of nested `if` statements
+    "B017",    #`pytest.raises(Exception)` should be considered evil
 ]
 [tool.ruff.format]
 preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,10 @@ extend-select = [
     "PL",
     # pyupgrade
     "UP",
-    # simply
+    # flake8-simply
     "SIM",
+    # flake8-bugbear
+    "B",
 
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ extend-select = [
     "SIM",
     # flake8-bugbear
     "B",
+    # flake8-comprehensions
+    "C4",
 
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 line-length = 88
 target-version = 'py311'
-required-version = "0.4.8"
+required-version = "0.5.1"
 
 src = ["reconcile", "tools", "release", "dockerfiles/hack", "setup.py"]
 extend-exclude = ["reconcile/gql_definitions"]
@@ -22,6 +22,8 @@ extend-select = [
     "PL",
     # pyupgrade
     "UP",
+    # simply
+    "SIM",
 
 ]
 ignore = [
@@ -38,6 +40,7 @@ ignore = [
     "PLW1641", # Object does not implement `__hash__` method
     "PLW2901", # `for` loop variable `v` overwritten by assignment target
     "UP031",   # Use format specifiers instead of percent format
+    "SIM102",  # Use a single `if` statement instead of nested `if` statements
 ]
 [tool.ruff.format]
 preview = true

--- a/reconcile/aus/healthchecks.py
+++ b/reconcile/aus/healthchecks.py
@@ -45,7 +45,7 @@ class AUSClusterHealthCheckProvider:
 
     def cluster_health(self, cluster_external_id: str, org_id: str) -> AUSClusterHealth:
         state: dict[str, list[AUSHealthError]] = {}
-        for provider_name in self.providers.keys():
+        for provider_name in self.providers:
             state[provider_name] = []
             provider, enforce = self.providers[provider_name]
             health = provider.cluster_health(cluster_external_id, org_id)

--- a/reconcile/aws_account_manager/reconciler.py
+++ b/reconcile/aws_account_manager/reconciler.py
@@ -204,7 +204,7 @@ class AWSReconciler:
                 except AWSResourceAlreadyExistsException:
                     raise AbortStateTransaction(
                         f"A quota increase for this {new_quota.service_code}/{new_quota.quota_code} already exists. Try it again later."
-                    )
+                    ) from None
                 ids.append(req.id)
 
             _state.value = {"last_applied_quotas": quotas_dict, "ids": ids}

--- a/reconcile/aws_saml_idp/integration.py
+++ b/reconcile/aws_saml_idp/integration.py
@@ -163,11 +163,11 @@ class AwsSamlIdpIntegration(QontractReconcileIntegration[AwsSamlIdpIntegrationPa
         if defer:
             defer(tf.cleanup)
 
-        runner_params: RunnerParams = dict(
-            tf=tf,
-            dry_run=dry_run,
-            enable_deletion=self.params.enable_deletion,
-        )
+        runner_params: RunnerParams = {
+            "tf": tf,
+            "dry_run": dry_run,
+            "enable_deletion": self.params.enable_deletion,
+        }
 
         if self.params.enable_extended_early_exit and get_feature_toggle_state(
             f"{QONTRACT_INTEGRATION}-extended-early-exit", default=True

--- a/reconcile/aws_saml_roles/integration.py
+++ b/reconcile/aws_saml_roles/integration.py
@@ -281,11 +281,11 @@ class AwsSamlRolesIntegration(
         if defer:
             defer(tf.cleanup)
 
-        runner_params: RunnerParams = dict(
-            tf=tf,
-            dry_run=dry_run,
-            enable_deletion=self.params.enable_deletion,
-        )
+        runner_params: RunnerParams = {
+            "tf": tf,
+            "dry_run": dry_run,
+            "enable_deletion": self.params.enable_deletion,
+        }
 
         if self.params.enable_extended_early_exit and get_feature_toggle_state(
             f"{QONTRACT_INTEGRATION}-extended-early-exit", default=True

--- a/reconcile/aws_version_sync/utils.py
+++ b/reconcile/aws_version_sync/utils.py
@@ -48,13 +48,13 @@ def get_values(gql_get_resource_func: Callable, path: str) -> dict[str, Any]:
     try:
         raw_values = gql_get_resource_func(path)
     except GqlGetResourceError as e:
-        raise FetchResourceError(str(e))
+        raise FetchResourceError(str(e)) from e
     try:
         values = anymarkup.parse(raw_values["content"], force_types=None)
         values.pop("$schema", None)
-    except anymarkup.AnyMarkupError:
+    except anymarkup.AnyMarkupError as e:
         e_msg = "Could not parse data. Skipping resource: {}"
-        raise FetchResourceError(e_msg.format(path))
+        raise FetchResourceError(e_msg.format(path)) from e
     return values
 
 

--- a/reconcile/cna/state.py
+++ b/reconcile/cna/state.py
@@ -36,10 +36,10 @@ class State:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, State):
             return False
-        if not set(list(self._assets.keys())) == set(list(other._assets.keys())):
+        if not set(self._assets.keys()) == set(other._assets.keys()):
             return False
         for kind in list(self._assets.keys()):
-            if not set(list(self._assets[kind])) == set(list(other._assets[kind])):
+            if not set(self._assets[kind]) == set(other._assets[kind]):
                 return False
             for name, asset in self._assets[kind].items():
                 if asset != other._assets[kind][name]:

--- a/reconcile/database_access_manager.py
+++ b/reconcile/database_access_manager.py
@@ -406,13 +406,10 @@ class JobStatus(BaseModel):
     conditions: list[JobStatusCondition]
 
     def is_complete(self) -> bool:
-        return True if self.conditions else False
+        return bool(self.conditions)
 
     def has_errors(self) -> bool:
-        for condition in self.conditions:
-            if condition.type == "Failed":
-                return True
-        return False
+        return any(condition.type == "Failed" for condition in self.conditions)
 
 
 def _populate_resources(

--- a/reconcile/external_resources/manager.py
+++ b/reconcile/external_resources/manager.py
@@ -210,10 +210,10 @@ class ExternalResourcesManager:
         """
         need_secret_sync = False
 
-        if state.resource_status not in set([
+        if state.resource_status not in {
             ResourceStatus.DELETE_IN_PROGRESS,
             ResourceStatus.IN_PROGRESS,
-        ]):
+        }:
             return False
 
         logging.info(
@@ -374,5 +374,5 @@ class ExternalResourcesManager:
         for r in triggered:
             self.reconciler.get_resource_reconcile_logs(reconciliation=r)
 
-        if ReconcileStatus.ERROR in [rs for rs in results.values()]:
+        if ReconcileStatus.ERROR in list(results.values()):
             raise Exception("Some Resources have reconciliation errors.")

--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -118,7 +118,7 @@ class ExternalResourcesInventory(MutableMapping):
             return self._inventory[key]
         except KeyError:
             msg = f"Resource spec not found: Provider {provider}, Id: {identifier}"
-            raise FetchResourceError(msg)
+            raise FetchResourceError(msg) from None
 
 
 class Action(StrEnum):

--- a/reconcile/external_resources/secrets_sync.py
+++ b/reconcile/external_resources/secrets_sync.py
@@ -52,7 +52,7 @@ class VaultSecret(BaseModel):
 class SecretHelper:
     @staticmethod
     def get_comparable_secret(resource: OpenshiftResource) -> OpenshiftResource:
-        metadata = {k: v for k, v in resource.body["metadata"].items()}
+        metadata = dict(resource.body["metadata"].items())
         metadata["annotations"] = {
             k: v
             for k, v in metadata.get("annotations", {}).items()
@@ -177,7 +177,7 @@ class SecretsReconciler:
         """
         self._populate_secret_data(specs)
 
-        to_sync_specs = [spec for spec in self._specs_with_secret(specs)]
+        to_sync_specs = list(self._specs_with_secret(specs))
         ocmap = self._init_ocmap(to_sync_specs)
 
         for spec in to_sync_specs:

--- a/reconcile/external_resources/state.py
+++ b/reconcile/external_resources/state.py
@@ -235,7 +235,7 @@ class ExternalResourcesStateDynamoDB:
         return partials
 
     def get_all_resource_keys(self) -> set[ExternalResourceKey]:
-        return {k for k in self.partial_resources.keys()}
+        return {k for k in self.partial_resources}
 
     def get_keys_by_status(
         self, resource_status: ResourceStatus

--- a/reconcile/external_resources/state.py
+++ b/reconcile/external_resources/state.py
@@ -235,7 +235,7 @@ class ExternalResourcesStateDynamoDB:
         return partials
 
     def get_all_resource_keys(self) -> set[ExternalResourceKey]:
-        return {k for k in self.partial_resources}
+        return set(self.partial_resources)
 
     def get_keys_by_status(
         self, resource_status: ResourceStatus

--- a/reconcile/gcr_mirror.py
+++ b/reconcile/gcr_mirror.py
@@ -124,12 +124,8 @@ class QuayMirror:
     @staticmethod
     def sync_tag(tags, tags_exclude, candidate):
         if tags is not None:
-            for tag in tags:
-                if re.match(tag, candidate):
-                    return True
-            # When tags is defined, we don't look at
-            # tags_exclude
-            return False
+            # When tags is defined, we don't look at tags_exclude
+            return any(re.match(tag, candidate) for tag in tags)
 
         if tags_exclude is not None:
             for tag_exclude in tags_exclude:

--- a/reconcile/jira_permissions_validator.py
+++ b/reconcile/jira_permissions_validator.py
@@ -277,10 +277,10 @@ def run(
 ) -> None:
     gql_api = gql.get_api()
     boards = get_jira_boards(query_func=gql_api.query)
-    runner_params: RunnerParams = dict(
-        exit_on_permission_errors=exit_on_permission_errors,
-        boards=boards,
-    )
+    runner_params: RunnerParams = {
+        "exit_on_permission_errors": exit_on_permission_errors,
+        "boards": boards,
+    }
     if enable_extended_early_exit and get_feature_toggle_state(
         "jira-permissions-validator-extended-early-exit",
         default=True,

--- a/reconcile/ldap_groups/integration.py
+++ b/reconcile/ldap_groups/integration.py
@@ -143,7 +143,7 @@ class LdapGroupsIntegration(QontractReconcileIntegration[LdapGroupsIntegrationPa
     def get_roles(self, query_func: Callable) -> list[RoleV1]:
         """Return the roles with ldap_group set."""
         data = roles_query(query_func, variables={})
-        roles = [role for role in data.roles or []]
+        roles = list(data.roles or [])
         if duplicates := find_duplicates(
             role.ldap_group.name for role in roles if role.ldap_group
         ):

--- a/reconcile/ldap_groups/integration.py
+++ b/reconcile/ldap_groups/integration.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 from collections.abc import (
     Callable,
@@ -224,10 +225,8 @@ class LdapGroupsIntegration(QontractReconcileIntegration[LdapGroupsIntegrationPa
         """Reach out to the internal groups API and fetch all managed groups."""
         groups = []
         for group_name in group_names:
-            try:
+            with contextlib.suppress(NotFound):
                 groups.append(internal_groups_client.group(group_name))
-            except NotFound:
-                pass
         return groups
 
     def reconcile(
@@ -263,10 +262,8 @@ class LdapGroupsIntegration(QontractReconcileIntegration[LdapGroupsIntegrationPa
         for group_to_remove in diff_result.delete.values():
             logging.info(["delete_ldap_group", group_to_remove.name])
             if not dry_run:
-                try:
+                with contextlib.suppress(NotFound):
                     internal_groups_client.delete_group(group_to_remove.name)
-                except NotFound:
-                    pass
                 self._managed_groups.remove(group_to_remove.name)
 
         for diff_pair in diff_result.change.values():

--- a/reconcile/ocm_internal_notifications/integration.py
+++ b/reconcile/ocm_internal_notifications/integration.py
@@ -36,6 +36,7 @@ class OcmInternalNotifications(QontractReconcileIntegration[NoParams]):
         self.slack = slackapi_from_queries(
             integration_name=self.name, init_usergroups=False
         )
+        self.slack_get_user_id_by_name = lru_cache()(self._slack_get_user_id_by_name)
 
     @property
     def name(self) -> str:
@@ -44,8 +45,7 @@ class OcmInternalNotifications(QontractReconcileIntegration[NoParams]):
     def get_environments(self, query_func: Callable) -> list[OCMEnvironment]:
         return ocm_environment_query(query_func).environments
 
-    @lru_cache
-    def slack_get_user_id_by_name(
+    def _slack_get_user_id_by_name(
         self, user_name: str, mail_address: str
     ) -> str | None:
         try:

--- a/reconcile/openshift_base.py
+++ b/reconcile/openshift_base.py
@@ -1360,8 +1360,9 @@ def aggregate_shared_resources_typed(
         case HasOpenshiftServiceAccountTokensAndSharedResources():
             shared_type_resources_items = []
             for ost_shared_resources_item in namespace.shared_resources:
-                if shared_type_resources := getattr(
-                    ost_shared_resources_item, "openshift_service_account_tokens"
+                if (
+                    shared_type_resources
+                    := ost_shared_resources_item.openshift_service_account_tokens
                 ):
                     shared_type_resources_items.extend(shared_type_resources)
             if namespace.openshift_service_account_tokens:
@@ -1373,8 +1374,9 @@ def aggregate_shared_resources_typed(
         case HasOpenShiftResourcesAndSharedResources():
             shared_type_resources_items = []
             for or_shared_resources_item in namespace.shared_resources:
-                if shared_type_resources := getattr(
-                    or_shared_resources_item, "openshift_resources"
+                if (
+                    shared_type_resources
+                    := or_shared_resources_item.openshift_resources
                 ):
                     shared_type_resources_items.extend(shared_type_resources)
             if namespace.openshift_resources:
@@ -1414,7 +1416,7 @@ def determine_user_keys_for_access(
         except KeyError:
             raise NotImplementedError(
                 f"[{cluster_name}] auth service not implemented: {service}"
-            )
+            ) from None
     return user_keys
 
 

--- a/reconcile/openshift_cluster_bots.py
+++ b/reconcile/openshift_cluster_bots.py
@@ -208,7 +208,7 @@ def create_cluster_bots(
             mode="w+", encoding="locale", delete=True
         ) as kc:
             kc.write(kubeconfig_content)
-            kc.flush
+            kc.flush()
             logging.info(
                 f"[{cluster.name}] create {config.dedicated_admin_sa} service account"
             )

--- a/reconcile/openshift_namespace_labels.py
+++ b/reconcile/openshift_namespace_labels.py
@@ -164,7 +164,7 @@ class LabelInventory:
             desired = types[DESIRED]
             managed = self.get(cluster, ns, MANAGED, [])
             current = self.get(cluster, ns, CURRENT, {})
-            changed = self.setdefault(cluster, ns, CHANGED, {})
+            changed = self.setdefault(cluster, ns, CHANGED, {})  # noqa: B909
 
             # cleanup managed items
             for k in managed:
@@ -192,7 +192,7 @@ class LabelInventory:
                     changed[k] = v
 
             # remove old labels
-            for k, v in current.items():
+            for k, _ in current.items():
                 if k in managed and k not in desired:
                     changed[k] = None
 

--- a/reconcile/openshift_namespaces.py
+++ b/reconcile/openshift_namespaces.py
@@ -127,7 +127,7 @@ def check_results(
     desired_state: Iterable[Mapping[str, str]], results: Iterable[Any]
 ) -> bool:
     err = False
-    for s, e in zip(desired_state, results):
+    for s, e in zip(desired_state, results, strict=False):
         if isinstance(e, Exception):
             err = True
             msg = (

--- a/reconcile/openshift_resources_base.py
+++ b/reconcile/openshift_resources_base.py
@@ -287,7 +287,7 @@ def check_alertmanager_config(
             f"error validating alertmanager config in {path}: "
             f"missing key {alertmanager_config_key}"
         )
-        raise FetchResourceError(e_msg)
+        raise FetchResourceError(e_msg) from None
 
     if decode_base64:
         config = base64.b64decode(config).decode("utf-8")
@@ -329,10 +329,10 @@ def fetch_provider_resource(
     except TypeError:
         body_type = type(body).__name__
         e_msg = f"invalid resource type {body_type} found in path: {path}"
-        raise FetchResourceError(e_msg)
+        raise FetchResourceError(e_msg) from None
     except anymarkup.AnyMarkupError:
         e_msg = f"Could not parse data. Skipping resource: {path}"
-        raise FetchResourceError(e_msg)
+        raise FetchResourceError(e_msg) from None
 
     if validate_json:
         files = body["data"]
@@ -341,7 +341,7 @@ def fetch_provider_resource(
                 json.loads(file_content)
             except ValueError:
                 e_msg = f"invalid json in {path} under {file_name}"
-                raise FetchResourceError(e_msg)
+                raise FetchResourceError(e_msg) from None
 
     if validate_alertmanager_config:
         if body["kind"] == "Secret":
@@ -383,7 +383,7 @@ def fetch_provider_resource(
             body, QONTRACT_INTEGRATION, QONTRACT_INTEGRATION_VERSION, error_details=path
         )
     except ConstructResourceError as e:
-        raise FetchResourceError(str(e))
+        raise FetchResourceError(str(e)) from None
 
 
 def fetch_provider_vault_secret(
@@ -430,7 +430,7 @@ def fetch_provider_vault_secret(
     try:
         return OR(body, integration, integration_version, error_details=path)
     except ConstructResourceError as e:
-        raise FetchResourceError(str(e))
+        raise FetchResourceError(str(e)) from None
 
 
 # check to ensure that all of the keys are valid by looking to see if there are
@@ -554,7 +554,7 @@ def fetch_openshift_resource(
             )
         except Exception as e:
             msg = f"could not render template at path {path}\n{e}"
-            raise ResourceTemplateRenderError(msg)
+            raise ResourceTemplateRenderError(msg) from None
     elif provider == "vault-secret":
         path = resource["path"]
         version = resource["version"]
@@ -588,7 +588,7 @@ def fetch_openshift_resource(
                 settings=settings,
             )
         except (SecretVersionNotFound, SecretVersionIsNone) as e:
-            raise FetchSecretError(e)
+            raise FetchSecretError(e) from None
     elif provider == "route":
         path = resource["resource"]["path"]
         _locked_debug_log(f"Processing {provider}: {path}")
@@ -628,7 +628,7 @@ def fetch_openshift_resource(
             )
         except Exception as e:
             msg = f"could not render template at path {path}\n{e}"
-            raise ResourceTemplateRenderError(msg)
+            raise ResourceTemplateRenderError(msg) from None
 
     else:
         raise UnknownProviderError(provider)

--- a/reconcile/openshift_saas_deploy_trigger_base.py
+++ b/reconcile/openshift_saas_deploy_trigger_base.py
@@ -313,11 +313,14 @@ def _pipeline_exists(
     if isinstance(oc, OCLogMsg):
         logging.error(oc.message)
         raise RuntimeError(f"No OC client for {tkn_cluster_name}: {oc.message}")
-    if oc.get(
-        namespace=tkn_namespace_name, kind="Pipeline", name=name, allow_not_found=True
-    ):
-        return True
-    return False
+    return bool(
+        oc.get(
+            namespace=tkn_namespace_name,
+            kind="Pipeline",
+            name=name,
+            allow_not_found=True,
+        )
+    )
 
 
 def _construct_tekton_trigger_resource(

--- a/reconcile/oum/base.py
+++ b/reconcile/oum/base.py
@@ -265,7 +265,7 @@ def reconcile_cluster_roles(
         }
         # only process roles present in the desired state and ignore the ones that are not
         # this way a role can still be managed manually while another one is managed by this integration
-        for group in desired_groups.keys():
+        for group in desired_groups:
             desired_members = desired_groups.get(group, set())
             current_members = current_groups.get(group, set())
 

--- a/reconcile/quay_mirror.py
+++ b/reconcile/quay_mirror.py
@@ -207,12 +207,8 @@ class QuayMirror:
     @staticmethod
     def sync_tag(tags, tags_exclude, candidate):
         if tags is not None:
-            for tag in tags:
-                if re.match(tag, candidate):
-                    return True
-            # When tags is defined, we don't look at
-            # tags_exclude
-            return False
+            # When tags is defined, we don't look at tags_exclude
+            return any(re.match(tag, candidate) for tag in tags)
 
         if tags_exclude is not None:
             for tag_exclude in tags_exclude:
@@ -375,10 +371,7 @@ class QuayMirror:
             return True
 
         next_compare_tags = last_compare_tags + interval
-        if time.time() >= next_compare_tags:
-            return True
-
-        return False
+        return time.time() >= next_compare_tags
 
     @staticmethod
     def record_timestamp(path) -> None:

--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -591,7 +591,7 @@ def get_state_aws_accounts(reset_passwords=False):
 
 def get_queue_aws_accounts():
     """Returns AWS accounts to use for queue management"""
-    uid = os.environ["gitlab_pr_submitter_queue_url"].split("/")[3]
+    uid = os.environ["gitlab_pr_submitter_queue_url"].split("/")[3]  # noqa: SIM112
     return get_aws_accounts(uid=uid)
 
 

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/mr_parser.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/mr_parser.py
@@ -78,7 +78,7 @@ class MRParser:
             attrs = mr.attributes
             desc = str(attrs.get("description", ""))
             parts = desc.split(PROMOTION_DATA_SEPARATOR)
-            if not len(parts) == 2:
+            if len(parts) != 2:
                 logging.info(
                     "Bad data separator format. Closing %s",
                     mr.attributes.get("web_url", "NO_WEBURL"),

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/mr_parser.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/mr_parser.py
@@ -202,7 +202,7 @@ class MRParser:
             is_batchable_str = self._apply_regex(
                 pattern=self._is_batchable_regex, promotion_data=promotion_data
             )
-            if is_batchable_str not in set(["True", "False"]):
+            if is_batchable_str not in {"True", "False"}:
                 logging.info(
                     "Bad %s format. Closing %s",
                     IS_BATCHABLE,

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
@@ -163,7 +163,7 @@ def _parse_expression(expression: str) -> Any:
     except JsonPathParserError as e:
         raise RuntimeError(
             f"Invalid jsonpath expression in namespaceSelector '{expression}' :{e}"
-        )
+        ) from None
 
 
 def is_namespace_addressed_by_selector(

--- a/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
+++ b/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
@@ -102,7 +102,6 @@ class SaasFilesInventory:
                     soak_days = (
                         target.promotion.soak_days if target.promotion.soak_days else 0
                     )
-                    resource_template.url
                     subscriber = Subscriber(
                         uid=target.uid(
                             parent_saas_file_name=saas_file.name,

--- a/reconcile/skupper_network/integration.py
+++ b/reconcile/skupper_network/integration.py
@@ -55,7 +55,9 @@ def load_site_controller_template(
             resource["content"], undefined=jinja2.StrictUndefined
         ).render(variables)
     except jinja2.exceptions.UndefinedError as e:
-        raise SkupperNetworkExcpetion(f"Failed to render template {path}: {e.message}")
+        raise SkupperNetworkExcpetion(
+            f"Failed to render template {path}: {e.message}"
+        ) from None
     return yaml.safe_load(body)
 
 

--- a/reconcile/skupper_network/site_controller.py
+++ b/reconcile/skupper_network/site_controller.py
@@ -30,14 +30,14 @@ class SiteController:
         """Skupper site token secret."""
         _labels = copy.deepcopy(labels)
         _labels["skupper.io/type"] = "connection-token-request"
-        return dict(
-            apiVersion="v1",
-            kind="Secret",
-            metadata=dict(
-                name=name,
-                labels=_labels,
-            ),
-        )
+        return {
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+                "name": name,
+                "labels": _labels,
+            },
+        }
 
 
 def get_site_controller(site: SkupperSite) -> SiteController:

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -560,7 +560,7 @@ def _update_usergroup_users_from_state(
             desired_ug_state.user_names
         ).items()
     ]
-    active_user_names = set(s.name for s in slack_user_objects)
+    active_user_names = {s.name for s in slack_user_objects}
 
     if len(active_user_names) != len(desired_ug_state.user_names):
         logging.info(
@@ -804,14 +804,14 @@ def run(
     # merge the two desired states recursively
     desired_state = deep_update(desired_state, desired_state_cluster_usergroups)
 
-    runner_params: RunnerParams = dict(
-        dry_run=dry_run,
-        slack_map=slack_map,
-        desired_state=desired_state,
-        clusters=clusters,
-        workspace_name=workspace_name,
-        usergroup_name=usergroup_name,
-    )
+    runner_params: RunnerParams = {
+        "dry_run": dry_run,
+        "slack_map": slack_map,
+        "desired_state": desired_state,
+        "clusters": clusters,
+        "workspace_name": workspace_name,
+        "usergroup_name": usergroup_name,
+    }
 
     if enable_extended_early_exit:
         extended_early_exit_run(

--- a/reconcile/slack_usergroups.py
+++ b/reconcile/slack_usergroups.py
@@ -768,7 +768,7 @@ def run(
 
     gqlapi = gql.get_api()
     secret_reader = SecretReader(queries.get_secret_reader_settings())
-    init_users = False if usergroup_name else True
+    init_users = not usergroup_name
 
     # queries
     permissions = get_permissions(query_func=gqlapi.query)

--- a/reconcile/status_board.py
+++ b/reconcile/status_board.py
@@ -223,7 +223,7 @@ class StatusBoardExporterIntegration(QontractReconcileIntegration):
                     )
 
         # product is deleted entirely
-        for product_name in diff_result.delete.keys():
+        for product_name in diff_result.delete:
             for application in current_products[product_name].applications or []:
                 return_list.append(
                     StatusBoardHandler(action="delete", status_board_object=application)

--- a/reconcile/statuspage/status.py
+++ b/reconcile/statuspage/status.py
@@ -73,9 +73,7 @@ class ManualStatusProvider(StatusProvider, BaseModel):
         now = datetime.now(UTC)
         if self.start and now < self.start:
             return False
-        if self.end and self.end < now:
-            return False
-        return True
+        return not (self.end and self.end < now)
 
 
 def build_status_provider_config(

--- a/reconcile/terraform_cloudflare_dns.py
+++ b/reconcile/terraform_cloudflare_dns.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import sys
 from collections.abc import (
@@ -344,10 +345,8 @@ def build_cloudflare_terraform_config_collection(
             rps,
         )
 
-        try:
+        with contextlib.suppress(ClientAlreadyRegisteredError):
             cf_clients.register_client(f"{cf_account.name}-{zone.identifier}", client)
-        except ClientAlreadyRegisteredError:
-            pass
 
     return cf_clients
 

--- a/reconcile/terraform_cloudflare_users.py
+++ b/reconcile/terraform_cloudflare_users.py
@@ -1,3 +1,4 @@
+import contextlib
 from collections.abc import (
     Iterable,
     Mapping,
@@ -264,10 +265,8 @@ class TerraformCloudflareUsers(
                 False,
             )
 
-            try:
+            with contextlib.suppress(ClientAlreadyRegisteredError):
                 cf_clients.register_client(cf_account.name, client)
-            except ClientAlreadyRegisteredError:
-                pass
 
         return cf_clients
 

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -284,7 +284,7 @@ class TerraformRepoIntegration(
                 # state.add already performs a json.dumps(key) so we export the
                 # pydantic model as a dict to avoid a double json dump with extra quotes
                 state.add(add_key, add_val.dict(by_alias=True), force=True)
-            for delete_key in diff_result.delete.keys():
+            for delete_key in diff_result.delete:
                 state.rm(delete_key)
             for change_key, change_val in diff_result.change.items():
                 if change_val.desired.delete:

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -175,7 +175,9 @@ class TerraformRepoIntegration(
                         explicit_start=True,
                     )
             except FileNotFoundError:
-                raise ParameterError(f"Unable to write to '{self.params.output_file}'")
+                raise ParameterError(
+                    f"Unable to write to '{self.params.output_file}'"
+                ) from None
         else:
             print(yaml.safe_dump(data=output.dict(), explicit_start=True))
 
@@ -231,7 +233,7 @@ class TerraformRepoIntegration(
             except (KeyError, AttributeError):
                 raise ParameterError(
                     f'Invalid ref: "{ref}" on repo: "{repo_url}". Or the project repo is not reachable'
-                )
+                ) from None
 
     def merge_results(
         self,

--- a/reconcile/terraform_resources.py
+++ b/reconcile/terraform_resources.py
@@ -399,22 +399,22 @@ def run(
     if print_to_file:
         return
 
-    runner_params: RunnerParams = dict(
-        accounts=accounts,
-        account_names=account_names,
-        tf_namespaces=tf_namespaces,
-        tf=tf,
-        ts=ts,
-        secret_reader=secret_reader,
-        dry_run=dry_run,
-        enable_deletion=enable_deletion,
-        thread_pool_size=thread_pool_size,
-        internal=internal,
-        use_jump_host=use_jump_host,
-        light=light,
-        vault_output_path=vault_output_path,
-        defer=defer,
-    )
+    runner_params: RunnerParams = {
+        "accounts": accounts,
+        "account_names": account_names,
+        "tf_namespaces": tf_namespaces,
+        "tf": tf,
+        "ts": ts,
+        "secret_reader": secret_reader,
+        "dry_run": dry_run,
+        "enable_deletion": enable_deletion,
+        "thread_pool_size": thread_pool_size,
+        "internal": internal,
+        "use_jump_host": use_jump_host,
+        "light": light,
+        "vault_output_path": vault_output_path,
+        "defer": defer,
+    }
 
     if enable_extended_early_exit and get_feature_toggle_state(
         "terraform-resources-extended-early-exit",

--- a/reconcile/terraform_tgw_attachments.py
+++ b/reconcile/terraform_tgw_attachments.py
@@ -528,12 +528,12 @@ def run(
         defer(tf.cleanup)
     if print_to_file:
         return
-    runner_params: RunnerParams = dict(
-        terraform_client=tf,
-        terrascript_client=ts,
-        enable_deletion=enable_deletion,
-        dry_run=dry_run,
-    )
+    runner_params: RunnerParams = {
+        "terraform_client": tf,
+        "terrascript_client": ts,
+        "enable_deletion": enable_deletion,
+        "dry_run": dry_run,
+    }
     if enable_extended_early_exit and get_feature_toggle_state(
         "terraform-tgw-attachments-extended-early-exit",
         default=False,

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -686,11 +686,11 @@ def run(
     if defer:
         defer(tf.cleanup)
 
-    runner_params: RunnerParams = dict(
-        tf=tf,
-        dry_run=dry_run,
-        enable_deletion=enable_deletion,
-    )
+    runner_params: RunnerParams = {
+        "tf": tf,
+        "dry_run": dry_run,
+        "enable_deletion": enable_deletion,
+    }
 
     if enable_extended_early_exit and get_feature_toggle_state(
         "terraform-vpc-peerings-extended-early-exit",

--- a/reconcile/terraform_vpc_peerings.py
+++ b/reconcile/terraform_vpc_peerings.py
@@ -44,7 +44,7 @@ def find_matching_peering(
     peering_info = to_cluster["peering"]
     peer_connections = peering_info["connections"]
     for peer_connection in peer_connections:
-        if not peer_connection["provider"] == desired_provider:
+        if peer_connection["provider"] != desired_provider:
             continue
         if not peer_connection["cluster"]:
             continue
@@ -318,7 +318,7 @@ def build_desired_state_vpc_mesh_single_cluster(
     for peer_connection in peer_connections:
         # We only care about account-vpc-mesh peering providers
         peer_connection_provider = peer_connection["provider"]
-        if not peer_connection_provider == "account-vpc-mesh":
+        if peer_connection_provider != "account-vpc-mesh":
             continue
         # filter on account
         account = peer_connection["account"]
@@ -443,7 +443,7 @@ def build_desired_state_vpc_single_cluster(
     for peer_connection in peer_connections:
         # We only care about account-vpc peering providers
         peer_connection_provider = peer_connection["provider"]
-        if not peer_connection_provider == "account-vpc":
+        if peer_connection_provider != "account-vpc":
             continue
         # requester is the cluster's AWS account
         requester = {

--- a/reconcile/terraform_vpc_resources/integration.py
+++ b/reconcile/terraform_vpc_resources/integration.py
@@ -74,7 +74,7 @@ class TerraformVpcResources(QontractReconcileIntegration[TerraformVpcResourcesPa
             # this happens because we are not filtering the requests
             # when running the integration for a single account with --account-name.
             # We also don't want to create outputs for deleted requets.
-            if request.account.name not in outputs.keys() or request.delete:
+            if request.account.name not in outputs or request.delete:
                 continue
 
             outputs_per_request[request.identifier] = []

--- a/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
+++ b/reconcile/test/aws_account_manager/test_aws_account_manager_reconciler.py
@@ -679,7 +679,7 @@ def test_aws_account_manager_reconcile_create_organization_account(
 ) -> None:
     reconciler._create_account = MagicMock(return_value="id")  # type: ignore
     reconciler._org_account_exists = MagicMock(return_value="uid")  # type: ignore
-    reconciler.create_organization_account(aws_api, "account", "email") == "uid"
+    assert reconciler.create_organization_account(aws_api, "account", "email") == "uid"
 
 
 def test_aws_account_manager_reconcile_create_organization_account_no_request(
@@ -687,7 +687,7 @@ def test_aws_account_manager_reconcile_create_organization_account_no_request(
 ) -> None:
     reconciler._create_account = MagicMock(return_value=None)  # type: ignore
     reconciler._org_account_exists = MagicMock(return_value="uid")  # type: ignore
-    reconciler.create_organization_account(aws_api, "account", "email") is None
+    assert reconciler.create_organization_account(aws_api, "account", "email") is None
     reconciler._org_account_exists.assert_not_called()
 
 
@@ -696,7 +696,7 @@ def test_aws_account_manager_reconcile_create_organization_account_not_created_y
 ) -> None:
     reconciler._create_account = MagicMock(return_value="id")  # type: ignore
     reconciler._org_account_exists = MagicMock(return_value=None)  # type: ignore
-    reconciler.create_organization_account(aws_api, "account", "email") is None
+    assert reconciler.create_organization_account(aws_api, "account", "email") is None
 
 
 def test_aws_account_manager_reconcile_create_iam_user(

--- a/reconcile/test/aws_account_manager/test_aws_account_manager_utils.py
+++ b/reconcile/test/aws_account_manager/test_aws_account_manager_utils.py
@@ -54,4 +54,4 @@ def test_aws_account_manager_utils_security_contact_is_set(
 def test_aws_account_manager_utils_state_key() -> None:
     account = "account"
     task = "task"
-    assert "task.account.task" == state_key(account, task)
+    assert state_key(account, task) == "task.account.task"

--- a/reconcile/test/change_owners/test_change_type_diff_splitting.py
+++ b/reconcile/test/change_owners/test_change_type_diff_splitting.py
@@ -213,7 +213,7 @@ def test_nested_splits() -> None:
 
     # check that the `top` field has a split for `top.sub` and is covered
     # by the `top` change-type
-    assert ["top.sub"] == [s.diff.path_str() for s in diffs["top"]._split_into]
+    assert [s.diff.path_str() for s in diffs["top"]._split_into] == ["top.sub"]
     assert diffs["top"].is_directly_covered()
     assert {ctx.change_type_processor.name for ctx in diffs["top"].coverage} == {
         top.change_type_processor.name
@@ -221,8 +221,8 @@ def test_nested_splits() -> None:
 
     # check that the `top.sub` field has a split for `top.sub.sub-sub` and is covered
     # by the `sub` and `top` change-types
-    assert ["top.sub.sub-sub"] == [
-        s.diff.path_str() for s in diffs["top.sub"]._split_into
+    assert [s.diff.path_str() for s in diffs["top.sub"]._split_into] == [
+        "top.sub.sub-sub"
     ]
     assert diffs["top.sub"].is_directly_covered()
     assert {ctx.change_type_processor.name for ctx in diffs["top.sub"].coverage} == {
@@ -232,7 +232,7 @@ def test_nested_splits() -> None:
 
     # check that the `top.sub.sub-sub` field is not split and is covered
     # by the `sub-sub`, `sub` and `top` change-types
-    assert [] == [s.diff.path_str() for s in diffs["top.sub.sub-sub"]._split_into]
+    assert [s.diff.path_str() for s in diffs["top.sub.sub-sub"]._split_into] == []
     assert diffs["top.sub.sub-sub"].is_directly_covered()
     assert not diffs["top.sub.sub-sub"].is_covered_by_splits()
     assert {

--- a/reconcile/test/change_owners/test_change_type_priorities.py
+++ b/reconcile/test/change_owners/test_change_type_priorities.py
@@ -41,7 +41,7 @@ def test_priority_for_changes(
         return_value=[change_type_to_processor(secret_promoter_change_type)]
     )
 
-    assert ChangeTypePriority.MEDIUM == get_priority_for_changes([c1, c2])
+    assert get_priority_for_changes([c1, c2]) == ChangeTypePriority.MEDIUM
 
 
 def test_priorty_for_changes_no_coverage() -> None:

--- a/reconcile/test/change_owners/test_change_type_various.py
+++ b/reconcile/test/change_owners/test_change_type_various.py
@@ -115,8 +115,8 @@ def test_templated_path_expression() -> None:
         )
     )
     assert (
-        "path.to.some.value.[?[Expression(Child(This(), Fields('name')) == 'some-file.yaml')]]"
-        == str(jsonpath)
+        str(jsonpath)
+        == "path.to.some.value.[?[Expression(Child(This(), Fields('name')) == 'some-file.yaml')]]"
     )
 
 

--- a/reconcile/test/cna/test_state_diff.py
+++ b/reconcile/test/cna/test_state_diff.py
@@ -263,7 +263,7 @@ def test_state_create_delete_update(
     assert deletions == expected_deletions
     assert updates == expected_updates
 
-    for update, expected_update in zip(updates, expected_updates):
+    for update, expected_update in zip(updates, expected_updates, strict=False):
         """
         The update should contain the uuid of the actual asset.
         Currently CNA does not support addressing w/o use of

--- a/reconcile/test/cna/test_state_overrides.py
+++ b/reconcile/test/cna/test_state_overrides.py
@@ -178,7 +178,7 @@ def test_state_iter():
         ),
     ]
     state = State(assets={AssetType.NULL: {asset.name: asset for asset in assets}})
-    iterated_assets = [asset for asset in state]
+    iterated_assets = list(state)
 
     assert len(assets) == len(iterated_assets)
     assert set(assets) == set(iterated_assets)

--- a/reconcile/test/ocm/aus/test_base.py
+++ b/reconcile/test/ocm/aus/test_base.py
@@ -254,7 +254,7 @@ def test_upgradeable_version_no_block(cluster_1: OCMCluster) -> None:
         upgradePolicy=build_upgrade_policy(workloads=["workload1"], soak_days=0),
         health=build_healthy_cluster_health(),
     )
-    assert "4.12.19" == base.upgradeable_version(upgrade_spec, VersionData(), None)
+    assert base.upgradeable_version(upgrade_spec, VersionData(), None) == "4.12.19"
 
 
 #
@@ -280,7 +280,7 @@ def test_sorted_version() -> None:
             ),
         ],
     )
-    assert ["cluster1", "cluster2", "cluster3"] == [s.cluster.name for s in org.specs]
+    assert [s.cluster.name for s in org.specs] == ["cluster1", "cluster2", "cluster3"]
 
 
 def test_sorted_soakdays() -> None:
@@ -301,7 +301,7 @@ def test_sorted_soakdays() -> None:
             ),
         ],
     )
-    assert ["cluster1", "cluster2", "cluster3"] == [s.cluster.name for s in org.specs]
+    assert [s.cluster.name for s in org.specs] == ["cluster1", "cluster2", "cluster3"]
 
 
 def test_sorted_version_soakdays() -> None:
@@ -328,8 +328,11 @@ def test_sorted_version_soakdays() -> None:
             ),
         ],
     )
-    assert ["cluster11", "cluster12", "cluster21", "cluster22"] == [
-        s.cluster.name for s in org.specs
+    assert [s.cluster.name for s in org.specs] == [
+        "cluster11",
+        "cluster12",
+        "cluster21",
+        "cluster22",
     ]
 
 

--- a/reconcile/test/ocm/aus/test_expose_metrics.py
+++ b/reconcile/test/ocm/aus/test_expose_metrics.py
@@ -21,7 +21,7 @@ def test_remaining_soak_day_metric_values_for_cluster_skip_early_ready() -> None
     Test that ready versions are skipped in metric reporting if there is a later
     version that is not ready.
     """
-    assert {"4.13.11": 0.0} == remaining_soak_day_metric_values_for_cluster(
+    assert remaining_soak_day_metric_values_for_cluster(
         spec=build_cluster_upgrade_spec(
             name="cluster1",
             current_version="4.13.0",
@@ -30,7 +30,7 @@ def test_remaining_soak_day_metric_values_for_cluster_skip_early_ready() -> None
         ),
         soaked_versions={},
         current_upgrade=None,
-    )
+    ) == {"4.13.11": 0.0}
 
 
 def test_remaining_soak_day_metric_values_for_cluster_skip_early_non_ready() -> None:
@@ -38,7 +38,7 @@ def test_remaining_soak_day_metric_values_for_cluster_skip_early_non_ready() -> 
     Test that still soaking versions are skipped in metric reporting if there is
     a later version that is not ready.
     """
-    assert {"4.13.11": 0.0} == remaining_soak_day_metric_values_for_cluster(
+    assert remaining_soak_day_metric_values_for_cluster(
         spec=build_cluster_upgrade_spec(
             name="cluster1",
             current_version="4.13.0",
@@ -47,7 +47,7 @@ def test_remaining_soak_day_metric_values_for_cluster_skip_early_non_ready() -> 
         ),
         soaked_versions={"4.13.10": 1.8, "4.13.11": 2.0},
         current_upgrade=None,
-    )
+    ) == {"4.13.11": 0.0}
 
 
 def test_remaining_soak_day_metric_values_for_cluster_skip_early_mixed() -> None:
@@ -55,7 +55,7 @@ def test_remaining_soak_day_metric_values_for_cluster_skip_early_mixed() -> None
     Test that still soaking versions and soakey versions are skipped in metric
     reporting if there is a later version that is not ready.
     """
-    assert {"4.13.11": 0.0} == remaining_soak_day_metric_values_for_cluster(
+    assert remaining_soak_day_metric_values_for_cluster(
         spec=build_cluster_upgrade_spec(
             name="cluster1",
             current_version="4.13.0",
@@ -64,17 +64,14 @@ def test_remaining_soak_day_metric_values_for_cluster_skip_early_mixed() -> None
         ),
         soaked_versions={"4.13.9": 2.0, "4.13.10": 1.8, "4.13.11": 2.0},
         current_upgrade=None,
-    )
+    ) == {"4.13.11": 0.0}
 
 
 def test_remaining_soak_day_metric_values_for_cluster_blocked_versions() -> None:
     """
     Test that blocked versions are reported as blocked
     """
-    assert {
-        "4.14.0-rc.1": UPGRADE_BLOCKED_METRIC_VALUE,
-        "4.14.0": 0.0,
-    } == remaining_soak_day_metric_values_for_cluster(
+    assert remaining_soak_day_metric_values_for_cluster(
         spec=build_cluster_upgrade_spec(
             name="cluster1",
             current_version="4.13.0",
@@ -84,7 +81,10 @@ def test_remaining_soak_day_metric_values_for_cluster_blocked_versions() -> None
         ),
         soaked_versions={},
         current_upgrade=None,
-    )
+    ) == {
+        "4.14.0-rc.1": UPGRADE_BLOCKED_METRIC_VALUE,
+        "4.14.0": 0.0,
+    }
 
 
 def test_remaining_soak_day_metric_values_for_cluster_blocked_versions_and_skip_early_ready() -> (
@@ -94,10 +94,7 @@ def test_remaining_soak_day_metric_values_for_cluster_blocked_versions_and_skip_
     Test that blocked versions are reported as blocked and do not interfere with
     skipping ready early versions.
     """
-    assert {
-        "4.14.0-rc.1": UPGRADE_BLOCKED_METRIC_VALUE,
-        "4.14.0": 0.0,
-    } == remaining_soak_day_metric_values_for_cluster(
+    assert remaining_soak_day_metric_values_for_cluster(
         spec=build_cluster_upgrade_spec(
             name="cluster1",
             current_version="4.13.0",
@@ -107,7 +104,10 @@ def test_remaining_soak_day_metric_values_for_cluster_blocked_versions_and_skip_
         ),
         soaked_versions={},
         current_upgrade=None,
-    )
+    ) == {
+        "4.14.0-rc.1": UPGRADE_BLOCKED_METRIC_VALUE,
+        "4.14.0": 0.0,
+    }
 
 
 def test_remaining_soak_day_metric_values_for_cluster_blocked_version_currently_upgrading() -> (
@@ -124,10 +124,7 @@ def test_remaining_soak_day_metric_values_for_cluster_blocked_version_currently_
         soak_days=0,
         blocked_versions=[r"^.*-rc\..*$"],
     )
-    assert {
-        "4.14.0-rc.1": UPGRADE_SCHEDULED_METRIC_VALUE,
-        "4.14.0": 0.0,
-    } == remaining_soak_day_metric_values_for_cluster(
+    assert remaining_soak_day_metric_values_for_cluster(
         spec=spec,
         soaked_versions={},
         current_upgrade=build_cluster_upgrade_policy(
@@ -135,7 +132,10 @@ def test_remaining_soak_day_metric_values_for_cluster_blocked_version_currently_
             version="4.14.0-rc.1",
             state="scheduled",
         ),
-    )
+    ) == {
+        "4.14.0-rc.1": UPGRADE_SCHEDULED_METRIC_VALUE,
+        "4.14.0": 0.0,
+    }
 
 
 def test_remaining_soak_day_metric_values_for_cluster_currently_upgrading() -> None:
@@ -149,10 +149,7 @@ def test_remaining_soak_day_metric_values_for_cluster_currently_upgrading() -> N
         available_upgrades=["4.13.11", "4.14.0"],
         soak_days=0,
     )
-    assert {
-        "4.13.11": UPGRADE_STARTED_METRIC_VALUE,
-        "4.14.0": 0.0,
-    } == remaining_soak_day_metric_values_for_cluster(
+    assert remaining_soak_day_metric_values_for_cluster(
         spec=spec,
         soaked_versions={},
         current_upgrade=build_cluster_upgrade_policy(
@@ -160,7 +157,10 @@ def test_remaining_soak_day_metric_values_for_cluster_currently_upgrading() -> N
             version="4.13.11",
             state="started",
         ),
-    )
+    ) == {
+        "4.13.11": UPGRADE_STARTED_METRIC_VALUE,
+        "4.14.0": 0.0,
+    }
 
 
 def test_remaining_soak_day_metric_values_for_cluster_currently_scheduled() -> None:
@@ -174,10 +174,7 @@ def test_remaining_soak_day_metric_values_for_cluster_currently_scheduled() -> N
         available_upgrades=["4.13.11", "4.14.0"],
         soak_days=0,
     )
-    assert {
-        "4.13.11": UPGRADE_SCHEDULED_METRIC_VALUE,
-        "4.14.0": 0.0,
-    } == remaining_soak_day_metric_values_for_cluster(
+    assert remaining_soak_day_metric_values_for_cluster(
         spec=spec,
         soaked_versions={},
         current_upgrade=build_cluster_upgrade_policy(
@@ -185,7 +182,10 @@ def test_remaining_soak_day_metric_values_for_cluster_currently_scheduled() -> N
             version="4.13.11",
             state="scheduled",
         ),
-    )
+    ) == {
+        "4.13.11": UPGRADE_SCHEDULED_METRIC_VALUE,
+        "4.14.0": 0.0,
+    }
 
 
 def test_remaining_soak_day_metric_values_for_cluster_currently_scheduled_skip_earlier() -> (
@@ -201,9 +201,7 @@ def test_remaining_soak_day_metric_values_for_cluster_currently_scheduled_skip_e
         available_upgrades=["4.13.11", "4.14.0"],
         soak_days=0,
     )
-    assert {
-        "4.14.0": UPGRADE_SCHEDULED_METRIC_VALUE
-    } == remaining_soak_day_metric_values_for_cluster(
+    assert remaining_soak_day_metric_values_for_cluster(
         spec=spec,
         soaked_versions={},
         current_upgrade=build_cluster_upgrade_policy(
@@ -211,7 +209,7 @@ def test_remaining_soak_day_metric_values_for_cluster_currently_scheduled_skip_e
             version="4.14.0",
             state="scheduled",
         ),
-    )
+    ) == {"4.14.0": UPGRADE_SCHEDULED_METRIC_VALUE}
 
 
 def test_remaining_soak_day_metric_values_for_cluster_currently_upgrading_skip_earlier() -> (
@@ -227,9 +225,7 @@ def test_remaining_soak_day_metric_values_for_cluster_currently_upgrading_skip_e
         available_upgrades=["4.13.11", "4.14.0"],
         soak_days=0,
     )
-    assert {
-        "4.14.0": UPGRADE_STARTED_METRIC_VALUE
-    } == remaining_soak_day_metric_values_for_cluster(
+    assert remaining_soak_day_metric_values_for_cluster(
         spec=spec,
         soaked_versions={},
         current_upgrade=build_cluster_upgrade_policy(
@@ -237,7 +233,7 @@ def test_remaining_soak_day_metric_values_for_cluster_currently_upgrading_skip_e
             version="4.14.0",
             state="started",
         ),
-    )
+    ) == {"4.14.0": UPGRADE_STARTED_METRIC_VALUE}
 
 
 def test_remaining_soak_day_metric_values_for_cluster_long_running_upgrade() -> None:
@@ -250,9 +246,7 @@ def test_remaining_soak_day_metric_values_for_cluster_long_running_upgrade() -> 
         available_upgrades=["4.13.11"],
         soak_days=0,
     )
-    assert {
-        "4.13.11": UPGRADE_LONG_RUNNING_METRIC_VALUE
-    } == remaining_soak_day_metric_values_for_cluster(
+    assert remaining_soak_day_metric_values_for_cluster(
         spec=spec,
         soaked_versions={},
         current_upgrade=build_cluster_upgrade_policy(
@@ -261,7 +255,7 @@ def test_remaining_soak_day_metric_values_for_cluster_long_running_upgrade() -> 
             state="started",
             next_run=datetime.utcnow() - timedelta(hours=7),
         ),
-    )
+    ) == {"4.13.11": UPGRADE_LONG_RUNNING_METRIC_VALUE}
 
 
 def test_remaining_soak_day_metric_values_for_cluster_not_filtering() -> None:
@@ -272,12 +266,12 @@ def test_remaining_soak_day_metric_values_for_cluster_not_filtering() -> None:
         soak_days=2,
         blocked_versions=[r"^4\.14\..*$"],
     )
-    assert {
-        "4.13.11": 0.0,
-        "4.13.12": 2.0,
-        "4.14.1": UPGRADE_BLOCKED_METRIC_VALUE,
-    } == remaining_soak_day_metric_values_for_cluster(
+    assert remaining_soak_day_metric_values_for_cluster(
         spec=spec,
         soaked_versions={"4.13.11": 2.0},
         current_upgrade=None,
-    )
+    ) == {
+        "4.13.11": 0.0,
+        "4.13.12": 2.0,
+        "4.14.1": UPGRADE_BLOCKED_METRIC_VALUE,
+    }

--- a/reconcile/test/ocm/conftest.py
+++ b/reconcile/test/ocm/conftest.py
@@ -116,10 +116,7 @@ def _request_matches(
     if f"{parsed_url.scheme}://{parsed_url.netloc}" != base_url:
         return False
 
-    if path and parsed_url.path != path:
-        return False
-
-    return True
+    return not (path and parsed_url.path != path)
 
 
 @pytest.fixture

--- a/reconcile/test/ocm/test_utils_ocm_clusters.py
+++ b/reconcile/test/ocm/test_utils_ocm_clusters.py
@@ -342,7 +342,7 @@ def test_get_service_clusters_empty(mocker: MockFixture) -> None:
     ocm = mocker.patch("reconcile.utils.ocm_base_client.OCMBaseClient", autospec=True)
     ocm.get_paginated.return_value = []
 
-    service_clusters = [cluster for cluster in get_service_clusters(ocm_api=ocm)]
+    service_clusters = list(get_service_clusters(ocm_api=ocm))
 
     assert service_clusters == []
 
@@ -373,6 +373,6 @@ def test_get_service_clusters_no_provision_shard(mocker: MockFixture) -> None:
 
     ocm.get_paginated.return_value = [data_a, data_b]
 
-    service_clusters = [cluster for cluster in get_service_clusters(ocm_api=ocm)]
+    service_clusters = list(get_service_clusters(ocm_api=ocm))
 
     assert service_clusters == [cluster_a]

--- a/reconcile/test/ocm/test_utils_ocm_manifest.py
+++ b/reconcile/test/ocm/test_utils_ocm_manifest.py
@@ -58,7 +58,7 @@ def test_utils_get_manifests(
 
     response = manifests.get_manifests(ocm_client=ocm_api, cluster_id=cluster_id)
 
-    assert [item for item in response] == [manifest_a, manifest_b]
+    assert list(response) == [manifest_a, manifest_b]
 
     get_manifests_call.assert_called_once_with(
         ocm_client=ocm_api, cluster_id=cluster_id

--- a/reconcile/test/ocm/test_utils_ocm_search_filters.py
+++ b/reconcile/test/ocm/test_utils_ocm_search_filters.py
@@ -19,7 +19,7 @@ from reconcile.utils.ocm.search_filters import (
 
 
 def test_search_filter_eq() -> None:
-    assert "some_field='some_value'" == Filter().eq("some_field", "some_value").render()
+    assert Filter().eq("some_field", "some_value").render() == "some_field='some_value'"
 
 
 def test_search_filter_eq_none_value() -> None:
@@ -29,8 +29,8 @@ def test_search_filter_eq_none_value() -> None:
 
 def test_search_filter_is_in() -> None:
     assert (
-        "some_field in ('a','b','c')"
-        == Filter().is_in("some_field", ["a", "b", "c"]).render()
+        Filter().is_in("some_field", ["a", "b", "c"]).render()
+        == "some_field in ('a','b','c')"
     )
 
 
@@ -48,29 +48,29 @@ def test_search_filter_is_in_one_items() -> None:
 def test_search_filter_merge_eq_eq_and() -> None:
     f1 = Filter().eq("some_field", "a")
     f2 = Filter().eq("some_field", "b")
-    assert "some_field in ('a','b')" == (f1 & f2).render()
+    assert (f1 & f2).render() == "some_field in ('a','b')"
 
 
 def test_search_filter_merge_eq_eq_chain() -> None:
     f = Filter().eq("some_field", "a").eq("some_field", "b")
-    assert "some_field in ('a','b')" == f.render()
+    assert f.render() == "some_field in ('a','b')"
 
 
 def test_search_filter_merge_eq_is_in_and() -> None:
     f1 = Filter().eq("some_field", "a")
     f2 = Filter().is_in("some_field", ["b", "c"])
-    assert "some_field in ('a','b','c')" == (f1 & f2).render()
+    assert (f1 & f2).render() == "some_field in ('a','b','c')"
 
 
 def test_search_filter_merge_eq_is_in_chain() -> None:
     f = Filter().eq("some_field", "a").is_in("some_field", ["b", "c"])
-    assert "some_field in ('a','b','c')" == f.render()
+    assert f.render() == "some_field in ('a','b','c')"
 
 
 def test_search_filter_merge_eq_is_in_dedup() -> None:
     f1 = Filter().eq("some_field", "a")
     f2 = Filter().is_in("some_field", ["a", "b", "c"])
-    assert "some_field in ('a','b','c')" == (f1 & f2).render()
+    assert (f1 & f2).render() == "some_field in ('a','b','c')"
 
 
 #
@@ -80,8 +80,8 @@ def test_search_filter_merge_eq_is_in_dedup() -> None:
 
 def test_search_filter_like() -> None:
     assert (
-        "some_field like 'some_value%'"
-        == Filter().like("some_field", "some_value%").render()
+        Filter().like("some_field", "some_value%").render()
+        == "some_field like 'some_value%'"
     )
 
 
@@ -93,12 +93,12 @@ def test_search_filter_like_none_value() -> None:
 def test_search_filter_merge_like_merge() -> None:
     f1 = Filter().like("some_field", "a%")
     f2 = Filter().like("some_field", "b%")
-    assert "(some_field like 'a%' or some_field like 'b%')" == (f1 & f2).render()
+    assert (f1 & f2).render() == "(some_field like 'a%' or some_field like 'b%')"
 
 
 def test_search_filter_merge_like_chain() -> None:
     f = Filter().like("some_field", "a%").like("some_field", "b%")
-    assert "(some_field like 'a%' or some_field like 'b%')" == f.render()
+    assert f.render() == "(some_field like 'a%' or some_field like 'b%')"
 
 
 #
@@ -234,7 +234,7 @@ def test_search_filter_chain_conditions() -> None:
     multi_filter = (
         Filter().eq("some_field", "some_value").is_in("some_list", ["a", "b"])
     )
-    assert "some_field='some_value' and some_list in ('a','b')" == multi_filter.render()
+    assert multi_filter.render() == "some_field='some_value' and some_list in ('a','b')"
 
 
 def test_search_filter_combine_different_conditions() -> None:
@@ -244,9 +244,9 @@ def test_search_filter_combine_different_conditions() -> None:
     f4 = Filter().like("like_field", "b%")
     combined = f1 & f2 & f3 & f4
     assert (
-        "eq_field_1='some_value' and eq_field_2='some_other_value' and "
+        combined.render()
+        == "eq_field_1='some_value' and eq_field_2='some_other_value' and "
         + "(like_field like 'a%' or like_field like 'b%')"
-        == combined.render()
     )
 
 
@@ -259,7 +259,7 @@ def test_search_filter_immutability() -> None:
     eq_filter = Filter().eq("some_field", "some_value")
     derive_filter = eq_filter.eq("some_other_field", "some_other_value")
     assert eq_filter != derive_filter
-    assert "some_field='some_value'" == eq_filter.render()
+    assert eq_filter.render() == "some_field='some_value'"
 
 
 #
@@ -272,8 +272,8 @@ def test_search_filter_or() -> None:
     f2 = Filter().eq("some_other_field", "some_other_value")
     or_condition = f1 | f2
     assert (
-        "(some_field='some_value' or some_other_field='some_other_value')"
-        == or_condition.render()
+        or_condition.render()
+        == "(some_field='some_value' or some_other_field='some_other_value')"
     )
 
 
@@ -283,8 +283,8 @@ def test_search_filter_combine_and_or() -> None:
     or_condition = f1 | f2
     combined_filter = Filter().eq("eq_field", "eq_value") & or_condition
     assert (
-        "(some_field='some_value' or some_other_field='some_other_value') and eq_field='eq_value'"
-        == combined_filter.render()
+        combined_filter.render()
+        == "(some_field='some_value' or some_other_field='some_other_value') and eq_field='eq_value'"
     )
 
 
@@ -294,8 +294,8 @@ def test_search_filter_combine_or_and() -> None:
     or_condition = f1 | f2
     combined_filter = or_condition & Filter().eq("eq_field", "eq_value")
     assert (
-        "(some_field='some_value' or some_other_field='some_other_value') and eq_field='eq_value'"
-        == combined_filter.render()
+        combined_filter.render()
+        == "(some_field='some_value' or some_other_field='some_other_value') and eq_field='eq_value'"
     )
 
 

--- a/reconcile/test/ocm/test_utils_ocm_syncset.py
+++ b/reconcile/test/ocm/test_utils_ocm_syncset.py
@@ -58,7 +58,7 @@ def test_utils_get_syncsets(
 
     response = syncsets.get_syncsets(ocm_client=ocm_api, cluster_id=cluster_id)
 
-    assert [item for item in response] == [syncet_a, syncset_b]
+    assert list(response) == [syncet_a, syncset_b]
 
     get_syncsets_call.assert_called_once_with(ocm_client=ocm_api, cluster_id=cluster_id)
 

--- a/reconcile/test/skupper_network/test_skupper_network_reconciler.py
+++ b/reconcile/test/skupper_network/test_skupper_network_reconciler.py
@@ -207,11 +207,7 @@ def test_skupper_network_reconciler_connect_sites(
         assert transfer_token.call_count == 0
         assert create_token.call_count == 0
         assert get_token.call_count == 0
-    elif local_token:
-        assert transfer_token.call_count == 0
-        assert create_token.call_count == 0
-        assert get_token.call_count == 1
-    elif not local_token and not remote_site_exists:
+    elif local_token or not local_token and not remote_site_exists:
         assert transfer_token.call_count == 0
         assert create_token.call_count == 0
         assert get_token.call_count == 1
@@ -284,9 +280,7 @@ def test_skupper_network_reconciler_delete_unused_tokens(
         oc_map,
         dry_run=dry_run,
     )
-    if dry_run:
-        assert oc.delete.call_count == 0
-    elif not token_secrets:
+    if dry_run or not token_secrets:
         assert oc.delete.call_count == 0
     else:
         assert oc.delete.call_count == expected_deletion_count

--- a/reconcile/test/skupper_network/test_skupper_network_reconciler.py
+++ b/reconcile/test/skupper_network/test_skupper_network_reconciler.py
@@ -64,9 +64,12 @@ def test_skupper_network_reconciler_get_token(
     fake_site_configmap: dict[str, Any],
 ) -> None:
     oc.get.return_value = fake_site_configmap
-    reconciler._get_token(
-        oc_map, skupper_sites[0], name=fake_site_configmap["metadata"]["name"]
-    ) == fake_site_configmap
+    assert (
+        reconciler._get_token(
+            oc_map, skupper_sites[0], name=fake_site_configmap["metadata"]["name"]
+        )
+        == fake_site_configmap
+    )
 
 
 @pytest.mark.parametrize("dry_run", [True, False])

--- a/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
+++ b/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
@@ -97,12 +97,12 @@ def mock_terraform_client(mocker: MockerFixture) -> MockerFixture:
 
 def secret_reader_side_effect(*args: Any) -> dict[str, Any] | None:
     """Mocking a secret reader call for aws account credentials"""
-    if {
+    if args[0] == {
         "path": "some-path",
         "field": "some-field",
         "version": None,
         "format": None,
-    } == args[0]:
+    }:
         return {
             "aws_access_key_id": "key_id",
             "aws_secret_access_key": "access_key",

--- a/reconcile/test/test_aws_cloudwatch_log_retention.py
+++ b/reconcile/test/test_aws_cloudwatch_log_retention.py
@@ -1,8 +1,5 @@
 from collections.abc import Generator
-from datetime import (
-    datetime,
-    timedelta,
-)
+from datetime import UTC, datetime, timedelta
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -97,7 +94,7 @@ def setup_mocks(
     aws_accounts: list[dict],
     log_groups: list[dict],
     tags: dict[str, Any],
-    utcnow: datetime = datetime.utcnow(),
+    utcnow: datetime = datetime.now(UTC),  # noqa: B008
 ) -> MagicMock:
     mocker.patch(
         "reconcile.aws_cloudwatch_log_retention.integration.get_aws_accounts",

--- a/reconcile/test/test_github_org.py
+++ b/reconcile/test/test_github_org.py
@@ -85,22 +85,24 @@ class TestGithubOrg:
     def do_current_state_test(path):
         fixture = fxt.get_anymarkup(path)
 
-        with patch("reconcile.github_org.RawGithubApi") as m_rga:
-            with patch("reconcile.github_org.Github") as m_gh:
-                m_gh.return_value = GithubMock(fixture["gh_api"])
-                m_rga.return_value = RawGithubApiMock()
+        with (
+            patch("reconcile.github_org.RawGithubApi") as m_rga,
+            patch("reconcile.github_org.Github") as m_gh,
+        ):
+            m_gh.return_value = GithubMock(fixture["gh_api"])
+            m_rga.return_value = RawGithubApiMock()
 
-                gh_api_store = github_org.GHApiStore(config.get_config())
-                current_state = github_org.fetch_current_state(gh_api_store)
-                current_state = current_state.dump()
+            gh_api_store = github_org.GHApiStore(config.get_config())
+            current_state = github_org.fetch_current_state(gh_api_store)
+            current_state = current_state.dump()
 
-                expected_current_state = fixture["state"]
+            expected_current_state = fixture["state"]
 
-                assert len(current_state) == len(expected_current_state)
-                for group in current_state:
-                    params = group["params"]
-                    items = sorted(group["items"])
-                    assert items == get_items_by_params(expected_current_state, params)
+            assert len(current_state) == len(expected_current_state)
+            for group in current_state:
+                params = group["params"]
+                items = sorted(group["items"])
+                assert items == get_items_by_params(expected_current_state, params)
 
     @staticmethod
     def do_desired_state_test(path):

--- a/reconcile/test/test_github_repo_invites.py
+++ b/reconcile/test/test_github_repo_invites.py
@@ -47,15 +47,15 @@ def test_parse_valid_code_components():
         },
     ]
     expected = github_repo_invites.CodeComponents(
-        urls=set([
+        urls={
             "https://github.com/org1/project1",
             "https://github.com/org2/project1",
             "https://github.com/org2/project2",
-        ]),
-        known_orgs=set([
+        },
+        known_orgs={
             "https://github.com/org1",
             "https://github.com/org2",
-        ]),
+        },
     )
     assert github_repo_invites._parse_code_components(raw_code_components) == expected
 
@@ -84,8 +84,8 @@ def test_accept_invitations_no_dry_run(github):
         ]
     ]
     code_components = github_repo_invites.CodeComponents(
-        urls=set([f"{expected_org}/project1"]),
-        known_orgs=set([expected_org]),
+        urls={f"{expected_org}/project1"},
+        known_orgs={expected_org},
     )
     dry_run = False
     accepted_invitations = github_repo_invites._accept_invitations(
@@ -93,7 +93,7 @@ def test_accept_invitations_no_dry_run(github):
     )
 
     github.accept_repo_invitation.assert_called_once_with(expected_id)
-    assert accepted_invitations == set([expected_org])
+    assert accepted_invitations == {expected_org}
 
 
 def test_accept_invitations_dry_run(github):
@@ -107,8 +107,8 @@ def test_accept_invitations_dry_run(github):
         ],
     ]
     code_components = github_repo_invites.CodeComponents(
-        urls=set([f"{expected_org}/project1"]),
-        known_orgs=set([expected_org]),
+        urls={f"{expected_org}/project1"},
+        known_orgs={expected_org},
     )
     dry_run = True
     accepted_invitations = github_repo_invites._accept_invitations(
@@ -116,4 +116,4 @@ def test_accept_invitations_dry_run(github):
     )
 
     github.accept_repo_invitation.assert_not_called()
-    assert accepted_invitations == set([expected_org])
+    assert accepted_invitations == {expected_org}

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -71,7 +71,7 @@ def test_collect_parameters() -> None:
     template = {
         "parameters": [
             {
-                "name": "tplt_param",
+                "name": "TPLT_PARAM",
                 "value": "default",
             }
         ]
@@ -82,7 +82,7 @@ def test_collect_parameters() -> None:
     parameters = intop.collect_parameters(template, environment, "", "", None)
     expected = {
         "env_param": "test",
-        "tplt_param": "override",
+        "TPLT_PARAM": "override",
     }
     assert parameters == expected
 
@@ -108,16 +108,16 @@ def test_collect_parameters_os_env_strongest() -> None:
     template = {
         "parameters": [
             {
-                "name": "env_param",
+                "name": "ENV_PARAM",
                 "value": "default",
             }
         ]
     }
     os.environ["ENV_PARAM"] = "strongest"
-    environment = EnvironmentV1(name="env", parameters='{"env_param": "override"}')
+    environment = EnvironmentV1(name="env", parameters='{"ENV_PARAM": "override"}')
     parameters = intop.collect_parameters(template, environment, "", "", None)
     expected = {
-        "env_param": "strongest",
+        "ENV_PARAM": "strongest",
     }
     assert parameters == expected
 

--- a/reconcile/test/test_integrations_manager.py
+++ b/reconcile/test/test_integrations_manager.py
@@ -76,7 +76,7 @@ def test_collect_parameters() -> None:
             }
         ]
     }
-    os.environ["tplt_param"] = "override"
+    os.environ["TPLT_PARAM"] = "override"
     environment = EnvironmentV1(name="e", parameters='{"env_param": "test"}')
 
     parameters = intop.collect_parameters(template, environment, "", "", None)
@@ -113,7 +113,7 @@ def test_collect_parameters_os_env_strongest() -> None:
             }
         ]
     }
-    os.environ["env_param"] = "strongest"
+    os.environ["ENV_PARAM"] = "strongest"
     environment = EnvironmentV1(name="env", parameters='{"env_param": "override"}')
     parameters = intop.collect_parameters(template, environment, "", "", None)
     expected = {
@@ -487,19 +487,19 @@ def shard_manager(
 def test_shard_manager_aws_account_filtering(
     aws_account_sharding_strategy: AWSAccountShardingStrategy,
 ) -> None:
-    assert ["acc-1", "acc-2", "acc-3", "acc-4"] == [
+    assert [
         a.name
         for a in aws_account_sharding_strategy.filter_objects("another-integration")
-    ]
+    ] == ["acc-1", "acc-2", "acc-3", "acc-4"]
 
 
 def test_shard_manager_aws_account_filtering_disabled(
     aws_account_sharding_strategy: AWSAccountShardingStrategy,
 ) -> None:
     # acc-4 is disabled for AWS_INTEGRATION
-    assert ["acc-1", "acc-2", "acc-3"] == [
+    assert [
         a.name for a in aws_account_sharding_strategy.filter_objects(AWS_INTEGRATION)
-    ]
+    ] == ["acc-1", "acc-2", "acc-3"]
 
 
 #

--- a/reconcile/test/test_ocm_additional_routers.py
+++ b/reconcile/test/test_ocm_additional_routers.py
@@ -50,14 +50,14 @@ class TestOCMAdditionalRouters(TestCase):
 
         router_create = ocm_act["create"]
         expected = []
-        for c in router_create.keys():
+        for c in router_create:
             expected.append(call(c, router_create[c]))
         calls = ocm.create_additional_router.call_args_list
         self.assertEqual(calls, expected)
 
         router_delete = ocm_act["delete"]
         expected = []
-        for c in router_delete.keys():
+        for c in router_delete:
             expected.append(call(c, router_delete[c]))
         calls = ocm.delete_additional_router.call_args_list
         self.assertEqual(calls, expected)
@@ -73,7 +73,7 @@ class TestOCMAdditionalRouters(TestCase):
 
         ocm_api = fixture["ocm_api"]
         clusters = []
-        for c in ocm_api.keys():
+        for c in ocm_api:
             clusters.append({"name": c})
         ocm = get.return_value
         ocm.get_additional_routers.side_effect = lambda x: fixture["ocm_api"][x]
@@ -108,7 +108,7 @@ class TestOCMAdditionalRouters(TestCase):
 
         ocm_api = fixture["ocm_api"]
         clusters = []
-        for c in ocm_api.keys():
+        for c in ocm_api:
             clusters.append({"name": c})
         ocm = get.return_value
 
@@ -120,14 +120,14 @@ class TestOCMAdditionalRouters(TestCase):
 
         router_create = ocm_act["create"]
         expected = []
-        for c in router_create.keys():
+        for c in router_create:
             expected.append(call(c, router_create[c]))
         calls = ocm.create_additional_router.call_args_list
         self.assertEqual(calls, expected)
 
         router_delete = ocm_act["delete"]
         expected = []
-        for c in router_delete.keys():
+        for c in router_delete:
             expected.append(call(c, router_delete[c]))
         calls = ocm.delete_additional_router.call_args_list
         self.assertEqual(calls, expected)

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -1,3 +1,4 @@
+# ruff: noqa: SIM117
 import typing
 from unittest.mock import patch
 

--- a/reconcile/test/test_ocm_update_recommended_version.py
+++ b/reconcile/test/test_ocm_update_recommended_version.py
@@ -29,14 +29,14 @@ def test_get_highest(version_set):
     highest = get_highest(version_set)
     assert highest == "1.1.1"
 
-    assert get_highest(set(["1.1.1"])) == "1.1.1"
+    assert get_highest({"1.1.1"}) == "1.1.1"
 
 
 def test_get_majority(versions, version_set):
     majority = get_majority(version_set, versions)
     assert majority == "1.1.0"
 
-    assert get_majority(set(["1.1.1"]), ["1.1.1"]) == "1.1.1"
+    assert get_majority({"1.1.1"}, ["1.1.1"]) == "1.1.1"
 
 
 def test_recommended_version(versions, version_set):

--- a/reconcile/test/test_openshift_serviceaccount_tokens.py
+++ b/reconcile/test/test_openshift_serviceaccount_tokens.py
@@ -125,7 +125,7 @@ def test_openshift_serviceaccount_tokens__write_outputs_to_vault(
         value=construct_sa_token_oc_resource("name", "token"),
     )
     write_outputs_to_vault(vault_client, "path/to/secrets", ri)
-    vault_client.write.call_count == 2
+    assert vault_client.write.call_count == 2
     vault_client.write.assert_has_calls([
         call({
             "path": "path/to/secrets/openshift-serviceaccount-tokens/cluster/namespace/name",
@@ -167,14 +167,14 @@ def test_openshift_serviceaccount_tokens__canonicalize_namespaces(
     assert nss[2].openshift_service_account_tokens is None
 
     # namespace with tokens or shared resources defined
-    nss[3].name == "with-shared-resources"
-    nss[3].cluster.name == "cluster"
+    assert nss[3].name == "with-shared-resources"
+    assert nss[3].cluster.name == "cluster"
     assert len(nss[3].openshift_service_account_tokens or []) == 1
 
-    nss[4].name == "with-openshift-serviceaccount-tokens"
+    assert nss[4].name == "with-openshift-serviceaccount-tokens"
     assert len(nss[4].openshift_service_account_tokens or []) == 2
 
-    nss[5].name == "with-openshift-serviceaccount-tokens-and-shared-resources"
+    assert nss[5].name == "with-openshift-serviceaccount-tokens-and-shared-resources"
     assert len(nss[5].openshift_service_account_tokens or []) == 2
 
 

--- a/reconcile/test/test_openshift_tekton_resources.py
+++ b/reconcile/test/test_openshift_tekton_resources.py
@@ -121,7 +121,7 @@ class TestOpenshiftTektonResources:
         self.test_data.providers = [self.provider1, self.provider2_wr]
 
         tkn_providers = otr.fetch_tkn_providers(None)
-        keys_expected = set([self.provider1["name"], self.provider2_wr["name"]])
+        keys_expected = {self.provider1["name"], self.provider2_wr["name"]}
         assert tkn_providers.keys() == keys_expected
 
     def test_duplicate_providers(self) -> None:
@@ -146,10 +146,10 @@ class TestOpenshiftTektonResources:
         self.test_data.providers = [self.provider1]
         desired_resources = otr.fetch_desired_resources(otr.fetch_tkn_providers(None))
 
-        expected_task_names = set([
+        expected_task_names = {
             "o-push-gateway-openshift-saas-deploy-task-status-metric",
             "o-openshift-saas-deploy-saas1",
-        ])
+        }
         expected_pipeline_name = "o-saas-deploy-saas1"
 
         task_names = set()

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -1487,39 +1487,39 @@ def test_render_templated_parameters(
     assert saas_file.resource_templates[0].targets[0].secret_parameters == [
         SaasResourceTemplateTargetV2_SaasSecretParametersV1(
             name="no-template",
-            secret=dict(
-                path="path/to/secret",
-                field="secret_key",
-                version=1,
-                format=None,
-            ),
+            secret={
+                "path": "path/to/secret",
+                "field": "secret_key",
+                "version": 1,
+                "format": None,
+            },
         ),
         SaasResourceTemplateTargetV2_SaasSecretParametersV1(
             name="ignore-go-template",
-            secret=dict(
-                path="path/{{ .GO_PARAM }}/secret",
-                field="{{ .GO_PARAM }}-secret_key",
-                version=1,
-                format=None,
-            ),
+            secret={
+                "path": "path/{{ .GO_PARAM }}/secret",
+                "field": "{{ .GO_PARAM }}-secret_key",
+                "version": 1,
+                "format": None,
+            },
         ),
         SaasResourceTemplateTargetV2_SaasSecretParametersV1(
             name="template-param-1",
-            secret=dict(
-                path="path/appsres03ue1/test-namespace/secret",
-                field="secret_key",
-                version=1,
-                format=None,
-            ),
+            secret={
+                "path": "path/appsres03ue1/test-namespace/secret",
+                "field": "secret_key",
+                "version": 1,
+                "format": None,
+            },
         ),
         SaasResourceTemplateTargetV2_SaasSecretParametersV1(
             name="template-param-2",
-            secret=dict(
-                path="path/appsres03ue1/test-namespace/secret",
-                field="App-SRE-stage-secret_key",
-                version=1,
-                format=None,
-            ),
+            secret={
+                "path": "path/appsres03ue1/test-namespace/secret",
+                "field": "App-SRE-stage-secret_key",
+                "version": 1,
+                "format": None,
+            },
         ),
     ]
 
@@ -1549,38 +1549,38 @@ def test_render_templated_parameters_in_init(
     assert saas_file.resource_templates[0].targets[0].secret_parameters == [
         SaasResourceTemplateTargetV2_SaasSecretParametersV1(
             name="no-template",
-            secret=dict(
-                path="path/to/secret",
-                field="secret_key",
-                version=1,
-                format=None,
-            ),
+            secret={
+                "path": "path/to/secret",
+                "field": "secret_key",
+                "version": 1,
+                "format": None,
+            },
         ),
         SaasResourceTemplateTargetV2_SaasSecretParametersV1(
             name="ignore-go-template",
-            secret=dict(
-                path="path/{{ .GO_PARAM }}/secret",
-                field="{{ .GO_PARAM }}-secret_key",
-                version=1,
-                format=None,
-            ),
+            secret={
+                "path": "path/{{ .GO_PARAM }}/secret",
+                "field": "{{ .GO_PARAM }}-secret_key",
+                "version": 1,
+                "format": None,
+            },
         ),
         SaasResourceTemplateTargetV2_SaasSecretParametersV1(
             name="template-param-1",
-            secret=dict(
-                path="path/appsres03ue1/test-namespace/secret",
-                field="secret_key",
-                version=1,
-                format=None,
-            ),
+            secret={
+                "path": "path/appsres03ue1/test-namespace/secret",
+                "field": "secret_key",
+                "version": 1,
+                "format": None,
+            },
         ),
         SaasResourceTemplateTargetV2_SaasSecretParametersV1(
             name="template-param-2",
-            secret=dict(
-                path="path/appsres03ue1/test-namespace/secret",
-                field="App-SRE-stage-secret_key",
-                version=1,
-                format=None,
-            ),
+            secret={
+                "path": "path/appsres03ue1/test-namespace/secret",
+                "field": "App-SRE-stage-secret_key",
+                "version": 1,
+                "format": None,
+            },
         ),
     ]

--- a/reconcile/test/test_sql_query.py
+++ b/reconcile/test/test_sql_query.py
@@ -107,7 +107,7 @@ def setup_mocks(
     mocked_queries.get_app_interface_settings.return_value = {}
     mocked_queries.get_app_interface_sql_queries.return_value = [sql_query]
     mocked_state = create_autospec(State)
-    mocked_state.ls.return_value = [f"/{k}" for k in state.keys()]
+    mocked_state.ls.return_value = [f"/{k}" for k in state]
     mocked_state.__getitem__.side_effect = lambda x: state[x]
     mocked_secret_reader = mocker.patch("reconcile.sql_query.SecretReader")
     mocked_secret_reader.return_value.read_all_secret.return_value = (

--- a/reconcile/test/test_terraform_cloudflare_resources.py
+++ b/reconcile/test/test_terraform_cloudflare_resources.py
@@ -166,23 +166,23 @@ def mock_app_interface_vault_settings(mocker):
 
 
 def secret_reader_side_effect(*args):
-    if {
+    if args[0] == {
         "path": "aws-account-path",
         "field": "token",
         "version": 1,
         "q_format": "plain",
-    } == args[0]:
+    }:
         aws_acct_creds = {}
         aws_acct_creds["aws_access_key_id"] = "key_id"
         aws_acct_creds["aws_secret_access_key"] = "access_key"
         return aws_acct_creds
 
-    if {
+    if args[0] == {
         "path": "cf-account-path",
         "field": "key",
         "version": 1,
         "q_format": "plain",
-    } == args[0]:
+    }:
         cf_acct_creds = {}
         cf_acct_creds["api_token"] = "api_token"
         cf_acct_creds["account_id"] = "account_id"
@@ -289,8 +289,8 @@ def test_cloudflare_accounts_validation(
     with caplog.at_level(logging.INFO), pytest.raises(SystemExit) as sample:
         integ.run(True, None, False, 10)
     assert sample.value.code == 0
-    assert ["No Cloudflare accounts were detected, nothing to do."] == [
-        rec.message for rec in caplog.records
+    assert [rec.message for rec in caplog.records] == [
+        "No Cloudflare accounts were detected, nothing to do."
     ]
 
 
@@ -313,8 +313,8 @@ def test_namespace_validation(
     with caplog.at_level(logging.INFO), pytest.raises(SystemExit) as sample:
         integ.run(True, None, False, 10)
     assert sample.value.code == 0
-    assert ["No namespaces were detected, nothing to do."] == [
-        rec.message for rec in caplog.records
+    assert [rec.message for rec in caplog.records] == [
+        "No namespaces were detected, nothing to do."
     ]
 
 
@@ -356,27 +356,27 @@ def test_cloudflare_namespace_validation(
     with caplog.at_level(logging.INFO), pytest.raises(SystemExit) as sample:
         integ.run(True, None, False, 10)
     assert sample.value.code == 0
-    assert ["No cloudflare namespaces were detected, nothing to do."] == [
-        rec.message for rec in caplog.records
+    assert [rec.message for rec in caplog.records] == [
+        "No cloudflare namespaces were detected, nothing to do."
     ]
 
 
 def custom_ssl_secret_reader_side_effect(*args):
     """For use of secret_reader inside cloudflare client"""
-    if {
+    if args[0] == {
         "path": "certificate/secret/cert/path",
         "field": "certificate.crt",
         "version": 1,
         "q_format": "plain",
-    } == args[0]:
+    }:
         return "----- CERTIFICATE -----"
 
-    if {
+    if args[0] == {
         "path": "certificate/secret/cert/path",
         "field": "certificate.key",
         "version": 1,
         "q_format": "plain",
-    } == args[0]:
+    }:
         return "----- KEY -----"
 
 

--- a/reconcile/test/test_terraform_cloudflare_users.py
+++ b/reconcile/test/test_terraform_cloudflare_users.py
@@ -426,23 +426,23 @@ def app_interface_settings_cloudflare_and_vault():
 
 
 def secret_reader_side_effect(*args):
-    if {
+    if args[0] == {
         "path": "some-path",
         "field": "some-field",
         "version": None,
         "q_format": None,
-    } == args[0]:
+    }:
         aws_acct_creds = {}
         aws_acct_creds["aws_access_key_id"] = "key_id"
         aws_acct_creds["aws_secret_access_key"] = "access_key"
         return aws_acct_creds
 
-    if {
+    if args[0] == {
         "path": "creds",
         "field": "some-field",
         "version": None,
         "q_format": None,
-    } == args[0]:
+    }:
         cf_acct_creds = {}
         cf_acct_creds["api_token"] = "api_token"
         cf_acct_creds["account_id"] = "account_id"

--- a/reconcile/test/test_terraform_resources.py
+++ b/reconcile/test/test_terraform_resources.py
@@ -449,22 +449,22 @@ def test_terraform_resources_runner_dry_run(
 
     defer = MagicMock()
 
-    runner_params = dict(
-        accounts=[{"name": "a"}],
-        account_names={"a"},
-        tf_namespaces=[],
-        tf=tf,
-        ts=ts,
-        secret_reader=secret_reader,
-        dry_run=True,
-        enable_deletion=False,
-        thread_pool_size=10,
-        internal=None,
-        use_jump_host=True,
-        light=False,
-        vault_output_path="",
-        defer=defer,
-    )
+    runner_params = {
+        "accounts": [{"name": "a"}],
+        "account_names": {"a"},
+        "tf_namespaces": [],
+        "tf": tf,
+        "ts": ts,
+        "secret_reader": secret_reader,
+        "dry_run": True,
+        "enable_deletion": False,
+        "thread_pool_size": 10,
+        "internal": None,
+        "use_jump_host": True,
+        "light": False,
+        "vault_output_path": "",
+        "defer": defer,
+    }
 
     result = integ.runner(**runner_params)
 
@@ -494,22 +494,22 @@ def test_terraform_resources_runner_no_dry_run(
     mocked_ob = mocker.patch("reconcile.terraform_resources.ob")
     mocked_ob.realize_data.return_value = [{"action": "applied"}]
 
-    runner_params = dict(
-        accounts=[{"name": "a"}],
-        account_names={"a"},
-        tf_namespaces=[],
-        tf=tf,
-        ts=ts,
-        secret_reader=secret_reader,
-        dry_run=False,
-        enable_deletion=False,
-        thread_pool_size=10,
-        internal=None,
-        use_jump_host=True,
-        light=False,
-        vault_output_path="",
-        defer=defer,
-    )
+    runner_params = {
+        "accounts": [{"name": "a"}],
+        "account_names": {"a"},
+        "tf_namespaces": [],
+        "tf": tf,
+        "ts": ts,
+        "secret_reader": secret_reader,
+        "dry_run": False,
+        "enable_deletion": False,
+        "thread_pool_size": 10,
+        "internal": None,
+        "use_jump_host": True,
+        "light": False,
+        "vault_output_path": "",
+        "defer": defer,
+    }
 
     result = integ.runner(**runner_params)
 

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -1124,7 +1124,7 @@ def test_duplicate_tgw_connection_names(
     with pytest.raises(integ.ValidationError) as e:
         integ.run(True)
 
-    assert "duplicate tgw connection names found" == str(e.value)
+    assert str(e.value) == "duplicate tgw connection names found"
 
 
 def test_missing_vpc_id(
@@ -1149,7 +1149,7 @@ def test_missing_vpc_id(
     with pytest.raises(RuntimeError) as e:
         integ.run(True)
 
-    assert "Could not find VPC ID for cluster" == str(e.value)
+    assert str(e.value) == "Could not find VPC ID for cluster"
 
 
 def test_error_in_tf_plan(
@@ -1176,7 +1176,7 @@ def test_error_in_tf_plan(
     with pytest.raises(RuntimeError) as e:
         integ.run(True)
 
-    assert "Error running terraform plan" == str(e.value)
+    assert str(e.value) == "Error running terraform plan"
 
 
 def test_disabled_deletions_detected_in_tf_plan(
@@ -1203,7 +1203,7 @@ def test_disabled_deletions_detected_in_tf_plan(
     with pytest.raises(RuntimeError) as e:
         integ.run(True)
 
-    assert "Disabled deletions detected running terraform plan" == str(e.value)
+    assert str(e.value) == "Disabled deletions detected running terraform plan"
 
 
 def test_error_in_terraform_apply(
@@ -1230,7 +1230,7 @@ def test_error_in_terraform_apply(
     with pytest.raises(RuntimeError) as e:
         integ.run(False)
 
-    assert "Error running terraform apply" == str(e.value)
+    assert str(e.value) == "Error running terraform apply"
 
 
 def test_early_exit_desired_state(

--- a/reconcile/test/utils/test_metrics.py
+++ b/reconcile/test/utils/test_metrics.py
@@ -258,9 +258,7 @@ def test_metrics_container_join_counters() -> None:
     assert len(metrics[0].samples) == 3
 
     for s in metrics[0].samples:
-        if s.labels["field"] == "1":
-            assert s.value == 1
-        elif s.labels["field"] == "2":
+        if s.labels["field"] == "1" or s.labels["field"] == "2":
             assert s.value == 1
         elif s.labels["field"] == "shared":
             assert s.value == 3
@@ -288,9 +286,7 @@ def test_metrics_container_join_gauges() -> None:
     for s in metrics[0].samples:
         if s.labels["field"] == "1":
             assert s.value == 1
-        elif s.labels["field"] == "2":
-            assert s.value == 2
-        elif s.labels["field"] == "shared":
+        elif s.labels["field"] == "2" or s.labels["field"] == "shared":
             assert s.value == 2
 
 

--- a/reconcile/test/utils/test_smtp_client.py
+++ b/reconcile/test/utils/test_smtp_client.py
@@ -48,8 +48,8 @@ def test_smtp_client_send_mail(smtp_client: SmtpClient, smtpd):
     smtp_client.send_mail(["benturner"], "subject_subject", "body_body_body")
     assert len(smtpd.messages) == 1
     msg = smtpd.messages[0]
-    assert "subject_subject" == msg.get("subject")
-    assert "benturner@mailAddress.com" == msg.get("to")
+    assert msg.get("subject") == "subject_subject"
+    assert msg.get("to") == "benturner@mailAddress.com"
     assert "\nbody_body_body" in msg.as_string()
 
 
@@ -61,11 +61,11 @@ def test_smtp_client_send_mails(smtp_client: SmtpClient, smtpd):
     assert len(smtpd.messages) == 2
 
     msg = smtpd.messages[0]
-    assert "subject_subject" == msg.get("subject")
-    assert "benturner@mailAddress.com" == msg.get("to")
+    assert msg.get("subject") == "subject_subject"
+    assert msg.get("to") == "benturner@mailAddress.com"
     assert "\nbody_body_body" in msg.as_string()
 
     msg = smtpd.messages[1]
-    assert "2subject_subject2" == msg.get("subject")
-    assert "2benturner2@mailAddress.com" == msg.get("to")
+    assert msg.get("subject") == "2subject_subject2"
+    assert msg.get("to") == "2benturner2@mailAddress.com"
     assert "\n2body_body_body2" in msg.as_string()

--- a/reconcile/test/utils/test_terraform_client.py
+++ b/reconcile/test/utils/test_terraform_client.py
@@ -558,8 +558,9 @@ def test_validate_db_upgrade_cannot_upgrade(aws_api, tf):
             },
         )
 
-    assert "Cannot upgrade RDS instance: test-database-1 from 11.12 to 14.2" == str(
-        error.value
+    assert (
+        str(error.value)
+        == "Cannot upgrade RDS instance: test-database-1 from 11.12 to 14.2"
     )
 
 
@@ -586,8 +587,8 @@ def test_validate_db_upgrade_major_version_upgrade_not_allow(aws_api, tf):
         )
 
     assert (
-        "allow_major_version_upgrade is not enabled for upgrading RDS instance: test-database-1 to a new major version."
-        == str(error.value)
+        str(error.value)
+        == "allow_major_version_upgrade is not enabled for upgrading RDS instance: test-database-1 to a new major version."
     )
 
 
@@ -614,8 +615,9 @@ def test_validate_db_upgrade_with_empty_valid_upgrade_target(
             },
         )
 
-    assert "Cannot upgrade RDS instance: test-database-1 from 11.12 to 11.17" == str(
-        error.value
+    assert (
+        str(error.value)
+        == "Cannot upgrade RDS instance: test-database-1 from 11.12 to 11.17"
     )
 
 

--- a/reconcile/test/utils/test_terrascript_aws_client.py
+++ b/reconcile/test/utils/test_terrascript_aws_client.py
@@ -297,7 +297,7 @@ def test_get_asg_image_id(mocker, ts: tsclient.TerrascriptClient):
 
 class MockProjectCommit:
     def __init__(self, id):
-        setattr(self, "id", id)
+        self.id = id
 
 
 @pytest.mark.parametrize(

--- a/reconcile/test/utils/test_terrascript_aws_client.py
+++ b/reconcile/test/utils/test_terrascript_aws_client.py
@@ -1,3 +1,5 @@
+import contextlib
+
 import pytest
 from pytest_mock import MockerFixture
 from terrascript.resource import (
@@ -458,12 +460,10 @@ def test_terraform_state_when_not_present(ts):
 def test_terraform_state_when_not_present_error(ts):
     account_name = "some-account"
     integration_name = "not-found-integration"
-    try:
+    with contextlib.suppress(ValueError):
         ts.state_bucket_for_account(
             integration_name, account_name, terraform_state_config_test_missing
         )
-    except ValueError:
-        pass
 
 
 def build_s3_spec(

--- a/reconcile/test/utils/test_terrascript_cloudflare_client.py
+++ b/reconcile/test/utils/test_terrascript_cloudflare_client.py
@@ -63,20 +63,20 @@ def cloudflare_account_test(account_config):
 
 def custom_ssl_secret_reader_side_effect(*args):
     """For use of secret_reader inside cloudflare client"""
-    if {
+    if args[0] == {
         "path": "certificate/path",
         "field": "cert.crt",
         "version": 1,
         "format": "plain",
-    } == args[0]:
+    }:
         return "----- CERTIFICATE -----"
 
-    if {
+    if args[0] == {
         "path": "key/path",
         "field": "cert.key",
         "version": 1,
         "format": "plain",
-    } == args[0]:
+    }:
         return "----- KEY -----"
 
 
@@ -507,22 +507,22 @@ def test_create_cloudflare_terrascript_not_include_account(
 
 
 def secret_reader_side_effect(*args):
-    if {
+    if asdict(args[0]) == {
         "path": "automation_token_path",
         "field": "some-field",
         "version": None,
         "q_format": None,
-    } == asdict(args[0]):
+    }:
         aws_acct_creds = {}
         aws_acct_creds["aws_access_key_id"] = "key_id"
         aws_acct_creds["aws_secret_access_key"] = "access_key"
         return aws_acct_creds
-    if {
+    if asdict(args[0]) == {
         "path": "creds",
         "field": "some-field",
         "version": None,
         "q_format": None,
-    } == asdict(args[0]):
+    }:
         cf_acct_creds = {}
         cf_acct_creds["api_token"] = "api_token"
         cf_acct_creds["account_id"] = "account_id"

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -235,7 +235,7 @@ class SaasFileList:
                 except JsonPathParserError as e:
                     raise ParameterError(
                         f"Invalid jsonpath expression in namespaceSelector '{selector}' :{e}"
-                    )
+                    ) from None
 
         return self._matching_namespaces_cache[selector]
 

--- a/reconcile/unleash_feature_toggles/integration.py
+++ b/reconcile/unleash_feature_toggles/integration.py
@@ -141,7 +141,7 @@ class UnleashTogglesIntegration(
             except KeyError:
                 raise ValueError(
                     f"[{instance.name}/{project_id}/{add.name}] Invalid feature toggle type '{add.unleash.q_type}', Possible values are: {', '.join(FeatureToggleType.__members__)}"
-                )
+                ) from None
             if not dry_run:
                 client.create_feature_toggle(
                     project_id=project_id,
@@ -161,7 +161,7 @@ class UnleashTogglesIntegration(
             except KeyError:
                 raise ValueError(
                     f"[{instance.name}/{project_id}/{change.current.name}] Invalid feature toggle type '{change.desired.unleash.q_type}', Possible values are: {', '.join(FeatureToggleType.__members__)}"
-                )
+                ) from None
             if not dry_run:
                 client.update_feature_toggle(
                     project_id=project_id,

--- a/reconcile/utils/aggregated_list.py
+++ b/reconcile/utils/aggregated_list.py
@@ -92,7 +92,7 @@ class AggregatedDiffRunner:
         self.actions = []
 
     def register(self, on, action, cond=None):
-        if on not in self.diff.keys():
+        if on not in self.diff:
             raise Exception(f"Unknown diff key for 'on': {on}")
         self.actions.append((on, action, cond))
 

--- a/reconcile/utils/aws_api.py
+++ b/reconcile/utils/aws_api.py
@@ -818,7 +818,7 @@ class AWSApi:  # pylint: disable=too-many-public-methods
         assume_role may be None for ROSA (CCS) clusters where we own the account
         """
         required_keys = ["name", "assume_region"]
-        ok = all(elem in account.keys() for elem in required_keys)
+        ok = all(elem in account for elem in required_keys)
         if not ok:
             account_name = account.get("name")
             raise KeyError(f"[{account_name}] account is missing required keys")

--- a/reconcile/utils/aws_api_typed/iam.py
+++ b/reconcile/utils/aws_api_typed/iam.py
@@ -41,7 +41,9 @@ class AWSApiIam:
             user = self.client.create_user(UserName=user_name)
             return AWSUser(**user["User"])
         except self.client.exceptions.EntityAlreadyExistsException:
-            raise AWSEntityAlreadyExistsException(f"User {user_name} already exists")
+            raise AWSEntityAlreadyExistsException(
+                f"User {user_name} already exists"
+            ) from None
 
     def attach_user_policy(self, user_name: str, policy_arn: str) -> None:
         """Attach a policy to a user."""
@@ -62,4 +64,4 @@ class AWSApiIam:
             if self.get_account_alias() != account_alias:
                 raise ValueError(
                     "Account alias already exists for another AWS account. Choose another one!"
-                )
+                ) from None

--- a/reconcile/utils/aws_api_typed/service_quotas.py
+++ b/reconcile/utils/aws_api_typed/service_quotas.py
@@ -64,7 +64,7 @@ class AWSApiServiceQuotas:
         except self.client.exceptions.ResourceAlreadyExistsException:
             raise AWSResourceAlreadyExistsException(
                 f"Service quota increase request {service_code=}, {quota_code=} already exists."
-            )
+            ) from None
 
     def get_service_quota(self, service_code: str, quota_code: str) -> AWSQuota:
         """Return the current value of the service quota."""
@@ -76,4 +76,4 @@ class AWSApiServiceQuotas:
         except self.client.exceptions.NoSuchResourceException:
             raise AWSNoSuchResourceException(
                 f"Service quota {service_code=}, {quota_code=} not found."
-            )
+            ) from None

--- a/reconcile/utils/binary.py
+++ b/reconcile/utils/binary.py
@@ -42,7 +42,7 @@ def binary_version(binary, version_args, search_regex, expected_versions):
                     f"Could not execute binary '{binary}' "
                     f"for binary version check: {e}"
                 )
-                raise Exception(msg)
+                raise Exception(msg) from e
 
             found = False
             match = None

--- a/reconcile/utils/config.py
+++ b/reconcile/utils/config.py
@@ -35,7 +35,7 @@ def read(secret):
             config = config[t]
         return config[field]
     except Exception as e:
-        raise SecretNotFound(f"key not found in config file {path}: {str(e)}")
+        raise SecretNotFound(f"key not found in config file {path}: {str(e)}") from None
 
 
 def read_all(secret):
@@ -47,4 +47,6 @@ def read_all(secret):
             config = config[t]
         return config
     except Exception as e:
-        raise SecretNotFound(f"secret {path} not found in config file: {str(e)}")
+        raise SecretNotFound(
+            f"secret {path} not found in config file: {str(e)}"
+        ) from None

--- a/reconcile/utils/expiration.py
+++ b/reconcile/utils/expiration.py
@@ -39,6 +39,6 @@ def filter(roles: DictsOrRoles | None) -> DictsOrRoles:
         except ValueError:
             raise ValueError(
                 f"{key} field is not formatted as YYYY-MM-DD, currently set as {expiration_date}"
-            )
+            ) from None
 
     return cast(DictsOrRoles, filtered)

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -173,7 +173,7 @@ class ResourceValueResolver:
             values.pop("$schema", None)
         except anymarkup.AnyMarkupError:
             e_msg = "Could not parse data. Skipping resource: {}"
-            raise FetchResourceError(e_msg.format(path))
+            raise FetchResourceError(e_msg.format(path)) from None
         return values
 
     @staticmethod
@@ -182,7 +182,7 @@ class ResourceValueResolver:
         try:
             raw_values = gqlapi.get_resource(path)
         except gql.GqlGetResourceError as e:
-            raise FetchResourceError(str(e))
+            raise FetchResourceError(str(e)) from e
         return raw_values
 
     @staticmethod

--- a/reconcile/utils/external_resources.py
+++ b/reconcile/utils/external_resources.py
@@ -62,10 +62,7 @@ def get_provision_providers(namespace_info: Mapping[str, Any]) -> set[str]:
 
 
 def managed_external_resources(namespace_info: Mapping[str, Any]) -> bool:
-    if namespace_info.get("managedExternalResources"):
-        return True
-
-    return False
+    return bool(namespace_info.get("managedExternalResources"))
 
 
 def get_inventory_count_combinations(
@@ -141,7 +138,7 @@ class ResourceValueResolver:
         resource = self._spec.resource
 
         keys_to_add = [
-            key for key in self._spec.resource.keys() if key not in self._IGNORE_KEYS
+            key for key in self._spec.resource if key not in self._IGNORE_KEYS
         ]
 
         defaults_path = resource.get("defaults", None)

--- a/reconcile/utils/git.py
+++ b/reconcile/utils/git.py
@@ -39,9 +39,7 @@ def has_uncommited_changes() -> bool:
     result = subprocess.run(
         cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, check=True
     )
-    if result.stdout:
-        return True
-    return False
+    return bool(result.stdout)
 
 
 def show_uncommited_changes() -> str:

--- a/reconcile/utils/gitlab_api.py
+++ b/reconcile/utils/gitlab_api.py
@@ -239,10 +239,7 @@ class GitLabApi:  # pylint: disable=too-many-public-methods
     def get_project_maintainers(
         self, repo_url: str | None = None, query: dict | None = None
     ) -> list[str] | None:
-        if repo_url is None:
-            project = self.project
-        else:
-            project = self.get_project(repo_url)
+        project = self.project if repo_url is None else self.get_project(repo_url)
         if project is None:
             return None
         if query:

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -141,11 +141,13 @@ class GqlApi:
                 gql(query), variables, get_execution_result=True
             ).formatted
         except requests.exceptions.ConnectionError as e:
-            raise GqlApiError(f"Could not connect to GraphQL server ({e})")
+            raise GqlApiError(f"Could not connect to GraphQL server ({e})") from None
         except TransportQueryError as e:
-            raise GqlApiError(f"`error` returned with GraphQL response {e}")
+            raise GqlApiError(f"`error` returned with GraphQL response {e}") from None
         except AssertionError:
-            raise GqlApiError("`data` field missing from GraphQL response payload")
+            raise GqlApiError(
+                "`data` field missing from GraphQL response payload"
+            ) from None
         except Exception as e:
             raise GqlApiError("Unexpected error occurred") from e
 
@@ -186,7 +188,7 @@ class GqlApi:
             if q_result:
                 templates = q_result["templates"]
         except GqlApiError:
-            raise GqlGetResourceError(path, "Template not found.")
+            raise GqlGetResourceError(path, "Template not found.") from None
 
         if len(templates) != 1:
             raise GqlGetResourceError(path, "Expecting one and only one template.")
@@ -211,7 +213,7 @@ class GqlApi:
                 "resources"
             ]
         except GqlApiError:
-            raise GqlGetResourceError(path, "Resource not found.")
+            raise GqlGetResourceError(path, "Resource not found.") from None
 
         if len(resources) != 1:
             raise GqlGetResourceError(path, "Expecting one and only one resource.")

--- a/reconcile/utils/gql.py
+++ b/reconcile/utils/gql.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import textwrap
 import threading
@@ -44,10 +45,8 @@ def capture_and_forget(error):
     :type error: Exception
     """
 
-    try:
+    with contextlib.suppress(Exception):
         capture_exception(error)
-    except Exception:
-        pass
 
 
 class GqlApiError(Exception):

--- a/reconcile/utils/helm.py
+++ b/reconcile/utils/helm.py
@@ -70,7 +70,7 @@ def do_template(
             msg += f" {e.stdout.decode()}"
         if e.stderr:
             msg += f" {e.stderr.decode()}"
-        raise HelmTemplateError(msg)
+        raise HelmTemplateError(msg) from None
 
     return result.stdout.decode()
 

--- a/reconcile/utils/imap_client.py
+++ b/reconcile/utils/imap_client.py
@@ -33,7 +33,9 @@ class ImapClient:
         try:
             config = {k: data[k] for k in required_keys}
         except KeyError as e:
-            raise Exception(f"Missing expected IMAP config key in vault secret: {e}")
+            raise Exception(
+                f"Missing expected IMAP config key in vault secret: {e}"
+            ) from None
         return config
 
     def get_mails(

--- a/reconcile/utils/internal_groups/client.py
+++ b/reconcile/utils/internal_groups/client.py
@@ -46,7 +46,7 @@ class InternalGroupsApi:
             resp.raise_for_status()
         except requests.exceptions.HTTPError as e:
             if e.response is not None and e.response.status_code == 404:
-                raise NotFound
+                raise NotFound(e.response.text) from e
             raise
 
     def __enter__(self) -> Self:

--- a/reconcile/utils/jinja2/utils.py
+++ b/reconcile/utils/jinja2/utils.py
@@ -175,9 +175,9 @@ def lookup_secret(
     except (SecretNotFound, SecretFieldNotFound) as e:
         if allow_not_found:
             return None
-        raise FetchSecretError(e)
+        raise FetchSecretError(e) from None
     except Exception as e:
-        raise FetchSecretError(e)
+        raise FetchSecretError(e) from e
 
 
 def process_jinja2_template(
@@ -221,12 +221,12 @@ def process_jinja2_template(
     })
     if "_template_mocks" in vars:
         for k, v in vars["_template_mocks"].items():
-            vars[k] = lambda *args, **kwargs: v
+            vars[k] = lambda *args, **kwargs: v  # noqa: B023
     try:
         template = compile_jinja2_template(body, extra_curly, template_render_options)
         r = template.render(vars)
     except Exception as e:
-        raise Jinja2TemplateError(e)
+        raise Jinja2TemplateError(e) from None
     return r
 
 

--- a/reconcile/utils/jobcontroller/models.py
+++ b/reconcile/utils/jobcontroller/models.py
@@ -160,7 +160,7 @@ class K8sJob(ABC):
                     )
                 ),
             )
-            for secret_key_name in self.secret_data().keys()
+            for secret_key_name in self.secret_data()
         ]
 
     def scripts_volume_mount(self, directory: str) -> V1VolumeMount:
@@ -189,7 +189,7 @@ class K8sJob(ABC):
                         key=script_name,
                         path=script_name,
                     )
-                    for script_name in self.scripts().keys()
+                    for script_name in self.scripts()
                 ],
             ),
         )

--- a/reconcile/utils/jump_host.py
+++ b/reconcile/utils/jump_host.py
@@ -90,7 +90,7 @@ class JumpHostSSH(JumpHostBase):
         try:
             known_hosts = self._gql_api.get_resource(known_hosts_path)
         except gql.GqlGetResourceError as e:
-            raise FetchResourceError(str(e))
+            raise FetchResourceError(str(e)) from None
         return known_hosts["content"]
 
     def _init_known_hosts_file(self) -> None:

--- a/reconcile/utils/ldap_client.py
+++ b/reconcile/utils/ldap_client.py
@@ -33,7 +33,7 @@ class LdapClient:
         _, _, results, _ = self.connection.search(
             self.base_dn, f"(&(objectclass=person)(|{user_filter}))", attributes=["uid"]
         )
-        return set(r["attributes"]["uid"][0] for r in results)
+        return {r["attributes"]["uid"][0] for r in results}
 
     def get_group_members(self, groups_dns: set[str]) -> dict[str, set[str]]:
         """

--- a/reconcile/utils/merge_request_manager/merge_request_manager.py
+++ b/reconcile/utils/merge_request_manager/merge_request_manager.py
@@ -43,10 +43,7 @@ class MergeRequestManagerBase(Generic[T]):
     ) -> OpenMergeRequest | None:
         for mr in self._open_mrs:
             mr_info_dict = mr.mr_info.dict()
-            if all(
-                mr_info_dict.get(k) == expected_data.get(k)
-                for k in expected_data.keys()
-            ):
+            if all(mr_info_dict.get(k) == expected_data.get(k) for k in expected_data):
                 return mr
 
         return None

--- a/reconcile/utils/models.py
+++ b/reconcile/utils/models.py
@@ -120,4 +120,4 @@ def cron_validator(value: str) -> str:
         croniter(value)
         return value
     except ValueError as e:
-        raise ValueError(f"Invalid cron expression: {e}")
+        raise ValueError(f"Invalid cron expression: {e}") from None

--- a/reconcile/utils/models.py
+++ b/reconcile/utils/models.py
@@ -94,10 +94,7 @@ class CSV(list[str]):
 
     @classmethod
     def validate(cls, value: str) -> list[str]:
-        if not value:
-            items = []
-        else:
-            items = value.split(",")
+        items = [] if not value else value.split(",")
         return items
 
     @classmethod

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -231,14 +231,10 @@ def equal_spec_template(t1: dict, t2: dict) -> bool:
     """Compare two spec.templates."""
     t1_copy = copy.deepcopy(t1)
     t2_copy = copy.deepcopy(t2)
-    try:
+    with suppress(KeyError):
         del t1_copy["metadata"]["labels"]["pod-template-hash"]
-    except KeyError:
-        pass
-    try:
+    with suppress(KeyError):
         del t2_copy["metadata"]["labels"]["pod-template-hash"]
-    except KeyError:
-        pass
     return t1_copy == t2_copy
 
 
@@ -740,11 +736,11 @@ class OCCli:  # pylint: disable=too-many-public-methods
         cmd = ["logs", "--all-containers=true", "-n", namespace, f"job/{name}"]
         if follow:
             cmd.append("-f")
-        # pylint: disable=consider-using-with
+
         if isinstance(output, TextIOWrapper):
             output_file = output
         else:
-            output_file = open(os.path.join(output, name), "w", encoding="locale")
+            output_file = open(os.path.join(output, name), "w", encoding="locale")  # noqa: SIM115
 
         if wait_for_logs_process:
             subprocess.run(self.oc_base_cmd + cmd, stdout=output_file, check=False)
@@ -1640,10 +1636,7 @@ class OC_Map:
                 )
                 return
 
-            if self.use_jump_host:
-                jump_host = cluster_info.get("jumpHost")
-            else:
-                jump_host = None
+            jump_host = cluster_info.get("jumpHost") if self.use_jump_host else None
             if jump_host:
                 self.set_jh_ports(jump_host)
             try:

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1134,7 +1134,7 @@ class OCCli:  # pylint: disable=too-many-public-methods
         try:
             out_json = json.loads(out)
         except ValueError as e:
-            raise JSONParsingError(out + "\n" + str(e))
+            raise JSONParsingError(out + "\n" + str(e)) from e
 
         return out_json
 
@@ -1303,7 +1303,7 @@ class OCNative(OCCli):
         try:
             return DynamicClient(k8s_client, discoverer=OpenshiftLazyDiscoverer)
         except urllib3.exceptions.MaxRetryError as e:
-            raise StatusCodeError(f"[{self.server}]: {e}")
+            raise StatusCodeError(f"[{self.server}]: {e}") from None
 
     def _get_obj_client(self, kind, group_version):
         key = f"{kind}.{group_version}"
@@ -1376,7 +1376,7 @@ class OCNative(OCCli):
         except NotFoundError as e:
             if allow_not_found:
                 return {}
-            raise StatusCodeError(f"[{self.server}]: {e}")
+            raise StatusCodeError(f"[{self.server}]: {e}") from None
 
     def get_all(self, kind, all_namespaces=False):
         k, group_version = self._parse_kind(kind)
@@ -1384,7 +1384,7 @@ class OCNative(OCCli):
         try:
             return obj_client.get(_request_timeout=REQUEST_TIMEOUT).to_dict()
         except NotFoundError as e:
-            raise StatusCodeError(f"[{self.server}]: {e}")
+            raise StatusCodeError(f"[{self.server}]: {e}") from None
 
 
 OCClient = OCNative | OCCli

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -1276,13 +1276,13 @@ class OCNative(OCCli):
 
     @retry(exceptions=(ServerTimeoutError, InternalServerError, ForbiddenError))
     def _get_client(self, server, token):
-        opts = dict(
-            api_key={"authorization": f"Bearer {token}"},
-            host=server,
-            verify_ssl=False,
+        opts = {
+            "api_key": {"authorization": f"Bearer {token}"},
+            "host": server,
+            "verify_ssl": False,
             # default timeout seems to be 1+ minutes
-            retries=5,
-        )
+            "retries": 5,
+        }
         if self.jump_host:
             # the ports could be parameterized, but at this point
             # we only have need of 1 tunnel for 1 service
@@ -1839,17 +1839,14 @@ class OpenshiftLazyDiscoverer(LazyDiscoverer):
             ]
         # If there are multiple matches, prefer non-List kinds
         if len(results) > 1 and not all(  # pylint: disable=R1729
-            [isinstance(x, ResourceList) for x in results]
+            isinstance(x, ResourceList) for x in results
         ):
             results = [
                 result for result in results if not isinstance(result, ResourceList)
             ]
         # if multiple resources are found that share a GVK, prefer the one with the most supported verbs
-        if (
-            len(results) > 1
-            and len(set((x.group_version, x.kind) for x in results)) == 1
-        ):
-            if len(set(len(x.verbs) for x in results)) != 1:
+        if len(results) > 1 and len({(x.group_version, x.kind) for x in results}) == 1:
+            if len({len(x.verbs) for x in results}) != 1:
                 results = [max(results, key=lambda x: len(x.verbs))]
         if len(results) == 1:
             return results[0]

--- a/reconcile/utils/ocm/ocm.py
+++ b/reconcile/utils/ocm/ocm.py
@@ -828,7 +828,9 @@ class OCM:  # pylint: disable=too-many-public-methods
             try:
                 re.compile(b)
             except re.error:
-                raise TypeError(f"blocked version is not a valid regex expression: {b}")
+                raise TypeError(
+                    f"blocked version is not a valid regex expression: {b}"
+                ) from None
 
     @retry(max_attempts=10)
     def _do_get_request(self, api: str, params: Mapping[str, str]) -> dict[str, Any]:

--- a/reconcile/utils/ocm/products.py
+++ b/reconcile/utils/ocm/products.py
@@ -354,7 +354,7 @@ class OCMProductRosa(OCMProduct):
             e.cleanup()
             raise OCMValidationException(
                 f"last 10 lines from failed cluster creation job...\n\n{logs}"
-            )
+            ) from None
 
     def update_cluster(
         self,
@@ -629,7 +629,7 @@ class OCMProductHypershift(OCMProduct):
             e.cleanup()
             raise OCMValidationException(
                 f"last 10 lines from failed cluster creation job...\n\n{logs}"
-            )
+            ) from None
 
     def update_cluster(
         self,

--- a/reconcile/utils/ocm/search_filters.py
+++ b/reconcile/utils/ocm/search_filters.py
@@ -56,7 +56,7 @@ class ListCondition(ABC, FilterCondition):
             raise InvalidFilterError(f"Cannot merge {self} with {other}")
         return type(self)(
             key=self.key,
-            values=sorted(list(set(self.values + other.values))),
+            values=sorted(set(self.values + other.values)),
         )
 
 
@@ -72,9 +72,7 @@ class EqCondition(ListCondition):
     def render(self) -> str:
         if len(self.values) == 1:
             return f"{self.key}='{self._escape_value(self.values[0])}'"
-        quoted_values = ",".join(
-            map(lambda x: f"'{self._escape_value(x)}'", self.values)
-        )
+        quoted_values = ",".join(f"'{self._escape_value(x)}'" for x in self.values)
         return f"{self.key} in ({quoted_values})"
 
     def _escape_value(self, value: Any) -> str:
@@ -93,9 +91,7 @@ class LikeCondition(ListCondition):
     def render(self) -> str:
         if len(self.values) == 1:
             return f"{self.key} like '{self.values[0]}'"
-        quoted_values = " or ".join(
-            map(lambda x: f"{self.key} like '{x}'", self.values)
-        )
+        quoted_values = " or ".join(f"{self.key} like '{x}'" for x in self.values)
         if len(self.values) > 1:
             return f"({quoted_values})"
         return quoted_values

--- a/reconcile/utils/ocm/search_filters.py
+++ b/reconcile/utils/ocm/search_filters.py
@@ -284,10 +284,7 @@ class Filter:
         are None or empty, the condition is not added.
         """
         if values:
-            if isinstance(values, list):
-                value_list = values
-            else:
-                value_list = list(values)
+            value_list = values if isinstance(values, list) else list(values)
             value_list.sort()
             return self.add_condition(EqCondition(key, value_list))
         return self

--- a/reconcile/utils/ocm_base_client.py
+++ b/reconcile/utils/ocm_base_client.py
@@ -84,10 +84,7 @@ class OCMBaseClient:
         max_page_size: int = 100,
         max_pages: int | None = None,
     ) -> Generator[dict[str, Any], None, None]:
-        if not params:
-            params_copy = {}
-        else:
-            params_copy = params.copy()
+        params_copy = {} if not params else params.copy()
         params_copy["size"] = max_page_size
 
         while True:

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -179,7 +179,9 @@ class OpenshiftResource:
     @staticmethod
     def ignorable_key_value_pair(key, val):
         ignorable_key_value_pair = {"annotations": None, "divisor": "0"}
-        return bool(key in ignorable_key_value_pair and ignorable_key_value_pair[key] == val)
+        return bool(
+            key in ignorable_key_value_pair and ignorable_key_value_pair[key] == val
+        )
 
     @staticmethod
     def cpu_equal(val1, val2):
@@ -234,11 +236,11 @@ class OpenshiftResource:
 
     def verify_valid_k8s_object(self):
         try:
-            self.name  # pylint: disable=pointless-statement
-            self.kind  # pylint: disable=pointless-statement
+            assert self.name
+            assert self.kind
         except (KeyError, TypeError) as e:
             msg = f"resource invalid data ({e.__class__.__name__}). details: {self.error_details}"
-            raise ConstructResourceError(msg)
+            raise ConstructResourceError(msg) from None
 
         if self.kind not in {
             "Role",

--- a/reconcile/utils/openshift_resource.py
+++ b/reconcile/utils/openshift_resource.py
@@ -1,4 +1,6 @@
+# ruff: noqa: SIM114
 import base64
+import contextlib
 import copy
 import datetime
 import hashlib
@@ -172,28 +174,20 @@ class OpenshiftResource:
             "uid",
             "fieldRef",
         ]
-        if val in ignorable_fields:
-            return True
-        return False
+        return val in ignorable_fields
 
     @staticmethod
     def ignorable_key_value_pair(key, val):
         ignorable_key_value_pair = {"annotations": None, "divisor": "0"}
-        if key in ignorable_key_value_pair and ignorable_key_value_pair[key] == val:
-            return True
-        return False
+        return bool(key in ignorable_key_value_pair and ignorable_key_value_pair[key] == val)
 
     @staticmethod
     def cpu_equal(val1, val2):
         # normalize both to string
-        try:
+        with contextlib.suppress(Exception):
             val1 = f"{int(float(val1) * 1000)}m"
-        except Exception:
-            pass
-        try:
+        with contextlib.suppress(Exception):
             val2 = f"{int(float(val2) * 1000)}m"
-        except Exception:
-            pass
         return val1 == val2
 
     @staticmethod
@@ -348,10 +342,7 @@ class OpenshiftResource:
             openshift_resource: new OpenshiftResource object with
                 annotations.
         """
-        if canonicalize:
-            body = self.canonicalize(self.body)
-        else:
-            body = self.body
+        body = self.canonicalize(self.body) if canonicalize else self.body
 
         sha256sum = self.calculate_sha256sum(self.serialize(body))
 

--- a/reconcile/utils/quay_api.py
+++ b/reconcile/utils/quay_api.py
@@ -57,9 +57,7 @@ class QuayApi:
     def user_exists(self, user):
         url = f"{self.api_url}/users/{user}"
         r = requests.get(url, headers=self.auth_header, timeout=self._timeout)
-        if not r.ok:
-            return False
-        return True
+        return r.ok
 
     def remove_user_from_team(self, user, team):
         """Deletes an user from a team.

--- a/reconcile/utils/repo_owners.py
+++ b/reconcile/utils/repo_owners.py
@@ -194,15 +194,9 @@ class RepoOwners:
     @staticmethod
     def _set_to_sorted_list(owners):
         approvers = owners["approvers"]
-        if approvers:
-            sorted_approvers = sorted(approvers)
-        else:
-            sorted_approvers = []
+        sorted_approvers = sorted(approvers) if approvers else []
 
         reviewers = owners["reviewers"]
-        if reviewers:
-            sorted_reviewers = sorted(reviewers)
-        else:
-            sorted_reviewers = []
+        sorted_reviewers = sorted(reviewers) if reviewers else []
 
         return {"approvers": sorted_approvers, "reviewers": sorted_reviewers}

--- a/reconcile/utils/runtime/runner.py
+++ b/reconcile/utils/runtime/runner.py
@@ -213,7 +213,7 @@ def _integration_dry_run(
             return_exceptions=True,
         )
 
-        for shard, result in zip(affected_shard_list, results):
+        for shard, result in zip(affected_shard_list, results, strict=False):
             if _is_task_result_an_error(result):
                 logging.error(f"Failed to run integration shard {shard}: {result}")
         failed_shards_count = sum(1 for _ in filter(_is_task_result_an_error, results))

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1189,8 +1189,8 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         creds = self.secret_reader.read_all_secret(saas_file.authentication.image)
         required_docker_config_keys = [".dockerconfigjson"]
         required_keys_basic_auth = ["user", "token"]
-        ok = all(k in creds.keys() for k in required_keys_basic_auth) or all(
-            k in creds.keys() for k in required_docker_config_keys
+        ok = all(k in creds for k in required_keys_basic_auth) or all(
+            k in creds for k in required_docker_config_keys
         )
         if not ok:
             logging.warning(

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -698,11 +698,11 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         return namespaces
 
     def _collect_repo_urls(self) -> set[str]:
-        return set(
+        return {
             rt.url
             for saas_file in self.saas_files
             for rt in saas_file.resource_templates
-        )
+        }
 
     @staticmethod
     def _get_file_contents_github(repo: Repository, path: str, commit_sha: str) -> str:

--- a/reconcile/utils/secret_reader.py
+++ b/reconcile/utils/secret_reader.py
@@ -164,7 +164,7 @@ class VaultSecretReader(SecretReaderBase):
         except Forbidden:
             raise VaultForbidden(
                 f"permission denied reading vault secret " f"at {path}"
-            )
+            ) from None
         except vault.SecretNotFound as e:
             raise SecretNotFound(*e.args) from e
         return data
@@ -316,7 +316,7 @@ class SecretReader(SecretReaderBase):
             except Forbidden:
                 raise VaultForbidden(
                     f"permission denied reading vault secret " f"at {path}"
-                )
+                ) from None
             except vault.SecretNotFound as e:
                 raise SecretNotFound(*e.args) from e
         else:

--- a/reconcile/utils/slack_api.py
+++ b/reconcile/utils/slack_api.py
@@ -398,7 +398,7 @@ class SlackApi:
             result = self._sc.users_lookupByEmail(email=f"{user_name}@{mail_address}")
         except SlackApiError as e:
             if e.response["error"] == "users_not_found":
-                raise UserNotFoundException(e.response["error"])
+                raise UserNotFoundException(e.response["error"]) from None
             raise
 
         return result["user"]["id"]

--- a/reconcile/utils/sqs_gateway.py
+++ b/reconcile/utils/sqs_gateway.py
@@ -13,7 +13,7 @@ class SQSGateway:
     """Wrapper around SQS AWS SDK"""
 
     def __init__(self, accounts, secret_reader: SecretReader):
-        queue_url = os.environ.get("gitlab_pr_submitter_queue_url")
+        queue_url = os.environ.get("gitlab_pr_submitter_queue_url")  # noqa: SIM112
         if not queue_url:
             raise SQSGatewayInitError(
                 "when /app-interface/app-interface-settings-1.yml#mergeRequestGateway "

--- a/reconcile/utils/state.py
+++ b/reconcile/utils/state.py
@@ -251,7 +251,7 @@ class State:
         except ClientError as details:
             raise StateInaccessibleException(
                 f"Bucket {self.bucket} is not accessible - {str(details)}"
-            )
+            ) from None
 
     def __enter__(self) -> Self:
         return self
@@ -302,7 +302,7 @@ class State:
             raise StateInaccessibleException(
                 f"Can not access state key {key_path} "
                 f"in bucket {self.bucket} - {str(details)}"
-            )
+            ) from None
 
     def ls(self) -> list[str]:
         """
@@ -407,10 +407,10 @@ class State:
             return json.loads(response["Body"].read())
         except ClientError as details:
             if details.response["Error"]["Code"] == "NoSuchKey":
-                raise KeyError(item)
+                raise KeyError(item) from None
             raise
         except json.decoder.JSONDecodeError:
-            raise KeyError(item)
+            raise KeyError(item) from None
 
     def __setitem__(self, key: str, value: Any) -> None:
         self._set(key, value)

--- a/reconcile/utils/terraform/config_client.py
+++ b/reconcile/utils/terraform/config_client.py
@@ -84,7 +84,7 @@ class TerraformConfigClientCollection:
             except KeyError:
                 raise ClientNotRegisteredError(
                     f"There aren't any clients registered with the account name: {spec.provisioner_name}"
-                )
+                ) from None
             self.resource_spec_inventory[spec.id_object()] = spec
 
     def populate_resources(self) -> None:

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -585,7 +585,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                         secret_copy["db.password"] = replica_src_password
 
             # clean metadata
-            for key in secret.keys():
+            for key in secret:
                 if integration_prefix in key:
                     secret_copy.pop(key)
 

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -407,7 +407,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                     f"[{account_name}] expiration not does not match "
                     f"date format {DATE_FORMAT}. details: "
                     f"type: {da['type']}, name: {da['name']}"
-                )
+                ) from None
             if (
                 resource_type == da["type"]
                 and resource_name == da["name"]

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1058,7 +1058,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                         except KeyError:
                             msg = f"Key '{rec['key']}' was not found in the contents of secret '{rec['path']}'"
                             logging.error(msg)
-                            raise KeyError(msg)
+                            raise KeyError(msg) from None
                     vault_values.append(value)
                 record["records"] = vault_values
 
@@ -4232,7 +4232,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         try:
             raw_values = gqlapi.get_resource(path)
         except gql.GqlGetResourceError as e:
-            raise FetchResourceError(str(e))
+            raise FetchResourceError(str(e)) from e
         return raw_values
 
     def get_values(self, path: str) -> dict[str, Any]:
@@ -4242,7 +4242,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             values.pop("$schema", None)
         except anymarkup.AnyMarkupError:
             e_msg = "Could not parse data. Skipping resource: {}"
-            raise FetchResourceError(e_msg.format(path))
+            raise FetchResourceError(e_msg.format(path)) from None
         return values
 
     @staticmethod
@@ -5703,7 +5703,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             except ClientError as details:
                 raise StateInaccessibleException(
                     f"Bucket {bucket_name} is not accessible - {str(details)}"
-                )
+                ) from None
 
             # todo: probably remove 'RedHat' from the object/variable/filepath
             # names to keep the code RedHat-agnostic?

--- a/reconcile/utils/three_way_diff_strategy.py
+++ b/reconcile/utils/three_way_diff_strategy.py
@@ -95,14 +95,11 @@ def is_empty_env_value(current: OR, desired: OR, patch: Mapping[str, Any]) -> bo
     :return: True if the change is not needed, False otherwise
     """
     pointer = patch["path"]
-    if (
+    return bool(
         patch["op"] == "add"
         and not patch["value"]
         and re.match(EMPTY_ENV_VALUE, pointer)
-    ):
-        return True
-
-    return False
+    )
 
 
 def is_valid_change(current: OR, desired: OR, patch: Mapping[str, Any]) -> bool:
@@ -116,10 +113,7 @@ def is_valid_change(current: OR, desired: OR, patch: Mapping[str, Any]) -> bool:
         return False
 
     # Other cases
-    if is_empty_env_value(current, desired, patch):
-        return False
-
-    return True
+    return not is_empty_env_value(current, desired, patch)
 
 
 def three_way_diff_using_hash(c_item: OR, d_item: OR) -> bool:

--- a/reconcile/utils/unleash/client.py
+++ b/reconcile/utils/unleash/client.py
@@ -43,7 +43,7 @@ class DisableClusterStrategy(ClusterStrategy):
     def apply(self, context: dict | None = None) -> bool:
         enable = True
 
-        if context and "cluster_name" in context.keys():
+        if context and "cluster_name" in context:
             # if cluster in context is in clusters sent from server, disable
             enable = context["cluster_name"] not in self.parsed_provisioning
 
@@ -54,7 +54,7 @@ class EnableClusterStrategy(ClusterStrategy):
     def apply(self, context: dict | None = None) -> bool:
         enable = False
 
-        if context and "cluster_name" in context.keys():
+        if context and "cluster_name" in context:
             # if cluster in context is in clusters sent from server, enable
             enable = context["cluster_name"] in self.parsed_provisioning
 

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -385,10 +385,7 @@ class _VaultClient:
     def list(self, path: str) -> list[str]:
         """Returns a list of secrets in a given path."""
         kv_version = self._get_mount_version_by_secret_path(path)
-        if kv_version == 2:
-            path_list = self._list_kv2(path)
-        else:
-            path_list = self._list(path)
+        path_list = self._list_kv2(path) if kv_version == 2 else self._list(path)
 
         if not path_list:
             # path list can be None if the path does not exist

--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -234,10 +234,10 @@ class _VaultClient:
             )
         except InvalidPath:
             msg = f"version '{version}' not found " f"for secret with path '{path}'."
-            raise SecretVersionNotFound(msg)
+            raise SecretVersionNotFound(msg) from None
         except hvac.exceptions.Forbidden:
             msg = f"permission denied accessing secret '{path}'"
-            raise SecretAccessForbidden(msg)
+            raise SecretAccessForbidden(msg) from None
         if secret is None or "data" not in secret or "data" not in secret["data"]:
             raise SecretNotFound(path)
 
@@ -250,7 +250,7 @@ class _VaultClient:
             secret = self._client.read(path)
         except hvac.exceptions.Forbidden:
             msg = f"permission denied accessing secret '{path}'"
-            raise SecretAccessForbidden(msg)
+            raise SecretAccessForbidden(msg) from None
 
         if secret is None or "data" not in secret:
             raise SecretNotFound(path)
@@ -295,7 +295,7 @@ class _VaultClient:
         try:
             secret_field = data[field]
         except KeyError:
-            raise SecretFieldNotFound(f"{path}/{field} ({version})")
+            raise SecretFieldNotFound(f"{path}/{field} ({version})") from None
         return secret_field
 
     def _read_v1(self, path, field):
@@ -303,7 +303,7 @@ class _VaultClient:
         try:
             secret_field = data[field]
         except KeyError:
-            raise SecretFieldNotFound(f"{path}/{field}")
+            raise SecretFieldNotFound(f"{path}/{field}") from None
         return secret_field
 
     @retry()
@@ -355,14 +355,14 @@ class _VaultClient:
             self._read_all_v2.cache_clear()
         except hvac.exceptions.Forbidden:
             msg = f"permission denied accessing secret '{path}'"
-            raise SecretAccessForbidden(msg)
+            raise SecretAccessForbidden(msg) from None
 
     def _write_v1(self, path, data):
         try:
             self._client.write(path, **data)
         except hvac.exceptions.Forbidden:
             msg = f"permission denied accessing secret '{path}'"
-            raise SecretAccessForbidden(msg)
+            raise SecretAccessForbidden(msg) from None
 
     def _list_kv2(self, path: str) -> dict:
         try:
@@ -373,14 +373,14 @@ class _VaultClient:
             return response
         except hvac.exceptions.Forbidden:
             msg = f"permission denied accessing path '{path}'"
-            raise PathAccessForbidden(msg)
+            raise PathAccessForbidden(msg) from None
 
     def _list(self, path: str) -> dict:
         try:
             return self._client.list(path)
         except hvac.exceptions.Forbidden:
             msg = f"permission denied accessing path '{path}'"
-            raise PathAccessForbidden(msg)
+            raise PathAccessForbidden(msg) from None
 
     def list(self, path: str) -> list[str]:
         """Returns a list of secrets in a given path."""
@@ -417,7 +417,7 @@ class _VaultClient:
             self._client.delete(path)
         except hvac.exceptions.Forbidden:
             msg = f"permission denied accessing secret '{path}'"
-            raise SecretAccessForbidden(msg)
+            raise SecretAccessForbidden(msg) from None
 
 
 class VaultClient:

--- a/reconcile/utils/vcs.py
+++ b/reconcile/utils/vcs.py
@@ -70,7 +70,7 @@ class VCS:
         self._allow_opening_mrs = allow_opening_mrs
         self._secret_reader = secret_reader
         self._gh_per_repo_url: dict[str, GithubRepositoryApi] = (
-            {} if not github_api_per_repo_url else github_api_per_repo_url
+            github_api_per_repo_url if github_api_per_repo_url else {}
         )
         self._default_gh_token = (
             default_gh_token

--- a/reconcile/vault_replication.py
+++ b/reconcile/vault_replication.py
@@ -121,7 +121,7 @@ def copy_vault_secret(
     except SecretAccessForbidden:
         # Raise exception if we can't read the secret from the source vault.
         # This is likely to be related to the approle permissions.
-        raise SecretAccessForbidden("Cannot read secret from source vault")
+        raise SecretAccessForbidden("Cannot read secret from source vault") from None
     except SecretNotFound:
         # If the secret is present in vault, but there are no versions of it
         # we want to be aware of it, but not cause a failure of the complete

--- a/requirements/requirements-test.txt
+++ b/requirements/requirements-test.txt
@@ -11,4 +11,4 @@ moto~=2.2
 MarkupSafe==2.1.1
 smtpdfix==0.3.3
 pyfakefs~=5.1
-ruff==0.4.8
+ruff==0.5.1

--- a/tools/app_interface_reporter.py
+++ b/tools/app_interface_reporter.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import os
 import textwrap
@@ -438,10 +439,8 @@ def main(
         if reports_path:
             report_file = os.path.join(reports_path, report["file_path"])
 
-            try:
+            with contextlib.suppress(FileExistsError):
                 os.makedirs(os.path.dirname(report_file))
-            except FileExistsError:
-                pass
 
             with open(report_file, "w", encoding="locale") as f:
                 f.write(report["content"])

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2799,7 +2799,7 @@ def jenkins_jobs(ctx):
 
             for pj in project["jobs"]:
                 for job in pj.values():
-                    node = job["node"] if "node" in job else root_node
+                    node = job.get("node", root_node)
                     if node in {"rhel8", "rhel8-app-interface"}:
                         apps[app_name]["rhel8"] += 1
                         totals["rhel8"] += 1


### PR DESCRIPTION
Upgrade to latest ruff version and enable addtional checks:

- **:arrow_up: ruff 0.5.1**
- **:recycle: ruff: enable flake8-simplify checks**
- **:recycle: ruff: enable flake8-bugbear and fix B904**
- **:recycle: B019: Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks**
- **:recycle: B018: Found useless expression. Either assign it to a variable or remove it**
- **:recycle: B015: Pointless comparison. Did you mean to assign a value? Otherwise, prepend assert or remove it.**
- ** ignore B017**
- **fix other minor errors**
- **:recycle: ruff: enable flake8-comprehension**
