### PR TITLE
Add CLI commands to get external resource reconciliation logs

### DIFF
--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -73,8 +73,6 @@ SUPPORTED_RESOURCE_TYPES = (
 
 
 class ExternalResourcesInventory(MutableMapping):
-    _inventory: dict[ExternalResourceKey, ExternalResourceSpec] = {}
-
     def _build_external_resource_spec(
         self,
         namespace: NamespaceV1,
@@ -98,6 +96,8 @@ class ExternalResourcesInventory(MutableMapping):
         return spec
 
     def __init__(self, namespaces: Iterable[NamespaceV1]) -> None:
+        self._inventory: dict[ExternalResourceKey, ExternalResourceSpec] = {}
+
         desired_providers = [
             (p, ns)
             for ns in namespaces
@@ -106,10 +106,10 @@ class ExternalResourcesInventory(MutableMapping):
         ]
 
         desired_specs = [
-            self._build_external_resource_spec(ns, p, r)
+            self._build_external_resource_spec(ns, p, r)  # type: ignore[unused-ignore, arg-type]
             for (p, ns) in desired_providers
             for r in p.resources
-            if isinstance(r, SUPPORTED_RESOURCE_TYPES) and r.managed_by_erv2
+            if isinstance(r, SUPPORTED_RESOURCE_TYPES) and r.managed_by_erv2  # type: ignore[unused-ignore, union-attr, misc, arg-type]
         ]
 
         for spec in desired_specs:


### PR DESCRIPTION
APPSRE-10886 

The idea is having an outputs page like this one: 

![image](https://github.com/user-attachments/assets/26ca713c-3155-4262-8306-89c5a89d1d5f)


and a CLI Command to get specific logs: 
```bash 
qontract-cli --config config.debug.toml external-resources get-logs aws app-sre-stage rds glitchtip-dev

https://grafana.app-sre.devshift.net/explore?schemaVersion=1&panes=%7B%22dummy%22%3A+%7B%22datasource%22%3A+%22P1A97A9592CB7F392%22%2C+%22queries%22%3A+%5B%7B%22id%22%3A+%22er-9c28652f92%22%2C+%22region%22%3A+%22default%22%2C+%22namespace%22%3A+%22%22%2C+%22refId%22%3A+%22A%22%2C+%22datasource%22%3A+%7B%22type%22%3A+%22cloudwatch%22%2C+%22uid%22%3A+%22P1A97A9592CB7F392%22%7D%2C+%22queryMode%22%3A+%22Logs%22%2C+%22logGroups%22%3A+%5B%7B%22arn%22%3A+%22arn%3Aaws%3Alogs%3Aus-east-1%3A744086762512%3Alog-group%3Aappsrep09ue1.external-resources-jobs%3A%2A%22%2C+%22name%22%3A+%22appsrep09ue1.external-resources-jobs%22%2C+%22accountId%22%3A+%22744086762512%22%7D%5D%2C+%22expression%22%3A+%22fields+message+%7C+filter+kubernetes.pod_name+like+%2Fer-9c28652f92%2F%5Cn%22%2C+%22statsGroups%22%3A+%5B%5D%7D%5D%2C+%22range%22%3A+%7B%22from%22%3A+%22now-24h%22%2C+%22to%22%3A+%22now%22%7D%7D%7D&orgId=1
```