### PR TITLE
APPSRE-10732 remove default token spec

### DIFF
--- a/reconcile/dynatrace_token_provider/integration.py
+++ b/reconcile/dynatrace_token_provider/integration.py
@@ -107,7 +107,11 @@ class DynatraceTokenProviderIntegration(QontractReconcileIntegration[NoParams]):
     ) -> list[Cluster]:
         filtered_clusters = []
         for cluster in clusters:
-            token_spec = token_spec_by_name.get(cluster.token_spec_name)
+            token_spec = (
+                token_spec_by_name.get(cluster.token_spec_name)
+                if cluster.token_spec_name
+                else None
+            )
             if not token_spec:
                 logging.debug(
                     f"[{cluster.external_id=}] Skipping cluster. {cluster.token_spec_name=} does not exist."
@@ -188,8 +192,12 @@ class DynatraceTokenProviderIntegration(QontractReconcileIntegration[NoParams]):
                                 tenant_id
                             ]
 
-                            token_spec = dependencies.token_spec_by_name.get(
-                                cluster.token_spec_name
+                            token_spec = (
+                                dependencies.token_spec_by_name.get(
+                                    cluster.token_spec_name
+                                )
+                                if cluster.token_spec_name
+                                else None
                             )
                             if not token_spec:
                                 _expose_errors_as_service_log(

--- a/reconcile/dynatrace_token_provider/ocm.py
+++ b/reconcile/dynatrace_token_provider/ocm.py
@@ -43,23 +43,15 @@ class Cluster(BaseModel):
     id: str
     external_id: str
     organization_id: str
-    dt_tenant: str
-    token_spec_name: str
+    dt_tenant: str | None
+    token_spec_name: str | None
     is_hcp: bool
 
     @staticmethod
     def from_cluster_details(cluster: ClusterDetails) -> Cluster:
         dt_tenant = cluster.labels.get_label_value(DTP_TENANT_LABEL)
         token_spec_name = cluster.labels.get_label_value(DTP_LABEL)
-        if not token_spec_name:
-            """
-            We want to stay backwards compatible.
-            Earlier version of DTP did not set a value for the label.
-            We fall back to a default token in that case.
 
-            Long-term, we want to remove this behavior.
-            """
-            token_spec_name = "hypershift-management-cluster-v1"
         return Cluster(
             id=cluster.ocm_cluster.id,
             external_id=cluster.ocm_cluster.external_id,

--- a/reconcile/test/dynatrace_token_provider/fixtures.py
+++ b/reconcile/test/dynatrace_token_provider/fixtures.py
@@ -43,9 +43,10 @@ def _build_secret_data(
 
 def build_syncset(
     secrets: Iterable[K8sSecret],
-    tenant_id: str,
+    tenant_id: str | None,
     with_id: bool,
 ) -> dict:
+    tenant_id = tenant_id if tenant_id else ""
     secrets_data = _build_secret_data(
         secrets=secrets,
         tenant_id=tenant_id,
@@ -61,9 +62,10 @@ def build_syncset(
 
 def build_manifest(
     secrets: Iterable[K8sSecret],
-    tenant_id: str,
+    tenant_id: str | None,
     with_id: bool,
 ) -> dict:
+    tenant_id = tenant_id if tenant_id else ""
     secrets_data = _build_secret_data(
         secrets=secrets,
         tenant_id=tenant_id,

--- a/reconcile/test/dynatrace_token_provider/test_missing_label_values.py
+++ b/reconcile/test/dynatrace_token_provider/test_missing_label_values.py
@@ -1,0 +1,70 @@
+from reconcile.dynatrace_token_provider.dependencies import Dependencies
+from reconcile.dynatrace_token_provider.integration import (
+    DynatraceTokenProviderIntegration,
+)
+from reconcile.dynatrace_token_provider.ocm import Cluster
+from reconcile.gql_definitions.dynatrace_token_provider.token_specs import (
+    DynatraceTokenProviderTokenSpecV1,
+)
+from reconcile.test.dynatrace_token_provider.fixtures import (
+    build_dynatrace_client,
+    build_ocm_client,
+)
+from reconcile.utils.secret_reader import SecretReaderBase
+
+
+def test_missing_all_dtp_label_value(
+    secret_reader: SecretReaderBase,
+    default_token_spec: DynatraceTokenProviderTokenSpecV1,
+    default_integration: DynatraceTokenProviderIntegration,
+) -> None:
+    """
+    We have a cluster that misses values for sre-capabilities.dtp
+    and sre-capabilities.dtp.tenant labels.
+    There should be no action and no blocking error.
+    """
+    ocm_client = build_ocm_client(
+        discover_clusters_by_labels=[
+            Cluster(
+                id="test_id",
+                external_id="test_external_id",
+                organization_id="ocm_env_a",
+                token_spec_name=None,
+                dt_tenant=None,
+                is_hcp=False,
+            )
+        ],
+        get_syncset={},
+        get_manifest={},
+    )
+
+    ocm_client_by_env_name = {
+        "ocm_env_a": ocm_client,
+    }
+
+    dynatrace_client = build_dynatrace_client(
+        create_api_token={},
+        existing_token_ids={},
+    )
+
+    dynatrace_client_by_tenant_id = {
+        "dt_tenant_a": dynatrace_client,
+    }
+
+    dependencies = Dependencies(
+        secret_reader=secret_reader,
+        dynatrace_client_by_tenant_id=dynatrace_client_by_tenant_id,
+        ocm_client_by_env_name=ocm_client_by_env_name,
+        token_spec_by_name={
+            "default": default_token_spec,
+        },
+    )
+
+    default_integration.reconcile(dry_run=False, dependencies=dependencies)
+
+    ocm_client.create_syncset.assert_not_called()  # type: ignore[attr-defined]
+    ocm_client.create_manifest.assert_not_called()  # type: ignore[attr-defined]
+    ocm_client.patch_syncset.assert_not_called()  # type: ignore[attr-defined]
+    dynatrace_client.update_token.assert_not_called()  # type: ignore[attr-defined]
+    dynatrace_client.create_api_token.assert_not_called()  # type: ignore[attr-defined]
+    ocm_client.patch_manifest.assert_not_called()  # type: ignore[attr-defined]


### PR DESCRIPTION
We remove the DTP default token spec. We expect `sre-capabilities.dtp` label to always hold the value of the token spec to be used.

Note, required OSDFM change got recently merged https://gitlab.cee.redhat.com/service/osd-fleet-manager/-/merge_requests/872 - we are now waiting for change to get into production and for label values to get applied.

Regularly confirming locally if this works - until then, this remains in draft mode.