### PR TITLE
[change-log] support app ref or obj

### DIFF
--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -157,7 +157,9 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                         changed_apps = {
                             name
                             for c in change_versions
-                            if (name := app_name_by_path.get(c["app"]["$ref"]))
+                            if (app := c["app"])
+                            and (app_path := app.get("$ref") or app.get("path"))
+                            and (name := app_name_by_path.get(app_path))
                         }
                         change_log_item.apps.extend(changed_apps)
                     case "/openshift/cluster-1.yml":


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/reconcile/cli.py", line 609, in run_class_integration
    run_integration_cfg(
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 158, in run_integration_cfg
    _integration_wet_run(run_cfg.integration)
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/runtime/runner.py", line 167, in _integration_wet_run
    integration.run(False)
  File "/usr/local/lib/python3.11/site-packages/reconcile/utils/defer.py", line 13, in func_wrapper
    return func(*args, defer=stack.callback, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/reconcile/change_owners/change_log_tracking.py", line 152, in run
    changed_apps = {
                   ^
  File "/usr/local/lib/python3.11/site-packages/reconcile/change_owners/change_log_tracking.py", line 155, in <setcomp>
    if (name := app_name_by_path.get(c["app"]["$ref"]))
                                     ~~~~~~~~^^^^^^^^
KeyError: '$ref'
```