### PR TITLE
[saasherder/helm] alter image tag behavior

### DIFF
--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -969,11 +969,9 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 else True
             )
             consolidated_parameters = spec.parameters(adjust=False)
-            image = consolidated_parameters.get("image", {})
-            if isinstance(image, dict) and not image.get("tag"):
-                commit_sha = self._get_commit_sha(url, ref, github)
-                image_tag = commit_sha[:hash_length]
-                consolidated_parameters.setdefault("image", {})["tag"] = image_tag
+            commit_sha = self._get_commit_sha(url, ref, github)
+            image_tag = commit_sha[:hash_length]
+            consolidated_parameters.setdefault("image", {})["tag"] = image_tag
             resources = helm.template_all(
                 url=url,
                 path=path,

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -971,7 +971,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             consolidated_parameters = spec.parameters(adjust=False)
             commit_sha = self._get_commit_sha(url, ref, github)
             image_tag = commit_sha[:hash_length]
-            consolidated_parameters.setdefault("image", {})["tag"] = image_tag
+            consolidated_parameters.setdefault("IMAGE_TAG", image_tag)
             resources = helm.template_all(
                 url=url,
                 path=path,

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -970,6 +970,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
             )
             commit_sha = self._get_commit_sha(url, ref, github)
             image_tag = commit_sha[:hash_length]
+            spec.target.parameters = spec.target.parameters or {}
             spec.target.parameters.setdefault("IMAGE_TAG", image_tag)
             consolidated_parameters = spec.parameters(adjust=False)
             resources = helm.template_all(

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -968,10 +968,10 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 if self.gitlab and url.startswith(self.gitlab.server)
                 else True
             )
-            consolidated_parameters = spec.parameters(adjust=False)
             commit_sha = self._get_commit_sha(url, ref, github)
             image_tag = commit_sha[:hash_length]
-            consolidated_parameters.setdefault("IMAGE_TAG", image_tag)
+            spec.target.parameters.setdefault("IMAGE_TAG", image_tag)
+            consolidated_parameters = spec.parameters(adjust=False)
             resources = helm.template_all(
                 url=url,
                 path=path,


### PR DESCRIPTION
in the helm world, we may need to define image_tag in various indentations or fields.

this PR makes `${IMAGE_TAG}` a usable parameter within the saas file itself.
for example:
```
resourceTemplates:
- provider: helm
  ...
  targets:
  - namespace:
      $ref: /path/to/namespace.yml
    ref: main
    parameters:
      componentA:
        image:
          tag: ${IMAGE_TAG}
      componentB:
        image:
          tag: ${IMAGE_TAG}
```