### PR TITLE
[AUS/addon] clean completed upgrade plans

### DIFF
--- a/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
+++ b/reconcile/aus/ocm_addons_upgrade_scheduler_org.py
@@ -251,7 +251,9 @@ def calculate_diff(
         addon_id,
     )
     for current in addon_current_state:
-        if addon_id == current.addon_id and current.schedule_type == "automatic":
+        if addon_id == current.addon_id and (
+            current.schedule_type == "automatic" or current.state == "completed"
+        ):
             diffs.append(
                 aus.UpgradePolicyHandler(
                     action="delete",


### PR DESCRIPTION
https://issues.redhat.com/browse/APPSRE-10973

Since recently, addon service does not delete the addon upgrade plans but sets them as completed. AUS will not create any new plan if one exists already. Also, if a plan exists, the addon upgrade holds any configured mutex for that cluster. So this blocks further upgrades.

This PR cleans up the completed upgrade plan, much like what we do for automatic upgrade plans