### PR TITLE
mypy ci fixes

### DIFF
--- a/reconcile/test/change_owners/test_change_type_admission.py
+++ b/reconcile/test/change_owners/test_change_type_admission.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import pytest
 from pytest_mock import MockerFixture
 
@@ -72,7 +74,7 @@ def test_assert_restrictive_non_restrictive(
             ],
         )
     ]
-    changes = [b]
+    changes = [cast(BundleFileChange, b)]  # the cast is to make mypy happy
 
     assert is_change_admitted(changes, "baz", {""})
 
@@ -119,7 +121,7 @@ def test_assert_restrictive_all_need_approval(
             ],
         ),
     ]
-    changes = [b]
+    changes = [cast(BundleFileChange, b)]  # the cast is to make mypy happy
 
     assert is_change_admitted(changes, "baz", {"foo", "bar"})
     assert not is_change_admitted(changes, "baz", {"bar"})

--- a/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
+++ b/reconcile/test/terraform_vpc_resources/test_terraform_vpc_resources_integration.py
@@ -2,7 +2,7 @@ import logging
 import random
 from collections.abc import Callable
 from typing import Any
-from unittest.mock import call
+from unittest.mock import MagicMock, call
 
 import pytest
 from pytest_mock import MockerFixture
@@ -59,7 +59,7 @@ def vpc_request_dict() -> dict[str, Any]:
 
 
 @pytest.fixture
-def mock_gql(mocker: MockerFixture) -> MockerFixture:
+def mock_gql(mocker: MockerFixture) -> MagicMock:
     return mocker.patch(
         "reconcile.terraform_vpc_resources.integration.gql",
         autospec=True,
@@ -67,7 +67,7 @@ def mock_gql(mocker: MockerFixture) -> MockerFixture:
 
 
 @pytest.fixture
-def mock_app_interface_vault_settings(mocker: MockerFixture) -> MockerFixture:
+def mock_app_interface_vault_settings(mocker: MockerFixture) -> MagicMock:
     mocked_app_interfafe_vault_settings = mocker.patch(
         "reconcile.terraform_vpc_resources.integration.get_app_interface_vault_settings",
         autospec=True,
@@ -79,7 +79,7 @@ def mock_app_interface_vault_settings(mocker: MockerFixture) -> MockerFixture:
 
 
 @pytest.fixture
-def mock_create_secret_reader(mocker: MockerFixture) -> MockerFixture:
+def mock_create_secret_reader(mocker: MockerFixture) -> MagicMock:
     return mocker.patch(
         "reconcile.terraform_vpc_resources.integration.create_secret_reader",
         autospec=True,
@@ -87,7 +87,7 @@ def mock_create_secret_reader(mocker: MockerFixture) -> MockerFixture:
 
 
 @pytest.fixture
-def mock_terraform_client(mocker: MockerFixture) -> MockerFixture:
+def mock_terraform_client(mocker: MockerFixture) -> MagicMock:
     mocked_tf_client = mocker.patch(
         "reconcile.terraform_vpc_resources.integration.TerraformClient", autospec=True
     )
@@ -118,10 +118,10 @@ def secret_reader_side_effect(*args: Any) -> dict[str, Any] | None:
 def test_log_message_for_accounts_having_vpc_requests(
     mocker: MockerFixture,
     caplog: pytest.LogCaptureFixture,
-    mock_gql: MockerFixture,
+    mock_gql: MagicMock,
     gql_class_factory: Callable,
-    mock_app_interface_vault_settings: MockerFixture,
-    mock_create_secret_reader: MockerFixture,
+    mock_app_interface_vault_settings: MagicMock,
+    mock_create_secret_reader: MagicMock,
 ) -> None:
     # Mock a query with an account that doesn't have the related state
     mocked_query = mocker.patch(
@@ -151,9 +151,9 @@ def test_dry_run(
     mocker: MockerFixture,
     mock_gql: pytest.LogCaptureFixture,
     gql_class_factory: Callable,
-    mock_app_interface_vault_settings: MockerFixture,
-    mock_create_secret_reader: MockerFixture,
-    mock_terraform_client: MockerFixture,
+    mock_app_interface_vault_settings: MagicMock,
+    mock_create_secret_reader: MagicMock,
+    mock_terraform_client: MagicMock,
 ) -> None:
     mocked_query = mocker.patch(
         "reconcile.terraform_vpc_resources.integration.get_aws_vpc_requests",

--- a/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
+++ b/reconcile/test/test_terraform_vpc_peerings_build_desired_state.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import pytest
 import testslide
 from pytest_mock import MockerFixture
@@ -628,11 +630,15 @@ class TestBuildDesiredStateVpcMesh(testslide.TestCase):
         )
         self.maxDiff = None
         self.ocm = testslide.StrictMock(ocm.OCM)
-        self.ocm_map: ocm.OCMMap = {"clustername": self.ocm}  # type: ignore
+        self.ocm_map = cast(
+            ocm.OCMMap, {"clustername": self.ocm}
+        )  # the cast is to make mypy happy
         self.ocm.get_aws_infrastructure_access_terraform_assume_role = (
             lambda cluster, uid, tfuser: self.peer_account["assume_role"]
         )
-        self.awsapi: aws_api.AWSApi = testslide.StrictMock(aws_api.AWSApi)
+        self.awsapi = cast(
+            aws_api.AWSApi, testslide.StrictMock(aws_api.AWSApi)
+        )  # the cast is to make mypy happy
         self.account_vpcs = [
             {
                 "vpc_id": "vpc1",
@@ -776,7 +782,9 @@ class TestBuildDesiredStateVpcMeshSingleCluster(testslide.TestCase):
                 ]
             },
         }
-        self.awsapi: aws_api.AWSApi = testslide.StrictMock(aws_api.AWSApi)
+        self.awsapi = cast(
+            aws_api.AWSApi, testslide.StrictMock(aws_api.AWSApi)
+        )  # the cast is to make mypy happy
         self.mock_constructor(aws_api, "AWSApi").to_return_value(self.awsapi)
         self.find_matching_peering = self.mock_callable(sut, "find_matching_peering")
         self.aws_account = {
@@ -806,7 +814,9 @@ class TestBuildDesiredStateVpcMeshSingleCluster(testslide.TestCase):
         }
         self.maxDiff = None
         self.addCleanup(testslide.mock_callable.unpatch_all_callable_mocks)
-        self.ocm: ocm.OCM = testslide.StrictMock(template=ocm.OCM)
+        self.ocm = cast(
+            ocm.OCM, testslide.StrictMock(template=ocm.OCM)
+        )  # the cast is to make mypy happy
         self.ocm.get_aws_infrastructure_access_terraform_assume_role = (  # type: ignore
             lambda cluster, uid, tfuser: self.peer_account["assume_role"]
         )
@@ -1064,7 +1074,9 @@ class TestBuildDesiredStateVpc(testslide.TestCase):
         )
         self.ocm = testslide.StrictMock(template=ocm.OCM)
         self.ocm_map: ocm.OCMMap = {"clustername": self.ocm}  # type: ignore
-        self.awsapi: aws_api.AWSApi = testslide.StrictMock(aws_api.AWSApi)
+        self.awsapi = cast(
+            aws_api.AWSApi, testslide.StrictMock(aws_api.AWSApi)
+        )  # the cast is to make mypy happy
 
         self.build_single_cluster = self.mock_callable(
             sut, "build_desired_state_vpc_single_cluster"
@@ -1232,8 +1244,12 @@ class TestBuildDesiredStateVpcSingleCluster(testslide.TestCase):
         self.build_single_cluster = self.mock_callable(
             sut, "build_desired_state_single_cluster"
         )
-        self.ocm: ocm.OCM = testslide.StrictMock(template=ocm.OCM)
-        self.awsapi: aws_api.AWSApi = testslide.StrictMock(aws_api.AWSApi)
+        self.ocm = cast(
+            ocm.OCM, testslide.StrictMock(template=ocm.OCM)
+        )  # the cast is to make mypy happy
+        self.awsapi = cast(
+            aws_api.AWSApi, testslide.StrictMock(aws_api.AWSApi)
+        )  # the cast is to make mypy happy
         self.mock_constructor(aws_api, "AWSApi").to_return_value(self.awsapi)
         self.ocm.get_aws_infrastructure_access_terraform_assume_role = (  # type: ignore
             lambda cluster, uid, tfuser: self.aws_account["assume_role"]

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,9 @@ commands =
 commands =
     mypy --version
     mypy {posargs}
-deps = -r{toxinidir}/requirements/requirements-type.txt
+deps =
+    -r{toxinidir}/requirements/requirements-type.txt
+    -r{toxinidir}/requirements/requirements-test.txt
 
 [testenv:generate]
 # We want to ensure that there is no drift between introspection.json


### PR DESCRIPTION
We also need to install the test requirements in your CI `type` test. Otherwise, `mypy` can't validate all our test Python files, and errors may be hidden. 
Especially, `mypy` shows different output/errors in the local developer environment than in the CI checks.