### PR TITLE
APPSRE-10783 add tgw attachements CIDR blocks in the output of qontract-cli get cidr-blocks

### DIFF
--- a/reconcile/queries.py
+++ b/reconcile/queries.py
@@ -880,6 +880,7 @@ CLUSTERS_QUERY = """
           }
           tags
           cidrBlock
+          cidrBlocks
           manageSecurityGroups
           assumeRole
         }


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-10783

This allows to include those CIDR block in this view and avoid collisions