### PR TITLE
aggregate_resource_changes allow datafile to not exist

### DIFF
--- a/reconcile/change_owners/changes.py
+++ b/reconcile/change_owners/changes.py
@@ -482,7 +482,7 @@ def aggregate_resource_changes(
         for change in bundle_changes
         for file_ref in change.old_backrefs | change.new_backrefs
         if file_ref.schema in supported_schemas
-        and (file_content := content_store[file_ref.path])
+        and (file_content := content_store.get(file_ref.path))
     ]
 
     return bundle_changes + resource_changes


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/reconcile/cli.py", line 609, in run_class_integration
    run_integration_cfg(
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/reconcile/utils/runtime/runner.py", line 155, in run_integration_cfg
    _integration_dry_run(run_cfg.integration, desired_state_diff)
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/reconcile/utils/runtime/runner.py", line 226, in _integration_dry_run
    integration.run(True)
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/reconcile/utils/defer.py", line 13, in func_wrapper
    return func(*args, defer=stack.callback, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/reconcile/change_owners/change_log_tracking.py", line 147, in run
    changes = aggregate_resource_changes(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/reconcile/change_owners/changes.py", line 466, in aggregate_resource_changes
    resource_changes = [
                       ^
  File "/home/mafriedm/repos/app-sre/qontract-reconcile/reconcile/change_owners/changes.py", line 485, in <listcomp>
    and (file_content := content_store[file_ref.path])
                         ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
```