### PR TITLE
[ocm-clusters] ignore network type change

### DIFF
--- a/reconcile/ocm_clusters.py
+++ b/reconcile/ocm_clusters.py
@@ -23,6 +23,7 @@ from reconcile.status import ExitCodes
 from reconcile.utils.disabled_integrations import integration_is_enabled
 from reconcile.utils.jobcontroller.controller import build_job_controller
 from reconcile.utils.ocm.products import (
+    IGNORE_NETWORK_TYPE_ATTR,
     OCMProduct,
     OCMProductPortfolio,
     OCMValidationException,
@@ -248,10 +249,14 @@ def get_cluster_ocm_update_spec(
         desired_spec.network.type = "OVNKubernetes"
 
     cspec = current_spec.spec.dict()
-    cspec[ocmmod.SPEC_ATTR_NETWORK] = current_spec.network.dict()
+    cspec[ocmmod.SPEC_ATTR_NETWORK] = current_spec.network.dict(
+        exclude={IGNORE_NETWORK_TYPE_ATTR}
+    )
 
     dspec = desired_spec.spec.dict()
-    dspec[ocmmod.SPEC_ATTR_NETWORK] = desired_spec.network.dict()
+    dspec[ocmmod.SPEC_ATTR_NETWORK] = desired_spec.network.dict(
+        exclude={IGNORE_NETWORK_TYPE_ATTR}
+    )
 
     # Convert ocm specs to dicts, removing null values and excluded attributes
     current_ocm_spec = {

--- a/reconcile/test/test_ocm_clusters.py
+++ b/reconcile/test/test_ocm_clusters.py
@@ -461,6 +461,18 @@ def test_get_ocm_cluster_update_spec_network_banned(
     assert err is True
 
 
+def test_get_ocm_cluster_update_spec_network_type_ignored(
+    osd_product: OCMProductOsd, ocm_osd_cluster_spec: OCMSpec
+):
+    current_spec = ocm_osd_cluster_spec
+    desired_spec = current_spec.copy(deep=True)
+    desired_spec.network.type = "OVNKubernetes"
+    upd, err = occ.get_cluster_ocm_update_spec(
+        osd_product, "cluster1", current_spec, desired_spec
+    )
+    assert (upd, err) == ({}, False)
+
+
 @typing.no_type_check
 def test_get_ocm_cluster_update_spec_allowed_change(
     osd_product: OCMProductOsd, ocm_osd_cluster_spec: OCMSpec

--- a/reconcile/utils/ocm/products.py
+++ b/reconcile/utils/ocm/products.py
@@ -46,6 +46,7 @@ SPEC_ATTR_SUBNET_IDS = "subnet_ids"
 SPEC_ATTR_AVAILABILITY_ZONES = "availability_zones"
 
 SPEC_ATTR_NETWORK = "network"
+IGNORE_NETWORK_TYPE_ATTR = "type"
 
 SPEC_ATTR_CONSOLE_URL = "consoleUrl"
 SPEC_ATTR_SERVER_URL = "serverUrl"


### PR DESCRIPTION
OCM API doesn't support update `network.type` after cluster created, we need to update `type` from `OpenShiftSDN` to `OVNKubernetes` to ensure the value matches cluster for OVN migration tasks. We need to ignore this field until OCM has proper support for CNI migration.

[APPSRE-10881](https://issues.redhat.com/browse/APPSRE-10881)