### PR TITLE
Revert "[tf-repo] change behavior when state has to be recreated"

### DIFF
--- a/reconcile/terraform_repo.py
+++ b/reconcile/terraform_repo.py
@@ -109,6 +109,7 @@ class TerraformRepoIntegration(
             # when updating TerraformRepoV1 GQL schema, Pydantic does not gracefully handle these changes and fails to parse
             # the existing state stored in S3. This is due to a behavior in Pydantic V1 that has since been addressed in V2
             # https://docs.pydantic.dev/latest/blog/pydantic-v2/#required-vs-nullable-cleanup
+            # so in this case, tf-repo will just recreate all of those state files in S3 and not actually do a plan or apply
             logging.error(err)
             logging.info(
                 "Unable to parse existing Terraform-Repo state from S3. Note that this is separate from the actual .tfstate files. Terraform Repo will re-create its own state upon merge and will not update any infrastructure. This typically occurs with changes to the Terraform Repo schema files and is normally resolved once state is re-created."
@@ -120,9 +121,6 @@ class TerraformRepoIntegration(
                 state=state,
                 recreate_state=True,
             )
-
-            if repo_diff_result:
-                self.print_output(repo_diff_result, dry_run)
 
     def print_output(self, diff: list[TerraformRepoV1], dry_run: bool) -> OutputFile:
         """Parses and prints the output of a Terraform Repo diff for the executor


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#4326

This behavior made sense back then but now in FedRamp we have Terraform resources having to do with API gateway objects which don't gracefully handle recreations like other AWS resources in Terraform.