### PR TITLE
[change-log] fix docs/hack section indentation

### DIFF
--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -180,15 +180,15 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                         if ctp.name not in change_log_item.change_types:
                             change_log_item.change_types.append(ctp.name)
 
-                change_log_item.change_types.extend(
-                    special_dir
-                    for special_dir in ("docs", "hack")
-                    if any(
-                        path.startswith(special_dir)
-                        for gl_diff in gl_commit.diff()
-                        for path in (gl_diff["old_path"], gl_diff["new_path"])
-                    )
+            change_log_item.change_types.extend(
+                special_dir
+                for special_dir in ("docs", "hack")
+                if any(
+                    path.startswith(special_dir)
+                    for gl_diff in gl_commit.diff()
+                    for path in (gl_diff["old_path"], gl_diff["new_path"])
                 )
+            )
 
         change_log.items = sorted(
             change_log.items, key=lambda i: i.merged_at, reverse=True


### PR DESCRIPTION
to not depend on `changes`, and to be able to parse a commit that only has changes to docs.