### PR TITLE
[openshift-saas-deploy] enable skipping planned data validation

### DIFF
--- a/reconcile/gql_definitions/common/saas_files.gql
+++ b/reconcile/gql_definitions/common/saas_files.gql
@@ -108,6 +108,7 @@ query SaasFiles {
       }
     }
     validateTargetsInApp
+    validatePlannedData
     resourceTemplates {
       name
       url

--- a/reconcile/gql_definitions/common/saas_files.py
+++ b/reconcile/gql_definitions/common/saas_files.py
@@ -233,6 +233,7 @@ query SaasFiles {
       }
     }
     validateTargetsInApp
+    validatePlannedData
     resourceTemplates {
       name
       url
@@ -560,6 +561,7 @@ class SaasFileV2(ConfiguredBaseModel):
     parameters: Optional[Json] = Field(..., alias="parameters")
     secret_parameters: Optional[list[SaasSecretParametersV1]] = Field(..., alias="secretParameters")
     validate_targets_in_app: Optional[bool] = Field(..., alias="validateTargetsInApp")
+    validate_planned_data: Optional[bool] = Field(..., alias="validatePlannedData")
     resource_templates: list[SaasResourceTemplateV2] = Field(..., alias="resourceTemplates")
     self_service_roles: Optional[list[SaasFileV2_RoleV1]] = Field(..., alias="selfServiceRoles")
 

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -21469,6 +21469,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "validatePlannedData",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "resourceTemplates",
                             "description": null,
                             "args": [],

--- a/reconcile/openshift_saas_deploy.py
+++ b/reconcile/openshift_saas_deploy.py
@@ -238,7 +238,8 @@ def run(
 
     # validate that the deployment will succeed
     # to the best of our ability to predict
-    ob.validate_planned_data(ri, oc_map)
+    if saasherder.validate_planned_data:
+        ob.validate_planned_data(ri, oc_map)
 
     # if saas_file_name is defined, the integration
     # is being called from multiple running instances

--- a/reconcile/test/test_typed_queries/test_saas_files.py
+++ b/reconcile/test/test_typed_queries/test_saas_files.py
@@ -682,6 +682,7 @@ def test_export_model(
             "parameters": '{"SAAS_PARAM": "foobar"}',
             "secretParameters": None,
             "validateTargetsInApp": None,
+            "validatePlannedData": None,
             "resourceTemplates": [
                 {
                     "name": "deploy-app",
@@ -857,6 +858,7 @@ def test_export_model(
             "parameters": None,
             "secretParameters": None,
             "validateTargetsInApp": None,
+            "validatePlannedData": None,
             "resourceTemplates": [
                 {
                     "name": "deploy-app",
@@ -1032,6 +1034,7 @@ def test_export_model(
             "parameters": None,
             "secretParameters": None,
             "validateTargetsInApp": None,
+            "validatePlannedData": None,
             "resourceTemplates": [
                 {
                     "name": "deploy-app",

--- a/reconcile/typed_queries/saas_files.py
+++ b/reconcile/typed_queries/saas_files.py
@@ -126,6 +126,7 @@ class SaasFile(ConfiguredBaseModel):
         ..., alias="secretParameters"
     )
     validate_targets_in_app: bool | None = Field(..., alias="validateTargetsInApp")
+    validate_planned_data: bool | None = Field(..., alias="validatePlannedData")
     managed_resource_names: list[ManagedResourceNamesV1] | None = Field(
         ..., alias="managedResourceNames"
     )

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -158,6 +158,9 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
         self.compare = self._get_saas_file_feature_enabled("compare", default=True)
         self.publish_job_logs = self._get_saas_file_feature_enabled("publish_job_logs")
         self.cluster_admin = self._get_saas_file_feature_enabled("cluster_admin")
+        self.validate_planned_data = self._get_saas_file_feature_enabled(
+            "validate_planned_data", default=True
+        )
 
     def __enter__(self) -> "SaasHerder":
         return self


### PR DESCRIPTION
depends on https://github.com/app-sre/qontract-schemas/pull/692

follow up on #2261

this PR introduces handling for a saas file to define `validatePlannedData: false` and to skip validation of planned data:
https://github.com/app-sre/qontract-reconcile/blob/ccca2e5031ce5436d011dbabfc557368c1215cfc/reconcile/openshift_base.py#L1117-L1129