### PR TITLE
 endpoints-discovery: bug fixes

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -1810,6 +1810,9 @@ def openshift_prometheus_rules(
 @use_jump_host()
 @cluster_name
 @namespace_name
+@enable_extended_early_exit
+@extended_early_exit_cache_ttl_seconds
+@log_cached_log_output
 @click.option(
     "--endpoint-tmpl-resource",
     help="Resource name of the endpoint template in the app-interface.",
@@ -1823,6 +1826,9 @@ def endpoints_discovery(
     use_jump_host,
     cluster_name,
     namespace_name,
+    enable_extended_early_exit,
+    extended_early_exit_cache_ttl_seconds,
+    log_cached_log_output,
     endpoint_tmpl_resource,
 ):
     from reconcile.endpoints_discovery.integration import (
@@ -1836,6 +1842,9 @@ def endpoints_discovery(
         use_jump_host=use_jump_host,
         cluster_name=cluster_name,
         namespace_name=namespace_name,
+        enable_extended_early_exit=enable_extended_early_exit,
+        extended_early_exit_cache_ttl_seconds=extended_early_exit_cache_ttl_seconds,
+        log_cached_log_output=log_cached_log_output,
     )
     if endpoint_tmpl_resource:
         params.endpoint_tmpl_resource = endpoint_tmpl_resource

--- a/reconcile/endpoints_discovery/integration.py
+++ b/reconcile/endpoints_discovery/integration.py
@@ -261,7 +261,8 @@ class EndpointsDiscoveryIntegration(
     ) -> ExtendedEarlyExitRunnerResult:
         """Reconcile the endpoints for all namespaces."""
         apps = self.get_apps(oc_map, endpoint_template, namespaces)
-        merge_request_manager.create_merge_request(apps=apps)
+        if apps:
+            merge_request_manager.create_merge_request(apps=apps)
         return ExtendedEarlyExitRunnerResult(payload={}, applied_count=len(apps))
 
     @defer

--- a/reconcile/endpoints_discovery/integration.py
+++ b/reconcile/endpoints_discovery/integration.py
@@ -70,11 +70,11 @@ class Route(BaseModel):
 
 
 def endpoint_prefix(namespace: NamespaceV1) -> str:
-    return f"{QONTRACT_INTEGRATION}-{namespace.cluster.name}-{namespace.name}"
+    return f"{QONTRACT_INTEGRATION}/{namespace.cluster.name}/{namespace.name}/"
 
 
 def compile_endpoint_name(endpoint_prefix: str, route: Route) -> str:
-    return f"{endpoint_prefix}-{route.name}"
+    return f"{endpoint_prefix}{route.name}"
 
 
 def render_template(template: str, endpoint_name: str, route: Route) -> dict:

--- a/reconcile/test/endpoints_discovery/test_endpoints_discovery_integration.py
+++ b/reconcile/test/endpoints_discovery/test_endpoints_discovery_integration.py
@@ -37,12 +37,12 @@ def test_endpoints_discovery_integration_endpoint_prefix(
     namespaces: Sequence[NamespaceV1],
 ) -> None:
     ns = namespaces[0]
-    assert endpoint_prefix(namespace=ns).endswith(ns.name)
+    assert endpoint_prefix(namespace=ns).endswith(ns.name + "/")
 
 
 def test_endpoints_discovery_integration_compile_endpoint_name() -> None:
     r = Route(name="with-tls", host="example.com", tls=True)
-    assert compile_endpoint_name("prefix", r) == "prefix-with-tls"
+    assert compile_endpoint_name("prefix-", r) == "prefix-with-tls"
 
 
 def test_endpoints_discovery_integration_render_template() -> None:
@@ -96,7 +96,7 @@ def test_endpoints_discovery_integration_get_endpoint_changes_no_routes_no_endpo
 ) -> None:
     assert intg.get_endpoint_changes(
         app="app",
-        endpoint_prefix="prefix",
+        endpoint_prefix="prefix-",
         endpoint_template=TEMPLATE,
         endpoints=[],
         routes=[],
@@ -129,7 +129,7 @@ def test_endpoints_discovery_integration_get_endpoint_changes(
     endpoints_to_add, endpoints_to_change, endpoints_to_delete = (
         intg.get_endpoint_changes(
             app="app",
-            endpoint_prefix="prefix",
+            endpoint_prefix="prefix-",
             endpoint_template=TEMPLATE,
             endpoints=endpoints,
             routes=routes,
@@ -158,9 +158,9 @@ def test_endpoints_discovery_integration_get_apps(
             path="/path/app-1.yml",
             endpoints_to_add=[
                 Endpoint(
-                    name="endpoints-discovery-cluster-1-app-1-ns-1-fake-route",
+                    name="endpoints-discovery/cluster-1/app-1-ns-1/fake-route",
                     data={
-                        "name": "endpoints-discovery-cluster-1-app-1-ns-1-fake-route",
+                        "name": "endpoints-discovery/cluster-1/app-1-ns-1/fake-route",
                         "url": "https://fake-route.com:80",
                     },
                 )
@@ -173,9 +173,9 @@ def test_endpoints_discovery_integration_get_apps(
             path="/path/app-2.yml",
             endpoints_to_add=[
                 Endpoint(
-                    name="endpoints-discovery-cluster-1-app-2-ns-1-fake-route",
+                    name="endpoints-discovery/cluster-1/app-2-ns-1/fake-route",
                     data={
-                        "name": "endpoints-discovery-cluster-1-app-2-ns-1-fake-route",
+                        "name": "endpoints-discovery/cluster-1/app-2-ns-1/fake-route",
                         "url": "https://fake-route.com:80",
                     },
                 )
@@ -201,9 +201,9 @@ def test_endpoints_discovery_integration_runner(
             path="/path/app-2.yml",
             endpoints_to_add=[
                 Endpoint(
-                    name="endpoints-discovery-cluster-1-app-2-ns-1-fake-route",
+                    name="endpoints-discovery/cluster-1/app-2-ns-1/fake-route",
                     data={
-                        "name": "endpoints-discovery-cluster-1-app-2-ns-1-fake-route",
+                        "name": "endpoints-discovery/cluster-1/app-2-ns-1/fake-route",
                         "url": "https://fake-route.com:80",
                     },
                 )


### PR DESCRIPTION
* extended early exit: Add missing extended early exit command line options.
* fix `get_endpoint_changes`: use `/` as delimiter between cluster, namespace and route names, otherwise endpoints for namespaces like `namespace` and `namespace-stage` collides
