### PR TITLE
[change-log] defense against missing app and helpful logging

### DIFF
--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -46,6 +46,14 @@ class ChangeLogItem:
 class ChangeLog:
     items: list[ChangeLogItem] = field(default_factory=list)
 
+    @property
+    def apps(self) -> set[str]:
+        return {app for item in self.items for app in item.apps}
+
+    @property
+    def change_types(self) -> set[str]:
+        return {change_type for item in self.items for change_type in item.change_types}
+
 
 class ChangeLogIntegrationParams(PydanticRunParams):
     gitlab_project_id: str
@@ -204,6 +212,9 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                     for path in (gl_diff["old_path"], gl_diff["new_path"])
                 )
             )
+
+        logging.info(f"apps: {change_log.apps}")
+        logging.info(f"change_types: {change_log.change_types}")
 
         change_log.items = sorted(
             change_log.items, key=lambda i: i.merged_at, reverse=True

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -2,6 +2,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
+from typing import Any
 
 from reconcile.change_owners.bundle import (
     NoOpFileDiffResolver,
@@ -169,15 +170,18 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                         | "/app-sre/app-changelog-1.yml"
                     ):
                         for c in change_versions:
-                            app = c["app"]
-                            app_path = app.get("$ref") or app.get("path")
-                            app_name = app_name_by_path.get(app_path)
-                            if app_name:
-                                change_log_item.apps.append(app_name)
-                            else:
+                            c_app: dict[str, str] = c["app"]
+                            app_path = c_app.get("$ref") or c_app.get("path")
+                            if not app_path:
                                 raise KeyError(
                                     "app path is expected. missing in query?"
                                 )
+                            app_name = app_name_by_path.get(app_path)
+                            if not app_name:
+                                raise KeyError(
+                                    "app name is expected. missing in query?"
+                                )
+                            change_log_item.apps.append(app_name)
                     case "/openshift/cluster-1.yml":
                         changed_apps = {
                             name

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -2,7 +2,6 @@ import logging
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import asdict, dataclass, field
-from typing import Any
 
 from reconcile.change_owners.bundle import (
     NoOpFileDiffResolver,

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -160,14 +160,16 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                         | "/dependencies/status-page-component-1.yml"
                         | "/app-sre/app-changelog-1.yml"
                     ):
-                        changed_apps = {
-                            name
-                            for c in change_versions
-                            if (app := c["app"])
-                            and (app_path := app.get("$ref") or app.get("path"))
-                            and (name := app_name_by_path.get(app_path))
-                        }
-                        change_log_item.apps.extend(changed_apps)
+                        for c in change_versions:
+                            app = c["app"]
+                            app_path = app.get("$ref") or app.get("path")
+                            app_name = app_name_by_path.get(app_path)
+                            if app_name:
+                                change_log_item.apps.append(app_name)
+                            else:
+                                raise KeyError(
+                                    "app path is expected. missing in query?"
+                                )
                     case "/openshift/cluster-1.yml":
                         changed_apps = {
                             name

--- a/reconcile/change_owners/change_log_tracking.py
+++ b/reconcile/change_owners/change_log_tracking.py
@@ -173,12 +173,12 @@ class ChangeLogIntegration(QontractReconcileIntegration[ChangeLogIntegrationPara
                             app_path = c_app.get("$ref") or c_app.get("path")
                             if not app_path:
                                 raise KeyError(
-                                    "app path is expected. missing in query?"
+                                    f"app path is expected. missing in query? app information: {c_app}"
                                 )
                             app_name = app_name_by_path.get(app_path)
                             if not app_name:
                                 raise KeyError(
-                                    "app name is expected. missing in query?"
+                                    f"app name is expected. missing in query? app information: {c_app}"
                                 )
                             change_log_item.apps.append(app_name)
                     case "/openshift/cluster-1.yml":


### PR DESCRIPTION
protect against missing `app` or `app.path` in the query, and be more defensive if that information is missing.

also provide helpful logging.