### PR TITLE
gitlab merge request to promote qontract-schemas

### DIFF
--- a/reconcile/utils/mr/__init__.py
+++ b/reconcile/utils/mr/__init__.py
@@ -12,6 +12,7 @@ from reconcile.utils.mr.ocm_update_recommended_version import (
 from reconcile.utils.mr.ocm_upgrade_scheduler_org_updates import (
     CreateOCMUpgradeSchedulerOrgUpdates,
 )
+from reconcile.utils.mr.promote_qontract import PromoteQontractSchemas
 from reconcile.utils.mr.user_maintenance import (
     CreateDeleteUserAppInterface,
     CreateDeleteUserInfra,
@@ -29,6 +30,7 @@ __all__ = [
     "CreateAppInterfaceNotificator",
     "CreateDeleteUserAppInterface",
     "CreateDeleteUserInfra",
+    "PromoteQontractSchemas",
 ]
 
 

--- a/reconcile/utils/mr/promote_qontract.py
+++ b/reconcile/utils/mr/promote_qontract.py
@@ -1,0 +1,41 @@
+from reconcile.utils.gitlab_api import GitLabApi
+from reconcile.utils.mr.base import MergeRequestBase
+
+
+class PromoteQontractSchemas(MergeRequestBase):
+    name = "promote_qontract_schemas"
+
+    def __init__(self, version: str):
+        self.path = ".env"
+        self.version = version
+
+        super().__init__()
+
+        self.labels = []
+
+    @property
+    def title(self) -> str:
+        return f"[{self.name}] promote qontract-schemas to version {self.version}"
+
+    @property
+    def description(self) -> str:
+        return f"promote qontract-schemas to version {self.version}"
+
+    def process(self, gitlab_cli: GitLabApi) -> None:
+        raw_file = gitlab_cli.project.files.get(
+            file_path=self.path, ref=gitlab_cli.main_branch
+        )
+        content = raw_file.decode().decode("utf-8")
+        lines = content.splitlines()
+        for index, text in enumerate(lines):
+            if text.startswith("export SCHEMAS_IMAGE_TAG="):
+                lines[index] = f"export SCHEMAS_IMAGE_TAG={self.version}"
+
+        new_content = "\n".join(lines) + "\n"
+
+        gitlab_cli.update_file(
+            branch_name=self.branch,
+            file_path=self.path,
+            commit_message=self.description,
+            content=new_content,
+        )


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10688

given a message such as `{"pr_type": "promote_qontract_schemas", "version": "testing123"}` reaches the app-interface SQS queue, it will produce a merge request such as https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/113644

this merge request is not auto merged and should be used by the person wanting to promote.