### PR TITLE
APPSRE-7516 saas target re-deploy flag

### DIFF
--- a/reconcile/gql_definitions/common/saas_files.gql
+++ b/reconcile/gql_definitions/common/saas_files.gql
@@ -140,7 +140,7 @@ query SaasFiles {
           auto
           publish
           subscribe
-          reDeployOnPublisherConfigChange
+          redeployOnPublisherConfigChange
           soakDays
           schedule
           promotion_data {

--- a/reconcile/gql_definitions/common/saas_files.gql
+++ b/reconcile/gql_definitions/common/saas_files.gql
@@ -140,6 +140,7 @@ query SaasFiles {
           auto
           publish
           subscribe
+          reDeployOnPublisherConfigChange
           soakDays
           schedule
           promotion_data {

--- a/reconcile/gql_definitions/common/saas_files.py
+++ b/reconcile/gql_definitions/common/saas_files.py
@@ -265,6 +265,7 @@ query SaasFiles {
           auto
           publish
           subscribe
+          reDeployOnPublisherConfigChange
           soakDays
           schedule
           promotion_data {
@@ -472,6 +473,7 @@ class SaasResourceTemplateTargetPromotionV1(ConfiguredBaseModel):
     auto: Optional[bool] = Field(..., alias="auto")
     publish: Optional[list[str]] = Field(..., alias="publish")
     subscribe: Optional[list[str]] = Field(..., alias="subscribe")
+    re_deploy_on_publisher_config_change: Optional[bool] = Field(..., alias="reDeployOnPublisherConfigChange")
     soak_days: Optional[int] = Field(..., alias="soakDays")
     schedule: Optional[str] = Field(..., alias="schedule")
     promotion_data: Optional[list[PromotionDataV1]] = Field(..., alias="promotion_data")

--- a/reconcile/gql_definitions/common/saas_files.py
+++ b/reconcile/gql_definitions/common/saas_files.py
@@ -265,7 +265,7 @@ query SaasFiles {
           auto
           publish
           subscribe
-          reDeployOnPublisherConfigChange
+          redeployOnPublisherConfigChange
           soakDays
           schedule
           promotion_data {
@@ -473,7 +473,7 @@ class SaasResourceTemplateTargetPromotionV1(ConfiguredBaseModel):
     auto: Optional[bool] = Field(..., alias="auto")
     publish: Optional[list[str]] = Field(..., alias="publish")
     subscribe: Optional[list[str]] = Field(..., alias="subscribe")
-    re_deploy_on_publisher_config_change: Optional[bool] = Field(..., alias="reDeployOnPublisherConfigChange")
+    redeploy_on_publisher_config_change: Optional[bool] = Field(..., alias="redeployOnPublisherConfigChange")
     soak_days: Optional[int] = Field(..., alias="soakDays")
     schedule: Optional[str] = Field(..., alias="schedule")
     promotion_data: Optional[list[PromotionDataV1]] = Field(..., alias="promotion_data")

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -22286,6 +22286,18 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "reDeployOnPublisherConfigChange",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "SCALAR",
+                                "name": "Boolean",
+                                "ofType": null
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "publish",
                             "description": null,
                             "args": [],

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -22286,7 +22286,7 @@
                             "deprecationReason": null
                         },
                         {
-                            "name": "reDeployOnPublisherConfigChange",
+                            "name": "redeployOnPublisherConfigChange",
                             "description": null,
                             "args": [],
                             "type": {

--- a/reconcile/saas_auto_promotions_manager/publisher.py
+++ b/reconcile/saas_auto_promotions_manager/publisher.py
@@ -39,7 +39,7 @@ class Publisher:
         target_name: str | None,
         cluster_name: str,
         auth_code: HasSecret | None,
-        publish_job_logs: bool | None,
+        re_deploy_on_config_change: bool | None,
         has_subscriber: bool = True,
     ):
         self._ref = ref
@@ -56,7 +56,7 @@ class Publisher:
         self.resource_template_name = resource_template_name
         self.target_name = target_name if target_name else "None"
         self.cluster_name = cluster_name
-        self.publish_job_logs = bool(publish_job_logs)
+        self.re_deploy_on_config_change = bool(re_deploy_on_config_change)
         self.has_subscriber = has_subscriber
 
     def fetch_commit_shas_and_deployment_info(

--- a/reconcile/saas_auto_promotions_manager/publisher.py
+++ b/reconcile/saas_auto_promotions_manager/publisher.py
@@ -39,7 +39,7 @@ class Publisher:
         target_name: str | None,
         cluster_name: str,
         auth_code: HasSecret | None,
-        re_deploy_on_config_change: bool | None,
+        redeploy_on_config_change: bool | None,
         has_subscriber: bool = True,
     ):
         self._ref = ref
@@ -56,7 +56,7 @@ class Publisher:
         self.resource_template_name = resource_template_name
         self.target_name = target_name if target_name else "None"
         self.cluster_name = cluster_name
-        self.re_deploy_on_config_change = bool(re_deploy_on_config_change)
+        self.redeploy_on_config_change = bool(redeploy_on_config_change)
         self.has_subscriber = has_subscriber
 
     def fetch_commit_shas_and_deployment_info(

--- a/reconcile/saas_auto_promotions_manager/s3_exporter.py
+++ b/reconcile/saas_auto_promotions_manager/s3_exporter.py
@@ -62,8 +62,8 @@ class S3Exporter:
         data: dict[str, dict] = {}
         for publisher in publishers:
             publisher_data = PublisherData.from_publisher(publisher)
-            # Note, re_deploy_on_config_change indicates that this publisher is a test job
-            key = f"{publisher.app_name}/{publisher.saas_name}/{publisher.resource_template_name}/{publisher.target_name}/{publisher.cluster_name}/{publisher.namespace_name}/{publisher.re_deploy_on_config_change}"
+            # Note, redeploy_on_config_change indicates that this publisher is a test job
+            key = f"{publisher.app_name}/{publisher.saas_name}/{publisher.resource_template_name}/{publisher.target_name}/{publisher.cluster_name}/{publisher.namespace_name}/{publisher.redeploy_on_config_change}"
             data[key] = {
                 "commit_sha": publisher_data.commit_sha,
                 "deployment_state": publisher_data.deployment_state.value,

--- a/reconcile/saas_auto_promotions_manager/s3_exporter.py
+++ b/reconcile/saas_auto_promotions_manager/s3_exporter.py
@@ -62,7 +62,8 @@ class S3Exporter:
         data: dict[str, dict] = {}
         for publisher in publishers:
             publisher_data = PublisherData.from_publisher(publisher)
-            key = f"{publisher.app_name}/{publisher.saas_name}/{publisher.resource_template_name}/{publisher.target_name}/{publisher.cluster_name}/{publisher.namespace_name}/{publisher.publish_job_logs}"
+            # Note, re_deploy_on_config_change indicates that this publisher is a test job
+            key = f"{publisher.app_name}/{publisher.saas_name}/{publisher.resource_template_name}/{publisher.target_name}/{publisher.cluster_name}/{publisher.namespace_name}/{publisher.re_deploy_on_config_change}"
             data[key] = {
                 "commit_sha": publisher_data.commit_sha,
                 "deployment_state": publisher_data.deployment_state.value,

--- a/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
+++ b/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
@@ -65,8 +65,8 @@ class SaasFilesInventory:
                         cluster_name=target.namespace.cluster.name,
                         resource_template_name=resource_template.name,
                         target_name=target.name,
-                        publish_job_logs=saas_file.publish_job_logs,
                         auth_code=auth_code,
+                        re_deploy_on_config_change=target.promotion.re_deploy_on_publisher_config_change,
                     )
 
                     has_subscriber = False
@@ -122,9 +122,9 @@ class SaasFilesInventory:
                         blocked_versions=blocked_versions.get(
                             resource_template.url, set()
                         ),
-                        # Note: this will be refactored at a later point.
-                        # https://issues.redhat.com/browse/APPSRE-7516
-                        use_target_config_hash=bool(saas_file.publish_job_logs),
+                        use_target_config_hash=bool(
+                            target.promotion.re_deploy_on_publisher_config_change
+                        ),
                     )
                     self.subscribers.append(subscriber)
                     for prom_data in target.promotion.promotion_data or []:

--- a/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
+++ b/reconcile/saas_auto_promotions_manager/utils/saas_files_inventory.py
@@ -66,7 +66,7 @@ class SaasFilesInventory:
                         resource_template_name=resource_template.name,
                         target_name=target.name,
                         auth_code=auth_code,
-                        re_deploy_on_config_change=target.promotion.re_deploy_on_publisher_config_change,
+                        redeploy_on_config_change=target.promotion.redeploy_on_publisher_config_change,
                     )
 
                     has_subscriber = False
@@ -123,7 +123,7 @@ class SaasFilesInventory:
                             resource_template.url, set()
                         ),
                         use_target_config_hash=bool(
-                            target.promotion.re_deploy_on_publisher_config_change
+                            target.promotion.redeploy_on_publisher_config_change
                         ),
                     )
                     self.subscribers.append(subscriber)

--- a/reconcile/test/saas_auto_promotions_manager/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/conftest.py
@@ -131,7 +131,7 @@ def subscriber_builder(
                     app_name="",
                     resource_template_name="",
                     target_name=None,
-                    publish_job_logs=True,
+                    re_deploy_on_config_change=True,
                     has_subscriber=True,
                     auth_code=None,
                 )

--- a/reconcile/test/saas_auto_promotions_manager/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/conftest.py
@@ -131,7 +131,7 @@ def subscriber_builder(
                     app_name="",
                     resource_template_name="",
                     target_name=None,
-                    re_deploy_on_config_change=True,
+                    redeploy_on_config_change=True,
                     has_subscriber=True,
                     auth_code=None,
                 )

--- a/reconcile/test/saas_auto_promotions_manager/s3_exporter/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/s3_exporter/conftest.py
@@ -20,7 +20,7 @@ def publisher_builder() -> Callable[[Mapping], Publisher]:
             cluster_name=data["cluster_name"],
             target_name=data.get("target_name"),
             resource_template_name=data["resource_template_name"],
-            publish_job_logs=True,
+            re_deploy_on_config_change=True,
             has_subscriber=True,
             auth_code=None,
         )

--- a/reconcile/test/saas_auto_promotions_manager/s3_exporter/conftest.py
+++ b/reconcile/test/saas_auto_promotions_manager/s3_exporter/conftest.py
@@ -20,7 +20,7 @@ def publisher_builder() -> Callable[[Mapping], Publisher]:
             cluster_name=data["cluster_name"],
             target_name=data.get("target_name"),
             resource_template_name=data["resource_template_name"],
-            re_deploy_on_config_change=True,
+            redeploy_on_config_change=True,
             has_subscriber=True,
             auth_code=None,
         )

--- a/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_use_target_config_hash.py
+++ b/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_use_target_config_hash.py
@@ -46,7 +46,7 @@ def test_use_target_config_hash(
                             "namespace": {"path": "/namespace2.yml"},
                             "promotion": {
                                 "subscribe": ["channel-a"],
-                                "reDeployOnPublisherConfigChange": True,
+                                "redeployOnPublisherConfigChange": True,
                                 "auto": True,
                             },
                         }

--- a/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_use_target_config_hash.py
+++ b/reconcile/test/saas_auto_promotions_manager/utils/saas_files_inventory/test_saas_files_use_target_config_hash.py
@@ -36,7 +36,6 @@ def test_use_target_config_hash(
         {
             "path": "/saas2.yml",
             "name": "saas_2",
-            "publishJobLogs": True,
             "resourceTemplates": [
                 {
                     "name": "template_2",
@@ -47,6 +46,7 @@ def test_use_target_config_hash(
                             "namespace": {"path": "/namespace2.yml"},
                             "promotion": {
                                 "subscribe": ["channel-a"],
+                                "reDeployOnPublisherConfigChange": True,
                                 "auto": True,
                             },
                         }

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -164,6 +164,7 @@ class TestSaasFileValid(TestCase):
             auto=True,
             publish=None,
             subscribe=None,
+            reDeployOnPublisherConfigChange=None,
             promotion_data=None,
             soakDays=0,
             schedule="* * * * *",
@@ -190,6 +191,7 @@ class TestSaasFileValid(TestCase):
             publish=None,
             subscribe=None,
             promotion_data=None,
+            reDeployOnPublisherConfigChange=None,
             soakDays=0,
             schedule="* * * * *",
         )

--- a/reconcile/test/test_saasherder.py
+++ b/reconcile/test/test_saasherder.py
@@ -164,7 +164,7 @@ class TestSaasFileValid(TestCase):
             auto=True,
             publish=None,
             subscribe=None,
-            reDeployOnPublisherConfigChange=None,
+            redeployOnPublisherConfigChange=None,
             promotion_data=None,
             soakDays=0,
             schedule="* * * * *",
@@ -191,7 +191,7 @@ class TestSaasFileValid(TestCase):
             publish=None,
             subscribe=None,
             promotion_data=None,
-            reDeployOnPublisherConfigChange=None,
+            redeployOnPublisherConfigChange=None,
             soakDays=0,
             schedule="* * * * *",
         )


### PR DESCRIPTION
This new flag on saas targets determines whether we want to re-deploy the target on config changes in its publishers. (aka setting target_config_hash)

Corresponding schema https://github.com/app-sre/qontract-schemas/pull/705