### PR TITLE
APPSRE-10875 dedicated progressive delivery label

### DIFF
--- a/reconcile/change_owners/change_types.py
+++ b/reconcile/change_owners/change_types.py
@@ -55,6 +55,7 @@ class ChangeTypePriority(Enum):
     CRITICAL = "critical"
     URGENT = "urgent"
     HIGH = "high"
+    PROGRESSIVE_DELIVERY = "progressive-delivery"
     MEDIUM = "medium"
     LOW = "low"
 

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager_v2.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/merge_request_manager_v2.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 
 from gitlab.exceptions import GitlabGetError
 
+from reconcile.change_owners.change_types import ChangeTypePriority
 from reconcile.saas_auto_promotions_manager.merge_request_manager.batcher import (
     Addition,
     Batcher,
@@ -30,12 +31,16 @@ from reconcile.saas_auto_promotions_manager.merge_request_manager.renderer impor
 )
 from reconcile.saas_auto_promotions_manager.subscriber import Subscriber
 from reconcile.utils import metrics
+from reconcile.utils.mr.labels import prioritized_approval_label
 from reconcile.utils.vcs import VCS
 
 BATCH_SIZE_LIMIT = 5
 
 SAPM_LABEL = "SAPM"
-SAPM_MR_LABELS = [SAPM_LABEL]
+SAPM_MR_LABELS = [
+    SAPM_LABEL,
+    prioritized_approval_label(ChangeTypePriority.PROGRESSIVE_DELIVERY.value),
+]
 
 MR_DESC = """
 This is an auto-promotion triggered by app-interface's [saas-auto-promotions-manager](https://github.com/app-sre/qontract-reconcile/tree/master/reconcile/saas_auto_promotions_manager) (SAPM).

--- a/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
+++ b/reconcile/saas_auto_promotions_manager/merge_request_manager/renderer.py
@@ -146,9 +146,6 @@ class Renderer:
 
 {VERSION_REF}: {SAPM_VERSION}
 
-This MR is auto-approved
-
-/lgtm
         """
 
     def render_title(


### PR DESCRIPTION
- add a dedicated progressive delivery priority in change types (1 above medium)
- SAPM sets the new label directly on every MR -> no change-type role is responsible for this prio
- SAPM does not use lgtm semantic (change-type role)

 Once we fix https://issues.redhat.com/browse/APPSRE-10875, we can again define a change-type role for this prio in app-interface.
