### PR TITLE
[gitlab] replace wip with draft

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -313,7 +313,7 @@ def preprocess_merge_requests(
             MRStatus.CANNOT_BE_MERGED_RECHECK,
         }:
             continue
-        if mr.work_in_progress:
+        if mr.draft:
             continue
         if len(mr.commits()) == 0:
             continue

--- a/reconcile/test/test_gitlab_housekeeping.py
+++ b/reconcile/test/test_gitlab_housekeeping.py
@@ -177,7 +177,7 @@ def project() -> Project:
 def can_be_merged_merge_request() -> Mock:
     mr = create_autospec(ProjectMergeRequest)
     mr.merge_status = "can_be_merged"
-    mr.work_in_progress = False
+    mr.draft = False
     mr.commits.return_value = [create_autospec(ProjectCommit)]
     mr.labels = ["lgtm"]
     mr.iid = 1

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2017,7 +2017,7 @@ def app_interface_review_queue(ctx) -> None:
 
         queue_data = []
         for mr in merge_requests:
-            if mr.work_in_progress:
+            if mr.draft:
                 continue
             if len(mr.commits()) == 0:
                 continue
@@ -2116,7 +2116,7 @@ def app_interface_open_selfserviceable_mr_queue(ctx):
     ]
     queue_data = []
     for mr in merge_requests:
-        if mr.work_in_progress:
+        if mr.draft:
             continue
         if len(mr.commits()) == 0:
             continue


### PR DESCRIPTION
```
[].work_in_progress 	boolean 	Deprecated: Use draft instead. Indicates if the merge request is a draft. 
```
from https://docs.gitlab.com/ee/api/merge_requests.html

ref: https://gitlab.com/gitlab-org/gitlab/-/issues/228685