### PR TITLE
qontract-cli get change-log-tracking disable natural sort to sort by merged_at

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2910,6 +2910,8 @@ def change_log_tracking(ctx):
         }
         data.append(item)
 
+    # TODO(mafriedm): Fix this
+    ctx.obj["options"]["sort"] = False
     columns = ["commit", "merged_at", "apps", "changes", "error"]
     print_output(ctx.obj["options"], data, columns)
 


### PR DESCRIPTION
to display the change log by date