### PR TITLE
 endpoints-discovery: debug message

### DIFF
--- a/reconcile/endpoints_discovery/integration.py
+++ b/reconcile/endpoints_discovery/integration.py
@@ -221,6 +221,9 @@ class EndpointsDiscoveryIntegration(
         """Compile a list of apps with their endpoints to add, change and delete."""
         apps: dict[str, App] = {}
         for namespace in namespaces:
+            logging.debug(
+                f"Processing namespace {namespace.cluster.name}/{namespace.name}"
+            )
             routes = self.get_routes(oc_map, namespace)
             endpoints_to_add, endpoints_to_change, endpoints_to_delete = (
                 self.get_endpoint_changes(


### PR DESCRIPTION

Debugging

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/reconcile/cli.py", line 609, in run_class_integration
    run_integration_cfg(
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 158, in run_integration_cfg
    _integration_wet_run(run_cfg.integration)
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 167, in _integration_wet_run
    integration.run(False)
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/defer.py", line 13, in func_wrapper
    return func(*args, defer=stack.callback, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/endpoints_discovery/integration.py", line 336, in run
    self.runner(**runner_params)
  File "/usr/local/lib/python3.11/site-packages/reconcile/endpoints_discovery/integration.py", line 260, in runner
    apps = self.get_apps(oc_map, endpoint_template, namespaces)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/endpoints_discovery/integration.py", line 224, in get_apps
    routes = self.get_routes(oc_map, namespace)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/endpoints_discovery/integration.py", line 133, in get_routes
    oc = oc_map.get_cluster(namespace.cluster.name)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/oc_map.py", line 167, in get_cluster
    raise result
reconcile.utils.oc.OCLogMsg
```