### PR TITLE
:bug: terraform-resources msk: fix MSK cluster upgrade

### DIFF
--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -6570,7 +6570,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         msk_version_str = values["kafka_version"].replace(".", "-")
         msk_config_name = f"{resource_id}-{msk_version_str}"
         msk_config = aws_msk_configuration(
-            resource_id,
+            msk_config_name,
             name=msk_config_name,
             kafka_versions=[values["kafka_version"]],
             server_properties=values["server_properties"],


### PR DESCRIPTION
To support MSK cluster upgrades, use a version-dependent Terraform resource id for the AWS MSK configuration. There is no need to replace the existing configuration.

I'll tackle the resource ID change during the promotion by manually removing and importing the existing MSK configurations.

Ticket: [APPSRE-10579](https://issues.redhat.com/browse/APPSRE-10579)