### PR TITLE
[git-housekeeping] update token expiration metric to only include active tokens

### DIFF
--- a/grafana-dashboards/grafana-dashboard-integrations.configmap.yaml
+++ b/grafana-dashboards/grafana-dashboard-integrations.configmap.yaml
@@ -1425,7 +1425,7 @@ data:
               },
               "disableTextWrap": false,
               "editorMode": "builder",
-              "expr": "max by(name) (qontract_reconcile_gitlab_token_expiration_days{active=\"True\"})",
+              "expr": "max by(name) (qontract_reconcile_gitlab_token_expiration_days)",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
               "instant": false,


### PR DESCRIPTION
[APPSRE-10433](https://issues.redhat.com/browse/APPSRE-10433)

Updates the `qontract_reconcile_gitlab_token_expiration_days` metric exported by `gitlab-housekeeping` to only factor in active tokens. This also removes the `active` label from the metric which should cut down on unnecessary cardinality. There's no real need to monitor inactive tokens since they cannot be used.

Additionally updates the Grafana dashboard for integrations to remove that `active` label.

Second take at https://github.com/app-sre/qontract-reconcile/pull/4663