### PR TITLE
APPSRE-10615 refactor for scope updates

### DIFF
--- a/reconcile/test/dynatrace_token_provider/fixtures.py
+++ b/reconcile/test/dynatrace_token_provider/fixtures.py
@@ -102,7 +102,7 @@ def build_ocm_client(
 
 def build_dynatrace_client(
     create_api_token: Mapping[str, DynatraceAPITokenCreated],
-    existing_token_ids: set[str],
+    existing_token_ids: dict[str, str],
 ) -> DynatraceClient:
     dynatrace_client = create_autospec(spec=DynatraceClient)
 
@@ -115,6 +115,6 @@ def build_dynatrace_client(
 
     mock_create_api_token = MagicMock(side_effect=create_api_token_side_effect)
     dynatrace_client.create_api_token = mock_create_api_token
-    dynatrace_client.get_token_ids_for_name_prefix.return_value = existing_token_ids
+    dynatrace_client.get_token_ids_map_for_name_prefix.return_value = existing_token_ids
 
     return dynatrace_client

--- a/reconcile/test/dynatrace_token_provider/test_create_manifest.py
+++ b/reconcile/test/dynatrace_token_provider/test_create_manifest.py
@@ -57,7 +57,7 @@ def test_single_hcp_cluster_create_tokens(
             f"dtp-ingestion-token-{default_hcp_cluster.external_id}": ingestion_token,
             f"dtp-operator-token-{default_hcp_cluster.external_id}": operator_token,
         },
-        existing_token_ids=set(),
+        existing_token_ids={},
     )
 
     dynatrace_client_by_tenant_id = {

--- a/reconcile/test/dynatrace_token_provider/test_create_syncset.py
+++ b/reconcile/test/dynatrace_token_provider/test_create_syncset.py
@@ -57,7 +57,7 @@ def test_single_non_hcp_cluster_create_tokens(
             f"dtp-ingestion-token-{default_cluster.external_id}": ingestion_token,
             f"dtp-operator-token-{default_cluster.external_id}": operator_token,
         },
-        existing_token_ids=set(),
+        existing_token_ids={},
     )
 
     dynatrace_client_by_tenant_id = {

--- a/reconcile/test/dynatrace_token_provider/test_dry_run.py
+++ b/reconcile/test/dynatrace_token_provider/test_dry_run.py
@@ -75,7 +75,7 @@ def test_dry_run(
     dynatrace_client = build_dynatrace_client(
         create_api_token={},
         # Operator token id is missing
-        existing_token_ids={default_ingestion_token.id},
+        existing_token_ids={default_ingestion_token.id: "name123"},
     )
 
     dynatrace_client_by_tenant_id = {

--- a/reconcile/test/dynatrace_token_provider/test_no_change_manifest.py
+++ b/reconcile/test/dynatrace_token_provider/test_no_change_manifest.py
@@ -73,7 +73,10 @@ def test_no_change_hcp_cluster(
             f"dtp-ingestion-token-{default_hcp_cluster.external_id}": ingestion_token,
             f"dtp-operator-token-{default_hcp_cluster.external_id}": operator_token,
         },
-        existing_token_ids={default_ingestion_token.id, default_operator_token.id},
+        existing_token_ids={
+            default_ingestion_token.id: "name1",
+            default_operator_token.id: "name2",
+        },
     )
 
     dynatrace_client_by_tenant_id = {

--- a/reconcile/test/dynatrace_token_provider/test_no_change_syncset.py
+++ b/reconcile/test/dynatrace_token_provider/test_no_change_syncset.py
@@ -73,7 +73,10 @@ def test_no_change_non_hcp_cluster(
             f"dtp-ingestion-token-{default_cluster.external_id}": ingestion_token,
             f"dtp-operator-token-{default_cluster.external_id}": operator_token,
         },
-        existing_token_ids={default_ingestion_token.id, default_operator_token.id},
+        existing_token_ids={
+            default_ingestion_token.id: "name1",
+            default_operator_token.id: "name2",
+        },
     )
 
     dynatrace_client_by_tenant_id = {

--- a/reconcile/test/dynatrace_token_provider/test_ocm_org_filters.py
+++ b/reconcile/test/dynatrace_token_provider/test_ocm_org_filters.py
@@ -79,7 +79,7 @@ def test_ocm_org_filters(
     dynatrace_client = build_dynatrace_client(
         create_api_token={},
         # Operator token id is missing
-        existing_token_ids={default_ingestion_token.id},
+        existing_token_ids={default_ingestion_token.id: "name1"},
     )
 
     dynatrace_client_by_tenant_id = {

--- a/reconcile/test/dynatrace_token_provider/test_patch_manifest.py
+++ b/reconcile/test/dynatrace_token_provider/test_patch_manifest.py
@@ -75,7 +75,7 @@ def test_single_hcp_cluster_patch_tokens(
         },
         # Operator token id is missing
         existing_token_ids={
-            default_ingestion_token.id,
+            default_ingestion_token.id: "name1",
         },
     )
 

--- a/reconcile/test/dynatrace_token_provider/test_patch_syncset.py
+++ b/reconcile/test/dynatrace_token_provider/test_patch_syncset.py
@@ -75,7 +75,7 @@ def test_single_non_hcp_cluster_patch_tokens(
         },
         # Operator token id is missing
         existing_token_ids={
-            default_ingestion_token.id,
+            default_ingestion_token.id: "name1",
         },
     )
 

--- a/reconcile/test/utils/dynatrace/test_dynatrace_client.py
+++ b/reconcile/test/utils/dynatrace/test_dynatrace_client.py
@@ -33,7 +33,7 @@ def test_dynatrace_create_token_error() -> None:
     api.tokens.create.assert_called_once_with(name="test-token", scopes=["test-scope"])
 
 
-def test_dynatrace_token_ids_for_name_prefix_success() -> None:
+def test_dynatrace_token_ids_map_for_name_prefix_success() -> None:
     api = build_dynatrace_api(
         list_tokens=[
             ("test-prefix-1", "123"),
@@ -43,35 +43,35 @@ def test_dynatrace_token_ids_for_name_prefix_success() -> None:
     )
 
     client = DynatraceClient(environment_url="test-env", api=api)
-    token_ids = client.get_token_ids_for_name_prefix(prefix="test-prefix")
+    token_ids = client.get_token_ids_map_for_name_prefix(prefix="test-prefix")
 
-    assert token_ids == ["123", "456"]
+    assert token_ids == {"123": "test-prefix-1", "456": "test-prefix-2"}
     api.tokens.list.assert_called_once_with()
 
 
-def test_dynatrace_token_ids_for_name_empty_prefix_success() -> None:
+def test_dynatrace_token_ids_map_for_name_empty_prefix_success() -> None:
     api = build_dynatrace_api(
         list_tokens=[
             ("test-prefix-1", "123"),
             ("test-prefix-2", "456"),
-            ("filter-this", "789"),
+            ("other", "789"),
         ]
     )
 
     client = DynatraceClient(environment_url="test-env", api=api)
-    token_ids = client.get_token_ids_for_name_prefix(prefix="")
+    token_ids = client.get_token_ids_map_for_name_prefix(prefix="")
 
-    assert token_ids == ["123", "456", "789"]
+    assert token_ids == {"123": "test-prefix-1", "456": "test-prefix-2", "789": "other"}
     api.tokens.list.assert_called_once_with()
 
 
-def test_dynatrace_token_ids_for_name_prefix_error() -> None:
+def test_dynatrace_token_ids_map_for_name_prefix_error() -> None:
     api = build_dynatrace_api(list_error=Exception("test-error"))
 
     client = DynatraceClient(environment_url="test-env", api=api)
 
     with raises(DynatraceTokenRetrievalError):
-        client.get_token_ids_for_name_prefix(prefix="test-prefix")
+        client.get_token_ids_map_for_name_prefix(prefix="test-prefix")
 
     api.tokens.list.assert_called_once_with()
 

--- a/reconcile/utils/dynatrace/client.py
+++ b/reconcile/utils/dynatrace/client.py
@@ -49,14 +49,16 @@ class DynatraceClient:
             ) from e
         return DynatraceAPITokenCreated(token=token.token, id=token.id)
 
-    def get_token_ids_for_name_prefix(self, prefix: str) -> list[str]:
+    def get_token_ids_map_for_name_prefix(self, prefix: str) -> dict[str, str]:
         try:
             dt_tokens = self._api.tokens.list()
         except Exception as e:
             raise DynatraceTokenRetrievalError(
                 f"{self._environment_url=} Failed to retrieve tokens for {prefix=}", e
             ) from e
-        return [token.id for token in dt_tokens if token.name.startswith(prefix)]
+        return {
+            token.id: token.name for token in dt_tokens if token.name.startswith(prefix)
+        }
 
     def get_token_by_id(self, token_id: str) -> DynatraceAPIToken:
         try:
@@ -67,10 +69,11 @@ class DynatraceClient:
             ) from e
         return DynatraceAPIToken(id=token.id, scopes=token.scopes)
 
-    def update_token_scopes(self, token_id: str, scopes: list[str]) -> None:
+    def update_token(self, token_id: str, name: str, scopes: list[str]) -> None:
         try:
             self._api.tokens.put(
                 token_id=token_id,
+                name=name,
                 api_token=ApiTokenUpdate(
                     scopes=scopes,
                 ),


### PR DESCRIPTION
This is a refactor PR for a follow-up DTP token scope sync feature.

Currently, DTP does not act on scope changes in schema.

In this PR, we:

- enable DT client to update token names
- return a map of `token_id: token_name` instead of only `token_id` when we list-query DT API.

In a follow-up PR we will put the hash of token scopes as a prefix for the token name. Through this, we can detect diff with already used list query against DT API, i.e., we will not put any extra stress on the API to detect a diff. DT Token name will be `dtp-{token.name}-{cluster.uuid}-{scopes_hash}`. Note that there is a limit of 100 chars on token name.