### PR TITLE
:bug: endpoints-discovery: avoid duplicated urls

### DIFF
--- a/reconcile/test/endpoints_discovery/conftest.py
+++ b/reconcile/test/endpoints_discovery/conftest.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable, Mapping
+from copy import deepcopy
 from typing import Any
 
 import pytest
@@ -68,7 +69,10 @@ def fake_route() -> dict[str, Any]:
 def oc(mocker: MockerFixture, fake_route: dict[str, Any]) -> OCNative:
     oc = mocker.patch("reconcile.utils.oc.OCNative", autospec=True)
     oc.project_exists.return_value = True
-    oc.get_items.return_value = [fake_route]
+    # return 2 routes with the same hostname. this should be filtered out by get_routes
+    fake_route2 = deepcopy(fake_route)
+    fake_route2["metadata"]["name"] = "zzz-fake-route"
+    oc.get_items.return_value = [fake_route, fake_route2]
     return oc
 
 

--- a/reconcile/test/endpoints_discovery/test_endpoints_discovery_integration.py
+++ b/reconcile/test/endpoints_discovery/test_endpoints_discovery_integration.py
@@ -88,7 +88,7 @@ def test_endpoints_discovery_integration_get_routes(
     # see fake_route fixture!
     assert len(routes) == 1
     assert isinstance(routes[0], Route)
-    assert routes[0].name == "fake-route"
+    assert routes[0].name == "fake-route|zzz-fake-route"
 
 
 def test_endpoints_discovery_integration_get_endpoint_changes_no_routes_no_endpoints(
@@ -158,9 +158,9 @@ def test_endpoints_discovery_integration_get_apps(
             path="/path/app-1.yml",
             endpoints_to_add=[
                 Endpoint(
-                    name="endpoints-discovery/cluster-1/app-1-ns-1/fake-route",
+                    name="endpoints-discovery/cluster-1/app-1-ns-1/fake-route|zzz-fake-route",
                     data={
-                        "name": "endpoints-discovery/cluster-1/app-1-ns-1/fake-route",
+                        "name": "endpoints-discovery/cluster-1/app-1-ns-1/fake-route|zzz-fake-route",
                         "url": "https://fake-route.com:80",
                     },
                 )
@@ -173,9 +173,9 @@ def test_endpoints_discovery_integration_get_apps(
             path="/path/app-2.yml",
             endpoints_to_add=[
                 Endpoint(
-                    name="endpoints-discovery/cluster-1/app-2-ns-1/fake-route",
+                    name="endpoints-discovery/cluster-1/app-2-ns-1/fake-route|zzz-fake-route",
                     data={
-                        "name": "endpoints-discovery/cluster-1/app-2-ns-1/fake-route",
+                        "name": "endpoints-discovery/cluster-1/app-2-ns-1/fake-route|zzz-fake-route",
                         "url": "https://fake-route.com:80",
                     },
                 )


### PR DESCRIPTION
Several routes may have the same hostname, e.g., if `path` is used. Remove duplicates and unclutter the `app.yml` files 

Ticket: https://issues.redhat.com/browse/APPSRE-10847