### PR TITLE
[gitlab-housekeeping] remove duplicate token expiration metrics

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -563,6 +563,9 @@ def publish_access_token_expiration_metrics(gl: GitLabApi) -> None:
         gitlab_token_expiration.labels(name=pat.name, active=pat.active).set(
             days_until_expiration.days
         )
+        # ensure that inactive tokens no longer send out alerts
+        if not pat.active:
+            gitlab_token_expiration.labels(name=pat.name, active=True).clear()
 
 
 def run(dry_run, wait_for_pipeline):


### PR DESCRIPTION
When a PAT becomes inactive, do not publish metrics indicating that token is active since that will result in alerting and pages.


[APPSRE-10433](https://issues.redhat.com/browse/APPSRE-10433)

The current behavior is that when a token becomes inactive, two gauges are created with `active=true` and `active=false`.