### PR TITLE
helm repository-cache is actually a dir and not a file

### DIFF
--- a/reconcile/utils/helm.py
+++ b/reconcile/utils/helm.py
@@ -35,9 +35,7 @@ def do_template(
             tempfile.NamedTemporaryFile(
                 mode="w+", encoding="locale"
             ) as repository_config_file,
-            tempfile.NamedTemporaryFile(
-                mode="w+", encoding="locale"
-            ) as repository_cache_file,
+            tempfile.TemporaryDirectory() as repository_cache_dir,
         ):
             with open(
                 os.path.join(path, "Chart.yaml"), encoding="locale"
@@ -55,7 +53,7 @@ def do_template(
                                 "--repository-config",
                                 repository_config_file.name,
                                 "--repository-cache",
-                                repository_cache_file.name,
+                                repository_cache_dir,
                             ]
                             run(cmd, capture_output=False, check=True)
                     cmd = [
@@ -66,7 +64,7 @@ def do_template(
                         "--repository-config",
                         repository_config_file.name,
                         "--repository-cache",
-                        repository_cache_file.name,
+                        repository_cache_dir,
                     ]
                     run(cmd, capture_output=False, check=True)
             with tempfile.NamedTemporaryFile(
@@ -85,7 +83,7 @@ def do_template(
                     "--repository-config",
                     repository_config_file.name,
                     "--repository-cache",
-                    repository_cache_file.name,
+                    repository_cache_dir,
                 ]
                 result = run(cmd, capture_output=True, check=True)
     except CalledProcessError as e:


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2250

fixes #4547

avoid error:
```
Error: looks like "https://charts.external-secrets.io/" is not a valid chart repository or cannot be reached: open /tmp/tmp0w9w6vxl/external-secrets-index.yaml: not a directory
[ERROR] [saasherder.py:populate_desired_state_saas_file:1285] - Error in populate_desired_state_saas_file: Error running helm template [helm repo add external-secrets https://charts.external-secrets.io/ --repository-config /tmp/tmpba2sdc98 --repository-cache /tmp/tmp0w9w6vxl]
```