### PR TITLE
Ensure a status page component is set before creating a maintenance

### DIFF
--- a/reconcile/statuspage/integrations/maintenances.py
+++ b/reconcile/statuspage/integrations/maintenances.py
@@ -80,6 +80,7 @@ class StatusPageMaintenancesIntegration(QontractReconcileIntegration[NoParams]):
                     for m in p.maintenances or []
                     if datetime.fromisoformat(m.scheduled_start) > now
                 ]
+                desired_state = sorted(desired_state, key=lambda d: d.name)
                 page_provider = AtlassianStatusPageProvider.init_from_page(
                     page=p,
                     token=self.secret_reader.read_secret(p.credentials),
@@ -90,6 +91,7 @@ class StatusPageMaintenancesIntegration(QontractReconcileIntegration[NoParams]):
                     for m in page_provider.scheduled_maintenances
                     if page_provider.has_component_binding_for(m.name)
                 ]
+                current_state = sorted(current_state, key=lambda c: c.name)
                 self.reconcile(
                     dry_run=dry_run,
                     desired_state=desired_state,

--- a/reconcile/statuspage/page.py
+++ b/reconcile/statuspage/page.py
@@ -146,20 +146,24 @@ class StatusMaintenance(BaseModel):
             for c in page_components
             if c.app.name in affected_services
         ]
-        if affected_components:
-            statuspage_announcements = [
-                StatusMaintenanceAnnouncement.init_from_announcement(
-                    cast(MaintenanceStatuspageAnnouncementV1, m)
-                )
-                for m in maintenance.announcements or []
-                if m.provider == PROVIDER_NAME
-            ]
-        else:
-            statuspage_announcements = [StatusMaintenanceAnnouncement()]
+        if not affected_components:
+            raise ValueError(
+                f"No StatusPage component found for maintenance '{maintenance.name}'"
+                f"via apps {affected_services}. Please define at least one StatusPage component."
+            )
+
+        statuspage_announcements = [
+            StatusMaintenanceAnnouncement.init_from_announcement(
+                cast(MaintenanceStatuspageAnnouncementV1, m)
+            )
+            for m in maintenance.announcements or []
+            if m.provider == PROVIDER_NAME
+        ]
         if len(statuspage_announcements) != 1:
             raise ValueError(
-                f"Maintenanace announcements must include exactly one item of provider {PROVIDER_NAME}"
+                f"Maintenance announcements must include exactly one item of provider {PROVIDER_NAME}"
             )
+
         return cls(
             name=maintenance.name,
             message=maintenance.message.rstrip("\n"),


### PR DESCRIPTION
If there are no components, status page replies with a `500`

Also added a commit to sort current and desired states so we can diff the 2 lists securely