### PR TITLE
APPSRE-10086 sapm cron schedule

### DIFF
--- a/reconcile/gql_definitions/common/saas_files.gql
+++ b/reconcile/gql_definitions/common/saas_files.gql
@@ -140,6 +140,7 @@ query SaasFiles {
           publish
           subscribe
           soakDays
+          schedule
           promotion_data {
             channel
             data {

--- a/reconcile/gql_definitions/common/saas_files.py
+++ b/reconcile/gql_definitions/common/saas_files.py
@@ -265,6 +265,7 @@ query SaasFiles {
           publish
           subscribe
           soakDays
+          schedule
           promotion_data {
             channel
             data {
@@ -471,6 +472,7 @@ class SaasResourceTemplateTargetPromotionV1(ConfiguredBaseModel):
     publish: Optional[list[str]] = Field(..., alias="publish")
     subscribe: Optional[list[str]] = Field(..., alias="subscribe")
     soak_days: Optional[int] = Field(..., alias="soakDays")
+    schedule: Optional[str] = Field(..., alias="schedule")
     promotion_data: Optional[list[PromotionDataV1]] = Field(..., alias="promotion_data")
 
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -22280,6 +22280,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "schedule",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "promotion_data",
                             "description": null,
                             "args": [],

--- a/reconcile/saas_auto_promotions_manager/subscriber.py
+++ b/reconcile/saas_auto_promotions_manager/subscriber.py
@@ -123,6 +123,14 @@ class Subscriber:
         return delta >= timedelta(days=self.soak_days)
 
     def _is_valid_deployment_window(self) -> bool:
+        # Ideally we would catch that at schema validation time
+        if not croniter.is_valid(self.schedule):
+            logging.error(
+                "Subscriber at %s has an invalid schedule declaration %s. We will block any promotion for that target until this is fixed.",
+                self.target_file_path,
+                self.schedule,
+            )
+            return False
         return croniter.match(self.schedule, datetime.now(UTC))
 
     def _compute_desired_ref(self) -> None:

--- a/reconcile/saas_auto_promotions_manager/subscriber.py
+++ b/reconcile/saas_auto_promotions_manager/subscriber.py
@@ -45,6 +45,7 @@ class Subscriber:
         uid: str,
         soak_days: int,
         blocked_versions: set[str],
+        schedule: str,
     ):
         self.saas_name = saas_name
         self.template_name = template_name
@@ -117,6 +118,10 @@ class Subscriber:
                     continue
                 delta += now - deployed_at
         return delta >= timedelta(days=self.soak_days)
+    
+    def _is_valid_deployment_window(self) -> bool:
+        # TODO: implement
+        return True
 
     def _compute_desired_ref(self) -> None:
         """

--- a/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
+++ b/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
@@ -1,8 +1,6 @@
 import logging
 from collections.abc import Iterable
 
-from croniter import croniter
-
 from reconcile.gql_definitions.common.saas_files import ParentSaasPromotionV1
 from reconcile.saas_auto_promotions_manager.publisher import Publisher
 from reconcile.saas_auto_promotions_manager.subscriber import (
@@ -109,15 +107,6 @@ class SaasFilesInventory:
                         if target.promotion.schedule
                         else "* * * * *"
                     )
-                    # Ideally we would catch that at schema validation time
-                    if not croniter.is_valid(schedule):
-                        logging.error(
-                            "Subscriber at %s has an invalid schedule declaration %s. We will block any promotion for that target until this is fixed.",
-                            file_path,
-                            schedule,
-                        )
-                        # Lets set schedule for impossible date to block promotions
-                        schedule = "0 5 31 2 1"
                     subscriber = Subscriber(
                         uid=target.uid(
                             parent_saas_file_name=saas_file.name,

--- a/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
+++ b/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
@@ -9,6 +9,9 @@ from reconcile.saas_auto_promotions_manager.subscriber import (
     Subscriber,
 )
 from reconcile.typed_queries.saas_files import SaasFile
+from reconcile.utils.models import (
+    cron_validator,
+)
 
 
 class SaasFileInventoryError(Exception):
@@ -113,6 +116,7 @@ class SaasFilesInventory:
                         ref=target.ref,
                         target_namespace=target.namespace,
                         soak_days=soak_days,
+                        schedule=schedule,
                         blocked_versions=blocked_versions.get(
                             resource_template.url, set()
                         ),

--- a/reconcile/test/saas_auto_promotions_manager/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/conftest.py
@@ -159,6 +159,7 @@ def subscriber_builder(
             use_target_config_hash=data.get("USE_TARGET_CONFIG_HASH", True),
             soak_days=data.get("SOAK_DAYS", 0),
             blocked_versions=data.get("BLOCKED_VERSIONS", {}),
+            schedule=data.get("SCHEDULE", "* * * * *"),
         )
         subscriber.channels = channels
         subscriber.config_hashes_by_channel_name = cur_config_hashes_by_channel

--- a/reconcile/test/saas_auto_promotions_manager/subscriber/test_schedule.py
+++ b/reconcile/test/saas_auto_promotions_manager/subscriber/test_schedule.py
@@ -53,3 +53,26 @@ def test_single_publisher_outside_schedule(
     # We are outside of our cron expression-> do not promote
     assert subscriber.desired_ref == "current_sha"
     assert subscriber.desired_hashes == []
+
+
+def test_single_publisher_invalid_schedule(
+    subscriber_builder: Callable[[Mapping[str, Any]], Subscriber],
+) -> None:
+    subscriber = subscriber_builder({
+        "CUR_SUBSCRIBER_REF": "current_sha",
+        # invalid format
+        "SCHEDULE": "* * * * * ? 2099",
+        "USE_TARGET_CONFIG_HASH": False,
+        "CHANNELS": {
+            "channel-a": {
+                "publisher_a": {
+                    "REAL_WORLD_SHA": "new_sha",
+                }
+            },
+        },
+    })
+    subscriber.compute_desired_state()
+
+    # Invalid cron expression-> do not promote
+    assert subscriber.desired_ref == "current_sha"
+    assert subscriber.desired_hashes == []

--- a/reconcile/test/saas_auto_promotions_manager/subscriber/test_schedule.py
+++ b/reconcile/test/saas_auto_promotions_manager/subscriber/test_schedule.py
@@ -1,0 +1,55 @@
+from collections.abc import (
+    Callable,
+    Mapping,
+)
+from typing import Any
+
+from reconcile.saas_auto_promotions_manager.subscriber import (
+    Subscriber,
+)
+
+
+def test_single_publisher_in_schedule(
+    subscriber_builder: Callable[[Mapping[str, Any]], Subscriber],
+) -> None:
+    subscriber = subscriber_builder({
+        "CUR_SUBSCRIBER_REF": "current_sha",
+        "SCHEDULE": "* * * * *",
+        "USE_TARGET_CONFIG_HASH": False,
+        "CHANNELS": {
+            "channel-a": {
+                "publisher_a": {
+                    "REAL_WORLD_SHA": "new_sha",
+                }
+            },
+        },
+    })
+    subscriber.compute_desired_state()
+
+    # We are within cron expression -> promote new ref
+    assert subscriber.desired_ref == "new_sha"
+    assert subscriber.desired_hashes == []
+
+
+def test_single_publisher_outside_schedule(
+    subscriber_builder: Callable[[Mapping[str, Any]], Subscriber],
+) -> None:
+    subscriber = subscriber_builder({
+        "CUR_SUBSCRIBER_REF": "current_sha",
+        # We stay away from datetime mocking for now as it conflicts with other gates
+        # Very unlikely we have a test running at exactly this time
+        "SCHEDULE": "1 1 1 1 1",
+        "USE_TARGET_CONFIG_HASH": False,
+        "CHANNELS": {
+            "channel-a": {
+                "publisher_a": {
+                    "REAL_WORLD_SHA": "new_sha",
+                }
+            },
+        },
+    })
+    subscriber.compute_desired_state()
+
+    # We are outside of our cron expression-> do not promote
+    assert subscriber.desired_ref == "current_sha"
+    assert subscriber.desired_hashes == []

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -166,6 +166,7 @@ class TestSaasFileValid(TestCase):
             subscribe=None,
             promotion_data=None,
             soakDays=0,
+            schedule="* * * * *",
         )
         saasherder = SaasHerder(
             [self.saas_file],
@@ -190,6 +191,7 @@ class TestSaasFileValid(TestCase):
             subscribe=None,
             promotion_data=None,
             soakDays=0,
+            schedule="* * * * *",
         )
         saasherder = SaasHerder(
             [self.saas_file],


### PR DESCRIPTION
Adding `schedule` gate to saas auto-promotions.

SAPM will obey to the given cron expression and only schedule auto-promotions if they fall within the schedule.

Note, that we do not add this gate to saasherder, as it could block unrelated promotions. The `schedule` feature is relevant for auto-promotions only.

Schema: https://github.com/app-sre/qontract-schemas/pull/680