### PR TITLE
Support forced re-runs of Terraform Repo with a new key in the schema file

### DIFF
--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -32089,6 +32089,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "forceRerunTimestamp",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "String",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "tfVersion",
                             "description": null,
                             "args": [],

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.gql
@@ -25,6 +25,7 @@ query TerraformRepo {
     delete
     requireFips
     tfVersion
+    forceRerunTimestamp
     variables {
       inputs {
         ...VaultSecret

--- a/reconcile/gql_definitions/terraform_repo/terraform_repo.py
+++ b/reconcile/gql_definitions/terraform_repo/terraform_repo.py
@@ -53,6 +53,7 @@ query TerraformRepo {
     delete
     requireFips
     tfVersion
+    forceRerunTimestamp
     variables {
       inputs {
         ...VaultSecret
@@ -105,6 +106,7 @@ class TerraformRepoV1(ConfiguredBaseModel):
     delete: Optional[bool] = Field(..., alias="delete")
     require_fips: Optional[bool] = Field(..., alias="requireFips")
     tf_version: str = Field(..., alias="tfVersion")
+    force_rerun_timestamp: Optional[str] = Field(..., alias="forceRerunTimestamp")
     variables: Optional[TerraformRepoVariablesV1] = Field(..., alias="variables")
 
 

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -361,7 +361,7 @@ class TerraformRepoIntegration(
                 )
             if self.params.validate_git:
                 self.check_ref(d.repository, d.ref)
-            if d.force_rerun_timestamp:
+            if c.force_rerun_timestamp != d.force_rerun_timestamp:
                 logging.info("user has forced a re-run of tf-repo execution")
 
         if len(merged) != 0:

--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -361,6 +361,8 @@ class TerraformRepoIntegration(
                 )
             if self.params.validate_git:
                 self.check_ref(d.repository, d.ref)
+            if d.force_rerun_timestamp:
+                logging.info("user has forced a re-run of tf-repo execution")
 
         if len(merged) != 0:
             if not dry_run and state:


### PR DESCRIPTION
[APPSRE-8705](https://issues.redhat.com/browse/APPSRE-8705)

Depends on https://github.com/app-sre/qontract-schemas/pull/691, see that MR for more background on why this approach was chosen. Re-runs are implemented in Terraform Repo by just adding a new key that is considered during the diffing process between `existing` and `desired`. If a user updates the timestamp in an MR, then tf-repo will perform a `terraform plan` & `apply` again. No changes are needed to executor since this key isn't used by executor.