### PR TITLE
Revert "refactor gitlab-permissions integration"

### DIFF
--- a/reconcile/test/test_gitlab_permissions.py
+++ b/reconcile/test/test_gitlab_permissions.py
@@ -1,17 +1,7 @@
 from unittest.mock import MagicMock, create_autospec
 
 import pytest
-from gitlab.v4.objects import (
-    CurrentUser,
-    Group,
-    GroupMember,
-    GroupProjectManager,
-    Project,
-    ProjectMember,
-    ProjectMemberAllManager,
-    SharedProject,
-    SharedProjectManager,
-)
+from gitlab.v4.objects import CurrentUser, GroupMember
 from pytest_mock import MockerFixture
 
 from reconcile import gitlab_permissions
@@ -33,7 +23,6 @@ def mocked_gl() -> MagicMock:
     gl.server = "test_server"
     gl.user = create_autospec(CurrentUser)
     gl.user.username = "test_name"
-    gl.user.id = 1234
     return gl
 
 
@@ -60,25 +49,13 @@ def test_run_share_with_group(
     mocker.patch(
         "reconcile.gitlab_permissions.get_feature_toggle_state"
     ).return_value = True
-    group = create_autospec(Group, id=1234)
-    group.name = "app-sre"
-    group.projects = create_autospec(GroupProjectManager)
-    group.shared_projects = create_autospec(SharedProjectManager)
-    mocked_gl.get_items.side_effect = [
-        [],
-        [],
-    ]
-    mocked_gl.get_group.return_value = group
-    mocked_gl.get_access_level.return_value = 40
-    project = create_autospec(Project, web_url="https://test.com")
-    project.members_all = create_autospec(ProjectMemberAllManager)
-    project.members_all.get.return_value = create_autospec(
-        ProjectMember, id=mocked_gl.user.id, access_level=40
+    mocked_gl.get_group_id_and_shared_projects.return_value = (
+        1234,
+        {"https://test.com": {"group_access_level": 30}},
     )
-    mocked_gl.get_project.return_value = project
     gitlab_permissions.run(False, thread_pool_size=1)
     mocked_gl.share_project_with_group.assert_called_once_with(
-        project, group_id=1234, access_level=40
+        repo_url="https://test-gitlab.com", group_id=1234, dry_run=False
     )
 
 
@@ -89,76 +66,11 @@ def test_run_reshare_with_group(
     mocker.patch(
         "reconcile.gitlab_permissions.get_feature_toggle_state"
     ).return_value = True
-    group = create_autospec(Group, id=1234)
-    group.name = "app-sre"
-    group.projects = create_autospec(GroupProjectManager)
-    group.shared_projects = create_autospec(SharedProjectManager)
-    mocked_gl.get_items.side_effect = [
-        [],
-        [
-            create_autospec(
-                SharedProject,
-                web_url="https://test-gitlab.com",
-                shared_with_groups=[
-                    {
-                        "group_access_level": 30,
-                        "group_name": "app-sre",
-                        "group_id": 1234,
-                    }
-                ],
-            )
-        ],
-    ]
-    mocked_gl.get_group.return_value = group
-    mocked_gl.get_access_level.return_value = 40
-    project = create_autospec(Project, web_url="https://test-gitlab.com")
-    project.members_all = create_autospec(ProjectMemberAllManager)
-    project.members_all.get.return_value = create_autospec(
-        ProjectMember, id=mocked_gl.user.id, access_level=40
+    mocked_gl.get_group_id_and_shared_projects.return_value = (
+        1234,
+        {"https://test-gitlab.com": {"group_access_level": 30}},
     )
-    mocked_gl.get_project.return_value = project
     gitlab_permissions.run(False, thread_pool_size=1)
     mocked_gl.share_project_with_group.assert_called_once_with(
-        project=project, group_id=1234, access_level=40, reshare=True
+        repo_url="https://test-gitlab.com", group_id=1234, dry_run=False, reshare=True
     )
-
-
-def test_run_share_with_group_failed(
-    mocked_queries: MagicMock, mocker: MockerFixture, mocked_gl: MagicMock
-) -> None:
-    mocker.patch("reconcile.gitlab_permissions.GitLabApi").return_value = mocked_gl
-    mocker.patch(
-        "reconcile.gitlab_permissions.get_feature_toggle_state"
-    ).return_value = True
-    group = create_autospec(Group, id=1234)
-    group.name = "app-sre"
-    group.projects = create_autospec(GroupProjectManager)
-    group.shared_projects = create_autospec(SharedProjectManager)
-    group.projects = create_autospec(GroupProjectManager)
-    group.shared_projects = create_autospec(SharedProjectManager)
-    mocked_gl.get_items.side_effect = [
-        [],
-        [
-            create_autospec(
-                SharedProject,
-                web_url="https://test-gitlab.com",
-                shared_with_groups=[
-                    {
-                        "group_access_level": 30,
-                        "group_name": "app-sre",
-                        "group_id": 134,
-                    }
-                ],
-            )
-        ],
-    ]
-    mocked_gl.get_group.return_value = group
-    mocked_gl.get_access_level.return_value = 40
-    project = create_autospec(Project)
-    project.members_all = create_autospec(ProjectMemberAllManager)
-    project.members_all.get.return_value = create_autospec(
-        ProjectMember, id=mocked_gl.user.id, access_level=10
-    )
-    mocked_gl.get_project.return_value = project
-    with pytest.raises(Exception):
-        gitlab_permissions.run(False, thread_pool_size=1)

--- a/reconcile/test/utils/test_gitlab_api.py
+++ b/reconcile/test/utils/test_gitlab_api.py
@@ -8,6 +8,8 @@ from gitlab.v4.objects import (
     GroupManager,
     GroupMember,
     GroupMemberManager,
+    GroupProject,
+    GroupProjectManager,
     Project,
     ProjectIssue,
     ProjectIssueManager,
@@ -480,10 +482,63 @@ def test_share_project_with_group_positive(
     projects = create_autospec(ProjectManager)
     project = create_autospec(Project)
     project.members_all = create_autospec(ProjectMemberAllManager)
-    project.members_all.get.return_value = [
+    project.members_all.list.return_value = [
         create_autospec(ProjectMember, id=mocked_gitlab_api.user.id, access_level=40)
     ]
     projects.get.return_value = project
     mocked_gl.projects = projects
-    mocked_gitlab_api.share_project_with_group(project, 1111, 40)
+    mocked_gitlab_api.share_project_with_group("test_repo", 1111, False)
     project.share.assert_called_once_with(1111, 40)
+
+
+def test_share_project_with_group_errored(
+    mocker: MockerFixture,
+    mocked_gitlab_api: GitLabApi,
+    mocked_gl: Any,
+):
+    projects = create_autospec(ProjectManager)
+    project = create_autospec(Project)
+    project.members_all = create_autospec(ProjectMemberAllManager)
+    project.members_all.list.return_value = []
+    projects.get.return_value = project
+    mocked_gl.projects = projects
+    mocked_logger = mocker.patch("reconcile.utils.gitlab_api.logging")
+    mocked_gitlab_api.share_project_with_group("test_repo", 1111, False, "maintainer")
+    mocked_logger.error.assert_called_once_with(
+        "%s is not shared with %s as %s",
+        "test_repo",
+        mocked_gitlab_api.user.username,
+        "maintainer",
+    )
+
+
+def test_get_group_id_and_shared_projects(mocked_gitlab_api: GitLabApi, mocked_gl: Any):
+    groups = create_autospec(GroupManager)
+    mocked_group = create_autospec(
+        Group,
+        id=1234,
+    )
+    mocked_group.projects = create_autospec(GroupProjectManager)
+    mocked_group.projects.list.return_value = [
+        create_autospec(
+            GroupProject,
+            web_url="https://xyz1.com",
+            shared_with_groups=[
+                {
+                    "group_id": 1234,
+                    "group_access_level": 40,
+                },
+                {"group_id": 1244, "group_access_level": 50},
+            ],
+        ),
+        create_autospec(
+            GroupProject,
+            web_url="https://xyz2.com",
+            shared_with_groups=[{"group_id": 1234, "group_access_level": 30}],
+        ),
+    ]
+    groups.get.return_value = mocked_group
+    mocked_gl.groups = groups
+    id, shared_projects = mocked_gitlab_api.get_group_id_and_shared_projects("test")
+    assert id == 1234
+    assert shared_projects["https://xyz1.com"]["group_access_level"] == 40


### PR DESCRIPTION
Reverts app-sre/qontract-reconcile#4541

Apologies @mehfuz but I am reverting this MR. Unsure why CI didn't catch this but the old `get_group_id_and_projects` function call was not updated in this file: https://github.com/app-sre/qontract-reconcile/blob/master/reconcile/gitlab_projects.py#L26 causing a failure when trying to promote qontract-reconcile in FedRamp. 