### PR TITLE
[change-log] add handling for special dirs in app-interface (docs, hack)

### DIFF
--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -171,6 +171,16 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                         if ctp.name not in change_log_item.change_types:
                             change_log_item.change_types.append(ctp.name)
 
+                change_log_item.change_types.extend(
+                    special_dir
+                    for special_dir in ("docs", "hack")
+                    if any(
+                        path.startswith(special_dir)
+                        for gl_diff in gl_commit.diff()
+                        for path in (gl_diff["old_path"], gl_diff["new_path"])
+                    )
+                )
+
         change_log.items = sorted(
             change_log.items, key=lambda i: i.merged_at, reverse=True
         )


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10755

add a check for the changed paths of the gitlab commit objects, to discover changes to paths (data, hack) that are not covered by the granular permissions model (data, resoruces)

this PR depends on the existence of dummy change types: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/117790