### PR TITLE
[change-log] fix support for resource analysis

### DIFF
--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -18,8 +18,8 @@ from reconcile.change_owners.changes import (
     parse_bundle_changes,
 )
 from reconcile.typed_queries.apps import get_apps
-from reconcile.typed_queries.external_resources import get_namespaces
 from reconcile.typed_queries.jenkins import get_jenkins_configs
+from reconcile.typed_queries.namespaces import get_namespaces
 from reconcile.utils import gql
 from reconcile.utils.defer import defer
 from reconcile.utils.gitlab_api import MRState

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -135,7 +135,9 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
             diff = QontractServerDiff(**obj)
             changes = aggregate_resource_changes(
                 bundle_changes=aggregate_file_moves(parse_bundle_changes(diff)),
-                content_store={c.path: c.dict() for c in namespaces + jenkins_configs},
+                content_store={
+                    c.path: c.dict(by_alias=True) for c in namespaces + jenkins_configs
+                },
                 supported_schemas={
                     "/openshift/namespace-1.yml",
                     "/dependencies/jenkins-config-1.yml",

--- a/reconcile/change_owners/changes.py
+++ b/reconcile/change_owners/changes.py
@@ -10,7 +10,6 @@ from dataclasses import (
 from typing import Any
 
 import anymarkup
-import jsonpath_ng
 
 from reconcile.change_owners.bundle import (
     DATAFILE_PATH_FIELD_NAME,
@@ -473,7 +472,7 @@ def aggregate_resource_changes(
             new_content_sha="",
             diffs=[
                 Diff(
-                    path=jsonpath_ng.parse(file_ref.json_path),
+                    path=parse_jsonpath(file_ref.json_path),
                     diff_type=DiffType.CHANGED,
                     old=file_content,
                     new=file_content,

--- a/reconcile/gql_definitions/common/namespaces.gql
+++ b/reconcile/gql_definitions/common/namespaces.gql
@@ -2,6 +2,7 @@
 
 query Namespaces {
   namespaces: namespaces_v1 {
+    path
     name
     delete
     labels
@@ -13,6 +14,29 @@ query Namespaces {
         name
         email
       }
+    }
+    openshiftResources {
+        provider
+        ... on NamespaceOpenshiftResourceResource_v1 {
+          path {
+            content
+          }
+        }
+        ... on NamespaceOpenshiftResourceResourceTemplate_v1 {
+          path {
+            content
+          }
+        }
+        ... on NamespaceOpenshiftResourceRoute_v1 {
+          path {
+            content
+          }
+        }
+        ... on NamespaceOpenshiftResourcePrometheusRule_v1 {
+          path {
+            content
+          }
+        }
     }
     managedExternalResources
     externalResources {

--- a/reconcile/gql_definitions/common/namespaces.py
+++ b/reconcile/gql_definitions/common/namespaces.py
@@ -48,6 +48,7 @@ fragment VaultSecret on VaultSecret_v1 {
 
 query Namespaces {
   namespaces: namespaces_v1 {
+    path
     name
     delete
     labels
@@ -59,6 +60,29 @@ query Namespaces {
         name
         email
       }
+    }
+    openshiftResources {
+        provider
+        ... on NamespaceOpenshiftResourceResource_v1 {
+          path {
+            content
+          }
+        }
+        ... on NamespaceOpenshiftResourceResourceTemplate_v1 {
+          path {
+            content
+          }
+        }
+        ... on NamespaceOpenshiftResourceRoute_v1 {
+          path {
+            content
+          }
+        }
+        ... on NamespaceOpenshiftResourcePrometheusRule_v1 {
+          path {
+            content
+          }
+        }
     }
     managedExternalResources
     externalResources {
@@ -172,6 +196,42 @@ class AppV1(ConfiguredBaseModel):
     service_owners: Optional[list[OwnerV1]] = Field(..., alias="serviceOwners")
 
 
+class NamespaceOpenshiftResourceV1(ConfiguredBaseModel):
+    provider: str = Field(..., alias="provider")
+
+
+class ResourceV1(ConfiguredBaseModel):
+    content: str = Field(..., alias="content")
+
+
+class NamespaceOpenshiftResourceResourceV1(NamespaceOpenshiftResourceV1):
+    path: Optional[ResourceV1] = Field(..., alias="path")
+
+
+class NamespaceOpenshiftResourceResourceTemplateV1_ResourceV1(ConfiguredBaseModel):
+    content: str = Field(..., alias="content")
+
+
+class NamespaceOpenshiftResourceResourceTemplateV1(NamespaceOpenshiftResourceV1):
+    path: Optional[NamespaceOpenshiftResourceResourceTemplateV1_ResourceV1] = Field(..., alias="path")
+
+
+class NamespaceOpenshiftResourceRouteV1_ResourceV1(ConfiguredBaseModel):
+    content: str = Field(..., alias="content")
+
+
+class NamespaceOpenshiftResourceRouteV1(NamespaceOpenshiftResourceV1):
+    path: Optional[NamespaceOpenshiftResourceRouteV1_ResourceV1] = Field(..., alias="path")
+
+
+class NamespaceOpenshiftResourcePrometheusRuleV1_ResourceV1(ConfiguredBaseModel):
+    content: str = Field(..., alias="content")
+
+
+class NamespaceOpenshiftResourcePrometheusRuleV1(NamespaceOpenshiftResourceV1):
+    path: Optional[NamespaceOpenshiftResourcePrometheusRuleV1_ResourceV1] = Field(..., alias="path")
+
+
 class ExternalResourcesProvisionerV1(ConfiguredBaseModel):
     name: str = Field(..., alias="name")
 
@@ -261,12 +321,14 @@ class ResourceQuotaV1(ConfiguredBaseModel):
 
 
 class NamespaceV1(ConfiguredBaseModel):
+    path: str = Field(..., alias="path")
     name: str = Field(..., alias="name")
     delete: Optional[bool] = Field(..., alias="delete")
     labels: Optional[Json] = Field(..., alias="labels")
     cluster_admin: Optional[bool] = Field(..., alias="clusterAdmin")
     managed_roles: Optional[bool] = Field(..., alias="managedRoles")
     app: AppV1 = Field(..., alias="app")
+    openshift_resources: Optional[list[Union[NamespaceOpenshiftResourceResourceV1, NamespaceOpenshiftResourceResourceTemplateV1, NamespaceOpenshiftResourceRouteV1, NamespaceOpenshiftResourcePrometheusRuleV1, NamespaceOpenshiftResourceV1]]] = Field(..., alias="openshiftResources")
     managed_external_resources: Optional[bool] = Field(..., alias="managedExternalResources")
     external_resources: Optional[list[Union[NamespaceTerraformProviderResourceAWSV1, NamespaceExternalResourceV1]]] = Field(..., alias="externalResources")
     cluster: ClusterV1 = Field(..., alias="cluster")

--- a/reconcile/test/fixtures/openshift_namespace_labels/namespace.yml
+++ b/reconcile/test/fixtures/openshift_namespace_labels/namespace.yml
@@ -58,3 +58,5 @@ managedResourceNames: null
 managedRoles: true
 name: name
 quota: null
+path: path
+openshiftResources: []


### PR DESCRIPTION
part of https://issues.redhat.com/browse/APPSRE-10755

follows up on #4669

this PR fixes problems which prevented resource analysis from fully working:
1. we didn't query for `openshiftResources`
2. we didn't use `by_alias`, which means the query result as a dict had `openshift_resources`.