### PR TITLE
saas re-use check_in time

### DIFF
--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1947,6 +1947,15 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     if current_state and current_state.has_succeeded_once:
                         has_succeeded_once = True
 
+                    check_in = str(now)
+                    if success and current_state and current_state.check_in:
+                        # We want to avoid an override of the timestamp.
+                        # This can happen on re-deployments of the same ref.
+                        # We only re-use the check_in time if the deployment
+                        # was successful - on unsuccessful deployments, we
+                        # update the check_in time to current time.
+                        check_in = current_state.check_in
+
                     # publish to state to pass promotion gate
                     self._promotion_state.publish_promotion_data(
                         sha=promotion.commit_sha,
@@ -1957,8 +1966,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                             success=success,
                             target_config_hash=promotion.target_config_hash,
                             has_succeeded_once=has_succeeded_once,
-                            # TODO: do not override - check if timestamp already exists
-                            check_in=str(now),
+                            check_in=check_in,
                         ),
                     )
                     logging.info(

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -1948,11 +1948,17 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                         has_succeeded_once = True
 
                     check_in = str(now)
-                    if success and current_state and current_state.check_in:
+                    if (
+                        success
+                        and current_state
+                        and current_state.check_in
+                        and current_state.success
+                    ):
                         # We want to avoid an override of the timestamp.
                         # This can happen on re-deployments of the same ref.
-                        # We only re-use the check_in time if the deployment
-                        # was successful - on unsuccessful deployments, we
+                        # We only re-use the check_in time if the previous
+                        # and current deployment was successful.
+                        # On unsuccessful deployments, we
                         # update the check_in time to current time.
                         check_in = current_state.check_in
 


### PR DESCRIPTION
A successful saas re-deployment of the same ref currently overrides the `check_in` time. This can easily block saas files which rely on the soakDays feature. Example https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/113754

In this PR we avoid overrides of `check_in` time if the deployment was successful. On unsuccessful deployments, we update the `check_in` time, i.e., we reset the soakDays counter for this target.