### PR TITLE
Allow the replication of single secret policies

### DIFF
--- a/reconcile/test/test_vault_replication.py
+++ b/reconcile/test/test_vault_replication.py
@@ -504,13 +504,32 @@ def test_get_policy_secret_list(mocker):
     vault_client.list_all.side_effect = [
         ["policy/path/1/secret1", "policy/path/1/secret2"],
         ["policy/path/2/secret1", "policy/path/2/secret2"],
+        ["my-policy/path_to_it/3/secret1"],
     ]
 
-    assert integ.get_policy_secret_list(
-        vault_client, ["policy/path/1/*", "policy/path/2/*"]
-    ) == [
+    assert set(
+        integ.get_policy_secret_list(
+            vault_client,
+            ["policy/path/1/*", "policy/path/2/*", "policy/path/3/secret1"],
+        )
+    ) == {
         "policy/path/1/secret1",
         "policy/path/1/secret2",
         "policy/path/2/secret1",
         "policy/path/2/secret2",
-    ]
+        "policy/path/3/secret1",
+    }
+
+
+@pytest.mark.parametrize(
+    "paths",
+    [
+        ["policy/path*"],
+        ["policy/p*th"],
+        ["policy/+/p*th"],
+    ],
+)
+def test_get_policy_secret_list_failure(paths, mocker):
+    vault_client = mocker.patch("reconcile.utils.vault._VaultClient", autospec=True)
+    with pytest.raises(integ.VaultInvalidPaths):
+        integ.get_policy_secret_list(vault_client, paths)

--- a/reconcile/vault_replication.py
+++ b/reconcile/vault_replication.py
@@ -34,6 +34,7 @@ from reconcile.utils.vault import (
 )
 
 QONTRACT_INTEGRATION = "vault-replication"
+SECRET_PATH_PATTERN = re.compile(r"^[\w/-]+?(?P<folder>/\*?)?$")
 
 
 class VaultInvalidPaths(Exception):
@@ -232,14 +233,21 @@ def get_policy_secret_list(
     vault_instance: _VaultClient, policy_paths: Iterable[str]
 ) -> list[str]:
     """Returns a list of secrets to be copied from the given policy"""
-    secret_list = []
+    secrets = set()
     for path in policy_paths:
-        # Remove the * at the end of the path because list method expects
-        # a folder path without any secret or wilcard
-        path = path[:-1] if path.endswith("*") else path
-        secret_list.extend(vault_instance.list_all(path))
+        match = SECRET_PATH_PATTERN.match(path)
+        if not match:
+            logging.error(["get_policy_secret_list", "Invalid path to replicate", path])
+            raise VaultInvalidPaths
 
-    return secret_list
+        if match.group("folder"):
+            # Remove the * at the end of the path because list method expects
+            # a folder path without any secret or wilcard
+            secrets.update(vault_instance.list_all(path.rstrip("*")))
+        else:
+            secrets.add(path)
+
+    return list(secrets)
 
 
 def get_jenkins_secret_list(


### PR DESCRIPTION
we may have policies with paths that do not have globs, being just a single secret:
```
path my/nice/secret
```
instead of the more general that catches everything inside the folder
```
path my/nice/*
```
The code didn't behave properly with the former ones.

related to APPSRE-10999