### PR TITLE
[saasherder/helm] repository cache

### DIFF
--- a/reconcile/utils/helm.py
+++ b/reconcile/utils/helm.py
@@ -31,9 +31,14 @@ def do_template(
     name: str,
 ) -> str:
     try:
-        with tempfile.NamedTemporaryFile(
-            mode="w+", encoding="locale"
-        ) as repository_config_file:
+        with (
+            tempfile.NamedTemporaryFile(
+                mode="w+", encoding="locale"
+            ) as repository_config_file,
+            tempfile.NamedTemporaryFile(
+                mode="w+", encoding="locale"
+            ) as repository_cache_file,
+        ):
             with open(
                 os.path.join(path, "Chart.yaml"), encoding="locale"
             ) as chart_file:
@@ -49,6 +54,8 @@ def do_template(
                                 repo,
                                 "--repository-config",
                                 repository_config_file.name,
+                                "--repository-cache",
+                                repository_cache_file.name,
                             ]
                             run(cmd, capture_output=False, check=True)
                     cmd = [
@@ -58,6 +65,8 @@ def do_template(
                         path,
                         "--repository-config",
                         repository_config_file.name,
+                        "--repository-cache",
+                        repository_cache_file.name,
                     ]
                     run(cmd, capture_output=False, check=True)
             with tempfile.NamedTemporaryFile(
@@ -75,6 +84,8 @@ def do_template(
                     values_file.name,
                     "--repository-config",
                     repository_config_file.name,
+                    "--repository-cache",
+                    repository_cache_file.name,
                 ]
                 result = run(cmd, capture_output=True, check=True)
     except CalledProcessError as e:

--- a/reconcile/utils/helm.py
+++ b/reconcile/utils/helm.py
@@ -33,7 +33,7 @@ def do_template(
     try:
         with tempfile.NamedTemporaryFile(
             mode="w+", encoding="locale"
-        ) as repositories_file:
+        ) as repository_config_file:
             with open(
                 os.path.join(path, "Chart.yaml"), encoding="locale"
             ) as chart_file:
@@ -48,7 +48,7 @@ def do_template(
                                 dep["name"],
                                 repo,
                                 "--repository-config",
-                                repositories_file.name,
+                                repository_config_file.name,
                             ]
                             run(cmd, capture_output=False, check=True)
                     cmd = [
@@ -57,7 +57,7 @@ def do_template(
                         "build",
                         path,
                         "--repository-config",
-                        repositories_file.name,
+                        repository_config_file.name,
                     ]
                     run(cmd, capture_output=False, check=True)
             with tempfile.NamedTemporaryFile(
@@ -74,7 +74,7 @@ def do_template(
                     "-f",
                     values_file.name,
                     "--repository-config",
-                    repositories_file.name,
+                    repository_config_file.name,
                 ]
                 result = run(cmd, capture_output=True, check=True)
     except CalledProcessError as e:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2250

avoid error:
```
Error: looks like "https://charts.external-secrets.io/" is not a valid chart repository or cannot be reached: open /.cache/helm/repository/external-secrets-index.yaml: no such file or directory
[ERROR] [saasherder.py:populate_desired_state_saas_file:1285] - Error in populate_desired_state_saas_file: Error running helm template [helm repo add external-secrets https://charts.external-secrets.io/ --repository-config /tmp/tmp6wbzfi5k]
```