### PR TITLE
log ocm client DELETE failure text to easily get more details

### DIFF
--- a/reconcile/utils/ocm_base_client.py
+++ b/reconcile/utils/ocm_base_client.py
@@ -142,7 +142,11 @@ class OCMBaseClient:
     def delete(self, api_path: str):
         ocm_request.labels(verb="DELETE", client_id=self._access_token_client_id).inc()
         r = self._session.delete(f"{self._url}{api_path}", timeout=REQUEST_TIMEOUT_SEC)
-        r.raise_for_status()
+        try:
+            r.raise_for_status()
+        except Exception:
+            logging.error(r.text)
+            raise
 
     def close(self) -> None:
         self._session.close()


### PR DESCRIPTION
For example, during a status board application DELETE failure, the reason is hidden in the text:
```
{"id":"6","kind":"Error","href":"/api/status-board/v1/errors/6","code":"OCM-SB-6","reason":"Cannot delete an application with services or dependencies.","operation_id":"..."}
```