### PR TITLE
[qontract-cli] copy_tfstate command

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1370,6 +1370,7 @@ def aws_creds(ctx, account_name):
     print(f"export AWS_ACCESS_KEY_ID={secret['aws_access_key_id']}")
     print(f"export AWS_SECRET_ACCESS_KEY={secret['aws_secret_access_key']}")
 
+
 @root.command()
 @click.argument("account_name")
 @click.argument("bucket")
@@ -1393,11 +1394,17 @@ def copy_tfstate(ctx, account_name, bucket, src, dest, region):
         sys.exit(1)
     account = accounts[0]
 
-    state_key = [i for i in account["terraformState"]["integrations"] if i["integration"] == "terraform-repo"]
+    state_key = [
+        i
+        for i in account["terraformState"]["integrations"]
+        if i["integration"] == "terraform-repo"
+    ]
     if len(state_key) == 0:
-        logging.error("terraform-repo is missing a section in this account's '/dependencies/terraform-state-1.yml' file, please add one using the docs in https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/terraform-repo/sop/migrating-existing-state.md?ref_type=heads and then try again")
+        logging.error(
+            "terraform-repo is missing a section in this account's '/dependencies/terraform-state-1.yml' file, please add one using the docs in https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/terraform-repo/sop/migrating-existing-state.md?ref_type=heads and then try again"
+        )
         return
-    
+
     dest_key = f"{state_key[0]['key']}/{dest}-tf-repo.tfstate"
     dest_bucket = account["terraformState"]["bucket"]
 
@@ -1405,10 +1412,10 @@ def copy_tfstate(ctx, account_name, bucket, src, dest, region):
         prompt_text = f"Are you sure you want to copy 's3://{bucket}/{src}' to 's3://{dest_bucket}/{dest_key}'? This will overwrite any object currently at the destination path."
         if click.confirm(prompt_text):
             session = aws.get_session(account_name)
-            s3_client = aws.get_session_client(session, "s3", region)   
+            s3_client = aws.get_session_client(session, "s3", region)
             copy_source = {
-                'Bucket': bucket,
-                'Key': src,
+                "Bucket": bucket,
+                "Key": src,
             }
 
             s3_client.copy(copy_source, dest_bucket, dest_key)


### PR DESCRIPTION
[APPSRE-10882](https://issues.redhat.com/browse/APPSRE-10882)

Introduces a new command to Qontract CLI for migrating Terraform statefiles for usage with Terraform Repo.

Example of usage:
`qontract-cli --config config.debug.toml copy-tfstate app-sre my-backend-bucket app-sre-ci-stage.tfstate app-sre-ci-stage us-east-1`

This command allows for migration from manually managed Terraform repositories (ex: our infra repo on GitLab), to be Terraform Repo managed. 

The command will prompt the user to OK the change like so:
```
❯ qontract-cli --config config.debug.toml copy-tfstate app-sre my-backend-bucket app-sre-ci-stage.tfstate app-sre-ci-stage us-east-1 
Are you sure you want to copy 's3://my-backend-bucket/app-sre-ci-stage.tfstate' to 's3://my-backend-bucket/tf-repo-statefiles/app-sre-ci-stage-tf-repo.tfstate'? This will overwrite any object currently at the destination path. [y/N]:
```

From there, the user can provision the repo definition in App-Interface which will use the migrated statefile.

Here is the whole migration guide in GitLab: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/120196