### PR TITLE
Revert "APPSRE-10884 always checkout chart from ref (#4677)"

### DIFF
--- a/reconcile/utils/helm.py
+++ b/reconcile/utils/helm.py
@@ -110,13 +110,10 @@ def template_all(
     path: str,
     name: str,
     values: Mapping[str, Any],
-    ref: str | None,
     ssl_verify: bool = True,
 ) -> Iterable[Mapping[str, Any]]:
     with tempfile.TemporaryDirectory() as wd:
         git.clone(url, wd, depth=1, verify=ssl_verify)
-        if ref:
-            git.checkout(ref, wd)
         return yaml.safe_load_all(
             do_template(values=values, path=f"{wd}{path}", name=name)
         )

--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -988,7 +988,6 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                     image.setdefault("tag", image_tag)
             resources = helm.template_all(
                 url=url,
-                ref=commit_sha,
                 path=path,
                 name=resource_template_name,
                 values=consolidated_parameters,


### PR DESCRIPTION
Checkout not working properly on good refs, e.g.,

```
Error in populate_desired_state_saas_file: git checkout failed: 05c58fb26cccc880a7cd75fbab89658ab98cea22
```

This reverts commit e5113e73507f7a5438412526c9556518d4f7acc3.