### PR TITLE
Fix error in ocm-upgrade-scheduler-org for org without clusters

### DIFF
--- a/reconcile/aus/ocm_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_upgrade_scheduler_org.py
@@ -67,9 +67,10 @@ class OCMClusterUpgradeSchedulerOrgIntegration(OCMClusterUpgradeSchedulerIntegra
                             org=org,
                             providers=cluster_health_providers,
                         ),
-                        node_pool_specs_by_cluster_id=node_pool_specs_by_org_cluster[
+                        node_pool_specs_by_cluster_id=node_pool_specs_by_org_cluster.get(
                             org.org_id
-                        ],
+                        )
+                        or {},
                     ),
                 )
                 for org in organizations

--- a/reconcile/test/ocm/aus/test_ocm_upgrade_scheduler_org.py
+++ b/reconcile/test/ocm/aus/test_ocm_upgrade_scheduler_org.py
@@ -122,3 +122,32 @@ def test_get_ocm_env_upgrade_specs(
 
     assert upgrade_specs == expected_upgrade_specs
     assert upgrade_specs[org.name].specs[0] == expected_cluster_upgrade_spec
+
+
+def test_get_ocm_env_upgrade_specs_for_org_without_clusters(
+    mocker: MockerFixture,
+    ocm_env: OCMEnvironment,
+) -> None:
+    org = build_organization(org_id=ORG_ID)
+    setup_mocks(
+        mocker,
+        orgs=[org],
+        clusters=[],
+        node_pool_specs_by_org_cluster={},
+    )
+    expected_upgrade_specs = {
+        org.name: OrganizationUpgradeSpec(
+            org=org,
+            specs=[],
+        )
+    }
+    integration = OCMClusterUpgradeSchedulerOrgIntegration(
+        params=AdvancedUpgradeSchedulerBaseIntegrationParams(
+            ocm_organization_ids={ORG_ID},
+            excluded_ocm_organization_ids=set(),
+        ),
+    )
+
+    upgrade_specs = integration.get_ocm_env_upgrade_specs(ocm_env)
+
+    assert upgrade_specs == expected_upgrade_specs


### PR DESCRIPTION
Fix `KeyError` for `node_pool_specs_by_org_cluster` when org has no clusters.

Follow up for #4460

[APPSRE-10332](https://issues.redhat.com/browse/APPSRE-10332)

