### PR TITLE
APPSRE-10844 dedicated dtp.spec label

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,10 @@ build-test:
 test-app: build-test ## Target to test app with tox on docker
 	@$(CONTAINER_ENGINE) run --rm $(IMAGE_TEST)
 
+print-host-versions:
+	@$(CONTAINER_ENGINE) --version
+	python3 --version
+
 test-container-image: build ## Target to test the final image
 	@CONTAINER_ENGINE=$(CONTAINER_ENGINE) \
 	CTR_STRUCTURE_IMG=$(CTR_STRUCTURE_IMG) \
@@ -64,7 +68,7 @@ test-container-image: build ## Target to test the final image
 	IMAGE_TAG=$(IMAGE_TAG) \
 	$(CURDIR)/run-test-container-image.sh
 
-test: test-app test-container-image
+test: print-host-versions test-app test-container-image
 
 dev-reconcile-loop: build-dev ## Trigger the reconcile loop inside a container for an integration
 	@$(CONTAINER_ENGINE) run --rm -it \

--- a/reconcile/dynatrace_token_provider/ocm.py
+++ b/reconcile/dynatrace_token_provider/ocm.py
@@ -34,7 +34,6 @@ from reconcile.utils.ocm_base_client import (
 Thin abstractions of reconcile.ocm module to reduce coupling.
 """
 
-DTP_LABEL = sre_capability_label_key("dtp", None)
 DTP_TENANT_LABEL = sre_capability_label_key("dtp", "tenant")
 DTP_SPEC_LABEL = sre_capability_label_key("dtp", "token-spec")
 DTP_LABEL_SEARCH = sre_capability_label_key("dtp", "%")

--- a/reconcile/dynatrace_token_provider/ocm.py
+++ b/reconcile/dynatrace_token_provider/ocm.py
@@ -36,6 +36,7 @@ Thin abstractions of reconcile.ocm module to reduce coupling.
 
 DTP_LABEL = sre_capability_label_key("dtp", None)
 DTP_TENANT_LABEL = sre_capability_label_key("dtp", "tenant")
+DTP_SPEC_LABEL = sre_capability_label_key("dtp", "token-spec")
 DTP_LABEL_SEARCH = sre_capability_label_key("dtp", "%")
 
 
@@ -50,7 +51,7 @@ class Cluster(BaseModel):
     @staticmethod
     def from_cluster_details(cluster: ClusterDetails) -> Cluster:
         dt_tenant = cluster.labels.get_label_value(DTP_TENANT_LABEL)
-        token_spec_name = cluster.labels.get_label_value(DTP_LABEL)
+        token_spec_name = cluster.labels.get_label_value(DTP_SPEC_LABEL)
         if not token_spec_name:
             """
             We want to stay backwards compatible.


### PR DESCRIPTION
Up until now the DTP spec was set via `sre-capabilities.dtp = spec-name`. However, our integrations treat `sre-capabilites.dtp` as a map.

In this PR we set the DTP spec now via `sre-capabilities.dtp.spec = spec-name` to comply with our schema.
Note, that this is fully backwards compatible. If a spec label is missing, DTP falls back to a default spec (which is what all clusters are doing right now).

In this PR we also start printing host level tooling versions for any potential debugging.