### PR TITLE
APPSRE-10884 always checkout chart from ref

### DIFF
--- a/reconcile/utils/helm.py
+++ b/reconcile/utils/helm.py
@@ -110,10 +110,13 @@ def template_all(
     path: str,
     name: str,
     values: Mapping[str, Any],
+    ref: str | None,
     ssl_verify: bool = True,
 ) -> Iterable[Mapping[str, Any]]:
     with tempfile.TemporaryDirectory() as wd:
         git.clone(url, wd, depth=1, verify=ssl_verify)
+        if ref:
+            git.checkout(ref, wd)
         return yaml.safe_load_all(
             do_template(values=values, path=f"{wd}{path}", name=name)
         )

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -988,6 +988,7 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     image.setdefault("tag", image_tag)
             resources = helm.template_all(
                 url=url,
+                ref=commit_sha,
                 path=path,
                 name=resource_template_name,
                 values=consolidated_parameters,


### PR DESCRIPTION
Some tenants would like to checkout the helm chart from the ref in the saas file. I believe this makes sense.

Are there scenarios in which we always want to checkout from main? Do we need an extra saas helm provider flag (`checkoutChartFromRef`?) or can we make this general behavior?