### PR TITLE
[change-log] support processing single commit

### DIFF
--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -50,6 +50,7 @@ class ChangeLog:
 class ChangeLogIntegrationParams(PydanticRunParams):
     gitlab_project_id: str
     process_existing: bool = False
+    commit: str | None = None
 
 
 class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationParams]):
@@ -105,6 +106,8 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
         for item in diff_state.ls():
             key = item.lstrip("/")
             commit = key.rstrip(".json")
+            if self.params.commit and self.params.commit != commit:
+                continue
             if not self.params.process_existing:
                 existing_change_log_item = next(
                     (i for i in existing_change_log_items if i.commit == commit), None

--- a/reconcile/cli.py
+++ b/reconcile/cli.py
@@ -3564,8 +3564,9 @@ def change_owners(
     default=False,
     help="wait for pending/running pipelines before acting.",
 )
+@click.option("--commit", help="Reconcile just this commit.", default=None)
 @click.pass_context
-def change_log_tracking(ctx, gitlab_project_id, process_existing):
+def change_log_tracking(ctx, gitlab_project_id, process_existing, commit):
     from reconcile.change_owners.change_log_tracking import (
         ChangeLogIntegration,
         ChangeLogIntegrationParams,
@@ -3576,6 +3577,7 @@ def change_log_tracking(ctx, gitlab_project_id, process_existing):
             ChangeLogIntegrationParams(
                 gitlab_project_id=gitlab_project_id,
                 process_existing=process_existing,
+                commit=commit,
             )
         ),
         ctx=ctx.obj,


### PR DESCRIPTION
mostly for debugging purposes, but can be useful to process existing commits