### PR TITLE
Extract ocm-env as optional param for ocm_addons_upgrade_scheduler_org

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -2710,11 +2710,20 @@ def ocm_upgrade_scheduler_org_updater(ctx, gitlab_project_id):
 @integration.command(
     short_help="Manage Addons Upgrade Policy schedules in OCM organizations."
 )
+@click.option(
+    "--ocm-env",
+    help="The OCM environment the integration should operator on. If none is specified, all environments will be operated on.",
+    required=False,
+    envvar="OCM_ENV",
+)
 @org_id_multiple
 @exclude_org_id
 @click.pass_context
 def ocm_addons_upgrade_scheduler_org(
-    ctx, org_id: Iterable[str], exclude_org_id: Iterable[str]
+    ctx,
+    ocm_env: str,
+    org_id: Iterable[str],
+    exclude_org_id: Iterable[str],
 ) -> None:
     from reconcile.aus.base import AdvancedUpgradeSchedulerBaseIntegrationParams
     from reconcile.aus.ocm_addons_upgrade_scheduler_org import (
@@ -2724,7 +2733,7 @@ def ocm_addons_upgrade_scheduler_org(
     run_class_integration(
         integration=OCMAddonsUpgradeSchedulerOrgIntegration(
             AdvancedUpgradeSchedulerBaseIntegrationParams(
-                ocm_environment="ocm-integration",
+                ocm_environment=ocm_env,
                 ocm_organization_ids=set(org_id),
                 excluded_ocm_organization_ids=set(exclude_org_id),
             )


### PR DESCRIPTION
Fix hardcoded `ocm_environment="ocm-integration"` from https://github.com/app-sre/qontract-reconcile/pull/4224