### PR TITLE
[APPSRE-10253] - Validate storage changes for RDS blue/green updates

### DIFF
--- a/reconcile/test/utils/test_terraform_client.py
+++ b/reconcile/test/utils/test_terraform_client.py
@@ -740,7 +740,7 @@ def test_validate_db_upgrade_with_blue_green_update(
 def test_validate_blue_green_update_requirements_with_storage_type_change(
     mocker: MockerFixture, aws_api: AWSApi, tf: tfclient.TerraformClient
 ) -> None:
-    aws_api.describe_db_parameter_group.return_value = {"rds.logical_replication": "1"} # type: ignore[attr-defined]
+    aws_api.describe_db_parameter_group.return_value = {"rds.logical_replication": "1"}  # type: ignore[attr-defined]
     mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
 
     tf.validate_blue_green_update_requirements(

--- a/reconcile/test/utils/test_terraform_client.py
+++ b/reconcile/test/utils/test_terraform_client.py
@@ -740,7 +740,7 @@ def test_validate_db_upgrade_with_blue_green_update(
 def test_validate_blue_green_update_requirements_with_storage_type_change(
     mocker: MockerFixture, aws_api: AWSApi, tf: tfclient.TerraformClient
 ) -> None:
-    aws_api.describe_db_parameter_group.return_value = {"rds.logical_replication": "1"}
+    aws_api.describe_db_parameter_group.return_value = {"rds.logical_replication": "1"} # type: ignore[attr-defined]
     mocked_logging = mocker.patch("reconcile.utils.terraform_client.logging")
 
     tf.validate_blue_green_update_requirements(


### PR DESCRIPTION
Adds validation for RDS blue/green updates to raise an error when storage_type or allocated_storage fields have changed.