### PR TITLE
[saasherder/helm] remove image.tag functionality

### DIFF
--- a/reconcile/utils/saasherder/saasherder.py
+++ b/reconcile/utils/saasherder/saasherder.py
@@ -976,16 +976,6 @@ class SaasHerder:  # pylint: disable=too-many-public-methods
                 else True
             )
             consolidated_parameters = spec.parameters(adjust=False)
-            commit_sha = self._get_commit_sha(url, ref, github)
-            image_tag = commit_sha[:hash_length]
-            image = consolidated_parameters.setdefault("image", {})
-            if isinstance(image, dict):
-                image.setdefault("tag", image_tag)
-            global_parameters = consolidated_parameters.setdefault("global", {})
-            if isinstance(global_parameters, dict):
-                image = global_parameters.setdefault("image", {})
-                if isinstance(image, dict):
-                    image.setdefault("tag", image_tag)
             resources = helm.template_all(
                 url=url,
                 path=path,


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10885

removing this functionality (for now) to enable more strict helm charts.
this may be re-introduced in the future with a different implementation.