### PR TITLE
Erv2: Improve Logs dashboard + add a new metric

### DIFF
--- a/grafana-dashboards/grafana-dashboard-external-resource-log.configmap.yaml
+++ b/grafana-dashboards/grafana-dashboard-external-resource-log.configmap.yaml
@@ -431,7 +431,7 @@ data:
               "type": "prometheus",
               "uid": "P7B77307D2CE073BC"
             },
-            "definition": "label_values(external_resources_reconcile_status,provision_provider)",
+            "definition": "label_values(external_resources_resource_status,provision_provider)",
             "hide": 0,
             "includeAll": false,
             "multi": false,
@@ -439,7 +439,7 @@ data:
             "options": [],
             "query": {
               "qryType": 1,
-              "query": "label_values(external_resources_reconcile_status,provision_provider)",
+              "query": "label_values(external_resources_resource_status,provision_provider)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 1,
@@ -458,7 +458,7 @@ data:
               "type": "prometheus",
               "uid": "P7B77307D2CE073BC"
             },
-            "definition": "label_values(external_resources_reconcile_time{provision_provider=\"$provision_provider\"},provisioner_name)",
+            "definition": "label_values(external_resources_resource_status{provision_provider=\"$provision_provider\"},provisioner_name)",
             "hide": 0,
             "includeAll": false,
             "multi": false,
@@ -466,7 +466,7 @@ data:
             "options": [],
             "query": {
               "qryType": 1,
-              "query": "label_values(external_resources_reconcile_time{provision_provider=\"$provision_provider\"},provisioner_name)",
+              "query": "label_values(external_resources_resource_status{provision_provider=\"$provision_provider\"},provisioner_name)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 1,
@@ -485,7 +485,7 @@ data:
               "type": "prometheus",
               "uid": "P7B77307D2CE073BC"
             },
-            "definition": "label_values(external_resources_reconcile_time{provision_provider=\"$provision_provider\", provisioner_name=\"$provisioner\"},provider)",
+            "definition": "label_values(external_resources_resource_status{provision_provider=\"$provision_provider\", provisioner_name=\"$provisioner\"},provider)",
             "hide": 0,
             "includeAll": false,
             "multi": false,
@@ -493,7 +493,7 @@ data:
             "options": [],
             "query": {
               "qryType": 1,
-              "query": "label_values(external_resources_reconcile_time{provision_provider=\"$provision_provider\", provisioner_name=\"$provisioner\"},provider)",
+              "query": "label_values(external_resources_resource_status{provision_provider=\"$provision_provider\", provisioner_name=\"$provisioner\"},provider)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 1,
@@ -512,7 +512,7 @@ data:
               "type": "prometheus",
               "uid": "P7B77307D2CE073BC"
             },
-            "definition": "label_values(external_resources_reconcile_time{provision_provider=\"$provision_provider\", provisioner_name=\"$provisioner\", provider=\"$provider\"},identifier)",
+            "definition": "label_values(external_resources_resource_status{provision_provider=\"$provision_provider\", provisioner_name=\"$provisioner\", provider=\"$provider\"},identifier)",
             "hide": 0,
             "includeAll": false,
             "multi": false,
@@ -520,7 +520,7 @@ data:
             "options": [],
             "query": {
               "qryType": 1,
-              "query": "label_values(external_resources_reconcile_time{provision_provider=\"$provision_provider\", provisioner_name=\"$provisioner\", provider=\"$provider\"},identifier)",
+              "query": "label_values(external_resources_resource_status{provision_provider=\"$provision_provider\", provisioner_name=\"$provisioner\", provider=\"$provider\"},identifier)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 1,
@@ -539,7 +539,7 @@ data:
               "type": "prometheus",
               "uid": "P7B77307D2CE073BC"
             },
-            "definition": "label_values(external_resources_reconcile_time{provision_provider=\"$provision_provider\", provisioner_name=\"$provisioner\", provider=\"$provider\", identifier=\"$identifier\"},job_name)",
+            "definition": "label_values(external_resources_resource_status{provision_provider=\"$provision_provider\", provisioner_name=\"$provisioner\", provider=\"$provider\", identifier=\"$identifier\"},job_name)",
             "hide": 0,
             "includeAll": false,
             "label": "jobname",
@@ -548,7 +548,7 @@ data:
             "options": [],
             "query": {
               "qryType": 1,
-              "query": "label_values(external_resources_reconcile_time{provision_provider=\"$provision_provider\", provisioner_name=\"$provisioner\", provider=\"$provider\", identifier=\"$identifier\"},job_name)",
+              "query": "label_values(external_resources_resource_status{provision_provider=\"$provision_provider\", provisioner_name=\"$provisioner\", provider=\"$provider\", identifier=\"$identifier\"},job_name)",
               "refId": "PrometheusVariableQueryEditor-VariableQuery"
             },
             "refresh": 2,

--- a/reconcile/external_resources/metrics.py
+++ b/reconcile/external_resources/metrics.py
@@ -24,3 +24,11 @@ class ExternalResourcesReconcileTimeGauge(ExternalResourcesBaseMetric, GaugeMetr
     @classmethod
     def name(cls) -> str:
         return "external_resources_reconcile_time"
+
+
+class ExternalResourcesResourceStatus(ExternalResourcesBaseMetric, GaugeMetric):
+    status: str
+
+    @classmethod
+    def name(cls) -> str:
+        return "external_resources_resource_status"

--- a/reconcile/test/external_resources/test_manager.py
+++ b/reconcile/test/external_resources/test_manager.py
@@ -159,5 +159,5 @@ def test_update_in_progress_state_status(
     _r = Reconciliation.parse_obj(r_dict)
     manager.reconciler.get_resource_reconcile_status.return_value = _reconcile_status  # type:ignore
 
-    manager._update_in_progress_state(_r, state)
+    manager._update_in_progress_state(_r, state, "dummy")
     assert state.resource_status == _expected_status


### PR DESCRIPTION
* Add external_resources_resource_status metric to hold resource status. This metric is useful for filtering since it has a value at every run (not only when a resource has been reconciled)
* Use the new metric on the dashboard filtering options
