### PR TITLE
[saasherder/helm] image.tag functionality update

### DIFF
--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -969,11 +969,16 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 else True
             )
             consolidated_parameters = spec.parameters(adjust=False)
-            image = consolidated_parameters.get("image", {})
-            if isinstance(image, dict) and not image.get("tag"):
-                commit_sha = self._get_commit_sha(url, ref, github)
-                image_tag = commit_sha[:hash_length]
-                consolidated_parameters.setdefault("image", {})["tag"] = image_tag
+            commit_sha = self._get_commit_sha(url, ref, github)
+            image_tag = commit_sha[:hash_length]
+            image = consolidated_parameters.setdefault("image", {})
+            if isinstance(image, dict):
+                image.setdefault("tag", image_tag)
+            global_parameters = consolidated_parameters.setdefault("global", {})
+            if isinstance(global_parameters, dict):
+                image = global_parameters.setdefault("image", {})
+                if isinstance(image, dict):
+                    image.setdefault("tag", image_tag)
             resources = helm.template_all(
                 url=url,
                 path=path,


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-2250

follow up on #4483

this PR updates the auto-generated image tag to be exposed in the values file at the following levels:
- `image.tag`
- `global.image.tag`

this is to enable deployment of "parent" charts. the global pattern is quite common.