### PR TITLE
[change-log] support for resource analysis

### DIFF
--- a/reconcile/change_owners/bundle.py
+++ b/reconcile/change_owners/bundle.py
@@ -32,6 +32,7 @@ class FileRef:
     file_type: BundleFileType
     path: str
     schema: str | None
+    json_path: str | None = None
 
     def __str__(self) -> str:
         return f"{self.file_type.value}:{self.path}"
@@ -106,6 +107,7 @@ class QontractServerResourcefileBackref(BaseModel):
 
     path: str
     datafileschema: str = Field(..., alias="datafileSchema")
+    jsonpath: str = Field(..., alias="jsonpath")
 
 
 class QontractServerResourcefileDiffState(BaseModel):

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -138,28 +138,30 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
             resource_changes: list[BundleFileChange] = []
             for change in changes:
                 for file_ref in change.old_backrefs | change.new_backrefs:
+                    file_content = None
                     match file_ref.schema:
                         case "/openshift/namespace-1.yml":
                             file_content = next(
                                 n for n in namespaces if n.path == file_ref.path
                             ).dict()
-                    resource_changes.append(
-                        BundleFileChange(
-                            fileref=file_ref,
-                            old=file_content,
-                            new=file_content,
-                            old_content_sha="",
-                            new_content_sha="",
-                            diffs=[
-                                Diff(
-                                    path=jsonpath_ng.parse(file_ref.json_path),
-                                    diff_type=DiffType.CHANGED,
-                                    old=file_content,
-                                    new=file_content,
-                                )
-                            ],
+                    if file_content:
+                        resource_changes.append(
+                            BundleFileChange(
+                                fileref=file_ref,
+                                old=file_content,
+                                new=file_content,
+                                old_content_sha="",
+                                new_content_sha="",
+                                diffs=[
+                                    Diff(
+                                        path=jsonpath_ng.parse(file_ref.json_path),
+                                        diff_type=DiffType.CHANGED,
+                                        old=file_content,
+                                        new=file_content,
+                                    )
+                                ],
+                            )
                         )
-                    )
             changes.extend(resource_changes)
             for change in changes:
                 logging.debug(f"Processing change {change}")

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -22,6 +22,7 @@ from reconcile.change_owners.changes import (
 from reconcile.change_owners.diff import Diff, DiffType
 from reconcile.typed_queries.apps import get_apps
 from reconcile.typed_queries.external_resources import get_namespaces
+from reconcile.typed_queries.jenkins import get_jenkins_configs
 from reconcile.utils import gql
 from reconcile.utils.defer import defer
 from reconcile.utils.gitlab_api import MRState
@@ -80,6 +81,7 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
             cluster = ns.cluster.name
             app = ns.app.name
             app_names_by_cluster_name[cluster].add(app)
+        jenkins_configs = get_jenkins_configs()
 
         integration_state = init_state(
             integration=self.name,
@@ -143,6 +145,10 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                         case "/openshift/namespace-1.yml":
                             file_content = next(
                                 n for n in namespaces if n.path == file_ref.path
+                            ).dict()
+                        case "/dependencies/jenkins-config-1.yml":
+                            file_content = next(
+                                c for c in jenkins_configs if c.path == file_ref.path
                             ).dict()
                     if file_content:
                         resource_changes.append(

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -135,7 +135,7 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
             diff = QontractServerDiff(**obj)
             changes = aggregate_resource_changes(
                 aggregate_file_moves(parse_bundle_changes(diff)),
-                [c.dict() for c in namespaces + jenkins_configs],
+                {c.path: c.dict() for c in namespaces + jenkins_configs},
             )
             for change in changes:
                 logging.debug(f"Processing change {change}")

--- a/reconcile/change_owners/changes.py
+++ b/reconcile/change_owners/changes.py
@@ -434,6 +434,7 @@ def parse_bundle_changes(
                     file_type=BundleFileType.DATAFILE,
                     path=br.path,
                     schema=br.datafileschema,
+                    json_path=br.jsonpath,
                 )
                 for br in (rf.old.backrefs if rf.old and rf.old.backrefs else [])
             ],
@@ -442,6 +443,7 @@ def parse_bundle_changes(
                     file_type=BundleFileType.DATAFILE,
                     path=br.path,
                     schema=br.datafileschema,
+                    json_path=br.jsonpath,
                 )
                 for br in (rf.new.backrefs if rf.new and rf.new.backrefs else [])
             ],

--- a/reconcile/change_owners/changes.py
+++ b/reconcile/change_owners/changes.py
@@ -461,14 +461,14 @@ def parse_bundle_changes(
 
 def aggregate_resource_changes(
     bundle_changes: list[BundleFileChange],
-    content_store: list[dict[str, Any]],
+    content_store: dict[str, Any],
 ) -> list[BundleFileChange]:
     new_bundle_changes: list[BundleFileChange] = []
     resource_changes: list[BundleFileChange] = []
     for change in bundle_changes:
         new_bundle_changes.append(change)
         for file_ref in change.old_backrefs | change.new_backrefs:
-            file_content = next(c for c in content_store if c["path"] == file_ref.path)
+            file_content = content_store[file_ref.path]
             resource_changes.append(
                 BundleFileChange(
                     fileref=file_ref,

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.gql
@@ -5,6 +5,7 @@
 
 query ExternalResourcesNamespaces {
   namespaces: namespaces_v1 {
+    path
     name
     delete
     clusterAdmin

--- a/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
+++ b/reconcile/gql_definitions/external_resources/external_resources_namespaces.py
@@ -62,6 +62,7 @@ fragment VaultSecret on VaultSecret_v1 {
 
 query ExternalResourcesNamespaces {
   namespaces: namespaces_v1 {
+    path
     name
     delete
     clusterAdmin
@@ -1044,6 +1045,7 @@ class NamespaceV1_ClusterV1(ConfiguredBaseModel):
 
 
 class NamespaceV1(ConfiguredBaseModel):
+    path: str = Field(..., alias="path")
     name: str = Field(..., alias="name")
     delete: Optional[bool] = Field(..., alias="delete")
     cluster_admin: Optional[bool] = Field(..., alias="clusterAdmin")

--- a/reconcile/gql_definitions/jenkins_configs/jenkins_configs.gql
+++ b/reconcile/gql_definitions/jenkins_configs/jenkins_configs.gql
@@ -2,7 +2,11 @@
 
 query JenkinsConfigs {
   jenkins_configs: jenkins_configs_v1 {
+    path
     name
+    app {
+      name
+    }
     ...on JenkinsConfig_v1 {
       instance {
         name

--- a/reconcile/gql_definitions/jenkins_configs/jenkins_configs.py
+++ b/reconcile/gql_definitions/jenkins_configs/jenkins_configs.py
@@ -30,7 +30,11 @@ fragment VaultSecret on VaultSecret_v1 {
 
 query JenkinsConfigs {
   jenkins_configs: jenkins_configs_v1 {
+    path
     name
+    app {
+      name
+    }
     ...on JenkinsConfig_v1 {
       instance {
         name
@@ -57,8 +61,14 @@ class ConfiguredBaseModel(BaseModel):
         extra=Extra.forbid
 
 
-class JenkinsConfigV1(ConfiguredBaseModel):
+class AppV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
+
+
+class JenkinsConfigV1(ConfiguredBaseModel):
+    path: str = Field(..., alias="path")
+    name: str = Field(..., alias="name")
+    app: AppV1 = Field(..., alias="app")
 
 
 class JenkinsInstanceV1(ConfiguredBaseModel):

--- a/reconcile/test/fixtures/vault_replication/jenkins_configs/jenkins_config_insta_path.yaml
+++ b/reconcile/test/fixtures/vault_replication/jenkins_configs/jenkins_config_insta_path.yaml
@@ -11,5 +11,8 @@ jenkins_configs:
       format: null
       path: path/to/token
       version: null
+  path: path/to/config
   name: ci-jenkins-secrets
+  app:
+    name: my-app
   type: secrets

--- a/reconcile/test/test_vault_replication.py
+++ b/reconcile/test/test_vault_replication.py
@@ -5,6 +5,7 @@ import pytest
 import reconcile.vault_replication as integ
 from reconcile.gql_definitions.fragments.vault_secret import VaultSecret
 from reconcile.gql_definitions.jenkins_configs.jenkins_configs import (
+    AppV1,
     JenkinsConfigsQueryData,
     JenkinsConfigV1_JenkinsConfigV1,
     JenkinsInstanceV1,
@@ -32,7 +33,11 @@ def jenkins_config_query_data() -> JenkinsConfigsQueryData:
     return JenkinsConfigsQueryData(
         jenkins_configs=[
             JenkinsConfigV1_JenkinsConfigV1(
+                path="path/to/config",
                 name="jenkins-secrets-config",
+                app=AppV1(
+                    name="my-app",
+                ),
                 instance=JenkinsInstanceV1(
                     name="jenkins-instance",
                     serverUrl="https://test.net",

--- a/reconcile/typed_queries/jenkins.py
+++ b/reconcile/typed_queries/jenkins.py
@@ -1,11 +1,25 @@
+from reconcile.gql_definitions.jenkins_configs.jenkins_configs import (
+    JenkinsConfigV1,
+)
+from reconcile.gql_definitions.jenkins_configs.jenkins_configs import (
+    query as jenkins_configs_query,
+)
 from reconcile.gql_definitions.jenkins_configs.jenkins_instances import (
     JenkinsInstanceV1,
-    query,
+)
+from reconcile.gql_definitions.jenkins_configs.jenkins_instances import (
+    query as jenkins_instances_query,
 )
 from reconcile.utils import gql
 
 
 def get_jenkins_instances() -> list[JenkinsInstanceV1]:
     gqlapi = gql.get_api()
-    data = query(gqlapi.query)
+    data = jenkins_instances_query(gqlapi.query)
     return list(data.instances or [])
+
+
+def get_jenkins_configs() -> list[JenkinsConfigV1]:
+    gqlapi = gql.get_api()
+    data = jenkins_configs_query(gqlapi.query)
+    return list(data.jenkins_configs or [])


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10755

we iterate over changes. if the change is to a resource file, we want to add each backref to the list of changes, as if that file is changing as well.

for example, if a ConfigMap that is referenced from a namespace is updated, we want to express the change in the context of the namespace, to later match all change types that refer to a namespace.