### PR TITLE
APPSRE-10782 support multiple cidr blocks routing to TGW - 2

### DIFF
--- a/reconcile/gql_definitions/common/clusters_with_peering.gql
+++ b/reconcile/gql_definitions/common/clusters_with_peering.gql
@@ -71,6 +71,7 @@ query ClustersWithPeering {
           }
           tags
           cidrBlock
+          cidrBlocks
           manageSecurityGroups
           manageRoute53Associations
           allowPrivateHcpApiAccess

--- a/reconcile/gql_definitions/common/clusters_with_peering.py
+++ b/reconcile/gql_definitions/common/clusters_with_peering.py
@@ -147,6 +147,7 @@ query ClustersWithPeering {
           }
           tags
           cidrBlock
+          cidrBlocks
           manageSecurityGroups
           manageRoute53Associations
           allowPrivateHcpApiAccess
@@ -268,6 +269,7 @@ class ClusterPeeringConnectionAccountTGWV1(ClusterPeeringConnectionV1):
     account: ClusterPeeringConnectionAccountTGWV1_AWSAccountV1 = Field(..., alias="account")
     tags: Optional[Json] = Field(..., alias="tags")
     cidr_block: Optional[str] = Field(..., alias="cidrBlock")
+    cidr_blocks: Optional[list[str]] = Field(..., alias="cidrBlocks")
     manage_security_groups: Optional[bool] = Field(..., alias="manageSecurityGroups")
     manage_route53_associations: Optional[bool] = Field(..., alias="manageRoute53Associations")
     allow_private_hcp_api_access: Optional[bool] = Field(..., alias="allowPrivateHcpApiAccess")

--- a/reconcile/gql_definitions/introspection.json
+++ b/reconcile/gql_definitions/introspection.json
@@ -37698,6 +37698,26 @@
                             "deprecationReason": null
                         },
                         {
+                            "name": "cidrBlocks",
+                            "description": null,
+                            "args": [],
+                            "type": {
+                                "kind": "LIST",
+                                "name": null,
+                                "ofType": {
+                                    "kind": "NON_NULL",
+                                    "name": null,
+                                    "ofType": {
+                                        "kind": "SCALAR",
+                                        "name": "String",
+                                        "ofType": null
+                                    }
+                                }
+                            },
+                            "isDeprecated": false,
+                            "deprecationReason": null
+                        },
+                        {
                             "name": "delete",
                             "description": null,
                             "args": [],

--- a/reconcile/test/test_terraform_tgw_attachments.py
+++ b/reconcile/test/test_terraform_tgw_attachments.py
@@ -161,6 +161,7 @@ def peering_connection_builder(
         account: ClusterPeeringConnectionAccountTGWV1_AWSAccountV1 | None = None,
         assume_role: str | None = None,
         cidr_block: str | None = None,
+        cidr_blocks: list[str] | None = None,
         delete: bool | None = None,
     ) -> ClusterPeeringConnectionAccountTGWV1:
         return gql_class_factory(
@@ -172,6 +173,7 @@ def peering_connection_builder(
                 "account": account.dict(by_alias=True) if account is not None else None,
                 "assumeRole": assume_role,
                 "cidrBlock": cidr_block,
+                "cidrBlocks": cidr_blocks,
                 "delete": delete,
             },
         )
@@ -191,6 +193,7 @@ def account_tgw_connection(
         account=tgw_connection_account,
         assume_role=None,
         cidr_block="172.16.0.0/16",
+        cidr_blocks=["10.240.0.0/12"],
         delete=False,
     )
 
@@ -481,6 +484,7 @@ def build_expected_desired_state_item(
             rules=tgw["rules"],
             hostedzones=tgw["hostedzones"],
             cidr_block=connection.cidr_block,
+            cidr_blocks=connection.cidr_blocks or [],
             account=expected_tgw_account,
         ),
         accepter=Accepter(

--- a/reconcile/utils/terraform_client.py
+++ b/reconcile/utils/terraform_client.py
@@ -331,6 +331,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
         for resource_change in resource_changes:
             resource_type = resource_change["type"]
             resource_name = resource_change["name"]
+            resource_address = resource_change["address"]
             resource_previous_address = resource_change.get("previous_address")
             resource_change = resource_change["change"]
             actions = resource_change["actions"]
@@ -342,7 +343,7 @@ class TerraformClient:  # pylint: disable=too-many-public-methods
                             "move/rename",
                             name,
                             resource_previous_address,
-                            resource_change["address"],
+                            resource_address,
                         ])
 
                 if action == "no-op":

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -1405,13 +1405,6 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                 req_cidr_blocks.append(req_cidr_block)
             if route_table_ids and (req_cidr_block or req_cidr_blocks):
                 for route_table_id in route_table_ids:
-                    if req_cidr_block:
-                        req_cidr_id = req_cidr_block.replace(".", "-").replace("/", "_")
-                        moved = Moved(
-                            fro=f"aws_route.{identifier}-{route_table_id}",
-                            to=f"aws_route.{identifier}-{route_table_id}-dest-{req_cidr_id}",
-                        )
-                        self.add_moved(infra_account_name, moved)
                     for cidr_block in req_cidr_blocks:
                         values = {
                             "provider": "aws." + acc_alias,
@@ -1426,6 +1419,13 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
                         )
                         tf_resource = aws_route(route_identifier, **values)
                         self.add_resource(infra_account_name, tf_resource)
+                    if req_cidr_block:
+                        req_cidr_id = req_cidr_block.replace(".", "-").replace("/", "_")
+                        moved = Moved(
+                            fro=f"aws_route.{identifier}-{route_table_id}",
+                            to=f"aws_route.{identifier}-{route_table_id}-dest-{req_cidr_id}",
+                        )
+                        self.add_moved(infra_account_name, moved)
 
             # add routes to peered transit gateways in the requester's
             # account to achieve global routing from all regions
@@ -4107,7 +4107,7 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
         with self.locks[account]:
             self.tss[account].add(tf_resource)
 
-    def add_moved(self, account: str, moved):
+    def add_moved(self, account: str, moved: Moved):
         if account not in self.locks:
             logging.debug(
                 f"integration {self.integration} is disabled for account {account}. "

--- a/reconcile/utils/terrascript_aws_client.py
+++ b/reconcile/utils/terrascript_aws_client.py
@@ -35,6 +35,7 @@ from sretoolbox.utils import threaded
 # temporary to create aws_ecrpublic_repository
 from terrascript import (
     Backend,
+    Block,
     Data,
     Module,
     Output,
@@ -297,6 +298,13 @@ class UnknownProviderError(Exception):
 
 class UnapprovedSecretPathError(Exception):
     pass
+
+
+class Moved(Block):
+    """Terraform `moved` block, available since Terraform 1.1"""
+
+    def __init__(self, fro: str, to: str):
+        super().__init__(fro=fro, to=to)
 
 
 class aws_ecrpublic_repository(Resource):
@@ -1392,17 +1400,32 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             # add routes to existing route tables
             route_table_ids = accepter.route_table_ids
             req_cidr_block = requester.cidr_block
-            if route_table_ids and req_cidr_block:
+            req_cidr_blocks = requester.cidr_blocks or []
+            if req_cidr_block:
+                req_cidr_blocks.append(req_cidr_block)
+            if route_table_ids and (req_cidr_block or req_cidr_blocks):
                 for route_table_id in route_table_ids:
-                    values = {
-                        "provider": "aws." + acc_alias,
-                        "route_table_id": route_table_id,
-                        "destination_cidr_block": req_cidr_block,
-                        "transit_gateway_id": requester.tgw_id,
-                    }
-                    route_identifier = f"{identifier}-{route_table_id}"
-                    tf_resource = aws_route(route_identifier, **values)
-                    self.add_resource(infra_account_name, tf_resource)
+                    if req_cidr_block:
+                        req_cidr_id = req_cidr_block.replace(".", "-").replace("/", "_")
+                        moved = Moved(
+                            fro=f"aws_route.{identifier}-{route_table_id}",
+                            to=f"aws_route.{identifier}-{route_table_id}-dest-{req_cidr_id}",
+                        )
+                        self.add_moved(infra_account_name, moved)
+                    for cidr_block in req_cidr_blocks:
+                        values = {
+                            "provider": "aws." + acc_alias,
+                            "route_table_id": route_table_id,
+                            "destination_cidr_block": cidr_block,
+                            "transit_gateway_id": requester.tgw_id,
+                        }
+                        # use the cidr block in the resource name to allow re-ordering
+                        cidr_id = cidr_block.replace(".", "-").replace("/", "_")
+                        route_identifier = (
+                            f"{identifier}-{route_table_id}-dest-{cidr_id}"
+                        )
+                        tf_resource = aws_route(route_identifier, **values)
+                        self.add_resource(infra_account_name, tf_resource)
 
             # add routes to peered transit gateways in the requester's
             # account to achieve global routing from all regions
@@ -4083,6 +4106,19 @@ class TerrascriptClient:  # pylint: disable=too-many-public-methods
             return
         with self.locks[account]:
             self.tss[account].add(tf_resource)
+
+    def add_moved(self, account: str, moved):
+        if account not in self.locks:
+            logging.debug(
+                f"integration {self.integration} is disabled for account {account}. "
+                "can not add resource"
+            )
+            return
+        with self.locks[account]:
+            self.tss[account].setdefault("moved", []).append({
+                "from": moved.fro,
+                "to": moved.to,
+            })
 
     def dump(
         self,


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-10782

Fixing PR https://github.com/app-sre/qontract-reconcile/pull/4632 which was reverted by https://github.com/app-sre/qontract-reconcile/pull/4633

```
File "/usr/local/lib/python3.11/site-packages/reconcile/utils/terraform_client.py", line 345, in log_plan_diff
    resource_change["address"],
    ~~~~~~~~~~~~~~~^^^^^^^^^^^
KeyError: 'address'
```

`resource_change` is being redefined in between... The fix is in commit [01300ea5eb728624e767caf6dbe15dbbba2b7f88](https://github.com/app-sre/qontract-reconcile/pull/4634/commits/01300ea5eb728624e767caf6dbe15dbbba2b7f88)

Still depends on https://github.com/app-sre/qontract-schemas/pull/709