### PR TITLE
[openshift-tekton-resources] early-exit

### DIFF
--- a/reconcile/openshift_tekton_resources.py
+++ b/reconcile/openshift_tekton_resources.py
@@ -464,3 +464,7 @@ def run(
         sys.exit(ExitCodes.ERROR)
 
     sys.exit(0)
+
+
+def early_exit_desired_state(*args: Any, **kwargs: Any) -> dict[str, Any]:
+    return fetch_tkn_providers()


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10864

by using early exit we reduce run time of this integration in case the MR does not affect tekton resources.

for example, a standard promotion.