### PR TITLE
:sparkles: qontract-cli: external-resources migrate command

### DIFF
--- a/reconcile/external_resources/integration.py
+++ b/reconcile/external_resources/integration.py
@@ -84,7 +84,7 @@ def create_er_manager(
 ) -> ExternalResourcesManager:
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-    er_settings = get_settings()[0]
+    er_settings = get_settings()
     m_inventory = load_module_inventory(get_modules())
     namespaces = [ns for ns in get_namespaces() if ns.external_resources]
     er_inventory = ExternalResourcesInventory(namespaces)
@@ -139,7 +139,7 @@ def run(
 ) -> None:
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-    er_settings = get_settings()[0]
+    er_settings = get_settings()
 
     if not workers_cluster:
         workers_cluster = er_settings.workers_cluster.name
@@ -173,7 +173,7 @@ def run(
 def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-    er_settings = get_settings()[0]
+    er_settings = get_settings()
 
     with get_aws_api(
         query_func=gql.get_api().query,

--- a/reconcile/external_resources/integration_secrets_sync.py
+++ b/reconcile/external_resources/integration_secrets_sync.py
@@ -25,7 +25,7 @@ def run(dry_run: bool, thread_pool_size: int) -> None:
     """
     vault_settings = get_app_interface_vault_settings()
     secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-    er_settings = get_settings()[0]
+    er_settings = get_settings()
 
     namespaces = [ns for ns in get_namespaces() if ns.external_resources]
     er_inventory = ExternalResourcesInventory(namespaces)

--- a/reconcile/typed_queries/external_resources.py
+++ b/reconcile/typed_queries/external_resources.py
@@ -28,13 +28,13 @@ def get_namespaces(query_func: Callable | None = None) -> list[NamespaceV1]:
     return list(data.namespaces or [])
 
 
-def get_settings(
-    query_func: Callable | None = None,
-) -> list[ExternalResourcesSettingsV1]:
+def get_settings(query_func: Callable | None = None) -> ExternalResourcesSettingsV1:
     if not query_func:
         query_func = gql.get_api().query
     data = query_settings(query_func=query_func)
-    return list(data.settings or [])
+    if not data.settings:
+        raise ValueError("No external resources settings found.")
+    return data.settings[0]
 
 
 def get_modules(

--- a/tools/cli_commands/erv2.py
+++ b/tools/cli_commands/erv2.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from enum import Enum
+from pathlib import Path
+from subprocess import CalledProcessError, run
+from typing import Protocol
+
+from pydantic import BaseModel
+from rich import print as rich_print
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
+from rich.prompt import Confirm
+
+from reconcile.external_resources.integration import get_aws_api
+from reconcile.external_resources.manager import setup_factories
+from reconcile.external_resources.meta import FLAG_RESOURCE_MANAGED_BY_ERV2
+from reconcile.external_resources.model import (
+    ExternalResourceKey,
+    ExternalResourceModuleConfiguration,
+    ExternalResourcesInventory,
+    load_module_inventory,
+)
+from reconcile.external_resources.state import (
+    ExternalResourcesStateDynamoDB,
+    ResourceStatus,
+)
+from reconcile.typed_queries.external_resources import (
+    get_modules,
+    get_namespaces,
+    get_settings,
+)
+from reconcile.utils import gql
+from reconcile.utils.exceptions import FetchResourceError
+from reconcile.utils.secret_reader import SecretReaderBase
+
+
+def progress_spinner() -> Progress:
+    """Display shiny progress spinner."""
+    console = Console(record=True)
+    return Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        TimeElapsedColumn(),
+        console=console,
+    )
+
+
+@contextmanager
+def task(progress: Progress | None, description: str) -> Iterator:
+    """Display a task in the progress spinner."""
+    if progress:
+        task = progress.add_task(description, total=1)
+    yield
+    if progress:
+        progress.advance(task)
+
+
+class Erv2Cli:
+    def __init__(
+        self,
+        provision_provider: str,
+        provisioner: str,
+        provider: str,
+        identifier: str,
+        secret_reader: SecretReaderBase,
+        temp_dir: Path | None = None,
+        progress_spinner: Progress | None = None,
+    ) -> None:
+        self._provision_provider = provision_provider
+        self._provisioner = provisioner
+        self._provider = provider
+        self._identifier = identifier
+        self._temp_dir = temp_dir
+        self.progress_spinner = progress_spinner
+
+        namespaces = [ns for ns in get_namespaces() if ns.external_resources]
+        er_inventory = ExternalResourcesInventory(namespaces)
+
+        try:
+            spec = er_inventory.get_inventory_spec(
+                provision_provider=provision_provider,
+                provisioner=provisioner,
+                provider=provider,
+                identifier=identifier,
+            )
+        except FetchResourceError:
+            rich_print(
+                f"[b red]Resource {provision_provider}/{provisioner}/{provider}/{identifier} not found[/]. Ensure `managed_by_erv2: true` is set!"
+            )
+            sys.exit(1)
+
+        self._secret_reader = secret_reader
+        self._er_settings = get_settings()
+        m_inventory = load_module_inventory(get_modules())
+        factories = setup_factories(
+            self._er_settings, m_inventory, er_inventory, self._secret_reader
+        )
+        f = factories.get_factory(spec.provision_provider)
+        self._resource = f.create_external_resource(spec)
+        f.validate_external_resource(self._resource)
+        self._module_configuration = (
+            ExternalResourceModuleConfiguration.resolve_configuration(
+                m_inventory.get_from_spec(spec), spec
+            )
+        )
+
+    @property
+    def input_data(self) -> str:
+        return self._resource.json(exclude={"data": {FLAG_RESOURCE_MANAGED_BY_ERV2}})
+
+    @property
+    def image(self) -> str:
+        return self._module_configuration.image_version
+
+    @property
+    def temp(self) -> Path:
+        if not self._temp_dir:
+            raise ValueError("temp_dir is not set")
+        return self._temp_dir
+
+    def reconcile(self) -> None:
+        with get_aws_api(
+            query_func=gql.get_api().query,
+            account_name=self._er_settings.state_dynamodb_account.name,
+            region=self._er_settings.state_dynamodb_region,
+            secret_reader=self._secret_reader,
+        ) as aws_api:
+            state_manager = ExternalResourcesStateDynamoDB(
+                aws_api=aws_api,
+                table_name=self._er_settings.state_dynamodb_table,
+            )
+            key = ExternalResourceKey(
+                provision_provider=self._provision_provider,
+                provisioner_name=self._provisioner,
+                provider=self._provider,
+                identifier=self._identifier,
+            )
+            current_state = state_manager.get_external_resource_state(key)
+            if current_state.resource_status != ResourceStatus.NOT_EXISTS:
+                state_manager.update_resource_status(
+                    key, ResourceStatus.RECONCILIATION_REQUESTED
+                )
+            else:
+                rich_print("[b red]External Resource does not exist")
+
+    def build_cdktf(self, credentials: Path) -> None:
+        """Run the CDKTF container and return the generated CDKTF json."""
+        input_file = self.temp / "input.json"
+        input_file.write_text(self.input_data)
+
+        # delete previous ERv2 container
+        run(["docker", "rm", "-f", "erv2"], capture_output=True, check=True)
+
+        try:
+            # run cdktf synth
+            with task(self.progress_spinner, "-- Running CDKTF synth"):
+                run(
+                    [
+                        "docker",
+                        "run",
+                        "--name",
+                        "erv2",
+                        "--mount",
+                        f"type=bind,source={input_file!s},target=/inputs/input.json",
+                        "--mount",
+                        f"type=bind,source={credentials!s},target=/credentials",
+                        "-e",
+                        "DRY_RUN=True",
+                        self.image,
+                    ],
+                    check=True,
+                    capture_output=True,
+                )
+
+            # # get the cdk.tf.json
+            with task(self.progress_spinner, "-- Copying the generated cdk.tf.json"):
+                run(
+                    [
+                        "docker",
+                        "cp",
+                        "erv2:/home/app/cdktf.out/stacks/CDKTF/cdk.tf.json",
+                        str(self.temp),
+                    ],
+                    check=True,
+                    capture_output=True,
+                )
+        except CalledProcessError as e:
+            print(e.stderr.decode("utf-8"))
+            print(e.stdout.decode("utf-8"))
+            raise
+
+
+class TfRun(Protocol):
+    def __call__(self, path: Path, cmd: list[str]) -> str: ...
+
+
+def tf_run(path: Path, cmd: list[str]) -> str:
+    env = os.environ.copy()
+    env["TF_CLI_ARGS"] = "-no-color"
+    try:
+        return run(
+            ["terraform", *cmd],
+            cwd=path,
+            check=True,
+            capture_output=True,
+            env=env,
+        ).stdout.decode("utf-8")
+    except CalledProcessError as e:
+        print(e.stderr.decode("utf-8"))
+        print(e.stdout.decode("utf-8"))
+        raise
+
+
+class TfAction(Enum):
+    CREATE = "create"
+    DESTROY = "delete"
+
+
+class TfResource(BaseModel):
+    address: str
+
+    @property
+    def id(self) -> str:
+        return self.address.split(".")[1]
+
+    @property
+    def type(self) -> str:
+        return self.address.split(".")[0]
+
+    def __str__(self) -> str:
+        return self.address
+
+    def __repr__(self) -> str:
+        return str(self)
+
+    def __lt__(self, other: TfResource) -> bool:
+        return self.address < other.address
+
+
+class TfResourceList(BaseModel):
+    resources: list[TfResource]
+
+    def __iter__(self) -> Iterator[TfResource]:  # type: ignore
+        return iter(self.resources)
+
+    def _get_resource_by_type(self, type: str) -> list[TfResource]:
+        results = [resource for resource in self.resources if resource.type == type]
+        if not results:
+            raise KeyError(f"Resource type {type} not found!")
+        return results
+
+    def __getitem__(self, tf_resource: TfResource) -> TfResource:
+        results = self._get_resource_by_type(tf_resource.type)
+        if len(results) == 1:
+            # best case scenario
+            return results[0]
+        # try to find the resource by fuzzy matching the id
+        # reverse sort to get the longest match first
+        for resource in sorted(results, reverse=True):
+            if tf_resource.id.startswith(resource.id):
+                # new resource id has a prefix
+                return resource
+            if tf_resource.id.endswith(resource.id):
+                # new resource id has a suffix
+                return resource
+        raise KeyError(f"Resource {tf_resource} not found!")
+
+    def __len__(self) -> int:
+        return len(self.resources)
+
+
+class TerraformCli:
+    def __init__(
+        self,
+        path: Path,
+        dry_run: bool = True,
+        tf_run: TfRun = tf_run,
+        progress_spinner: Progress | None = None,
+    ) -> None:
+        self._path = path
+        self._dry_run = dry_run
+        self._tf_run = tf_run
+        self.progress_spinner = progress_spinner
+        self.initialized = False
+
+    def init(self) -> None:
+        """Initialize the terraform modules."""
+        self._tf_init()
+        self._tf_plan()
+        self._tf_state_pull()
+        self.initialized = True
+
+    @property
+    def state_file(self) -> Path:
+        return self._path / "state.json"
+
+    def _tf_init(self) -> None:
+        with task(self.progress_spinner, "-- Running terraform init"):
+            self._tf_run(self._path, ["init"])
+
+    def _tf_plan(self) -> None:
+        with task(self.progress_spinner, "-- Running terraform plan"):
+            self._tf_run(self._path, ["plan", "-out=plan.out"])
+
+    def _tf_state_pull(self) -> None:
+        with task(self.progress_spinner, "-- Retrieving the terraform state"):
+            self.state_file.write_text(self._tf_run(self._path, ["state", "pull"]))
+
+    def _tf_state_push(self) -> None:
+        with task(
+            self.progress_spinner,
+            f"-- Uploading the terraform state {'[b red](DRY-RUN)' if self._dry_run else ''}",
+        ):
+            if not self._dry_run:
+                self._tf_run(self._path, ["state", "push", str(self.state_file)])
+
+    def upload_state(self) -> None:
+        self._tf_state_push()
+
+    def resource_changes(self, action: TfAction) -> TfResourceList:
+        """Get the resource changes."""
+        plan = json.loads(self._tf_run(self._path, ["show", "-json", "plan.out"]))
+        return TfResourceList(
+            resources=[
+                TfResource(address=r["address"])
+                for r in plan["resource_changes"]
+                if action.value.lower() in r["change"]["actions"]
+            ]
+        )
+
+    def move_resource(
+        self, source_state_file: Path, source: TfResource, destination: TfResource
+    ) -> None:
+        """Move the resource from source state file to destination state file."""
+        with task(
+            self.progress_spinner,
+            f"-- Moving {destination} {'[b red](DRY-RUN)' if self._dry_run else ''}",
+        ):
+            if not self._dry_run:
+                self._tf_run(
+                    self._path,
+                    [
+                        "state",
+                        "mv",
+                        "-lock=false",
+                        f"-state={source_state_file!s}",
+                        f"-state-out={self.state_file!s}",
+                        f"{source.address}",
+                        f"{destination.address}",
+                    ],
+                )
+
+    def migrate_resources(self, source: TerraformCli) -> None:
+        """Migrate the resources from source."""
+        if not self.initialized or not source.initialized:
+            raise ValueError("Terraform must be initialized before!")
+
+        source_resources = source.resource_changes(TfAction.DESTROY)
+        destionation_resources = self.resource_changes(TfAction.CREATE)
+
+        if (
+            not source_resources
+            or not destionation_resources
+            # I'm not sure if this is always true
+            or len(source_resources) != len(destionation_resources)
+        ):
+            raise ValueError(
+                "No resource changes found or the number of resources is different!"
+            )
+
+        for destionation_resource in destionation_resources:
+            source_resource = source_resources[destionation_resource]
+            if source_resource.id != destionation_resource.id:
+                if self.progress_spinner:
+                    self.progress_spinner.log(
+                        f"[b red]Resource id mismatch! Please review it carefully![/]\n  {source_resource} -> {destionation_resource}"
+                    )
+
+            self.move_resource(
+                source_state_file=source.state_file,
+                source=source_resource,
+                destination=destionation_resource,
+            )
+
+        if not self._dry_run:
+            if self.progress_spinner:
+                self.progress_spinner.stop()
+            if not Confirm.ask(
+                "\nEverything ok? Would you like to upload the modified terraform states",
+                default=False,
+            ):
+                return
+
+            if self.progress_spinner:
+                self.progress_spinner.start()
+
+            # finally push the terraform states
+            self.upload_state()
+            source.upload_state()

--- a/tools/cli_commands/erv2.py
+++ b/tools/cli_commands/erv2.py
@@ -68,7 +68,7 @@ class Erv2Cli:
         provider: str,
         identifier: str,
         secret_reader: SecretReaderBase,
-        temp_dir: Path | None = None,
+        temp_dir: Path,
         progress_spinner: Progress | None = None,
     ) -> None:
         self._provision_provider = provision_provider
@@ -119,8 +119,6 @@ class Erv2Cli:
 
     @property
     def temp(self) -> Path:
-        if not self._temp_dir:
-            raise ValueError("temp_dir is not set")
         return self._temp_dir
 
     def reconcile(self) -> None:

--- a/tools/cli_commands/erv2.py
+++ b/tools/cli_commands/erv2.py
@@ -387,12 +387,12 @@ class TerraformCli:
         #     raise ValueError("Terraform must be initialized before!")
 
         source_resources = source.resource_changes(TfAction.DESTROY)
-        destionation_resources = self.resource_changes(TfAction.CREATE)
+        destination_resources = self.resource_changes(TfAction.CREATE)
 
-        if not source_resources or not destionation_resources:
+        if not source_resources or not destination_resources:
             raise ValueError("No resource changes found!")
 
-        if len(source_resources) != len(destionation_resources):
+        if len(source_resources) != len(destination_resources):
             with pause_progress_spinner(self.progress_spinner):
                 rich_print(
                     "[b red]The number of changes (ERv2 vs terraform-resource) does not match! Please review them carefully![/]"
@@ -401,7 +401,7 @@ class TerraformCli:
                 rich_print(
                     "\n".join([
                         f"  {i}: {r.address}"
-                        for i, r in enumerate(destionation_resources, start=1)
+                        for i, r in enumerate(destination_resources, start=1)
                     ])
                 )
                 rich_print("Terraform:")
@@ -414,11 +414,11 @@ class TerraformCli:
                 if not Confirm.ask("Would you like to continue anyway?", default=False):
                     return
 
-        for destionation_resource in destionation_resources:
-            possible_source_resouces = source_resources[destionation_resource]
+        for destination_resource in destination_resources:
+            possible_source_resouces = source_resources[destination_resource]
             if not possible_source_resouces:
                 raise ValueError(
-                    f"Source resource for {destionation_resource} not found!"
+                    f"Source resource for {destination_resource} not found!"
                 )
             elif len(possible_source_resouces) == 1:
                 # just one resource found.
@@ -427,7 +427,7 @@ class TerraformCli:
                 # more than one resource found. Let the user decide.
                 with pause_progress_spinner(self.progress_spinner):
                     rich_print(
-                        f"[b red]{destionation_resource.address} not found![/] Please select the related source ID manually!"
+                        f"[b red]{destination_resource.address} not found![/] Please select the related source ID manually!"
                     )
                     for i, r in enumerate(possible_source_resouces, start=1):
                         print(f"{i}: {r.address}")
@@ -444,7 +444,7 @@ class TerraformCli:
             self.move_resource(
                 source_state_file=source.state_file,
                 source=source_resource,
-                destination=destionation_resource,
+                destination=destination_resource,
             )
 
         if not self._dry_run:

--- a/tools/cli_commands/erv2.py
+++ b/tools/cli_commands/erv2.py
@@ -281,7 +281,10 @@ class TfResourceList(BaseModel):
         # * we need to find the correct resource by the ID
         # * but we know that the ID is slightly different
 
-        # reverse sort to get the longest match first
+        # reverse sort to get the longest match first.
+        # if we have resources with a "similar" ID, e.g.
+        # one resource contains the ID of another resource
+        # playground-user and playground-user-foobar
         for resource in sorted(results, reverse=True):
             if tf_resource.id.startswith(resource.id):
                 # the resource id has a prefix, e.g.

--- a/tools/cli_commands/erv2.py
+++ b/tools/cli_commands/erv2.py
@@ -253,9 +253,6 @@ class TfResource(BaseModel):
     def __repr__(self) -> str:
         return str(self)
 
-    def __lt__(self, other: TfResource) -> bool:
-        return self.address < other.address
-
 
 class TfResourceList(BaseModel):
     resources: list[TfResource]

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -14,7 +14,9 @@ from datetime import (
     timedelta,
 )
 from operator import itemgetter
+from pathlib import Path
 from statistics import median
+from textwrap import dedent
 from typing import Any
 
 import boto3
@@ -23,10 +25,9 @@ import click.core
 import requests
 import yaml
 from rich import box
-from rich.console import (
-    Console,
-    Group,
-)
+from rich import print as rich_print
+from rich.console import Console, Group
+from rich.prompt import Confirm
 from rich.table import Table
 from rich.tree import Tree
 
@@ -59,24 +60,10 @@ from reconcile.change_owners.change_owners import (
 )
 from reconcile.checkpoint import report_invalid_metadata
 from reconcile.cli import (
+    TERRAFORM_VERSION,
+    TERRAFORM_VERSION_REGEX,
     config_file,
     use_jump_host,
-)
-from reconcile.external_resources.integration import (
-    get_aws_api,
-)
-from reconcile.external_resources.manager import (
-    setup_factories,
-)
-from reconcile.external_resources.meta import FLAG_RESOURCE_MANAGED_BY_ERV2
-from reconcile.external_resources.model import (
-    ExternalResourceKey,
-    ExternalResourcesInventory,
-    load_module_inventory,
-)
-from reconcile.external_resources.state import (
-    ExternalResourcesStateDynamoDB,
-    ResourceStatus,
 )
 from reconcile.gql_definitions.advanced_upgrade_service.aus_clusters import (
     query as aus_clusters_query,
@@ -99,11 +86,6 @@ from reconcile.typed_queries.app_quay_repos_escalation_policies import (
     get_apps_quay_repos_escalation_policies,
 )
 from reconcile.typed_queries.clusters import get_clusters
-from reconcile.typed_queries.external_resources import (
-    get_modules,
-    get_namespaces,
-    get_settings,
-)
 from reconcile.typed_queries.saas_files import get_saas_files
 from reconcile.typed_queries.slo_documents import get_slo_documents
 from reconcile.typed_queries.status_board import get_status_board
@@ -168,6 +150,12 @@ from reconcile.utils.state import init_state
 from reconcile.utils.terraform_client import TerraformClient as Terraform
 from tools.cli_commands.cost_report.aws import AwsCostReportCommand
 from tools.cli_commands.cost_report.openshift import OpenShiftCostReportCommand
+from tools.cli_commands.erv2 import (
+    Erv2Cli,
+    TerraformCli,
+    progress_spinner,
+    task,
+)
 from tools.cli_commands.gpg_encrypt import (
     GPGEncryptCommand,
     GPGEncryptCommandData,
@@ -3945,85 +3933,172 @@ def remove(ctx, sso_client_vault_secret_path: str):
 
 
 @root.group()
+@click.option(
+    "--provision-provider",
+    required=True,
+    help="externalResources.provider",
+    default="aws",
+)
+@click.option(
+    "--provisioner",
+    required=True,
+    help="externalResources.provisioner.name. E.g. app-sre-stage",
+    prompt=True,
+)
+@click.option(
+    "--provider",
+    required=True,
+    help="externalResources.resources.provider. E.g. rds, msk, ...",
+    prompt=True,
+)
+@click.option(
+    "--identifier",
+    required=True,
+    help="externalResources.resources.identifier. E.g. erv2-example",
+    prompt=True,
+)
 @click.pass_context
-def external_resources(ctx):
+def external_resources(
+    ctx, provision_provider: str, provisioner: str, provider: str, identifier: str
+):
     """External resources commands"""
+    ctx.obj["provision_provider"] = provision_provider
+    ctx.obj["provisioner"] = provisioner
+    ctx.obj["provider"] = provider
+    ctx.obj["identifier"] = identifier
+    vault_settings = get_app_interface_vault_settings()
+    ctx.obj["secret_reader"] = create_secret_reader(use_vault=vault_settings.vault)
 
 
 @external_resources.command()
-@click.argument("provision-provider", required=True)
-@click.argument("provisioner", required=True)
-@click.argument("provider", required=True)
-@click.argument("identifier", required=True)
 @click.pass_context
-def get_input(
-    ctx, provision_provider: str, provisioner: str, provider: str, identifier: str
-):
+def get_input(ctx):
     """Gets the input data for an external resource asset. Input data is what is used
-    in the Reconciliation Job to manage the resource.
-
-    e.g: qontract-reconcile --config=<config> external-resources get-input aws app-sre-stage rds dashdotdb-stage
-    """
-    namespaces = [ns for ns in get_namespaces() if ns.external_resources]
-    er_inventory = ExternalResourcesInventory(namespaces)
-
-    spec = er_inventory.get_inventory_spec(
-        provision_provider=provision_provider,
-        provisioner=provisioner,
-        provider=provider,
-        identifier=identifier,
+    in the Reconciliation Job to manage the resource."""
+    erv2cli = Erv2Cli(
+        provision_provider=ctx.obj["provision_provider"],
+        provisioner=ctx.obj["provisioner"],
+        provider=ctx.obj["provider"],
+        identifier=ctx.obj["identifier"],
+        secret_reader=ctx.obj["secret_reader"],
     )
-    vault_settings = get_app_interface_vault_settings()
-    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-    er_settings = get_settings()[0]
-    m_inventory = load_module_inventory(get_modules())
-    factories = setup_factories(er_settings, m_inventory, er_inventory, secret_reader)
-    f = factories.get_factory(spec.provision_provider)
-    resource = f.create_external_resource(spec)
-    f.validate_external_resource(resource)
-    print(resource.json(exclude={"data": {FLAG_RESOURCE_MANAGED_BY_ERV2}}))
+    print(erv2cli.input_data)
 
 
 @external_resources.command()
-@click.argument("provision-provider", required=True)
-@click.argument("provisioner", required=True)
-@click.argument("provider", required=True)
-@click.argument("identifier", required=True)
 @click.pass_context
-def request_reconciliation(
-    ctx, provision_provider: str, provisioner: str, provider: str, identifier: str
-):
+def request_reconciliation(ctx):
     """Marks a resource as it needs to get reconciled. The itegration will reconcile the resource at
-    its next iteration.
+    its next iteration."""
+    erv2cli = Erv2Cli(
+        provision_provider=ctx.obj["provision_provider"],
+        provisioner=ctx.obj["provisioner"],
+        provider=ctx.obj["provider"],
+        identifier=ctx.obj["identifier"],
+        secret_reader=ctx.obj["secret_reader"],
+    )
+    erv2cli.reconcile()
 
-    e.g: e.g: qontract-reconcile --config=<config> external-resources request-reconciliation aws app-sre-stage rds dashdotdb-stage
+
+@external_resources.command()
+@binary(["terraform"])
+@binary_version("terraform", ["version"], TERRAFORM_VERSION_REGEX, TERRAFORM_VERSION)
+@click.option(
+    "--dry-run/--no-dry-run",
+    help="Enable/Disable dry-run. Default: dry-run enabled!",
+    default=True,
+)
+@click.pass_context
+def migrate(ctx, dry_run: bool) -> None:
+    """Migrate an existing external resource managed by terraform-resources to ERv2.
+
+
+    E.g: qontract-reconcile --config=<config> external-resources migrate aws app-sre-stage rds dashdotdb-stage
     """
-    er_settings = get_settings()[0]
-    vault_settings = get_app_interface_vault_settings()
-    secret_reader = create_secret_reader(use_vault=vault_settings.vault)
-    with get_aws_api(
-        query_func=gql.get_api().query,
-        account_name=er_settings.state_dynamodb_account.name,
-        region=er_settings.state_dynamodb_region,
-        secret_reader=secret_reader,
-    ) as aws_api:
-        state_manager = ExternalResourcesStateDynamoDB(
-            aws_api=aws_api,
-            table_name=er_settings.state_dynamodb_table,
-        )
-        key = ExternalResourceKey(
-            provision_provider=provision_provider,
-            provisioner_name=provisioner,
-            provider=provider,
-            identifier=identifier,
-        )
-        current_state = state_manager.get_external_resource_state(key)
-        if current_state.resource_status != ResourceStatus.NOT_EXISTS:
-            state_manager.update_resource_status(
-                key, ResourceStatus.RECONCILIATION_REQUESTED
+    if not Confirm.ask(
+        dedent("""
+            Please disable terraform-resources: [i blue]https://app-interface.unleash.devshift.net/projects/default/features/terraform-resources[/]
+            in Unleash before proceeding!
+
+            Do you want to proceed?"""),
+        default=True,
+    ):
+        sys.exit(0)
+
+    # use a temporary directory in $HOME. The MacOS colima default configuration allows docker mounts from $HOME.
+    tempdir = Path.home() / ".erv2-migration"
+    rich_print(f"Using temporary directory: [b]{tempdir}[/]")
+    tempdir.mkdir(exist_ok=True)
+    temp_erv2 = Path(tempdir) / "erv2"
+    temp_erv2.mkdir(exist_ok=True)
+    temp_tfr = tempdir / "terraform-resources"
+    temp_tfr.mkdir(exist_ok=True)
+
+    with progress_spinner() as progress:
+        with task(progress, "Preparing AWS credentials for CDKTF and local terraform"):
+            # prepare AWS credentials for CDKTF and local terraform
+            credentials_file = tempdir / "credentials"
+            credentials_file.write_text(
+                ctx.obj["secret_reader"].read_with_parameters(
+                    path=f"app-sre/external-resources/{ctx.obj['provisioner']}",
+                    field="credentials",
+                    format=None,
+                    version=None,
+                )
             )
-        else:
-            logging.info("External Resource does not exist")
+        os.environ["AWS_SHARED_CREDENTIALS_FILE"] = str(credentials_file)
+
+        erv2cli = Erv2Cli(
+            provision_provider=ctx.obj["provision_provider"],
+            provisioner=ctx.obj["provisioner"],
+            provider=ctx.obj["provider"],
+            identifier=ctx.obj["identifier"],
+            secret_reader=ctx.obj["secret_reader"],
+            temp_dir=temp_erv2,
+            progress_spinner=progress,
+        )
+
+        with task(progress, "(erv2) Building the terraform configuration"):
+            # build the CDKTF output
+            erv2cli.build_cdktf(credentials_file)
+            erv2_tf_cli = TerraformCli(
+                temp_erv2, dry_run=dry_run, progress_spinner=progress
+            )
+            erv2_tf_cli.init()
+
+        with task(
+            progress, "(terraform-resources) Building the terraform configuration"
+        ):
+            # build the terraform-resources output
+            conf_tf = temp_tfr / "conf.tf.json"
+            tfr.run(
+                dry_run=True,
+                print_to_file=str(conf_tf),
+                account_name=[ctx.obj["provisioner"]],
+            )
+            # remove comments
+            conf_tf.write_text(
+                "\n".join(
+                    line
+                    for line in conf_tf.read_text().splitlines()
+                    if not line.startswith("#")
+                )
+            )
+            tfr_tf_cli = TerraformCli(
+                temp_tfr, dry_run=dry_run, progress_spinner=progress
+            )
+            tfr_tf_cli.init()
+
+    with progress_spinner() as progress:
+        # start a new spinner instance for clean output
+        erv2_tf_cli.progress_spinner = progress
+        with task(
+            progress,
+            "Migrating the resources from terraform-resources to ERv2",
+        ):
+            erv2_tf_cli.migrate_resources(source=tfr_tf_cli)
+
+    rich_print(f"[b red]Please remove the temporary directory ({tempdir}) manually!")
 
 
 if __name__ == "__main__":

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -4015,6 +4015,10 @@ def migrate(ctx, dry_run: bool) -> None:
 
     E.g: qontract-reconcile --config=<config> external-resources migrate aws app-sre-stage rds dashdotdb-stage
     """
+    if ctx.obj["provider"] == "rds":
+        # The "random_password" is not an AWS resource. It's just in the outputs and can't be migrated :(
+        raise NotImplementedError("RDS migration is not supported yet!")
+
     if not Confirm.ask(
         dedent("""
             Please disable terraform-resources: [i blue]https://app-interface.unleash.devshift.net/projects/default/features/terraform-resources[/]

--- a/tools/test/test_erv2.py
+++ b/tools/test/test_erv2.py
@@ -3,14 +3,6 @@ import pytest
 from tools.cli_commands.erv2 import TfResource, TfResourceList
 
 
-def test_erv2_model_tfresource() -> None:
-    tfr1 = TfResource(address="aws_module.identifier")
-    assert tfr1.type == "aws_module"
-    assert tfr1.id == "identifier"
-    tfr2 = TfResource(address="aws_module.identifier-with-postfix")
-    assert tfr2 > tfr1
-
-
 def test_erv2_model_tfresource_list() -> None:
     # terraform_resource_list
     terraform_resource_list = TfResourceList(

--- a/tools/test/test_erv2.py
+++ b/tools/test/test_erv2.py
@@ -23,10 +23,10 @@ def test_erv2_model_tfresource_list() -> None:
             TfResource(address="something.else"),
             # real life example
             TfResource(
-                address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user"
+                address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage"
             ),
             TfResource(
-                address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage"
+                address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user"
             ),
         ]
     )
@@ -59,6 +59,14 @@ def test_erv2_model_tfresource_list() -> None:
         ].address
         == "aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage"
     )
-
+    # test sorting in TfResourceList.__getitem__
+    assert (
+        terraform_resource_list[
+            TfResource(
+                address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user-secret"
+            )
+        ].address
+        == "aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user"
+    )
     with pytest.raises(KeyError):
         terraform_resource_list[TfResource(address="not.found")]

--- a/tools/test/test_erv2.py
+++ b/tools/test/test_erv2.py
@@ -21,52 +21,68 @@ def test_erv2_model_tfresource_list() -> None:
             TfResource(address="prefix-module.user-2"),
             TfResource(address="exact-module.identifier"),
             TfResource(address="something.else"),
-            # real life example
+            # real life examples
             TfResource(
                 address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage"
             ),
             TfResource(
                 address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user"
             ),
+            TfResource(address="aws_secretsmanager_secret.playground-user"),
+            TfResource(address="aws_secretsmanager_secret.foobar-playground-user"),
         ]
     )
-    assert len(terraform_resource_list) == 8
+    assert len(terraform_resource_list) == 10
     # exact match
-    assert (
-        terraform_resource_list[TfResource(address="exact-module.identifier")].address
-        == "exact-module.identifier"
-    )
+    assert terraform_resource_list[TfResource(address="exact-module.identifier")] == [
+        TfResource(address="exact-module.identifier")
+    ]
     # with postfix
-    assert (
-        terraform_resource_list[
-            TfResource(address="postfix-module.user-1-postfix")
-        ].address
-        == "postfix-module.user-1"
-    )
+    assert terraform_resource_list[
+        TfResource(address="postfix-module.user-1-postfix")
+    ] == [TfResource(address="postfix-module.user-1")]
     # with prefix
-    assert (
-        terraform_resource_list[
-            TfResource(address="prefix-module.prefix-user-1")
-        ].address
-        == "prefix-module.user-1"
-    )
-    # real life example
-    assert (
-        terraform_resource_list[
-            TfResource(
-                address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-secret"
-            )
-        ].address
-        == "aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage"
-    )
-    # test sorting in TfResourceList.__getitem__
-    assert (
-        terraform_resource_list[
-            TfResource(
-                address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user-secret"
-            )
-        ].address
-        == "aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user"
-    )
+    assert terraform_resource_list[
+        TfResource(address="prefix-module.prefix-user-1")
+    ] == [TfResource(address="prefix-module.user-1")]
+
+    # real life examples
+    assert terraform_resource_list[
+        TfResource(
+            address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-secret"
+        )
+    ] == [
+        TfResource(
+            address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage"
+        ),
+        TfResource(
+            address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user"
+        ),
+    ]
+    assert terraform_resource_list[
+        TfResource(
+            address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user-secret"
+        )
+    ] == [
+        TfResource(
+            address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage"
+        ),
+        TfResource(
+            address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user"
+        ),
+    ]
+
+    assert terraform_resource_list[
+        TfResource(address="aws_secretsmanager_secret.secret-foobar-playground-user")
+    ] == [
+        TfResource(address="aws_secretsmanager_secret.playground-user"),
+        TfResource(address="aws_secretsmanager_secret.foobar-playground-user"),
+    ]
     with pytest.raises(KeyError):
+        # unknown resource type
         terraform_resource_list[TfResource(address="not.found")]
+
+    assert (
+        terraform_resource_list[TfResource(address="aws_secretsmanager_secret.found")]
+        == []
+    )

--- a/tools/test/test_erv2.py
+++ b/tools/test/test_erv2.py
@@ -1,0 +1,41 @@
+import pytest
+
+from tools.cli_commands.erv2 import TfResource, TfResourceList
+
+
+def test_erv2_model_tfresource() -> None:
+    tfr1 = TfResource(address="aws_module.identifier")
+    assert tfr1.type == "aws_module"
+    assert tfr1.id == "identifier"
+    tfr2 = TfResource(address="aws_module.identifier-with-postfix")
+    assert tfr2 > tfr1
+
+
+def test_erv2_model_tfresource_list() -> None:
+    tfrl = TfResourceList(
+        resources=[
+            TfResource(address="postfix-module.identifier-postfix"),
+            TfResource(address="prefix-module.prefix-identifier"),
+            TfResource(address="exact-module.identifier"),
+            TfResource(address="something.else"),
+        ]
+    )
+    assert len(tfrl) == 4
+    # exact match
+    assert (
+        tfrl[TfResource(address="exact-module.identifier")].address
+        == "exact-module.identifier"
+    )
+    # with postfix
+    assert (
+        tfrl[TfResource(address="postfix-module.identifier")].address
+        == "postfix-module.identifier-postfix"
+    )
+    # with prefix
+    assert (
+        tfrl[TfResource(address="prefix-module.identifier")].address
+        == "prefix-module.prefix-identifier"
+    )
+
+    with pytest.raises(KeyError):
+        tfrl[TfResource(address="not.found")]

--- a/tools/test/test_erv2.py
+++ b/tools/test/test_erv2.py
@@ -12,30 +12,53 @@ def test_erv2_model_tfresource() -> None:
 
 
 def test_erv2_model_tfresource_list() -> None:
-    tfrl = TfResourceList(
+    # terraform_resource_list
+    terraform_resource_list = TfResourceList(
         resources=[
-            TfResource(address="postfix-module.identifier-postfix"),
-            TfResource(address="prefix-module.prefix-identifier"),
+            TfResource(address="postfix-module.user-1"),
+            TfResource(address="postfix-module.user-2"),
+            TfResource(address="prefix-module.user-1"),
+            TfResource(address="prefix-module.user-2"),
             TfResource(address="exact-module.identifier"),
             TfResource(address="something.else"),
+            # real life example
+            TfResource(
+                address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user"
+            ),
+            TfResource(
+                address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage"
+            ),
         ]
     )
-    assert len(tfrl) == 4
+    assert len(terraform_resource_list) == 8
     # exact match
     assert (
-        tfrl[TfResource(address="exact-module.identifier")].address
+        terraform_resource_list[TfResource(address="exact-module.identifier")].address
         == "exact-module.identifier"
     )
     # with postfix
     assert (
-        tfrl[TfResource(address="postfix-module.identifier")].address
-        == "postfix-module.identifier-postfix"
+        terraform_resource_list[
+            TfResource(address="postfix-module.user-1-postfix")
+        ].address
+        == "postfix-module.user-1"
     )
     # with prefix
     assert (
-        tfrl[TfResource(address="prefix-module.identifier")].address
-        == "prefix-module.prefix-identifier"
+        terraform_resource_list[
+            TfResource(address="prefix-module.prefix-user-1")
+        ].address
+        == "prefix-module.user-1"
+    )
+    # real life example
+    assert (
+        terraform_resource_list[
+            TfResource(
+                address="aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-secret"
+            )
+        ].address
+        == "aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage"
     )
 
     with pytest.raises(KeyError):
-        tfrl[TfResource(address="not.found")]
+        terraform_resource_list[TfResource(address="not.found")]


### PR DESCRIPTION
This PR introduces the `qontract-cli external-resources migrate` command, which will help us with the ERv2 migration. It makes the [terraform-resources -> ExternalResources RDS migration Guide](https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/runbook/external-resources/aws-rds-migration.md) much easier.

High-level: it retrieves the ERv2 and the terraform-resources configs and states and moves all involved resources. Something like

```
get CDKTF output and state
get terraform-resources output and state

for resources in diff CDKTF terraform:
  terraform state mv -lock=false -state=terraform-resources-state -state-out=scdktf_state \
    "resource_in_terraform_state" \
    "resource_in_cdktf_state"

terraform push both states
```

Example run:

```
$ qontract-cli --config=config.prod-local-cli.toml external-resources --provisioner app-sre-stage --provider msk --identifier playground-msk-stage migrate --dry-run

Please disable terraform-resources: https://app-interface.unleash.devshift.net/projects/default/features/terraform-resources
in Unleash before proceeding!

Do you want to proceed? [y/n] (y):
Using temporary directory: /Users/cassing/.erv2-migration
  Preparing AWS credentials for CDKTF and local terraform    0:00:01
  (erv2) Building the terraform configuration                0:00:48
  -- Running CDKTF synth                                     0:00:36
  -- Copying the generated cdk.tf.json                       0:00:00
  -- Running terraform init                                  0:00:03
  -- Running terraform plan                                  0:00:05
  -- Retrieving the terraform state                          0:00:02
  (terraform-resources) Building the terraform configuration 0:01:30
  -- Running terraform init                                  0:00:03
  -- Running terraform plan                                  0:00:54
  -- Retrieving the terraform state                          0:00:02
[08:19:58] Resource id mismatch! Please review it carefully!                                                                                                                                                                                                         erv2.py:380
             aws_cloudwatch_log_group.playground-msk-stage -> aws_cloudwatch_log_group.playground-msk-stage-msk-broker-logs
           Resource id mismatch! Please review it carefully!                                                                                                                                                                                                         erv2.py:380
             aws_kms_alias.playground-msk-stage -> aws_kms_alias.playground-msk-stage-msk-scram
           Resource id mismatch! Please review it carefully!                                                                                                                                                                                                         erv2.py:380
             aws_kms_key.playground-msk-stage -> aws_kms_key.playground-msk-stage-kms-key
           Resource id mismatch! Please review it carefully!                                                                                                                                                                                                         erv2.py:380
             aws_msk_scram_secret_association.playground-msk-stage -> aws_msk_scram_secret_association.playground-msk-stage-scram-secret-link
           Resource id mismatch! Please review it carefully!                                                                                                                                                                                                         erv2.py:380
             aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user -> aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user-secret
           Resource id mismatch! Please review it carefully!                                                                                                                                                                                                         erv2.py:380
             aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage -> aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-secret
           Resource id mismatch! Please review it carefully!                                                                                                                                                                                                         erv2.py:380
             aws_secretsmanager_secret_policy.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user -> aws_secretsmanager_secret_policy.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user-secret-policy
           Resource id mismatch! Please review it carefully!                                                                                                                                                                                                         erv2.py:380
             aws_secretsmanager_secret_policy.AmazonMSK_playground-msk-stage-playground-msk-stage -> aws_secretsmanager_secret_policy.AmazonMSK_playground-msk-stage-playground-msk-stage-secret-policy
           Resource id mismatch! Please review it carefully!                                                                                                                                                                                                         erv2.py:380
             aws_secretsmanager_secret_version.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user -> aws_secretsmanager_secret_version.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user-secret-version
           Resource id mismatch! Please review it carefully!                                                                                                                                                                                                         erv2.py:380
             aws_secretsmanager_secret_version.AmazonMSK_playground-msk-stage-playground-msk-stage -> aws_secretsmanager_secret_version.AmazonMSK_playground-msk-stage-playground-msk-stage-secret-version
⠸ Migrating the resources from terraform-resources to ERv2                                                                              0:00:01
  -- Moving aws_cloudwatch_log_group.playground-msk-stage-msk-broker-logs (DRY-RUN)                                                     0:00:00
  -- Moving aws_kms_alias.playground-msk-stage-msk-scram (DRY-RUN)                                                                      0:00:00
  -- Moving aws_kms_key.playground-msk-stage-kms-key (DRY-RUN)                                                                          0:00:00
  -- Moving aws_msk_cluster.playground-msk-stage (DRY-RUN)                                                                              0:00:00
  -- Moving aws_msk_configuration.playground-msk-stage-3-7-x (DRY-RUN)                                                                  0:00:00
  -- Moving aws_msk_scram_secret_association.playground-msk-stage-scram-secret-link (DRY-RUN)                                           0:00:00
  -- Moving aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user-secret (DRY-RUN)                 0:00:00
  -- Moving aws_secretsmanager_secret.AmazonMSK_playground-msk-stage-playground-msk-stage-secret (DRY-RUN)                              0:00:00
  -- Moving aws_secretsmanager_secret_policy.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user-secret-policy (DRY-RUN)   0:00:00
  -- Moving aws_secretsmanager_secret_policy.AmazonMSK_playground-msk-stage-playground-msk-stage-secret-policy (DRY-RUN)                0:00:00
  -- Moving aws_secretsmanager_secret_version.AmazonMSK_playground-msk-stage-playground-msk-stage-another-user-secret-version (DRY-RUN) 0:00:00
  -- Moving aws_secretsmanager_secret_version.AmazonMSK_playground-msk-stage-playground-msk-stage-secret-version (DRY-RUN)              0:00:00

Everything ok? Would you like to upload the modified terraform states? [y/n] (n):
```

Ticket; [APPSRE-10598](https://issues.redhat.com/browse/APPSRE-10598)

Hints for the reviewers:

* This PR also refactors the `external-resources` sub-command options. 
* The terraform resource IDs may differ between `terraform-resources` and `CDKTF.` See https://github.com/hashicorp/terraform-cdk/issues/279 for more details. I did my best to find a proper resource-matching logic in `TfResourceList.__getitem__`
* local `docker` installation is needed
* tested on MacOS, but should work on Linux as well