### PR TITLE
[change-log] resource backref support for specific schemas

### DIFF
--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -134,8 +134,12 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                 continue
             diff = QontractServerDiff(**obj)
             changes = aggregate_resource_changes(
-                aggregate_file_moves(parse_bundle_changes(diff)),
-                {c.path: c.dict() for c in namespaces + jenkins_configs},
+                bundle_changes=aggregate_file_moves(parse_bundle_changes(diff)),
+                content_store={c.path: c.dict() for c in namespaces + jenkins_configs},
+                supported_schemas={
+                    "/openshift/namespace-1.yml",
+                    "/dependencies/jenkins-config-1.yml",
+                },
             )
             for change in changes:
                 logging.debug(f"Processing change {change}")

--- a/reconcile/change_owners/changes.py
+++ b/reconcile/change_owners/changes.py
@@ -462,6 +462,7 @@ def parse_bundle_changes(
 def aggregate_resource_changes(
     bundle_changes: list[BundleFileChange],
     content_store: dict[str, Any],
+    supported_schemas: set[str],
 ) -> list[BundleFileChange]:
     resource_changes = [
         BundleFileChange(
@@ -481,7 +482,8 @@ def aggregate_resource_changes(
         )
         for change in bundle_changes
         for file_ref in change.old_backrefs | change.new_backrefs
-        if (file_content := content_store[file_ref.path])
+        if file_ref.schema in supported_schemas
+        and (file_content := content_store[file_ref.path])
     ]
 
     return bundle_changes + resource_changes


### PR DESCRIPTION
most backrefs are namespaces and jenkins configs. these are "functional" backrefs.

some backrefs are roles, where resources are referenced under the self_service section. these are "non-functional" backrefs. why? because a change to a ConfigMap does not indicate anything about the roles that may own that ConfigMap.

this PR adds a list of supported schemas, so we are future proof.