### PR TITLE
:bug: aws-version-sync: enforce string

### DIFF
--- a/reconcile/aws_version_sync/integration.py
+++ b/reconcile/aws_version_sync/integration.py
@@ -304,9 +304,9 @@ class AVSIntegration(QontractReconcileIntegration[AVSIntegrationParams]):
                             )
                             _defaults_cache[resource.defaults] = values
                     values = override_values(values, resource.overrides)
-                    if resource.provider.lower() == "elasticache" and values[
-                        "engine_version"
-                    ].lower().endswith("x"):
+                    if resource.provider.lower() == "elasticache" and str(
+                        values["engine_version"]
+                    ).lower().endswith("x"):
                         # see https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/app-sre/sop/upgrade-redis-minor-version.md
                         # minor version not managed by app-interface anymore. skip it
                         continue


### PR DESCRIPTION
AWS elasticache `engine_version` could be a float. Fix comparison of versions like `6.x`.