### PR TITLE
External Resources metrics redesign

### DIFF
--- a/reconcile/external_resources/metrics.py
+++ b/reconcile/external_resources/metrics.py
@@ -1,20 +1,26 @@
 from pydantic import BaseModel
 
-from reconcile.utils.metrics import (
-    GaugeMetric,
-)
+from reconcile.utils.metrics import CounterMetric, GaugeMetric
 
 
 class ExternalResourcesBaseMetric(BaseModel):
     integration = "external_resources"
-
-
-class ExternalResourcesReconcileErrorsGauge(ExternalResourcesBaseMetric, GaugeMetric):
     provision_provider: str
     provisioner_name: str
     provider: str
     identifier: str
+    job_name: str
 
+
+class ExternalResourcesReconcileErrorsCounter(
+    ExternalResourcesBaseMetric, CounterMetric
+):
     @classmethod
     def name(cls) -> str:
-        return "external_resources_reconcile_status"
+        return "external_resources_reconcile_errors"
+
+
+class ExternalResourcesReconcileTimeGauge(ExternalResourcesBaseMetric, GaugeMetric):
+    @classmethod
+    def name(cls) -> str:
+        return "external_resources_reconcile_time"

--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -106,10 +106,10 @@ class ExternalResourcesInventory(MutableMapping):
         ]
 
         desired_specs = [
-            self._build_external_resource_spec(ns, p, r)
+            self._build_external_resource_spec(ns, p, r)  # type:ignore[arg-type]
             for (p, ns) in desired_providers
             for r in p.resources
-            if isinstance(r, SUPPORTED_RESOURCE_TYPES) and r.managed_by_erv2
+            if isinstance(r, SUPPORTED_RESOURCE_TYPES) and r.managed_by_erv2  # type:ignore[union-attr, misc, arg-type]
         ]
 
         for spec in desired_specs:

--- a/reconcile/external_resources/model.py
+++ b/reconcile/external_resources/model.py
@@ -106,10 +106,10 @@ class ExternalResourcesInventory(MutableMapping):
         ]
 
         desired_specs = [
-            self._build_external_resource_spec(ns, p, r)  # type:ignore[arg-type]
+            self._build_external_resource_spec(ns, p, r)
             for (p, ns) in desired_providers
             for r in p.resources
-            if isinstance(r, SUPPORTED_RESOURCE_TYPES) and r.managed_by_erv2  # type:ignore[union-attr, misc, arg-type]
+            if isinstance(r, SUPPORTED_RESOURCE_TYPES) and r.managed_by_erv2
         ]
 
         for spec in desired_specs:

--- a/reconcile/external_resources/reconciler.py
+++ b/reconcile/external_resources/reconciler.py
@@ -39,6 +39,11 @@ class ExternalResourcesReconciler(ABC):
     ) -> ReconcileStatus: ...
 
     @abstractmethod
+    def get_resource_reconcile_duration(
+        self, reconciliation: Reconciliation
+    ) -> int | None: ...
+
+    @abstractmethod
     def reconcile_resource(self, reconciliation: Reconciliation) -> None: ...
 
     @abstractmethod
@@ -198,6 +203,12 @@ class K8sExternalResourcesReconciler(ExternalResourcesReconciler):
     ) -> ReconcileStatus:
         job_name = ReconciliationK8sJob(reconciliation=reconciliation).name()
         return ReconcileStatus(self.controller.get_job_status(job_name))
+
+    def get_resource_reconcile_duration(
+        self, reconciliation: Reconciliation
+    ) -> int | None:
+        job_name = ReconciliationK8sJob(reconciliation=reconciliation).name()
+        return self.controller.get_success_job_duration(job_name)
 
     def reconcile_resource(self, reconciliation: Reconciliation) -> None:
         concurrency_policy = (

--- a/reconcile/external_resources/state.py
+++ b/reconcile/external_resources/state.py
@@ -44,7 +44,6 @@ class ExternalResourceState(BaseModel):
     ts: datetime
     resource_status: ResourceStatus
     reconciliation: Reconciliation
-    reconciliation_errors: int = 0
 
 
 class DynamoDBStateAdapter:
@@ -53,7 +52,6 @@ class DynamoDBStateAdapter:
 
     RESOURCE_STATUS = "resource_status"
     TIMESTAMP = "time_stamp"
-    RECONCILIATION_ERRORS = "reconciliation_errors"
 
     ER_KEY = "external_resource_key"
     ER_KEY_PROVISION_PROVIDER = "provision_provider"
@@ -120,9 +118,6 @@ class DynamoDBStateAdapter:
             ts=self._get_value(item, self.TIMESTAMP),
             resource_status=self._get_value(item, self.RESOURCE_STATUS),
             reconciliation=r,
-            reconciliation_errors=int(
-                self._get_value(item, self.RECONCILIATION_ERRORS, _type="N")
-            ),
         )
 
     def serialize(self, state: ExternalResourceState) -> dict[str, Any]:
@@ -130,7 +125,6 @@ class DynamoDBStateAdapter:
             self.ER_KEY_HASH: {"S": state.key.hash()},
             self.TIMESTAMP: {"S": state.ts.isoformat()},
             self.RESOURCE_STATUS: {"S": state.resource_status.value},
-            self.RECONCILIATION_ERRORS: {"N": str(state.reconciliation_errors)},
             self.ER_KEY: {
                 "M": {
                     self.ER_KEY_PROVISION_PROVIDER: {"S": state.key.provision_provider},
@@ -176,7 +170,6 @@ class ExternalResourcesStateDynamoDB:
         DynamoDBStateAdapter.ER_KEY,
         DynamoDBStateAdapter.TIMESTAMP,
         DynamoDBStateAdapter.RESOURCE_STATUS,
-        DynamoDBStateAdapter.RECONCILIATION_ERRORS,
         f"{DynamoDBStateAdapter.RECONC}.{DynamoDBStateAdapter.RECONC_RESOURCE_HASH}",
     ])
 

--- a/reconcile/test/external_resources/test_er_state.py
+++ b/reconcile/test/external_resources/test_er_state.py
@@ -15,7 +15,6 @@ def dynamodb_serialized_values() -> dict[str, Any]:
         DynamoDBStateAdapter.ER_KEY_HASH: {"S": "c9795cf754e47cc31400c7e4bd56486f"},
         DynamoDBStateAdapter.TIMESTAMP: {"S": "2024-01-01T17:14:00"},
         DynamoDBStateAdapter.RESOURCE_STATUS: {"S": "NOT_EXISTS"},
-        DynamoDBStateAdapter.RECONCILIATION_ERRORS: {"N": "0"},
         DynamoDBStateAdapter.ER_KEY: {
             "M": {
                 DynamoDBStateAdapter.ER_KEY_PROVISION_PROVIDER: {"S": "aws"},


### PR DESCRIPTION
- **Ignore mypy errors. This will be enventually solved once all resources have the managed_by_erv2 attr.**
- **Add a method to get the job duration time for a successful run**
- **External resources metrics redesign**
  - reconcile_errors moved out of the state. I t can be handled with prometheus metrics directly
  - add reconcile_time  
