### PR TITLE
[change-log] remove error from app-interface-output report

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -2906,13 +2906,12 @@ def change_log_tracking(ctx):
             "merged_at": change_log_item.merged_at,
             "apps": ", ".join(change_log_item.apps),
             "changes": ", ".join(covered_change_types_descriptions),
-            "error": change_log_item.error,
         }
         data.append(item)
 
     # TODO(mafriedm): Fix this
     ctx.obj["options"]["sort"] = False
-    columns = ["commit", "merged_at", "apps", "changes", "error"]
+    columns = ["commit", "merged_at", "apps", "changes"]
     print_output(ctx.obj["options"], data, columns)
 
 


### PR DESCRIPTION
we have not seen errors since work to stabilize, it's now safe to remove the error from the report

part of https://issues.redhat.com/browse/APPSRE-10740