### PR TITLE
retry on TooManyRedirects

### DIFF
--- a/reconcile/utils/vault.py
+++ b/reconcile/utils/vault.py
@@ -109,7 +109,10 @@ class _VaultClient:
                 self._refresh_client_auth()
                 authenticated = self._client.is_authenticated()
                 break
-            except requests.exceptions.ConnectionError:
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.TooManyRedirects,
+            ):
                 time.sleep(1)
 
         if not authenticated:


### PR DESCRIPTION
We repeatedly see `TooManyRedirects` on `openshift-saas-deploy`, which will make tenants retry the pipeline. Note, that this happens on every integration, but for saas deploys this is especially annoying.

Lets add `TooManyRedirects` to the list of exceptions for which we retry

Example error from a recent pipeline run:

```
File "/usr/local/lib/python3.11/site-packages/reconcile/utils/vault.py", line 163, in _refresh_client_auth
    self._client.auth_approle(self.role_id, self.secret_id)
  File "/usr/local/lib/python3.11/site-packages/hvac/v1/__init__.py", line 1428, in auth_approle
    return self.login('/v1/auth/{0}/login'.format(mount_point), json=params, use_token=use_token)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/hvac/v1/__init__.py", line 1188, in login
    return self._adapter.login(
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/hvac/adapters.py", line 177, in login
    response = self.post(url, **kwargs).json()
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/hvac/adapters.py", line 106, in post
    return self.request('post', url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/hvac/adapters.py", line 262, in request
    response = self.session.request(
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/sessions.py", line 724, in send
    history = [resp for resp in gen]
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/sessions.py", line 724, in <listcomp>
    history = [resp for resp in gen]
              ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/requests/sessions.py", line 191, in resolve_redirects
    raise TooManyRedirects(
requests.exceptions.TooManyRedirects: Exceeded 30 redirects.
```