### PR TITLE
:recycle: aws-account-manager: do not raise an error

### DIFF
--- a/reconcile/aws_account_manager/merge_request_manager.py
+++ b/reconcile/aws_account_manager/merge_request_manager.py
@@ -89,6 +89,10 @@ class MergeRequestManager:
                 file_path=account_tmpl_file_path
             )
             # File already exists. nothing to do.
+            logging.debug(
+                "The template collection file %s already exists. This may happen if the MR has been merged but template-renderer isn't running yet.",
+                account_tmpl_file_path,
+            )
             return
         except GitlabGetError as e:
             if e.response_code != 404:

--- a/reconcile/aws_account_manager/merge_request_manager.py
+++ b/reconcile/aws_account_manager/merge_request_manager.py
@@ -88,10 +88,8 @@ class MergeRequestManager:
             self._vcs.get_file_content_from_app_interface_master(
                 file_path=account_tmpl_file_path
             )
-            # File already exists
-            raise FileExistsError(
-                f"File {account_tmpl_file_path} already exists in the repository"
-            )
+            # File already exists. nothing to do.
+            return
         except GitlabGetError as e:
             if e.response_code != 404:
                 raise e


### PR DESCRIPTION
If the AWS account manager template MR has already been merged but the `template-renderer` isn't running yet, the account template collection file already exists, which throws an error message. Just remove this confusing message.


Ticket: [APPSRE-10814](https://issues.redhat.com/browse/APPSRE-10814)