### PR TITLE
Fix PAT graph in Integrations dashboard

### DIFF
--- a/grafana-dashboards/grafana-dashboard-integrations.configmap.yaml
+++ b/grafana-dashboards/grafana-dashboard-integrations.configmap.yaml
@@ -27,7 +27,7 @@ data:
       "editable": true,
       "fiscalYearStartMonth": 0,
       "graphTooltip": 0,
-      "id": 933348,
+      "id": 951487,
       "links": [],
       "liveNow": false,
       "panels": [
@@ -1425,7 +1425,7 @@ data:
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "qontract_reconcile_gitlab_token_expiration_days{active=\"True\"}",
+              "expr": "max by(name) (qontract_reconcile_gitlab_token_expiration_days{active=\"True\"})",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,
@@ -1446,9 +1446,9 @@ data:
         "list": [
           {
             "current": {
-              "selected": true,
+              "selected": false,
               "text": "appsrep09ue1-prometheus",
-              "value": "appsrep09ue1-prometheus"
+              "value": "P7B77307D2CE073BC"
             },
             "hide": 0,
             "includeAll": false,
@@ -1522,7 +1522,7 @@ data:
       "timezone": "",
       "title": "Integrations",
       "uid": "Integrations",
-      "version": 1,
+      "version": 2,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
[APPSRE-10433](https://issues.redhat.com/browse/APPSRE-10433)

Now that GitLab housekeeping is run as a sharded process with 5 replicas, that means 5 times the data points for the PAT expiration graph. This fixes that behavior by performing a `max` summation by name to remove duplicates.

`max by(name) (qontract_reconcile_gitlab_token_expiration_days{active=\"True\"}`