### PR TITLE
make sure dep_annotations is always dict

### DIFF
--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -903,9 +903,8 @@ class OCCli:  # pylint: disable=too-many-public-methods
             return
 
         dep_annotations = dep_resource.body["metadata"].get("annotations", {})
-        if dep_annotations is None:
-            # Note, that annotations might have been set to None explicitly
-            dep_annotations = {}
+        # Note, that annotations might have been set to None explicitly
+        dep_annotations = dep_resource.body["metadata"].get("annotations") or {}
         qontract_recycle = dep_annotations.get("qontract.recycle")
         if qontract_recycle is True:
             raise RecyclePodsInvalidAnnotationValue('should be "true"')

--- a/reconcile/utils/oc.py
+++ b/reconcile/utils/oc.py
@@ -903,6 +903,9 @@ class OCCli:  # pylint: disable=too-many-public-methods
             return
 
         dep_annotations = dep_resource.body["metadata"].get("annotations", {})
+        if dep_annotations is None:
+            # Note, that annotations might have been set to None explicitly
+            dep_annotations = {}
         qontract_recycle = dep_annotations.get("qontract.recycle")
         if qontract_recycle is True:
             raise RecyclePodsInvalidAnnotationValue('should be "true"')


### PR DESCRIPTION
Annotations might be set to None. Lets avoid

```
File "/usr/local/lib/python3.11/site-packages/reconcile/utils/oc.py", line 906, in recycle_pods
     qontract_recycle = dep_annotations.get("qontract.recycle")

AttributeError: 'NoneType' object has no attribute 'get'
```