### PR TITLE
APPSRE-10731 DTP single ocm org filter

### DIFF
--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -3107,26 +3107,14 @@ def cluster_auth_rhidp(ctx):
 @integration.command(
     short_help="Automatically provide dedicated Dynatrace tokens to management clusters"
 )
-@click.option(
-    "--ocm-org-ids",
-    help="A comma seperated list of OCM organization IDs DTP should operate on. If none is specified, all organizations are considered.",
-    required=False,
-    envvar="DTP_OCM_ORG_IDS",
-)
 @click.pass_context
-def dynatrace_token_provider(ctx, ocm_org_ids):
+def dynatrace_token_provider(ctx):
     from reconcile.dynatrace_token_provider.integration import (
         DynatraceTokenProviderIntegration,
-        DynatraceTokenProviderIntegrationParams,
     )
 
-    parsed_ocm_org_ids = set(ocm_org_ids.split(",")) if ocm_org_ids else None
     run_class_integration(
-        integration=DynatraceTokenProviderIntegration(
-            DynatraceTokenProviderIntegrationParams(
-                ocm_organization_ids=parsed_ocm_org_ids,
-            )
-        ),
+        integration=DynatraceTokenProviderIntegration(),
         ctx=ctx.obj,
     )
 

--- a/reconcile/test/dynatrace_token_provider/conftest.py
+++ b/reconcile/test/dynatrace_token_provider/conftest.py
@@ -5,7 +5,6 @@ import pytest
 from reconcile.dynatrace_token_provider.dependencies import Dependencies
 from reconcile.dynatrace_token_provider.integration import (
     DynatraceTokenProviderIntegration,
-    DynatraceTokenProviderIntegrationParams,
 )
 from reconcile.dynatrace_token_provider.model import DynatraceAPIToken
 from reconcile.dynatrace_token_provider.ocm import Cluster
@@ -59,9 +58,7 @@ def default_token_spec(
 
 @pytest.fixture
 def default_integration() -> DynatraceTokenProviderIntegration:
-    return DynatraceTokenProviderIntegration(
-        DynatraceTokenProviderIntegrationParams(ocm_organization_ids={"ocm_org_id_a"})
-    )
+    return DynatraceTokenProviderIntegration()
 
 
 @pytest.fixture

--- a/reconcile/test/dynatrace_token_provider/test_ocm_org_filters.py
+++ b/reconcile/test/dynatrace_token_provider/test_ocm_org_filters.py
@@ -23,35 +23,24 @@ def test_ocm_org_filters(
     default_integration: DynatraceTokenProviderIntegration,
 ) -> None:
     """
-    In this case we have 2 clusters. One cluster's ocm org does
-    not match the ocm org ids given to the integration.
-    The other cluster's ocm org does not match the ocm org id
-    filter on the token spec.
-    Both clusters have a diff to desired state (patch + create).
-    However, we expect both clusters to be filtered.
+    We have a cluster that is not part of its spec's ocm org ids.
+    There is a diff to desired state (patch + create).
+    However, we expect the cluster to be filtered.
     """
     cluster_a = Cluster(
         id="cluster_a",
-        external_id="external_id_a",
-        organization_id="ocm_org_id_a",
-        dt_tenant="dt_tenant_a",
-        token_spec_name="default",
-        is_hcp=False,
-    )
-    cluster_b = Cluster(
-        id="cluster_b",
         external_id="external_id_b",
         organization_id="does-not-exist",
         dt_tenant="dt_tenant_a",
         token_spec_name="default",
         is_hcp=False,
     )
-    given_clusters = [cluster_a, cluster_b]
+    given_clusters = [cluster_a]
     ocm_client = build_ocm_client(
         discover_clusters_by_labels=given_clusters,
         get_manifest={},
         get_syncset={
-            cluster_b.id: build_syncset(
+            cluster_a.id: build_syncset(
                 secrets=[
                     K8sSecret(
                         secret_name="dynatrace-tokens-dtp",


### PR DESCRIPTION
In DTP we had 2 places to filter ocm orgs: the token spec and integration arg `--ocm-org-ids`

The ocm org filter in the token spec should be the only source of truth. We remove `--ocm-org-ids` integration argument.