### PR TITLE
[change-log] replace diff state with aws api

### DIFF
--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -1,4 +1,6 @@
+import json
 import logging
+import os
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
 
@@ -10,7 +12,9 @@ from reconcile.change_owners.change_owners import fetch_change_type_processors
 from reconcile.change_owners.change_types import ChangeTypeContext
 from reconcile.change_owners.changes import aggregate_file_moves, parse_bundle_changes
 from reconcile.typed_queries.apps import get_apps
+from reconcile.typed_queries.get_state_aws_account import get_state_aws_account
 from reconcile.utils import gql
+from reconcile.utils.aws_api import AWSApi
 from reconcile.utils.defer import defer
 from reconcile.utils.runtime.integration import (
     PydanticRunParams,
@@ -50,6 +54,9 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
         dry_run: bool,
         defer: Callable | None = None,
     ) -> None:
+        state_bucket_name = os.environ["APP_INTERFACE_STATE_BUCKET"]
+        state_bucket_account_name = os.environ["APP_INTERFACE_STATE_BUCKET_ACCOUNT"]
+
         change_type_processors = [
             ctp
             for ctp in fetch_change_type_processors(
@@ -65,12 +72,17 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
         )
         if defer:
             defer(integration_state.cleanup)
-        diff_state = init_state(
-            integration=self.name,
+        account = get_state_aws_account(state_bucket_account_name)
+        if not account:
+            raise ValueError("no state aws account found")
+        aws_api = AWSApi(
+            1,
+            [account.dict(by_alias=True)],
+            secret_reader=self.secret_reader,
+            init_users=False,
         )
         if defer:
-            defer(diff_state.cleanup)
-        diff_state.state_path = "bundle-archive/diff"
+            defer(aws_api.cleanup)
 
         if not self.params.process_existing:
             existing_change_log = ChangeLog(**integration_state.get(BUNDLE_DIFFS_OBJ))
@@ -79,9 +91,12 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                 for i in existing_change_log.items
             ]
         change_log = ChangeLog()
-        for item in diff_state.ls():
-            key = item.lstrip("/")
-            commit = key.rstrip(".json")
+        for key in aws_api.list_s3_objects(
+            account.name,
+            state_bucket_name,
+            "bundle-archive/diff",
+        ):
+            commit = os.path.basename(key).rstrip(".json")
             if not self.params.process_existing:
                 existing_change_log_item = next(
                     (i for i in existing_change_log_items if i.commit == commit), None
@@ -96,12 +111,12 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                 commit=commit,
             )
             change_log.items.append(change_log_item)
-            obj = diff_state.get(key, None)
+            obj = aws_api.get_s3_object_content(account.name, state_bucket_name, key)
             if not obj:
                 logging.error(f"Error processing commit {commit}")
                 change_log_item.error = True
                 continue
-            diff = QontractServerDiff(**obj)
+            diff = QontractServerDiff(**json.loads(obj))
             changes = aggregate_file_moves(parse_bundle_changes(diff))
             for change in changes:
                 logging.debug(f"Processing change {change}")


### PR DESCRIPTION
part of part of https://issues.redhat.com/browse/APPSRE-10755

using State was a hack to get quick results. AWSApi is better suited here. One main positive outcome is that the commits are returned ordered, which makes sense for a change log.