### PR TITLE
[gitlab-housekeeping] remove expired PAT tokens

### DIFF
--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -565,7 +565,7 @@ def publish_access_token_expiration_metrics(gl: GitLabApi) -> None:
             days_until_expiration = expiration_date.date() - datetime.now(UTC).date()
             gitlab_token_expiration.labels(pat.name).set(days_until_expiration.days)
         else:
-            with suppress(KeyError | ValueError):
+            with suppress(KeyError, ValueError):
                 # there's no publicly exposed method to determine if a label exists for a gauge
                 # which is why I wrapped the error like this
                 gitlab_token_expiration.remove(pat.name)

--- a/reconcile/gitlab_housekeeping.py
+++ b/reconcile/gitlab_housekeeping.py
@@ -565,7 +565,7 @@ def publish_access_token_expiration_metrics(gl: GitLabApi) -> None:
             days_until_expiration = expiration_date.date() - datetime.now(UTC).date()
             gitlab_token_expiration.labels(pat.name).set(days_until_expiration.days)
         else:
-            with suppress(KeyError):
+            with suppress(KeyError | ValueError):
                 # there's no publicly exposed method to determine if a label exists for a gauge
                 # which is why I wrapped the error like this
                 gitlab_token_expiration.remove(pat.name)


### PR DESCRIPTION
[APPSRE-10433](https://issues.redhat.com/browse/APPSRE-10433)

Follow-up from #4695 

I found out how this `remove()` function is supposed to work (it's not actually documented by the Prometheus client library). This should take care of removing inactive/expired tokens from the exported metrics.