### PR TITLE
[change-log-tracking] replace commit created_at with merge request merged_at

### DIFF
--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -153,7 +153,7 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                             change_log_item.change_types.append(ctp.name)
 
         change_log.items = sorted(
-            change_log.items, key=lambda i: i.created_at, reverse=True
+            change_log.items, key=lambda i: i.merged_at, reverse=True
         )
         if not dry_run:
             integration_state.add(BUNDLE_DIFFS_OBJ, asdict(change_log), force=True)

--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2903,13 +2903,14 @@ def change_log_tracking(ctx):
         ]
         item = {
             "commit": f"[{commit}]({repo_url}/commit/{commit})",
+            "merged_at": change_log_item.merged_at,
             "apps": ", ".join(change_log_item.apps),
             "changes": ", ".join(covered_change_types_descriptions),
             "error": change_log_item.error,
         }
         data.append(item)
 
-    columns = ["commit", "apps", "changes", "error"]
+    columns = ["commit", "merged_at", "apps", "changes", "error"]
     print_output(ctx.obj["options"], data, columns)
 
 


### PR DESCRIPTION
we care less when a commit was created, and more when it became active in production (merged).

this PR changes the date to be merged at, from the associated merge request(s).