### PR TITLE
APPSRE-10615 sync token with spec

### DIFF
--- a/reconcile/dynatrace_token_provider/integration.py
+++ b/reconcile/dynatrace_token_provider/integration.py
@@ -1,6 +1,7 @@
 import base64
+import hashlib
 import logging
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable, Mapping, MutableMapping
 from datetime import timedelta
 from typing import Any
 
@@ -140,7 +141,7 @@ class DynatraceTokenProviderIntegration(
                             if tenant_id not in existing_dtp_tokens:
                                 existing_dtp_tokens[tenant_id] = (
                                     dt_client.get_token_ids_map_for_name_prefix(
-                                        prefix="dtp-"
+                                        prefix="dtp"
                                     )
                                 )
 
@@ -172,7 +173,7 @@ class DynatraceTokenProviderIntegration(
         cluster: Cluster,
         dt_client: DynatraceClient,
         ocm_client: OCMClient,
-        existing_dtp_tokens: Mapping[str, str],
+        existing_dtp_tokens: MutableMapping[str, str],
         tenant_id: str,
         token_spec: DynatraceTokenProviderTokenSpecV1,
     ) -> None:
@@ -276,12 +277,52 @@ class DynatraceTokenProviderIntegration(
                     f"Patched {token_spec.name=} for {SYNCSET_AND_MANIFEST_ID} in {cluster.external_id=}."
                 )
 
+    def scopes_hash(self, scopes: Iterable[str], length: int) -> str:
+        m = hashlib.sha256()
+        msg = ",".join(sorted(scopes))
+        m.update(msg.encode("utf-8"))
+        return m.hexdigest()[:length]
+
+    def dynatrace_token_name(self, spec: DynatraceAPITokenV1, cluster_uuid: str) -> str:
+        scopes_hash = self.scopes_hash(scopes=spec.scopes, length=12)
+        # We have a limit of 100 chars
+        # cluster_uuid = 36 chars
+        # scopes_hash = 12 chars
+        # prefix + separators = 6 chars
+        return f"dtp_{spec.name[:46]}_{cluster_uuid}_{scopes_hash}"
+
+    def sync_token_in_dynatrace(
+        self,
+        token_id: str,
+        spec: DynatraceAPITokenV1,
+        cluster_uuid: str,
+        dt_client: DynatraceClient,
+        token_name_in_dt_api: str,
+        dry_run: bool,
+    ) -> None:
+        """
+        We ensure that the given token is properly configured in Dynatrace
+        according to the given spec.
+
+        A list query on the tokens does not return each tokens configuration.
+        We encode the token configuration in the token name to save API calls.
+        """
+        expected_name = self.dynatrace_token_name(spec=spec, cluster_uuid=cluster_uuid)
+        if token_name_in_dt_api != expected_name:
+            logging.info(
+                f"{token_name_in_dt_api=} != {expected_name=}. Sync dynatrace token {token_id=} with {spec=} for {cluster_uuid=}."
+            )
+            if not dry_run:
+                dt_client.update_token(
+                    token_id=token_id, name=expected_name, scopes=spec.scopes
+                )
+
     def generate_desired(
         self,
         dry_run: bool,
         current_k8s_secrets: Iterable[K8sSecret],
         desired_spec: DynatraceTokenProviderTokenSpecV1,
-        existing_dtp_tokens: Mapping[str, str],
+        existing_dtp_tokens: MutableMapping[str, str],
         dt_client: DynatraceClient,
         cluster_uuid: str,
     ) -> tuple[bool, Iterable[K8sSecret]]:
@@ -301,15 +342,24 @@ class DynatraceTokenProviderIntegration(
                 else {}
             )
             for desired_token in secret.tokens:
-                new_token = current_tokens_by_name.get(desired_token.name)
-                if not new_token or new_token.id not in existing_dtp_tokens:
+                cur_token = current_tokens_by_name.get(desired_token.name)
+                if not cur_token or cur_token.id not in existing_dtp_tokens:
                     has_diff = True
                     if not dry_run:
-                        new_token = self.create_dynatrace_token(
+                        cur_token = self.create_dynatrace_token(
                             dt_client, cluster_uuid, desired_token
                         )
-                if new_token:
-                    desired_tokens.append(new_token)
+                        existing_dtp_tokens[cur_token.id] = cur_token.name
+                if cur_token:
+                    self.sync_token_in_dynatrace(
+                        token_id=cur_token.id,
+                        spec=desired_token,
+                        cluster_uuid=cluster_uuid,
+                        dt_client=dt_client,
+                        dry_run=dry_run,
+                        token_name_in_dt_api=existing_dtp_tokens[cur_token.id],
+                    )
+                    desired_tokens.append(cur_token)
             desired.append(
                 K8sSecret(
                     secret_name=secret.name,
@@ -323,7 +373,7 @@ class DynatraceTokenProviderIntegration(
     def create_dynatrace_token(
         self, dt_client: DynatraceClient, cluster_uuid: str, token: DynatraceAPITokenV1
     ) -> DynatraceAPIToken:
-        token_name = f"dtp-{token.name}-{cluster_uuid}"
+        token_name = self.dynatrace_token_name(spec=token, cluster_uuid=cluster_uuid)
         new_token = dt_client.create_api_token(
             name=token_name,
             scopes=token.scopes,

--- a/reconcile/test/dynatrace_token_provider/fixtures.py
+++ b/reconcile/test/dynatrace_token_provider/fixtures.py
@@ -109,9 +109,9 @@ def build_dynatrace_client(
     def create_api_token_side_effect(
         name: str, scopes: Iterable[str]
     ) -> DynatraceAPITokenCreated:
-        return create_api_token.get(
-            name, DynatraceAPITokenCreated(token="dummy", id="dummy")
-        )
+        if name not in create_api_token:
+            raise ValueError(f"token {name=} not found in dynatrace_mock")
+        return create_api_token[name]
 
     mock_create_api_token = MagicMock(side_effect=create_api_token_side_effect)
     dynatrace_client.create_api_token = mock_create_api_token

--- a/reconcile/test/dynatrace_token_provider/test_create_manifest.py
+++ b/reconcile/test/dynatrace_token_provider/test_create_manifest.py
@@ -54,8 +54,8 @@ def test_single_hcp_cluster_create_tokens(
 
     dynatrace_client = build_dynatrace_client(
         create_api_token={
-            f"dtp-ingestion-token-{default_hcp_cluster.external_id}": ingestion_token,
-            f"dtp-operator-token-{default_hcp_cluster.external_id}": operator_token,
+            "dtp_ingestion-token_external_id_a_f6e7fac64719": ingestion_token,
+            "dtp_operator-token_external_id_a_1b6c3b9a7248": operator_token,
         },
         existing_token_ids={},
     )
@@ -78,6 +78,27 @@ def test_single_hcp_cluster_create_tokens(
     ocm_client.patch_syncset.assert_not_called()  # type: ignore[attr-defined]
     ocm_client.create_syncset.assert_not_called()  # type: ignore[attr-defined]
     ocm_client.patch_manifest.assert_not_called()  # type: ignore[attr-defined]
+    dynatrace_client.update_token.assert_not_called()  # type: ignore[attr-defined]
+
+    assert (
+        len(dynatrace_client.create_api_token.mock_calls)  # type: ignore[attr-defined]
+        == 2
+    )
+    dynatrace_client.create_api_token.assert_any_call(  # type: ignore[attr-defined]
+        name="dtp_operator-token_external_id_a_1b6c3b9a7248",
+        scopes=[
+            "activeGateTokenManagement.create",
+            "entities.read",
+            "settings.write",
+            "settings.read",
+            "DataExport",
+            "InstallerDownload",
+        ],
+    )
+    dynatrace_client.create_api_token.assert_any_call(  # type: ignore[attr-defined]
+        name="dtp_ingestion-token_external_id_a_f6e7fac64719",
+        scopes=["metrics.ingest", "logs.ingest", "events.ingest"],
+    )
     ocm_client.create_manifest.assert_called_once_with(  # type: ignore[attr-defined]
         cluster_id="cluster_a",
         manifest_map=build_manifest(
@@ -94,23 +115,4 @@ def test_single_hcp_cluster_create_tokens(
             tenant_id=default_hcp_cluster.dt_tenant,
             with_id=True,
         ),
-    )
-    assert (
-        len(dynatrace_client.create_api_token.mock_calls)  # type: ignore[attr-defined]
-        == 2
-    )
-    dynatrace_client.create_api_token.assert_any_call(  # type: ignore[attr-defined]
-        name="dtp-operator-token-external_id_a",
-        scopes=[
-            "activeGateTokenManagement.create",
-            "entities.read",
-            "settings.write",
-            "settings.read",
-            "DataExport",
-            "InstallerDownload",
-        ],
-    )
-    dynatrace_client.create_api_token.assert_any_call(  # type: ignore[attr-defined]
-        name="dtp-ingestion-token-external_id_a",
-        scopes=["metrics.ingest", "logs.ingest", "events.ingest"],
     )

--- a/reconcile/test/dynatrace_token_provider/test_create_syncset.py
+++ b/reconcile/test/dynatrace_token_provider/test_create_syncset.py
@@ -54,8 +54,8 @@ def test_single_non_hcp_cluster_create_tokens(
 
     dynatrace_client = build_dynatrace_client(
         create_api_token={
-            f"dtp-ingestion-token-{default_cluster.external_id}": ingestion_token,
-            f"dtp-operator-token-{default_cluster.external_id}": operator_token,
+            "dtp_ingestion-token_external_id_a_f6e7fac64719": ingestion_token,
+            "dtp_operator-token_external_id_a_1b6c3b9a7248": operator_token,
         },
         existing_token_ids={},
     )
@@ -78,6 +78,27 @@ def test_single_non_hcp_cluster_create_tokens(
     ocm_client.patch_syncset.assert_not_called()  # type: ignore[attr-defined]
     ocm_client.patch_manifest.assert_not_called()  # type: ignore[attr-defined]
     ocm_client.create_manifest.assert_not_called()  # type: ignore[attr-defined]
+    dynatrace_client.update_token.assert_not_called()  # type: ignore[attr-defined]
+
+    assert (
+        len(dynatrace_client.create_api_token.mock_calls)  # type: ignore[attr-defined]
+        == 2
+    )
+    dynatrace_client.create_api_token.assert_any_call(  # type: ignore[attr-defined]
+        name="dtp_operator-token_external_id_a_1b6c3b9a7248",
+        scopes=[
+            "activeGateTokenManagement.create",
+            "entities.read",
+            "settings.write",
+            "settings.read",
+            "DataExport",
+            "InstallerDownload",
+        ],
+    )
+    dynatrace_client.create_api_token.assert_any_call(  # type: ignore[attr-defined]
+        name="dtp_ingestion-token_external_id_a_f6e7fac64719",
+        scopes=["metrics.ingest", "logs.ingest", "events.ingest"],
+    )
     ocm_client.create_syncset.assert_called_once_with(  # type: ignore[attr-defined]
         cluster_id="cluster_a",
         syncset_map=build_syncset(
@@ -94,23 +115,4 @@ def test_single_non_hcp_cluster_create_tokens(
             tenant_id=default_cluster.dt_tenant,
             with_id=True,
         ),
-    )
-    assert (
-        len(dynatrace_client.create_api_token.mock_calls)  # type: ignore[attr-defined]
-        == 2
-    )
-    dynatrace_client.create_api_token.assert_any_call(  # type: ignore[attr-defined]
-        name="dtp-operator-token-external_id_a",
-        scopes=[
-            "activeGateTokenManagement.create",
-            "entities.read",
-            "settings.write",
-            "settings.read",
-            "DataExport",
-            "InstallerDownload",
-        ],
-    )
-    dynatrace_client.create_api_token.assert_any_call(  # type: ignore[attr-defined]
-        name="dtp-ingestion-token-external_id_a",
-        scopes=["metrics.ingest", "logs.ingest", "events.ingest"],
     )

--- a/reconcile/test/dynatrace_token_provider/test_patch_manifest.py
+++ b/reconcile/test/dynatrace_token_provider/test_patch_manifest.py
@@ -58,11 +58,6 @@ def test_single_hcp_cluster_patch_tokens(
         "ocm_env_a": ocm_client,
     }
 
-    ingestion_token = DynatraceAPITokenCreated(
-        id=default_ingestion_token.id,
-        token=default_ingestion_token.token,
-    )
-
     operator_token = DynatraceAPITokenCreated(
         id=default_operator_token.id,
         token=default_operator_token.token,
@@ -70,12 +65,11 @@ def test_single_hcp_cluster_patch_tokens(
 
     dynatrace_client = build_dynatrace_client(
         create_api_token={
-            f"dtp-ingestion-token-{default_hcp_cluster.external_id}": ingestion_token,
-            f"dtp-operator-token-{default_hcp_cluster.external_id}": operator_token,
+            "dtp_operator-token_external_id_a_1b6c3b9a7248": operator_token,
         },
-        # Operator token id is missing
+        # Operator token does not exist
         existing_token_ids={
-            default_ingestion_token.id: "name1",
+            default_ingestion_token.id: "dtp_ingestion-token_external_id_a_f6e7fac64719",
         },
     )
 
@@ -97,6 +91,19 @@ def test_single_hcp_cluster_patch_tokens(
     ocm_client.create_syncset.assert_not_called()  # type: ignore[attr-defined]
     ocm_client.create_manifest.assert_not_called()  # type: ignore[attr-defined]
     ocm_client.patch_syncset.assert_not_called()  # type: ignore[attr-defined]
+    dynatrace_client.update_token.assert_not_called()  # type: ignore[attr-defined]
+
+    dynatrace_client.create_api_token.assert_called_once_with(  # type: ignore[attr-defined]
+        name="dtp_operator-token_external_id_a_1b6c3b9a7248",
+        scopes=[
+            "activeGateTokenManagement.create",
+            "entities.read",
+            "settings.write",
+            "settings.read",
+            "DataExport",
+            "InstallerDownload",
+        ],
+    )
     ocm_client.patch_manifest.assert_called_once_with(  # type: ignore[attr-defined]
         cluster_id=default_hcp_cluster.id,
         manifest_id="ext-dynatrace-tokens-dtp",
@@ -114,15 +121,4 @@ def test_single_hcp_cluster_patch_tokens(
             tenant_id=default_hcp_cluster.dt_tenant,
             with_id=False,
         ),
-    )
-    dynatrace_client.create_api_token.called_once_with(  # type: ignore[attr-defined]
-        name="dtp-operator-token-external_id_a",
-        scopes=[
-            "activeGateTokenManagement.create",
-            "entities.read",
-            "settings.write",
-            "settings.read",
-            "DataExport",
-            "InstallerDownload",
-        ],
     )


### PR DESCRIPTION
Enable DTP to detect diffs between token spec in app-interface and current existing API token in Dynatrace. If diff is detected, then DTP will make an API call to DT to properly configure the API token.

We use the DT token name to store a config hash (currently scope hash). By doing so, we can detect diffs between the token in Dynatrace and the token spec defined in app-interface. Further, we do not need any additional API calls, as we must query the token name and id with list queries anyways. Note, that a list query on tokens does not return every detail about each token, such as scopes. We do not need to query any additional information about each API token (such as scopes). By comparing the hash in the name, we know if we need to POST an update for the token.

Note, this will rename all existing DTP tokens to the new schema. Renaming a token does not have any further side-effect, so this is fine.