### PR TITLE
[tf-repo migrate] explicitly named arguments

### DIFF
--- a/tools/qontract_cli.py
+++ b/tools/qontract_cli.py
@@ -1416,7 +1416,7 @@ def copy_tfstate(
         for i in account["terraformState"]["integrations"]
         if i["integration"] == "terraform-repo"
     ]
-    if len(dest_folder) == 0:
+    if not dest_folder:
         logging.error(
             "terraform-repo is missing a section in this account's '/dependencies/terraform-state-1.yml' file, please add one using the docs in https://gitlab.cee.redhat.com/service/app-interface/-/blob/master/docs/terraform-repo/getting-started.md?ref_type=heads#step-1-setup-aws-account and then try again"
         )


### PR DESCRIPTION
APPSRE-10882

Following some feedback in the migration guide: https://gitlab.cee.redhat.com/service/app-interface/-/merge_requests/120196#note_13167927, this updates the migrate command to use explicitly named options instead of value ordered arguments. Here is what the output/format looks now:

```
qontract-cli --config config.debug.toml copy-tfstate --account-uid <account_uid> --source-bucket <source_bucket> --source-object-path athena.tfstate

Are you sure you want to copy 's3://<source_bucket>/athena.tfstate' to 's3://<dest_bucket>/tf-repo-statefiles/athena-tf-repo.tfstate'? [y/N]: y

Nicely done! Your tfstate file has been migrated. Now you can create a repo definition in App-Interface like so:

---
$schema: /aws/terraform-repo-1.yml

account:
    $ref: /aws/<account_name>/account.yml

name: athena
repository: <FILL_IN>
projectPath: <FILL_IN>
tfVersion: <FILL_IN>
ref: <FILL_IN>
```

Users can optionally use the `--rename` parameter to rename the new repository. I'll document this in the migration guide if merged.